### PR TITLE
EY-1820 Flytte grunnlagsrelatert logikk til grunnlagsappen

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/GenerellBehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/GenerellBehandlingService.kt
@@ -21,7 +21,6 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.SakType
-import no.nav.etterlatte.libs.common.behandling.Saksrolle
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.person.Person
@@ -51,14 +50,11 @@ interface GenerellBehandlingService {
 
     fun hentHendelserIBehandling(behandlingId: UUID): List<LagretHendelse>
     fun alleBehandlingerForSoekerMedFnr(fnr: String): List<Behandling>
-    fun alleSakIderForSoekerMedFnr(fnr: String): List<Long>
     fun hentDetaljertBehandling(behandlingId: UUID): DetaljertBehandling?
     suspend fun hentDetaljertBehandlingMedTilbehoer(
         behandlingId: UUID,
         bruker: Bruker
     ): DetaljertBehandlingDto
-
-    fun hentSakerOgRollerMedFnrIPersongalleri(fnr: String): List<Pair<Saksrolle, Long>>
 
     suspend fun hentBehandlingMedEnkelPersonopplysning(
         behandlingId: UUID,
@@ -328,18 +324,6 @@ class RealGenerellBehandlingService(
     override fun alleBehandlingerForSoekerMedFnr(fnr: String): List<Behandling> {
         return inTransaction {
             behandlinger.alleBehandlingerForSoekerMedFnr(fnr)
-        }
-    }
-
-    override fun alleSakIderForSoekerMedFnr(fnr: String): List<Long> {
-        return inTransaction {
-            behandlinger.alleSakIderMedUavbruttBehandlingForSoekerMedFnr(fnr)
-        }
-    }
-
-    override fun hentSakerOgRollerMedFnrIPersongalleri(fnr: String): List<Pair<Saksrolle, Long>> {
-        return inTransaction {
-            behandlinger.sakerOgRollerMedFnrIPersongalleri(fnr)
         }
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/klienter/GrunnlagKlient.kt
@@ -5,18 +5,35 @@ import io.ktor.client.call.body
 import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.http.ContentType
+import no.nav.etterlatte.libs.common.behandling.PersonMedSakerOgRoller
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 
 interface GrunnlagKlient {
 
     suspend fun hentGrunnlag(sakId: Long): Grunnlag?
+    suspend fun hentAlleSakIder(fnr: String): Set<Long>
+    suspend fun hentPersonSakOgRolle(fnr: String): PersonMedSakerOgRoller
 }
 
-class GrunnlagKlientImpl(private val grunnlagHttpClient: HttpClient, private val url: String) :
-    GrunnlagKlient {
+class GrunnlagKlientImpl(
+    private val grunnlagHttpClient: HttpClient,
+    private val url: String
+) : GrunnlagKlient {
 
     override suspend fun hentGrunnlag(sakId: Long): Grunnlag? {
         return grunnlagHttpClient.get("$url/api/grunnlag/$sakId") {
+            accept(ContentType.Application.Json)
+        }.body()
+    }
+
+    override suspend fun hentAlleSakIder(fnr: String): Set<Long> {
+        return grunnlagHttpClient.get("$url/api/person/$fnr/saker") {
+            accept(ContentType.Application.Json)
+        }.body()
+    }
+
+    override suspend fun hentPersonSakOgRolle(fnr: String): PersonMedSakerOgRoller {
+        return grunnlagHttpClient.get("$url/api/person/$fnr/roller") {
             accept(ContentType.Application.Json)
         }.body()
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/BehandlingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/BehandlingIntegrationTest.kt
@@ -17,7 +17,10 @@ import no.nav.etterlatte.behandling.klienter.GrunnlagKlient
 import no.nav.etterlatte.behandling.klienter.VedtakKlient
 import no.nav.etterlatte.kafka.KafkaProdusent
 import no.nav.etterlatte.kafka.TestProdusent
+import no.nav.etterlatte.libs.common.behandling.PersonMedSakerOgRoller
+import no.nav.etterlatte.libs.common.behandling.SakOgRolle
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.behandling.Saksrolle
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
@@ -37,7 +40,7 @@ import org.testcontainers.junit.jupiter.Container
 import testsupport.buildTestApplicationConfigurationForOauth
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
 import javax.sql.DataSource
 
 abstract class BehandlingIntegrationTest {
@@ -236,9 +239,21 @@ class TestBeanFactory(
     override fun grunnlagHttpClient(): HttpClient = HttpClient(MockEngine) {
         engine {
             addHandler { request ->
-                if (request.url.fullPath.startsWith("/")) {
+                if (request.url.fullPath.contains("api/grunnlag")) {
                     val headers = headersOf("Content-Type" to listOf(ContentType.Application.Json.toString()))
                     respond(Grunnlag.empty().toJson(), headers = headers)
+                } else if (request.url.fullPath.endsWith("/roller")) {
+                    val headers = headersOf("Content-Type" to listOf(ContentType.Application.Json.toString()))
+                    respond(
+                        PersonMedSakerOgRoller("08071272487", listOf(SakOgRolle(1, Saksrolle.SOEKER))).toJson(),
+                        headers = headers
+                    )
+                } else if (request.url.fullPath.endsWith("/saker")) {
+                    val headers = headersOf("Content-Type" to listOf(ContentType.Application.Json.toString()))
+                    respond(
+                        setOf(1).toJson(),
+                        headers = headers
+                    )
                 } else {
                     error(request.url.fullPath)
                 }

--- a/apps/etterlatte-behandling/src/test/kotlin/IntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/IntegrationTest.kt
@@ -120,7 +120,7 @@ class IntegrationTest : BehandlingIntegrationTest() {
             client.get("/behandlinger/$behandlingId") {
                 addAuthToken(tokenSaksbehandler)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-            }.let {
+            }.also {
                 assertEquals(HttpStatusCode.OK, it.status)
                 it.body<DetaljertBehandling>()
             }
@@ -141,7 +141,7 @@ class IntegrationTest : BehandlingIntegrationTest() {
                         Tidspunkt.now().toLocalDatetimeUTC()
                     )
                 )
-            }.let {
+            }.also {
                 assertEquals(HttpStatusCode.OK, it.status)
             }
 
@@ -307,6 +307,8 @@ class IntegrationTest : BehandlingIntegrationTest() {
                         endringstype = Endringstype.OPPRETTET
                     )
                 )
+            }.also {
+                assertEquals(HttpStatusCode.OK, it.status)
             }
 
             client.post("/grunnlagsendringshendelse/forelderbarnrelasjonhendelse") {
@@ -322,6 +324,30 @@ class IntegrationTest : BehandlingIntegrationTest() {
                         endringstype = Endringstype.OPPRETTET
                     )
                 )
+            }.also {
+                assertEquals(HttpStatusCode.OK, it.status)
+            }
+
+            val behandlingIdNyFoerstegangsbehandling = client.post("/behandlinger/foerstegangsbehandling") {
+                addAuthToken(tokenServiceUser)
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                setBody(
+                    BehandlingsBehov(
+                        1,
+                        Persongalleri(fnr, "innsender", emptyList(), emptyList(), emptyList()),
+                        Tidspunkt.now().toLocalDatetimeUTC().toString()
+                    )
+
+                )
+            }.let {
+                assertEquals(HttpStatusCode.OK, it.status)
+                UUID.fromString(it.body())
+            }
+
+            client.post("/api/behandling/$behandlingIdNyFoerstegangsbehandling/avbryt") {
+                addAuthToken(tokenSaksbehandler)
+            }.also {
+                assertEquals(HttpStatusCode.OK, it.status)
             }
 
             client.post("/grunnlagsendringshendelse/adressebeskyttelse") {
@@ -334,6 +360,8 @@ class IntegrationTest : BehandlingIntegrationTest() {
                         endringstype = Endringstype.OPPRETTET
                     )
                 )
+            }.also {
+                assertEquals(HttpStatusCode.OK, it.status)
             }
 
             client.post("/api/behandlinger/${sak.id}/manueltopphoer") {
@@ -354,34 +382,10 @@ class IntegrationTest : BehandlingIntegrationTest() {
                 it.body<ManueltOpphoerResponse>()
             }
 
-            val behandlingIdNyFoerstegangsbehandling = client.post("/behandlinger/foerstegangsbehandling") {
-                addAuthToken(tokenServiceUser)
-                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                setBody(
-                    BehandlingsBehov(
-                        1,
-                        Persongalleri(fnr, "innsender", emptyList(), emptyList(), emptyList()),
-                        Tidspunkt.now().toLocalDatetimeUTC().toString()
-                    )
-
-                )
-            }.let {
-                assertEquals(HttpStatusCode.OK, it.status)
-                UUID.fromString(it.body())
-            }
-
-            client.post("api/behandling/$behandlingIdNyFoerstegangsbehandling/avbryt") {
+            client.get("/behandlinger/$behandlingId") {
                 addAuthToken(tokenSaksbehandler)
             }.also {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
-
-            client.get("/behandlinger/foerstegangsbehandling?behandlingsid=$behandlingIdNyFoerstegangsbehandling") {
-                addAuthToken(tokenSaksbehandler)
-            }.also {
-                assertEquals(HttpStatusCode.OK, it.status)
-                val result = it.body<DetaljertBehandling>()
-                assertEquals(BehandlingStatus.AVBRUTT, result.status)
+                assertEquals(HttpStatusCode.NotFound, it.status) // 404 pga adressebeskyttelse
             }
         }
 
@@ -404,13 +408,12 @@ class IntegrationTest : BehandlingIntegrationTest() {
             objectMapper.readTree(rapid.publiserteMeldinger[2].verdi)["@event_name"].textValue()
         )
         assertEquals(
-            "BEHANDLING:OPPRETTET",
+            "BEHANDLING:AVBRUTT",
             objectMapper.readTree(rapid.publiserteMeldinger[3].verdi)["@event_name"].textValue()
-
         )
         assertEquals(
-            "BEHANDLING:AVBRUTT",
-            objectMapper.readTree(rapid.publiserteMeldinger.last().verdi)["@event_name"].textValue()
+            "BEHANDLING:OPPRETTET",
+            objectMapper.readTree(rapid.publiserteMeldinger[4].verdi)["@event_name"].textValue()
         )
         beanFactory.dataSource().connection.use {
             HendelseDao { it }.finnHendelserIBehandling(behandlingOpprettet!!).also { println(it) }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
@@ -49,7 +49,7 @@ class ApplicationBuilder {
         }
         .build().apply {
             GrunnlagHendelser(this, grunnlagService)
-            BehandlingHendelser(this)
+            BehandlingHendelser(this, grunnlagService)
         }
 
     fun start() = setReady().also { rapidsConnection.start() }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingHendelser.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingHendelser.kt
@@ -14,39 +14,44 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 
 class BehandlingHendelser(
-    rapidsConnection: RapidsConnection
+    rapidsConnection: RapidsConnection,
+    private val grunnlagService: GrunnlagService
 ) : River.PacketListener {
     init {
         River(rapidsConnection).apply {
             eventName("BEHANDLING:GYLDIG_FREMSATT")
             correlationId()
-            validate { it.requireKey(BehandlingRiverKey.persongalleriKey) }
             validate { it.requireKey(BehandlingRiverKey.sakIdKey) }
         }.register(this)
     }
 
     override fun onPacket(packet: JsonMessage, context: MessageContext) =
         withLogContext(packet.correlationId) {
-            // TODO dette må jeg gjøre smartere, ellers må Persongalleri restruktureres
+            val sakId = packet["sakId"].asLong()
+
+            val persongalleriJsonNode =
+                requireNotNull(grunnlagService.hentGrunnlagAvType(sakId, Opplysningstype.PERSONGALLERI_V1)) {
+                    "Persongalleri ikke funnet for sakid=$sakId"
+                }.opplysning
 
             context.publish(
                 JsonMessage.newMessage(
                     mapOf(
                         BEHOV_NAME_KEY to Opplysningstype.SOEKER_PDL_V1,
-                        "sakId" to packet["sakId"],
-                        "fnr" to packet["persongalleri"]["soeker"],
+                        "sakId" to sakId,
+                        "fnr" to persongalleriJsonNode["soeker"],
                         "rolle" to PersonRolle.BARN,
                         CORRELATION_ID_KEY to packet[CORRELATION_ID_KEY]
                     )
                 ).toJson()
             )
 
-            packet["persongalleri"]["gjenlevende"].forEach { fnr ->
+            persongalleriJsonNode["gjenlevende"].forEach { fnr ->
                 context.publish(
                     JsonMessage.newMessage(
                         mapOf(
                             BEHOV_NAME_KEY to Opplysningstype.GJENLEVENDE_FORELDER_PDL_V1,
-                            "sakId" to packet["sakId"],
+                            "sakId" to sakId,
                             "fnr" to fnr.asText(),
                             "rolle" to PersonRolle.GJENLEVENDE,
                             CORRELATION_ID_KEY to packet[CORRELATION_ID_KEY]
@@ -55,12 +60,12 @@ class BehandlingHendelser(
                 )
             }
 
-            packet["persongalleri"]["avdoed"].forEach { fnr ->
+            persongalleriJsonNode["avdoed"].forEach { fnr ->
                 context.publish(
                     JsonMessage.newMessage(
                         mapOf(
                             BEHOV_NAME_KEY to Opplysningstype.AVDOED_PDL_V1,
-                            "sakId" to packet["sakId"],
+                            "sakId" to sakId,
                             "fnr" to fnr.asText(),
                             "rolle" to PersonRolle.AVDOED,
                             CORRELATION_ID_KEY to packet[CORRELATION_ID_KEY]

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagRoutes.kt
@@ -57,6 +57,30 @@ fun Route.grunnlagRoute(grunnlagService: GrunnlagService, behandlingKlient: Beha
                 }
             }
         }
+
+        get("/person/{fnr}/saker}") {
+            withFoedselsnummer(call.parameters["fnr"].toString(), behandlingKlient) {
+                val saksliste = grunnlagService.hentAlleSakerForIdent(it)
+
+                if (saksliste.isNotEmpty()) {
+                    call.respond(saksliste)
+                } else {
+                    call.respond(HttpStatusCode.NoContent)
+                }
+            }
+        }
+        get("/person/{fnr}/roller}") {
+            withFoedselsnummer(call.parameters["fnr"].toString(), behandlingKlient) {
+                val sakOgRoller = grunnlagService.hentSakerOgRoller(it)
+
+                if (sakOgRoller.sakerOgRoller.isNotEmpty()) {
+                    call.respond(sakOgRoller)
+                } else {
+                    call.respond(HttpStatusCode.NoContent)
+                }
+            }
+        }
+
         post("/person") {
             val navIdent = navIdentFraToken() ?: return@post call.respond(
                 HttpStatusCode.Unauthorized,

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/BehandlingHendelserTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/BehandlingHendelserTest.kt
@@ -1,23 +1,42 @@
 package no.nav.etterlatte.grunnlag
 
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.event.BehandlingRiverKey
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
-import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
+import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class BehandlingHendelserTest {
-    private val inspector = TestRapid().apply { BehandlingHendelser(this) }
+    private val mockService = mockk<GrunnlagService>()
+
+    private val inspector = TestRapid().apply { BehandlingHendelser(this, mockService) }
 
     @Test
     fun `skal lese melding om behandling gyldig fremsatt og lage opplysningsbehov`() {
+        every {
+            mockService.hentGrunnlagAvType(any(), Opplysningstype.PERSONGALLERI_V1)
+        } returns mockk {
+            every { opplysning } returns Persongalleri(
+                soeker = "soeker",
+                gjenlevende = listOf("gjenlevende"),
+                avdoed = listOf("avdoed")
+            ).toJsonNode()
+        }
+
         val melding = behandlingOpprettetMelding()
         val inspector = inspector.apply { sendTestMessage(melding.toJson()) }.inspektør
 
-        Assertions.assertEquals(Opplysningstype.SOEKER_PDL_V1.name, inspector.message(0).get("@behov").asText())
+        Assertions.assertEquals(
+            Opplysningstype.SOEKER_PDL_V1.name,
+            inspector.message(0).get("@behov").asText()
+        )
         Assertions.assertEquals(
             Opplysningstype.GJENLEVENDE_FORELDER_PDL_V1.name,
             inspector.message(1).get("@behov").asText()
@@ -27,13 +46,14 @@ class BehandlingHendelserTest {
             inspector.message(2).get("@behov").asText()
         )
         Assertions.assertEquals(3, inspector.size)
+
+        verify(exactly = 1) { mockService.hentGrunnlagAvType(1, Opplysningstype.PERSONGALLERI_V1) }
     }
 
     private fun behandlingOpprettetMelding() = JsonMessage.newMessage(
         mapOf(
             EVENT_NAME_KEY to "BEHANDLING:GYLDIG_FREMSATT",
-            BehandlingRiverKey.sakIdKey to 1,
-            BehandlingRiverKey.persongalleriKey to GrunnlagTestData().hentPersonGalleri()
+            BehandlingRiverKey.sakIdKey to 1
         )
     )
 }

--- a/apps/etterlatte-grunnlag/src/test/kotlin/itest/RapidTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/itest/RapidTest.kt
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
-import java.util.*
+import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class RapidTest {
@@ -56,7 +56,7 @@ internal class RapidTest {
         grunnlagService = RealGrunnlagService(opplysningRepo, behandlingKlient, mockk())
         inspector = TestRapid().apply {
             GrunnlagHendelser(this, grunnlagService)
-            BehandlingHendelser(this)
+            BehandlingHendelser(this, grunnlagService)
         }
     }
 

--- a/libs/common/src/main/kotlin/behandling/Grunnlagsendringshendelse.kt
+++ b/libs/common/src/main/kotlin/behandling/Grunnlagsendringshendelse.kt
@@ -9,7 +9,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
 
 data class Grunnlagsendringshendelse(
     val id: UUID,
@@ -40,6 +40,16 @@ enum class GrunnlagsendringStatus {
         fun relevantForSaksbehandler() = listOf(SJEKKET_AV_JOBB, TATT_MED_I_BEHANDLING, VURDERT_SOM_IKKE_RELEVANT)
     }
 }
+
+data class PersonMedSakerOgRoller(
+    val fnr: String,
+    val sakerOgRoller: List<SakOgRolle>
+)
+
+data class SakOgRolle(
+    val sakId: Long,
+    val rolle: Saksrolle
+)
 
 enum class Saksrolle {
     SOEKER,


### PR DESCRIPTION
Mer forarbeid for å bli kvitt persongalleriet i behandling.

Har flyttet en logikk tilknyttet grunnlag fra **behandling** til **grunnlag**, så behandlingsappen henter nå personer og roller fra grunnlag i stedet. 