### PR TITLE
EY-1820 Fjerne unødvendig kode

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
@@ -35,24 +35,6 @@ import java.util.UUID
 
 class BehandlingDao(private val connection: () -> Connection) {
 
-    fun hentBehandling(id: UUID, type: BehandlingType): Behandling? {
-        val stmt =
-            connection().prepareStatement(
-                """
-                    SELECT b.*, s.sakType, s.fnr 
-                    FROM behandling b
-                    INNER JOIN sak s ON b.sak_id = s.id
-                    WHERE b.id = ? AND b.behandlingstype = ? 
-                    """
-            )
-        stmt.setObject(1, id)
-        stmt.setString(2, type.name)
-
-        return stmt.executeQuery().singleOrNull {
-            behandlingAvRettType()
-        }
-    }
-
     fun hentBehandling(id: UUID): Behandling? {
         val stmt =
             connection().prepareStatement(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/GenerellBehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/GenerellBehandlingService.kt
@@ -89,7 +89,7 @@ class RealGenerellBehandlingService(
 
     override fun hentBehandling(behandlingId: UUID): Behandling? {
         return inTransaction {
-            behandlinger.hentBehandlingType(behandlingId)?.let { behandlinger.hentBehandling(behandlingId, it) }
+            behandlinger.hentBehandling(behandlingId)
         }
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingAggregat.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingAggregat.kt
@@ -18,7 +18,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
 import java.time.YearMonth
-import java.util.*
+import java.util.UUID
 
 class FoerstegangsbehandlingAggregat(
     id: UUID,
@@ -52,8 +52,7 @@ class FoerstegangsbehandlingAggregat(
         }
     }
 
-    var lagretBehandling: Foerstegangsbehandling =
-        requireNotNull(behandlinger.hentBehandling(id, BehandlingType.FØRSTEGANGSBEHANDLING) as Foerstegangsbehandling)
+    var lagretBehandling = requireNotNull(behandlinger.hentBehandling(id) as Foerstegangsbehandling)
 
     fun lagreGyldighetproeving(gyldighetsproeving: GyldighetsResultat) {
         lagretBehandling = lagretBehandling.oppdaterGyldighetsproeving(gyldighetsproeving)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/manueltopphoer/ManueltOpphoerService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/manueltopphoer/ManueltOpphoerService.kt
@@ -53,16 +53,16 @@ class RealManueltOpphoerService(
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     override fun hentManueltOpphoer(behandling: UUID): ManueltOpphoer? =
-        behandlinger.hentBehandling(behandling, BehandlingType.MANUELT_OPPHOER) as ManueltOpphoer?
+        behandlinger.hentBehandling(behandling) as ManueltOpphoer?
 
     override fun hentManueltOpphoerInTransaction(behandling: UUID): ManueltOpphoer? =
-        inTransaction { behandlinger.hentBehandling(behandling, BehandlingType.MANUELT_OPPHOER) as ManueltOpphoer? }
+        inTransaction { behandlinger.hentBehandling(behandling) as ManueltOpphoer? }
 
     override fun hentManueltOpphoerOgAlleIverksatteBehandlingerISak(
         behandling: UUID
     ): Pair<ManueltOpphoer, List<Behandling>>? =
         inTransaction {
-            val opphoer = behandlinger.hentBehandling(behandling, BehandlingType.MANUELT_OPPHOER) as ManueltOpphoer?
+            val opphoer = behandlinger.hentBehandling(behandling) as ManueltOpphoer?
                 ?: return@inTransaction null
             val andreBehandlinger = behandlinger.alleBehandlingerISak(opphoer.sak.id)
                 .filter { it.id != behandling && it.status == BehandlingStatus.IVERKSATT }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/regulering/ReguleringAggregat.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/regulering/ReguleringAggregat.kt
@@ -16,7 +16,7 @@ import no.nav.etterlatte.libs.common.behandling.tilVirkningstidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 
 class ReguleringAggregat(
     id: UUID,
@@ -54,8 +54,7 @@ class ReguleringAggregat(
         }
     }
 
-    var lagretBehandling: Regulering =
-        requireNotNull(behandlinger.hentBehandling(id, BehandlingType.OMREGNING) as Regulering)
+    var lagretBehandling = requireNotNull(behandlinger.hentBehandling(id) as Regulering)
 
     fun registrerVedtakHendelse(
         vedtakId: Long,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingAggregat.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingAggregat.kt
@@ -14,7 +14,7 @@ import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import org.slf4j.LoggerFactory
-import java.util.*
+import java.util.UUID
 
 class RevurderingAggregat(
     id: UUID,
@@ -51,8 +51,7 @@ class RevurderingAggregat(
         }
     }
 
-    var lagretBehandling: Revurdering =
-        requireNotNull(behandlinger.hentBehandling(id, BehandlingType.REVURDERING) as Revurdering)
+    var lagretBehandling = requireNotNull(behandlinger.hentBehandling(id) as Revurdering)
 
     fun registrerVedtakHendelse(
         vedtakId: Long,

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoIntegrationTest.kt
@@ -94,10 +94,7 @@ internal class BehandlingDaoIntegrationTest {
 
         behandlingRepo.opprettBehandling(opprettBehandlingMedPersongalleri)
         val opprettetBehandling = requireNotNull(
-            behandlingRepo.hentBehandling(
-                opprettBehandlingMedPersongalleri.id,
-                BehandlingType.FØRSTEGANGSBEHANDLING
-            )
+            behandlingRepo.hentBehandling(opprettBehandlingMedPersongalleri.id)
         ) as Foerstegangsbehandling
         assertEquals(opprettBehandlingMedPersongalleri.id, opprettetBehandling.id)
         assertEquals(
@@ -126,12 +123,8 @@ internal class BehandlingDaoIntegrationTest {
         )
 
         behandlingRepo.opprettBehandling(opprettBehandling)
-        val opprettetBehandling = requireNotNull(
-            behandlingRepo.hentBehandling(
-                opprettBehandling.id,
-                BehandlingType.REVURDERING
-            )
-        ) as Revurdering
+        val opprettetBehandling = requireNotNull(behandlingRepo.hentBehandling(opprettBehandling.id)) as Revurdering
+
         assertEquals(opprettBehandling.id, opprettetBehandling.id)
         assertEquals(
             opprettBehandling.persongalleri.avdoed,
@@ -171,12 +164,7 @@ internal class BehandlingDaoIntegrationTest {
         )
 
         behandlingRepo.opprettBehandling(opprettBehandling)
-        val opprettetBehandling = requireNotNull(
-            behandlingRepo.hentBehandling(
-                opprettBehandling.id,
-                BehandlingType.MANUELT_OPPHOER
-            )
-        ) as ManueltOpphoer
+        val opprettetBehandling = requireNotNull(behandlingRepo.hentBehandling(opprettBehandling.id)) as ManueltOpphoer
 
         assertEquals(sakId, opprettetBehandling.sak.id)
         assertEquals(persongalleri(), opprettetBehandling.persongalleri)
@@ -197,12 +185,8 @@ internal class BehandlingDaoIntegrationTest {
 
         behandlingRepo.opprettBehandling(opprettBehandling)
 
-        val lagretPersongalleriBehandling = requireNotNull(
-            behandlingRepo.hentBehandling(
-                opprettBehandling.id,
-                BehandlingType.FØRSTEGANGSBEHANDLING
-            )
-        ) as Foerstegangsbehandling
+        val lagretPersongalleriBehandling =
+            requireNotNull(behandlingRepo.hentBehandling(opprettBehandling.id)) as Foerstegangsbehandling
 
         val gyldighetsproevingBehanding = lagretPersongalleriBehandling.copy(
             gyldighetsproeving = GyldighetsResultat(
@@ -220,12 +204,8 @@ internal class BehandlingDaoIntegrationTest {
         )
 
         behandlingRepo.lagreGyldighetsproving(gyldighetsproevingBehanding)
-        val lagretGyldighetsproving = requireNotNull(
-            behandlingRepo.hentBehandling(
-                opprettBehandling.id,
-                BehandlingType.FØRSTEGANGSBEHANDLING
-            )
-        ) as Foerstegangsbehandling
+        val lagretGyldighetsproving =
+            requireNotNull(behandlingRepo.hentBehandling(opprettBehandling.id)) as Foerstegangsbehandling
 
         assertEquals(
             gyldighetsproevingBehanding.gyldighetsproeving,
@@ -328,10 +308,7 @@ internal class BehandlingDaoIntegrationTest {
             behandlingRepo.opprettBehandling(it)
         }
 
-        val behandling = behandlingRepo.hentBehandling(
-            id = opprettBehandling.id,
-            type = BehandlingType.FØRSTEGANGSBEHANDLING
-        )
+        val behandling = behandlingRepo.hentBehandling(opprettBehandling.id)
         assertTrue(behandling is Foerstegangsbehandling)
     }
 
@@ -347,7 +324,7 @@ internal class BehandlingDaoIntegrationTest {
             behandlingRepo.opprettBehandling(it)
         }
 
-        val behandling = behandlingRepo.hentBehandling(id = opprettBehandling.id, type = BehandlingType.REVURDERING)
+        val behandling = behandlingRepo.hentBehandling(id = opprettBehandling.id)
         assertTrue(behandling is Revurdering)
     }
 
@@ -364,7 +341,7 @@ internal class BehandlingDaoIntegrationTest {
         ).also {
             behandlingRepo.opprettBehandling(it)
         }
-        val behandling = behandlingRepo.hentBehandling(opprettBehandling.id, BehandlingType.MANUELT_OPPHOER)
+        val behandling = behandlingRepo.hentBehandling(opprettBehandling.id)
         assertTrue(behandling is ManueltOpphoer)
     }
 
@@ -442,11 +419,7 @@ internal class BehandlingDaoIntegrationTest {
             behandlingRepo.opprettBehandling(it)
         }
 
-        val behandlingFoerStatusendring =
-            behandlingRepo.hentBehandling(
-                opprettBehandling.id,
-                BehandlingType.FØRSTEGANGSBEHANDLING
-            ) as? Foerstegangsbehandling
+        val behandlingFoerStatusendring = behandlingRepo.hentBehandling(opprettBehandling.id) as? Foerstegangsbehandling
         assertNotNull(behandlingFoerStatusendring)
 
         val endretTidspunkt = Tidspunkt.now().toLocalDatetimeUTC()
@@ -454,8 +427,7 @@ internal class BehandlingDaoIntegrationTest {
             behandlingFoerStatusendring!!.copy(status = BehandlingStatus.VILKAARSVURDERT, sistEndret = endretTidspunkt)
         behandlingRepo.lagreStatus(behandlingMedNyStatus)
 
-        val behandlingEtterStatusendring =
-            behandlingRepo.hentBehandling(opprettBehandling.id, BehandlingType.FØRSTEGANGSBEHANDLING)
+        val behandlingEtterStatusendring = behandlingRepo.hentBehandling(opprettBehandling.id)
 
         assertEquals(BehandlingStatus.OPPRETTET, behandlingFoerStatusendring.status)
         assertEquals(BehandlingStatus.VILKAARSVURDERT, behandlingEtterStatusendring!!.status)

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealFoerstegangsbehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealFoerstegangsbehandlingServiceTest.kt
@@ -15,7 +15,6 @@ import no.nav.etterlatte.behandling.foerstegangsbehandling.Foerstegangsbehandlin
 import no.nav.etterlatte.behandling.foerstegangsbehandling.RealFoerstegangsbehandlingService
 import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
-import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
@@ -71,10 +70,7 @@ internal class RealFoerstegangsbehandlingServiceTest {
         val id = UUID.randomUUID()
 
         every {
-            behandlingerMock.hentBehandling(
-                id,
-                BehandlingType.FØRSTEGANGSBEHANDLING
-            )
+            behandlingerMock.hentBehandling(id)
         } returns Foerstegangsbehandling(
             id = id,
             sak = Sak(
@@ -160,10 +156,7 @@ internal class RealFoerstegangsbehandlingServiceTest {
 
         every { behandlingerMock.opprettBehandling(capture(behandlingOpprettes)) } returns Unit
         every {
-            behandlingerMock.hentBehandling(
-                capture(behandlingHentes),
-                BehandlingType.FØRSTEGANGSBEHANDLING
-            )
+            behandlingerMock.hentBehandling(capture(behandlingHentes))
         } returns opprettetBehandling
         every { hendelserMock.behandlingOpprettet(any()) } returns Unit
         every { behandlingerMock.lagreGyldighetsproving(any()) } returns Unit

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealGenerellBehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealGenerellBehandlingServiceTest.kt
@@ -42,7 +42,7 @@ import java.sql.Connection
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
 
 class RealGenerellBehandlingServiceTest {
     @BeforeEach
@@ -281,7 +281,7 @@ class RealGenerellBehandlingServiceTest {
         val service = lagRealGenerellBehandlingService(
             behandlinger = mockk {
                 every { hentBehandlingType(BEHANDLINGS_ID) } returns BehandlingType.FØRSTEGANGSBEHANDLING
-                every { hentBehandling(BEHANDLINGS_ID, BehandlingType.FØRSTEGANGSBEHANDLING) } returns behandling
+                every { hentBehandling(BEHANDLINGS_ID) } returns behandling
             },
             grunnlagKlient = mockk {
                 coEvery {
@@ -371,7 +371,7 @@ class RealGenerellBehandlingServiceTest {
             behandlinger = mockk {
                 every { hentBehandlingType(BEHANDLINGS_ID) } returns BehandlingType.FØRSTEGANGSBEHANDLING
                 every {
-                    hentBehandling(BEHANDLINGS_ID, BehandlingType.FØRSTEGANGSBEHANDLING)
+                    hentBehandling(BEHANDLINGS_ID)
                 } returns behandling
             },
             grunnlagKlient = mockk {

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealManueltOpphoerServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealManueltOpphoerServiceTest.kt
@@ -61,7 +61,7 @@ internal class RealManueltOpphoerServiceTest {
         val sakId = 1L
         val id = UUID.randomUUID()
         val behandlingerMock = mockk<BehandlingDao> {
-            every { hentBehandling(id = id, type = BehandlingType.MANUELT_OPPHOER) } returns manueltOpphoer(
+            every { hentBehandling(id) } returns manueltOpphoer(
                 sakId = sakId
             )
         }
@@ -296,7 +296,7 @@ internal class RealManueltOpphoerServiceTest {
         val hendelsesKanal = mockk<SendChannel<Pair<UUID, BehandlingHendelseType>>>()
         val hendelserMock = mockk<HendelseDao>()
         val behandlingerMock = mockk<BehandlingDao> {
-            every { hentBehandling(any(), BehandlingType.MANUELT_OPPHOER) } returns null
+            every { hentBehandling(any()) } returns null
             every { alleBehandlingerISak(any()) } returns listOf()
         }
         val service = RealManueltOpphoerService(
@@ -327,7 +327,7 @@ internal class RealManueltOpphoerServiceTest {
             opphoerAarsaker = listOf(ManueltOpphoerAarsak.GJENLEVENDE_FORELDER_DOED)
         )
         val behandlingerMock = mockk<BehandlingDao> {
-            every { hentBehandling(manueltOpphoerId, BehandlingType.MANUELT_OPPHOER) } returns opphoer
+            every { hentBehandling(manueltOpphoerId) } returns opphoer
             every { alleBehandlingerISak(sakId) } returns listOf(
                 opphoer,
                 foerstegangsbehandling(sakId = sakId, status = BehandlingStatus.BEREGNET),

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealRevurderingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealRevurderingServiceTest.kt
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import java.sql.Connection
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 
 class RealRevurderingServiceTest {
 
@@ -50,7 +50,7 @@ class RealRevurderingServiceTest {
     fun `skal hente revurdering`() {
         val id = UUID.randomUUID()
         val behandlingerMock = mockk<BehandlingDao> {
-            every { hentBehandling(id = id, type = BehandlingType.REVURDERING) } returns revurdering(
+            every { hentBehandling(id) } returns revurdering(
                 id = id,
                 sakId = 1,
                 revurderingAarsak = RevurderingAarsak.SOEKER_DOD
@@ -110,7 +110,7 @@ class RealRevurderingServiceTest {
         val hendelse = slot<Pair<UUID, BehandlingHendelseType>>()
         val behandlingerMock = mockk<BehandlingDao> {
             every { opprettBehandling(capture(behandlingOpprettes)) } returns Unit
-            every { hentBehandling(capture(behandlingHentes), BehandlingType.REVURDERING) } returns revurdering
+            every { hentBehandling(capture(behandlingHentes)) } returns revurdering
         }
         val hendelserMock = mockk<HendelseDao>() {
             every { behandlingOpprettet(any()) } returns Unit


### PR DESCRIPTION
Type tilhørende behandling skal alltid være det samme. Derfor unødvendig å hente basert på både `behandlingType` _og_ `id`. 