### PR TITLE
EY-1226: Kjoerer konsistensavstemming hver time

### DIFF
--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingService.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingService.kt
@@ -139,6 +139,20 @@ class KonsistensavstemmingService(
             loependeUtbetalinger = loependeUtbetalinger
         )
     }
+
+    fun konsistensavstemmingErKjoertIDag(saktype: Saktype, idag: LocalDate): Boolean {
+        val tidspunktForSisteKonsistensavstemming: Tidspunkt? =
+            hentSisteKonsistensavstemming(saktype)?.opprettet
+
+        val datoForSisteKonsistensavstemming = tidspunktForSisteKonsistensavstemming?.let {
+            LocalDate.ofInstant(it.instant, norskTidssone)
+        }
+
+        return datoForSisteKonsistensavstemming == idag
+    }
+
+    fun hentSisteKonsistensavstemming(saktype: Saktype): Konsistensavstemming? =
+        avstemmingDao.hentSisteKonsistensavsvemming(saktype)
 }
 
 /**

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/config/ApplicationContext.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/config/ApplicationContext.kt
@@ -103,8 +103,8 @@ class ApplicationContext(
     val konsistensavstemmingJob = KonsistensavstemmingJob(
         konsistensavstemmingService,
         leaderElection,
-        starttidspunkt = ZonedDateTime.now(norskTidssone).next(LocalTime.of(3, 30, 0)),
-        periode = Duration.of(1, ChronoUnit.DAYS)
+        initialDelay = Duration.of(2, ChronoUnit.MINUTES).toMillis(),
+        periode = Duration.of(1, ChronoUnit.HOURS)
 
     )
 

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/KonsistensavstemmingJobTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/KonsistensavstemmingJobTest.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.utbetaling.config.LeaderElection
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 
 internal class KonsistensavstemmingJobTest {
 
@@ -33,12 +34,38 @@ internal class KonsistensavstemmingJobTest {
 
     @Test
     fun `skal konsistensavstemme for Barnepensjon siden pod er leader`() {
+        val idag = LocalDate.now()
         every { leaderElection.isLeader() } returns true
+        every { konsistensavstemmingService.konsistensavstemmingErKjoertIDag(Saktype.BARNEPENSJON, idag) } returns false
         every { konsistensavstemmingService.startKonsistensavstemming(any(), any()) } returns emptyList()
 
         konsistensavstemming.run()
 
         verify(exactly = 1) { konsistensavstemmingService.startKonsistensavstemming(any(), Saktype.BARNEPENSJON) }
         Assertions.assertTrue(leaderElection.isLeader())
+    }
+
+    @Test
+    fun `skal konsistensavstemme for barnepensjon naar jobb ikke er kjoert samme dag`() {
+        val idag = LocalDate.now()
+        every { leaderElection.isLeader() } returns true
+        every { konsistensavstemmingService.konsistensavstemmingErKjoertIDag(Saktype.BARNEPENSJON, idag) } returns false
+        every { konsistensavstemmingService.startKonsistensavstemming(idag, Saktype.BARNEPENSJON) } returns emptyList()
+
+        konsistensavstemming.run()
+
+        verify(exactly = 1) { konsistensavstemmingService.startKonsistensavstemming(idag, Saktype.BARNEPENSJON) }
+    }
+
+    @Test
+    fun `skal ikke konsistensavstemme for barnepensjon naar jobb er kjoert samme dag`() {
+        val idag = LocalDate.now()
+        every { leaderElection.isLeader() } returns true
+        every { konsistensavstemmingService.konsistensavstemmingErKjoertIDag(Saktype.BARNEPENSJON, idag) } returns true
+        every { konsistensavstemmingService.startKonsistensavstemming(idag, Saktype.BARNEPENSJON) } returns emptyList()
+
+        konsistensavstemming.run()
+
+        verify(exactly = 0) { konsistensavstemmingService.startKonsistensavstemming(idag, Saktype.BARNEPENSJON) }
     }
 }


### PR DESCRIPTION
- Konsistensavstemming er satt opp til å kjøre hver time. Dersom konsistensavstemming allerede er kjørt en dag, gjøres det ikke på nytt. Dette er i testøyemed, og vil endres så snart vi har fått bekreftet fra Oppdrag at konsistensavstemmingen som sendes over ser ok ut.
- Funksjonalitet for å sjekke om konsistensavstemming er kjørt på en gitt dag