### PR TITLE
Etterlatte-vedtaksvurdering: Legg til endepunkt for å hente alle vedtak

### DIFF
--- a/apps/etterlatte-api/src/test/kotlin/behandling/OppgaveServiceTest.kt
+++ b/apps/etterlatte-api/src/test/kotlin/behandling/OppgaveServiceTest.kt
@@ -55,10 +55,11 @@ internal class OppgaveServiceTest {
             null,
             null
         )
+        val behandlingId = UUID.randomUUID()
         coEvery { behandlingKlient.hentOppgaver(accessToken) } returns OppgaveListe(
             oppgaver = listOf(
                 BehandlingsOppgave(
-                    UUID.randomUUID(),
+                    behandlingId,
                     BehandlingStatus.UNDER_BEHANDLING,
                     OppgaveStatus.NY,
                     Sak("ident", "saktype", 1),
@@ -69,6 +70,7 @@ internal class OppgaveServiceTest {
             )
         )
         coEvery { vedtakKlient.hentVedtak(UUID.randomUUID().toString(), accessToken) } returns vedtak
+        coEvery { vedtakKlient.hentVedtakBolk(listOf(behandlingId.toString()), accessToken) } returns listOf(vedtak)
 
         val resultat = runBlocking { service.hentAlleOppgaver(accessToken) }
 

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/Api.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/Api.kt
@@ -2,11 +2,16 @@ package no.nav.etterlatte
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
+import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import no.nav.etterlatte.database.Vedtak
+import org.slf4j.LoggerFactory
 import java.util.*
 
+private val logger = LoggerFactory.getLogger("RouteApi")
 fun Route.Api(service: VedtaksvurderingService) {
     get("hentvedtak/{sakId}/{behandlingId}") {
         val sakId = call.parameters["sakId"].toString()
@@ -29,7 +34,12 @@ fun Route.Api(service: VedtaksvurderingService) {
         }
     }
 
-    get("/vedtak") {
-        call.respond(service.hentAlleVedtak())
+    post("vedtak") {
+        logger.debug("Request om vedtak bolk")
+        val request = call.receive<VedtakBolkRequest>()
+        val vedtak = service.hentVedtakBolk(request.behandlingsidenter.map { UUID.fromString(it) })
+        call.respond(VedtakBolkResponse(vedtak))
     }
 }
+private data class VedtakBolkRequest(val behandlingsidenter: List<String>)
+private data class VedtakBolkResponse(val vedtak: List<Vedtak>)

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/VedtaksvurderingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/VedtaksvurderingService.kt
@@ -142,8 +142,8 @@ class VedtaksvurderingService(
         }
     }
 
-    fun hentAlleVedtak(): List<Vedtak> {
-        return repository.hentAlleVedtak()
+    fun hentVedtakBolk(behandlingsidenter: List<UUID>): List<Vedtak> {
+        return repository.hentVedtakBolk(behandlingsidenter)
     }
     fun hentVedtak(sakId: String, behandlingId: UUID): Vedtak? {
         return repository.hentVedtak(sakId, behandlingId)

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/database/VedtaksvurderingRepository.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/database/VedtaksvurderingRepository.kt
@@ -158,10 +158,13 @@ class VedtaksvurderingRepository(private val datasource: DataSource) {
         }
     }
 
-    fun hentAlleVedtak(): List<Vedtak> {
+    fun hentVedtakBolk(behandlingsidenter: List<UUID>): List<Vedtak> {
         logger.info("Henter alle vedtak")
+
         return connection.use {
-            val statement = it.prepareStatement(Queries.hentAlleVedtak)
+            val identer = it.createArrayOf("uuid", behandlingsidenter.toTypedArray())
+            val statement = it.prepareStatement(Queries.hentVedtakBolk)
+            statement.setArray(1, identer)
             statement.executeQuery().toList { toVedtak() }
         }
     }
@@ -384,10 +387,10 @@ private object Queries {
     val underkjennVedtak =
         "UPDATE vedtak SET attestant = null, datoAttestert = null, saksbehandlerId = null, vedtakfattet = false, datoFattet = null, vedtakstatus = ? WHERE sakId = ? AND behandlingId = ?" // ktlint-disable max-line-length
 
-    val hentAlleVedtak =
+    val hentVedtakBolk =
         "SELECT sakId, behandlingId, saksbehandlerId, avkortingsresultat, beregningsresultat, vilkaarsresultat," +
             "kommersoekertilgoderesultat, vedtakfattet, id, fnr, datoFattet, datoattestert, attestant," +
-            "datoVirkFom, vedtakstatus, saktype FROM vedtak"
+            "datoVirkFom, vedtakstatus, saktype FROM vedtak where behandlingId = ANY(?)"
     val hentVedtak =
         "SELECT sakId, behandlingId, saksbehandlerId, avkortingsresultat, beregningsresultat, vilkaarsresultat, kommersoekertilgoderesultat, vedtakfattet, id, fnr, datoFattet, datoattestert, attestant, datoVirkFom, vedtakstatus, saktype FROM vedtak WHERE sakId = ? AND behandlingId = ?" // ktlint-disable max-line-length
     val hentVedtakForBehandling =

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/DBTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/DBTest.kt
@@ -208,10 +208,16 @@ internal class DBTest {
     fun `kan lagre å hente alle vedtak`() {
         val vedtakRepo = VedtaksvurderingRepository(dataSource)
         val vedtaksvurderingService = VedtaksvurderingService(vedtakRepo)
-        lagreNyttVilkaarsresultat(vedtaksvurderingService, "1", UUID.randomUUID())
-        lagreNyttVilkaarsresultat(vedtaksvurderingService, "2", UUID.randomUUID())
-        lagreNyttVilkaarsresultat(vedtaksvurderingService, "3", UUID.randomUUID())
-        Assertions.assertEquals(vedtaksvurderingService.hentAlleVedtak().size, 3)
+
+        val uuid1 = UUID.randomUUID()
+        val uuid2 = UUID.randomUUID()
+        val uuid3 = UUID.randomUUID()
+
+        lagreNyttVilkaarsresultat(vedtaksvurderingService, "1", uuid1)
+        lagreNyttVilkaarsresultat(vedtaksvurderingService, "2", uuid2)
+        lagreNyttVilkaarsresultat(vedtaksvurderingService, "3", uuid3)
+
+        Assertions.assertEquals(3, vedtaksvurderingService.hentVedtakBolk(listOf(uuid1, uuid2, uuid3)).size)
     }
     private fun lagreNyttVilkaarsresultat(service: VedtaksvurderingService, sakId: String, behandlingId: UUID) {
         service.lagreVilkaarsresultat(


### PR DESCRIPTION
* Lagt til ett endepunkt for å hente alle vedtak istedet for kun en. Då slipper vi gjøre ett API-kall per oppgave vi skal sende til frontend.