### PR TITLE
EY-1347 Hack for å parse saksbehandler fra apikall

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/hooks/useInnloggetSaksbehandler.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/hooks/useInnloggetSaksbehandler.tsx
@@ -11,7 +11,7 @@ const useInnloggetSaksbehandler = () => {
   useEffect(() => {
     hentSaksbehandler({}, (response) => {
       if (response) {
-        dispatch(setSaksbehandler(response))
+        dispatch(setSaksbehandler(JSON.parse(response.toString())))
       }
     })
   }, [])


### PR DESCRIPTION
Attesteringsløypen fungerte ikke fordi parsing av saksbehandler fra `/modiacontextholder/decorator'` ikke ble rett. Dette er en rask hack for å få parset responsen til ISaksbehandler slik at flyten fortsatt funker