### PR TITLE
Bugfix/fjerne sporingslogg for pdltjenester

### DIFF
--- a/apps/etterlatte-pdltjenester/.nais/dev.yaml
+++ b/apps/etterlatte-pdltjenester/.nais/dev.yaml
@@ -57,5 +57,3 @@ spec:
         - application: etterlatte-gyldig-soeknad
         - application: etterlatte-hendelser-pdl
         - application: etterlatte-behandling
-        - application: etterlatte-saksbehandling-ui-lokal
-        - application: etterlatte-saksbehandling-ui

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/Application.kt
@@ -14,7 +14,6 @@ import io.ktor.serialization.jackson.JacksonConverter
 import no.nav.etterlatte.ktortokenexchange.SecurityContextMediator
 import no.nav.etterlatte.ktortokenexchange.SecurityContextMediatorFactory
 import no.nav.etterlatte.libs.common.objectMapper
-import no.nav.etterlatte.libs.sporingslogg.Sporingslogg
 import no.nav.etterlatte.pdl.ParallelleSannheterKlient
 import no.nav.etterlatte.pdl.PdlKlient
 import no.nav.etterlatte.person.PersonService
@@ -26,8 +25,7 @@ class ApplicationContext(configLocation: String? = null) {
     val securityMediator: SecurityContextMediator = SecurityContextMediatorFactory.from(config)
     val personService: PersonService = PersonService(
         PdlKlient(pdlhttpclient(config.getConfig("no.nav.etterlatte.tjenester.pdl.aad"))),
-        ParallelleSannheterKlient(ppsHttpClient(), config.getString("no.nav.etterlatte.tjenester.pps.url")),
-        Sporingslogg()
+        ParallelleSannheterKlient(ppsHttpClient(), config.getString("no.nav.etterlatte.tjenester.pps.url"))
     )
 
     private fun pdlhttpclient(aad: Config) = HttpClient(OkHttp) {

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/Server.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/Server.kt
@@ -25,8 +25,6 @@ import no.nav.etterlatte.ktortokenexchange.secureRoutUsing
 import no.nav.etterlatte.libs.common.logging.CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.objectMapper
-import no.nav.etterlatte.libs.ktor.SaksbehandlerProvider
-import no.nav.etterlatte.libs.ktor.hentSaksbehandler
 import no.nav.etterlatte.person.PdlFantIkkePerson
 import no.nav.etterlatte.person.PersonService
 import no.nav.etterlatte.person.personApi
@@ -41,8 +39,7 @@ class Server(applicationContext: ApplicationContext) {
             module {
                 module(
                     securityContextMediator = applicationContext.securityMediator,
-                    personService = applicationContext.personService,
-                    saksbehandlerProvider = SaksbehandlerProvider { hentSaksbehandler(it) }
+                    personService = applicationContext.personService
                 )
             }
             connector { port = 8080 }
@@ -54,8 +51,7 @@ class Server(applicationContext: ApplicationContext) {
 
 fun io.ktor.server.application.Application.module(
     securityContextMediator: SecurityContextMediator,
-    personService: PersonService,
-    saksbehandlerProvider: SaksbehandlerProvider
+    personService: PersonService
 ) {
     install(ContentNegotiation) {
         register(ContentType.Application.Json, JacksonConverter(objectMapper))
@@ -93,7 +89,7 @@ fun io.ktor.server.application.Application.module(
     routing {
         healthApi()
         secureRoutUsing(securityContextMediator) {
-            personApi(personService, saksbehandlerProvider)
+            personApi(personService)
         }
     }
 }

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonRoute.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonRoute.kt
@@ -10,9 +10,8 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.libs.common.person.HentFolkeregisterIdentRequest
 import no.nav.etterlatte.libs.common.person.HentPersonRequest
-import no.nav.etterlatte.libs.ktor.SaksbehandlerProvider
 
-fun Route.personApi(service: PersonService, saksbehandlerProvider: SaksbehandlerProvider) {
+fun Route.personApi(service: PersonService) {
     route("person") {
         val logger = application.log
 
@@ -20,7 +19,7 @@ fun Route.personApi(service: PersonService, saksbehandlerProvider: Saksbehandler
             val hentPersonRequest = call.receive<HentPersonRequest>()
             logger.info("Henter person med fnr=${hentPersonRequest.foedselsnummer}")
 
-            service.hentPerson(hentPersonRequest, saksbehandlerProvider.invoke(call)).let { call.respond(it) }
+            service.hentPerson(hentPersonRequest).let { call.respond(it) }
         }
 
         route("/v2") {
@@ -28,7 +27,7 @@ fun Route.personApi(service: PersonService, saksbehandlerProvider: Saksbehandler
                 val hentPersonRequest = call.receive<HentPersonRequest>()
                 logger.info("Henter personopplysning med fnr=${hentPersonRequest.foedselsnummer}")
 
-                service.hentOpplysningsperson(hentPersonRequest, saksbehandlerProvider.invoke(call))
+                service.hentOpplysningsperson(hentPersonRequest)
                     .let { call.respond(it) }
             }
         }
@@ -41,7 +40,7 @@ fun Route.personApi(service: PersonService, saksbehandlerProvider: Saksbehandler
             val hentPersonRequest = call.receive<HentPersonRequest>()
             logger.info("Henter person med fnr=${hentPersonRequest.foedselsnummer}")
 
-            service.hentPerson(hentPersonRequest, saksbehandlerProvider.invoke(call)).let { call.respond(it) }
+            service.hentPerson(hentPersonRequest).let { call.respond(it) }
         }
     }
 
@@ -52,7 +51,7 @@ fun Route.personApi(service: PersonService, saksbehandlerProvider: Saksbehandler
             val hentFolkeregisterIdentRequest = call.receive<HentFolkeregisterIdentRequest>()
             logger.info("Henter identer for ident=${hentFolkeregisterIdentRequest.ident}")
 
-            service.hentFolkeregisterIdent(hentFolkeregisterIdentRequest, saksbehandlerProvider.invoke(call)).let {
+            service.hentFolkeregisterIdent(hentFolkeregisterIdentRequest).let {
                 call.respond(it)
             }
         }

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonService.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonService.kt
@@ -6,11 +6,6 @@ import no.nav.etterlatte.libs.common.person.FolkeregisterIdent
 import no.nav.etterlatte.libs.common.person.HentFolkeregisterIdentRequest
 import no.nav.etterlatte.libs.common.person.HentPersonRequest
 import no.nav.etterlatte.libs.common.person.Person
-import no.nav.etterlatte.libs.ktor.Saksbehandler
-import no.nav.etterlatte.libs.sporingslogg.Decision
-import no.nav.etterlatte.libs.sporingslogg.HttpMethod
-import no.nav.etterlatte.libs.sporingslogg.Sporingslogg
-import no.nav.etterlatte.libs.sporingslogg.Sporingsrequest
 import no.nav.etterlatte.pdl.ParallelleSannheterKlient
 import no.nav.etterlatte.pdl.PdlKlient
 import no.nav.etterlatte.pdl.PdlResponseError
@@ -22,23 +17,15 @@ class PdlFantIkkePerson(message: String) : RuntimeException(message)
 
 class PersonService(
     private val pdlKlient: PdlKlient,
-    private val ppsKlient: ParallelleSannheterKlient,
-    private val sporingslogg: Sporingslogg
+    private val ppsKlient: ParallelleSannheterKlient
 ) {
     private val logger = LoggerFactory.getLogger(PersonService::class.java)
 
-    suspend fun hentPerson(hentPersonRequest: HentPersonRequest, saksbehandler: Saksbehandler): Person {
+    suspend fun hentPerson(hentPersonRequest: HentPersonRequest): Person {
         logger.info("Henter person med fnr=${hentPersonRequest.foedselsnummer} fra PDL")
 
         return pdlKlient.hentPerson(hentPersonRequest.foedselsnummer, hentPersonRequest.rolle).let {
             if (it.data?.hentPerson == null) {
-                sporingslogg.logg(
-                    feilendeRequest(
-                        ident = hentPersonRequest.foedselsnummer.value,
-                        bruker = saksbehandler,
-                        endepunkt = "person"
-                    )
-                )
                 val pdlFeil = it.errors?.asFormatertFeil()
                 if (it.errors?.personIkkeFunnet() == true) {
                     throw PdlFantIkkePerson("Fant ikke personen ${hentPersonRequest.foedselsnummer}")
@@ -48,13 +35,6 @@ class PersonService(
                     )
                 }
             } else {
-                sporingslogg.logg(
-                    vellykkaRequest(
-                        ident = hentPersonRequest.foedselsnummer.value,
-                        bruker = saksbehandler,
-                        endepunkt = "person"
-                    )
-                )
                 PersonMapper.mapPerson(
                     ppsKlient = ppsKlient,
                     pdlKlient = pdlKlient,
@@ -66,38 +46,11 @@ class PersonService(
         }
     }
 
-    private fun vellykkaRequest(ident: String, bruker: Saksbehandler, endepunkt: String) = Sporingsrequest(
-        kallendeApplikasjon = "pdltjenester",
-        oppdateringstype = HttpMethod.GET,
-        brukerId = bruker.ident,
-        hvemBlirSlaattOpp = ident,
-        endepunkt = "/$endepunkt",
-        resultat = Decision.Permit,
-        melding = "Hent $endepunkt var vellykka"
-    )
-
-    private fun feilendeRequest(ident: String, bruker: Saksbehandler, endepunkt: String) = Sporingsrequest(
-        kallendeApplikasjon = "api",
-        oppdateringstype = HttpMethod.GET,
-        brukerId = bruker.ident,
-        hvemBlirSlaattOpp = ident,
-        endepunkt = "/$endepunkt",
-        resultat = Decision.Deny,
-        melding = "Hent $endepunkt feilet"
-    )
-
-    suspend fun hentOpplysningsperson(hentPersonRequest: HentPersonRequest, saksbehandler: Saksbehandler): PersonDTO {
+    suspend fun hentOpplysningsperson(hentPersonRequest: HentPersonRequest): PersonDTO {
         logger.info("Henter opplysninger for person med fnr=${hentPersonRequest.foedselsnummer} fra PDL")
 
         return pdlKlient.hentPerson(hentPersonRequest.foedselsnummer, hentPersonRequest.rolle).let {
             if (it.data?.hentPerson == null) {
-                sporingslogg.logg(
-                    feilendeRequest(
-                        ident = hentPersonRequest.foedselsnummer.value,
-                        bruker = saksbehandler,
-                        endepunkt = "opplysningsperson"
-                    )
-                )
                 val pdlFeil = it.errors?.asFormatertFeil()
                 if (it.errors?.personIkkeFunnet() == true) {
                     throw PdlFantIkkePerson("Fant ikke personen ${hentPersonRequest.foedselsnummer}")
@@ -107,13 +60,6 @@ class PersonService(
                     )
                 }
             } else {
-                sporingslogg.logg(
-                    vellykkaRequest(
-                        ident = hentPersonRequest.foedselsnummer.value,
-                        bruker = saksbehandler,
-                        endepunkt = "opplysningsperson"
-                    )
-                )
                 PersonMapper.mapOpplysningsperson(
                     ppsKlient = ppsKlient,
                     pdlKlient = pdlKlient,
@@ -126,20 +72,12 @@ class PersonService(
     }
 
     suspend fun hentFolkeregisterIdent(
-        hentFolkeregisterIdentRequest: HentFolkeregisterIdentRequest,
-        saksbehandler: Saksbehandler
+        hentFolkeregisterIdentRequest: HentFolkeregisterIdentRequest
     ): FolkeregisterIdent {
         logger.info("Henter folkeregisterident for ident=${hentFolkeregisterIdentRequest.ident} fra PDL")
 
         return pdlKlient.hentFolkeregisterIdent(hentFolkeregisterIdentRequest.ident).let {
             if (it.data?.hentIdenter == null) {
-                sporingslogg.logg(
-                    feilendeRequest(
-                        ident = hentFolkeregisterIdentRequest.ident,
-                        bruker = saksbehandler,
-                        endepunkt = "folkeregisterIdent"
-                    )
-                )
                 val pdlFeil = it.errors?.asFormatertFeil()
                 if (it.errors?.personIkkeFunnet() == true) {
                     throw PdlFantIkkePerson("Fant ikke personen ${hentFolkeregisterIdentRequest.ident}")

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/TestApplication.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/TestApplication.kt
@@ -9,7 +9,6 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.etterlatte.libs.common.objectMapper
-import no.nav.etterlatte.libs.sporingslogg.Sporingslogg
 import no.nav.etterlatte.pdl.ParallelleSannheterKlient
 import no.nav.etterlatte.person.PersonService
 
@@ -22,8 +21,7 @@ fun main() {
                 install(ContentNegotiation) { register(ContentType.Application.Json, JacksonConverter(objectMapper)) }
             },
             apiUrl = "https://pensjon-parallelle-sannheter.dev.intern.nav.no"
-        ),
-        sporingslogg = Sporingslogg()
+        )
     )
 
     val applicationContext = mockk<ApplicationContext>().apply {

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonRouteTest.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonRouteTest.kt
@@ -25,7 +25,6 @@ import no.nav.etterlatte.libs.common.person.HentPersonRequest
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.ktor.Saksbehandler
-import no.nav.etterlatte.libs.ktor.SaksbehandlerProvider
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.mockFolkeregisterident
 import no.nav.etterlatte.mockPerson
@@ -46,13 +45,12 @@ class PersonRouteTest {
             rolle = PersonRolle.BARN
         )
 
-        coEvery { personService.hentPerson(hentPersonRequest, any()) } returns GrunnlagTestData().soeker
+        coEvery { personService.hentPerson(hentPersonRequest) } returns GrunnlagTestData().soeker
 
         withTestApplication({
             module(
                 securityContextMediator,
-                personService,
-                SaksbehandlerProvider { saksbehandler }
+                personService
             )
         }) {
             handleRequest(HttpMethod.Post, PERSON_ENDEPUNKT) {
@@ -60,7 +58,7 @@ class PersonRouteTest {
                 setBody(hentPersonRequest.toJson())
             }.apply {
                 assertEquals(HttpStatusCode.OK, response.status())
-                coVerify { personService.hentPerson(any(), any()) }
+                coVerify { personService.hentPerson(any()) }
                 verify { securityContextMediator.secureRoute(any(), any()) }
                 confirmVerified(personService)
             }
@@ -74,13 +72,12 @@ class PersonRouteTest {
             rolle = PersonRolle.BARN
         )
 
-        coEvery { personService.hentOpplysningsperson(hentPersonRequest, any()) } returns mockPerson()
+        coEvery { personService.hentOpplysningsperson(hentPersonRequest) } returns mockPerson()
 
         withTestApplication({
             module(
                 securityContextMediator,
-                personService,
-                SaksbehandlerProvider { saksbehandler }
+                personService
             )
         }) {
             handleRequest(HttpMethod.Post, PERSON_ENDEPUNKT_V2) {
@@ -88,7 +85,7 @@ class PersonRouteTest {
                 setBody(hentPersonRequest.toJson())
             }.apply {
                 assertEquals(HttpStatusCode.OK, response.status())
-                coVerify { personService.hentOpplysningsperson(any(), any()) }
+                coVerify { personService.hentOpplysningsperson(any()) }
                 verify { securityContextMediator.secureRoute(any(), any()) }
                 confirmVerified(personService)
             }
@@ -101,7 +98,7 @@ class PersonRouteTest {
             ident = "2305469522806"
         )
         coEvery {
-            personService.hentFolkeregisterIdent(hentFolkeregisterIdentRequest, any())
+            personService.hentFolkeregisterIdent(hentFolkeregisterIdentRequest)
         } returns mockFolkeregisterident(
             "70078749472"
         )
@@ -109,8 +106,7 @@ class PersonRouteTest {
         withTestApplication({
             module(
                 securityContextMediator,
-                personService,
-                SaksbehandlerProvider { saksbehandler }
+                personService
             )
         }) {
             handleRequest(HttpMethod.Post, FOLKEREGISTERIDENT_ENDEPUNKT) {
@@ -118,7 +114,7 @@ class PersonRouteTest {
                 setBody(hentFolkeregisterIdentRequest.toJson())
             }.apply {
                 assertEquals(HttpStatusCode.OK, response.status())
-                coVerify { personService.hentFolkeregisterIdent(any(), any()) }
+                coVerify { personService.hentFolkeregisterIdent(any()) }
                 verify { securityContextMediator.secureRoute(any(), any()) }
                 confirmVerified(personService)
             }
@@ -133,14 +129,13 @@ class PersonRouteTest {
         )
 
         coEvery {
-            personService.hentPerson(hentPersonRequest, any())
+            personService.hentPerson(hentPersonRequest)
         } throws PdlForesporselFeilet("Noe feilet")
 
         withTestApplication({
             module(
                 securityContextMediator,
-                personService,
-                SaksbehandlerProvider { saksbehandler }
+                personService
             )
         }) {
             handleRequest(HttpMethod.Post, PERSON_ENDEPUNKT) {
@@ -149,7 +144,7 @@ class PersonRouteTest {
             }.apply {
                 assertEquals(HttpStatusCode.InternalServerError, response.status())
                 assertEquals("En feil oppstod: Noe feilet", response.content)
-                coVerify { personService.hentPerson(any(), any()) }
+                coVerify { personService.hentPerson(any()) }
                 verify { securityContextMediator.secureRoute(any(), any()) }
                 confirmVerified(personService)
             }
@@ -163,14 +158,14 @@ class PersonRouteTest {
         )
 
         coEvery {
-            personService.hentFolkeregisterIdent(hentFolkeregisterIdentReq, any())
+            personService.hentFolkeregisterIdent(hentFolkeregisterIdentReq)
         } throws PdlForesporselFeilet(
             "Noe feilet"
         )
 
         testApplication {
             application {
-                module(securityContextMediator, personService, SaksbehandlerProvider { saksbehandler })
+                module(securityContextMediator, personService)
             }
             client.post(FOLKEREGISTERIDENT_ENDEPUNKT) {
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -178,7 +173,7 @@ class PersonRouteTest {
             }.apply {
                 assertEquals(HttpStatusCode.InternalServerError, status)
                 assertEquals("En feil oppstod: Noe feilet", bodyAsText())
-                coVerify { personService.hentFolkeregisterIdent(any(), any()) }
+                coVerify { personService.hentFolkeregisterIdent(any()) }
                 verify { securityContextMediator.secureRoute(any(), any()) }
                 confirmVerified(personService)
             }

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonServiceTest.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonServiceTest.kt
@@ -10,7 +10,6 @@ import no.nav.etterlatte.libs.common.person.HentFolkeregisterIdentRequest
 import no.nav.etterlatte.libs.common.person.HentPersonRequest
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.ktor.Saksbehandler
-import no.nav.etterlatte.libs.sporingslogg.Sporingslogg
 import no.nav.etterlatte.mockResponse
 import no.nav.etterlatte.pdl.ParallelleSannheterKlient
 import no.nav.etterlatte.pdl.PdlFolkeregisterIdentResponse
@@ -31,7 +30,7 @@ internal class PersonServiceTest {
 
     private val pdlKlient = mockk<PdlKlient>()
     private val ppsKlient = mockk<ParallelleSannheterKlient>()
-    private val personService = PersonService(pdlKlient, ppsKlient, Sporingslogg())
+    private val personService = PersonService(pdlKlient, ppsKlient)
     private val saksbehandler = Saksbehandler("A1234")
 
     @BeforeEach
@@ -63,7 +62,7 @@ internal class PersonServiceTest {
     @Test
     fun `skal mappe avdoed med barnekull`() {
         val person = runBlocking {
-            personService.hentPerson(HentPersonRequest(TRIVIELL_MIDTPUNKT, rolle = PersonRolle.AVDOED), saksbehandler)
+            personService.hentPerson(HentPersonRequest(TRIVIELL_MIDTPUNKT, rolle = PersonRolle.AVDOED))
         }
 
         val expectedBarnFnr = listOf("70078749472", "06067018735")
@@ -78,8 +77,7 @@ internal class PersonServiceTest {
     fun `skal mappe person som inkluderer familierelasjon (foreldre)`() {
         val person = runBlocking {
             personService.hentOpplysningsperson(
-                HentPersonRequest(TRIVIELL_MIDTPUNKT, rolle = PersonRolle.BARN),
-                saksbehandler
+                HentPersonRequest(TRIVIELL_MIDTPUNKT, rolle = PersonRolle.BARN)
             )
         }
 
@@ -95,8 +93,7 @@ internal class PersonServiceTest {
     fun `skal mappe person som inkluderer familierelasjon (ansvarlige foreldre)`() {
         val person = runBlocking {
             personService.hentOpplysningsperson(
-                HentPersonRequest(TRIVIELL_MIDTPUNKT, rolle = PersonRolle.BARN),
-                saksbehandler
+                HentPersonRequest(TRIVIELL_MIDTPUNKT, rolle = PersonRolle.BARN)
             )
         }
 
@@ -113,8 +110,7 @@ internal class PersonServiceTest {
     fun `skal mappe person som inkluderer familierelasjon (barn)`() {
         val person = runBlocking {
             personService.hentOpplysningsperson(
-                HentPersonRequest(TRIVIELL_MIDTPUNKT, rolle = PersonRolle.BARN),
-                saksbehandler
+                HentPersonRequest(TRIVIELL_MIDTPUNKT, rolle = PersonRolle.BARN)
             )
         }
 
@@ -130,8 +126,7 @@ internal class PersonServiceTest {
     fun `Hent utland med innflytting mappes korrekt`() {
         val person = runBlocking {
             personService.hentOpplysningsperson(
-                HentPersonRequest(TRIVIELL_MIDTPUNKT, rolle = PersonRolle.BARN),
-                saksbehandler
+                HentPersonRequest(TRIVIELL_MIDTPUNKT, rolle = PersonRolle.BARN)
             )
         }
 
@@ -144,8 +139,7 @@ internal class PersonServiceTest {
     fun `Hent utland med utflytting mappes korrekt`() {
         val person = runBlocking {
             personService.hentOpplysningsperson(
-                HentPersonRequest(TRIVIELL_MIDTPUNKT, rolle = PersonRolle.BARN),
-                saksbehandler
+                HentPersonRequest(TRIVIELL_MIDTPUNKT, rolle = PersonRolle.BARN)
             )
         }
 
@@ -160,7 +154,7 @@ internal class PersonServiceTest {
 
         assertThrows<PdlForesporselFeilet> {
             runBlocking {
-                personService.hentPerson(HentPersonRequest(TRIVIELL_MIDTPUNKT, rolle = PersonRolle.BARN), saksbehandler)
+                personService.hentPerson(HentPersonRequest(TRIVIELL_MIDTPUNKT, rolle = PersonRolle.BARN))
             }
         }
     }
@@ -171,7 +165,7 @@ internal class PersonServiceTest {
 
         runBlocking {
             assertThrows<PdlFantIkkePerson> {
-                personService.hentPerson(HentPersonRequest(STOR_SNERK, rolle = PersonRolle.BARN), saksbehandler)
+                personService.hentPerson(HentPersonRequest(STOR_SNERK, rolle = PersonRolle.BARN))
             }
         }
     }
@@ -181,8 +175,7 @@ internal class PersonServiceTest {
         val personIdentResponse =
             runBlocking {
                 personService.hentFolkeregisterIdent(
-                    HentFolkeregisterIdentRequest("2305469522806"),
-                    saksbehandler
+                    HentFolkeregisterIdentRequest("2305469522806")
                 )
             }
         val expectedFolkeregisterIdent = "70078749472"
@@ -194,7 +187,7 @@ internal class PersonServiceTest {
         coEvery { pdlKlient.hentFolkeregisterIdent(any()) } returns mockResponse("/pdl/ident_ikke_funnet.json")
         runBlocking {
             assertThrows<PdlFantIkkePerson> {
-                personService.hentFolkeregisterIdent(HentFolkeregisterIdentRequest("1234"), saksbehandler)
+                personService.hentFolkeregisterIdent(HentFolkeregisterIdentRequest("1234"))
             }
         }
     }


### PR DESCRIPTION
Ref https://logs.adeo.no/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))&_a=(columns:!(message,level,application,stack_trace),filters:!(),grid:(columns:(application:(width:193),host:(width:393),level:(width:59),message:(width:928),stack_trace:(width:1320))),hideChart:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',interval:auto,query:(language:lucene,query:'namespace:%22etterlatte%22%20AND%20application:etterlatte-*%20envclass:q%20AND%20level:Error%20'),rowHeight:-1,sort:!(!('@timestamp',desc)))


Så må vi fjerne sporingslogg i pdl-tjenester som skal være en maskin til maskin tjeneste.
Så får frontend søke i grunnlag i stedet for.