### PR TITLE
Flyt i frontend for førstegångsbehandling (EY-1268)

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/Behandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/Behandling.kt
@@ -46,20 +46,30 @@ sealed class Behandling {
         get() = this.status.kanRedigeres()
 
     protected fun <T : Behandling> hvisRedigerbar(block: () -> T): T {
-        if (kanRedigeres) return block() else kastFeilTilstand()
+        if (kanRedigeres) {
+            return block()
+        } else {
+            logger.info("behandling ($id) med status $status kan ikke redigeres")
+            throw TilstandException.UgyldigtTilstand
+        }
     }
 
     protected fun <T : Behandling> hvisTilstandEr(behandlingStatus: BehandlingStatus, block: () -> T): T {
-        if (status == behandlingStatus) return block() else kastFeilTilstand()
+        if (status == behandlingStatus) {
+            return block()
+        } else {
+            logger.info("Ugyldig operasjon på behandling ($id) med status $status")
+            throw TilstandException.UgyldigtTilstand
+        }
     }
 
     protected fun <T : Behandling> hvisTilstandEr(behandlingStatuser: List<BehandlingStatus>, block: () -> T): T {
-        if (status in behandlingStatuser) return block() else kastFeilTilstand()
-    }
-
-    private fun kastFeilTilstand(): Nothing {
-        logger.info("kan ikke oppdatere en behandling ($id) som ikke er under behandling")
-        throw TilstandException.UgyldigtTilstand
+        if (status in behandlingStatuser) {
+            return block()
+        } else {
+            logger.info("Ugyldig operasjon på behandling ($id) med status $status")
+            throw TilstandException.UgyldigtTilstand
+        }
     }
 }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingTest.kt
@@ -114,4 +114,19 @@ internal class BehandlingTest {
                 assertEquals(nyttVirkningstidspunkt, it.virkningstidspunkt)
             }
     }
+
+    @Test
+    fun `man maa gjennom hele loeypen paa nytt dersom man gjoer operasjoner i tidligere steg`() {
+        val vilkaarsvurdertBehandling = behandling.oppdaterKommerBarnetTilgode(kommerBarnetTilgode)
+            .oppdaterVirkningstidspunkt(virkningstidspunkt.dato, virkningstidspunkt.kilde)
+            .oppdaterGyldighetsproeving(gyldighetsResultat)
+            .tilVilkaarsvurdert()
+        val nyttVirkningstidspunkt = Virkningstidspunkt(YearMonth.of(2022, 2), saksbehandler)
+
+        vilkaarsvurdertBehandling
+            .oppdaterVirkningstidspunkt(nyttVirkningstidspunkt.dato, nyttVirkningstidspunkt.kilde)
+            .let {
+                assertEquals(it.status, BehandlingStatus.OPPRETTET)
+            }
+    }
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
@@ -4,9 +4,10 @@ import { Beregne } from './beregne/Beregne'
 import { Vilkaarsvurdering } from './vilkaarsvurdering/Vilkaarsvurdering'
 import { Soeknadsoversikt } from './soeknadsoversikt/Soeknadoversikt'
 import Beregningsgrunnlag from './beregningsgrunnlag/Beregningsgrunnlag'
