### PR TITLE
Vedtaksvurdering bruker utbetalt beløp og ikke G

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
@@ -187,7 +187,7 @@ class VedtaksvurderingService(
                                     it.datoTOM?.takeIf { it.isBefore(YearMonth.from(LocalDateTime.MAX)) }
                                         ?.let(YearMonth::from)
                                 ),
-                                BigDecimal.valueOf(it.grunnbelopMnd.toLong())
+                                BigDecimal.valueOf(it.utbetaltBeloep.toLong())
                             )
                         }
                     )


### PR DESCRIPTION
Vedtaksvurdering mappet om grunnbeløpet og ikke faktisk utbetalt beløp, som gjorde at alle betalinger til oppdrag ble satt til 1 G, uavhengig av søskenflokk etc.