### PR TITLE
Send ut behandling som detaljertbehandling for å få riktig objekt ut og

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsHendelser.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsHendelser.kt
@@ -15,6 +15,7 @@ import no.nav.etterlatte.behandling.domain.Foerstegangsbehandling
 import no.nav.etterlatte.behandling.domain.ManueltOpphoer
 import no.nav.etterlatte.behandling.domain.Regulering
 import no.nav.etterlatte.behandling.domain.Revurdering
+import no.nav.etterlatte.behandling.domain.toDetaljertBehandling
 import no.nav.etterlatte.common.DatabaseContext
 import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.kafka.JsonMessage
@@ -80,7 +81,7 @@ class BehandlingsHendelser(
                     mapOf(
                         "behandlingId" to behandling.id,
                         CORRELATION_ID_KEY to getCorrelationId(),
-                        BehandlingGrunnlagEndret.behandlingObjectKey to behandling,
+                        BehandlingGrunnlagEndret.behandlingObjectKey to behandling.toDetaljertBehandling(),
                         BehandlingGrunnlagEndret.sakIdKey to behandling.sak.id,
                         BehandlingGrunnlagEndret.sakObjectKey to behandling.sak,
                         BehandlingGrunnlagEndret.behandlingOpprettetKey to behandling.behandlingOpprettet

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsHendelser.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsHendelser.kt
@@ -23,7 +23,6 @@ import no.nav.etterlatte.kafka.KafkaProdusent
 import no.nav.etterlatte.libs.common.event.BehandlingGrunnlagEndret
 import no.nav.etterlatte.libs.common.logging.getCorrelationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.CORRELATION_ID_KEY
-import no.nav.etterlatte.sak.SakService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.UUID
@@ -36,8 +35,7 @@ enum class BehandlingHendelseType {
 class BehandlingsHendelser(
     private val rapid: KafkaProdusent<String, String>,
     private val behandlingDao: BehandlingDao,
-    private val datasource: DataSource,
-    private val sakService: SakService
+    private val datasource: DataSource
 ) {
     private val kanal: Channel<Pair<UUID, BehandlingHendelseType>> = Channel(Channel.UNLIMITED)
     val nyHendelse: SendChannel<Pair<UUID, BehandlingHendelseType>> get() = kanal

--- a/apps/etterlatte-behandling/src/main/kotlin/config/BeanFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/BeanFactory.kt
@@ -96,8 +96,7 @@ abstract class CommonFactory : BeanFactory {
         BehandlingsHendelser(
             rapid(),
             behandlingDao(),
-            dataSource(),
-            sakService()
+            dataSource()
         )
     }
     private val foerstegangsbehandlingFactory: FoerstegangsbehandlingFactory by lazy {
@@ -275,7 +274,7 @@ class EnvBasedBeanFactory(val env: Map<String, String>) : CommonFactory() {
     override fun grunnlagsendringshendelseJob(): Timer {
         logger.info(
             "Setter opp GrunnlagsendringshendelseJob. LeaderElection: ${leaderElection().isLeader()} , initialDelay: ${
-            Duration.of(1, ChronoUnit.MINUTES).toMillis()
+                Duration.of(1, ChronoUnit.MINUTES).toMillis()
             }" +
                 ", periode: ${Duration.of(env.getValue("HENDELSE_JOB_FREKVENS").toLong(), ChronoUnit.MINUTES)}" +
                 ", minutterGamleHendelser: ${env.getValue("HENDELSE_MINUTTER_GAMLE_HENDELSER").toLong()} "

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/BehandlinghendelseRiver.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/BehandlinghendelseRiver.kt
@@ -52,18 +52,10 @@ class BehandlinghendelseRiver(
         withLogContext(packet.correlationId) {
             try {
                 val behandling: DetaljertBehandling = objectMapper.treeToValue(packet["behandling"])
-                val internBehandling: BehandlingIntern = BehandlingIntern(
-                    id = behandling.id,
-                    sakId = behandling.sak,
-                    behandlingOpprettet = behandling.behandlingOpprettet,
-                    sistEndret = behandling.sistEndret,
-                    status = behandling.status,
-                    type = behandling.behandlingType,
-                    persongalleri = behandling.toPersongalleri()
-                )
+                val behandlingIntern: BehandlingIntern = behandling.toInternBehandling()
                 val hendelse: BehandlingHendelse = enumValueOf(packet[EVENT_NAME_KEY].textValue().split(":")[1])
                 val tekniskTid = parseTekniskTid(packet, logger)
-                service.registrerStatistikkForBehandlinghendelse(internBehandling, hendelse, tekniskTid)
+                service.registrerStatistikkForBehandlinghendelse(behandlingIntern, hendelse, tekniskTid)
                     ?.also {
                         context.publish(
                             mapOf(
@@ -95,6 +87,17 @@ data class BehandlingIntern(
     val type: BehandlingType,
     val persongalleri: Persongalleri
 )
+
+private fun DetaljertBehandling.toInternBehandling() =
+    BehandlingIntern(
+        id = id,
+        sakId = sak,
+        behandlingOpprettet = behandlingOpprettet,
+        sistEndret = sistEndret,
+        status = status,
+        type = behandlingType,
+        persongalleri = toPersongalleri()
+    )
 
 enum class BehandlingHendelse {
     OPPRETTET, AVBRUTT

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/service/StatistikkService.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/service/StatistikkService.kt
@@ -20,8 +20,8 @@ import no.nav.etterlatte.statistikk.domain.SakRad
 import no.nav.etterlatte.statistikk.domain.SakUtland
 import no.nav.etterlatte.statistikk.domain.SoeknadFormat
 import no.nav.etterlatte.statistikk.domain.StoenadRad
-import no.nav.etterlatte.statistikk.river.Behandling
 import no.nav.etterlatte.statistikk.river.BehandlingHendelse
+import no.nav.etterlatte.statistikk.river.BehandlingIntern
 import java.time.LocalDateTime
 import java.time.YearMonth
 import java.util.*
@@ -181,27 +181,27 @@ class StatistikkService(
     }
 
     private fun behandlingTilSakRad(
-        behandling: Behandling,
+        behandlingIntern: BehandlingIntern,
         behandlingHendelse: BehandlingHendelse,
         tekniskTid: LocalDateTime
     ): SakRad {
-        val sak = hentSak(behandling.sak)
+        val sak = hentSak(behandlingIntern.sakId)
         val fellesRad = SakRad(
             id = -1,
-            behandlingId = behandling.id,
-            sakId = behandling.sak,
-            mottattTidspunkt = behandling.behandlingOpprettet.toTidspunkt(),
-            registrertTidspunkt = behandling.behandlingOpprettet.toTidspunkt(),
+            behandlingId = behandlingIntern.id,
+            sakId = behandlingIntern.sakId,
+            mottattTidspunkt = behandlingIntern.behandlingOpprettet.toTidspunkt(),
+            registrertTidspunkt = behandlingIntern.behandlingOpprettet.toTidspunkt(),
             ferdigbehandletTidspunkt = null,
             vedtakTidspunkt = null,
-            behandlingType = behandling.type,
+            behandlingType = behandlingIntern.type,
             behandlingStatus = behandlingHendelse.name,
             behandlingResultat = null,
             resultatBegrunnelse = null,
             behandlingMetode = null,
             opprettetAv = null,
             ansvarligBeslutter = null,
-            aktorId = behandling.persongalleri.soeker,
+            aktorId = behandlingIntern.persongalleri.soeker,
             datoFoersteUtbetaling = null,
             tekniskTid = tekniskTid.toTidspunkt(),
             sakYtelse = sak.sakType.name,
@@ -215,7 +215,7 @@ class StatistikkService(
         )
         if (behandlingHendelse == BehandlingHendelse.AVBRUTT) {
             return fellesRad.copy(
-                ferdigbehandletTidspunkt = behandling.sistEndret.toTidspunkt(),
+                ferdigbehandletTidspunkt = behandlingIntern.sistEndret.toTidspunkt(),
                 behandlingResultat = BehandlingResultat.AVBRUTT
             )
         }
@@ -223,11 +223,11 @@ class StatistikkService(
     }
 
     fun registrerStatistikkForBehandlinghendelse(
-        behandling: Behandling,
+        behandlingIntern: BehandlingIntern,
         hendelse: BehandlingHendelse,
         tekniskTid: LocalDateTime
     ): SakRad? {
-        return sakRepository.lagreRad(behandlingTilSakRad(behandling, hendelse, tekniskTid))
+        return sakRepository.lagreRad(behandlingTilSakRad(behandlingIntern, hendelse, tekniskTid))
     }
 }
 

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/service/StatistikkServiceTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/service/StatistikkServiceTest.kt
@@ -172,7 +172,7 @@ class StatistikkServiceTest {
 
         val tekniskTidForHendelse = LocalDateTime.of(2023, 2, 1, 8, 30)
         val registrertStatistikk = service.registrerStatistikkForBehandlinghendelse(
-            behandling = behandling(id = behandlingId, sakId = sakId),
+            behandlingIntern = behandling(id = behandlingId, sakId = sakId),
             hendelse = BehandlingHendelse.OPPRETTET,
             tekniskTid = tekniskTidForHendelse
         ) ?: throw NullPointerException("Fikk ikke registrert statistikk")
@@ -229,9 +229,9 @@ fun behandling(
     soesken: List<String> = emptyList(),
     avdoed: List<String> = emptyList(),
     gjenlevende: List<String> = emptyList()
-): no.nav.etterlatte.statistikk.river.Behandling = no.nav.etterlatte.statistikk.river.Behandling(
+): no.nav.etterlatte.statistikk.river.BehandlingIntern = no.nav.etterlatte.statistikk.river.BehandlingIntern(
     id = id,
-    sak = sakId,
+    sakId = sakId,
     behandlingOpprettet = behandlingOpprettet,
     sistEndret = sistEndret,
     status = status,


### PR DESCRIPTION
bugfiks fra https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/859

SE log:
com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `long` from Object value (token `JsonToken.START_OBJECT`)
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: no.nav.etterlatte.statistikk.river.Behandling["sak"])
	at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:59)
	at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1746)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1520)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1425)
	at com.fasterxml.jackson.databind.DeserializationContext.extractScalarFromObject(DeserializationContext.java:937)
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer._parseLongPrimitive(StdDeserializer.java:873)
	at com.fasterxml.jackson.databind.deser.std.NumberDeserializers$LongDeserializer.deserialize(NumberDeserializers.java:573)
	at com.fasterxml.jackson.databind.deser.std.NumberDeserializers$LongDeserializer.deserialize(NumberDeserializers.java:550)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:542)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeWithErrorWrapping(BeanDeserializer.java:564)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:439)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1405)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:352)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:185)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:323)
	at com.fasterxml.jackson.databind.ObjectMapper._readValue(ObjectMapper.java:4706)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2904)
	at no.nav.etterlatte.statistikk.river.BehandlinghendelseRiver$onPacket$1.invoke(BehandlinghendelseRiver.kt:91)
	at no.nav.etterlatte.statistikk.river.BehandlinghendelseRiver$onPacket$1.invoke(BehandlinghendelseRiver.kt:50)
	at no.nav.etterlatte.libs.common.logging.LogUtilsKt.innerLogContext(LogUtils.kt:23)
	at no.nav.etterlatte.libs.common.logging.LogUtilsKt.withLogContext(LogUtils.kt:13)
	at no.nav.etterlatte.libs.common.logging.LogUtilsKt.withLogContext$default(LogUtils.kt:12)
	at no.nav.etterlatte.statistikk.river.BehandlinghendelseRiver.onPacket(BehandlinghendelseRiver.kt:50)
	at no.nav.helse.rapids_rivers.River.onPacket$lambda$2$lambda$1(River.kt:65)
	at io.prometheus.client.Histogram$Child.timeWithExemplar(Histogram.java:273)
	at io.prometheus.client.Histogram$Child.time(Histogram.java:260)
	at no.nav.helse.rapids_rivers.River.onPacket(River.kt:64)
	at no.nav.helse.rapids_rivers.River.onMessage(River.kt:50)
	at no.nav.helse.rapids_rivers.RapidsConnection.notifyMessage(RapidsConnection.kt:40)