### PR TITLE
Pakkenamn

### DIFF
--- a/apps/etterlatte-api/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-api/src/main/kotlin/Application.kt
@@ -18,7 +18,7 @@ import no.nav.etterlatte.behandling.VilkaarsvurderingKlientImpl
 import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getCorrelationId
 import no.nav.etterlatte.libs.common.objectMapper
-import sporingslogg.Sporingslogg
+import no.nav.etterlatte.libs.sporingslogg.Sporingslogg
 
 class ApplicationContext(configLocation: String? = null) {
     private val config: Config = configLocation?.let { ConfigFactory.load(it) } ?: ConfigFactory.load()

--- a/apps/etterlatte-api/src/main/kotlin/behandling/BehandlingService.kt
+++ b/apps/etterlatte-api/src/main/kotlin/behandling/BehandlingService.kt
@@ -9,15 +9,15 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.G
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.SOEKER_PDL_V1
 import no.nav.etterlatte.libs.common.person.InvalidFoedselsnummer
 import no.nav.etterlatte.libs.common.person.Person
+import no.nav.etterlatte.libs.sporingslogg.Decision
+import no.nav.etterlatte.libs.sporingslogg.HttpMethod
+import no.nav.etterlatte.libs.sporingslogg.Sporingslogg
+import no.nav.etterlatte.libs.sporingslogg.Sporingsrequest
 import no.nav.etterlatte.saksbehandling.api.typer.klientside.DetaljertBehandlingDto
 import no.nav.etterlatte.saksbehandling.api.typer.klientside.Familieforhold
 import no.nav.etterlatte.typer.LagretHendelser
 import no.nav.etterlatte.typer.Saker
 import org.slf4j.LoggerFactory
-import sporingslogg.Decision
-import sporingslogg.HttpMethod
-import sporingslogg.Sporingslogg
-import sporingslogg.Sporingsrequest
 import java.time.YearMonth
 import java.util.*
 

--- a/apps/etterlatte-api/src/test/kotlin/behandling/BehandlingServiceTest.kt
+++ b/apps/etterlatte-api/src/test/kotlin/behandling/BehandlingServiceTest.kt
@@ -1,4 +1,4 @@
-package behandling
+package no.nav.etterlatte.behandling
 
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -6,15 +6,6 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.runBlocking
-import no.nav.etterlatte.behandling.BehandlingKlient
-import no.nav.etterlatte.behandling.BehandlingService
-import no.nav.etterlatte.behandling.BeregningKlient
-import no.nav.etterlatte.behandling.EtterlatteGrunnlag
-import no.nav.etterlatte.behandling.EtterlatteVedtak
-import no.nav.etterlatte.behandling.PdltjenesterKlient
-import no.nav.etterlatte.behandling.Vedtak
-import no.nav.etterlatte.behandling.VilkaarsvurderingKlient
-import no.nav.etterlatte.behandling.VirkningstidspunktResponse
 import no.nav.etterlatte.libs.common.behandling.BehandlingListe
 import no.nav.etterlatte.libs.common.behandling.BehandlingSammendrag
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
@@ -33,6 +24,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingDto
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
+import no.nav.etterlatte.libs.sporingslogg.Sporingslogg
 import no.nav.etterlatte.typer.LagretHendelse
 import no.nav.etterlatte.typer.LagretHendelser
 import no.nav.etterlatte.typer.Sak
@@ -41,7 +33,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import no.nav.etterlatte.libs.sporingslogg.Sporingslogg
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime

--- a/apps/etterlatte-api/src/test/kotlin/behandling/BehandlingServiceTest.kt
+++ b/apps/etterlatte-api/src/test/kotlin/behandling/BehandlingServiceTest.kt
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import sporingslogg.Sporingslogg
+import no.nav.etterlatte.libs.sporingslogg.Sporingslogg
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagClientImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagClientImplTest.kt
@@ -1,6 +1,5 @@
-package grunnlagsendring
+package no.nav.etterlatte.grunnlagsendring
 
-import GrunnlagTestData
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -12,9 +11,9 @@ import io.ktor.http.fullPath
 import io.ktor.http.headersOf
 import io.ktor.serialization.jackson.jackson
 import kotlinx.coroutines.runBlocking
-import no.nav.etterlatte.grunnlagsendring.GrunnlagClientImpl
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.toJson
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagHelperKtTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagHelperKtTest.kt
@@ -1,11 +1,5 @@
-package grunnlagsendring
+package no.nav.etterlatte.grunnlagsendring
 
-import GrunnlagTestData
-import grunnlag.kilde
-import no.nav.etterlatte.grunnlagsendring.ansvarligeForeldre
-import no.nav.etterlatte.grunnlagsendring.barn
-import no.nav.etterlatte.grunnlagsendring.doedsdato
-import no.nav.etterlatte.grunnlagsendring.utland
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.Opplysning
@@ -16,6 +10,8 @@ import no.nav.etterlatte.libs.common.person.InnflyttingTilNorge
 import no.nav.etterlatte.libs.common.person.UtflyttingFraNorge
 import no.nav.etterlatte.libs.common.person.Utland
 import no.nav.etterlatte.libs.common.toJsonNode
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
+import no.nav.etterlatte.libs.testdata.grunnlag.kilde
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/SamsvarHelperKtTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/SamsvarHelperKtTest.kt
@@ -1,11 +1,7 @@
-package grunnlagsendring
+package no.nav.etterlatte.grunnlagsendring
 
 import no.nav.etterlatte.STOR_SNERK
 import no.nav.etterlatte.TRIVIELL_MIDTPUNKT
-import no.nav.etterlatte.grunnlagsendring.samsvarAnsvarligeForeldre
-import no.nav.etterlatte.grunnlagsendring.samsvarBarn
-import no.nav.etterlatte.grunnlagsendring.samsvarDoedsdatoer
-import no.nav.etterlatte.grunnlagsendring.samsvarUtflytting
 import no.nav.etterlatte.libs.common.person.InnflyttingTilNorge
 import no.nav.etterlatte.libs.common.person.UtflyttingFraNorge
 import no.nav.etterlatte.libs.common.person.Utland

--- a/apps/etterlatte-beregning/src/main/kotlin/model/BeregningService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/model/BeregningService.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.model
 
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import model.finnSoeskenperiode.FinnSoeskenPeriode
 import no.nav.etterlatte.BeregningRepository
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
@@ -17,6 +16,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.norskTidssone
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import no.nav.etterlatte.model.behandling.BehandlingKlient
+import no.nav.etterlatte.model.finnSoeskenperiode.FinnSoeskenPeriode
 import no.nav.etterlatte.model.grunnlag.GrunnlagKlient
 import rapidsandrivers.vedlikehold.VedlikeholdService
 import java.time.LocalDate

--- a/apps/etterlatte-beregning/src/main/kotlin/model/Soeskenjustering.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/model/Soeskenjustering.kt
@@ -1,6 +1,6 @@
 package no.nav.etterlatte.model
 
-import model.avrund.avrund
+import no.nav.etterlatte.model.avrund.avrund
 import java.math.BigDecimal
 
 private val `0,4` = 0.4.toBigDecimal()

--- a/apps/etterlatte-beregning/src/main/kotlin/model/avrund/Avrund.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/model/avrund/Avrund.kt
@@ -1,4 +1,4 @@
-package model.avrund
+package no.nav.etterlatte.model.avrund
 
 import java.math.BigDecimal
 import java.math.RoundingMode

--- a/apps/etterlatte-beregning/src/main/kotlin/model/finnSoeskenperiode/FinnSoeskenPeriode.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/model/finnSoeskenperiode/FinnSoeskenPeriode.kt
@@ -1,4 +1,4 @@
-package model.finnSoeskenperiode
+package no.nav.etterlatte.model.finnSoeskenperiode
 
 import com.fasterxml.jackson.databind.JsonNode
 import no.nav.etterlatte.libs.common.beregning.SoeskenPeriode

--- a/apps/etterlatte-beregning/src/test/kotlin/BeregningRepositoryImplTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/BeregningRepositoryImplTest.kt
@@ -1,12 +1,12 @@
+package no.nav.etterlatte
+
 import io.mockk.mockk
 import io.mockk.mockkClass
-import no.nav.etterlatte.BeregningRepository
-import no.nav.etterlatte.BeregningRepositoryImpl
-import no.nav.etterlatte.DataSourceBuilder
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.grunnlag.Metadata
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.model.Beregning
 import no.nav.etterlatte.model.BeregningService
 import org.junit.jupiter.api.AfterAll

--- a/apps/etterlatte-beregning/src/test/kotlin/model/BeregningServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/model/BeregningServiceTest.kt
@@ -1,7 +1,5 @@
-package model
+package no.nav.etterlatte.model
 
-import GrunnlagTestData
-import grunnlag.kilde
 import io.mockk.mockk
 import no.nav.etterlatte.BeregningRepository
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
@@ -9,15 +7,14 @@ import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.grunnlag.Opplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.toJsonNode
-import no.nav.etterlatte.model.BeregningService
-import no.nav.etterlatte.model.VilkaarsvurderingKlient
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
+import no.nav.etterlatte.libs.testdata.grunnlag.kilde
+import no.nav.etterlatte.libs.testdata.vilkaarsvurdering.VilkaarsvurderingTestData
 import no.nav.etterlatte.model.behandling.BehandlingKlientImpl
-import no.nav.etterlatte.model.beregnSisteTom
 import no.nav.etterlatte.model.grunnlag.GrunnlagKlientImpl
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import vilkaarsvurdering.VilkaarsvurderingTestData
 import java.time.LocalDate
 import java.time.YearMonth
 import java.util.UUID.randomUUID

--- a/apps/etterlatte-beregning/src/test/kotlin/model/GrunnbeloepTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/model/GrunnbeloepTest.kt
@@ -1,6 +1,5 @@
-package model
+package no.nav.etterlatte.model
 
-import no.nav.etterlatte.model.Grunnbeloep
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.time.YearMonth

--- a/apps/etterlatte-beregning/src/test/kotlin/model/SoeskenjusteringTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/model/SoeskenjusteringTest.kt
@@ -1,6 +1,5 @@
-package model
+package no.nav.etterlatte.model
 
-import no.nav.etterlatte.model.Soeskenjustering
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 

--- a/apps/etterlatte-beregning/src/test/kotlin/model/avrund/AvrundKtTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/model/avrund/AvrundKtTest.kt
@@ -1,4 +1,4 @@
-package model.avrund
+package no.nav.etterlatte.model.avrund
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test

--- a/apps/etterlatte-beregning/src/test/kotlin/model/finnSoeskenperiode/FinnSoeskenPeriodeTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/model/finnSoeskenperiode/FinnSoeskenPeriodeTest.kt
@@ -1,10 +1,8 @@
-package model.finnSoeskenperiode
+package no.nav.etterlatte.model.finnSoeskenperiode
 
-import GrunnlagTestData
-import grunnlag.ADRESSE_DEFAULT
-import grunnlag.HALVSOESKEN_FOEDSELSNUMMER
-import grunnlag.HELSOESKEN_FOEDSELSNUMMER
-import grunnlag.kilde
+import model.finnSoeskenperiode.FinnSoeskenPeriode
+import model.finnSoeskenperiode.Soesken
+import model.finnSoeskenperiode.finnHelOgHalvsoesken
 import no.nav.etterlatte.libs.common.beregning.SoeskenPeriode
 import no.nav.etterlatte.libs.common.grunnlag.Opplysning
 import no.nav.etterlatte.libs.common.grunnlag.PeriodisertOpplysning
@@ -17,6 +15,11 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.F
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.SoeskenMedIBeregning
 import no.nav.etterlatte.libs.common.person.AvdoedesBarn
 import no.nav.etterlatte.libs.common.toJsonNode
+import no.nav.etterlatte.libs.testdata.grunnlag.ADRESSE_DEFAULT
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
+import no.nav.etterlatte.libs.testdata.grunnlag.HALVSOESKEN_FOEDSELSNUMMER
+import no.nav.etterlatte.libs.testdata.grunnlag.HELSOESKEN_FOEDSELSNUMMER
+import no.nav.etterlatte.libs.testdata.grunnlag.kilde
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.time.LocalDate

--- a/apps/etterlatte-beregning/src/test/kotlin/model/finnSoeskenperiode/FinnSoeskenPeriodeTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/model/finnSoeskenperiode/FinnSoeskenPeriodeTest.kt
@@ -1,8 +1,5 @@
 package no.nav.etterlatte.model.finnSoeskenperiode
 
-import model.finnSoeskenperiode.FinnSoeskenPeriode
-import model.finnSoeskenperiode.Soesken
-import model.finnSoeskenperiode.finnHelOgHalvsoesken
 import no.nav.etterlatte.libs.common.beregning.SoeskenPeriode
 import no.nav.etterlatte.libs.common.grunnlag.Opplysning
 import no.nav.etterlatte.libs.common.grunnlag.PeriodisertOpplysning

--- a/apps/etterlatte-brev-distribusjon/src/main/kotlin/AppBuilder.kt
+++ b/apps/etterlatte-brev-distribusjon/src/main/kotlin/AppBuilder.kt
@@ -1,20 +1,20 @@
 package no.nav.etterlatte
 
-import JournalpostServiceMock
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.ContentType
 import io.ktor.serialization.jackson.JacksonConverter
-import journalpost.JournalpostService
-import journalpost.JournalpostServiceImpl
 import no.nav.etterlatte.brev.BrevServiceImpl
 import no.nav.etterlatte.distribusjon.DistribusjonKlient
 import no.nav.etterlatte.distribusjon.DistribusjonService
 import no.nav.etterlatte.distribusjon.DistribusjonServiceImpl
 import no.nav.etterlatte.distribusjon.DistribusjonServiceMock
 import no.nav.etterlatte.journalpost.JournalpostKlient
+import no.nav.etterlatte.journalpost.JournalpostService
+import no.nav.etterlatte.journalpost.JournalpostServiceImpl
+import no.nav.etterlatte.journalpost.JournalpostServiceMock
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.security.ktor.clientCredential
 

--- a/apps/etterlatte-brev-distribusjon/src/main/kotlin/JournalfoerBrev.kt
+++ b/apps/etterlatte-brev-distribusjon/src/main/kotlin/JournalfoerBrev.kt
@@ -1,7 +1,7 @@
 package no.nav.etterlatte
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import journalpost.JournalpostService
+import no.nav.etterlatte.journalpost.JournalpostService
 import no.nav.etterlatte.libs.common.brev.model.BrevEventTypes
 import no.nav.etterlatte.libs.common.brev.model.DistribusjonMelding
 import no.nav.etterlatte.libs.common.journalpost.JournalpostResponse

--- a/apps/etterlatte-brev-distribusjon/src/main/kotlin/journalpost/JournalpostService.kt
+++ b/apps/etterlatte-brev-distribusjon/src/main/kotlin/journalpost/JournalpostService.kt
@@ -1,8 +1,7 @@
-package journalpost
+package no.nav.etterlatte.journalpost
 
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.brev.BrevService
-import no.nav.etterlatte.journalpost.JournalpostKlient
 import no.nav.etterlatte.libs.common.brev.model.DistribusjonMelding
 import no.nav.etterlatte.libs.common.brev.model.Mottaker
 import no.nav.etterlatte.libs.common.journalpost.AvsenderMottaker

--- a/apps/etterlatte-brev-distribusjon/src/main/kotlin/journalpost/JournalpostServiceMock.kt
+++ b/apps/etterlatte-brev-distribusjon/src/main/kotlin/journalpost/JournalpostServiceMock.kt
@@ -1,4 +1,5 @@
-import journalpost.JournalpostService
+package no.nav.etterlatte.journalpost
+
 import no.nav.etterlatte.libs.common.brev.model.DistribusjonMelding
 import no.nav.etterlatte.libs.common.journalpost.JournalpostResponse
 import org.slf4j.LoggerFactory

--- a/apps/etterlatte-brev-distribusjon/src/test/kotlin/JournalfoerBrevTest.kt
+++ b/apps/etterlatte-brev-distribusjon/src/test/kotlin/JournalfoerBrevTest.kt
@@ -1,3 +1,5 @@
+package no.nav.etterlatte.journalpost
+
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/BehandlingEndretHendelseTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/BehandlingEndretHendelseTest.kt
@@ -1,15 +1,12 @@
-package grunnlag
+package no.nav.etterlatte.grunnlag
 
-import GrunnlagTestData
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.etterlatte.grunnlag.BehandlingEndretHendlese
-import no.nav.etterlatte.grunnlag.OpplysningDao
-import no.nav.etterlatte.grunnlag.RealGrunnlagService
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.event.BehandlingGrunnlagEndret
 import no.nav.etterlatte.libs.common.event.BehandlingGrunnlagEndretMedGrunnlag
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventNameKey
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/BehandlingHendelserTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/BehandlingHendelserTest.kt
@@ -1,9 +1,8 @@
-package grunnlag
+package no.nav.etterlatte.grunnlag
 
-import GrunnlagTestData
-import no.nav.etterlatte.grunnlag.BehandlingHendelser
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventNameKey
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import org.junit.jupiter.api.Assertions

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagRoutesKtTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagRoutesKtTest.kt
@@ -1,6 +1,5 @@
-package grunnlag
+package no.nav.etterlatte.grunnlag
 
-import GrunnlagTestData
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.headers
@@ -11,9 +10,8 @@ import io.ktor.server.testing.testApplication
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.etterlatte.apiModule
-import no.nav.etterlatte.grunnlag.GrunnlagService
-import no.nav.etterlatte.grunnlag.grunnlagRoute
 import no.nav.etterlatte.libs.common.serialize
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagServiceTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagServiceTest.kt
@@ -1,11 +1,8 @@
-package grunnlag
+package no.nav.etterlatte.grunnlag
 
-import GrunnlagTestData
 import io.mockk.every
 import io.mockk.mockk
 import lagGrunnlagHendelse
-import no.nav.etterlatte.grunnlag.OpplysningDao
-import no.nav.etterlatte.grunnlag.RealGrunnlagService
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.Opplysning
@@ -24,6 +21,10 @@ import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.toJsonNode
+import no.nav.etterlatte.libs.testdata.grunnlag.ADRESSE_DEFAULT
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
+import no.nav.etterlatte.libs.testdata.grunnlag.kilde
+import no.nav.etterlatte.libs.testdata.grunnlag.statiskUuid
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/apps/etterlatte-grunnlag/src/test/kotlin/itest/GrunnlagDatabaseTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/itest/GrunnlagDatabaseTest.kt
@@ -2,9 +2,6 @@ package no.nav.etterlatte.itest
 
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.kotlin.treeToValue
-import grunnlag.ADRESSE_DEFAULT
-import grunnlag.SOEKER_FOEDSELSNUMMER
-import grunnlag.kilde
 import lagGrunnlagsopplysning
 import no.nav.etterlatte.DataSourceBuilder
 import no.nav.etterlatte.grunnlag.OpplysningDao
@@ -21,6 +18,9 @@ import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.toJsonNode
+import no.nav.etterlatte.libs.testdata.grunnlag.ADRESSE_DEFAULT
+import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
+import no.nav.etterlatte.libs.testdata.grunnlag.kilde
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/apps/etterlatte-grunnlag/src/test/kotlin/itest/RapidTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/itest/RapidTest.kt
@@ -1,7 +1,6 @@
-package itest
+package no.nav.etterlatte.itest
 
 import com.fasterxml.jackson.databind.JsonNode
-import grunnlag.statiskUuid
 import io.mockk.mockk
 import lagGrunnlagsopplysning
 import no.nav.etterlatte.DataSourceBuilder
@@ -24,6 +23,7 @@ import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventNameKey
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.toJsonNode
+import no.nav.etterlatte.libs.testdata.grunnlag.statiskUuid
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import org.junit.jupiter.api.AfterAll

--- a/apps/etterlatte-opplysninger-fra-inntektskomponenten/src/test/kotlin/OpplysningsbyggerTest.kt
+++ b/apps/etterlatte-opplysninger-fra-inntektskomponenten/src/test/kotlin/OpplysningsbyggerTest.kt
@@ -1,10 +1,10 @@
 import com.fasterxml.jackson.module.kotlin.readValue
-import grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.common.arbeidsforhold.AaregResponse
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.inntekt.Ident
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
+import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.opplysninger.kilde.inntektskomponenten.InntektsKomponentenResponse
 import no.nav.etterlatte.opplysninger.kilde.inntektskomponenten.OpplysningsByggerService
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/apps/etterlatte-opplysninger-fra-pdl/src/test/kotlin/opplysninger/kilde/pdl/BesvarOpplysningsbehovTest.kt
+++ b/apps/etterlatte-opplysninger-fra-pdl/src/test/kotlin/opplysninger/kilde/pdl/BesvarOpplysningsbehovTest.kt
@@ -1,4 +1,4 @@
-package opplysninger.kilde.pdl
+package no.nav.etterlatte.opplysninger.kilde.pdl
 
 import io.mockk.every
 import io.mockk.mockk
@@ -9,8 +9,6 @@ import no.nav.etterlatte.libs.common.person.Adresse
 import no.nav.etterlatte.libs.common.person.AdresseType
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.rapidsandrivers.behovNameKey
-import no.nav.etterlatte.opplysninger.kilde.pdl.BesvarOpplysningsbehov
-import no.nav.etterlatte.opplysninger.kilde.pdl.Pdl
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test

--- a/apps/etterlatte-opplysninger-fra-soeknad/src/test/kotlin/behandlingfrasoknad/OpplysningsuthenterTest.kt
+++ b/apps/etterlatte-opplysninger-fra-soeknad/src/test/kotlin/behandlingfrasoknad/OpplysningsuthenterTest.kt
@@ -1,4 +1,4 @@
-package behandlingfrasoknad
+package no.nav.etterlatte.behandlingfrasoknad
 
 import com.fasterxml.jackson.module.kotlin.treeToValue
 import no.nav.etterlatte.common.objectMapper

--- a/apps/etterlatte-opplysninger-fra-soeknad/src/test/kotlin/behandlingfrasoknad/StartUthentingFraSoeknadTest.kt
+++ b/apps/etterlatte-opplysninger-fra-soeknad/src/test/kotlin/behandlingfrasoknad/StartUthentingFraSoeknadTest.kt
@@ -1,4 +1,4 @@
-package behandlingfrasoknad
+package no.nav.etterlatte.behandlingfrasoknad
 
 import com.fasterxml.jackson.module.kotlin.treeToValue
 import io.mockk.every

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/pdl/mapper/UtlandMapperTest.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/pdl/mapper/UtlandMapperTest.kt
@@ -1,9 +1,8 @@
-package pdl.mapper
+package no.nav.etterlatte.pdl.mapper
 
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.etterlatte.pdl.PdlHentPerson
-import no.nav.etterlatte.pdl.mapper.UtlandMapper
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.time.LocalDate

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonRouteTest.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonRouteTest.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.person
 
-import GrunnlagTestData
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -22,6 +21,7 @@ import no.nav.etterlatte.libs.common.person.HentFolkeregisterIdentRequest
 import no.nav.etterlatte.libs.common.person.HentPersonRequest
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.toJson
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.mockFolkeregisterident
 import no.nav.etterlatte.mockPerson
 import no.nav.etterlatte.module

--- a/apps/etterlatte-statistikk/src/test/kotlin/statistikk/VedtakhendelserRiverTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/statistikk/VedtakhendelserRiverTest.kt
@@ -1,4 +1,4 @@
-package statistikk
+package no.nav.etterlatte.statistikk
 
 import io.mockk.every
 import io.mockk.mockk

--- a/apps/etterlatte-testdata/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/Application.kt
@@ -1,4 +1,4 @@
-package no.nav.etterlatte
+package no.nav.etterlatte.testdata
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
@@ -8,8 +8,6 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.github.mustachejava.DefaultMustacheFactory
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import dolly.DollyClientImpl
-import dolly.DollyService
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.defaultRequest
@@ -47,16 +45,18 @@ import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getCorrelationId
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.ktorobo.AzureAdClient
+import no.nav.etterlatte.testdata.dolly.DollyClientImpl
+import no.nav.etterlatte.testdata.dolly.DollyService
+import no.nav.etterlatte.testdata.features.SlettsakFeature
+import no.nav.etterlatte.testdata.features.dolly.DollyFeature
+import no.nav.etterlatte.testdata.features.egendefinert.EgendefinertMeldingFeature
+import no.nav.etterlatte.testdata.features.index.IndexFeature
+import no.nav.etterlatte.testdata.features.soeknad.OpprettSoeknadFeature
+import no.nav.etterlatte.testdata.features.standardmelding.StandardMeldingFeature
 import no.nav.security.token.support.v2.TokenValidationContextPrincipal
 import no.nav.security.token.support.v2.tokenValidationSupport
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import testdata.features.SlettsakFeature
-import testdata.features.dolly.DollyFeature
-import testdata.features.egendefinert.EgendefinertMeldingFeature
-import testdata.features.index.IndexFeature
-import testdata.features.soeknad.OpprettSoeknadFeature
-import testdata.features.standardmelding.StandardMeldingFeature
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
 
 private val env = System.getenv()

--- a/apps/etterlatte-testdata/src/main/kotlin/JsonMessage.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/JsonMessage.kt
@@ -1,3 +1,5 @@
+package no.nav.etterlatte.testdata
+
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.SerializationFeature

--- a/apps/etterlatte-testdata/src/main/kotlin/dolly/DollyClient.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/dolly/DollyClient.kt
@@ -1,4 +1,4 @@
-package dolly
+package no.nav.etterlatte.testdata.dolly
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.readValue

--- a/apps/etterlatte-testdata/src/main/kotlin/dolly/DollyService.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/dolly/DollyService.kt
@@ -1,4 +1,4 @@
-package dolly
+package no.nav.etterlatte.testdata.dolly
 
 import kotlinx.coroutines.runBlocking
 

--- a/apps/etterlatte-testdata/src/main/kotlin/dolly/Model.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/dolly/Model.kt
@@ -1,4 +1,4 @@
-package dolly
+package no.nav.etterlatte.testdata.dolly
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 

--- a/apps/etterlatte-testdata/src/main/kotlin/testdata/features/dolly/BestillingUtil.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/testdata/features/dolly/BestillingUtil.kt
@@ -1,6 +1,6 @@
-package testdata.features.dolly
+package no.nav.etterlatte.testdata.features.dolly
 
-import dolly.BestillingRequest
+import no.nav.etterlatte.testdata.dolly.BestillingRequest
 
 fun generererBestilling(bestilling: BestillingRequest): String {
     val soeker = soeskenTemplate(true)

--- a/apps/etterlatte-testdata/src/main/kotlin/testdata/features/dolly/DollyFeature.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/testdata/features/dolly/DollyFeature.kt
@@ -1,10 +1,7 @@
-package testdata.features.dolly
+package no.nav.etterlatte.testdata.features.dolly
 
-import JsonMessage
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.kotlin.readValue
-import dolly.BestillingRequest
-import dolly.DollyService
 import io.ktor.server.application.call
 import io.ktor.server.mustache.MustacheContent
 import io.ktor.server.request.receiveParameters
@@ -12,14 +9,17 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
-import no.nav.etterlatte.TestDataFeature
-import no.nav.etterlatte.getClientAccessToken
 import no.nav.etterlatte.libs.common.toJson
-import no.nav.etterlatte.logger
-import no.nav.etterlatte.navIdentFraToken
-import no.nav.etterlatte.objectMapper
-import no.nav.etterlatte.producer
-import no.nav.etterlatte.usernameFraToken
+import no.nav.etterlatte.testdata.JsonMessage
+import no.nav.etterlatte.testdata.TestDataFeature
+import no.nav.etterlatte.testdata.dolly.BestillingRequest
+import no.nav.etterlatte.testdata.dolly.DollyService
+import no.nav.etterlatte.testdata.getClientAccessToken
+import no.nav.etterlatte.testdata.logger
+import no.nav.etterlatte.testdata.navIdentFraToken
+import no.nav.etterlatte.testdata.objectMapper
+import no.nav.etterlatte.testdata.producer
+import no.nav.etterlatte.testdata.usernameFraToken
 import java.time.OffsetDateTime
 import java.util.*
 

--- a/apps/etterlatte-testdata/src/main/kotlin/testdata/features/egendefinert/EgendefinertMeldingFeature.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/testdata/features/egendefinert/EgendefinertMeldingFeature.kt
@@ -1,6 +1,5 @@
-package testdata.features.egendefinert
+package no.nav.etterlatte.testdata.features.egendefinert
 
-import JsonMessage
 import io.ktor.server.application.call
 import io.ktor.server.mustache.MustacheContent
 import io.ktor.server.request.receiveParameters
@@ -9,10 +8,11 @@ import io.ktor.server.response.respondRedirect
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
-import no.nav.etterlatte.TestDataFeature
-import no.nav.etterlatte.logger
-import no.nav.etterlatte.navIdentFraToken
-import no.nav.etterlatte.producer
+import no.nav.etterlatte.testdata.JsonMessage
+import no.nav.etterlatte.testdata.TestDataFeature
+import no.nav.etterlatte.testdata.logger
+import no.nav.etterlatte.testdata.navIdentFraToken
+import no.nav.etterlatte.testdata.producer
 
 object EgendefinertMeldingFeature : TestDataFeature {
     override val beskrivelse: String

--- a/apps/etterlatte-testdata/src/main/kotlin/testdata/features/index/IndexFeature.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/testdata/features/index/IndexFeature.kt
@@ -1,13 +1,13 @@
-package testdata.features.index
+package no.nav.etterlatte.testdata.features.index
 
 import io.ktor.server.application.call
 import io.ktor.server.mustache.MustacheContent
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
-import no.nav.etterlatte.TestDataFeature
-import no.nav.etterlatte.features
-import no.nav.etterlatte.navIdentFraToken
+import no.nav.etterlatte.testdata.TestDataFeature
+import no.nav.etterlatte.testdata.features
+import no.nav.etterlatte.testdata.navIdentFraToken
 
 object IndexFeature : TestDataFeature {
     override val beskrivelse: String

--- a/apps/etterlatte-testdata/src/main/kotlin/testdata/features/slettsak/SlettSak.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/testdata/features/slettsak/SlettSak.kt
@@ -1,6 +1,5 @@
-package testdata.features
+package no.nav.etterlatte.testdata.features
 
-import JsonMessage
 import io.ktor.server.application.call
 import io.ktor.server.mustache.MustacheContent
 import io.ktor.server.request.receiveParameters
@@ -9,10 +8,11 @@ import io.ktor.server.response.respondRedirect
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
-import no.nav.etterlatte.TestDataFeature
-import no.nav.etterlatte.logger
-import no.nav.etterlatte.navIdentFraToken
-import no.nav.etterlatte.producer
+import no.nav.etterlatte.testdata.JsonMessage
+import no.nav.etterlatte.testdata.TestDataFeature
+import no.nav.etterlatte.testdata.logger
+import no.nav.etterlatte.testdata.navIdentFraToken
+import no.nav.etterlatte.testdata.producer
 
 object SlettsakFeature : TestDataFeature {
     override val beskrivelse: String

--- a/apps/etterlatte-testdata/src/main/kotlin/testdata/features/soeknad/OpprettSoeknad.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/testdata/features/soeknad/OpprettSoeknad.kt
@@ -1,6 +1,6 @@
-package testdata.features.soeknad // ktlint-disable filename
 
-import JsonMessage
+package no.nav.etterlatte.testdata.features.soeknad // ktlint-disable filename
+
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.server.application.call
@@ -11,11 +11,12 @@ import io.ktor.server.response.respondRedirect
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
-import no.nav.etterlatte.TestDataFeature
-import no.nav.etterlatte.logger
-import no.nav.etterlatte.navIdentFraToken
-import no.nav.etterlatte.objectMapper
-import no.nav.etterlatte.producer
+import no.nav.etterlatte.testdata.JsonMessage
+import no.nav.etterlatte.testdata.TestDataFeature
+import no.nav.etterlatte.testdata.logger
+import no.nav.etterlatte.testdata.navIdentFraToken
+import no.nav.etterlatte.testdata.objectMapper
+import no.nav.etterlatte.testdata.producer
 import java.time.OffsetDateTime
 import java.util.*
 

--- a/apps/etterlatte-testdata/src/main/kotlin/testdata/features/standardmelding/StandardMeldingFeature.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/testdata/features/standardmelding/StandardMeldingFeature.kt
@@ -1,6 +1,5 @@
-package testdata.features.standardmelding
+package no.nav.etterlatte.testdata.features.standardmelding
 
-import JsonMessage
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.server.application.call
@@ -8,14 +7,15 @@ import io.ktor.server.mustache.MustacheContent
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
-import no.nav.etterlatte.TestDataFeature
 import no.nav.etterlatte.batch.payload
 import no.nav.etterlatte.kafka.KafkaProdusent
-import no.nav.etterlatte.logger
-import no.nav.etterlatte.objectMapper
-import no.nav.etterlatte.producer
+import no.nav.etterlatte.testdata.JsonMessage
+import no.nav.etterlatte.testdata.TestDataFeature
+import no.nav.etterlatte.testdata.logger
+import no.nav.etterlatte.testdata.objectMapper
+import no.nav.etterlatte.testdata.producer
 import java.time.OffsetDateTime
-import java.util.UUID
+import java.util.*
 
 const val aremark_person = "12101376212"
 

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingService.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingService.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.utbetaling.avstemming
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.norskTidssone
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
+import no.nav.etterlatte.utbetaling.avstemming.avstemmingsdata.KonsistensavstemmingDataMapper
 import no.nav.etterlatte.utbetaling.grensesnittavstemming.AvstemmingDao
 import no.nav.etterlatte.utbetaling.grensesnittavstemming.UUIDBase64
 import no.nav.etterlatte.utbetaling.grensesnittavstemming.avstemmingsdata.AvstemmingsdataSender
@@ -14,7 +15,6 @@ import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Utbetalingslinje
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.UtbetalingslinjeId
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Utbetalingslinjetype
 import org.slf4j.LoggerFactory
-import utbetaling.avstemming.avstemmingsdata.KonsistensavstemmingDataMapper
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/avstemmingsdata/KonsistensavstemmingDataMapper.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/avstemmingsdata/KonsistensavstemmingDataMapper.kt
@@ -1,4 +1,4 @@
-package utbetaling.avstemming.avstemmingsdata
+package no.nav.etterlatte.utbetaling.avstemming.avstemmingsdata
 
 import no.nav.etterlatte.libs.common.tidspunkt.toNorskTid
 import no.nav.etterlatte.utbetaling.avstemming.Konsistensavstemming

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/AvstemmingDaoIntegrationTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/AvstemmingDaoIntegrationTest.kt
@@ -6,6 +6,7 @@ import kotliquery.using
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.utbetaling.TestContainers
 import no.nav.etterlatte.utbetaling.avstemming.Konsistensavstemming
+import no.nav.etterlatte.utbetaling.avstemming.avstemmingsdata.KonsistensavstemmingDataMapper
 import no.nav.etterlatte.utbetaling.config.DataSourceBuilder
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
 import no.nav.etterlatte.utbetaling.oppdragForKonsistensavstemming
@@ -17,7 +18,6 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.junit.jupiter.Container
-import utbetaling.avstemming.avstemmingsdata.KonsistensavstemmingDataMapper
 import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/KonsistensavstemmingJobTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/KonsistensavstemmingJobTest.kt
@@ -1,10 +1,8 @@
-package utbetaling.avstemming
+package no.nav.etterlatte.utbetaling.avstemming
 
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import no.nav.etterlatte.utbetaling.avstemming.KonsistensavstemmingJob
-import no.nav.etterlatte.utbetaling.avstemming.KonsistensavstemmingService
 import no.nav.etterlatte.utbetaling.config.LeaderElection
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
 import org.junit.jupiter.api.Assertions

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/KonsistensavstemmingServiceKtTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/KonsistensavstemmingServiceKtTest.kt
@@ -1,4 +1,4 @@
-package utbetaling.avstemming
+package no.nav.etterlatte.utbetaling.avstemming
 
 import io.mockk.every
 import io.mockk.mockk
@@ -6,8 +6,6 @@ import io.mockk.verify
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.norskTidssone
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
-import no.nav.etterlatte.utbetaling.avstemming.KonsistensavstemmingService
-import no.nav.etterlatte.utbetaling.avstemming.OppdragForKonsistensavstemming
 import no.nav.etterlatte.utbetaling.grensesnittavstemming.AvstemmingDao
 import no.nav.etterlatte.utbetaling.grensesnittavstemming.avstemmingsdata.AvstemmingsdataSender
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.SakId

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/avstemmingsdata/AvstemmingsdataJaxbTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/avstemmingsdata/AvstemmingsdataJaxbTest.kt
@@ -4,6 +4,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.norskTidssone
 import no.nav.etterlatte.libs.common.tidspunkt.toNorskTid
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
+import no.nav.etterlatte.utbetaling.avstemming.avstemmingsdata.KonsistensavstemmingDataMapper
 import no.nav.etterlatte.utbetaling.common.tidsstempelMikroOppdrag
 import no.nav.etterlatte.utbetaling.common.tidsstempelTimeOppdrag
 import no.nav.etterlatte.utbetaling.grensesnittavstemming.UUIDBase64
@@ -18,7 +19,6 @@ import no.nav.etterlatte.utbetaling.utbetaling
 import no.nav.etterlatte.utbetaling.utbetalingshendelse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import utbetaling.avstemming.avstemmingsdata.KonsistensavstemmingDataMapper
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/avstemmingsdata/AvstemmingsdataSenderIntegrationTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/avstemmingsdata/AvstemmingsdataSenderIntegrationTest.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.utbetaling.grensesnittavstemming.avstemmingsdata
 
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.utbetaling.TestContainers
+import no.nav.etterlatte.utbetaling.avstemming.avstemmingsdata.KonsistensavstemmingDataMapper
 import no.nav.etterlatte.utbetaling.config.JmsConnectionFactory
 import no.nav.etterlatte.utbetaling.grensesnittavstemming.UUIDBase64
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.UtbetalingStatus
@@ -16,7 +17,6 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.junit.jupiter.Container
-import utbetaling.avstemming.avstemmingsdata.KonsistensavstemmingDataMapper
 import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/avstemmingsdata/KonsistensavstemmingDataMapperTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/avstemmingsdata/KonsistensavstemmingDataMapperTest.kt
@@ -1,4 +1,4 @@
-package utbetaling.avstemming.avstemmingsdata
+package no.nav.etterlatte.utbetaling.avstemming.avstemmingsdata
 
 import no.nav.etterlatte.utbetaling.mockKonsistensavstemming
 import no.nav.etterlatte.utbetaling.oppdragForKonsistensavstemming
@@ -114,7 +114,7 @@ fun `liste av konsistensavstemmingsdata har rett struktur`(konsistensavstemmings
     }
 
     if (konsistensavstemmingsdata.subList(1, konsistensavstemmingsdata.size - 1)
-        .any { it.aksjonsdata.aksjonsType != "DATA" }
+            .any { it.aksjonsdata.aksjonsType != "DATA" }
     ) {
         throw IllegalArgumentException(
             "Aksjonstypen til en eller flere av meldingene mellom START og AVSL var ikke DATA"

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/iverksetting/utbetaling/UtbetalingsvedtakTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/iverksetting/utbetaling/UtbetalingsvedtakTest.kt
@@ -1,8 +1,7 @@
-package utbetaling.iverksetting.utbetaling
+package no.nav.etterlatte.utbetaling.iverksetting.utbetaling
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.libs.common.objectMapper
-import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Utbetalingsvedtak
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/DBTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/DBTest.kt
@@ -1,4 +1,4 @@
-package vedtaksvurdering
+package no.nav.etterlatte.vedtaksvurdering
 
 import io.mockk.coEvery
 import io.mockk.every
@@ -15,6 +15,7 @@ import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.norskTidssone
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
 import no.nav.etterlatte.libs.common.vedtak.Vedtak
+import no.nav.etterlatte.libs.testdata.vilkaarsvurdering.VilkaarsvurderingTestData
 import no.nav.etterlatte.vedtaksvurdering.database.DataSourceBuilder
 import no.nav.etterlatte.vedtaksvurdering.database.VedtaksvurderingRepository
 import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
@@ -27,7 +28,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
-import vilkaarsvurdering.VilkaarsvurderingTestData
 import java.time.LocalDateTime
 import java.util.*
 import javax.sql.DataSource

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/LesIverksattVedtakmeldingTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/LesIverksattVedtakmeldingTest.kt
@@ -1,4 +1,4 @@
-package vedtaksvurdering.rivers
+package no.nav.etterlatte.vedtaksvurdering
 
 import io.mockk.every
 import io.mockk.mockk

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/StatussjekkTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/StatussjekkTest.kt
@@ -1,4 +1,4 @@
-package vedtaksvurdering
+package no.nav.etterlatte.vedtaksvurdering
 
 import io.mockk.coEvery
 import io.mockk.coVerify

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/UtledeUtbetalingsperioderTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/UtledeUtbetalingsperioderTest.kt
@@ -1,4 +1,4 @@
-package vedtaksvurdering
+package no.nav.etterlatte.vedtaksvurdering
 
 import io.mockk.mockk
 import no.nav.etterlatte.VedtaksvurderingService

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingServiceTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingServiceTest.kt
@@ -1,4 +1,4 @@
-package vedtaksvurdering
+package no.nav.etterlatte.vedtaksvurdering
 
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -14,7 +14,6 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingDto
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
-import no.nav.etterlatte.vedtaksvurdering.Vedtak
 import no.nav.etterlatte.vedtaksvurdering.database.VedtaksvurderingRepository
 import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
 import no.nav.etterlatte.vedtaksvurdering.klienter.BeregningKlient

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRepositoryTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRepositoryTest.kt
@@ -1,7 +1,5 @@
 package no.nav.etterlatte.vilkaarsvurdering
 
-import GrunnlagTestData
-import behandling.VirkningstidspunktTestData
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.Utfall
@@ -12,6 +10,8 @@ import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.database.migrate
+import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.vilkaarsvurdering.barnepensjon.BarnepensjonVilkaar
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
@@ -1,7 +1,5 @@
 package no.nav.etterlatte.vilkaarsvurdering
 
-import GrunnlagTestData
-import behandling.VirkningstidspunktTestData
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -30,6 +28,8 @@ import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.restModule
+import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.vilkaarsvurdering.behandling.BehandlingKlient
 import no.nav.etterlatte.vilkaarsvurdering.grunnlag.GrunnlagKlient
 import no.nav.security.mock.oauth2.MockOAuth2Server

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
@@ -1,7 +1,5 @@
 package no.nav.etterlatte.vilkaarsvurdering
 
-import GrunnlagTestData
-import behandling.VirkningstidspunktTestData
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -26,6 +24,8 @@ import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarType
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarVurderingData
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.database.migrate
+import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.vilkaarsvurdering.behandling.BehandlingKlient
 import no.nav.etterlatte.vilkaarsvurdering.grunnlag.GrunnlagKlient
 import org.junit.jupiter.api.AfterAll

--- a/libs/common/src/test/kotlin/beregning/BeregningsResultatKtTest.kt
+++ b/libs/common/src/test/kotlin/beregning/BeregningsResultatKtTest.kt
@@ -1,4 +1,4 @@
-package beregning
+package no.nav.etterlatte.beregning
 
 import no.nav.etterlatte.libs.common.beregning.SoeskenPeriode
 import no.nav.etterlatte.libs.common.beregning.erInklusiv

--- a/libs/common/src/test/kotlin/person/FoedselsnummerTest.kt
+++ b/libs/common/src/test/kotlin/person/FoedselsnummerTest.kt
@@ -1,4 +1,4 @@
-package person
+package no.nav.etterlatte.person
 
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.person.InvalidFoedselsnummer

--- a/libs/common/src/test/kotlin/person/FoedselsnummerValidatorTest.kt
+++ b/libs/common/src/test/kotlin/person/FoedselsnummerValidatorTest.kt
@@ -1,4 +1,4 @@
-package person
+package no.nav.etterlatte.person
 
 import io.kotest.matchers.shouldBe
 import no.nav.etterlatte.libs.common.person.FoedselsnummerValidator.Companion.isValid

--- a/libs/etterlatte-kafka/src/main/kotlin/kafka/JesonMessageSerializer.kt
+++ b/libs/etterlatte-kafka/src/main/kotlin/kafka/JesonMessageSerializer.kt
@@ -1,6 +1,5 @@
-package kafka
+package no.nav.etterlatte.kafka
 
-import no.nav.etterlatte.kafka.JsonMessage
 import org.apache.kafka.common.serialization.Deserializer
 import org.apache.kafka.common.serialization.Serializer
 

--- a/libs/etterlatte-kafka/src/main/kotlin/kafka/KafkaProdusent.kt
+++ b/libs/etterlatte-kafka/src/main/kotlin/kafka/KafkaProdusent.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.kafka
 
-import kafka.JsonMessageSerializer
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.StringSerializer

--- a/libs/etterlatte-regler/src/main/kotlin/regler/Node.kt
+++ b/libs/etterlatte-regler/src/main/kotlin/regler/Node.kt
@@ -1,4 +1,4 @@
-package regler
+package no.nav.etterlatte.libs.regler
 
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import java.time.Instant

--- a/libs/etterlatte-regler/src/main/kotlin/regler/Properties.kt
+++ b/libs/etterlatte-regler/src/main/kotlin/regler/Properties.kt
@@ -1,4 +1,4 @@
-package regler
+package no.nav.etterlatte.libs.regler
 
 import java.util.Properties
 

--- a/libs/etterlatte-regler/src/main/kotlin/regler/RegelDsl.kt
+++ b/libs/etterlatte-regler/src/main/kotlin/regler/RegelDsl.kt
@@ -1,4 +1,4 @@
-package regler
+package no.nav.etterlatte.libs.regler
 
 import java.math.BigDecimal
 import java.time.LocalDate

--- a/libs/etterlatte-regler/src/main/kotlin/regler/Regelkjoering.kt
+++ b/libs/etterlatte-regler/src/main/kotlin/regler/Regelkjoering.kt
@@ -1,4 +1,4 @@
-package regler
+package no.nav.etterlatte.libs.regler
 
 import java.time.LocalDate
 

--- a/libs/etterlatte-regler/src/main/kotlin/regler/Regler.kt
+++ b/libs/etterlatte-regler/src/main/kotlin/regler/Regler.kt
@@ -1,4 +1,4 @@
-package regler
+package no.nav.etterlatte.libs.regler
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import java.math.BigDecimal

--- a/libs/etterlatte-regler/src/main/kotlin/regler/Visitor.kt
+++ b/libs/etterlatte-regler/src/main/kotlin/regler/Visitor.kt
@@ -1,4 +1,4 @@
-package regler
+package no.nav.etterlatte.libs.regler
 
 import java.time.LocalDate
 

--- a/libs/etterlatte-regler/src/test/kotlin/beregning/BeregnBarnepensjon.kt
+++ b/libs/etterlatte-regler/src/test/kotlin/beregning/BeregnBarnepensjon.kt
@@ -1,13 +1,13 @@
-package beregning
+package no.nav.etterlatte.libs.regler.beregning
 
-import beregning.barnepensjon1967.BP_1967_DATO
-import beregning.barnepensjon1967.beregnBarnepensjon1967Regel
-import beregning.barnepensjon2024.beregnBarnepensjon2024Regel
-import regler.FaktumNode
-import regler.RegelMeta
-import regler.ToDoRegelReferanse
-import regler.og
-import regler.velgNyesteGyldige
+import no.nav.etterlatte.libs.regler.FaktumNode
+import no.nav.etterlatte.libs.regler.RegelMeta
+import no.nav.etterlatte.libs.regler.ToDoRegelReferanse
+import no.nav.etterlatte.libs.regler.beregning.barnepensjon1967.BP_1967_DATO
+import no.nav.etterlatte.libs.regler.beregning.barnepensjon1967.beregnBarnepensjon1967Regel
+import no.nav.etterlatte.libs.regler.beregning.barnepensjon2024.beregnBarnepensjon2024Regel
+import no.nav.etterlatte.libs.regler.og
+import no.nav.etterlatte.libs.regler.velgNyesteGyldige
 import java.math.BigDecimal
 
 data class AvdoedForelder(val trygdetid: BigDecimal)

--- a/libs/etterlatte-regler/src/test/kotlin/beregning/BeregnBarnepensjonTest.kt
+++ b/libs/etterlatte-regler/src/test/kotlin/beregning/BeregnBarnepensjonTest.kt
@@ -1,13 +1,13 @@
-package beregning
+package no.nav.etterlatte.libs.regler.beregning
 
 import io.kotest.matchers.shouldBe
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.toJson
+import no.nav.etterlatte.libs.regler.FaktumNode
+import no.nav.etterlatte.libs.regler.RegelPeriode
+import no.nav.etterlatte.libs.regler.eksekver
+import no.nav.etterlatte.libs.regler.finnAlleKnekkpunkter
 import org.junit.jupiter.api.Test
-import regler.FaktumNode
-import regler.RegelPeriode
-import regler.eksekver
-import regler.finnAlleKnekkpunkter
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate

--- a/libs/etterlatte-regler/src/test/kotlin/beregning/barnepensjon1967/BeregnBarnepensjon1967.kt
+++ b/libs/etterlatte-regler/src/test/kotlin/beregning/barnepensjon1967/BeregnBarnepensjon1967.kt
@@ -1,14 +1,14 @@
-package beregning.barnepensjon1967
+package no.nav.etterlatte.libs.regler.beregning.barnepensjon1967
 
-import beregning.BarnepensjonGrunnlag
-import beregning.barnepensjon1967.barnekull.barnekullRegel
-import beregning.barnepensjon1967.trygdetidsfaktor.trygdetidsFaktor
-import regler.RegelMeta
-import regler.ToDoRegelReferanse
-import regler.definerKonstant
-import regler.kombinerer
-import regler.med
-import regler.og
+import no.nav.etterlatte.libs.regler.RegelMeta
+import no.nav.etterlatte.libs.regler.ToDoRegelReferanse
+import no.nav.etterlatte.libs.regler.beregning.BarnepensjonGrunnlag
+import no.nav.etterlatte.libs.regler.beregning.barnepensjon1967.barnekull.barnekullRegel
+import no.nav.etterlatte.libs.regler.beregning.barnepensjon1967.trygdetidsfaktor.trygdetidsFaktor
+import no.nav.etterlatte.libs.regler.definerKonstant
+import no.nav.etterlatte.libs.regler.kombinerer
+import no.nav.etterlatte.libs.regler.med
+import no.nav.etterlatte.libs.regler.og
 import java.math.RoundingMode
 import java.time.LocalDate
 

--- a/libs/etterlatte-regler/src/test/kotlin/beregning/barnepensjon1967/barnekull/Barnekull.kt
+++ b/libs/etterlatte-regler/src/test/kotlin/beregning/barnepensjon1967/barnekull/Barnekull.kt
@@ -1,16 +1,16 @@
-package beregning.barnepensjon1967.barnekull
+package no.nav.etterlatte.libs.regler.beregning.barnepensjon1967.barnekull
 
-import beregning.BarnepensjonGrunnlag
-import beregning.barnepensjon1967.BP_1967_DATO
-import regler.Regel
-import regler.RegelMeta
-import regler.ToDoRegelReferanse
-import regler.definerKonstant
-import regler.finnFaktumIGrunnlag
-import regler.kombinerer
-import regler.med
-import regler.multipliser
-import regler.og
+import no.nav.etterlatte.libs.regler.Regel
+import no.nav.etterlatte.libs.regler.RegelMeta
+import no.nav.etterlatte.libs.regler.ToDoRegelReferanse
+import no.nav.etterlatte.libs.regler.beregning.BarnepensjonGrunnlag
+import no.nav.etterlatte.libs.regler.beregning.barnepensjon1967.BP_1967_DATO
+import no.nav.etterlatte.libs.regler.definerKonstant
+import no.nav.etterlatte.libs.regler.finnFaktumIGrunnlag
+import no.nav.etterlatte.libs.regler.kombinerer
+import no.nav.etterlatte.libs.regler.med
+import no.nav.etterlatte.libs.regler.multipliser
+import no.nav.etterlatte.libs.regler.og
 import java.math.BigDecimal
 
 private val grunnbeloep: Regel<BarnepensjonGrunnlag, BigDecimal> =

--- a/libs/etterlatte-regler/src/test/kotlin/beregning/barnepensjon1967/trygdetidsfaktor/Trygdetidsfaktor.kt
+++ b/libs/etterlatte-regler/src/test/kotlin/beregning/barnepensjon1967/trygdetidsfaktor/Trygdetidsfaktor.kt
@@ -1,16 +1,16 @@
-package beregning.barnepensjon1967.trygdetidsfaktor
+package no.nav.etterlatte.libs.regler.beregning.barnepensjon1967.trygdetidsfaktor
 
-import beregning.AvdoedForelder
-import beregning.BarnepensjonGrunnlag
-import beregning.barnepensjon1967.BP_1967_DATO
-import regler.Regel
-import regler.RegelMeta
-import regler.ToDoRegelReferanse
-import regler.definerKonstant
-import regler.finnFaktumIGrunnlag
-import regler.kombinerer
-import regler.med
-import regler.og
+import no.nav.etterlatte.libs.regler.Regel
+import no.nav.etterlatte.libs.regler.RegelMeta
+import no.nav.etterlatte.libs.regler.ToDoRegelReferanse
+import no.nav.etterlatte.libs.regler.beregning.AvdoedForelder
+import no.nav.etterlatte.libs.regler.beregning.BarnepensjonGrunnlag
+import no.nav.etterlatte.libs.regler.beregning.barnepensjon1967.BP_1967_DATO
+import no.nav.etterlatte.libs.regler.definerKonstant
+import no.nav.etterlatte.libs.regler.finnFaktumIGrunnlag
+import no.nav.etterlatte.libs.regler.kombinerer
+import no.nav.etterlatte.libs.regler.med
+import no.nav.etterlatte.libs.regler.og
 import java.math.BigDecimal
 
 private val trygdetidRegel: Regel<BarnepensjonGrunnlag, BigDecimal> =

--- a/libs/etterlatte-regler/src/test/kotlin/beregning/barnepensjon2024/BeregnBarnepensjon2024.kt
+++ b/libs/etterlatte-regler/src/test/kotlin/beregning/barnepensjon2024/BeregnBarnepensjon2024.kt
@@ -1,15 +1,15 @@
-package beregning.barnepensjon2024
+package no.nav.etterlatte.libs.regler.beregning.barnepensjon2024
 
-import beregning.BarnepensjonGrunnlag
-import beregning.barnepensjon1967.BP_1967_DATO
-import beregning.barnepensjon1967.kroneavrundingKonstant
-import beregning.barnepensjon1967.trygdetidsfaktor.trygdetidsFaktor
-import regler.RegelMeta
-import regler.ToDoRegelReferanse
-import regler.definerKonstant
-import regler.kombinerer
-import regler.med
-import regler.og
+import no.nav.etterlatte.libs.regler.RegelMeta
+import no.nav.etterlatte.libs.regler.ToDoRegelReferanse
+import no.nav.etterlatte.libs.regler.beregning.BarnepensjonGrunnlag
+import no.nav.etterlatte.libs.regler.beregning.barnepensjon1967.BP_1967_DATO
+import no.nav.etterlatte.libs.regler.beregning.barnepensjon1967.kroneavrundingKonstant
+import no.nav.etterlatte.libs.regler.beregning.barnepensjon1967.trygdetidsfaktor.trygdetidsFaktor
+import no.nav.etterlatte.libs.regler.definerKonstant
+import no.nav.etterlatte.libs.regler.kombinerer
+import no.nav.etterlatte.libs.regler.med
+import no.nav.etterlatte.libs.regler.og
 import java.math.BigDecimal
 import java.time.LocalDate
 

--- a/libs/etterlatte-regler/src/test/kotlin/regler/FinnFaktumIGrunnlagRegelTest.kt
+++ b/libs/etterlatte-regler/src/test/kotlin/regler/FinnFaktumIGrunnlagRegelTest.kt
@@ -1,4 +1,4 @@
-package regler
+package no.nav.etterlatte.libs.regler
 
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -7,7 +7,8 @@ import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.time.LocalDate
 
-class FinnFaktumIGrunnlagRegelTest {
+class
+FinnFaktumIGrunnlagRegelTest {
     data class Grunnlag(val testVerdi2021: FaktumNode<Int>)
 
     private val saksbehandler = Grunnlagsopplysning.Saksbehandler("Z12345", Instant.now())

--- a/libs/etterlatte-regler/src/test/kotlin/regler/GangSammenRegelTest.kt
+++ b/libs/etterlatte-regler/src/test/kotlin/regler/GangSammenRegelTest.kt
@@ -1,4 +1,4 @@
-package regler
+package no.nav.etterlatte.libs.regler
 
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test

--- a/libs/etterlatte-regler/src/test/kotlin/regler/KonstantRegelTest.kt
+++ b/libs/etterlatte-regler/src/test/kotlin/regler/KonstantRegelTest.kt
@@ -1,4 +1,4 @@
-package regler
+package no.nav.etterlatte.libs.regler
 
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test

--- a/libs/etterlatte-regler/src/test/kotlin/regler/RegelkjoeringTest.kt
+++ b/libs/etterlatte-regler/src/test/kotlin/regler/RegelkjoeringTest.kt
@@ -1,4 +1,4 @@
-package regler
+package no.nav.etterlatte.libs.regler
 
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize

--- a/libs/etterlatte-regler/src/test/kotlin/regler/SlaaSammenToReglerTest.kt
+++ b/libs/etterlatte-regler/src/test/kotlin/regler/SlaaSammenToReglerTest.kt
@@ -1,4 +1,4 @@
-package regler
+package no.nav.etterlatte.libs.regler
 
 import io.kotest.matchers.shouldBe
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning

--- a/libs/etterlatte-regler/src/test/kotlin/regler/SlaaSammenTreReglerTest.kt
+++ b/libs/etterlatte-regler/src/test/kotlin/regler/SlaaSammenTreReglerTest.kt
@@ -1,4 +1,4 @@
-package regler
+package no.nav.etterlatte.libs.regler
 
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test

--- a/libs/etterlatte-regler/src/test/kotlin/regler/VelgNyesteGyldigeRegelTest.kt
+++ b/libs/etterlatte-regler/src/test/kotlin/regler/VelgNyesteGyldigeRegelTest.kt
@@ -1,4 +1,4 @@
-package regler
+package no.nav.etterlatte.libs.regler
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe

--- a/libs/etterlatte-regler/src/test/kotlin/regler/VisitorTest.kt
+++ b/libs/etterlatte-regler/src/test/kotlin/regler/VisitorTest.kt
@@ -1,4 +1,4 @@
-package regler
+package no.nav.etterlatte.libs.regler
 
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize

--- a/libs/etterlatte-sporingslogg/src/main/kotlin/sporingslogg/CEFEntry.kt
+++ b/libs/etterlatte-sporingslogg/src/main/kotlin/sporingslogg/CEFEntry.kt
@@ -1,4 +1,4 @@
-package sporingslogg
+package no.nav.etterlatte.libs.sporingslogg
 
 import java.time.Instant
 

--- a/libs/etterlatte-sporingslogg/src/main/kotlin/sporingslogg/Sporingslogg.kt
+++ b/libs/etterlatte-sporingslogg/src/main/kotlin/sporingslogg/Sporingslogg.kt
@@ -1,4 +1,4 @@
-package sporingslogg
+package no.nav.etterlatte.libs.sporingslogg
 
 class Sporingslogg {
 

--- a/libs/etterlatte-sporingslogg/src/main/kotlin/sporingslogg/Sporingsrequest.kt
+++ b/libs/etterlatte-sporingslogg/src/main/kotlin/sporingslogg/Sporingsrequest.kt
@@ -1,4 +1,4 @@
-package sporingslogg
+package no.nav.etterlatte.libs.sporingslogg
 
 enum class HttpMethod {
     GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS

--- a/libs/etterlatte-sporingslogg/src/test/kotlin/sporingslogg/SporingsloggerTest.kt
+++ b/libs/etterlatte-sporingslogg/src/test/kotlin/sporingslogg/SporingsloggerTest.kt
@@ -1,4 +1,4 @@
-package sporingslogg
+package no.nav.etterlatte.libs.sporingslogg
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test

--- a/libs/testdata/src/main/kotlin/behandling/VirkningstidspunktTestData.kt
+++ b/libs/testdata/src/main/kotlin/behandling/VirkningstidspunktTestData.kt
@@ -1,4 +1,4 @@
-package behandling
+package no.nav.etterlatte.libs.testdata.behandling
 
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning

--- a/libs/testdata/src/main/kotlin/grunnlag/GrunnlagTestData.kt
+++ b/libs/testdata/src/main/kotlin/grunnlag/GrunnlagTestData.kt
@@ -1,10 +1,6 @@
+package no.nav.etterlatte.libs.testdata.grunnlag
+
 import com.fasterxml.jackson.databind.JsonNode
-import grunnlag.avdoedTestopplysningerMap
-import grunnlag.gjenlevendeTestopplysningerMap
-import grunnlag.halvsoeskenTestopplysningerMap
-import grunnlag.kilde
-import grunnlag.soekerTestopplysningerMap
-import grunnlag.soeskenTestopplysningerMap
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.grunnlag.Metadata
@@ -13,6 +9,7 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.AVDOEDESBARN
 import no.nav.etterlatte.libs.common.person.AvdoedesBarn
 import no.nav.etterlatte.libs.common.toJsonNode
+import no.nav.etterlatte.libs.testdata.pdl.personTestData
 import java.util.UUID.randomUUID
 
 data class GrunnlagTestData(

--- a/libs/testdata/src/main/kotlin/grunnlag/TestDataMaps.kt
+++ b/libs/testdata/src/main/kotlin/grunnlag/TestDataMaps.kt
@@ -1,4 +1,4 @@
-package grunnlag
+package no.nav.etterlatte.libs.testdata.grunnlag
 
 import com.fasterxml.jackson.databind.JsonNode
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -28,7 +28,7 @@ import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.person.Sivilstatus
 import no.nav.etterlatte.libs.common.toJsonNode
-import personTestData
+import no.nav.etterlatte.libs.testdata.pdl.personTestData
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.YearMonth

--- a/libs/testdata/src/main/kotlin/grunnlag/Testopplysninger.kt
+++ b/libs/testdata/src/main/kotlin/grunnlag/Testopplysninger.kt
@@ -1,4 +1,4 @@
-package grunnlag
+package no.nav.etterlatte.libs.testdata.grunnlag
 
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.PeriodisertOpplysning

--- a/libs/testdata/src/main/kotlin/pdl/PersonTestData.kt
+++ b/libs/testdata/src/main/kotlin/pdl/PersonTestData.kt
@@ -1,3 +1,5 @@
+package no.nav.etterlatte.libs.testdata.pdl
+
 import com.fasterxml.jackson.databind.JsonNode
 import no.nav.etterlatte.libs.common.grunnlag.Opplysning
 import no.nav.etterlatte.libs.common.grunnlag.hentAdressebeskyttelse

--- a/libs/testdata/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingTestData.kt
+++ b/libs/testdata/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingTestData.kt
@@ -1,4 +1,4 @@
-package vilkaarsvurdering
+package no.nav.etterlatte.libs.testdata.vilkaarsvurdering
 
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingDto
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat

--- a/libs/testdata/src/test/kotlin/grunnlag/OpplysningTest.kt
+++ b/libs/testdata/src/test/kotlin/grunnlag/OpplysningTest.kt
@@ -1,6 +1,5 @@
-package grunnlag
+package no.nav.etterlatte.libs.testdata.grunnlag
 
-import GrunnlagTestData
 import no.nav.etterlatte.libs.common.grunnlag.Opplysning
 import no.nav.etterlatte.libs.common.grunnlag.hentDoedsdato
 import no.nav.etterlatte.libs.common.objectMapper


### PR DESCRIPTION
Endrar pakke for alle våre filer til å starte med `no.nav.etterlatte`

Eg har ikkje tatt grep for å vera konsekvent i bruk av underpakker etc, men det bør vi nok ta ein prat om før vi eventuelt gjer.

Har sjekka på alle filene våre som hadde pakke definert, men det kan vera filer som ikkje hadde pakke-definisjon, dei har eg ikkje gjort noko med no.