### PR TITLE
Fjerner søskenjustering i beregningsgrunnlaget for omstillingsstønad

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Sammendrag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Sammendrag.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { lastDayOfMonth } from 'date-fns'
 import { formaterDato, formaterStringDato } from '~utils/formattering'
 import { IPdlPerson } from '~shared/types/Person'
-import { Beregning } from '~shared/types/Beregning'
+import { Beregning, Beregningstype } from '~shared/types/Beregning'
 import { GjelderTooltip } from '~components/behandling/beregne/GjelderToolTip'
 
 interface Props {
@@ -14,7 +14,7 @@ interface Props {
 
 export const Sammendrag = ({ beregning, soeker, soesken }: Props) => {
   const beregningsperioder = beregning.beregningsperioder
-    
+
   return (
     <TableWrapper>
       <Heading spacing size="small" level="2">
@@ -40,7 +40,12 @@ export const Sammendrag = ({ beregning, soeker, soesken }: Props) => {
                 }`}
               </Table.DataCell>
               <Table.DataCell>
-                {beregningsperiode.type == 'GP' ? 'Grunnpensjon' : beregningsperiode.type}
+                {
+                  {
+                    [Beregningstype.BP]: 'Barnepensjon',
+                    [Beregningstype.OMS]: 'Omstillingsstønad',
+                  }[beregning.type]
+                }
               </Table.DataCell>
               <Table.DataCell>40 år</Table.DataCell>
               <Table.DataCell>{beregningsperiode.grunnbelop} kr</Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Beregningsgrunnlag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Beregningsgrunnlag.tsx
@@ -1,91 +1,15 @@
-import { BodyShort, Button, Heading, Loader, Radio, RadioGroup } from '@navikt/ds-react'
-import { Content, ContentHeader } from '~shared/styled'
-import { useEffect, useState } from 'react'
-import { Border, HeadingWrapper } from '../soeknadsoversikt/styled'
-import { Barn } from '../soeknadsoversikt/familieforhold/personer/Barn'
-import { Soesken } from '../soeknadsoversikt/familieforhold/personer/Soesken'
-import styled from 'styled-components'
-import { BehandlingHandlingKnapper } from '../handlinger/BehandlingHandlingKnapper'
-import { useBehandlingRoutes } from '../BehandlingRoutes'
-import { Controller, useForm } from 'react-hook-form'
+import { useAppSelector } from '~store/Store'
+import { ISaksType } from '~components/behandling/fargetags/saksType'
+import BeregningsgrunnlagBarnepensjon from '~components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon'
+import BeregningsgrunnlagOmstillingsstoenad from '~components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad'
+import { HeadingWrapper } from '~components/behandling/soeknadsoversikt/styled'
+import { BodyShort, Heading } from '@navikt/ds-react'
 import { formaterStringDato } from '~utils/formattering'
-import { hentBehandlesFraStatus } from '../felles/utils'
-import { NesteOgTilbake } from '../handlinger/NesteOgTilbake'
-import { useAppDispatch, useAppSelector } from '~store/Store'
-import { opprettEllerEndreBeregning } from '~shared/api/beregning'
-import { isFailure, isPending, useApiCall } from '~shared/hooks/useApiCall'
-import { hentSoeskenjusteringsgrunnlag, lagreSoeskenMedIBeregning } from '~shared/api/grunnlag'
-import { SoeskenMedIBeregning } from '~shared/types/Grunnlagsopplysning'
-import Spinner from '~shared/Spinner'
-import { IPdlPerson } from '~shared/types/Person'
-import { Soeknadsvurdering } from '~components/behandling/soeknadsoversikt/soeknadoversikt/SoeknadsVurdering'
-import {
-  oppdaterBehandlingsstatus,
-  oppdaterSoeskenjusteringsgrunnlag,
-  resetBeregning,
-} from '~store/reducers/BehandlingReducer'
-import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
-import { ApiErrorAlert } from '~ErrorBoundary'
-
-interface FormValues {
-  foedselsnummer: string
-  skalBrukes?: boolean
-}
+import { Content, ContentHeader } from '~shared/styled'
+import Trygdetid from '~components/behandling/beregningsgrunnlag/Trygdetid'
 
 const Beregningsgrunnlag = () => {
-  const { next } = useBehandlingRoutes()
   const behandling = useAppSelector((state) => state.behandlingReducer.behandling)
-  const behandles = hentBehandlesFraStatus(behandling?.status)
-  const soeskenjustering = behandling.soeskenjusteringsgrunnlag?.beregningsgrunnlag
-  const [ikkeValgtOppdrasSammenPaaAlle, setIkkeValgtOppdrasSammenPaaAlleFeil] = useState(false)
-  const dispatch = useAppDispatch()
-  const [soeskenjusteringsgrunnlag, fetchSoeskenjusteringsgrunnlag] = useApiCall(hentSoeskenjusteringsgrunnlag)
-  const [lagreSoeskenMedIBeregningStatus, postSoeskenMedIBeregning] = useApiCall(lagreSoeskenMedIBeregning)
-  const [endreBeregning, postOpprettEllerEndreBeregning] = useApiCall(opprettEllerEndreBeregning)
-  const { control, handleSubmit, reset } = useForm<{ soeskengrunnlag: FormValues[] }>({
-    defaultValues: {
-      soeskengrunnlag: soeskenjustering,
-    },
-  })
-
-  const soeskenjusteringErDefinertIRedux = soeskenjustering !== undefined
-
-  useEffect(() => {
-    if (!soeskenjusteringErDefinertIRedux) {
-      fetchSoeskenjusteringsgrunnlag(behandling.sak, (result) => {
-        reset({ soeskengrunnlag: result?.opplysning?.beregningsgrunnlag ?? [] })
-        dispatch(
-          oppdaterSoeskenjusteringsgrunnlag({ beregningsgrunnlag: result?.opplysning?.beregningsgrunnlag ?? [] })
-        )
-      })
-    }
-  }, [])
-
-  if (behandling.kommerBarnetTilgode == null || behandling.familieforhold?.avdoede == null) {
-    return <ApiErrorAlert>Familieforhold kan ikke hentes ut</ApiErrorAlert>
-  }
-
-  const soesken: IPdlPerson[] =
-    behandling.familieforhold.avdoede.opplysning.avdoedesBarn?.filter(
-      (barn) => barn.foedselsnummer !== behandling.søker?.foedselsnummer
-    ) ?? []
-
-  const onSubmit = (soeskengrunnlag: SoeskenMedIBeregning[]) => {
-    dispatch(resetBeregning())
-    postSoeskenMedIBeregning({ behandlingsId: behandling.id, soeskenMedIBeregning: soeskengrunnlag }, () =>
-      postOpprettEllerEndreBeregning(behandling.id, () => {
-        dispatch(
-          oppdaterSoeskenjusteringsgrunnlag({
-            beregningsgrunnlag: soeskengrunnlag,
-          })
-        )
-        dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.BEREGNET))
-        next()
-      })
-    )
-  }
-
-  const doedsdato = behandling.familieforhold.avdoede.opplysning.doedsdato
 
   return (
     <Content>
@@ -103,144 +27,15 @@ const Beregningsgrunnlag = () => {
           </BodyShort>
         </HeadingWrapper>
       </ContentHeader>
-      <TrygdetidWrapper>
-        <Soeknadsvurdering
-          tittel={'Trygdetid'}
-          hjemler={[
-            {
-              tittel: '§ 3-5 Trygdetid ved beregning av ytelser',
-              lenke: 'https://lovdata.no/lov/1997-02-28-19/§3-5',
-            },
-          ]}
-          status={null}
-        >
-          <TrygdetidInfo>
-            <p>
-              Trygdetiden er minst 40 år som følge av faktisk trygdetid og fremtidig trygdetid. Faktisk trygdetid er den
-              tiden fra avdøde fylte 16 til personen døde. Fremtidig trygdetid er tiden fra dødsfallet til og med
-              kalenderåret avdøde hadde blitt 66 år. Saksbehandler bekrefter at følgende stemmer for denne behandlingen
-              ved å gå videre til beregning:
-            </p>
-            <p>
-              Trygdetid: <strong>40 år</strong>
-            </p>
-          </TrygdetidInfo>
-        </Soeknadsvurdering>
-      </TrygdetidWrapper>
-      <ContentHeader>
-        <HeadingWrapper>
-          <Heading level="2" size="medium">
-            Søskenjustering
-          </Heading>
-        </HeadingWrapper>
-      </ContentHeader>
-      <FamilieforholdWrapper
-        id="form"
-        onSubmit={handleSubmit(({ soeskengrunnlag }) => {
-          if (validerSoeskenjustering(soesken, soeskengrunnlag)) {
-            onSubmit(soeskengrunnlag)
-          } else {
-            setIkkeValgtOppdrasSammenPaaAlleFeil(true)
-          }
-        })}
-      >
-        {behandling.søker && <Barn person={behandling.søker} doedsdato={doedsdato} />}
-        <Border />
-        <Spinner visible={isPending(soeskenjusteringsgrunnlag)} label={'Henter beregningsgrunnlag for søsken'} />
-        {isFailure(soeskenjusteringsgrunnlag) && <ApiErrorAlert>Søskenjustering kan ikke hentes</ApiErrorAlert>}
-        {soeskenjusteringErDefinertIRedux &&
-          soesken.map((barn, index) => (
-            <SoeskenContainer key={barn.foedselsnummer}>
-              <Soesken person={barn} familieforhold={behandling.familieforhold!} />
-              <Controller
-                name={`soeskengrunnlag.${index}`}
-                control={control}
-                render={(soesken) =>
-                  behandles ? (
-                    <RadioGroupRow
-                      legend="Oppdras sammen"
-                      value={soesken.field.value?.skalBrukes ?? null}
-                      error={
-                        soesken.field.value?.skalBrukes === undefined && ikkeValgtOppdrasSammenPaaAlle
-                          ? 'Du må velge ja/nei på alle søsken'
-                          : ''
-                      }
-                      onChange={(value: boolean) => {
-                        soesken.field.onChange({ foedselsnummer: barn.foedselsnummer, skalBrukes: value })
-                        setIkkeValgtOppdrasSammenPaaAlleFeil(false)
-                      }}
-                    >
-                      <Radio value={true}>Ja</Radio>
-                      <Radio value={false}>Nei</Radio>
-                    </RadioGroupRow>
-                  ) : (
-                    <OppdrasSammenLes>
-                      <strong>Oppdras sammen</strong>
-                      <label>{soesken.field.value?.skalBrukes ? 'Ja' : 'Nei'}</label>
-                    </OppdrasSammenLes>
-                  )
-                }
-              />
-            </SoeskenContainer>
-          ))}
-      </FamilieforholdWrapper>
-
-      {isFailure(endreBeregning) && <ApiErrorAlert>Kunne ikke opprette ny beregning</ApiErrorAlert>}
-      {isFailure(lagreSoeskenMedIBeregningStatus) && <ApiErrorAlert>Kunne ikke lagre beregningsgrunnlag</ApiErrorAlert>}
-
-      {behandles ? (
-        <BehandlingHandlingKnapper>
-          {soeskenjusteringErDefinertIRedux && (
-            <Button variant="primary" size="medium" form="form">
-              Beregne og fatte vedtak{' '}
-              {(isPending(lagreSoeskenMedIBeregningStatus) || isPending(endreBeregning)) && <Loader />}
-            </Button>
-          )}
-        </BehandlingHandlingKnapper>
-      ) : (
-        <NesteOgTilbake />
-      )}
+      <Trygdetid />
+      {
+        {
+          [ISaksType.BARNEPENSJON]: <BeregningsgrunnlagBarnepensjon />,
+          [ISaksType.OMSTILLINGSSTOENAD]: <BeregningsgrunnlagOmstillingsstoenad />,
+        }[behandling.sakType]
+      }
     </Content>
   )
 }
-
-const validerSoeskenjustering = (soesken: IPdlPerson[], justering: FormValues[]): justering is SoeskenMedIBeregning[] =>
-  soesken.length === justering.length && justering.every((barn) => barn?.skalBrukes !== undefined)
-
-const OppdrasSammenLes = styled.div`
-  display: flex;
-  flex-direction: column;
-`
-
-const SoeskenContainer = styled.div`
-  display: flex;
-  align-items: center;
-`
-
-const RadioGroupRow = styled(RadioGroup)`
-  margin-top: 1.2em;
-  .navds-radio-buttons {
-    display: flex;
-    flex-direction: row;
-    gap: 12px;
-  }
-
-  legend {
-    padding-top: 9px;
-  }
-`
-const FamilieforholdWrapper = styled.form`
-  padding: 0em 6em;
-`
-
-const TrygdetidWrapper = styled.form`
-  padding: 0em 4em;
-  max-width: 56em;
-`
-
-const TrygdetidInfo = styled.div`
-  display: flex;
-  flex-direction: column;
-`
 
 export default Beregningsgrunnlag

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
@@ -1,0 +1,196 @@
+import { Button, Heading, Loader, Radio, RadioGroup } from '@navikt/ds-react'
+import { ContentHeader } from '~shared/styled'
+import { useEffect, useState } from 'react'
+import { Border, HeadingWrapper } from '../soeknadsoversikt/styled'
+import { Barn } from '../soeknadsoversikt/familieforhold/personer/Barn'
+import { Soesken } from '../soeknadsoversikt/familieforhold/personer/Soesken'
+import styled from 'styled-components'
+import { BehandlingHandlingKnapper } from '../handlinger/BehandlingHandlingKnapper'
+import { useBehandlingRoutes } from '../BehandlingRoutes'
+import { Controller, useForm } from 'react-hook-form'
+import { hentBehandlesFraStatus } from '../felles/utils'
+import { NesteOgTilbake } from '../handlinger/NesteOgTilbake'
+import { useAppDispatch, useAppSelector } from '~store/Store'
+import { opprettEllerEndreBeregning } from '~shared/api/beregning'
+import { isFailure, isPending, useApiCall } from '~shared/hooks/useApiCall'
+import { hentSoeskenjusteringsgrunnlag, lagreSoeskenMedIBeregning } from '~shared/api/grunnlag'
+import { SoeskenMedIBeregning } from '~shared/types/Grunnlagsopplysning'
+import Spinner from '~shared/Spinner'
+import { IPdlPerson } from '~shared/types/Person'
+import {
+  oppdaterBehandlingsstatus,
+  oppdaterSoeskenjusteringsgrunnlag,
+  resetBeregning,
+} from '~store/reducers/BehandlingReducer'
+import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
+import { ApiErrorAlert } from '~ErrorBoundary'
+
+interface FormValues {
+  foedselsnummer: string
+  skalBrukes?: boolean
+}
+
+const BeregningsgrunnlagBarnepensjon = () => {
+  const { next } = useBehandlingRoutes()
+  const behandling = useAppSelector((state) => state.behandlingReducer.behandling)
+  const behandles = hentBehandlesFraStatus(behandling?.status)
+  const soeskenjustering = behandling.soeskenjusteringsgrunnlag?.beregningsgrunnlag
+  const [ikkeValgtOppdrasSammenPaaAlle, setIkkeValgtOppdrasSammenPaaAlleFeil] = useState(false)
+  const dispatch = useAppDispatch()
+  const [soeskenjusteringsgrunnlag, fetchSoeskenjusteringsgrunnlag] = useApiCall(hentSoeskenjusteringsgrunnlag)
+  const [lagreSoeskenMedIBeregningStatus, postSoeskenMedIBeregning] = useApiCall(lagreSoeskenMedIBeregning)
+  const [endreBeregning, postOpprettEllerEndreBeregning] = useApiCall(opprettEllerEndreBeregning)
+  const { control, handleSubmit, reset } = useForm<{ soeskengrunnlag: FormValues[] }>({
+    defaultValues: {
+      soeskengrunnlag: soeskenjustering,
+    },
+  })
+
+  const soeskenjusteringErDefinertIRedux = soeskenjustering !== undefined
+
+  useEffect(() => {
+    if (!soeskenjusteringErDefinertIRedux) {
+      fetchSoeskenjusteringsgrunnlag(behandling.sak, (result) => {
+        reset({ soeskengrunnlag: result?.opplysning?.beregningsgrunnlag ?? [] })
+        dispatch(
+          oppdaterSoeskenjusteringsgrunnlag({ beregningsgrunnlag: result?.opplysning?.beregningsgrunnlag ?? [] })
+        )
+      })
+    }
+  }, [])
+
+  if (behandling.kommerBarnetTilgode == null || behandling.familieforhold?.avdoede == null) {
+    return <ApiErrorAlert>Familieforhold kan ikke hentes ut</ApiErrorAlert>
+  }
+
+  const soesken: IPdlPerson[] =
+    behandling.familieforhold.avdoede.opplysning.avdoedesBarn?.filter(
+      (barn) => barn.foedselsnummer !== behandling.søker?.foedselsnummer
+    ) ?? []
+
+  const onSubmit = (soeskengrunnlag: SoeskenMedIBeregning[]) => {
+    dispatch(resetBeregning())
+    postSoeskenMedIBeregning({ behandlingsId: behandling.id, soeskenMedIBeregning: soeskengrunnlag }, () =>
+      postOpprettEllerEndreBeregning(behandling.id, () => {
+        dispatch(
+          oppdaterSoeskenjusteringsgrunnlag({
+            beregningsgrunnlag: soeskengrunnlag,
+          })
+        )
+        dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.BEREGNET))
+        next()
+      })
+    )
+  }
+
+  const doedsdato = behandling.familieforhold.avdoede.opplysning.doedsdato
+
+  return (
+    <>
+      <ContentHeader>
+        <HeadingWrapper>
+          <Heading level="2" size="medium">
+            Søskenjustering
+          </Heading>
+        </HeadingWrapper>
+      </ContentHeader>
+      <FamilieforholdWrapper
+        id="form"
+        onSubmit={handleSubmit(({ soeskengrunnlag }) => {
+          if (validerSoeskenjustering(soesken, soeskengrunnlag)) {
+            onSubmit(soeskengrunnlag)
+          } else {
+            setIkkeValgtOppdrasSammenPaaAlleFeil(true)
+          }
+        })}
+      >
+        {behandling.søker && <Barn person={behandling.søker} doedsdato={doedsdato} />}
+        <Border />
+        <Spinner visible={isPending(soeskenjusteringsgrunnlag)} label={'Henter beregningsgrunnlag for søsken'} />
+        {isFailure(soeskenjusteringsgrunnlag) && <ApiErrorAlert>Søskenjustering kan ikke hentes</ApiErrorAlert>}
+        {soeskenjusteringErDefinertIRedux &&
+          soesken.map((barn, index) => (
+            <SoeskenContainer key={barn.foedselsnummer}>
+              <Soesken person={barn} familieforhold={behandling.familieforhold!} />
+              <Controller
+                name={`soeskengrunnlag.${index}`}
+                control={control}
+                render={(soesken) =>
+                  behandles ? (
+                    <RadioGroupRow
+                      legend="Oppdras sammen"
+                      value={soesken.field.value?.skalBrukes ?? null}
+                      error={
+                        soesken.field.value?.skalBrukes === undefined && ikkeValgtOppdrasSammenPaaAlle
+                          ? 'Du må velge ja/nei på alle søsken'
+                          : ''
+                      }
+                      onChange={(value: boolean) => {
+                        soesken.field.onChange({ foedselsnummer: barn.foedselsnummer, skalBrukes: value })
+                        setIkkeValgtOppdrasSammenPaaAlleFeil(false)
+                      }}
+                    >
+                      <Radio value={true}>Ja</Radio>
+                      <Radio value={false}>Nei</Radio>
+                    </RadioGroupRow>
+                  ) : (
+                    <OppdrasSammenLes>
+                      <strong>Oppdras sammen</strong>
+                      <label>{soesken.field.value?.skalBrukes ? 'Ja' : 'Nei'}</label>
+                    </OppdrasSammenLes>
+                  )
+                }
+              />
+            </SoeskenContainer>
+          ))}
+      </FamilieforholdWrapper>
+
+      {isFailure(endreBeregning) && <ApiErrorAlert>Kunne ikke opprette ny beregning</ApiErrorAlert>}
+      {isFailure(lagreSoeskenMedIBeregningStatus) && <ApiErrorAlert>Kunne ikke lagre beregningsgrunnlag</ApiErrorAlert>}
+
+      {behandles ? (
+        <BehandlingHandlingKnapper>
+          {soeskenjusteringErDefinertIRedux && (
+            <Button variant="primary" size="medium" form="form">
+              Beregne og fatte vedtak{' '}
+              {(isPending(lagreSoeskenMedIBeregningStatus) || isPending(endreBeregning)) && <Loader />}
+            </Button>
+          )}
+        </BehandlingHandlingKnapper>
+      ) : (
+        <NesteOgTilbake />
+      )}
+    </>
+  )
+}
+
+const validerSoeskenjustering = (soesken: IPdlPerson[], justering: FormValues[]): justering is SoeskenMedIBeregning[] =>
+  soesken.length === justering.length && justering.every((barn) => barn?.skalBrukes !== undefined)
+
+const OppdrasSammenLes = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+const SoeskenContainer = styled.div`
+  display: flex;
+  align-items: center;
+`
+
+const RadioGroupRow = styled(RadioGroup)`
+  margin-top: 1.2em;
+  .navds-radio-buttons {
+    display: flex;
+    flex-direction: row;
+    gap: 12px;
+  }
+
+  legend {
+    padding-top: 9px;
+  }
+`
+const FamilieforholdWrapper = styled.form`
+  padding: 0em 6em;
+`
+
+export default BeregningsgrunnlagBarnepensjon

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
@@ -1,0 +1,44 @@
+import { Button, Loader } from '@navikt/ds-react'
+import { BehandlingHandlingKnapper } from '../handlinger/BehandlingHandlingKnapper'
+import { useBehandlingRoutes } from '../BehandlingRoutes'
+import { hentBehandlesFraStatus } from '../felles/utils'
+import { NesteOgTilbake } from '../handlinger/NesteOgTilbake'
+import { useAppDispatch, useAppSelector } from '~store/Store'
+import { opprettEllerEndreBeregning } from '~shared/api/beregning'
+import { isFailure, isPending, useApiCall } from '~shared/hooks/useApiCall'
+import { ApiErrorAlert } from '~ErrorBoundary'
+import { oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'
+import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
+
+const BeregningsgrunnlagOmstillingsstoenad = () => {
+  const [beregning, setOpprettEllerEndreBeregning] = useApiCall(opprettEllerEndreBeregning)
+  const { next } = useBehandlingRoutes()
+  const dispatch = useAppDispatch()
+  const behandling = useAppSelector((state) => state.behandlingReducer.behandling)
+  const behandles = hentBehandlesFraStatus(behandling?.status)
+
+  const oppdaterBeregning = () => {
+    setOpprettEllerEndreBeregning(behandling.id, () => {
+      dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.BEREGNET))
+      next()
+    })
+  }
+
+  return (
+    <>
+      {isFailure(beregning) && <ApiErrorAlert>Kunne ikke opprette ny beregning</ApiErrorAlert>}
+
+      {behandles ? (
+        <BehandlingHandlingKnapper>
+          <Button variant="primary" size="medium" onClick={oppdaterBeregning}>
+            Beregne og fatte vedtak {isPending(beregning) && <Loader />}
+          </Button>
+        </BehandlingHandlingKnapper>
+      ) : (
+        <NesteOgTilbake />
+      )}
+    </>
+  )
+}
+
+export default BeregningsgrunnlagOmstillingsstoenad

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Trygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Trygdetid.tsx
@@ -1,0 +1,43 @@
+import styled from 'styled-components'
+import { Soeknadsvurdering } from '~components/behandling/soeknadsoversikt/soeknadoversikt/SoeknadsVurdering'
+
+const Trygdetid = () => {
+  return (
+    <TrygdetidWrapper>
+      <Soeknadsvurdering
+        tittel={'Trygdetid'}
+        hjemler={[
+          {
+            tittel: '§ 3-5 Trygdetid ved beregning av ytelser',
+            lenke: 'https://lovdata.no/lov/1997-02-28-19/§3-5',
+          },
+        ]}
+        status={null}
+      >
+        <TrygdetidInfo>
+          <p>
+            Trygdetiden er minst 40 år som følge av faktisk trygdetid og fremtidig trygdetid. Faktisk trygdetid er den
+            tiden fra avdøde fylte 16 til personen døde. Fremtidig trygdetid er tiden fra dødsfallet til og med
+            kalenderåret avdøde hadde blitt 66 år. Saksbehandler bekrefter at følgende stemmer for denne behandlingen
+            ved å gå videre til beregning:
+          </p>
+          <p>
+            Trygdetid: <strong>40 år</strong>
+          </p>
+        </TrygdetidInfo>
+      </Soeknadsvurdering>
+    </TrygdetidWrapper>
+  )
+}
+
+const TrygdetidWrapper = styled.form`
+  padding: 0em 4em;
+  max-width: 56em;
+`
+
+const TrygdetidInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+export default Trygdetid

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Beregning.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Beregning.ts
@@ -1,6 +1,7 @@
 export interface Beregning {
   beregningId: string
   behandlingId: string
+  type: Beregningstype
   beregningsperioder: Beregningsperiode[]
   beregnetDato: string
   grunnlagMetadata: GrunnlagMetadata
@@ -11,9 +12,13 @@ export interface GrunnlagMetadata {
   versjon: number
 }
 
+export enum Beregningstype {
+  BP = 'BP',
+  OMS = 'OMS',
+}
+
 export interface Beregningsperiode {
   delytelsesId: string
-  type: string
   datoFOM: string
   datoTOM: string
   utbetaltBeloep: number


### PR DESCRIPTION
Splitter opp beregningsgrunnlaget slik at den viser søskenjustering kun for barnepensjon. Viser i tillegg riktig ytelse på beregningssammendraget.

EY-1888