### PR TITLE
Støtte for kjøreplan i konsistensavstemming

### DIFF
--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingJob.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingJob.kt
@@ -56,11 +56,11 @@ class KonsistensavstemmingJob(
 
         fun run() {
             withLogContext {
-                log.info("Starter $jobbNavn")
-
                 val idag = LocalDate.now(clock.withZone(norskTidssone))
                 kjoereplan.find { dato -> dato == idag }?.let {
                     if (leaderElection.isLeader()) {
+                        log.info("Starter $jobbNavn")
+
                         Saktype.values().forEach {
                             when (it) {
                                 Saktype.BARNEPENSJON -> {

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingJob.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingJob.kt
@@ -1,9 +1,11 @@
 package no.nav.etterlatte.utbetaling.avstemming
 
 import no.nav.etterlatte.libs.common.logging.withLogContext
+import no.nav.etterlatte.libs.common.tidspunkt.norskTidssone
 import no.nav.etterlatte.libs.jobs.LeaderElection
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
 import org.slf4j.LoggerFactory
+import java.time.Clock
 import java.time.Duration
 import java.time.LocalDate
 import java.util.*
@@ -11,9 +13,11 @@ import kotlin.concurrent.fixedRateTimer
 
 class KonsistensavstemmingJob(
     private val konsistensavstemmingService: KonsistensavstemmingService,
+    private val kjoereplan: Set<LocalDate>,
     private val leaderElection: LeaderElection,
     private val initialDelay: Long,
-    private val periode: Duration
+    private val periode: Duration,
+    private val clock: Clock
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
     private val jobbNavn = this::class.simpleName
@@ -30,8 +34,10 @@ class KonsistensavstemmingJob(
             try {
                 Konsistensavstemming(
                     konsistensavstemmingService = konsistensavstemmingService,
+                    kjoereplan = kjoereplan,
                     leaderElection = leaderElection,
-                    jobbNavn = jobbNavn!!
+                    jobbNavn = jobbNavn!!,
+                    clock = clock
                 ).run()
             } catch (throwable: Throwable) {
                 logger.error("Konsistensavstemming feilet", throwable)
@@ -41,36 +47,41 @@ class KonsistensavstemmingJob(
 
     class Konsistensavstemming(
         val konsistensavstemmingService: KonsistensavstemmingService,
+        val kjoereplan: Set<LocalDate>,
         val leaderElection: LeaderElection,
-        val jobbNavn: String
+        val jobbNavn: String,
+        val clock: Clock
     ) {
         private val log = LoggerFactory.getLogger(this::class.java)
 
         fun run() {
-            log.info("Starter $jobbNavn")
-            val idag = LocalDate.now()
             withLogContext {
-                if (leaderElection.isLeader()) {
-                    Saktype.values().forEach {
-                        when (it) {
-                            Saktype.BARNEPENSJON -> {
-                                if (!konsistensavstemmingService.konsistensavstemmingErKjoertIDag(
-                                        saktype = it,
-                                        idag = idag
-                                    )
-                                ) {
-                                    konsistensavstemmingService.startKonsistensavstemming(dag = idag, saktype = it)
-                                } else {
-                                    log.info("Konsistensavstemming er allerede kjoert i dag")
+                log.info("Starter $jobbNavn")
+
+                val idag = LocalDate.now(clock.withZone(norskTidssone))
+                kjoereplan.find { dato -> dato == idag }?.let {
+                    if (leaderElection.isLeader()) {
+                        Saktype.values().forEach {
+                            when (it) {
+                                Saktype.BARNEPENSJON -> {
+                                    if (!konsistensavstemmingService.konsistensavstemmingErKjoertIDag(
+                                            saktype = it,
+                                            idag = idag
+                                        )
+                                    ) {
+                                        konsistensavstemmingService.startKonsistensavstemming(dag = idag, saktype = it)
+                                    } else {
+                                        log.info("Konsistensavstemming er allerede kjoert i dag ($idag)")
+                                    }
                                 }
-                            }
-                            Saktype.OMSTILLINGSSTOENAD -> {
-                                log.info("Konsistensavstemming for omstillingsstoenad ennaa ikke implementert")
-                                /* TODO: Blir haandtert i EY-1274 */
+                                Saktype.OMSTILLINGSSTOENAD -> {
+                                    log.info("Konsistensavstemming for omstillingsstoenad ennaa ikke implementert")
+                                    /* TODO: Blir haandtert i EY-1274 */
+                                }
                             }
                         }
                     }
-                }
+                } ?: log.info("Denne datoen ($idag) er ikke en del av kjøreplanen for konsistensavstemming")
             }
         }
     }

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/common/Utils.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/common/Utils.kt
@@ -7,6 +7,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
 import java.time.Clock
 import java.time.LocalDate
 import java.time.LocalTime
+import java.time.Month
 import java.time.YearMonth
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -15,6 +16,19 @@ import java.util.*
 import javax.xml.datatype.DatatypeConstants
 import javax.xml.datatype.DatatypeFactory
 import javax.xml.datatype.XMLGregorianCalendar
+
+fun Int.januar(year: Int): LocalDate = LocalDate.of(year, Month.JANUARY, this)
+fun Int.februar(year: Int): LocalDate = LocalDate.of(year, Month.FEBRUARY, this)
+fun Int.mars(year: Int): LocalDate = LocalDate.of(year, Month.MARCH, this)
+fun Int.april(year: Int): LocalDate = LocalDate.of(year, Month.APRIL, this)
+fun Int.mai(year: Int): LocalDate = LocalDate.of(year, Month.MAY, this)
+fun Int.juni(year: Int): LocalDate = LocalDate.of(year, Month.JUNE, this)
+fun Int.juli(year: Int): LocalDate = LocalDate.of(year, Month.JULY, this)
+fun Int.august(year: Int): LocalDate = LocalDate.of(year, Month.AUGUST, this)
+fun Int.september(year: Int): LocalDate = LocalDate.of(year, Month.SEPTEMBER, this)
+fun Int.oktober(year: Int): LocalDate = LocalDate.of(year, Month.OCTOBER, this)
+fun Int.november(year: Int): LocalDate = LocalDate.of(year, Month.NOVEMBER, this)
+fun Int.desember(year: Int): LocalDate = LocalDate.of(year, Month.DECEMBER, this)
 
 fun ZonedDateTime.next(atTime: LocalTime): Date {
     return if (this.toLocalTime().isAfter(atTime)) {

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/config/ApplicationContext.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/config/ApplicationContext.kt
@@ -7,7 +7,18 @@ import no.nav.etterlatte.libs.jobs.LeaderElection
 import no.nav.etterlatte.utbetaling.avstemming.KonsistensavstemmingJob
 import no.nav.etterlatte.utbetaling.avstemming.KonsistensavstemmingService
 import no.nav.etterlatte.utbetaling.common.Oppgavetrigger
+import no.nav.etterlatte.utbetaling.common.april
+import no.nav.etterlatte.utbetaling.common.august
+import no.nav.etterlatte.utbetaling.common.februar
+import no.nav.etterlatte.utbetaling.common.januar
+import no.nav.etterlatte.utbetaling.common.juli
+import no.nav.etterlatte.utbetaling.common.juni
+import no.nav.etterlatte.utbetaling.common.mai
+import no.nav.etterlatte.utbetaling.common.mars
 import no.nav.etterlatte.utbetaling.common.next
+import no.nav.etterlatte.utbetaling.common.november
+import no.nav.etterlatte.utbetaling.common.oktober
+import no.nav.etterlatte.utbetaling.common.september
 import no.nav.etterlatte.utbetaling.grensesnittavstemming.AvstemmingDao
 import no.nav.etterlatte.utbetaling.grensesnittavstemming.GrensesnittsavstemmingJob
 import no.nav.etterlatte.utbetaling.grensesnittavstemming.GrensesnittsavstemmingService
@@ -103,10 +114,11 @@ class ApplicationContext(
 
     val konsistensavstemmingJob = KonsistensavstemmingJob(
         konsistensavstemmingService,
+        kjoereplanKonsistensavstemming(),
         leaderElection,
         initialDelay = Duration.of(2, ChronoUnit.MINUTES).toMillis(),
-        periode = Duration.of(1, ChronoUnit.HOURS)
-
+        periode = Duration.of(4, ChronoUnit.HOURS),
+        clock = clock
     )
 
     val oppgavetrigger by lazy {
@@ -133,6 +145,25 @@ class ApplicationContext(
         )
     }
 }
+
+/**
+ * Kjøreplan får vi en gang i året fra økonomi og brukes for konsistensavstemming
+ * av løpende/aktive utbetalinger
+ */
+private fun kjoereplanKonsistensavstemming() = setOf(
+    5.januar(2023),
+    30.januar(2023),
+    27.februar(2023),
+    28.mars(2023),
+    25.april(2023),
+    30.mai(2023),
+    29.juni(2023),
+    28.juli(2023),
+    30.august(2023),
+    29.september(2023),
+    30.oktober(2023),
+    22.november(2023)
+)
 
 private fun Map<String, String>.withConsumerGroupId() =
     this.toMutableMap().apply {

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/KonsistensavstemmingJobTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/KonsistensavstemmingJobTest.kt
@@ -1,23 +1,30 @@
 package no.nav.etterlatte.utbetaling.avstemming
 
+import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.etterlatte.libs.common.tidspunkt.norskTidssone
 import no.nav.etterlatte.libs.jobs.LeaderElection
+import no.nav.etterlatte.utbetaling.common.februar
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
+import java.time.Clock
+import java.time.temporal.ChronoUnit
 
 internal class KonsistensavstemmingJobTest {
 
     private val konsistensavstemmingService: KonsistensavstemmingService = mockk {
     }
     private val leaderElection: LeaderElection = mockk()
+    private val datoEksekvering = 1.februar(2023)
     private val konsistensavstemming = KonsistensavstemmingJob.Konsistensavstemming(
         konsistensavstemmingService = konsistensavstemmingService,
+        kjoereplan = setOf(datoEksekvering),
         leaderElection = leaderElection,
-        jobbNavn = "jobb"
+        jobbNavn = "jobb",
+        clock = Clock.fixed(datoEksekvering.atStartOfDay(norskTidssone).toInstant(), norskTidssone)
     )
 
     @Test
@@ -32,9 +39,13 @@ internal class KonsistensavstemmingJobTest {
 
     @Test
     fun `skal konsistensavstemme for Barnepensjon siden pod er leader`() {
-        val idag = LocalDate.now()
         every { leaderElection.isLeader() } returns true
-        every { konsistensavstemmingService.konsistensavstemmingErKjoertIDag(Saktype.BARNEPENSJON, idag) } returns false
+        every {
+            konsistensavstemmingService.konsistensavstemmingErKjoertIDag(
+                Saktype.BARNEPENSJON,
+                datoEksekvering
+            )
+        } returns false
         every { konsistensavstemmingService.startKonsistensavstemming(any(), any()) } returns emptyList()
 
         konsistensavstemming.run()
@@ -44,26 +55,108 @@ internal class KonsistensavstemmingJobTest {
     }
 
     @Test
-    fun `skal konsistensavstemme for barnepensjon naar jobb ikke er kjoert samme dag`() {
-        val idag = LocalDate.now()
+    fun `skal ikke konsistensavstemme for barnepensjon naar datoen ikke er en del av kjoereplan`() {
         every { leaderElection.isLeader() } returns true
-        every { konsistensavstemmingService.konsistensavstemmingErKjoertIDag(Saktype.BARNEPENSJON, idag) } returns false
-        every { konsistensavstemmingService.startKonsistensavstemming(idag, Saktype.BARNEPENSJON) } returns emptyList()
+
+        val dagForTestMinusFemDager = datoEksekvering.atStartOfDay(norskTidssone).toInstant().minus(5, ChronoUnit.DAYS)
+
+        val konsistensavstemming = KonsistensavstemmingJob.Konsistensavstemming(
+            konsistensavstemmingService = konsistensavstemmingService,
+            kjoereplan = setOf(datoEksekvering),
+            leaderElection = leaderElection,
+            jobbNavn = "jobb",
+            clock = Clock.fixed(dagForTestMinusFemDager, norskTidssone)
+        )
 
         konsistensavstemming.run()
 
-        verify(exactly = 1) { konsistensavstemmingService.startKonsistensavstemming(idag, Saktype.BARNEPENSJON) }
+        verify(exactly = 0) {
+            konsistensavstemmingService.konsistensavstemmingErKjoertIDag(
+                Saktype.BARNEPENSJON,
+                datoEksekvering
+            )
+        }
+        verify(exactly = 0) {
+            konsistensavstemmingService.startKonsistensavstemming(
+                datoEksekvering,
+                Saktype.BARNEPENSJON
+            )
+        }
+        confirmVerified(konsistensavstemmingService)
+    }
+
+    @Test
+    fun `skal konsistensavstemme for barnepensjon naar datoen er en del av kjoereplan`() {
+        every { leaderElection.isLeader() } returns true
+        every {
+            konsistensavstemmingService.konsistensavstemmingErKjoertIDag(
+                Saktype.BARNEPENSJON,
+                datoEksekvering
+            )
+        } returns false
+        every { konsistensavstemmingService.startKonsistensavstemming(any(), any()) } returns emptyList()
+
+        konsistensavstemming.run()
+
+        verify(exactly = 1) {
+            konsistensavstemmingService.konsistensavstemmingErKjoertIDag(
+                Saktype.BARNEPENSJON,
+                any()
+            )
+        }
+        verify(exactly = 1) { konsistensavstemmingService.startKonsistensavstemming(any(), Saktype.BARNEPENSJON) }
+        confirmVerified(konsistensavstemmingService)
+    }
+
+    @Test
+    fun `skal konsistensavstemme for barnepensjon naar jobb ikke er kjoert samme dag`() {
+        every { leaderElection.isLeader() } returns true
+        every {
+            konsistensavstemmingService.konsistensavstemmingErKjoertIDag(
+                Saktype.BARNEPENSJON,
+                datoEksekvering
+            )
+        } returns false
+        every {
+            konsistensavstemmingService.startKonsistensavstemming(
+                datoEksekvering,
+                Saktype.BARNEPENSJON
+            )
+        } returns emptyList()
+
+        konsistensavstemming.run()
+
+        verify(exactly = 1) {
+            konsistensavstemmingService.startKonsistensavstemming(
+                datoEksekvering,
+                Saktype.BARNEPENSJON
+            )
+        }
     }
 
     @Test
     fun `skal ikke konsistensavstemme for barnepensjon naar jobb er kjoert samme dag`() {
-        val idag = LocalDate.now()
         every { leaderElection.isLeader() } returns true
-        every { konsistensavstemmingService.konsistensavstemmingErKjoertIDag(Saktype.BARNEPENSJON, idag) } returns true
-        every { konsistensavstemmingService.startKonsistensavstemming(idag, Saktype.BARNEPENSJON) } returns emptyList()
+        every {
+            konsistensavstemmingService.konsistensavstemmingErKjoertIDag(
+                Saktype.BARNEPENSJON,
+                datoEksekvering
+            )
+        } returns true
+        every {
+            konsistensavstemmingService.startKonsistensavstemming(
+                datoEksekvering,
+                Saktype.BARNEPENSJON
+            )
+        } returns emptyList()
 
         konsistensavstemming.run()
 
-        verify(exactly = 0) { konsistensavstemmingService.startKonsistensavstemming(idag, Saktype.BARNEPENSJON) }
+        verify(exactly = 0) {
+            konsistensavstemmingService.startKonsistensavstemming(
+                datoEksekvering,
+                Saktype.BARNEPENSJON
+            )
+        }
     }
 }


### PR DESCRIPTION
- Starter konsistensavstemming kun på dager oppgitt i kjøreplan vi får en gang i året fra økonomi

EY-1718