### PR TITLE
Logger ikke feil hvis vi mangler grunnlag for avdød i vilkårsvurdering

### DIFF
--- a/apps/etterlatte-vilkaar-kafka/src/main/kotlin/barnepensjon/model/VilkaarService.kt
+++ b/apps/etterlatte-vilkaar-kafka/src/main/kotlin/barnepensjon/model/VilkaarService.kt
@@ -6,6 +6,7 @@ import barnepensjon.kommerbarnettilgode.saksbehandlerResultat
 import barnepensjon.vilkaar.avdoedesmedlemskap.vilkaarAvdoedesMedlemskap
 import barnepensjon.vilkaar.vilkaarKanBehandleSakenISystemet
 import barnepensjon.vilkaarFormaalForYtelsen
+import no.nav.etterlatte.barnepensjon.GrunnlagForAvdoedMangler
 import no.nav.etterlatte.barnepensjon.OpplysningKanIkkeHentesUt
 import no.nav.etterlatte.barnepensjon.hentSisteVurderteDato
 import no.nav.etterlatte.barnepensjon.setVilkaarVurderingFraVilkaar
@@ -122,12 +123,7 @@ class VilkaarService {
 
     fun hentVirkningstidspunktFoerstegangssoeknad(doedsdato: LocalDate?, mottattDato: LocalDate): YearMonth {
         if (doedsdato == null) {
-            throw OpplysningKanIkkeHentesUt(
-                """
-                Vi har en førstegangssøknad der vi ikke kan hente ut avdød sin dødsdato. 
-                Vi kan dermed heller ikke beslutte virkningstidspunkt og vilkårsvurdere
-                """.trimIndent()
-            )
+            throw GrunnlagForAvdoedMangler
         }
         if (mottattDato.year - doedsdato.year > 3) {
             return YearMonth.of(mottattDato.year - 3, mottattDato.month)

--- a/apps/etterlatte-vilkaar-kafka/src/main/kotlin/barnepensjon/utils.kt
+++ b/apps/etterlatte-vilkaar-kafka/src/main/kotlin/barnepensjon/utils.kt
@@ -16,6 +16,8 @@ import java.util.*
 
 class OpplysningKanIkkeHentesUt constructor(override val message: String? = null) : IllegalStateException(message)
 
+object GrunnlagForAvdoedMangler : IllegalStateException("Kunne ikke hente ut grunnlagsinformasjon om avdød")
+
 fun setVilkaarVurderingFraKriterier(kriterie: List<Kriterie>): VurderingsResultat {
     val resultat = kriterie.map { it.resultat }
     return hentVurdering(resultat)


### PR DESCRIPTION
Siden vi henter flere grunnlag samtidig er det flere innslag i loggene i vilkårsvurdering at informasjon om avdød mangler. Jeg la til en enkel håndtering for akkurat dette tilfellet, siden det skjer ofte i normal flyt i systemet.

Det er mulig vi endrer en del på hvordan hele dette flyter med ny vilkårsvurdering, men jeg tenker det uansett er et eksempel til diskusjon ref håndtering av feil.