### PR TITLE
EY-1667 204 på soeskenjustering dersom den ikke finnes (i steden for 404)

### DIFF
--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagRoutes.kt
@@ -40,13 +40,14 @@ fun Route.grunnlagRoute(grunnlagService: GrunnlagService) {
         }
 
         get("{sakId}/{opplysningType}") {
-            val grunnlag = grunnlagService.hentGrunnlagAvType(
-                call.parameters["sakId"]!!.toLong(),
-                Opplysningstype.valueOf(call.parameters["opplysningType"].toString())
-            )
+            val opplysningstype = Opplysningstype.valueOf(call.parameters["opplysningType"].toString())
+            val sakId = call.parameters["sakId"]!!.toLong()
+            val grunnlag = grunnlagService.hentGrunnlagAvType(sakId, opplysningstype)
 
             if (grunnlag != null) {
                 call.respond(grunnlag)
+            } else if (opplysningstype == Opplysningstype.SOESKEN_I_BEREGNINGEN) {
+                call.respond(HttpStatusCode.NoContent)
             } else {
                 call.respond(HttpStatusCode.NotFound)
             }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Beregningsgrunnlag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Beregningsgrunnlag.tsx
@@ -45,7 +45,7 @@ const Beregningsgrunnlag = () => {
 
   useEffect(() => {
     hentBeregningsgrunnlag(behandling.sak, (result) => {
-      setValue('beregningsgrunnlag', result.opplysning.beregningsgrunnlag)
+      setValue('beregningsgrunnlag', result?.opplysning?.beregningsgrunnlag ?? [])
     })
   }, [])
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenken/Oppgavebenken.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenken/Oppgavebenken.tsx
@@ -15,7 +15,8 @@ import { kolonner } from './OppgaveKolonner'
 import { initialOppgaveFelter, IOppgaveFelter } from './typer/oppgavefelter'
 import { hentOppgaver, OppgaveDTO } from '~shared/api/oppgaver'
 import Spinner from '~shared/Spinner'
-import { isSuccess, isPending, useApiCall } from '~shared/hooks/useApiCall'
+import { mapApiResult, useApiCall } from '~shared/hooks/useApiCall'
+import { ApiErrorAlert } from '~ErrorBoundary'
 
 const OppgavebenkContainer = styled.div`
   max-width: 60em;
@@ -42,9 +43,7 @@ const Oppgavebenken = () => {
       .map((felt) => ({ id: felt.noekkel, value: setValue(felt.filter?.selectedValue) }))
   }
 
-  useEffect(() => {
-    fetchOppgaver({})
-  }, [])
+  useEffect(() => fetchOppgaver({}), [])
 
   const columns: ReadonlyArray<Column<IOppgave>> = React.useMemo(() => kolonner, [])
 
@@ -57,14 +56,22 @@ const Oppgavebenken = () => {
           setGlobalFilter={setGlobalFilter}
           henterOppgaver={() => fetchOppgaver({})}
         />
-        <Spinner visible={isPending(oppgaver)} label={'Laster oppgaver'} />
-        {isSuccess(oppgaver) && (
-          <OppgaveListe
-            columns={columns}
-            data={oppgaver.data.oppgaver.map(mapOppgaveResponse)}
-            globalFilterValue={globalFilter}
-            filterPar={filterPar}
-          />
+        {mapApiResult(
+          oppgaver,
+          () => (
+            <Spinner visible={true} label={'Laster oppgaver'} />
+          ),
+          () => (
+            <ApiErrorAlert>Kunne ikke hente oppgaver</ApiErrorAlert>
+          ),
+          (data) => (
+            <OppgaveListe
+              columns={columns}
+              data={data.oppgaver.map(mapOppgaveResponse)}
+              globalFilterValue={globalFilter}
+              filterPar={filterPar}
+            />
+          )
         )}
       </>
     </OppgavebenkContainer>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/grunnlag.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/grunnlag.ts
@@ -13,6 +13,6 @@ export const lagreSoeskenMedIBeregning = async (args: {
 
 export const hentSoeskenMedIBeregning = async (
   sakId: number
-): Promise<ApiResponse<Grunnlagsopplysning<Soeskenjusteringsgrunnlag, KildePdl>>> => {
+): Promise<ApiResponse<Grunnlagsopplysning<Soeskenjusteringsgrunnlag | null, KildePdl>>> => {
   return apiClient.get(`/grunnlag/${sakId}/SOESKEN_I_BEREGNINGEN`)
 }


### PR DESCRIPTION
Enkel PR for å unngå 404 ved henting av søskenjustering på en helt ny sak. Dersom søskenjustering ikke er gjort av en saksbehandler _enda_ så er det mer rett å returnere 204 Success enn en failure. Per nå sjekkes det om det er søskenjustering man forsøker å hente ut fra grunnlag for å returnere 204 bare for å unngå å fucke opp evt andre integrasjoner mot endepunktet. Tanken er uansett å flytte ut Søskenjustering fra Grunnlag-db til Beregning-db (https://jira.adeo.no/browse/EY-1618)

To:
![image](https://user-images.githubusercontent.com/6595794/217209554-1c844e0a-1b8a-492a-a530-b738a4da6ee1.png)
