### PR TITLE
EY-1787 - steg 3 - behandling kan hente norg2 enhet info

### DIFF
--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -73,6 +73,8 @@ spec:
       value: 8bb9b8d1-f46a-4ade-8ee8-5895eccdf8cf
     - name: AZUREAD_STRENGT_FORTROLIG_GROUPID
       value: 5ef775f2-61f8-4283-bf3d-8d03f428aa14
+    - name: NORG2_URL
+      value: https://norg2.dev-fss-pub.nais.io/norg2/api/v1
   accessPolicy:
     outbound:
       rules:
@@ -82,6 +84,7 @@ spec:
         - application: etterlatte-vedtaksvurdering
       external:
         - host: unleash.nais.io
+        - host: norg2.dev-fss-pub.nais.io
     inbound:
       rules:
         - application: etterlatte-egne-ansatte-lytter

--- a/apps/etterlatte-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-behandling/.nais/prod.yaml
@@ -83,6 +83,8 @@ spec:
       value: 0af3955f-df85-4eb0-b5b2-45bf2c8aeb9e
     - name: AZUREAD_STRENGT_FORTROLIG_GROUPID
       value: ad7b87a6-9180-467c-affc-20a566b0fec0
+    - name: NORG2_URL
+      value: https://norg2.prod-fss-pub.nais.io/norg2/api/v1
   accessPolicy:
     outbound:
       rules:
@@ -92,6 +94,7 @@ spec:
         - application: etterlatte-vedtaksvurdering
       external:
         - host: unleash.nais.io
+        - host: norg2.prod-fss-pub.nais.io
     inbound:
       rules:
         - application: etterlatte-egne-ansatte-lytter

--- a/apps/etterlatte-behandling/build.gradle.kts
+++ b/apps/etterlatte-behandling/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     testImplementation(libs.ktor2.servertests)
     testImplementation(libs.kotlinx.coroutinescore)
     testImplementation(libs.navfelles.mockoauth2server)
