### PR TITLE
EY-1565 Forenkle søskenjustering i front og hente fra rett kilde

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Beregningsgrunnlag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Beregningsgrunnlag.tsx
@@ -57,7 +57,7 @@ const Beregningsgrunnlag = () => {
 
   const doedsdato = behandling.familieforhold.avdoede.opplysning.doedsdato
 
-  const visSøskenjustering =
+  const visSoeskenjustering =
     isSuccess(beregningsgrunnlag) || (isFailure(beregningsgrunnlag) && beregningsgrunnlag.error.statusCode === 404)
 
   return (
@@ -89,7 +89,7 @@ const Beregningsgrunnlag = () => {
         {behandling.søker && <Barn person={behandling.søker} doedsdato={doedsdato} />}
         <Border />
         <Spinner visible={isPendingOrInitial(beregningsgrunnlag)} label={'Henter beregningsgrunnlag for søsken'} />
-        {visSøskenjustering &&
+        {visSoeskenjustering &&
           soesken.map((barn, index) => (
             <SoeskenContainer key={barn.foedselsnummer}>
               <Soesken person={barn} familieforhold={behandling.familieforhold!} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
@@ -1,4 +1,4 @@
-import { IDetaljertBehandling, Virkningstidspunkt, IKommerBarnetTilgode } from '~shared/types/IDetaljertBehandling'
+import { IDetaljertBehandling, IKommerBarnetTilgode, Virkningstidspunkt } from '~shared/types/IDetaljertBehandling'
 import { apiClient, ApiResponse } from './apiClient'
 
 export const hentBehandlingerForPerson = async (fnr: string): Promise<ApiResponse<any>> => {
@@ -53,13 +53,6 @@ export const lagreBegrunnelseKommerBarnetTilgode = async (args: {
     svar: args.svar,
     begrunnelse: args.begrunnelse,
   })
-}
-
-export const lagreSoeskenMedIBeregning = async (
-  behandlingsId: string,
-  soeskenMedIBeregning: { foedselsnummer: string; skalBrukes: boolean }[]
-): Promise<ApiResponse<any>> => {
-  return apiClient.post(`/grunnlag/beregningsgrunnlag/${behandlingsId}`, { soeskenMedIBeregning })
 }
 
 interface GrunnlagResponse {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/grunnlag.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/grunnlag.ts
@@ -1,0 +1,15 @@
+import { apiClient, ApiResponse } from '~shared/api/apiClient'
+import { Grunnlagsopplysning, Soeskenjusteringsgrunnlag } from '~shared/types/Grunnlagsopplysning'
+
+export const lagreSoeskenMedIBeregning = async (
+  behandlingsId: string,
+  soeskenMedIBeregning: { foedselsnummer: string; skalBrukes: boolean }[]
+): Promise<ApiResponse<any>> => {
+  return apiClient.post(`/grunnlag/beregningsgrunnlag/${behandlingsId}`, { soeskenMedIBeregning })
+}
+
+export const hentSoeskenMedIBeregning = async (
+  sakId: number
+): Promise<ApiResponse<Grunnlagsopplysning<Soeskenjusteringsgrunnlag>>> => {
+  return apiClient.get(`/grunnlag/${sakId}/SOESKEN_I_BEREGNINGEN`)
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/grunnlag.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/grunnlag.ts
@@ -1,11 +1,13 @@
 import { apiClient, ApiResponse } from '~shared/api/apiClient'
 import { Grunnlagsopplysning, Soeskenjusteringsgrunnlag } from '~shared/types/Grunnlagsopplysning'
 
-export const lagreSoeskenMedIBeregning = async (
-  behandlingsId: string,
+export const lagreSoeskenMedIBeregning = async (args: {
+  behandlingsId: string
   soeskenMedIBeregning: { foedselsnummer: string; skalBrukes: boolean }[]
-): Promise<ApiResponse<any>> => {
-  return apiClient.post(`/grunnlag/beregningsgrunnlag/${behandlingsId}`, { soeskenMedIBeregning })
+}): Promise<ApiResponse<any>> => {
+  return apiClient.post(`/grunnlag/beregningsgrunnlag/${args.behandlingsId}`, {
+    soeskenMedIBeregning: args.soeskenMedIBeregning,
+  })
 }
 
 export const hentSoeskenMedIBeregning = async (

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Grunnlagsopplysning.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Grunnlagsopplysning.ts
@@ -4,3 +4,12 @@ export interface Grunnlagsopplysning<T> {
   opplysningsType: string
   opplysning: T
 }
+
+export interface Soeskenjusteringsgrunnlag {
+  beregningsgrunnlag: SoeskenMedIBeregning[]
+}
+
+export interface SoeskenMedIBeregning {
+  foedselsnummer: string
+  skalBrukes: boolean
+}

--- a/apps/etterlatte-saksbehandling-ui/server/src/index.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/index.ts
@@ -61,11 +61,7 @@ if (isDev) {
     proxy(ApiConfig.behandling.url!!)
   )
 
-  app.use(
-    '/api/grunnlag/beregningsgrunnlag/:behandlingId',
-    tokenMiddleware(ApiConfig.grunnlag.scope),
-    proxy(ApiConfig.grunnlag.url!!)
-  )
+  app.use('/api/grunnlag', tokenMiddleware(ApiConfig.grunnlag.scope), proxy(ApiConfig.grunnlag.url!!))
 
   app.use('/api/person', tokenMiddleware(ApiConfig.pdltjenester.scope), proxy(ApiConfig.pdltjenester.url!!))
 


### PR DESCRIPTION
Ren frontend-endring som henter søskenjusteringsvalgene direkte fra kilden (grunnlag) og ikke metadata i beregning. Saksbehandler må også _faktisk_ ta et bevisst valg, da ingen radiobuttons er valgt på forhånd. Kan ikke gå videre om noen søsken ikke er blitt tatt stilling til. 

Ingen visuelle endringer, så legger ikke ved screenshots