### PR TITLE
EY-1321 Attestering gjøres på siste steg alltid

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/attestering/attestering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/attestering/attestering.tsx
@@ -9,7 +9,7 @@ type Props = {
 }
 
 export const Attestering: React.FC<Props> = ({ setBeslutning, beslutning }) => {
-  const { currentRoute } = useBehandlingRoutes()
+  const { lastPage } = useBehandlingRoutes()
 
   return (
     <AttesteringWrapper>
@@ -18,7 +18,7 @@ export const Attestering: React.FC<Props> = ({ setBeslutning, beslutning }) => {
       </div>
       <TextWrapper>
         Beslutning
-        {currentRoute === 'brev' ? (
+        {lastPage ? (
           <Beslutningsvalg beslutning={beslutning} setBeslutning={setBeslutning} />
         ) : (
           <>


### PR DESCRIPTION
Ser på om vi er på `lastPage` i stedet for spesifikt `brev`, som virker mer robust uansett