+    testImplementation(libs.test.kotest.assertionscore)
     testImplementation(project(":libs:testdata"))
     testImplementation(project(":libs:etterlatte-funksjonsbrytere"))
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ArbeidsFordeling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ArbeidsFordeling.kt
@@ -1,0 +1,14 @@
+package no.nav.etterlatte.behandling.domain
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+data class ArbeidsFordelingRequest(
+    val tema: String,
+    val geografiskOmraade: String
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ArbeidsFordelingEnhet(
+    val navn: String,
+    val enhetNr: String
+)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/Norg2Klient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/Norg2Klient.kt
@@ -1,0 +1,65 @@
+package no.nav.etterlatte.behandling.klienter
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.ResponseException
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.behandling.domain.ArbeidsFordelingEnhet
+import no.nav.etterlatte.behandling.domain.ArbeidsFordelingRequest
+import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
+import no.nav.etterlatte.libs.common.logging.getXCorrelationId
+import org.slf4j.LoggerFactory
+import java.time.Duration
+
+interface Norg2Klient {
+    fun hentEnheterForOmraade(
+        tema: String,
+        omraade: String
+    ): List<ArbeidsFordelingEnhet>
+}
+
+class Norg2KlientImpl(private val client: HttpClient, private val url: String) : Norg2Klient {
+    private val logger = LoggerFactory.getLogger(Norg2KlientImpl::class.java)
+
+    private val cache = Caffeine.newBuilder().expireAfterWrite(Duration.ofMinutes(15))
+        .build<ArbeidsFordelingRequest, List<ArbeidsFordelingEnhet>>()
+
+    override fun hentEnheterForOmraade(tema: String, omraade: String): List<ArbeidsFordelingEnhet> =
+        hentArbeidsfordelingForOmraadeOgTema(ArbeidsFordelingRequest(tema, omraade))
+
+    private fun hentArbeidsfordelingForOmraadeOgTema(request: ArbeidsFordelingRequest): List<ArbeidsFordelingEnhet> =
+        try {
+            val cachedInfo = cache.getIfPresent(request)
+
+            if (cachedInfo != null) {
+                logger.info("Fant cachet enheter for tema ${request.tema} og omraade ${request.geografiskOmraade}")
+                cachedInfo
+            } else {
+                logger.info("Henter enheter for tema og omraade $request")
+
+                runBlocking {
+                    val response = client.post("$url/arbeidsfordeling/enheter/bestmatch") {
+                        header(X_CORRELATION_ID, getXCorrelationId())
+                        header("Nav_Call_Id", getXCorrelationId())
+                        contentType(ContentType.Application.Json)
+                        setBody(request)
+                    }
+
+                    if (response.status.isSuccess()) {
+                        response.body<List<ArbeidsFordelingEnhet>>().also { cache.put(request, it) }
+                    } else {
+                        throw ResponseException(response, "Ukjent feil fra norg2 api")
+                    }
+                }
+            }
+        } catch (exception: Exception) {
+            throw RuntimeException("Feil i kall mot norg2 med tema og omraade: $request", exception)
+        }
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/config/BeanFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/BeanFactory.kt
@@ -15,6 +15,8 @@ import no.nav.etterlatte.behandling.foerstegangsbehandling.RealFoerstegangsbehan
 import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.behandling.klienter.GrunnlagKlient
 import no.nav.etterlatte.behandling.klienter.GrunnlagKlientImpl
+import no.nav.etterlatte.behandling.klienter.Norg2Klient
+import no.nav.etterlatte.behandling.klienter.Norg2KlientImpl
 import no.nav.etterlatte.behandling.klienter.VedtakKlient
 import no.nav.etterlatte.behandling.klienter.VedtakKlientImpl
 import no.nav.etterlatte.behandling.manueltopphoer.ManueltOpphoerService
@@ -85,6 +87,7 @@ interface BeanFactory {
     fun sporingslogg(): Sporingslogg
     fun getSaksbehandlerGroupIdsByKey(): Map<String, String?>
     fun featureToggleService(): FeatureToggleService
+    fun norg2HttpClient(): Norg2Klient
 }
 
 abstract class CommonFactory : BeanFactory {
@@ -284,5 +287,9 @@ class EnvBasedBeanFactory(private val env: Map<String, String>) : CommonFactory(
                 FeatureToggleServiceProperties.CLUSTER.navn to config.getString("funksjonsbrytere.unleash.cluster")
             )
         )
+    }
+
+    override fun norg2HttpClient(): Norg2Klient {
+        return Norg2KlientImpl(httpClient(), env.getValue("NORG2_URL"))
     }
 }

--- a/apps/etterlatte-behandling/src/test/kotlin/BehandlingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/BehandlingIntegrationTest.kt
@@ -12,8 +12,10 @@ import io.ktor.http.fullPath
 import io.ktor.http.headersOf
 import io.ktor.serialization.jackson.JacksonConverter
 import io.ktor.server.config.HoconApplicationConfig
+import no.nav.etterlatte.behandling.domain.ArbeidsFordelingEnhet
 import no.nav.etterlatte.behandling.domain.Foerstegangsbehandling
 import no.nav.etterlatte.behandling.klienter.GrunnlagKlient
+import no.nav.etterlatte.behandling.klienter.Norg2Klient
 import no.nav.etterlatte.behandling.klienter.VedtakKlient
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleServiceProperties
@@ -161,6 +163,12 @@ class GrunnlagKlientTest : GrunnlagKlient {
     }
 }
 
+class Norg2KlientTest : Norg2Klient {
+    override fun hentEnheterForOmraade(tema: String, omraade: String): List<ArbeidsFordelingEnhet> {
+        return listOf(ArbeidsFordelingEnhet("NAV Familie- og pensjonsytelser Steinkjer", "4817"))
+    }
+}
+
 class TestBeanFactory(
     private val jdbcUrl: String,
     private val username: String,
@@ -291,5 +299,9 @@ class TestBeanFactory(
                 FeatureToggleServiceProperties.ENABLED.navn to "false"
             )
         )
