### PR TITLE
EY-1768: Handterer tokens for app-til-app-kommunikasjon annleis enn viss det fins ein saksbehandlar

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRoutes.kt
@@ -10,7 +10,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.libs.common.withBehandlingId
-import no.nav.etterlatte.libs.ktor.accesstoken
+import no.nav.etterlatte.libs.ktor.accesstokenWrapper
 
 fun Route.beregning(beregningService: BeregningService) {
     route("/api/beregning") {
@@ -30,7 +30,7 @@ fun Route.beregning(beregningService: BeregningService) {
         post("/{behandlingId}") {
             withBehandlingId {
                 logger.info("Oppretter beregning for behandlingId=$it")
-                val beregning = beregningService.lagreBeregning(it, accesstoken)
+                val beregning = beregningService.lagreBeregning(it, accesstokenWrapper)
                 call.respond(beregning.toDTO())
             }
         }

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
@@ -24,6 +24,7 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Beregningsgrunnla
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
+import no.nav.etterlatte.libs.ktor.AccessTokenWrapper
 import no.nav.etterlatte.libs.regler.FaktumNode
 import no.nav.etterlatte.libs.regler.RegelPeriode
 import no.nav.etterlatte.libs.regler.RegelkjoeringResultat
@@ -47,7 +48,7 @@ class BeregningService(
 
     fun hentBeregning(behandlingId: UUID): Beregning? = beregningRepository.hent(behandlingId)
 
-    suspend fun lagreBeregning(behandlingId: UUID, accessToken: String): Beregning {
+    suspend fun lagreBeregning(behandlingId: UUID, accessToken: AccessTokenWrapper): Beregning {
         logger.info("Oppretter barnepensjonberegning for behandlingId=$behandlingId")
         return tilstandssjekkFoerKjoerning(behandlingId, accessToken) {
             coroutineScope {
@@ -229,7 +230,7 @@ class BeregningService(
 
     private suspend fun tilstandssjekkFoerKjoerning(
         behandlingId: UUID,
-        accessToken: String,
+        accessToken: AccessTokenWrapper,
         block: suspend () -> Beregning
     ): Beregning {
         val kanBeregne = behandlingKlient.beregn(behandlingId, accessToken, false)

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
@@ -24,12 +24,12 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Beregningsgrunnla
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
-import no.nav.etterlatte.libs.ktor.AccessTokenWrapper
 import no.nav.etterlatte.libs.regler.FaktumNode
 import no.nav.etterlatte.libs.regler.RegelPeriode
 import no.nav.etterlatte.libs.regler.RegelkjoeringResultat
 import no.nav.etterlatte.libs.regler.eksekver
 import no.nav.etterlatte.libs.regler.finnAnvendteRegler
+import no.nav.etterlatte.token.AccessTokenWrapper
 import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.time.YearMonth

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/klienter/BehandlingKlient.kt
@@ -41,7 +41,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
                         clientId = clientId,
                         url = "$resourceUrl/behandlinger/$behandlingId"
                     ),
-                    accessToken = accessToken.accessToken
+                    accessToken = accessToken
                 )
                 .mapBoth(
                     success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },
@@ -65,8 +65,8 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
         val resource = Resource(clientId = clientId, url = "$resourceUrl/behandlinger/$behandlingId/beregn")
 
         val response = when (commit) {
-            false -> downstreamResourceClient.get(resource, accessToken.accessToken)
-            true -> downstreamResourceClient.post(resource, accessToken.accessToken, "{}")
+            false -> downstreamResourceClient.get(resource, accessToken)
+            true -> downstreamResourceClient.post(resource, accessToken, "{}")
         }
 
         return response.mapBoth(

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/klienter/BehandlingKlient.kt
@@ -8,10 +8,10 @@ import no.nav.etterlatte.libs.common.RetryResult
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.retry
-import no.nav.etterlatte.libs.ktor.AccessTokenWrapper
 import no.nav.etterlatte.libs.ktorobo.AzureAdClient
 import no.nav.etterlatte.libs.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktorobo.Resource
+import no.nav.etterlatte.token.AccessTokenWrapper
 import org.slf4j.LoggerFactory
 import java.util.*
 

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/klienter/GrunnlagKlient.kt
@@ -39,7 +39,7 @@ class GrunnlagKlientImpl(config: Config, httpClient: HttpClient) : GrunnlagKlien
                         clientId = clientId,
                         url = "$resourceUrl/api/grunnlag/$sakId"
                     ),
-                    accessToken = accessToken.accessToken
+                    accessToken = accessToken
                 )
                 .mapBoth(
                     success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/klienter/GrunnlagKlient.kt
@@ -8,10 +8,10 @@ import no.nav.etterlatte.libs.common.RetryResult
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.retry
-import no.nav.etterlatte.libs.ktor.AccessTokenWrapper
 import no.nav.etterlatte.libs.ktorobo.AzureAdClient
 import no.nav.etterlatte.libs.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktorobo.Resource
+import no.nav.etterlatte.token.AccessTokenWrapper
 import org.slf4j.LoggerFactory
 
 interface GrunnlagKlient {

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/klienter/GrunnlagKlient.kt
@@ -8,13 +8,14 @@ import no.nav.etterlatte.libs.common.RetryResult
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.retry
+import no.nav.etterlatte.libs.ktor.AccessTokenWrapper
 import no.nav.etterlatte.libs.ktorobo.AzureAdClient
 import no.nav.etterlatte.libs.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktorobo.Resource
 import org.slf4j.LoggerFactory
 
 interface GrunnlagKlient {
-    suspend fun hentGrunnlag(sakId: Long, accessToken: String): Grunnlag
+    suspend fun hentGrunnlag(sakId: Long, accessToken: AccessTokenWrapper): Grunnlag
 }
 
 class GrunnlagKlientException(override val message: String, override val cause: Throwable) : Exception(message, cause)
@@ -28,7 +29,7 @@ class GrunnlagKlientImpl(config: Config, httpClient: HttpClient) : GrunnlagKlien
     private val clientId = config.getString("grunnlag.client.id")
     private val resourceUrl = config.getString("grunnlag.resource.url")
 
-    override suspend fun hentGrunnlag(sakId: Long, accessToken: String): Grunnlag {
+    override suspend fun hentGrunnlag(sakId: Long, accessToken: AccessTokenWrapper): Grunnlag {
         logger.info("Henter grunnlag for sak med sakId = $sakId")
 
         return retry<Grunnlag> {
@@ -38,7 +39,7 @@ class GrunnlagKlientImpl(config: Config, httpClient: HttpClient) : GrunnlagKlien
                         clientId = clientId,
                         url = "$resourceUrl/api/grunnlag/$sakId"
                     ),
-                    accessToken = accessToken
+                    accessToken = accessToken.accessToken
                 )
                 .mapBoth(
                     success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/klienter/VilkaarsvurderingKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/klienter/VilkaarsvurderingKlient.kt
@@ -42,7 +42,7 @@ class VilkaarsvurderingKlientImpl(config: Config, httpClient: HttpClient) : Vilk
                         clientId = clientId,
                         url = "$resourceUrl/api/vilkaarsvurdering/$behandlingId"
                     ),
-                    accessToken = accessToken.accessToken
+                    accessToken = accessToken
                 )
                 .mapBoth(
                     success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/klienter/VilkaarsvurderingKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/klienter/VilkaarsvurderingKlient.kt
@@ -8,10 +8,10 @@ import no.nav.etterlatte.libs.common.RetryResult
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.retry
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingDto
-import no.nav.etterlatte.libs.ktor.AccessTokenWrapper
 import no.nav.etterlatte.libs.ktorobo.AzureAdClient
 import no.nav.etterlatte.libs.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktorobo.Resource
+import no.nav.etterlatte.token.AccessTokenWrapper
 import org.slf4j.LoggerFactory
 import java.util.*
 

--- a/apps/etterlatte-testdata/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/Application.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.github.michaelbull.result.get
 import com.github.mustachejava.DefaultMustacheFactory
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
@@ -167,5 +168,6 @@ fun PipelineContext<Unit, ApplicationCall>.usernameFraToken() = call.principal<T
     ?.context?.firstValidToken?.get()?.jwtTokenClaims?.get("preferred_username")?.toString()
 
 fun getClientAccessToken(): String = runBlocking {
-    azureAdClient.getAccessTokenForResource(listOf("api://${config.getString("dolly.client.id")}/.default")).accessToken
+    azureAdClient.getAccessTokenForResource(listOf("api://${config.getString("dolly.client.id")}/.default"))
+        .get()!!.accessToken
 }

--- a/jobs/start-regulering/deploy/dev.yml
+++ b/jobs/start-regulering/deploy/dev.yml
@@ -6,7 +6,7 @@ metadata:
   name: start-regulering
   namespace: etterlatte
 spec:
-  image: ghcr.io/navikt/pensjon-etterlatte-saksbehandling/start-regulering:8dd6c2db63b5e499f3da14a43821ca0e39795718
+  image: ghcr.io/navikt/pensjon-etterlatte-saksbehandling/start-regulering:134c0ba7a6eef18deb9b5a761718b256f9c09c5d
   kafka:
     pool: nav-dev
   env:

--- a/libs/etterlatte-ktor/build.gradle.kts
+++ b/libs/etterlatte-ktor/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
 
     implementation(project(":libs:common"))
     implementation(project(":libs:ktor2client-auth-clientcredentials"))
+    implementation(project(":libs:etterlatte-token-model"))
     implementation(project(":libs:etterlatte-helsesjekk"))
 
     implementation(Ktor2.ServerCore)

--- a/libs/etterlatte-ktor/src/main/kotlin/TokenUtils.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/TokenUtils.kt
@@ -7,6 +7,7 @@ import io.ktor.server.auth.parseAuthorizationHeader
 import io.ktor.server.auth.principal
 import io.ktor.util.pipeline.PipelineContext
 import no.nav.etterlatte.libs.common.sak.Saksbehandler
+import no.nav.security.token.support.core.jwt.JwtTokenClaims
 import no.nav.security.token.support.v2.TokenValidationContextPrincipal
 
 inline val PipelineContext<*, ApplicationCall>.saksbehandler: Saksbehandler
@@ -14,20 +15,44 @@ inline val PipelineContext<*, ApplicationCall>.saksbehandler: Saksbehandler
 
 fun hentSaksbehandler(call: ApplicationCall) = call.principal<TokenValidationContextPrincipal>().let {
     val navIdent = it?.context?.getJwtToken("azure")
-        ?.jwtTokenClaims?.getStringClaim("NAVident")
+        ?.jwtTokenClaims?.getClaim(Claims.NAVident)
         ?: throw Exception("Navident is null in token, probably missing claim NAVident")
     Saksbehandler(navIdent)
 }
 
 inline val PipelineContext<*, ApplicationCall>.accesstoken: String
-    get() = call.request.parseAuthorizationHeader().let {
-        if (!(it == null || it !is HttpAuthHeader.Single || it.authScheme != "Bearer")) {
-            it.blob
-        } else {
-            throw Exception("Missing authorization header")
+    get() = hentAccessToken(call)
+
+fun hentAccessToken(call: ApplicationCall) = call.request.parseAuthorizationHeader().let {
+    if (!(it == null || it !is HttpAuthHeader.Single || it.authScheme != "Bearer")) {
+        it.blob
+    } else {
+        throw Exception("Missing authorization header")
+    }
+}
+
+inline val PipelineContext<*, ApplicationCall>.accesstokenWrapper: AccessTokenWrapper
+    get() {
+        val oidSub = call.principal<TokenValidationContextPrincipal>().let {
+            val claims = it?.context?.getJwtToken("azure")
+                ?.jwtTokenClaims
+            val oid = claims?.getClaim(Claims.oid)
+            val sub = claims?.getClaim(Claims.sub)
+            Pair(oid, sub)
         }
+        return AccessTokenWrapper(accessToken = hentAccessToken(call), oid = oidSub.first, sub = oidSub.second)
     }
 
 data class SaksbehandlerProvider(val saksbehandler: (call: ApplicationCall) -> Saksbehandler) {
     fun invoke(call: ApplicationCall) = saksbehandler.invoke(call)
 }
+
+data class AccessTokenWrapper(val accessToken: String, val oid: String?, val sub: String?)
+
+enum class Claims {
+    NAVident,
+    oid, // ktlint-disable enum-entry-name-case
+    sub // ktlint-disable enum-entry-name-case
+}
+
+fun JwtTokenClaims.getClaim(claim: Claims) = getStringClaim(claim.name)

--- a/libs/etterlatte-ktor/src/main/kotlin/TokenUtils.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/TokenUtils.kt
@@ -7,6 +7,8 @@ import io.ktor.server.auth.parseAuthorizationHeader
 import io.ktor.server.auth.principal
 import io.ktor.util.pipeline.PipelineContext
 import no.nav.etterlatte.libs.common.sak.Saksbehandler
+import no.nav.etterlatte.token.AccessTokenWrapper
+import no.nav.etterlatte.token.Claims
 import no.nav.security.token.support.core.jwt.JwtTokenClaims
 import no.nav.security.token.support.v2.TokenValidationContextPrincipal
 
@@ -45,14 +47,6 @@ inline val PipelineContext<*, ApplicationCall>.accesstokenWrapper: AccessTokenWr
 
 data class SaksbehandlerProvider(val saksbehandler: (call: ApplicationCall) -> Saksbehandler) {
     fun invoke(call: ApplicationCall) = saksbehandler.invoke(call)
-}
-
-data class AccessTokenWrapper(val accessToken: String, val oid: String?, val sub: String?)
-
-enum class Claims {
-    NAVident,
-    oid, // ktlint-disable enum-entry-name-case
-    sub // ktlint-disable enum-entry-name-case
 }
 
 fun JwtTokenClaims.getClaim(claim: Claims) = getStringClaim(claim.name)

--- a/libs/etterlatte-token-model/build.gradle.kts
+++ b/libs/etterlatte-token-model/build.gradle.kts
@@ -1,0 +1,9 @@
+
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    mavenCentral()
+    maven("https://packages.confluent.io/maven/")
+}

--- a/libs/etterlatte-token-model/src/main/kotlin/no/nav/etterlatte/token/AccessTokenWrapper.kt
+++ b/libs/etterlatte-token-model/src/main/kotlin/no/nav/etterlatte/token/AccessTokenWrapper.kt
@@ -1,0 +1,9 @@
+package no.nav.etterlatte.token
+
+data class AccessTokenWrapper(val accessToken: String, val oid: String?, val sub: String?)
+
+enum class Claims {
+    NAVident,
+    oid, // ktlint-disable enum-entry-name-case
+    sub // ktlint-disable enum-entry-name-case
+}

--- a/libs/etterlatte-token-model/src/main/kotlin/no/nav/etterlatte/token/AccessTokenWrapper.kt
+++ b/libs/etterlatte-token-model/src/main/kotlin/no/nav/etterlatte/token/AccessTokenWrapper.kt
@@ -1,6 +1,8 @@
 package no.nav.etterlatte.token
 
-data class AccessTokenWrapper(val accessToken: String, val oid: String?, val sub: String?)
+data class AccessTokenWrapper(val accessToken: String, val oid: String?, val sub: String?) {
+    fun erMaskinTilMaskin() = oid == sub
+}
 
 enum class Claims {
     NAVident,

--- a/libs/ktor2client-auth-clientcredentials/build.gradle.kts
+++ b/libs/ktor2client-auth-clientcredentials/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     api(Ktor2.ClientContentNegotiation)
     api(Ktor2.Jackson)
     api(Ktor2.ClientLoggingJvm)
+    api(project(":libs:etterlatte-token-model"))
 
     api(NavFelles.TokenClientCore)
 }

--- a/libs/ktor2client-onbehalfof/build.gradle.kts
+++ b/libs/ktor2client-onbehalfof/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     testImplementation(Jupiter.Api)
     testImplementation(Ktor2.ClientMock)
     testImplementation(Kotest.AssertionsCore)
+    testImplementation(MockK.MockK)
 
     tasks {
         withType<Test> {

--- a/libs/ktor2client-onbehalfof/build.gradle.kts
+++ b/libs/ktor2client-onbehalfof/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     api("com.natpryce:konfig:1.6.10.0")
     api("com.michael-bull.kotlin-result:kotlin-result:1.1.16")
     api(Cache.Caffeine)
+    api(project(":libs:etterlatte-token-model"))
 
     testImplementation(Kotlinx.CoroutinesTest)
     testImplementation("com.github.tomakehurst:wiremock-jre8:2.35.0")

--- a/libs/ktor2client-onbehalfof/src/main/kotlin/AzureAdClient.kt
+++ b/libs/ktor2client-onbehalfof/src/main/kotlin/AzureAdClient.kt
@@ -56,17 +56,6 @@ data class AzureAdOpenIdConfiguration(
     val authorizationEndpoint: String
 )
 
-sealed class TokenRequest(
-    open val scopes: List<String>
-)
-
-data class OboTokenRequest(
-    override val scopes: List<String>,
-    val accessToken: String
-) : TokenRequest(scopes)
-
-data class ClientCredentialsTokenRequest(override val scopes: List<String>) : TokenRequest(scopes)
-
 class AzureAdClient(
     private val config: Config,
     private val httpClient: HttpClient = defaultHttpClient,
@@ -195,13 +184,3 @@ class AzureAdClient(
             .andThen { oboAccessToken -> get(url, oboAccessToken) }
     }
 }
-
-@JsonIgnoreProperties(ignoreUnknown = true)
-data class AccessToken(
-    @JsonProperty("access_token")
-    val accessToken: String,
-    @JsonProperty("expires_in")
-    val expiresIn: Int,
-    @JsonProperty("token_type")
-    val tokenType: String
-)

--- a/libs/ktor2client-onbehalfof/src/main/kotlin/DownstreamResourceClass.kt
+++ b/libs/ktor2client-onbehalfof/src/main/kotlin/DownstreamResourceClass.kt
@@ -48,6 +48,7 @@ class DownstreamResourceClient(
             .getOnBehalfOfAccessTokenForResource(scopes, accessToken.accessToken)
     }
 
+    @Deprecated(message = "Bruk heller den som tar inn AccessTokenWrapper")
     suspend fun get(
         resource: Resource,
         accessToken: String
@@ -71,14 +72,15 @@ class DownstreamResourceClient(
     ): Result<Resource, ThrowableErrorMessage> {
         val scopes = listOf("api://${resource.clientId}/.default")
         return hentTokenFraAD(accessToken, scopes)
-            .andThen { oboAccessToken ->
-                postToDownstreamApi(resource, oboAccessToken, postBody)
+            .andThen { token ->
+                postToDownstreamApi(resource, token, postBody)
             }
             .andThen { response ->
                 Ok(resource.addResponse(response))
             }
     }
 
+    @Deprecated(message = "Bruk heller den som tar inn AccessTokenWrapper")
     suspend fun post(
         resource: Resource,
         accessToken: String,

--- a/libs/ktor2client-onbehalfof/src/main/kotlin/DownstreamResourceClass.kt
+++ b/libs/ktor2client-onbehalfof/src/main/kotlin/DownstreamResourceClass.kt
@@ -41,7 +41,7 @@ class DownstreamResourceClient(
     private suspend fun hentTokenFraAD(
         accessToken: AccessTokenWrapper,
         scopes: List<String>
-    ): Result<AccessToken, ThrowableErrorMessage> = if (accessToken.oid == accessToken.sub) {
+    ): Result<AccessToken, ThrowableErrorMessage> = if (accessToken.erMaskinTilMaskin()) {
         azureAdClient.getAccessTokenForResource(scopes)
     } else {
         azureAdClient

--- a/libs/ktor2client-onbehalfof/src/main/kotlin/DownstreamResourceClass.kt
+++ b/libs/ktor2client-onbehalfof/src/main/kotlin/DownstreamResourceClass.kt
@@ -28,23 +28,14 @@ class DownstreamResourceClient(
         accessToken: String
     ): Result<Resource, ThrowableErrorMessage> {
         val scopes = listOf("api://${resource.clientId}/.default")
-
-        return try {
-            azureAdClient
-                .getOnBehalfOfAccessTokenForResource(scopes, accessToken)
-                .andThen { oboAccessToken ->
-                    fetchFromDownstreamApi(resource, oboAccessToken)
-                }
-                .andThen { response ->
-                    Ok(resource.addResponse(response))
-                }
-        } catch (e: Error) {
-            azureAdClient
-                .getAccessTokenForResource(scopes)
-                .let { fetchFromDownstreamApi(resource, it) }
-                .let { resource.addResponse(it) }
-                .let { Ok(it) }
-        }
+        return azureAdClient
+            .getOnBehalfOfAccessTokenForResource(scopes, accessToken)
+            .andThen { oboAccessToken ->
+                fetchFromDownstreamApi(resource, oboAccessToken)
+            }
+            .andThen { response ->
+                Ok(resource.addResponse(response))
+            }
     }
 
     suspend fun post(

--- a/libs/ktor2client-onbehalfof/src/main/kotlin/DownstreamResourceClass.kt
+++ b/libs/ktor2client-onbehalfof/src/main/kotlin/DownstreamResourceClass.kt
@@ -34,8 +34,9 @@ class DownstreamResourceClient(
         accessToken: String
     ): Result<Resource, ThrowableErrorMessage> {
         val scopes = listOf("api://${resource.clientId}/.default")
-        return azureAdClient
+        val result = azureAdClient
             .getOnBehalfOfAccessTokenForResource(scopes, accessToken)
+        return result
             .andThen { oboAccessToken ->
                 fetchFromDownstreamApi(resource, oboAccessToken)
             }

--- a/libs/ktor2client-onbehalfof/src/main/kotlin/DownstreamResourceClass.kt
+++ b/libs/ktor2client-onbehalfof/src/main/kotlin/DownstreamResourceClass.kt
@@ -15,6 +15,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMessage
 import io.ktor.http.contentType
+import no.nav.etterlatte.token.AccessTokenWrapper
 import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger(DownstreamResourceClient::class.java)
@@ -23,6 +24,11 @@ class DownstreamResourceClient(
     private val azureAdClient: AzureAdClient,
     private val httpClient: HttpClient = defaultHttpClient
 ) {
+    suspend fun get(
+        resource: Resource,
+        accessToken: AccessTokenWrapper
+    ): Result<Resource, ThrowableErrorMessage> = get(resource, accessToken.accessToken)
+
     suspend fun get(
         resource: Resource,
         accessToken: String
@@ -37,6 +43,12 @@ class DownstreamResourceClient(
                 Ok(resource.addResponse(response))
             }
     }
+
+    suspend fun post(
+        resource: Resource,
+        accessToken: AccessTokenWrapper,
+        postBody: Any
+    ): Result<Resource, ThrowableErrorMessage> = post(resource, accessToken.accessToken, postBody)
 
     suspend fun post(
         resource: Resource,

--- a/libs/ktor2client-onbehalfof/src/main/kotlin/Tokens.kt
+++ b/libs/ktor2client-onbehalfof/src/main/kotlin/Tokens.kt
@@ -1,0 +1,25 @@
+package no.nav.etterlatte.libs.ktorobo
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+sealed class TokenRequest(
+    open val scopes: List<String>
+)
+
+data class OboTokenRequest(
+    override val scopes: List<String>,
+    val accessToken: String
+) : TokenRequest(scopes)
+
+data class ClientCredentialsTokenRequest(override val scopes: List<String>) : TokenRequest(scopes)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AccessToken(
+    @JsonProperty("access_token")
+    val accessToken: String,
+    @JsonProperty("expires_in")
+    val expiresIn: Int,
+    @JsonProperty("token_type")
+    val tokenType: String
+)

--- a/libs/ktor2client-onbehalfof/src/test/kotlin/DownstreamResourceClientTest.kt
+++ b/libs/ktor2client-onbehalfof/src/test/kotlin/DownstreamResourceClientTest.kt
@@ -1,9 +1,21 @@
+package no.nav.etterlatte.libs.ktorobo
+
+import com.github.michaelbull.result.Ok
 import io.ktor.http.ContentType
-import no.nav.etterlatte.libs.ktorobo.contentTypeErLik
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.token.AccessTokenWrapper
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 internal class DownstreamResourceClientTest {
+    private val azureAdClient = mockk<AzureAdClient>()
+    private val resource = Resource("clientId1", "")
+    private val client = DownstreamResourceClient(
+        azureAdClient = azureAdClient
+    )
 
     @Test
     fun `egen sjekk av content-type håndterer parsede parametere`() {
@@ -11,5 +23,29 @@ internal class DownstreamResourceClientTest {
 
         assertTrue(contentTypeErLik(contenttypeMedCharset, ContentType.Application.Json))
         assertTrue(contentTypeErLik(ContentType.Application.Json, contenttypeMedCharset))
+    }
+
+    @Test
+    fun `bruker client credentials viss JWT-claims sub og oid er like`() {
+        every { runBlocking { azureAdClient.getAccessTokenForResource(any()) } } returns Ok(mockk())
+
+        runBlocking {
+            client.get(resource, AccessTokenWrapper(accessToken = "a", oid = "b", sub = "b"))
+        }
+        verify { runBlocking { azureAdClient.getAccessTokenForResource(any()) } }
+        verify(exactly = 0) {
+            runBlocking { azureAdClient.getOnBehalfOfAccessTokenForResource(any(), any()) }
+        }
+    }
+
+    @Test
+    fun `bruker OBO viss JWT-claims sub og oid er ulike`() {
+        every { runBlocking { azureAdClient.getOnBehalfOfAccessTokenForResource(any(), any()) } } returns Ok(mockk())
+
+        runBlocking {
+            client.get(resource, AccessTokenWrapper(accessToken = "a", oid = "b", sub = "c"))
+        }
+        verify { runBlocking { azureAdClient.getOnBehalfOfAccessTokenForResource(any(), "a") } }
+        verify(exactly = 0) { runBlocking { azureAdClient.getAccessTokenForResource(any()) } }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ include(
     "apps:etterlatte-statistikk",
     "apps:etterlatte-vilkaarsvurdering",
     "libs:ktor2client-auth-clientcredentials",
+    "libs:etterlatte-token-model",
     "libs:common",
     "libs:ktor2client-onbehalfof",
     "libs:rapidsandrivers-extras",


### PR DESCRIPTION
Hovudpoenget i denne PR-en er å bruke JWT-en som kjem inn for å sjå om det er ein saksbehandlar eller ei maskin i den andre enden. Gjer det ved å sjekke om oid = sub. (@LarsErikDahl er betre på detaljane på korfor akkurat desse)

Har løyst det ved å pakke inn dagens accessToken-string i eit objekt, som i tillegg tar med seg også sub og oid vidare. Denne wrappinga gjer det også lettare å gjera endringar av denne typen seinare utan å endre ein gasillion signaturar (og er ein liten shoutout til prinsippet om at alle problem i systemutvikling kan løysast ved eit ekstra lag indireksjon)