### PR TITLE
EY-1787 - steg 2 - PDL tjeneste kan hente geografisk tilknytning

### DIFF
--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
@@ -416,3 +416,31 @@ data class PdlVergeEllerFullmektig(
     val omfang: String?,
     val omfangetErInnenPersonligOmraade: Boolean
 )
+
+data class PdlGeografiskTilknytningIdentVariables(
+    val ident: String
+)
+data class PdlGeografiskTilknytningRequest(
+    val query: String,
+    val variables: PdlGeografiskTilknytningIdentVariables
+)
+
+enum class PdlGtType {
+    KOMMUNE, BYDEL, UTLAND, UDEFINERT
+}
+
+data class PdlGeografiskTilknytning(
+    val gtBydel: String?,
+    val gtKommune: String?,
+    val gtLand: String?,
+    val gtType: PdlGtType?
+)
+
+data class PdlGeografiskTilknytningData(
+    val hentGeografiskTilknytning: PdlGeografiskTilknytning? = null
+)
+
+data class PdlGeografiskTilknytningResponse(
+    val data: PdlGeografiskTilknytningData? = null,
+    val errors: List<PdlResponseError>? = null
+)

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/GeografiskTilknytningMapper.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/GeografiskTilknytningMapper.kt
@@ -1,0 +1,18 @@
+package no.nav.etterlatte.pdl.mapper
+
+import no.nav.etterlatte.libs.common.person.GeografiskTilknytning
+import no.nav.etterlatte.pdl.PdlGeografiskTilknytning
+import no.nav.etterlatte.pdl.PdlGtType
+
+object GeografiskTilknytningMapper {
+    fun mapGeografiskTilknytning(
+        geografiskTilknytning: PdlGeografiskTilknytning
+    ): GeografiskTilknytning =
+        when (geografiskTilknytning.gtType) {
+            PdlGtType.KOMMUNE -> GeografiskTilknytning(kommune = geografiskTilknytning.gtKommune)
+            PdlGtType.BYDEL -> GeografiskTilknytning(bydel = geografiskTilknytning.gtBydel)
+            PdlGtType.UTLAND -> GeografiskTilknytning(land = geografiskTilknytning.gtLand)
+            PdlGtType.UDEFINERT -> GeografiskTilknytning(ukjent = true)
+            else -> GeografiskTilknytning()
+        }
+}

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonRoute.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonRoute.kt
@@ -10,6 +10,7 @@ import io.ktor.server.routing.application
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.libs.common.person.HentFolkeregisterIdentRequest
+import no.nav.etterlatte.libs.common.person.HentGeografiskTilknytningRequest
 import no.nav.etterlatte.libs.common.person.HentPersonRequest
 
 fun Route.personRoute(service: PersonService) {
@@ -50,6 +51,21 @@ fun Route.personRoute(service: PersonService) {
 
             try {
                 service.hentFolkeregisterIdent(hentFolkeregisterIdentRequest).let { call.respond(it) }
+            } catch (e: PdlFantIkkePerson) {
+                call.respond(HttpStatusCode.NotFound)
+            }
+        }
+    }
+
+    route("geografisktilknyttning") {
+        val logger = application.log
+
+        post {
+            val hentGeografiskTilknytningRequest = call.receive<HentGeografiskTilknytningRequest>()
+            logger.info("Henter geografisk tilknyttning med fnr=${hentGeografiskTilknytningRequest.foedselsnummer}")
+
+            try {
+                service.hentGeografiskTilknytning(hentGeografiskTilknytningRequest).let { call.respond(it) }
             } catch (e: PdlFantIkkePerson) {
                 call.respond(HttpStatusCode.NotFound)
             }

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonService.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonService.kt
@@ -3,12 +3,15 @@ package no.nav.etterlatte.person
 import no.nav.etterlatte.libs.common.pdl.PersonDTO
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.person.FolkeregisterIdent
+import no.nav.etterlatte.libs.common.person.GeografiskTilknytning
 import no.nav.etterlatte.libs.common.person.HentFolkeregisterIdentRequest
+import no.nav.etterlatte.libs.common.person.HentGeografiskTilknytningRequest
 import no.nav.etterlatte.libs.common.person.HentPersonRequest
 import no.nav.etterlatte.libs.common.person.Person
 import no.nav.etterlatte.pdl.ParallelleSannheterKlient
 import no.nav.etterlatte.pdl.PdlKlient
 import no.nav.etterlatte.pdl.PdlResponseError
+import no.nav.etterlatte.pdl.mapper.GeografiskTilknytningMapper
 import no.nav.etterlatte.pdl.mapper.PersonMapper
 import org.slf4j.LoggerFactory
 
@@ -21,70 +24,68 @@ class PersonService(
 ) {
     private val logger = LoggerFactory.getLogger(PersonService::class.java)
 
-    suspend fun hentPerson(hentPersonRequest: HentPersonRequest): Person {
-        logger.info("Henter person med fnr=${hentPersonRequest.foedselsnummer} fra PDL")
+    suspend fun hentPerson(request: HentPersonRequest): Person {
+        logger.info("Henter person med fnr=${request.foedselsnummer} fra PDL")
 
-        return pdlKlient.hentPerson(hentPersonRequest.foedselsnummer, hentPersonRequest.rolle).let {
+        return pdlKlient.hentPerson(request.foedselsnummer, request.rolle).let {
             if (it.data?.hentPerson == null) {
                 val pdlFeil = it.errors?.asFormatertFeil()
                 if (it.errors?.personIkkeFunnet() == true) {
-                    throw PdlFantIkkePerson("Fant ikke personen ${hentPersonRequest.foedselsnummer}")
+                    throw PdlFantIkkePerson("Fant ikke personen ${request.foedselsnummer}")
                 } else {
                     throw PdlForesporselFeilet(
-                        "Kunne ikke hente person med fnr=${hentPersonRequest.foedselsnummer} fra PDL: $pdlFeil"
+                        "Kunne ikke hente person med fnr=${request.foedselsnummer} fra PDL: $pdlFeil"
                     )
                 }
             } else {
                 PersonMapper.mapPerson(
                     ppsKlient = ppsKlient,
                     pdlKlient = pdlKlient,
-                    fnr = hentPersonRequest.foedselsnummer,
-                    personRolle = hentPersonRequest.rolle,
+                    fnr = request.foedselsnummer,
+                    personRolle = request.rolle,
                     hentPerson = it.data.hentPerson
                 )
             }
         }
     }
 
-    suspend fun hentOpplysningsperson(hentPersonRequest: HentPersonRequest): PersonDTO {
-        logger.info("Henter opplysninger for person med fnr=${hentPersonRequest.foedselsnummer} fra PDL")
+    suspend fun hentOpplysningsperson(request: HentPersonRequest): PersonDTO {
+        logger.info("Henter opplysninger for person med fnr=${request.foedselsnummer} fra PDL")
 
-        return pdlKlient.hentPerson(hentPersonRequest.foedselsnummer, hentPersonRequest.rolle).let {
+        return pdlKlient.hentPerson(request.foedselsnummer, request.rolle).let {
             if (it.data?.hentPerson == null) {
                 val pdlFeil = it.errors?.asFormatertFeil()
                 if (it.errors?.personIkkeFunnet() == true) {
-                    throw PdlFantIkkePerson("Fant ikke personen ${hentPersonRequest.foedselsnummer}")
+                    throw PdlFantIkkePerson("Fant ikke personen ${request.foedselsnummer}")
                 } else {
                     throw PdlForesporselFeilet(
-                        "Kunne ikke hente opplysninger for ${hentPersonRequest.foedselsnummer} fra PDL: $pdlFeil"
+                        "Kunne ikke hente opplysninger for ${request.foedselsnummer} fra PDL: $pdlFeil"
                     )
                 }
             } else {
                 PersonMapper.mapOpplysningsperson(
                     ppsKlient = ppsKlient,
                     pdlKlient = pdlKlient,
-                    fnr = hentPersonRequest.foedselsnummer,
-                    personRolle = hentPersonRequest.rolle,
+                    fnr = request.foedselsnummer,
+                    personRolle = request.rolle,
                     hentPerson = it.data.hentPerson
                 )
             }
         }
     }
 
-    suspend fun hentFolkeregisterIdent(
-        hentFolkeregisterIdentRequest: HentFolkeregisterIdentRequest
-    ): FolkeregisterIdent {
-        logger.info("Henter folkeregisterident for ident=${hentFolkeregisterIdentRequest.ident} fra PDL")
+    suspend fun hentFolkeregisterIdent(request: HentFolkeregisterIdentRequest): FolkeregisterIdent {
+        logger.info("Henter folkeregisterident for ident=${request.ident} fra PDL")
 
-        return pdlKlient.hentFolkeregisterIdent(hentFolkeregisterIdentRequest.ident).let {
+        return pdlKlient.hentFolkeregisterIdent(request.ident).let {
             if (it.data?.hentIdenter == null) {
                 val pdlFeil = it.errors?.asFormatertFeil()
                 if (it.errors?.personIkkeFunnet() == true) {
-                    throw PdlFantIkkePerson("Fant ikke personen ${hentFolkeregisterIdentRequest.ident}")
+                    throw PdlFantIkkePerson("Fant ikke personen ${request.ident}")
                 } else {
                     throw PdlForesporselFeilet(
                         "Kunne ikke hente folkeregisterident " +
-                            "for ${hentFolkeregisterIdentRequest.ident} fra PDL: $pdlFeil"
+                            "for ${request.ident} fra PDL: $pdlFeil"
                     )
                 }
             } else {
@@ -95,9 +96,28 @@ class PersonService(
                     FolkeregisterIdent(folkeregisterident = Foedselsnummer.of(folkeregisterIdent))
                 } catch (e: Exception) {
                     throw PdlForesporselFeilet(
-                        "Fant ingen folkeregisterident for ${hentFolkeregisterIdentRequest.ident} fra PDL"
+                        "Fant ingen folkeregisterident for ${request.ident} fra PDL"
                     )
                 }
+            }
+        }
+    }
+
+    suspend fun hentGeografiskTilknytning(request: HentGeografiskTilknytningRequest): GeografiskTilknytning {
+        logger.info("Henter geografisk tilknytning med fnr=${request.foedselsnummer} fra PDL")
+
+        return pdlKlient.hentGeografiskTilknytning(request.foedselsnummer).let {
+            if (it.data?.hentGeografiskTilknytning == null) {
+                val pdlFeil = it.errors?.asFormatertFeil()
+                if (it.errors?.personIkkeFunnet() == true) {
+                    throw PdlFantIkkePerson("Fant ikke personen ${request.foedselsnummer}")
+                } else {
+                    throw PdlForesporselFeilet(
+                        "Kunne ikke hente fnr=${request.foedselsnummer} fra PDL: $pdlFeil"
+                    )
+                }
+            } else {
+                GeografiskTilknytningMapper.mapGeografiskTilknytning(it.data.hentGeografiskTilknytning)
             }
         }
     }

--- a/apps/etterlatte-pdltjenester/src/main/resources/pdl/hentGeografiskTilknytning.graphql
+++ b/apps/etterlatte-pdltjenester/src/main/resources/pdl/hentGeografiskTilknytning.graphql
@@ -1,0 +1,10 @@
+query(
+    $ident: ID!,
+) {
+    hentGeografiskTilknytning(ident: $ident) {
+        gtBydel
+        gtKommune
+        gtLand
+        gtType
+    }
+}

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/TestHelper.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.libs.common.person.AdresseType
 import no.nav.etterlatte.libs.common.person.FamilieRelasjon
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.person.FolkeregisterIdent
+import no.nav.etterlatte.libs.common.person.GeografiskTilknytning
 import no.nav.etterlatte.libs.common.person.Utland
 import no.nav.etterlatte.libs.common.person.VergemaalEllerFremtidsfullmakt
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -70,3 +71,5 @@ fun mockPerson(
 )
 
 fun mockFolkeregisterident(fnr: String) = FolkeregisterIdent(Foedselsnummer.of(fnr))
+
+fun mockGeografiskTilknytning() = GeografiskTilknytning(kommune = "0301", ukjent = false)

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/pdl/PdlKlientTest.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/pdl/PdlKlientTest.kt
@@ -88,6 +88,18 @@ internal class PdlKlientTest {
         }
     }
 
+    @Test
+    fun `hentGeografiskTilknytning returnerer geografisk tilknytning`() {
+        mockEndpoint("/pdl/geografisk_tilknytning.json")
+
+        runBlocking {
+            val personResponse = pdlKlient.hentGeografiskTilknytning(STOR_SNERK)
+
+            assertEquals("0301", personResponse.data?.hentGeografiskTilknytning?.gtKommune)
+            assertEquals(PdlGtType.KOMMUNE, personResponse.data?.hentGeografiskTilknytning?.gtType)
+        }
+    }
+
     private fun mockEndpoint(jsonUrl: String) {
         val httpClient = HttpClient(MockEngine) {
             expectSuccess = true

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/pdl/mapper/GeografiskTilknytningMapperTest.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/pdl/mapper/GeografiskTilknytningMapperTest.kt
@@ -1,0 +1,47 @@
+package no.nav.etterlatte.pdl.mapper
+
+import no.nav.etterlatte.libs.common.person.GeografiskTilknytning
+import no.nav.etterlatte.pdl.PdlGeografiskTilknytning
+import no.nav.etterlatte.pdl.PdlGtType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class GeografiskTilknytningMapperTest {
+
+    @ParameterizedTest
+    @MethodSource("valuesForTest")
+    fun testMapper(gtType: PdlGtType?, forventet: GeografiskTilknytning) {
+        val tilknytning = PdlGeografiskTilknytning(
+            gtBydel = "Bydel",
+            gtKommune = "Kommune",
+            gtLand = "Land",
+            gtType = gtType
+        )
+
+        val resultat = GeografiskTilknytningMapper.mapGeografiskTilknytning(tilknytning)
+
+        assertEquals(
+            forventet.geografiskTilknytning(),
+            resultat.geografiskTilknytning()
+        )
+
+        assertEquals(
+            forventet.ukjent,
+            resultat.ukjent
+        )
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun valuesForTest(): List<Arguments> = listOf(
+            Arguments.of(PdlGtType.BYDEL, GeografiskTilknytning(bydel = "Bydel", ukjent = false)),
+            Arguments.of(PdlGtType.KOMMUNE, GeografiskTilknytning(bydel = "Kommune", ukjent = false)),
+            Arguments.of(PdlGtType.UTLAND, GeografiskTilknytning(bydel = "Land", ukjent = false)),
+            Arguments.of(PdlGtType.UDEFINERT, GeografiskTilknytning(ukjent = true)),
+            Arguments.of(null, GeografiskTilknytning())
+        )
+    }
+}

--- a/apps/etterlatte-pdltjenester/src/test/resources/pdl/geografisk_tilknytning.json
+++ b/apps/etterlatte-pdltjenester/src/test/resources/pdl/geografisk_tilknytning.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "hentGeografiskTilknytning": {
+      "gtBydel": null,
+      "gtKommune": "0301",
+      "gtLand": null,
+      "gtType": "KOMMUNE"
+    }
+  }
+}

--- a/libs/common/src/main/kotlin/person/HentGeografiskTilknytningRequest.kt
+++ b/libs/common/src/main/kotlin/person/HentGeografiskTilknytningRequest.kt
@@ -1,0 +1,5 @@
+package no.nav.etterlatte.libs.common.person
+
+data class HentGeografiskTilknytningRequest(
+    val foedselsnummer: Foedselsnummer
+)

--- a/libs/common/src/main/kotlin/person/Person.kt
+++ b/libs/common/src/main/kotlin/person/Person.kt
@@ -140,6 +140,20 @@ data class UtenlandsoppholdOpplysninger(
     val pensjonsutbetaling: String?
 )
 
+data class GeografiskTilknytning(
+    val kommune: String? = null,
+    val bydel: String? = null,
+    val land: String? = null,
+    val ukjent: Boolean = false
+) {
+    fun geografiskTilknytning() = when {
+        bydel != null -> bydel
+        kommune != null -> kommune
+        land != null -> land
+        else -> null
+    }
+}
+
 fun Person.alder(): Int? {
     return foedselsdato?.let { Period.between(foedselsdato, LocalDate.now()).years }
 }


### PR DESCRIPTION
Splitter opp EY-1787 i flere mindre PR'er.

Denne skal kun gi etterlatte-pdltjenester mulighet å hente geografisk tilknytning