### PR TITLE
EY-1633: Enkel vasking av input som vi sender direkte vidare

### DIFF
--- a/apps/etterlatte-brreg/src/main/kotlin/no/nav/etterlatte/enhetsregister/EnhetsregisterRoute.kt
+++ b/apps/etterlatte-brreg/src/main/kotlin/no/nav/etterlatte/enhetsregister/EnhetsregisterRoute.kt
@@ -10,7 +10,7 @@ import io.ktor.server.routing.route
 fun Route.enhetsregApi(service: EnhetsregService) {
     route("enheter") {
         get {
-            val navn = vaskInput(call.request.queryParameters["navn"]) {
+            val navn = vaskEnhetsnavn(call.request.queryParameters["navn"]) {
                 "Query param \"navn\" må være satt for å hente ut bedrifter."
             }
 
@@ -20,7 +20,7 @@ fun Route.enhetsregApi(service: EnhetsregService) {
         }
 
         get("{orgnr}") {
-            val orgnr = vaskInput(call.parameters["orgnr"]) {
+            val orgnr = vaskEnhetsnavn(call.parameters["orgnr"]) {
                 "Orgnr. må være satt for å hente ut enhet fra BRREG."
             }
 
@@ -35,7 +35,7 @@ fun Route.enhetsregApi(service: EnhetsregService) {
     }
 }
 
-internal fun vaskInput(input: String?, orElse: () -> String) = requireNotNull(input) {
+internal fun vaskEnhetsnavn(input: String?, orElse: () -> String) = requireNotNull(input) {
     orElse
 }.replaceBefore("://", "")
     .replace("://", "")

--- a/apps/etterlatte-brreg/src/main/kotlin/no/nav/etterlatte/enhetsregister/EnhetsregisterRoute.kt
+++ b/apps/etterlatte-brreg/src/main/kotlin/no/nav/etterlatte/enhetsregister/EnhetsregisterRoute.kt
@@ -39,3 +39,7 @@ internal fun vaskInput(input: String?, orElse: () -> String) = requireNotNull(in
     orElse
 }.replaceBefore("://", "")
     .replace("://", "")
+
+internal fun vaskOrgnr(input: String?, orElse: () -> String) = requireNotNull(input) {
+    orElse
+}.replace("[^0-9]".toRegex(), "")

--- a/apps/etterlatte-brreg/src/main/kotlin/no/nav/etterlatte/enhetsregister/EnhetsregisterRoute.kt
+++ b/apps/etterlatte-brreg/src/main/kotlin/no/nav/etterlatte/enhetsregister/EnhetsregisterRoute.kt
@@ -10,7 +10,7 @@ import io.ktor.server.routing.route
 fun Route.enhetsregApi(service: EnhetsregService) {
     route("enheter") {
         get {
-            val navn = requireNotNull(call.request.queryParameters["navn"]) {
+            val navn = vaskInput(call.request.queryParameters["navn"]) {
                 "Query param \"navn\" må være satt for å hente ut bedrifter."
             }
 
@@ -20,7 +20,7 @@ fun Route.enhetsregApi(service: EnhetsregService) {
         }
 
         get("{orgnr}") {
-            val orgnr = requireNotNull(call.parameters["orgnr"]) {
+            val orgnr = vaskInput(call.parameters["orgnr"]) {
                 "Orgnr. må være satt for å hente ut enhet fra BRREG."
             }
 
@@ -34,3 +34,8 @@ fun Route.enhetsregApi(service: EnhetsregService) {
         }
     }
 }
+
+internal fun vaskInput(input: String?, orElse: () -> String) = requireNotNull(input) {
+    orElse
+}.replaceBefore("://", "")
+    .replace("://", "")

--- a/apps/etterlatte-brreg/src/main/kotlin/no/nav/etterlatte/enhetsregister/EnhetsregisterRoute.kt
+++ b/apps/etterlatte-brreg/src/main/kotlin/no/nav/etterlatte/enhetsregister/EnhetsregisterRoute.kt
@@ -37,8 +37,7 @@ fun Route.enhetsregApi(service: EnhetsregService) {
 
 internal fun vaskEnhetsnavn(input: String?, orElse: () -> String) = requireNotNull(input) {
     orElse
-}.replaceBefore("://", "")
-    .replace("://", "")
+}.replace("[^a-zA-Z\\sæøåÆØÅ]".toRegex(), "")
 
 internal fun vaskOrgnr(input: String?, orElse: () -> String) = requireNotNull(input) {
     orElse

--- a/apps/etterlatte-brreg/src/test/kotlin/no/nav/etterlatte/enhetsregister/EnhetsregisterRouteKtTest.kt
+++ b/apps/etterlatte-brreg/src/test/kotlin/no/nav/etterlatte/enhetsregister/EnhetsregisterRouteKtTest.kt
@@ -1,0 +1,25 @@
+package no.nav.etterlatte.enhetsregister
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class EnhetsregisterRouteKtTest {
+
+    @Test
+    fun `url i inputnavn blir haandtert`() {
+        val url = "http://localhost:123/mistenkelig"
+        val vaska = vaskInput(url) {
+            ""
+        }
+        assertEquals("localhost:123/mistenkelig", vaska)
+    }
+
+    @Test
+    fun `vanleg inputnavn blir haandtert uten endring`() {
+        val url = "Lorem Ipsum Dolor"
+        val vaska = vaskInput(url) {
+            ""
+        }
+        assertEquals(url, vaska)
+    }
+}

--- a/apps/etterlatte-brreg/src/test/kotlin/no/nav/etterlatte/enhetsregister/EnhetsregisterRouteKtTest.kt
+++ b/apps/etterlatte-brreg/src/test/kotlin/no/nav/etterlatte/enhetsregister/EnhetsregisterRouteKtTest.kt
@@ -8,18 +8,21 @@ internal class EnhetsregisterRouteKtTest {
     @Test
     fun `url i inputnavn blir haandtert`() {
         val url = "http://localhost:123/mistenkelig"
-        val vaska = vaskInput(url) {
-            ""
-        }
+        val vaska = vaskInput(url) { "" }
         assertEquals("localhost:123/mistenkelig", vaska)
     }
 
     @Test
     fun `vanleg inputnavn blir haandtert uten endring`() {
         val url = "Lorem Ipsum Dolor"
-        val vaska = vaskInput(url) {
-            ""
-        }
+        val vaska = vaskInput(url) { "" }
         assertEquals(url, vaska)
+    }
+
+    @Test
+    fun `orgnr er kun tall`() {
+        val orgnr = "tull     1    \t 2     3 :/!\\\\"
+        val vaska = vaskOrgnr(orgnr) { "" }
+        assertEquals("123", vaska)
     }
 }

--- a/apps/etterlatte-brreg/src/test/kotlin/no/nav/etterlatte/enhetsregister/EnhetsregisterRouteTest.kt
+++ b/apps/etterlatte-brreg/src/test/kotlin/no/nav/etterlatte/enhetsregister/EnhetsregisterRouteTest.kt
@@ -9,12 +9,12 @@ internal class EnhetsregisterRouteTest {
     fun `url i inputnavn blir haandtert`() {
         val url = "http://localhost:123/mistenkelig"
         val vaska = vaskEnhetsnavn(url) { "" }
-        assertEquals("localhost:123/mistenkelig", vaska)
+        assertEquals("httplocalhostmistenkelig", vaska)
     }
 
     @Test
     fun `vanleg inputnavn blir haandtert uten endring`() {
-        val url = "Lorem Ipsum Dolor"
+        val url = "Lorem Ipsum Dolor ÆØÅZæøåz"
         val vaska = vaskEnhetsnavn(url) { "" }
         assertEquals(url, vaska)
     }

--- a/apps/etterlatte-brreg/src/test/kotlin/no/nav/etterlatte/enhetsregister/EnhetsregisterRouteTest.kt
+++ b/apps/etterlatte-brreg/src/test/kotlin/no/nav/etterlatte/enhetsregister/EnhetsregisterRouteTest.kt
@@ -3,19 +3,19 @@ package no.nav.etterlatte.enhetsregister
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-internal class EnhetsregisterRouteKtTest {
+internal class EnhetsregisterRouteTest {
 
     @Test
     fun `url i inputnavn blir haandtert`() {
         val url = "http://localhost:123/mistenkelig"
-        val vaska = vaskInput(url) { "" }
+        val vaska = vaskEnhetsnavn(url) { "" }
         assertEquals("localhost:123/mistenkelig", vaska)
     }
 
     @Test
     fun `vanleg inputnavn blir haandtert uten endring`() {
         val url = "Lorem Ipsum Dolor"
-        val vaska = vaskInput(url) { "" }
+        val vaska = vaskEnhetsnavn(url) { "" }
         assertEquals(url, vaska)
     }
 


### PR DESCRIPTION
Verksemder kan jo heite så mykje forskjellig, så feks ktor sin innebygde escapeIfNeeded tar tak i for mykje. Det å fjerne :// og protokollen før kjens som noko som bør ha veldig låg risiko for falske positive, og samtidig noko som bør ta unna det meste av det problematiske.

Denne rettar dei to snyk reknar som _high severity_ i vår kode: https://app.snyk.io/org/etterlatte/project/5df56718-a6a0-41ac-9342-0024e0568922