### PR TITLE
EY-1565 VurderingsboksWrapper som eget component

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vurdering.tsx
@@ -60,40 +60,38 @@ export const Vurdering = ({
     return vilkaarForm.resultat !== undefined && (vilkaarForm?.kommentar ?? '').length >= MIN_KOMMENTAR_LENGDE
   }
 
-  const vilkaarVurdert = (onSuccess?: () => void) => {
-    if (valider(vilkaarutkast)) {
-      const unntaksvilkaar =
-        vilkaarutkast.resultat == VurderingsResultat.IKKE_OPPFYLT &&
-        vilkaarutkast.vilkaarsUnntakType &&
-        vilkaarutkast.vilkaarsUnntakType !== ''
-          ? {
-              unntaksvilkaar: {
-                type: vilkaarutkast.vilkaarsUnntakType,
-                resultat: VurderingsResultat.OPPFYLT,
-              },
-            }
-          : {}
-
-      return postVurderVilkaar(
-        {
-          behandlingId,
-          request: {
-            vilkaarId: vilkaar.id,
-            hovedvilkaar: {
-              type: vilkaar.hovedvilkaar.type,
-              resultat: vilkaarutkast.resultat,
+  const vilkaarVurdert = (values: VilkaarFormValidert, onSuccess?: () => void) => {
+    const unntaksvilkaar =
+      values.resultat == VurderingsResultat.IKKE_OPPFYLT &&
+      values.vilkaarsUnntakType &&
+      values.vilkaarsUnntakType !== ''
+        ? {
+            unntaksvilkaar: {
+              type: values.vilkaarsUnntakType,
+              resultat: VurderingsResultat.OPPFYLT,
             },
-            ...unntaksvilkaar,
-            kommentar: vilkaarutkast.kommentar,
+          }
+        : {}
+
+    return postVurderVilkaar(
+      {
+        behandlingId,
+        request: {
+          vilkaarId: vilkaar.id,
+          hovedvilkaar: {
+            type: vilkaar.hovedvilkaar.type,
+            resultat: values.resultat,
           },
+          ...unntaksvilkaar,
+          kommentar: values.kommentar,
         },
-        (response) => {
-          oppdaterVilkaar(response)
-          setAktivVurdering(false)
-          onSuccess?.()
-        }
-      )
-    }
+      },
+      (response) => {
+        oppdaterVilkaar(response)
+        setAktivVurdering(false)
+        onSuccess?.()
+      }
+    )
   }
 
   const slettVurderingAvVilkaar = () =>
@@ -162,7 +160,7 @@ export const Vurdering = ({
           defaultRediger={aktivVurdering}
           redigerbar={redigerbar}
           slett={slettVurderingAvVilkaar}
-          lagreklikk={vilkaarVurdert}
+          lagreklikk={(callback) => (valider(vilkaarutkast) ? vilkaarVurdert(vilkaarutkast, callback) : {})}
           avbrytklikk={reset}
         >
           <>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vurdering.tsx
@@ -1,17 +1,37 @@
-import { BodyShort, Button, Detail, Heading, Radio, RadioGroup, Textarea } from '@navikt/ds-react'
+import { Button, Detail, Heading, Radio, RadioGroup, Textarea } from '@navikt/ds-react'
 import React, { useState } from 'react'
 import {
+  IVilkaarsvurdering,
   slettVurdering,
   Vilkaar,
-  IVilkaarsvurdering,
   VurderingsResultat,
   vurderVilkaar,
 } from '~shared/api/vilkaarsvurdering'
 import styled from 'styled-components'
 import { format } from 'date-fns'
-import { Delete, Edit } from '@navikt/ds-icons'
+import { VurderingsboksWrapper } from '~components/vurderingsboks/VurderingsboksWrapper'
 
 const MIN_KOMMENTAR_LENGDE = 1
+
+interface VilkaarForm {
+  resultat: VurderingsResultat | null
+  kommentar: string | undefined
+  vilkaarsUnntakType: string | undefined
+}
+
+interface VilkaarFormValidert {
+  resultat: VurderingsResultat
+  kommentar: string
+  vilkaarsUnntakType: string | undefined
+}
+
+const initiellForm = (vilkaar: Vilkaar): VilkaarForm => ({
+  resultat: vilkaar.hovedvilkaar?.resultat ?? null,
+  kommentar: vilkaar.vurdering?.kommentar ?? '',
+  vilkaarsUnntakType:
+    vilkaar.unntaksvilkaar?.find((unntaksvilkaar) => VurderingsResultat.OPPFYLT === unntaksvilkaar.resultat)?.type ??
+    '',
+})
 
 export const Vurdering = ({
   vilkaar,
@@ -25,44 +45,45 @@ export const Vurdering = ({
   redigerbar: boolean
 }) => {
   const [aktivVurdering, setAktivVurdering] = useState<boolean>(false)
-  const [resultat, setResultat] = useState<VurderingsResultat>()
+  const [vilkaarutkast, setVilkaarutkast] = useState<VilkaarForm>(initiellForm(vilkaar))
   const [radioError, setRadioError] = useState<string>()
-  const [kommentar, setKommentar] = useState<string>('')
   const [kommentarError, setKommentarError] = useState<string>()
-  const [vilkaarsUnntakType, setVilkaarsUnntakType] = useState<string>()
 
-  const vilkaarVurdert = () => {
-    !resultat ? setRadioError('Du må velge et svar') : setRadioError(undefined)
-    !(kommentar.length >= MIN_KOMMENTAR_LENGDE)
+  const valider = (vilkaarForm: VilkaarForm): vilkaarForm is VilkaarFormValidert => {
+    vilkaarForm.resultat ? setRadioError(undefined) : setRadioError('Du må velge et svar')
+    MIN_KOMMENTAR_LENGDE > (vilkaarForm.kommentar?.length ?? 0)
       ? setKommentarError('Du må oppgi en begrunnelse')
       : setKommentarError(undefined)
+    return vilkaarForm.resultat !== undefined && (vilkaarForm?.kommentar ?? '').length >= MIN_KOMMENTAR_LENGDE
+  }
 
-    if (
-      radioError === undefined &&
-      kommentarError === undefined &&
-      resultat !== undefined &&
-      kommentar.length >= MIN_KOMMENTAR_LENGDE
-    ) {
-      const inkluderUnntaksvilkaar =
-        resultat == VurderingsResultat.IKKE_OPPFYLT && vilkaarsUnntakType && vilkaarsUnntakType != ''
+  const vilkaarVurdert = async (onSuccess?: () => void) => {
+    if (valider(vilkaarutkast)) {
+      const unntaksvilkaar =
+        vilkaarutkast.resultat == VurderingsResultat.IKKE_OPPFYLT &&
+        vilkaarutkast.vilkaarsUnntakType &&
+        vilkaarutkast.vilkaarsUnntakType != ''
+          ? {
+              unntaksvilkaar: {
+                type: vilkaarutkast.vilkaarsUnntakType,
+                resultat: VurderingsResultat.OPPFYLT,
+              },
+            }
+          : {}
 
       vurderVilkaar(behandlingId, {
         vilkaarId: vilkaar.id,
         hovedvilkaar: {
           type: vilkaar.hovedvilkaar.type,
-          resultat,
+          resultat: vilkaarutkast.resultat,
         },
-        ...(inkluderUnntaksvilkaar && {
-          unntaksvilkaar: {
-            type: vilkaarsUnntakType,
-            resultat: VurderingsResultat.OPPFYLT,
-          },
-        }),
-        kommentar: kommentar,
+        ...unntaksvilkaar,
+        kommentar: vilkaarutkast.kommentar,
       }).then((response) => {
         if (response.status == 'ok') {
           oppdaterVilkaar(response.data)
-          reset()
+          setAktivVurdering(false)
+          onSuccess?.()
         }
       })
     }
@@ -76,29 +97,12 @@ export const Vurdering = ({
     })
   }
 
-  const redigerVilkaar = () => {
-    setAktivVurdering(true)
-    setResultat(vilkaar.hovedvilkaar?.resultat)
-
-    const unntaksvilkaarOppfylt = vilkaar.unntaksvilkaar?.find(
-      (unntaksvilkaar) => VurderingsResultat.OPPFYLT === unntaksvilkaar.resultat
-    )
-
-    if (unntaksvilkaarOppfylt) {
-      setVilkaarsUnntakType(unntaksvilkaarOppfylt.type)
-    } else {
-      setVilkaarsUnntakType('')
-    }
-
-    setKommentar(vilkaar.vurdering?.kommentar || '')
-  }
-
-  const reset = () => {
+  const reset = (onSuccess?: () => void) => {
     setAktivVurdering(false)
-    setResultat(undefined)
     setRadioError(undefined)
-    setKommentar('')
     setKommentarError(undefined)
+    setVilkaarutkast(initiellForm(vilkaar))
+    onSuccess?.()
   }
 
   const overskrift = () => {
@@ -123,166 +127,105 @@ export const Vurdering = ({
 
   return (
     <div>
-      {vilkaar.vurdering && !aktivVurdering && (
-        <>
-          <KildeVilkaar>
-            <Heading size="small" level={'2'}>
-              {overskrift()}
-            </Heading>
-            <VilkaarVurdertInformasjon>
-              <Detail>Manuelt av {vilkaar.vurdering?.saksbehandler}</Detail>
-              <Detail>Sist endret {format(new Date(vilkaar.vurdering!!.tidspunkt), 'dd.MM.yyyy HH:mm')}</Detail>
-            </VilkaarVurdertInformasjon>
-            {oppfyltUnntaksvilkaar && (
-              <VilkaarVurdertInformasjon>
-                <Heading size="xsmall" level={'3'}>
-                  Unntak er oppfylt
-                </Heading>
-                <BodyShort size="small">{oppfyltUnntaksvilkaar?.tittel}</BodyShort>
-              </VilkaarVurdertInformasjon>
-            )}
-            {vilkaar.vurdering?.kommentar && (
-              <VilkaarVurdertInformasjon>
-                <Heading size="xsmall" level={'3'}>
-                  Begrunnelse
-                </Heading>
-                <BodyShort size="small">{vilkaar.vurdering?.kommentar}</BodyShort>
-              </VilkaarVurdertInformasjon>
-            )}
-          </KildeVilkaar>
-
-          {redigerbar && (
-            <>
-              <RedigerWrapper onClick={redigerVilkaar}>
-                <Edit aria-hidden={'true'} />
-                <span className={'text'}> Rediger</span>
-              </RedigerWrapper>
-              <RedigerWrapper onClick={slettVurderingAvVilkaar}>
-                <Delete aria-hidden={'true'} />
-                <span className={'text'}> Slett</span>
-              </RedigerWrapper>
-            </>
-          )}
-        </>
-      )}
-      {aktivVurdering && (
-        <>
-          <RadioGroupWrapper>
-            <RadioGroup
-              legend="Er hovedvilkår oppfylt?"
-              size="small"
-              className="radioGroup"
-              onChange={(event) => {
-                setResultat(VurderingsResultat[event as VurderingsResultat])
-                setRadioError(undefined)
-              }}
-              value={resultat || ''}
-              error={radioError ? radioError : false}
-            >
-              <div className="flex">
-                <Radio value={VurderingsResultat.OPPFYLT}>Oppfylt</Radio>
-                <Radio value={VurderingsResultat.IKKE_OPPFYLT}>Ikke oppfylt</Radio>
-                <Radio value={VurderingsResultat.IKKE_VURDERT}>Ikke vurdert</Radio>
-              </div>
-            </RadioGroup>
-          </RadioGroupWrapper>
-
-          {VurderingsResultat.IKKE_OPPFYLT === resultat && vilkaar.unntaksvilkaar && vilkaar.unntaksvilkaar.length > 0 && (
-            <>
-              <Unntaksvilkaar>
-                <RadioGroup
-                  legend="Er unntak fra hovedregelen oppfylt?"
-                  size="small"
-                  className="radioGroup"
-                  onChange={(event) => setVilkaarsUnntakType(event)}
-                  value={vilkaarsUnntakType || ''}
-                >
-                  <div className="flex">
-                    {vilkaar.unntaksvilkaar.map((unntakvilkaar) => {
-                      return (
-                        <Radio key={unntakvilkaar.type} value={unntakvilkaar.type}>
-                          {unntakvilkaar.tittel}
-                        </Radio>
-                      )
-                    })}
-                    <Radio key="Nei" value="">
-                      Nei, ingen av unntakene er oppfylt
-                    </Radio>
-                  </div>
-                </RadioGroup>
-              </Unntaksvilkaar>
-            </>
-          )}
-          <VurderingsLabel htmlFor={vilkaar.hovedvilkaar.tittel}>Begrunnelse (obligatorisk)</VurderingsLabel>
-          <Textarea
-            label=""
-            hideLabel={false}
-            placeholder="Gi en begrunnelse for vurderingen"
-            value={kommentar}
-            onChange={(e) => {
-              const kommentarLocal = e.target.value
-              setKommentar(kommentarLocal)
-              kommentarLocal.length >= MIN_KOMMENTAR_LENGDE && setKommentarError(undefined)
-            }}
-            minRows={3}
-            size="small"
-            error={kommentarError ? kommentarError : false}
-            autoComplete="off"
-            name={vilkaar.hovedvilkaar.tittel}
-          />
-          <VurderingKnapper>
-            <Button variant={'primary'} size={'small'} onClick={vilkaarVurdert}>
-              Lagre
-            </Button>
-            <Button variant={'secondary'} size={'small'} onClick={reset}>
-              Avbryt
-            </Button>
-          </VurderingKnapper>
-        </>
-      )}
-      {!vilkaar.vurdering && !aktivVurdering && (
+      {!vilkaar.vurdering && !aktivVurdering ? (
         <IkkeVurdert>
           <Heading size="small">Vilkåret er ikke vurdert</Heading>
           <Button variant={'secondary'} size={'small'} onClick={() => setAktivVurdering(true)}>
             Vurder vilkår
           </Button>
         </IkkeVurdert>
+      ) : (
+        <VurderingsboksWrapper
+          tittel={overskrift()}
+          subtittelKomponent={
+            <VilkaarVurdertInformasjon>
+              <Detail>Manuelt av {vilkaar.vurdering?.saksbehandler}</Detail>
+              <Detail>
+                Sist endret{' '}
+                {vilkaar.vurdering?.tidspunkt ? format(new Date(vilkaar.vurdering.tidspunkt), 'dd.MM.yyyy HH:mm') : '-'}
+              </Detail>
+            </VilkaarVurdertInformasjon>
+          }
+          oppfyltUnntaksvilkaarstittel={oppfyltUnntaksvilkaar?.tittel}
+          kommentar={vilkaarutkast?.kommentar}
+          defaultRediger={aktivVurdering}
+          redigerbar={redigerbar}
+          slettVurdering={slettVurderingAvVilkaar}
+          lagreklikk={vilkaarVurdert}
+          avbrytklikk={reset}
+        >
+          <>
+            <RadioGroupWrapper>
+              <RadioGroup
+                legend="Er hovedvilkår oppfylt?"
+                size="small"
+                className="radioGroup"
+                onChange={(event) => {
+                  setVilkaarutkast({ ...vilkaarutkast, resultat: VurderingsResultat[event as VurderingsResultat] })
+                  setRadioError(undefined)
+                }}
+                value={vilkaarutkast.resultat}
+                error={radioError}
+              >
+                <div className="flex">
+                  <Radio value={VurderingsResultat.OPPFYLT}>Oppfylt</Radio>
+                  <Radio value={VurderingsResultat.IKKE_OPPFYLT}>Ikke oppfylt</Radio>
+                  <Radio value={VurderingsResultat.IKKE_VURDERT}>Ikke vurdert</Radio>
+                </div>
+              </RadioGroup>
+            </RadioGroupWrapper>
+
+            {vilkaarutkast.resultat === VurderingsResultat.IKKE_OPPFYLT &&
+              vilkaar.unntaksvilkaar &&
+              vilkaar.unntaksvilkaar.length > 0 && (
+                <>
+                  <Unntaksvilkaar>
+                    <RadioGroup
+                      legend="Er unntak fra hovedregelen oppfylt?"
+                      size="small"
+                      className="radioGroup"
+                      onChange={(type) => setVilkaarutkast({ ...vilkaarutkast, vilkaarsUnntakType: type })}
+                      value={vilkaarutkast.vilkaarsUnntakType}
+                    >
+                      <div className="flex">
+                        {vilkaar.unntaksvilkaar.map((unntakvilkaar) => (
+                          <Radio key={unntakvilkaar.type} value={unntakvilkaar.type}>
+                            {unntakvilkaar.tittel}
+                          </Radio>
+                        ))}
+                        <Radio key="Nei" value="">
+                          Nei, ingen av unntakene er oppfylt
+                        </Radio>
+                      </div>
+                    </RadioGroup>
+                  </Unntaksvilkaar>
+                </>
+              )}
+            <VurderingsLabel htmlFor={vilkaar.hovedvilkaar.tittel}>Begrunnelse (obligatorisk)</VurderingsLabel>
+            <Textarea
+              label=""
+              hideLabel={false}
+              placeholder="Gi en begrunnelse for vurderingen"
+              defaultValue={vilkaarutkast.kommentar}
+              onBlur={(e) => setVilkaarutkast({ ...vilkaarutkast, kommentar: e.target.value })}
+              minRows={3}
+              size="small"
+              error={kommentarError ? kommentarError : false}
+              autoComplete="off"
+              name={vilkaar.hovedvilkaar.tittel}
+            />
+          </>
+        </VurderingsboksWrapper>
       )}
     </div>
   )
 }
-
-const RedigerWrapper = styled.div`
-  display: inline-flex;
-  float: left;
-  cursor: pointer;
-  color: #0067c5;
-  margin-right: 10px;
-
-  .text {
-    margin-left: 0.3em;
-    font-size: 0.7em;
-    font-weight: normal;
-  }
-
-  &:hover {
-    text-decoration-line: underline;
-  }
-`
 
 export const IkkeVurdert = styled.div`
   font-size: 0.8em;
 
   button {
     margin-top: 1em;
-  }
-`
-
-export const KildeVilkaar = styled.div`
-  font-size: 0.7em;
-
-  p {
-    font-weight: normal;
   }
 `
 
@@ -307,13 +250,6 @@ export const RadioGroupWrapper = styled.div`
 
 export const Unntaksvilkaar = styled.div`
   margin-bottom: 1em;
-`
-
-export const VurderingKnapper = styled.div`
-  button {
-    margin-top: 10px;
-    margin-right: 10px;
-  }
 `
 
 export const VilkaarVurdertInformasjon = styled.div`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/vurderingsboks/VurderingsboksWrapper.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/vurderingsboks/VurderingsboksWrapper.tsx
@@ -1,0 +1,125 @@
+import { BodyShort, Button, Heading } from '@navikt/ds-react'
+import { Delete, Edit } from '@navikt/ds-icons'
+import React, { ReactElement, useState } from 'react'
+import styled from 'styled-components'
+
+interface Props {
+  tittel: string
+  subtittelKomponent?: ReactElement
+  oppfyltUnntaksvilkaarstittel?: string
+  kommentar?: string
+  defaultRediger?: boolean
+  redigerbar: boolean
+  slettVurdering: () => void
+  children: ReactElement
+  lagreklikk: (onSuccess?: () => void) => Promise<any>
+  avbrytklikk: (onSuccess?: () => void) => void
+}
+
+export const VurderingsboksWrapper = (props: Props) => {
+  const [rediger, setRediger] = useState<null | boolean>(props.defaultRediger ?? false)
+  const [lagrer, setLagrer] = useState(false)
+
+  return (
+    <div>
+      {!rediger && (
+        <>
+          <KildeVilkaar>
+            <Heading size="small" level={'2'}>
+              {props.tittel}
+            </Heading>
+            {props.subtittelKomponent ?? <></>}
+            {props.oppfyltUnntaksvilkaarstittel && (
+              <VilkaarVurdertInformasjon>
+                <Heading size="xsmall" level={'3'}>
+                  Unntak er oppfylt
+                </Heading>
+                <BodyShort size="small">{props.oppfyltUnntaksvilkaarstittel}</BodyShort>
+              </VilkaarVurdertInformasjon>
+            )}
+            {props.kommentar && (
+              <VilkaarVurdertInformasjon>
+                <Heading size="xsmall" level={'3'}>
+                  Begrunnelse
+                </Heading>
+                <BodyShort size="small">{props.kommentar}</BodyShort>
+              </VilkaarVurdertInformasjon>
+            )}
+          </KildeVilkaar>
+
+          {props.redigerbar && (
+            <>
+              <RedigerWrapper onClick={() => setRediger(true)}>
+                <Edit aria-hidden={'true'} />
+                <span className={'text'}> Rediger</span>
+              </RedigerWrapper>
+              <RedigerWrapper onClick={props.slettVurdering}>
+                <Delete aria-hidden={'true'} />
+                <span className={'text'}> Slett</span>
+              </RedigerWrapper>
+            </>
+          )}
+        </>
+      )}
+      {rediger && (
+        <>
+          {props.children}
+          <VurderingKnapper>
+            <Button
+              loading={lagrer}
+              variant={'primary'}
+              size={'small'}
+              onClick={() => {
+                setLagrer(true)
+                props.lagreklikk(() => setRediger(false)).finally(() => setLagrer(false))
+              }}
+            >
+              Lagre
+            </Button>
+            <Button variant={'secondary'} size={'small'} onClick={() => props.avbrytklikk(() => setRediger(false))}>
+              Avbryt
+            </Button>
+          </VurderingKnapper>
+        </>
+      )}
+    </div>
+  )
+}
+
+const RedigerWrapper = styled.div`
+  display: inline-flex;
+  float: left;
+  cursor: pointer;
+  color: #0067c5;
+  margin-right: 10px;
+
+  .text {
+    margin-left: 0.3em;
+    font-size: 0.7em;
+    font-weight: normal;
+  }
+
+  &:hover {
+    text-decoration-line: underline;
+  }
+`
+
+const KildeVilkaar = styled.div`
+  font-size: 0.7em;
+
+  p {
+    font-weight: normal;
+  }
+`
+
+const VurderingKnapper = styled.div`
+  button {
+    margin-top: 10px;
+    margin-right: 10px;
+  }
+`
+
+const VilkaarVurdertInformasjon = styled.div`
+  margin-bottom: 1.5em;
+  color: var(--navds-global-color-gray-700);
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/vurderingsboks/VurderingsboksWrapper.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/vurderingsboks/VurderingsboksWrapper.tsx
@@ -74,11 +74,8 @@ export const VurderingsboksWrapper = (props: Props) => {
               size={'small'}
               onClick={async () => {
                 setLagrer(true)
-                new Promise(() =>
-                  props.lagreklikk(() => {
-                    setRediger(false)
-                    setLagrer(false)
-                  })
+                new Promise((resolve) => resolve(props.lagreklikk(() => setRediger(false)))).finally(() =>
+                  setLagrer(false)
                 )
               }}
             >

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/Spinner.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/Spinner.tsx
@@ -1,15 +1,22 @@
 import { BodyLong, Loader } from '@navikt/ds-react'
 import styled from 'styled-components'
 
-const Spinner = ({ visible, label, margin = '3em' }: { visible: boolean; label: string; margin?: string }) => {
+interface Props {
+  visible: boolean
+  label: string
+  margin?: string
+  variant?: 'neutral' | 'interaction' | 'inverted'
+}
+
+const Spinner = ({ visible, label, margin = '3em', variant }: Props) => {
   if (!visible) return null
 
   return (
     <SpinnerWrap margin={margin}>
       <div className={'spinner-overlay'}>
         <div className={'spinner-content'}>
-          <Loader />
-            {label && <BodyLong spacing>{label}</BodyLong>}
+          <Loader variant={variant} />
+          {label && <BodyLong spacing>{label}</BodyLong>}
         </div>
       </div>
     </SpinnerWrap>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vilkaarsvurdering.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vilkaarsvurdering.ts
@@ -39,7 +39,7 @@ export interface Vilkaar {
   id: string
   hovedvilkaar: Hovedvilkaar
   unntaksvilkaar?: Unntaksvilkaar[]
-  vurdering?: VurdertResultat
+  vurdering?: VurdertResultat | null
   grunnlag: Vilkaarsgrunnlag<any>[]
 }
 
@@ -55,7 +55,7 @@ export interface Hovedvilkaar {
   tittel: string
   beskrivelse: string
   lovreferanse: Paragraf
-  resultat?: VurderingsResultat
+  resultat?: VurderingsResultat | null
 }
 
 export interface Unntaksvilkaar {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vilkaarsvurdering.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vilkaarsvurdering.ts
@@ -4,17 +4,16 @@ import { apiClient, ApiResponse } from './apiClient'
 export const hentVilkaarsvurdering = async (behandlingsId: string): Promise<ApiResponse<IVilkaarsvurdering>> =>
   apiClient.get<IVilkaarsvurdering>(`/vilkaarsvurdering/${behandlingsId}`)
 
-export const vurderVilkaar = async (
-  behandlingId: string,
+export const vurderVilkaar = async (args: {
+  behandlingId: string
   request: VurderVilkaarRequest
-): Promise<ApiResponse<IVilkaarsvurdering>> =>
-  apiClient.post(`/vilkaarsvurdering/${behandlingId}`, {
-    ...request,
-    kommentar: request.kommentar,
-  })
+}): Promise<ApiResponse<IVilkaarsvurdering>> =>
+  apiClient.post(`/vilkaarsvurdering/${args.behandlingId}`, { ...args.request })
 
-export const slettVurdering = async (behandlingId: string, type: string): Promise<ApiResponse<IVilkaarsvurdering>> =>
-  apiClient.delete(`/vilkaarsvurdering/${behandlingId}/${type}`)
+export const slettVurdering = async (args: {
+  behandlingId: string
+  type: string
+}): Promise<ApiResponse<IVilkaarsvurdering>> => apiClient.delete(`/vilkaarsvurdering/${args.behandlingId}/${args.type}`)
 
 export const slettTotalVurdering = async (behandlingId: string): Promise<ApiResponse<IVilkaarsvurdering>> =>
   apiClient.delete(`/vilkaarsvurdering/resultat/${behandlingId}`)

--- a/apps/etterlatte-saksbehandling-ui/client/src/utils/formattering.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/utils/formattering.ts
@@ -17,3 +17,5 @@ export const formaterStringDato = (dato: string) => format(new Date(dato), 'dd.M
 export const formaterTidspunkt = (dato: Date) => format(dato, 'HH:mm').toString()
 
 export const formaterStringTidspunkt = (dato: string) => format(new Date(dato), 'HH:mm').toString()
+
+export const formaterDatoMedTidspunkt = (dato: Date) => format(new Date(dato), 'dd.MM.yyyy HH:mm').toString()


### PR DESCRIPTION
Et steg på veien for å kunne legge til kommentar til søskenjustering:

Skal gjenbruke samme "vilkårsboks" som i vilkårsvurdering, så gjorde det om til et gjenbrukbart komponent. Ryddet samtidig opp litt i koden i Vurdering.tsx

Også et steg i riktig retning for EY-1284