### PR TITLE
Lag en wrapper for api-kall (remote data) for å håndtere forskjellige states

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/attesterVedtak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/attesterVedtak.tsx
@@ -12,7 +12,7 @@ export const AttesterVedtak = ({ behandlingId }: { behandlingId?: string }) => {
     attesterVedtak(behandlingId).then((response) => {
       if (response.status === 'ok') {
         hentBehandling(behandlingId).then((response) => {
-          if (response.statusCode === 200) {
+          if (response.status === 'ok') {
             window.location.reload()
           }
         })

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/underkjennVedtak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/underkjennVedtak.tsx
@@ -19,7 +19,7 @@ export const UnderkjennVedtak: React.FC<Props> = ({ behandlingId, kommentar, val
     underkjennVedtak(behandlingId, kommentar, valgtBegrunnelse).then((response) => {
       if (response.status === 'ok') {
         hentBehandling(behandlingId).then((response) => {
-          if (response.statusCode === 200) {
+          if (response.status === 'ok') {
             window.location.reload()
           }
         })

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/kommerBarnetTilgode/EndreVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/kommerBarnetTilgode/EndreVurdering.tsx
@@ -22,7 +22,7 @@ export const EndreVurdering = ({ setRedigeringsModusFalse }: { setRedigeringsMod
       lagreBegrunnelseKommerBarnetTilgode(behandlingId, kommentar, svar.toString()).then((response) => {
         if (response.status === 'ok') {
           hentBehandling(behandlingId).then((response) => {
-            if (response.statusCode === 200) {
+            if (response.status === 'ok') {
               window.location.reload()
             }
           })

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/apiClient.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/apiClient.ts
@@ -1,9 +1,9 @@
 const path = process.env.REACT_APP_VEDTAK_URL
 
-type Success<T> = { status: 'ok'; data: T; statusCode: number }
-type Error = { status: 'error'; statusCode: number; error?: any }
+type ApiSuccess<T> = { status: 'ok'; data: T; statusCode: number }
+export type ApiError = { status: 'error'; statusCode: number; error?: any }
 
-export type ApiResponse<T> = Success<T> | Error
+export type ApiResponse<T> = ApiSuccess<T> | ApiError
 
 type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
@@ -9,8 +9,11 @@ export const avbrytBehandling = async (id: string): Promise<ApiResponse<unknown>
   return apiClient.post(`/behandling/${id}/avbryt`, {})
 }
 
-export const fastsettVirkningstidspunkt = async (id: string, dato: Date): Promise<ApiResponse<Virkningstidspunkt>> => {
-  return apiClient.post(`/behandling/${id}/virkningstidspunkt`, { dato })
+export const fastsettVirkningstidspunkt = async (args: {
+  id: string
+  dato: Date
+}): Promise<ApiResponse<Virkningstidspunkt>> => {
+  return apiClient.post(`/behandling/${args.id}/virkningstidspunkt`, { dato: args.dato })
 }
 
 export const fattVedtak = async (behandlingsId: string): Promise<ApiResponse<unknown>> => {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/hooks/useApiCall.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/hooks/useApiCall.ts
@@ -1,0 +1,54 @@
+import React, { useState } from 'react'
+import { ApiError, ApiResponse } from '../api/apiClient'
+
+export function useApiCall<T, U>(
+  fn: (req: T) => Promise<ApiResponse<U>>
+): [Result<U>, (args: T, onSuccess?: (result: U) => void) => void, () => void] {
+  const [apiResult, setApiResult] = useState<Result<U>>(initial)
+
+  const callFn = React.useCallback(
+    async (args: T, onSuccess?: (result: U) => void) => {
+      if (!isPending(apiResult)) {
+        setApiResult(pending)
+
+        const res = await fn(args)
+        if (res.status === 'ok') {
+          setApiResult(success(res.data))
+          onSuccess?.(res.data)
+        } else {
+          setApiResult(error(res))
+        }
+      }
+    },
+    [apiResult, fn]
+  )
+
+  const resetToInitial = React.useCallback(() => {
+    setApiResult(initial)
+  }, [setApiResult])
+
+  return [apiResult, callFn, resetToInitial]
+}
+
+export type Result<T> = Initial | Pending | Error<ApiError> | Success<T>
+
+type Initial = { status: 'initial' }
+type Pending = { status: 'pending' }
+type Error<U> = { status: 'error'; error: U }
+type Success<T> = { status: 'success'; data: T }
+
+export const isPending = (result: Result<unknown>): result is Pending => result.status === 'pending'
+export const isSuccess = <T>(result: Result<T>): result is Success<T> => result.status === 'success'
+export const isFailure = (result: Result<unknown>): result is Error<ApiError> => result.status === 'error'
+export const isInitial = (result: Result<unknown>): result is Initial => result.status === 'initial'
+
+const initial = <A = never>(): Result<A> => ({ status: 'initial' })
+const pending = <A = never>(): Result<A> => ({ status: 'pending' })
+const success = <A = never>(data: A): Result<A> => ({
+  status: 'success',
+  data,
+})
+const error = <A = never>(error: ApiError): Result<A> => ({
+  status: 'error',
+  error,
+})


### PR DESCRIPTION
Hensikten med denne PR:en er å gjøre api-kall, og håndteringen av de olika states:en ett api-kall kan være i, enklere.

Per nå så er det modellert sån att ett API-kall kan være i følgende states:
`Initial`, `Pending`, `Error`, `Success`

Initial - Før api-kallet har fyrt av
Pending - Når vi venter på svar
Error - Hvis vi får tilbake en feil fra backsystemene så blir det error med ett **error-objekt**
Success - Når allt går bra så får vi success-state med tilsvarende **data**

Nå skal det ikke være behov får boilerplate kode knyttet til api-kall. 😊 

Hjelpefunksjonene `isSuccess`, `isPending`, `isFailure`, `isInitial` kan brukes hvis man trenger å gjøre noe speciellt ved vær state tilstand. 😊 