### PR TITLE
Fjerner seekToBeginning når rapids starter opp i fordeler

### DIFF
--- a/apps/etterlatte-fordeler/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-fordeler/src/main/kotlin/Application.kt
@@ -28,9 +28,7 @@ fun main() {
         put("KAFKA_CONSUMER_GROUP_ID", requireNotNull(get("NAIS_APP_NAME")).replace("-", ""))
     }
 
-    RapidApplication.create(env) { _, kafkaRapid ->
-        kafkaRapid.seekToBeginning()
-    }
+    RapidApplication.create(env)
         .also {
             Fordeler(
                 rapidsConnection = it,


### PR DESCRIPTION
For å unngå at fordeler leser alle historiske kafka-meldinger og feiler på disse da de har gått ut på tid, må vi fjerne `seekToBeginning`. Dette ble lagt inn i forbindelse med statistikk-innhenting tidligere.

EY-1677