### PR TITLE
EY-1646 Vilkårsvurdering henter fra redux state om den finnes

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
@@ -32,11 +32,13 @@ export const Vilkaarsvurdering = () => {
 
   useEffect(() => {
     if (!behandlingId) throw new Error('Mangler behandlingsid')
-    fetchVilkaarsvurdering(
-      behandlingId,
-      (vilkaarsvurdering) => dispatch(updateVilkaarsvurdering(vilkaarsvurdering)),
-      (error) => opprettHvisDenIkkeFinnes(error)
-    )
+    if (!vilkaarsvurdering) {
+      fetchVilkaarsvurdering(
+        behandlingId,
+        (vilkaarsvurdering) => dispatch(updateVilkaarsvurdering(vilkaarsvurdering)),
+        (error) => opprettHvisDenIkkeFinnes(error)
+      )
+    }
   }, [behandlingId])
 
   const opprettHvisDenIkkeFinnes = (error: ApiError) => {


### PR DESCRIPTION
Bjørn og jeg fikset så Vilkårsvurdering blir hentet fra Redux-state dersom den finnes. Vi dobbeltsjekket at den alltid er up to date, slik at vi ikke ender med en divergert state fra db