### PR TITLE
Fiks av H-tags og layout

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
@@ -32,25 +32,25 @@ export const StegMeny = () => {
           <li>
             <NavLink to="soeknadsoversikt">Søknadsoversikt</NavLink>
           </li>
-          <Separator />
+          <Separator aria-hidden={"true"} />
         </>
       )}
       <li className={classNames({ disabled: !klarForVidereBehandling || !gyldighet })}>
         <NavLink to="vilkaarsvurdering">Vilkårsvurdering</NavLink>
       </li>
-      <Separator />
+      <Separator aria-hidden={"true"} />
       {behandling.behandlingType === IBehandlingsType.FØRSTEGANGSBEHANDLING && (
         <>
           <li className={classNames({ disabled: !gyldighet || !vilkaar })}>
             <NavLink to="beregningsgrunnlag">Beregningsgrunnlag</NavLink>
           </li>
-          <Separator />
+          <Separator aria-hidden={"true"} />
         </>
       )}
       <li className={classNames({ disabled: !gyldighet || !vilkaar || !harBeregning })}>
         <NavLink to="beregne">Beregning</NavLink>
       </li>
-      <Separator />
+      <Separator aria-hidden={"true"} />
       <li
         className={classNames({
           disabled: !vurdert || (oppfylt && !harBeregning),

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
@@ -26,7 +26,7 @@ export const StegMeny = () => {
   const vurdert = !!behandling.vilkårsprøving?.resultat && klarForVidereBehandling
 
   return (
-    <StegMenyWrapper>
+    <StegMenyWrapper role="navigation">
       {behandling.behandlingType === IBehandlingsType.FØRSTEGANGSBEHANDLING && (
         <>
           <li>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
@@ -1,5 +1,5 @@
 import { Content, ContentHeader } from '~shared/styled'
-import { TypeStatusWrap } from '../soeknadsoversikt/styled'
+import { HeadingWrapper, TypeStatusWrap } from '../soeknadsoversikt/styled'
 import { hentBehandlesFraStatus } from '../felles/utils'
 import { formaterStringDato } from '~utils/formattering'
 import { formaterVedtaksResultat, useVedtaksResultat } from '../useVedtaksResultat'
@@ -46,7 +46,11 @@ export const Beregne = () => {
   return (
     <Content>
       <ContentHeader>
-        <Heading size={"large"} level={"1"}>Beregning og vedtak</Heading>
+        <HeadingWrapper>
+          <Heading size={'large'} level={'1'}>
+            Beregning og vedtak
+          </Heading>
+        </HeadingWrapper>
         <InfoWrapper>
           <DetailWrapper>
             <TypeStatusWrap type="barn">Barnepensjon</TypeStatusWrap>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
@@ -11,7 +11,7 @@ import { oppdaterBeregning } from '~store/reducers/BehandlingReducer'
 import Spinner from '~shared/Spinner'
 import { Sammendrag } from './Sammendrag'
 import { BehandlingHandlingKnapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
-import { Alert, Button, ErrorMessage } from '@navikt/ds-react'
+import { Alert, Button, ErrorMessage, Heading } from '@navikt/ds-react'
 import { NesteOgTilbake } from '~components/behandling/handlinger/NesteOgTilbake'
 import styled from 'styled-components'
 import { isFailure, isPending, isPendingOrInitial, isSuccess, useApiCall } from '~shared/hooks/useApiCall'
@@ -46,7 +46,7 @@ export const Beregne = () => {
   return (
     <Content>
       <ContentHeader>
-        <h1>Beregning og vedtak</h1>
+        <Heading size={"large"} level={"1"}>Beregning og vedtak</Heading>
         <InfoWrapper>
           <DetailWrapper>
             <TypeStatusWrap type="barn">Barnepensjon</TypeStatusWrap>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/GjelderToolTip.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/GjelderToolTip.tsx
@@ -25,6 +25,7 @@ export const GjelderTooltip = ({ soesken, soeker }: { soesken: ToolTipPerson[]; 
         ref={ref}
         onClick={() => setIsOpen(true)}
         icon={<InformationColored title="Få mer informasjon om beregningsgrunnlaget" />}
+        onBlur={() => setIsOpen(false)}
       />
       <Popover anchorEl={ref.current} open={isOpen} onClose={() => setIsOpen(false)} placement="top">
         <PopoverContent>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Sammendrag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Sammendrag.tsx
@@ -14,10 +14,10 @@ interface Props {
 
 export const Sammendrag = ({ beregning, soeker, soesken }: Props) => {
   const beregningsperioder = beregning.beregningsperioder
-
+    
   return (
     <TableWrapper>
-      <Heading spacing size="small" level="5">
+      <Heading spacing size="small" level="2">
         Beregningssammendrag
       </Heading>
       <Table className="table" zebraStripes>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Beregningsgrunnlag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Beregningsgrunnlag.tsx
@@ -1,7 +1,7 @@
 import { BodyShort, Button, Heading, Loader, Radio, RadioGroup } from '@navikt/ds-react'
 import { Content, ContentHeader } from '~shared/styled'
 import { useState } from 'react'
-import { Border, HeadingWrapper, Innhold } from '../soeknadsoversikt/styled'
+import { Border, HeadingWrapper } from '../soeknadsoversikt/styled'
 import { Barn } from '../soeknadsoversikt/familieforhold/personer/Barn'
 import { Soesken } from '../soeknadsoversikt/familieforhold/personer/Soesken'
 import styled from 'styled-components'

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Beregningsgrunnlag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Beregningsgrunnlag.tsx
@@ -1,7 +1,7 @@
 import { BodyShort, Button, Heading, Loader, Radio, RadioGroup } from '@navikt/ds-react'
-import { Content, Header } from '~shared/styled'
+import { Content, ContentHeader } from '~shared/styled'
 import { useState } from 'react'
-import { Border } from '../soeknadsoversikt/styled'
+import { Border, HeadingWrapper, Innhold } from '../soeknadsoversikt/styled'
 import { Barn } from '../soeknadsoversikt/familieforhold/personer/Barn'
 import { Soesken } from '../soeknadsoversikt/familieforhold/personer/Soesken'
 import styled from 'styled-components'
@@ -52,20 +52,23 @@ const Beregningsgrunnlag = () => {
 
   return (
     <Content>
-      <Header>
-        <h1>Beregningsgrunnlag</h1>
-        <BodyShort spacing>
-          Vilkårsresultat:{' '}
-          <strong>
-            Innvilget fra{' '}
-            {behandling.virkningstidspunkt ? formaterStringDato(behandling.virkningstidspunkt.dato) : 'ukjent dato'}
-          </strong>
-        </BodyShort>
-        <Heading level="2" size="small">
-          Søskenjustering
-        </Heading>
-      </Header>
-
+      <ContentHeader>
+        <HeadingWrapper>
+          <Heading spacing size={'large'} level={'1'}>
+            Beregningsgrunnlag
+          </Heading>
+          <BodyShort spacing>
+            Vilkårsresultat:{' '}
+            <strong>
+              Innvilget fra{' '}
+              {behandling.virkningstidspunkt ? formaterStringDato(behandling.virkningstidspunkt.dato) : 'ukjent dato'}
+            </strong>
+          </BodyShort>
+          <Heading level="2" size="medium">
+            Søskenjustering
+          </Heading>
+        </HeadingWrapper>
+      </ContentHeader>
       <FamilieforholdWrapper
         id="form"
         onSubmit={handleSubmit(async (formValues) => {
@@ -131,7 +134,7 @@ const RadioGroupRow = styled(RadioGroup)`
   }
 `
 const FamilieforholdWrapper = styled.form`
-  margin-left: 3em;
+  padding: 0em 5em;
 `
 
 export default Beregningsgrunnlag

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/Soeknadoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/Soeknadoversikt.tsx
@@ -23,7 +23,7 @@ export const Soeknadsoversikt = () => {
     <Content>
       <ContentHeader>
         <HeadingWrapper>
-          <Heading spacing size="xlarge" level="1">
+          <Heading spacing size="large" level="1">
             Søknadsoversikt
           </Heading>
           <div className="details">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/Soeknadoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/Soeknadoversikt.tsx
@@ -23,7 +23,7 @@ export const Soeknadsoversikt = () => {
     <Content>
       <ContentHeader>
         <HeadingWrapper>
-          <Heading spacing size="xlarge" level="5">
+          <Heading spacing size="xlarge" level="1">
             Søknadsoversikt
           </Heading>
           <div className="details">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/Familieforhold.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/Familieforhold.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components'
 import { Heading } from '@navikt/ds-react'
-import { AvdoedForelder } from './personer/AvdoedForelder'
 import { GjenlevendeForelder } from './personer/GjenlevendeForelder'
 import { Barn } from './personer/Barn'
 import { ContentHeader } from '~shared/styled'
@@ -8,6 +7,7 @@ import { Border, DashedBorder } from '../styled'
 import { SoeskenListe } from './personer/Soesken'
 import { GyldigFramsattType, IDetaljertBehandling, IGyldighetproving } from '~shared/types/IDetaljertBehandling'
 import { VurderingsResultat } from '~shared/types/VurderingsResultat'
+import { Foreldre } from '~components/behandling/soeknadsoversikt/familieforhold/personer/Foreldre'
 
 export interface PropsFamilieforhold {
   behandling: IDetaljertBehandling
@@ -30,23 +30,22 @@ export const Familieforhold: React.FC<PropsFamilieforhold> = ({ behandling }) =>
       {behandling.gyldighetsprøving?.resultat === VurderingsResultat.OPPFYLT ? (
         <>
           <ContentHeader>
-            <Heading spacing size="medium" level="5">
+            <Heading spacing size="medium" level="2">
               Familieforhold
             </Heading>
           </ContentHeader>
           <FamilieforholdWrapper>
             <Barn person={behandling.søker} doedsdato={doedsdato} />
             <DashedBorder />
-            <GjenlevendeForelder
-              person={behandling.familieforhold.gjenlevende.opplysning}
-              innsenderErGjenlevendeForelder={innsenderErGjenlevende}
+            <Foreldre
+              gjenlevende={behandling.familieforhold.gjenlevende.opplysning}
+              innsenderErGjenlevende={innsenderErGjenlevende}
               doedsdato={doedsdato}
+              avdoed={behandling.familieforhold.avdoede.opplysning}
             />
-            <AvdoedForelder person={behandling.familieforhold.avdoede.opplysning} />
             <DashedBorder />
             <SoeskenListe soekerFnr={behandling.søker.foedselsnummer} familieforhold={behandling.familieforhold!!} />
           </FamilieforholdWrapper>
-          <Border />
         </>
       ) : (
         <>
@@ -57,9 +56,9 @@ export const Familieforhold: React.FC<PropsFamilieforhold> = ({ behandling }) =>
               doedsdato={doedsdato}
             />
           </FamilieforholdWrapper>
-          <Border />
         </>
       )}
+      <Border />
     </>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/Barn.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/Barn.tsx
@@ -25,7 +25,6 @@ export const Barn: React.FC<Props> = ({ person, doedsdato }) => {
         </span>
         {`${person.fornavn} ${person.etternavn}`}{' '}
         <span className={'personRolle'}>({differenceInYears(new Date(), new Date(person.foedselsdato))} år)</span>
-        <br />
         <TypeStatusWrap type="barn">Mottaker av pensjon</TypeStatusWrap>
       </PersonHeader>
       <PersonInfoWrapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/Foreldre.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/Foreldre.tsx
@@ -1,0 +1,27 @@
+import { Heading } from '@navikt/ds-react'
+import { GjenlevendeForelder } from '~components/behandling/soeknadsoversikt/familieforhold/personer/GjenlevendeForelder'
+import { AvdoedForelder } from '~components/behandling/soeknadsoversikt/familieforhold/personer/AvdoedForelder'
+import { IPdlPerson } from '~shared/types/Person'
+
+interface IProps {
+  gjenlevende: IPdlPerson
+  innsenderErGjenlevende: boolean
+  doedsdato: string
+  avdoed: IPdlPerson
+}
+
+export const Foreldre = ({ gjenlevende, innsenderErGjenlevende, doedsdato, avdoed }: IProps) => {
+  return (
+    <>
+      <Heading size="small" level="3">
+        Foreldre
+      </Heading>
+      <GjenlevendeForelder
+        person={gjenlevende}
+        innsenderErGjenlevendeForelder={innsenderErGjenlevende}
+        doedsdato={doedsdato}
+      />
+      <AvdoedForelder person={avdoed} />
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/Soesken.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/Soesken.tsx
@@ -18,7 +18,7 @@ export const SoeskenListe: React.FC<Props> = ({ soekerFnr, familieforhold }) => 
 
   return (
     <>
-      <Heading spacing size="small" level="5">
+      <Heading spacing size="small" level="3">
         Søsken <span style={{ fontWeight: 'normal' }}>(avdødes barn)</span>
       </Heading>
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/OversiktElement.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/OversiktElement.tsx
@@ -15,7 +15,7 @@ export const OversiktElement = ({ navn, label, tekst, erOppfylt }: Props) => {
   return (
     <Infoboks>
       <DetailWrapper>
-        <Label size="small" className={labelClassName}>
+        <Label size="small" as={"p"} className={labelClassName}>
           {label}
         </Label>
         <span>{navn}</span>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/gyldigFramsattSoeknad/GyldigFramsattVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/gyldigFramsattSoeknad/GyldigFramsattVurdering.tsx
@@ -36,7 +36,7 @@ export const GyldigFramsattVurdering = ({
     <VurderingsContainer>
       <div>{gyldigFramsatt.resultat && <GyldighetIcon status={gyldigFramsatt.resultat} large={true} />}</div>
       <div>
-        <VurderingsTitle>{tittel}</VurderingsTitle>
+        <VurderingsTitle title={tittel} />
         <Undertekst $gray>Automatisk {format(new Date(gyldigFramsatt.vurdertDato), 'dd.MM.yyyy')}</Undertekst>
         {gyldigFramsatt.resultat !== VurderingsResultat.OPPFYLT && <Undertekst>{vurderingstekst}</Undertekst>}
       </div>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/gyldigFramsattSoeknad/OversiktGyldigFramsatt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/gyldigFramsattSoeknad/OversiktGyldigFramsatt.tsx
@@ -2,8 +2,9 @@ import { GyldigFramsattVurdering } from './GyldigFramsattVurdering'
 import { Foreldreansvar } from './Foreldreansvar'
 import { Innsender } from './Innsender'
 import { Verge } from './Verge'
-import { InfobokserWrapper, Header, VurderingsWrapper, SoeknadOversiktWrapper } from '../../styled'
+import { InfobokserWrapper, VurderingsWrapper, SoeknadOversiktWrapper } from '../../styled'
 import { IGyldighetResultat, IGyldighetproving, GyldigFramsattType } from '~shared/types/IDetaljertBehandling'
+import { Heading } from "@navikt/ds-react";
 
 export const OversiktGyldigFramsatt = ({ gyldigFramsatt }: { gyldigFramsatt: IGyldighetResultat | undefined }) => {
   if (gyldigFramsatt == null) {
@@ -24,7 +25,7 @@ export const OversiktGyldigFramsatt = ({ gyldigFramsatt }: { gyldigFramsatt: IGy
 
   return (
     <>
-      <Header>Gyldig fremsatt</Header>
+      <Heading size={"medium"} level={"2"}>Gyldig fremsatt</Heading>
       <SoeknadOversiktWrapper>
         <InfobokserWrapper>
           <Innsender innsenderErForelder={innsenderErForelder} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/kommerBarnetTilgode/EndreVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/kommerBarnetTilgode/EndreVurdering.tsx
@@ -39,7 +39,7 @@ export const EndreVurdering = ({
 
   return (
     <div>
-      <VurderingsTitle>Trenger avklaring</VurderingsTitle>
+      <VurderingsTitle title={"Trenger avklaring"} />
       <Undertekst gray={false}>
         Boforholdet er avklart og sannsynliggjort at pensjonen kommer barnet til gode?
       </Undertekst>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/kommerBarnetTilgode/KommerBarnetTilGodeVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/kommerBarnetTilgode/KommerBarnetTilGodeVurdering.tsx
@@ -43,7 +43,7 @@ export const KommerBarnetTilGodeVurdering = ({
         />
       ) : (
         <div>
-          <VurderingsTitle>{tittel}</VurderingsTitle>
+          <VurderingsTitle title={tittel} />
           {kommerBarnetTilgode?.kilde ? (
             <>
               <Undertekst $gray>{`Manuelt av ${kommerBarnetTilgode.kilde.ident}`}</Undertekst>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/kommerBarnetTilgode/OversiktKommerBarnetTilgode.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/kommerBarnetTilgode/OversiktKommerBarnetTilgode.tsx
@@ -1,6 +1,7 @@
 import { KommerBarnetTilGodeVurdering } from './KommerBarnetTilGodeVurdering'
-import { Header, InfobokserWrapper, InfoWrapper, SoeknadOversiktWrapper, VurderingsWrapper } from '../../styled'
+import { InfobokserWrapper, InfoWrapper, SoeknadOversiktWrapper, VurderingsWrapper } from '../../styled'
 import { IKommerBarnetTilgode } from '~shared/types/IDetaljertBehandling'
+import { Heading } from "@navikt/ds-react";
 
 interface Props {
   kommerBarnetTilgode: IKommerBarnetTilgode | null
@@ -8,7 +9,7 @@ interface Props {
 
 export const OversiktKommerBarnetTilgode: React.FC<Props> = ({ kommerBarnetTilgode }) => (
   <>
-    <Header>Vurdering om pensjonen kommer barnet til gode</Header>
+    <Heading size={"medium"} level={"2"}>Vurdering om pensjonen kommer barnet til gode</Heading>
     <SoeknadOversiktWrapper>
       <InfobokserWrapper>
         <InfoWrapper>Har barnet samme adresse som den gjenlevende forelder?</InfoWrapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import DatePicker from 'react-datepicker'
-import { Alert, Button, Label } from '@navikt/ds-react'
+import { Alert, Button, Heading, Label } from '@navikt/ds-react'
 import { useRef, useState } from 'react'
 import { GyldighetIcon } from '~shared/icons/gyldigIcon'
 import { oppdaterVirkningstidspunkt } from '~store/reducers/BehandlingReducer'
@@ -11,7 +11,6 @@ import { formaterStringDato, formaterStringTidspunkt } from '~utils/formattering
 import { fastsettVirkningstidspunkt } from '~shared/api/behandling'
 import { useApiCall, isPending, isFailure } from '~shared/hooks/useApiCall'
 import {
-  Header,
   SoeknadOversiktWrapper,
   InfobokserWrapper,
   Infoboks,
@@ -25,7 +24,7 @@ import { VurderingsResultat } from '~shared/types/VurderingsResultat'
 export const Info = ({ tekst, label }: { tekst: string; label: string }) => {
   return (
     <InfoElement>
-      <Label size="small">{label}</Label>
+      <Label size="small" as={"p"}>{label}</Label>
       <div>{tekst}</div>
     </InfoElement>
   )
@@ -51,7 +50,7 @@ const Virkningstidspunkt = () => {
 
   return (
     <>
-      <Header>Virkningstidspunkt</Header>
+      <Heading size={"medium"} level={"2"}>Virkningstidspunkt</Heading>
       <SoeknadOversiktWrapper>
         <InfobokserWrapper>
           <Infoboks>
@@ -78,7 +77,7 @@ const Virkningstidspunkt = () => {
             />
           </div>
           <div>
-            <VurderingsTitle>Virkningstidspunkt</VurderingsTitle>
+            <VurderingsTitle title={"Virkningstidspunkt"} />
             <div>
               {rediger ? (
                 <>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/styled.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/styled.tsx
@@ -112,11 +112,10 @@ export const HistorikkElement = styled.div`
 `
 
 export const HeadingWrapper = styled.div`
-  display: inline-flex;
   margin-top: 3em;
 
   .details {
-    padding: 0.6em;
+    margin-bottom: 0.6em;
   }
 `
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/styled.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/styled.tsx
@@ -1,4 +1,4 @@
-import { BodyShort } from '@navikt/ds-react'
+import { BodyShort, Heading } from '@navikt/ds-react'
 import styled from 'styled-components'
 
 export const Innhold = styled.div`
@@ -11,13 +11,6 @@ export const SoeknadOversiktWrapper = styled.div`
   flex-direction: row;
   justify-content: space-between;
   align-items: top;
-`
-
-export const Header = styled.div`
-  font-size: 1.2em;
-  font-weight: bold;
-  margin-bottom: 1em;
-  margin-top: 0em;
 `
 
 export const InfobokserWrapper = styled.div`
@@ -90,11 +83,13 @@ export const VurderingsContainer = styled.div`
   min-width: 300px;
 `
 
-export const VurderingsTitle = styled.div`
-  display: flex;
-  font-size: 1.1em;
-  font-weight: bold;
-`
+export const VurderingsTitle = ({ title }: { title: string }) => {
+  return (
+    <Heading level={'3'} size={'small'}>
+      {title}
+    </Heading>
+  )
+}
 
 export const PersonDetailWrapper = styled.div<{ adresse: boolean }>`
   padding-top: 0.5em;

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vedtaksbrev/Vedtaksbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vedtaksbrev/Vedtaksbrev.tsx
@@ -18,8 +18,8 @@ import {
   VurderingsResultat,
 } from '~shared/api/vilkaarsvurdering'
 import { hentBehandlesFraStatus } from '~components/behandling/felles/utils'
-import { tagColors, TagList } from "~shared/Tags";
-import { formaterEnumTilLesbarString } from "~utils/formattering";
+import { tagColors, TagList } from '~shared/Tags'
+import { formaterEnumTilLesbarString } from '~utils/formattering'
 
 interface VilkaarOption {
   value: string
@@ -116,7 +116,7 @@ export const Vedtaksbrev = () => {
         <Editor>
           <ContentHeader>
             <HeadingWrapper>
-              <Heading spacing size={'xlarge'} level={'5'}>
+              <Heading spacing size={'large'} level={'1'}>
                 Vedtaksbrev
               </Heading>
               <div className="details">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/ManueltVilkaar.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/ManueltVilkaar.tsx
@@ -57,7 +57,6 @@ export const ManueltVilkaar = (props: VilkaarProps) => {
                   {vilkaar.hovedvilkaar.lovreferanse.paragraf} {vilkaar.hovedvilkaar.tittel}
                 </Link>
               </Title>
-
               <Lovtekst>
                 <p>{vilkaar.hovedvilkaar.beskrivelse}</p>
               </Lovtekst>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Resultat.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Resultat.tsx
@@ -8,7 +8,7 @@ import {
   IVilkaarsvurdering,
   VilkaarsvurderingResultat,
 } from '~shared/api/vilkaarsvurdering'
-import { VilkaarBorder } from './styled'
+import { VilkaarBorder, VilkaarWrapper } from './styled'
 import { BodyShort, Button, Heading, Radio, RadioGroup, Textarea } from '@navikt/ds-react'
 import { svarTilTotalResultat } from './utils'
 import { Delete } from '@navikt/ds-icons'
@@ -88,71 +88,77 @@ export const Resultat: React.FC<Props> = ({
 
   return (
     <>
-      <VilkaarsvurderingContent>
-        <HeadingWrapper>
-          <Heading size="small" level={"2"}>Er vilkårene for barnepensjon oppfylt?</Heading>
-        </HeadingWrapper>
-        {vilkaarsvurdering.resultat && (
-          <ContentWrapper>
-            <TekstWrapper>
-              <StatusIcon status={status} noLeftPadding /> {`${resultatTekst()}`}
-            </TekstWrapper>
-            {vilkaarsvurdering?.resultat?.utfall == VilkaarsvurderingResultat.OPPFYLT && (
-              <BodyShort>Barnepensjon er innvilget f.o.m {formaterStringDato(virkningstidspunktDato)}</BodyShort>
-            )}
-            <Kommentar>
-              <Heading size="xsmall" level={"3"}>Begrunnelse</Heading>
-              <BodyShort size="small">{vilkaarsvurdering.resultat.kommentar}</BodyShort>
-            </Kommentar>
-            <SlettWrapper onClick={slettVilkaarsvurderingResultat}>
-              <Delete aria-hidden={"true"} />
-              <span className={'text'}>Slett vurdering</span>
-            </SlettWrapper>
-          </ContentWrapper>
-        )}
+      <VilkaarWrapper>
+        <VilkaarsvurderingContent>
+          <HeadingWrapper>
+            <Heading size="small" level={'2'}>
+              Er vilkårene for barnepensjon oppfylt?
+            </Heading>
+          </HeadingWrapper>
+          {vilkaarsvurdering.resultat && (
+            <ContentWrapper>
+              <TekstWrapper>
+                <StatusIcon status={status} noLeftPadding /> {`${resultatTekst()}`}
+              </TekstWrapper>
+              {vilkaarsvurdering?.resultat?.utfall == VilkaarsvurderingResultat.OPPFYLT && (
+                <BodyShort>Barnepensjon er innvilget f.o.m {formaterStringDato(virkningstidspunktDato)}</BodyShort>
+              )}
+              <Kommentar>
+                <Heading size="xsmall" level={'3'}>
+                  Begrunnelse
+                </Heading>
+                <BodyShort size="small">{vilkaarsvurdering.resultat.kommentar}</BodyShort>
+              </Kommentar>
+              <SlettWrapper onClick={slettVilkaarsvurderingResultat}>
+                <Delete aria-hidden={'true'} />
+                <span className={'text'}>Slett vurdering</span>
+              </SlettWrapper>
+            </ContentWrapper>
+          )}
 
-        {!vilkaarsvurdering.resultat && !alleVilkaarErVurdert && (
-          <TekstWrapper>Alle vilkår må vurderes før man kan gå videre</TekstWrapper>
-        )}
+          {!vilkaarsvurdering.resultat && !alleVilkaarErVurdert && (
+            <TekstWrapper>Alle vilkår må vurderes før man kan gå videre</TekstWrapper>
+          )}
 
-        {!vilkaarsvurdering.resultat && alleVilkaarErVurdert && (
-          <>
-            <RadioGroupWrapper>
-              <RadioGroup
-                legend=""
-                size="small"
-                className="radioGroup"
-                onChange={(event) => {
-                  setSvar(ISvar[event as ISvar])
-                  setRadioError(undefined)
+          {!vilkaarsvurdering.resultat && alleVilkaarErVurdert && (
+            <>
+              <RadioGroupWrapper>
+                <RadioGroup
+                  legend=""
+                  size="small"
+                  className="radioGroup"
+                  onChange={(event) => {
+                    setSvar(ISvar[event as ISvar])
+                    setRadioError(undefined)
+                  }}
+                  error={radioError ? radioError : false}
+                >
+                  <Radio value={ISvar.JA}>Ja, vilkår er oppfylt</Radio>
+                  <Radio value={ISvar.NEI}>Nei, vilkår er ikke oppfylt</Radio>
+                </RadioGroup>
+              </RadioGroupWrapper>
+              <Textarea
+                label="Begrunnelse (obligatorisk)"
+                hideLabel={false}
+                placeholder="Gi en begrunnelse for vurderingen"
+                value={kommentar}
+                onChange={(e) => {
+                  const kommentarLocal = e.target.value
+                  setKommentar(kommentarLocal)
+                  kommentarLocal.length >= MIN_KOMMENTAR_LENGDE && setKommentarError(undefined)
                 }}
-                error={radioError ? radioError : false}
-              >
-                <Radio value={ISvar.JA}>Ja, vilkår er oppfylt</Radio>
-                <Radio value={ISvar.NEI}>Nei, vilkår er ikke oppfylt</Radio>
-              </RadioGroup>
-            </RadioGroupWrapper>
-            <Textarea
-              label="Begrunnelse (obligatorisk)"
-              hideLabel={false}
-              placeholder="Gi en begrunnelse for vurderingen"
-              value={kommentar}
-              onChange={(e) => {
-                const kommentarLocal = e.target.value
-                setKommentar(kommentarLocal)
-                kommentarLocal.length >= MIN_KOMMENTAR_LENGDE && setKommentarError(undefined)
-              }}
-              minRows={3}
-              size="medium"
-              error={kommentarError ? kommentarError : false}
-              autoComplete="off"
-            />
-            <Button variant={'primary'} size={'small'} onClick={lagreVilkaarsvurderingResultat}>
-              Lagre
-            </Button>
-          </>
-        )}
-      </VilkaarsvurderingContent>
+                minRows={3}
+                size="medium"
+                error={kommentarError ? kommentarError : false}
+                autoComplete="off"
+              />
+              <Button variant={'primary'} size={'small'} onClick={lagreVilkaarsvurderingResultat}>
+                Lagre
+              </Button>
+            </>
+          )}
+        </VilkaarsvurderingContent>
+      </VilkaarWrapper>
 
       <VilkaarBorder />
       <BehandlingHandlingKnapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Resultat.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Resultat.tsx
@@ -90,7 +90,7 @@ export const Resultat: React.FC<Props> = ({
     <>
       <VilkaarsvurderingContent>
         <HeadingWrapper>
-          <Heading size="small">Er vilkårene for barnepensjon oppfylt?</Heading>
+          <Heading size="small" level={"2"}>Er vilkårene for barnepensjon oppfylt?</Heading>
         </HeadingWrapper>
         {vilkaarsvurdering.resultat && (
           <ContentWrapper>
@@ -101,11 +101,11 @@ export const Resultat: React.FC<Props> = ({
               <BodyShort>Barnepensjon er innvilget f.o.m {formaterStringDato(virkningstidspunktDato)}</BodyShort>
             )}
             <Kommentar>
-              <Heading size="xsmall">Begrunnelse</Heading>
+              <Heading size="xsmall" level={"3"}>Begrunnelse</Heading>
               <BodyShort size="small">{vilkaarsvurdering.resultat.kommentar}</BodyShort>
             </Kommentar>
             <SlettWrapper onClick={slettVilkaarsvurderingResultat}>
-              <Delete />
+              <Delete aria-hidden={"true"} />
               <span className={'text'}>Slett vurdering</span>
             </SlettWrapper>
           </ContentWrapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
@@ -1,4 +1,4 @@
-import { Content, Header } from '~shared/styled'
+import { Content, ContentHeader } from '~shared/styled'
 import React, { useEffect, useState } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 import { hentVilkaarsvurdering, IVilkaarsvurdering } from '~shared/api/vilkaarsvurdering'
@@ -9,7 +9,8 @@ import { RequestStatus } from './utils'
 import Spinner from '~shared/Spinner'
 import { updateVilkaarsvurdering } from '~store/reducers/BehandlingReducer'
 import { useAppDispatch } from '~store/Store'
-import { Heading } from "@navikt/ds-react";
+import { Heading } from '@navikt/ds-react'
+import { HeadingWrapper } from '../soeknadsoversikt/styled'
 
 export const Vilkaarsvurdering = () => {
   const location = useLocation()
@@ -55,9 +56,13 @@ export const Vilkaarsvurdering = () => {
 
   return (
     <Content>
-      <Header>
-          <Heading size={"large"} level={"1"}>Vilkårsvurdering</Heading>
-      </Header>
+      <ContentHeader>
+        <HeadingWrapper>
+          <Heading size={'large'} level={'1'}>
+            Vilkårsvurdering
+          </Heading>
+        </HeadingWrapper>
+      </ContentHeader>
 
       {behandlingId && status === RequestStatus.ok && vilkaarsvurdering?.virkningstidspunkt && (
         <>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
@@ -9,6 +9,7 @@ import { RequestStatus } from './utils'
 import Spinner from '~shared/Spinner'
 import { updateVilkaarsvurdering } from '~store/reducers/BehandlingReducer'
 import { useAppDispatch } from '~store/Store'
+import { Heading } from "@navikt/ds-react";
 
 export const Vilkaarsvurdering = () => {
   const location = useLocation()
@@ -55,7 +56,7 @@ export const Vilkaarsvurdering = () => {
   return (
     <Content>
       <Header>
-        <h1>Vilkårsvurdering</h1>
+          <Heading size={"large"} level={"1"}>Vilkårsvurdering</Heading>
       </Header>
 
       {behandlingId && status === RequestStatus.ok && vilkaarsvurdering?.virkningstidspunkt && (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vurdering.tsx
@@ -124,33 +124,33 @@ export const Vurdering = ({
       {vilkaar.vurdering && !aktivVurdering && (
         <>
           <KildeVilkaar>
-            <Heading size="small">{overskrift()}</Heading>
+            <Heading size="small" level={"2"}>{overskrift()}</Heading>
             <VilkaarVurdertInformasjon>
-              <Detail size="medium">Manuelt av {vilkaar.vurdering?.saksbehandler}</Detail>
-              <Detail size="medium">
+              <Detail>Manuelt av {vilkaar.vurdering?.saksbehandler}</Detail>
+              <Detail>
                 Sist endret {format(new Date(vilkaar.vurdering!!.tidspunkt), 'dd.MM.yyyy HH:mm')}
               </Detail>
             </VilkaarVurdertInformasjon>
             {oppfyltUnntaksvilkaar && (
               <VilkaarVurdertInformasjon>
-                <Heading size="xsmall">Unntak er oppfylt</Heading>
+                <Heading size="xsmall" level={"3"}>Unntak er oppfylt</Heading>
                 <BodyShort size="small">{oppfyltUnntaksvilkaar?.tittel}</BodyShort>
               </VilkaarVurdertInformasjon>
             )}
             {vilkaar.vurdering?.kommentar && (
               <VilkaarVurdertInformasjon>
-                <Heading size="xsmall">Begrunnelse</Heading>
+                <Heading size="xsmall" level={"3"}>Begrunnelse</Heading>
                 <BodyShort size="small">{vilkaar.vurdering?.kommentar}</BodyShort>
               </VilkaarVurdertInformasjon>
             )}
           </KildeVilkaar>
 
           <RedigerWrapper onClick={redigerVilkaar}>
-            <Edit />
+            <Edit aria-hidden={"true"} />
             <span className={'text'}> Rediger</span>
           </RedigerWrapper>
           <RedigerWrapper onClick={slettVurderingAvVilkaar}>
-            <Delete />
+            <Delete aria-hidden={"true"} />
             <span className={'text'}> Slett</span>
           </RedigerWrapper>
         </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/styled.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/styled.ts
@@ -19,7 +19,7 @@ export const Innhold = styled.div`
 `
 
 export const VilkaarWrapper = styled.div`
-  padding: 1em 1em 1em 0;
+  padding: 1em 1em 1em 2em;
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/styled.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/styled.ts
@@ -47,20 +47,8 @@ export const VilkaarInfobokser = styled.div`
 `
 
 export const VilkaarColumn = styled.div`
-  width: calc((100% / 4) - (60px / 4));
-
-  @media (max-width: 1900px) {
-    width: calc((100% / 3) - (40px / 3));
-  }
-
-  @media (max-width: 1600px) {
-    width: calc((100% / 2) - (20px / 2));
-  }
-
-  @media (max-width: 1300px) {
-    width: 100%;
-  }
-
+  height: fit-content;
+  
   .missing {
     color: red;
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/vilkaar/AlderBarn.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/vilkaar/AlderBarn.tsx
@@ -4,6 +4,7 @@ import { VilkaarColumn } from '../styled'
 import { hentKildenavn } from '../utils'
 import { formaterStringDato } from '~utils/formattering'
 import { KildeType } from '~shared/types/kilde'
+import { Detail } from "@navikt/ds-react";
 
 export const AlderBarn = ({ grunnlag }: { grunnlag: Vilkaarsgrunnlag<any>[] }) => {
   const foedselsdatoGrunnlag = grunnlag.find((grunnlag) => grunnlag.opplysningsType == 'SOEKER_FOEDSELSDATO')
@@ -21,35 +22,29 @@ export const AlderBarn = ({ grunnlag }: { grunnlag: Vilkaarsgrunnlag<any>[] }) =
     <>
       {doedsdato && doedsdatoKilde && doedsdatoKilde?.type === KildeType.pdl && (
         <VilkaarColumn>
-          <Center>
             <div>
-              <strong>Dødsfall</strong>
+              <VilkaarStrong>Dødsfall</VilkaarStrong>
             </div>
             <span>{formaterStringDato(doedsdato)}</span>
             <KildeDatoOpplysning type={doedsdatoKilde.type} dato={doedsdatoKilde.tidspunktForInnhenting} />
-          </Center>
         </VilkaarColumn>
       )}
       {foedselsdato && foedselsdatoKilde && foedselsdatoKilde?.type === KildeType.pdl && (
         <VilkaarColumn>
-          <Center>
             <div>
-              <strong>Barnets fødselsdato</strong>
+              <VilkaarStrong>Barnets fødselsdato</VilkaarStrong>
             </div>
             <span>{formaterStringDato(foedselsdato)}</span>
             <KildeDatoOpplysning type={foedselsdatoKilde.type} dato={foedselsdatoKilde.tidspunktForInnhenting} />
-          </Center>
         </VilkaarColumn>
       )}
       {virkningstidspunkt && virkningstidspunktKilde && virkningstidspunktKilde?.type == KildeType.saksbehandler && (
         <VilkaarColumn>
-          <Center>
             <div>
-              <strong>Virkningstidspunkt</strong>
+              <VilkaarStrong>Virkningstidspunkt</VilkaarStrong>
             </div>
             <span>{formaterStringDato(virkningstidspunkt)}</span>
             <KildeDatoOpplysning type={virkningstidspunktKilde.type} dato={virkningstidspunktKilde.tidspunkt} />
-          </Center>
         </VilkaarColumn>
       )}
     </>
@@ -64,18 +59,12 @@ const KildeDatoOpplysning = ({ type, dato }: { type?: KildeType; dato?: string }
   const kilde = hentKildenavn(type)
 
   return (
-    <KildeOppysning>
+    <Detail>
       {kilde} {dataDato}
-    </KildeOppysning>
+    </Detail>
   )
 }
 
-export const KildeOppysning = styled.div`
-  color: grey;
-  font-size: 0.9em;
-  margin-top: 5px;
-`
-
-export const Center = styled.div`
-  text-align: center;
+const VilkaarStrong = styled.strong`
+    white-space: nowrap;
 `

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/vilkaar/VilkaarGrunnlagsStoette.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/vilkaar/VilkaarGrunnlagsStoette.tsx
@@ -1,5 +1,6 @@
 import { Vilkaar } from '~shared/api/vilkaarsvurdering'
 import { AlderBarn } from './AlderBarn'
+import styled from 'styled-components'
 
 export const VilkaarGrunnlagsStoette = ({ vilkaar }: { vilkaar: Vilkaar }) => {
   const finnGrunnlag = (vilkaar: Vilkaar) => {
@@ -11,5 +12,11 @@ export const VilkaarGrunnlagsStoette = ({ vilkaar }: { vilkaar: Vilkaar }) => {
     }
   }
 
-  return finnGrunnlag(vilkaar)
+  return <VilkaarGrunnlagsStoetteWrapper>{finnGrunnlag(vilkaar)}</VilkaarGrunnlagsStoetteWrapper>
 }
+
+const VilkaarGrunnlagsStoetteWrapper = styled.div`
+  display: flex;
+  gap: 1em;
+  flex-wrap: wrap;
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenken/filtere/DropdownColumnFilter.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenken/filtere/DropdownColumnFilter.tsx
@@ -24,6 +24,7 @@ const DropdownColumnFilter: React.FC<Props> = ({ oppgaveFelt, liste, oppgaveFelt
         onChange={(e) => {
           settFilterVerdi(oppgaveFelt, e.target.value, oppgaveFelter, setOppgaveFelter)
         }}
+        autoComplete="off"
       >
         {options.map((par: IPar) => {
           return (

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/header/Search.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/header/Search.tsx
@@ -74,6 +74,7 @@ export const Search = () => {
         hideLabel
         onChange={setSearchInput}
         onKeyUp={onEnter}
+        autoComplete="off"
       >
         <SearchField.Button onClick={search} />
       </SearchField>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/icons/statusIcon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/icons/statusIcon.tsx
@@ -10,11 +10,11 @@ export const StatusIcon = (props: { status: VurderingsResultat; noLeftPadding?: 
   function hentSymbol() {
     switch (props.status) {
       case VurderingsResultat.OPPFYLT:
-        return <SuccessColored />
+        return <SuccessColored aria-hidden={"true"} /> // Vurder å bruk tittel for å forklare istendenfor å skjule
       case VurderingsResultat.IKKE_OPPFYLT:
-        return <ErrorColored />
+        return <ErrorColored aria-hidden={"true"} />
       case VurderingsResultat.KAN_IKKE_VURDERE_PGA_MANGLENDE_OPPLYSNING:
-        return <WarningColored />
+        return <WarningColored aria-hidden={"true"} />
     }
   }
 


### PR DESCRIPTION
- Endret til kun 1 H1 på hver side og endret level på de fleste Heading for å gi bedre forståelse av sidestrukteren. 
(EY-1464, EY-1465, EY-1470)
- Fikset feil med popover som gjorde at den ikke lukket seg. (EY-1469)
- Endret layout slik at alle har lik margin og tittel størrelse
- Mindre endringer som aria-hidden på svg og autocomplete off
- Endre Label til p tags. Beholder stilen. (EY-1462)

