### PR TITLE
EY-1424: lagrer ikke ned dupliserte gr.lag.endringshendelser

### DIFF
--- a/libs/common/src/main/kotlin/behandling/Grunnlagsendringshendelse.kt
+++ b/libs/common/src/main/kotlin/behandling/Grunnlagsendringshendelse.kt
@@ -46,7 +46,7 @@ enum class GrunnlagsendringsType {
 
 enum class GrunnlagsendringStatus {
     VENTER_PAA_JOBB, // naar hendelsen registreres // FØR: IKKE_VURDERT
-    SJEKKET_AV_JOBB, // skifte til noe som indikerer at venteperiode er utført? FØR: ED_I_BEHANDLING
+    SJEKKET_AV_JOBB, // FØR: ED_I_BEHANDLING
     TATT_MED_I_BEHANDLING, // tatt med i behandling av saksbehandler
     FORKASTET,
     VURDERT_SOM_IKKE_RELEVANT

--- a/libs/common/src/main/kotlin/pdlhendelse/PdlHendelser.kt
+++ b/libs/common/src/main/kotlin/pdlhendelse/PdlHendelser.kt
@@ -10,6 +10,9 @@ data class Doedshendelse(
     val endringstype: Endringstype
 ) : PdlHendelse
 
+fun Doedshendelse.erLik(other: Doedshendelse) =
+    this.avdoedFnr == other.avdoedFnr && this.doedsdato == other.doedsdato
+
 data class UtflyttingsHendelse(
     val fnr: String,
     val tilflyttingsLand: String?,
@@ -17,6 +20,11 @@ data class UtflyttingsHendelse(
     val utflyttingsdato: LocalDate?,
     val endringstype: Endringstype
 ) : PdlHendelse
+
+fun UtflyttingsHendelse.erLik(other: UtflyttingsHendelse) =
+    this.fnr == other.fnr &&
+        this.tilflyttingsLand == other.tilflyttingsLand &&
+        this.utflyttingsdato == other.utflyttingsdato
 
 data class ForelderBarnRelasjonHendelse(
     val fnr: String,
@@ -26,6 +34,14 @@ data class ForelderBarnRelasjonHendelse(
     val relatertPersonUtenFolkeregisteridentifikator: String?,
     val endringstype: Endringstype
 )
+
+fun ForelderBarnRelasjonHendelse.erLik(other: ForelderBarnRelasjonHendelse) =
+    this.fnr == other.fnr &&
+        if (this.relatertPersonsIdent != null) {
+            this.relatertPersonsIdent == other.relatertPersonsIdent
+        } else {
+            this.relatertPersonUtenFolkeregisteridentifikator == other.relatertPersonUtenFolkeregisteridentifikator
+        }
 
 enum class Endringstype {
     OPPRETTET, KORRIGERT, ANNULLERT, OPPHOERT


### PR DESCRIPTION
Sjekker om en grunnlagsendringshendelse eksisterer i databasen fra før når den mottas. Lagrer ikke en ny hendelse dersom det er tilfelle