### PR TITLE
Ey 1762 haandtere ikke iverksatt regulering

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
@@ -154,6 +154,17 @@ class BehandlingDao(private val connection: () -> Connection) {
         return stmt.executeQuery().behandlingsListe()
     }
 
+    fun migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning() {
+        val stmt = connection().prepareStatement(
+            """
+                SET status = ${BehandlingStatus.VILKAARSVURDERT} 
+                FROM behandling 
+                WHERE status NOT IN ${BehandlingStatus.skalIkkeOmberegnesVedGRegulering()}
+            """.trimIndent()
+        )
+        stmt.executeQuery()
+    }
+
     private fun asFoerstegangsbehandling(rs: ResultSet) = Foerstegangsbehandling(
         id = rs.getObject("id") as UUID,
         sak = rs.getLong("sak_id"),

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
@@ -157,12 +157,14 @@ class BehandlingDao(private val connection: () -> Connection) {
     fun migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning() {
         val stmt = connection().prepareStatement(
             """
-                SET status = ${BehandlingStatus.VILKAARSVURDERT} 
-                FROM behandling 
-                WHERE status NOT IN ${BehandlingStatus.skalIkkeOmberegnesVedGRegulering()}
+                UPDATE behandling
+                SET status = '${BehandlingStatus.VILKAARSVURDERT}'
+                WHERE status not in (${
+            BehandlingStatus.skalIkkeOmberegnesVedGRegulering().joinToString(", ") { "'$it'" }
+            })
             """.trimIndent()
         )
-        stmt.executeQuery()
+        stmt.executeUpdate()
     }
 
     private fun asFoerstegangsbehandling(rs: ResultSet) = Foerstegangsbehandling(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
@@ -19,6 +19,7 @@ interface BehandlingStatusService {
     fun sjekkOmKanReturnereVedtak(behandlingId: UUID)
     fun settReturnertVedtak(behandlingId: UUID, vedtakHendelse: VedtakHendelse)
     fun settIverksattVedtak(behandlingId: UUID, vedtakHendelse: VedtakHendelse)
+    fun migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning()
 }
 
 class BehandlingStatusServiceImpl constructor(
@@ -93,6 +94,10 @@ class BehandlingStatusServiceImpl constructor(
             lagreNyBehandlingStatus(behandling.tilIverksatt(), LocalDateTime.now())
             registrerVedtakHendelse(behandlingId, vedtakHendelse, HendelseType.IVERKSATT)
         }
+    }
+
+    override fun migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning() {
+        behandlingDao.migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning()
     }
 
     fun registrerVedtakHendelse(behandlingId: UUID, vedtakHendelse: VedtakHendelse, hendelseType: HendelseType) {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
@@ -95,6 +95,10 @@ internal fun Route.behandlingsstatusRoutes(
             }
         }
     }
+
+    route("/behandlinger/settTilbakeTilVilkaarsvurdert") {
+        behandlingsstatusService.migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning()
+    }
 }
 
 data class OperasjonGyldig(val gyldig: Boolean)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
@@ -96,8 +96,10 @@ internal fun Route.behandlingsstatusRoutes(
         }
     }
 
-    route("/behandlinger/settTilbakeTilVilkaarsvurdert") {
-        behandlingsstatusService.migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning()
+    route("/behandlinger") {
+        get("/settTilbakeTilVilkaarsvurdert") {
+            behandlingsstatusService.migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning()
+        }
     }
 }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoReguleringTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoReguleringTest.kt
