### PR TITLE
Skru på redux devtools alltid

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/store/Store.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/store/Store.tsx
@@ -13,7 +13,7 @@ const reducer = {
 }
 export const store = configureStore({
   reducer,
-  devTools: process.env.NODE_ENV !== 'production',
+  devTools: true,
 })
 
 export type RootState = ReturnType<typeof store.getState>


### PR DESCRIPTION
Finnes det noen gode grunner til å ikke alltid ha dette på?