### PR TITLE
EY-1666 - legg til metrics på rest apiene

### DIFF
--- a/.github/workflows/app-etterlatte-behandling.yaml
+++ b/.github/workflows/app-etterlatte-behandling.yaml
@@ -30,6 +30,7 @@ on:
       - buildSrc/src/main/kotlin/Micrometer.kt
       - buildSrc/src/main/kotlin/MockK.kt
       - buildSrc/src/main/kotlin/NavFelles.kt
+      - buildSrc/src/main/kotlin/Prometheus
   pull_request:
     branches:
       - main
@@ -49,6 +50,7 @@ on:
       - buildSrc/src/main/kotlin/Micrometer.kt
       - buildSrc/src/main/kotlin/MockK.kt
       - buildSrc/src/main/kotlin/NavFelles.kt
+      - buildSrc/src/main/kotlin/Prometheus
 
 jobs:
   test:

--- a/.github/workflows/app-etterlatte-beregning.yaml
+++ b/.github/workflows/app-etterlatte-beregning.yaml
@@ -30,6 +30,7 @@ on:
       - buildSrc/src/main/kotlin/Ktor2.kt
       - buildSrc/src/main/kotlin/MockK.kt
       - buildSrc/src/main/kotlin/NavFelles.kt
+      - buildSrc/src/main/kotlin/Prometheus
       - buildSrc/src/main/kotlin/TestContainer.kt
   pull_request:
     branches:
@@ -50,6 +51,7 @@ on:
       - buildSrc/src/main/kotlin/Ktor2.kt
       - buildSrc/src/main/kotlin/MockK.kt
       - buildSrc/src/main/kotlin/NavFelles.kt
+      - buildSrc/src/main/kotlin/Prometheus
       - buildSrc/src/main/kotlin/TestContainer.kt
 
 jobs:

--- a/.github/workflows/app-etterlatte-brev-api.yaml
+++ b/.github/workflows/app-etterlatte-brev-api.yaml
@@ -29,6 +29,7 @@ on:
       - buildSrc/src/main/kotlin/Micrometer.kt
       - buildSrc/src/main/kotlin/MockK.kt
       - buildSrc/src/main/kotlin/NavFelles.kt
+      - buildSrc/src/main/kotlin/Prometheus
       - buildSrc/src/main/kotlin/TestContainer.kt
   pull_request:
     branches:
@@ -48,6 +49,7 @@ on:
       - buildSrc/src/main/kotlin/Micrometer.kt
       - buildSrc/src/main/kotlin/MockK.kt
       - buildSrc/src/main/kotlin/NavFelles.kt
+      - buildSrc/src/main/kotlin/Prometheus
       - buildSrc/src/main/kotlin/TestContainer.kt
 
 jobs:

--- a/.github/workflows/app-etterlatte-grunnlag.yaml
+++ b/.github/workflows/app-etterlatte-grunnlag.yaml
@@ -27,6 +27,7 @@ on:
       - buildSrc/src/main/kotlin/Ktor2.kt
       - buildSrc/src/main/kotlin/MockK.kt
       - buildSrc/src/main/kotlin/NavFelles.kt
+      - buildSrc/src/main/kotlin/Prometheus
   pull_request:
     branches:
       - main
@@ -43,6 +44,7 @@ on:
       - buildSrc/src/main/kotlin/Ktor2.kt
       - buildSrc/src/main/kotlin/MockK.kt
       - buildSrc/src/main/kotlin/NavFelles.kt
+      - buildSrc/src/main/kotlin/Prometheus
 
 jobs:
   test:

--- a/.github/workflows/app-etterlatte-vedtaksvurdering.yaml
+++ b/.github/workflows/app-etterlatte-vedtaksvurdering.yaml
@@ -30,6 +30,7 @@ on:
       - buildSrc/src/main/kotlin/Micrometer.kt
       - buildSrc/src/main/kotlin/MockK.kt
       - buildSrc/src/main/kotlin/NavFelles.kt
+      - buildSrc/src/main/kotlin/Prometheus
   pull_request:
     branches:
       - main
@@ -49,6 +50,7 @@ on:
       - buildSrc/src/main/kotlin/Micrometer.kt
       - buildSrc/src/main/kotlin/MockK.kt
       - buildSrc/src/main/kotlin/NavFelles.kt
+      - buildSrc/src/main/kotlin/Prometheus
 jobs:
   test:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/app-etterlatte-vilkaarsvurdering.yaml
