### PR TITLE
Ikke gå videre i flyten hvis noe tidligere feiler (EY-1872)

### DIFF
--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/OpprettVedtakforespoersel.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/OpprettVedtakforespoersel.kt
@@ -47,10 +47,10 @@ internal class OpprettVedtakforespoersel(
                 logger.info("Opprettet vedtak ${respons.vedtakId} for sak: $sakId og behandling: $behandlingId")
             }
                 .takeIf { it == Status.SUKSESS }
-                .let {
+                ?.let {
                     fattVedtak(packet, context, behandlingId, sakId)
                         .takeIf { it == Status.SUKSESS }
-                        .let { attester(packet, context, behandlingId, sakId) }
+                        ?.let { attester(packet, context, behandlingId, sakId) }
                 }
         }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26689337/224749521-d5c6ecf6-075c-453a-af1e-de596057856e.png)

Fant en bug der man gikk videre i flyten trots att ting feilet tidligere. F.eks hvis opprettelse av vedtaket feilet så prøvde man likevel å fatte + attestere det etterpå.