### PR TITLE
Fix test og sett timeout session på pdl

### DIFF
--- a/apps/etterlatte-egne-ansatte-lytter/src/main/kotlin/kafka/KafkaConsumerConfiguration.kt
+++ b/apps/etterlatte-egne-ansatte-lytter/src/main/kotlin/kafka/KafkaConsumerConfiguration.kt
@@ -16,7 +16,7 @@ interface KafkaConsumerConfiguration {
 
 class KafkaEnvironment : KafkaConsumerConfiguration {
     override fun generateKafkaConsumerProperties(env: Map<String, String>): Properties {
-        val fiveMinutesInMs = 300000
+        val fiveMinutesInMs = Duration.ofMinutes(8L).toMillis().toInt()
         val properties = Properties().apply {
             put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, env["KAFKA_BROKERS"])
             put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name)

--- a/apps/etterlatte-egne-ansatte-lytter/src/test/kotlin/SkjermingslesingTest.kt
+++ b/apps/etterlatte-egne-ansatte-lytter/src/test/kotlin/SkjermingslesingTest.kt
@@ -53,7 +53,7 @@ class SkjermingslesingTest {
             ),
             behandlingKlient,
             KafkaConsumerEnvironmentTest(),
-            Duration.ofSeconds(8L)
+            Duration.ofSeconds(20L)
         )
         runBlocking(Dispatchers.Default) {
             val job = launch {
@@ -86,10 +86,10 @@ class SkjermingslesingTest {
                 put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java)
                 put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java)
                 put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-                put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 100)
+                put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 10)
                 put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false)
                 put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, trettiSekunder)
-                put(CommonClientConfigs.SESSION_TIMEOUT_MS_CONFIG, Duration.ofSeconds(20L).toMillis().toInt())
+                put(CommonClientConfigs.SESSION_TIMEOUT_MS_CONFIG, Duration.ofSeconds(40L).toMillis().toInt())
             }
             return properties
         }

--- a/apps/etterlatte-hendelser-pdl/src/main/kotlin/hendelserpdl/leesah/KafkaConsumerConfiguration.kt
+++ b/apps/etterlatte-hendelser-pdl/src/main/kotlin/hendelserpdl/leesah/KafkaConsumerConfiguration.kt
@@ -9,7 +9,6 @@ import org.apache.kafka.common.config.SslConfigs
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.serialization.StringDeserializer
 import java.time.Duration
-import java.time.temporal.ChronoUnit
 import java.util.Properties
 
 interface KafkaConsumerConfiguration {
@@ -18,7 +17,7 @@ interface KafkaConsumerConfiguration {
 
 class KafkaEnvironment : KafkaConsumerConfiguration {
     override fun generateKafkaConsumerProperties(env: Map<String, String>): Properties {
-        val maxPollInterval = Duration.of(5, ChronoUnit.MINUTES).toMillis().toInt()
+        val maxPollInterval = Duration.ofMinutes(8L).toMillis().toInt()
         val properties = Properties().apply {
             put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, env["KAFKA_BROKERS"])
             put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name)
@@ -39,6 +38,8 @@ class KafkaEnvironment : KafkaConsumerConfiguration {
             put(ConsumerConfig.CLIENT_ID_CONFIG, env["NAIS_APP_NAME"])
             put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
             put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxPollInterval)
+            put(CommonClientConfigs.SESSION_TIMEOUT_MS_CONFIG, Duration.ofSeconds(20L).toMillis().toInt())
+
             put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java)
             put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer::class.java)
 


### PR DESCRIPTION
Siden kafka heartbeat skjer i `.poll()` og vi poller med 8 sek timeout økes den til 20 sek her da prosessering av meldingene kan ta tid.