### PR TITLE
EY-1837: Ignorerer patch-versjonar av frontend-avhengnadar

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,16 +10,25 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types: "version-update:semver-patch"
   - package-ecosystem: "npm"
     directory: "/apps/etterlatte-saksbehandling-ui/client"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types: "version-update:semver-patch"
   - package-ecosystem: "npm"
     directory: "/apps/etterlatte-saksbehandling-ui/server"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types: "version-update:semver-patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Det bør halde greitt at vi oppdaterer med minor-versjonane

Frå [dokumentasjonen](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore):
update-types—use to ignore types of updates, such as semver major, minor, or patch updates on version updates (for example: version-update:semver-patch will ignore patch updates). You can combine this with dependency-name: "*" to ignore particular update-types for all dependencies. Currently, version-update:semver-major, version-update:semver-minor, and version-update:semver-patch are the only supported options. **Security updates are unaffected by this setting.**