### PR TITLE
Fikser problem med lagring av json-payload i vilkårsvurdering

### DIFF
--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/GrunnlagEndretRiver.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/GrunnlagEndretRiver.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.libs.common.logging.withLogContext
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
+import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
@@ -47,7 +48,7 @@ class GrunnlagEndretRiver(
     override fun onPacket(packet: JsonMessage, context: MessageContext) =
         withLogContext(packet.correlationId) {
             try {
-                val grunnlagEndretPayload = packet.toJson()
+                val grunnlagEndretPayload = packet.toJsonNode()
                 val behandlingId = packet["behandlingId"].asText().toUUID()
                 val behandlingType = BehandlingType.valueOf(packet["behandling.type"].asText())
                 val sakType = SakType.valueOf(packet["sak.sakType"].asText())

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/Vilkaarsvurdering.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/Vilkaarsvurdering.kt
@@ -1,12 +1,13 @@
 package no.nav.etterlatte.vilkaarsvurdering
 
+import com.fasterxml.jackson.databind.JsonNode
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import java.time.LocalDateTime
 import java.util.*
 
 data class Vilkaarsvurdering(
     val behandlingId: UUID,
-    val payload: String,
+    val payload: JsonNode,
     val vilkaar: List<Vilkaar>,
     val resultat: VilkaarsvurderingResultat? = null
 )

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingRepository.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingRepository.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.toJson
 import java.sql.ResultSet
-import java.util.UUID
+import java.util.*
 import javax.sql.DataSource
 
 interface VilkaarsvurderingRepository {
@@ -22,7 +22,9 @@ class VilkaarsvurderingRepositoryImpl(private val ds: DataSource) : Vilkaarsvurd
             .singleOrNull {
                 Vilkaarsvurdering(
                     behandlingId = getObject("behandlingId") as UUID,
-                    payload = getString("payload"),
+                    payload = getString("payload").let { payload ->
+                        objectMapper.readValue(payload)
+                    },
                     vilkaar = getString("vilkaar").let { vilkaar ->
                         objectMapper.readValue(vilkaar)
                     },
@@ -59,8 +61,10 @@ class VilkaarsvurderingRepositoryImpl(private val ds: DataSource) : Vilkaarsvurd
 }
 
 private object Queries {
-    val hentVilkaarsvurdering = "SELECT behandlingId, payload, vilkaar, resultat FROM vilkaarsvurdering WHERE behandlingId = ?" // ktlint-disable max-line-length
-    val lagreVilkaarsvurdering = "INSERT INTO vilkaarsvurdering(behandlingId, payload, vilkaar, resultat) " +
-        "VALUES(?::UUID, ?::JSON, ?::JSONB, ?::JSONB) ON CONFLICT (behandlingId) DO " +
-        "UPDATE SET payload = EXCLUDED.payload, vilkaar = EXCLUDED.vilkaar, resultat = EXCLUDED.resultat"
+    val hentVilkaarsvurdering =
+        "SELECT behandlingId, payload, vilkaar, resultat FROM vilkaarsvurdering WHERE behandlingId = ?"
+    val lagreVilkaarsvurdering =
+        "INSERT INTO vilkaarsvurdering(behandlingId, payload, vilkaar, resultat) " +
+            "VALUES(?::UUID, ?::JSON, ?::JSONB, ?::JSONB) ON CONFLICT (behandlingId) DO " +
+            "UPDATE SET payload = EXCLUDED.payload, vilkaar = EXCLUDED.vilkaar, resultat = EXCLUDED.resultat"
 }

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingService.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.vilkaarsvurdering
 
+import com.fasterxml.jackson.databind.JsonNode
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.vilkaarsvurdering.barnepensjon.barnepensjonVilkaar
@@ -18,7 +19,7 @@ class VilkaarsvurderingService(private val vilkaarsvurderingRepository: Vilkaars
         behandlingId: UUID,
         sakType: SakType,
         behandlingType: BehandlingType,
-        payload: String,
+        payload: JsonNode,
         grunnlag: Grunnlag
     ): Vilkaarsvurdering {
         return when (sakType) {
@@ -38,7 +39,7 @@ class VilkaarsvurderingService(private val vilkaarsvurderingRepository: Vilkaars
         }
     }
 
-    fun oppdaterVilkaarsvurderingPayload(behandlingId: UUID, payload: String): Vilkaarsvurdering {
+    fun oppdaterVilkaarsvurderingPayload(behandlingId: UUID, payload: JsonNode): Vilkaarsvurdering {
         return vilkaarsvurderingRepository.hent(behandlingId)?.let {
             vilkaarsvurderingRepository.lagre(it.copy(payload = payload))
         } ?: throw VilkaarsvurderingFinnesIkkeException("Fant ikke vilkårsvurdering for behandlingId=$behandlingId")

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/GrunnlagEndretRiverTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/GrunnlagEndretRiverTest.kt
@@ -6,6 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.vilkaarsvurdering.barnepensjon.barnepensjonVilkaar
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import org.junit.jupiter.api.Test
@@ -62,7 +63,7 @@ internal class GrunnlagEndretRiverTest {
     private fun eksisterendeVilkaarsvurdering() =
         Vilkaarsvurdering(
             behandlingId = UUID.fromString("dbbd9a01-3e5d-4ec1-819c-1781d1f6a440"),
-            payload = grunnlagEndretMelding,
+            payload = grunnlagEndretMelding.toJsonNode(),
             vilkaar = barnepensjonVilkaar(grunnlag)
         )
 

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
@@ -141,7 +141,7 @@ internal class VilkaarsvurderingRoutesTest {
     }
 
     @Test
-    fun `skal opprette vurdering på hovedvilkår og endre til vurdering på unntaksvilkår`() {
+    fun `skal opprette vurdering paa hovedvilkaar og endre til vurdering paa unntaksvilkaar`() {
         testApplication {
             application { restModule(applicationContext) }
 
@@ -295,7 +295,7 @@ internal class VilkaarsvurderingRoutesTest {
             behandlingId,
             SakType.BARNEPENSJON,
             BehandlingType.FØRSTEGANGSBEHANDLING,
-            """{"json": 123}""",
+            objectMapper.createObjectNode(),
             grunnlag
         )
     }

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.grunnlag.hentDoedsdato
 import no.nav.etterlatte.libs.common.grunnlag.hentFoedselsdato
 import no.nav.etterlatte.libs.common.grunnlag.hentFoedselsnummer
+import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.vikaar.kriteriegrunnlagTyper.Doedsdato
 import no.nav.etterlatte.libs.common.vikaar.kriteriegrunnlagTyper.Foedselsdato
 import no.nav.etterlatte.vilkaarsvurdering.SakType
@@ -24,10 +25,10 @@ import no.nav.etterlatte.vilkaarsvurdering.config.DataSourceBuilder
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import java.time.LocalDateTime
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
+import java.time.LocalDateTime
 import java.util.*
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -63,7 +64,7 @@ internal class VilkaarsvurderingServiceTest {
             uuid,
             SakType.BARNEPENSJON,
             BehandlingType.FØRSTEGANGSBEHANDLING,
-            "",
+            objectMapper.createObjectNode(),
             grunnlag
         )
 
@@ -182,7 +183,7 @@ internal class VilkaarsvurderingServiceTest {
             uuid,
             SakType.BARNEPENSJON,
             BehandlingType.FØRSTEGANGSBEHANDLING,
-            "",
+            objectMapper.createObjectNode(),
             GrunnlagTestData().hentOpplysningsgrunnlag()
         )
     }


### PR DESCRIPTION
- Fjerner problemet med at det kjøres .toJson() før dette lagres da dette medfører at innholdet escapes på nytt hver gang og til slutt blir for stort for databasen 😄 
- Endrer til å bruke JsonNode i stedet for String for json-payloaden da dette også gjør at vi unngår slike problemer i fremtiden

EY-985