### PR TITLE
EY-1948: Fallbacker til en periode fra 1900-01 hvis periode mangler

### DIFF
--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/OpplysningsgrunnlagMapper.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/OpplysningsgrunnlagMapper.kt
@@ -21,13 +21,11 @@ class OpplysningsgrunnlagMapper(
             assert(alleOpplysningerErAvSammeType(hendelser.map { it.opplysning }))
         }
 
-        val opplysning: Opplysning<JsonNode> = hendelser.first().let {
-            if (it.opplysning.erPeriodisert()) {
-                Opplysning.Periodisert.create(hendelser.map { it.opplysning })
-            } else {
-                hendelser.maxBy { hendelse -> hendelse.hendelseNummer }
-                    .let { Opplysning.Konstant.create(it.opplysning) }
-            }
+        val opplysning: Opplysning<JsonNode> = if (hendelser.any { it.opplysning.periode != null }) {
+            Opplysning.Periodisert.create(hendelser.map { it.opplysning })
+        } else {
+            hendelser.maxBy { hendelse -> hendelse.hendelseNummer }
+                .let { Opplysning.Konstant.create(it.opplysning) }
         }
 
         val opplysningstype: Opplysningstype

--- a/libs/common/src/main/kotlin/grunnlag/Grunnlagsopplysning.kt
+++ b/libs/common/src/main/kotlin/grunnlag/Grunnlagsopplysning.kt
@@ -51,8 +51,6 @@ open class Grunnlagsopplysning<T>(
         return "Opplysning om ${opplysningType.name}: oppgitt av $kilde til å være: $opplysning. Id: $id"
     }
 
-    fun erPeriodisert() = periode != null
-
     @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.EXISTING_PROPERTY,


### PR DESCRIPTION
Dette gjelder for en adresse på en sak i produksjon. 