### PR TITLE
Skrur av dependabot-pushinga av patch-versjonar også for gradle-avhengnadar

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: "npm"
     directory: "/apps/etterlatte-saksbehandling-ui/"
     schedule:


### PR DESCRIPTION
Det held med sikkerheitspatchar pluss minor- og major-versjonar