### PR TITLE
EY-1425: Sammenligner grunnlag mellom pdl og grunnlag

### DIFF
--- a/apps/etterlatte-behandling/build.gradle.kts
+++ b/apps/etterlatte-behandling/build.gradle.kts
@@ -37,4 +37,5 @@ dependencies {
     testImplementation(Ktor2.ServerTests)
     testImplementation(Kotlinx.CoroutinesCore)
     testImplementation(NavFelles.MockOauth2Server)
+    testImplementation(project(":libs:testdata"))
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
@@ -434,18 +434,19 @@ class BehandlingDao(private val connection: () -> Connection) {
     }
 
     /*sjekker om et fnr opptrer i persongalleriet til behandlinger. Returnerer rollen og saksnr som Pair*/
+    /* TODO: EY-1430: Skriv om denne*/
     fun sakerOgRollerMedFnrIPersongalleri(fnr: String): List<Pair<Saksrolle, Long>> {
         val statement = connection().prepareStatement(
             """
               SELECT (
                 SELECT string_agg(col, ', ' ORDER BY col) AS rolle
-                FROM jsonb_each_text(to_jsonb(json_build_object('innsender', behandling.innsender, 'soeker', behandling.soeker, 'gjenlevende', behandling.gjenlevende, 'avdoed', behandling.avdoed, 'soesken', behandling.soesken))) t(col, val)
+                FROM jsonb_each_text(to_jsonb(json_build_object('soeker', behandling.soeker, 'gjenlevende', behandling.gjenlevende, 'avdoed', behandling.avdoed, 'soesken', behandling.soesken))) t(col, val)
                 WHERE t.val LIKE '%' || ? || '%'
               ), sak_id
               FROM behandling
               WHERE (
                 SELECT string_agg(col, ', ' ORDER BY col)
-                FROM jsonb_each_text(to_jsonb(json_build_object('innsender', behandling.innsender, 'soeker', behandling.soeker, 'gjenlevende', behandling.gjenlevende, 'avdoed', behandling.avdoed, 'soesken', behandling.soesken))) t(col, val)
+                FROM jsonb_each_text(to_jsonb(json_build_object('soeker', behandling.soeker, 'gjenlevende', behandling.gjenlevende, 'avdoed', behandling.avdoed, 'soesken', behandling.soesken))) t(col, val)
                 WHERE t.val LIKE '%' || ? || '%'
               ) IS NOT NULL;
             """.trimIndent()

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagClient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagClient.kt
@@ -14,7 +14,7 @@ interface GrunnlagClient {
 
 class GrunnlagClientImpl(private val grunnlagHttpClient: HttpClient) : GrunnlagClient {
 
-    override suspend fun hentGrunnlag(sakId: Long): Grunnlag {
+    override suspend fun hentGrunnlag(sakId: Long): Grunnlag? {
         return grunnlagHttpClient.get("grunnlag/$sakId") {
             accept(ContentType.Application.Json)
         }.body()

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagHelper.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagHelper.kt
@@ -1,0 +1,73 @@
+package no.nav.etterlatte.grunnlagsendring
+
+import no.nav.etterlatte.libs.common.behandling.Saksrolle
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
+import no.nav.etterlatte.libs.common.grunnlag.hentDoedsdato
+import no.nav.etterlatte.libs.common.grunnlag.hentFamilierelasjon
+import no.nav.etterlatte.libs.common.grunnlag.hentFoedselsnummer
+import no.nav.etterlatte.libs.common.grunnlag.hentUtland
+
+fun Grunnlag.doedsdato(saksrolle: Saksrolle, fnr: String) =
+    when (saksrolle) {
+        Saksrolle.AVDOED -> {
+            hentAvdoed().hentDoedsdato()
+        }
+        Saksrolle.GJENLEVENDE -> {
+            hentGjenlevende().hentDoedsdato()
+        }
+        Saksrolle.SOEKER -> {
+            soeker.hentDoedsdato()
+        }
+        Saksrolle.SOESKEN -> {
+            hentSoesken().find { it.hentFoedselsnummer()?.verdi?.value == fnr }?.hentDoedsdato()
+        }
+        else -> throw IllegalArgumentException(
+            "Proevde aa finne doedsdato for $saksrolle, men det skal ikke kunne skje D:"
+        )
+    }
+
+fun Grunnlag.ansvarligeForeldre(saksrolle: Saksrolle, fnr: String) =
+    when (saksrolle) {
+        Saksrolle.SOEKER -> {
+            soeker.hentFamilierelasjon()?.verdi?.ansvarligeForeldre
+        }
+        Saksrolle.SOESKEN -> {
+            hentSoesken().find { it.hentFoedselsnummer()?.verdi?.value == fnr }
+                ?.hentFamilierelasjon()?.verdi?.ansvarligeForeldre
+        }
+        else -> throw IllegalArgumentException(
+            "Proevde aa finne doedsdato for $saksrolle, men det skal ikke kunne skje D:"
+        )
+    }
+
+fun Grunnlag.barn(saksrolle: Saksrolle) =
+    when (saksrolle) {
+        Saksrolle.AVDOED -> {
+            hentAvdoed().hentFamilierelasjon()?.verdi?.barn
+        }
+        Saksrolle.GJENLEVENDE -> {
+            hentGjenlevende().hentFamilierelasjon()?.verdi?.barn
+        }
+        else -> throw IllegalArgumentException(
+            "Proevde aa finne doedsdato for $saksrolle, men det skal ikke kunne skje D:"
+        )
+    }
+
+fun Grunnlag.utland(saksrolle: Saksrolle, fnr: String) =
+    when (saksrolle) {
+        Saksrolle.SOEKER -> {
+            soeker.hentUtland()?.verdi
+        }
+        Saksrolle.SOESKEN -> {
+            hentSoesken().find { it.hentFoedselsnummer()?.verdi?.value == fnr }?.hentUtland()?.verdi
+        }
+        Saksrolle.AVDOED -> {
+            hentAvdoed().hentUtland()?.verdi
+        }
+        Saksrolle.GJENLEVENDE -> {
+            hentGjenlevende().hentUtland()?.verdi
+        }
+        else -> throw IllegalArgumentException(
+            "Proevde aa finne doedsdato for $saksrolle, men det skal ikke kunne skje D:"
+        )
+    }

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseDao.kt
@@ -7,9 +7,11 @@ import no.nav.etterlatte.libs.common.behandling.GrunnlagsendringStatus
 import no.nav.etterlatte.libs.common.behandling.GrunnlagsendringsType
 import no.nav.etterlatte.libs.common.behandling.Grunnlagsendringshendelse
 import no.nav.etterlatte.libs.common.behandling.Grunnlagsinformasjon
-import no.nav.etterlatte.libs.common.behandling.KorrektIPDL
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
+import no.nav.etterlatte.libs.common.behandling.SamsvarMellomPdlOgGrunnlag
+import org.postgresql.util.PGobject
 import java.sql.Connection
+import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.Timestamp
 import java.time.Instant
@@ -23,8 +25,8 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
         with(connection()) {
             val stmt = prepareStatement(
                 """
-                INSERT INTO grunnlagsendringshendelse(id, sak_id, type, opprettet, data, status, hendelse_gjelder_rolle, korrekt_i_pdl)
-                VALUES(?, ?, ?, ?, to_json(?::json), ?, ?, ?)
+                INSERT INTO grunnlagsendringshendelse(id, sak_id, type, opprettet, data, status, hendelse_gjelder_rolle, samsvar_mellom_pdl_og_grunnlag)
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?)
                 """.trimIndent()
             )
             with(hendelse) {
@@ -32,10 +34,11 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
                 stmt.setLong(2, sakId)
                 stmt.setString(3, type.name)
                 stmt.setTimestamp(4, Timestamp.from(opprettet.atZone(ZoneId.systemDefault()).toInstant()))
-                hendelse.data?.let { stmt.setString(5, objectMapper.writeValueAsString(hendelse.data)) }
+                stmt.setJsonb(5, hendelse.data)
+                // hendelse.data?.let { stmt.setString(5, objectMapper.writeValueAsString(hendelse.data)) }
                 stmt.setString(6, status.name)
                 stmt.setString(7, hendelseGjelderRolle.name)
-                stmt.setString(8, korrektIPDL.name)
+                stmt.setJsonb(8, samsvarMellomPdlOgGrunnlag)
             }
             stmt.executeUpdate()
         }.let {
@@ -48,7 +51,7 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
         with(connection()) {
             val stmt = prepareStatement(
                 """
-                    SELECT id, sak_id, type, opprettet, data, status, behandling_id, hendelse_gjelder_rolle, korrekt_i_pdl
+                    SELECT id, sak_id, type, opprettet, data, status, behandling_id, hendelse_gjelder_rolle, samsvar_mellom_pdl_og_grunnlag 
                     FROM grunnlagsendringshendelse
                     WHERE id = ?
                 """.trimIndent()
@@ -62,7 +65,7 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
         with(connection()) {
             val stmt = prepareStatement(
                 """
-                    SELECT id, sak_id, type, opprettet, data, status, behandling_id, hendelse_gjelder_rolle, korrekt_i_pdl
+                    SELECT id, sak_id, type, opprettet, data, status, behandling_id, hendelse_gjelder_rolle, samsvar_mellom_pdl_og_grunnlag
                     FROM grunnlagsendringshendelse
                 """.trimIndent()
             )
@@ -74,20 +77,20 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
         hendelseId: UUID,
         foerStatus: GrunnlagsendringStatus,
         etterStatus: GrunnlagsendringStatus,
-        korrektIPDL: KorrektIPDL
+        samsvarMellomPdlOgGrunnlag: SamsvarMellomPdlOgGrunnlag
     ) {
         with(connection()) {
             prepareStatement(
                 """
                    UPDATE grunnlagsendringshendelse
                    SET status = ?,
-                   korrekt_i_pdl = ?
+                   samsvar_mellom_pdl_og_grunnlag = ?
                    WHERE id = ?
                    AND status = ?
                 """.trimIndent()
             ).use {
                 it.setString(1, etterStatus.name)
-                it.setString(2, korrektIPDL.name)
+                it.setJsonb(2, samsvarMellomPdlOgGrunnlag)
                 it.setObject(3, hendelseId)
                 it.setString(4, foerStatus.name)
                 it.executeUpdate()
@@ -122,7 +125,7 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
         with(connection()) {
             prepareStatement(
                 """
-                   SELECT id, sak_id, type, opprettet, data, status, behandling_id, hendelse_gjelder_rolle, korrekt_i_pdl
+                   SELECT id, sak_id, type, opprettet, data, status, behandling_id, hendelse_gjelder_rolle, samsvar_mellom_pdl_og_grunnlag
                    FROM grunnlagsendringshendelse
                    WHERE opprettet <= ?
                    AND status = ?
@@ -142,7 +145,7 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
         with(connection()) {
             prepareStatement(
                 """
-                    SELECT id, sak_id, type, opprettet, data, status, behandling_id, hendelse_gjelder_rolle, korrekt_i_pdl
+                    SELECT id, sak_id, type, opprettet, data, status, behandling_id, hendelse_gjelder_rolle, samsvar_mellom_pdl_og_grunnlag
                     FROM grunnlagsendringshendelse
                     WHERE sak_id = ?
                     AND status = ANY(?)
@@ -175,7 +178,10 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
                     GrunnlagsendringStatus.valueOf(getString("status")),
                     getObject("behandling_id")?.let { it as UUID },
                     Saksrolle.valueOf(getString("hendelse_gjelder_rolle")),
-                    KorrektIPDL.valueOf(getString("korrekt_i_pdl"))
+                    objectMapper.readValue(
+                        getString("samsvar_mellom_pdl_og_grunnlag"),
+                        SamsvarMellomPdlOgGrunnlag.Doedsdatoforhold::class.java
+                    )
                 )
             }
             GrunnlagsendringsType.UTFLYTTING -> {
@@ -188,7 +194,10 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
                     GrunnlagsendringStatus.valueOf(getString("status")),
                     getObject("behandling_id")?.let { it as UUID },
                     Saksrolle.valueOf(getString("hendelse_gjelder_rolle")),
-                    KorrektIPDL.valueOf(getString("korrekt_i_pdl"))
+                    objectMapper.readValue(
+                        getString("samsvar_mellom_pdl_og_grunnlag"),
+                        SamsvarMellomPdlOgGrunnlag.Utlandsforhold::class.java
+                    )
                 )
             }
             GrunnlagsendringsType.FORELDER_BARN_RELASJON -> {
@@ -201,9 +210,20 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
                     GrunnlagsendringStatus.valueOf(getString("status")),
                     getObject("behandling_id")?.let { it as UUID },
                     Saksrolle.valueOf(getString("hendelse_gjelder_rolle")),
-                    KorrektIPDL.valueOf(getString("korrekt_i_pdl"))
+                    objectMapper.readValue(
+                        getString("samsvar_mellom_pdl_og_grunnlag"),
+                        SamsvarMellomPdlOgGrunnlag::class.java
+                    )
                 )
             }
         }
     }
+}
+
+inline fun <reified T> PreparedStatement.setJsonb(parameterIndex: Int, jsonb: T): PreparedStatement {
+    val jsonObject = PGobject()
+    jsonObject.type = "json"
+    jsonObject.value = objectMapper.writeValueAsString(jsonb)
+    this.setObject(parameterIndex, jsonObject)
+    return this
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseDao.kt
@@ -35,7 +35,6 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
                 stmt.setString(3, type.name)
                 stmt.setTimestamp(4, Timestamp.from(opprettet.atZone(ZoneId.systemDefault()).toInstant()))
                 stmt.setJsonb(5, hendelse.data)
-                // hendelse.data?.let { stmt.setString(5, objectMapper.writeValueAsString(hendelse.data)) }
                 stmt.setString(6, status.name)
                 stmt.setString(7, hendelseGjelderRolle.name)
                 stmt.setJsonb(8, samsvarMellomPdlOgGrunnlag)

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/SamsvarHelper.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/SamsvarHelper.kt
@@ -1,0 +1,47 @@
+package no.nav.etterlatte.grunnlagsendring
+
+import no.nav.etterlatte.libs.common.behandling.SamsvarMellomPdlOgGrunnlag
+import no.nav.etterlatte.libs.common.person.Foedselsnummer
+import no.nav.etterlatte.libs.common.person.Utland
+import java.time.LocalDate
+
+fun samsvarDoedsdatoer(
+    doedsdatoPdl: LocalDate?,
+    doedsdatoGrunnlag: LocalDate?
+) = SamsvarMellomPdlOgGrunnlag.Doedsdatoforhold(
+    fraGrunnlag = doedsdatoGrunnlag,
+    fraPdl = doedsdatoPdl,
+    samsvar = doedsdatoPdl == doedsdatoGrunnlag
+)
+
+fun samsvarAnsvarligeForeldre(
+    ansvarligeForeldrePdl: List<Foedselsnummer>?,
+    ansvarligeForeldreGrunnlag: List<Foedselsnummer>?
+) = SamsvarMellomPdlOgGrunnlag.AnsvarligeForeldre(
+    fraPdl = ansvarligeForeldrePdl,
+    fraGrunnlag = ansvarligeForeldreGrunnlag,
+    samsvar = ansvarligeForeldrePdl erLikRekkefoelgeIgnorert ansvarligeForeldreGrunnlag
+)
+
+fun samsvarBarn(
+    barnPdl: List<Foedselsnummer>?,
+    barnGrunnlag: List<Foedselsnummer>?
+) = SamsvarMellomPdlOgGrunnlag.Barn(
+    fraPdl = barnPdl,
+    fraGrunnlag = barnGrunnlag,
+    samsvar = barnPdl erLikRekkefoelgeIgnorert barnGrunnlag
+)
+
+fun samsvarUtflytting(
+    utflyttingPdl: Utland?,
+    utflyttingGrunnlag: Utland?
+) = SamsvarMellomPdlOgGrunnlag.Utlandsforhold(
+    fraPdl = utflyttingPdl,
+    fraGrunnlag = utflyttingGrunnlag,
+    samsvar = utflyttingPdl?.utflyttingFraNorge erLikRekkefoelgeIgnorert utflyttingGrunnlag?.utflyttingFraNorge &&
+        utflyttingPdl?.innflyttingTilNorge erLikRekkefoelgeIgnorert utflyttingGrunnlag?.innflyttingTilNorge
+
+)
+
+infix fun <T> List<T>?.erLikRekkefoelgeIgnorert(other: List<T>?): Boolean =
+    this?.size == other?.size && this?.toSet() == other?.toSet()

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V15__add_samsvarmellompdloggrunnlag_remove_korrektipdl.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V15__add_samsvarmellompdloggrunnlag_remove_korrektipdl.sql
@@ -1,0 +1,4 @@
+ALTER TABLE grunnlagsendringshendelse
+    DROP COLUMN korrekt_i_pdl;
+ALTER TABLE grunnlagsendringshendelse
+    ADD COLUMN samsvar_mellom_pdl_og_grunnlag JSONB;

--- a/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
@@ -332,29 +332,3 @@ fun mockPerson(
     avdoedesBarn = null,
     vergemaalEllerFremtidsfullmakt = vergemaal?.map { OpplysningDTO(it, UUID.randomUUID().toString()) }
 )
-/*
-fun mockPerson(
-    doedsdato: LocalDate? = null,
-    utland: Utland? = null
-) = PersonDTO(
-    fornavn = "Test",
-    etternavn = "Testulfsen",
-    foedselsnummer = Foedselsnummer.of("70078749472"),
-    foedselsdato = LocalDate.parse("2020-06-10"),
-    foedselsaar = 1985,
-    foedeland = null,
-    doedsdato = doedsdato,
-    adressebeskyttelse = Adressebeskyttelse.UGRADERT,
-    bostedsadresse = null,
-    deltBostedsadresse = null,
-    kontaktadresse = null,
-    oppholdsadresse = null,
-    sivilstatus = null,
-    statsborgerskap = null,
-    utland = utland,
-    familieRelasjon = FamilieRelasjon(null, null, null),
-    avdoedesBarn = null,
-    vergemaalEllerFremtidsfullmakt = null
-)
-
- */

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagClientImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagClientImplTest.kt
@@ -1,0 +1,59 @@
+package grunnlagsendring
+
+import GrunnlagTestData
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.fullPath
+import io.ktor.http.headersOf
+import io.ktor.serialization.jackson.jackson
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.grunnlagsendring.GrunnlagClientImpl
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
+import no.nav.etterlatte.libs.common.toJson
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class GrunnlagClientImplTest {
+
+    private val defaultHeaders = headersOf("Content-Type" to listOf(ContentType.Application.Json.toString()))
+
+    @Test
+    fun `skal hente grunnlag`() {
+        val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
+        val klient = GrunnlagClientImpl(mockHttpClient(grunnlag))
+        val hentetGrunnlag = runBlocking {
+            klient.hentGrunnlag(1)
+        }
+        assertEquals(grunnlag.soeker, hentetGrunnlag?.soeker)
+    }
+
+    private fun mockHttpClient(grunnlagResponse: Grunnlag): HttpClient {
+        val httpClient = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.fullPath) {
+                        "/grunnlag/1" -> respond(
+                            grunnlagResponse.toJson(),
+                            HttpStatusCode.OK,
+                            defaultHeaders
+                        )
+                        else -> error("Unhandled ${request.url.fullPath}")
+                    }
+                }
+            }
+            expectSuccess = true
+            install(ContentNegotiation) {
+                jackson {
+                    registerModule(JavaTimeModule())
+                }
+            }
+        }
+
+        return httpClient
+    }
+}

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagHelperKtTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagHelperKtTest.kt
@@ -1,0 +1,184 @@
+package grunnlagsendring
+
+import GrunnlagTestData
+import grunnlag.kilde
+import no.nav.etterlatte.grunnlagsendring.ansvarligeForeldre
+import no.nav.etterlatte.grunnlagsendring.barn
+import no.nav.etterlatte.grunnlagsendring.doedsdato
+import no.nav.etterlatte.grunnlagsendring.utland
+import no.nav.etterlatte.libs.common.behandling.Saksrolle
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import no.nav.etterlatte.libs.common.grunnlag.Opplysning
+import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
+import no.nav.etterlatte.libs.common.person.FamilieRelasjon
+import no.nav.etterlatte.libs.common.person.Foedselsnummer
+import no.nav.etterlatte.libs.common.person.InnflyttingTilNorge
+import no.nav.etterlatte.libs.common.person.UtflyttingFraNorge
+import no.nav.etterlatte.libs.common.person.Utland
+import no.nav.etterlatte.libs.common.toJsonNode
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import java.time.LocalDate
+import java.util.*
+
+internal class GrunnlagHelperKtTest {
+
+    @Test
+    fun `skal hente doedsdatoer`() {
+        val grunnlagDoedsdato = LocalDate.of(2022, 8, 17)
+        val grunnlagDoedsdatoJsonNode = grunnlagDoedsdato.toJsonNode()
+        val opplysningDoedsdato =
+            Opplysningstype.DOEDSDATO to Opplysning.Konstant(
+                UUID.randomUUID(),
+                KILDE,
+                grunnlagDoedsdatoJsonNode
+            )
+        val grunnlag = GrunnlagTestData(
+            opplysningsmapSoekerOverrides = mapOf(opplysningDoedsdato),
+            opplysningsmapGjenlevendeOverrides = mapOf(opplysningDoedsdato),
+            opplysningsmapAvdoedOverrides = mapOf(opplysningDoedsdato),
+            opplysningsmapSoeskenOverrides = mapOf(
+                opplysningDoedsdato,
+                Opplysningstype.FOEDSELSNUMMER to Opplysning.Konstant(
+                    UUID.randomUUID(),
+                    KILDE,
+                    HELSOESKEN_FOEDSELSNUMMER.toJsonNode()
+                )
+            )
+        ).hentOpplysningsgrunnlag()
+        val doedsdatoAvdoed = grunnlag.doedsdato(Saksrolle.AVDOED, AVDOED_FOEDSELSNUMMER.value)
+        val doedsdatoGjenlevende = grunnlag.doedsdato(Saksrolle.GJENLEVENDE, GJENLEVENDE_FOEDSELSNUMMER.value)
+        val doedsdatoSoeker = grunnlag.doedsdato(Saksrolle.SOEKER, SOEKER_FOEDSELSNUMMER.value)
+        val doedsdatoSoesken = grunnlag.doedsdato(Saksrolle.SOESKEN, HELSOESKEN_FOEDSELSNUMMER.value)
+        assertEquals(grunnlagDoedsdato, doedsdatoAvdoed?.verdi)
+        assertEquals(grunnlagDoedsdato, doedsdatoGjenlevende?.verdi)
+        assertEquals(grunnlagDoedsdato, doedsdatoSoeker?.verdi)
+        assertEquals(grunnlagDoedsdato, doedsdatoSoesken?.verdi)
+    }
+
+    @Test
+    fun `skal hente ansvarlige foreldre`() {
+        val ansvarligeForeldre = listOf(AVDOED_FOEDSELSNUMMER, GJENLEVENDE_FOEDSELSNUMMER)
+        val opplysningFamilierelasjon =
+            Opplysningstype.FAMILIERELASJON to Opplysning.Konstant(
+                UUID.randomUUID(),
+                kilde,
+                FamilieRelasjon(
+                    ansvarligeForeldre = ansvarligeForeldre,
+                    foreldre = null,
+                    barn = null
+                ).toJsonNode()
+            )
+        val grunnlag = GrunnlagTestData(
+            opplysningsmapSoekerOverrides = mapOf(opplysningFamilierelasjon),
+            opplysningsmapSoeskenOverrides = mapOf(OPPLYSNINGSTYPE_FOEDSELSNUMMER_HELSOESKEN, opplysningFamilierelasjon)
+
+        ).hentOpplysningsgrunnlag()
+
+        val ansvarligeForeldreSoeker = grunnlag.ansvarligeForeldre(Saksrolle.SOEKER, SOEKER_FOEDSELSNUMMER.value)
+        val ansvarligeForeldreSoesken = grunnlag.ansvarligeForeldre(Saksrolle.SOESKEN, HELSOESKEN_FOEDSELSNUMMER.value)
+        assertEquals(ansvarligeForeldre, ansvarligeForeldreSoeker)
+        assertEquals(ansvarligeForeldre, ansvarligeForeldreSoesken)
+        assertThrows<IllegalArgumentException> {
+            grunnlag.ansvarligeForeldre(
+                Saksrolle.AVDOED,
+                AVDOED_FOEDSELSNUMMER.value
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            grunnlag.ansvarligeForeldre(
+                Saksrolle.GJENLEVENDE,
+                GJENLEVENDE_FOEDSELSNUMMER.value
+            )
+        }
+        assertThrows<IllegalArgumentException> { grunnlag.ansvarligeForeldre(Saksrolle.UKJENT, "123") }
+    }
+
+    @Test
+    fun `skal hente barn`() {
+        val barn = listOf(SOEKER_FOEDSELSNUMMER, HELSOESKEN_FOEDSELSNUMMER)
+        val grunnlag = GrunnlagTestData(
+            opplysningsmapAvdoedOverrides = mapOf(
+                Opplysningstype.FAMILIERELASJON to Opplysning.Konstant(
+                    UUID.randomUUID(),
+                    kilde,
+                    FamilieRelasjon(
+                        ansvarligeForeldre = null,
+                        foreldre = null,
+                        barn = barn
+                    ).toJsonNode()
+                )
+            ),
+            opplysningsmapGjenlevendeOverrides = mapOf(
+                Opplysningstype.FAMILIERELASJON to Opplysning.Konstant(
+                    UUID.randomUUID(),
+                    kilde,
+                    FamilieRelasjon(
+                        ansvarligeForeldre = null,
+                        foreldre = null,
+                        barn = barn
+                    ).toJsonNode()
+                )
+            )
+        ).hentOpplysningsgrunnlag()
+        val avdoedesBarn = grunnlag.barn(Saksrolle.AVDOED)
+        val gjenlevendesBarn = grunnlag.barn(Saksrolle.GJENLEVENDE)
+        assertEquals(barn, avdoedesBarn)
+        assertEquals(barn, gjenlevendesBarn)
+        assertThrows<IllegalArgumentException> { grunnlag.barn(Saksrolle.SOEKER) }
+        assertThrows<IllegalArgumentException> { grunnlag.barn(Saksrolle.SOESKEN) }
+        assertThrows<IllegalArgumentException> { grunnlag.barn(Saksrolle.UKJENT) }
+    }
+
+    @Test
+    fun `skal hente utland`() {
+        val utland = Utland(
+            innflyttingTilNorge = listOf(InnflyttingTilNorge("Danmark", LocalDate.of(2007, 4, 1))),
+            utflyttingFraNorge = listOf(
+                UtflyttingFraNorge("Sverige", LocalDate.of(2005, 7, 8)),
+                UtflyttingFraNorge("Sveits", LocalDate.of(2022, 12, 12))
+            )
+        )
+        val opplysningUtland = Opplysningstype.UTLAND to Opplysning.Konstant(
+            UUID.randomUUID(),
+            kilde,
+            utland.toJsonNode()
+        )
+
+        val grunnlag = GrunnlagTestData(
+            opplysningsmapAvdoedOverrides = mapOf(opplysningUtland),
+            opplysningsmapGjenlevendeOverrides = mapOf(opplysningUtland),
+            opplysningsmapSoekerOverrides = mapOf(opplysningUtland),
+            opplysningsmapSoeskenOverrides = mapOf(OPPLYSNINGSTYPE_FOEDSELSNUMMER_HELSOESKEN, opplysningUtland)
+        ).hentOpplysningsgrunnlag()
+
+        val utlandAvdoed = grunnlag.utland(Saksrolle.AVDOED, AVDOED_FOEDSELSNUMMER.value)
+        val utlandGjenlevende = grunnlag.utland(Saksrolle.GJENLEVENDE, GJENLEVENDE_FOEDSELSNUMMER.value)
+        val utlandSoeker = grunnlag.utland(Saksrolle.SOEKER, SOEKER_FOEDSELSNUMMER.value)
+        val utlandSoesken = grunnlag.utland(Saksrolle.SOESKEN, HELSOESKEN_FOEDSELSNUMMER.value)
+        assertEquals(utland, utlandAvdoed)
+        assertEquals(utland, utlandGjenlevende)
+        assertEquals(utland, utlandSoeker)
+        assertEquals(utland, utlandSoesken)
+    }
+
+    companion object {
+        val KILDE = Grunnlagsopplysning.Pdl(
+            navn = "pdl",
+            tidspunktForInnhenting = Instant.now(),
+            registersReferanse = null,
+            opplysningId = "opplysningsId1"
+        )
+        val SOEKER_FOEDSELSNUMMER = Foedselsnummer.of("30106519672")
+        val HELSOESKEN_FOEDSELSNUMMER = Foedselsnummer.of("01018100157")
+        val OPPLYSNINGSTYPE_FOEDSELSNUMMER_HELSOESKEN = Opplysningstype.FOEDSELSNUMMER to Opplysning.Konstant(
+            UUID.randomUUID(),
+            KILDE,
+            HELSOESKEN_FOEDSELSNUMMER.toJsonNode()
+        )
+        val AVDOED_FOEDSELSNUMMER = Foedselsnummer.of("07081177656")
+        val GJENLEVENDE_FOEDSELSNUMMER = Foedselsnummer.of("06048010820")
+    }
+}

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.grunnlagsendring
 
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -8,7 +9,7 @@ import no.nav.etterlatte.DatabaseKontekst
 import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.behandling.GenerellBehandlingService
 import no.nav.etterlatte.foerstegangsbehandling
-import no.nav.etterlatte.grunnlagsendringshendelse
+import no.nav.etterlatte.grunnlagsendringshendelseUtenSamsvar
 import no.nav.etterlatte.grunnlagsinformasjonDoedshendelse
 import no.nav.etterlatte.grunnlagsinformasjonForelderBarnRelasjonHendelse
 import no.nav.etterlatte.grunnlagsinformasjonUtflyttingshendelse
@@ -18,13 +19,11 @@ import no.nav.etterlatte.libs.common.behandling.GrunnlagsendringStatus
 import no.nav.etterlatte.libs.common.behandling.GrunnlagsendringsType
 import no.nav.etterlatte.libs.common.behandling.Grunnlagsendringshendelse
 import no.nav.etterlatte.libs.common.behandling.Grunnlagsinformasjon
-import no.nav.etterlatte.libs.common.behandling.KorrektIPDL
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
 import no.nav.etterlatte.libs.common.pdlhendelse.Doedshendelse
 import no.nav.etterlatte.libs.common.pdlhendelse.Endringstype
 import no.nav.etterlatte.libs.common.pdlhendelse.ForelderBarnRelasjonHendelse
 import no.nav.etterlatte.libs.common.pdlhendelse.UtflyttingsHendelse
-import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.pdl.PdlService
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -64,10 +63,11 @@ internal class GrunnlagsendringshendelseServiceTest {
             foerstegangsbehandling(sak = sakId, status = BehandlingStatus.IVERKSATT),
             foerstegangsbehandling(sak = sakId, status = BehandlingStatus.FATTET_VEDTAK)
         )
-        val grunnlagsendringshendelse = grunnlagsendringshendelse(
+        val grunnlagsendringshendelse = grunnlagsendringshendelseUtenSamsvar(
             id = UUID.randomUUID(),
             sakId = sakId,
-            data = grunnlagsinformasjonDoedshendelse(fnr)
+            data = grunnlagsinformasjonDoedshendelse(fnr),
+            samsvarMellomPdlOgGrunnlag = null
         )
 
         val opprettGrunnlagsendringshendelse = slot<Grunnlagsendringshendelse>()
@@ -86,10 +86,12 @@ internal class GrunnlagsendringshendelseServiceTest {
             every { hentSakerOgRollerMedFnrIPersongalleri(any()) } returns listOf(Pair(Saksrolle.SOEKER, sakId))
         }
         val pdlService = mockk<PdlService>()
+        val grunnlagClient = mockk<GrunnlagClient>()
         val grunnlagsendringshendelseService = GrunnlagsendringshendelseService(
             grunnlagshendelsesDao,
             generellBehandlingService,
-            pdlService
+            pdlService,
+            grunnlagClient
         )
 
         val lagredeGrunnlagsendringshendelser = grunnlagsendringshendelseService.opprettDoedshendelse(
@@ -115,15 +117,17 @@ internal class GrunnlagsendringshendelseServiceTest {
     fun `skal opprette grunnlagsendringshendelser i databasen for utflytting og forelder-barn`() {
         val sakId = 1L
         val fnr = "Soeker"
-        val grlagEndringUtflytting = grunnlagsendringshendelse(
+        val grlagEndringUtflytting = grunnlagsendringshendelseUtenSamsvar(
             id = UUID.randomUUID(),
             sakId = sakId,
-            data = grunnlagsinformasjonUtflyttingshendelse(fnr)
+            data = grunnlagsinformasjonUtflyttingshendelse(fnr),
+            samsvarMellomPdlOgGrunnlag = null
         )
-        val grlagEndringForelderBarn = grunnlagsendringshendelse(
+        val grlagEndringForelderBarn = grunnlagsendringshendelseUtenSamsvar(
             id = UUID.randomUUID(),
             sakId = sakId,
-            data = grunnlagsinformasjonForelderBarnRelasjonHendelse(fnr)
+            data = grunnlagsinformasjonForelderBarnRelasjonHendelse(fnr),
+            samsvarMellomPdlOgGrunnlag = null
         )
 
         val opprettGrlaghendelseUtflytting = slot<Grunnlagsendringshendelse>()
@@ -138,11 +142,13 @@ internal class GrunnlagsendringshendelseServiceTest {
             every { alleSakIderForSoekerMedFnr(fnr) } returns listOf(1L)
             every { hentSakerOgRollerMedFnrIPersongalleri(any()) } returns listOf(Pair(Saksrolle.SOEKER, sakId))
         }
+        val grunnlagClient = mockk<GrunnlagClient>()
         val pdlService = mockk<PdlService>()
         val grunnlagsendringshendelseService = GrunnlagsendringshendelseService(
             grunnlagshendelsesDao,
             generellBehandlingService,
-            pdlService
+            pdlService,
+            grunnlagClient
         )
 
         grunnlagsendringshendelseService.opprettUtflyttingshendelse(
@@ -183,18 +189,20 @@ internal class GrunnlagsendringshendelseServiceTest {
         val sakId = 1L
         val fnr = "Soeker"
         val doedsdato = LocalDate.of(2022, 7, 8)
-        val grunnlagsendringshendelse1 = grunnlagsendringshendelse(
+        val grunnlagsendringshendelse1 = grunnlagsendringshendelseUtenSamsvar(
             type = GrunnlagsendringsType.DOEDSFALL,
             id = UUID.randomUUID(),
             sakId = sakId,
-            data = grunnlagsinformasjonDoedshendelse(fnr, doedsdato)
+            data = grunnlagsinformasjonDoedshendelse(fnr, doedsdato),
+            samsvarMellomPdlOgGrunnlag = null
         )
 
-        val grunnlagsendringshendelse2 = grunnlagsendringshendelse(
+        val grunnlagsendringshendelse2 = grunnlagsendringshendelseUtenSamsvar(
             type = GrunnlagsendringsType.UTFLYTTING,
             id = UUID.randomUUID(),
             sakId = sakId,
-            data = grunnlagsinformasjonUtflyttingshendelse(fnr)
+            data = grunnlagsinformasjonUtflyttingshendelse(fnr),
+            samsvarMellomPdlOgGrunnlag = null
         )
 
         val grunnlagshendelsesDao = mockk<GrunnlagsendringshendelseDao> {
@@ -212,10 +220,12 @@ internal class GrunnlagsendringshendelseServiceTest {
             every { hentSakerOgRollerMedFnrIPersongalleri(any()) } returns listOf(Pair(Saksrolle.SOEKER, sakId))
         }
         val pdlService = mockk<PdlService>()
+        val grunnlagClient = mockk<GrunnlagClient>()
         val grunnlagsendringshendelseService = GrunnlagsendringshendelseService(
             grunnlagshendelsesDao,
             generellBehandlingService,
-            pdlService
+            pdlService,
+            grunnlagClient
         )
         val lagredeGrunnlagsendringshendelser1 = grunnlagsendringshendelseService.opprettDoedshendelse(
             Doedshendelse(
@@ -255,7 +265,7 @@ internal class GrunnlagsendringshendelseServiceTest {
         val fnr = "Soeker"
         val tilflyttingsland = "Sverige"
         val utflyttingsdato = LocalDate.of(2022, 2, 8)
-        val grunnlagsendringshendelse1 = grunnlagsendringshendelse(
+        val grunnlagsendringshendelse1 = grunnlagsendringshendelseUtenSamsvar(
             type = GrunnlagsendringsType.UTFLYTTING,
             id = UUID.randomUUID(),
             sakId = sakId,
@@ -263,13 +273,15 @@ internal class GrunnlagsendringshendelseServiceTest {
                 fnr = fnr,
                 tilflyttingsLand = tilflyttingsland,
                 utflyttingsdato = utflyttingsdato
-            )
+            ),
+            samsvarMellomPdlOgGrunnlag = null
         )
-        val grunnlagsendringshendelse2 = grunnlagsendringshendelse(
+        val grunnlagsendringshendelse2 = grunnlagsendringshendelseUtenSamsvar(
             type = GrunnlagsendringsType.DOEDSFALL,
             id = UUID.randomUUID(),
             sakId = sakId,
-            data = grunnlagsinformasjonDoedshendelse(fnr)
+            data = grunnlagsinformasjonDoedshendelse(fnr),
+            samsvarMellomPdlOgGrunnlag = null
         )
 
         val grunnlagshendelsesDao = mockk<GrunnlagsendringshendelseDao> {
@@ -287,10 +299,12 @@ internal class GrunnlagsendringshendelseServiceTest {
             every { hentSakerOgRollerMedFnrIPersongalleri(any()) } returns listOf(Pair(Saksrolle.SOEKER, sakId))
         }
         val pdlService = mockk<PdlService>()
+        val grunnlagClient = mockk<GrunnlagClient>()
         val grunnlagsendringshendelseService = GrunnlagsendringshendelseService(
             grunnlagshendelsesDao,
             generellBehandlingService,
-            pdlService
+            pdlService,
+            grunnlagClient
         )
         val lagredeGrunnlagsendringshendelser1 = grunnlagsendringshendelseService.opprettUtflyttingshendelse(
             UtflyttingsHendelse(
@@ -329,20 +343,22 @@ internal class GrunnlagsendringshendelseServiceTest {
     @Test
     fun `skal ikke opprette ny forelder-barn-relasjon-hendelse dersom en lignende allerede eksisterer`() {
         val sakId = 1L
-        val grunnlagsendringshendelse1 = grunnlagsendringshendelse(
+        val grunnlagsendringshendelse1 = grunnlagsendringshendelseUtenSamsvar(
             type = GrunnlagsendringsType.FORELDER_BARN_RELASJON,
             id = UUID.randomUUID(),
             sakId = sakId,
             data = grunnlagsinformasjonForelderBarnRelasjonHendelse(
                 fnr = "Soeker",
                 relatertPersonsIdent = "Ny forelder"
-            )
+            ),
+            samsvarMellomPdlOgGrunnlag = null
         )
-        val grunnlagsendringshendelse2 = grunnlagsendringshendelse(
+        val grunnlagsendringshendelse2 = grunnlagsendringshendelseUtenSamsvar(
             type = GrunnlagsendringsType.DOEDSFALL,
             id = UUID.randomUUID(),
             sakId = sakId,
-            data = grunnlagsinformasjonDoedshendelse("Soeker")
+            data = grunnlagsinformasjonDoedshendelse("Soeker"),
+            samsvarMellomPdlOgGrunnlag = null
         )
 
         val grunnlagshendelsesDao = mockk<GrunnlagsendringshendelseDao> {
@@ -360,10 +376,12 @@ internal class GrunnlagsendringshendelseServiceTest {
             every { hentSakerOgRollerMedFnrIPersongalleri(any()) } returns listOf(Pair(Saksrolle.SOEKER, sakId))
         }
         val pdlService = mockk<PdlService>()
+        val grunnlagClient = mockk<GrunnlagClient>()
         val grunnlagsendringshendelseService = GrunnlagsendringshendelseService(
             grunnlagshendelsesDao,
             generellBehandlingService,
-            pdlService
+            pdlService,
+            grunnlagClient
         )
         val lagredeGrunnlagsendringshendelser1 = grunnlagsendringshendelseService.opprettForelderBarnRelasjonHendelse(
             ForelderBarnRelasjonHendelse(
@@ -404,17 +422,23 @@ internal class GrunnlagsendringshendelseServiceTest {
     @Test
     fun `skal sette status til SJEKKET_AV_JOBB, for hendelser som er sjekket av jobb`() {
         val minutter = 60L
-        val avdoedFnr = "soeker"
+        val avdoedFnr = "16017919184"
         val sakId = 1L
         val grlg_id = UUID.randomUUID()
+        val doedsdato = LocalDate.of(2022, 3, 13)
+        val rolle = Saksrolle.SOEKER
+        val personRolle = Saksrolle.SaksrolleToPersonrolle(rolle)
         val grunnlagsendringshendelser = listOf(
-            grunnlagsendringshendelse(
+            grunnlagsendringshendelseUtenSamsvar(
                 id = grlg_id,
                 sakId = sakId,
                 opprettet = LocalDateTime.now().minusHours(1),
-                data = grunnlagsinformasjonDoedshendelse(avdoedFnr = avdoedFnr)
+                data = grunnlagsinformasjonDoedshendelse(avdoedFnr = avdoedFnr, doedsdato = doedsdato),
+                hendelseGjelderRolle = rolle,
+                samsvarMellomPdlOgGrunnlag = null
             )
         )
+        // val samsvarMellomPdlOgGrunnlag = samsvarMellomPdlOgGrunnlagDoed(doedsdato)
         val idArg = slot<UUID>()
         val grunnlagshendelsesDao = mockk<GrunnlagsendringshendelseDao> {
             every {
@@ -427,16 +451,14 @@ internal class GrunnlagsendringshendelseServiceTest {
                     capture(idArg),
                     GrunnlagsendringStatus.VENTER_PAA_JOBB,
                     GrunnlagsendringStatus.SJEKKET_AV_JOBB,
-                    korrektIPDL = KorrektIPDL.JA
+                    any()
                 )
             } returns Unit
         }
         val pdlService = mockk<PdlService> {
-            every { hentPdlModell(avdoedFnr, PersonRolle.BARN) } returns mockk {
-                every { doedsdato } returns LocalDate.of(2022, 10, 8)
-            }
-            every { personErDoed(avdoedFnr) } returns KorrektIPDL.JA
+            every { hentDoedsdato(avdoedFnr, personRolle) } returns doedsdato
         }
+
         val behandlingId = UUID.randomUUID()
         val generellBehandlingService = mockk<GenerellBehandlingService> {
             every { hentBehandlingerISak(sakId) } returns listOf(
@@ -447,10 +469,15 @@ internal class GrunnlagsendringshendelseServiceTest {
                 }
             )
         }
+
+        val grunnlagClient = mockk<GrunnlagClientImpl> {
+            coEvery { hentGrunnlag(any()) } returns null
+        }
         val grunnlagsendringshendelseService = GrunnlagsendringshendelseService(
             grunnlagshendelsesDao,
             generellBehandlingService,
-            pdlService
+            pdlService,
+            grunnlagClient
         )
         grunnlagsendringshendelseService.sjekkKlareGrunnlagsendringshendelser(minutter)
 

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/SamsvarHelperKtTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/SamsvarHelperKtTest.kt
@@ -1,0 +1,92 @@
+package grunnlagsendring
+
+import no.nav.etterlatte.STOR_SNERK
+import no.nav.etterlatte.TRIVIELL_MIDTPUNKT
+import no.nav.etterlatte.grunnlagsendring.samsvarAnsvarligeForeldre
+import no.nav.etterlatte.grunnlagsendring.samsvarBarn
+import no.nav.etterlatte.grunnlagsendring.samsvarDoedsdatoer
+import no.nav.etterlatte.grunnlagsendring.samsvarUtflytting
+import no.nav.etterlatte.libs.common.person.InnflyttingTilNorge
+import no.nav.etterlatte.libs.common.person.UtflyttingFraNorge
+import no.nav.etterlatte.libs.common.person.Utland
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+internal class SamsvarHelperKtTest {
+
+    @Test
+    fun `samsvarDoedsdatoer med samsvar`() {
+        val doedsdatoPdl = LocalDate.now()
+        val doedsdatoGrunnlag = LocalDate.now()
+        val resultat = samsvarDoedsdatoer(doedsdatoPdl, doedsdatoGrunnlag)
+        assertTrue(resultat.samsvar)
+    }
+
+    @Test
+    fun `samsvarDoedsdatoer uten samsvar`() {
+        val doedsdatoPdl = LocalDate.now()
+        val doedsdatoGrunnlag = null
+        val resultat = samsvarDoedsdatoer(doedsdatoPdl, doedsdatoGrunnlag)
+        assertFalse(resultat.samsvar)
+    }
+
+    @Test
+    fun `samsvarAnsvarligeForeldre med samsvar`() {
+        val ansvarligeForeldrePdl = listOf(STOR_SNERK, TRIVIELL_MIDTPUNKT)
+        val ansvarligeForeldreGrunnlag = listOf(STOR_SNERK, TRIVIELL_MIDTPUNKT)
+        val resultat = samsvarAnsvarligeForeldre(ansvarligeForeldrePdl, ansvarligeForeldreGrunnlag)
+        assertTrue(resultat.samsvar)
+    }
+
+    @Test
+    fun `samsvarAnsvarligeForeldre uten samsvar`() {
+        val ansvarligeForeldrePdl = listOf(STOR_SNERK, TRIVIELL_MIDTPUNKT)
+        val ansvarligeForeldreGrunnlag = listOf(STOR_SNERK)
+        val resultat = samsvarAnsvarligeForeldre(ansvarligeForeldrePdl, ansvarligeForeldreGrunnlag)
+        assertFalse(resultat.samsvar)
+    }
+
+    @Test
+    fun `samsvarBarn med samsvar`() {
+        val barnPdl = listOf(STOR_SNERK, TRIVIELL_MIDTPUNKT)
+        val barnGrunnlag = listOf(TRIVIELL_MIDTPUNKT, STOR_SNERK)
+        val resultat = samsvarBarn(barnPdl, barnGrunnlag)
+        assertTrue(resultat.samsvar)
+    }
+
+    @Test
+    fun `samsvarBarn uten samsvar`() {
+        val barnPdl = listOf(STOR_SNERK, TRIVIELL_MIDTPUNKT)
+        val barnGrunnlag = listOf(TRIVIELL_MIDTPUNKT)
+        val resultat = samsvarBarn(barnPdl, barnGrunnlag)
+        assertFalse(resultat.samsvar)
+    }
+
+    @Test
+    fun `samsvarUtflytting med samsvar`() {
+        val utland = Utland(
+            innflyttingTilNorge = listOf(InnflyttingTilNorge("Tyskland", LocalDate.of(2013, 7, 9))),
+            utflyttingFraNorge = listOf(UtflyttingFraNorge("Tyskland", LocalDate.of(2022, 1, 1)))
+        )
+        val utflyttingPdl = utland
+        val utflyttingGrunnlag = utland
+        val resultat = samsvarUtflytting(utflyttingPdl, utflyttingGrunnlag)
+        assertTrue(resultat.samsvar)
+    }
+
+    @Test
+    fun `samsvarUtflytting uten samsvar`() {
+        val utflyttingPdl = Utland(
+            innflyttingTilNorge = listOf(InnflyttingTilNorge("Tyskland", LocalDate.of(2013, 7, 9))),
+            utflyttingFraNorge = listOf(UtflyttingFraNorge("Tyskland", LocalDate.of(2022, 1, 1)))
+        )
+        val utflyttingGrunnlag = Utland(
+            innflyttingTilNorge = null,
+            utflyttingFraNorge = listOf(UtflyttingFraNorge("Tyskland", LocalDate.of(2022, 1, 1)))
+        )
+        val resultat = samsvarUtflytting(utflyttingPdl, utflyttingGrunnlag)
+        assertFalse(resultat.samsvar)
+    }
+}

--- a/apps/etterlatte-behandling/src/test/kotlin/itest/BehandlingDaoIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/itest/BehandlingDaoIntegrationTest.kt
@@ -163,7 +163,7 @@ internal class BehandlingDaoIntegrationTest {
     }
 
     @Test
-    fun `Skal legge til gyldighetsprøving til en opprettet behandling`() {
+    fun `Skal legge til gyldighetsproeving til en opprettet behandling`() {
         val sak1 = sakRepo.opprettSak("123", SakType.BARNEPENSJON).id
 
         val behandling = foerstegangsbehandling(sak = sak1)
@@ -634,19 +634,17 @@ internal class BehandlingDaoIntegrationTest {
         }
 
         val sakerOgRoller = behandlingRepo.sakerOgRollerMedFnrIPersongalleri("11111")
-        assertEquals(6, sakerOgRoller.size)
+        assertEquals(5, sakerOgRoller.size)
         assertEquals(Saksrolle.SOEKER, sakerOgRoller[0].first)
         assertEquals(sak1, sakerOgRoller[0].second)
         assertEquals(Saksrolle.AVDOED, sakerOgRoller[1].first)
         assertEquals(sak2, sakerOgRoller[1].second)
         assertEquals(Saksrolle.GJENLEVENDE, sakerOgRoller[2].first)
         assertEquals(sak2, sakerOgRoller[2].second)
-        assertEquals(Saksrolle.INNSENDER, sakerOgRoller[3].first)
+        assertEquals(Saksrolle.SOEKER, sakerOgRoller[3].first)
         assertEquals(sak2, sakerOgRoller[3].second)
-        assertEquals(Saksrolle.SOEKER, sakerOgRoller[4].first)
+        assertEquals(Saksrolle.SOESKEN, sakerOgRoller[4].first)
         assertEquals(sak2, sakerOgRoller[4].second)
-        assertEquals(Saksrolle.SOESKEN, sakerOgRoller[5].first)
-        assertEquals(sak2, sakerOgRoller[5].second)
     }
 
     @Test

--- a/libs/common/src/main/kotlin/grunnlag/Grunnlag.kt
+++ b/libs/common/src/main/kotlin/grunnlag/Grunnlag.kt
@@ -21,6 +21,9 @@ class Grunnlag(
     fun hentAvdoed(): Grunnlagsdata<JsonNode> = hentFamiliemedlem(PersonRolle.AVDOED)
     fun hentGjenlevende(): Grunnlagsdata<JsonNode> = hentFamiliemedlem(PersonRolle.GJENLEVENDE)
 
+    fun hentSoesken() =
+        familie.filter { it.hentPersonrolle()?.verdi == PersonRolle.BARN }
+
     private fun hentFamiliemedlem(personRolle: PersonRolle) =
         familie.find { it.hentPersonrolle()?.verdi == personRolle }!!
 

--- a/libs/common/src/main/kotlin/pdlhendelse/PdlHendelser.kt
+++ b/libs/common/src/main/kotlin/pdlhendelse/PdlHendelser.kt
@@ -33,7 +33,7 @@ data class ForelderBarnRelasjonHendelse(
     val minRolleForPerson: String?,
     val relatertPersonUtenFolkeregisteridentifikator: String?,
     val endringstype: Endringstype
-)
+) : PdlHendelse
 
 fun ForelderBarnRelasjonHendelse.erLik(other: ForelderBarnRelasjonHendelse) =
     this.fnr == other.fnr &&

--- a/libs/testdata/build.gradle.kts
+++ b/libs/testdata/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    maven("https://jitpack.io")
+    maven("https://github.com")
     mavenCentral()
 }
 


### PR DESCRIPTION
Ved en grunnlagsendringshendelse, kontrolleres det nå at informasjonen i pdl og grunnlaget til saken er ulikt. Dersom grunnlaget er ulikt, lagres dette ned i databasen, og grunnlagsendringshendelsen er klar for uthenting.