### PR TITLE
Fikser avhengigheter for tjenester under path i workflows basert på build.gradle

### DIFF
--- a/.github/workflows/app-etterlatte-behandling.yaml
+++ b/.github/workflows/app-etterlatte-behandling.yaml
@@ -18,6 +18,10 @@ on:
       - apps/etterlatte-behandling/**
       - libs/common/**
       - libs/etterlatte-ktor/**
+      - libs/etterlatte-sporingslogg/**
+      - libs/ktor2client-onbehalfof/**
+      - libs/ktor2client-auth-clientcredentials/**
+      - libs/rapidsandrivers-extras/**
   pull_request:
     branches:
       - main
@@ -25,6 +29,10 @@ on:
       - apps/etterlatte-behandling/**
       - libs/common/**
       - libs/etterlatte-ktor/**
+      - libs/etterlatte-sporingslogg/**
+      - libs/ktor2client-onbehalfof/**
+      - libs/ktor2client-auth-clientcredentials/**
+      - libs/rapidsandrivers-extras/**
 
 jobs:
   test:

--- a/.github/workflows/app-etterlatte-beregning.yaml
+++ b/.github/workflows/app-etterlatte-beregning.yaml
@@ -17,18 +17,22 @@ on:
     paths:
       - apps/etterlatte-beregning/**
       - libs/common/**
-      - libs/testdata/**
       - libs/etterlatte-ktor/**
       - libs/etterlatte-database/**
+      - libs/etterlatte-regler/**
+      - libs/ktor2client-onbehalfof/**
+      - libs/testdata/**
   pull_request:
     branches:
       - main
     paths:
       - apps/etterlatte-beregning/**
       - libs/common/**
-      - libs/testdata/**
       - libs/etterlatte-ktor/**
       - libs/etterlatte-database/**
+      - libs/etterlatte-regler/**
+      - libs/ktor2client-onbehalfof/**
+      - libs/testdata/**
 
 jobs:
   test:

--- a/.github/workflows/app-etterlatte-brev-api.yaml
+++ b/.github/workflows/app-etterlatte-brev-api.yaml
@@ -18,6 +18,8 @@ on:
       - apps/etterlatte-brev-api/**
       - libs/common/**
       - libs/etterlatte-ktor/**
+      - libs/ktor2client-onbehalfof/**
+      - libs/ktor2client-auth-clientcredentials/**
   pull_request:
     branches:
       - main
@@ -25,6 +27,8 @@ on:
       - apps/etterlatte-brev-api/**
       - libs/common/**
       - libs/etterlatte-ktor/**
+      - libs/ktor2client-onbehalfof/**
+      - libs/ktor2client-auth-clientcredentials/**
 
 jobs:
   test:

--- a/.github/workflows/app-etterlatte-brreg.yaml
+++ b/.github/workflows/app-etterlatte-brreg.yaml
@@ -17,12 +17,14 @@ on:
     paths:
       - apps/etterlatte-brreg/**
       - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
   pull_request:
     branches:
       - main
     paths:
       - apps/etterlatte-brreg/**
       - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
 
 jobs:
   test:

--- a/.github/workflows/app-etterlatte-fordeler.yaml
+++ b/.github/workflows/app-etterlatte-fordeler.yaml
@@ -16,11 +16,15 @@ on:
       - main
     paths:
       - apps/etterlatte-fordeler/**
+      - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
   pull_request:
     branches:
       - main
     paths:
       - apps/etterlatte-fordeler/**
+      - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
 
 jobs:
   test:

--- a/.github/workflows/app-etterlatte-grunnlag.yaml
+++ b/.github/workflows/app-etterlatte-grunnlag.yaml
@@ -19,13 +19,17 @@ on:
       - libs/common/**
       - libs/testdata/**
       - libs/etterlatte-ktor/**
+      - libs/etterlatte-sporingslogg/**
+      - libs/etterlatte-ktor/**
   pull_request:
     branches:
       - main
     paths:
-      - apps/etterlatte-gyldig-soeknad/**
+      - apps/etterlatte-grunnlag/**
       - libs/common/**
       - libs/testdata/**
+      - libs/etterlatte-ktor/**
+      - libs/etterlatte-sporingslogg/**
       - libs/etterlatte-ktor/**
 
 jobs:

--- a/.github/workflows/app-etterlatte-gyldig-soeknad.yaml
+++ b/.github/workflows/app-etterlatte-gyldig-soeknad.yaml
@@ -17,12 +17,14 @@ on:
     paths:
       - apps/etterlatte-gyldig-soeknad/**
       - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
   pull_request:
     branches:
       - main
     paths:
       - apps/etterlatte-gyldig-soeknad/**
       - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
 
 jobs:
   test:

--- a/.github/workflows/app-etterlatte-hendelser-pdl.yaml
+++ b/.github/workflows/app-etterlatte-hendelser-pdl.yaml
@@ -17,12 +17,14 @@ on:
     paths:
       - apps/etterlatte-hendelser-pdl/**
       - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
   pull_request:
     branches:
       - main
     paths:
       - apps/etterlatte-hendelser-pdl/**
       - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
 
 jobs:
   test:

--- a/.github/workflows/app-etterlatte-medl.yaml
+++ b/.github/workflows/app-etterlatte-medl.yaml
@@ -17,12 +17,14 @@ on:
     paths:
       - apps/etterlatte-medl-proxy/**
       - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
   pull_request:
     branches:
       - main
     paths:
       - apps/etterlatte-medl-proxy/**
       - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
 
 jobs:
   test:

--- a/.github/workflows/app-etterlatte-oppdater-behandling.yaml
+++ b/.github/workflows/app-etterlatte-oppdater-behandling.yaml
@@ -17,12 +17,14 @@ on:
     paths:
       - apps/etterlatte-oppdater-behandling/**
       - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
   pull_request:
     branches:
       - main
     paths:
       - apps/etterlatte-oppdater-behandling/**
       - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
 
 jobs:
   test:

--- a/.github/workflows/app-etterlatte-opplysninger-fra-inntektskomponenten.yaml
+++ b/.github/workflows/app-etterlatte-opplysninger-fra-inntektskomponenten.yaml
@@ -16,12 +16,16 @@ on:
       - main
     paths:
       - apps/etterlatte-opplysninger-fra-inntektskomponenten/**
+      - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
       - libs/testdata/**
   pull_request:
     branches:
       - main
     paths:
       - apps/etterlatte-opplysninger-fra-inntektskomponenten/**
+      - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
       - libs/testdata/**
 
 jobs:

--- a/.github/workflows/app-etterlatte-opplysninger-fra-pdl.yaml
+++ b/.github/workflows/app-etterlatte-opplysninger-fra-pdl.yaml
@@ -16,12 +16,16 @@ on:
       - main
     paths:
       - apps/etterlatte-opplysninger-fra-pdl/**
+      - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
       - libs/testdata/**
   pull_request:
     branches:
       - main
     paths:
       - apps/etterlatte-opplysninger-fra-pdl/**
+      - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
       - libs/testdata/**
 
 jobs:

--- a/.github/workflows/app-etterlatte-opplysninger-fra-soeknad.yaml
+++ b/.github/workflows/app-etterlatte-opplysninger-fra-soeknad.yaml
@@ -16,11 +16,13 @@ on:
       - main
     paths:
       - apps/etterlatte-opplysninger-fra-soeknad/**
+      - libs/common/**
   pull_request:
     branches:
       - main
     paths:
       - apps/etterlatte-opplysninger-fra-soeknad/**
+      - libs/common/**
 
 jobs:
   test:

--- a/.github/workflows/app-etterlatte-pdltjenester.yaml
+++ b/.github/workflows/app-etterlatte-pdltjenester.yaml
@@ -16,12 +16,18 @@ on:
       - main
     paths:
       - apps/etterlatte-pdltjenester/**
+      - libs/etterlatte-sporingslogg/**
+      - libs/etterlatte-ktor/**
+      - libs/ktor2client-auth-clientcredentials/**
       - libs/testdata/**
   pull_request:
     branches:
       - main
     paths:
       - apps/etterlatte-pdltjenester/**
+      - libs/etterlatte-sporingslogg/**
+      - libs/etterlatte-ktor/**
+      - libs/ktor2client-auth-clientcredentials/**
       - libs/testdata/**
 
 jobs:

--- a/.github/workflows/app-etterlatte-statistikk.yaml
+++ b/.github/workflows/app-etterlatte-statistikk.yaml
@@ -17,12 +17,14 @@ on:
     paths:
       - apps/etterlatte-statistikk/**
       - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
   pull_request:
     branches:
       - main
     paths:
       - apps/etterlatte-statistikk/**
       - libs/common/**
+      - libs/ktor2client-auth-clientcredentials/**
 
 jobs:
   test:

--- a/.github/workflows/app-etterlatte-testdata.yaml
+++ b/.github/workflows/app-etterlatte-testdata.yaml
@@ -7,11 +7,13 @@ on:
       - main
     paths:
       - apps/etterlatte-testdata/**
+      - libs/ktor2client-onbehalfof/**
   pull_request:
     branches:
       - main
     paths:
       - apps/etterlatte-testdata/**
+      - libs/ktor2client-onbehalfof/**
 
 jobs:
   test:

--- a/.github/workflows/app-etterlatte-utbetaling.yaml
+++ b/.github/workflows/app-etterlatte-utbetaling.yaml
@@ -16,11 +16,13 @@ on:
       - main
     paths:
       - apps/etterlatte-utbetaling/**
+      - libs/common/**
   pull_request:
     branches:
       - main
     paths:
       - apps/etterlatte-utbetaling/**
+      - libs/common/**
 
 jobs:
   test:

--- a/.github/workflows/app-etterlatte-vedtaksvurdering.yaml
+++ b/.github/workflows/app-etterlatte-vedtaksvurdering.yaml
@@ -19,6 +19,9 @@ on:
       - libs/common/**
       - libs/testdata/**
       - libs/etterlatte-ktor/**
+      - libs/etterlatte-database/**
+      - libs/ktor2client-onbehalfof/**
+      - libs/ktor2client-auth-clientcredentials/**
   pull_request:
     branches:
       - main
@@ -27,6 +30,9 @@ on:
       - libs/common/**
       - libs/testdata/**
       - libs/etterlatte-ktor/**
+      - libs/etterlatte-database/**
+      - libs/ktor2client-onbehalfof/**
+      - libs/ktor2client-auth-clientcredentials/**
 jobs:
   test:
     if: github.event_name == 'pull_request'

--- a/apps/etterlatte-brreg/build.gradle.kts
+++ b/apps/etterlatte-brreg/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":libs:ktor2client-auth-clientcredentials"))
+    implementation(project(":libs:common"))
+
     implementation(Ktor2.ClientCore)
     implementation(Ktor2.ClientLoggingJvm)
     implementation(Ktor2.ClientAuth)
@@ -16,9 +19,6 @@ dependencies {
     implementation(Ktor2.ServerContentNegotiation)
     implementation(Ktor2.CallLogging)
     implementation(Ktor2.StatusPages)
-
-    implementation(project(":libs:ktor2client-auth-clientcredentials"))
-    implementation(project(":libs:common"))
 
     implementation(NavFelles.TokenClientCore)
     implementation(NavFelles.TokenValidationKtor2)

--- a/apps/etterlatte-fordeler/build.gradle.kts
+++ b/apps/etterlatte-fordeler/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":libs:common"))
+    implementation(project(":libs:ktor2client-auth-clientcredentials"))
+
     implementation(Ktor2.OkHttp)
     implementation(Ktor2.ClientCore)
     implementation(Ktor2.ClientLoggingJvm)
@@ -11,9 +14,6 @@ dependencies {
     implementation(Ktor2.ClientJackson)
     implementation(Ktor2.ClientContentNegotiation)
     implementation(Ktor2.Jackson)
-
-    implementation(project(":libs:ktor2client-auth-clientcredentials"))
-    implementation(project(":libs:common"))
 
     testImplementation(Ktor2.ClientMock)
     testImplementation(MockK.MockK)

--- a/apps/etterlatte-gyldig-soeknad/build.gradle.kts
+++ b/apps/etterlatte-gyldig-soeknad/build.gradle.kts
@@ -5,9 +5,10 @@ plugins {
 }
 
 dependencies {
-    implementation(Ktor2.OkHttp)
-    implementation(project(":libs:ktor2client-auth-clientcredentials"))
     implementation(project(":libs:common"))
+    implementation(project(":libs:ktor2client-auth-clientcredentials"))
+
+    implementation(Ktor2.OkHttp)
     implementation(Ktor2.ClientCore)
     implementation(Ktor2.ClientContentNegotiation)
     implementation(Ktor2.ClientCioJvm)

--- a/apps/etterlatte-hendelser-pdl/build.gradle.kts
+++ b/apps/etterlatte-hendelser-pdl/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":libs:ktor2client-auth-clientcredentials"))
+    implementation(project(":libs:common"))
+
     implementation(Ktor2.OkHttp)
     implementation(Ktor2.ClientCore)
     implementation(Ktor2.ClientLoggingJvm)
@@ -20,14 +23,13 @@ dependencies {
     implementation(Kafka.Avro)
     implementation(Kafka.AvroSerializer)
     implementation(Logging.LogbackClassic)
+
     testImplementation(Jupiter.Api)
     testImplementation(Kafka.EmbeddedEnv)
     testImplementation(Jupiter.Engine)
     testImplementation(Ktor2.ServerTests)
     testImplementation(MockK.MockK)
     testImplementation(Ktor2.ClientMock)
-    implementation(project(":libs:ktor2client-auth-clientcredentials"))
-    implementation(project(":libs:common"))
 }
 
 tasks.named("compileKotlin").configure { dependsOn(":apps:etterlatte-hendelser-pdl:generateAvroJava") }

--- a/apps/etterlatte-medl-proxy/build.gradle.kts
+++ b/apps/etterlatte-medl-proxy/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":libs:common"))
+    implementation(project(":libs:ktor2client-auth-clientcredentials"))
+
     implementation(Ktor2.Auth)
     implementation(Ktor2.ClientCore)
     implementation(Ktor2.ClientLoggingJvm)
@@ -17,9 +20,6 @@ dependencies {
     implementation(Ktor2.ServerContentNegotiation)
     implementation(Ktor2.CallLogging)
     implementation(Ktor2.StatusPages)
-
-    implementation(project(":libs:ktor2client-auth-clientcredentials"))
-    implementation(project(":libs:common"))
 
     implementation(NavFelles.TokenClientCore)
     implementation(NavFelles.TokenValidationKtor2)

--- a/apps/etterlatte-oppdater-behandling/build.gradle.kts
+++ b/apps/etterlatte-oppdater-behandling/build.gradle.kts
@@ -4,15 +4,15 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":libs:ktor2client-auth-clientcredentials"))
+    implementation(project(":libs:common"))
+
     implementation(Ktor2.OkHttp)
     implementation(Ktor2.ClientCore)
     implementation(Ktor2.ClientLoggingJvm)
     implementation(Ktor2.ClientAuth)
     implementation(Ktor2.ClientContentNegotiation)
     implementation(Ktor2.ClientJackson)
-
-    implementation(project(":libs:ktor2client-auth-clientcredentials"))
-    implementation(project(":libs:common"))
 
     testImplementation(Ktor2.ClientMock)
     testImplementation(MockK.MockK)

--- a/apps/etterlatte-opplysninger-fra-inntektskomponenten/build.gradle.kts
+++ b/apps/etterlatte-opplysninger-fra-inntektskomponenten/build.gradle.kts
@@ -3,15 +3,15 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":libs:common"))
+    implementation(project(":libs:ktor2client-auth-clientcredentials"))
+
     implementation(Ktor2.OkHttp)
     implementation(Ktor2.ClientCore)
     implementation(Ktor2.ClientLoggingJvm)
     implementation(Ktor2.ClientAuth)
     implementation(Ktor2.ClientJackson)
     implementation(Ktor2.ClientContentNegotiation)
-
-    implementation(project(":libs:ktor2client-auth-clientcredentials"))
-    implementation(project(":libs:common"))
 
     testImplementation(Jupiter.Root)
     testImplementation(Ktor2.ClientMock)

--- a/apps/etterlatte-opplysninger-fra-pdl/build.gradle.kts
+++ b/apps/etterlatte-opplysninger-fra-pdl/build.gradle.kts
@@ -3,15 +3,15 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":libs:ktor2client-auth-clientcredentials"))
+    implementation(project(":libs:common"))
+
     implementation(Ktor2.OkHttp)
     implementation(Ktor2.ClientCore)
     implementation(Ktor2.ClientLoggingJvm)
     implementation(Ktor2.ClientAuth)
     implementation(Ktor2.ClientJackson)
     implementation(Ktor2.ClientContentNegotiation)
-
-    implementation(project(":libs:ktor2client-auth-clientcredentials"))
-    implementation(project(":libs:common"))
 
     testImplementation(Jupiter.Root)
     testImplementation(Ktor2.ClientMock)

--- a/apps/etterlatte-tilbakekreving/build.gradle.kts
+++ b/apps/etterlatte-tilbakekreving/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("com.faire.gradle.analyze") version "1.0.9"
 }
 dependencies {
-    implementation(project(":libs:ktor2client-auth-clientcredentials"))
+    implementation(project(":libs:common"))
 
     implementation(Ktor2.ServerCore)
     implementation(Ktor2.ServerCio)
@@ -35,9 +35,7 @@ dependencies {
     implementation("javax.xml.bind:jaxb-api:2.3.1")
     implementation("org.glassfish.jaxb:jaxb-runtime:2.3.2")
 
-    implementation(project(":libs:common"))
-
-    implementation("com.zaxxer:HikariCP:3.4.5")
+    implementation(Database.HikariCP)
     implementation(Database.FlywayDB)
     implementation(Database.Postgresql)
     implementation(Database.KotliQuery)
@@ -47,8 +45,7 @@ dependencies {
     testImplementation(MockK.MockK)
     testImplementation(Kotlinx.CoroutinesCore)
 
-    testImplementation("org.testcontainers:testcontainers:1.17.6")
-    testImplementation("com.github.tomakehurst:wiremock:2.33.2")
-    testImplementation("org.testcontainers:junit-jupiter:1.17.6")
-    testImplementation("org.testcontainers:postgresql:1.17.6")
+    testImplementation(WireMock.WireMock)
+    testImplementation(TestContainer.Jupiter)
+    testImplementation(TestContainer.Postgresql)
 }

--- a/apps/etterlatte-utbetaling/build.gradle.kts
+++ b/apps/etterlatte-utbetaling/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     id("com.faire.gradle.analyze") version "1.0.9"
 }
 dependencies {
+    implementation(project(":libs:common"))
+
     implementation(Ktor2.OkHttp)
     implementation(Ktor2.ClientCore)
     implementation(Ktor2.ClientContentNegotiation)
@@ -22,8 +24,6 @@ dependencies {
     implementation("javax.xml.bind:jaxb-api:2.3.1")
     implementation("org.glassfish.jaxb:jaxb-runtime:2.3.2")
 
-    implementation(project(":libs:common"))
-
     implementation(Database.HikariCP)
     implementation(Database.FlywayDB)
     implementation(Database.Postgresql)
@@ -33,8 +33,7 @@ dependencies {
     testImplementation(MockK.MockK)
     testImplementation(Kotlinx.CoroutinesCore)
 
-    testImplementation("org.testcontainers:testcontainers:1.17.6")
-    testImplementation("com.github.tomakehurst:wiremock:2.33.2")
-    testImplementation("org.testcontainers:junit-jupiter:1.17.6")
+    testImplementation(WireMock.WireMock)
+    testImplementation(TestContainer.Jupiter)
     testImplementation(TestContainer.Postgresql)
 }

--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -82,6 +82,10 @@ object MockK {
     const val MockK = "io.mockk:mockk:1.12.0"
 }
 
+object WireMock {
+    const val WireMock = "com.github.tomakehurst:wiremock:2.33.2"
+}
+
 object Kotest {
     private const val version = "4.6.3"
 


### PR DESCRIPTION
Dersom man oppdaterer libs som andre tjenester har avhengigheter til skal dette bygges i pr. Tilsvarende skal en merge til main trigge en redeploy av tjenesten.

EY-1644