### PR TITLE
Etterlatte-behandling: Legg til correlation id på melding

### DIFF
--- a/apps/etterlatte-behandling/build.gradle.kts
+++ b/apps/etterlatte-behandling/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 dependencies {
     implementation(project(":libs:common"))
     implementation(project(":libs:ktor2client-auth-clientcredentials"))
+    implementation(project(":libs:rapidsandrivers-extras"))
     implementation(Ktor2.OkHttp)
     implementation(Ktor2.ServerCore)
     implementation(Ktor2.ServerCio)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsHendelser.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsHendelser.kt
@@ -16,6 +16,8 @@ import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.kafka.JsonMessage
 import no.nav.etterlatte.kafka.KafkaProdusent
 import no.nav.etterlatte.libs.common.event.BehandlingGrunnlagEndret
+import no.nav.etterlatte.libs.common.logging.getCorrelationId
+import no.nav.etterlatte.libs.common.rapidsandrivers.correlationIdKey
 import no.nav.etterlatte.sak.SakService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -74,6 +76,7 @@ class BehandlingsHendelser(
                     "BEHANDLING:${hendelse.second.name}",
                     mapOf(
                         "behandlingId" to behandling.id,
+                        correlationIdKey to getCorrelationId(),
                         BehandlingGrunnlagEndret.behandlingObjectKey to behandling,
                         BehandlingGrunnlagEndret.sakIdKey to behandling.sak,
                         BehandlingGrunnlagEndret.sakObjectKey to sak,
@@ -97,7 +100,6 @@ class BehandlingsHendelser(
                             it[BehandlingGrunnlagEndret.manueltOpphoerfritekstAarsakKey] =
                                 behandling.fritekstAarsak ?: ""
                         }
-                        else -> {}
                     }
                 }.toJson()
             ).also {


### PR DESCRIPTION
Er mange meldinger som ikke har noen correlation id og det leder til att det blir vanskelig å debugge data flyten. 

<img width="510" alt="image" src="https://user-images.githubusercontent.com/26689337/192511182-7c233976-2bd6-4861-afd4-26578c61d399.png">