-import { IBehandlingsType } from '~shared/types/IDetaljertBehandling'
+import { IBehandlingsType, IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 import { useAppSelector } from '~store/Store'
 import { Vedtaksbrev } from './vedtaksbrev/Vedtaksbrev'
+import { VilkaarsvurderingResultat } from '~shared/api/vilkaarsvurdering'
 
 const behandlingRoutes = [
   { path: 'soeknadsoversikt', element: <Soeknadsoversikt />, erRevurderingRoute: false },
@@ -15,8 +16,6 @@ const behandlingRoutes = [
   { path: 'beregne', element: <Beregne />, erRevurderingRoute: true },
   { path: 'brev', element: <Vedtaksbrev />, erRevurderingRoute: true },
 ] as const
-
-const revurderingBehandlingRoutes = () => behandlingRoutes.filter((route) => route.erRevurderingRoute)
 
 function useRouteNavigation() {
   const [currentRoute, setCurrentRoute] = useState<string | undefined>()
@@ -40,11 +39,7 @@ export const useBehandlingRoutes = () => {
   const { currentRoute, goto } = useRouteNavigation()
   const behandling = useAppSelector((state) => state.behandlingReducer.behandling)
 
-  const aktuelleRoutes =
-    behandling?.behandlingType === IBehandlingsType.REVURDERING ||
-    behandling?.behandlingType === IBehandlingsType.MANUELT_OPPHOER
-      ? revurderingBehandlingRoutes()
-      : behandlingRoutes
+  const aktuelleRoutes = hentAktuelleRoutes(behandling)
 
   const firstPage = aktuelleRoutes.findIndex((item) => item.path === currentRoute) === 0
   const lastPage = aktuelleRoutes.findIndex((item) => item.path === currentRoute) === aktuelleRoutes.length - 1
@@ -58,8 +53,23 @@ export const useBehandlingRoutes = () => {
   const back = () => {
     const index = aktuelleRoutes.findIndex((item) => item.path === currentRoute)
     const previousPath = aktuelleRoutes[index - 1].path
+
     goto(previousPath)
   }
 
-  return { next, back, lastPage, firstPage, behandlingRoutes: aktuelleRoutes, currentRoute }
+  return { next, back, lastPage, firstPage, behandlingRoutes: aktuelleRoutes, currentRoute, goto }
+}
+
+const hentAktuelleRoutes = (behandling: IDetaljertBehandling) => {
+  switch (behandling.behandlingType) {
+    case IBehandlingsType.FØRSTEGANGSBEHANDLING:
+      if (behandling.vilkårsprøving?.resultat?.utfall === VilkaarsvurderingResultat.IKKE_OPPFYLT) {
+        return behandlingRoutes.filter((route) => route.path !== 'beregne' && route.path !== 'beregningsgrunnlag')
+      }
+
+      return behandlingRoutes
+    case IBehandlingsType.REVURDERING:
+    case IBehandlingsType.MANUELT_OPPHOER:
+      return behandlingRoutes.filter((route) => route.erRevurderingRoute)
+  }
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
@@ -21,6 +21,8 @@ export const StegMeny = () => {
     (behandling.vilkårsprøving?.resultat?.utfall === VilkaarsvurderingResultat.OPPFYLT && klarForVidereBehandling)
 
   const harBeregning = !!behandling.beregning
+
+  const oppfylt = behandling.vilkårsprøving?.resultat?.utfall === VilkaarsvurderingResultat.OPPFYLT
   const vurdert = !!behandling.vilkårsprøving?.resultat && klarForVidereBehandling
 
   return (
@@ -51,9 +53,7 @@ export const StegMeny = () => {
       <Separator />
       <li
         className={classNames({
-          disabled:
-            !vurdert ||
-            (behandling.vilkårsprøving?.resultat?.utfall === VilkaarsvurderingResultat.OPPFYLT && !harBeregning),
+          disabled: !vurdert || (oppfylt && !harBeregning),
         })}
       >
         <NavLink to="brev">Vedtaksbrev</NavLink>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
@@ -6,20 +6,22 @@ import { useAppSelector } from '~store/Store'
 import { VilkaarsvurderingResultat } from '~shared/api/vilkaarsvurdering'
 import { IBehandlingsType } from '~shared/types/IDetaljertBehandling'
 import { VurderingsResultat } from '~shared/types/VurderingsResultat'
+import { behandlingErUtfylt } from '~components/behandling/felles/utils'
+import { JaNei } from '~shared/types/ISvar'
 
 export const StegMeny = () => {
   const behandling = useAppSelector((state) => state.behandlingReducer.behandling)
 
+  const klarForVidereBehandling = behandlingErUtfylt(behandling) && behandling.kommerBarnetTilgode?.svar === JaNei.JA
   const gyldighet =
     behandling.behandlingType !== IBehandlingsType.FØRSTEGANGSBEHANDLING ||
     behandling.gyldighetsprøving?.resultat === VurderingsResultat.OPPFYLT
   const vilkaar =
     behandling.behandlingType !== IBehandlingsType.FØRSTEGANGSBEHANDLING ||
-    behandling.vilkårsprøving?.resultat?.utfall === VilkaarsvurderingResultat.OPPFYLT
-  const vurdert = !!behandling.vilkårsprøving?.resultat
+    (behandling.vilkårsprøving?.resultat?.utfall === VilkaarsvurderingResultat.OPPFYLT && klarForVidereBehandling)
 
-  const avdoedesBarn = behandling.familieforhold?.avdoede.opplysning.avdoedesBarn
-  const soekerHarSoesken = avdoedesBarn ? avdoedesBarn.length > 1 : false
+  const harBeregning = !!behandling.beregning
+  const vurdert = !!behandling.vilkårsprøving?.resultat && klarForVidereBehandling
 
   return (
     <StegMenyWrapper>
@@ -31,11 +33,11 @@ export const StegMeny = () => {
           <Separator />
         </>
       )}
-      <li className={classNames({ disabled: !gyldighet })}>
+      <li className={classNames({ disabled: !klarForVidereBehandling || !gyldighet })}>
         <NavLink to="vilkaarsvurdering">Vilkårsvurdering</NavLink>
       </li>
       <Separator />
-      {behandling.behandlingType === IBehandlingsType.FØRSTEGANGSBEHANDLING && soekerHarSoesken && (
+      {behandling.behandlingType === IBehandlingsType.FØRSTEGANGSBEHANDLING && (
         <>
           <li className={classNames({ disabled: !gyldighet || !vilkaar })}>
             <NavLink to="beregningsgrunnlag">Beregningsgrunnlag</NavLink>
@@ -43,11 +45,17 @@ export const StegMeny = () => {
           <Separator />
         </>
       )}
-      <li className={classNames({ disabled: !gyldighet || !vilkaar })}>
+      <li className={classNames({ disabled: !gyldighet || !vilkaar || !harBeregning })}>
         <NavLink to="beregne">Beregning</NavLink>
       </li>
       <Separator />
-      <li className={classNames({ disabled: !vurdert })}>
+      <li
+        className={classNames({
+          disabled:
+            !vurdert ||
+            (behandling.vilkårsprøving?.resultat?.utfall === VilkaarsvurderingResultat.OPPFYLT && !harBeregning),
+        })}
+      >
         <NavLink to="brev">Vedtaksbrev</NavLink>
       </li>
     </StegMenyWrapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/oversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/oversikt.tsx
@@ -11,6 +11,8 @@ export const Oversikt = ({ behandlingsInfo }: { behandlingsInfo: IBehandlingInfo
     switch (behandlingsInfo.status) {
       case IBehandlingStatus.FATTET_VEDTAK:
         return 'To-trinnskontroll'
+      case IBehandlingStatus.IVERKSATT:
+        return 'Iverksatt'
       default:
         return 'Under behandling'
     }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.tsx
@@ -1,13 +1,22 @@
 import { isAfter } from 'date-fns'
+import { VilkaarsvurderingResultat } from '~shared/api/vilkaarsvurdering'
 import { IAdresse } from '~shared/types/IAdresse'
-import { IBehandlingStatus, IVilkaarsproving } from '~shared/types/IDetaljertBehandling'
+import { IBehandlingStatus, IDetaljertBehandling, IVilkaarsproving } from '~shared/types/IDetaljertBehandling'
 import { Kriterietype, IKriterie, KriterieOpplysningsType, IKriterieOpplysning } from '~shared/types/Kriterie'
+
+export function behandlingErUtfylt(behandling: IDetaljertBehandling): boolean {
+  return Boolean(behandling.gyldighetsprøving && behandling.kommerBarnetTilgode && behandling.virkningstidspunkt)
+}
 
 export function hentAdresserEtterDoedsdato(adresser: IAdresse[], doedsdato: string | null): IAdresse[] {
   if (doedsdato == null) {
     return adresser
   }
   return adresser?.filter((adresse) => adresse.aktiv || isAfter(new Date(adresse.gyldigTilOgMed!), new Date(doedsdato)))
+}
+
+export function behandlingErAvslag(behandling: IDetaljertBehandling) {
+  return behandling.vilkårsprøving?.resultat?.utfall === VilkaarsvurderingResultat.IKKE_OPPFYLT
 }
 
 export const hentBehandlesFraStatus = (status: IBehandlingStatus): boolean => {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/typer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/typer.ts
@@ -5,7 +5,7 @@ export const handlinger = {
 
   VILKAARSVURDERING: {
     BEREGNE: { id: 'beregne', navn: 'Gå videre' },
-    AVSLAG: { id: 'avslag', navn: 'Avslå og send til attestering' },
+    AVSLAG: { id: 'avslag', navn: 'Avslå og gå til brev' },
     VENT: { id: 'vent', navn: 'Sett saken på vent' },
     GJENNOPPTA: { id: 'vent', navn: 'Gjennoppta saken' },
     OPPHOER: { id: 'opphoer', navn: 'Gå til beregning' },

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/vilkaarsvurderingKnapper.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/vilkaarsvurderingKnapper.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import { useVedtaksResultat } from '../useVedtaksResultat'
 
 export const VilkaarsVurderingKnapper = () => {
-  const { next } = useBehandlingRoutes()
+  const { next, goto } = useBehandlingRoutes()
   const [ventNavn, setVentNavn] = useState<string>(handlinger.VILKAARSVURDERING.VENT.navn)
   const vedtaksresultat = useVedtaksResultat()
 
@@ -24,7 +24,7 @@ export const VilkaarsVurderingKnapper = () => {
           case 'avslag':
             return (
               //TODO - Avslag
-              <Button variant="primary" size="medium" className="button" onClick={() => console.log('Avslag')}>
+              <Button variant="primary" size="medium" className="button" onClick={() => goto('brev')}>
                 {handlinger.VILKAARSVURDERING.AVSLAG.navn}
               </Button>
             )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/Soeknadoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/Soeknadoversikt.tsx
@@ -9,9 +9,10 @@ import { BehandlingHandlingKnapper } from '../handlinger/BehandlingHandlingKnapp
 import { Start } from '../handlinger/start'
 import { Soeknadsdato } from './soeknadoversikt/Soeknadsdato'
 import { NesteOgTilbake } from '../handlinger/NesteOgTilbake'
-import { hentBehandlesFraStatus } from '../felles/utils'
+import { behandlingErUtfylt, hentBehandlesFraStatus } from '../felles/utils'
 import { useAppSelector } from '~store/Store'
 import { VurderingsResultat } from '~shared/types/VurderingsResultat'
+import { JaNei } from '~shared/types/ISvar'
 
 export const Soeknadsoversikt = () => {
   const behandling = useAppSelector((state) => state.behandlingReducer.behandling)
@@ -36,7 +37,9 @@ export const Soeknadsoversikt = () => {
       <Familieforhold behandling={behandling} />
       {behandles ? (
         <BehandlingHandlingKnapper>
-          <Start soeknadGyldigFremsatt={behandling.gyldighetsprøving?.resultat === VurderingsResultat.OPPFYLT} />
+          {behandlingErUtfylt(behandling) && behandling.kommerBarnetTilgode?.svar === JaNei.JA && (
+            <Start soeknadGyldigFremsatt={behandling.gyldighetsprøving?.resultat === VurderingsResultat.OPPFYLT} />
+          )}
         </BehandlingHandlingKnapper>
       ) : (
         <NesteOgTilbake />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/Soeknadsoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/Soeknadsoversikt.tsx
@@ -14,9 +14,11 @@ export const SoeknadOversikt: React.FC<PropsOmSoeknad> = ({ behandling }) => {
     <Innhold>
       <OversiktGyldigFramsatt gyldigFramsatt={behandling.gyldighetsprøving} />
       {behandling.gyldighetsprøving?.resultat === VurderingsResultat.OPPFYLT && (
-        <OversiktKommerBarnetTilgode kommerBarnetTilgode={behandling.kommerBarnetTilgode} />
+        <>
+          <OversiktKommerBarnetTilgode kommerBarnetTilgode={behandling.kommerBarnetTilgode} />
+          <Virkningstidspunkt />
+        </>
       )}
-      <Virkningstidspunkt />
     </Innhold>
   )
 }


### PR DESCRIPTION
Nå skal stegmenyn vise de steg man skal gå igenom, og den endrer seg basert på om vilkårsvurderingen er til avslag eller oppfylt.

F.eks ved avslag så trenger man ikke å gå gjennom beregningsgrunnlag og beregningen:
![image](https://user-images.githubusercontent.com/26689337/207868606-e5bd6c8d-ffa8-4a10-bd86-8ad1d71af4fe.png)