+    }
+
+    override fun norg2HttpClient(): Norg2Klient {
+        return Norg2KlientTest()
     }
 }

--- a/apps/etterlatte-behandling/src/test/kotlin/TestApp.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/TestApp.kt
@@ -9,6 +9,7 @@ import io.ktor.http.fullPath
 import io.ktor.http.headersOf
 import io.ktor.serialization.jackson.JacksonConverter
 import no.nav.etterlatte.behandling.klienter.GrunnlagKlient
+import no.nav.etterlatte.behandling.klienter.Norg2Klient
 import no.nav.etterlatte.behandling.klienter.VedtakKlient
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleServiceProperties
@@ -135,5 +136,9 @@ class LocalAppBeanFactory(
                 FeatureToggleServiceProperties.ENABLED.navn to "false"
             )
         )
+    }
+
+    override fun norg2HttpClient(): Norg2Klient {
+        return Norg2KlientTest()
     }
 }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/klienter/Norg2KlientTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/klienter/Norg2KlientTest.kt
@@ -1,0 +1,83 @@
+package no.nav.etterlatte.behandling.klienter
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.ints.shouldBeExactly
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.fullPath
+import io.ktor.http.headersOf
+import io.ktor.serialization.jackson.jackson
+import no.nav.etterlatte.behandling.domain.ArbeidsFordelingEnhet
+import org.junit.jupiter.api.Test
+
+class Norg2KlientTest {
+    private val defaultHeaders = headersOf("Content-Type" to listOf(ContentType.Application.Json.toString()))
+
+    @Test
+    fun `hent best skal returnere en liste av enheter`() {
+        val forventet = """
+            [
+                {
+                  "enhetId": 100000589,
+                  "navn": "NAV Familie- og pensjonsytelser Steinkjer",
+                  "enhetNr": "4817",
+                  "antallRessurser": 0,
+                  "status": "Aktiv",
+                  "orgNivaa": "SPESEN",
+                  "type": "FPY",
+                  "organisasjonsnummer": null,
+                  "underEtableringDato": "1970-01-01",
+                  "aktiveringsdato": "1970-01-01",
+                  "underAvviklingDato": null,
+                  "nedleggelsesdato": null,
+                  "oppgavebehandler": true,
+                  "versjon": 2,
+                  "sosialeTjenester": null,
+                  "kanalstrategi": null,
+                  "orgNrTilKommunaltNavKontor": null
+                }
+            ]
+        """.trimIndent()
+
+        val klient = mockHttpClient(forventet)
+
+        val norg2Klient: Norg2Klient = Norg2KlientImpl(klient, "")
+
+        val resultat = norg2Klient.hentEnheterForOmraade("EYB", "0301")
+
+        resultat.size shouldBeExactly 1
+
+        resultat shouldContainExactly listOf(ArbeidsFordelingEnhet("NAV Familie- og pensjonsytelser Steinkjer", "4817"))
+    }
+
+    private fun mockHttpClient(jsonRespons: String): HttpClient {
+        val httpClient = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.fullPath) {
+                        "/arbeidsfordeling/enheter/bestmatch" -> respond(
+                            jsonRespons,
+                            HttpStatusCode.OK,
+                            defaultHeaders
+                        )
+
+                        else -> error("Unhandled ${request.url.fullPath}")
+                    }
+                }
+            }
+            expectSuccess = true
+            install(ContentNegotiation) {
+                jackson {
+                    registerModule(JavaTimeModule())
+                }
+            }
+        }
+
+        return httpClient
+    }
+}


### PR DESCRIPTION
Splitter opp EY-1787 i flere mindre PR'er.

Denne skal kun gi etterlatte-behandling mulighet å hente enhet fra Norg2