### PR TITLE
Legger til visning av dokumenter i sidemenyen for behandling

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/SideMeny/SideMeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/SideMeny/SideMeny.tsx
@@ -9,6 +9,7 @@ import { Behandlingsoppsummering } from '~components/behandling/attestering/opps
 import { Attestering } from '~components/behandling/attestering/attestering/attestering'
 import { IBeslutning } from '~components/behandling/attestering/types'
 import { IBehandlingInfo } from '~components/behandling/SideMeny/types'
+import { Dokumentoversikt } from '~components/person/dokumentoversikt'
 
 export const SideMeny = () => {
   const saksbehandler = useAppSelector((state) => state.saksbehandlerReducer.saksbehandler)
@@ -48,6 +49,12 @@ export const SideMeny = () => {
             <Behandlingsoppsummering behandlingsInfo={behandlingsinfo} beslutning={beslutning} />
             {kanAttestere && <Attestering setBeslutning={setBeslutning} beslutning={beslutning} />}
           </>
+        )}
+      </SidebarContent>
+
+      <SidebarContent collapsed={collapsed}>
+        {behandlingsinfo && behandling.søker?.foedselsnummer && (
+          <Dokumentoversikt fnr={behandling.søker.foedselsnummer} liten />
         )}
       </SidebarContent>
     </CollapsibleSidebar>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumentlisteLiten.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumentlisteLiten.tsx
@@ -1,0 +1,77 @@
+import { Alert, Link } from '@navikt/ds-react'
+import styled from 'styled-components'
+import { Journalpost } from '../behandling/types'
+import { formaterStringDato } from '~utils/formattering'
+import Spinner from '~shared/Spinner'
+import { ExternalLink } from '@navikt/ds-icons'
+
+export const DokumentlisteLiten = ({
+  dokumenter,
+  dokumenterHentet,
+  error,
+}: {
+  dokumenter: Journalpost[]
+  dokumenterHentet: boolean
+  error: boolean
+}) => {
+  return (
+    <>
+      {dokumenter.length > 0 &&
+        !error &&
+        dokumenter.map((brev) => (
+          <div key={`${brev.journalpostId}/${brev.dokumenter[0].dokumentInfoId}`}>
+            <Dokumentnavn>
+              <Link
+                href={`/api/dokumenter/${brev.journalpostId}/${brev.dokumenter[0].dokumentInfoId}`}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                {brev.tittel}
+                <ExternalLink title={brev.tittel} />
+              </Link>
+            </Dokumentnavn>
+            <Avsender>
+              Avsender: {brev.avsenderMottaker.navn} ({formaterStringDato(brev.datoOpprettet)})
+            </Avsender>
+          </div>
+        ))}
+      {dokumenter.length === 0 && !error && (
+        <IngenDokumenterRad>
+          {dokumenterHentet ? (
+            'Ingen dokumenter ble funnet'
+          ) : (
+            <Spinner margin={'0'} visible={!dokumenterHentet} label="Henter dokumenter" />
+          )}
+        </IngenDokumenterRad>
+      )}
+      {error && (
+        <Alert variant={'error'} style={{ marginTop: '10px' }}>
+          Det har oppstått en feil ved henting av henting av dokumenter..
+        </Alert>
+      )}
+    </>
+  )
+}
+
+const IngenDokumenterRad = styled.div`
+  text-align: center;
+  padding-top: 16px;
+  font-size: 14px;
+  font-style: italic;
+`
+const Dokumentnavn = styled.div`
+  font-weight: 600;
+  font-size: 14px;
+  padding-top: 20px;
+  margin-top: 20px;
+  border-top: 1px solid;
+`
+
+const Avsender = styled.div`
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+
+  color: #3e3832;
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumentoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumentoversikt.tsx
@@ -3,8 +3,9 @@ import styled from 'styled-components'
 import { useEffect, useState } from 'react'
 import { hentDokumenter } from '~shared/api/dokument'
 import { Journalpost } from '../behandling/types'
+import { DokumentlisteLiten } from '~components/person/dokumentlisteLiten'
 
-export const Dokumentoversikt = (props: { fnr: string }) => {
+export const Dokumentoversikt = (props: { fnr: string; liten?: boolean }) => {
   const [dokumenter, setDokumenter] = useState<Journalpost[]>([])
   const [error, setError] = useState(false)
   const [dokumenterHentet, setDokumenterHentet] = useState(false)
@@ -27,10 +28,17 @@ export const Dokumentoversikt = (props: { fnr: string }) => {
   }, [props.fnr])
 
   return (
-    <OversiktWrapper>
-      <h1>Dokumenter</h1>
-      <Dokumentliste dokumenter={dokumenter} dokumenterHentet={dokumenterHentet} error={error} />
-    </OversiktWrapper>
+    (props.liten && (
+      <OversiktWrapperLiten>
+        <Overskrift>Dokumenter</Overskrift>
+        <DokumentlisteLiten dokumenter={dokumenter} dokumenterHentet={dokumenterHentet} error={error} />
+      </OversiktWrapperLiten>
+    )) || (
+      <OversiktWrapper>
+        <h1>Dokumenter</h1>
+        <Dokumentliste dokumenter={dokumenter} dokumenterHentet={dokumenterHentet} error={error} />
+      </OversiktWrapper>
+    )
   )
 }
 
@@ -39,7 +47,20 @@ export const OversiktWrapper = styled.div`
   max-width: 70%;
 
   margin: 3em 1em;
+
   .behandlinger {
     margin-top: 5em;
   }
+`
+
+export const OversiktWrapperLiten = styled.div`
+  border: 1px solid #c7c0c0;
+  margin: 20px 8px 0px 8px;
+  padding: 1em;
+`
+
+export const Overskrift = styled.div`
+  font-weight: 600;
+  font-size: 20px;
+  color: #3e3832;
 `


### PR DESCRIPTION
Dokumenter åpnes i ny fane. Primærbehovet er at saksbehandler skal ha enkel tilgang til søknaden uten å måtte gå ut av behandlingen. Og de ønsker å ha den oppe på egen skjerm (ny fane).

![Screenshot 2023-03-14 at 11 52 01](https://user-images.githubusercontent.com/1083866/224984369-88c42265-06a8-4f93-a901-6e8344f2cffa.png)

EY-1891