### PR TITLE
EY-1972: Vise regulering som revurderingsårsak til brukaren

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/saksliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/saksliste.tsx
@@ -87,6 +87,8 @@ function mapAarsak(aarsak: AarsaksTyper) {
       return 'Søker er død'
     case AarsaksTyper.SOEKNAD:
       return 'Søknad'
+    case AarsaksTyper.REGULERING:
+      return 'Automatisk regulering'
   }
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/typer.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/typer.tsx
@@ -38,6 +38,7 @@ export enum AarsaksTyper {
   SOEKER_DOD = 'SOEKER_DOD',
   MANUELT_OPPHOER = 'MANUELT_OPPHOER',
   SOEKNAD = 'SOEKNAD',
+  REGULERING = 'REGULERING',
 }
 
 export type GrunnlagsendringsType = SamsvarMellomGrunnlagOgPdl['type']
@@ -91,11 +92,11 @@ export interface AnsvarligeForeldreSamsvar {
 
 export type SamsvarMellomGrunnlagOgPdl = DoedsdatoSamsvar | UtlandSamsvar | BarnSamsvar | AnsvarligeForeldreSamsvar
 
-export type GrunnlagsendringStatus = typeof GRUNNLAGSENDRING_STATUS[number]
+export type GrunnlagsendringStatus = (typeof GRUNNLAGSENDRING_STATUS)[number]
 
 const SAKSROLLER = ['SOEKER', 'INNSENDER', 'SOESKEN', 'AVDOED', 'GJENLEVENDE', 'UKJENT'] as const
 
-export type Saksrolle = typeof SAKSROLLER[number]
+export type Saksrolle = (typeof SAKSROLLER)[number]
 
 export interface GrunnlagsendringsListe {
   hendelser: Grunnlagsendringshendelse[]


### PR DESCRIPTION
Vel i denne omgang å vise teksten som automatisk regulering for alle reguleringar, ut frå den hypotesa vi har per no om at vi kun regulerer automatisk.