### PR TITLE
EY-1646 La til errormelding på beregningsgrunnlag ved api errors

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Beregningsgrunnlag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Beregningsgrunnlag.tsx
@@ -21,6 +21,7 @@ import { IPdlPerson } from '~shared/types/Person'
 import { Soeknadsvurdering } from '~components/behandling/soeknadsoversikt/soeknadoversikt/SoeknadsVurdering'
 import { oppdaterBehandlingsstatus, resetBeregning } from '~store/reducers/BehandlingReducer'
 import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
+import { ApiErrorAlert } from '~ErrorBoundary'
 
 interface FormValues {
   foedselsnummer: string
@@ -166,6 +167,10 @@ const Beregningsgrunnlag = () => {
             </SoeskenContainer>
           ))}
       </FamilieforholdWrapper>
+
+      {isFailure(endreBeregning) && <ApiErrorAlert>Kunne ikke opprette ny beregning</ApiErrorAlert>}
+      {isFailure(soeskenMedIBeregning) && <ApiErrorAlert>Kunne ikke lagre beregningsgrunnlag</ApiErrorAlert>}
+
       {visSoeskenjustering &&
         (behandles ? (
           <BehandlingHandlingKnapper>


### PR DESCRIPTION
Beregningsgrunnlag viste ingen feilmeldinger dersom apikallet feilet. La inn ApiErrorAlert

![image](https://user-images.githubusercontent.com/6595794/216342911-fca194ff-731d-4182-9492-38918e18990d.png)
