### PR TITLE
Fjern gammel api-type i frontend

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/types.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/types.ts
@@ -1,4 +1,0 @@
-export interface IApiResponse<T> {
-  status: number
-  data?: T
-}

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/user.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/user.ts
@@ -1,32 +1,5 @@
-import { IApiResponse } from './types'
+import { apiClient, ApiResponse } from './apiClient'
 
-const path = process.env.REACT_APP_VEDTAK_URL
-
-console.log('path', path)
-
-export const login = async (): Promise<IApiResponse<any>> => {
-  // Bare tester litt
-  try {
-    const result: Response = await fetch('https://etterlatte-overvaaking.dev.intern.nav.no/')
-    return {
-      status: result.status,
-      data: await result.json(),
-    }
-  } catch (e) {
-    console.log(e)
-    return { status: 500 }
-  }
-}
-
-export const hentInnloggetSaksbehandler = async (): Promise<IApiResponse<any>> => {
-  try {
-    const result: Response = await fetch(`${path}/modiacontextholder/api/decorator`)
-    return {
-      status: result.status,
-      data: await result.json(),
-    }
-  } catch (e) {
-    console.log(e)
-    return { status: 500 }
-  }
+export const hentInnloggetSaksbehandler = async (): Promise<ApiResponse<any>> => {
+  return apiClient.get('/modiacontextholder/decorator')
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/hooks/useInnloggetSaksbehandler.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/hooks/useInnloggetSaksbehandler.tsx
@@ -1,24 +1,22 @@
-import { useEffect, useState } from 'react'
-import { ISaksbehandler } from '../../store/reducers/SaksbehandlerReducer'
+import { useEffect } from 'react'
 import { hentInnloggetSaksbehandler } from '../api/user'
-import { IApiResponse } from '../api/types'
 import { useAppDispatch } from '../../store/Store'
 import { setSaksbehandler } from '../../store/reducers/SaksbehandlerReducer'
+import { isSuccess, useApiCall } from './useApiCall'
 
 const useInnloggetSaksbehandler = () => {
   const dispatch = useAppDispatch()
-  const [loaded, setLoaded] = useState<boolean>(false)
+  const [saksbehandler, hentSaksbehandler] = useApiCall(hentInnloggetSaksbehandler)
 
   useEffect(() => {
-    hentInnloggetSaksbehandler().then((response: IApiResponse<ISaksbehandler>) => {
+    hentSaksbehandler({}, (response) => {
       if (response.data) {
         dispatch(setSaksbehandler(response.data))
       }
-      setLoaded(true)
     })
   }, [])
 
-  return loaded
+  return isSuccess(saksbehandler)
 }
 
 export default useInnloggetSaksbehandler

--- a/apps/etterlatte-saksbehandling-ui/server/src/index.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/index.ts
@@ -43,7 +43,7 @@ if (isDev) {
   app.use('/brev', expressProxy(`${process.env.BREV_API_URL}`, 'api://d6add52a-5807-49cd-a181-76908efee836/.default'))
 }
 
-app.use('/modiacontextholder/api/', modiaRouter) // bytte ut med etterlatte-innlogget?
+app.use('/api/modiacontextholder/', modiaRouter) // bytte ut med etterlatte-innlogget?
 app.use(/^(?!.*\/(internal|static)\/).*$/, (req: any, res: any) => {
   return res.sendFile(`${clientPath}/index.html`)
 })


### PR DESCRIPTION
Per nå så har vi to api-typer i kodebasen. I denne PR:en så er den gamle typen fjernet så vi kun trenger å forholde seg til en.