### PR TITLE
Gjenbruke workflows / rydde i workflow-kode

### DIFF
--- a/.github/workflows/.build.yaml
+++ b/.github/workflows/.build.yaml
@@ -1,0 +1,37 @@
+name: .build.yaml
+
+on:
+  workflow_call:
+    outputs:
+      image:
+        description: "Docker image url"
+        value: ${{ jobs.build-and-publish.outputs.image }}
+
+jobs:
+  build-and-publish:
+    name: Build & publish
+    runs-on: ubuntu-latest
+    env:
+      image: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
+    outputs:
+      image: ${{ env.image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Java v17.x
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17.x
+          cache: gradle
+      - name: Gradle test and build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew :apps:${{ github.workflow }}:build
+      - name: Build and publish docker image
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
+          docker build --tag ${{ env.image }} -f docker/Dockerfile apps/${{ github.workflow }}
+          docker push ${{ env.image }}

--- a/.github/workflows/.deploy.yaml
+++ b/.github/workflows/.deploy.yaml
@@ -1,0 +1,53 @@
+name: .deploy.yaml
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: 'Lenke til docker image'
+        required: true
+        type: string
+      labs:
+        description: 'Om appen skal deployes til labs-gcp (default er false)'
+        required: false
+        type: boolean
+
+jobs:
+  deploy-to-labs-gcp:
+    name: labs-gcp
+    if: ${{ inputs.labs == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: labs-gcp
+          RESOURCE: apps/${{ github.workflow }}/.nais/labs.yaml
+          VAR: image=${{ inputs.image }}
+
+  deploy-to-dev-gcp:
+    name: dev-gcp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: apps/${{ github.workflow }}/.nais/dev.yaml
+          VAR: image=${{ inputs.image }}
+
+  deploy-to-prod-gcp:
+    name: prod-gcp
+    if: ${{ github.event.inputs.deploy-prod == 'true' }} # Tvinge manuell prod deploy inntil videre
+    needs: deploy-to-dev-gcp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: apps/${{ github.workflow }}/.nais/prod.yaml
+          VAR: image=${{ inputs.image }}

--- a/.github/workflows/.test.yaml
+++ b/.github/workflows/.test.yaml
@@ -1,0 +1,20 @@
+name: .build-backend.yaml
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    name: Verify pull request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Java v17.x
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17.x
+          cache: gradle
+      - name: Gradle test and build
+        run: ./gradlew :apps:${{ github.workflow }}:test

--- a/.github/workflows/app-etterlatte-api.yaml
+++ b/.github/workflows/app-etterlatte-api.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-api
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   pull_request:
     branches:
       - main
@@ -29,68 +29,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
-  deploy-to-prod-gcp:
-    name: Deploy to prod-gcp
-    if: ${{ github.event.inputs.deploy-prod == 'true' }}
-    needs: deploy-to-dev-gcp
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/prod.yaml
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-avkorting.yaml
+++ b/.github/workflows/app-etterlatte-avkorting.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-avkorting
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -27,56 +27,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-behandling.yaml
+++ b/.github/workflows/app-etterlatte-behandling.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-behandling
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -27,68 +27,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
-  deploy-to-prod-gcp:
-    name: Deploy to prod-gcp
-    if: ${{ github.event.inputs.deploy-prod == 'true' }}
-    needs: deploy-to-dev-gcp
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/prod.yaml
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-beregning.yaml
+++ b/.github/workflows/app-etterlatte-beregning.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-beregning
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -27,56 +27,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-brev-api.yaml
+++ b/.github/workflows/app-etterlatte-brev-api.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-brev-api
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -27,66 +27,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
-  deploy-to-prod-gcp:
-    name: Deploy to prod-gcp
-    if: ${{ github.event.inputs.deploy-prod == 'true' }}
-    needs: deploy-to-dev-gcp
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/prod.yaml
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-brev-distribusjon.yaml
+++ b/.github/workflows/app-etterlatte-brev-distribusjon.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-brev-distribusjon
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -28,68 +28,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
-  deploy-to-prod-gcp:
-    name: Deploy to prod-gcp
-    if: ${{ github.event.inputs.deploy-prod == 'true' }}
-    needs: deploy-to-dev-gcp
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/prod.yaml
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-brreg.yaml
+++ b/.github/workflows/app-etterlatte-brreg.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-brreg
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -27,68 +27,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
-  deploy-to-prod-gcp:
-    name: Deploy to prod-gcp
-    if: ${{ github.event.inputs.deploy-prod == 'true' }}
-    needs: deploy-to-dev-gcp
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/prod.yaml
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-fordeler.yaml
+++ b/.github/workflows/app-etterlatte-fordeler.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-fordeler
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -25,68 +25,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
-  deploy-to-prod-gcp:
-    name: Deploy to prod-gcp
-    if: ${{ github.event.inputs.deploy-prod == 'true' }}
-    needs: deploy-to-dev-gcp
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/prod.yaml
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-grunnlag.yaml
+++ b/.github/workflows/app-etterlatte-grunnlag.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-grunnlag
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -27,69 +27,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
-
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
-  deploy-to-prod-gcp:
-    name: Deploy to prod-gcp
-    if: ${{ github.event.inputs.deploy-prod == 'true' }}
-    needs: deploy-to-dev-gcp
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/prod.yaml
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-gyldig-soeknad.yaml
+++ b/.github/workflows/app-etterlatte-gyldig-soeknad.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-gyldig-soeknad
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -27,57 +27,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
-
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-hendelser-pdl.yaml
+++ b/.github/workflows/app-etterlatte-hendelser-pdl.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-hendelser-pdl
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -27,68 +27,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
-  deploy-to-prod-gcp:
-    name: Deploy to prod-gcp
-    if: ${{ github.event.inputs.deploy-prod == 'true' }}
-    needs: deploy-to-dev-gcp
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/prod.yaml
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-medl.yaml
+++ b/.github/workflows/app-etterlatte-medl.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-medl-proxy
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -27,68 +27,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
-  deploy-to-prod-gcp:
-    name: Deploy to prod-gcp
-    if: ${{ github.event.inputs.deploy-prod == 'true' }}
-    needs: deploy-to-dev-gcp
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/prod.yaml
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-oppdater-behandling.yaml
+++ b/.github/workflows/app-etterlatte-oppdater-behandling.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-oppdater-behandling
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -27,56 +27,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-opplysninger-fra-inntektskomponenten.yaml
+++ b/.github/workflows/app-etterlatte-opplysninger-fra-inntektskomponenten.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-opplysninger-fra-inntektskomponenten
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -25,56 +25,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-opplysninger-fra-pdl.yaml
+++ b/.github/workflows/app-etterlatte-opplysninger-fra-pdl.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-opplysninger-fra-pdl
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -25,56 +25,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-opplysninger-fra-soeknad.yaml
+++ b/.github/workflows/app-etterlatte-opplysninger-fra-soeknad.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-opplysninger-fra-soeknad
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -25,56 +25,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-overvaaking.yaml
+++ b/.github/workflows/app-etterlatte-overvaaking.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-overvaaking
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -25,68 +25,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
-  deploy-to-prod-gcp:
-    name: Deploy to prod-gcp
-    if: ${{ github.ref == 'refs/heads/main' || github.event.inputs.deploy-prod == 'true' }}
-    needs: deploy-to-dev-gcp
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/prod.yaml
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-pdltjenester.yaml
+++ b/.github/workflows/app-etterlatte-pdltjenester.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-pdltjenester
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -25,68 +25,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
-  deploy-to-prod-gcp:
-    name: Deploy to prod-gcp
-    if: ${{ github.event.inputs.deploy-prod == 'true' }}
-    needs: deploy-to-dev-gcp
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/prod.yaml
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-saksbehandling-ui.yaml
+++ b/.github/workflows/app-etterlatte-saksbehandling-ui.yaml
@@ -11,6 +11,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main

--- a/.github/workflows/app-etterlatte-statistikk.yaml
+++ b/.github/workflows/app-etterlatte-statistikk.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-statistikk
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -27,68 +27,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
-  deploy-to-prod-gcp:
-    name: Deploy to prod-gcp
-    if: ${{ github.event.inputs.deploy-prod == 'true' }}
-    needs: deploy-to-dev-gcp
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/prod.yaml
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-testdata.yaml
+++ b/.github/workflows/app-etterlatte-testdata.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-testdata
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   push:
     branches:
@@ -19,56 +15,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-tilbakekreving.yaml
+++ b/.github/workflows/app-etterlatte-tilbakekreving.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-tilbakekreving
 
-env:
-  IMAGE: docker.pkg.github.com/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -25,55 +25,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-utbetaling.yaml
+++ b/.github/workflows/app-etterlatte-utbetaling.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-utbetaling
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -25,55 +25,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-vedtaksvurdering.yaml
+++ b/.github/workflows/app-etterlatte-vedtaksvurdering.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-vedtaksvurdering
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -27,68 +27,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
-  deploy-to-prod-gcp:
-    name: Deploy to prod-gcp
-    if: ${{ github.event.inputs.deploy-prod == 'true' }}
-    needs: deploy-to-dev-gcp
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/prod.yaml
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-vilkaar-kafka.yaml
+++ b/.github/workflows/app-etterlatte-vilkaar-kafka.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-vilkaar-kafka
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -27,56 +27,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/.github/workflows/app-etterlatte-vilkaarsvurdering.yaml
+++ b/.github/workflows/app-etterlatte-vilkaarsvurdering.yaml
@@ -1,9 +1,5 @@
 name: etterlatte-vilkaarsvurdering
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  APP_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -11,6 +7,10 @@ on:
         description: 'Deploy til produksjon'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - true
+          - false
   push:
     branches:
       - main
@@ -27,56 +27,16 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test
+    uses: ./.github/workflows/.test.yaml
 
-  build-and-publish:
+  build:
     if: github.event_name != 'pull_request'
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :apps:${APP_NAME}:test :apps:${APP_NAME}:build
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} -f docker/Dockerfile apps/${APP_NAME}
-          docker push ${IMAGE}
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
 
-  deploy-to-dev-gcp:
-    name: Deploy to dev-gcp
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ env.APP_NAME }}/.nais/dev.yaml
-
+  deploy:
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit


### PR DESCRIPTION
Forslag om innføring av gjenbrukbare workflows. Siden frontend kun har én workflow og ingen duplikater, har jeg kun gjort endringen for backend.

Gjenbrukbare workflows består av: 
- `.test.yaml` - kjører gradle test. 
- `.build.yaml` - kjører gradle build og docker build/publish.
- `.deploy.yaml` - kjører nais deploy for samtlige miljøer.

Hvordan det vil se ut på Github: 
![Screenshot 2022-10-13 at 15 17 11](https://user-images.githubusercontent.com/1224956/195607720-eaf1d284-204a-468d-8c7b-347b464acad6.png)
