### PR TITLE
EY-1174 Lagrer ned beregning for stønad og saksstatistikk

### DIFF
--- a/apps/etterlatte-beregning/.nais/dev.yaml
+++ b/apps/etterlatte-beregning/.nais/dev.yaml
@@ -62,3 +62,4 @@ spec:
         - application: etterlatte-brev-api
         - application: etterlatte-vedtaksvurdering
         - application: etterlatte-behandling
+        - application: etterlatte-statistikk

--- a/apps/etterlatte-beregning/.nais/prod.yaml
+++ b/apps/etterlatte-beregning/.nais/prod.yaml
@@ -74,3 +74,4 @@ spec:
         - application: etterlatte-brev-api
         - application: etterlatte-vedtaksvurdering
         - application: etterlatte-behandling
+        - application: etterlatte-statistikk

--- a/apps/etterlatte-statistikk/.nais/dev.yaml
+++ b/apps/etterlatte-statistikk/.nais/dev.yaml
@@ -35,7 +35,10 @@ spec:
       value: etterlatte.dodsmelding
     - name: BEHANDLING_AZURE_SCOPE
       value: api://dev-gcp.etterlatte.etterlatte-behandling/.default
+    - name: BEREGNING_AZURE_SCOPE
+      value: api://dev-gcp.etterlatte.etterlatte-beregning/.default
   accessPolicy:
     outbound:
       rules:
         - application: etterlatte-behandling
+        - application: etterlatte-beregning

--- a/apps/etterlatte-statistikk/.nais/prod.yaml
+++ b/apps/etterlatte-statistikk/.nais/prod.yaml
@@ -46,7 +46,9 @@ spec:
     - name: KAFKA_RAPID_TOPIC
       value: etterlatte.etterlatteytelser
     - name: BEHANDLING_AZURE_SCOPE
-      value: api://dev-gcp.etterlatte.etterlatte-behandling/.default
+      value: api://prod-gcp.etterlatte.etterlatte-behandling/.default
+    - name: BEREGNING_AZURE_SCOPE
+      value: api://prod-gcp.etterlatte.etterlatte-beregning/.default
   accessPolicy:
     outbound:
       rules:

--- a/apps/etterlatte-statistikk/.nais/prod.yaml
+++ b/apps/etterlatte-statistikk/.nais/prod.yaml
@@ -51,3 +51,4 @@ spec:
     outbound:
       rules:
         - application: etterlatte-behandling
+        - application: etterlatte-beregning

--- a/apps/etterlatte-statistikk/build.gradle.kts
+++ b/apps/etterlatte-statistikk/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     implementation(project(":libs:common"))
     implementation(project(":libs:ktor2client-auth-clientcredentials"))
     implementation(project(":libs:etterlatte-database"))
+    implementation(project(":libs:etterlatte-ktor"))
 
     implementation(Ktor2.ClientCore)
 

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/clients/BehandlingKlient.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/clients/BehandlingKlient.kt
@@ -6,15 +6,18 @@ import io.ktor.client.request.get
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.sak.Sak
-import java.util.UUID
+import java.util.*
 
