### PR TITLE
Etterlatte-saksbehandling-ui: Avrund til slutt

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/model/BeregningService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/model/BeregningService.kt
@@ -21,10 +21,7 @@ import java.time.YearMonth
 import java.util.*
 
 // TODO hvordan håndtere vedtakstidspunkt?
-
 class BeregningService {
-    // private val logger = LoggerFactory.getLogger(BeregningService::class.java)
-
     fun beregnResultat(grunnlag: Grunnlag, virkFOM: YearMonth, virkTOM: YearMonth): BeregningsResultat {
         val beregningsperioder = finnBeregningsperioder(grunnlag, virkFOM, virkTOM)
 
@@ -56,6 +53,7 @@ class BeregningService {
         return alleFOM.map {
             val gjeldendeG = Grunnbeloep.hentGjeldendeG(it.first)
             val flokkForPeriode = hentFlokkforPeriode(it.first, it.second, soeskenPerioder)
+            val utbetaltBeloep = Soeskenjustering(flokkForPeriode.size, gjeldendeG.grunnbeløp).beloep
 
             (
                 Beregningsperiode(
@@ -66,10 +64,7 @@ class BeregningService {
                     grunnbelopMnd = gjeldendeG.grunnbeløpPerMåned,
                     grunnbelop = gjeldendeG.grunnbeløp,
                     soeskenFlokk = flokkForPeriode,
-                    utbetaltBeloep = beregnUtbetaling(
-                        soeskenFlokk = flokkForPeriode.size,
-                        g = gjeldendeG.grunnbeløpPerMåned
-                    )
+                    utbetaltBeloep = utbetaltBeloep
                 )
                 )
         }
@@ -86,14 +81,6 @@ class BeregningService {
             .filter { !it.datoFOM.isAfter(datoTOM) }
             .filter { it.datoFOM != datoTOM }
         return if (flokk.isNotEmpty()) flokk[0].soeskenFlokk!! else emptyList()
-    }
-
-    // 40% av G til første barn, 25% til resten. Fordeles likt
-    private fun beregnUtbetaling(soeskenFlokk: Int, g: Int): Double {
-        if (soeskenFlokk == 0) return 0.0
-        val antallSoesken = soeskenFlokk - 1
-
-        return (g * 0.40 + (g * 0.25 * antallSoesken)) / (soeskenFlokk)
     }
     private fun beregnFoersteFom(first: YearMonth, virkFOM: YearMonth): YearMonth {
         return if (first.isBefore(virkFOM)) {

--- a/apps/etterlatte-beregning/src/main/kotlin/model/Soeskenjustering.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/model/Soeskenjustering.kt
@@ -1,0 +1,36 @@
+package no.nav.etterlatte.model
+
+import model.avrund.avrund
+import org.slf4j.LoggerFactory
+import java.math.BigDecimal
+
+/**
+ * @param soeskenFlokk  Antall barn i kullet. Inklusive soeker.
+ * @param grunnbeloepPerÅr  Grunnbeløp, årsbeløp.
+ * */
+private val `0,4` = 0.4.toBigDecimal()
+private val `0,25` = 0.25.toBigDecimal()
+
+class Soeskenjustering(private val soeskenFlokk: Int, grunnbeloepPerÅr: Int) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    val beloep
+        get() = avrund(beregnUtbetaling())
+
+    /** Månedsbeløp for G */
+    private val g = BigDecimal(grunnbeloepPerÅr) / BigDecimal.valueOf(12)
+
+    /** 40% av G til første barn, 25% til resten. Fordeles likt */
+    private fun beregnUtbetaling(): BigDecimal =
+        when (soeskenFlokk) {
+            0 -> {
+                logger.warn("Søskenjustering ble kalt på uten søskenflokk")
+                BigDecimal.ZERO
+            }
+            1 -> g * `0,4`
+            else -> {
+                val antallSoesken = (soeskenFlokk - 1).toBigDecimal()
+                (g * `0,4` + g * `0,25` * antallSoesken) / (soeskenFlokk.toBigDecimal())
+            }
+        }
+}

--- a/apps/etterlatte-beregning/src/main/kotlin/model/avrund/Avrund.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/model/avrund/Avrund.kt
@@ -1,0 +1,8 @@
+package model.avrund
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+internal fun avrund(value: BigDecimal): Int {
+    return value.setScale(0, RoundingMode.HALF_UP).toInt()
+}

--- a/apps/etterlatte-beregning/src/test/kotlin/model/BeregningServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/model/BeregningServiceTest.kt
@@ -51,9 +51,9 @@ internal class BeregningServiceTest {
 
     @Test
     fun `beregningsperiodene får riktig beløp`() {
-        Assertions.assertEquals(2744.95, beregningsperioder[0].utbetaltBeloep)
-        Assertions.assertEquals(2881.775, beregningsperioder[1].utbetaltBeloep)
-        Assertions.assertEquals(2881.775, beregningsperioder[2].utbetaltBeloep)
-        Assertions.assertEquals(3546.8, beregningsperioder[3].utbetaltBeloep)
+        Assertions.assertEquals(2745, beregningsperioder[0].utbetaltBeloep)
+        Assertions.assertEquals(2882, beregningsperioder[1].utbetaltBeloep)
+        Assertions.assertEquals(2882, beregningsperioder[2].utbetaltBeloep)
+        Assertions.assertEquals(3547, beregningsperioder[3].utbetaltBeloep)
     }
 }

--- a/apps/etterlatte-beregning/src/test/kotlin/model/avrund/AvrundKtTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/model/avrund/AvrundKtTest.kt
@@ -1,0 +1,19 @@
+package model.avrund
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+internal class AvrundKtTest {
+
+    @Test
+    fun `avrunder til nermest krone`() {
+        assertEquals(100, avrund(BigDecimal.valueOf(99.6)))
+        assertEquals(99, avrund(BigDecimal.valueOf(99.4)))
+    }
+
+    @Test
+    fun `avrunder opp`() {
+        assertEquals(100, avrund(BigDecimal.valueOf(99.5)))
+    }
+}

--- a/libs/common/src/main/kotlin/beregning/BeregningsResultat.kt
+++ b/libs/common/src/main/kotlin/beregning/BeregningsResultat.kt
@@ -35,7 +35,7 @@ data class Beregningsperiode(
     val type: Beregningstyper,
     val datoFOM: YearMonth,
     val datoTOM: YearMonth?,
-    val utbetaltBeloep: Double,
+    val utbetaltBeloep: Int,
     val soeskenFlokk: List<Person>?,
     val grunnbelopMnd: Int,
     val grunnbelop: Int


### PR DESCRIPTION
Oppsummert:

- Bytt typen som bruks ved utregning fra `Double` til `BigDecimal` for mer nøyaktig presision.
- Tidligere så avrundades grunnbeløpet per måned, men nå avrunder vi allt etter beregningen er ferdig.
- Byt fra `Double` til `Int` for `utbetaltBeloep` i `Beregningsperiode`.

En konsekvens som intreffer er att datan i test-miljøet har `Double`-verdier lagret men blir nå parset som `Int`s, det betyr att f.eks verdier som eksempelvis `3.999999` blir parset som `3`. Men tenker att det er greit så lenge vi bara er i test-miljøet, nye verdier blir lagt in riktig.