### PR TITLE
Definiere flyt for behandling og lovlige transisjoner

### DIFF
--- a/apps/etterlatte-api/src/test/kotlin/behandling/OppgaveServiceTest.kt
+++ b/apps/etterlatte-api/src/test/kotlin/behandling/OppgaveServiceTest.kt
@@ -38,7 +38,7 @@ internal class OppgaveServiceTest {
             oppgaver = listOf(
                 BehandlingsOppgave(
                     behandlingId,
-                    BehandlingStatus.VILKAARSVURDERING,
+                    BehandlingStatus.VILKAARSVURDERT,
                     OppgaveStatus.NY,
                     Sak("ident", "saktype", 1),
                     ZonedDateTime.now(),
@@ -51,7 +51,7 @@ internal class OppgaveServiceTest {
 
         val resultat = runBlocking { service.hentAlleOppgaver(accessToken) }
 
-        assertEquals(BehandlingStatus.VILKAARSVURDERING, resultat.oppgaver.first().status)
+        assertEquals(BehandlingStatus.VILKAARSVURDERT, resultat.oppgaver.first().status)
         assertEquals(BehandlingType.REVURDERING, resultat.oppgaver.first().behandlingType)
         assertEquals(OppgaveStatus.NY, resultat.oppgaver.first().oppgaveStatus)
     }

--- a/apps/etterlatte-api/src/test/kotlin/behandling/OppgaveServiceTest.kt
+++ b/apps/etterlatte-api/src/test/kotlin/behandling/OppgaveServiceTest.kt
@@ -38,7 +38,7 @@ internal class OppgaveServiceTest {
             oppgaver = listOf(
                 BehandlingsOppgave(
                     behandlingId,
-                    BehandlingStatus.UNDER_BEHANDLING,
+                    BehandlingStatus.VILKAARSVURDERING,
                     OppgaveStatus.NY,
                     Sak("ident", "saktype", 1),
                     ZonedDateTime.now(),
@@ -51,7 +51,7 @@ internal class OppgaveServiceTest {
 
         val resultat = runBlocking { service.hentAlleOppgaver(accessToken) }
 
-        assertEquals(BehandlingStatus.UNDER_BEHANDLING, resultat.oppgaver.first().status)
+        assertEquals(BehandlingStatus.VILKAARSVURDERING, resultat.oppgaver.first().status)
         assertEquals(BehandlingType.REVURDERING, resultat.oppgaver.first().behandlingType)
         assertEquals(OppgaveStatus.NY, resultat.oppgaver.first().oppgaveStatus)
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/BeanFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/BeanFactory.kt
@@ -10,12 +10,12 @@ import io.ktor.serialization.jackson.jackson
 import no.nav.etterlatte.behandling.BehandlingDao
 import no.nav.etterlatte.behandling.BehandlingsHendelser
 import no.nav.etterlatte.behandling.GenerellBehandlingService
-import no.nav.etterlatte.behandling.HendelseDao
 import no.nav.etterlatte.behandling.RealGenerellBehandlingService
 import no.nav.etterlatte.behandling.common.LeaderElection
 import no.nav.etterlatte.behandling.foerstegangsbehandling.FoerstegangsbehandlingFactory
 import no.nav.etterlatte.behandling.foerstegangsbehandling.FoerstegangsbehandlingService
 import no.nav.etterlatte.behandling.foerstegangsbehandling.RealFoerstegangsbehandlingService
+import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.behandling.manueltopphoer.ManueltOpphoerService
 import no.nav.etterlatte.behandling.manueltopphoer.RealManueltOpphoerService
 import no.nav.etterlatte.behandling.revurdering.RealRevurderingService

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/Behandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/Behandling.kt
@@ -39,11 +39,11 @@ sealed class Behandling {
 
     val oppgaveStatus get() = OppgaveStatus.from(status)
 
-    fun <T : Behandling> hvisRedigerbar(block: () -> T): T {
+    protected fun <T : Behandling> hvisRedigerbar(block: () -> T): T {
         if (kanRedigeres) return block() else kastFeilTilstand()
     }
 
-    fun <T : Behandling> hvisTilstandEr(behandlingStatus: BehandlingStatus, block: () -> T): T {
+    protected fun <T : Behandling> hvisTilstandEr(behandlingStatus: BehandlingStatus, block: () -> T): T {
         if (status == behandlingStatus) return block() else kastFeilTilstand()
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/Behandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/Behandling.kt
@@ -11,11 +11,47 @@ import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.gyldigSoeknad.GyldighetsResultat
+import no.nav.etterlatte.libs.common.gyldigSoeknad.VurderingsResultat
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
 import java.time.YearMonth
 import java.util.*
 
-sealed interface Behandling {
+internal sealed class TilstandException : Throwable() {
+    internal object UgyldigtTilstand : TilstandException()
+    internal object IkkeFyltUt : TilstandException()
+}
+
+sealed class Behandling {
+    abstract val id: UUID
+    abstract val sak: Long
+    abstract val behandlingOpprettet: LocalDateTime
+    abstract val sistEndret: LocalDateTime
+    abstract val status: BehandlingStatus
+    abstract val oppgaveStatus: OppgaveStatus?
+    abstract val type: BehandlingType
+    abstract val persongalleri: Persongalleri
+    abstract val kommerBarnetTilgode: KommerBarnetTilgode?
+
+    val logger: Logger = LoggerFactory.getLogger(Behandling::class.java)
+
+    private val kanRedigeres: Boolean
+        get() = this.status.kanRedigeres()
+
+    fun <T : Behandling> hvisRedigerbar(block: () -> T): T {
+        if (kanRedigeres) return block() else kastFeilTilstand()
+    }
+
+    fun <T : Behandling> hvisTilstandEr(behandlingStatus: BehandlingStatus, block: () -> T): T {
+        if (status == behandlingStatus) return block() else kastFeilTilstand()
+    }
+
+    private fun kastFeilTilstand(): Nothing {
+        logger.info("kan ikke oppdatere en behandling ($id) som ikke er under behandling")
+        throw TilstandException.UgyldigtTilstand
+    }
+
     fun toDetaljertBehandling(): DetaljertBehandling {
         val (soeknadMottatDato, gyldighetsproeving) = when (this) {
             is Foerstegangsbehandling -> this.soeknadMottattDato to this.gyldighetsproeving
@@ -45,16 +81,6 @@ sealed interface Behandling {
             kommerBarnetTilgode = kommerBarnetTilgode
         )
     }
-
-    val id: UUID
-    val sak: Long
-    val behandlingOpprettet: LocalDateTime
-    val sistEndret: LocalDateTime
-    val status: BehandlingStatus
-    val oppgaveStatus: OppgaveStatus?
-    val type: BehandlingType
-    val persongalleri: Persongalleri
-    val kommerBarnetTilgode: KommerBarnetTilgode?
 }
 
 data class Foerstegangsbehandling(
@@ -64,30 +90,88 @@ data class Foerstegangsbehandling(
     override val sistEndret: LocalDateTime,
     override val status: BehandlingStatus,
     override val oppgaveStatus: OppgaveStatus?,
-    override val type: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
     override val persongalleri: Persongalleri,
     override val kommerBarnetTilgode: KommerBarnetTilgode?,
     val virkningstidspunkt: Virkningstidspunkt?,
     val soeknadMottattDato: LocalDateTime,
     val gyldighetsproeving: GyldighetsResultat?
-) : Behandling {
-    private val kanRedigeres: Boolean
-        get() = this.status.kanRedigeres()
-    fun hentVirkningstidspunkt() = virkningstidspunkt
-    fun oppdaterVirkningstidspunkt(dato: YearMonth, kilde: Grunnlagsopplysning.Saksbehandler): Foerstegangsbehandling {
-        if (kanRedigeres) {
-            throw RuntimeException("Kan ikke endre virkningstidspunkt for behandling som ikke er under behandling.")
+) : Behandling() {
+    override val type: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING
+
+    private val erFyltUt: Boolean
+        get() {
+            return (virkningstidspunkt != null) &&
+                (gyldighetsproeving != null) &&
+                (kommerBarnetTilgode != null)
         }
 
-        return this.copy(virkningstidspunkt = Virkningstidspunkt(dato, kilde))
+    fun hentVirkningstidspunkt() = virkningstidspunkt
+
+    fun oppdaterGyldighetsproeving(gyldighetsResultat: GyldighetsResultat): Foerstegangsbehandling = hvisRedigerbar {
+        this.copy(
+            gyldighetsproeving = gyldighetsResultat,
+            status = if (gyldighetsResultat.resultat == VurderingsResultat.OPPFYLT) {
+                BehandlingStatus.GYLDIG_SOEKNAD
+            } else {
+                BehandlingStatus.IKKE_GYLDIG_SOEKNAD
+            },
+            sistEndret = LocalDateTime.now(),
+            oppgaveStatus = OppgaveStatus.NY
+        )
     }
 
-    fun oppdaterKommerBarnetTilgode(kommerBarnetTilgode: KommerBarnetTilgode): Foerstegangsbehandling {
-        if (kanRedigeres) {
-            throw RuntimeException("Kan ikke endre kommer barnet til gode for behandling som ikke er under behandling")
+    fun oppdaterVirkningstidspunkt(dato: YearMonth, kilde: Grunnlagsopplysning.Saksbehandler) =
+        this.hvisRedigerbar {
+            this.copy(
+                virkningstidspunkt = Virkningstidspunkt(dato, kilde),
+                sistEndret = LocalDateTime.now()
+            )
         }
 
-        return this.copy(kommerBarnetTilgode = kommerBarnetTilgode)
+    fun oppdaterKommerBarnetTilgode(kommerBarnetTilgode: KommerBarnetTilgode): Foerstegangsbehandling = hvisRedigerbar {
+        this.copy(kommerBarnetTilgode = kommerBarnetTilgode, sistEndret = LocalDateTime.now())
+    }
+
+    fun tilVilkaarsvurdering(): Foerstegangsbehandling {
+        if (!erFyltUt) {
+            logger.info(("Behandling ($id) må være fylt ut for å settes til vilkårsvurdering"))
+            throw TilstandException.IkkeFyltUt
+        }
+
+        return hvisRedigerbar {
+            this.copy(status = BehandlingStatus.VILKAARSVURDERING, sistEndret = LocalDateTime.now())
+        }
+    }
+
+    fun tilFattetVedtak(): Foerstegangsbehandling {
+        if (!erFyltUt) {
+            logger.info(("Behandling ($id) må være fylt ut for å settes til fattet vedtak"))
+            throw TilstandException.IkkeFyltUt
+        }
+
+        return hvisRedigerbar {
+            this.copy(
+                status = BehandlingStatus.FATTET_VEDTAK,
+                sistEndret = LocalDateTime.now(),
+                oppgaveStatus = OppgaveStatus.TIL_ATTESTERING
+            )
+        }
+    }
+
+    fun tilAttestert() = hvisTilstandEr(BehandlingStatus.FATTET_VEDTAK) {
+        this.copy(status = BehandlingStatus.ATTESTERT, oppgaveStatus = null, sistEndret = LocalDateTime.now())
+    }
+
+    fun tilReturnert() = hvisTilstandEr(BehandlingStatus.FATTET_VEDTAK) {
+        this.copy(
+            status = BehandlingStatus.RETURNERT,
+            sistEndret = LocalDateTime.now(),
+            oppgaveStatus = OppgaveStatus.RETURNERT
+        )
+    }
+
+    fun tilIverksatt() = hvisTilstandEr(BehandlingStatus.ATTESTERT) {
+        this.copy(status = BehandlingStatus.IVERKSATT, sistEndret = LocalDateTime.now(), oppgaveStatus = null)
     }
 }
 
@@ -98,11 +182,12 @@ data class Revurdering(
     override val sistEndret: LocalDateTime,
     override val status: BehandlingStatus,
     override val oppgaveStatus: OppgaveStatus?,
-    override val type: BehandlingType = BehandlingType.REVURDERING,
     override val persongalleri: Persongalleri,
     override val kommerBarnetTilgode: KommerBarnetTilgode?,
     val revurderingsaarsak: RevurderingAarsak
-) : Behandling
+) : Behandling() {
+    override val type: BehandlingType = BehandlingType.REVURDERING
+}
 
 data class ManueltOpphoer(
     override val id: UUID,
@@ -111,11 +196,12 @@ data class ManueltOpphoer(
     override val sistEndret: LocalDateTime,
     override val status: BehandlingStatus,
     override val oppgaveStatus: OppgaveStatus?,
-    override val type: BehandlingType = BehandlingType.MANUELT_OPPHOER,
     override val persongalleri: Persongalleri,
     val opphoerAarsaker: List<ManueltOpphoerAarsak>,
     val fritekstAarsak: String?
-) : Behandling {
+) : Behandling() {
+    override val type: BehandlingType = BehandlingType.MANUELT_OPPHOER
+
     constructor(
         sak: Long,
         persongalleri: Persongalleri,
@@ -128,7 +214,6 @@ data class ManueltOpphoer(
         sistEndret = LocalDateTime.now(),
         status = BehandlingStatus.OPPRETTET,
         oppgaveStatus = OppgaveStatus.NY,
-        type = BehandlingType.MANUELT_OPPHOER,
         persongalleri = persongalleri,
         opphoerAarsaker = opphoerAarsaker,
         fritekstAarsak = fritekstAarsak

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
@@ -171,7 +171,6 @@ class BehandlingDao(private val connection: () -> Connection) {
         persongalleri = hentPersongalleri(rs),
         gyldighetsproeving = rs.getString("gyldighetssproving")?.let { objectMapper.readValue(it) },
         status = rs.getString("status").let { BehandlingStatus.valueOf(it) },
-        type = rs.getString("behandlingstype").let { BehandlingType.valueOf(it) },
         oppgaveStatus = rs.getString("oppgave_status")?.let { OppgaveStatus.valueOf(it) },
         virkningstidspunkt = rs.getString("virkningstidspunkt")?.let { objectMapper.readValue(it) },
         kommerBarnetTilgode = rs.getString("kommer_barnet_tilgode")?.let { objectMapper.readValue(it) }
@@ -193,7 +192,6 @@ class BehandlingDao(private val connection: () -> Connection) {
         sistEndret = rs.getTimestamp("sist_endret").toLocalDateTime(),
         persongalleri = hentPersongalleri(rs),
         status = rs.getString("status").let { BehandlingStatus.valueOf(it) },
-        type = rs.getString("behandlingstype").let { BehandlingType.valueOf(it) },
         oppgaveStatus = rs.getString("oppgave_status")?.let { OppgaveStatus.valueOf(it) },
         revurderingsaarsak = rs.getString("revurdering_aarsak").let { RevurderingAarsak.valueOf(it) },
         kommerBarnetTilgode = rs.getString("kommer_barnet_tilgode")?.let { objectMapper.readValue(it) }
@@ -207,7 +205,6 @@ class BehandlingDao(private val connection: () -> Connection) {
         sistEndret = rs.getTimestamp("sist_endret").toLocalDateTime(),
         persongalleri = hentPersongalleri(rs),
         status = rs.getString("status").let { BehandlingStatus.valueOf(it) },
-        type = rs.getString("behandlingstype").let { BehandlingType.valueOf(it) },
         oppgaveStatus = rs.getString("oppgave_status")?.let { OppgaveStatus.valueOf(it) },
         opphoerAarsaker = rs.getString("opphoer_aarsaker").let { objectMapper.readValue(it) },
         fritekstAarsak = rs.getString("fritekst_aarsak")
@@ -377,6 +374,7 @@ class BehandlingDao(private val connection: () -> Connection) {
         statement.executeUpdate()
     }
 
+    // TODO ai: brukes kun i test
     fun lagreStatus(lagretBehandling: Behandling) {
         lagreStatus(lagretBehandling.id, lagretBehandling.status, lagretBehandling.sistEndret)
     }
@@ -397,6 +395,7 @@ class BehandlingDao(private val connection: () -> Connection) {
         )
     }
 
+    // TODO ai: Brukes kun i test
     fun lagreOppgaveStatus(behandling: Behandling) {
         val stmt =
             connection().prepareStatement("UPDATE behandling SET oppgave_status = ?, sist_endret = ? WHERE id = ?")

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
@@ -10,7 +10,6 @@ import no.nav.etterlatte.database.toList
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.KommerBarnetTilgode
-import no.nav.etterlatte.libs.common.behandling.OppgaveStatus
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
@@ -171,7 +170,6 @@ class BehandlingDao(private val connection: () -> Connection) {
         persongalleri = hentPersongalleri(rs),
         gyldighetsproeving = rs.getString("gyldighetssproving")?.let { objectMapper.readValue(it) },
         status = rs.getString("status").let { BehandlingStatus.valueOf(it) },
-        oppgaveStatus = rs.getString("oppgave_status")?.let { OppgaveStatus.valueOf(it) },
         virkningstidspunkt = rs.getString("virkningstidspunkt")?.let { objectMapper.readValue(it) },
         kommerBarnetTilgode = rs.getString("kommer_barnet_tilgode")?.let { objectMapper.readValue(it) }
     )
@@ -192,7 +190,6 @@ class BehandlingDao(private val connection: () -> Connection) {
         sistEndret = rs.getTimestamp("sist_endret").toLocalDateTime(),
         persongalleri = hentPersongalleri(rs),
         status = rs.getString("status").let { BehandlingStatus.valueOf(it) },
-        oppgaveStatus = rs.getString("oppgave_status")?.let { OppgaveStatus.valueOf(it) },
         revurderingsaarsak = rs.getString("revurdering_aarsak").let { RevurderingAarsak.valueOf(it) },
         kommerBarnetTilgode = rs.getString("kommer_barnet_tilgode")?.let { objectMapper.readValue(it) }
     )
@@ -205,7 +202,6 @@ class BehandlingDao(private val connection: () -> Connection) {
         sistEndret = rs.getTimestamp("sist_endret").toLocalDateTime(),
         persongalleri = hentPersongalleri(rs),
         status = rs.getString("status").let { BehandlingStatus.valueOf(it) },
-        oppgaveStatus = rs.getString("oppgave_status")?.let { OppgaveStatus.valueOf(it) },
         opphoerAarsaker = rs.getString("opphoer_aarsaker").let { objectMapper.readValue(it) },
         fritekstAarsak = rs.getString("fritekst_aarsak")
     )
@@ -233,8 +229,8 @@ class BehandlingDao(private val connection: () -> Connection) {
             connection().prepareStatement(
                 """
                 INSERT INTO behandling(id, sak_id, behandling_opprettet, sist_endret, status, behandlingstype, 
-                soekand_mottatt_dato, innsender, soeker, gjenlevende, avdoed, soesken, oppgave_status, virkningstidspunkt, kommer_barnet_tilgode)
-                 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                soekand_mottatt_dato, innsender, soeker, gjenlevende, avdoed, soesken, virkningstidspunkt, kommer_barnet_tilgode)
+                 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """.trimIndent()
             )
         with(foerstegangsbehandling) {
@@ -261,15 +257,11 @@ class BehandlingDao(private val connection: () -> Connection) {
                 stmt.setString(11, avdoed.toJson())
                 stmt.setString(12, soesken.toJson())
             }
-            stmt.setString(13, oppgaveStatus?.name)
             stmt.setString(
-                14,
-                foerstegangsbehandling.hentVirkningstidspunkt()?.toJson()
+                13,
+                foerstegangsbehandling.virkningstidspunkt?.toJson()
             )
-            stmt.setString(
-                15,
-                kommerBarnetTilgode?.toJson()
-            )
+            stmt.setString(14, kommerBarnetTilgode?.toJson())
         }
         stmt.executeUpdate()
     }
@@ -279,8 +271,8 @@ class BehandlingDao(private val connection: () -> Connection) {
             connection().prepareStatement(
                 """
                 INSERT INTO behandling(id, sak_id, behandling_opprettet, sist_endret, status, behandlingstype, 
-                 innsender, soeker, gjenlevende, avdoed, soesken, oppgave_status, revurdering_aarsak, kommer_barnet_tilgode)
-                 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 innsender, soeker, gjenlevende, avdoed, soesken, revurdering_aarsak, kommer_barnet_tilgode)
+                 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """.trimIndent()
             )
         with(revurdering) {
@@ -303,9 +295,8 @@ class BehandlingDao(private val connection: () -> Connection) {
                 stmt.setString(10, avdoed.toJson())
                 stmt.setString(11, soesken.toJson())
             }
-            stmt.setString(12, oppgaveStatus?.name)
-            stmt.setString(13, revurderingsaarsak.name)
-            stmt.setString(14, kommerBarnetTilgode?.let { objectMapper.writeValueAsString(it) })
+            stmt.setString(12, revurderingsaarsak.name)
+            stmt.setString(13, kommerBarnetTilgode?.let { objectMapper.writeValueAsString(it) })
         }
         require(stmt.executeUpdate() == 1)
     }
@@ -315,8 +306,8 @@ class BehandlingDao(private val connection: () -> Connection) {
             connection().prepareStatement(
                 """
                     INSERT INTO behandling(id, sak_id, behandling_opprettet, sist_endret, status, behandlingstype, 
-                    innsender, soeker, gjenlevende, avdoed, soesken, oppgave_status, opphoer_aarsaker, fritekst_aarsak)
-                    VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    innsender, soeker, gjenlevende, avdoed, soesken, opphoer_aarsaker, fritekst_aarsak)
+                    VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     RETURNING *
                 """.trimIndent()
             )
@@ -340,9 +331,8 @@ class BehandlingDao(private val connection: () -> Connection) {
                 stmt.setString(10, avdoed.toJson())
                 stmt.setString(11, soesken.toJson())
             }
-            stmt.setString(12, oppgaveStatus?.name)
-            stmt.setString(13, opphoerAarsaker.toJson())
-            stmt.setString(14, fritekstAarsak)
+            stmt.setString(12, opphoerAarsaker.toJson())
+            stmt.setString(13, fritekstAarsak)
         }
         return stmt.executeQuery().singleOrNull {
             behandlingAvRettType() as ManueltOpphoer
@@ -354,17 +344,16 @@ class BehandlingDao(private val connection: () -> Connection) {
         val stmt =
             connection().prepareStatement(
                 "UPDATE behandling " +
-                    "SET gyldighetssproving = ?, status = ?, oppgave_status = ?, sist_endret = ? " +
+                    "SET gyldighetssproving = ?, status = ?, sist_endret = ? " +
                     "WHERE id = ?"
             )
         stmt.setObject(1, objectMapper.writeValueAsString(behandling.gyldighetsproeving))
         stmt.setString(2, behandling.status.name)
-        stmt.setString(3, behandling.oppgaveStatus?.name)
         stmt.setTimestamp(
-            4,
+            3,
             Timestamp.from(behandling.sistEndret.atZone(ZoneId.systemDefault()).toInstant())
         )
-        stmt.setObject(5, behandling.id)
+        stmt.setObject(4, behandling.id)
         require(stmt.executeUpdate() == 1)
     }
 
@@ -379,7 +368,7 @@ class BehandlingDao(private val connection: () -> Connection) {
         lagreStatus(lagretBehandling.id, lagretBehandling.status, lagretBehandling.sistEndret)
     }
 
-    private fun lagreStatus(behandling: UUID, status: BehandlingStatus, sistEndret: LocalDateTime): Behandling {
+    fun lagreStatus(behandling: UUID, status: BehandlingStatus, sistEndret: LocalDateTime): Behandling {
         val stmt =
             connection().prepareStatement("UPDATE behandling SET status = ?, sist_endret = ? WHERE id = ? RETURNING *")
         stmt.setString(1, status.name)
@@ -395,44 +384,7 @@ class BehandlingDao(private val connection: () -> Connection) {
         )
     }
 
-    // TODO ai: Brukes kun i test
-    fun lagreOppgaveStatus(behandling: Behandling) {
-        val stmt =
-            connection().prepareStatement("UPDATE behandling SET oppgave_status = ?, sist_endret = ? WHERE id = ?")
-        stmt.setString(1, behandling.oppgaveStatus?.name)
-        stmt.setTimestamp(
-            2,
-            Timestamp.from(behandling.sistEndret.atZone(ZoneId.systemDefault()).toInstant())
-        )
-        stmt.setObject(3, behandling.id)
-        require(stmt.executeUpdate() == 1)
-    }
-
-    fun lagreStatusOgOppgaveStatus(
-        behandling: UUID,
-        behandlingStatus: BehandlingStatus,
-        oppgaveStatus: OppgaveStatus?,
-        sistEndret: LocalDateTime
-    ): Behandling {
-        val stmt =
-            connection().prepareStatement(
-                "UPDATE behandling SET status = ?, oppgave_status = ?, sist_endret = ? WHERE id = ? RETURNING *"
-            )
-        stmt.setString(1, behandlingStatus.name)
-        stmt.setString(2, oppgaveStatus?.name)
-        stmt.setTimestamp(
-            3,
-            Timestamp.from(sistEndret.atZone(ZoneId.systemDefault()).toInstant())
-        )
-        stmt.setObject(4, behandling)
-        return requireNotNull(
-            stmt.executeQuery().singleOrNull {
-                behandlingAvRettType()
-            }
-        )
-    }
-
-    fun ResultSet.behandlingsListe(): List<Behandling> =
+    private fun ResultSet.behandlingsListe(): List<Behandling> =
         toList {
             when (getString("behandlingstype")) {
                 BehandlingType.FØRSTEGANGSBEHANDLING.name -> asFoerstegangsbehandling(this)
@@ -458,10 +410,9 @@ class BehandlingDao(private val connection: () -> Connection) {
     }
 
     fun avbrytBehandling(behandlingId: UUID): Behandling {
-        return this.lagreStatusOgOppgaveStatus(
+        return this.lagreStatus(
             behandling = behandlingId,
-            behandlingStatus = BehandlingStatus.AVBRUTT,
-            oppgaveStatus = OppgaveStatus.LUKKET,
+            status = BehandlingStatus.AVBRUTT,
             sistEndret = LocalDateTime.now()
         )
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -155,23 +155,41 @@ fun Route.behandlingRoutes(
                 }
             }
 
-            post("/vilkaarsvurder") {
+            get("/vilkaarsvurder") {
                 foerstegangsbehandlingService.settVilkaarsvurdert(behandlingsId)
                 call.respond(HttpStatusCode.OK)
             }
-
-            post("/fatteVedtak") {
-                foerstegangsbehandlingService.settFattetVedtak(behandlingsId)
+            post("/vilkaarsvurder") {
+                foerstegangsbehandlingService.settVilkaarsvurdert(behandlingsId, false)
                 call.respond(HttpStatusCode.OK)
             }
 
-            post("/returner") {
+            get("/fatteVedtak") {
+                foerstegangsbehandlingService.settFattetVedtak(behandlingsId)
+                call.respond(HttpStatusCode.OK)
+            }
+            post("/fatteVedtak") {
+                foerstegangsbehandlingService.settFattetVedtak(behandlingsId, false)
+                call.respond(HttpStatusCode.OK)
+            }
+
+            get("/returner") {
                 foerstegangsbehandlingService.settReturnert(behandlingsId)
                 call.respond(HttpStatusCode.OK)
             }
 
-            post("/iverksett") {
+            post("/returner") {
+                foerstegangsbehandlingService.settReturnert(behandlingsId, false)
+                call.respond(HttpStatusCode.OK)
+            }
+
+            get("/iverksett") {
                 foerstegangsbehandlingService.settIverksatt(behandlingsId)
+                call.respond(HttpStatusCode.OK)
+            }
+
+            post("/iverksett") {
+                foerstegangsbehandlingService.settIverksatt(behandlingsId, false)
                 call.respond(HttpStatusCode.OK)
             }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/GenerellBehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/GenerellBehandlingService.kt
@@ -3,6 +3,9 @@ package no.nav.etterlatte.behandling
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.foerstegangsbehandling.FoerstegangsbehandlingFactory
+import no.nav.etterlatte.behandling.hendelse.HendelseDao
+import no.nav.etterlatte.behandling.hendelse.HendelseType
+import no.nav.etterlatte.behandling.hendelse.LagretHendelse
 import no.nav.etterlatte.behandling.manueltopphoer.ManueltOpphoerService
 import no.nav.etterlatte.behandling.revurdering.RevurderingFactory
 import no.nav.etterlatte.inTransaction

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingAggregat.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingAggregat.kt
@@ -8,7 +8,6 @@ import no.nav.etterlatte.behandling.hendelse.registrerVedtakHendelseFelles
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.KommerBarnetTilgode
-import no.nav.etterlatte.libs.common.behandling.OppgaveStatus
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -18,8 +17,6 @@ import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
 import java.time.YearMonth
 import java.util.*
-
-class AvbruttBehandlingException(message: String) : RuntimeException(message)
 
 class FoerstegangsbehandlingAggregat(
     id: UUID,
@@ -46,7 +43,6 @@ class FoerstegangsbehandlingAggregat(
                 soeknadMottattDato = LocalDateTime.parse(mottattDato),
                 persongalleri = persongalleri,
                 gyldighetsproeving = null,
-                oppgaveStatus = OppgaveStatus.NY,
                 virkningstidspunkt = null,
                 kommerBarnetTilgode = null
             )
@@ -63,44 +59,24 @@ class FoerstegangsbehandlingAggregat(
         requireNotNull(behandlinger.hentBehandling(id, BehandlingType.FØRSTEGANGSBEHANDLING) as Foerstegangsbehandling)
 
     fun lagreGyldighetprøving(gyldighetsproeving: GyldighetsResultat) {
-        try {
-            lagretBehandling.oppdaterGyldighetsproeving(gyldighetsproeving).let {
+        lagretBehandling = lagretBehandling.oppdaterGyldighetsproeving(gyldighetsproeving)
+            .also {
                 behandlinger.lagreGyldighetsproving(it)
                 logger.info("behandling ${it.id} i sak ${it.sak} er gyldighetsprøvd")
             }
-        } catch (_: Exception) {
-            throw AvbruttBehandlingException(
-                "Det tillates ikke å gyldighetsprøve Behandling med id ${lagretBehandling.id} " +
-                    "og status: ${lagretBehandling.status}"
-            )
-        }
     }
 
     fun lagreVirkningstidspunkt(yearMonth: YearMonth, ident: String): Virkningstidspunkt {
-        try {
-            return lagretBehandling.oppdaterVirkningstidspunkt(
-                yearMonth,
-                Grunnlagsopplysning.Saksbehandler.create(ident)
-            )
-                .let {
-                    behandlinger.lagreNyttVirkningstidspunkt(it.id, it.virkningstidspunkt!!)
-                    it.virkningstidspunkt
-                }
-        } catch (_: Exception) {
-            // TODO ai: fiks
-            TODO()
-        }
+        lagretBehandling =
+            lagretBehandling.oppdaterVirkningstidspunkt(yearMonth, Grunnlagsopplysning.Saksbehandler.create(ident))
+                .also { behandlinger.lagreNyttVirkningstidspunkt(it.id, it.virkningstidspunkt!!) }
+
+        return lagretBehandling.virkningstidspunkt!!
     }
 
-    // Flytt fra service til aggregat
     fun lagreKommerBarnetTilgode(kommerBarnetTilgode: KommerBarnetTilgode) {
-        try {
-            lagretBehandling
-                .oppdaterKommerBarnetTilgode(kommerBarnetTilgode)
-                .let { behandlinger.lagreKommerBarnetTilgode(it.id, kommerBarnetTilgode) }
-        } catch (_: Exception) {
-            TODO()
-        }
+        lagretBehandling = lagretBehandling.oppdaterKommerBarnetTilgode(kommerBarnetTilgode)
+            .also { behandlinger.lagreKommerBarnetTilgode(it.id, kommerBarnetTilgode) }
     }
 
     fun serialiserbarUtgave() = lagretBehandling.copy()

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingFactory.kt
@@ -1,7 +1,7 @@
 package no.nav.etterlatte.behandling.foerstegangsbehandling
 
 import no.nav.etterlatte.behandling.BehandlingDao
-import no.nav.etterlatte.behandling.HendelseDao
+import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import java.util.*
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
@@ -26,6 +26,7 @@ interface FoerstegangsbehandlingService {
     fun lagreVirkningstidspunkt(behandlingId: UUID, dato: YearMonth, ident: String): Virkningstidspunkt
     fun lagreKommerBarnetTilgode(behandlingId: UUID, kommerBarnetTilgode: KommerBarnetTilgode)
     fun settVilkaarsvurdert(behandlingId: UUID)
+    fun settBeregnet(behandlingId: UUID)
     fun settFattetVedtak(behandlingId: UUID)
     fun settAttestert(behandlingId: UUID)
     fun settReturnert(behandlingId: UUID)
@@ -85,44 +86,33 @@ class RealFoerstegangsbehandlingService(
     }
 
     override fun settVilkaarsvurdert(behandlingId: UUID) {
-        hentFoerstegangsbehandling(behandlingId)
-            .tilVilkaarsvurdering()
-            .let { lagreNyBehandlingStatus(it) }
+        lagreNyBehandlingStatus(hentFoerstegangsbehandling(behandlingId).tilVilkaarsvurdert())
+    }
+
+    override fun settBeregnet(behandlingId: UUID) {
+        lagreNyBehandlingStatus(hentFoerstegangsbehandling(behandlingId).tilBeregnet())
     }
 
     override fun settFattetVedtak(behandlingId: UUID) {
-        hentFoerstegangsbehandling(behandlingId)
-            .tilFattetVedtak()
-            .let { lagreNyBehandlingStatus(it) }
+        lagreNyBehandlingStatus(hentFoerstegangsbehandling(behandlingId).tilFattetVedtak())
     }
 
     override fun settAttestert(behandlingId: UUID) {
-        hentFoerstegangsbehandling(behandlingId)
-            .tilAttestert()
-            .let { lagreNyBehandlingStatus(it) }
+        lagreNyBehandlingStatus(hentFoerstegangsbehandling(behandlingId).tilAttestert())
     }
 
     override fun settReturnert(behandlingId: UUID) {
-        hentFoerstegangsbehandling(behandlingId)
-            .tilReturnert()
-            .let { lagreNyBehandlingStatus(it) }
+        lagreNyBehandlingStatus(hentFoerstegangsbehandling(behandlingId).tilReturnert())
     }
 
     override fun settIverksatt(behandlingId: UUID) {
-        hentFoerstegangsbehandling(behandlingId)
-            .tilIverksatt()
-            .let { lagreNyBehandlingStatus(it) }
+        lagreNyBehandlingStatus(hentFoerstegangsbehandling(behandlingId).tilIverksatt())
     }
 
     private fun lagreNyBehandlingStatus(behandling: Foerstegangsbehandling) {
         inTransaction {
             behandling.let {
-                behandlinger.lagreStatusOgOppgaveStatus(
-                    it.id,
-                    it.status,
-                    it.oppgaveStatus,
-                    it.sistEndret
-                )
+                behandlinger.lagreStatus(it.id, it.status, it.sistEndret)
             }
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
@@ -25,12 +25,12 @@ interface FoerstegangsbehandlingService {
     fun lagreGyldighetsprøving(behandling: UUID, gyldighetsproeving: GyldighetsResultat)
     fun lagreVirkningstidspunkt(behandlingId: UUID, dato: YearMonth, ident: String): Virkningstidspunkt
     fun lagreKommerBarnetTilgode(behandlingId: UUID, kommerBarnetTilgode: KommerBarnetTilgode)
-    fun settVilkaarsvurdert(behandlingId: UUID)
-    fun settBeregnet(behandlingId: UUID)
-    fun settFattetVedtak(behandlingId: UUID)
-    fun settAttestert(behandlingId: UUID)
-    fun settReturnert(behandlingId: UUID)
-    fun settIverksatt(behandlingId: UUID)
+    fun settVilkaarsvurdert(behandlingId: UUID, dryRun: Boolean = true)
+    fun settBeregnet(behandlingId: UUID, dryRun: Boolean = true)
+    fun settFattetVedtak(behandlingId: UUID, dryRun: Boolean = true)
+    fun settAttestert(behandlingId: UUID, dryRun: Boolean = true)
+    fun settReturnert(behandlingId: UUID, dryRun: Boolean = true)
+    fun settIverksatt(behandlingId: UUID, dryRun: Boolean = true)
 }
 
 class RealFoerstegangsbehandlingService(
@@ -85,28 +85,34 @@ class RealFoerstegangsbehandlingService(
         }
     }
 
-    override fun settVilkaarsvurdert(behandlingId: UUID) {
-        lagreNyBehandlingStatus(hentFoerstegangsbehandling(behandlingId).tilVilkaarsvurdert())
+    override fun settVilkaarsvurdert(behandlingId: UUID, dryRun: Boolean) {
+        hentFoerstegangsbehandling(behandlingId).tilVilkaarsvurdert().lagreEndring(dryRun)
     }
 
-    override fun settBeregnet(behandlingId: UUID) {
-        lagreNyBehandlingStatus(hentFoerstegangsbehandling(behandlingId).tilBeregnet())
+    override fun settBeregnet(behandlingId: UUID, dryRun: Boolean) {
+        hentFoerstegangsbehandling(behandlingId).tilBeregnet().lagreEndring(dryRun)
     }
 
-    override fun settFattetVedtak(behandlingId: UUID) {
-        lagreNyBehandlingStatus(hentFoerstegangsbehandling(behandlingId).tilFattetVedtak())
+    override fun settFattetVedtak(behandlingId: UUID, dryRun: Boolean) {
+        hentFoerstegangsbehandling(behandlingId).tilFattetVedtak().lagreEndring(dryRun)
     }
 
-    override fun settAttestert(behandlingId: UUID) {
-        lagreNyBehandlingStatus(hentFoerstegangsbehandling(behandlingId).tilAttestert())
+    override fun settAttestert(behandlingId: UUID, dryRun: Boolean) {
+        hentFoerstegangsbehandling(behandlingId).tilAttestert().lagreEndring(dryRun)
     }
 
-    override fun settReturnert(behandlingId: UUID) {
-        lagreNyBehandlingStatus(hentFoerstegangsbehandling(behandlingId).tilReturnert())
+    override fun settReturnert(behandlingId: UUID, dryRun: Boolean) {
+        hentFoerstegangsbehandling(behandlingId).tilReturnert().lagreEndring(dryRun)
     }
 
-    override fun settIverksatt(behandlingId: UUID) {
-        lagreNyBehandlingStatus(hentFoerstegangsbehandling(behandlingId).tilIverksatt())
+    override fun settIverksatt(behandlingId: UUID, dryRun: Boolean) {
+        hentFoerstegangsbehandling(behandlingId).tilIverksatt().lagreEndring(dryRun)
+    }
+
+    private fun Foerstegangsbehandling.lagreEndring(dryRun: Boolean) {
+        if (dryRun) return
+
+        lagreNyBehandlingStatus(this)
     }
 
     private fun lagreNyBehandlingStatus(behandling: Foerstegangsbehandling) {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
@@ -5,24 +5,17 @@ import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.BehandlingDao
 import no.nav.etterlatte.behandling.BehandlingHendelseType
 import no.nav.etterlatte.behandling.Foerstegangsbehandling
-import no.nav.etterlatte.behandling.ManueltOpphoer
-import no.nav.etterlatte.behandling.Revurdering
 import no.nav.etterlatte.inTransaction
-import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.KommerBarnetTilgode
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
-import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.gyldigSoeknad.GyldighetsResultat
 import org.slf4j.LoggerFactory
-import java.time.Instant
 import java.time.YearMonth
 import java.util.*
 
 interface FoerstegangsbehandlingService {
-    fun hentBehandling(behandling: UUID): Foerstegangsbehandling?
-    fun hentFoerstegangsbehandling(behandling: UUID): Foerstegangsbehandling
-    fun hentFoerstegangsbehandlinger(): List<Foerstegangsbehandling>
+    fun hentFoerstegangsbehandling(behandling: UUID): Foerstegangsbehandling?
     fun startFoerstegangsbehandling(
         sak: Long,
         persongalleri: Persongalleri,
@@ -30,8 +23,13 @@ interface FoerstegangsbehandlingService {
     ): Foerstegangsbehandling
 
     fun lagreGyldighetsprøving(behandling: UUID, gyldighetsproeving: GyldighetsResultat)
-    fun fastsettVirkningstidspunkt(behandlingId: UUID, dato: YearMonth, ident: String): Virkningstidspunkt
-    fun settKommerBarnetTilgode(behandlingId: UUID, kommerBarnetTilgode: KommerBarnetTilgode)
+    fun lagreVirkningstidspunkt(behandlingId: UUID, dato: YearMonth, ident: String): Virkningstidspunkt
+    fun lagreKommerBarnetTilgode(behandlingId: UUID, kommerBarnetTilgode: KommerBarnetTilgode)
+    fun settVilkaarsvurdert(behandlingId: UUID)
+    fun settFattetVedtak(behandlingId: UUID)
+    fun settAttestert(behandlingId: UUID)
+    fun settReturnert(behandlingId: UUID)
+    fun settIverksatt(behandlingId: UUID)
 }
 
 class RealFoerstegangsbehandlingService(
@@ -41,22 +39,9 @@ class RealFoerstegangsbehandlingService(
 ) : FoerstegangsbehandlingService {
     private val logger = LoggerFactory.getLogger(RealFoerstegangsbehandlingService::class.java)
 
-    override fun hentBehandling(behandling: UUID): Foerstegangsbehandling {
-        return inTransaction {
-            foerstegangsbehandlingFactory.hentFoerstegangsbehandling(behandling).serialiserbarUtgave()
-        }
-    }
-
     override fun hentFoerstegangsbehandling(behandling: UUID): Foerstegangsbehandling {
         return inTransaction {
             foerstegangsbehandlingFactory.hentFoerstegangsbehandling(behandling).serialiserbarUtgave()
-        }
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    override fun hentFoerstegangsbehandlinger(): List<Foerstegangsbehandling> {
-        return inTransaction {
-            behandlinger.alleBehandlingerAvType(BehandlingType.FØRSTEGANGSBEHANDLING) as List<Foerstegangsbehandling>
         }
     }
 
@@ -86,64 +71,59 @@ class RealFoerstegangsbehandlingService(
         }
     }
 
-    override fun fastsettVirkningstidspunkt(behandlingId: UUID, dato: YearMonth, ident: String): Virkningstidspunkt {
-        val behandling = inTransaction {
-            behandlinger.hentBehandling(behandlingId) ?: throw RuntimeException("Fant ikke behandling")
-        }
-
-        when (behandling) {
-            is Foerstegangsbehandling -> {
-                val oppdatertBehandling =
-                    behandling.oppdaterVirkningstidspunkt(dato, Grunnlagsopplysning.Saksbehandler(ident, Instant.now()))
-                val virkningstidspunkt = oppdatertBehandling.virkningstidspunkt!!
-
-                inTransaction {
-                    behandlinger.lagreNyttVirkningstidspunkt(
-                        behandling.id,
-                        virkningstidspunkt
-                    )
-                }
-
-                return virkningstidspunkt
-            }
-
-            is ManueltOpphoer -> throw RuntimeException(
-                "Kan ikke fastsette virkningstidspunkt for ${ManueltOpphoer::class.java.simpleName}"
-            ) // TODO ai: Hvordan håndtere error cases?
-            is Revurdering -> throw RuntimeException(
-                "Kan ikke fastsette virkningstidspunkt for ${Revurdering::class.java.simpleName}"
-            )
+    override fun lagreVirkningstidspunkt(behandlingId: UUID, dato: YearMonth, ident: String): Virkningstidspunkt {
+        return inTransaction {
+            foerstegangsbehandlingFactory.hentFoerstegangsbehandling(behandlingId).lagreVirkningstidspunkt(dato, ident)
         }
     }
 
-    override fun settKommerBarnetTilgode(behandlingId: UUID, kommerBarnetTilgode: KommerBarnetTilgode) {
-        val behandling = inTransaction {
-            behandlinger.hentBehandling(behandlingId)
-                ?: throw RuntimeException(
-                    "Kunne ikke sette kommer barnet til gode. Fant ikke behandling med id $behandlingId"
-                )
+    override fun lagreKommerBarnetTilgode(behandlingId: UUID, kommerBarnetTilgode: KommerBarnetTilgode) {
+        return inTransaction {
+            foerstegangsbehandlingFactory.hentFoerstegangsbehandling(behandlingId)
+                .lagreKommerBarnetTilgode(kommerBarnetTilgode)
         }
+    }
 
-        when (behandling) {
-            is Foerstegangsbehandling -> {
-                val oppdatertBehandling =
-                    behandling.oppdaterKommerBarnetTilgode(kommerBarnetTilgode)
+    override fun settVilkaarsvurdert(behandlingId: UUID) {
+        hentFoerstegangsbehandling(behandlingId)
+            .tilVilkaarsvurdering()
+            .let { lagreNyBehandlingStatus(it) }
+    }
 
-                inTransaction {
-                    behandlinger.lagreKommerBarnetTilgode(
-                        behandlingId,
-                        oppdatertBehandling.kommerBarnetTilgode!!
-                    )
-                }
+    override fun settFattetVedtak(behandlingId: UUID) {
+        hentFoerstegangsbehandling(behandlingId)
+            .tilFattetVedtak()
+            .let { lagreNyBehandlingStatus(it) }
+    }
+
+    override fun settAttestert(behandlingId: UUID) {
+        hentFoerstegangsbehandling(behandlingId)
+            .tilAttestert()
+            .let { lagreNyBehandlingStatus(it) }
+    }
+
+    override fun settReturnert(behandlingId: UUID) {
+        hentFoerstegangsbehandling(behandlingId)
+            .tilReturnert()
+            .let { lagreNyBehandlingStatus(it) }
+    }
+
+    override fun settIverksatt(behandlingId: UUID) {
+        hentFoerstegangsbehandling(behandlingId)
+            .tilIverksatt()
+            .let { lagreNyBehandlingStatus(it) }
+    }
+
+    private fun lagreNyBehandlingStatus(behandling: Foerstegangsbehandling) {
+        inTransaction {
+            behandling.let {
+                behandlinger.lagreStatusOgOppgaveStatus(
+                    it.id,
+                    it.status,
+                    it.oppgaveStatus,
+                    it.sistEndret
+                )
             }
-
-            is ManueltOpphoer -> throw RuntimeException(
-                "Kan ikke endre kommer barnet til gode for ${ManueltOpphoer::class.java.simpleName}"
-            )
-
-            is Revurdering -> throw RuntimeException(
-                "Kan ikke endre kommer barnet til gode for ${Revurdering::class.java.simpleName}"
-            )
         }
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/HendelseDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/HendelseDao.kt
@@ -1,5 +1,6 @@
-package no.nav.etterlatte.behandling
+package no.nav.etterlatte.behandling.hendelse
 
+import no.nav.etterlatte.behandling.Behandling
 import no.nav.etterlatte.database.toList
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
@@ -99,7 +100,7 @@ class HendelseDao(private val connection: () -> Connection) {
         }
     }
 
-    fun lagreHendelse(hendelse: UlagretHendelse) {
+    private fun lagreHendelse(hendelse: UlagretHendelse) {
         val stmt = connection().prepareStatement(
             """
             |INSERT INTO behandlinghendelse(hendelse, inntruffet, vedtakid, behandlingid, sakid, ident, identtype, kommentar, valgtbegrunnelse) 
@@ -131,29 +132,3 @@ fun PreparedStatement.setLong(index: Int, value: Long?) =
 fun ResultSet.getTidspunkt(name: String) = getTimestamp(name)?.toInstant()?.toTidspunkt()
 fun ResultSet.getUUID(name: String) = getObject(name) as UUID
 fun ResultSet.getLongOrNull(name: String) = getLong(name).takeIf { !wasNull() }
-
-data class LagretHendelse(
-    val id: Long,
-    val hendelse: String,
-    val opprettet: Tidspunkt,
-    val inntruffet: Tidspunkt?,
-    val vedtakId: Long?,
-    val behandlingId: UUID,
-    val sakId: Long,
-    val ident: String?,
-    val identType: String?,
-    val kommentar: String?,
-    val valgtBegrunnelse: String?
-)
-
-data class UlagretHendelse(
-    val hendelse: String,
-    val inntruffet: Tidspunkt?,
-    val vedtakId: Long?,
-    val behandlingId: UUID,
-    val sakId: Long,
-    val ident: String?,
-    val identType: String?,
-    val kommentar: String?,
-    val valgtBegrunnelse: String?
-)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/HendelseType.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/HendelseType.kt
@@ -1,5 +1,10 @@
 package no.nav.etterlatte.behandling.hendelse
 
 enum class HendelseType {
-    FATTET, ATTESTERT, UNDERKJENT, VILKAARSVURDERT, BEREGNET, AVKORTET, IVERKSATT
+    VILKAARSVURDERT,
+    BEREGNET,
+    FATTET,
+    ATTESTERT,
+    UNDERKJENT,
+    IVERKSATT
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/HendelseType.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/HendelseType.kt
@@ -1,0 +1,5 @@
+package no.nav.etterlatte.behandling.hendelse
+
+enum class HendelseType {
+    FATTET, ATTESTERT, UNDERKJENT, VILKAARSVURDERT, BEREGNET, AVKORTET, IVERKSATT
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/LagretHendelse.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/LagretHendelse.kt
@@ -1,0 +1,18 @@
+package no.nav.etterlatte.behandling.hendelse
+
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import java.util.*
+
+data class LagretHendelse(
+    val id: Long,
+    val hendelse: String,
+    val opprettet: Tidspunkt,
+    val inntruffet: Tidspunkt?,
+    val vedtakId: Long?,
+    val behandlingId: UUID,
+    val sakId: Long,
+    val ident: String?,
+    val identType: String?,
+    val kommentar: String?,
+    val valgtBegrunnelse: String?
+)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/UlagretHendelse.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/UlagretHendelse.kt
@@ -1,0 +1,16 @@
+package no.nav.etterlatte.behandling.hendelse
+
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import java.util.*
+
+data class UlagretHendelse(
+    val hendelse: String,
+    val inntruffet: Tidspunkt?,
+    val vedtakId: Long?,
+    val behandlingId: UUID,
+    val sakId: Long,
+    val ident: String?,
+    val identType: String?,
+    val kommentar: String?,
+    val valgtBegrunnelse: String?
+)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/VedtakHendelseHelper.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/VedtakHendelseHelper.kt
@@ -1,5 +1,7 @@
-package no.nav.etterlatte.behandling
+package no.nav.etterlatte.behandling.hendelse
 
+import no.nav.etterlatte.behandling.Behandling
+import no.nav.etterlatte.behandling.BehandlingDao
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.OppgaveStatus
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -22,7 +24,7 @@ fun HendelseType.tilBehandlingStatus(behandling: Behandling) = when (this) {
         if (behandling.behandlingKanIkkeSettesUnderBehandling()) {
             behandling.status
         } else {
-            BehandlingStatus.UNDER_BEHANDLING
+            BehandlingStatus.VILKAARSVURDERING
         }
     }
     HendelseType.IVERKSATT -> BehandlingStatus.IVERKSATT

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/manueltopphoer/ManueltOpphoerService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/manueltopphoer/ManueltOpphoerService.kt
@@ -6,16 +6,17 @@ import no.nav.etterlatte.behandling.Behandling
 import no.nav.etterlatte.behandling.BehandlingDao
 import no.nav.etterlatte.behandling.BehandlingHendelseType
 import no.nav.etterlatte.behandling.Foerstegangsbehandling
-import no.nav.etterlatte.behandling.HendelseDao
-import no.nav.etterlatte.behandling.HendelseType
 import no.nav.etterlatte.behandling.ManueltOpphoer
 import no.nav.etterlatte.behandling.Revurdering
-import no.nav.etterlatte.behandling.registrerVedtakHendelseFelles
+import no.nav.etterlatte.behandling.hendelse.HendelseDao
+import no.nav.etterlatte.behandling.hendelse.HendelseType
+import no.nav.etterlatte.behandling.hendelse.registrerVedtakHendelseFelles
 import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.ManueltOpphoerRequest
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.*
 
@@ -43,7 +44,7 @@ class RealManueltOpphoerService(
     private val behandlingHendelser: SendChannel<Pair<UUID, BehandlingHendelseType>>,
     private val hendelser: HendelseDao
 ) : ManueltOpphoerService {
-    val logger = LoggerFactory.getLogger(this::class.java)
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     override fun hentManueltOpphoer(behandling: UUID): ManueltOpphoer? =
         behandlinger.hentBehandling(behandling, BehandlingType.MANUELT_OPPHOER) as ManueltOpphoer?
@@ -123,7 +124,7 @@ class RealManueltOpphoerService(
         }
     }
 
-    fun List<Behandling>.`siste ikke-avbrutte behandling`() =
+    private fun List<Behandling>.`siste ikke-avbrutte behandling`() =
         this.sortedByDescending { it.behandlingOpprettet }
             .firstOrNull { it.status in BehandlingStatus.ikkeAvbrutt() }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingAggregat.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingAggregat.kt
@@ -1,11 +1,11 @@
 package no.nav.etterlatte.behandling.revurdering
 
 import no.nav.etterlatte.behandling.BehandlingDao
-import no.nav.etterlatte.behandling.HendelseDao
-import no.nav.etterlatte.behandling.HendelseType
 import no.nav.etterlatte.behandling.Revurdering
 import no.nav.etterlatte.behandling.foerstegangsbehandling.FoerstegangsbehandlingAggregat
-import no.nav.etterlatte.behandling.registrerVedtakHendelseFelles
+import no.nav.etterlatte.behandling.hendelse.HendelseDao
+import no.nav.etterlatte.behandling.hendelse.HendelseType
+import no.nav.etterlatte.behandling.hendelse.registrerVedtakHendelseFelles
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.OppgaveStatus
@@ -38,7 +38,6 @@ class RevurderingAggregat(
                 behandlingOpprettet = LocalDateTime.now(),
                 sistEndret = LocalDateTime.now(),
                 status = BehandlingStatus.OPPRETTET,
-                type = BehandlingType.REVURDERING,
                 persongalleri = persongalleri,
                 oppgaveStatus = OppgaveStatus.NY,
                 revurderingsaarsak = revurderingAarsak,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingAggregat.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingAggregat.kt
@@ -8,7 +8,6 @@ import no.nav.etterlatte.behandling.hendelse.HendelseType
 import no.nav.etterlatte.behandling.hendelse.registrerVedtakHendelseFelles
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
-import no.nav.etterlatte.libs.common.behandling.OppgaveStatus
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -39,7 +38,6 @@ class RevurderingAggregat(
                 sistEndret = LocalDateTime.now(),
                 status = BehandlingStatus.OPPRETTET,
                 persongalleri = persongalleri,
-                oppgaveStatus = OppgaveStatus.NY,
                 revurderingsaarsak = revurderingAarsak,
                 kommerBarnetTilgode = null
             )

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingFactory.kt
@@ -1,7 +1,7 @@
 package no.nav.etterlatte.behandling.revurdering
 
 import no.nav.etterlatte.behandling.BehandlingDao
-import no.nav.etterlatte.behandling.HendelseDao
+import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import java.util.*

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDao.kt
@@ -34,7 +34,7 @@ class OppgaveDao(private val datasource: DataSource) {
         val aktuelleStatuser = roller.flatMap {
             when (it) {
                 Rolle.SAKSBEHANDLER -> listOf(
-                    BehandlingStatus.UNDER_BEHANDLING,
+                    BehandlingStatus.VILKAARSVURDERING,
                     BehandlingStatus.GYLDIG_SOEKNAD,
                     BehandlingStatus.RETURNERT
                 )

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V13__remove_oppgave_status.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V13__remove_oppgave_status.sql
@@ -1,0 +1,1 @@
+ALTER TABLE behandling DROP COLUMN oppgave_status

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V14__migrer_behandlingsstatus.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V14__migrer_behandlingsstatus.sql
@@ -1,0 +1,3 @@
+UPDATE behandling
+SET status = 'OPPRETTET'
+where status in ('GYLDIG_SOEKNAD', 'IKKE_GYLDIG_SOEKNAD', 'UNDER_BEHANDLING')

--- a/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
@@ -4,7 +4,6 @@ import no.nav.etterlatte.behandling.Foerstegangsbehandling
 import no.nav.etterlatte.behandling.ManueltOpphoer
 import no.nav.etterlatte.behandling.Revurdering
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
-import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.GrunnlagsendringStatus
 import no.nav.etterlatte.libs.common.behandling.GrunnlagsendringsType
 import no.nav.etterlatte.libs.common.behandling.Grunnlagsendringshendelse
@@ -97,7 +96,6 @@ fun manueltOpphoer(
     sistEndret = LocalDateTime.now(),
     status = BehandlingStatus.OPPRETTET,
     oppgaveStatus = OppgaveStatus.NY,
-    type = BehandlingType.MANUELT_OPPHOER,
     persongalleri = persongalleri,
     opphoerAarsaker = opphoerAarsaker,
     fritekstAarsak = fritekstAarsak

--- a/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
@@ -10,7 +10,6 @@ import no.nav.etterlatte.libs.common.behandling.Grunnlagsendringshendelse
 import no.nav.etterlatte.libs.common.behandling.Grunnlagsinformasjon
 import no.nav.etterlatte.libs.common.behandling.KommerBarnetTilgode
 import no.nav.etterlatte.libs.common.behandling.ManueltOpphoerAarsak
-import no.nav.etterlatte.libs.common.behandling.OppgaveStatus
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
@@ -38,7 +37,6 @@ fun foerstegangsbehandling(
     behandlingOpprettet: LocalDateTime = LocalDateTime.now(),
     sistEndret: LocalDateTime = LocalDateTime.now(),
     status: BehandlingStatus = BehandlingStatus.OPPRETTET,
-    oppgaveStatus: OppgaveStatus = OppgaveStatus.NY,
     soeknadMottattDato: LocalDateTime = LocalDateTime.now(),
     persongalleri: Persongalleri = persongalleri(),
     gyldighetsproeving: GyldighetsResultat? = null,
@@ -50,7 +48,6 @@ fun foerstegangsbehandling(
     behandlingOpprettet = behandlingOpprettet,
     sistEndret = sistEndret,
     status = status,
-    oppgaveStatus = oppgaveStatus,
     soeknadMottattDato = soeknadMottattDato,
     persongalleri = persongalleri,
     gyldighetsproeving = gyldighetsproeving,
@@ -64,7 +61,6 @@ fun revurdering(
     behandlingOpprettet: LocalDateTime = LocalDateTime.now(),
     sistEndret: LocalDateTime = LocalDateTime.now(),
     status: BehandlingStatus = BehandlingStatus.OPPRETTET,
-    oppgaveStatus: OppgaveStatus = OppgaveStatus.NY,
     persongalleri: Persongalleri = persongalleri(),
     revurderingAarsak: RevurderingAarsak,
     kommerBarnetTilgode: KommerBarnetTilgode = kommerBarnetTilgode()
@@ -74,7 +70,6 @@ fun revurdering(
     behandlingOpprettet = behandlingOpprettet,
     sistEndret = sistEndret,
     status = status,
-    oppgaveStatus = oppgaveStatus,
     persongalleri = persongalleri,
     revurderingsaarsak = revurderingAarsak,
     kommerBarnetTilgode = kommerBarnetTilgode
@@ -95,7 +90,6 @@ fun manueltOpphoer(
     behandlingOpprettet = LocalDateTime.now(),
     sistEndret = LocalDateTime.now(),
     status = BehandlingStatus.OPPRETTET,
-    oppgaveStatus = OppgaveStatus.NY,
     persongalleri = persongalleri,
     opphoerAarsaker = opphoerAarsaker,
     fritekstAarsak = fritekstAarsak

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingTest.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.behandling
 
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.KommerBarnetTilgode
-import no.nav.etterlatte.libs.common.behandling.OppgaveStatus
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -25,7 +24,6 @@ internal class BehandlingTest {
         behandlingOpprettet = LocalDateTime.now(),
         sistEndret = LocalDateTime.now(),
         status = BehandlingStatus.OPPRETTET,
-        oppgaveStatus = OppgaveStatus.NY,
         persongalleri = Persongalleri(
             soeker = "",
             innsender = null,
@@ -50,11 +48,11 @@ internal class BehandlingTest {
         behandling.oppdaterKommerBarnetTilgode(kommerBarnetTilgode)
             .oppdaterVirkningstidspunkt(virkningstidspunkt.dato, virkningstidspunkt.kilde)
             .oppdaterGyldighetsproeving(gyldighetsResultat)
-            .tilVilkaarsvurdering()
+            .tilVilkaarsvurdert()
             .let {
                 assertEquals(kommerBarnetTilgode, it.kommerBarnetTilgode)
                 assertEquals(virkningstidspunkt, it.virkningstidspunkt)
-                assertEquals(BehandlingStatus.VILKAARSVURDERING, it.status)
+                assertEquals(BehandlingStatus.VILKAARSVURDERT, it.status)
             }
     }
 
@@ -63,7 +61,7 @@ internal class BehandlingTest {
         val behandlingTilAttestering = behandling.oppdaterKommerBarnetTilgode(kommerBarnetTilgode)
             .oppdaterVirkningstidspunkt(virkningstidspunkt.dato, virkningstidspunkt.kilde)
             .oppdaterGyldighetsproeving(gyldighetsResultat)
-            .tilVilkaarsvurdering()
+            .tilVilkaarsvurdert()
             .tilFattetVedtak()
 
         assertThrows<TilstandException.UgyldigtTilstand> {
@@ -76,7 +74,7 @@ internal class BehandlingTest {
         val iverksattBehandling = behandling.oppdaterKommerBarnetTilgode(kommerBarnetTilgode)
             .oppdaterVirkningstidspunkt(virkningstidspunkt.dato, virkningstidspunkt.kilde)
             .oppdaterGyldighetsproeving(gyldighetsResultat)
-            .tilVilkaarsvurdering()
+            .tilVilkaarsvurdert()
             .tilFattetVedtak()
             .tilAttestert()
             .tilIverksatt()
@@ -91,7 +89,7 @@ internal class BehandlingTest {
 
     @Test
     fun `behandling må være fylt ut for å settes til VILKAARSVURDERING`() {
-        assertThrows<TilstandException.IkkeFyltUt> { behandling.tilVilkaarsvurdering() }
+        assertThrows<TilstandException.IkkeFyltUt> { behandling.tilVilkaarsvurdert() }
     }
 
     @Test
@@ -104,7 +102,7 @@ internal class BehandlingTest {
         val returnertBehandling = behandling.oppdaterKommerBarnetTilgode(kommerBarnetTilgode)
             .oppdaterVirkningstidspunkt(virkningstidspunkt.dato, virkningstidspunkt.kilde)
             .oppdaterGyldighetsproeving(gyldighetsResultat)
-            .tilVilkaarsvurdering()
+            .tilVilkaarsvurdert()
             .tilFattetVedtak()
             .tilReturnert()
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingTest.kt
@@ -1,0 +1,119 @@
+package no.nav.etterlatte.behandling
+
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
+import no.nav.etterlatte.libs.common.behandling.KommerBarnetTilgode
+import no.nav.etterlatte.libs.common.behandling.OppgaveStatus
+import no.nav.etterlatte.libs.common.behandling.Persongalleri
+import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import no.nav.etterlatte.libs.common.gyldigSoeknad.GyldighetsResultat
+import no.nav.etterlatte.libs.common.gyldigSoeknad.VurderingsResultat
+import no.nav.etterlatte.libs.common.soeknad.dataklasser.common.JaNeiVetIkke
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+import java.time.YearMonth
+import java.util.*
+
+internal class BehandlingTest {
+
+    private val behandling = Foerstegangsbehandling(
+        id = UUID.randomUUID(),
+        sak = 1,
+        behandlingOpprettet = LocalDateTime.now(),
+        sistEndret = LocalDateTime.now(),
+        status = BehandlingStatus.OPPRETTET,
+        oppgaveStatus = OppgaveStatus.NY,
+        persongalleri = Persongalleri(
+            soeker = "",
+            innsender = null,
+            soesken = listOf(),
+            avdoed = listOf(),
+            gjenlevende = listOf()
+        ),
+        kommerBarnetTilgode = null,
+        virkningstidspunkt = null,
+        soeknadMottattDato = LocalDateTime.now(),
+        gyldighetsproeving = null
+    )
+
+    private val saksbehandler = Grunnlagsopplysning.Saksbehandler("saksbehandler01", Tidspunkt.now().instant)
+
+    private val kommerBarnetTilgode = KommerBarnetTilgode(JaNeiVetIkke.JA, "", saksbehandler)
+    private val virkningstidspunkt = Virkningstidspunkt(YearMonth.of(2021, 1), saksbehandler)
+    private val gyldighetsResultat = GyldighetsResultat(VurderingsResultat.OPPFYLT, listOf(), LocalDateTime.now())
+
+    @Test
+    fun `kan oppdatere behandling når den er OPPRETTET`() {
+        behandling.oppdaterKommerBarnetTilgode(kommerBarnetTilgode)
+            .oppdaterVirkningstidspunkt(virkningstidspunkt.dato, virkningstidspunkt.kilde)
+            .oppdaterGyldighetsproeving(gyldighetsResultat)
+            .tilVilkaarsvurdering()
+            .let {
+                assertEquals(kommerBarnetTilgode, it.kommerBarnetTilgode)
+                assertEquals(virkningstidspunkt, it.virkningstidspunkt)
+                assertEquals(BehandlingStatus.VILKAARSVURDERING, it.status)
+            }
+    }
+
+    @Test
+    fun `kan ikke oppdatere behandlingen når den er til attestering`() {
+        val behandlingTilAttestering = behandling.oppdaterKommerBarnetTilgode(kommerBarnetTilgode)
+            .oppdaterVirkningstidspunkt(virkningstidspunkt.dato, virkningstidspunkt.kilde)
+            .oppdaterGyldighetsproeving(gyldighetsResultat)
+            .tilVilkaarsvurdering()
+            .tilFattetVedtak()
+
+        assertThrows<TilstandException.UgyldigtTilstand> {
+            behandlingTilAttestering.oppdaterKommerBarnetTilgode(kommerBarnetTilgode)
+        }
+    }
+
+    @Test
+    fun `kan ikke oppdatere behandling når den er iverksatt`() {
+        val iverksattBehandling = behandling.oppdaterKommerBarnetTilgode(kommerBarnetTilgode)
+            .oppdaterVirkningstidspunkt(virkningstidspunkt.dato, virkningstidspunkt.kilde)
+            .oppdaterGyldighetsproeving(gyldighetsResultat)
+            .tilVilkaarsvurdering()
+            .tilFattetVedtak()
+            .tilAttestert()
+            .tilIverksatt()
+
+        assertThrows<TilstandException.UgyldigtTilstand> { iverksattBehandling.tilReturnert() }
+        assertThrows<TilstandException.UgyldigtTilstand> {
+            iverksattBehandling.oppdaterKommerBarnetTilgode(
+                kommerBarnetTilgode
+            )
+        }
+    }
+
+    @Test
+    fun `behandling må være fylt ut for å settes til VILKAARSVURDERING`() {
+        assertThrows<TilstandException.IkkeFyltUt> { behandling.tilVilkaarsvurdering() }
+    }
+
+    @Test
+    fun `behandling må være fylt ut for å settes til FATTET VEDTAK`() {
+        assertThrows<TilstandException.IkkeFyltUt> { behandling.tilFattetVedtak() }
+    }
+
+    @Test
+    fun `behandling kan endres igjen etter den har blitt returnet av attestant`() {
+        val returnertBehandling = behandling.oppdaterKommerBarnetTilgode(kommerBarnetTilgode)
+            .oppdaterVirkningstidspunkt(virkningstidspunkt.dato, virkningstidspunkt.kilde)
+            .oppdaterGyldighetsproeving(gyldighetsResultat)
+            .tilVilkaarsvurdering()
+            .tilFattetVedtak()
+            .tilReturnert()
+
+        val nyttVirkningstidspunkt = Virkningstidspunkt(YearMonth.of(2022, 2), saksbehandler)
+
+        returnertBehandling
+            .oppdaterVirkningstidspunkt(nyttVirkningstidspunkt.dato, nyttVirkningstidspunkt.kilde)
+            .let {
+                assertEquals(nyttVirkningstidspunkt, it.virkningstidspunkt)
+            }
+    }
+}

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealFoerstegangsbehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealFoerstegangsbehandlingServiceTest.kt
@@ -10,6 +10,7 @@ import no.nav.etterlatte.DatabaseKontekst
 import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.behandling.foerstegangsbehandling.FoerstegangsbehandlingFactory
 import no.nav.etterlatte.behandling.foerstegangsbehandling.RealFoerstegangsbehandlingService
+import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.OppgaveStatus
@@ -67,7 +68,6 @@ internal class RealFoerstegangsbehandlingServiceTest {
             behandlingOpprettet = LocalDateTime.now(),
             sistEndret = LocalDateTime.now(),
             status = BehandlingStatus.OPPRETTET,
-            type = BehandlingType.FØRSTEGANGSBEHANDLING,
             soeknadMottattDato = LocalDateTime.now(),
             persongalleri = Persongalleri(
                 soeker = "Ola Olsen",
@@ -104,7 +104,6 @@ internal class RealFoerstegangsbehandlingServiceTest {
             behandlingOpprettet = datoNaa,
             sistEndret = datoNaa,
             status = BehandlingStatus.OPPRETTET,
-            type = BehandlingType.FØRSTEGANGSBEHANDLING,
             soeknadMottattDato = LocalDateTime.now(),
             persongalleri = Persongalleri(
                 "Innsender",

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealFoerstegangsbehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealFoerstegangsbehandlingServiceTest.kt
@@ -13,7 +13,6 @@ import no.nav.etterlatte.behandling.foerstegangsbehandling.RealFoerstegangsbehan
 import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
-import no.nav.etterlatte.libs.common.behandling.OppgaveStatus
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -77,7 +76,6 @@ internal class RealFoerstegangsbehandlingServiceTest {
                 emptyList()
             ),
             gyldighetsproeving = null,
-            oppgaveStatus = OppgaveStatus.NY,
             virkningstidspunkt = Virkningstidspunkt(
                 YearMonth.of(2022, 1),
                 Grunnlagsopplysning.Saksbehandler("ident", Instant.now())
@@ -113,7 +111,6 @@ internal class RealFoerstegangsbehandlingServiceTest {
                 emptyList()
             ),
             gyldighetsproeving = null,
-            oppgaveStatus = OppgaveStatus.NY,
             virkningstidspunkt = Virkningstidspunkt(
                 YearMonth.of(2022, 1),
                 Grunnlagsopplysning.Saksbehandler("ident", Instant.now())

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealGenerellBehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealGenerellBehandlingServiceTest.kt
@@ -10,6 +10,7 @@ import no.nav.etterlatte.Context
 import no.nav.etterlatte.DatabaseKontekst
 import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.behandling.foerstegangsbehandling.FoerstegangsbehandlingFactory
+import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.behandling.manueltopphoer.ManueltOpphoerService
 import no.nav.etterlatte.behandling.revurdering.RevurderingFactory
 import no.nav.etterlatte.foerstegangsbehandling

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealManueltOpphoerServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealManueltOpphoerServiceTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.channels.SendChannel
 import no.nav.etterlatte.Context
 import no.nav.etterlatte.DatabaseKontekst
 import no.nav.etterlatte.Kontekst
+import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.behandling.manueltopphoer.RealManueltOpphoerService
 import no.nav.etterlatte.foerstegangsbehandling
 import no.nav.etterlatte.libs.common.behandling.BehandlingType

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealRevurderingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealRevurderingServiceTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.channels.SendChannel
 import no.nav.etterlatte.Context
 import no.nav.etterlatte.DatabaseKontekst
 import no.nav.etterlatte.Kontekst
+import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.behandling.revurdering.RealRevurderingService
 import no.nav.etterlatte.behandling.revurdering.RevurderingFactory
 import no.nav.etterlatte.foerstegangsbehandling

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
@@ -222,7 +222,7 @@ internal class GrunnlagsendringshendelseServiceTest {
         val generellBehandlingService = mockk<GenerellBehandlingService> {
             every { hentBehandlingerISak(sakId) } returns listOf(
                 mockk {
-                    every { status } returns BehandlingStatus.VILKAARSVURDERING
+                    every { status } returns BehandlingStatus.VILKAARSVURDERT
                     every { id } returns behandlingId
                     every { type } returns BehandlingType.FØRSTEGANGSBEHANDLING
                 }

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
@@ -222,7 +222,7 @@ internal class GrunnlagsendringshendelseServiceTest {
         val generellBehandlingService = mockk<GenerellBehandlingService> {
             every { hentBehandlingerISak(sakId) } returns listOf(
                 mockk {
-                    every { status } returns BehandlingStatus.UNDER_BEHANDLING
+                    every { status } returns BehandlingStatus.VILKAARSVURDERING
                     every { id } returns behandlingId
                     every { type } returns BehandlingType.FØRSTEGANGSBEHANDLING
                 }

--- a/apps/etterlatte-behandling/src/test/kotlin/itest/BehandlingDaoIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/itest/BehandlingDaoIntegrationTest.kt
@@ -683,10 +683,10 @@ internal class BehandlingDaoIntegrationTest {
             }
 
         with(behandlingRepo.hentBehandling(foerstegangsbehandling.id) as Foerstegangsbehandling) {
-            assertEquals(this.status, BehandlingStatus.VILKAARSVURDERT)
-            assertEquals(this.kommerBarnetTilgode, kommerBarnetTilgode)
-            assertEquals(this.virkningstidspunkt, virkningstidspunkt)
-            assertEquals(this.gyldighetsproeving, gyldighetsResultat)
+            assertEquals(BehandlingStatus.VILKAARSVURDERT, this.status)
+            assertEquals(kommerBarnetTilgode, this.kommerBarnetTilgode)
+            assertEquals(virkningstidspunkt, this.virkningstidspunkt)
+            assertEquals(gyldighetsResultat, this.gyldighetsproeving)
             assert(this.sistEndret > foerstegangsbehandling.sistEndret)
         }
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/itest/IntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/itest/IntegrationTest.kt
@@ -24,11 +24,11 @@ import no.nav.etterlatte.CommonFactory
 import no.nav.etterlatte.behandling.BehandlingsBehov
 import no.nav.etterlatte.behandling.FastsettVirkningstidspunktRequest
 import no.nav.etterlatte.behandling.FastsettVirkningstidspunktResponse
-import no.nav.etterlatte.behandling.HendelseDao
 import no.nav.etterlatte.behandling.KommerBarnetTilgodeJson
 import no.nav.etterlatte.behandling.ManueltOpphoerResponse
 import no.nav.etterlatte.behandling.VedtakHendelse
 import no.nav.etterlatte.behandling.common.LeaderElection
+import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.behandling.objectMapper
 import no.nav.etterlatte.database.DataSourceBuilder
 import no.nav.etterlatte.kafka.KafkaProdusent
@@ -192,6 +192,10 @@ class ApplicationTest {
             }.also {
                 assertEquals(HttpStatusCode.OK, it.status)
             }
+
+            client.post("/behandlinger/$behandlingId/vilkaarsvurder") {
+                addAuthSaksbehandler()
+            }.also { assertEquals(HttpStatusCode.OK, it.status) }
 
             client.post("/behandlinger/$behandlingId/hendelser/vedtak/FATTET") {
                 addAuthSaksbehandler()

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/oversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/oversikt.tsx
@@ -9,12 +9,10 @@ export const Oversikt = ({ behandlingsInfo }: { behandlingsInfo: IBehandlingInfo
 
   const hentStatus = () => {
     switch (behandlingsInfo.status) {
-      case IBehandlingStatus.UNDER_BEHANDLING:
-        return 'Under behandling'
-      case IBehandlingStatus.GYLDIG_SOEKNAD:
-        return 'Under behandling'
       case IBehandlingStatus.FATTET_VEDTAK:
         return 'To-trinnskontroll'
+      default:
+        return 'Under behandling'
     }
   }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.tsx
@@ -18,8 +18,9 @@ export function hentAdresserEtterDoedsdato(adresser: IAdresse[], doedsdato: stri
 
 export const hentBehandlesFraStatus = (status: IBehandlingStatus): boolean => {
   return (
-    status === IBehandlingStatus.UNDER_BEHANDLING ||
-    status === IBehandlingStatus.GYLDIG_SOEKNAD ||
+    status === IBehandlingStatus.OPPRETTET ||
+    status === IBehandlingStatus.VILKAARSVURDERT ||
+    status === IBehandlingStatus.BEREGNET ||
     status === IBehandlingStatus.RETURNERT
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vedtaksbrev/Vedtaksbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vedtaksbrev/Vedtaksbrev.tsx
@@ -18,7 +18,7 @@ import {
   VilkaarsvurderingResultat,
   VurderingsResultat,
 } from '~shared/api/vilkaarsvurdering'
-import { IBehandlingStatus } from '~store/reducers/BehandlingReducer'
+import { hentBehandlesFraStatus } from '~components/behandling/felles/utils'
 
 interface VilkaarOption {
   value: string
@@ -145,7 +145,7 @@ export const Vedtaksbrev = () => {
 
       <BrevContentFooter>
         <BehandlingHandlingKnapper>
-          {status === IBehandlingStatus.UNDER_BEHANDLING && <SendTilAttesteringModal />}
+          {hentBehandlesFraStatus(status) && <SendTilAttesteringModal />}
         </BehandlingHandlingKnapper>
       </BrevContentFooter>
     </Content>

--- a/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/BehandlingReducer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/BehandlingReducer.ts
@@ -51,12 +51,11 @@ export enum IBehandlingsType {
 
 export enum IBehandlingStatus {
   OPPRETTET = 'OPPRETTET',
-  GYLDIG_SOEKNAD = 'GYLDIG_SOEKNAD',
-  IKKE_GYLDIG_SOEKNAD = 'IKKE_GYLDIG_SOEKNAD',
-  UNDER_BEHANDLING = 'UNDER_BEHANDLING',
+  VILKAARSVURDERT = 'VILKAARSVURDERT',
+  BEREGNET = 'BEREGNET',
   FATTET_VEDTAK = 'FATTET_VEDTAK',
-  RETURNERT = 'RETURNERT',
   ATTESTERT = 'ATTESTERT',
+  RETURNERT = 'RETURNERT',
   IVERKSATT = 'IVERKSATT',
   AVBRUTT = 'AVBRUTT',
 }
@@ -308,7 +307,7 @@ export enum ISvar {
 export const detaljertBehandlingInitialState: IDetaljertBehandling = {
   id: '',
   sak: 0,
-  status: IBehandlingStatus.UNDER_BEHANDLING, //test
+  status: IBehandlingStatus.OPPRETTET, //test
   saksbehandlerId: '',
   attestant: '',
   vilkårsprøving: undefined,

--- a/libs/common/src/main/kotlin/behandling/BehandlingStatus.kt
+++ b/libs/common/src/main/kotlin/behandling/BehandlingStatus.kt
@@ -4,7 +4,7 @@ enum class BehandlingStatus {
     OPPRETTET,
     GYLDIG_SOEKNAD,
     IKKE_GYLDIG_SOEKNAD,
-    UNDER_BEHANDLING,
+    VILKAARSVURDERING,
     FATTET_VEDTAK,
     ATTESTERT,
     RETURNERT,
@@ -15,13 +15,13 @@ enum class BehandlingStatus {
         return this !in iverksattEllerAttestert() && this != AVBRUTT
     }
 
-    fun kanRedigeres() = this !in redigerbar()
+    fun kanRedigeres() = this in redigerbar()
 
     companion object {
         fun underBehandling() = listOf(
             OPPRETTET,
             GYLDIG_SOEKNAD,
-            UNDER_BEHANDLING,
+            VILKAARSVURDERING,
             RETURNERT,
             FATTET_VEDTAK
         )

--- a/libs/common/src/main/kotlin/behandling/BehandlingStatus.kt
+++ b/libs/common/src/main/kotlin/behandling/BehandlingStatus.kt
@@ -2,9 +2,8 @@ package no.nav.etterlatte.libs.common.behandling
 
 enum class BehandlingStatus {
     OPPRETTET,
-    GYLDIG_SOEKNAD,
-    IKKE_GYLDIG_SOEKNAD,
-    VILKAARSVURDERING,
+    VILKAARSVURDERT,
+    BEREGNET,
     FATTET_VEDTAK,
     ATTESTERT,
     RETURNERT,
@@ -20,8 +19,8 @@ enum class BehandlingStatus {
     companion object {
         fun underBehandling() = listOf(
             OPPRETTET,
-            GYLDIG_SOEKNAD,
-            VILKAARSVURDERING,
+            VILKAARSVURDERT,
+            BEREGNET,
             RETURNERT,
             FATTET_VEDTAK
         )

--- a/libs/common/src/main/kotlin/behandling/OppgaveStatus.kt
+++ b/libs/common/src/main/kotlin/behandling/OppgaveStatus.kt
@@ -4,5 +4,22 @@ enum class OppgaveStatus {
     NY,
     TIL_ATTESTERING,
     RETURNERT,
-    LUKKET
+    LUKKET;
+
+    companion object {
+        fun from(behandlingStatus: BehandlingStatus) {
+            when (behandlingStatus) {
+                BehandlingStatus.OPPRETTET,
+                BehandlingStatus.VILKAARSVURDERT,
+                BehandlingStatus.BEREGNET -> NY
+
+                BehandlingStatus.FATTET_VEDTAK -> TIL_ATTESTERING
+                BehandlingStatus.RETURNERT -> RETURNERT
+
+                BehandlingStatus.AVBRUTT,
+                BehandlingStatus.ATTESTERT,
+                BehandlingStatus.IVERKSATT -> LUKKET
+            }
+        }
+    }
 }

--- a/libs/common/src/main/kotlin/grunnlag/Grunnlagsopplysning.kt
+++ b/libs/common/src/main/kotlin/grunnlag/Grunnlagsopplysning.kt
@@ -10,6 +10,7 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.time.Instant
 import java.time.YearMonth
 import java.util.*
@@ -72,6 +73,9 @@ open class Grunnlagsopplysning<T>(
     }
 
     data class Saksbehandler(val ident: String, val tidspunkt: Instant) : Kilde("saksbehandler") {
+        companion object {
+            fun create(ident: String) = Saksbehandler(ident, Tidspunkt.now().instant)
+        }
         override fun toString(): String {
             return "saksbehandler $ident"
         }


### PR DESCRIPTION
Ref: https://jira.adeo.no/browse/EY-1148

Ett utkast på hvordan man kan implementere tilstandshåndtering for en behandling. Se gjerne på `Foerstegangsbehandling` i `Behandling.kt` for å se implementasjon, og tilsvarende tester for å se bruk av den.

Som man ser i `Foerstegangsbehandling` så baserer behandlingen seg på status (`BehandlingStatus`) for å vite hva som er lov å gjøre. En ulempe med dette er att hvis de statusen endrer seg mye og ofte overtid så hade det medført mye endringer i behandlingene og, men jeg tenker att når vi landet de statusen så er de ganske like på tvers av behandlinger.

Tanken for utvidelse for andra type behandlinger er at de tar i bruk statusene og hjelpefunksjonene på samma måte som `Foerstegangsbehandling` har gjort, og definerer gyldige regler selv. Kom gjerne med tanker/inspill!

**Edit: 07.12.22**: Har lagt til migreringsskript sån att det (forhåpningsvis) ikke skal brekke i dev, lagt til støtte for dry-runs for statusendringer sån att man kan sjekke hva man har lov til å gjøre i behandlingens tilstand utan å faktiskt endre behandlingen, og andra diverse refaktoreringer + småendringer. 

Det som gjenstår er att andra apper skal ta endepunktene i bruk, og bruke de som en del av sin egen flyt. Det gjenstår og å lagre "hva som har skjedd" på behandlingen, i form av behandlingshendelser.