### PR TITLE
Fiks feil med readonly-array etter redux-endring

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/personinfo/PersonInfoAdresse.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/personinfo/PersonInfoAdresse.tsx
@@ -5,12 +5,13 @@ import { Adressevisning } from '../../../../felles/Adressevisning'
 import { IAdresse } from '../../../../../../store/reducers/BehandlingReducer'
 
 type Props = {
-  adresser: IAdresse[] | undefined
+  adresser: Readonly<IAdresse[]> | undefined
   visHistorikk: boolean
 }
 
-export const PersonInfoAdresse: React.FC<Props> = ({ adresser, visHistorikk }) => {
+export const PersonInfoAdresse: React.FC<Props> = (props) => {
   const [visAdresseHistorikk, setVisAdresseHistorikk] = useState(false)
+  const adresser = props.adresser ? [...props.adresser] : []
 
   const aktivAdresse: IAdresse | undefined = adresser?.find((adresse: IAdresse) => adresse.aktiv)
   let sisteEllerAktivAdresse
@@ -26,7 +27,7 @@ export const PersonInfoAdresse: React.FC<Props> = ({ adresser, visHistorikk }) =
   return (
     <PersonDetailWrapper adresse={true}>
       <div>
-        <strong>{visHistorikk ? 'Bostedadresse' : 'Bostedadresse dødsfallstidspunkt'}</strong>
+        <strong>{props.visHistorikk ? 'Bostedadresse' : 'Bostedadresse dødsfallstidspunkt'}</strong>
       </div>
       {sisteEllerAktivAdresse ? (
         <span>
@@ -36,7 +37,7 @@ export const PersonInfoAdresse: React.FC<Props> = ({ adresser, visHistorikk }) =
         <span>Ingen bostedadresse</span>
       )}
 
-      {adresser && visHistorikk && (
+      {adresser && props.visHistorikk && (
         <Historikk>
           <TextButton isOpen={visAdresseHistorikk} setIsOpen={setVisAdresseHistorikk} />
           {visAdresseHistorikk && <Adressevisning adresser={adresser} soeknadsoversikt={true} />}


### PR DESCRIPTION
Nå når vi henter ut data fra redux-state så er datan på type: `Readonly<x>`.

Dette leder til att ting som muterer datan feiler.