### PR TITLE
Passer på at vi henter gjenlevende via "GIFT"-sivilstand

### DIFF
--- a/apps/etterlatte-testdata/src/main/kotlin/dolly/DollyService.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/dolly/DollyService.kt
@@ -35,7 +35,7 @@ class DollyService(
             dollyClient.hentPersonInfo(bestillinger.identer.map { it.ident }, accessToken).map { personResponse ->
                 ForenkletFamilieModell(
                     avdoed = personResponse.ident,
-                    gjenlevende = personResponse.person.sivilstand.first().relatertVedSivilstand,
+                    gjenlevende = personResponse.person.sivilstand.first { it.type == "GIFT" }.relatertVedSivilstand,
                     barn = personResponse.person.forelderBarnRelasjon
                         .filter { it.barn }
                         .map { it.relatertPersonsIdent }


### PR DESCRIPTION
Ser ut som vi får både "GIFT" og "UGIFT" tilbake i sivilstand, og ikke nødvendigvis i riktig rekkefølge (ny endring?). 