### PR TITLE
EY-1795: Skjul implementasjonsdetalj tidspunkt

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/DetaljertBehandlingDto.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/DetaljertBehandlingDto.kt
@@ -9,7 +9,7 @@ import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.gyldigSoeknad.GyldighetsResultat
 import no.nav.etterlatte.libs.common.person.Person
-import java.time.Instant
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.time.LocalDateTime
 import java.util.*
 
@@ -19,8 +19,8 @@ data class DetaljertBehandlingDto(
     val sakType: SakType,
     val gyldighetsprøving: GyldighetsResultat?,
     val saksbehandlerId: String?,
-    val datoFattet: Instant?,
-    val datoattestert: Instant?,
+    val datoFattet: Tidspunkt?,
+    val datoattestert: Tidspunkt?,
     val attestant: String?,
     val soeknadMottattDato: LocalDateTime?,
     val virkningstidspunkt: Virkningstidspunkt?,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/GenerellBehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/GenerellBehandlingService.kt
@@ -216,8 +216,8 @@ class RealGenerellBehandlingService(
                 gyldighetsprøving = detaljertBehandling.gyldighetsproeving,
                 kommerBarnetTilgode = kommerBarnetTilgode,
                 saksbehandlerId = vedtak.await()?.vedtakFattet?.ansvarligSaksbehandler,
-                datoFattet = vedtak.await()?.vedtakFattet?.tidspunkt?.instant, // TODO burde ikke være instant
-                datoattestert = vedtak.await()?.attestasjon?.tidspunkt?.instant, // TODO burde ikke være instant
+                datoFattet = vedtak.await()?.vedtakFattet?.tidspunkt,
+                datoattestert = vedtak.await()?.attestasjon?.tidspunkt,
                 attestant = vedtak.await()?.attestasjon?.attestant,
                 soeknadMottattDato = detaljertBehandling.soeknadMottattDato,
                 virkningstidspunkt = detaljertBehandling.virkningstidspunkt,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/HendelseDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/HendelseDao.kt
@@ -4,13 +4,13 @@ import no.nav.etterlatte.behandling.domain.Behandling
 import no.nav.etterlatte.behandling.domain.BehandlingOpprettet
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.toTimestamp
 import no.nav.etterlatte.libs.database.toList
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.sql.Connection
 import java.sql.PreparedStatement
 import java.sql.ResultSet
-import java.sql.Timestamp
 import java.sql.Types
 import java.util.*
 
@@ -124,8 +124,7 @@ class HendelseDao(private val connection: () -> Connection) {
     }
 }
 
-fun PreparedStatement.setTidspunkt(index: Int, value: Tidspunkt?) =
-    setTimestamp(index, value?.instant?.let(Timestamp::from))
+fun PreparedStatement.setTidspunkt(index: Int, value: Tidspunkt?) = setTimestamp(index, value?.toTimestamp())
 
 fun PreparedStatement.setLong(index: Int, value: Long?) =
     if (value == null) setNull(index, Types.BIGINT) else setLong(3, value)

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealFoerstegangsbehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealFoerstegangsbehandlingServiceTest.kt
@@ -189,7 +189,7 @@ internal class RealFoerstegangsbehandlingServiceTest {
     @Test
     fun `lagring av gyldighetsproeving skal lagre og returnere gyldighetsresultat for innsender er gjenlevende`() {
         val id = UUID.randomUUID()
-        val naaTid = Instant.now()
+        val naaTid = Tidspunkt.now().instant
         val forventetResultat = GyldighetsResultat(
             resultat = VurderingsResultat.OPPFYLT,
             vurderinger = listOf(

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealFoerstegangsbehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealFoerstegangsbehandlingServiceTest.kt
@@ -189,7 +189,7 @@ internal class RealFoerstegangsbehandlingServiceTest {
     @Test
     fun `lagring av gyldighetsproeving skal lagre og returnere gyldighetsresultat for innsender er gjenlevende`() {
         val id = UUID.randomUUID()
-        val naaTid = Tidspunkt.now().instant
+        val naaTid = Instant.now()
         val forventetResultat = GyldighetsResultat(
             resultat = VurderingsResultat.OPPFYLT,
             vurderinger = listOf(

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/domain/MaanedStatistikk.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/domain/MaanedStatistikk.kt
@@ -36,7 +36,7 @@ class MaanedStatistikk(val maaned: YearMonth, stoenadRader: List<StoenadRad>) {
         val vedtakPerSak = stoenadRader.groupBy { it.sakId }
 
         rader = vedtakPerSak.mapNotNull { (_, vedtakPaaSak) ->
-            val sisteVedtak = vedtakPaaSak.maxBy { it.tekniskTid.instant }
+            val sisteVedtak = vedtakPaaSak.maxBy { it.tekniskTid }
 
             // finn aktuell utbetalingsperiode for dette vedtaket
             val aktuellPeriode = when (val beregning = sisteVedtak.beregning) {

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/database/SakRepositoryTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/database/SakRepositoryTest.kt
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
-import java.time.Instant
 import java.time.LocalDate
 import java.util.*
 import javax.sql.DataSource
@@ -50,7 +49,7 @@ class SakRepositoryTest {
         beregningId = UUID.randomUUID(),
         behandlingId = UUID.randomUUID(),
         type = Beregningstype.BP,
-        beregnetDato = Tidspunkt(instant = Instant.now()),
+        beregnetDato = Tidspunkt.now(),
         beregningsperioder = listOf()
     )
 

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/database/StoenadRepositoryTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/database/StoenadRepositoryTest.kt
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
-import java.time.Instant
 import java.time.LocalDate
 import java.time.Month
 import java.time.YearMonth
@@ -52,7 +51,7 @@ class StoenadRepositoryTest {
         beregningId = UUID.randomUUID(),
         behandlingId = UUID.randomUUID(),
         type = Beregningstype.BP,
-        beregnetDato = Tidspunkt(instant = Instant.now()),
+        beregnetDato = Tidspunkt.now(),
         beregningsperioder = listOf()
     )
 

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/service/StatistikkServiceTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/service/StatistikkServiceTest.kt
@@ -30,7 +30,6 @@ import no.nav.etterlatte.statistikk.domain.SakUtland
 import no.nav.etterlatte.statistikk.river.BehandlingHendelse
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import java.time.Instant
 import java.time.LocalDateTime
 import java.time.YearMonth
 import java.util.*
@@ -75,7 +74,7 @@ class StatistikkServiceTest {
             beregningId = UUID.randomUUID(),
             behandlingId = behandlingId,
             type = Beregningstype.BP,
-            beregnetDato = Tidspunkt(instant = Instant.now()),
+            beregnetDato = Tidspunkt.now(),
             beregningsperioder = listOf()
         )
         val beregningKlient = mockk<BeregningKlient>()

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/Grensesnittavstemming.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/Grensesnittavstemming.kt
@@ -21,7 +21,7 @@ data class Avstemmingsperiode(
     val til: Tidspunkt
 ) {
     init {
-        require(fraOgMed.instant.isBefore(til.instant)) { "fraOgMed-tidspunkt maa vaere foer til-tidspunkt" }
+        require(fraOgMed.isBefore(til)) { "fraOgMed-tidspunkt maa vaere foer til-tidspunkt" }
     }
 }
 

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingService.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingService.kt
@@ -79,7 +79,7 @@ class KonsistensavstemmingService(
          * Inspirasjon og takk rettes mot su-se-bakover's implementasjon av tilsvarende
          */
         val loependeUtbetalinger: List<OppdragForKonsistensavstemming> = relevanteUtbetalinger
-            .filter { it.opprettet <= registrertFoerTom.instant } // 1
+            .filter { it.opprettet <= registrertFoerTom } // 1
             .groupBy { it.sakId } // 2
             .mapValues { entry -> // 3
                 entry.value.map { utbetaling ->

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingService.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingService.kt
@@ -4,6 +4,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.midnattNorskTid
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeNorskTid
 import no.nav.etterlatte.libs.common.tidspunkt.toNorskTidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
 import no.nav.etterlatte.utbetaling.avstemming.avstemmingsdata.KonsistensavstemmingDataMapper
 import no.nav.etterlatte.utbetaling.grensesnittavstemming.AvstemmingDao
 import no.nav.etterlatte.utbetaling.grensesnittavstemming.UUIDBase64
@@ -183,7 +184,7 @@ class KonsistensavstemmingService(
 fun gjeldendeLinjerForEnDato(utbetalingslinjer: List<Utbetalingslinje>, dato: LocalDate): List<Utbetalingslinje> {
     val linjerSomErOpprettetOgIkkeAvsluttetPaaDato = utbetalingslinjer
         .filter {
-            it.opprettet.instant <= dato.midnattNorskTid().toInstant()
+            it.opprettet <= dato.midnattNorskTid().toTidspunkt()
         } // 1
         .filter { (it.periode.til ?: dato) >= dato } // 2
 

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingService.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingService.kt
@@ -16,7 +16,6 @@ import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Utbetalingslinje
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.UtbetalingslinjeId
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Utbetalingslinjetype
 import org.slf4j.LoggerFactory
-import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -132,7 +131,7 @@ class KonsistensavstemmingService(
         return Konsistensavstemming(
             id = UUIDBase64(),
             sakType = saktype,
-            opprettet = Tidspunkt(instant = Instant.now()),
+            opprettet = Tidspunkt.now(),
             avstemmingsdata = null,
             loependeFraOgMed = loependeYtelseFom,
             opprettetTilOgMed = registrertFoerTom,

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/avstemmingsdata/GrensesnittavstemmingDataMapper.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/avstemmingsdata/GrensesnittavstemmingDataMapper.kt
@@ -21,7 +21,6 @@ import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.KildeType
 import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.Periodedata
 import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.Totaldata
 import java.math.BigDecimal
-import java.time.Instant
 
 class GrensesnittavstemmingDataMapper(
     private val utbetalinger: List<Utbetaling>,
@@ -61,13 +60,9 @@ class GrensesnittavstemmingDataMapper(
                 mottakendeKomponentKode = OppdragDefaults.MOTTAKENDE_KOMPONENTKODE
                 underkomponentKode = fagomraade
                 nokkelFom =
-                    avstemmingsperiode?.start?.let {
-                        Tidspunkt(it).toNorskTid()
-                    }?.format(tidsstempelMikroOppdrag) ?: "0"
+                    avstemmingsperiode?.start?.toNorskTid()?.format(tidsstempelMikroOppdrag) ?: "0"
                 nokkelTom =
-                    avstemmingsperiode?.endInclusive?.let {
-                        Tidspunkt(it).toNorskTid()
-                    }?.format(tidsstempelMikroOppdrag) ?: "0"
+                    avstemmingsperiode?.endInclusive?.toNorskTid()?.format(tidsstempelMikroOppdrag) ?: "0"
                 avleverendeAvstemmingId = avstemmingId.value
                 brukerId = fagomraade
             }
@@ -162,13 +157,13 @@ class GrensesnittavstemmingDataMapper(
             datoAvstemtTom = periodeTil.toNorskTid().minusHours(1).format(tidsstempelTimeOppdrag)
         }
 
-    private fun periode(liste: List<Utbetaling>): ClosedRange<Instant>? {
+    private fun periode(liste: List<Utbetaling>): ClosedRange<Tidspunkt>? {
         return if (liste.isEmpty()) {
             null
         } else {
-            object : ClosedRange<Instant> {
-                override val start = liste.minOf { it.avstemmingsnoekkel.instant }
-                override val endInclusive = liste.maxOf { it.avstemmingsnoekkel.instant }
+            object : ClosedRange<Tidspunkt> {
+                override val start = liste.minOf { it.avstemmingsnoekkel }
+                override val endInclusive = liste.maxOf { it.avstemmingsnoekkel }
             }
         }
     }

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/utbetaling/UtbetalingMapper.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/utbetaling/UtbetalingMapper.kt
@@ -92,7 +92,7 @@ class UtbetalingMapper(
             UtbetalingStatus.GODKJENT,
             UtbetalingStatus.GODKJENT_MED_FEIL
         )
-    }.maxByOrNull { it.opprettet.instant }?.utbetalingslinjer?.last()?.id
+    }.maxByOrNull { it.opprettet }?.utbetalingslinjer?.last()?.id
 
     private fun indeksForUtbetalingslinje(utbetalingslinjeId: Long) =
         utbetalingsperioder.indexOfFirst { it.id == utbetalingslinjeId }

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/KonsistensavstemmingJobTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/KonsistensavstemmingJobTest.kt
@@ -58,7 +58,7 @@ internal class KonsistensavstemmingJobTest {
     fun `skal ikke konsistensavstemme for barnepensjon naar datoen ikke er en del av kjoereplan`() {
         every { leaderElection.isLeader() } returns true
 
-        val dagForTestMinusFemDager = datoEksekvering.midnattNorskTid().toInstant().minus(5, ChronoUnit.DAYS)
+        val dagForTestMinusFemDager = datoEksekvering.midnattNorskTid().minus(5, ChronoUnit.DAYS)
 
         val konsistensavstemming = KonsistensavstemmingJob.Konsistensavstemming(
             konsistensavstemmingService = konsistensavstemmingService,

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/common/UtilsTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/common/UtilsTest.kt
@@ -17,7 +17,7 @@ internal class UtilsTest {
         val statiskKlokke = Instant.parse("2022-01-01T21:14:29.4839104Z").fixedNorskTid()
         val midnatt = tidspunktMidnattIdag(statiskKlokke)
 
-        assertEquals("2021-12-31T23:00:00Z", midnatt.instant.toString())
+        assertEquals("2021-12-31T23:00:00Z", midnatt.toString())
     }
 
     @Test
@@ -25,7 +25,7 @@ internal class UtilsTest {
         val statiskKlokke = Instant.parse("2022-06-01T21:14:29.4839104Z").fixedNorskTid()
         val midnatt = tidspunktMidnattIdag(statiskKlokke)
 
-        assertEquals("2022-05-31T22:00:00Z", midnatt.instant.toString())
+        assertEquals("2022-05-31T22:00:00Z", midnatt.toString())
     }
 
     @Test

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/iverksetting/utbetaling/UtbetalingDaoIntegrationTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/iverksetting/utbetaling/UtbetalingDaoIntegrationTest.kt
@@ -30,6 +30,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.YearMonth
+import java.time.temporal.ChronoUnit
 import java.util.*
 import javax.sql.DataSource
 
@@ -78,23 +79,23 @@ internal class UtbetalingDaoIntegrationTest {
             { assertEquals(utbetaling.vedtakId.value, opprettetUtbetaling?.vedtakId?.value) },
             {
                 assertTrue(
-                    opprettetUtbetaling?.opprettet!!.instant.isAfter(
-                        Instant.now().minusSeconds(10)
-                    ) and opprettetUtbetaling.opprettet.instant.isBefore(Instant.now())
+                    opprettetUtbetaling?.opprettet!!.isAfter(
+                        Tidspunkt.now().minus(10, ChronoUnit.SECONDS)
+                    ) and opprettetUtbetaling.opprettet.isBefore(Tidspunkt.now())
                 )
             },
             {
                 assertTrue(
-                    opprettetUtbetaling!!.endret.instant.isAfter(
-                        Instant.now().minusSeconds(10)
-                    ) and opprettetUtbetaling.endret.instant.isBefore(Instant.now())
+                    opprettetUtbetaling!!.endret.isAfter(
+                        Tidspunkt.now().minus(10, ChronoUnit.SECONDS)
+                    ) and opprettetUtbetaling.endret.isBefore(Tidspunkt.now())
                 )
             },
             {
                 assertTrue(
-                    opprettetUtbetaling!!.avstemmingsnoekkel.instant.isAfter(
-                        Instant.now().minusSeconds(10)
-                    ) and opprettetUtbetaling.avstemmingsnoekkel.instant.isBefore(Instant.now())
+                    opprettetUtbetaling!!.avstemmingsnoekkel.isAfter(
+                        Tidspunkt.now().minus(10, ChronoUnit.SECONDS)
+                    ) and opprettetUtbetaling.avstemmingsnoekkel.isBefore(Tidspunkt.now())
                 )
             },
             { assertEquals(utbetaling.stoenadsmottaker.value, opprettetUtbetaling?.stoenadsmottaker?.value) },

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/Vedtakstidslinje.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/Vedtakstidslinje.kt
@@ -21,13 +21,13 @@ class Vedtakstidslinje(private val vedtak: List<Vedtak>) {
 
     private fun hentSenesteVedtakPaaDato(dato: LocalDate): Vedtak? = iverksatteVedtak
         .filter { it.virkningstidspunkt.atDay(1).isAfter(foersteMuligeVedtaksdag(dato)).not() }
-        .maxByOrNull { it.attestasjon?.tidspunkt?.instant!! }
+        .maxByOrNull { it.attestasjon?.tidspunkt!! }
 
     private fun hentIverksatteVedtak(): List<Vedtak> = vedtak.filter { it.status === VedtakStatus.IVERKSATT }
 
     private fun foersteMuligeVedtaksdag(fraDato: LocalDate): LocalDate {
         val foersteVirkningsdato = iverksatteVedtak.minBy {
-            it.attestasjon?.tidspunkt?.instant ?: throw Error("Kunne ikke finne datoattestert paa vedtak")
+            it.attestasjon?.tidspunkt ?: throw Error("Kunne ikke finne datoattestert paa vedtak")
         }.virkningstidspunkt.atDay(1)
         return maxOf(foersteVirkningsdato, fraDato)
     }

--- a/libs/common/src/main/kotlin/grunnlag/Grunnlagsopplysning.kt
+++ b/libs/common/src/main/kotlin/grunnlag/Grunnlagsopplysning.kt
@@ -10,7 +10,6 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
-import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.time.Instant
 import java.time.YearMonth
 import java.util.*
@@ -71,7 +70,7 @@ open class Grunnlagsopplysning<T>(
 
     data class Saksbehandler(val ident: String, val tidspunkt: Instant) : Kilde("saksbehandler") {
         companion object {
-            fun create(ident: String) = Saksbehandler(ident, Tidspunkt.now().instant)
+            fun create(ident: String) = Saksbehandler(ident, Instant.now())
         }
 
         override fun toString(): String {

--- a/libs/common/src/main/kotlin/tidspunkt/Klokke.kt
+++ b/libs/common/src/main/kotlin/tidspunkt/Klokke.kt
@@ -2,9 +2,12 @@ package no.nav.etterlatte.libs.common.tidspunkt
 
 import java.time.Clock
 import java.time.Instant
+import java.time.ZonedDateTime
 
 fun klokke(): Clock = Clock.systemUTC()
 
 fun Clock.norskKlokke(): Clock = withZone(norskTidssone)
 
 fun Instant.fixedNorskTid(): Clock = Clock.fixed(this, norskTidssone)
+
+fun ZonedDateTime.fixedNorskTid() = toInstant().fixedNorskTid()

--- a/libs/common/src/main/kotlin/tidspunkt/Tidspunkt.kt
+++ b/libs/common/src/main/kotlin/tidspunkt/Tidspunkt.kt
@@ -20,6 +20,8 @@ abstract class TruncatedInstant(
 
     override fun toString() = instant.toString()
     override fun compareTo(other: TruncatedInstant) = this.instant.compareTo(other.instant)
+    fun isBefore(other: TruncatedInstant) = this.instant.isBefore(other.instant)
+    fun isAfter(other: TruncatedInstant) = this.instant.isAfter(other.instant)
 }
 
 /**

--- a/libs/common/src/main/kotlin/tidspunkt/Tidspunkt.kt
+++ b/libs/common/src/main/kotlin/tidspunkt/Tidspunkt.kt
@@ -12,7 +12,7 @@ import java.time.temporal.TemporalUnit
 
 abstract class TruncatedInstant(
     @JsonValue
-    val instant: Instant
+    internal val instant: Instant
 ) : Temporal by instant,
     TemporalAdjuster by instant,
     Comparable<TruncatedInstant>,

--- a/libs/common/src/main/kotlin/tidspunkt/Tidspunkt.kt
+++ b/libs/common/src/main/kotlin/tidspunkt/Tidspunkt.kt
@@ -15,10 +15,11 @@ abstract class TruncatedInstant(
     val instant: Instant
 ) : Temporal by instant,
     TemporalAdjuster by instant,
-    Comparable<Instant> by instant,
+    Comparable<TruncatedInstant>,
     Serializable by instant {
 
     override fun toString() = instant.toString()
+    override fun compareTo(other: TruncatedInstant) = this.instant.compareTo(other.instant)
 }
 
 /**
@@ -26,7 +27,7 @@ abstract class TruncatedInstant(
  * Purpose is to unify the level of precision such that comparison of time behaves as expected on all levels (code/db).
  * Scenarios to avoid includes cases where timestamps of db-queries wraps around to the next day at different times
  * based on the precision at hand - which may lead to rows not being picked up as expected. This case is especially
- * relevant i.e when combining timestamp-db-fields (truncated by db) with Instants stored as json (not truncated by db).
+ * relevant i.e. when combining timestamp-db-fields (truncated by db) with Instants stored as json (not truncated by db).
  */
 class Tidspunkt
 @JsonCreator(mode = JsonCreator.Mode.DELEGATING)


### PR DESCRIPTION
At den underliggjande implementasjonen er `Instant` er ein implementasjonsdetalj som ikkje bør lekke ut av `Tidspunkt`.

Må ta nokre kompromiss for å komme dit i denne PR-en, inkludert å gå tilbake til `Instant.now()` eit par plassar, men eg synes det er verdt det. Det er uansett berre midlertidige tilbakesteg, planen er jo å komme heilt bort frå Instant-bruk.