### PR TITLE
EY-1766 Lag hent alle saker-hendelse i kafka-flyten for regulering

### DIFF
--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/Application.kt
@@ -13,6 +13,7 @@ fun main() {
                     OppdaterBehandling(it, behandlingservice)
                     PdlHendelser(it, behandlingservice)
                     OmberegningsHendelser(it, behandlingservice)
+                    Reguleringsforespoersel(it, behandlingservice)
                 }
                 .start()
         }

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/BehandlingsService.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/BehandlingsService.kt
@@ -14,7 +14,7 @@ import no.nav.etterlatte.libs.common.pdlhendelse.Adressebeskyttelse
 import no.nav.etterlatte.libs.common.pdlhendelse.Doedshendelse
 import no.nav.etterlatte.libs.common.pdlhendelse.ForelderBarnRelasjonHendelse
 import no.nav.etterlatte.libs.common.pdlhendelse.UtflyttingsHendelse
-import no.nav.etterlatte.libs.common.sak.Sak
+import no.nav.etterlatte.libs.common.sak.Saker
 
 interface Behandling {
     fun grunnlagEndretISak(sak: Long)
@@ -24,7 +24,7 @@ interface Behandling {
     fun sendForelderBarnRelasjonHendelse(forelderBarnRelasjon: ForelderBarnRelasjonHendelse)
     fun sendAdressebeskyttelseHendelse(adressebeskyttelse: Adressebeskyttelse)
 
-    fun hentAlleSaker(): List<Sak>
+    fun hentAlleSaker(): Saker
 
     fun opprettOmberegning(omberegningshendelse: Omberegningshendelse): HttpResponse
 }
@@ -84,7 +84,7 @@ class BehandlingsService(
         }
     }
 
-    override fun hentAlleSaker(): List<Sak> =
+    override fun hentAlleSaker(): Saker =
         runBlocking {
             behandling_app.get("$url/saker").body()
         }

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/BehandlingsService.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/BehandlingsService.kt
@@ -1,6 +1,8 @@
 package no.nav.etterlatte
 
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
@@ -12,6 +14,7 @@ import no.nav.etterlatte.libs.common.pdlhendelse.Adressebeskyttelse
 import no.nav.etterlatte.libs.common.pdlhendelse.Doedshendelse
 import no.nav.etterlatte.libs.common.pdlhendelse.ForelderBarnRelasjonHendelse
 import no.nav.etterlatte.libs.common.pdlhendelse.UtflyttingsHendelse
+import no.nav.etterlatte.libs.common.sak.Sak
 
 interface Behandling {
     fun grunnlagEndretISak(sak: Long)
@@ -20,6 +23,8 @@ interface Behandling {
     fun sendUtflyttingshendelse(utflyttingsHendelse: UtflyttingsHendelse)
     fun sendForelderBarnRelasjonHendelse(forelderBarnRelasjon: ForelderBarnRelasjonHendelse)
     fun sendAdressebeskyttelseHendelse(adressebeskyttelse: Adressebeskyttelse)
+
+    fun hentAlleSaker(): List<Sak>
 
     fun opprettOmberegning(omberegningshendelse: Omberegningshendelse): HttpResponse
 }
@@ -78,4 +83,9 @@ class BehandlingsService(
             }
         }
     }
+
+    override fun hentAlleSaker(): List<Sak> =
+        runBlocking {
+            behandling_app.get("$url/saker").body()
+        }
 }

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/OmberegningsHendelser.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/OmberegningsHendelser.kt
@@ -3,12 +3,12 @@ package no.nav.etterlatte
 import com.fasterxml.jackson.module.kotlin.treeToValue
 import io.ktor.client.call.body
 import kotlinx.coroutines.runBlocking
