### PR TITLE
EY-1795: Fjern Instant.now(), og startar å bytte ut Instant med Tidspunkt

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
@@ -279,13 +279,13 @@ class BehandlingDao(private val connection: () -> Connection) {
         with(behandling) {
             stmt.setObject(1, id)
             stmt.setLong(2, sakId)
-            stmt.setTimestamp(3, opprettet.somTimestampUTC())
-            stmt.setTimestamp(4, opprettet.somTimestampUTC())
+            stmt.setTimestamp(3, opprettet.tilUTCTimestamp())
+            stmt.setTimestamp(4, opprettet.tilUTCTimestamp())
             stmt.setString(5, status.name)
             stmt.setString(6, type.name)
             stmt.setTimestamp(
                 7,
-                soeknadMottattDato?.somTimestampUTC()
+                soeknadMottattDato?.tilUTCTimestamp()
             )
             with(persongalleri) {
                 stmt.setString(8, innsender)
@@ -320,7 +320,7 @@ class BehandlingDao(private val connection: () -> Connection) {
         stmt.setString(2, behandling.status.name)
         stmt.setTimestamp(
             3,
-            behandling.sistEndret.somTimestampUTC()
+            behandling.sistEndret.tilUTCTimestamp()
         )
         stmt.setObject(4, behandling.id)
         require(stmt.executeUpdate() == 1)
@@ -342,7 +342,7 @@ class BehandlingDao(private val connection: () -> Connection) {
         stmt.setString(1, status.name)
         stmt.setTimestamp(
             2,
-            sistEndret.somTimestampUTC()
+            sistEndret.tilUTCTimestamp()
         )
         stmt.setObject(3, behandling)
         require(stmt.executeUpdate() == 1)
@@ -429,8 +429,6 @@ class BehandlingDao(private val connection: () -> Connection) {
         }
     }
 }
-
-private fun LocalDateTime.somTimestampUTC() = tilUTCTimestamp()
 
 private fun ResultSet.somLocalDateTimeUTC(kolonne: String) = getTimestamp(kolonne).tilUTCLocalDateTime()
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -41,11 +41,10 @@ import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.gyldigSoeknad.GyldighetsResultat
 import no.nav.etterlatte.libs.common.soeknad.dataklasser.common.JaNeiVetIkke
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.common.tidspunkt.toLocalDateTimeNorskTid
+import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeNorskTid
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.ktor.bruker
 import no.nav.security.token.support.v2.TokenValidationContextPrincipal
-import java.time.Instant
 import java.time.YearMonth
 import java.util.*
 
@@ -382,7 +381,7 @@ data class ManueltOpphoerResponse(val behandlingId: String)
 
 data class VirkningstidspunktRequest(@JsonProperty("dato") private val _dato: String, val begrunnelse: String?) {
     val dato: YearMonth = try {
-        Instant.parse(_dato).toLocalDateTimeNorskTid()?.let {
+        Tidspunkt.parse(_dato).toLocalDatetimeNorskTid().let {
             YearMonth.of(it.year, it.month)
         } ?: throw IllegalArgumentException("Dato $_dato må være definert")
     } catch (e: Exception) {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -47,7 +47,7 @@ import no.nav.etterlatte.libs.ktor.bruker
 import no.nav.security.token.support.v2.TokenValidationContextPrincipal
 import java.time.Instant
 import java.time.YearMonth
-import java.util.UUID
+import java.util.*
 
 internal fun Route.behandlingRoutes(
     generellBehandlingService: GenerellBehandlingService,
@@ -72,7 +72,7 @@ internal fun Route.behandlingRoutes(
             val kommerBarnetTilgode = KommerBarnetTilgode(
                 body.svar,
                 body.begrunnelse,
-                Grunnlagsopplysning.Saksbehandler(navIdent, Instant.now())
+                Grunnlagsopplysning.Saksbehandler(navIdent, Tidspunkt.now().instant)
             )
 
             try {

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseDao.kt
@@ -7,6 +7,7 @@ import no.nav.etterlatte.libs.common.behandling.GrunnlagsendringsType
 import no.nav.etterlatte.libs.common.behandling.Grunnlagsendringshendelse
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
 import no.nav.etterlatte.libs.common.behandling.SamsvarMellomPdlOgGrunnlag
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.tilUTCLocalDateTime
 import no.nav.etterlatte.libs.common.tidspunkt.tilUTCTimestamp
 import no.nav.etterlatte.libs.database.singleOrNull
@@ -16,7 +17,6 @@ import java.sql.Connection
 import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.Timestamp
-import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.*
 
@@ -135,7 +135,7 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
                    AND status = ?
                 """.trimIndent()
             ).use {
-                it.setTimestamp(1, Timestamp.from(Instant.now().minus(minutter, ChronoUnit.MINUTES)))
+                it.setTimestamp(1, Timestamp.from(Tidspunkt.now().instant.minus(minutter, ChronoUnit.MINUTES)))
                 it.setString(2, GrunnlagsendringStatus.VENTER_PAA_JOBB.name)
                 return it.executeQuery().toList { asGrunnlagsendringshendelse() }
             }

--- a/apps/etterlatte-behandling/src/test/kotlin/IntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/IntegrationTest.kt
@@ -54,7 +54,6 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.lang.Thread.sleep
-import java.time.Instant
 import java.time.LocalDate
 import java.time.YearMonth
 import java.util.*
@@ -172,7 +171,7 @@ class IntegrationTest : BehandlingIntegrationTest() {
 
                 val expected = FastsettVirkningstidspunktResponse(
                     YearMonth.of(2022, 2),
-                    Grunnlagsopplysning.Saksbehandler("Saksbehandler01", Instant.now()),
+                    Grunnlagsopplysning.Saksbehandler("Saksbehandler01", Tidspunkt.now().instant),
                     "En begrunnelse"
                 )
                 assertEquals(expected.dato, it.body<FastsettVirkningstidspunktResponse>().dato)

--- a/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
@@ -41,7 +41,6 @@ import no.nav.etterlatte.libs.common.soeknad.dataklasser.common.JaNeiVetIkke
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
-import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
@@ -236,7 +235,7 @@ fun grunnlagsOpplysningMedPersonopplysning(
     personopplysning: Person
 ) = Grunnlagsopplysning(
     id = UUID.randomUUID(),
-    kilde = Grunnlagsopplysning.Pdl("pdl", Instant.now(), null, "opplysningsId1"),
+    kilde = Grunnlagsopplysning.Pdl("pdl", Tidspunkt.now().instant, null, "opplysningsId1"),
     opplysningType = Opplysningstype.DOEDSDATO,
     meta = ObjectMapper().createObjectNode(),
     opplysning = personopplysning,
@@ -271,7 +270,7 @@ fun personOpplysning(
 fun kommerBarnetTilgode(
     svar: JaNeiVetIkke = JaNeiVetIkke.JA,
     begrunnelse: String = "En begrunnelse",
-    kilde: Grunnlagsopplysning.Saksbehandler = Grunnlagsopplysning.Saksbehandler("S01", Instant.now())
+    kilde: Grunnlagsopplysning.Saksbehandler = Grunnlagsopplysning.Saksbehandler("S01", Tidspunkt.now().instant)
 ) = KommerBarnetTilgode(svar, begrunnelse, kilde)
 
 val TRIVIELL_MIDTPUNKT = Foedselsnummer.of("19040550081")

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoIntegrationTest.kt
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertAll
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
-import java.time.Instant
 import java.time.YearMonth
 import javax.sql.DataSource
 
@@ -618,7 +617,7 @@ internal class BehandlingDaoIntegrationTest {
 
         assertNotNull(behandling)
 
-        val saksbehandler = Grunnlagsopplysning.Saksbehandler("navIdent", Instant.now())
+        val saksbehandler = Grunnlagsopplysning.Saksbehandler("navIdent", Tidspunkt.now().instant)
         val nyDato = YearMonth.of(2021, 2)
         behandling!!.oppdaterVirkningstidspunkt(nyDato, saksbehandler, "enBegrunnelse").let {
             behandlingRepo.lagreNyttVirkningstidspunkt(behandling.id, it.virkningstidspunkt!!)
@@ -645,7 +644,7 @@ internal class BehandlingDaoIntegrationTest {
         val kommerBarnetTilgode = KommerBarnetTilgode(
             JaNeiVetIkke.JA,
             "begrunnelse",
-            Grunnlagsopplysning.Saksbehandler("navIdent", Instant.now())
+            Grunnlagsopplysning.Saksbehandler("navIdent", Tidspunkt.now().instant)
         )
         behandlingRepo.lagreKommerBarnetTilgode(opprettBehandling.id, kommerBarnetTilgode)
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
@@ -25,7 +25,7 @@ import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.common.tidspunkt.toLocalDateTimeNorskTid
+import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeNorskTid
 import no.nav.etterlatte.libs.ktor.restModule
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import testsupport.buildTestApplicationConfigurationForOauth
-import java.time.Instant
 import java.time.YearMonth
 import java.util.*
 
@@ -68,7 +67,7 @@ internal class BehandlingRoutesTest {
 
     @Test
     fun `kan lagre virkningstidspunkt hvis det er gyldig`() {
-        val bodyVirkningstidspunkt = Instant.parse("2017-02-01T00:00:00Z")
+        val bodyVirkningstidspunkt = Tidspunkt.parse("2017-02-01T00:00:00Z")
         val bodyBegrunnelse = "begrunnelse"
 
         mockBehandlingService(bodyVirkningstidspunkt, bodyBegrunnelse)
@@ -117,7 +116,7 @@ internal class BehandlingRoutesTest {
 
     @Test
     fun `faar bad request hvis virkningstidspunkt ikke er gyldig`() {
-        val bodyVirkningstidspunkt = Instant.parse("2017-02-01T00:00:00Z")
+        val bodyVirkningstidspunkt = Tidspunkt.parse("2017-02-01T00:00:00Z")
         val bodyBegrunnelse = "begrunnelse"
 
         mockBehandlingService(bodyVirkningstidspunkt, bodyBegrunnelse)
@@ -165,9 +164,9 @@ internal class BehandlingRoutesTest {
         }
     }
 
-    private fun mockBehandlingService(bodyVirkningstidspunkt: Instant, bodyBegrunnelse: String) {
+    private fun mockBehandlingService(bodyVirkningstidspunkt: Tidspunkt, bodyBegrunnelse: String) {
         val parsetVirkningstidspunkt = YearMonth.from(
-            bodyVirkningstidspunkt.toLocalDateTimeNorskTid()!!.let {
+            bodyVirkningstidspunkt.toLocalDatetimeNorskTid().let {
                 YearMonth.of(it.year, it.month)
             }
         )

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealFoerstegangsbehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealFoerstegangsbehandlingServiceTest.kt
@@ -26,9 +26,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.sql.Connection
-import java.time.Instant
 import java.time.YearMonth
-import java.util.UUID
+import java.util.*
 
 internal class RealFoerstegangsbehandlingServiceTest {
 
@@ -87,7 +86,7 @@ internal class RealFoerstegangsbehandlingServiceTest {
             gyldighetsproeving = null,
             virkningstidspunkt = Virkningstidspunkt(
                 YearMonth.of(2022, 1),
-                Grunnlagsopplysning.Saksbehandler("ident", Instant.now()),
+                Grunnlagsopplysning.Saksbehandler("ident", Tidspunkt.now().instant),
                 "begrunnelse"
             ),
             kommerBarnetTilgode = null,
@@ -128,7 +127,7 @@ internal class RealFoerstegangsbehandlingServiceTest {
             gyldighetsproeving = null,
             virkningstidspunkt = Virkningstidspunkt(
                 YearMonth.of(2022, 1),
-                Grunnlagsopplysning.Saksbehandler("ident", Instant.now()),
+                Grunnlagsopplysning.Saksbehandler("ident", Tidspunkt.now().instant),
                 "begrunnelse"
             ),
             kommerBarnetTilgode = null,

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealGenerellBehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealGenerellBehandlingServiceTest.kt
@@ -27,6 +27,7 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.personOpplysning
 import no.nav.etterlatte.revurdering
 import no.nav.etterlatte.token.Bruker
@@ -39,7 +40,6 @@ import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.sql.Connection
-import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
@@ -303,7 +303,7 @@ class RealGenerellBehandlingServiceTest {
 
     @Test
     fun `erGyldigVirkningstidspunkt hvis tidspunkt er maaned etter doedsfall og maks tre aar foer mottatt soeknad`() {
-        val bodyVirkningstidspunkt = Instant.parse("2017-02-01T00:00:00Z")
+        val bodyVirkningstidspunkt = Tidspunkt.parse("2017-02-01T00:00:00Z")
         val bodyBegrunnelse = "begrunnelse"
         val request = VirkningstidspunktRequest(bodyVirkningstidspunkt.toString(), bodyBegrunnelse)
 
@@ -321,7 +321,7 @@ class RealGenerellBehandlingServiceTest {
 
     @Test
     fun `erGyldigVirkningstidspunkt er false hvis tidspunkt er foer en maaned etter doedsfall`() {
-        val bodyVirkningstidspunkt = Instant.parse("2020-01-01T00:00:00Z")
+        val bodyVirkningstidspunkt = Tidspunkt.parse("2020-01-01T00:00:00Z")
         val bodyBegrunnelse = "begrunnelse"
         val request = VirkningstidspunktRequest(bodyVirkningstidspunkt.toString(), bodyBegrunnelse)
 
@@ -339,7 +339,7 @@ class RealGenerellBehandlingServiceTest {
 
     @Test
     fun `erGyldigVirkningstidspunkt hvis tidspunkt er tre aar foer mottatt soeknad`() {
-        val bodyVirkningstidspunkt = Instant.parse("2017-01-01T00:00:00Z")
+        val bodyVirkningstidspunkt = Tidspunkt.parse("2017-01-01T00:00:00Z")
         val bodyBegrunnelse = "begrunnelse"
         val request = VirkningstidspunktRequest(bodyVirkningstidspunkt.toString(), bodyBegrunnelse)
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealManueltOpphoerServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealManueltOpphoerServiceTest.kt
@@ -23,6 +23,7 @@ import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.manueltOpphoer
 import no.nav.etterlatte.revurdering
 import no.nav.etterlatte.saksbehandlerToken
@@ -33,9 +34,8 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.sql.Connection
-import java.time.Instant
 import java.time.YearMonth
-import java.util.UUID
+import java.util.*
 
 internal class RealManueltOpphoerServiceTest {
 
@@ -100,7 +100,7 @@ internal class RealManueltOpphoerServiceTest {
                     sakId = sak,
                     virkningstidspunkt = Virkningstidspunkt(
                         dato = YearMonth.of(2022, 8),
-                        kilde = Grunnlagsopplysning.Saksbehandler(ident = "", tidspunkt = Instant.now()),
+                        kilde = Grunnlagsopplysning.Saksbehandler(ident = "", tidspunkt = Tidspunkt.now().instant),
                         begrunnelse = ""
                     ),
                     status = BehandlingStatus.IVERKSATT
@@ -273,7 +273,7 @@ internal class RealManueltOpphoerServiceTest {
                     status = BehandlingStatus.FATTET_VEDTAK,
                     virkningstidspunkt = Virkningstidspunkt(
                         dato = YearMonth.of(2020, 8),
-                        kilde = Grunnlagsopplysning.Saksbehandler(ident = "", tidspunkt = Instant.now()),
+                        kilde = Grunnlagsopplysning.Saksbehandler(ident = "", tidspunkt = Tidspunkt.now().instant),
                         begrunnelse = "dab on the haters"
                     )
                 )

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagHelperKtTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagHelperKtTest.kt
@@ -9,13 +9,13 @@ import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.person.InnflyttingTilNorge
 import no.nav.etterlatte.libs.common.person.UtflyttingFraNorge
 import no.nav.etterlatte.libs.common.person.Utland
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.kilde
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.time.Instant
 import java.time.LocalDate
 import java.util.*
 
@@ -163,7 +163,7 @@ internal class GrunnlagHelperKtTest {
     companion object {
         val KILDE = Grunnlagsopplysning.Pdl(
             navn = "pdl",
-            tidspunktForInnhenting = Instant.now(),
+            tidspunktForInnhenting = Tidspunkt.now().instant,
             registersReferanse = null,
             opplysningId = "opplysningsId1"
         )

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/BehandlingTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/BehandlingTest.kt
@@ -8,11 +8,11 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.soeknad.dataklasser.common.PersonType
 import no.nav.etterlatte.libs.common.soeknad.dataklasser.common.Spraak
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import java.time.Instant
 import java.time.LocalDate
 import java.time.YearMonth
 import java.util.*
@@ -106,7 +106,7 @@ internal class BehandlingTest {
     private fun opprettOpplysning(jsonNode: JsonNode) =
         Opplysning.Konstant(
             UUID.randomUUID(),
-            Grunnlagsopplysning.Pdl("pdl", Instant.now(), null, null),
+            Grunnlagsopplysning.Pdl("pdl", Tidspunkt.now().instant, null, null),
             jsonNode
         )
 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/SakOgBehandlingServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/SakOgBehandlingServiceTest.kt
@@ -22,6 +22,7 @@ import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.soeknad.dataklasser.common.PersonType
 import no.nav.etterlatte.libs.common.soeknad.dataklasser.common.Spraak
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.common.vedtak.Attestasjon
 import no.nav.etterlatte.libs.common.vedtak.Periode
@@ -35,7 +36,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.time.Instant
 import java.time.YearMonth
 import java.time.ZonedDateTime
 import java.util.*
@@ -203,7 +203,7 @@ internal class SakOgBehandlingServiceTest {
 
     private companion object {
         private val FNR = Foedselsnummer.of("11057523044")
-        private val GRUNNLAGSOPPLYSNING_PDL = Grunnlagsopplysning.Pdl("pdl", Instant.now(), null, null)
+        private val GRUNNLAGSOPPLYSNING_PDL = Grunnlagsopplysning.Pdl("pdl", Tidspunkt.now().instant, null, null)
         private val STATISK_UUID = UUID.randomUUID()
         private val BEHANDLING_ID = UUID.randomUUID()
         private const val SAKSBEHANDLER_IDENT = "Z1235"

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagService.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagService.kt
@@ -15,6 +15,7 @@ import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.rapidsandrivers.CORRELATION_ID_KEY
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.sporingslogg.Decision
@@ -24,7 +25,6 @@ import no.nav.etterlatte.libs.sporingslogg.Sporingsrequest
 import no.nav.etterlatte.token.Bruker
 import no.nav.helse.rapids_rivers.JsonMessage
 import org.slf4j.LoggerFactory
-import java.time.Instant
 import java.util.*
 
 interface GrunnlagService {
@@ -98,7 +98,7 @@ class RealGrunnlagService(
         val opplysning: List<Grunnlagsopplysning<JsonNode>> = listOf(
             lagOpplysning(
                 opplysningsType = Opplysningstype.SOESKEN_I_BEREGNINGEN,
-                kilde = Grunnlagsopplysning.Saksbehandler(bruker.ident(), Instant.now()),
+                kilde = Grunnlagsopplysning.Saksbehandler(bruker.ident(), Tidspunkt.now().instant),
                 opplysning = Beregningsgrunnlag(soeskenMedIBeregning).toJsonNode()
             )
         )

--- a/apps/etterlatte-grunnlag/src/test/kotlin/Utils.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/Utils.kt
@@ -1,17 +1,18 @@
+
 import com.fasterxml.jackson.databind.JsonNode
 import no.nav.etterlatte.grunnlag.OpplysningDao
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
-import java.time.Instant
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.util.*
 
 internal fun lagGrunnlagsopplysning(
     opplysningstype: Opplysningstype,
     kilde: Grunnlagsopplysning.Kilde = Grunnlagsopplysning.Pdl(
         navn = "pdl",
-        tidspunktForInnhenting = Instant.now(),
+        tidspunktForInnhenting = Tidspunkt.now().instant,
         registersReferanse = null,
         opplysningId = UUID.randomUUID().toString()
     ),
@@ -37,7 +38,7 @@ internal fun lagGrunnlagHendelse(
     verdi: JsonNode = objectMapper.createObjectNode(),
     kilde: Grunnlagsopplysning.Kilde = Grunnlagsopplysning.Pdl(
         navn = "pdl",
-        tidspunktForInnhenting = Instant.now(),
+        tidspunktForInnhenting = Tidspunkt.now().instant,
         registersReferanse = null,
         opplysningId = UUID.randomUUID().toString()
     )

--- a/apps/etterlatte-grunnlag/src/test/kotlin/itest/RapidTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/itest/RapidTest.kt
@@ -20,6 +20,7 @@ import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.database.DataSourceBuilder
@@ -35,7 +36,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
-import java.time.Instant
 import java.util.*
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -77,7 +77,7 @@ internal class RapidTest {
     }
 
     private val fnr = Foedselsnummer.of("18057404783")
-    private val tidspunkt = Instant.now()
+    private val tidspunkt = Tidspunkt.now().instant
     private val kilde = Grunnlagsopplysning.Pdl("pdl", tidspunkt, null, null)
     private val nyOpplysning = Grunnlagsopplysning(
         id = statiskUuid,

--- a/apps/etterlatte-hendelser-pdl/src/test/kotlin/hendelserpdl/IntegrationTest.kt
+++ b/apps/etterlatte-hendelser-pdl/src/test/kotlin/hendelserpdl/IntegrationTest.kt
@@ -21,6 +21,7 @@ import no.nav.etterlatte.libs.common.pdlhendelse.Doedshendelse
 import no.nav.etterlatte.libs.common.pdlhendelse.ForelderBarnRelasjonHendelse
 import no.nav.etterlatte.libs.common.pdlhendelse.UtflyttingsHendelse
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import no.nav.person.pdl.leesah.Endringstype
 import no.nav.person.pdl.leesah.Personhendelse
@@ -36,7 +37,6 @@ import org.apache.kafka.common.serialization.StringDeserializer
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import java.time.Instant
 import java.time.LocalDate
 import java.util.*
 
@@ -75,7 +75,7 @@ class IntegrationTest {
                     "1",
                     listOf("1234567"),
                     "",
-                    Instant.now(),
+                    Tidspunkt.now().instant,
                     "DOEDSFALL_V1",
                     Endringstype.OPPRETTET,
                     null,
@@ -116,7 +116,7 @@ class IntegrationTest {
                     "1",
                     listOf("1234567"),
                     "",
-                    Instant.now(),
+                    Tidspunkt.now().instant,
                     "UTFLYTTING_FRA_NORGE",
                     Endringstype.OPPRETTET,
                     null,
@@ -155,7 +155,7 @@ class IntegrationTest {
                     "1",
                     listOf("1234567"),
                     "",
-                    Instant.now(),
+                    Tidspunkt.now().instant,
                     "FORELDERBARNRELASJON_V1",
                     Endringstype.OPPRETTET,
                     null,

--- a/apps/etterlatte-opplysninger-fra-pdl/src/main/kotlin/opplysninger/kilde/pdl/OpplysningsBygger.kt
+++ b/apps/etterlatte-opplysninger-fra-pdl/src/main/kotlin/opplysninger/kilde/pdl/OpplysningsBygger.kt
@@ -30,10 +30,9 @@ import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.person.Person
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import java.time.Instant
 import java.time.YearMonth
 
-class Opplysningsbolk(private val fnr: Foedselsnummer, private val innhentetTidspunkt: Instant) {
+class Opplysningsbolk(private val fnr: Foedselsnummer, private val innhentetTidspunkt: Tidspunkt) {
     private val opplysninger = mutableListOf<Grunnlagsopplysning<out Any>>()
     fun leggTilOpplysninger(
         opplysningstype: Opplysningstype,
@@ -69,7 +68,7 @@ fun lagEnkelopplysningerFraPDL(
     opplysningsbehov: Opplysningstype, // AVDOED_PDL_V1 || SOEKER_PDL_V1 || GJENLEVENDE_PDL_V1
     fnr: Foedselsnummer
 ): List<Grunnlagsopplysning<*>> {
-    val tidspunktForInnhenting = Tidspunkt.now().instant
+    val tidspunktForInnhenting = Tidspunkt.now()
     val opplysningsbolk = Opplysningsbolk(fnr, tidspunktForInnhenting)
     val personRolle = behovNameTilPersonRolle(opplysningsbehov)
 

--- a/apps/etterlatte-opplysninger-fra-pdl/src/main/kotlin/opplysninger/kilde/pdl/OpplysningsBygger.kt
+++ b/apps/etterlatte-opplysninger-fra-pdl/src/main/kotlin/opplysninger/kilde/pdl/OpplysningsBygger.kt
@@ -29,6 +29,7 @@ import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.person.Person
 import no.nav.etterlatte.libs.common.person.PersonRolle
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.time.Instant
 import java.time.YearMonth
 
@@ -68,7 +69,7 @@ fun lagEnkelopplysningerFraPDL(
     opplysningsbehov: Opplysningstype, // AVDOED_PDL_V1 || SOEKER_PDL_V1 || GJENLEVENDE_PDL_V1
     fnr: Foedselsnummer
 ): List<Grunnlagsopplysning<*>> {
-    val tidspunktForInnhenting = Instant.now()
+    val tidspunktForInnhenting = Tidspunkt.now().instant
     val opplysningsbolk = Opplysningsbolk(fnr, tidspunktForInnhenting)
     val personRolle = behovNameTilPersonRolle(opplysningsbehov)
 

--- a/apps/etterlatte-opplysninger-fra-pdl/src/main/kotlin/opplysninger/kilde/pdl/Utils.kt
+++ b/apps/etterlatte-opplysninger-fra-pdl/src/main/kotlin/opplysninger/kilde/pdl/Utils.kt
@@ -6,17 +6,17 @@ import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.pdl.OpplysningDTO
 import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
-import java.time.Instant
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.util.*
 
 fun <T> lagPdlOpplysning(
     opplysningsType: Opplysningstype,
     opplysning: T,
-    tidspunktForInnhenting: Instant
+    tidspunktForInnhenting: Tidspunkt
 ): Grunnlagsopplysning<T> {
     return Grunnlagsopplysning(
         UUID.randomUUID(),
-        Grunnlagsopplysning.Pdl("pdl", tidspunktForInnhenting, null, null),
+        Grunnlagsopplysning.Pdl("pdl", tidspunktForInnhenting.instant, null, null),
         opplysningsType,
         objectMapper.createObjectNode(),
         opplysning
@@ -24,7 +24,7 @@ fun <T> lagPdlOpplysning(
 }
 
 fun <T> lagPdlPersonopplysning(
-    tidspunktForInnhenting: Instant,
+    tidspunktForInnhenting: Tidspunkt,
     opplysningsType: Opplysningstype,
     opplysning: OpplysningDTO<T>,
     fnr: Foedselsnummer,
@@ -34,7 +34,7 @@ fun <T> lagPdlPersonopplysning(
         id = UUID.randomUUID(),
         kilde = Grunnlagsopplysning.Pdl(
             navn = "pdl",
-            tidspunktForInnhenting = tidspunktForInnhenting,
+            tidspunktForInnhenting = tidspunktForInnhenting.instant,
             registersReferanse = null,
             opplysningId = opplysning.opplysningsid.toString()
         ),

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/database/SakRepositoryTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/database/SakRepositoryTest.kt
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
-import java.time.Instant
 import java.time.LocalDate
 import java.util.*
 import javax.sql.DataSource
@@ -50,7 +49,7 @@ class SakRepositoryTest {
         beregningId = UUID.randomUUID(),
         behandlingId = UUID.randomUUID(),
         type = Beregningstype.BP,
-        beregnetDato = Tidspunkt(instant = Instant.now()),
+        beregnetDato = Tidspunkt.now(),
         beregningsperioder = listOf()
     )
 

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/database/StoenadRepositoryTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/database/StoenadRepositoryTest.kt
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
-import java.time.Instant
 import java.time.LocalDate
 import java.time.YearMonth
 import java.util.*
@@ -50,7 +49,7 @@ class StoenadRepositoryTest {
         beregningId = UUID.randomUUID(),
         behandlingId = UUID.randomUUID(),
         type = Beregningstype.BP,
-        beregnetDato = Tidspunkt(instant = Instant.now()),
+        beregnetDato = Tidspunkt(instant = Tidspunkt.now().instant),
         beregningsperioder = listOf()
     )
 

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/service/StatistikkServiceTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/service/StatistikkServiceTest.kt
@@ -33,7 +33,6 @@ import no.nav.etterlatte.statistikk.domain.SakUtland
 import no.nav.etterlatte.statistikk.river.BehandlingHendelse
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import java.time.Instant
 import java.time.LocalDateTime
 import java.time.YearMonth
 import java.time.ZonedDateTime
@@ -79,7 +78,7 @@ class StatistikkServiceTest {
             beregningId = UUID.randomUUID(),
             behandlingId = behandlingId,
             type = Beregningstype.BP,
-            beregnetDato = Tidspunkt(instant = Instant.now()),
+            beregnetDato = Tidspunkt(instant = Tidspunkt.now().instant),
             beregningsperioder = listOf()
         )
         val beregningKlient = mockk<BeregningKlient>()

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/GrensesnittsavstemmingService.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/GrensesnittsavstemmingService.kt
@@ -8,7 +8,6 @@ import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.UtbetalingDao
 import org.slf4j.LoggerFactory
 import java.time.Clock
-import java.time.Instant
 
 class GrensesnittsavstemmingService(
     private val avstemmingsdataSender: AvstemmingsdataSender,
@@ -62,6 +61,6 @@ class GrensesnittsavstemmingService(
     }
 
     companion object {
-        private val MIN_INSTANT = Tidspunkt(Instant.EPOCH)
+        private val MIN_INSTANT = Tidspunkt.min()
     }
 }

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingService.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingService.kt
@@ -16,7 +16,6 @@ import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Utbetalingslinje
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.UtbetalingslinjeId
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Utbetalingslinjetype
 import org.slf4j.LoggerFactory
-import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -132,7 +131,7 @@ class KonsistensavstemmingService(
         return Konsistensavstemming(
             id = UUIDBase64(),
             sakType = saktype,
-            opprettet = Tidspunkt(instant = Instant.now()),
+            opprettet = Tidspunkt.now(),
             avstemmingsdata = null,
             loependeFraOgMed = loependeYtelseFom,
             opprettetTilOgMed = registrertFoerTom,

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/AvstemmingDaoIntegrationTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/AvstemmingDaoIntegrationTest.kt
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.junit.jupiter.Container
-import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import javax.sql.DataSource
@@ -68,7 +67,7 @@ internal class AvstemmingDaoIntegrationTest {
     fun `skal opprette grensesnittavstemming for barnepensjon`() {
         val grensesnittavstemming = Grensesnittavstemming(
             periode = Avstemmingsperiode(
-                fraOgMed = Tidspunkt(Instant.now().minus(1, ChronoUnit.DAYS)),
+                fraOgMed = Tidspunkt.now().minus(1, ChronoUnit.DAYS),
                 til = Tidspunkt.now()
             ),
             antallOppdrag = 1,

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/GrensesnittavstemmingServiceTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/GrensesnittavstemmingServiceTest.kt
@@ -15,7 +15,6 @@ import no.nav.etterlatte.utbetaling.utbetalingshendelse
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.Clock
-import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 internal class GrensesnittavstemmingServiceTest {
@@ -35,7 +34,7 @@ internal class GrensesnittavstemmingServiceTest {
     @Test
     fun `skal opprette avstemming og sende til oppdrag`() {
         val periode = Avstemmingsperiode(
-            fraOgMed = Tidspunkt(Instant.now().minus(1, ChronoUnit.DAYS)),
+            fraOgMed = Tidspunkt.now().minus(1, ChronoUnit.DAYS),
             til = Tidspunkt.now()
         )
         val utbetaling =

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/KonsistensavstemmingJobTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/KonsistensavstemmingJobTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.etterlatte.libs.common.tidspunkt.fixedNorskTid
 import no.nav.etterlatte.libs.common.tidspunkt.midnattNorskTid
+import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
 import no.nav.etterlatte.libs.jobs.LeaderElection
 import no.nav.etterlatte.utbetaling.common.februar
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
@@ -24,7 +25,7 @@ internal class KonsistensavstemmingJobTest {
         kjoereplan = setOf(datoEksekvering),
         leaderElection = leaderElection,
         jobbNavn = "jobb",
-        clock = datoEksekvering.midnattNorskTid().toInstant().fixedNorskTid()
+        clock = datoEksekvering.midnattNorskTid().toTidspunkt().fixedNorskTid()
     )
 
     @Test
@@ -58,7 +59,7 @@ internal class KonsistensavstemmingJobTest {
     fun `skal ikke konsistensavstemme for barnepensjon naar datoen ikke er en del av kjoereplan`() {
         every { leaderElection.isLeader() } returns true
 
-        val dagForTestMinusFemDager = datoEksekvering.midnattNorskTid().toInstant().minus(5, ChronoUnit.DAYS)
+        val dagForTestMinusFemDager = datoEksekvering.midnattNorskTid().minus(5, ChronoUnit.DAYS).toTidspunkt()
 
         val konsistensavstemming = KonsistensavstemmingJob.Konsistensavstemming(
             konsistensavstemmingService = konsistensavstemmingService,

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/avstemmingsdata/AvstemmingsdataJaxbTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/avstemmingsdata/AvstemmingsdataJaxbTest.kt
@@ -3,7 +3,6 @@ package no.nav.etterlatte.utbetaling.grensesnittavstemming.avstemmingsdata
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toNorskTid
 import no.nav.etterlatte.libs.common.tidspunkt.toNorskTidspunkt
-import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
 import no.nav.etterlatte.utbetaling.avstemming.avstemmingsdata.KonsistensavstemmingDataMapper
 import no.nav.etterlatte.utbetaling.common.tidsstempelMikroOppdrag
 import no.nav.etterlatte.utbetaling.common.tidsstempelTimeOppdrag
@@ -19,7 +18,6 @@ import no.nav.etterlatte.utbetaling.utbetaling
 import no.nav.etterlatte.utbetaling.utbetalingshendelse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.temporal.ChronoUnit
@@ -166,9 +164,9 @@ internal class AvstemmingsdataJaxbTest {
 
     @Test
     fun `skal konvertere grensesnittavstemmingsdata til gyldig xml`() {
-        val now = Instant.now()
-        val fraOgMed = now.minus(1, ChronoUnit.DAYS).toTidspunkt()
-        val til = now.toTidspunkt()
+        val now = Tidspunkt.now()
+        val fraOgMed = now.minus(1, ChronoUnit.DAYS)
+        val til = now
 
         val uuid = UUIDBase64()
         val utbetalingId = UUID.randomUUID()

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/avstemmingsdata/AvstemmingsdataSenderIntegrationTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/avstemmingsdata/AvstemmingsdataSenderIntegrationTest.kt
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.junit.jupiter.Container
-import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
@@ -64,7 +63,7 @@ internal class AvstemmingsdataSenderIntegrationTest {
 
     @Test
     fun `skal sende grensesnittavstemmingsmeldinger paa koeen`() {
-        val fraOgMed = Tidspunkt(Instant.now().minus(1, ChronoUnit.DAYS))
+        val fraOgMed = Tidspunkt.now().minus(1, ChronoUnit.DAYS)
         val til = Tidspunkt.now()
 
         val utbetalinger = listOf(

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/avstemmingsdata/GrensesnittavstemmingDataMapperTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/avstemmingsdata/GrensesnittavstemmingDataMapperTest.kt
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import java.math.BigDecimal
-import java.time.Instant
 import java.time.LocalDateTime
 import java.time.Month
 import java.time.temporal.ChronoUnit
@@ -25,7 +24,7 @@ internal class GrensesnittavstemmingDataMapperTest {
 
     @Test
     fun `skal opprette avstemming fra utbetaling med startmelding, datamelding og sluttmelding`() {
-        val fraOgMed = Tidspunkt(Instant.now().minus(1, ChronoUnit.DAYS))
+        val fraOgMed = Tidspunkt.now().minus(1, ChronoUnit.DAYS)
         val til = Tidspunkt.now()
 
         val utbetalinger =
@@ -43,7 +42,7 @@ internal class GrensesnittavstemmingDataMapperTest {
 
     @Test
     fun `skal skal splitte opp datameldinger slik at de kun inneholder et gitt antall detaljer`() {
-        val fraOgMed = Tidspunkt(Instant.now().minus(1, ChronoUnit.DAYS))
+        val fraOgMed = Tidspunkt.now().minus(1, ChronoUnit.DAYS)
         val til = Tidspunkt.now()
 
         val utbetalinger = listOf(
@@ -67,7 +66,7 @@ internal class GrensesnittavstemmingDataMapperTest {
 
     @Test
     fun `skal kun inneholde grunnadata, total og periode i forste datamelding`() {
-        val fraOgMed = Tidspunkt(Instant.now().minus(1, ChronoUnit.DAYS))
+        val fraOgMed = Tidspunkt.now().minus(1, ChronoUnit.DAYS)
         val til = Tidspunkt.now()
 
         val utbetalinger = listOf(
@@ -95,7 +94,7 @@ internal class GrensesnittavstemmingDataMapperTest {
 
     @Test
     fun `skal returnere riktig totalantall, totalbelop og fortegn`() {
-        val fraOgMed = Tidspunkt(Instant.now().minus(1, ChronoUnit.DAYS))
+        val fraOgMed = Tidspunkt.now().minus(1, ChronoUnit.DAYS)
         val til = Tidspunkt.now()
 
         val utbetalinger = listOf(
@@ -118,7 +117,7 @@ internal class GrensesnittavstemmingDataMapperTest {
 
     @Test
     fun `skal returnere riktig totalantall, totalbelop og fortegn ved opphor`() {
-        val fraOgMed = Tidspunkt(Instant.now().minus(1, ChronoUnit.DAYS))
+        val fraOgMed = Tidspunkt.now().minus(1, ChronoUnit.DAYS)
         val til = Tidspunkt.now()
 
         val utbetalinger = listOf(utbetalingMedOpphoer())
@@ -135,7 +134,7 @@ internal class GrensesnittavstemmingDataMapperTest {
 
     @Test
     fun `antall i grunnlagsdata skal telles opp korrekt for godkjent, varsel, avvist og mangler`() {
-        val fraOgMed = Tidspunkt(Instant.now().minus(1, ChronoUnit.DAYS))
+        val fraOgMed = Tidspunkt.now().minus(1, ChronoUnit.DAYS)
         val til = Tidspunkt.now()
 
         val utbetalinger = listOf(
@@ -179,7 +178,7 @@ internal class GrensesnittavstemmingDataMapperTest {
 
     @Test
     fun `antall i grunnlagsdata skal vaere 0 for alle statuser naar det er ingen utbetalinger aa avstemme`() {
-        val fraOgMed = Tidspunkt(Instant.now().minus(1, ChronoUnit.DAYS))
+        val fraOgMed = Tidspunkt.now().minus(1, ChronoUnit.DAYS)
         val til = Tidspunkt.now()
 
         val utbetalinger = emptyList<Utbetaling>()
@@ -204,7 +203,7 @@ internal class GrensesnittavstemmingDataMapperTest {
 
     @Test
     fun `antall meldinger skal vaere satt til 0 naar det er ingen utbetalinger aa avstemme`() {
-        val fraOgMed = Tidspunkt(Instant.now().minus(1, ChronoUnit.DAYS))
+        val fraOgMed = Tidspunkt.now().minus(1, ChronoUnit.DAYS)
         val til = Tidspunkt.now()
 
         val utbetalinger = emptyList<Utbetaling>()
@@ -223,7 +222,7 @@ internal class GrensesnittavstemmingDataMapperTest {
 
     @Test
     fun `nokkelTom og nokkelFom er satt til 0 naar det er ingen utbetalinger aa avstemme`() {
-        val fraOgMed = Tidspunkt(Instant.now().minus(1, ChronoUnit.DAYS))
+        val fraOgMed = Tidspunkt.now().minus(1, ChronoUnit.DAYS)
         val til = Tidspunkt.now()
 
         val utbetalinger = emptyList<Utbetaling>()

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/common/UtilsTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/common/UtilsTest.kt
@@ -1,11 +1,11 @@
 package no.nav.etterlatte.utbetaling.common
 
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.fixedNorskTid
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
-import java.time.Instant
 import java.time.Month
 import java.time.YearMonth
 import java.util.*
@@ -14,7 +14,7 @@ internal class UtilsTest {
 
     @Test
     fun `skal returnere Tidspunkt-objekt for midnatt i dag for norsk vintertid`() {
-        val statiskKlokke = Instant.parse("2022-01-01T21:14:29.4839104Z").fixedNorskTid()
+        val statiskKlokke = Tidspunkt.parse("2022-01-01T21:14:29.4839104Z").fixedNorskTid()
         val midnatt = tidspunktMidnattIdag(statiskKlokke)
 
         assertEquals("2021-12-31T23:00:00Z", midnatt.instant.toString())
@@ -22,7 +22,7 @@ internal class UtilsTest {
 
     @Test
     fun `skal returnere Tidspunkt-objekt for midnatt i dag for norsk sommertid`() {
-        val statiskKlokke = Instant.parse("2022-06-01T21:14:29.4839104Z").fixedNorskTid()
+        val statiskKlokke = Tidspunkt.parse("2022-06-01T21:14:29.4839104Z").fixedNorskTid()
         val midnatt = tidspunktMidnattIdag(statiskKlokke)
 
         assertEquals("2022-05-31T22:00:00Z", midnatt.instant.toString())

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/iverksetting/utbetaling/UtbetalingDaoIntegrationTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/iverksetting/utbetaling/UtbetalingDaoIntegrationTest.kt
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.junit.jupiter.Container
 import java.math.BigDecimal
-import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -79,22 +78,22 @@ internal class UtbetalingDaoIntegrationTest {
             { assertEquals(utbetaling.vedtakId.value, opprettetUtbetaling?.vedtakId?.value) },
             {
                 assertTrue(
-                    opprettetUtbetaling?.opprettet!!.instant.isAfter(
-                        Tidspunkt.now().minus(10, ChronoUnit.SECONDS).instant
+                    opprettetUtbetaling?.opprettet!!.isAfter(
+                        Tidspunkt.now().minus(10, ChronoUnit.SECONDS)
                     ) and opprettetUtbetaling.opprettet.isBefore(Tidspunkt.now())
                 )
             },
             {
                 assertTrue(
-                    opprettetUtbetaling!!.endret.instant.isAfter(
-                        Tidspunkt.now().minus(10, ChronoUnit.SECONDS).instant
+                    opprettetUtbetaling!!.endret.isAfter(
+                        Tidspunkt.now().minus(10, ChronoUnit.SECONDS)
                     ) and opprettetUtbetaling.endret.isBefore(Tidspunkt.now())
                 )
             },
             {
                 assertTrue(
-                    opprettetUtbetaling!!.avstemmingsnoekkel.instant.isAfter(
-                        Tidspunkt.now().minus(10, ChronoUnit.SECONDS).instant
+                    opprettetUtbetaling!!.avstemmingsnoekkel.isAfter(
+                        Tidspunkt.now().minus(10, ChronoUnit.SECONDS)
                     ) and opprettetUtbetaling.avstemmingsnoekkel.isBefore(Tidspunkt.now())
                 )
             },
@@ -166,12 +165,12 @@ internal class UtbetalingDaoIntegrationTest {
 
     @Test
     fun `skal hente alle utbetalinger mellom to tidspunkter`() {
-        val jan1 = Tidspunkt(Instant.parse("2022-01-01T00:00:00Z"))
-        val jan2 = Tidspunkt(Instant.parse("2022-02-01T00:00:00Z"))
-        val jan3 = Tidspunkt(Instant.parse("2022-03-01T00:00:00Z"))
-        val jan4 = Tidspunkt(Instant.parse("2022-04-01T00:00:00Z"))
-        val jan5 = Tidspunkt(Instant.parse("2022-05-01T00:00:00Z"))
-        val jan6 = Tidspunkt(Instant.parse("2022-06-01T00:00:00Z"))
+        val jan1 = Tidspunkt.parse("2022-01-01T00:00:00Z")
+        val jan2 = Tidspunkt.parse("2022-02-01T00:00:00Z")
+        val jan3 = Tidspunkt.parse("2022-03-01T00:00:00Z")
+        val jan4 = Tidspunkt.parse("2022-04-01T00:00:00Z")
+        val jan5 = Tidspunkt.parse("2022-05-01T00:00:00Z")
+        val jan6 = Tidspunkt.parse("2022-06-01T00:00:00Z")
 
         utbetalingDao.opprettUtbetaling(
             opprettUtbetaling(
@@ -402,7 +401,7 @@ internal class UtbetalingDaoIntegrationTest {
                 vedtakId = 2L,
                 utbetalingslinjeId = 2L,
                 periodeFra = LocalDate.now().plusDays(1),
-                opprettet = Tidspunkt(Instant.from(LocalDate.now().plusDays(1).midnattNorskTid()))
+                opprettet = Tidspunkt.from(LocalDate.now().plusDays(1).midnattNorskTid())
             )
         val oppdrag2 = oppdrag(utbetaling2)
         val utbetalingId3 = UUID.randomUUID()

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/iverksetting/utbetaling/UtbetalingDaoIntegrationTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/iverksetting/utbetaling/UtbetalingDaoIntegrationTest.kt
@@ -30,6 +30,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.YearMonth
+import java.time.temporal.ChronoUnit
 import java.util.*
 import javax.sql.DataSource
 
@@ -79,22 +80,22 @@ internal class UtbetalingDaoIntegrationTest {
             {
                 assertTrue(
                     opprettetUtbetaling?.opprettet!!.instant.isAfter(
-                        Instant.now().minusSeconds(10)
-                    ) and opprettetUtbetaling.opprettet.instant.isBefore(Instant.now())
+                        Tidspunkt.now().minus(10, ChronoUnit.SECONDS).instant
+                    ) and opprettetUtbetaling.opprettet.isBefore(Tidspunkt.now())
                 )
             },
             {
                 assertTrue(
                     opprettetUtbetaling!!.endret.instant.isAfter(
-                        Instant.now().minusSeconds(10)
-                    ) and opprettetUtbetaling.endret.instant.isBefore(Instant.now())
+                        Tidspunkt.now().minus(10, ChronoUnit.SECONDS).instant
+                    ) and opprettetUtbetaling.endret.isBefore(Tidspunkt.now())
                 )
             },
             {
                 assertTrue(
                     opprettetUtbetaling!!.avstemmingsnoekkel.instant.isAfter(
-                        Instant.now().minusSeconds(10)
-                    ) and opprettetUtbetaling.avstemmingsnoekkel.instant.isBefore(Instant.now())
+                        Tidspunkt.now().minus(10, ChronoUnit.SECONDS).instant
+                    ) and opprettetUtbetaling.avstemmingsnoekkel.isBefore(Tidspunkt.now())
                 )
             },
             { assertEquals(utbetaling.stoenadsmottaker.value, opprettetUtbetaling?.stoenadsmottaker?.value) },

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/VedtakstidslinjeTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/VedtakstidslinjeTest.kt
@@ -3,14 +3,12 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.VedtakStatus
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.common.tidspunkt.tilInstant
-import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.vedtaksvurdering.Vedtak
 import no.nav.etterlatte.vedtaksvurdering.Vedtakstidslinje
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import java.time.Instant
 import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 import java.util.*
 
 internal class VedtakstidslinjeTest {
@@ -71,19 +69,19 @@ internal class VedtakstidslinjeTest {
      * */
     @Test
     fun `sak som blir opphoert foer fraOgMed er ikke loepende`() {
-        val attesteringsdato = Tidspunkt.now().toLocalDatetimeUTC()
+        val attesteringsdato = Tidspunkt.now()
         val iverksattDato = lagVedtak(
             id = 1,
             virkningsDato = LocalDate.of(2023, 1, 1),
             vedtakStatus = VedtakStatus.IVERKSATT,
-            datoAttestert = attesteringsdato.tilInstant()
+            datoAttestert = attesteringsdato
         )
         val opphoertDato = lagVedtak(
             id = 2,
             virkningsDato = LocalDate.of(2023, 4, 1),
             vedtakStatus = VedtakStatus.IVERKSATT,
             behandlingType = BehandlingType.REVURDERING,
-            datoAttestert = attesteringsdato.plusDays(1).tilInstant()
+            datoAttestert = attesteringsdato.plus(1, ChronoUnit.DAYS)
         )
 
         val actual = Vedtakstidslinje(
@@ -104,19 +102,19 @@ internal class VedtakstidslinjeTest {
      * */
     @Test
     fun `sak som blir opphoert maaneden etter fraOgMed er loepende`() {
-        val attesteringsdato = Tidspunkt.now().toLocalDatetimeUTC()
+        val attesteringsdato = Tidspunkt.now()
         val iverksattDato = lagVedtak(
             id = 1,
             virkningsDato = LocalDate.of(2023, 1, 1),
             vedtakStatus = VedtakStatus.IVERKSATT,
-            datoAttestert = attesteringsdato.tilInstant()
+            datoAttestert = attesteringsdato
         )
         val opphoertDato = lagVedtak(
             id = 2,
             virkningsDato = LocalDate.of(2023, 6, 1),
             vedtakStatus = VedtakStatus.IVERKSATT,
             behandlingType = BehandlingType.REVURDERING,
-            datoAttestert = attesteringsdato.plusDays(1).tilInstant()
+            datoAttestert = attesteringsdato.plus(1, ChronoUnit.DAYS)
         )
 
         val actual = Vedtakstidslinje(
@@ -136,12 +134,12 @@ internal class VedtakstidslinjeTest {
      * */
     @Test
     fun `sak som er iverksatt maanaden etter fraOgMed-datoen er loepende`() {
-        val attesteringsdato = Tidspunkt.now().toLocalDatetimeUTC()
+        val attesteringsdato = Tidspunkt.now()
         val iverksattDato = lagVedtak(
             id = 1,
             virkningsDato = LocalDate.of(2023, 6, 1),
             vedtakStatus = VedtakStatus.IVERKSATT,
-            datoAttestert = attesteringsdato.tilInstant()
+            datoAttestert = attesteringsdato
         )
 
         val actual = Vedtakstidslinje(listOf(iverksattDato)).erLoependePaa(fraOgMed)
@@ -157,19 +155,19 @@ internal class VedtakstidslinjeTest {
      * */
     @Test
     fun `sak som er iverksatt etter fraOgMed og opphoert etterpaa er loepende`() {
-        val attesteringsdato = Tidspunkt.now().toLocalDatetimeUTC()
+        val attesteringsdato = Tidspunkt.now()
         val iverksattDato = lagVedtak(
             id = 1,
             virkningsDato = LocalDate.of(2023, 6, 1),
             vedtakStatus = VedtakStatus.IVERKSATT,
-            datoAttestert = attesteringsdato.tilInstant()
+            datoAttestert = attesteringsdato
         )
         val opphoertDato = lagVedtak(
             id = 2,
             virkningsDato = LocalDate.of(2023, 7, 1),
             vedtakStatus = VedtakStatus.IVERKSATT,
             behandlingType = BehandlingType.REVURDERING,
-            datoAttestert = attesteringsdato.plusDays(1).tilInstant()
+            datoAttestert = attesteringsdato.plus(1, ChronoUnit.DAYS)
         )
 
         val actual = Vedtakstidslinje(listOf(iverksattDato, opphoertDato)).erLoependePaa(fraOgMed)
@@ -185,19 +183,19 @@ internal class VedtakstidslinjeTest {
      * */
     @Test
     fun `sak som er iverksatt maanaden etter fraOgMed og opphoert samme maanad er ikke loepende`() {
-        val attesteringsdato = Tidspunkt.now().toLocalDatetimeUTC()
+        val attesteringsdato = Tidspunkt.now()
         val iverksattDato = lagVedtak(
             id = 1,
             virkningsDato = LocalDate.of(2023, 6, 1),
             vedtakStatus = VedtakStatus.IVERKSATT,
-            datoAttestert = attesteringsdato.tilInstant()
+            datoAttestert = attesteringsdato
         )
         val opphoertDato = lagVedtak(
             id = 2,
             virkningsDato = LocalDate.of(2023, 6, 1),
             vedtakStatus = VedtakStatus.IVERKSATT,
             behandlingType = BehandlingType.REVURDERING,
-            datoAttestert = attesteringsdato.plusDays(1).tilInstant()
+            datoAttestert = attesteringsdato.plus(1, ChronoUnit.DAYS)
         )
 
         val actual = Vedtakstidslinje(listOf(iverksattDato, opphoertDato)).erLoependePaa(fraOgMed)
@@ -211,7 +209,7 @@ private fun lagVedtak(
     virkningsDato: LocalDate,
     behandlingType: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
     vedtakStatus: VedtakStatus,
-    datoAttestert: Instant = Instant.now()
+    datoAttestert: Tidspunkt = Tidspunkt.now()
 ): Vedtak {
     return Vedtak(
         id = id,
@@ -224,7 +222,7 @@ private fun lagVedtak(
         vedtakFattet = null,
         fnr = null,
         datoFattet = null,
-        datoattestert = datoAttestert,
+        datoattestert = datoAttestert.instant,
         attestant = null,
         virkningsDato = virkningsDato,
         vedtakStatus = vedtakStatus,

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingServiceTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingServiceTest.kt
@@ -24,7 +24,6 @@ import no.nav.etterlatte.vedtaksvurdering.klienter.BeregningKlient
 import no.nav.etterlatte.vedtaksvurdering.klienter.VilkaarsvurderingKlient
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import java.time.Instant
 import java.time.LocalDate
 import java.time.YearMonth
 import java.util.*
@@ -79,8 +78,8 @@ internal class VedtaksvurderingServiceTest {
         vilkaarsResultat = null,
         vedtakFattet = null,
         fnr = "12312312312",
-        datoFattet = Instant.now(),
-        datoattestert = Instant.now(),
+        datoFattet = Tidspunkt.now().instant,
+        datoattestert = Tidspunkt.now().instant,
         attestant = "Attestant",
         virkningsDato = LocalDate.now(),
         vedtakStatus = null,

--- a/libs/common/src/main/kotlin/tidspunkt/Klokke.kt
+++ b/libs/common/src/main/kotlin/tidspunkt/Klokke.kt
@@ -1,10 +1,9 @@
 package no.nav.etterlatte.libs.common.tidspunkt
 
 import java.time.Clock
-import java.time.Instant
 
 fun klokke(): Clock = Clock.systemUTC()
 
 fun Clock.norskKlokke(): Clock = withZone(norskTidssone)
 
-fun Instant.fixedNorskTid(): Clock = Clock.fixed(this, norskTidssone)
+fun Tidspunkt.fixedNorskTid(): Clock = Clock.fixed(this.instant, norskTidssone)

--- a/libs/common/src/main/kotlin/tidspunkt/Tidspunkt.kt
+++ b/libs/common/src/main/kotlin/tidspunkt/Tidspunkt.kt
@@ -28,6 +28,8 @@ abstract class TruncatedInstant(
 
     override fun toString() = instant.toString()
     fun toEpochMilli() = instant.toEpochMilli()
+    fun isBefore(other: TruncatedInstant) = instant.isBefore(other.instant)
+    fun isAfter(other: TruncatedInstant) = instant.isAfter(other.instant)
 }
 
 /**
@@ -65,8 +67,6 @@ constructor(
     }
 
     override fun hashCode() = instant.hashCode()
-    override fun plus(amount: Long, unit: TemporalUnit): Tidspunkt = instant.plus(amount, unit).toTidspunkt()
-    override fun minus(amount: Long, unit: TemporalUnit): Tidspunkt = instant.minus(amount, unit).toTidspunkt()
-    fun isBefore(other: Tidspunkt) = instant.isBefore(other.instant)
-    fun isAfter(other: Tidspunkt) = instant.isAfter(other.instant)
+    override fun plus(amount: Long, unit: TemporalUnit): Tidspunkt = Tidspunkt(instant.plus(amount, unit))
+    override fun minus(amount: Long, unit: TemporalUnit): Tidspunkt = Tidspunkt(instant.minus(amount, unit))
 }

--- a/libs/common/src/main/kotlin/tidspunkt/Tidspunkt.kt
+++ b/libs/common/src/main/kotlin/tidspunkt/Tidspunkt.kt
@@ -5,20 +5,25 @@ import com.fasterxml.jackson.annotation.JsonValue
 import java.io.Serializable
 import java.time.Clock
 import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.temporal.ChronoUnit
 import java.time.temporal.Temporal
+import java.time.temporal.TemporalAccessor
 import java.time.temporal.TemporalAdjuster
 import java.time.temporal.TemporalUnit
 
 abstract class TruncatedInstant(
     @JsonValue
-    val instant: Instant
+    protected val instant: Instant
 ) : Temporal by instant,
     TemporalAdjuster by instant,
     Comparable<Instant> by instant,
     Serializable by instant {
 
     override fun toString() = instant.toString()
+    fun toEpochMilli() = instant.toEpochMilli()
 }
 
 /**
@@ -37,6 +42,12 @@ constructor(
     companion object {
         val unit: ChronoUnit = ChronoUnit.MICROS
         fun now(clock: Clock = klokke()) = Tidspunkt(Instant.now(clock))
+        fun parse(text: CharSequence): Tidspunkt = Tidspunkt(Instant.parse(text))
+
+        fun from(temporal: TemporalAccessor): Tidspunkt = Tidspunkt(Instant.from(temporal))
+
+        fun min() = Tidspunkt(Instant.EPOCH)
+        fun of(date: LocalDate, time: LocalTime) = from(LocalDateTime.of(date, time).atZone(standardTidssoneUTC))
     }
 
     /**
@@ -53,4 +64,5 @@ constructor(
     override fun plus(amount: Long, unit: TemporalUnit): Tidspunkt = instant.plus(amount, unit).toTidspunkt()
     override fun minus(amount: Long, unit: TemporalUnit): Tidspunkt = instant.minus(amount, unit).toTidspunkt()
     fun isBefore(other: Tidspunkt) = instant.isBefore(other.instant)
+    fun isAfter(other: Tidspunkt) = instant.isAfter(other.instant)
 }

--- a/libs/common/src/main/kotlin/tidspunkt/Tidspunkt.kt
+++ b/libs/common/src/main/kotlin/tidspunkt/Tidspunkt.kt
@@ -52,4 +52,5 @@ constructor(
     override fun hashCode() = instant.hashCode()
     override fun plus(amount: Long, unit: TemporalUnit): Tidspunkt = instant.plus(amount, unit).toTidspunkt()
     override fun minus(amount: Long, unit: TemporalUnit): Tidspunkt = instant.minus(amount, unit).toTidspunkt()
+    fun isBefore(other: Tidspunkt) = instant.isBefore(other.instant)
 }

--- a/libs/common/src/main/kotlin/tidspunkt/Tidspunkt.kt
+++ b/libs/common/src/main/kotlin/tidspunkt/Tidspunkt.kt
@@ -15,8 +15,12 @@ import java.time.temporal.TemporalAdjuster
 import java.time.temporal.TemporalUnit
 
 abstract class TruncatedInstant(
+    /* TODO: På sikt bør denne bli protected.
+        At vi bruker instant som underliggjande representasjonsdetalj som ikkje skal lekke ut i resten av applikasjonen.
+        Vi har dog ein del opprydding å gjera før vi kan gjera den endringa
+     */
     @JsonValue
-    protected val instant: Instant
+    val instant: Instant
 ) : Temporal by instant,
     TemporalAdjuster by instant,
     Comparable<Instant> by instant,
@@ -31,7 +35,7 @@ abstract class TruncatedInstant(
  * Purpose is to unify the level of precision such that comparison of time behaves as expected on all levels (code/db).
  * Scenarios to avoid includes cases where timestamps of db-queries wraps around to the next day at different times
  * based on the precision at hand - which may lead to rows not being picked up as expected. This case is especially
- * relevant i.e when combining timestamp-db-fields (truncated by db) with Instants stored as json (not truncated by db).
+ * relevant i.e. when combining timestamp-db-fields (truncated by db) with Instants stored as json (not truncated by db).
  */
 class Tidspunkt
 @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/libs/etterlatte-sporingslogg/src/main/kotlin/sporingslogg/CEFEntry.kt
+++ b/libs/etterlatte-sporingslogg/src/main/kotlin/sporingslogg/CEFEntry.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.libs.sporingslogg
 
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import java.time.Instant
 
 enum class Format {
     CEF
@@ -47,7 +46,7 @@ data class CEFEntry(
 }
 
 data class Extension(
-    val endTime: Instant = Tidspunkt.now().instant,
+    val endTime: Tidspunkt = Tidspunkt.now(),
     val sourceUserId: String, // merk: Vi støtter pr i dag ikke Azure AD ID’er, og vil ha behov for vanlig NAV ID.
     val destinationUserId: String,
     val request: String? = null,

--- a/libs/etterlatte-sporingslogg/src/main/kotlin/sporingslogg/CEFEntry.kt
+++ b/libs/etterlatte-sporingslogg/src/main/kotlin/sporingslogg/CEFEntry.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.libs.sporingslogg
 
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.time.Instant
 
 enum class Format {
@@ -46,7 +47,7 @@ data class CEFEntry(
 }
 
 data class Extension(
-    val endTime: Instant = Instant.now(),
+    val endTime: Instant = Tidspunkt.now().instant,
     val sourceUserId: String, // merk: Vi støtter pr i dag ikke Azure AD ID’er, og vil ha behov for vanlig NAV ID.
     val destinationUserId: String,
     val request: String? = null,

--- a/libs/etterlatte-sporingslogg/src/test/kotlin/sporingslogg/SporingsloggerTest.kt
+++ b/libs/etterlatte-sporingslogg/src/test/kotlin/sporingslogg/SporingsloggerTest.kt
@@ -1,16 +1,15 @@
 package no.nav.etterlatte.libs.sporingslogg
 
-import no.nav.etterlatte.libs.common.tidspunkt.tilInstant
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.Month
 
 internal class SporingsloggerTest {
 
-    private val timestamp = LocalDateTime.of(LocalDate.of(2020, Month.FEBRUARY, 1), LocalTime.NOON).tilInstant()
+    private val timestamp = Tidspunkt.of(LocalDate.of(2020, Month.FEBRUARY, 1), LocalTime.NOON)
 
     @Test
     fun `skal logge i CEF-format`() {

--- a/libs/testdata/src/main/kotlin/behandling/VirkningstidspunktTestData.kt
+++ b/libs/testdata/src/main/kotlin/behandling/VirkningstidspunktTestData.kt
@@ -2,13 +2,17 @@ package no.nav.etterlatte.libs.testdata.behandling
 
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
-import java.time.Instant
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.time.YearMonth
 
 class VirkningstidspunktTestData {
 
     companion object {
         fun virkningstidsunkt(dato: YearMonth = YearMonth.now()) =
-            Virkningstidspunkt(dato, Grunnlagsopplysning.Saksbehandler("Z12345678", Instant.now()), "begrunnelse")
+            Virkningstidspunkt(
+                dato,
+                Grunnlagsopplysning.Saksbehandler("Z12345678", Tidspunkt.now().instant),
+                "begrunnelse"
+            )
     }
 }

--- a/libs/testdata/src/main/kotlin/grunnlag/TestDataMaps.kt
+++ b/libs/testdata/src/main/kotlin/grunnlag/TestDataMaps.kt
@@ -27,14 +27,14 @@ import no.nav.etterlatte.libs.common.person.FamilieRelasjon
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.person.Sivilstatus
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.testdata.pdl.personTestData
-import java.time.Instant
 import java.time.LocalDateTime
 import java.time.YearMonth
 import java.util.UUID.randomUUID
 
-val kilde = Grunnlagsopplysning.Pdl("pdl", Instant.now(), null, "opplysningsId1")
+val kilde = Grunnlagsopplysning.Pdl("pdl", Tidspunkt.now().instant, null, "opplysningsId1")
 val statiskUuid = randomUUID()!!
 
 val AVDOED_FOEDSELSNUMMER = Foedselsnummer.of("01448203510")


### PR DESCRIPTION
Gjenstår sjølvsagt mange plassar.