### PR TITLE
Endring av begrunnelse bør føre til lagring av virkningstidspunkt

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -55,7 +55,9 @@ const Virkningstidspunkt = (props: Props) => {
       return setErrorTekst('Begrunnelsen må fylles ut')
     }
 
-    const harVirkningstidspunktEndretSeg = props.virkningstidspunkt?.dato !== formaterDatoTilYearMonth(formData)
+    const harVirkningstidspunktEndretSeg =
+      props.virkningstidspunkt?.dato !== formaterDatoTilYearMonth(formData) ||
+      props.virkningstidspunkt?.begrunnelse !== begrunnelse
     if (harVirkningstidspunktEndretSeg) {
       return fastsettVirkningstidspunktRequest(
         { id: props.behandlingId, dato: formData, begrunnelse: begrunnelse },


### PR DESCRIPTION
Oppdaget at virkningstidspunkt ikke ble oppdatert når man oppdaterte begrunnelsen.

En uheldig bieffekt er at man må gå igjennom behandlingen på nytt, men tenker det likevel bør være sånn, @simejo?