-import no.nav.etterlatte.libs.common.behandling.Hendelsestype
 import no.nav.etterlatte.libs.common.behandling.Omberegningshendelse
 import no.nav.etterlatte.libs.common.logging.withLogContext
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
+import no.nav.etterlatte.rapidsandrivers.EventNames.OMBEREGNINGSHENDELSE
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
@@ -24,7 +24,7 @@ internal class OmberegningsHendelser(rapidsConnection: RapidsConnection, private
     init {
         logger.info("initierer rapid for omberegningshendelser")
         River(rapidsConnection).apply {
-            eventName(Hendelsestype.OMBEREGNINGSHENDELSE.toString())
+            eventName(OMBEREGNINGSHENDELSE)
 
             correlationId()
             validate { it.rejectKey("omberegning") }

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/Reguleringsforespoersel.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/Reguleringsforespoersel.kt
@@ -1,0 +1,38 @@
+package no.nav.etterlatte
+
+import no.nav.etterlatte.libs.common.logging.withLogContext
+import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
+import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
+import no.nav.etterlatte.libs.common.rapidsandrivers.sakId
+import no.nav.etterlatte.rapidsandrivers.EventNames.FINN_LOEPENDE_YTELSER
+import no.nav.etterlatte.rapidsandrivers.EventNames.REGULERING_EVENT_NAME
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.MessageContext
+import no.nav.helse.rapids_rivers.RapidsConnection
+import no.nav.helse.rapids_rivers.River
+import org.slf4j.LoggerFactory
+
+internal class Reguleringsforespoersel(
+    rapidsConnection: RapidsConnection,
+    private val behandlingService: Behandling
+) : River.PacketListener {
+    private val logger = LoggerFactory.getLogger(Reguleringsforespoersel::class.java)
+
+    init {
+        River(rapidsConnection).apply {
+            eventName(REGULERING_EVENT_NAME)
+            validate { it.requireKey("dato") }
+            correlationId()
+        }.register(this)
+    }
+
+    override fun onPacket(packet: JsonMessage, context: MessageContext) =
+        withLogContext(packet.correlationId) {
+            logger.info("Leser reguleringsfoerespoersel for dato ${packet["dato"]}")
+            behandlingService.hentAlleSaker().forEach {
+                packet.eventName = FINN_LOEPENDE_YTELSER
+                packet.sakId = it.id
+                context.publish(packet.toJson())
+            }
+        }
+}

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/Reguleringsforespoersel.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/Reguleringsforespoersel.kt
@@ -29,7 +29,7 @@ internal class Reguleringsforespoersel(
     override fun onPacket(packet: JsonMessage, context: MessageContext) =
         withLogContext(packet.correlationId) {
             logger.info("Leser reguleringsfoerespoersel for dato ${packet["dato"]}")
-            behandlingService.hentAlleSaker().forEach {
+            behandlingService.hentAlleSaker().saker.forEach {
                 packet.eventName = FINN_LOEPENDE_YTELSER
                 packet.sakId = it.id
                 context.publish(packet.toJson())

--- a/apps/etterlatte-oppdater-behandling/src/test/kotlin/ReguleringsforespoerselTest.kt
+++ b/apps/etterlatte-oppdater-behandling/src/test/kotlin/ReguleringsforespoerselTest.kt
@@ -7,6 +7,7 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventNameKey
 import no.nav.etterlatte.libs.common.rapidsandrivers.sakIdKey
 import no.nav.etterlatte.libs.common.sak.Sak
+import no.nav.etterlatte.libs.common.sak.Saker
 import no.nav.etterlatte.rapidsandrivers.EventNames.FINN_LOEPENDE_YTELSER
 import no.nav.etterlatte.rapidsandrivers.EventNames.REGULERING_EVENT_NAME
 import no.nav.helse.rapids_rivers.JsonMessage
@@ -42,10 +43,12 @@ internal class ReguleringsforespoerselTest {
     fun `skal lage ny melding for hver sak den faar tilbake`() {
         val melding = genererReguleringMelding(`1_mai_2023`)
         val vedtakServiceMock = mockk<Behandling>(relaxed = true)
-        every { vedtakServiceMock.hentAlleSaker() } returns listOf(
-            Sak("saksbehandler1", SakType.BARNEPENSJON, 1L),
-            Sak("saksbehandler2", SakType.BARNEPENSJON, 2L),
-            Sak("saksbehandler1", SakType.BARNEPENSJON, 3L)
+        every { vedtakServiceMock.hentAlleSaker() } returns Saker(
+            listOf(
+                Sak("saksbehandler1", SakType.BARNEPENSJON, 1L),
+                Sak("saksbehandler2", SakType.BARNEPENSJON, 2L),
+                Sak("saksbehandler1", SakType.BARNEPENSJON, 3L)
+            )
         )
         val inspector = TestRapid().apply { Reguleringsforespoersel(this, vedtakServiceMock) }
 
@@ -63,10 +66,12 @@ internal class ReguleringsforespoerselTest {
     fun `skal sende med sakId for alle saker i basen`() {
         val melding = genererReguleringMelding(`1_mai_2023`)
         val behandlingServiceMock = mockk<Behandling>(relaxed = true)
-        every { behandlingServiceMock.hentAlleSaker() } returns listOf(
-            Sak("saksbehandler1", SakType.BARNEPENSJON, 1000L),
-            Sak("saksbehandler2", SakType.BARNEPENSJON, 1002L),
-            Sak("saksbehandler1", SakType.BARNEPENSJON, 1003L)
+        every { behandlingServiceMock.hentAlleSaker() } returns Saker(
+            listOf(
+                Sak("saksbehandler1", SakType.BARNEPENSJON, 1000L),
+                Sak("saksbehandler2", SakType.BARNEPENSJON, 1002L),
+                Sak("saksbehandler1", SakType.BARNEPENSJON, 1003L)
+            )
         )
         val inspector = TestRapid().apply { Reguleringsforespoersel(this, behandlingServiceMock) }
         inspector.sendTestMessage(melding.toJson())

--- a/apps/etterlatte-oppdater-behandling/src/test/kotlin/ReguleringsforespoerselTest.kt
+++ b/apps/etterlatte-oppdater-behandling/src/test/kotlin/ReguleringsforespoerselTest.kt
@@ -1,0 +1,82 @@
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.etterlatte.Behandling
+import no.nav.etterlatte.Reguleringsforespoersel
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.rapidsandrivers.eventNameKey
+import no.nav.etterlatte.libs.common.rapidsandrivers.sakIdKey
+import no.nav.etterlatte.libs.common.sak.Sak
+import no.nav.etterlatte.rapidsandrivers.EventNames.FINN_LOEPENDE_YTELSER
+import no.nav.etterlatte.rapidsandrivers.EventNames.REGULERING_EVENT_NAME
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.testsupport.TestRapid
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+internal class ReguleringsforespoerselTest {
+
+    private val `1_mai_2023` = LocalDate.of(2023, 5, 1)
+
+    private fun genererReguleringMelding(dato: LocalDate) = JsonMessage.newMessage(
+        mapOf(
+            eventNameKey to REGULERING_EVENT_NAME,
+            "dato" to dato
+        )
+    )
+
+    @Test
+    fun `kan ta imot reguleringsmelding og kalle på behandling`() {
+        val melding = genererReguleringMelding(`1_mai_2023`)
+        val vedtakServiceMock = mockk<Behandling>(relaxed = true)
+        val inspector = TestRapid().apply { Reguleringsforespoersel(this, vedtakServiceMock) }
+
+        inspector.sendTestMessage(melding.toJson())
+        verify(exactly = 1) {
+            vedtakServiceMock.hentAlleSaker()
+        }
+    }
+
+    @Test
+    fun `skal lage ny melding for hver sak den faar tilbake`() {
+        val melding = genererReguleringMelding(`1_mai_2023`)
+        val vedtakServiceMock = mockk<Behandling>(relaxed = true)
+        every { vedtakServiceMock.hentAlleSaker() } returns listOf(
+            Sak("saksbehandler1", SakType.BARNEPENSJON, 1L),
+            Sak("saksbehandler2", SakType.BARNEPENSJON, 2L),
+            Sak("saksbehandler1", SakType.BARNEPENSJON, 3L)
+        )
+        val inspector = TestRapid().apply { Reguleringsforespoersel(this, vedtakServiceMock) }
+
+        inspector.sendTestMessage(melding.toJson())
+        val sendteMeldinger = inspector.inspektør.size
+        Assertions.assertEquals(3, sendteMeldinger)
+
+        for (i in 0 until inspector.inspektør.size) {
+            Assertions.assertEquals(FINN_LOEPENDE_YTELSER, inspector.inspektør.message(i).get(eventNameKey).asText())
+            Assertions.assertEquals(`1_mai_2023`.toString(), inspector.inspektør.message(i).get("dato").asText())
+        }
+    }
+
+    @Test
+    fun `skal sende med sakId for alle saker i basen`() {
+        val melding = genererReguleringMelding(`1_mai_2023`)
+        val behandlingServiceMock = mockk<Behandling>(relaxed = true)
+        every { behandlingServiceMock.hentAlleSaker() } returns listOf(
+            Sak("saksbehandler1", SakType.BARNEPENSJON, 1000L),
+            Sak("saksbehandler2", SakType.BARNEPENSJON, 1002L),
+            Sak("saksbehandler1", SakType.BARNEPENSJON, 1003L)
+        )
+        val inspector = TestRapid().apply { Reguleringsforespoersel(this, behandlingServiceMock) }
+        inspector.sendTestMessage(melding.toJson())
+
+        val melding1 = inspector.inspektør.message(0)
+        val melding2 = inspector.inspektør.message(1)
+        val melding3 = inspector.inspektør.message(2)
+
+        Assertions.assertEquals(1000L, melding1.get(sakIdKey).asLong())
+        Assertions.assertEquals(1002L, melding2.get(sakIdKey).asLong())
+        Assertions.assertEquals(1003L, melding3.get(sakIdKey).asLong())
+    }
+}

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/Application.kt
@@ -1,7 +1,7 @@
 package no.nav.etterlatte
 
 import no.nav.etterlatte.regulering.AppBuilder
-import no.nav.etterlatte.regulering.Reguleringsforespoersel
+import no.nav.etterlatte.regulering.LoependeYtelserforespoersel
 import no.nav.helse.rapids_rivers.RapidApplication
 
 fun main() {
@@ -9,7 +9,7 @@ fun main() {
         put("KAFKA_CONSUMER_GROUP_ID", get("NAIS_APP_NAME")!!.replace("-", ""))
     }.also { env ->
         AppBuilder(env).also { ab ->
-            RapidApplication.create(env).also { Reguleringsforespoersel(it, ab.lagVedtakKlient()) }.start()
+            RapidApplication.create(env).also { LoependeYtelserforespoersel(it, ab.lagVedtakKlient()) }.start()
         }
     }
 }

--- a/libs/common/src/main/kotlin/behandling/Omberegningshendelse.kt
+++ b/libs/common/src/main/kotlin/behandling/Omberegningshendelse.kt
@@ -7,9 +7,3 @@ data class Omberegningshendelse(
     val fradato: LocalDate,
     val aarsak: RevurderingAarsak
 )
-
-enum class Hendelsestype {
-    OMBEREGNINGSHENDELSE;
-
-    override fun toString() = name
-}

--- a/libs/common/src/main/kotlin/sak/Sak.kt
+++ b/libs/common/src/main/kotlin/sak/Sak.kt
@@ -3,3 +3,4 @@ package no.nav.etterlatte.libs.common.sak
 import no.nav.etterlatte.libs.common.behandling.SakType
 
 data class Sak(val ident: String, val sakType: SakType, val id: Long)
+data class Saker(val saker: List<Sak>)

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/EventNames.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/EventNames.kt
@@ -1,0 +1,7 @@
+package no.nav.etterlatte.rapidsandrivers
+
+object EventNames {
+    const val REGULERING_EVENT_NAME = "REGULERING"
+    const val FINN_LOEPENDE_YTELSER = "FINN_LOEPENDE_YTELSER"
+    const val OMBEREGNINGSHENDELSE = "OMBEREGNINGSHENDELSE"
+}

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/StandardKeys.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/StandardKeys.kt
@@ -7,6 +7,7 @@ const val eventNameKey = "@event_name"
 const val behovNameKey = "@behov"
 const val correlationIdKey = "@correlation_id"
 const val tekniskTidKey = "teknisk_tid"
+const val sakIdKey = "sakId"
 
 fun River.eventName(eventName: String) {
     validate { it.demandValue(eventNameKey, eventName) }
@@ -27,4 +28,10 @@ var JsonMessage.correlationId: String?
     set(name) {
         name?.also { this[correlationIdKey] = it }
             ?: throw IllegalArgumentException("Kan ikke sette correlationId til null")
+    }
+
+var JsonMessage.sakId: Long
+    get() = this[sakIdKey].asLong()
+    set(name) {
+        this[sakIdKey] = name
     }


### PR DESCRIPTION
App som tar i mot en g-reguleringsmelding og henter ut alle saker for å sende videre til vedtaks-kafka-appen