### PR TITLE
Ey 1694

### DIFF
--- a/apps/etterlatte-vedtaksvurdering-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/.nais/dev.yaml
@@ -33,8 +33,6 @@ spec:
       value: earliest
     - name: VEDTAK_AZURE_SCOPE
       value: api://dev-gcp.etterlatte.etterlatte-vedtaksvurdering/.default
-    - name: ETTERLATTE_VEDTAK_CLIENT_ID
-      value: 069b1b2c-0a06-4cc9-8418-f100b8ff71be
     - name: ETTERLATTE_VEDTAK_URL
       value: http://etterlatte-vedtaksvurdering
   accessPolicy:

--- a/apps/etterlatte-vedtaksvurdering-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/.nais/dev.yaml
@@ -1,0 +1,43 @@
+apiVersion: "nais.io/v1alpha1"
+kind: "Application"
+metadata:
+  name: etterlatte-vedtaksvurdering-kafka
+  namespace: etterlatte
+  labels:
+    team: etterlatte
+spec:
+  image: {{image}}
+  port: 8080
+  liveness:
+    initialDelay: 5
+    path: /isalive
+  readiness:
+    initialDelay: 5
+    path: /isready
+  prometheus:
+    enabled: true
+    path: /metrics
+  kafka:
+    pool: nav-dev
+  azure:
+    application:
+      enabled: true
+  replicas:
+    cpuThresholdPercentage: 90
+    max: 1
+    min: 1
+  env:
+    - name: KAFKA_RAPID_TOPIC
+      value: etterlatte.dodsmelding
+    - name: KAFKA_RESET_POLICY
+      value: earliest
+    - name: VEDTAK_AZURE_SCOPE
+      value: api://dev-gcp.etterlatte.etterlatte-vedtaksvurdering/.default
+    - name: ETTERLATTE_VEDTAK_CLIENT_ID
+      value: 069b1b2c-0a06-4cc9-8418-f100b8ff71be
+    - name: ETTERLATTE_VEDTAK_URL
+      value: http://etterlatte-vedtaksvurdering
+  accessPolicy:
+    outbound:
+      rules:
+        - application: etterlatte-vedtaksvurdering

--- a/apps/etterlatte-vedtaksvurdering-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/.nais/prod.yaml
@@ -31,6 +31,10 @@ spec:
       value: etterlatte.etterlatteytelser
     - name: KAFKA_RESET_POLICY
       value: earliest
+    - name: VEDTAK_AZURE_SCOPE
+      value: api://prod-gcp.etterlatte.etterlatte-vedtaksvurdering/.default
+    - name: ETTERLATTE_VEDTAK_URL
+      value: http://etterlatte-vedtaksvurdering
   accessPolicy:
     outbound:
       rules:

--- a/apps/etterlatte-vedtaksvurdering-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/.nais/prod.yaml
@@ -1,0 +1,37 @@
+apiVersion: "nais.io/v1alpha1"
+kind: "Application"
+metadata:
+  name: etterlatte-vedtaksvurdering-kafka
+  namespace: etterlatte
+  labels:
+    team: etterlatte
+spec:
+  image: {{image}}
+  port: 8080
+  liveness:
+    initialDelay: 5
+    path: /isalive
+  readiness:
+    initialDelay: 5
+    path: /isready
+  prometheus:
+    enabled: true
+    path: /metrics
+  kafka:
+    pool: nav-dev
+  azure:
+    application:
+      enabled: true
+  replicas:
+    cpuThresholdPercentage: 90
+    max: 1
+    min: 1
+  env:
+    - name: KAFKA_RAPID_TOPIC
+      value: etterlatte.etterlatteytelser
+    - name: KAFKA_RESET_POLICY
+      value: earliest
+  accessPolicy:
+    outbound:
+      rules:
+        - application: etterlatte-vedtaksvurdering

