### PR TITLE
Kan ikke endre 'kommer barnet til gode' hvis behandlingen ikke er under behandling

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/Behandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/Behandling.kt
@@ -71,9 +71,11 @@ data class Foerstegangsbehandling(
     val soeknadMottattDato: LocalDateTime,
     val gyldighetsproeving: GyldighetsResultat?
 ) : Behandling {
+    private val kanRedigeres: Boolean
+        get() = this.status.kanRedigeres()
     fun hentVirkningstidspunkt() = virkningstidspunkt
     fun oppdaterVirkningstidspunkt(dato: YearMonth, kilde: Grunnlagsopplysning.Saksbehandler): Foerstegangsbehandling {
-        if (!BehandlingStatus.kanRedigeres().contains(this.status)) {
+        if (kanRedigeres) {
             throw RuntimeException("Kan ikke endre virkningstidspunkt for behandling som ikke er under behandling.")
         }
 
@@ -81,7 +83,7 @@ data class Foerstegangsbehandling(
     }
 
     fun oppdaterKommerBarnetTilgode(kommerBarnetTilgode: KommerBarnetTilgode): Foerstegangsbehandling {
-        if (!BehandlingStatus.kanRedigeres().contains(this.status)) {
+        if (kanRedigeres) {
             throw RuntimeException("Kan ikke endre kommer barnet til gode for behandling som ikke er under behandling")
         }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/Behandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/Behandling.kt
@@ -11,7 +11,6 @@ import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.gyldigSoeknad.GyldighetsResultat
-import java.lang.RuntimeException
 import java.time.LocalDateTime
 import java.time.YearMonth
 import java.util.*
@@ -68,17 +67,25 @@ data class Foerstegangsbehandling(
     override val type: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
     override val persongalleri: Persongalleri,
     override val kommerBarnetTilgode: KommerBarnetTilgode?,
-    private var virkningstidspunkt: Virkningstidspunkt?,
+    val virkningstidspunkt: Virkningstidspunkt?,
     val soeknadMottattDato: LocalDateTime,
     val gyldighetsproeving: GyldighetsResultat?
 ) : Behandling {
     fun hentVirkningstidspunkt() = virkningstidspunkt
-    fun oppdaterVirkningstidspunkt(dato: YearMonth, kilde: Grunnlagsopplysning.Saksbehandler) {
-        if (BehandlingStatus.kanRedigeres().contains(this.status)) {
-            virkningstidspunkt = Virkningstidspunkt(dato, kilde)
-        } else {
+    fun oppdaterVirkningstidspunkt(dato: YearMonth, kilde: Grunnlagsopplysning.Saksbehandler): Foerstegangsbehandling {
+        if (!BehandlingStatus.kanRedigeres().contains(this.status)) {
             throw RuntimeException("Kan ikke endre virkningstidspunkt for behandling som ikke er under behandling.")
         }
+
+        return this.copy(virkningstidspunkt = Virkningstidspunkt(dato, kilde))
+    }
+
+    fun oppdaterKommerBarnetTilgode(kommerBarnetTilgode: KommerBarnetTilgode): Foerstegangsbehandling {
+        if (!BehandlingStatus.kanRedigeres().contains(this.status)) {
+            throw RuntimeException("Kan ikke endre kommer barnet til gode for behandling som ikke er under behandling")
+        }
+
+        return this.copy(kommerBarnetTilgode = kommerBarnetTilgode)
     }
 }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/itest/BehandlingDaoIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/itest/BehandlingDaoIntegrationTest.kt
@@ -592,7 +592,7 @@ internal class BehandlingDaoIntegrationTest {
     }
 
     @Test
-    fun `skal lagre kommer soeker til gode for en behandling`() {
+    fun `skal lagre kommer barnet til gode for en behandling`() {
         val sak = sakRepo.opprettSak("123", SakType.BARNEPENSJON).id
         val behandling = foerstegangsbehandling(sak = sak, status = BehandlingStatus.OPPRETTET)
 

--- a/apps/etterlatte-behandling/src/test/kotlin/itest/BehandlingDaoIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/itest/BehandlingDaoIntegrationTest.kt
@@ -8,6 +8,7 @@ import no.nav.etterlatte.database.DataSourceBuilder
 import no.nav.etterlatte.foerstegangsbehandling
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.KommerBarnetTilgode
 import no.nav.etterlatte.libs.common.behandling.ManueltOpphoerAarsak
 import no.nav.etterlatte.libs.common.behandling.OppgaveStatus
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
@@ -18,6 +19,7 @@ import no.nav.etterlatte.libs.common.gyldigSoeknad.GyldighetsResultat
 import no.nav.etterlatte.libs.common.gyldigSoeknad.GyldighetsTyper
 import no.nav.etterlatte.libs.common.gyldigSoeknad.VurderingsResultat
 import no.nav.etterlatte.libs.common.gyldigSoeknad.VurdertGyldighet
+import no.nav.etterlatte.libs.common.soeknad.dataklasser.common.JaNeiVetIkke
 import no.nav.etterlatte.manueltOpphoer
 import no.nav.etterlatte.persongalleri
 import no.nav.etterlatte.revurdering
@@ -578,12 +580,35 @@ internal class BehandlingDaoIntegrationTest {
 
         val saksbehandler = Grunnlagsopplysning.Saksbehandler("navIdent", Instant.now())
         val nyDato = YearMonth.of(2021, 2)
-        behandling.oppdaterVirkningstidspunkt(nyDato, saksbehandler)
-        behandlingRepo.lagreNyttVirkningstidspunkt(behandling.id, behandling.hentVirkningstidspunkt()!!)
+        behandling.oppdaterVirkningstidspunkt(nyDato, saksbehandler).let {
+            behandlingRepo.lagreNyttVirkningstidspunkt(behandling.id, it.hentVirkningstidspunkt()!!)
+        }
 
         val expected = Virkningstidspunkt(nyDato, saksbehandler)
         with(behandlingRepo.hentBehandling(behandling.id)) {
             val actual = (this as Foerstegangsbehandling).hentVirkningstidspunkt()
+            assertEquals(expected, actual)
+        }
+    }
+
+    @Test
+    fun `skal lagre kommer soeker til gode for en behandling`() {
+        val sak = sakRepo.opprettSak("123", SakType.BARNEPENSJON).id
+        val behandling = foerstegangsbehandling(sak = sak, status = BehandlingStatus.OPPRETTET)
+
+        behandlingRepo.opprettFoerstegangsbehandling(behandling)
+
+        val kommerBarnetTilgode = KommerBarnetTilgode(
+            JaNeiVetIkke.JA,
+            "begrunnelse",
+            Grunnlagsopplysning.Saksbehandler("navIdent", Instant.now())
+        )
+        behandlingRepo.lagreKommerBarnetTilgode(behandling.id, kommerBarnetTilgode)
+
+        with(behandlingRepo.hentBehandling(behandling.id)) {
+            val expected = kommerBarnetTilgode
+            val actual = (this as Foerstegangsbehandling).kommerBarnetTilgode
+
             assertEquals(expected, actual)
         }
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/itest/IntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/itest/IntegrationTest.kt
@@ -25,6 +25,7 @@ import no.nav.etterlatte.behandling.BehandlingsBehov
 import no.nav.etterlatte.behandling.FastsettVirkningstidspunktRequest
 import no.nav.etterlatte.behandling.FastsettVirkningstidspunktResponse
 import no.nav.etterlatte.behandling.HendelseDao
+import no.nav.etterlatte.behandling.KommerBarnetTilgodeJson
 import no.nav.etterlatte.behandling.ManueltOpphoerResponse
 import no.nav.etterlatte.behandling.VedtakHendelse
 import no.nav.etterlatte.behandling.common.LeaderElection
@@ -49,6 +50,7 @@ import no.nav.etterlatte.libs.common.pdlhendelse.Doedshendelse
 import no.nav.etterlatte.libs.common.pdlhendelse.Endringstype
 import no.nav.etterlatte.libs.common.pdlhendelse.ForelderBarnRelasjonHendelse
 import no.nav.etterlatte.libs.common.pdlhendelse.UtflyttingsHendelse
+import no.nav.etterlatte.libs.common.soeknad.dataklasser.common.JaNeiVetIkke
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.module
 import no.nav.etterlatte.oppgave.OppgaveListeDto
@@ -181,6 +183,14 @@ class ApplicationTest {
                 )
                 assertEquals(expected.dato, it.body<FastsettVirkningstidspunktResponse>().dato)
                 assertEquals(expected.kilde.ident, it.body<FastsettVirkningstidspunktResponse>().kilde.ident)
+            }
+
+            client.post("/api/behandling/$behandlingId/kommerbarnettilgode") {
+                addAuthSaksbehandler()
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                setBody(KommerBarnetTilgodeJson(JaNeiVetIkke.JA, "begrunnelse"))
+            }.also {
+                assertEquals(HttpStatusCode.OK, it.status)
             }
 
             client.post("/behandlinger/$behandlingId/hendelser/vedtak/FATTET") {

--- a/libs/common/src/main/kotlin/behandling/BehandlingStatus.kt
+++ b/libs/common/src/main/kotlin/behandling/BehandlingStatus.kt
@@ -15,6 +15,8 @@ enum class BehandlingStatus {
         return this !in iverksattEllerAttestert() && this != AVBRUTT
     }
 
+    fun kanRedigeres() = this !in redigerbar()
+
     companion object {
         fun underBehandling() = listOf(
             OPPRETTET,
@@ -28,8 +30,7 @@ enum class BehandlingStatus {
             IVERKSATT,
             ATTESTERT
         )
-
-        fun kanRedigeres() = underBehandling() - FATTET_VEDTAK
+        fun redigerbar() = underBehandling() - FATTET_VEDTAK
 
         fun ikkeAvbrutt() = iverksattEllerAttestert() + underBehandling()
     }


### PR DESCRIPTION
Per idag så har man mulighet å endre 'Kommer soeker til gode' i alla mulige tilstander, f.eks når den er sendt til attestering eller når den er iverksatt o.s.v. 

Denne PR:en ser til att man kan kun endre den verdien hvis behandlinger er i statusen 'under behandling'