### PR TITLE
Relatert persons ident er ikke nødvendigvis satt

### DIFF
--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
@@ -391,7 +391,7 @@ data class PdlForelderBarnRelasjon(
     val folkeregistermetadata: PdlFolkeregistermetadata? = null,
     val metadata: PdlMetadata,
     val minRolleForPerson: PdlForelderBarnRelasjonRolle? = null,
-    val relatertPersonsIdent: String,
+    val relatertPersonsIdent: String?,
     val relatertPersonsRolle: PdlForelderBarnRelasjonRolle
 )
 


### PR DESCRIPTION
Basert på logger fra produksjon feiler pdltjenester i henting av enkelte personer, med json-feil i deserialiseringen på feltet "relatertPersonsIdent" som kreves i vår modell, men ikke er til stede i PDL-responsen.

Setter dermed feltet som optional i vår modell, så det ikke skal feile i mappingen.

Issue: EY-1074