--- a/apps/etterlatte-vedtaksvurdering-kafka/build.gradle.kts
+++ b/apps/etterlatte-vedtaksvurdering-kafka/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    id("etterlatte.rapids-and-rivers-ktor2")
+}
+
+dependencies {
+    implementation(project(":libs:ktor2client-auth-clientcredentials"))
+    implementation(project(":libs:common"))
+
+    implementation(Ktor2.OkHttp)
+    implementation(Ktor2.ClientCore)
+    implementation(Ktor2.ClientLoggingJvm)
+    implementation(Ktor2.ClientAuth)
+    implementation(Ktor2.ClientJackson)
+    implementation(Ktor2.ClientContentNegotiation)
+
+    testImplementation(Jupiter.Root)
+    testImplementation(Ktor2.ClientMock)
+    testImplementation(MockK.MockK)
+    testImplementation(Kotlinx.CoroutinesCore)
+    testImplementation(project(":libs:testdata"))
+}

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/README.md
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/README.md
@@ -1,0 +1,13 @@
+# Vedtaksvurdering-Kafka
+
+Vedtaksvurdering-Kafka er en Rapid app.
+
+Appen har ansvar for å lytte etter saker som skal reguleres. Den sjekker opp mot vedtaksappen om en sak har en løpende
+ytelse. Dersom den har det, så sendes meldingen videre til Omberegning
+
+## Konsepter
+
+### Løpende ytelse
+
+En sak er løpende dersom den har 1 eller flere perioder med utbetalinger etter en gitt dato. En opphørt sak kan fortsatt
+være løpende dersom opphøret har virkningstidspunkt etter den gitte datoen

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/Application.kt
@@ -1,0 +1,15 @@
+package no.nav.etterlatte
+
+import no.nav.etterlatte.regulering.AppBuilder
+import no.nav.etterlatte.regulering.Reguleringsforespoersel
+import no.nav.helse.rapids_rivers.RapidApplication
+
+fun main() {
+    System.getenv().toMutableMap().apply {
+        put("KAFKA_CONSUMER_GROUP_ID", get("NAIS_APP_NAME")!!.replace("-", ""))
+    }.also { env ->
+        AppBuilder(env).also { ab ->
+            RapidApplication.create(env).also { Reguleringsforespoersel(it, ab.lagVedtakKlient()) }.start()
+        }
+    }
+}

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/AppBuilder.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/AppBuilder.kt
@@ -15,10 +15,10 @@ import no.nav.etterlatte.security.ktor.clientCredential
 
 class AppBuilder(private val props: Map<String, String>) {
     private val vedtakHttpKlient = vedtakHttpKlient()
-    private val vedtakUrl = props["ETTERLATTE_VEDTAK_URL"]
+    private val vedtakUrl = requireNotNull(props["ETTERLATTE_VEDTAK_URL"])
 
     fun lagVedtakKlient(): VedtakServiceImpl {
-        return VedtakServiceImpl(vedtakHttpKlient, (vedtakUrl ?: ""))
+        return VedtakServiceImpl(vedtakHttpKlient, vedtakUrl)
     }
 
     private fun vedtakHttpKlient() = HttpClient(OkHttp) {

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/AppBuilder.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/AppBuilder.kt
@@ -1,0 +1,42 @@
+package no.nav.etterlatte.regulering
+
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.header
+import io.ktor.serialization.jackson.jackson
+import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
+import no.nav.etterlatte.libs.common.logging.getCorrelationId
+import no.nav.etterlatte.security.ktor.clientCredential
+
+class AppBuilder(private val props: Map<String, String>) {
+    private val vedtakHttpKlient = vedtakHttpKlient()
+    private val vedtakUrl = props["ETTERLATTE_VEDTAK_URL"]
+
+    fun lagVedtakKlient(): VedtakServiceImpl {
+        return VedtakServiceImpl(vedtakHttpKlient, (vedtakUrl ?: ""))
+    }
+
+    private fun vedtakHttpKlient() = HttpClient(OkHttp) {
+        expectSuccess = true
+        install(ContentNegotiation) {
+            jackson {
+                registerModule(JavaTimeModule())
+                disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            }
+        }
+        install(Auth) {
+            clientCredential {
+                config = props.toMutableMap()
+                    .apply { put("AZURE_APP_OUTBOUND_SCOPE", requireNotNull(get("VEDTAK_AZURE_SCOPE"))) }
+            }
+        }
+        defaultRequest {
+            header(X_CORRELATION_ID, getCorrelationId())
+        }
+    }.also { Runtime.getRuntime().addShutdownHook(Thread { it.close() }) }
+}

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/Reguleringsforespoersel.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/Reguleringsforespoersel.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.regulering
 
+import no.nav.etterlatte.libs.common.behandling.Hendelsestype
 import no.nav.etterlatte.libs.common.behandling.Omberegningshendelse
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.logging.withLogContext
@@ -13,7 +14,6 @@ import no.nav.helse.rapids_rivers.asLocalDate
 import org.slf4j.LoggerFactory
 
 const val REGULERING_EVENT_NAME = "REGULERING" // TODO sj: Flyttes ut
-const val OMBEREGNING_EVENT_NAME = "OMBEREGNINGHENDELSE"
 
 internal class Reguleringsforespoersel(
     rapidsConnection: RapidsConnection,
@@ -38,7 +38,7 @@ internal class Reguleringsforespoersel(
             val reguleringsdato = packet["dato"].asLocalDate()
             val respons = vedtak.harLoependeYtelserFra(sakId, reguleringsdato)
             respons.takeIf { it.erLoepende }?.let {
-                packet.eventName = OMBEREGNING_EVENT_NAME
+                packet.eventName = Hendelsestype.OMBEREGNINGSHENDELSE.toString()
                 packet["hendelse_data"] = Omberegningshendelse(
                     sakId = sakId,
                     fradato = it.dato,

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/Reguleringsforespoersel.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/Reguleringsforespoersel.kt
@@ -1,0 +1,51 @@
+package no.nav.etterlatte.regulering
+
+import no.nav.etterlatte.libs.common.behandling.Omberegningshendelse
+import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
+import no.nav.etterlatte.libs.common.logging.withLogContext
+import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
+import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.MessageContext
+import no.nav.helse.rapids_rivers.RapidsConnection
+import no.nav.helse.rapids_rivers.River
+import no.nav.helse.rapids_rivers.asLocalDate
+import org.slf4j.LoggerFactory
+
+const val REGULERING_EVENT_NAME = "REGULERING" // TODO sj: Flyttes ut
+const val OMBEREGNING_EVENT_NAME = "OMBEREGNINGHENDELSE"
+
+internal class Reguleringsforespoersel(
+    rapidsConnection: RapidsConnection,
+    private val vedtak: VedtakService
+) : River.PacketListener {
+    private val logger = LoggerFactory.getLogger(Reguleringsforespoersel::class.java)
+
+    init {
+        River(rapidsConnection).apply {
+            eventName(REGULERING_EVENT_NAME)
+            validate { it.requireKey("sakId") }
+            validate { it.requireKey("dato") }
+            correlationId()
+        }.register(this)
+    }
+
+    override fun onPacket(packet: JsonMessage, context: MessageContext) =
+        withLogContext(packet.correlationId) {
+            val sakId = packet["sakId"].asLong()
+            logger.info("Leser reguleringsfoerespoersel for sak $sakId")
+
+            val reguleringsdato = packet["dato"].asLocalDate()
+            val respons = vedtak.harLoependeYtelserFra(sakId, reguleringsdato)
+            respons.takeIf { it.erLoepende }?.let {
+                packet.eventName = OMBEREGNING_EVENT_NAME
+                packet["hendelse_data"] = Omberegningshendelse(
+                    sakId = sakId,
+                    fradato = it.dato,
+                    aarsak = RevurderingAarsak.GRUNNBELOEPREGULERING
+                )
+                context.publish(packet.toJson())
+                logger.info("Grunnlopesreguleringmelding ble sendt for sak $sakId. Dato=${respons.dato}")
+            } ?: logger.info("Grunnlopesreguleringmelding ble ikke sendt for sak $sakId. Dato=${respons.dato}")
+        }
+}

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/Reguleringsforespoersel.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/Reguleringsforespoersel.kt
@@ -13,7 +13,7 @@ import no.nav.helse.rapids_rivers.River
 import no.nav.helse.rapids_rivers.asLocalDate
 import org.slf4j.LoggerFactory
 
-const val REGULERING_EVENT_NAME = "REGULERING" // TODO sj: Flyttes ut
+const val REGULERING_EVENT_NAME = "REGULERING"
 
 internal class Reguleringsforespoersel(
     rapidsConnection: RapidsConnection,

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/services/VedtakService.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/services/VedtakService.kt
@@ -1,0 +1,19 @@
+package no.nav.etterlatte.regulering
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.libs.common.loependeYtelse.LoependeYtelseDTO
+import java.time.LocalDate
+
+interface VedtakService {
+    fun harLoependeYtelserFra(sakId: Long, dato: LocalDate): LoependeYtelseDTO
+}
+
+class VedtakServiceImpl(private val vedtakKlient: HttpClient, private val url: String) : VedtakService {
+    override fun harLoependeYtelserFra(sakId: Long, dato: LocalDate): LoependeYtelseDTO =
+        runBlocking {
+            vedtakKlient.get("$url/api/vedtak/loepende/$sakId?dato=$dato").body()
+        }
+}

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/resources/logback.xml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/resources/logback.xml
@@ -1,0 +1,20 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT_JSON"/>
+    </root>
+
+    <logger name="org.eclipse.jetty" level="INFO"/>
+    <logger name="org.apache.kafka" level="INFO"/>
+    <logger name="io.netty" level="INFO"/>
+    <logger name="no.nav.helse.rapids_rivers.PingPong" level="DEBUG"/>
+</configuration>

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/regulering/ReguleringsforespoerselTest.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/regulering/ReguleringsforespoerselTest.kt
@@ -3,12 +3,12 @@ package regulering
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.etterlatte.libs.common.behandling.Hendelsestype
 import no.nav.etterlatte.libs.common.behandling.Omberegningshendelse
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.loependeYtelse.LoependeYtelseDTO
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventNameKey
-import no.nav.etterlatte.regulering.OMBEREGNING_EVENT_NAME
 import no.nav.etterlatte.regulering.Reguleringsforespoersel
 import no.nav.etterlatte.regulering.VedtakService
 import no.nav.helse.rapids_rivers.JsonMessage
@@ -52,7 +52,7 @@ internal class ReguleringsforespoerselTest {
 
         inspector.sendTestMessage(melding.toJson())
         val sendtMelding = inspector.inspektør.message(0)
-        Assertions.assertEquals(OMBEREGNING_EVENT_NAME, sendtMelding.get(eventNameKey).asText())
+        Assertions.assertEquals(Hendelsestype.OMBEREGNINGSHENDELSE.toString(), sendtMelding.get(eventNameKey).asText())
         Assertions.assertEquals(
             Omberegningshendelse(
                 sakId = sakId,

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/regulering/ReguleringsforespoerselTest.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/regulering/ReguleringsforespoerselTest.kt
@@ -1,0 +1,79 @@
+package regulering
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.etterlatte.libs.common.behandling.Omberegningshendelse
+import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
+import no.nav.etterlatte.libs.common.loependeYtelse.LoependeYtelseDTO
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.rapidsandrivers.eventNameKey
+import no.nav.etterlatte.regulering.OMBEREGNING_EVENT_NAME
+import no.nav.etterlatte.regulering.Reguleringsforespoersel
+import no.nav.etterlatte.regulering.VedtakService
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.testsupport.TestRapid
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+internal class ReguleringsforespoerselTest {
+
+    private val `1_mai_2023` = LocalDate.of(2023, 5, 1)
+    private val sakId = 1L
+
+    private fun genererReguleringMelding(dato: LocalDate, sakId: Long) = JsonMessage.newMessage(
+        mapOf(
+            eventNameKey to "REGULERING",
+            "sakId" to sakId,
+            "dato" to dato
+        )
+    )
+
+    @Test
+    fun `kan ta imot reguleringsmelding og kalle paa vedtakservice med riktige verdier`() {
+        val melding = genererReguleringMelding(`1_mai_2023`, sakId)
+        val vedtakServiceMock = mockk<VedtakService>(relaxed = true)
+        val inspector = TestRapid().apply { Reguleringsforespoersel(this, vedtakServiceMock) }
+
+        inspector.sendTestMessage(melding.toJson())
+        verify(exactly = 1) {
+            vedtakServiceMock.harLoependeYtelserFra(1L, LocalDate.of(2023, 5, 1))
+        }
+    }
+
+    @Test
+    fun `skal lage ny melding med dato basert paa hva ytelsen har som foerste mulige dato`() {
+        val fraDato = LocalDate.of(2023, 8, 1)
+        val melding = genererReguleringMelding(`1_mai_2023`, sakId)
+        val vedtakServiceMock = mockk<VedtakService>(relaxed = true)
+        every { vedtakServiceMock.harLoependeYtelserFra(sakId, `1_mai_2023`) } returns LoependeYtelseDTO(true, fraDato)
+        val inspector = TestRapid().apply { Reguleringsforespoersel(this, vedtakServiceMock) }
+
+        inspector.sendTestMessage(melding.toJson())
+        val sendtMelding = inspector.inspektør.message(0)
+        Assertions.assertEquals(OMBEREGNING_EVENT_NAME, sendtMelding.get(eventNameKey).asText())
+        Assertions.assertEquals(
+            Omberegningshendelse(
+                sakId = sakId,
+                fradato = fraDato,
+                aarsak = RevurderingAarsak.GRUNNBELOEPREGULERING
+            ),
+            objectMapper.readValue(sendtMelding.get("hendelse_data").toString(), Omberegningshendelse::class.java)
+        )
+    }
+
+    @Test
+    fun `sender ikke ny melding dersom det ikke er en loepende ytelse`() {
+        val melding = genererReguleringMelding(`1_mai_2023`, sakId)
+        val vedtakServiceMock = mockk<VedtakService>(relaxed = true)
+        every { vedtakServiceMock.harLoependeYtelserFra(sakId, `1_mai_2023`) } returns LoependeYtelseDTO(
+            false,
+            `1_mai_2023`
+        )
+        val inspector = TestRapid().apply { Reguleringsforespoersel(this, vedtakServiceMock) }
+
+        inspector.sendTestMessage(melding.toJson())
+        Assertions.assertEquals(0, inspector.inspektør.size)
+    }
+}

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/regulering/VedtakServiceImplTest.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/regulering/VedtakServiceImplTest.kt
@@ -1,0 +1,46 @@
+package regulering
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.Url
+import io.ktor.http.headersOf
+import io.ktor.serialization.jackson.JacksonConverter
+import no.nav.etterlatte.libs.common.loependeYtelse.LoependeYtelseDTO
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.toJson
+import no.nav.etterlatte.regulering.VedtakServiceImpl
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+internal class VedtakServiceImplTest {
+    @Test
+    fun `kaller paa vedtakklient med riktig formatert url`() {
+        lateinit var request: Url
+        val mockEngine = MockEngine { req ->
+            request = req.url
+            val headers = headersOf("Content-Type" to listOf(ContentType.Application.Json.toString()))
+            respond(
+                LoependeYtelseDTO(true, LocalDate.of(2023, 5, 1)).toJson(),
+                headers = headers
+            )
+        }
+
+        val httpClientMock = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                register(
+                    ContentType.Application.Json,
+                    JacksonConverter(objectMapper)
+                )
+            }
+        }
+        val vedtakService = VedtakServiceImpl(httpClientMock, "http://test")
+        val dato = LocalDate.of(2023, 1, 1)
+        vedtakService.harLoependeYtelserFra(1, dato)
+
+        Assertions.assertEquals("/api/vedtak/loepende/1?dato=2023-01-01", request.encodedPathAndQuery)
+    }
+}

--- a/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
@@ -74,6 +74,7 @@ spec:
         - application: etterlatte-saksbehandling-ui
         - application: etterlatte-saksbehandling-ui-lokal
         - application: etterlatte-behandling
+        - application: etterlatte-vedtaksvurdering-kafka
     outbound:
       rules:
         - application: etterlatte-vilkaarsvurdering

--- a/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
@@ -83,6 +83,7 @@ spec:
         - application: etterlatte-saksbehandling-ui
         - application: etterlatte-saksbehandling-ui-lokal
         - application: etterlatte-behandling
+        - application: etterlatte-vedtaksvurdering-kafka
     outbound:
       rules:
         - application: etterlatte-vilkaarsvurdering

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/Vedtakstidslinje.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/Vedtakstidslinje.kt
@@ -1,0 +1,28 @@
+package no.nav.etterlatte
+
+import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.VedtakStatus
+import no.nav.etterlatte.vedtaksvurdering.Vedtak
+import java.time.LocalDate
+
+class Vedtakstidslinje(private val vedtak: List<Vedtak>) {
+    fun erLoependePaa(dato: LocalDate): Boolean {
+        val iverksatteVedtak = hentIverksatteVedtak()
+        if (iverksatteVedtak.isEmpty()) return false
+
+        return hentSenesteVedtakPaaDato(dato)?.behandlingType == BehandlingType.FØRSTEGANGSBEHANDLING
+    }
+
+    private fun hentSenesteVedtakPaaDato(dato: LocalDate): Vedtak? {
+        val foersteVirkningsdato = hentIverksatteVedtak().minBy { it.datoattestert!! }.virkningsDato!!
+        val foersteMuligeVedtaksdag = maxOf(foersteVirkningsdato, dato)
+
+        return hentIverksatteVedtak()
+            .filter { !it.virkningsDato!!.isAfter(foersteMuligeVedtaksdag) }
+            .maxByOrNull { it.datoattestert!! }
+    }
+
+    private fun hentIverksatteVedtak(): List<Vedtak> {
+        return vedtak.filter { it.vedtakStatus === VedtakStatus.IVERKSATT }
+    }
+}

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/TolketVedtak.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/TolketVedtak.kt
@@ -1,0 +1,17 @@
+package no.nav.etterlatte.vedtaksvurdering
+
+import no.nav.etterlatte.libs.common.behandling.BehandlingType
+
+enum class TolketVedtak {
+    INNVILGET,
+    OPPHOER
+}
+
+/**
+ * TODO ai 10.02.2023: Se på denne logikken og fiks tolking av vedtak
+ * */
+internal fun Vedtak.tolkVedtak(): TolketVedtak = when (this.behandlingType) {
+    BehandlingType.FØRSTEGANGSBEHANDLING -> TolketVedtak.INNVILGET
+    BehandlingType.REVURDERING -> TolketVedtak.OPPHOER
+    BehandlingType.MANUELT_OPPHOER -> TolketVedtak.OPPHOER
+}

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/Vedtakstidslinje.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/Vedtakstidslinje.kt
@@ -18,13 +18,15 @@ class Vedtakstidslinje(private val vedtak: List<Vedtak>) {
     }
 
     private fun hentSenesteVedtakPaaDato(dato: LocalDate): Vedtak? = iverksatteVedtak
-        .filter { !it.virkningsDato!!.isAfter(foersteMuligeVedtaksdag(dato)) }
+        .filter { it.virkningsDato?.isAfter(foersteMuligeVedtaksdag(dato))?.not() ?: false }
         .maxByOrNull { it.datoattestert!! }
 
     private fun hentIverksatteVedtak(): List<Vedtak> = vedtak.filter { it.vedtakStatus === VedtakStatus.IVERKSATT }
 
     private fun foersteMuligeVedtaksdag(fraDato: LocalDate): LocalDate {
-        val foersteVirkningsdato = iverksatteVedtak.minBy { it.datoattestert!! }.virkningsDato!! // TODO sj: remove !!
+        val foersteVirkningsdato = iverksatteVedtak.minBy {
+            it.datoattestert ?: throw Error("Kunne ikke finne datoattestert paa vedtak")
+        }.virkningsDato ?: throw Error("Fant ikke vikrningsdato på det iverksatte vedtaket")
         return maxOf(foersteVirkningsdato, fraDato)
     }
 }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/Vedtakstidslinje.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/Vedtakstidslinje.kt
@@ -1,8 +1,6 @@
-package no.nav.etterlatte
+package no.nav.etterlatte.vedtaksvurdering
 
-import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.VedtakStatus
-import no.nav.etterlatte.vedtaksvurdering.Vedtak
 import java.time.LocalDate
 
 class Vedtakstidslinje(private val vedtak: List<Vedtak>) {
@@ -10,7 +8,7 @@ class Vedtakstidslinje(private val vedtak: List<Vedtak>) {
         val iverksatteVedtak = hentIverksatteVedtak()
         if (iverksatteVedtak.isEmpty()) return false
 
-        return hentSenesteVedtakPaaDato(dato)?.behandlingType == BehandlingType.FØRSTEGANGSBEHANDLING
+        return hentSenesteVedtakPaaDato(dato)?.tolkVedtak() == TolketVedtak.INNVILGET
     }
 
     private fun hentSenesteVedtakPaaDato(dato: LocalDate): Vedtak? {

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/Vedtakstidslinje.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/Vedtakstidslinje.kt
@@ -1,26 +1,30 @@
 package no.nav.etterlatte.vedtaksvurdering
 
 import no.nav.etterlatte.libs.common.behandling.VedtakStatus
+import no.nav.etterlatte.libs.common.loependeYtelse.LoependeYtelseDTO
 import java.time.LocalDate
 
 class Vedtakstidslinje(private val vedtak: List<Vedtak>) {
-    fun erLoependePaa(dato: LocalDate): Boolean {
-        val iverksatteVedtak = hentIverksatteVedtak()
-        if (iverksatteVedtak.isEmpty()) return false
+    private val iverksatteVedtak = hentIverksatteVedtak()
 
-        return hentSenesteVedtakPaaDato(dato)?.tolkVedtak() == TolketVedtak.INNVILGET
+    fun erLoependePaa(dato: LocalDate): LoependeYtelseDTO {
+        if (iverksatteVedtak.isEmpty()) return LoependeYtelseDTO(false, dato)
+
+        val erLoepende = hentSenesteVedtakPaaDato(dato)?.tolkVedtak() == TolketVedtak.INNVILGET
+        return LoependeYtelseDTO(
+            erLoepende = erLoepende,
+            dato = if (erLoepende) foersteMuligeVedtaksdag(dato) else dato
+        )
     }
 
-    private fun hentSenesteVedtakPaaDato(dato: LocalDate): Vedtak? {
-        val foersteVirkningsdato = hentIverksatteVedtak().minBy { it.datoattestert!! }.virkningsDato!!
-        val foersteMuligeVedtaksdag = maxOf(foersteVirkningsdato, dato)
+    private fun hentSenesteVedtakPaaDato(dato: LocalDate): Vedtak? = iverksatteVedtak
+        .filter { !it.virkningsDato!!.isAfter(foersteMuligeVedtaksdag(dato)) }
+        .maxByOrNull { it.datoattestert!! }
 
-        return hentIverksatteVedtak()
-            .filter { !it.virkningsDato!!.isAfter(foersteMuligeVedtaksdag) }
-            .maxByOrNull { it.datoattestert!! }
-    }
+    private fun hentIverksatteVedtak(): List<Vedtak> = vedtak.filter { it.vedtakStatus === VedtakStatus.IVERKSATT }
 
-    private fun hentIverksatteVedtak(): List<Vedtak> {
-        return vedtak.filter { it.vedtakStatus === VedtakStatus.IVERKSATT }
+    private fun foersteMuligeVedtaksdag(fraDato: LocalDate): LocalDate {
+        val foersteVirkningsdato = iverksatteVedtak.minBy { it.datoattestert!! }.virkningsDato!! // TODO sj: remove !!
+        return maxOf(foersteVirkningsdato, fraDato)
     }
 }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRepository.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRepository.kt
@@ -96,6 +96,15 @@ class VedtaksvurderingRepository(datasource: DataSource) {
         ) { it.toVedtak() }
     }
 
+    fun hentVedtakForSak(sakId: Long): List<Vedtak> {
+        val hentVedtak =
+            "SELECT sakid, behandlingId, saksbehandlerId, beregningsresultat, vilkaarsresultat, vedtakfattet, id, fnr, datoFattet, datoattestert, attestant, datoVirkFom, vedtakstatus, saktype, behandlingtype, attestertVedtakEnhet, fattetVedtakEnhet FROM vedtak WHERE sakId = :sakId" // ktlint-disable max-line-length
+        return repositoryWrapper.hentListeMedKotliquery(
+            query = hentVedtak,
+            params = { mapOf("sakId" to sakId) }
+        ) { it.toVedtak() }
+    }
+
     private fun Row.toVedtak() = Vedtak(
         sakId = longOrNull("sakid"),
         behandlingId = uuid("behandlingid"),

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -13,6 +13,7 @@ import io.ktor.server.routing.route
 import no.nav.etterlatte.libs.common.withBehandlingId
 import no.nav.etterlatte.libs.ktor.accesstoken
 import no.nav.etterlatte.libs.ktor.saksbehandler
+import java.time.LocalDate
 import java.util.*
 
 fun Route.vedtaksvurderingRoute(service: VedtaksvurderingService) {
@@ -99,6 +100,16 @@ fun Route.vedtaksvurderingRoute(service: VedtaksvurderingService) {
             )
 
             call.respond(underkjentVedtak)
+        }
+
+        data class LoependeVedtakRequest(val dato: LocalDate)
+        data class LoependeVedtakResponse(val erLoepende: Boolean)
+        get("vedtak/loepende/{sakId}") {
+            val sakId = call.parameters["sakId"]?.toLong() ?: return@get call.respond(HttpStatusCode.BadRequest)
+            val body = call.receive<LoependeVedtakRequest>()
+
+            val erLoepende = service.vedtakErLoependePaaDato(sakId, body.dato)
+            call.respond(LoependeVedtakResponse(erLoepende))
         }
     }
 }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -11,7 +11,6 @@ import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
-import no.nav.etterlatte.libs.common.loependeYtelse.LoependeYtelseDTO
 import no.nav.etterlatte.libs.common.withBehandlingId
 import no.nav.etterlatte.libs.ktor.accesstoken
 import no.nav.etterlatte.libs.ktor.saksbehandler
@@ -117,8 +116,8 @@ fun Route.vedtaksvurderingRoute(service: VedtaksvurderingService) {
                 )
                 ?: return@get call.respond(BadRequest, "Det mangler et query parameter på dato")
 
-            val erLoepende = service.vedtakErLoependePaaDato(sakId, dato)
-            call.respond(LoependeYtelseDTO(erLoepende, dato)) // TODO sj: Returnere den faktiske datoen
+            val loependeYtelse = service.vedtakErLoependePaaDato(sakId, dato)
+            call.respond(loependeYtelse)
         }
     }
 }
@@ -126,10 +125,3 @@ fun Route.vedtaksvurderingRoute(service: VedtaksvurderingService) {
 data class UnderkjennVedtakClientRequest(val kommentar: String, val valgtBegrunnelse: String)
 private data class VedtakBolkRequest(val behandlingsidenter: List<String>)
 private data class VedtakBolkResponse(val vedtak: List<Vedtak>)
-
-enum class HendelseType {
-    FATTET,
-    ATTESTERT,
-    UNDERKJENT,
-    IVERKSATT
-}

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.vedtaksvurdering
 import kotlinx.coroutines.coroutineScope
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
+import no.nav.etterlatte.libs.common.loependeYtelse.LoependeYtelseDTO
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventNameKey
 import no.nav.etterlatte.libs.common.rapidsandrivers.tekniskTidKey
 import no.nav.etterlatte.libs.common.sak.Saksbehandler
@@ -89,7 +90,7 @@ class VedtaksvurderingService(
         return repository.hentVedtak(behandlingId)
     }
 
-    fun vedtakErLoependePaaDato(sakId: Long, dato: LocalDate): Boolean {
+    fun vedtakErLoependePaaDato(sakId: Long, dato: LocalDate): LoependeYtelseDTO {
         val alleVedtakForSak = repository.hentVedtakForSak(sakId)
 
         return Vedtakstidslinje(alleVedtakForSak).erLoependePaa(dato)

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
@@ -22,6 +22,7 @@ import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
 import no.nav.etterlatte.vedtaksvurdering.klienter.BeregningKlient
 import no.nav.etterlatte.vedtaksvurdering.klienter.VilkaarsvurderingKlient
 import no.nav.helse.rapids_rivers.JsonMessage
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 import no.nav.etterlatte.vedtaksvurdering.Vedtak as VedtakEntity
@@ -86,6 +87,12 @@ class VedtaksvurderingService(
 
     fun hentVedtak(behandlingId: UUID): VedtakEntity? {
         return repository.hentVedtak(behandlingId)
+    }
+
+    fun vedtakErLoependePaaDato(sakId: Long, dato: LocalDate): Boolean {
+        val alleVedtakForSak = repository.hentVedtakForSak(sakId)
+
+        return Vedtakstidslinje(alleVedtakForSak).erLoependePaa(dato)
     }
 
     suspend fun opprettEllerOppdaterVedtak(behandlingId: UUID, accessToken: String): Vedtak {

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/VedtakstidslinjeTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/VedtakstidslinjeTest.kt
@@ -3,7 +3,7 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.VedtakStatus
 import no.nav.etterlatte.vedtaksvurdering.Vedtak
 import no.nav.etterlatte.vedtaksvurdering.Vedtakstidslinje
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.time.LocalDate
@@ -22,7 +22,8 @@ internal class VedtakstidslinjeTest {
     @Test
     fun `sak uten vedtak er ikke loepende`() {
         val actual = Vedtakstidslinje(emptyList()).erLoependePaa(fraOgMed)
-        Assertions.assertEquals(false, actual)
+        assertEquals(false, actual.erLoepende)
+        assertEquals(LocalDate.of(2023, 5, 1), actual.dato)
     }
 
     /**
@@ -38,7 +39,8 @@ internal class VedtakstidslinjeTest {
             vedtakStatus = VedtakStatus.FATTET_VEDTAK
         )
         val actual = Vedtakstidslinje(listOf(fattetVedtak)).erLoependePaa(fraOgMed)
-        Assertions.assertEquals(false, actual)
+        assertEquals(false, actual.erLoepende)
+        assertEquals(LocalDate.of(2023, 5, 1), actual.dato)
     }
 
     /**
@@ -55,7 +57,8 @@ internal class VedtakstidslinjeTest {
         )
 
         val actual = Vedtakstidslinje(listOf(iverksattDato)).erLoependePaa(fraOgMed)
-        Assertions.assertEquals(true, actual)
+        assertEquals(true, actual.erLoepende)
+        assertEquals(LocalDate.of(2023, 5, 1), actual.dato)
     }
 
     /**
@@ -87,7 +90,8 @@ internal class VedtakstidslinjeTest {
                 opphoertDato
             )
         ).erLoependePaa(fraOgMed)
-        Assertions.assertEquals(false, actual)
+        assertEquals(false, actual.erLoepende)
+        assertEquals(LocalDate.of(2023, 5, 1), actual.dato)
     }
 
     /**
@@ -119,7 +123,8 @@ internal class VedtakstidslinjeTest {
                 opphoertDato
             )
         ).erLoependePaa(fraOgMed)
-        Assertions.assertEquals(true, actual)
+        assertEquals(true, actual.erLoepende)
+        assertEquals(LocalDate.of(2023, 5, 1), actual.dato)
     }
 
     /**
@@ -138,7 +143,8 @@ internal class VedtakstidslinjeTest {
         )
 
         val actual = Vedtakstidslinje(listOf(iverksattDato)).erLoependePaa(fraOgMed)
-        Assertions.assertEquals(true, actual)
+        assertEquals(true, actual.erLoepende)
+        assertEquals(LocalDate.of(2023, 6, 1), actual.dato)
     }
 
     /**
@@ -165,7 +171,8 @@ internal class VedtakstidslinjeTest {
         )
 
         val actual = Vedtakstidslinje(listOf(iverksattDato, opphoertDato)).erLoependePaa(fraOgMed)
-        Assertions.assertEquals(true, actual)
+        assertEquals(true, actual.erLoepende)
+        assertEquals(LocalDate.of(2023, 6, 1), actual.dato)
     }
 
     /**
@@ -192,7 +199,8 @@ internal class VedtakstidslinjeTest {
         )
 
         val actual = Vedtakstidslinje(listOf(iverksattDato, opphoertDato)).erLoependePaa(fraOgMed)
-        Assertions.assertEquals(false, actual)
+        assertEquals(false, actual.erLoepende)
+        assertEquals(LocalDate.of(2023, 5, 1), actual.dato)
     }
 }
 

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/VedtakstidslinjeTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/VedtakstidslinjeTest.kt
@@ -1,0 +1,225 @@
+import no.nav.etterlatte.Vedtakstidslinje
+import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.behandling.VedtakStatus
+import no.nav.etterlatte.vedtaksvurdering.Vedtak
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.*
+
+internal class VedtakstidslinjeTest {
+    private val fraOgMed = LocalDate.of(2023, 5, 1)
+
+    /**
+     *   Jan  Feb  Mar  Apr  Mai   Jun  Jul  Aug  Sep  Okt  Nov  Dec
+     * |----|----|----|----|--*--|----|----|----|----|----|----|----|
+     * Ingen vedtak
+     * */
+    @Test
+    fun `sak uten vedtak er ikke loepende`() {
+        val actual = Vedtakstidslinje(emptyList()).erLoependePaa(fraOgMed)
+        Assertions.assertEquals(false, actual)
+    }
+
+    /**
+     *   Jan  Feb  Mar  Apr  Mai   Jun  Jul  Aug  Sep  Okt  Nov  Dec
+     * |----|----|----|----|--*--|----|----|----|----|----|----|----|
+     * |------------------Fattet, ikke iverksatt--------------------|
+     * */
+    @Test
+    fun `sak uten iverksatte vedtak er ikke loepende`() {
+        val fattetVedtak = lagVedtak(
+            id = 1,
+            virkningsDato = LocalDate.of(2023, 1, 1),
+            vedtakStatus = VedtakStatus.FATTET_VEDTAK
+        )
+        val actual = Vedtakstidslinje(listOf(fattetVedtak)).erLoependePaa(fraOgMed)
+        Assertions.assertEquals(false, actual)
+    }
+
+    /**
+     *   Jan  Feb  Mar  Apr  Mai   Jun  Jul  Aug  Sep  Okt  Nov  Dec
+     * |----|----|----|----|--*--|----|----|----|----|----|----|----|
+     * |-----------------------Iverksatt----------------------------|
+     * */
+    @Test
+    fun `sak med iverksatt foerstegangsbehandling med vedtaksdato foer fraOgMed er loepende`() {
+        val iverksattDato = lagVedtak(
+            id = 1,
+            virkningsDato = LocalDate.of(2023, 1, 1),
+            vedtakStatus = VedtakStatus.IVERKSATT
+        )
+
+        val actual = Vedtakstidslinje(listOf(iverksattDato)).erLoependePaa(fraOgMed)
+        Assertions.assertEquals(true, actual)
+    }
+
+    /**
+     *   Jan  Feb  Mar  Apr  Mai   Jun  Jul  Aug  Sep  Okt  Nov  Dec
+     * |----|----|----|----|--*--|----|----|----|----|----|----|----|
+     * |-----------------------Iverksatt----------------------------|
+     *                |-----------------Opphør----------------------|
+     * */
+    @Test
+    fun `sak som blir opphoert foer fraOgMed er ikke loepende`() {
+        val attesteringsdato = LocalDateTime.now()
+        val iverksattDato = lagVedtak(
+            id = 1,
+            virkningsDato = LocalDate.of(2023, 1, 1),
+            vedtakStatus = VedtakStatus.IVERKSATT,
+            datoAttestert = attesteringsdato.toInstant(ZoneOffset.UTC)
+        )
+        val opphoertDato = lagVedtak(
+            id = 2,
+            virkningsDato = LocalDate.of(2023, 4, 1),
+            vedtakStatus = VedtakStatus.IVERKSATT,
+            behandlingType = BehandlingType.REVURDERING,
+            datoAttestert = attesteringsdato.plusDays(1).toInstant(ZoneOffset.UTC)
+        )
+
+        val actual = Vedtakstidslinje(
+            listOf(
+                iverksattDato,
+                opphoertDato
+            )
+        ).erLoependePaa(fraOgMed)
+        Assertions.assertEquals(false, actual)
+    }
+
+    /**
+     *   Jan  Feb  Mar  Apr  Mai   Jun  Jul  Aug  Sep  Okt  Nov  Dec
+     * |----|----|----|----|--*--|----|----|----|----|----|----|----|
+     * |-----------------------Iverksatt----------------------------|
+     *                           |-------------Opphør---------------|
+     * */
+    @Test
+    fun `sak som blir opphoert maaneden etter fraOgMed er loepende`() {
+        val attesteringsdato = LocalDateTime.now()
+        val iverksattDato = lagVedtak(
+            id = 1,
+            virkningsDato = LocalDate.of(2023, 1, 1),
+            vedtakStatus = VedtakStatus.IVERKSATT,
+            datoAttestert = attesteringsdato.toInstant(ZoneOffset.UTC)
+        )
+        val opphoertDato = lagVedtak(
+            id = 2,
+            virkningsDato = LocalDate.of(2023, 6, 1),
+            vedtakStatus = VedtakStatus.IVERKSATT,
+            behandlingType = BehandlingType.REVURDERING,
+            datoAttestert = attesteringsdato.plusDays(1).toInstant(ZoneOffset.UTC)
+        )
+
+        val actual = Vedtakstidslinje(
+            listOf(
+                iverksattDato,
+                opphoertDato
+            )
+        ).erLoependePaa(fraOgMed)
+        Assertions.assertEquals(true, actual)
+    }
+
+    /**
+     *   Jan  Feb  Mar  Apr  Mai   Jun  Jul  Aug  Sep  Okt  Nov  Dec
+     * |----|----|----|----|--*--|----|----|----|----|----|----|----|
+     *                           |---------Iverksatt----------------|
+     * */
+    @Test
+    fun `sak som er iverksatt maanaden etter fraOgMed-datoen er loepende`() {
+        val attesteringsdato = LocalDateTime.now()
+        val iverksattDato = lagVedtak(
+            id = 1,
+            virkningsDato = LocalDate.of(2023, 6, 1),
+            vedtakStatus = VedtakStatus.IVERKSATT,
+            datoAttestert = attesteringsdato.toInstant(ZoneOffset.UTC)
+        )
+
+        val actual = Vedtakstidslinje(listOf(iverksattDato)).erLoependePaa(fraOgMed)
+        Assertions.assertEquals(true, actual)
+    }
+
+    /**
+     *   Jan  Feb  Mar  Apr  Mai   Jun  Jul  Aug  Sep  Okt  Nov  Dec
+     * |----|----|----|----|--*--|----|----|----|----|----|----|----|
+     *                           |---------Iverksatt----------------|
+     *                                |---------Opphør--------------|
+     * */
+    @Test
+    fun `sak som er iverksatt etter fraOgMed og opphoert etterpaa er loepende`() {
+        val attesteringsdato = LocalDateTime.now()
+        val iverksattDato = lagVedtak(
+            id = 1,
+            virkningsDato = LocalDate.of(2023, 6, 1),
+            vedtakStatus = VedtakStatus.IVERKSATT,
+            datoAttestert = attesteringsdato.toInstant(ZoneOffset.UTC)
+        )
+        val opphoertDato = lagVedtak(
+            id = 2,
+            virkningsDato = LocalDate.of(2023, 7, 1),
+            vedtakStatus = VedtakStatus.IVERKSATT,
+            behandlingType = BehandlingType.REVURDERING,
+            datoAttestert = attesteringsdato.plusDays(1).toInstant(ZoneOffset.UTC)
+        )
+
+        val actual = Vedtakstidslinje(listOf(iverksattDato, opphoertDato)).erLoependePaa(fraOgMed)
+        Assertions.assertEquals(true, actual)
+    }
+
+    /**
+     *   Jan  Feb  Mar  Apr  Mai   Jun  Jul  Aug  Sep  Okt  Nov  Dec
+     * |----|----|----|----|--*--|----|----|----|----|----|----|----|
+     *                           |-----------Iverksatt--------------|
+     *                           |------------Opphør----------------|
+     * */
+    @Test
+    fun `sak som er iverksatt maanaden etter fraOgMed og opphoert samme maanad er ikke loepende`() {
+        val attesteringsdato = LocalDateTime.now()
+        val iverksattDato = lagVedtak(
+            id = 1,
+            virkningsDato = LocalDate.of(2023, 6, 1),
+            vedtakStatus = VedtakStatus.IVERKSATT,
+            datoAttestert = attesteringsdato.toInstant(ZoneOffset.UTC)
+        )
+        val opphoertDato = lagVedtak(
+            id = 2,
+            virkningsDato = LocalDate.of(2023, 6, 1),
+            vedtakStatus = VedtakStatus.IVERKSATT,
+            behandlingType = BehandlingType.REVURDERING,
+            datoAttestert = attesteringsdato.plusDays(1).toInstant(ZoneOffset.UTC)
+        )
+
+        val actual = Vedtakstidslinje(listOf(iverksattDato, opphoertDato)).erLoependePaa(fraOgMed)
+        Assertions.assertEquals(false, actual)
+    }
+}
+
+private fun lagVedtak(
+    id: Long,
+    virkningsDato: LocalDate,
+    behandlingType: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+    vedtakStatus: VedtakStatus,
+    datoAttestert: Instant = Instant.now()
+): Vedtak {
+    return Vedtak(
+        id = id,
+        sakId = 1L,
+        sakType = SakType.BARNEPENSJON,
+        behandlingId = UUID.randomUUID(),
+        saksbehandlerId = "saksbehandler01",
+        beregningsResultat = null,
+        vilkaarsResultat = null,
+        vedtakFattet = null,
+        fnr = null,
+        datoFattet = null,
+        datoattestert = datoAttestert,
+        attestant = null,
+        virkningsDato = virkningsDato,
+        vedtakStatus = vedtakStatus,
+        behandlingType = behandlingType,
+        attestertVedtakEnhet = null,
+        fattetVedtakEnhet = null
+    )
+}

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/VedtakstidslinjeTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/VedtakstidslinjeTest.kt
@@ -1,8 +1,8 @@
-import no.nav.etterlatte.Vedtakstidslinje
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.VedtakStatus
 import no.nav.etterlatte.vedtaksvurdering.Vedtak
+import no.nav.etterlatte.vedtaksvurdering.Vedtakstidslinje
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.time.Instant

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingRepositoryTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingRepositoryTest.kt
@@ -1,0 +1,67 @@
+package vedtaksvurdering
+
+import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.database.DataSourceBuilder
+import no.nav.etterlatte.libs.database.migrate
+import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingRepository
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import java.time.LocalDate
+import java.util.*
+import javax.sql.DataSource
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class VedtaksvurderingRepositoryTest {
+    @Container
+    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:12")
+
+    private lateinit var dataSource: DataSource
+    private lateinit var vedtaksvurderingRepository: VedtaksvurderingRepository
+
+    @BeforeAll
+    fun beforeAll() {
+        postgreSQLContainer.start()
+        postgreSQLContainer.withUrlParam("user", postgreSQLContainer.username)
+        postgreSQLContainer.withUrlParam("password", postgreSQLContainer.password)
+
+        dataSource = DataSourceBuilder.createDataSource(
+            postgreSQLContainer.jdbcUrl,
+            postgreSQLContainer.username,
+            postgreSQLContainer.password
+        ).also { it.migrate() }
+
+        vedtaksvurderingRepository = VedtaksvurderingRepository(dataSource)
+    }
+
+    @AfterAll
+    fun afterAll() {
+        postgreSQLContainer.stop()
+    }
+
+    @Test
+    fun `kan hente alle vedtak knyttet til en sak`() {
+        val sakId = 1L
+        listOf(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()).forEach {
+            vedtaksvurderingRepository.opprettVedtak(
+                behandlingsId = it,
+                sakid = sakId,
+                fnr = "",
+                saktype = SakType.BARNEPENSJON,
+                behandlingtype = BehandlingType.FØRSTEGANGSBEHANDLING,
+                virkningsDato = LocalDate.now(),
+                beregningsresultat = null,
+                vilkaarsresultat = null
+            )
+        }
+
+        with(vedtaksvurderingRepository.hentVedtakForSak(1)) {
+            Assertions.assertEquals(3, this.size)
+        }
+    }
+}

--- a/libs/common/src/main/kotlin/loependeYtelse/LoependeYtelseDTO.kt
+++ b/libs/common/src/main/kotlin/loependeYtelse/LoependeYtelseDTO.kt
@@ -1,0 +1,5 @@
+package no.nav.etterlatte.libs.common.loependeYtelse
+
+import java.time.LocalDate
+
+data class LoependeYtelseDTO(val erLoepende: Boolean, val dato: LocalDate)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@ include(
     "apps:etterlatte-oppdater-behandling",
     "apps:etterlatte-beregning",
     "apps:etterlatte-vedtaksvurdering",
+    "apps:etterlatte-vedtaksvurdering-kafka",
     "apps:etterlatte-grunnlag",
     "apps:etterlatte-brev-api",
     "apps:etterlatte-tilbakekreving",


### PR DESCRIPTION
Opprettelse av R&R-appen **etterlatte-vedtaksvurdering-kafka**

For å håndtere reguleringer (i denne omgang G-reguleringer), så er første steg på veien å finne ut hvilke ytelser som faktisk er løpende på en gitt dato. Denne appen tar imot en melding om et saksnummer og spør etterlatte-vedtaksvurdering om saken har noen vedtak som er løpende (og ingen motstridende opphørsvedtak) og får tilbake svaret sammen med en dato som sier når den evt er løpende fra.

For de sakene som er løpende sender vi videre en melding til etterlatte-behandling som gjør en omberegning.