### PR TITLE
etterlatte-grunnlag: Ny REST-tjeneste for å hente ut opplysninger fra grunnlag.

### DIFF
--- a/apps/etterlatte-grunnlag/.nais/dev.yaml
+++ b/apps/etterlatte-grunnlag/.nais/dev.yaml
@@ -43,4 +43,7 @@ spec:
   env:
     - name: KAFKA_RAPID_TOPIC
       value: etterlatte.dodsmelding
-
+  accessPolicy:
+    inbound:
+      rules:
+        - application: etterlatte-api

--- a/apps/etterlatte-grunnlag/build.gradle.kts
+++ b/apps/etterlatte-grunnlag/build.gradle.kts
@@ -6,6 +6,28 @@ plugins {
 
 dependencies {
     implementation(project(":libs:common"))
+
+    implementation(Ktor2.ServerCore)
+    implementation(Ktor2.ServerCio)
+    implementation(Ktor2.ClientCore)
+    implementation(Ktor2.ClientJackson)
+    implementation(Ktor2.ClientCioJvm)
+    implementation(Ktor2.ClientAuth)
+    implementation(Ktor2.ClientLogging)
+    implementation(Ktor2.MetricsMicrometer)
+    implementation(Ktor2.ServerContentNegotiation)
+    implementation(Ktor2.Jackson)
+    implementation(Ktor2.Auth)
+    implementation(Ktor2.StatusPages)
+    implementation(Ktor2.CallLogging)
+
+    implementation(Jackson.DatatypeJsr310)
+    implementation(Jackson.DatatypeJdk8)
+    implementation(Jackson.ModuleKotlin)
+
+    implementation(NavFelles.TokenClientCore)
+    implementation(NavFelles.TokenValidationKtor2)
+
     testImplementation(MockK.MockK)
     testImplementation(Kotlinx.CoroutinesCore)
 }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/ApiModule.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/ApiModule.kt
@@ -1,0 +1,69 @@
+package no.nav.etterlatte
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.typesafe.config.ConfigFactory
+import io.ktor.serialization.jackson.*
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.config.*
+import io.ktor.server.plugins.callloging.*
+import io.ktor.server.plugins.contentnegotiation.*
+import io.ktor.server.plugins.statuspages.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import no.nav.security.token.support.v2.tokenValidationSupport
+import org.slf4j.event.Level
+
+fun Application.apiModule(routes: Route.() -> Unit) {
+    install(ContentNegotiation) {
+        jackson {
+            registerModule(JavaTimeModule())
+            disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        }
+    }
+
+    install(CallLogging) {
+        level = Level.INFO
+        filter { call -> !call.request.path().startsWith("/internal") }
+        format { call -> "<- ${call.response.status()?.value} ${call.request.httpMethod.value} ${call.request.path()}" }
+        mdc(no.nav.etterlatte.libs.common.logging.CORRELATION_ID) { call ->
+            call.request.header(no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID) ?: java.util.UUID.randomUUID()
+                .toString()
+        }
+    }
+
+    install(StatusPages) {
+        exception<Throwable> { call, cause ->
+            call.application.log.error("En feil oppstod: ${cause.message}", cause)
+            call.respond(io.ktor.http.HttpStatusCode.InternalServerError, "En intern feil har oppstått")
+        }
+    }
+
+    install(Authentication) {
+        tokenValidationSupport(config = HoconApplicationConfig(ConfigFactory.load()))
+    }
+
+    routing {
+        healthApi()
+        authenticate {
+            route("api") {
+                routes()
+            }
+        }
+    }
+}
+
+fun Route.healthApi() {
+    route("internal") {
+        get("isalive") {
+            call.respondText { "OK" }
+        }
+        get("isready") {
+            call.respondText { "OK" }
+        }
+        get("started") {
+            call.respondText { "OK" }
+        }
+    }
+}

--- a/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
@@ -1,8 +1,13 @@
 package no.nav.etterlatte
 
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asContextElement
+import kotlinx.coroutines.withContext
 import no.nav.etterlatte.database.DatabaseContext
-import no.nav.etterlatte.grunnlag.*
+import no.nav.etterlatte.grunnlag.BehandlingEndretHendlese
+import no.nav.etterlatte.grunnlag.BehandlingHendelser
+import no.nav.etterlatte.grunnlag.GrunnlagHendelser
+import no.nav.etterlatte.grunnlag.grunnlagRoute
 import no.nav.helse.rapids_rivers.RapidApplication
 
 suspend fun main() {
@@ -10,21 +15,26 @@ suspend fun main() {
         put("KAFKA_CONSUMER_GROUP_ID", requireNotNull(get("NAIS_APP_NAME")).replace("-", ""))
     }
     val beanFactory = EnvBasedBeanFactory(env)
+    val grunnlag = beanFactory.grunnlagsService()
 
     beanFactory.datasourceBuilder().migrate()
 
-    RapidApplication.Builder(RapidApplication.RapidApplicationConfig.fromEnv(env)).build().apply {
-        val grunnlag = beanFactory.grunnlagsService()
-        GrunnlagHendelser(this, grunnlag)//, beanFactory.datasourceBuilder().dataSource)
-        BehandlingHendelser(this)
-        BehandlingEndretHendlese(this, grunnlag)
-    }.also {
-        withContext(Dispatchers.Default + Kontekst.asContextElement(
-            value = Context(Self("etterlatte-grunnlag"), DatabaseContext(beanFactory.datasourceBuilder().dataSource))
-        )) {
-            it.start()
+    RapidApplication.Builder(RapidApplication.RapidApplicationConfig.fromEnv(env))
+        .withKtorModule { apiModule { grunnlagRoute(grunnlag) } }
+        .build().apply {
+            GrunnlagHendelser(this, grunnlag)
+            BehandlingHendelser(this)
+            BehandlingEndretHendlese(this, grunnlag)
+        }.also {
+            withContext(
+                Dispatchers.Default + Kontekst.asContextElement(
+                    value = Context(
+                        Self("etterlatte-grunnlag"),
+                        DatabaseContext(beanFactory.datasourceBuilder().dataSource)
+                    )
+                )
+            ) {
+                it.start()
+            }
         }
-    }
 }
-
-

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagRoutes.kt
@@ -1,0 +1,24 @@
+package no.nav.etterlatte.grunnlag
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstyper
+
+fun Route.grunnlagRoute(service: GrunnlagService) {
+    route("grunnlag") {
+        get("{sakId}/{opplysningType}") {
+            val grunnlag = service.hentGrunnlagAvType(
+                call.parameters["sakId"]!!.toLong(),
+                Opplysningstyper.valueOf(call.parameters["opplysningType"].toString())
+            )
+
+            if (grunnlag != null) {
+                call.respond(grunnlag)
+            } else {
+                call.respond(HttpStatusCode.NotFound)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Opplysninger kan nå hentes ut fra grunnlag ved på kalle på endepunktet `api/{sakId}/{opplysningType}`. Planlagt benyttet fra etterlatte-api.

EY-803