### PR TITLE
Oppgraderer til nyaste Ktor

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -143,8 +143,8 @@ class App(private val beanFactory: BeanFactory) {
         embeddedServer(
             CIO,
             applicationEngineEnvironment {
-                modules.add { module(beanFactory) }
                 modules.add { sikkerhetsModul() }
+                modules.add { module(beanFactory) }
                 connector { port = 8080 }
             }
         ).start(true)

--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -1,7 +1,7 @@
 object NavFelles {
     const val RapidAndRiversKtor2 = "com.github.navikt:rapids-and-rivers:2022061809451655538329.d6deccc62862"
     const val TokenClientCore = "no.nav.security:token-client-core:3.0.2"
-    const val TokenValidationKtor2 = "no.nav.security:token-validation-ktor:3.0.2"
+    const val TokenValidationKtor2 = "no.nav.security:token-validation-ktor-v2:3.0.2"
     const val MockOauth2Server = "no.nav.security:mock-oauth2-server:0.5.7"
 }
 

--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -1,7 +1,7 @@
 object NavFelles {
     const val RapidAndRiversKtor2 = "com.github.navikt:rapids-and-rivers:2022061809451655538329.d6deccc62862"
-    const val TokenClientCore = "no.nav.security:token-client-core:2.1.2"
-    const val TokenValidationKtor2 = "no.nav.security:token-validation-ktor-v2:2.1.2"
+    const val TokenClientCore = "no.nav.security:token-client-core:3.0.2"
+    const val TokenValidationKtor2 = "no.nav.security:token-validation-ktor:3.0.2"
     const val MockOauth2Server = "no.nav.security:mock-oauth2-server:0.5.7"
 }
 

--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -15,7 +15,7 @@ object Kotlinx {
 }
 
 object Ktor2 {
-    private const val version = "2.0.3"
+    private const val version = "2.2.2"
 
     const val OkHttp = "io.ktor:ktor-client-okhttp:$version"
     const val ClientCore = "io.ktor:ktor-client-core:$version"


### PR DESCRIPTION
Oppgraderte med det samme token-valideringsbiblioteka våre.

Opphavleg feila etterlatte-behandling-deploy med denne ktor-versjonen. Det viste seg (etter ein del graving) å vera at vi har hatt feil initaliseringsrekkjefølgje, der vi initialiserer Authentication etter vi har kalt authenticate. Trur eldre ktor må vera meir tolerant mot denslags, for eg kan ikkje sjå at det burde ha funka sånn det er i dagens main.