### PR TITLE
Endre typingen av Verge til å samsvare med søknadsskjemat

### DIFF
--- a/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/opplysningerfrasoknad/opplysningsuthenter/BarnepensjonUthenter.kt
+++ b/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/opplysningerfrasoknad/opplysningsuthenter/BarnepensjonUthenter.kt
@@ -140,7 +140,7 @@ internal object BarnepensjonUthenter {
         }
     }
 
-    fun soeker(
+    private fun soeker(
         barnepensjon: Barnepensjon,
         opplysningsType: Opplysningstype
     ): Grunnlagsopplysning<out SoekerBarnSoeknad> {
@@ -179,7 +179,7 @@ internal object BarnepensjonUthenter {
         )
     }
 
-    fun gjenlevendeForelder(
+    private fun gjenlevendeForelder(
         barnepensjon: Barnepensjon,
         opplysningsType: Opplysningstype
     ): Grunnlagsopplysning<out GjenlevendeForelderSoeknad>? {

--- a/libs/common/src/main/kotlin/soeknad/dataklasser/common/Personer.kt
+++ b/libs/common/src/main/kotlin/soeknad/dataklasser/common/Personer.kt
@@ -119,11 +119,11 @@ data class Avdoed(
 }
 
 data class Verge(
-    override val fornavn: Opplysning<String>,
-    override val etternavn: Opplysning<String>,
-    override val foedselsnummer: Opplysning<Foedselsnummer>
-) : Person {
-    override val type = PersonType.VERGE
+    val fornavn: Opplysning<String>?,
+    val etternavn: Opplysning<String>?,
+    val foedselsnummer: Opplysning<Foedselsnummer>?
+) {
+    val type = PersonType.VERGE
 }
 
 data class Samboer(


### PR DESCRIPTION
Vi har hatt en del feil i prod når det kommer til deserializering av `Verge`. Ser at vi har forskjellige type definisjoner på hvordan `Verge` ser ut i vårt system og i `pensjon-etterlatte-libs` 