### PR TITLE
EY-1886 Håndterer hvis person ikke finnes i PDL i fordeleren

### DIFF
--- a/apps/etterlatte-fordeler/src/main/kotlin/fordeler/Fordeler.kt
+++ b/apps/etterlatte-fordeler/src/main/kotlin/fordeler/Fordeler.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.fordeler
 
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.nav.etterlatte.fordeler.FordelerResultat.GyldigForBehandling
 import no.nav.etterlatte.libs.common.event.FordelerFordelt
 import no.nav.etterlatte.libs.common.event.SoeknadInnsendt
 import no.nav.etterlatte.libs.common.logging.getCorrelationId
@@ -57,7 +56,7 @@ internal class Fordeler(
                 logger.info("Sjekker om soknad (${packet.soeknadId()}) er gyldig for fordeling")
 
                 when (val resultat = fordelerService.sjekkGyldighetForBehandling(packet.toFordelerEvent())) {
-                    is GyldigForBehandling -> {
+                    FordelerResultat.GyldigForBehandling -> {
                         logger.info("Soknad ${packet.soeknadId()} er gyldig for fordeling")
                         context.publish(packet.leggPaaFordeltStatus(true).toJson())
                         fordelerMetricLogger.logMetricFordelt()
@@ -70,7 +69,7 @@ internal class Fordeler(
                     }
 
                     is FordelerResultat.UgyldigHendelse -> {
-                        logger.error("Avbrutt fordeling: ${resultat.message}")
+                        logger.warn("Avbrutt fordeling: ${resultat.message}")
                     }
                 }
             } catch (e: JsonMappingException) {

--- a/apps/etterlatte-fordeler/src/main/kotlin/fordeler/FordelerService.kt
+++ b/apps/etterlatte-fordeler/src/main/kotlin/fordeler/FordelerService.kt
@@ -10,6 +10,7 @@ import no.nav.etterlatte.libs.common.soeknad.dataklasser.Barnepensjon
 import no.nav.etterlatte.libs.common.soeknad.dataklasser.common.PersonType
 import no.nav.etterlatte.libs.common.tidspunkt.utcKlokke
 import no.nav.etterlatte.pdltjenester.PdlTjenesterKlient
+import no.nav.etterlatte.pdltjenester.PersonFinnesIkkeException
 import java.time.Clock
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
@@ -38,11 +39,15 @@ class FordelerService(
                 "Hendelsen er ikke lenger gyldig (${hendelseGyldigTil(event)})"
             )
         } else {
-            fordelSoekand(event).let {
-                when (it.fordeltTil) {
-                    Vedtaksloesning.DOFFEN -> GyldigForBehandling
-                    Vedtaksloesning.PESYS -> IkkeGyldigForBehandling(it.kriterier)
+            try {
+                fordelSoekand(event).let {
+                    when (it.fordeltTil) {
+                        Vedtaksloesning.DOFFEN -> GyldigForBehandling
+                        Vedtaksloesning.PESYS -> IkkeGyldigForBehandling(it.kriterier)
+                    }
                 }
+            } catch (e: PersonFinnesIkkeException) {
+                UgyldigHendelse("Person fra søknaden med fnr=${e.fnr} finnes ikke i PDL")
             }
         }
     }


### PR DESCRIPTION
Setter resultatet av fordelingen til å være ugyldig hvis en av personene i galleriet ikke finnes i PDL