### PR TITLE
Legg til resultatet av en vilkårsvurdering i state

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/index.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/index.tsx
@@ -8,15 +8,21 @@ import { Resultat } from './Resultat'
 import { RequestStatus } from './utils'
 import Spinner from '../../../shared/Spinner'
 import { format } from 'date-fns'
+import { updateVilkaarsvurdering } from '../../../store/reducers/BehandlingReducer'
+import { useAppDispatch } from '../../../store/Store'
 
 export const Inngangsvilkaar = () => {
   const location = useLocation()
   const { behandlingId } = useParams()
+  const dispatch = useAppDispatch()
   const [vilkaarsvurdering, setVilkaarsvurdering] = useState<Vilkaarsvurdering | undefined>(undefined)
   const [status, setStatus] = useState<RequestStatus>(RequestStatus.notStarted)
 
   const oppdaterVilkaarsvurdering = (oppdatertVilkaarsvurdering: Vilkaarsvurdering) => {
     setVilkaarsvurdering(oppdatertVilkaarsvurdering)
+    if (oppdatertVilkaarsvurdering.resultat) {
+      dispatch(updateVilkaarsvurdering(oppdatertVilkaarsvurdering))
+    }
   }
 
   const hentVilkaarsvurderingLocal = () => {
@@ -26,7 +32,7 @@ export const Inngangsvilkaar = () => {
       .then((response) => {
         if (response.status == 'ok') {
           setStatus(RequestStatus.ok)
-          setVilkaarsvurdering(response.data)
+          oppdaterVilkaarsvurdering(response.data)
         } else {
           setStatus(RequestStatus.error)
         }

--- a/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/BehandlingReducer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/BehandlingReducer.ts
@@ -375,6 +375,7 @@ export const detaljertBehandlingInitialState: IDetaljertBehandling = {
 export const addBehandling = createAction<IDetaljertBehandling>('behandling/add')
 export const resetBehandling = createAction('behandling/reset')
 export const oppdaterVirkningstidspunkt = createAction<Virkningstidspunkt>('behandling/virkningstidspunkt')
+export const updateVilkaarsvurdering = createAction<Vilkaarsvurdering>('behandling/update_vilkaarsvurdering')
 
 export interface IBehandlingReducer {
   behandling: IDetaljertBehandling
@@ -385,6 +386,9 @@ export const behandlingReducer = createReducer(initialState, (builder) => {
   builder.addCase(addBehandling, (state, action) => {
     state.behandling = action.payload
     state.behandling.behandlingType = action.payload.behandlingType ?? IBehandlingsType.FØRSTEGANGSBEHANDLING // Default til behandlingstype hvis null
+  })
+  builder.addCase(updateVilkaarsvurdering, (state, action) => {
+    state.behandling.vilkårsprøving = action.payload
   })
   builder.addCase(resetBehandling, (state) => {
     state.behandling = detaljertBehandlingInitialState


### PR DESCRIPTION
Skal løse problemet med at man ikke kan komme seg videre fra vilkårsvurdering uten å refreshe siden.

Komponenten useVedtaksResultat blir benyttet flere steder og er avhengig av oppdatert state.

Tenkte først å bare bytte knappekomponenten til å ta inn vilkårsvurdering-objektet, men så at `useVedtaksResultat` uansett blir brukt flere steder senere i løypa, så like greit å oppdatere staten med nyeste.

EY-997