### PR TITLE
Utvider bostedsadresse-sjekk i fordeler

### DIFF
--- a/apps/etterlatte-fordeler/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-fordeler/src/test/kotlin/TestHelper.kt
@@ -49,7 +49,7 @@ fun mockPerson(
     familieRelasjon = familieRelasjon
 )
 
-fun mockNorskAdresse(adresseLinje1: String = "Testveien 4") = Adresse(
+fun mockNorskAdresse(adresseLinje1: String = "Testveien 4", gyldigTilOgMed: LocalDateTime? = null) = Adresse(
     type = AdresseType.VEGADRESSE,
     aktiv = true,
     coAdresseNavn = null,
@@ -61,11 +61,15 @@ fun mockNorskAdresse(adresseLinje1: String = "Testveien 4") = Adresse(
     land = null,
     kilde = "FREG",
     gyldigFraOgMed = LocalDateTime.now().minusYears(1),
-    gyldigTilOgMed = null
+    gyldigTilOgMed = gyldigTilOgMed
 )
 
-fun mockUgyldigAdresse() = Adresse(
-    type = AdresseType.UKJENT_BOSTED,
+fun mockUgyldigAdresse(
+    type: AdresseType = AdresseType.UKJENT_BOSTED,
+    gyldigFraOgMed: LocalDateTime = LocalDateTime.now().minusYears(1),
+    gyldigTilOgMed: LocalDateTime? = null
+) = Adresse(
+    type = type,
     aktiv = true,
     coAdresseNavn = null,
     adresseLinje1 = "Tull",
@@ -75,8 +79,8 @@ fun mockUgyldigAdresse() = Adresse(
     poststed = null,
     land = null,
     kilde = "FREG",
-    gyldigFraOgMed = LocalDateTime.now().minusYears(1),
-    gyldigTilOgMed = null
+    gyldigFraOgMed = gyldigFraOgMed,
+    gyldigTilOgMed = gyldigTilOgMed
 )
 
 fun readSoknad(file: String): Barnepensjon {

--- a/libs/common/src/main/kotlin/person/EtterlattePersonModel.kt
+++ b/libs/common/src/main/kotlin/person/EtterlattePersonModel.kt
@@ -99,3 +99,7 @@ fun Person.alder(): Int? {
 }
 
 fun List<Adresse>.aktiv(): Adresse? = firstOrNull { it.aktiv }
+
+fun List<Adresse>.nyeste(inkluderInaktiv: Boolean = false): Adresse? =
+    sortedByDescending { it.gyldigFraOgMed }.firstOrNull { if (inkluderInaktiv) true else it.gyldigTilOgMed == null }
+


### PR DESCRIPTION
- Sjekker om dødsdato for avdød er innenfor fra og til dato for siste bostedsadresse for avdød som er av typen vegadresse eller matrikkeladresse
- For barn og gjenlevende sjekkes det på nyeste adresse