### PR TITLE
EY-1795: Innkapsling av tidspunkt

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -49,7 +49,7 @@ import no.nav.etterlatte.libs.ktor.bruker
 import no.nav.security.token.support.v2.TokenValidationContextPrincipal
 import java.time.Instant
 import java.time.YearMonth
-import java.util.UUID
+import java.util.*
 
 internal fun Route.behandlingRoutes(
     generellBehandlingService: GenerellBehandlingService,
@@ -74,7 +74,7 @@ internal fun Route.behandlingRoutes(
             val kommerBarnetTilgode = KommerBarnetTilgode(
                 body.svar,
                 body.begrunnelse,
-                Grunnlagsopplysning.Saksbehandler(navIdent, Instant.now())
+                Grunnlagsopplysning.Saksbehandler.create(navIdent)
             )
 
             try {

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseDao.kt
@@ -7,16 +7,16 @@ import no.nav.etterlatte.libs.common.behandling.GrunnlagsendringsType
 import no.nav.etterlatte.libs.common.behandling.Grunnlagsendringshendelse
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
 import no.nav.etterlatte.libs.common.behandling.SamsvarMellomPdlOgGrunnlag
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.tilUTCLocalDateTime
 import no.nav.etterlatte.libs.common.tidspunkt.tilUTCTimestamp
+import no.nav.etterlatte.libs.common.tidspunkt.toTimestamp
 import no.nav.etterlatte.libs.database.singleOrNull
 import no.nav.etterlatte.libs.database.toList
 import org.postgresql.util.PGobject
 import java.sql.Connection
 import java.sql.PreparedStatement
 import java.sql.ResultSet
-import java.sql.Timestamp
-import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.*
 
@@ -135,7 +135,7 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
                    AND status = ?
                 """.trimIndent()
             ).use {
-                it.setTimestamp(1, Timestamp.from(Instant.now().minus(minutter, ChronoUnit.MINUTES)))
+                it.setTimestamp(1, Tidspunkt.now().minus(minutter, ChronoUnit.MINUTES).toTimestamp())
                 it.setString(2, GrunnlagsendringStatus.VENTER_PAA_JOBB.name)
                 return it.executeQuery().toList { asGrunnlagsendringshendelse() }
             }

--- a/apps/etterlatte-behandling/src/test/kotlin/IntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/IntegrationTest.kt
@@ -54,7 +54,6 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.lang.Thread.sleep
-import java.time.Instant
 import java.time.LocalDate
 import java.time.YearMonth
 import java.util.*
@@ -172,7 +171,7 @@ class IntegrationTest : BehandlingIntegrationTest() {
 
                 val expected = FastsettVirkningstidspunktResponse(
                     YearMonth.of(2022, 2),
-                    Grunnlagsopplysning.Saksbehandler("Saksbehandler01", Instant.now()),
+                    Grunnlagsopplysning.Saksbehandler.create("Saksbehandler01"),
                     "En begrunnelse"
                 )
                 assertEquals(expected.dato, it.body<FastsettVirkningstidspunktResponse>().dato)

--- a/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
@@ -44,7 +44,7 @@ import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.UUID
+import java.util.*
 
 fun opprettBehandling(
     type: BehandlingType,
@@ -271,7 +271,7 @@ fun personOpplysning(
 fun kommerBarnetTilgode(
     svar: JaNeiVetIkke = JaNeiVetIkke.JA,
     begrunnelse: String = "En begrunnelse",
-    kilde: Grunnlagsopplysning.Saksbehandler = Grunnlagsopplysning.Saksbehandler("S01", Instant.now())
+    kilde: Grunnlagsopplysning.Saksbehandler = Grunnlagsopplysning.Saksbehandler.create("S01")
 ) = KommerBarnetTilgode(svar, begrunnelse, kilde)
 
 val TRIVIELL_MIDTPUNKT = Foedselsnummer.of("19040550081")

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoIntegrationTest.kt
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertAll
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
-import java.time.Instant
 import java.time.YearMonth
 import javax.sql.DataSource
 
@@ -618,7 +617,7 @@ internal class BehandlingDaoIntegrationTest {
 
         assertNotNull(behandling)
 
-        val saksbehandler = Grunnlagsopplysning.Saksbehandler("navIdent", Instant.now())
+        val saksbehandler = Grunnlagsopplysning.Saksbehandler.create("navIdent")
         val nyDato = YearMonth.of(2021, 2)
         behandling!!.oppdaterVirkningstidspunkt(nyDato, saksbehandler, "enBegrunnelse").let {
             behandlingRepo.lagreNyttVirkningstidspunkt(behandling.id, it.virkningstidspunkt!!)
@@ -645,7 +644,7 @@ internal class BehandlingDaoIntegrationTest {
         val kommerBarnetTilgode = KommerBarnetTilgode(
             JaNeiVetIkke.JA,
             "begrunnelse",
-            Grunnlagsopplysning.Saksbehandler("navIdent", Instant.now())
+            Grunnlagsopplysning.Saksbehandler.create("navIdent")
         )
         behandlingRepo.lagreKommerBarnetTilgode(opprettBehandling.id, kommerBarnetTilgode)
 
@@ -734,7 +733,7 @@ internal class BehandlingDaoIntegrationTest {
 
         assertNotNull(foerstegangsbehandling)
 
-        val saksbehandler = Grunnlagsopplysning.Saksbehandler("saksbehandler01", Tidspunkt.now().instant)
+        val saksbehandler = Grunnlagsopplysning.Saksbehandler.create("saksbehandler01")
 
         val kommerBarnetTilgode = KommerBarnetTilgode(JaNeiVetIkke.JA, "", saksbehandler)
         val virkningstidspunkt = Virkningstidspunkt(YearMonth.of(2021, 1), saksbehandler, "")

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
@@ -24,7 +24,6 @@ import no.nav.etterlatte.behandling.regulering.RevurderingService
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.objectMapper
-import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDateTimeNorskTid
 import no.nav.etterlatte.libs.ktor.restModule
 import no.nav.security.mock.oauth2.MockOAuth2Server
@@ -173,7 +172,7 @@ internal class BehandlingRoutesTest {
         )
         val virkningstidspunkt = Virkningstidspunkt(
             parsetVirkningstidspunkt,
-            Grunnlagsopplysning.Saksbehandler(NAVident, Tidspunkt.now().instant),
+            Grunnlagsopplysning.Saksbehandler.create(NAVident),
             bodyBegrunnelse
         )
         every {

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingTest.kt
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.YearMonth
-import java.util.UUID
+import java.util.*
 
 internal class BehandlingTest {
 
@@ -47,7 +47,7 @@ internal class BehandlingTest {
         vilkaarUtfall = null
     )
 
-    private val saksbehandler = Grunnlagsopplysning.Saksbehandler("saksbehandler01", Tidspunkt.now().instant)
+    private val saksbehandler = Grunnlagsopplysning.Saksbehandler.create("saksbehandler01")
 
     private val kommerBarnetTilgode = KommerBarnetTilgode(JaNeiVetIkke.JA, "", saksbehandler)
     private val virkningstidspunkt = Virkningstidspunkt(YearMonth.of(2021, 1), saksbehandler, "begrunnelse")

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealFoerstegangsbehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealFoerstegangsbehandlingServiceTest.kt
@@ -26,9 +26,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.sql.Connection
-import java.time.Instant
 import java.time.YearMonth
-import java.util.UUID
+import java.util.*
 
 internal class RealFoerstegangsbehandlingServiceTest {
 
@@ -87,7 +86,7 @@ internal class RealFoerstegangsbehandlingServiceTest {
             gyldighetsproeving = null,
             virkningstidspunkt = Virkningstidspunkt(
                 YearMonth.of(2022, 1),
-                Grunnlagsopplysning.Saksbehandler("ident", Instant.now()),
+                Grunnlagsopplysning.Saksbehandler.create("ident"),
                 "begrunnelse"
             ),
             kommerBarnetTilgode = null,
@@ -128,7 +127,7 @@ internal class RealFoerstegangsbehandlingServiceTest {
             gyldighetsproeving = null,
             virkningstidspunkt = Virkningstidspunkt(
                 YearMonth.of(2022, 1),
-                Grunnlagsopplysning.Saksbehandler("ident", Instant.now()),
+                Grunnlagsopplysning.Saksbehandler.create("ident"),
                 "begrunnelse"
             ),
             kommerBarnetTilgode = null,

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealManueltOpphoerServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealManueltOpphoerServiceTest.kt
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.sql.Connection
-import java.time.Instant
 import java.time.YearMonth
 import java.util.UUID
 
@@ -100,7 +99,7 @@ internal class RealManueltOpphoerServiceTest {
                     sakId = sak,
                     virkningstidspunkt = Virkningstidspunkt(
                         dato = YearMonth.of(2022, 8),
-                        kilde = Grunnlagsopplysning.Saksbehandler(ident = "", tidspunkt = Instant.now()),
+                        kilde = Grunnlagsopplysning.Saksbehandler.create(ident = ""),
                         begrunnelse = ""
                     ),
                     status = BehandlingStatus.IVERKSATT
@@ -273,7 +272,7 @@ internal class RealManueltOpphoerServiceTest {
                     status = BehandlingStatus.FATTET_VEDTAK,
                     virkningstidspunkt = Virkningstidspunkt(
                         dato = YearMonth.of(2020, 8),
-                        kilde = Grunnlagsopplysning.Saksbehandler(ident = "", tidspunkt = Instant.now()),
+                        kilde = Grunnlagsopplysning.Saksbehandler.create(ident = ""),
                         begrunnelse = "dab on the haters"
                     )
                 )

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagService.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagService.kt
@@ -21,8 +21,7 @@ import no.nav.etterlatte.libs.sporingslogg.Sporingslogg
 import no.nav.etterlatte.libs.sporingslogg.Sporingsrequest
 import no.nav.etterlatte.token.Bruker
 import org.slf4j.LoggerFactory
-import java.time.Instant
-import java.util.UUID
+import java.util.*
 
 interface GrunnlagService {
     fun hentGrunnlagAvType(sak: Long, opplysningstype: Opplysningstype): Grunnlagsopplysning<JsonNode>?
@@ -94,7 +93,7 @@ class RealGrunnlagService(
         val opplysning: List<Grunnlagsopplysning<JsonNode>> = listOf(
             lagOpplysning(
                 opplysningsType = Opplysningstype.SOESKEN_I_BEREGNINGEN,
-                kilde = Grunnlagsopplysning.Saksbehandler(bruker.ident(), Instant.now()),
+                kilde = Grunnlagsopplysning.Saksbehandler.create(bruker.ident()),
                 opplysning = Beregningsgrunnlag(soeskenMedIBeregning).toJsonNode()
             )
         )

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingDao.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingDao.kt
@@ -8,6 +8,7 @@ import kotliquery.sessionOf
 import kotliquery.using
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.toTimestamp
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.BehandlingId
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.Kravgrunnlag
@@ -38,7 +39,7 @@ class TilbakekrevingDao(
                             "sak_id" to sakId.value.param<Long>(),
                             "behandling_id" to behandlingId.value.param<UUID>(),
                             "kravgrunnlag_id" to kravgrunnlagId.value.param<Long>(),
-                            "opprettet" to Timestamp.from(mottattKravgrunnlag.opprettet.instant).param<Timestamp>(),
+                            "opprettet" to mottattKravgrunnlag.opprettet.toTimestamp().param<Timestamp>(),
                             "kravgrunnlag" to kravgrunnlag.toJson().param<String>()
                         )
                     }

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/AvstemmingDao.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/AvstemmingDao.kt
@@ -8,10 +8,10 @@ import kotliquery.sessionOf
 import kotliquery.using
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.toTimestamp
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.utbetaling.avstemming.Konsistensavstemming
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
-import java.sql.Timestamp
 import javax.sql.DataSource
 
 class AvstemmingDao(private val dataSource: DataSource) {
@@ -27,9 +27,9 @@ class AvstemmingDao(private val dataSource: DataSource) {
                     """,
                 paramMap = mapOf(
                     "id" to konsistensavstemming.id.value.param(),
-                    "opprettet" to Timestamp.from(konsistensavstemming.opprettet.instant).param(),
-                    "loepende_fom" to Timestamp.from(konsistensavstemming.loependeFraOgMed.instant).param(),
-                    "opprettet_tom" to Timestamp.from(konsistensavstemming.opprettetTilOgMed.instant).param(),
+                    "opprettet" to konsistensavstemming.opprettet.toTimestamp().param(),
+                    "loepende_fom" to konsistensavstemming.loependeFraOgMed.toTimestamp().param(),
+                    "opprettet_tom" to konsistensavstemming.opprettetTilOgMed.toTimestamp().param(),
                     "avstemmingsdata" to konsistensavstemming.avstemmingsdata.param(),
                     "avstemmingtype" to Avstemmingtype.KONSISTENSAVSTEMMING.name.param(),
                     "saktype" to konsistensavstemming.sakType.name.param(),
@@ -82,9 +82,9 @@ class AvstemmingDao(private val dataSource: DataSource) {
                     """,
                 paramMap = mapOf(
                     "id" to grensesnittavstemming.id.value.param(),
-                    "opprettet" to Timestamp.from(grensesnittavstemming.opprettet.instant).param(),
-                    "periode_fra" to Timestamp.from(grensesnittavstemming.periode.fraOgMed.instant).param(),
-                    "periode_til" to Timestamp.from(grensesnittavstemming.periode.til.instant).param(),
+                    "opprettet" to grensesnittavstemming.opprettet.toTimestamp().param(),
+                    "periode_fra" to grensesnittavstemming.periode.fraOgMed.toTimestamp().param(),
+                    "periode_til" to grensesnittavstemming.periode.til.toTimestamp().param(),
                     "antall_oppdrag" to grensesnittavstemming.antallOppdrag.param(),
                     "avstemmingsdata" to grensesnittavstemming.avstemmingsdata.param(),
                     "avstemmingtype" to Avstemmingtype.GRENSESNITTAVSTEMMING.name.param(),

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/utbetaling/UtbetalingDao.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/utbetaling/UtbetalingDao.kt
@@ -9,13 +9,14 @@ import kotliquery.sessionOf
 import kotliquery.using
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.toTimestamp
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.utbetaling.common.UUID30
 import no.nav.etterlatte.utbetaling.iverksetting.oppdrag.OppdragJaxb
 import no.nav.etterlatte.utbetaling.iverksetting.oppdrag.vedtakId
 import no.trygdeetaten.skjema.oppdrag.Oppdrag
 import org.slf4j.LoggerFactory
-import java.sql.Timestamp
 import java.util.*
 import javax.sql.DataSource
 
@@ -43,9 +44,9 @@ class UtbetalingDao(private val dataSource: DataSource) {
                     "behandlingIdTilOppdrag" to utbetaling.behandlingId.shortValue.value.param(),
                     "sakId" to utbetaling.sakId.value.param(),
                     "vedtak" to utbetaling.vedtak.toJson().param(),
-                    "opprettet" to Timestamp.from(utbetaling.opprettet.instant).param(),
-                    "avstemmingsnoekkel" to Timestamp.from(utbetaling.avstemmingsnoekkel.instant).param(),
-                    "endret" to Timestamp.from(utbetaling.endret.instant).param(),
+                    "opprettet" to utbetaling.opprettet.toTimestamp().param(),
+                    "avstemmingsnoekkel" to utbetaling.avstemmingsnoekkel.toTimestamp().param(),
+                    "endret" to utbetaling.endret.toTimestamp().param(),
                     "stoenadsmottaker" to utbetaling.stoenadsmottaker.value.param(),
                     "saksbehandler" to utbetaling.saksbehandler.value.param(),
                     "saksbehandlerEnhet" to utbetaling.saksbehandlerEnhet.param(),
@@ -84,7 +85,7 @@ class UtbetalingDao(private val dataSource: DataSource) {
                 "type" to utbetalingslinje.type.name.param(),
                 "utbetaling_id" to utbetalingslinje.utbetalingId.param(),
                 "erstatter_id" to utbetalingslinje.erstatterId?.value.param(),
-                "opprettet" to Timestamp.from(utbetalingslinje.opprettet.instant).param(),
+                "opprettet" to utbetalingslinje.opprettet.toTimestamp().param(),
                 "sak_id" to utbetalingslinje.sakId.value.param(),
                 "periode_fra" to utbetalingslinje.periode.fra.param(),
                 "periode_til" to utbetalingslinje.periode.til.param(),
@@ -117,7 +118,7 @@ class UtbetalingDao(private val dataSource: DataSource) {
             paramMap = mapOf(
                 "id" to utbetalingshendelse.id.param(),
                 "utbetalingId" to utbetalingshendelse.utbetalingId.param(),
-                "tidspunkt" to Timestamp.from(utbetalingshendelse.tidspunkt.instant).param(),
+                "tidspunkt" to utbetalingshendelse.tidspunkt.toTimestamp().param(),
                 "status" to utbetalingshendelse.status.name.param()
             )
         ).let { tx.run(it.asUpdate) }
@@ -217,8 +218,8 @@ class UtbetalingDao(private val dataSource: DataSource) {
                 AND u.saktype = :saktype
             """.trimIndent(),
             paramMap = mapOf(
-                "loependeFom" to Timestamp.from(aktivFraOgMed.instant).param(),
-                "opprettetTom" to Timestamp.from(opprettetFramTilOgMed.instant).param(),
+                "loependeFom" to aktivFraOgMed.toTimestamp().param(),
+                "opprettetTom" to opprettetFramTilOgMed.toTimestamp().param(),
                 "saktype" to saktype.name.param()
             )
         ).let {
@@ -248,8 +249,8 @@ class UtbetalingDao(private val dataSource: DataSource) {
                     AND saktype = :saktype
                     """,
             paramMap = mapOf(
-                "fraOgMed" to Timestamp.from(fraOgMed.instant).param(),
-                "til" to Timestamp.from(til.instant).param(),
+                "fraOgMed" to fraOgMed.toTimestamp().param(),
+                "til" to til.toTimestamp().param(),
                 "saktype" to saktype.name.param()
             )
         ).let {
@@ -305,7 +306,7 @@ class UtbetalingDao(private val dataSource: DataSource) {
                         "beskrivelse" to oppdragMedKvittering.mmel.beskrMelding.param(),
                         "alvorlighetsgrad" to oppdragMedKvittering.mmel.alvorlighetsgrad.param(),
                         "kode" to oppdragMedKvittering.mmel.kodeMelding.param(),
-                        "endret" to Timestamp.from(endret.instant).param(),
+                        "endret" to endret.toTimestamp().param(),
                         "vedtakId" to oppdragMedKvittering.vedtakId().param()
                     )
                 ).let { tx.run(it.asUpdate) }
@@ -340,9 +341,9 @@ class UtbetalingDao(private val dataSource: DataSource) {
                 shortValue = UUID30(string("behandling_id_til_oppdrag"))
             ),
             vedtakId = VedtakId(long("vedtak_id")),
-            opprettet = Tidspunkt(sqlTimestamp("opprettet").toInstant()),
-            endret = Tidspunkt(sqlTimestamp("endret").toInstant()),
-            avstemmingsnoekkel = Tidspunkt(sqlTimestamp("avstemmingsnoekkel").toInstant()),
+            opprettet = sqlTimestamp("opprettet").toTidspunkt(),
+            endret = sqlTimestamp("endret").toTidspunkt(),
+            avstemmingsnoekkel = sqlTimestamp("avstemmingsnoekkel").toTidspunkt(),
             stoenadsmottaker = Foedselsnummer(string("stoenadsmottaker")),
             saksbehandler = NavIdent(string("saksbehandler")),
             saksbehandlerEnhet = string("saksbehandler_enhet"),
@@ -369,7 +370,7 @@ class UtbetalingDao(private val dataSource: DataSource) {
             type = string("type").let { Utbetalingslinjetype.valueOf(it) },
             utbetalingId = uuid("utbetaling_id"),
             erstatterId = longOrNull("erstatter_id")?.let { UtbetalingslinjeId(it) },
-            opprettet = Tidspunkt(sqlTimestamp("opprettet").toInstant()),
+            opprettet = sqlTimestamp("opprettet").toTidspunkt(),
             sakId = SakId(long("sak_id")),
             periode = PeriodeForUtbetaling(
                 fra = localDate("periode_fra"),
@@ -384,7 +385,7 @@ class UtbetalingDao(private val dataSource: DataSource) {
         Utbetalingshendelse(
             id = uuid("id"),
             utbetalingId = uuid("utbetaling_id"),
-            tidspunkt = Tidspunkt(sqlTimestamp("tidspunkt").toInstant()),
+            tidspunkt = sqlTimestamp("tidspunkt").toTidspunkt(),
             status = string("status").let(UtbetalingStatus::valueOf)
         )
     }

--- a/libs/testdata/src/main/kotlin/behandling/VirkningstidspunktTestData.kt
+++ b/libs/testdata/src/main/kotlin/behandling/VirkningstidspunktTestData.kt
@@ -2,13 +2,12 @@ package no.nav.etterlatte.libs.testdata.behandling
 
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
-import java.time.Instant
 import java.time.YearMonth
 
 class VirkningstidspunktTestData {
 
     companion object {
         fun virkningstidsunkt(dato: YearMonth = YearMonth.now()) =
-            Virkningstidspunkt(dato, Grunnlagsopplysning.Saksbehandler("Z12345678", Instant.now()), "begrunnelse")
+            Virkningstidspunkt(dato, Grunnlagsopplysning.Saksbehandler.create("Z12345678"), "begrunnelse")
     }
 }


### PR DESCRIPTION
- For å gå frå Tidspunkt til Timestamp går vi no kun via hjelpemetoden `.toTimestamp()`. Da sikrar vi at det gjerast likt, og gjer at vi slepp å eksponere ut den underliggjande implementasjonen ut frå pakka
- For å opprette `Grunnlagsopplysning.Saksbehandler` går vi no via factory-metoden som allereie fans der. Med det blir det lettare å endre type til Tidspunkt i neste omgang