### PR TITLE
Forenkler flyt for manuelt opphør

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ManueltOpphoer.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ManueltOpphoer.kt
@@ -11,7 +11,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import java.time.LocalDateTime
-import java.util.UUID
+import java.util.*
 
 data class ManueltOpphoer(
     override val id: UUID,
@@ -26,24 +26,6 @@ data class ManueltOpphoer(
 ) : Behandling() {
     override val type: BehandlingType = BehandlingType.MANUELT_OPPHOER
 
-    constructor(
-        sak: Sak,
-        persongalleri: Persongalleri,
-        opphoerAarsaker: List<ManueltOpphoerAarsak>,
-        fritekstAarsak: String?,
-        virkningstidspunkt: Virkningstidspunkt?
-    ) : this(
-        id = UUID.randomUUID(),
-        sak = sak,
-        behandlingOpprettet = Tidspunkt.now().toLocalDatetimeUTC(),
-        sistEndret = Tidspunkt.now().toLocalDatetimeUTC(),
-        status = BehandlingStatus.OPPRETTET,
-        persongalleri = persongalleri,
-        opphoerAarsaker = opphoerAarsaker,
-        fritekstAarsak = fritekstAarsak,
-        virkningstidspunkt = virkningstidspunkt
-    )
-
     private val erFyltUt: Boolean
         get() {
             return (virkningstidspunkt != null)
@@ -55,23 +37,13 @@ data class ManueltOpphoer(
     override val vilkaarUtfall: VilkaarsvurderingUtfall?
         get() = null
 
-    override fun tilBeregnet(): ManueltOpphoer = hvisTilstandEr(
-        listOf(
-            BehandlingStatus.OPPRETTET,
-            BehandlingStatus.BEREGNET,
-            BehandlingStatus.RETURNERT
-        )
-    ) {
-        endreTilStatus(BehandlingStatus.BEREGNET)
-    }
-
     override fun tilFattetVedtak(): ManueltOpphoer {
         if (!erFyltUt) {
             logger.info(("Behandling ($id) må være fylt ut for å settes til fattet vedtak"))
             throw TilstandException.IkkeFyltUt
         }
 
-        return hvisTilstandEr(listOf(BehandlingStatus.BEREGNET, BehandlingStatus.RETURNERT)) {
+        return hvisTilstandEr(listOf(BehandlingStatus.OPPRETTET, BehandlingStatus.RETURNERT)) {
             endreTilStatus(BehandlingStatus.FATTET_VEDTAK)
         }
     }

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnBarnepensjonService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnBarnepensjonService.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.beregning
 
 import beregning.regler.finnAnvendtGrunnbeloep
-import no.nav.etterlatte.beregning.grunnbeloep.GrunnbeloepRepository
 import no.nav.etterlatte.beregning.klienter.GrunnlagKlient
 import no.nav.etterlatte.beregning.klienter.VilkaarsvurderingKlient
 import no.nav.etterlatte.beregning.regler.Beregningstall
@@ -34,8 +33,7 @@ import java.util.*
 
 class BeregnBarnepensjonService(
     private val grunnlagKlient: GrunnlagKlient,
-    private val vilkaarsvurderingKlient: VilkaarsvurderingKlient,
-    private val grunnbeloepRepository: GrunnbeloepRepository = GrunnbeloepRepository
+    private val vilkaarsvurderingKlient: VilkaarsvurderingKlient
 ) {
     private val logger = LoggerFactory.getLogger(BeregnBarnepensjonService::class.java)
 
@@ -48,23 +46,23 @@ class BeregnBarnepensjonService(
         logger.info("Beregner barnepensjon for behandlingId=${behandling.id} med behandlingType=$behandlingType")
 
         return when (behandlingType) {
-            BehandlingType.FØRSTEGANGSBEHANDLING, BehandlingType.OMREGNING ->
+            BehandlingType.OMREGNING ->
                 beregnBarnepensjon(behandling.id, grunnlag, beregningsgrunnlag, virkningstidspunkt)
 
-            BehandlingType.REVURDERING -> {
+            BehandlingType.FØRSTEGANGSBEHANDLING, BehandlingType.REVURDERING -> {
                 val vilkaarsvurderingUtfall = vilkaarsvurderingKlient.hentVilkaarsvurdering(behandling.id, bruker)
                     .resultat?.utfall
-                    ?: throw RuntimeException("Forventa å ha resultat for behandling ${behandling.id}")
+                    ?: throw Exception("Forventa å ha resultat for behandling ${behandling.id}")
 
                 when (vilkaarsvurderingUtfall) {
                     VilkaarsvurderingUtfall.OPPFYLT ->
                         beregnBarnepensjon(behandling.id, grunnlag, beregningsgrunnlag, virkningstidspunkt)
                     VilkaarsvurderingUtfall.IKKE_OPPFYLT ->
-                        opphoer(behandling.id, grunnlag, virkningstidspunkt)
+                        throw Exception("Beregning for utfall $vilkaarsvurderingUtfall er ikke støttet")
                 }
             }
 
-            BehandlingType.MANUELT_OPPHOER -> opphoer(behandling.id, grunnlag, virkningstidspunkt)
+            else -> throw Exception("Beregning for $behandlingType er ikke støttet")
         }
     }
 
@@ -116,30 +114,6 @@ class BeregnBarnepensjonService(
             is RegelkjoeringResultat.UgyldigPeriode ->
                 throw RuntimeException("Ugyldig regler for periode: ${resultat.ugyldigeReglerForPeriode}")
         }
-    }
-
-    private fun opphoer(
-        behandlingId: UUID,
-        grunnlag: Grunnlag,
-        virkningstidspunkt: YearMonth
-    ): Beregning {
-        val grunnbeloep = grunnbeloepRepository.hentGjeldendeGrunnbeloep(virkningstidspunkt)
-
-        return beregning(
-            behandlingId = behandlingId,
-            grunnlagMetadata = grunnlag.metadata,
-            beregningsperioder = listOf(
-                Beregningsperiode(
-                    datoFOM = virkningstidspunkt,
-                    datoTOM = null,
-                    utbetaltBeloep = 0,
-                    soeskenFlokk = null,
-                    grunnbelopMnd = grunnbeloep.grunnbeloepPerMaaned,
-                    grunnbelop = grunnbeloep.grunnbeloep,
-                    trygdetid = 0
-                )
-            )
-        )
     }
 
     private fun beregning(

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
@@ -20,45 +20,25 @@ export const StegMeny = (props: { behandling: IDetaljertBehandling }) => {
             <NavLink to="soeknadsoversikt">Søknadsoversikt</NavLink>
           </li>
           <Separator aria-hidden={'true'} />
-        </>
-      )}
-      {behandlingType === IBehandlingsType.MANUELT_OPPHOER && (
-        <>
-          <li>
-            <NavLink to="opphoeroversikt">Opphør</NavLink>
-          </li>
-          <Separator aria-hidden={'true'} />
-        </>
-      )}
-      {behandlingType !== IBehandlingsType.MANUELT_OPPHOER && (
-        <>
           <li className={classNames({ disabled: stegErDisabled(IBehandlingStatus.VILKAARSVURDERT) })}>
             <NavLink to="vilkaarsvurdering">Vilkårsvurdering</NavLink>
           </li>
           <Separator aria-hidden={'true'} />
-        </>
-      )}
-      {behandlingType === IBehandlingsType.FØRSTEGANGSBEHANDLING && sakType === ISaksType.OMSTILLINGSSTOENAD && (
-        <>
-          <li className={classNames({ disabled: stegErDisabled(IBehandlingStatus.OPPRETTET) })}>
-            <NavLink to="trygdetid">Trygdetid</NavLink>
-          </li>
-          <Separator aria-hidden={'true'} />
-        </>
-      )}
-      {behandlingType === IBehandlingsType.FØRSTEGANGSBEHANDLING && (
-        <>
+          {sakType === ISaksType.OMSTILLINGSSTOENAD && (
+            <>
+              <li className={classNames({ disabled: stegErDisabled(IBehandlingStatus.OPPRETTET) })}>
+                <NavLink to="trygdetid">Trygdetid</NavLink>
+              </li>
+              <Separator aria-hidden={'true'} />
+            </>
+          )}
           <li className={classNames({ disabled: stegErDisabled(IBehandlingStatus.BEREGNET) })}>
             <NavLink to="beregningsgrunnlag">Beregningsgrunnlag</NavLink>
           </li>
           <Separator aria-hidden={'true'} />
-        </>
-      )}
-      <li className={classNames({ disabled: stegErDisabled(IBehandlingStatus.BEREGNET) })}>
-        <NavLink to="beregne">Beregning</NavLink>
-      </li>
-      {behandlingType !== IBehandlingsType.MANUELT_OPPHOER && (
-        <>
+          <li className={classNames({ disabled: stegErDisabled(IBehandlingStatus.BEREGNET) })}>
+            <NavLink to="beregne">Beregning</NavLink>
+          </li>
           <Separator aria-hidden={'true'} />
           <li
             className={classNames({
@@ -66,6 +46,13 @@ export const StegMeny = (props: { behandling: IDetaljertBehandling }) => {
             })}
           >
             <NavLink to="brev">Vedtaksbrev</NavLink>
+          </li>
+        </>
+      )}
+      {behandlingType === IBehandlingsType.MANUELT_OPPHOER && (
+        <>
+          <li>
+            <NavLink to="opphoeroversikt">Opphør</NavLink>
           </li>
         </>
       )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
@@ -81,7 +81,7 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
             <SendTilAttesteringModal />
           ) : (
             <Button loading={isPending(vedtak)} variant="primary" size="medium" onClick={opprettEllerOppdaterVedtak}>
-              {behandling.behandlingType !== IBehandlingsType.MANUELT_OPPHOER ? 'Gå videre til brev' : 'Fatt vedtak'}
+              Gå videre til brev
             </Button>
           )}
         </BehandlingHandlingKnapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/manueltopphoeroversikt/ManueltOpphoerOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/manueltopphoeroversikt/ManueltOpphoerOversikt.tsx
@@ -83,9 +83,7 @@ export const ManueltOpphoerOversikt = (props: { behandling: IBehandlingReducer }
           )}
           {mapApiResult(
             manueltOpphoerDetaljer,
-            () => (
-              <Spinner visible label="Henter detaljer om det manuelle opphøret" />
-            ),
+            <Spinner visible label="Henter detaljer om det manuelle opphøret" />,
             () => (
               <MainSection>
                 <Feilmelding>Kunne ikke hente ut detaljer om manuelt opphør</Feilmelding>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/manueltopphoeroversikt/ManueltOpphoerOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/manueltopphoeroversikt/ManueltOpphoerOversikt.tsx
@@ -16,6 +16,7 @@ import differenceInYears from 'date-fns/differenceInYears'
 import { SendTilAttesteringModal } from '~components/behandling/handlinger/sendTilAttesteringModal'
 import { IBehandlingsammendrag } from '~components/person/typer'
 import { IBehandlingReducer } from '~store/reducers/BehandlingReducer'
+import { hentBehandlesFraStatus } from '~components/behandling/felles/utils'
 
 export interface ManueltOpphoerDetaljer {
   id: string
@@ -49,7 +50,6 @@ export const ManueltOpphoerOversikt = (props: { behandling: IBehandlingReducer }
 
   const opprettEllerOppdaterVedtak = () => {
     oppdaterVedtakRequest(behandling.id, () => {
-      // TODO dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.BEREGNET))
       setVisAttesteringsmodal(true)
     })
   }
@@ -121,16 +121,18 @@ export const ManueltOpphoerOversikt = (props: { behandling: IBehandlingReducer }
           )}
         </SectionSpacing>
       </MainSection>
-      <BehandlingHandlingKnapper>
-        {isFailure(vedtak) && <ErrorMessage>Vedtaksoppdatering feilet</ErrorMessage>}
-        {visAttesteringsmodal ? (
-          <SendTilAttesteringModal />
-        ) : (
-          <Button loading={isPending(vedtak)} variant="primary" size="medium" onClick={opprettEllerOppdaterVedtak}>
-            Fatt vedtak
-          </Button>
-        )}
-      </BehandlingHandlingKnapper>
+      {hentBehandlesFraStatus(behandling.status) && (
+        <BehandlingHandlingKnapper>
+          {isFailure(vedtak) && <ErrorMessage>Vedtaksoppdatering feilet</ErrorMessage>}
+          {visAttesteringsmodal ? (
+            <SendTilAttesteringModal />
+          ) : (
+            <Button loading={isPending(vedtak)} variant="primary" size="medium" onClick={opprettEllerOppdaterVedtak}>
+              Opprett vedtak
+            </Button>
+          )}
+        </BehandlingHandlingKnapper>
+      )}
     </Content>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/styled.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/styled.ts
@@ -48,7 +48,7 @@ export const VilkaarInfobokser = styled.div`
 
 export const VilkaarColumn = styled.div`
   height: fit-content;
-  
+
   .missing {
     color: red;
   }


### PR DESCRIPTION
Fjerner beregningssteget i manuelt opphør - vedtak har kontroll på hva som skal gjøres mot utbetaling ved denne behandlingstypen. Medfører at noe av logikken flyttes til opphørsoversikten og at dette er det eneste steget for et manuelt opphør i frontend.

EY-1878