### PR TITLE
EY-1631 Fjern beregning fra hentBehandling og bruk riktig status i stepper

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.tsx
@@ -14,6 +14,17 @@ export function hentAdresserEtterDoedsdato(adresser: IAdresse[], doedsdato: stri
   return adresser?.filter((adresse) => adresse.aktiv || isAfter(new Date(adresse.gyldigTilOgMed!), new Date(doedsdato)))
 }
 
+export const kanGaaTilStatus = (status: IBehandlingStatus) => {
+  const rekkefoelge = [
+    IBehandlingStatus.OPPRETTET,
+    IBehandlingStatus.VILKAARSVURDERT,
+    IBehandlingStatus.BEREGNET,
+    IBehandlingStatus.FATTET_VEDTAK,
+    IBehandlingStatus.ATTESTERT,
+  ]
+  return rekkefoelge.slice(0, Math.min(rekkefoelge.findIndex((s) => s === status) + 1, rekkefoelge.length))
+}
+
 export const hentBehandlesFraStatus = (status: IBehandlingStatus): boolean => {
   return (
     status === IBehandlingStatus.OPPRETTET ||

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.tsx
@@ -22,7 +22,9 @@ export const kanGaaTilStatus = (status: IBehandlingStatus) => {
     IBehandlingStatus.FATTET_VEDTAK,
     IBehandlingStatus.ATTESTERT,
   ]
-  return rekkefoelge.slice(0, Math.min(rekkefoelge.findIndex((s) => s === status) + 1, rekkefoelge.length))
+  const statusEksisterer = rekkefoelge.includes(status)
+  const index = statusEksisterer ? rekkefoelge.findIndex((s) => s === status) + 1 : rekkefoelge.length
+  return rekkefoelge.slice(0, index)
 }
 
 export const hentBehandlesFraStatus = (status: IBehandlingStatus): boolean => {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/kommerBarnetTilgode/KommerBarnetTilGodeVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/kommerBarnetTilgode/KommerBarnetTilGodeVurdering.tsx
@@ -1,13 +1,13 @@
 import { Undertekst, VurderingsTitle } from '../../styled'
 import styled from 'styled-components'
 import { useState } from 'react'
-import { IKommerBarnetTilgode } from '~shared/types/IDetaljertBehandling'
+import { IBehandlingStatus, IKommerBarnetTilgode } from '~shared/types/IDetaljertBehandling'
 import { JaNei, JaNeiRec } from '~shared/types/ISvar'
 import { BodyShort, Label, Radio, RadioGroup } from '@navikt/ds-react'
 import { VurderingsboksWrapper } from '~components/vurderingsboks/VurderingsboksWrapper'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { lagreBegrunnelseKommerBarnetTilgode } from '~shared/api/behandling'
-import { oppdaterKommerBarnetTilgode } from '~store/reducers/BehandlingReducer'
+import { oppdaterBehandlingsstatus, oppdaterKommerBarnetTilgode } from '~store/reducers/BehandlingReducer'
 import { useAppDispatch, useAppSelector } from '~store/Store'
 import { SoeknadsoversiktTextArea } from '~components/behandling/soeknadsoversikt/soeknadoversikt/SoeknadsoversiktTextArea'
 
@@ -37,6 +37,7 @@ export const KommerBarnetTilGodeVurdering = ({
     if (svar !== undefined && harBegrunnelse)
       setKommerBarnetTilGode({ behandlingId, begrunnelse, svar }, (response) => {
         dispatch(oppdaterKommerBarnetTilgode(response))
+        dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.OPPRETTET))
         onSuccess?.()
       })
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -2,14 +2,14 @@ import styled from 'styled-components'
 import DatePicker from 'react-datepicker'
 import { ErrorMessage, Label } from '@navikt/ds-react'
 import { useRef, useState } from 'react'
-import { oppdaterVirkningstidspunkt } from '~store/reducers/BehandlingReducer'
+import { oppdaterBehandlingsstatus, oppdaterVirkningstidspunkt } from '~store/reducers/BehandlingReducer'
 import { Calender } from '@navikt/ds-icons'
 import { formaterStringDato } from '~utils/formattering'
 import { fastsettVirkningstidspunkt } from '~shared/api/behandling'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { Beskrivelse, InfoWrapper, InfobokserWrapper, VurderingsContainerWrapper } from '../../styled'
 import { useAppDispatch } from '~store/Store'
-import { Virkningstidspunkt } from '~shared/types/IDetaljertBehandling'
+import { IBehandlingStatus, Virkningstidspunkt } from '~shared/types/IDetaljertBehandling'
 import { addMonths } from 'date-fns'
 import { Soeknadsvurdering } from '../SoeknadsVurdering'
 import { VurderingsResultat } from '~shared/types/VurderingsResultat'
@@ -57,6 +57,7 @@ const Virkningstidspunkt = (props: Props) => {
 
     fastsettVirkningstidspunktRequest({ id: props.behandlingId, dato: formData, begrunnelse: begrunnelse }, (res) => {
       dispatch(oppdaterVirkningstidspunkt(res))
+      dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.OPPRETTET))
       onSuccess?.()
     })
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Resultat.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Resultat.tsx
@@ -16,6 +16,9 @@ import { StatusIcon } from '~shared/icons/statusIcon'
 import { formaterStringDato } from '~utils/formattering'
 import { ISvar } from '~shared/types/ISvar'
 import { isPending, useApiCall } from '~shared/hooks/useApiCall'
+import { useAppDispatch } from '~store/Store'
+import { oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'
+import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
 
 type Props = {
   virkningstidspunktDato: string
@@ -35,6 +38,7 @@ export const Resultat: React.FC<Props> = ({
   const [svar, setSvar] = useState<ISvar>()
   const [radioError, setRadioError] = useState<string>()
   const [kommentar, setKommentar] = useState<string>('')
+  const dispatch = useAppDispatch()
   const [totalVurderingStatus, lagreTotalVurderingCall] = useApiCall(lagreTotalVurdering)
   const [slettVurderingStatus, slettTotalVurderingCall] = useApiCall(slettTotalVurdering)
 
@@ -52,9 +56,10 @@ export const Resultat: React.FC<Props> = ({
       : setRadioError(undefined)
 
     if (radioError === undefined && svar !== undefined) {
-      lagreTotalVurderingCall({ behandlingId, resultat: svarTilTotalResultat(svar), kommentar }, (res) =>
+      lagreTotalVurderingCall({ behandlingId, resultat: svarTilTotalResultat(svar), kommentar }, (res) => {
         oppdaterVilkaar(res)
-      )
+        dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.VILKAARSVURDERT))
+      })
     }
   }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/BehandlingReducer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/BehandlingReducer.ts
@@ -34,6 +34,7 @@ export const oppdaterVirkningstidspunkt = createAction<Virkningstidspunkt>('beha
 export const updateVilkaarsvurdering = createAction<IVilkaarsvurdering>('behandling/update_vilkaarsvurdering')
 export const oppdaterKommerBarnetTilgode = createAction<IKommerBarnetTilgode>('behandling/kommerBarnetTilgode')
 export const oppdaterBeregning = createAction<Beregning>('behandling/beregning')
+export const oppdaterBehandlingsstatus = createAction<IBehandlingStatus>('behandling/status')
 export const resetBeregning = createAction('behandling/beregning/reset')
 export const loggError = createAction<any>('loggError')
 export const loggInfo = createAction<any>('loggInfo')
@@ -45,7 +46,7 @@ const initialState: IBehandlingReducer = { behandling: detaljertBehandlingInitia
 
 export const behandlingReducer = createReducer(initialState, (builder) => {
   builder.addCase(addBehandling, (state, action) => {
-    state.behandling = { ...action.payload, vilkårsprøving: undefined }
+    state.behandling = { ...action.payload, vilkårsprøving: undefined, beregning: undefined }
     state.behandling.behandlingType = action.payload.behandlingType ?? IBehandlingsType.FØRSTEGANGSBEHANDLING // Default til behandlingstype hvis null
   })
   builder.addCase(updateVilkaarsvurdering, (state, action) => {
@@ -62,6 +63,9 @@ export const behandlingReducer = createReducer(initialState, (builder) => {
   })
   builder.addCase(oppdaterBeregning, (state, action) => {
     state.behandling.beregning = action.payload
+  })
+  builder.addCase(oppdaterBehandlingsstatus, (state, action) => {
+    state.behandling.status = action.payload
   })
   builder.addCase(resetBeregning, (state) => {
     state.behandling.beregning = detaljertBehandlingInitialState.beregning

--- a/apps/etterlatte-saksbehandling-ui/client/src/tests/behandling-felles-utils.test.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/tests/behandling-felles-utils.test.tsx
@@ -1,8 +1,12 @@
-import { it, describe, expect } from 'vitest'
-import { hentAdresserEtterDoedsdato, hentKriterierMedOpplysning } from '~components/behandling/felles/utils'
+import { describe, expect, it } from 'vitest'
+import {
+  hentAdresserEtterDoedsdato,
+  hentKriterierMedOpplysning,
+  kanGaaTilStatus,
+} from '~components/behandling/felles/utils'
 import { IAdresse } from '~shared/types/IAdresse'
-import { IVilkaarsproving, VilkaarsType } from '~shared/types/IDetaljertBehandling'
-import { Kriterietype, KriterieOpplysningsType } from '~shared/types/Kriterie'
+import { IBehandlingStatus, IVilkaarsproving, VilkaarsType } from '~shared/types/IDetaljertBehandling'
+import { KriterieOpplysningsType, Kriterietype } from '~shared/types/Kriterie'
 import { VurderingsResultat } from '~shared/types/VurderingsResultat'
 
 const adresserMock: IAdresse[] = [
@@ -129,5 +133,30 @@ describe('Behandling-felles-utils', () => {
       KriterieOpplysningsType.DOEDSDATO
     )
     expect(vilkaarResult?.kriterieOpplysningsType).toBe(KriterieOpplysningsType.DOEDSDATO)
+  })
+})
+
+describe('kanGaaTilStatus', () => {
+  it('Skal kunne gå til seg selv', () => {
+    const gyldigeSteg = kanGaaTilStatus(IBehandlingStatus.OPPRETTET)
+    expect(gyldigeSteg).toMatchObject([IBehandlingStatus.OPPRETTET])
+  })
+  it('Skal få tilbake en liste med statuser man kan navigere til', () => {
+    const gyldigeSteg = kanGaaTilStatus(IBehandlingStatus.BEREGNET)
+    expect(gyldigeSteg).toMatchObject([
+      IBehandlingStatus.OPPRETTET,
+      IBehandlingStatus.VILKAARSVURDERT,
+      IBehandlingStatus.BEREGNET,
+    ])
+  })
+  it('Skal returnere alle steg om statusen ikke finnes i rekkefølge-lista', () => {
+    const gyldigeSteg = kanGaaTilStatus(IBehandlingStatus.IVERKSATT)
+    expect(gyldigeSteg).toMatchObject([
+      IBehandlingStatus.OPPRETTET,
+      IBehandlingStatus.VILKAARSVURDERT,
+      IBehandlingStatus.BEREGNET,
+      IBehandlingStatus.FATTET_VEDTAK,
+      IBehandlingStatus.ATTESTERT,
+    ])
   })
 })


### PR DESCRIPTION
Beregning hentes (fortsatt) først i Beregningssteget. Lagres i redux, ettersom man ikke kan kan endre beregningsgrunnlag uten å lage en ny beregning. Når beregningsgrunnlaget endres, så slettes også beregningen i redux

I tillegg er stegmenyen nå knyttet opp til behandling.status, og for å unngå å fetche behandlingen på nytt _hele_ tiden, så blir også denne statusen oppdatert i redux på de forskjellige actionsa 