### PR TITLE
Oppdater behandlingsstatus når man sletter totalvurdering

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Resultat.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Resultat.tsx
@@ -47,6 +47,7 @@ export const Resultat: React.FC<Props> = ({
   const slettVilkaarsvurderingResultat = () =>
     slettTotalVurderingCall(behandlingId, (res) => {
       oppdaterVilkaar(res)
+      dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.OPPRETTET))
       reset()
     })
 


### PR DESCRIPTION
Statusen oppdateres ikke når vi sletter totalvurderingen på vilkårsvurdering. Konsekvensen er at Stepper:n ikke oppdaterer seg og da ser det ut som man kan gjøre ting som man ikke har lov til egentligen.