### PR TITLE
Minimum two pods in dev and prod, max 4 in prod 2 in dev

### DIFF
--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -43,8 +43,8 @@ spec:
     pool: nav-dev
   replicas:
     cpuThresholdPercentage: 90
-    max: 1
-    min: 1
+    max: 2
+    min: 2
   env:
     - name: KAFKA_RAPID_TOPIC
       value: etterlatte.dodsmelding

--- a/apps/etterlatte-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-behandling/.nais/prod.yaml
@@ -58,8 +58,8 @@ spec:
     pool: nav-prod
   replicas:
     cpuThresholdPercentage: 90
-    max: 1
-    min: 1
+    max: 4
+    min: 2
   env:
     - name: KAFKA_RAPID_TOPIC
       value: etterlatte.etterlatteytelser

--- a/apps/etterlatte-beregning/.nais/dev.yaml
+++ b/apps/etterlatte-beregning/.nais/dev.yaml
@@ -23,8 +23,8 @@ spec:
     enabled: true
   replicas:
     cpuThresholdPercentage: 90
-    max: 1
-    min: 1
+    max: 2
+    min: 2
   azure:
     application:
       enabled: true

--- a/apps/etterlatte-beregning/.nais/prod.yaml
+++ b/apps/etterlatte-beregning/.nais/prod.yaml
@@ -23,8 +23,8 @@ spec:
     enabled: true
   replicas:
     cpuThresholdPercentage: 90
-    max: 1
-    min: 1
+    max: 4
+    min: 2
   azure:
     application:
       enabled: true

--- a/apps/etterlatte-grunnlag/.nais/dev.yaml
+++ b/apps/etterlatte-grunnlag/.nais/dev.yaml
@@ -51,8 +51,8 @@ spec:
     pool: nav-dev
   replicas:
     cpuThresholdPercentage: 90
-    max: 1
-    min: 1
+    max: 2
+    min: 2
   env:
     - name: KAFKA_RAPID_TOPIC
       value: etterlatte.dodsmelding

--- a/apps/etterlatte-grunnlag/.nais/prod.yaml
+++ b/apps/etterlatte-grunnlag/.nais/prod.yaml
@@ -60,8 +60,8 @@ spec:
     pool: nav-prod
   replicas:
     cpuThresholdPercentage: 90
-    max: 1
-    min: 1
+    max: 4
+    min: 2
   env:
     - name: KAFKA_RAPID_TOPIC
       value: etterlatte.etterlatteytelser

--- a/apps/etterlatte-saksbehandling-ui/.nais/dev.yaml
+++ b/apps/etterlatte-saksbehandling-ui/.nais/dev.yaml
@@ -11,8 +11,8 @@ spec:
   image: {{ image }}
   port: 8080
   replicas:
-    min: 1
-    max: 1
+    max: 2
+    min: 2
     cpuThresholdPercentage: 90
   ingresses:
     - https://etterlatte-saksbehandling.dev.intern.nav.no

--- a/apps/etterlatte-saksbehandling-ui/.nais/prod.yaml
+++ b/apps/etterlatte-saksbehandling-ui/.nais/prod.yaml
@@ -11,8 +11,8 @@ spec:
   image: {{ image }}
   port: 8080
   replicas:
-    min: 2
     max: 4
+    min: 2
     cpuThresholdPercentage: 90
   ingresses:
     - https://etterlatte-saksbehandling.intern.nav.no

--- a/apps/etterlatte-vilkaarsvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vilkaarsvurdering/.nais/dev.yaml
@@ -41,8 +41,8 @@ spec:
 
   replicas:
     cpuThresholdPercentage: 90
-    max: 1
-    min: 1
+    max: 4
+    min: 2
   env:
     - name: ETTERLATTE_BEHANDLING_URL
       value: http://etterlatte-behandling

--- a/apps/etterlatte-vilkaarsvurdering/.nais/prod.yaml
+++ b/apps/etterlatte-vilkaarsvurdering/.nais/prod.yaml
@@ -50,8 +50,8 @@ spec:
 
   replicas:
     cpuThresholdPercentage: 90
-    max: 1
-    min: 1
+    max: 4
+    min: 2
   env:
     - name: ETTERLATTE_BEHANDLING_URL
       value: http://etterlatte-behandling


### PR DESCRIPTION
https://docs.nais.io/nais-application/good-practices/?h=shutdown#exposes-relevant-application-metrics

```
If your application only has a single replica, then your users will experience downtime whenever your pod is restarted or moved.

If you wish to avoid unnecessary downtime, your application should run at least 2 replicas.
```


Vedtak er ikke med siden den har en lytter på en rapid..

Godt mulig Vedtak og de andre async appene skal alle ha en leaderElection impl som kun kjører hvis leader slik at man har en backup app der. Men for now tenker jeg dette holder ref nedetiden vi har hatt i dev.

Det er kun vedtak som burde virkelig kanskje trenger denne ekstra implementasjonen slik jeg ser det siden det er en hybrid app.