### PR TITLE
Vilkårsvurdering må ligge i state for at sidemenyen skal vises korrekt

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vedtaksbrev/Vedtaksbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vedtaksbrev/Vedtaksbrev.tsx
@@ -7,7 +7,7 @@ import { genererPdf, opprettEllerOppdaterBrevForVedtak } from '~shared/api/brev'
 import { useParams } from 'react-router-dom'
 import { Soeknadsdato } from '../soeknadsoversikt/soeknadoversikt/Soeknadsdato'
 import styled from 'styled-components'
-import { useAppSelector } from '~store/Store'
+import { useAppDispatch, useAppSelector } from '~store/Store'
 import { SendTilAttesteringModal } from '../handlinger/sendTilAttesteringModal'
 import { PdfVisning } from '../brev/pdf-visning'
 import {
@@ -17,6 +17,7 @@ import {
   VurderingsResultat,
 } from '~shared/api/vilkaarsvurdering'
 import { hentBehandlesFraStatus } from '~components/behandling/felles/utils'
+import { updateVilkaarsvurdering } from '~store/reducers/BehandlingReducer'
 
 interface VilkaarOption {
   value: string
@@ -26,6 +27,7 @@ interface VilkaarOption {
 export const Vedtaksbrev = () => {
   const { behandlingId } = useParams()
   const { sak, soeknadMottattDato, status } = useAppSelector((state) => state.behandlingReducer.behandling)
+  const dispatch = useAppDispatch()
 
   const [fileURL, setFileURL] = useState<string>()
   const [vedtaksbrev, setVedtaksbrev] = useState<any>(undefined)
@@ -89,6 +91,7 @@ export const Vedtaksbrev = () => {
     hentVilkaarsvurdering(behandlingId).then((response) => {
       if (response.status === 'ok') {
         setVilkaarsvurdering(response.data)
+        dispatch(updateVilkaarsvurdering(response.data))
       }
     })
 


### PR DESCRIPTION
Hvis man går inn på en behandling for å attestere, og går direkte til brev, så vises status "Uavklart" i stedet for innvilget, ettersom man ikke har vært innom vilkårsvurdering og populert state.

Før:
![Screenshot 2023-03-08 at 13 03 57](https://user-images.githubusercontent.com/1083866/223710387-b27a08e0-b1d1-461a-a120-b455f4d9ec82.png)

Etter:
![Screenshot 2023-03-08 at 13 09 23](https://user-images.githubusercontent.com/1083866/223710426-4f1d21ea-7a6e-498f-8c76-9f3cedad1bd9.png)


EY-1865