### PR TITLE
Fanger feil per hendelse i GrunnlagsendringshendelseJob

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
@@ -114,11 +114,19 @@ class GrunnlagsendringshendelseService(
     fun sjekkKlareGrunnlagsendringshendelser(minutterGamle: Long) {
         ikkeVurderteHendelser(minutterGamle)
             .forEach { hendelse ->
-                when (val data = hendelse.data) {
-                    is Doedsfall -> verifiserOgHaandterDoedsfall(data, hendelse.sakId, hendelse.id)
-                    is Utflytting -> verifiserOgHaandterSoekerErUtflyttet(data, hendelse.id)
-                    is ForelderBarnRelasjon -> verifiserOgHaandterForelderBarnRelasjon(data, hendelse.id)
-                    null -> Unit
+                try {
+                    when (val data = hendelse.data) {
+                        is Doedsfall -> verifiserOgHaandterDoedsfall(data, hendelse.sakId, hendelse.id)
+                        is Utflytting -> verifiserOgHaandterSoekerErUtflyttet(data, hendelse.id)
+                        is ForelderBarnRelasjon -> verifiserOgHaandterForelderBarnRelasjon(data, hendelse.id)
+                        null -> Unit
+                    }
+                } catch (e: Exception) {
+                    logger.error(
+                        "Kunne ikke sjekke opp for hendelsen med id=${hendelse.id} på sak ${hendelse.sakId} " +
+                            "på grunn av feil",
+                        e
+                    )
                 }
             }
     }


### PR DESCRIPTION
Vi har en (eller flere?) hendelser som ikke har gode data, og dette blokkerer jobben som sjekker alle hendelser å fullføre.

Tar en enkel fiks ut her, så sitter vi kun igjen med de som feiler.