### PR TITLE
Bruker beregningstype BP for barnepensjon

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/VedtakKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/VedtakKlient.kt
@@ -5,10 +5,8 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.github.michaelbull.result.mapBoth
 import com.typesafe.config.Config
 import io.ktor.client.HttpClient
-import no.nav.etterlatte.libs.common.beregning.BeregningsResultatType
 import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
-import no.nav.etterlatte.libs.common.beregning.Beregningstyper
-import no.nav.etterlatte.libs.common.beregning.Endringskode
+import no.nav.etterlatte.libs.common.beregning.Beregningstype
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.ktorobo.AzureAdClient
 import no.nav.etterlatte.libs.ktorobo.DownstreamResourceClient
@@ -77,9 +75,7 @@ data class Vedtak(
 
 data class BeregningsResultat(
     val id: UUID,
-    val type: Beregningstyper,
-    val endringskode: Endringskode,
-    val resultat: BeregningsResultatType,
+    val type: Beregningstype,
     val beregningsperioder: List<Beregningsperiode>,
     val beregnetDato: LocalDateTime,
     val grunnlagVersjon: Long = 0L

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/Beregning.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/Beregning.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.beregning
 import com.fasterxml.jackson.databind.JsonNode
 import no.nav.etterlatte.libs.common.beregning.BeregningDTO
 import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
+import no.nav.etterlatte.libs.common.beregning.Beregningstype
 import no.nav.etterlatte.libs.common.grunnlag.Metadata
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.time.YearMonth
@@ -11,6 +12,7 @@ import java.util.*
 data class BeregningsperiodeDAO(
     val beregningId: UUID,
     val behandlingId: UUID,
+    val type: Beregningstype,
     val beregnetDato: Tidspunkt,
     val datoFOM: YearMonth,
     val datoTOM: YearMonth?,
@@ -27,6 +29,7 @@ data class BeregningsperiodeDAO(
 data class Beregning(
     val beregningId: UUID,
     val behandlingId: UUID,
+    val type: Beregningstype,
     val beregningsperioder: List<Beregningsperiode>,
     val beregnetDato: Tidspunkt,
     val grunnlagMetadata: Metadata
@@ -35,6 +38,7 @@ data class Beregning(
         BeregningDTO(
             beregningId = beregningId,
             behandlingId = behandlingId,
+            type = type,
             beregningsperioder = beregningsperioder,
             beregnetDato = beregnetDato,
             grunnlagMetadata = grunnlagMetadata

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
@@ -13,8 +13,7 @@ import no.nav.etterlatte.beregning.regler.kroneavrundetBarnepensjonRegel
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
-import no.nav.etterlatte.libs.common.beregning.Beregningstyper
-import no.nav.etterlatte.libs.common.beregning.DelytelseId
+import no.nav.etterlatte.libs.common.beregning.Beregningstype
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.Opplysning
@@ -152,8 +151,6 @@ class BeregningService(
                         }
 
                         Beregningsperiode(
-                            delytelsesId = DelytelseId.BP,
-                            type = Beregningstyper.GP,
                             datoFOM = YearMonth.from(periodisertResultat.periode.fraDato),
                             datoTOM = periodisertResultat.periode.tilDato?.let { YearMonth.from(it) },
                             utbetaltBeloep = periodisertResultat.resultat.verdi,
@@ -185,8 +182,6 @@ class BeregningService(
             grunnlag = grunnlag,
             beregningsperioder = listOf(
                 Beregningsperiode(
-                    delytelsesId = DelytelseId.BP,
-                    type = Beregningstyper.GP,
                     datoFOM = virkningstidspunkt,
                     datoTOM = null,
                     utbetaltBeloep = 0,
@@ -206,6 +201,7 @@ class BeregningService(
     ) = Beregning(
         beregningId = randomUUID(),
         behandlingId = behandling.id,
+        type = Beregningstype.BP,
         beregningsperioder = beregningsperioder,
         beregnetDato = Tidspunkt.now(),
         grunnlagMetadata = grunnlag.metadata

--- a/apps/etterlatte-beregning/src/main/resources/db/migration/V4__legger_til_type.sql
+++ b/apps/etterlatte-beregning/src/main/resources/db/migration/V4__legger_til_type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE beregningsperiode ADD COLUMN type TEXT;
+UPDATE beregningsperiode SET type = 'BP';

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRepositoryTest.kt
@@ -1,8 +1,7 @@
 package no.nav.etterlatte.beregning
 
 import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
-import no.nav.etterlatte.libs.common.beregning.Beregningstyper
-import no.nav.etterlatte.libs.common.beregning.DelytelseId
+import no.nav.etterlatte.libs.common.beregning.Beregningstype
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toObjectNode
 import no.nav.etterlatte.libs.database.DataSourceBuilder
@@ -85,12 +84,11 @@ internal class BeregningRepositoryTest {
         Beregning(
             beregningId = randomUUID(),
             behandlingId = behandlingId,
+            type = Beregningstype.BP,
             beregnetDato = Tidspunkt.now(),
             grunnlagMetadata = no.nav.etterlatte.libs.common.grunnlag.Metadata(1, 1),
             beregningsperioder = listOf(
                 Beregningsperiode(
-                    delytelsesId = DelytelseId.BP,
-                    type = Beregningstyper.GP,
                     datoFOM = datoFOM,
                     datoTOM = null,
                     utbetaltBeloep = 3000,

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRoutesTest.kt
@@ -26,8 +26,7 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.beregning.BeregningDTO
 import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
-import no.nav.etterlatte.libs.common.beregning.Beregningstyper
-import no.nav.etterlatte.libs.common.beregning.DelytelseId
+import no.nav.etterlatte.libs.common.beregning.Beregningstype
 import no.nav.etterlatte.libs.common.grunnlag.Opplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Beregningsgrunnlag
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
@@ -154,12 +153,11 @@ internal class BeregningRoutesTest {
         Beregning(
             beregningId = randomUUID(),
             behandlingId = behandlingId,
+            type = Beregningstype.BP,
             beregnetDato = Tidspunkt.now(),
             grunnlagMetadata = no.nav.etterlatte.libs.common.grunnlag.Metadata(1, 1),
             beregningsperioder = listOf(
                 Beregningsperiode(
-                    delytelsesId = DelytelseId.BP,
-                    type = Beregningstyper.GP,
                     datoFOM = datoFOM,
                     datoTOM = null,
                     utbetaltBeloep = 3000,

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningServiceTest.kt
@@ -9,8 +9,7 @@ import no.nav.etterlatte.beregning.klienter.GrunnlagKlientImpl
 import no.nav.etterlatte.beregning.klienter.VilkaarsvurderingKlient
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
-import no.nav.etterlatte.libs.common.beregning.Beregningstyper
-import no.nav.etterlatte.libs.common.beregning.DelytelseId
+import no.nav.etterlatte.libs.common.beregning.Beregningstype
 import no.nav.etterlatte.libs.common.grunnlag.Opplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Beregningsgrunnlag
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
@@ -55,12 +54,11 @@ internal class BeregningServiceTest {
         with(beregning) {
             beregningId shouldNotBe null
             behandlingId shouldBe behandling.id
+            type shouldBe Beregningstype.BP
             beregnetDato shouldNotBe null
             grunnlagMetadata shouldBe grunnlag.metadata
             beregningsperioder.size shouldBe 1
             with(beregningsperioder.first()) {
-                delytelsesId shouldBe DelytelseId.BP
-                type shouldBe Beregningstyper.GP
                 utbetaltBeloep shouldBe BP_BELOEP_INGEN_SOESKEN_JAN_23
                 datoFOM shouldBe behandling.virkningstidspunkt?.dato
                 datoTOM shouldBe null
@@ -84,12 +82,11 @@ internal class BeregningServiceTest {
         with(beregning) {
             beregningId shouldNotBe null
             behandlingId shouldBe behandling.id
+            type shouldBe Beregningstype.BP
             beregnetDato shouldNotBe null
             grunnlagMetadata shouldBe grunnlag.metadata
             beregningsperioder.size shouldBe 1
             with(beregningsperioder.first()) {
-                delytelsesId shouldBe DelytelseId.BP
-                type shouldBe Beregningstyper.GP
                 utbetaltBeloep shouldBe BP_BELOEP_ETT_SOESKEN_JAN_23
                 datoFOM shouldBe behandling.virkningstidspunkt?.dato
                 datoTOM shouldBe null
@@ -111,12 +108,11 @@ internal class BeregningServiceTest {
         with(beregning) {
             beregningId shouldNotBe null
             behandlingId shouldBe behandling.id
+            type shouldBe Beregningstype.BP
             beregnetDato shouldNotBe null
             grunnlagMetadata shouldBe grunnlag.metadata
             beregningsperioder.size shouldBe 1
             with(beregningsperioder.first()) {
-                delytelsesId shouldBe DelytelseId.BP
-                type shouldBe Beregningstyper.GP
                 utbetaltBeloep shouldBe BP_BELOEP_TO_SOESKEN_JAN_23
                 datoFOM shouldBe behandling.virkningstidspunkt?.dato
                 datoTOM shouldBe null
@@ -138,12 +134,11 @@ internal class BeregningServiceTest {
         with(beregning) {
             beregningId shouldNotBe null
             behandlingId shouldBe behandling.id
+            type shouldBe Beregningstype.BP
             beregnetDato shouldNotBe null
             grunnlagMetadata shouldBe grunnlag.metadata
             beregningsperioder.size shouldBe 1
             with(beregningsperioder.first()) {
-                delytelsesId shouldBe DelytelseId.BP
-                type shouldBe Beregningstyper.GP
                 utbetaltBeloep shouldBe BP_BELOEP_INGEN_SOESKEN_JAN_23
                 datoFOM shouldBe behandling.virkningstidspunkt?.dato
                 datoTOM shouldBe null
@@ -165,12 +160,11 @@ internal class BeregningServiceTest {
         with(beregning) {
             beregningId shouldNotBe null
             behandlingId shouldBe behandling.id
+            type shouldBe Beregningstype.BP
             beregnetDato shouldNotBe null
             grunnlagMetadata shouldBe grunnlag.metadata
             beregningsperioder.size shouldBe 1
             with(beregningsperioder.first()) {
-                delytelsesId shouldBe DelytelseId.BP
-                type shouldBe Beregningstyper.GP
                 utbetaltBeloep shouldBe 0
                 datoFOM shouldBe behandling.virkningstidspunkt?.dato
                 datoTOM shouldBe null
@@ -191,12 +185,11 @@ internal class BeregningServiceTest {
         with(beregning) {
             beregningId shouldNotBe null
             behandlingId shouldBe behandling.id
+            type shouldBe Beregningstype.BP
             beregnetDato shouldNotBe null
             grunnlagMetadata shouldBe grunnlag.metadata
             beregningsperioder.size shouldBe 1
             with(beregningsperioder.first()) {
-                delytelsesId shouldBe DelytelseId.BP
-                type shouldBe Beregningstyper.GP
                 utbetaltBeloep shouldBe 0
                 datoFOM shouldBe behandling.virkningstidspunkt?.dato
                 datoTOM shouldBe null

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/Beregningsresultat.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/Beregningsresultat.kt
@@ -1,29 +1,23 @@
 package no.nav.etterlatte.vedtaksvurdering
 
 import no.nav.etterlatte.libs.common.beregning.BeregningDTO
-import no.nav.etterlatte.libs.common.beregning.BeregningsResultatType
 import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
-import no.nav.etterlatte.libs.common.beregning.Beregningstyper
-import no.nav.etterlatte.libs.common.beregning.Endringskode
+import no.nav.etterlatte.libs.common.beregning.Beregningstype
 import no.nav.etterlatte.libs.common.tidspunkt.toNorskTid
 import java.time.LocalDateTime
 import java.util.*
 
 data class Beregningsresultat(
     val id: UUID,
-    val type: Beregningstyper,
-    val endringskode: Endringskode,
-    val resultat: BeregningsResultatType,
+    val type: Beregningstype,
     val beregningsperioder: List<Beregningsperiode>,
     val beregnetDato: LocalDateTime,
-    val grunnlagVersjon: Long = 0L
+    val grunnlagVersjon: Long
 ) {
     companion object {
         fun fraDto(beregning: BeregningDTO) = Beregningsresultat(
             id = beregning.beregningId,
-            type = Beregningstyper.GP,
-            endringskode = Endringskode.NY,
-            resultat = BeregningsResultatType.BEREGNET,
+            type = beregning.type,
             beregningsperioder = beregning.beregningsperioder,
             beregnetDato = LocalDateTime.from(beregning.beregnetDato.toNorskTid()),
             grunnlagVersjon = beregning.grunnlagMetadata.versjon

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/DBTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/DBTest.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.VedtakStatus
 import no.nav.etterlatte.libs.common.beregning.BeregningDTO
+import no.nav.etterlatte.libs.common.beregning.Beregningstype
 import no.nav.etterlatte.libs.common.grunnlag.Metadata
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.norskTidssone
@@ -131,6 +132,7 @@ internal class DBTest {
         val beregningDTO = BeregningDTO(
             UUID.randomUUID(),
             uuid,
+            Beregningstype.BP,
             listOf(),
             LocalDateTime.now().toTidspunkt(
                 norskTidssone

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingServiceTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingServiceTest.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.beregning.BeregningDTO
+import no.nav.etterlatte.libs.common.beregning.Beregningstype
 import no.nav.etterlatte.libs.common.grunnlag.Metadata
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingDto
@@ -85,6 +86,7 @@ internal class VedtaksvurderingServiceTest {
         coEvery { beregningMock.hentBeregning(behandlingId, accessToken) } returns BeregningDTO(
             UUID.randomUUID(),
             behandlingId,
+            Beregningstype.BP,
             emptyList(),
             Tidspunkt.now(),
             Metadata(1, 1)

--- a/libs/common/src/main/kotlin/beregning/BeregningsResultat.kt
+++ b/libs/common/src/main/kotlin/beregning/BeregningsResultat.kt
@@ -6,34 +6,21 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.time.YearMonth
 import java.util.*
 
-enum class DelytelseId {
-    BP
-}
-
-enum class Beregningstyper {
-    GP
-}
-
-enum class Endringskode {
-    NY,
-    REVURDERING
-}
-
-enum class BeregningsResultatType {
-    BEREGNET
+enum class Beregningstype {
+    BP,
+    GP // TODO fjernes - må være her for å være bakoverkompatibel med eksisterende vedtak
 }
 
 data class BeregningDTO(
     val beregningId: UUID,
     val behandlingId: UUID,
+    val type: Beregningstype,
     val beregningsperioder: List<Beregningsperiode>,
     val beregnetDato: Tidspunkt,
     val grunnlagMetadata: Metadata
 )
 
 data class Beregningsperiode(
-    val delytelsesId: DelytelseId,
-    val type: Beregningstyper,
     val datoFOM: YearMonth,
     val datoTOM: YearMonth?,
     val utbetaltBeloep: Int,


### PR DESCRIPTION
Forenkler litt rundt dette med Beregningstyper og DelytelsesId. 
- Fjerner delytelseId - det mappes til denne direkte i Utbetaling
- Flytter `type` til `Beregning` - Lar `GP` bli liggende for å unngå at vedtak brekker. Må gjøre en liten migrering av data der.
- Fjerner `Endringskode`. Denne brukes tilsynelatende ikke til noe fornuftig.