@@ -1,0 +1,99 @@
+package no.nav.etterlatte.behandling
+
+import no.nav.etterlatte.behandling.domain.Foerstegangsbehandling
+import no.nav.etterlatte.foerstegangsbehandling
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.database.DataSourceBuilder
+import no.nav.etterlatte.libs.database.migrate
+import no.nav.etterlatte.sak.SakDao
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import javax.sql.DataSource
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class BehandlingDaoReguleringTest {
+    @Container
+    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:14")
+
+    private lateinit var dataSource: DataSource
+    private lateinit var sakRepo: SakDao
+    private lateinit var behandlingRepo: BehandlingDao
+
+    @BeforeAll
+    fun beforeAll() {
+        postgreSQLContainer.start()
+        postgreSQLContainer.withUrlParam("user", postgreSQLContainer.username)
+        postgreSQLContainer.withUrlParam("password", postgreSQLContainer.password)
+
+        dataSource = DataSourceBuilder.createDataSource(
+            jdbcUrl = postgreSQLContainer.jdbcUrl,
+            username = postgreSQLContainer.username,
+            password = postgreSQLContainer.password
+        ).apply { migrate() }
+
+        val connection = dataSource.connection
+        sakRepo = SakDao { connection }
+        behandlingRepo = BehandlingDao { connection }
+    }
+
+    @AfterEach
+    fun afterEach() {
+        dataSource.connection.use {
+            it.prepareStatement("TRUNCATE behandling CASCADE;").execute()
+        }
+    }
+
+    @AfterAll
+    fun afterAll() {
+        postgreSQLContainer.stop()
+    }
+
+    private fun hentMigrerbareStatuses() =
+        BehandlingStatus.values().toList() - BehandlingStatus.skalIkkeOmberegnesVedGRegulering().toSet()
+
+    @ParameterizedTest(
+        name = "behandling med status {0} skal endres til aa vaere VILKAARSVURDERT"
+    )
+    @MethodSource("hentMigrerbareStatuses")
+    fun `behandlinger som er beregnet maa beregnes paa nytt`(status: BehandlingStatus) {
+        val sak = sakRepo.opprettSak("123", SakType.BARNEPENSJON).id
+        val behandling = foerstegangsbehandling(sak = sak, status = status)
+
+        behandlingRepo.opprettFoerstegangsbehandling(behandling)
+        behandlingRepo.migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning()
+
+        with(behandlingRepo.hentBehandling(behandling.id)) {
+            val expected = BehandlingStatus.VILKAARSVURDERT
+            val actual = (this as Foerstegangsbehandling).status
+
+            assertEquals(expected, actual)
+        }
+    }
+
+    private fun hentStatuser() = BehandlingStatus.skalIkkeOmberegnesVedGRegulering()
+
+    @ParameterizedTest(name = "behandling med status {0} skal fortsette aa ha samme status ved migrering")
+    @MethodSource("hentStatuser")
+    fun `irrelevante behandlinger skal ikke endre status ved migrering`(status: BehandlingStatus) {
+        val sak = sakRepo.opprettSak("123", SakType.BARNEPENSJON).id
+        val behandling = foerstegangsbehandling(sak = sak, status = status)
+
+        behandlingRepo.opprettFoerstegangsbehandling(behandling)
+        behandlingRepo.migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning()
+
+        with(behandlingRepo.hentBehandling(behandling.id)) {
+            val expected = status
+            val actual = (this as Foerstegangsbehandling).status
+
+            assertEquals(expected, actual)
+        }
+    }
+}

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/BehandlingsService.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/BehandlingsService.kt
@@ -27,6 +27,7 @@ interface Behandling {
     fun hentAlleSaker(): Saker
 
     fun opprettOmberegning(omberegningshendelse: Omberegningshendelse): HttpResponse
+    fun migrerAlleTempBehandlingerTilbakeTilVilkaarsvurdert()
 }
 
 class BehandlingsService(
@@ -80,6 +81,14 @@ class BehandlingsService(
             behandling_app.post("$url/omberegning") {
                 contentType(ContentType.Application.Json)
                 setBody(omberegningshendelse)
+            }
+        }
+    }
+
+    override fun migrerAlleTempBehandlingerTilbakeTilVilkaarsvurdert() {
+        return runBlocking {
+            behandling_app.post("$url/behandlinger/settTilbakeTilVilkaarsvurdert") {
+                contentType(ContentType.Application.Json)
             }
         }
     }

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/Reguleringsforespoersel.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/Reguleringsforespoersel.kt
@@ -31,6 +31,8 @@ internal class Reguleringsforespoersel(
     override fun onPacket(packet: JsonMessage, context: MessageContext) =
         withLogContext(packet.correlationId) {
             logger.info("Leser reguleringsfoerespoersel for dato ${packet.dato}")
+
+            behandlingService.migrerAlleTempBehandlingerTilbakeTilVilkaarsvurdert()
             behandlingService.hentAlleSaker().saker.forEach {
                 packet.eventName = FINN_LOEPENDE_YTELSER
                 packet.sakId = it.id

--- a/apps/etterlatte-oppdater-behandling/src/test/kotlin/ReguleringsforespoerselTest.kt
+++ b/apps/etterlatte-oppdater-behandling/src/test/kotlin/ReguleringsforespoerselTest.kt
@@ -37,8 +37,6 @@ internal class ReguleringsforespoerselTest {
         inspector.sendTestMessage(melding.toJson())
         verify(exactly = 1) {
             vedtakServiceMock.migrerAlleTempBehandlingerTilbakeTilVilkaarsvurdert()
-        }
-        verify(exactly = 1) {
             vedtakServiceMock.hentAlleSaker()
         }
     }

--- a/apps/etterlatte-oppdater-behandling/src/test/kotlin/ReguleringsforespoerselTest.kt
+++ b/apps/etterlatte-oppdater-behandling/src/test/kotlin/ReguleringsforespoerselTest.kt
@@ -36,6 +36,9 @@ internal class ReguleringsforespoerselTest {
 
         inspector.sendTestMessage(melding.toJson())
         verify(exactly = 1) {
+            vedtakServiceMock.migrerAlleTempBehandlingerTilbakeTilVilkaarsvurdert()
+        }
+        verify(exactly = 1) {
             vedtakServiceMock.hentAlleSaker()
         }
     }

--- a/libs/common/src/main/kotlin/behandling/BehandlingStatus.kt
+++ b/libs/common/src/main/kotlin/behandling/BehandlingStatus.kt
@@ -29,8 +29,11 @@ enum class BehandlingStatus {
             IVERKSATT,
             ATTESTERT
         )
+
         fun kanEndres() = underBehandling() - FATTET_VEDTAK
 
         fun ikkeAvbrutt() = iverksattEllerAttestert() + underBehandling()
+
+        fun skalIkkeOmberegnesVedGRegulering() = listOf(IVERKSATT, AVBRUTT, ATTESTERT, OPPRETTET, VILKAARSVURDERT)
     }
 }


### PR DESCRIPTION
I Reguleringsflyten oppstår det et problem med de behandlingene som har gjort en beregning (men som fortsatt er under behandling) når grunnbeløpet endres. De vil da ha en beregning med feil grunnbeløp.

For å sørge for at en slik behandling ikke blir iverksatt med feil G, setter vi statusen på behandlinger tilbake til VILKAARSVURDERT for å tvinge saksbehandler til å gjøre en ny beregning med ny G