### PR TITLE
EY-1645 Fjerne oppdatering av behandlingshendelser i vedtak

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -10,8 +10,6 @@ import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
-import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
 import no.nav.etterlatte.libs.common.withBehandlingId
 import no.nav.etterlatte.libs.ktor.accesstoken
 import no.nav.etterlatte.libs.ktor.saksbehandler
@@ -70,13 +68,7 @@ fun Route.vedtaksvurderingRoute(service: VedtaksvurderingService) {
         post("vedtak/attester/{behandlingId}") {
             withBehandlingId { behandlingId ->
                 val attestert = service.attesterVedtak(behandlingId, saksbehandler.ident, accesstoken)
-                val vedtakHendelse = VedtakHendelse(
-                    vedtakId = attestert.vedtakId,
-                    inntruffet = attestert.attestasjon?.tidspunkt?.toTidspunkt()!!,
-                    saksbehandler = attestert.attestasjon?.attestant!!
-                )
 
-                service.postTilVedtakhendelse(behandlingId, accesstoken, HendelseType.ATTESTERT, vedtakHendelse)
                 call.respond(attestert)
             }
         }
@@ -92,12 +84,6 @@ fun Route.vedtaksvurderingRoute(service: VedtaksvurderingService) {
             withBehandlingId { behandlingId ->
                 val fattetVedtak = service.fattVedtak(behandlingId, saksbehandler.ident, accesstoken)
 
-                val vedtakHendelse = VedtakHendelse(
-                    vedtakId = fattetVedtak.vedtakId,
-                    inntruffet = fattetVedtak.vedtakFattet?.tidspunkt?.toTidspunkt()!!,
-                    saksbehandler = fattetVedtak.vedtakFattet?.ansvarligSaksbehandler!!
-                )
-                service.postTilVedtakhendelse(behandlingId, accesstoken, HendelseType.FATTET, vedtakHendelse)
                 call.respond(fattetVedtak)
             }
         }
@@ -107,15 +93,6 @@ fun Route.vedtaksvurderingRoute(service: VedtaksvurderingService) {
             val begrunnelse = call.receive<UnderkjennVedtakClientRequest>()
             val underkjentVedtak = service.underkjennVedtak(behandlingId, accesstoken)
 
-            val vedtakHendelse = VedtakHendelse(
-                vedtakId = underkjentVedtak.id,
-                inntruffet = Tidspunkt.now(),
-                saksbehandler = saksbehandler.ident,
-                kommentar = begrunnelse.kommentar,
-                valgtBegrunnelse = begrunnelse.valgtBegrunnelse
-            )
-
-            service.postTilVedtakhendelse(behandlingId, accesstoken, HendelseType.UNDERKJENT, vedtakHendelse)
             call.respond(underkjentVedtak)
         }
     }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
@@ -291,20 +291,6 @@ class VedtaksvurderingService(
             .filterNotNull()
             .sortedBy { it.periode.fom }
     }
-
-    suspend fun postTilVedtakhendelse(
-        behandlingId: UUID,
-        accessToken: String,
-        hendelse: HendelseType,
-        vedtakhendelse: VedtakHendelse
-    ) {
-        behandlingKlient.postVedtakHendelse(
-            vedtakHendelse = vedtakhendelse,
-            hendelse = hendelse,
-            behandlingId = behandlingId,
-            accessToken = accessToken
-        )
-    }
 }
 
 class SaksbehandlerManglerEnhetException(message: String) : Exception(message)

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/klienter/BehandlingKlient.kt
@@ -11,20 +11,12 @@ import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.ktorobo.AzureAdClient
 import no.nav.etterlatte.libs.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktorobo.Resource
-import no.nav.etterlatte.vedtaksvurdering.HendelseType
-import no.nav.etterlatte.vedtaksvurdering.VedtakHendelse
 import org.slf4j.LoggerFactory
 import java.util.*
 
 interface BehandlingKlient {
     suspend fun hentBehandling(behandlingId: UUID, accessToken: String): DetaljertBehandling
     suspend fun hentSak(sakId: Long, accessToken: String): Sak
-    suspend fun postVedtakHendelse(
-        vedtakHendelse: VedtakHendelse,
-        hendelse: HendelseType,
-        behandlingId: UUID,
-        accessToken: String
-    )
 
     suspend fun fattVedtak(behandlingId: UUID, accessToken: String, commit: Boolean = false): Boolean
     suspend fun attester(behandlingId: UUID, accessToken: String, commit: Boolean = false): Boolean
@@ -60,34 +52,6 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
                 )
         } catch (e: Exception) {
             throw BehandlingKlientException("Henting av behandling med behandlingId=$behandlingId feilet", e)
-        }
-    }
-
-    override suspend fun postVedtakHendelse(
-        vedtakHendelse: VedtakHendelse,
-        hendelse: HendelseType,
-        behandlingId: UUID,
-        accessToken: String
-    ) {
-        logger.info("Poster hendelse $hendelse om vedtak med vedtakId=${vedtakHendelse.vedtakId}")
-        try {
-            downstreamResourceClient
-                .post(
-                    resource = Resource(
-                        clientId = clientId,
-                        url = "$resourceUrl/behandlinger/$behandlingId/hendelser/vedtak/$hendelse"
-                    ),
-                    accessToken = accessToken,
-                    postBody = vedtakHendelse
-                ).mapBoth(
-                    success = { resource -> resource.response },
-                    failure = { throwableErrorMessage -> throw throwableErrorMessage }
-                )
-        } catch (e: Exception) {
-            throw BehandlingKlientException(
-                "Posting av hendelse $hendelse med for vedtakId=${vedtakHendelse.vedtakId} feilet",
-                e
-            )
         }
     }
 


### PR DESCRIPTION
@simejo Det er rett og slett fordi ingen vet om det brukes. Så da antar jeg at det er lagt inn uten et reelt behov og kan slettes.