### PR TITLE
Vis feedback til bruker for kommerbarnettilgode på søknadsoversikten

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import DatePicker from 'react-datepicker'
-import { Alert, Button, Label, Loader } from '@navikt/ds-react'
+import { Alert, Button, Label } from '@navikt/ds-react'
 import { useRef, useState } from 'react'
 import { GyldighetIcon } from '~shared/icons/gyldigIcon'
 import { oppdaterVirkningstidspunkt, VurderingsResultat } from '~store/reducers/BehandlingReducer'
@@ -117,10 +117,11 @@ const Virkningstidspunkt = () => {
                           setRediger(false)
                         })
                       }}
+                      loading={isPending(virkningstidspunkt)}
                       size="small"
                       variant="primary"
                     >
-                      Lagre {isPending(virkningstidspunkt) && <Loader />}
+                      Lagre
                     </Button>
                     <Button size="small" variant="secondary" onClick={() => setRediger(false)}>
                       Avbryt

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/utils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/utils.ts
@@ -1,5 +1,6 @@
-import { ISvar, KildeType } from '~store/reducers/BehandlingReducer'
+import { ISvar } from '~store/reducers/BehandlingReducer'
 import { VilkaarsvurderingResultat } from '~shared/api/vilkaarsvurdering'
+import { KildeType } from '~shared/types/kilde'
 
 export const svarTilTotalResultat = (svar: ISvar) => {
   switch (svar) {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/vilkaar/AlderBarn.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/vilkaar/AlderBarn.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { VilkaarColumn } from '../styled'
 import { hentKildenavn } from '../utils'
 import { formaterStringDato } from '~utils/formattering'
-import { KildeType } from '~store/reducers/BehandlingReducer'
+import { KildeType } from '~shared/types/kilde'
 
 export const AlderBarn = ({ grunnlag }: { grunnlag: Vilkaarsgrunnlag<any>[] }) => {
   const foedselsdatoGrunnlag = grunnlag.find((grunnlag) => grunnlag.opplysningsType == 'SOEKER_FOEDSELSDATO')

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
@@ -1,4 +1,4 @@
-import { IDetaljertBehandling, Virkningstidspunkt } from '~store/reducers/BehandlingReducer'
+import { IDetaljertBehandling, IKommerBarnetTilgode, Virkningstidspunkt } from '~store/reducers/BehandlingReducer'
 import { apiClient, ApiResponse } from './apiClient'
 
 export const hentBehandling = async (id: string): Promise<ApiResponse<IDetaljertBehandling>> => {
@@ -32,12 +32,15 @@ export const underkjennVedtak = async (
   return apiClient.post(`/underkjennVedtak/${behandlingId}`, { kommentar, valgtBegrunnelse })
 }
 
-export const lagreBegrunnelseKommerBarnetTilgode = async (
-  behandlingsId: string,
-  begrunnelse: string,
+export const lagreBegrunnelseKommerBarnetTilgode = async (args: {
+  behandlingId: string
+  begrunnelse: string
   svar: string
-): Promise<ApiResponse<any>> => {
-  return apiClient.post(`/behandling/${behandlingsId}/kommerbarnettilgode`, { svar, begrunnelse })
+}): Promise<ApiResponse<IKommerBarnetTilgode>> => {
+  return apiClient.post(`/behandling/${args.behandlingId}/kommerbarnettilgode`, {
+    svar: args.svar,
+    begrunnelse: args.begrunnelse,
+  })
 }
 
 export const lagreSoeskenMedIBeregning = async (

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vilkaarsvurdering.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vilkaarsvurdering.ts
@@ -1,5 +1,5 @@
+import { Kilde, KildeSaksbehandler } from '~shared/types/kilde'
 import { apiClient, ApiResponse } from './apiClient'
-import { KildeType } from '~store/reducers/BehandlingReducer'
 
 export const hentVilkaarsvurdering = async (behandlingsId: string): Promise<ApiResponse<Vilkaarsvurdering>> =>
   apiClient.get<Vilkaarsvurdering>(`/vilkaarsvurdering/${behandlingsId}`)
@@ -52,22 +52,6 @@ export interface Vilkaarsgrunnlag<T> {
   opplysningsType: string
   kilde: Kilde
   opplysning: T
-}
-
-export type Kilde = KildeSaksbehandler | KildePdl
-
-interface KildeSaksbehandler {
-  type: KildeType.saksbehandler
-  tidspunkt: string
-  ident: string
-}
-
-interface KildePdl {
-  type: KildeType.pdl
-  tidspunktForInnhenting: string
-  navn: string
-  registersReferanse: string
-  opplysningId: string
 }
 
 export interface Hovedvilkaar {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/kilde.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/kilde.ts
@@ -1,0 +1,24 @@
+export enum KildeType {
+  saksbehandler = 'saksbehandler',
+  privatperson = 'privatperson',
+  a_ordningen = 'a-ordningen',
+  aa_registeret = 'aa-registeret',
+  vilkaarskomponenten = 'vilkaarskomponenten',
+  pdl = 'pdl',
+}
+
+export type Kilde = KildeSaksbehandler | KildePdl
+
+export interface KildeSaksbehandler {
+  type: KildeType.saksbehandler
+  tidspunkt: string
+  ident: string
+}
+
+export interface KildePdl {
+  type: KildeType.pdl
+  tidspunktForInnhenting: string
+  navn: string
+  registersReferanse: string
+  opplysningId: string
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/BehandlingReducer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/BehandlingReducer.ts
@@ -1,6 +1,7 @@
 import { createAction, createReducer } from '@reduxjs/toolkit'
 import { Vilkaarsvurdering } from '~shared/api/vilkaarsvurdering'
 import { Beregning } from '~shared/api/beregning'
+import { KildeSaksbehandler, KildeType } from '~shared/types/kilde'
 
 export interface IDetaljertBehandling {
   id: string
@@ -65,10 +66,7 @@ export enum IBehandlingStatus {
 export interface IKommerBarnetTilgode {
   svar: JaNei
   begrunnelse: string
-  kilde: {
-    ident: string
-    tidspunkt: string
-  }
+  kilde: KildeSaksbehandler
 }
 
 export enum JaNei {
@@ -131,15 +129,6 @@ export enum OpplysningsType {
 
   soeknad_mottatt = 'SOEKNAD_MOTTATT_DATO',
   innsender = 'INNSENDER_SOEKNAD_V1',
-}
-
-export enum KildeType {
-  saksbehandler = 'saksbehandler',
-  privatperson = 'privatperson',
-  a_ordningen = 'a-ordningen',
-  aa_registeret = 'aa-registeret',
-  vilkaarskomponenten = 'vilkaarskomponenten',
-  pdl = 'pdl',
 }
 
 export enum VurderingsResultat {


### PR DESCRIPTION
Tidligere så vistes ikke spinners eller feilmeldinger når man vurderte 'kommer barnet til gode' på søknadsoversikten.

Har fikset sån att det gjøres det nå og i tillegg gjort noen mindre refaktoreringer. Har begynt å trekke ut domene-typer fra reducer:sen våres, og hellre istedet ha det en annan plass. Synes ikke det hører helt hjemme där. 😊 

![image](https://user-images.githubusercontent.com/26689337/203508386-827bb2ab-3aa3-4c90-ae01-51cbee90818d.png)
