### PR TITLE
Oppretter et view som BQ kan gå mot for statistikk

### DIFF
--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/database/DataSourceBuilder.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/database/DataSourceBuilder.kt
@@ -34,6 +34,12 @@ class DataSourceBuilder(private val env: Map<String, String>) {
     private fun runMigration(dataSource: DataSource) =
         Flyway.configure()
             .dataSource(dataSource)
+            .apply {
+                // Kjør GCP-spesifikke migrasjoner kun hvis vi er i GCP
+                if (env.containsKey("NAIS_CLUSTER_NAME")) {
+                    locations("db/migrations", "db/gcp")
+                }
+            }
             .load()
             .migrate()
 }

--- a/apps/etterlatte-statistikk/src/main/resources/db/gcp/V4__grant_read_access_bigquery.sql
+++ b/apps/etterlatte-statistikk/src/main/resources/db/gcp/V4__grant_read_access_bigquery.sql
@@ -1,0 +1,1 @@
+GRANT SELECT ON stoenad_statistikk TO bigquery_import;

--- a/apps/etterlatte-statistikk/src/main/resources/db/migration/V3__create_stoenad_view.sql
+++ b/apps/etterlatte-statistikk/src/main/resources/db/migration/V3__create_stoenad_view.sql
@@ -1,0 +1,4 @@
+-- Vi vil kun se på de nyere sakene, slik at vi ikke trenger å hente hele databasen til bigquery hver gang
+CREATE OR REPLACE VIEW stoenad_statistikk AS
+    SELECT * FROM stoenad
+    WHERE tidspunkt_registrert > DATE(now()) - interval '31 days';


### PR DESCRIPTION
På grunn av begrensninger i EXTERNAL_QUERY kan vi ikke ha dynamiske parametere i spørringen mot PSQL, så vi må hente mer data enn vi trenger. Setter opp et tids-sensitivt view slik at denne mengden saker aldri blir større enn volum produsert ila en måned. Filtreringen bort av eldre saker gjøres i BQ.

Setter også opp GCP-spesifikk migrering for å gi tilgang til databasebrukeren som BQ bruker -- dette scriptet vil vi kun kjøre i GCP.