### PR TITLE
Manuelt opphør hopper over vilkårsvurdering før beregning

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
@@ -48,18 +48,44 @@ class BeregningService(
         logger.info("Oppretter barnepensjonberegning for behandlingId=$behandlingId")
         return tilstandssjekkFoerKjoerning(behandlingId, accessToken) {
             coroutineScope {
-                val behandling = async { behandlingKlient.hentBehandling(behandlingId, accessToken) }
-                val grunnlag = async { grunnlagKlient.hentGrunnlag(behandling.await().sak, accessToken) }
+                val behandling = behandlingKlient.hentBehandling(behandlingId, accessToken)
+                val grunnlag = async { grunnlagKlient.hentGrunnlag(behandling.sak, accessToken) }
+
+                if (behandling.behandlingType == BehandlingType.MANUELT_OPPHOER) {
+                    return@coroutineScope beregnManueltOpphoerBarnepensjon(
+                        grunnlag = grunnlag.await(),
+                        behandling = behandling
+                    )
+                }
+
                 val vilkaarsvurdering =
                     async { vilkaarsvurderingKlient.hentVilkaarsvurdering(behandlingId, accessToken) }
-
-                val beregning = beregnBarnepensjon(grunnlag.await(), behandling.await(), vilkaarsvurdering.await())
+                val beregning = beregnBarnepensjon(grunnlag.await(), behandling, vilkaarsvurdering.await())
 
                 beregningRepository.lagreEllerOppdaterBeregning(beregning).also {
                     behandlingKlient.beregn(behandlingId, accessToken, true)
                 }
             }
         }
+    }
+
+    fun beregnManueltOpphoerBarnepensjon(
+        grunnlag: Grunnlag,
+        behandling: DetaljertBehandling
+    ): Beregning {
+        if (behandling.behandlingType != BehandlingType.MANUELT_OPPHOER) {
+            throw IllegalArgumentException(
+                "Fikk en behandling med id=${behandling.id} av type ${behandling.behandlingType} " +
+                    "som ikke kan beregnes som et manuelt opphør."
+            )
+        }
+        val beregningsgrunnlag = opprettBeregningsgrunnlag(requireNotNull(grunnlag.sak.hentSoeskenjustering()))
+        return beregnOpphoer(
+            behandling = behandling,
+            grunnlag = grunnlag,
+            beregningsgrunnlag = beregningsgrunnlag,
+            virkningstidspunkt = behandling.virkningstidspunkt!!.dato
+        )
     }
 
     fun beregnBarnepensjon(
@@ -76,17 +102,18 @@ class BeregningService(
         return when (behandlingType) {
             BehandlingType.FØRSTEGANGSBEHANDLING ->
                 beregn(behandling, grunnlag, beregningsgrunnlag, virkningstidspunkt)
+
             BehandlingType.REVURDERING -> {
                 when (requireNotNull(vilkaarsvurdering.resultat?.utfall)) {
                     VilkaarsvurderingUtfall.OPPFYLT ->
                         beregn(behandling, grunnlag, beregningsgrunnlag, virkningstidspunkt)
+
                     VilkaarsvurderingUtfall.IKKE_OPPFYLT ->
                         beregnOpphoer(behandling, grunnlag, beregningsgrunnlag, virkningstidspunkt)
                 }
             }
-            BehandlingType.MANUELT_OPPHOER -> {
-                beregnOpphoer(behandling, grunnlag, beregningsgrunnlag, virkningstidspunkt)
-            }
+
+            else -> throw IllegalArgumentException("Kan ikke beregne manuelt opphør med en vilkårsvurdering!")
         }
     }
 
@@ -118,6 +145,7 @@ class BeregningService(
                         )
                     }
                 )
+
             is RegelkjoeringResultat.UgyldigPeriode ->
                 throw RuntimeException("Ugyldig regler for periode: ${resultat.ugyldigeReglerForPeriode}")
         }

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningServiceTest.kt
@@ -181,11 +181,10 @@ internal class BeregningServiceTest {
 
     @Test
     fun `skal sette beloep til 0 ved manuelt opphoer`() {
-        val vilkaarsvurdering = vilkaarsvurdering(oppfylt = true)
         val behandling = behandling(BehandlingType.MANUELT_OPPHOER)
         val grunnlag = grunnlag(soesken = emptyList())
 
-        val beregning = beregningService.beregnBarnepensjon(grunnlag, behandling, vilkaarsvurdering)
+        val beregning = beregningService.beregnManueltOpphoerBarnepensjon(grunnlag, behandling)
 
         with(beregning) {
             beregningId shouldNotBe null


### PR DESCRIPTION
Manuelle opphør har ingen vilkår i saken som skal vurderes, og trenger en opphørsberegning for å opphøre stønaden riktig mot økonomi slik at den kan behandles i pesys.