+++ b/.github/workflows/app-etterlatte-vilkaarsvurdering.yaml
@@ -28,6 +28,7 @@ on:
       - buildSrc/src/main/kotlin/Ktor2.kt
       - buildSrc/src/main/kotlin/MockK.kt
       - buildSrc/src/main/kotlin/NavFelles.kt
+      - buildSrc/src/main/kotlin/Prometheus
   pull_request:
     branches:
       - main
@@ -39,6 +40,13 @@ on:
       - libs/etterlatte-database/**
       - libs/ktor2client-onbehalfof/**
       - libs/testdata/**
+      - buildSrc/src/main/kotlin/Database.kt
+      - buildSrc/src/main/kotlin/Jackson.kt
+      - buildSrc/src/main/kotlin/Kotest.kt
+      - buildSrc/src/main/kotlin/Ktor2.kt
+      - buildSrc/src/main/kotlin/MockK.kt
+      - buildSrc/src/main/kotlin/NavFelles.kt
+      - buildSrc/src/main/kotlin/Prometheus
 
 jobs:
   test:

--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -25,6 +25,9 @@ spec:
     initialDelay: 5
     path: /health/isready
   leaderElection: true
+  prometheus:
+    enabled: true
+    path: /metrics
   azure:
     application:
       enabled: true

--- a/apps/etterlatte-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-behandling/.nais/prod.yaml
@@ -41,6 +41,9 @@ spec:
     initialDelay: 5
     path: /health/isready
   leaderElection: true
+  prometheus:
+    enabled: true
+    path: /metrics
   azure:
     application:
       enabled: true

--- a/apps/etterlatte-beregning/.nais/dev.yaml
+++ b/apps/etterlatte-beregning/.nais/dev.yaml
@@ -16,6 +16,9 @@ spec:
   readiness:
     initialDelay: 5
     path: /health/isready
+  prometheus:
+    enabled: true
+    path: /metrics
   secureLogs:
     enabled: true
   replicas:

--- a/apps/etterlatte-beregning/.nais/prod.yaml
+++ b/apps/etterlatte-beregning/.nais/prod.yaml
@@ -16,6 +16,9 @@ spec:
   readiness:
     initialDelay: 5
     path: /health/isready
+  prometheus:
+    enabled: true
+    path: /metrics
   secureLogs:
     enabled: true
   replicas:

--- a/apps/etterlatte-brev-api/.nais/dev.yaml
+++ b/apps/etterlatte-brev-api/.nais/dev.yaml
@@ -18,6 +18,9 @@ spec:
   readiness:
     initialDelay: 5
     path: /health/isready
+  prometheus:
+    enabled: true
+    path: /metrics
   secureLogs:
     enabled: true
   gcp:

--- a/apps/etterlatte-brev-api/.nais/prod.yaml
+++ b/apps/etterlatte-brev-api/.nais/prod.yaml
@@ -18,6 +18,9 @@ spec:
   readiness:
     initialDelay: 5
     path: /health/isready
+  prometheus:
+    enabled: true
+    path: /metrics
   secureLogs:
     enabled: true
   gcp:

--- a/apps/etterlatte-grunnlag/.nais/dev.yaml
+++ b/apps/etterlatte-grunnlag/.nais/dev.yaml
@@ -32,6 +32,9 @@ spec:
     failureThreshold: 10
     periodSeconds: 5
     path: /isready
+  prometheus:
+    enabled: true
+    path: /metrics
   secureLogs:
     enabled: true
   azure:

--- a/apps/etterlatte-grunnlag/.nais/prod.yaml
+++ b/apps/etterlatte-grunnlag/.nais/prod.yaml
@@ -44,6 +44,9 @@ spec:
     failureThreshold: 10
     periodSeconds: 5
     path: /isready
+  prometheus:
+    enabled: true
+    path: /metrics
   secureLogs:
     enabled: true
   azure:

--- a/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
@@ -27,6 +27,9 @@ spec:
   readiness:
     initialDelay: 5
     path: /isready
+  prometheus:
+    enabled: true
+    path: /metrics
   secureLogs:
     enabled: true
   azure:

--- a/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
@@ -39,6 +39,9 @@ spec:
   readiness:
     initialDelay: 5
     path: /isready
+  prometheus:
+    enabled: true
+    path: /metrics
   secureLogs:
     enabled: true
   azure:

--- a/buildSrc/src/main/kotlin/Prometheus.kt
+++ b/buildSrc/src/main/kotlin/Prometheus.kt
@@ -1,0 +1,4 @@
+object Prometheus {
+    const val SimpleClientCommon = "io.prometheus:simpleclient_common:0.16.0"
+    const val SimpleClientHotspot = "io.prometheus:simpleclient_hotspot:0.16.0"
+}

--- a/libs/etterlatte-ktor/build.gradle.kts
+++ b/libs/etterlatte-ktor/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
 
     implementation(NavFelles.TokenValidationKtor2)
 
+    implementation(Prometheus.SimpleClientCommon)
+    implementation(Prometheus.SimpleClientHotspot)
+
     testImplementation(Jupiter.Engine)
     testImplementation(Ktor2.ServerTests)
     testImplementation(NavFelles.MockOauth2Server)

--- a/libs/etterlatte-ktor/src/main/kotlin/MetricsRoute.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/MetricsRoute.kt
@@ -1,0 +1,22 @@
+package no.nav.etterlatte.libs.ktor
+
+import io.ktor.http.ContentType
+import io.ktor.server.application.call
+import io.ktor.server.response.respondTextWriter
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.prometheus.client.CollectorRegistry
+import io.prometheus.client.exporter.common.TextFormat
+import io.prometheus.client.hotspot.DefaultExports
+
+fun Route.metrics() {
+    DefaultExports.initialize()
+
+    get("/metrics") {
+        val names = call.request.queryParameters.getAll("name[]")?.toSet() ?: emptySet()
+
+        call.respondTextWriter(ContentType.parse(TextFormat.CONTENT_TYPE_004)) {
+            TextFormat.write004(this, CollectorRegistry.defaultRegistry.filteredMetricFamilySamples(names))
+        }
+    }
+}

--- a/libs/etterlatte-ktor/src/main/kotlin/RestModule.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/RestModule.kt
@@ -6,6 +6,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.jackson.JacksonConverter
 import io.ktor.server.application.Application
+import io.ktor.server.application.call
 import io.ktor.server.application.install
 import io.ktor.server.application.log
 import io.ktor.server.auth.Authentication
@@ -20,6 +21,7 @@ import io.ktor.server.request.path
 import io.ktor.server.response.respond
 import io.ktor.server.routing.IgnoreTrailingSlash
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import no.nav.etterlatte.libs.common.logging.CORRELATION_ID
@@ -71,6 +73,7 @@ fun Application.restModule(
                 routes()
             }
         }
+        metrics()
     }
 }
 

--- a/libs/etterlatte-ktor/src/test/kotlin/RestModuleTest.kt
+++ b/libs/etterlatte-ktor/src/test/kotlin/RestModuleTest.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.libs.ktor
 
 import com.fasterxml.jackson.databind.JsonMappingException
+import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
@@ -139,6 +140,22 @@ class RestModuleTest {
 
         assertTrue(jacksonException.erDeserialiseringsException())
         assertTrue(wrappedException.erDeserialiseringsException())
+    }
+
+    @Test
+    fun `metrics test`() {
+        testApplication {
+            application {
+                restModule(this.log) { route1() }
+            }
+
+            client.get("/metrics").also {
+                val body: String = it.body()
+
+                assertEquals(OK, it.status)
+                assertTrue(body.contains("HELP"))
+            }
+        }
     }
 
     private fun Route.route1() {


### PR DESCRIPTION
Må støtte alle apps som bruker etterlatte-ktor sin restModule()

### Legg inn avhengighet til etterlatte-ktor til Prometheus sin simple client hotspot bibliotek

vi har flere prometheus simple client biblioteker på versjon 0.16 fra transitive - men - må dra inn prometheus client hotspot for å få tak i DefaultExports

### Legg inn prometheus config i .nais yaml i hver av appene som bruker restModule

VI har 6 apps som bruker restModule. En hadde allerede spec klausul fra før av selv om det ikke var i bruk - så dette legge til i de andre

* etterlatte-behandling
* etterlatte-beregning
* etterlatte-brev-api
* etterlatte-grunnlag
* etterlatte-vedtaksvurdering
* etterlatte-vilkaarsvurdering (hadde det i .nais yaml allerede)

### Kall DefaultExports.initialize() i restModule()

Gjort i Route.metrics() slik at vi kan teste det separat