### PR TITLE
Redusere spam fra dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,38 +1,89 @@
 version: 2
 updates:
+  # ==============
+  # KOTLIN BACKEND
+  # ==============
+
+  # Kjører sjekk hver måned for generelle oppdateringer
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly" 
+      day: "sunday"
     open-pull-requests-limit: 10
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+
+  # Daglig sjekk (limit=0) for å sikre sikkerhetsoppdateringer
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily" 
+    open-pull-requests-limit: 0
+
+
+  # =============
+  # FRONTEND ROOT
+  # =============
+  
+  # Kjører sjekk hver måned for generelle oppdateringer
+  - package-ecosystem: "npm"
+    directory: "/apps/etterlatte-saksbehandling-ui/"
+    schedule:
+      interval: "monthly"
+      day: "sunday"
+    open-pull-requests-limit: 10
+
+  # Daglig sjekk (limit=0) for å sikre sikkerhetsoppdateringer
   - package-ecosystem: "npm"
     directory: "/apps/etterlatte-saksbehandling-ui/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
+
+  # ===============
+  # FRONTEND CLIENT
+  # ===============
+
+  # Kjører sjekk hver måned for generelle oppdateringer
+  - package-ecosystem: "npm"
+    directory: "/apps/etterlatte-saksbehandling-ui/client"
+    schedule:
+      interval: "monthly"
+      day: "sunday"
     open-pull-requests-limit: 10
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+
+  # Daglig sjekk (limit=0) for å sikre sikkerhetsoppdateringer
   - package-ecosystem: "npm"
     directory: "/apps/etterlatte-saksbehandling-ui/client"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
+
+  # ===============
+  # FRONTEND SERVER
+  # ===============
+  
+  # Kjører sjekk hver måned for generelle oppdateringer
+  - package-ecosystem: "npm"
+    directory: "/apps/etterlatte-saksbehandling-ui/server"
+    schedule:
+      interval: "monthly"
+      day: "sunday"
     open-pull-requests-limit: 10
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+
+  # Daglig sjekk (limit=0) for å sikre sikkerhetsoppdateringer
   - package-ecosystem: "npm"
     directory: "/apps/etterlatte-saksbehandling-ui/server"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+    open-pull-requests-limit: 0
+
+  # ==============
+  # GITHUB ACTIONS
+  # ==============
+
+  # Kjører sjekk hver måned for generelle oppdateringer
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+      day: "sunday"


### PR DESCRIPTION
Litt hacky og rotete siden dependabot ikke har noen god støtte for å kjøre vanlige oppdateringer uavhengig av sikkerhetsoppdateringer. Derfor en del dobbelt opp...

- **Limit 0** med **daily** tvinger sikkerhetsoppdateringer, siden den har en [låst limit på 5](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit).
- **Limit 10** med **monthly** sikrer månedlig oppdateringer av andre avhegigheter. Satt til søndag slik at vi slipper spam midt i arbeidsdagen.