### PR TITLE
Legge opp til å kunne ha transakjsoner på service nivå, tatt i bruk av vilkårsvurdering

### DIFF
--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/SessionFactory.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/SessionFactory.kt
@@ -1,0 +1,20 @@
+package no.nav.etterlatte.vilkaarsvurdering
+
+import kotliquery.TransactionalSession
+import kotliquery.sessionOf
+import kotliquery.using
+import javax.sql.DataSource
+
+interface SessionFactory {
+    fun <A> withTransactionalSession(block: (transactionalSession: TransactionalSession) -> A): A
+}
+
+class PostgresSessionFactory(private val ds: DataSource) : SessionFactory {
+    override fun <A> withTransactionalSession(block: (transactionalSession: TransactionalSession) -> A): A {
+        return using(sessionOf(ds)) { session ->
+            session.transaction {
+                block(it)
+            }
+        }
+    }
+}

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/config/ApplicationContext.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/config/ApplicationContext.kt
@@ -4,6 +4,7 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.ktor.httpClient
+import no.nav.etterlatte.vilkaarsvurdering.PostgresSessionFactory
 import no.nav.etterlatte.vilkaarsvurdering.VilkaarsvurderingRepository
 import no.nav.etterlatte.vilkaarsvurdering.VilkaarsvurderingService
 import no.nav.etterlatte.vilkaarsvurdering.behandling.BehandlingKlientImpl
@@ -20,6 +21,7 @@ class ApplicationContext {
     val vilkaarsvurderingService = VilkaarsvurderingService(
         vilkaarsvurderingRepository = VilkaarsvurderingRepository(dataSource),
         behandlingKlient = BehandlingKlientImpl(config, httpClient()),
-        grunnlagKlient = GrunnlagKlientImpl(config, httpClient())
+        grunnlagKlient = GrunnlagKlientImpl(config, httpClient()),
+        sessionFactory = PostgresSessionFactory(dataSource)
     )
 }

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
@@ -85,7 +85,8 @@ internal class VilkaarsvurderingServiceTest {
         service = VilkaarsvurderingService(
             repository,
             behandlingKlient,
-            grunnlagKlient
+            grunnlagKlient,
+            PostgresSessionFactory(ds)
         )
     }
 


### PR DESCRIPTION
Vi har ibland behov for å bruke transaksjoner for å beholde data integriteten i db:n når f.eks en feil oppstår, men per nå har vi kun hatt muligheten å ha transaksjoner i kontext av _en repository_.

Har nå lagat en POC på hvordan vi enkelt kan få til transaksjoner på tvers av repo-kall eller i kombinasjon med api-kall. 