-interface BehandlingClient {
+interface BehandlingKlient {
     suspend fun hentPersongalleri(behandlingId: UUID): Persongalleri
     suspend fun hentDetaljertBehandling(behandlingId: UUID): DetaljertBehandling
     suspend fun hentSak(sakId: Long): Sak
 }
 
-class BehandlingClientImpl(private val behandlingHttpClient: HttpClient) : BehandlingClient {
+class BehandlingKlientImpl(
+    private val behandlingHttpClient: HttpClient,
+    private val behandlingUrl: String
+) : BehandlingKlient {
 
     override suspend fun hentPersongalleri(behandlingId: UUID): Persongalleri {
         return hentDetaljertBehandling(behandlingId).toPersongalleri()
@@ -22,7 +25,7 @@ class BehandlingClientImpl(private val behandlingHttpClient: HttpClient) : Behan
 
     override suspend fun hentDetaljertBehandling(behandlingId: UUID): DetaljertBehandling {
         return try {
-            behandlingHttpClient.get("behandlinger/$behandlingId")
+            behandlingHttpClient.get("$behandlingUrl/api/behandlinger/$behandlingId")
                 .body()
         } catch (e: Exception) {
             throw KunneIkkeHenteFraBehandling("Kunne ikke hente behandling med id $behandlingId fra Behandling", e)
@@ -31,7 +34,7 @@ class BehandlingClientImpl(private val behandlingHttpClient: HttpClient) : Behan
 
     override suspend fun hentSak(sakId: Long): Sak {
         return try {
-            behandlingHttpClient.get("saker/$sakId")
+            behandlingHttpClient.get("$behandlingUrl/api/saker/$sakId")
                 .body()
         } catch (e: Exception) {
             throw KunneIkkeHenteFraBehandling("Kunne ikke hente sak med id $sakId fra Behandling", e)

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/clients/BehandlingKlient.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/clients/BehandlingKlient.kt
@@ -25,7 +25,7 @@ class BehandlingKlientImpl(
 
     override suspend fun hentDetaljertBehandling(behandlingId: UUID): DetaljertBehandling {
         return try {
-            behandlingHttpClient.get("$behandlingUrl/api/behandlinger/$behandlingId")
+            behandlingHttpClient.get("$behandlingUrl/behandlinger/$behandlingId")
                 .body()
         } catch (e: Exception) {
             throw KunneIkkeHenteFraBehandling("Kunne ikke hente behandling med id $behandlingId fra Behandling", e)
@@ -34,7 +34,7 @@ class BehandlingKlientImpl(
 
     override suspend fun hentSak(sakId: Long): Sak {
         return try {
-            behandlingHttpClient.get("$behandlingUrl/api/saker/$sakId")
+            behandlingHttpClient.get("$behandlingUrl/saker/$sakId")
                 .body()
         } catch (e: Exception) {
             throw KunneIkkeHenteFraBehandling("Kunne ikke hente sak med id $sakId fra Behandling", e)

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/clients/BeregningClient.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/clients/BeregningClient.kt
@@ -1,0 +1,31 @@
+package no.nav.etterlatte.statistikk.clients
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import no.nav.etterlatte.libs.common.beregning.BeregningDTO
+import no.nav.etterlatte.statistikk.domain.Beregning
+import java.util.*
+
+interface BeregningClient {
+    suspend fun hentBeregningForVedtak(behandlingId: UUID): Beregning
+}
+
+class BeregningClientImpl(private val beregningHttpClient: HttpClient) : BeregningClient {
+    override suspend fun hentBeregningForVedtak(behandlingId: UUID): Beregning {
+        return try {
+            beregningHttpClient.get("api/beregning/$behandlingId") // TODO fix url her
+                .body<BeregningDTO>()
+                .let { Beregning.fraBeregningDTO(it) }
+        } catch (e: Exception) {
+            throw KunneIkkeHenteFraBeregning(
+                "Kunne ikke hente beregningen for behandlingen med id=$behandlingId " +
+                    "fra beregning",
+                e
+            )
+        }
+    }
+}
+
+class KunneIkkeHenteFraBeregning(override val message: String, override val cause: Throwable) :
+    Exception(message, cause)

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/clients/BeregningKlient.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/clients/BeregningKlient.kt
@@ -7,14 +7,17 @@ import no.nav.etterlatte.libs.common.beregning.BeregningDTO
 import no.nav.etterlatte.statistikk.domain.Beregning
 import java.util.*
 
-interface BeregningClient {
-    suspend fun hentBeregningForVedtak(behandlingId: UUID): Beregning
+interface BeregningKlient {
+    suspend fun hentBeregningForBehandling(behandlingId: UUID): Beregning
 }
 
-class BeregningClientImpl(private val beregningHttpClient: HttpClient) : BeregningClient {
-    override suspend fun hentBeregningForVedtak(behandlingId: UUID): Beregning {
+class BeregningKlientImpl(
+    private val beregningHttpClient: HttpClient,
+    private val beregningUrl: String
+) : BeregningKlient {
+    override suspend fun hentBeregningForBehandling(behandlingId: UUID): Beregning {
         return try {
-            beregningHttpClient.get("api/beregning/$behandlingId") // TODO fix url her
+            beregningHttpClient.get("$beregningUrl/api/beregning/$behandlingId")
                 .body<BeregningDTO>()
                 .let { Beregning.fraBeregningDTO(it) }
         } catch (e: Exception) {

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/config/ApplicationContext.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/config/ApplicationContext.kt
@@ -19,10 +19,8 @@ import no.nav.etterlatte.statistikk.clients.BehandlingClient
 import no.nav.etterlatte.statistikk.clients.BehandlingClientImpl
 import no.nav.etterlatte.statistikk.clients.BeregningClient
 import no.nav.etterlatte.statistikk.clients.BeregningClientImpl
-import no.nav.etterlatte.statistikk.database.DataSourceBuilder
 import no.nav.etterlatte.statistikk.database.SakRepository
 import no.nav.etterlatte.statistikk.database.StoenadRepository
-import no.nav.etterlatte.statistikk.domain.StoenadRad
 import no.nav.etterlatte.statistikk.river.BehandlinghendelseRiver
 import no.nav.etterlatte.statistikk.river.VedtakhendelserRiver
 import no.nav.etterlatte.statistikk.service.StatistikkService
@@ -34,7 +32,7 @@ class ApplicationContext {
     private val env = System.getenv()
     val rapidsConnection: RapidsConnection = RapidApplication.create(env.withConsumerGroupId())
 
-    val statistikkService: StatistikkService by lazy {
+    private val statistikkService: StatistikkService by lazy {
         StatistikkService(statistikkRepository, sakstatistikkRepository, behandlingClient, beregningClient)
     }
 
@@ -51,7 +49,7 @@ class ApplicationContext {
     }
 
     private val statistikkRepository: StoenadRepository by lazy {
-        StoenadRad(datasource)
+        StoenadRepository(datasource)
     }
 
     private val sakstatistikkRepository: SakRepository by lazy {

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/database/SakRepository.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/database/SakRepository.kt
@@ -91,7 +91,8 @@ class SakRepository(private val datasource: DataSource) {
             SELECT id, behandling_id, sak_id, mottatt_tid, registrert_tid, ferdigbehandlet_tid, vedtak_tid,
                 behandling_type, behandling_status, behandling_resultat, resultat_begrunnelse, behandling_metode,
                 opprettet_av, ansvarlig_beslutter, aktor_id, dato_foerste_utbetaling, teknisk_tid, sak_ytelse,
-                vedtak_loepende_fom, vedtak_loepende_tom, saksbehandler, ansvarlig_enhet, soeknad_format, sak_utland
+                vedtak_loepende_fom, vedtak_loepende_tom, saksbehandler, ansvarlig_enhet, soeknad_format, sak_utland,
+                beregning
             FROM sak
             """.trimIndent()
         )

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/database/StoenadRepository.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/database/StoenadRepository.kt
@@ -2,9 +2,9 @@ package no.nav.etterlatte.statistikk.database
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.libs.common.objectMapper
-import no.nav.etterlatte.libs.database.toList
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toTimestamp
+import no.nav.etterlatte.libs.database.toList
 import no.nav.etterlatte.statistikk.domain.StoenadRad
 import org.postgresql.util.PGobject
 import java.sql.Date
@@ -99,17 +99,19 @@ private fun PreparedStatement.setStoenadRad(stoenadsrad: StoenadRad): PreparedSt
     setString(15, stoenadsrad.attestant)
     setDate(16, Date.valueOf(stoenadsrad.vedtakLoependeFom))
     setDate(17, stoenadsrad.vedtakLoependeTom?.let { Date.valueOf(it) })
+    setJsonb(18, stoenadsrad?.beregning)
 }
 
 private object Queries {
     val insertMedPlaceholders = """INSERT INTO stoenad(
         |   fnrSoeker, fnrForeldre, fnrSoesken, anvendtTrygdetid, nettoYtelse, beregningType, anvendtSats, behandlingId,
-        |   sakId, sakNummer, tekniskTid, sakYtelse, versjon, saksbehandler, attestant, vedtakLoependeFom, vedtakLoependeTom
-        |) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        |   sakId, sakNummer, tekniskTid, sakYtelse, versjon, saksbehandler, attestant, vedtakLoependeFom, 
+        |   vedtakLoependeTom, beregning
+        |) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """.trimMargin()
     val fetchDatapakke = """SELECT id, fnrSoeker, fnrForeldre, 
         |   fnrSoesken, anvendtTrygdetid, nettoYtelse, beregningType, anvendtSats, behandlingId, sakId, sakNummer, 
-        |   tekniskTid, sakYtelse, versjon, saksbehandler, attestant, vedtakLoependeFom, vedtakLoependeTom 
+        |   tekniskTid, sakYtelse, versjon, saksbehandler, attestant, vedtakLoependeFom, vedtakLoependeTom, beregning
         |FROM stoenad
     """.trimMargin()
 }

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/domain/Beregning.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/domain/Beregning.kt
@@ -1,0 +1,61 @@
+package no.nav.etterlatte.statistikk.domain
+
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import java.time.YearMonth
+import java.util.*
+import no.nav.etterlatte.libs.common.beregning.BeregningDTO as CommonBeregningDTO
+import no.nav.etterlatte.libs.common.beregning.Beregningsperiode as CommonBeregningsperiode
+import no.nav.etterlatte.libs.common.beregning.Beregningstype as CommonBeregningstype
+
+enum class Beregningstype {
+    BP;
+
+    companion object {
+
+        fun fraDtoType(dto: CommonBeregningstype) = when (dto) {
+            CommonBeregningstype.BP -> BP
+        }
+    }
+}
+
+data class Beregning(
+    val beregningId: UUID,
+    val behandlingId: UUID,
+    val type: Beregningstype,
+    val beregnetDato: Tidspunkt,
+    val beregningsperioder: List<Beregningsperiode>
+) {
+    companion object {
+
+        fun fraBeregningDTO(dto: CommonBeregningDTO) = Beregning(
+            beregningId = dto.beregningId,
+            behandlingId = dto.behandlingId,
+            type = Beregningstype.fraDtoType(dto.type),
+            beregnetDato = dto.beregnetDato,
+            beregningsperioder = dto.beregningsperioder.map(Beregningsperiode::fraBeregningsperiodeDTO)
+        )
+    }
+}
+
+data class Beregningsperiode(
+    val datoFOM: YearMonth,
+    val datoTOM: YearMonth?,
+    val utbetaltBeloep: Int,
+    val soeskenFlokk: List<String>?,
+    val grunnbelopMnd: Int,
+    val grunnbelop: Int,
+    val trygdetid: Int
+) {
+    companion object {
+
+        fun fraBeregningsperiodeDTO(dto: CommonBeregningsperiode) = Beregningsperiode(
+            datoFOM = dto.datoFOM,
+            datoTOM = dto.datoTOM,
+            utbetaltBeloep = dto.utbetaltBeloep,
+            soeskenFlokk = dto.soeskenFlokk,
+            grunnbelopMnd = dto.grunnbelopMnd,
+            grunnbelop = dto.grunnbelop,
+            trygdetid = dto.trygdetid
+        )
+    }
+}

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/domain/Sak.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/domain/Sak.kt
@@ -1,4 +1,4 @@
-package no.nav.etterlatte.statistikk.sak
+package no.nav.etterlatte.statistikk.domain
 
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -45,5 +45,6 @@ data class SakRad(
     val tekniskTid: Tidspunkt,
     val sakYtelse: String,
     val vedtakLoependeFom: LocalDate?,
-    val vedtakLoependeTom: LocalDate?
+    val vedtakLoependeTom: LocalDate?,
+    val beregning: Beregning?
 )

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/domain/StoenadRad.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/domain/StoenadRad.kt
@@ -1,0 +1,27 @@
+package no.nav.etterlatte.statistikk.domain
+
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import java.time.LocalDate
+import java.util.*
+
+data class StoenadRad(
+    val id: Long,
+    val fnrSoeker: String,
+    val fnrForeldre: List<String>,
+    val fnrSoesken: List<String>,
+    val anvendtTrygdetid: String,
+    val nettoYtelse: String,
+    val beregningType: String,
+    val anvendtSats: String,
+    val behandlingId: UUID,
+    val sakId: Long,
+    val sakNummer: Long,
+    val tekniskTid: Tidspunkt,
+    val sakYtelse: String,
+    val versjon: String,
+    val saksbehandler: String,
+    val attestant: String?,
+    val vedtakLoependeFom: LocalDate,
+    val vedtakLoependeTom: LocalDate?,
+    val beregning: Beregning?
+)

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/service/StatistikkService.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/service/StatistikkService.kt
@@ -8,8 +8,8 @@ import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
 import no.nav.etterlatte.libs.common.vedtak.UtbetalingsperiodeType
 import no.nav.etterlatte.libs.common.vedtak.Vedtak
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
-import no.nav.etterlatte.statistikk.clients.BehandlingClient
-import no.nav.etterlatte.statistikk.clients.BeregningClient
+import no.nav.etterlatte.statistikk.clients.BehandlingKlient
+import no.nav.etterlatte.statistikk.clients.BeregningKlient
 import no.nav.etterlatte.statistikk.database.SakRepository
 import no.nav.etterlatte.statistikk.database.StoenadRepository
 import no.nav.etterlatte.statistikk.domain.BehandlingMetode
@@ -28,8 +28,8 @@ import java.util.*
 class StatistikkService(
     private val stoenadRepository: StoenadRepository,
     private val sakRepository: SakRepository,
-    private val behandlingClient: BehandlingClient,
-    private val beregningClient: BeregningClient
+    private val behandlingKlient: BehandlingKlient,
+    private val beregningKlient: BeregningKlient
 ) {
 
     fun registrerStatistikkForVedtak(
@@ -62,7 +62,7 @@ class StatistikkService(
 
     private fun hentBeregningForBehandling(behandlingId: UUID): Beregning {
         return runBlocking {
-            beregningClient.hentBeregningForVedtak(behandlingId)
+            beregningKlient.hentBeregningForBehandling(behandlingId)
         }
     }
 
@@ -137,15 +137,15 @@ class StatistikkService(
     }
 
     private fun hentDetaljertBehandling(behandlingId: UUID) = runBlocking {
-        behandlingClient.hentDetaljertBehandling(behandlingId)
+        behandlingKlient.hentDetaljertBehandling(behandlingId)
     }
 
     private fun hentPersongalleri(behandlingId: UUID): Persongalleri = runBlocking {
-        behandlingClient.hentPersongalleri(behandlingId)
+        behandlingKlient.hentPersongalleri(behandlingId)
     }
 
     private fun hentSak(sakId: Long) = runBlocking {
-        behandlingClient.hentSak(sakId)
+        behandlingKlient.hentSak(sakId)
     }
 
     private fun vedtakTilStoenadsrad(vedtak: Vedtak, tekniskTid: LocalDateTime): StoenadRad {

--- a/apps/etterlatte-statistikk/src/main/resources/db/migration/V10__add_beregning_column.sql
+++ b/apps/etterlatte-statistikk/src/main/resources/db/migration/V10__add_beregning_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sak ADD COLUMN beregning JSONB;
+ALTER TABLE stoenad ADD COLUMN beregning JSONB;

--- a/apps/etterlatte-statistikk/src/test/kotlin/DBTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/DBTest.kt
@@ -4,21 +4,24 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.database.migrate
-import no.nav.etterlatte.statistikk.database.DataSourceBuilder
 import no.nav.etterlatte.statistikk.database.SakRepository
 import no.nav.etterlatte.statistikk.database.StoenadRepository
 import no.nav.etterlatte.statistikk.domain.BehandlingMetode
+import no.nav.etterlatte.statistikk.domain.Beregning
+import no.nav.etterlatte.statistikk.domain.Beregningstype
 import no.nav.etterlatte.statistikk.domain.SakRad
 import no.nav.etterlatte.statistikk.domain.SakUtland
 import no.nav.etterlatte.statistikk.domain.StoenadRad
 import no.nav.etterlatte.statistikk.service.VedtakHendelse
 import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
+import java.time.Instant
 import java.time.LocalDate
 import java.util.*
 import javax.sql.DataSource
@@ -46,15 +49,69 @@ internal class DBTest {
         dataSource.migrate(gcp = false)
     }
 
+    val mockBeregning = Beregning(
+        beregningId = UUID.randomUUID(),
+        behandlingId = UUID.randomUUID(),
+        type = Beregningstype.BP,
+        beregnetDato = Tidspunkt(instant = Instant.now()),
+        beregningsperioder = listOf()
+    )
+
     @AfterAll
     fun afterAll() {
         postgreSQLContainer.stop()
     }
 
+    @AfterEach
+    fun afterEach() {
+        dataSource.connection.prepareStatement("TRUNCATE TABLE sak")
+            .executeUpdate()
+        dataSource.connection.prepareStatement("TRUNCATE TABLE stoenad")
+            .executeUpdate()
+    }
+
     @Test
-    fun testStatitstikkRepo() {
+    fun testStoenadRepository() {
         val repo = StoenadRepository.using(dataSource)
         repo.lagreStoenadsrad(
+            StoenadRad(
+                id = -1,
+                fnrSoeker = "123",
+                fnrForeldre = listOf("23427249697", "18458822782"),
+                fnrSoesken = listOf(),
+                anvendtTrygdetid = "40",
+                nettoYtelse = "1000",
+                beregningType = "FOLKETRYGD",
+                anvendtSats = "0,4G",
+                behandlingId = UUID.randomUUID(),
+                sakId = 5,
+                sakNummer = 5,
+                tekniskTid = Tidspunkt.now(),
+                sakYtelse = "BP",
+                versjon = "42",
+                saksbehandler = "Berit Behandler",
+                attestant = "Arne Attestant",
+                vedtakLoependeFom = LocalDate.now(),
+                vedtakLoependeTom = null,
+                beregning = mockBeregning
+            )
+        )
+        repo.datapakke().also {
+            Assertions.assertEquals(1, it.size)
+            val stoenadRad = it.first()
+            Assertions.assertEquals(5, stoenadRad.sakId)
+            Assertions.assertEquals(
+                stoenadRad.fnrForeldre,
+                listOf("23427249697", "18458822782")
+            )
+            Assertions.assertEquals(stoenadRad.beregning, mockBeregning)
+        }
+    }
+
+    @Test
+    fun `stoenadRepository lagrer ned og henter ut null for beregning riktig`() {
+        val repo = StoenadRepository.using(dataSource)
+        val lagretRad = repo.lagreStoenadsrad(
             StoenadRad(
                 id = -1,
                 fnrSoeker = "123",
@@ -77,15 +134,10 @@ internal class DBTest {
                 beregning = null
             )
         )
-        repo.datapakke().also {
-            Assertions.assertEquals(1, it.size)
-            val stoenadRad = it.first()
-            Assertions.assertEquals(5, stoenadRad.sakId)
-            Assertions.assertEquals(
-                stoenadRad.fnrForeldre,
-                listOf("23427249697", "18458822782")
-            )
-        }
+
+        Assertions.assertNotNull(lagretRad)
+        Assertions.assertNull(lagretRad?.beregning)
+        Assertions.assertNull(repo.datapakke()[0].beregning)
     }
 
     @Test
@@ -117,10 +169,48 @@ internal class DBTest {
                 ansvarligEnhet = "en enhet",
                 soeknadFormat = null,
                 sakUtland = SakUtland.NASJONAL,
-                beregning = null
+                beregning = mockBeregning
             )
         )
 
         Assertions.assertEquals(repo.hentRader()[0], lagretRad)
+        Assertions.assertEquals(lagretRad?.beregning, mockBeregning)
+    }
+
+    @Test
+    fun `sakRepository lagrer ned og henter ut null for beregning riktig`() {
+        val repo = SakRepository.using(dataSource)
+        val lagretRad = repo.lagreRad(
+            SakRad(
+                id = -2,
+                behandlingId = UUID.randomUUID(),
+                sakId = 1337,
+                mottattTidspunkt = Tidspunkt.now(),
+                registrertTidspunkt = Tidspunkt.now(),
+                ferdigbehandletTidspunkt = null,
+                vedtakTidspunkt = null,
+                behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                behandlingStatus = VedtakHendelse.IVERKSATT.name,
+                behandlingResultat = null,
+                resultatBegrunnelse = "for en begrunnelse",
+                behandlingMetode = BehandlingMetode.MANUELL,
+                opprettetAv = "test",
+                ansvarligBeslutter = "test testesen",
+                aktorId = "12345678911",
+                datoFoersteUtbetaling = LocalDate.now(),
+                tekniskTid = Tidspunkt.now(),
+                sakYtelse = "En ytelse",
+                vedtakLoependeFom = LocalDate.now(),
+                vedtakLoependeTom = LocalDate.now().plusYears(3),
+                saksbehandler = "en saksbehandler",
+                ansvarligEnhet = "en enhet",
+                soeknadFormat = null,
+                sakUtland = SakUtland.NASJONAL,
+                beregning = null
+            )
+        )
+        Assertions.assertNotNull(lagretRad)
+        Assertions.assertNull(lagretRad?.beregning)
+        Assertions.assertNull(repo.hentRader()[0].beregning)
     }
 }

--- a/apps/etterlatte-statistikk/src/test/kotlin/DBTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/DBTest.kt
@@ -4,12 +4,13 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.database.migrate
-import no.nav.etterlatte.statistikk.database.SakstatistikkRepository
-import no.nav.etterlatte.statistikk.database.StatistikkRepository
-import no.nav.etterlatte.statistikk.database.StoenadRad
-import no.nav.etterlatte.statistikk.sak.BehandlingMetode
-import no.nav.etterlatte.statistikk.sak.SakRad
-import no.nav.etterlatte.statistikk.sak.SakUtland
+import no.nav.etterlatte.statistikk.database.DataSourceBuilder
+import no.nav.etterlatte.statistikk.database.SakRepository
+import no.nav.etterlatte.statistikk.database.StoenadRepository
+import no.nav.etterlatte.statistikk.domain.BehandlingMetode
+import no.nav.etterlatte.statistikk.domain.SakRad
+import no.nav.etterlatte.statistikk.domain.SakUtland
+import no.nav.etterlatte.statistikk.domain.StoenadRad
 import no.nav.etterlatte.statistikk.service.VedtakHendelse
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
@@ -18,7 +19,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
-import java.time.Instant
 import java.time.LocalDate
 import java.util.*
 import javax.sql.DataSource
@@ -53,27 +53,28 @@ internal class DBTest {
 
     @Test
     fun testStatitstikkRepo() {
-        val repo = StatistikkRepository.using(dataSource)
+        val repo = StoenadRepository.using(dataSource)
         repo.lagreStoenadsrad(
             StoenadRad(
-                -1,
-                "123",
-                listOf("23427249697", "18458822782"),
-                listOf(),
-                "40",
-                "1000",
-                "FOLKETRYGD",
-                "0,4G",
-                UUID.randomUUID(),
-                5,
-                5,
-                Instant.now(),
-                "BP",
-                "42",
-                "Berit Behandler",
-                "Arne Attestant",
-                LocalDate.now(),
-                null
+                id = -1,
+                fnrSoeker = "123",
+                fnrForeldre = listOf("23427249697", "18458822782"),
+                fnrSoesken = listOf(),
+                anvendtTrygdetid = "40",
+                nettoYtelse = "1000",
+                beregningType = "FOLKETRYGD",
+                anvendtSats = "0,4G",
+                behandlingId = UUID.randomUUID(),
+                sakId = 5,
+                sakNummer = 5,
+                tekniskTid = Tidspunkt.now(),
+                sakYtelse = "BP",
+                versjon = "42",
+                saksbehandler = "Berit Behandler",
+                attestant = "Arne Attestant",
+                vedtakLoependeFom = LocalDate.now(),
+                vedtakLoependeTom = null,
+                beregning = null
             )
         )
         repo.datapakke().also {
@@ -89,7 +90,7 @@ internal class DBTest {
 
     @Test
     fun testSakRepo() {
-        val repo = SakstatistikkRepository.using(dataSource)
+        val repo = SakRepository.using(dataSource)
         val lagretRad = repo.lagreRad(
             SakRad(
                 id = -2,
@@ -115,7 +116,8 @@ internal class DBTest {
                 saksbehandler = "en saksbehandler",
                 ansvarligEnhet = "en enhet",
                 soeknadFormat = null,
-                sakUtland = SakUtland.NASJONAL
+                sakUtland = SakUtland.NASJONAL,
+                beregning = null
             )
         )
 

--- a/apps/etterlatte-statistikk/src/test/kotlin/statistikk/VedtakhendelserRiverTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/statistikk/VedtakhendelserRiverTest.kt
@@ -4,7 +4,8 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventNameKey
 import no.nav.etterlatte.libs.common.toJson
-import no.nav.etterlatte.statistikk.database.StoenadRad
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.statistikk.domain.StoenadRad
 import no.nav.etterlatte.statistikk.river.VedtakhendelserRiver
 import no.nav.etterlatte.statistikk.service.StatistikkService
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
@@ -12,7 +13,6 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.io.FileNotFoundException
-import java.time.Instant
 import java.time.LocalDate
 import java.util.*
 
@@ -22,7 +22,7 @@ internal class VedtakhendelserRiverTest {
     companion object {
         val melding = readFile("/melding.json")
 
-        fun readFile(file: String) = Companion::class.java.getResource(file)?.readText()
+        private fun readFile(file: String) = Companion::class.java.getResource(file)?.readText()
             ?: throw FileNotFoundException(
                 "Fant ikke filen $file for kjøring av test ${Companion::class.java.canonicalName}"
             )
@@ -44,13 +44,14 @@ internal class VedtakhendelserRiverTest {
         behandlingId = UUID.randomUUID(),
         sakId = 0,
         sakNummer = 0,
-        tekniskTid = Instant.now(),
+        tekniskTid = Tidspunkt.now(),
         sakYtelse = "",
         versjon = "",
         saksbehandler = "",
         attestant = "",
         vedtakLoependeFom = LocalDate.now(),
-        vedtakLoependeTom = null
+        vedtakLoependeTom = null,
+        beregning = null
     )
 
     @Test

--- a/apps/etterlatte-statistikk/src/test/kotlin/statistikk/service/StatistikkServiceTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/statistikk/service/StatistikkServiceTest.kt
@@ -1,0 +1,247 @@
+package statistikk.service
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
+import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
+import no.nav.etterlatte.libs.common.behandling.Persongalleri
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.sak.Sak
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
+import no.nav.etterlatte.libs.common.vedtak.Attestasjon
+import no.nav.etterlatte.libs.common.vedtak.Behandling
+import no.nav.etterlatte.libs.common.vedtak.BilagMedSammendrag
+import no.nav.etterlatte.libs.common.vedtak.Periode
+import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
+import no.nav.etterlatte.libs.common.vedtak.Vedtak
+import no.nav.etterlatte.libs.common.vedtak.VedtakFattet
+import no.nav.etterlatte.libs.common.vedtak.VedtakType
+import no.nav.etterlatte.statistikk.clients.BehandlingClient
+import no.nav.etterlatte.statistikk.clients.BeregningClient
+import no.nav.etterlatte.statistikk.database.SakRepository
+import no.nav.etterlatte.statistikk.database.StoenadRepository
+import no.nav.etterlatte.statistikk.domain.Beregning
+import no.nav.etterlatte.statistikk.domain.Beregningstype
+import no.nav.etterlatte.statistikk.domain.SakUtland
+import no.nav.etterlatte.statistikk.river.BehandlingHendelse
+import no.nav.etterlatte.statistikk.service.StatistikkService
+import no.nav.etterlatte.statistikk.service.VedtakHendelse
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.YearMonth
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.*
+
+class StatistikkServiceTest {
+
+    @Test
+    fun `mapper vedtakhendelse til både sakRad og stoenadRad riktig`() {
+        val behandlingId = UUID.randomUUID()
+        val sakId = 1L
+
+        val stoenadRepo = mockk<StoenadRepository>()
+        every { stoenadRepo.lagreStoenadsrad(any()) } returnsArgument 0
+
+        val sakRepo = mockk<SakRepository>()
+        every { sakRepo.lagreRad(any()) } returnsArgument 0
+
+        val behandlingClient = mockk<BehandlingClient>()
+        coEvery { behandlingClient.hentDetaljertBehandling(behandlingId) } returns DetaljertBehandling(
+            id = behandlingId,
+            sak = sakId,
+            behandlingOpprettet = LocalDateTime.now(),
+            sistEndret = LocalDateTime.now(),
+            soeknadMottattDato = null,
+            innsender = null,
+            soeker = null,
+            gjenlevende = listOf(),
+            avdoed = listOf(),
+            soesken = listOf(),
+            gyldighetsproeving = null,
+            status = BehandlingStatus.FATTET_VEDTAK,
+            behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+            virkningstidspunkt = null,
+            kommerBarnetTilgode = null,
+            revurderingsaarsak = null
+        )
+        coEvery { behandlingClient.hentPersongalleri(behandlingId) } returns Persongalleri(
+            "12312312312"
+        )
+        val mockBeregning = Beregning(
+            beregningId = UUID.randomUUID(),
+            behandlingId = behandlingId,
+            type = Beregningstype.BP,
+            beregnetDato = Tidspunkt(instant = Instant.now()),
+            beregningsperioder = listOf()
+        )
+        val beregningClient = mockk<BeregningClient>()
+        coEvery { beregningClient.hentBeregningForVedtak(behandlingId) } returns mockBeregning
+
+        val service = StatistikkService(
+            stoenadRepository = stoenadRepo,
+            sakRepository = sakRepo,
+            behandlingClient = behandlingClient,
+            beregningClient = beregningClient
+        )
+        val tekniskTidForHendelse = LocalDateTime.of(2023, 2, 1, 8, 30)
+
+        val (registrertSakRad, registrertStoenadRad) = service.registrerStatistikkForVedtak(
+            vedtak = vedtak(
+                sakId = sakId,
+                behandlingId = behandlingId,
+                vedtakFattet = VedtakFattet("Saksbehandler", "saksbehandlerEnhet", ZonedDateTime.now()),
+                attestasjon = Attestasjon("Attestant", "attestantEnhet", ZonedDateTime.now())
+            ),
+            vedtakHendelse = VedtakHendelse.IVERKSATT,
+            tekniskTid = tekniskTidForHendelse
+        )
+
+        // denne gjør at kotlin kan inferre at de ikke er null, så det ikke blir ? i alle assertions under
+        if (registrertStoenadRad == null || registrertSakRad == null) {
+            throw NullPointerException("Stønadrad=$registrertStoenadRad eller sakrad=$registrertSakRad var null")
+        }
+
+        Assertions.assertEquals(registrertSakRad.sakId, sakId)
+        Assertions.assertEquals(registrertSakRad.sakYtelse, "BARNEPENSJON")
+        Assertions.assertEquals(registrertSakRad.sakUtland, SakUtland.NASJONAL)
+        Assertions.assertEquals(registrertSakRad.behandlingId, behandlingId)
+        Assertions.assertEquals(registrertSakRad.tekniskTid, tekniskTidForHendelse.toTidspunkt(ZoneId.of("UTC")))
+        Assertions.assertEquals(registrertSakRad.ansvarligEnhet, "attestantEnhet")
+        Assertions.assertEquals(registrertSakRad.ansvarligBeslutter, "Attestant")
+        Assertions.assertEquals(registrertSakRad.saksbehandler, "Saksbehandler")
+        Assertions.assertEquals(registrertSakRad.beregning, mockBeregning)
+
+        Assertions.assertEquals(registrertStoenadRad.tekniskTid, tekniskTidForHendelse.toTidspunkt(ZoneId.of("UTC")))
+        Assertions.assertEquals(registrertStoenadRad.beregning, mockBeregning)
+        Assertions.assertEquals(registrertStoenadRad.behandlingId, behandlingId)
+        Assertions.assertEquals(registrertStoenadRad.sakId, sakId)
+        Assertions.assertEquals(registrertStoenadRad.attestant, "Attestant")
+        Assertions.assertEquals(registrertStoenadRad.saksbehandler, "Saksbehandler")
+    }
+
+    @Test
+    fun `mapper behandlinghendelse riktig`() {
+        val behandlingId = UUID.randomUUID()
+        val sakId = 1L
+        val stoenadRepo = mockk<StoenadRepository>()
+        every { stoenadRepo.lagreStoenadsrad(any()) } returnsArgument 0
+
+        val sakRepo = mockk<SakRepository>()
+        every { sakRepo.lagreRad(any()) } returnsArgument 0
+
+        val behandlingClient = mockk<BehandlingClient>()
+        coEvery { behandlingClient.hentDetaljertBehandling(behandlingId) } returns DetaljertBehandling(
+            id = behandlingId,
+            sak = sakId,
+            behandlingOpprettet = LocalDateTime.now(),
+            sistEndret = LocalDateTime.now(),
+            soeknadMottattDato = null,
+            innsender = null,
+            soeker = null,
+            gjenlevende = listOf(),
+            avdoed = listOf(),
+            soesken = listOf(),
+            gyldighetsproeving = null,
+            status = BehandlingStatus.OPPRETTET,
+            behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+            virkningstidspunkt = null,
+            kommerBarnetTilgode = null,
+            revurderingsaarsak = null
+        )
+        coEvery { behandlingClient.hentSak(sakId) } returns Sak(
+            ident = "12312312312",
+            sakType = SakType.BARNEPENSJON,
+            id = sakId
+        )
+
+        val beregningClient = mockk<BeregningClient>()
+
+        val service = StatistikkService(
+            stoenadRepository = stoenadRepo,
+            sakRepository = sakRepo,
+            behandlingClient = behandlingClient,
+            beregningClient = beregningClient
+        )
+
+        val tekniskTidForHendelse = LocalDateTime.of(2023, 2, 1, 8, 30)
+        val registrertStatistikk = service.registrerStatistikkForBehandlinghendelse(
+            behandling = behandling(id = behandlingId, sakId = sakId),
+            hendelse = BehandlingHendelse.OPPRETTET,
+            tekniskTid = tekniskTidForHendelse
+        ) ?: throw NullPointerException("Fikk ikke registrert statistikk")
+
+        Assertions.assertEquals(registrertStatistikk.sakId, sakId)
+        Assertions.assertEquals(registrertStatistikk.sakYtelse, "BARNEPENSJON")
+        Assertions.assertEquals(registrertStatistikk.sakUtland, SakUtland.NASJONAL)
+        Assertions.assertEquals(registrertStatistikk.behandlingId, behandlingId)
+        Assertions.assertEquals(registrertStatistikk.tekniskTid, tekniskTidForHendelse.toTidspunkt(ZoneId.of("UTC")))
+        Assertions.assertNull(registrertStatistikk.behandlingMetode)
+        Assertions.assertNull(registrertStatistikk.ansvarligBeslutter)
+        Assertions.assertNull(registrertStatistikk.ansvarligEnhet)
+        Assertions.assertNull(registrertStatistikk.saksbehandler)
+    }
+}
+
+fun vedtak(
+    vedtakId: Long = 0,
+    virk: Periode = Periode(fom = YearMonth.of(2022, 8), null),
+    sakId: Long = 0,
+    ident: String = "",
+    sakType: SakType = SakType.BARNEPENSJON,
+    behandlingId: UUID = UUID.randomUUID(),
+    behandlingType: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+    type: VedtakType = VedtakType.INNVILGELSE,
+    vilkaarsvurdering: JsonNode? = null,
+    beregning: BilagMedSammendrag<List<no.nav.etterlatte.libs.common.vedtak.Beregningsperiode>>? = null,
+    pensjonTilUtbetaling: List<Utbetalingsperiode>? = null,
+    vedtakFattet: VedtakFattet? = null,
+    attestasjon: Attestasjon? = null
+): Vedtak = Vedtak(
+    vedtakId = vedtakId,
+    virk = virk,
+    sak = Sak(ident = ident, sakType = sakType, id = sakId),
+    behandling = Behandling(type = behandlingType, id = behandlingId),
+    type = type,
+    grunnlag = emptyList(),
+    vilkaarsvurdering = vilkaarsvurdering,
+    beregning = beregning,
+    pensjonTilUtbetaling = pensjonTilUtbetaling,
+    vedtakFattet = vedtakFattet,
+    attestasjon = attestasjon
+)
+
+fun behandling(
+    id: UUID = UUID.randomUUID(),
+    sakId: Long = 1L,
+    behandlingOpprettet: LocalDateTime = LocalDateTime.now(),
+    sistEndret: LocalDateTime = LocalDateTime.now(),
+    status: BehandlingStatus = BehandlingStatus.OPPRETTET,
+    type: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+    soeker: String = "12312312312",
+    innsender: String? = null,
+    soesken: List<String> = emptyList(),
+    avdoed: List<String> = emptyList(),
+    gjenlevende: List<String> = emptyList()
+): no.nav.etterlatte.statistikk.river.Behandling = no.nav.etterlatte.statistikk.river.Behandling(
+    id = id,
+    sak = sakId,
+    behandlingOpprettet = behandlingOpprettet,
+    sistEndret = sistEndret,
+    status = status,
+    type = type,
+    persongalleri = Persongalleri(
+        soeker = soeker,
+        innsender = innsender,
+        soesken = soesken,
+        avdoed = avdoed,
+        gjenlevende = gjenlevende
+    )
+
+)

--- a/apps/etterlatte-statistikk/src/test/kotlin/statistikk/service/StatistikkServiceTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/statistikk/service/StatistikkServiceTest.kt
@@ -20,8 +20,8 @@ import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
 import no.nav.etterlatte.libs.common.vedtak.Vedtak
 import no.nav.etterlatte.libs.common.vedtak.VedtakFattet
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
-import no.nav.etterlatte.statistikk.clients.BehandlingClient
-import no.nav.etterlatte.statistikk.clients.BeregningClient
+import no.nav.etterlatte.statistikk.clients.BehandlingKlient
+import no.nav.etterlatte.statistikk.clients.BeregningKlient
 import no.nav.etterlatte.statistikk.database.SakRepository
 import no.nav.etterlatte.statistikk.database.StoenadRepository
 import no.nav.etterlatte.statistikk.domain.Beregning
@@ -52,8 +52,8 @@ class StatistikkServiceTest {
         val sakRepo = mockk<SakRepository>()
         every { sakRepo.lagreRad(any()) } returnsArgument 0
 
-        val behandlingClient = mockk<BehandlingClient>()
-        coEvery { behandlingClient.hentDetaljertBehandling(behandlingId) } returns DetaljertBehandling(
+        val behandlingKlient = mockk<BehandlingKlient>()
+        coEvery { behandlingKlient.hentDetaljertBehandling(behandlingId) } returns DetaljertBehandling(
             id = behandlingId,
             sak = sakId,
             behandlingOpprettet = LocalDateTime.now(),
@@ -71,7 +71,7 @@ class StatistikkServiceTest {
             kommerBarnetTilgode = null,
             revurderingsaarsak = null
         )
-        coEvery { behandlingClient.hentPersongalleri(behandlingId) } returns Persongalleri(
+        coEvery { behandlingKlient.hentPersongalleri(behandlingId) } returns Persongalleri(
             "12312312312"
         )
         val mockBeregning = Beregning(
@@ -81,14 +81,14 @@ class StatistikkServiceTest {
             beregnetDato = Tidspunkt(instant = Instant.now()),
             beregningsperioder = listOf()
         )
-        val beregningClient = mockk<BeregningClient>()
-        coEvery { beregningClient.hentBeregningForVedtak(behandlingId) } returns mockBeregning
+        val beregningKlient = mockk<BeregningKlient>()
+        coEvery { beregningKlient.hentBeregningForBehandling(behandlingId) } returns mockBeregning
 
         val service = StatistikkService(
             stoenadRepository = stoenadRepo,
             sakRepository = sakRepo,
-            behandlingClient = behandlingClient,
-            beregningClient = beregningClient
+            behandlingKlient = behandlingKlient,
+            beregningKlient = beregningKlient
         )
         val tekniskTidForHendelse = LocalDateTime.of(2023, 2, 1, 8, 30)
 
@@ -136,8 +136,8 @@ class StatistikkServiceTest {
         val sakRepo = mockk<SakRepository>()
         every { sakRepo.lagreRad(any()) } returnsArgument 0
 
-        val behandlingClient = mockk<BehandlingClient>()
-        coEvery { behandlingClient.hentDetaljertBehandling(behandlingId) } returns DetaljertBehandling(
+        val behandlingKlient = mockk<BehandlingKlient>()
+        coEvery { behandlingKlient.hentDetaljertBehandling(behandlingId) } returns DetaljertBehandling(
             id = behandlingId,
             sak = sakId,
             behandlingOpprettet = LocalDateTime.now(),
@@ -155,19 +155,19 @@ class StatistikkServiceTest {
             kommerBarnetTilgode = null,
             revurderingsaarsak = null
         )
-        coEvery { behandlingClient.hentSak(sakId) } returns Sak(
+        coEvery { behandlingKlient.hentSak(sakId) } returns Sak(
             ident = "12312312312",
             sakType = SakType.BARNEPENSJON,
             id = sakId
         )
 
-        val beregningClient = mockk<BeregningClient>()
+        val beregningKlient = mockk<BeregningKlient>()
 
         val service = StatistikkService(
             stoenadRepository = stoenadRepo,
             sakRepository = sakRepo,
-            behandlingClient = behandlingClient,
-            beregningClient = beregningClient
+            behandlingKlient = behandlingKlient,
+            beregningKlient = beregningKlient
         )
 
         val tekniskTidForHendelse = LocalDateTime.of(2023, 2, 1, 8, 30)


### PR DESCRIPTION
Dette er nødvendig for stønadsstatistikken for å kunne produsere data på alle aktive ytelser i systemet riktig, og lagres også for saksstatistikk i tilfelle det er nødvendig senere

Setter også opp noen enkle tester for å sjekke at mapping av statistikk er riktig. Sikter på bedre testdekning her etter hvert!