### PR TITLE
Forenkler endepunkter i vedtak slik at de har lik struktur

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/VedtakKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/VedtakKlient.kt
@@ -39,7 +39,7 @@ class VedtakKlientImpl(config: Config, httpClient: HttpClient) : VedtakKlient {
 
         try {
             return downstreamResourceClient.get(
-                resource = Resource(clientId, "$resourceUrl/api/behandlinger/$behandlingId/vedtak"),
+                resource = Resource(clientId, "$resourceUrl/api/vedtak/$behandlingId"),
                 bruker = bruker
             ).mapBoth(
                 success = { resource -> resource.response?.let { objectMapper.readValue(it.toString()) } },

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtak/VedtaksvurderingKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtak/VedtaksvurderingKlient.kt
@@ -30,7 +30,7 @@ class VedtaksvurderingKlient(config: Config, httpClient: HttpClient) {
             logger.info("Henter vedtaksvurdering behandling med behandlingId=$behandlingId")
 
             return downstreamResourceClient.get(
-                Resource(clientId, "$resourceUrl/api/behandlinger/$behandlingId/fellesvedtak"),
+                Resource(clientId, "$resourceUrl/api/vedtak/$behandlingId/fellesvedtak"),
                 bruker
             ).mapBoth(
                 success = { resource -> resource.response.let { deserialize(it.toString()) } },

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
@@ -33,15 +33,15 @@ export const hentManueltOpphoerDetaljer = async (
 }
 
 export const fattVedtak = async (behandlingsId: string): Promise<ApiResponse<unknown>> => {
-  return apiClient.post(`/vedtak/fattvedtak/${behandlingsId}`, {})
+  return apiClient.post(`/vedtak/${behandlingsId}/fattvedtak`, {})
 }
 
 export const upsertVedtak = async (behandlingsId: string): Promise<ApiResponse<unknown>> => {
-  return apiClient.post(`/vedtak/upsert/${behandlingsId}`, {})
+  return apiClient.post(`/vedtak/${behandlingsId}/upsert`, {})
 }
 
 export const attesterVedtak = async (behandlingId: string): Promise<ApiResponse<unknown>> => {
-  return apiClient.post(`/vedtak/attester/${behandlingId}`, {})
+  return apiClient.post(`/vedtak/${behandlingId}/attester`, {})
 }
 
 export const underkjennVedtak = async (
@@ -49,7 +49,7 @@ export const underkjennVedtak = async (
   kommentar: string,
   valgtBegrunnelse: string
 ): Promise<ApiResponse<unknown>> => {
-  return apiClient.post(`/vedtak/underkjenn/${behandlingId}`, { kommentar, valgtBegrunnelse })
+  return apiClient.post(`/vedtak/${behandlingId}/underkjenn`, { kommentar, valgtBegrunnelse })
 }
 
 export const lagreBegrunnelseKommerBarnetTilgode = async (args: {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vedtak.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vedtak.ts
@@ -1,5 +1,5 @@
 import { apiClient, ApiResponse } from './apiClient'
 
 export const hentVedtakSammendrag = async (behandlingsId: string): Promise<ApiResponse<any>> => {
-  return apiClient.get(`vedtak/sammendrag/${behandlingsId}`)
+  return apiClient.get(`vedtak/${behandlingsId}/sammendrag`)
 }

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/services/VedtakService.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/services/VedtakService.kt
@@ -25,16 +25,16 @@ class VedtakServiceImpl(private val vedtakKlient: HttpClient, private val url: S
 
     override fun upsertVedtak(behandlingId: UUID): Vedtak =
         runBlocking {
-            vedtakKlient.post("$url/api/vedtak/upsert/$behandlingId").body()
+            vedtakKlient.post("$url/api/vedtak/$behandlingId/upsert").body()
         }
 
     override fun fattVedtak(behandlingId: UUID): Vedtak =
         runBlocking {
-            vedtakKlient.post("$url/api/vedtak/fattvedtak/$behandlingId").body()
+            vedtakKlient.post("$url/api/vedtak/$behandlingId/fattvedtak").body()
         }
 
     override fun attesterVedtak(behandlingId: UUID): Vedtak =
         runBlocking {
-            vedtakKlient.post("$url/api/vedtak/attester/$behandlingId").body()
+            vedtakKlient.post("$url/api/vedtak/$behandlingId/attester").body()
         }
 }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -17,10 +17,10 @@ import java.time.LocalDate
 import java.util.*
 
 fun Route.vedtaksvurderingRoute(service: VedtaksvurderingService) {
-    route("api") {
+    route("/api/vedtak") {
         val logger = application.log
 
-        get("behandlinger/{behandlingId}/vedtak") {
+        get("/{behandlingId}") {
             withBehandlingId { behandlingId ->
                 val vedtaksresultat = service.hentVedtak(behandlingId)
                 if (vedtaksresultat == null) {
@@ -31,7 +31,7 @@ fun Route.vedtaksvurderingRoute(service: VedtaksvurderingService) {
             }
         }
 
-        get("behandlinger/{behandlingId}/fellesvedtak") {
+        get("/{behandlingId}/fellesvedtak") {
             withBehandlingId { behandlingId ->
                 val vedtaksresultat = service.hentFellesvedtak(
                     behandlingId = behandlingId
@@ -44,7 +44,7 @@ fun Route.vedtaksvurderingRoute(service: VedtaksvurderingService) {
             }
         }
 
-        get("vedtak/sammendrag/{behandlingId}") {
+        get("/{behandlingId}/sammendrag/") {
             withBehandlingId { behandlingId ->
                 val vedtaksresultat = service.hentVedtak(behandlingId)?.toVedtakSammendrag()
                 if (vedtaksresultat == null) {
@@ -55,7 +55,7 @@ fun Route.vedtaksvurderingRoute(service: VedtaksvurderingService) {
             }
         }
 
-        post("vedtak/upsert/{behandlingId}") {
+        post("/{behandlingId}/upsert") {
             withBehandlingId { behandlingId ->
                 val nyttVedtak = service.opprettEllerOppdaterVedtak(
                     behandlingId = behandlingId,
@@ -66,7 +66,7 @@ fun Route.vedtaksvurderingRoute(service: VedtaksvurderingService) {
             }
         }
 
-        post("vedtak/attester/{behandlingId}") {
+        post("/{behandlingId}/attester") {
             withBehandlingId { behandlingId ->
                 val attestert = service.attesterVedtak(behandlingId, bruker)
 
@@ -74,7 +74,7 @@ fun Route.vedtaksvurderingRoute(service: VedtaksvurderingService) {
             }
         }
 
-        post("vedtak/fattvedtak/{behandlingId}") {
+        post("/{behandlingId}/fattvedtak") {
             withBehandlingId { behandlingId ->
                 val fattetVedtak = service.fattVedtak(behandlingId, bruker)
 
@@ -82,7 +82,7 @@ fun Route.vedtaksvurderingRoute(service: VedtaksvurderingService) {
             }
         }
 
-        post("vedtak/underkjenn/{behandlingId}") {
+        post("/{behandlingId}/underkjenn") {
             val behandlingId = UUID.fromString(call.parameters["behandlingId"])
             val begrunnelse = call.receive<UnderkjennVedtakClientRequest>()
             val underkjentVedtak = service.underkjennVedtak(
@@ -94,7 +94,7 @@ fun Route.vedtaksvurderingRoute(service: VedtaksvurderingService) {
             call.respond(underkjentVedtak)
         }
 
-        get("vedtak/loepende/{sakId}") {
+        get("/loepende/{sakId}") {
             val sakId = call.parameters["sakId"]?.toLong() ?: return@get call.respond(
                 BadRequest,
                 "Sak ID må sendes med som et tall i requesten"


### PR DESCRIPTION
Legger de fleste endepunktene under /api/vedtak/{behandlingId}/{operasjon} fremfor å ha mange ulike varianter