### PR TITLE
Pdltjenester returnerer 404 når person ikke finnes

### DIFF
--- a/apps/etterlatte-pdltjenester/src/main/kotlin/Server.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/Server.kt
@@ -25,6 +25,7 @@ import no.nav.etterlatte.ktortokenexchange.secureRoutUsing
 import no.nav.etterlatte.libs.common.logging.CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.person.PdlFantIkkePerson
 import no.nav.etterlatte.person.PersonService
 import no.nav.etterlatte.person.personApi
 import org.slf4j.event.Level
@@ -69,6 +70,16 @@ fun io.ktor.server.application.Application.module(
                     "En feil oppstod: ${cause.message}",
                     ContentType.Text.Plain,
                     HttpStatusCode.InternalServerError
+                )
+            )
+        }
+        exception<PdlFantIkkePerson> { call, cause ->
+            call.application.log.info("Fant ikke person: ${cause.message}")
+            call.respond(
+                TextContent(
+                    "Fant ikke person",
+                    ContentType.Text.Plain,
+                    HttpStatusCode.NotFound
                 )
             )
         }

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonService.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonService.kt
@@ -8,10 +8,12 @@ import no.nav.etterlatte.libs.common.person.HentPersonRequest
 import no.nav.etterlatte.libs.common.person.Person
 import no.nav.etterlatte.pdl.ParallelleSannheterKlient
 import no.nav.etterlatte.pdl.PdlKlient
+import no.nav.etterlatte.pdl.PdlResponseError
 import no.nav.etterlatte.pdl.mapper.PersonMapper
 import org.slf4j.LoggerFactory
 
 class PdlForesporselFeilet(message: String) : RuntimeException(message)
+class PdlFantIkkePerson(message: String) : RuntimeException(message)
 
 class PersonService(
     private val pdlKlient: PdlKlient,
@@ -24,10 +26,14 @@ class PersonService(
 
         return pdlKlient.hentPerson(hentPersonRequest.foedselsnummer, hentPersonRequest.rolle).let {
             if (it.data?.hentPerson == null) {
-                val pdlFeil = it.errors?.joinToString(", ")
-                throw PdlForesporselFeilet(
-                    "Kunne ikke hente person med fnr=${hentPersonRequest.foedselsnummer} fra PDL: $pdlFeil"
-                )
+                val pdlFeil = it.errors?.asFormatertFeil()
+                if (it.errors?.personIkkeFunnet() == true) {
+                    throw PdlFantIkkePerson("Fant ikke personen ${hentPersonRequest.foedselsnummer}")
+                } else {
+                    throw PdlForesporselFeilet(
+                        "Kunne ikke hente person med fnr=${hentPersonRequest.foedselsnummer} fra PDL: $pdlFeil"
+                    )
+                }
             } else {
                 PersonMapper.mapPerson(
                     ppsKlient = ppsKlient,
@@ -45,11 +51,14 @@ class PersonService(
 
         return pdlKlient.hentPerson(hentPersonRequest.foedselsnummer, hentPersonRequest.rolle).let {
             if (it.data?.hentPerson == null) {
-                val pdlFeil = it.errors?.joinToString(", ")
-                throw PdlForesporselFeilet(
-                    "Kunne ikke hente opplysninger for person med fnr=" +
-                        "${hentPersonRequest.foedselsnummer} fra PDL: $pdlFeil"
-                )
+                val pdlFeil = it.errors?.asFormatertFeil()
+                if (it.errors?.personIkkeFunnet() == true) {
+                    throw PdlFantIkkePerson("Fant ikke personen ${hentPersonRequest.foedselsnummer}")
+                } else {
+                    throw PdlForesporselFeilet(
+                        "Kunne ikke hente opplysninger for ${hentPersonRequest.foedselsnummer} fra PDL: $pdlFeil"
+                    )
+                }
             } else {
                 PersonMapper.mapOpplysningsperson(
                     ppsKlient = ppsKlient,
@@ -69,11 +78,15 @@ class PersonService(
 
         return pdlKlient.hentFolkeregisterIdent(hentFolkeregisterIdentRequest.ident).let {
             if (it.data?.hentIdenter == null) {
-                val pdlFeil = it.errors?.joinToString(", ")
-                throw PdlForesporselFeilet(
-                    "Kunne ikke hente folkeregisterident for ident=${hentFolkeregisterIdentRequest.ident} " +
-                        "fra PDL: $pdlFeil"
-                )
+                val pdlFeil = it.errors?.asFormatertFeil()
+                if (it.errors?.personIkkeFunnet() == true) {
+                    throw PdlFantIkkePerson("Fant ikke personen ${hentFolkeregisterIdentRequest.ident}")
+                } else {
+                    throw PdlForesporselFeilet(
+                        "Kunne ikke hente folkeregisterident " +
+                            "for ${hentFolkeregisterIdentRequest.ident} fra PDL: $pdlFeil"
+                    )
+                }
             } else {
                 try {
                     val folkeregisterIdent: String = it.data.hentIdenter.identer
@@ -82,10 +95,13 @@ class PersonService(
                     FolkeregisterIdent(folkeregisterident = Foedselsnummer.of(folkeregisterIdent))
                 } catch (e: Exception) {
                     throw PdlForesporselFeilet(
-                        "Fant ingen folkeregisterident for ident=${hentFolkeregisterIdentRequest.ident} fra PDL"
+                        "Fant ingen folkeregisterident for ${hentFolkeregisterIdentRequest.ident} fra PDL"
                     )
                 }
             }
         }
     }
+
+    fun List<PdlResponseError>.asFormatertFeil() = this.joinToString(", ")
+    fun List<PdlResponseError>.personIkkeFunnet() = any { it.extensions?.code == "not_found" }
 }

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonServiceTest.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonServiceTest.kt
@@ -152,7 +152,7 @@ internal class PersonServiceTest {
         coEvery { pdlKlient.hentPerson(any(), any()) } returns mockResponse("/pdl/person_ikke_funnet.json")
 
         runBlocking {
-            assertThrows<PdlForesporselFeilet> {
+            assertThrows<PdlFantIkkePerson> {
                 personService.hentPerson(HentPersonRequest(STOR_SNERK, rolle = PersonRolle.BARN))
             }
         }
@@ -170,7 +170,7 @@ internal class PersonServiceTest {
     fun `finner ikke folkeregisterident`() {
         coEvery { pdlKlient.hentFolkeregisterIdent(any()) } returns mockResponse("/pdl/ident_ikke_funnet.json")
         runBlocking {
-            assertThrows<PdlForesporselFeilet> {
+            assertThrows<PdlFantIkkePerson> {
                 personService.hentFolkeregisterIdent(HentFolkeregisterIdentRequest("1234"))
             }
         }


### PR DESCRIPTION
Skal returnere 404 i stedet for 500 og logging av feil dersom en person ikke blir funnet siden dette ikke er en feil i pdl-tjenester.