### PR TITLE
EY-1549 Fikser opp i teknisk tid og tar med underkjenn-statistikk

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingAggregat.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingAggregat.kt
@@ -59,7 +59,7 @@ class FoerstegangsbehandlingAggregat(
     var lagretBehandling: Foerstegangsbehandling =
         requireNotNull(behandlinger.hentBehandling(id, BehandlingType.FØRSTEGANGSBEHANDLING) as Foerstegangsbehandling)
 
-    fun lagreGyldighetprøving(gyldighetsproeving: GyldighetsResultat) {
+    fun lagreGyldighetproeving(gyldighetsproeving: GyldighetsResultat) {
         lagretBehandling = lagretBehandling.oppdaterGyldighetsproeving(gyldighetsproeving)
             .also {
                 behandlinger.lagreGyldighetsproving(it)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
@@ -76,7 +76,7 @@ class RealFoerstegangsbehandlingService(
     override fun lagreGyldighetsprøving(behandling: UUID, gyldighetsproeving: GyldighetsResultat) {
         inTransaction {
             foerstegangsbehandlingFactory.hentFoerstegangsbehandling(behandling)
-                .lagreGyldighetprøving(gyldighetsproeving)
+                .lagreGyldighetproeving(gyldighetsproeving)
         }
     }
 

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/BehandlinghendelseRiver.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/BehandlinghendelseRiver.kt
@@ -15,7 +15,7 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
-import java.util.UUID
+import java.util.*
 
 class BehandlinghendelseRiver(
     rapidsConnection: RapidsConnection,
@@ -48,7 +48,8 @@ class BehandlinghendelseRiver(
             try {
                 val behandling: Behandling = objectMapper.treeToValue(packet["behandling"])
                 val hendelse: BehandlingHendelse = enumValueOf(packet[eventNameKey].textValue().split(":")[1])
-                service.registrerStatistikkForBehandlinghendelse(behandling, hendelse)
+                val tekniskTid = parseTekniskTid(packet, logger)
+                service.registrerStatistikkForBehandlinghendelse(behandling, hendelse, tekniskTid)
                     ?.also {
                         context.publish(
                             objectMapper.writeValueAsString(

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/Utils.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/Utils.kt
@@ -1,0 +1,18 @@
+package no.nav.etterlatte.statistikk.river
+
+import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
+import no.nav.etterlatte.libs.common.rapidsandrivers.tekniskTidKey
+import no.nav.helse.rapids_rivers.JsonMessage
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.time.LocalDateTime
+
+private val defaultLog = LoggerFactory.getLogger("parseTekniskTid")
+fun parseTekniskTid(packet: JsonMessage, logger: Logger = defaultLog): LocalDateTime {
+    val pakkeTid = packet[tekniskTidKey].textValue()
+    if (pakkeTid != null) {
+        return LocalDateTime.parse(pakkeTid)
+    }
+    logger.warn("Ingen teknisk tid på pakken med hendelse ${packet.eventName}, fallbacker til now()")
+    return LocalDateTime.now()
+}

--- a/apps/etterlatte-statistikk/src/test/kotlin/statistikk/VedtakhendelserRiverTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/statistikk/VedtakhendelserRiverTest.kt
@@ -56,7 +56,7 @@ internal class VedtakhendelserRiverTest {
     @Test
     fun `Når statistikk blir registrert sendes en kvittering ut på river`() {
         every {
-            statistikkService.registrerStatistikkForVedtak(any(), any())
+            statistikkService.registrerStatistikkForVedtak(any(), any(), any())
         } returns (null to mockStoenadRad)
         val inspector = testRapid.apply { sendTestMessage(melding) }.inspektør
 
@@ -70,7 +70,7 @@ internal class VedtakhendelserRiverTest {
     @Test
     fun `Hvis ingen statistikk blir registrert sendes det ikke ut en kvittering`() {
         every {
-            statistikkService.registrerStatistikkForVedtak(any(), any())
+            statistikkService.registrerStatistikkForVedtak(any(), any(), any())
         } returns (null to null)
         val inspector = testRapid.apply { sendTestMessage(melding) }.inspektør
 

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/StandardKeys.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/StandardKeys.kt
@@ -6,6 +6,7 @@ import no.nav.helse.rapids_rivers.River
 const val eventNameKey = "@event_name"
 const val behovNameKey = "@behov"
 const val correlationIdKey = "@correlation_id"
+const val tekniskTidKey = "teknisk_tid"
 
 fun River.eventName(eventName: String) {
     validate { it.demandValue(eventNameKey, eventName) }


### PR DESCRIPTION
Setter teknisk tid på Kafka-meldingen slik at den ikke blir tidspunktet statistikk leser den, men tidspunktet hendelsen har inntruffet