### PR TITLE
Legger på mer logging i vilkårsvurdering

### DIFF
--- a/apps/etterlatte-vilkaarsvurdering/build.gradle.kts
+++ b/apps/etterlatte-vilkaarsvurdering/build.gradle.kts
@@ -45,6 +45,8 @@ dependencies {
     testImplementation(TestContainer.Jupiter)
     testImplementation(TestContainer.Postgresql)
     testImplementation(Kotest.AssertionsCore)
-    testImplementation(NavFelles.MockOauth2Server)
+    testImplementation(NavFelles.MockOauth2Server) {
+        exclude("org.slf4j", "slf4j-api")
+    }
     testImplementation(project(":libs:testdata"))
 }


### PR DESCRIPTION
- Gjør det enklere å se flyten ved henting / opprettelse av vilkårsvurdering
- Eksluderer `slf4j-api` fra `MockOauth2Server` som gjør at det ikke logges under testkjøring