### PR TITLE
Fjern unødvendige behandlingshendelser og endre status for IVERKSATT (EY-1334)

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
@@ -368,7 +368,6 @@ class BehandlingDao(private val connection: () -> Connection) {
         statement.executeUpdate()
     }
 
-    // TODO ai: brukes kun i test
     fun lagreStatus(lagretBehandling: Behandling) {
         lagreStatus(lagretBehandling.id, lagretBehandling.status, lagretBehandling.sistEndret)
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingAggregat.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingAggregat.kt
@@ -100,7 +100,7 @@ class FoerstegangsbehandlingAggregat(
             begrunnelse = begrunnelse,
             lagretBehandling = lagretBehandling,
             hendelser = hendelser,
-            behandlingDao
+            behandlingDao = behandlingDao
         )
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingAggregat.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingAggregat.kt
@@ -88,7 +88,8 @@ class FoerstegangsbehandlingAggregat(
         inntruffet: Tidspunkt,
         saksbehandler: String?,
         kommentar: String?,
-        begrunnelse: String?
+        begrunnelse: String?,
+        behandlingDao: BehandlingDao
     ) {
         registrerVedtakHendelseFelles(
             vedtakId = vedtakId,
@@ -98,7 +99,8 @@ class FoerstegangsbehandlingAggregat(
             kommentar = kommentar,
             begrunnelse = begrunnelse,
             lagretBehandling = lagretBehandling,
-            hendelser = hendelser
+            hendelser = hendelser,
+            behandlingDao
         )
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
@@ -96,7 +96,7 @@ class RealFoerstegangsbehandlingService(
         if (!dryRun) {
             inTransaction {
                 behandlinger.lagreStatus(behandling.id, behandling.status, behandling.sistEndret)
-                behandlinger.lagreVilkaarstatus(behandling.id, behandling.vilkaarUtfall)
+                behandlinger.lagreVilkaarstatus(behandling.id, behandling.vilkaarUtfall) // Maa lagre vilkaarsutfall
             }
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
@@ -96,7 +96,7 @@ class RealFoerstegangsbehandlingService(
         if (!dryRun) {
             inTransaction {
                 behandlinger.lagreStatus(behandling.id, behandling.status, behandling.sistEndret)
-                behandlinger.lagreVilkaarstatus(behandling.id, behandling.vilkaarUtfall) // Maa lagre vilkaarsutfall
+                behandlinger.lagreVilkaarstatus(behandling.id, behandling.vilkaarUtfall)
             }
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/HendelseType.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/HendelseType.kt
@@ -1,8 +1,6 @@
 package no.nav.etterlatte.behandling.hendelse
 
 enum class HendelseType {
-    VILKAARSVURDERT,
-    BEREGNET,
     FATTET,
     ATTESTERT,
     UNDERKJENT,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/RegistrerVedtakHendelseFelles.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/RegistrerVedtakHendelseFelles.kt
@@ -1,7 +1,10 @@
 package no.nav.etterlatte.behandling.hendelse
 
 import no.nav.etterlatte.behandling.Behandling
+import no.nav.etterlatte.behandling.BehandlingDao
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import java.time.LocalDateTime
 
 fun registrerVedtakHendelseFelles(
     vedtakId: Long,
@@ -11,7 +14,8 @@ fun registrerVedtakHendelseFelles(
     kommentar: String?,
     begrunnelse: String?,
     lagretBehandling: Behandling,
-    hendelser: HendelseDao
+    hendelser: HendelseDao,
+    behandlingDao: BehandlingDao
 ) {
     if (hendelse.kreverSaksbehandler()) {
         requireNotNull(saksbehandler)
@@ -31,9 +35,14 @@ fun registrerVedtakHendelseFelles(
         kommentar,
         begrunnelse
     )
+
+    if (hendelse.erIverksatt()) {
+        behandlingDao.lagreStatus(lagretBehandling.id, BehandlingStatus.IVERKSATT, LocalDateTime.now())
+    }
 }
 
 private fun HendelseType.kreverSaksbehandler() =
     this in listOf(HendelseType.FATTET, HendelseType.ATTESTERT, HendelseType.UNDERKJENT)
 
 private fun HendelseType.erUnderkjent() = this == HendelseType.UNDERKJENT
+private fun HendelseType.erIverksatt() = this == HendelseType.IVERKSATT

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/manueltopphoer/ManueltOpphoerService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/manueltopphoer/ManueltOpphoerService.kt
@@ -121,7 +121,7 @@ class RealManueltOpphoerService(
                 begrunnelse = begrunnelse,
                 lagretBehandling = manueltOpphoer,
                 hendelser = hendelser,
-                behandlingDao
+                behandlingDao = behandlingDao
             )
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/manueltopphoer/ManueltOpphoerService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/manueltopphoer/ManueltOpphoerService.kt
@@ -33,7 +33,8 @@ interface ManueltOpphoerService {
         inntruffet: Tidspunkt,
         saksbehandler: String?,
         kommentar: String?,
-        begrunnelse: String?
+        begrunnelse: String?,
+        behandlingDao: BehandlingDao
     )
 
     fun hentManueltOpphoerInTransaction(behandling: UUID): ManueltOpphoer?
@@ -107,7 +108,8 @@ class RealManueltOpphoerService(
         inntruffet: Tidspunkt,
         saksbehandler: String?,
         kommentar: String?,
-        begrunnelse: String?
+        begrunnelse: String?,
+        behandlingDao: BehandlingDao
     ) {
         hentManueltOpphoer(behandling)?.let { manueltOpphoer ->
             registrerVedtakHendelseFelles(
@@ -118,7 +120,8 @@ class RealManueltOpphoerService(
                 kommentar = kommentar,
                 begrunnelse = begrunnelse,
                 lagretBehandling = manueltOpphoer,
-                hendelser = hendelser
+                hendelser = hendelser,
+                behandlingDao
             )
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingAggregat.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingAggregat.kt
@@ -60,7 +60,8 @@ class RevurderingAggregat(
         inntruffet: Tidspunkt,
         saksbehandler: String?,
         kommentar: String?,
-        begrunnelse: String?
+        begrunnelse: String?,
+        behandlingDao: BehandlingDao
     ) {
         registrerVedtakHendelseFelles(
             vedtakId = vedtakId,
@@ -70,7 +71,8 @@ class RevurderingAggregat(
             kommentar = kommentar,
             begrunnelse = begrunnelse,
             lagretBehandling = lagretBehandling,
-            hendelser = hendelser
+            hendelser = hendelser,
+            behandlingDao = behandlingDao
         )
     }
 

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/BehandlinghendelseRiver.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/BehandlinghendelseRiver.kt
@@ -21,12 +21,12 @@ class BehandlinghendelseRiver(
     rapidsConnection: RapidsConnection,
     private val service: StatistikkService
 ) : River.PacketListener {
-    val behandlingshendelser = listOf(
+    private val behandlingshendelser = listOf(
         "BEHANDLING:AVBRUTT",
         "BEHANDLING:OPPRETTET"
     )
 
-    val logger = LoggerFactory.getLogger(this::class.java)
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
         River(rapidsConnection).apply {

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/VedtaksvurderingRoute.kt
@@ -50,24 +50,6 @@ fun Route.vedtaksvurderingRoute(service: VedtaksvurderingService) {
                     behandlingId = behandlingId,
                     accessToken = accesstoken
                 )
-                val vedtakHendelse = VedtakHendelse(
-                    vedtakId = nyttVedtak.vedtakId,
-                    inntruffet = Tidspunkt.now(),
-                    saksbehandler = saksbehandler
-                )
-
-                service.postTilVedtakhendelse(
-                    behandlingId,
-                    accesstoken,
-                    HendelseType.VILKAARSVURDERT,
-                    vedtakHendelse
-                )
-                service.postTilVedtakhendelse(
-                    behandlingId,
-                    accesstoken,
-                    HendelseType.BEREGNET,
-                    vedtakHendelse
-                )
 
                 call.respond(nyttVedtak)
             }
@@ -132,8 +114,6 @@ private data class VedtakBolkRequest(val behandlingsidenter: List<String>)
 private data class VedtakBolkResponse(val vedtak: List<Vedtak>)
 
 enum class HendelseType {
-    VILKAARSVURDERT,
-    BEREGNET,
     FATTET,
     ATTESTERT,
     UNDERKJENT,


### PR DESCRIPTION
Fjernet lagring av følgende hendelser: 
`VILKAARSVURDERT`
`BEREGNET`

Og når `IVERKSATT`-hendelsen lagres så oppdaterer vi behandlingsstatusen og.