### PR TITLE
Virkningstidspunkt må oppdateres når man setter nytt utfall

### DIFF
--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingRepository.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingRepository.kt
@@ -19,6 +19,7 @@ import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import no.nav.etterlatte.libs.database.KotliqueryRepositoryWrapper
 import java.sql.Timestamp
+import java.time.LocalDate
 import java.time.YearMonth
 import java.util.*
 import javax.sql.DataSource
@@ -57,6 +58,7 @@ class VilkaarsvurderingRepository(private val ds: DataSource) {
 
     fun lagreVilkaarsvurderingResultat(
         behandlingId: UUID,
+        virkningstidspunkt: LocalDate,
         resultat: VilkaarsvurderingResultat
     ): Vilkaarsvurdering {
         using(sessionOf(ds)) { session ->
@@ -66,6 +68,7 @@ class VilkaarsvurderingRepository(private val ds: DataSource) {
                 statement = Queries.lagreVilkaarsvurderingResultat,
                 paramMap = mapOf(
                     "id" to vilkaarsvurdering.id,
+                    "virkningstidspunkt" to virkningstidspunkt,
                     "resultat_utfall" to resultat.utfall.name,
                     "resultat_kommentar" to resultat.kommentar,
                     "resultat_tidspunkt" to Timestamp.valueOf(resultat.tidspunkt),
@@ -250,8 +253,11 @@ class VilkaarsvurderingRepository(private val ds: DataSource) {
 
         const val lagreVilkaarsvurderingResultat = """
             UPDATE vilkaarsvurdering
-            SET resultat_utfall = :resultat_utfall, resultat_kommentar = :resultat_kommentar, 
-                resultat_tidspunkt = :resultat_tidspunkt, resultat_saksbehandler = :resultat_saksbehandler 
+            SET virkningstidspunkt = :virkningstidspunkt, 
+                resultat_utfall = :resultat_utfall, 
+                resultat_kommentar = :resultat_kommentar, 
+                resultat_tidspunkt = :resultat_tidspunkt, 
+                resultat_saksbehandler = :resultat_saksbehandler 
             WHERE id = :id
         """
 

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingService.kt
@@ -44,7 +44,14 @@ class VilkaarsvurderingService(
         accessToken: String,
         resultat: VilkaarsvurderingResultat
     ): Vilkaarsvurdering = tilstandssjekkFoerKjoering(behandlingId, accessToken) {
-        val vilkaarsvurdering = vilkaarsvurderingRepository.lagreVilkaarsvurderingResultat(behandlingId, resultat)
+        val virkningstidspunkt = behandlingKlient.hentBehandling(behandlingId, accessToken).let {
+            it.virkningstidspunkt?.dato?.atDay(1)
+        } ?: throw IllegalStateException("Virkningstidspunkt må være satt for å sette en vurdering")
+        val vilkaarsvurdering = vilkaarsvurderingRepository.lagreVilkaarsvurderingResultat(
+            behandlingId = behandlingId,
+            virkningstidspunkt = virkningstidspunkt,
+            resultat = resultat
+        )
         val utfall = vilkaarsvurdering.resultat?.utfall ?: throw IllegalStateException("Utfall kan ikke vaere null")
         behandlingKlient.commitVilkaarsvurdering(behandlingId, accessToken, utfall)
         vilkaarsvurdering

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRepositoryTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRepositoryTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.TestInstance
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
 import java.time.LocalDateTime
+import java.time.YearMonth
 import java.util.*
 import javax.sql.DataSource
 
@@ -79,15 +80,18 @@ internal class VilkaarsvurderingRepository2Test {
     }
 
     @Test
-    fun `skal sette resultat paa vilkaarsvurdering`() {
+    fun `skal oppdatere virkningstidspunkt og sette resultat paa vilkaarsvurdering`() {
         val opprettetVilkaarsvurdering = vilkaarsvurderingRepository.opprettVilkaarsvurdering(vilkaarsvurdering)
+        val nyttVirkningstidspunkt = opprettetVilkaarsvurdering.virkningstidspunkt.minusYears(1)
 
         val oppdatertVilkaarsvurdering =
             vilkaarsvurderingRepository.lagreVilkaarsvurderingResultat(
                 opprettetVilkaarsvurdering.behandlingId,
+                nyttVirkningstidspunkt.atDay(1),
                 vilkaarsvurderingResultat
             )
 
+        oppdatertVilkaarsvurdering.virkningstidspunkt shouldBe YearMonth.from(nyttVirkningstidspunkt)
         with(oppdatertVilkaarsvurdering.resultat!!) {
             utfall shouldBe vilkaarsvurderingResultat.utfall
             kommentar shouldBe vilkaarsvurderingResultat.kommentar
@@ -102,6 +106,7 @@ internal class VilkaarsvurderingRepository2Test {
 
         vilkaarsvurderingRepository.lagreVilkaarsvurderingResultat(
             opprettetVilkaarsvurdering.behandlingId,
+            vilkaarsvurdering.virkningstidspunkt.atDay(1),
             vilkaarsvurderingResultat
         )
         val oppdatertVilkaarsvurdering =

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRepositoryTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRepositoryTest.kt
@@ -91,7 +91,7 @@ internal class VilkaarsvurderingRepository2Test {
                 vilkaarsvurderingResultat
             )
 
-        oppdatertVilkaarsvurdering.virkningstidspunkt shouldBe YearMonth.from(nyttVirkningstidspunkt)
+        oppdatertVilkaarsvurdering.virkningstidspunkt shouldBe nyttVirkningstidspunkt
         with(oppdatertVilkaarsvurdering.resultat!!) {
             utfall shouldBe vilkaarsvurderingResultat.utfall
             kommentar shouldBe vilkaarsvurderingResultat.kommentar


### PR DESCRIPTION
Datoen kan ha blitt endret i ettertid, og vi må derfor spørre behandling hva som er gjeldende før vi lagrer totalresultatet. 

Forenklet løsning ifm. pilot.

Som skjermbildene under viser var det ikke mulig å få rett dato på **Barnepensjon innvilget fom. xx.xx.xxxx**. 

Dette er en midlertidig løsning for pilot, ettersom vi egentlig burde slettet/ugyldiggjort hele den opprinnelige vilkårsvurderingen dersom virk. endrer seg.

![Screenshot 2023-01-27 at 10 46 03](https://user-images.githubusercontent.com/1083866/215061927-4ea13ec2-83a3-4681-8100-728a787459c1.png)
![Screenshot 2023-01-27 at 10 46 00](https://user-images.githubusercontent.com/1083866/215061939-2a4f2d5a-dcdd-43fa-8058-b8a7392241e1.png)

EY-1629