### PR TITLE
Viser grunnlagsendringshendelser basert på samsvar

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
@@ -174,7 +174,7 @@ class GrunnlagsendringshendelseService(
         hendelseGjelderRolle: Saksrolle
     ) {
         val fnr = data.hendelse.avdoedFnr
-        val personRolle = Saksrolle.SaksrolleToPersonrolle(hendelseGjelderRolle)
+        val personRolle = hendelseGjelderRolle.toPersonrolle()
 
         val doedsdatoPdl = pdlService.hentDoedsdato(fnr, personRolle)
         val doedsdatoGrunnlag = runBlocking {
@@ -197,7 +197,7 @@ class GrunnlagsendringshendelseService(
         hendelseGjelderRolle: Saksrolle
     ) {
         val fnr = data.hendelse.fnr
-        val personRolle = Saksrolle.SaksrolleToPersonrolle(hendelseGjelderRolle)
+        val personRolle = hendelseGjelderRolle.toPersonrolle()
         val utlandPdl = pdlService.hentUtland(fnr, personRolle)
         val utlandGrunnlag =
             runBlocking { grunnlagClient.hentGrunnlag(sakId)?.utland(hendelseGjelderRolle, fnr) }
@@ -218,7 +218,7 @@ class GrunnlagsendringshendelseService(
         hendelseGjelderRolle: Saksrolle
     ) {
         val fnr = data.hendelse.fnr
-        val personRolle = Saksrolle.SaksrolleToPersonrolle(hendelseGjelderRolle)
+        val personRolle = hendelseGjelderRolle.toPersonrolle()
         val samsvarMellomPdlOgGrunnlag = when (personRolle) {
             PersonRolle.BARN -> {
                 val ansvarligeForeldrePDL = pdlService.hentAnsvarligeForeldre(fnr, personRolle)

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
@@ -427,7 +427,7 @@ internal class GrunnlagsendringshendelseServiceTest {
         val grlg_id = UUID.randomUUID()
         val doedsdato = LocalDate.of(2022, 3, 13)
         val rolle = Saksrolle.SOEKER
-        val personRolle = Saksrolle.SaksrolleToPersonrolle(rolle)
+        val personRolle = rolle.toPersonrolle()
         val grunnlagsendringshendelser = listOf(
             grunnlagsendringshendelseUtenSamsvar(
                 id = grlg_id,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/grunnlagshendelser/Grunnlagsendringshendelser.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/grunnlagshendelser/Grunnlagsendringshendelser.tsx
@@ -121,7 +121,6 @@ const VisAnsvarligeForeldreSamsvar = (props: { data: AnsvarligeForeldreSamsvar }
 }
 
 const HendelseVisning = (props: { data?: SamsvarMellomGrunnlagOgPdl }) => {
-  const type = props.data?.type
   switch (props.data?.type) {
     case 'DOEDSDATO':
       return <VisDoedsdatoSamsvar data={props.data} />
@@ -132,7 +131,7 @@ const HendelseVisning = (props: { data?: SamsvarMellomGrunnlagOgPdl }) => {
     case 'ANSVARLIGE_FORELDRE':
       return <VisAnsvarligeForeldreSamsvar data={props.data} />
     default:
-      return <p>Ukjent hendelse av type {type}</p>
+      return <p>Ukjent hendelse</p>
   }
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/grunnlagshendelser/Grunnlagsendringshendelser.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/grunnlagshendelser/Grunnlagsendringshendelser.tsx
@@ -21,7 +21,7 @@ const VisDoedsdatoSamsvar = (props: { data: DoedsdatoSamsvar }) => {
       <dt>Dødsdato i grunnlag</dt>
       <dd>{formaterKanskjeStringDato('Ingen', props.data.fraGrunnlag)}</dd>
       <dt>Dødsdato i PDL</dt>
-      <dd>{formaterKanskjeStringDato('Ingen', props.data.fraGrunnlag)}</dd>
+      <dd>{formaterKanskjeStringDato('Ingen', props.data.fraPdl)}</dd>
     </HendelseSammenligning>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/grunnlagshendelser/Grunnlagsendringshendelser.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/grunnlagshendelser/Grunnlagsendringshendelser.tsx
@@ -4,21 +4,13 @@ import {
   DoedsdatoSamsvar,
   Grunnlagsendringshendelse,
   GrunnlagsendringStatus,
-  GrunnlagsendringsType,
-  Saksrolle,
   SamsvarMellomGrunnlagOgPdl,
   UtlandSamsvar,
 } from '../typer'
 import { formaterStringDato } from '~utils/formattering'
-import styled from 'styled-components'
 import { Heading } from '@navikt/ds-react'
-
-const teksterForGrunnlagshendelser: Record<GrunnlagsendringsType, string> = {
-  ANSVARLIGE_FORELDRE: 'Ansvarlige foreldre',
-  BARN: 'Barn',
-  UTLAND: 'Ut-/innflytting',
-  DOEDSDATO: 'Dødsfall',
-}
+import { teksterForGrunnlagshendelser, teksterForSaksrolle } from '~components/person/grunnlagshendelser/tekster'
+import { HendelseMetaItem, HendelseMetaWrapper, HendelseSammenligning, HendelseWrapper } from './styled'
 
 const formaterKanskjeStringDato = (fallback = 'Ukjent dato', dato?: string): string =>
   dato ? formaterStringDato(dato) : fallback
@@ -142,57 +134,6 @@ const HendelseVisning = (props: { data?: SamsvarMellomGrunnlagOgPdl }) => {
     default:
       return <p>Ukjent hendelse av type {type}</p>
   }
-}
-
-const HendelseSammenligning = styled.dl`
-  display: grid;
-  width: 100%;
-  grid-template-columns: repeat(2, auto);
-  grid-gap: 5px;
-
-  p {
-    margin: 0;
-  }
-`
-// TODO: Hele dette designet må tas en avsjekk med fag / design om det
-//      1. dekker behovet for å se relevante opplysninger
-//      2. må fikses så det ikke ser helt løk ut
-const HendelseWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  padding: 5px;
-  background-color: #f5f5f5;
-  margin-bottom: 30px;
-`
-
-const HendelseMetaWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  width: 100%;
-  border-bottom: 1px solid black;
-`
-
-const HendelseMetaItem = styled.div`
-  display: inline-block;
-  width: 33%;
-  padding-right: 10px;
-  padding: 5px;
-  font-weight: bold;
-
-  small {
-    font-weight: normal;
-    font-size: 14px;
-  }
-`
-
-const teksterForSaksrolle: Record<Saksrolle, string> = {
-  AVDOED: 'Avdød',
-  GJENLEVENDE: 'Gjenlevende',
-  INNSENDER: 'Innsender',
-  SOEKER: 'Søker',
-  SOESKEN: 'Søsken',
-  UKJENT: 'Ukjent',
 }
 
 const ListeAvHendelser = ({ hendelser }: { hendelser: Grunnlagsendringshendelse[] }) => (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/grunnlagshendelser/Grunnlagsendringshendelser.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/grunnlagshendelser/Grunnlagsendringshendelser.tsx
@@ -1,94 +1,241 @@
 import {
-  Doedshendelse,
+  AnsvarligeForeldreSamsvar,
+  BarnSamsvar,
+  DoedsdatoSamsvar,
   Grunnlagsendringshendelse,
+  GrunnlagsendringStatus,
   GrunnlagsendringsType,
-  Grunnlagsinformasjon,
-  Utflyttingshendelse,
+  Saksrolle,
+  SamsvarMellomGrunnlagOgPdl,
+  UtlandSamsvar,
 } from '../typer'
-import { Table } from '@navikt/ds-react'
 import { formaterStringDato } from '~utils/formattering'
+import styled from 'styled-components'
+import { Heading } from '@navikt/ds-react'
 
 const teksterForGrunnlagshendelser: Record<GrunnlagsendringsType, string> = {
-  GJENLEVENDE_FORELDER_DOED: 'Dødsfall gjenlevende forelder',
-  SOEKER_DOED: 'Dødsfall søker',
-  SOESKEN_DOED: 'Dødsfall søsken',
-  UTFLYTTING: 'Utflytting',
+  ANSVARLIGE_FORELDRE: 'Ansvarlige foreldre',
+  BARN: 'Barn',
+  UTLAND: 'Ut-/innflytting',
+  DOEDSDATO: 'Dødsfall',
 }
 
-const VisUtflytting = ({ utflytting }: { utflytting: Utflyttingshendelse }) => {
+const formaterKanskjeStringDato = (fallback = 'Ukjent dato', dato?: string): string =>
+  dato ? formaterStringDato(dato) : fallback
+
+const VisDoedsdatoSamsvar = (props: { data: DoedsdatoSamsvar }) => {
   return (
-    <p>
-      {`${utflytting.fnr} har flyttet ut til ${utflytting.tilflyttingsLand}
-      ${utflytting?.tilflyttingsstedIUtlandet ? utflytting.tilflyttingsstedIUtlandet : ''} den 
-      ${formaterStringDato(utflytting.utflyttingsdato)}`}
-    </p>
+    <HendelseSammenligning>
+      <dt>Dødsdato i grunnlag</dt>
+      <dd>{formaterKanskjeStringDato('Ingen', props.data.fraGrunnlag)}</dd>
+      <dt>Dødsdato i PDL</dt>
+      <dd>{formaterKanskjeStringDato('Ingen', props.data.fraGrunnlag)}</dd>
+    </HendelseSammenligning>
   )
 }
 
-const formaterKanskjeStringDato = (dato?: string): string => (dato ? formaterStringDato(dato) : 'Ukjent dato')
+const VisBarnSamsvar = (props: { data: BarnSamsvar }) => {
+  return (
+    <HendelseSammenligning>
+      <dt>Barn i grunnlag</dt>
+      <dd>{props.data.fraGrunnlag?.join(', ') ?? 'Ingen barn'}</dd>
+      <dt>Barn i PDL</dt>
+      <dd>{props.data.fraPdl?.join(', ') ?? 'Ingen barn'}</dd>
+    </HendelseSammenligning>
+  )
+}
 
-const VisDoedshendelse = ({ doedshendelse }: { doedshendelse: Doedshendelse }) => (
-  <p>
-    {doedshendelse.avdoedFnr} døde {formaterKanskjeStringDato(doedshendelse.doedsdato)}
-  </p>
-)
+const LandListeMedDatoOgOverskrift = (props: { tittel: string; land: { land?: string; dato?: string }[] }) => {
+  if (!props.land || props.land.length === 0) {
+    return (
+      <>
+        <strong>{props.tittel}</strong>
+        <p>Ingen</p>
+      </>
+    )
+  }
+  return (
+    <>
+      <strong>{props.tittel}</strong>
+      <ul style={{ listStyle: 'none' }}>
+        {props.land.map(({ land, dato }, i) => (
+          <li key={i}>
+            {land} - {formaterKanskjeStringDato(dato)}
+          </li>
+        ))}
+      </ul>
+    </>
+  )
+}
 
-const HendelseVisning = (props: { data?: Grunnlagsinformasjon }) => {
+const VisUtlandSamsvar = (props: { data: UtlandSamsvar }) => {
+  return (
+    <HendelseSammenligning>
+      <dt>Ut-/innflyttinger i grunnlag</dt>
+      <dd>
+        <LandListeMedDatoOgOverskrift
+          tittel={'Utflyttinger'}
+          land={
+            props.data.fraGrunnlag?.utflyttingFraNorge?.map(({ tilflyttingsland, dato }) => ({
+              land: tilflyttingsland,
+              dato,
+            })) ?? []
+          }
+        />
+        <LandListeMedDatoOgOverskrift
+          tittel={'Innflyttinger'}
+          land={
+            props.data.fraGrunnlag?.innflyttingTilNorge?.map(({ fraflyttingsland, dato }) => ({
+              land: fraflyttingsland,
+              dato,
+            })) ?? []
+          }
+        />
+      </dd>
+      <dt>Ut-/innflyttinger i PDL</dt>
+      <dd>
+        <LandListeMedDatoOgOverskrift
+          tittel={'Utflyttinger'}
+          land={
+            props.data.fraPdl?.utflyttingFraNorge?.map(({ tilflyttingsland, dato }) => ({
+              land: tilflyttingsland,
+              dato,
+            })) ?? []
+          }
+        />
+        <LandListeMedDatoOgOverskrift
+          tittel={'Innflyttinger'}
+          land={
+            props.data.fraPdl?.innflyttingTilNorge?.map(({ fraflyttingsland, dato }) => ({
+              land: fraflyttingsland,
+              dato,
+            })) ?? []
+          }
+        />
+      </dd>
+    </HendelseSammenligning>
+  )
+}
+
+const VisAnsvarligeForeldreSamsvar = (props: { data: AnsvarligeForeldreSamsvar }) => {
+  return (
+    <HendelseSammenligning>
+      <dt>Ansvarlige foreldre i grunnlag</dt>
+      <dd>{props.data.fraGrunnlag?.join(', ') ?? 'Ingen ansvarlige foreldre'}</dd>
+      <dt>Ansvarlige foreldre i PDL</dt>
+      <dd>{props.data.fraPdl?.join(', ') ?? 'Ingen ansvarlige foreldre'}</dd>
+    </HendelseSammenligning>
+  )
+}
+
+const HendelseVisning = (props: { data?: SamsvarMellomGrunnlagOgPdl }) => {
+  const type = props.data?.type
   switch (props.data?.type) {
-    case 'UTFLYTTING':
-      return <VisUtflytting utflytting={props.data.hendelse} />
-    case 'GJENLEVENDE_FORELDER_DOED':
-    case 'SOEKER_DOED':
-    case 'SOESKEN_DOED':
-      return <VisDoedshendelse doedshendelse={props.data.hendelse} />
+    case 'DOEDSDATO':
+      return <VisDoedsdatoSamsvar data={props.data} />
+    case 'BARN':
+      return <VisBarnSamsvar data={props.data} />
+    case 'UTLAND':
+      return <VisUtlandSamsvar data={props.data} />
+    case 'ANSVARLIGE_FORELDRE':
+      return <VisAnsvarligeForeldreSamsvar data={props.data} />
     default:
-      return <p>Ukjent hendelse</p>
+      return <p>Ukjent hendelse av type {type}</p>
   }
 }
 
-const TabellForHendelser = ({ hendelser }: { hendelser: Grunnlagsendringshendelse[] }) => (
-  <Table>
-    <Table.Header>
-      <Table.Row>
-        <Table.HeaderCell>Type</Table.HeaderCell>
-        <Table.HeaderCell>Dato</Table.HeaderCell>
-        <Table.HeaderCell>Ekstra data</Table.HeaderCell>
-      </Table.Row>
-    </Table.Header>
-    <Table.Body>
-      {hendelser.map((hendelse) => (
-        <Table.Row key={hendelse.id}>
-          <Table.DataCell>{teksterForGrunnlagshendelser[hendelse.type]}</Table.DataCell>
-          <Table.DataCell>{formaterStringDato(hendelse.opprettet)}</Table.DataCell>
-          <Table.DataCell>
-            <HendelseVisning data={hendelse.data} />
-          </Table.DataCell>
-        </Table.Row>
-      ))}
-    </Table.Body>
-  </Table>
+const HendelseSammenligning = styled.dl`
+  display: grid;
+  width: 100%;
+  grid-template-columns: repeat(2, auto);
+  grid-gap: 5px;
+
+  p {
+    margin: 0;
+  }
+`
+// TODO: Hele dette designet må tas en avsjekk med fag / design om det
+//      1. dekker behovet for å se relevante opplysninger
+//      2. må fikses så det ikke ser helt løk ut
+const HendelseWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 5px;
+  background-color: #f5f5f5;
+  margin-bottom: 30px;
+`
+
+const HendelseMetaWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  border-bottom: 1px solid black;
+`
+
+const HendelseMetaItem = styled.div`
+  display: inline-block;
+  width: 33%;
+  padding-right: 10px;
+  padding: 5px;
+  font-weight: bold;
+
+  small {
+    font-weight: normal;
+    font-size: 14px;
+  }
+`
+
+const teksterForSaksrolle: Record<Saksrolle, string> = {
+  AVDOED: 'Avdød',
+  GJENLEVENDE: 'Gjenlevende',
+  INNSENDER: 'Innsender',
+  SOEKER: 'Søker',
+  SOESKEN: 'Søsken',
+  UKJENT: 'Ukjent',
+}
+
+const ListeAvHendelser = ({ hendelser }: { hendelser: Grunnlagsendringshendelse[] }) => (
+  <div>
+    {hendelser.map((hendelse) => (
+      <HendelseWrapper key={hendelse.id}>
+        <HendelseMetaWrapper>
+          <HendelseMetaItem>{teksterForGrunnlagshendelser[hendelse.type]}</HendelseMetaItem>
+          <HendelseMetaItem>
+            Gjelder {teksterForSaksrolle[hendelse.hendelseGjelderRolle].toLowerCase()} ({hendelse.gjelderPerson})
+          </HendelseMetaItem>
+          <HendelseMetaItem>Opprettet {formaterStringDato(hendelse.opprettet)}</HendelseMetaItem>
+        </HendelseMetaWrapper>
+        <div>
+          <HendelseVisning data={hendelse.samsvarMedPdl} />
+        </div>
+      </HendelseWrapper>
+    ))}
+  </div>
 )
 
+const STATUSER_SOM_ER_UHAANDTERTE: Readonly<GrunnlagsendringStatus[]> = ['VENTER_PAA_JOBB', 'SJEKKET_AV_JOBB'] as const
+
 export const Grunnlagshendelser = ({ hendelser }: { hendelser: Grunnlagsendringshendelse[] }) => {
-  const uhaandterteHendelser = hendelser.filter((hendelse) =>
-    ['IKKE_VURDERT', 'GYLDIG_OG_KAN_TAS_MED_I_BEHANDLING'].includes(hendelse.status)
-  )
-  const vurderteHendelser = hendelser.filter(
-    (hendelse) => !['IKKE_VURDERT', 'GYLDIG_OG_KAN_TAS_MED_I_BEHANDLING'].includes(hendelse.status)
-  )
+  const uhaandterteHendelser = hendelser.filter((hendelse) => STATUSER_SOM_ER_UHAANDTERTE.includes(hendelse.status))
+  const vurderteHendelser = hendelser.filter((hendelse) => !STATUSER_SOM_ER_UHAANDTERTE.includes(hendelse.status))
 
   return (
     <>
       {uhaandterteHendelser.length > 0 ? (
         <div>
-          <h2>Uhåndterte hendelser</h2>
-          <TabellForHendelser hendelser={uhaandterteHendelser} />
+          <Heading size="medium" level="2">
+            Uhåndterte hendelser
+          </Heading>
+          <ListeAvHendelser hendelser={uhaandterteHendelser} />
         </div>
       ) : null}
       {vurderteHendelser.length > 0 ? (
         <div>
-          <h2>Tidligere hendelser</h2>
-          <TabellForHendelser hendelser={vurderteHendelser} />
+          <Heading size="medium" level="2">
+            Tidligere hendelser
+          </Heading>
+          <ListeAvHendelser hendelser={vurderteHendelser} />
         </div>
       ) : null}
     </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/grunnlagshendelser/styled.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/grunnlagshendelser/styled.ts
@@ -1,0 +1,44 @@
+import styled from 'styled-components'
+
+export const HendelseSammenligning = styled.dl`
+  display: grid;
+  width: 100%;
+  grid-template-columns: repeat(2, auto);
+  grid-gap: 5px;
+
+  p {
+    margin: 0;
+  }
+`
+
+// TODO: Hele dette designet må tas en avsjekk med fag / design om det
+//      1. dekker behovet for å se relevante opplysninger
+//      2. må fikses så det ikke ser helt løk ut
+export const HendelseWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 5px;
+  background-color: #f5f5f5;
+  margin-bottom: 30px;
+`
+
+export const HendelseMetaWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  border-bottom: 1px solid black;
+`
+
+export const HendelseMetaItem = styled.div`
+  display: inline-block;
+  width: 33%;
+  padding-right: 10px;
+  padding: 5px;
+  font-weight: bold;
+
+  small {
+    font-weight: normal;
+    font-size: 14px;
+  }
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/grunnlagshendelser/tekster.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/grunnlagshendelser/tekster.ts
@@ -1,0 +1,17 @@
+import { GrunnlagsendringsType, Saksrolle } from '~components/person/typer'
+
+export const teksterForSaksrolle: Record<Saksrolle, string> = {
+  AVDOED: 'Avdød',
+  GJENLEVENDE: 'Gjenlevende',
+  INNSENDER: 'Innsender',
+  SOEKER: 'Søker',
+  SOESKEN: 'Søsken',
+  UKJENT: 'Ukjent',
+}
+
+export const teksterForGrunnlagshendelser: Record<GrunnlagsendringsType, string> = {
+  ANSVARLIGE_FORELDRE: 'Ansvarlige foreldre',
+  BARN: 'Barn',
+  UTLAND: 'Ut-/innflytting',
+  DOEDSDATO: 'Dødsfall',
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/typer.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/typer.tsx
@@ -47,46 +47,71 @@ export enum AarsaksTyper {
   SOEKNAD = 'SOEKNAD',
 }
 
-export interface Utflyttingshendelse {
-  fnr: string
-  tilflyttingsLand?: string
-  tilflyttingsstedIUtlandet?: string
-  utflyttingsdato: string
-  endringstype: Endringstype
-}
-
-export interface Doedshendelse {
-  avdoedFnr: string
-  doedsdato?: string
-  endringstype: Endringstype
-}
-
-export type Grunnlagsinformasjon =
-  | { type: 'SOEKER_DOED'; hendelse: Doedshendelse }
-  | { type: 'SOESKEN_DOED'; hendelse: Doedshendelse }
-  | { type: 'GJENLEVENDE_FORELDER_DOED'; hendelse: Doedshendelse }
-  | { type: 'UTFLYTTING'; hendelse: Utflyttingshendelse }
-
-export type GrunnlagsendringsType = Grunnlagsinformasjon['type']
-
-export const ENDRINGSTYPER = ['OPPRETTET', 'KORRIGERT', 'ANNULERT', 'OPPHOERT'] as const
-export type Endringstype = typeof ENDRINGSTYPER[number]
+export type GrunnlagsendringsType = SamsvarMellomGrunnlagOgPdl['type']
 
 const GRUNNLAGSENDRING_STATUS = [
-  'IKKE_VURDERT',
+  'VENTER_PAA_JOBB',
+  'SJEKKET_AV_JOBB',
   'TATT_MED_I_BEHANDLING',
-  'GYLDIG_OG_KAN_TAS_MED_I_BEHANDLING',
+  'VURDERT_SOM_IKKE_RELEVANT',
   'FORKASTET',
 ] as const
 
+interface Utland {
+  utflyttingFraNorge?: {
+    tilflyttingsland?: string
+    dato?: string
+  }[]
+  innflyttingTilNorge?: {
+    fraflyttingsland?: string
+    dato?: string
+  }[]
+}
+
+export interface DoedsdatoSamsvar {
+  type: 'DOEDSDATO'
+  samsvar: boolean
+  fraPdl?: string
+  fraGrunnlag?: string
+}
+
+export interface UtlandSamsvar {
+  type: 'UTLAND'
+  samsvar: boolean
+  fraPdl?: Utland
+  fraGrunnlag?: Utland
+}
+
+export interface BarnSamsvar {
+  type: 'BARN'
+  samsvar: boolean
+  fraPdl?: string[]
+  fraGrunnlag?: string[]
+}
+
+export interface AnsvarligeForeldreSamsvar {
+  type: 'ANSVARLIGE_FORELDRE'
+  samsvar: boolean
+  fraPdl?: string[]
+  fraGrunnlag?: string[]
+}
+
+export type SamsvarMellomGrunnlagOgPdl = DoedsdatoSamsvar | UtlandSamsvar | BarnSamsvar | AnsvarligeForeldreSamsvar
+
 export type GrunnlagsendringStatus = typeof GRUNNLAGSENDRING_STATUS[number]
+
+const SAKSROLLER = ['SOEKER', 'INNSENDER', 'SOESKEN', 'AVDOED', 'GJENLEVENDE', 'UKJENT'] as const
+
+export type Saksrolle = typeof SAKSROLLER[number]
 
 export interface Grunnlagsendringshendelse {
   id: string
   sakId: number
   type: GrunnlagsendringsType
-  data?: Grunnlagsinformasjon
   status: GrunnlagsendringStatus
   behandlingId?: string
   opprettet: string
+  hendelseGjelderRolle: Saksrolle
+  gjelderPerson: string
+  samsvarMedPdl: SamsvarMellomGrunnlagOgPdl
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/apiClient.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/apiClient.ts
@@ -16,16 +16,18 @@ async function retrieveData(props: Options, response: Response): Promise<any> {
   if (props.noData) {
     return null
   } else {
-    const type = response.headers.get('content-type')
+    const type = response.headers.get('content-type')?.toLowerCase()
 
-    switch (type) {
-      case 'application/json':
-        return await response.json()
-      case 'application/pdf':
-        return await response.arrayBuffer()
-      default:
-        return await response.text()
+    // content-type-headeren tillater ekstra meta-informasjon, eks: "text/html; charset=utf-8"
+    // eller "multipart/form-data; boundary=something". Derfor sjekker vi på om den inneholder
+    // den relevante content-typen vi er ute etter
+    if (type?.includes('application/json')) {
+      return await response.json()
     }
+    if (type?.includes('application/pdf')) {
+      return await response.arrayBuffer()
+    }
+    return await response.text()
   }
 }
 

--- a/apps/etterlatte-saksbehandling-ui/server/src/index.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/index.ts
@@ -12,7 +12,7 @@ import { loggerRouter } from './routers/loggerRouter'
 
 logger.info(`environment: ${process.env.NODE_ENV}`)
 
-const clientPath = path.resolve(__dirname, '../client')
+const clientPath = path.resolve(__dirname, '..', '..', 'client')
 const isDev = process.env.NODE_ENV !== 'production'
 
 const app = express()

--- a/apps/etterlatte-saksbehandling-ui/server/src/mockdata/personsok_23011255000.json
+++ b/apps/etterlatte-saksbehandling-ui/server/src/mockdata/personsok_23011255000.json
@@ -1,0 +1,186 @@
+{
+  "person" : {
+    "fornavn" : "Konsentrisk",
+    "etternavn" : "Handlekraft",
+    "foedselsnummer" : "23011255000",
+    "foedselsdato" : "2012-01-23",
+    "foedselsaar" : 2012,
+    "foedeland" : "NOR",
+    "doedsdato" : null,
+    "adressebeskyttelse" : "UGRADERT",
+    "bostedsadresse" : [
+      {
+        "type" : "VEGADRESSE",
+        "aktiv" : true,
+        "coAdresseNavn" : null,
+        "adresseLinje1" : "Limilia 58",
+        "adresseLinje2" : null,
+        "adresseLinje3" : null,
+        "postnr" : "3721",
+        "poststed" : null,
+        "land" : null,
+        "kilde" : "FREG",
+        "gyldigFraOgMed" : "2012-01-23T00:00:00",
+        "gyldigTilOgMed" : null
+      },
+      {
+        "type" : "VEGADRESSE",
+        "aktiv" : false,
+        "coAdresseNavn" : null,
+        "adresseLinje1" : "Limilia 58",
+        "adresseLinje2" : null,
+        "adresseLinje3" : null,
+        "postnr" : "3721",
+        "poststed" : null,
+        "land" : null,
+        "kilde" : "FREG",
+        "gyldigFraOgMed" : "2012-01-23T00:00:00",
+        "gyldigTilOgMed" : null
+      }
+    ],
+    "deltBostedsadresse" : null,
+    "kontaktadresse" : [],
+    "oppholdsadresse" : [],
+    "sivilstatus" : "UOPPGITT",
+    "statsborgerskap" : "NOR",
+    "utland" : {
+      "innflyttingTilNorge" : [],
+      "utflyttingFraNorge" : []
+    },
+    "familieRelasjon" : {
+      "ansvarligeForeldre" : [
+        "18488230294",
+        "08106319953"
+      ],
+      "foreldre" : [
+        "08106319953",
+        "18488230294"
+      ],
+      "barn" : null
+    },
+    "avdoedesBarn" : null,
+    "vergemaalEllerFremtidsfullmakt" : []
+  },
+  "behandlingListe" : {
+    "behandlinger" : [
+      {
+        "id" : "dfd0f04f-9b06-421d-bddd-c63dfdd849ea",
+        "sak" : 126,
+        "status" : "FATTET_VEDTAK",
+        "soeknadMottattDato" : "2022-12-13T15:40:17.737755",
+        "behandlingOpprettet" : "2022-12-13T15:40:18.698951",
+        "behandlingType" : "FØRSTEGANGSBEHANDLING",
+        "aarsak" : "SOEKNAD"
+      },
+      {
+        "id" : "0435e303-d77b-4f82-a150-d77830169e0e",
+        "sak" : 126,
+        "status" : "VILKAARSVURDERT",
+        "soeknadMottattDato" : "2022-12-21T11:42:45.414479",
+        "behandlingOpprettet" : "2022-12-21T11:42:47.434017",
+        "behandlingType" : "FØRSTEGANGSBEHANDLING",
+        "aarsak" : "SOEKNAD"
+      },
+      {
+        "id" : "3ff1407d-886b-4d62-b41f-9d6f88c83245",
+        "sak" : 126,
+        "status" : "IVERKSATT",
+        "soeknadMottattDato" : "2022-12-20T10:01:00.1578",
+        "behandlingOpprettet" : "2022-12-20T10:01:01.317135",
+        "behandlingType" : "FØRSTEGANGSBEHANDLING",
+        "aarsak" : "SOEKNAD"
+      }
+    ]
+  },
+  "grunnlagsendringshendelser" : {
+    "hendelser" : [
+      {
+        "id" : "a",
+        "sakId" : 126,
+        "type" : "UTLAND",
+        "opprettet" : "2022-12-20T10:01:00.1578",
+        "status" : "VENTER_PAA_JOBB",
+        "hendelseGjelderRolle" : "SOEKER",
+        "gjelderPerson" : "23011255000",
+        "samsvarMedPdl" : {
+          "type" : "UTLAND",
+          "fraGrunnlag" : {
+            "innflyttingTilNorge" : [],
+            "utflyttingFraNorge" : []
+          },
+          "fraPdl" : {
+            "innflyttingTilNorge" : [
+              {
+                "fraflyttingsland" : "Sverige",
+                "dato" : "2022-12-05"
+              }
+            ],
+            "utflyttingFraNorge" : [
+              {
+                "tilflyttingsland" : "Sverige",
+                "dato" : "2022-12-01"
+              }
+            ]
+          },
+          "samsvar" : false
+        }
+      },
+      {
+        "id" : "b",
+        "sakId" : 126,
+        "type" : "ANSVARLIGE_FORELDRE",
+        "opprettet" : "2022-12-20T10:01:00.1578",
+        "status" : "VENTER_PAA_JOBB",
+        "hendelseGjelderRolle" : "SOEKER",
+        "gjelderPerson" : "23011255000",
+        "samsvarMedPdl" : {
+          "type" : "ANSVARLIGE_FORELDRE",
+          "fraGrunnlag" : [
+            "18488230294",
+            "08106319953"
+          ],
+          "fraPdl" : [
+            "18488230294",
+            "12312312312"
+          ],
+          "samsvar" : false
+        }
+      },
+      {
+        "id" : "c",
+        "sakId" : 126,
+        "type" : "BARN",
+        "opprettet" : "2022-12-20T10:01:00.1578",
+        "status" : "VENTER_PAA_JOBB",
+        "hendelseGjelderRolle" : "AVDOED",
+        "gjelderPerson" : "18488230294",
+        "samsvarMedPdl" : {
+          "type" : "BARN",
+          "fraGrunnlag" : [
+            "23011255000"
+          ],
+          "fraPdl" : [
+            "23011255000",
+            "12312312312"
+          ],
+          "samsvar" : false
+        }
+      },
+      {
+        "id" : "d",
+        "sakId" : 126,
+        "type" : "DOEDSDATO",
+        "opprettet" : "2022-12-20T10:01:00.1578",
+        "status" : "VENTER_PAA_JOBB",
+        "hendelseGjelderRolle" : "SOEKER",
+        "gjelderPerson" : "23011255000",
+        "samsvarMedPdl" : {
+          "type" : "DOEDSDATO",
+          "fraGrunnlag" : null,
+          "fraPdl" : "2022-12-18",
+          "samsvar" : false
+        }
+      }
+    ]
+  }
+}

--- a/libs/common/src/main/kotlin/behandling/Grunnlagsendringshendelse.kt
+++ b/libs/common/src/main/kotlin/behandling/Grunnlagsendringshendelse.kt
@@ -8,6 +8,7 @@ import no.nav.etterlatte.libs.common.pdlhendelse.UtflyttingsHendelse
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.person.Utland
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -50,7 +51,7 @@ enum class GrunnlagsendringsType {
 
 enum class GrunnlagsendringStatus {
     VENTER_PAA_JOBB, // naar hendelsen registreres // FØR: IKKE_VURDERT
-    SJEKKET_AV_JOBB, // FØR: ED_I_BEHANDLING
+    SJEKKET_AV_JOBB, // FØR: MED_I_BEHANDLING
     TATT_MED_I_BEHANDLING, // tatt med i behandling av saksbehandler
     FORKASTET,
     VURDERT_SOM_IKKE_RELEVANT
@@ -63,8 +64,17 @@ enum class Saksrolle {
     GJENLEVENDE,
     UKJENT;
 
+    fun toPersonrolle(): PersonRolle =
+        when (this) {
+            SOEKER -> PersonRolle.BARN
+            SOESKEN -> PersonRolle.BARN
+            AVDOED -> PersonRolle.AVDOED
+            GJENLEVENDE -> PersonRolle.AVDOED
+            UKJENT -> throw Exception("Ukjent Saksrolle kan ikke castes til PersonRolle")
+        }
+
     companion object {
-        val log = LoggerFactory.getLogger(Saksrolle::class.java)
+        val log: Logger = LoggerFactory.getLogger(Saksrolle::class.java)
         fun enumVedNavnEllerUkjent(rolle: String) =
             try {
                 Saksrolle.valueOf(rolle.uppercase())
@@ -76,19 +86,10 @@ enum class Saksrolle {
                 )
                 UKJENT
             }
-
-        fun SaksrolleToPersonrolle(saksrolle: Saksrolle): PersonRolle =
-            when (saksrolle) {
-                SOEKER -> PersonRolle.BARN
-                SOESKEN -> PersonRolle.BARN
-                AVDOED -> PersonRolle.AVDOED
-                GJENLEVENDE -> PersonRolle.AVDOED
-                UKJENT -> throw Exception("Ukjent Saksrolle kan ikke castes til PersonRolle")
-            }
     }
 }
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 sealed class SamsvarMellomPdlOgGrunnlag {
     abstract val samsvar: Boolean
 


### PR DESCRIPTION
Nå som grunnlagsendringshendelser baserer seg på en sjekk om det er en forskjell mellom det vi har i grunnlag og det som ligger i PDL må dette også vises fram i frontend. Utseende er veldig WIP utviklerdesign, det trengs litt avklaringer her med fag og designere
<img width="441" alt="Screenshot 2023-01-04 at 13 03 20" src="https://user-images.githubusercontent.com/4296255/210551287-4bf190bf-72a3-4dc6-be6f-05902a1c4d12.png">

<img width="1585" alt="Screenshot 2023-01-04 at 13 03 30" src="https://user-images.githubusercontent.com/4296255/210551297-b68717ea-fcdb-46d0-9ff7-8445892dc956.png">
