### PR TITLE
Vedtaksbrev skal sendes til barnet, ikke gjenlevende forelder.

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivService.kt
@@ -3,7 +3,6 @@ package no.nav.etterlatte.brev.dokarkiv
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.libs.common.brev.model.Brev
-import no.nav.etterlatte.libs.common.brev.model.Mottaker
 import no.nav.etterlatte.libs.common.journalpost.AvsenderMottaker
 import no.nav.etterlatte.libs.common.journalpost.Bruker
 import no.nav.etterlatte.libs.common.journalpost.DokumentVariant
@@ -17,7 +16,7 @@ import no.nav.etterlatte.libs.common.journalpost.Sak
 import no.nav.etterlatte.libs.common.journalpost.Sakstype
 import no.nav.etterlatte.rivers.VedtakTilJournalfoering
 import org.slf4j.LoggerFactory
-import java.util.Base64
+import java.util.*
 
 interface DokarkivService {
     fun journalfoer(vedtaksbrev: Brev, vedtak: VedtakTilJournalfoering): JournalpostResponse
@@ -50,7 +49,7 @@ class DokarkivServiceImpl(
             tittel = vedtaksbrev.tittel,
             journalpostType = JournalPostType.UTGAAENDE,
             behandlingstema = BEHANDLINGSTEMA_BP,
-            avsenderMottaker = vedtaksbrev.mottaker.tilAvsenderMottaker(),
+            avsenderMottaker = AvsenderMottaker(vedtak.soekerIdent),
             bruker = Bruker(vedtak.soekerIdent),
             eksternReferanseId = "${vedtaksbrev.behandlingId}.${vedtaksbrev.id}",
             sak = Sak(Sakstype.FAGSAK, vedtaksbrev.behandlingId.toString()),
@@ -66,13 +65,4 @@ class DokarkivServiceImpl(
         brevkode = BREV_KODE,
         dokumentvarianter = listOf(DokumentVariant.ArkivPDF(Base64.getEncoder().encodeToString(this)))
     )
-
-    private fun Mottaker.tilAvsenderMottaker() = when {
-        foedselsnummer != null -> AvsenderMottaker(id = foedselsnummer!!.value)
-        orgnummer != null -> AvsenderMottaker(id = orgnummer, idType = "ORGNR")
-        adresse != null -> {
-            AvsenderMottaker(id = null, navn = adresse!!.navn, idType = null, land = adresse!!.land)
-        }
-        else -> throw Exception("Ingen brevmottaker spesifisert")
-    }
 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivServiceTest.kt
@@ -50,7 +50,7 @@ internal class DokarkivServiceTest {
     }
 
     @Test
-    fun `Journalfoering`() {
+    fun `journalfoer brevet med barnet som mottaker`() {
         every { mockDb.hentBrevInnhold(any()) } returns BrevInnhold("mal", Spraak.NB, "".toByteArray())
         coEvery { mockKlient.opprettJournalpost(any(), any()) } returns JournalpostResponse("id", "OK", "melding", true)
 
@@ -69,7 +69,7 @@ internal class DokarkivServiceTest {
         assertEquals(JournalPostType.UTGAAENDE, actualRequest.journalpostType)
         assertEquals(BEHANDLINGSTEMA_BP, actualRequest.behandlingstema)
 
-        assertEquals(vedtaksbrev.mottaker.foedselsnummer!!.value, actualRequest.avsenderMottaker.id)
+        assertEquals(vedtak.soekerIdent, actualRequest.avsenderMottaker.id)
 
         assertEquals(Bruker(vedtak.soekerIdent), actualRequest.bruker)
         assertEquals("${vedtaksbrev.behandlingId}.${vedtaksbrev.id}", actualRequest.eksternReferanseId)


### PR DESCRIPTION
Det skal også alltid sendes ut på papir, så det ser ikke ut til at det vi har definert under har fungert:
`kanal = "S", // https://confluence.adeo.no/display/BOA/Utsendingskanal`

Det er likevel ingen krise for nå siden barn under 15 år ikke kan ha kodebrikke.

EY-1955