### PR TITLE
Tolker @lagret_soeknad_id som text, og ikke int

### DIFF
--- a/apps/etterlatte-fordeler/src/main/kotlin/fordeler/Fordeler.kt
+++ b/apps/etterlatte-fordeler/src/main/kotlin/fordeler/Fordeler.kt
@@ -91,5 +91,5 @@ internal class Fordeler(
         return this
     }
 
-    private fun JsonMessage.soeknadId(): Int = get(SoeknadInnsendt.lagretSoeknadIdKey).intValue()
+    private fun JsonMessage.soeknadId(): String = get(SoeknadInnsendt.lagretSoeknadIdKey).textValue()
 }

--- a/apps/etterlatte-fordeler/src/main/kotlin/fordeler/Fordeler.kt
+++ b/apps/etterlatte-fordeler/src/main/kotlin/fordeler/Fordeler.kt
@@ -62,19 +62,23 @@ internal class Fordeler(
                     }
 
                     is FordelerResultat.IkkeGyldigForBehandling -> {
-                        logger.info("Avbrutt fordeling: ${resultat.ikkeOppfylteKriterier}")
+                        logger.info(
+                            "Avbrutt fordeling for søknad (${packet.soeknadId()}): ${resultat.ikkeOppfylteKriterier}"
+                        )
                         fordelerMetricLogger.logMetricIkkeFordelt(resultat)
                     }
 
                     is FordelerResultat.UgyldigHendelse -> {
-                        logger.error("Avbrutt fordeling: ${resultat.message}")
+                        logger.error("Avbrutt fordeling for søknad (${packet.soeknadId()}): ${resultat.message}")
                     }
                 }
             } catch (e: JsonMappingException) {
-                sikkerLogg.error("Feil under deserialisering", e)
-                logger.error("Feil under deserialisering. Sjekk sikkerlogg for detaljer")
+                sikkerLogg.error("Feil under deserialisering av søknad (${packet.soeknadId()})", e)
+                logger.error(
+                    "Feil under deserialisering av søknad (${packet.soeknadId()}). Sjekk sikkerlogg for detaljer"
+                )
             } catch (e: Exception) {
-                logger.error("Uhåndtert feilsituasjon", e)
+                logger.error("Uhåndtert feilsituasjon for søknad (${packet.soeknadId()})", e)
             }
         }
 


### PR DESCRIPTION
I loggene i produksjon ser vi at fordeleren alltid logger "Sjekker om soknad (0) er gyldig for fordeling", som skyldes at intValue gir 0 for alle noder som ikke er tall. Bytter til textValue som henter nøkkelen i stedet