### PR TITLE
Fikser (de-)serialisering av grunnlagsendringshendelser

### DIFF
--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseDaoTest.kt
@@ -128,12 +128,9 @@ internal class GrunnlagsendringshendelseDaoTest {
         val forelderBarnRelasjonHendelseFraDatabase =
             grunnlagsendringshendelsesRepo.hentGrunnlagsendringshendelse(uuidForelderBarn)
 
-        assertTrue(doedshendelseFraDatabase!!.data!!.type == "SOEKER_DOED")
-        assertTrue(doedshendelseFraDatabase.data is Grunnlagsinformasjon.SoekerDoed)
-        assertTrue(utflyttingHendelseFraDatabase!!.data!!.type == "UTFLYTTING")
-        assertTrue(utflyttingHendelseFraDatabase.data is Grunnlagsinformasjon.Utflytting)
-        assertTrue(forelderBarnRelasjonHendelseFraDatabase!!.data!!.type == "FORELDER_BARN_RELASJON")
-        assertTrue(forelderBarnRelasjonHendelseFraDatabase.data is Grunnlagsinformasjon.ForelderBarnRelasjon)
+        assertTrue(doedshendelseFraDatabase?.data is Grunnlagsinformasjon.SoekerDoed)
+        assertTrue(utflyttingHendelseFraDatabase?.data is Grunnlagsinformasjon.Utflytting)
+        assertTrue(forelderBarnRelasjonHendelseFraDatabase?.data is Grunnlagsinformasjon.ForelderBarnRelasjon)
     }
 
     @Test

--- a/libs/common/src/main/kotlin/behandling/Grunnlagsendringshendelse.kt
+++ b/libs/common/src/main/kotlin/behandling/Grunnlagsendringshendelse.kt
@@ -1,10 +1,12 @@
 package no.nav.etterlatte.libs.common.behandling
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
 import no.nav.etterlatte.libs.common.pdlhendelse.Doedshendelse
 import no.nav.etterlatte.libs.common.pdlhendelse.ForelderBarnRelasjonHendelse
 import no.nav.etterlatte.libs.common.pdlhendelse.UtflyttingsHendelse
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
 
 data class Grunnlagsendringshendelse(
     val id: UUID,
@@ -16,26 +18,23 @@ data class Grunnlagsendringshendelse(
     val behandlingId: UUID? = null
 )
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 sealed class Grunnlagsinformasjon {
-    abstract val type: String
 
+    @JsonTypeName("UTFLYTTING")
     data class Utflytting(
         val hendelse: UtflyttingsHendelse
-    ) : Grunnlagsinformasjon() {
-        override val type: String = "UTFLYTTING"
-    }
+    ) : Grunnlagsinformasjon()
 
+    @JsonTypeName("SOEKER_DOED")
     data class SoekerDoed(
         val hendelse: Doedshendelse
-    ) : Grunnlagsinformasjon() {
-        override val type: String = "SOEKER_DOED"
-    }
+    ) : Grunnlagsinformasjon()
 
+    @JsonTypeName("FORELDER_BARN_RELASJON")
     data class ForelderBarnRelasjon(
         val hendelse: ForelderBarnRelasjonHendelse
-    ) : Grunnlagsinformasjon() {
-        override val type: String = "FORELDER_BARN_RELASJON"
-    }
+    ) : Grunnlagsinformasjon()
 }
 
 enum class GrunnlagsendringsType {


### PR DESCRIPTION
Flytter type-felt til å være en JSON-property i stedet, så får Jackson kontroll på deserialiseringen av grunnlagsinformasjon uten å endre typen.