### PR TITLE
Fjerner beregningstype GP

### DIFF
--- a/libs/common/src/main/kotlin/beregning/BeregningsResultat.kt
+++ b/libs/common/src/main/kotlin/beregning/BeregningsResultat.kt
@@ -7,8 +7,7 @@ import java.time.YearMonth
 import java.util.*
 
 enum class Beregningstype {
-    BP,
-    GP // TODO fjernes - må være her for å være bakoverkompatibel med eksisterende vedtak
+    BP
 }
 
 data class BeregningDTO(


### PR DESCRIPTION
Dataene i vedtak er også migrert til å bruke BP der de tidligere brukte GP

EY-1615