### PR TITLE
EY-1820 Flytte grunnlagsrelatert logikk til grunnlagsappen

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/GenerellBehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/GenerellBehandlingService.kt
@@ -21,7 +21,6 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.SakType
-import no.nav.etterlatte.libs.common.behandling.Saksrolle
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.person.Person
@@ -51,14 +50,11 @@ interface GenerellBehandlingService {
 
     fun hentHendelserIBehandling(behandlingId: UUID): List<LagretHendelse>
     fun alleBehandlingerForSoekerMedFnr(fnr: String): List<Behandling>
-    fun alleSakIderForSoekerMedFnr(fnr: String): List<Long>
     fun hentDetaljertBehandling(behandlingId: UUID): DetaljertBehandling?
     suspend fun hentDetaljertBehandlingMedTilbehoer(
         behandlingId: UUID,
         bruker: Bruker
     ): DetaljertBehandlingDto
-
-    fun hentSakerOgRollerMedFnrIPersongalleri(fnr: String): List<Pair<Saksrolle, Long>>
 
     suspend fun hentBehandlingMedEnkelPersonopplysning(
         behandlingId: UUID,
@@ -328,18 +324,6 @@ class RealGenerellBehandlingService(
     override fun alleBehandlingerForSoekerMedFnr(fnr: String): List<Behandling> {
         return inTransaction {
             behandlinger.alleBehandlingerForSoekerMedFnr(fnr)
-        }
-    }
-
-    override fun alleSakIderForSoekerMedFnr(fnr: String): List<Long> {
-        return inTransaction {
-            behandlinger.alleSakIderMedUavbruttBehandlingForSoekerMedFnr(fnr)
-        }
-    }
-
-    override fun hentSakerOgRollerMedFnrIPersongalleri(fnr: String): List<Pair<Saksrolle, Long>> {
-        return inTransaction {
-            behandlinger.sakerOgRollerMedFnrIPersongalleri(fnr)
         }
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
@@ -15,7 +15,6 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.GrunnlagsendringStatus
 import no.nav.etterlatte.libs.common.behandling.GrunnlagsendringsType
 import no.nav.etterlatte.libs.common.behandling.Grunnlagsendringshendelse
-import no.nav.etterlatte.libs.common.behandling.Saksrolle
 import no.nav.etterlatte.libs.common.behandling.SamsvarMellomPdlOgGrunnlag
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.pdl.PersonDTO
@@ -30,7 +29,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.sak.SakServiceAdressebeskyttelse
 import no.nav.etterlatte.sikkerLogg
 import org.slf4j.LoggerFactory
-import java.util.*
+import java.util.UUID
 
 class GrunnlagsendringshendelseService(
     private val grunnlagsendringshendelseDao: GrunnlagsendringshendelseDao,
@@ -78,7 +77,7 @@ class GrunnlagsendringshendelseService(
 
     suspend fun oppdaterAdressebeskyttelseHendelse(adressebeskyttelse: Adressebeskyttelse) {
         val gradering = adressebeskyttelse.adressebeskyttelseGradering
-        val sakIder = finnSakIdForFnr(adressebeskyttelse.fnr).distinct()
+        val sakIder = grunnlagKlient.hentAlleSakIder(adressebeskyttelse.fnr)
         sakIder.forEach { sakId ->
             sakServiceAdressebeskyttelse.oppdaterAdressebeskyttelse(
                 sakId,
@@ -92,12 +91,6 @@ class GrunnlagsendringshendelseService(
         }
     }
 
-    private fun finnSakIdForFnr(fnr: String): List<Long> {
-        return generellBehandlingService.hentSakerOgRollerMedFnrIPersongalleri(fnr).map {
-            it.second
-        }
-    }
-
     private fun opprettHendelseAvTypeForPerson(
         fnr: String,
         grunnlagendringType: GrunnlagsendringsType,
@@ -105,11 +98,13 @@ class GrunnlagsendringshendelseService(
     ):
         List<Grunnlagsendringshendelse> {
         val tidspunktForMottakAvHendelse = Tidspunkt.now().toLocalDatetimeUTC()
-        return generellBehandlingService.hentSakerOgRollerMedFnrIPersongalleri(fnr).let {
+        val sakerOgRoller = runBlocking { grunnlagKlient.hentPersonSakOgRolle(fnr).sakerOgRoller }
+
+        return sakerOgRoller.let {
             inTransaction {
                 it.filter { rolleOgSak ->
                     !hendelseEksistererFraFoer(
-                        rolleOgSak,
+                        rolleOgSak.sakId,
                         fnr,
                         grunnlagendringType
                     )
@@ -118,16 +113,16 @@ class GrunnlagsendringshendelseService(
                         val hendelseId = UUID.randomUUID()
                         logger.info(
                             "Oppretter grunnlagsendringshendelse med id=$hendelseId for hendelse av " +
-                                "type $grunnlagendringType på sak med id=${rolleOgSak.second}"
+                                "type $grunnlagendringType på sak med id=${rolleOgSak.sakId}"
                         )
                         grunnlagsendringshendelseDao.opprettGrunnlagsendringshendelse(
                             Grunnlagsendringshendelse(
                                 id = hendelseId,
-                                sakId = rolleOgSak.second,
+                                sakId = rolleOgSak.sakId,
                                 status = grunnlagsEndringsStatus,
                                 type = grunnlagendringType,
                                 opprettet = tidspunktForMottakAvHendelse,
-                                hendelseGjelderRolle = rolleOgSak.first,
+                                hendelseGjelderRolle = rolleOgSak.rolle,
                                 gjelderPerson = fnr
                             )
                         )
@@ -266,12 +261,12 @@ class GrunnlagsendringshendelseService(
     }
 
     private fun hendelseEksistererFraFoer(
-        rolleOgSak: Pair<Saksrolle, Long>,
+        sakId: Long,
         fnr: String,
         hendelsesType: GrunnlagsendringsType
     ): Boolean {
         return grunnlagsendringshendelseDao.hentGrunnlagsendringshendelserMedStatuserISak(
-            rolleOgSak.second,
+            sakId,
             listOf(GrunnlagsendringStatus.VENTER_PAA_JOBB, GrunnlagsendringStatus.SJEKKET_AV_JOBB)
         ).any {
             it.gjelderPerson == fnr && it.type == hendelsesType

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/klienter/GrunnlagKlient.kt
@@ -5,18 +5,35 @@ import io.ktor.client.call.body
 import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.http.ContentType
+import no.nav.etterlatte.libs.common.behandling.PersonMedSakerOgRoller
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 
 interface GrunnlagKlient {
 
     suspend fun hentGrunnlag(sakId: Long): Grunnlag?
+    suspend fun hentAlleSakIder(fnr: String): Set<Long>
+    suspend fun hentPersonSakOgRolle(fnr: String): PersonMedSakerOgRoller
 }
 
-class GrunnlagKlientImpl(private val grunnlagHttpClient: HttpClient, private val url: String) :
-    GrunnlagKlient {
+class GrunnlagKlientImpl(
+    private val grunnlagHttpClient: HttpClient,
+    private val url: String
+) : GrunnlagKlient {
 
     override suspend fun hentGrunnlag(sakId: Long): Grunnlag? {
         return grunnlagHttpClient.get("$url/api/grunnlag/$sakId") {
+            accept(ContentType.Application.Json)
+        }.body()
+    }
+
+    override suspend fun hentAlleSakIder(fnr: String): Set<Long> {
+        return grunnlagHttpClient.get("$url/api/person/$fnr/saker") {
+            accept(ContentType.Application.Json)
+        }.body()
+    }
+
+    override suspend fun hentPersonSakOgRolle(fnr: String): PersonMedSakerOgRoller {
+        return grunnlagHttpClient.get("$url/api/person/$fnr/roller") {
             accept(ContentType.Application.Json)
         }.body()
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/BehandlingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/BehandlingIntegrationTest.kt
@@ -17,7 +17,10 @@ import no.nav.etterlatte.behandling.klienter.GrunnlagKlient
 import no.nav.etterlatte.behandling.klienter.VedtakKlient
 import no.nav.etterlatte.kafka.KafkaProdusent
 import no.nav.etterlatte.kafka.TestProdusent
+import no.nav.etterlatte.libs.common.behandling.PersonMedSakerOgRoller
+import no.nav.etterlatte.libs.common.behandling.SakOgRolle
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.behandling.Saksrolle
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
@@ -37,7 +40,7 @@ import org.testcontainers.junit.jupiter.Container
 import testsupport.buildTestApplicationConfigurationForOauth
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
 import javax.sql.DataSource
 
 abstract class BehandlingIntegrationTest {
@@ -236,9 +239,21 @@ class TestBeanFactory(
     override fun grunnlagHttpClient(): HttpClient = HttpClient(MockEngine) {
         engine {
             addHandler { request ->
-                if (request.url.fullPath.startsWith("/")) {
+                if (request.url.fullPath.contains("api/grunnlag")) {
                     val headers = headersOf("Content-Type" to listOf(ContentType.Application.Json.toString()))
                     respond(Grunnlag.empty().toJson(), headers = headers)
+                } else if (request.url.fullPath.endsWith("/roller")) {
+                    val headers = headersOf("Content-Type" to listOf(ContentType.Application.Json.toString()))
+                    respond(
+                        PersonMedSakerOgRoller("08071272487", listOf(SakOgRolle(1, Saksrolle.SOEKER))).toJson(),
+                        headers = headers
+                    )
+                } else if (request.url.fullPath.endsWith("/saker")) {
+                    val headers = headersOf("Content-Type" to listOf(ContentType.Application.Json.toString()))
+                    respond(
+                        setOf(1).toJson(),
+                        headers = headers
+                    )
                 } else {
                     error(request.url.fullPath)
                 }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoIntegrationTest.kt
@@ -10,7 +10,6 @@ import no.nav.etterlatte.libs.common.behandling.ManueltOpphoerAarsak
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
-import no.nav.etterlatte.libs.common.behandling.Saksrolle
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.gyldigSoeknad.GyldighetsResultat
@@ -626,63 +625,6 @@ internal class BehandlingDaoIntegrationTest {
 
             assertEquals(expected, actual)
         }
-    }
-
-    @Test
-    fun `skal hente ut saksnr og rolle for saker hvor et fnr opptrer`() {
-        val sak1 = sakRepo.opprettSak("123", SakType.BARNEPENSJON).id
-        val sak2 = sakRepo.opprettSak("321", SakType.BARNEPENSJON).id
-
-        listOf(
-            opprettBehandling(
-                type = BehandlingType.FØRSTEGANGSBEHANDLING,
-                sakId = sak1,
-                persongalleri = Persongalleri(
-                    soeker = "11111",
-                    innsender = "22222",
-                    soesken = listOf("33333", "44444"),
-                    avdoed = listOf("55555"),
-                    gjenlevende = listOf("66666")
-                )
-            ),
-            opprettBehandling(
-                type = BehandlingType.FØRSTEGANGSBEHANDLING,
-                sakId = sak1,
-                persongalleri = Persongalleri(
-                    soeker = "77777",
-                    innsender = "88888",
-                    soesken = listOf("99999"),
-                    avdoed = listOf("00000"),
-                    gjenlevende = listOf("01010")
-                )
-            ),
-            opprettBehandling(
-                type = BehandlingType.FØRSTEGANGSBEHANDLING,
-                sakId = sak2,
-                persongalleri = Persongalleri(
-                    soeker = "11111",
-                    innsender = "11111",
-                    soesken = listOf("11111", "04040", "05050"),
-                    avdoed = listOf("06060", "11111"),
-                    gjenlevende = listOf("11111")
-                )
-            )
-        ).forEach {
-            behandlingRepo.opprettBehandling(it)
-        }
-
-        val sakerOgRoller = behandlingRepo.sakerOgRollerMedFnrIPersongalleri("11111")
-        assertEquals(5, sakerOgRoller.size)
-        assertEquals(Saksrolle.SOEKER, sakerOgRoller[0].first)
-        assertEquals(sak1, sakerOgRoller[0].second)
-        assertEquals(Saksrolle.AVDOED, sakerOgRoller[1].first)
-        assertEquals(sak2, sakerOgRoller[1].second)
-        assertEquals(Saksrolle.GJENLEVENDE, sakerOgRoller[2].first)
-        assertEquals(sak2, sakerOgRoller[2].second)
-        assertEquals(Saksrolle.SOEKER, sakerOgRoller[3].first)
-        assertEquals(sak2, sakerOgRoller[3].second)
-        assertEquals(Saksrolle.SOESKEN, sakerOgRoller[4].first)
-        assertEquals(sak2, sakerOgRoller[4].second)
     }
 
     @Test

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagRoutes.kt
@@ -57,6 +57,30 @@ fun Route.grunnlagRoute(grunnlagService: GrunnlagService, behandlingKlient: Beha
                 }
             }
         }
+
+        get("/person/{fnr}/saker}") {
+            withFoedselsnummer(call.parameters["fnr"].toString(), behandlingKlient) {
+                val saksliste = grunnlagService.hentAlleSakerForIdent(it)
+
+                if (saksliste.isNotEmpty()) {
+                    call.respond(saksliste)
+                } else {
+                    call.respond(HttpStatusCode.NoContent)
+                }
+            }
+        }
+        get("/person/{fnr}/roller}") {
+            withFoedselsnummer(call.parameters["fnr"].toString(), behandlingKlient) {
+                val sakOgRoller = grunnlagService.hentSakerOgRoller(it)
+
+                if (sakOgRoller.sakerOgRoller.isNotEmpty()) {
+                    call.respond(sakOgRoller)
+                } else {
+                    call.respond(HttpStatusCode.NoContent)
+                }
+            }
+        }
+
         post("/person") {
             val navIdent = navIdentFraToken() ?: return@post call.respond(
                 HttpStatusCode.Unauthorized,

--- a/libs/common/src/main/kotlin/behandling/Grunnlagsendringshendelse.kt
+++ b/libs/common/src/main/kotlin/behandling/Grunnlagsendringshendelse.kt
@@ -9,7 +9,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
 
 data class Grunnlagsendringshendelse(
     val id: UUID,
@@ -40,6 +40,16 @@ enum class GrunnlagsendringStatus {
         fun relevantForSaksbehandler() = listOf(SJEKKET_AV_JOBB, TATT_MED_I_BEHANDLING, VURDERT_SOM_IKKE_RELEVANT)
     }
 }
+
+data class PersonMedSakerOgRoller(
+    val fnr: String,
+    val sakerOgRoller: List<SakOgRolle>
+)
+
+data class SakOgRolle(
+    val sakId: Long,
+    val rolle: Saksrolle
+)
 
 enum class Saksrolle {
     SOEKER,


### PR DESCRIPTION
Henter nå ut alle fnr med tilknyttet sak og rolle fra grunnlag i stedet for behandling. 