### PR TITLE
Fjerner ekstra " i url til pensjon-parallelle-sannheter

### DIFF
--- a/apps/etterlatte-pdltjenester/.nais/prod.yaml
+++ b/apps/etterlatte-pdltjenester/.nais/prod.yaml
@@ -39,7 +39,7 @@ spec:
     - name: PDL_OUTBOUND_SCOPE
       value: api://prod-fss.pdl.pdl-api/.default
     - name: PPS_URL
-      value: https://pensjon-parallelle-sannheter.intern.nav.no"
+      value: https://pensjon-parallelle-sannheter.intern.nav.no
     - name: ROOT_LOGLEVEL
       value: "INFO"
     - name: NAV_CONSUMER_ID


### PR DESCRIPTION
Vi har en `java.net.UnknownHostException: pensjon-parallelle-sannheter.intern.nav.no"` i prod