### PR TITLE
Etterlatte-brev-distribusjon: Byt til Java 17

### DIFF
--- a/.github/workflows/app-etterlatte-brev-distribusjon.yaml
+++ b/.github/workflows/app-etterlatte-brev-distribusjon.yaml
@@ -25,11 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Setup Java v16.x
-        uses: actions/setup-java@v1
+        uses: actions/checkout@v3
+      - name: Setup Java v17.x
+        uses: actions/setup-java@v3
         with:
-          java-version: '16.x'
+          distribution: temurin
+          java-version: 17.x
+          cache: gradle
       - name: Gradle test and build
         run: |
           chmod +x ./gradlew

--- a/apps/etterlatte-brev-distribusjon/Dockerfile
+++ b/apps/etterlatte-brev-distribusjon/Dockerfile
@@ -1,3 +1,3 @@
-FROM navikt/java:16
+FROM navikt/java:17
 COPY build/libs/*.jar ./
 

--- a/libs/common/build.gradle.kts
+++ b/libs/common/build.gradle.kts
@@ -31,8 +31,4 @@ tasks {
     withType<Test> {
         useJUnitPlatform()
     }
-
-    withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "16"
-    }
 }

--- a/libs/etterlatte-kafka/build.gradle.kts
+++ b/libs/etterlatte-kafka/build.gradle.kts
@@ -33,8 +33,4 @@ tasks {
     withType<Test> {
         useJUnitPlatform()
     }
-
-    withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "16"
-    }
 }

--- a/libs/rapidsandrivers-extras/build.gradle.kts
+++ b/libs/rapidsandrivers-extras/build.gradle.kts
@@ -31,8 +31,4 @@ tasks {
     withType<Test> {
         useJUnitPlatform()
     }
-
-    withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "16"
-    }
 }


### PR DESCRIPTION
Appen feilet tidligere p.g.a avhengigheter til java 17, men kjørte på 16.