### PR TITLE
EY-1284 - sett ikon for kommer barnet til gode.

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/kommerBarnetTilgode/OversiktKommerBarnetTilgode.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/kommerBarnetTilgode/OversiktKommerBarnetTilgode.tsx
@@ -2,9 +2,8 @@ import { KommerBarnetTilGodeVurdering } from './KommerBarnetTilGodeVurdering'
 import { Beskrivelse, InfoWrapper, InfobokserWrapper, VurderingsContainerWrapper } from '../../styled'
 import { IKommerBarnetTilgode } from '~shared/types/IDetaljertBehandling'
 import { IPdlPerson } from '~shared/types/Person'
-import { svarTilVurderingsstatus } from '../../utils'
+import { svarTilStatusIcon, svarTilVurderingsstatus } from '../../utils'
 import { VurderingsResultat } from '~shared/types/VurderingsResultat'
-import { JaNei } from '~shared/types/ISvar'
 import { Soeknadsvurdering } from '../SoeknadsVurdering'
 import { Info } from '../../Info'
 import { LeggTilVurderingButton } from '~components/behandling/soeknadsoversikt/soeknadoversikt/LeggTilVurderingButton'
@@ -46,7 +45,7 @@ export const OversiktKommerBarnetTilgode = ({ kommerBarnetTilgode, redigerbar, s
         { lenke: 'https://lovdata.no/lov/2010-03-26-9/§9', tittel: 'Vergemålsloven § 9, § 16 og § 19' },
         { lenke: 'https://lovdata.no/lov/1981-04-08-7/§30', tittel: 'Barneloven § 30 og § 38' },
       ]}
-      status={kommerBarnetTilgode?.svar === JaNei.JA ? 'success' : 'warning'}
+      status={svarTilStatusIcon(kommerBarnetTilgode?.svar)}
     >
       <div>
         <Beskrivelse>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/utils.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/utils.tsx
@@ -1,3 +1,4 @@
+import { StatusIconProps } from '~shared/icons/statusIcon'
 import { JaNei } from '~shared/types/ISvar'
 import { VurderingsResultat } from '~shared/types/VurderingsResultat'
 
@@ -80,5 +81,16 @@ export const svarTilVurderingsstatus = (svar: JaNei) => {
       return VurderingsResultat.OPPFYLT
     case JaNei.NEI:
       return VurderingsResultat.IKKE_OPPFYLT
+  }
+}
+
+export const svarTilStatusIcon = (svar: JaNei | undefined): StatusIconProps => {
+  switch (svar) {
+    case JaNei.JA:
+      return 'success'
+    case JaNei.NEI:
+      return 'error'
+    default:
+      return 'warning'
   }
 }


### PR DESCRIPTION
Fiks for kommentar på jira: "Endre statusikon til Error når en vurdering er vurdert “nei”"

Vi trenger det ikke for Virkningspunkt - det har ikke en "nei" status.

Gyldig fremsatt er ikke implementert enda - så den må gjøres som en del av den.