### PR TITLE
EY-1621: Dependabot også på dei spesifikke klient- og server-avhengnadane

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,16 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+  - package-ecosystem: "npm"
+    directory: "/apps/etterlatte-saksbehandling-ui/client"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "npm"
+    directory: "/apps/etterlatte-saksbehandling-ui/server"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Ser at dependabot no lager PRs på frontend-avhengnadane som ligg deklarert rett i felles-package.json, men ikkje dei som er spesifikt definert for klient og server, så prøver meg på å tvinge dependabot til å sjå der også