### PR TITLE
EY-527: Legger til connection pooling for MQ

### DIFF
--- a/apps/etterlatte-okonomi-vedtak/build.gradle.kts
+++ b/apps/etterlatte-okonomi-vedtak/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation("com.zaxxer:HikariCP:3.4.5")
     implementation("org.flywaydb:flyway-core:6.5.0")
     implementation("org.postgresql:postgresql:42.3.3")
+    implementation("org.messaginghub:pooled-jms:2.0.5")
 
     testImplementation(Ktor.ClientMock)
     testImplementation(MockK.MockK)

--- a/apps/etterlatte-okonomi-vedtak/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-okonomi-vedtak/src/main/kotlin/config/ApplicationContext.kt
@@ -27,7 +27,7 @@ class ApplicationContext(
         password = env.required("DB_PASSWORD"),
     )
 
-    fun jmsConnectionFactoryBuilder() = JmsConnectionFactoryBuilder(
+    fun jmsConnectionFactory() = JmsConnectionFactory(
         hostname = env.required("OPPDRAG_MQ_HOSTNAME"),
         port = env.required("OPPDRAG_MQ_PORT").toInt(),
         queueManager = env.required("OPPDRAG_MQ_MANAGER"),
@@ -36,8 +36,8 @@ class ApplicationContext(
         password = env.required("srvpwd")
     )
 
-    fun oppdragSender(jmsConnection: Connection) = OppdragSender(
-        jmsConnection = jmsConnection,
+    fun oppdragSender(jmsConnectionFactory: JmsConnectionFactory) = OppdragSender(
+        jmsConnectionFactory = jmsConnectionFactory,
         queue = env.required("OPPDRAG_SEND_MQ_NAME"),
         replyQueue = env.required("OPPDRAG_KVITTERING_MQ_NAME"),
     )
@@ -53,11 +53,11 @@ class ApplicationContext(
     fun kvitteringMottaker(
         rapidsConnection: RapidsConnection,
         utbetalingsoppdragDao: UtbetalingsoppdragDao,
-        jmsConnection: Connection
+        jmsConnectionFactory: JmsConnectionFactory
     ) = KvitteringMottaker(
         rapidsConnection = rapidsConnection,
         utbetalingsoppdragDao = utbetalingsoppdragDao,
-        jmsConnection = jmsConnection,
+        jmsConnectionFactory = jmsConnectionFactory,
         queue = env.required("OPPDRAG_KVITTERING_MQ_NAME"),
     )
 

--- a/apps/etterlatte-okonomi-vedtak/src/main/kotlin/config/JmsConnectionFactory.kt
+++ b/apps/etterlatte-okonomi-vedtak/src/main/kotlin/config/JmsConnectionFactory.kt
@@ -4,11 +4,13 @@ import com.ibm.mq.MQC
 import com.ibm.mq.jms.MQConnectionFactory
 import com.ibm.msg.client.jms.JmsConstants
 import com.ibm.msg.client.wmq.WMQConstants
+import org.messaginghub.pooled.jms.JmsPoolConnectionFactory
 import javax.jms.Connection
+
 
 private const val UTF_8_WITH_PUA = 1208
 
-class JmsConnectionFactoryBuilder(
+class JmsConnectionFactory(
     private val hostname: String,
     private val port: Int,
     private val queueManager: String,
@@ -24,10 +26,21 @@ class JmsConnectionFactoryBuilder(
         it.transportType = WMQConstants.WMQ_CM_CLIENT
         it.ccsid = UTF_8_WITH_PUA
 
+        // TODO trenger man dette?
+        //it.clientReconnectOptions = WMQConstants.WMQ_CLIENT_RECONNECT
+        //it.clientReconnectTimeout = 600
+
         it.setBooleanProperty(JmsConstants.USER_AUTHENTICATION_MQCSP, true)
         it.setIntProperty(WMQConstants.JMS_IBM_CHARACTER_SET, UTF_8_WITH_PUA)
         it.setIntProperty(WMQConstants.JMS_IBM_ENCODING, MQC.MQENC_NATIVE)
+    }.let {
+        val pooledConnectionFactory = JmsPoolConnectionFactory()
+        pooledConnectionFactory.connectionFactory = it
+        pooledConnectionFactory.maxConnections = 1
+        pooledConnectionFactory
     }
 
     fun connection(): Connection = connectionFactory.createConnection(username, password)
+
+    fun stop() = connectionFactory.stop()
 }

--- a/apps/etterlatte-okonomi-vedtak/src/main/kotlin/oppdrag/KvitteringMottaker.kt
+++ b/apps/etterlatte-okonomi-vedtak/src/main/kotlin/oppdrag/KvitteringMottaker.kt
@@ -3,52 +3,62 @@ package no.nav.etterlatte.oppdrag
 
 import net.logstash.logback.argument.StructuredArguments.kv
 import no.nav.etterlatte.common.Jaxb
+import no.nav.etterlatte.config.JmsConnectionFactory
 import no.nav.etterlatte.domain.UtbetalingsoppdragStatus
 import no.nav.etterlatte.libs.common.logging.withLogContext
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.helse.rapids_rivers.RapidsConnection
 import no.trygdeetaten.skjema.oppdrag.Oppdrag
 import org.slf4j.LoggerFactory
-import javax.jms.Connection
+import javax.jms.ExceptionListener
+import javax.jms.Message
+import javax.jms.MessageListener
 import javax.jms.Session
 
 
 class KvitteringMottaker(
     private val rapidsConnection: RapidsConnection,
     private val utbetalingsoppdragDao: UtbetalingsoppdragDao,
-    jmsConnection: Connection,
+    jmsConnectionFactory: JmsConnectionFactory,
     queue: String,
-) {
-    private val session = jmsConnection.createSession(false, Session.CLIENT_ACKNOWLEDGE)
-    private val consumer = session.createConsumer(session.createQueue(queue))
+) : MessageListener {
 
     init {
         withLogContext {
-            consumer.setMessageListener { message ->
-                var oppdragXml: String? = null
-
-                try {
-                    logger.info("Kvittering på utbetalingsoppdrag fra Oppdrag mottatt med id=${message.jmsMessageID}")
-                    oppdragXml = message.getBody(String::class.java)
-                    val oppdrag = Jaxb.toOppdrag(oppdragXml)
-
-                    utbetalingsoppdragDao.oppdaterKvittering(oppdrag)
-
-                    when (oppdrag.mmel.alvorlighetsgrad) {
-                        "00", "04" -> oppdragGodkjent(oppdrag)
-                        //"08" // noe saksbehandler må håndtere
-                        //"12" // hånteres av tjenesten
-                        else -> oppdragFeilet(oppdrag, oppdragXml)
-                    }
-
-                    message.acknowledge()
-                    logger.info("Melding med id=${message.jmsMessageID} er lest og behandlet")
-
-                } catch (t: Throwable) {
-                    logger.info("Mottatt melding fra MQ: $oppdragXml") // TODO hva med fnr og slikt i denne meldingen? securelogs?
-                    logger.error("Feilet under mottak av kvittering på utbetalingsoppdrag fra Oppdrag", t)
+            val connection = jmsConnectionFactory.connection().apply {
+                // TODO hvordan forsøke å sette opp connection på nytt?
+                exceptionListener = ExceptionListener {
+                    logger.error("En feil oppstod med tilkobling mot MQ: ${it.message}", it)
                 }
+            }.also { it.start() }
+
+            val session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
+            val consumer = session.createConsumer(session.createQueue(queue))
+            consumer.messageListener = this
+        }
+    }
+
+    override fun onMessage(message: Message) {
+        var oppdragXml: String? = null
+
+        try {
+            logger.info("Kvittering på utbetalingsoppdrag fra Oppdrag mottatt med id=${message.jmsMessageID}")
+            oppdragXml = message.getBody(String::class.java)
+            val oppdrag = Jaxb.toOppdrag(oppdragXml)
+
+            utbetalingsoppdragDao.oppdaterKvittering(oppdrag)
+
+            when (oppdrag.mmel.alvorlighetsgrad) {
+                "00", "04" -> oppdragGodkjent(oppdrag)
+                //"08" // noe saksbehandler må håndtere
+                //"12" // hånteres av tjenesten
+                else -> oppdragFeilet(oppdrag, oppdragXml)
             }
+
+            logger.info("Melding med id=${message.jmsMessageID} er lest og behandlet")
+
+        } catch (t: Throwable) {
+            logger.error("Feilet under mottak av kvittering fra Oppdrag", kv("oppdragXml", oppdragXml), t)
         }
     }
 

--- a/apps/etterlatte-okonomi-vedtak/src/main/kotlin/oppdrag/OppdragMapper.kt
+++ b/apps/etterlatte-okonomi-vedtak/src/main/kotlin/oppdrag/OppdragMapper.kt
@@ -23,11 +23,11 @@ object OppdragMapper {
         val oppdrag110 = Oppdrag110().apply {
             kodeAksjon = "1" // 3 = simulering
             kodeEndring = "NY" // Alltid NY for førstegangsinnvilgelse
-            kodeFagomraade = "EY" // TODO må legges inn hos økonomi // PENBP for å teste tilsvarende PESYS
+            kodeFagomraade = "PENBP" // TODO midlertidig verdi fra pesys
             fagsystemId = vedtak.sakId
             utbetFrekvens = "MND"
             oppdragGjelderId = vedtak.sakIdGjelderFnr
-            datoOppdragGjelderFom = vedtak.aktorFoedselsdato.toXMLDate()
+            datoOppdragGjelderFom = vedtak.aktorFoedselsdato.toXMLDate() // TODO første virkningsdato eller 01.01.1900
             saksbehId = vedtak.saksbehandlerId
 
             // aktuelle enheter knyttet til oppdraget
@@ -37,8 +37,8 @@ object OppdragMapper {
                         typeEnhet = when (it.enhetsType) {
                             Enhetstype.BOSTED -> "BOS"
                         }
-                        enhet = it.enhetsnummer
-                        datoEnhetFom = it.datoEnhetFOM.toXMLDate()
+                        enhet = it.enhetsnummer // alltid 4819 enhetsnummer (ikke enheten som fatter vedtaket)
+                        datoEnhetFom = it.datoEnhetFOM.toXMLDate() // TODO 01.01.1900
                     }
                 )
             }
@@ -48,9 +48,9 @@ object OppdragMapper {
                     OppdragsLinje150().apply {
                         kodeEndringLinje = Endringskode.NY.toString()
                         //kodeStatusLinje
-                        //datoStatusFom
+                        //datoStatusFom TODO ved opphør skal denne være fra første mnd etter
                         vedtakId = vedtak.vedtakId
-                        delytelseId = it.delytelsesId // TODO: finne tilsvarende delytelsesId for PESYS
+                        delytelseId = it.delytelsesId // TODO: kan være hva som helst - må være unik innenfor Oppdrag - må taes vare på
                         //linjeid // får dette fra Oppdragssystemet
                         kodeKlassifik = it.ytelseskomponent.toString()
                         //datoKlassifikFom

--- a/apps/etterlatte-okonomi-vedtak/src/main/kotlin/oppdrag/OppdragSender.kt
+++ b/apps/etterlatte-okonomi-vedtak/src/main/kotlin/oppdrag/OppdragSender.kt
@@ -2,24 +2,25 @@ package no.nav.etterlatte.oppdrag
 
 import com.ibm.mq.jms.MQQueue
 import no.nav.etterlatte.common.Jaxb
+import no.nav.etterlatte.config.JmsConnectionFactory
 import no.trygdeetaten.skjema.oppdrag.Oppdrag
 import org.slf4j.LoggerFactory
-import javax.jms.Connection
 
 class OppdragSender(
-    val jmsConnection: Connection,
-    val queue: String,
-    val replyQueue: String,
+    private val jmsConnectionFactory: JmsConnectionFactory,
+    private val queue: String,
+    private val replyQueue: String,
 ) {
     fun sendOppdrag(oppdrag: Oppdrag) {
         logger.info("Sender utbetalingsoppdrag til Oppdrag")
-        jmsConnection.createSession().use { session ->
+        val connection = jmsConnectionFactory.connection()
+        connection.createSession().use { session ->
             val producer = session.createProducer(session.createQueue(queue))
             val message = session.createTextMessage(Jaxb.toXml(oppdrag)).apply {
                 jmsReplyTo = MQQueue(replyQueue)
             }
             producer.send(message)
-            logger.info("Utbetalingsoppdrag overførert til Oppdrag")
+            logger.info("Utbetalingsoppdrag overført til Oppdrag")
         }
     }
 


### PR DESCRIPTION
- Legger på en connection pool for å holde på connections mot MQ. Dette for å slippe å opprette connections, sessions og producers hver gang en melding skal sendes. 
- Endret litt på oppsettet ved start av applikasjon slik at man nå kan få en `RapidsConnection` og selv velge om den skal startes eller ikke.