### PR TITLE
Tilstandssjekk trygdetid

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
@@ -94,11 +94,12 @@ const hentAktuelleRoutes = (behandling: IBehandlingReducer | null) => {
 function finnRoutesFoerstegangbehandling(behandling: IBehandlingReducer): Array<behandlingRouteTypes> {
   const routes: Array<behandlingRouteTypes> = ['soeknadsoversikt', 'vilkaarsvurdering', 'brev']
   if (behandling.vilkårsprøving?.resultat?.utfall === VilkaarsvurderingResultat.OPPFYLT) {
+    if (behandling.sakType == ISaksType.OMSTILLINGSSTOENAD) {
+      routes.push('trygdetid')
+    }
     routes.push('beregningsgrunnlag')
     routes.push('beregne')
   }
-  if (behandling.sakType == ISaksType.OMSTILLINGSSTOENAD) {
-    routes.push('trygdetid')
-  }
+
   return routes
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
@@ -38,7 +38,7 @@ export const StegMeny = (props: { behandling: IDetaljertBehandling }) => {
       )}
       {behandlingType !== IBehandlingsType.MANUELT_OPPHOER && sakType === ISaksType.OMSTILLINGSSTOENAD && (
         <>
-          <li className={classNames({ disabled: stegErDisabled(IBehandlingStatus.OPPRETTET) })}>
+          <li className={classNames({ disabled: stegErDisabled(IBehandlingStatus.BEREGNET) })}>
             <NavLink to="trygdetid">Trygdetid</NavLink>
           </li>
           <Separator aria-hidden={'true'} />

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
@@ -13,6 +13,7 @@ import io.ktor.server.routing.route
 import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.behandlingsId
 import no.nav.etterlatte.libs.common.withBehandlingId
+import no.nav.etterlatte.libs.ktor.bruker
 import no.nav.etterlatte.trygdetid.klienter.BehandlingKlient
 import java.time.LocalDate
 import java.util.*
@@ -36,7 +37,7 @@ fun Route.trygdetid(trygdetidService: TrygdetidService, behandlingKlient: Behand
         post {
             withBehandlingId(behandlingKlient) {
                 logger.info("Oppretter trygdetid for behandling $behandlingsId")
-                val trygdetid = trygdetidService.opprettTrygdetid(behandlingsId)
+                val trygdetid = trygdetidService.opprettTrygdetid(behandlingsId, bruker)
                 call.respond(trygdetid.toDto())
             }
         }
@@ -46,7 +47,11 @@ fun Route.trygdetid(trygdetidService: TrygdetidService, behandlingKlient: Behand
                 logger.info("Legger til trygdetidsgrunnlag for behandling $behandlingsId")
                 val trygdetidgrunnlagDto = call.receive<TrygdetidGrunnlagDto>()
                 val trygdetid =
-                    trygdetidService.lagreTrygdetidGrunnlag(behandlingsId, trygdetidgrunnlagDto.toTrygdetidGrunnlag())
+                    trygdetidService.lagreTrygdetidGrunnlag(
+                        behandlingsId,
+                        bruker,
+                        trygdetidgrunnlagDto.toTrygdetidGrunnlag()
+                    )
                 call.respond(trygdetid.toDto())
             }
         }
@@ -56,7 +61,11 @@ fun Route.trygdetid(trygdetidService: TrygdetidService, behandlingKlient: Behand
                 logger.info("Oppdaterer beregnet trygdetid for behandling $behandlingsId")
                 val beregnetTrygdetid = call.receive<BeregnetTrygdetidDto>()
                 val trygdetid =
-                    trygdetidService.lagreBeregnetTrygdetid(behandlingsId, beregnetTrygdetid.toBeregnetTrygdetid())
+                    trygdetidService.lagreBeregnetTrygdetid(
+                        behandlingsId,
+                        bruker,
+                        beregnetTrygdetid.toBeregnetTrygdetid()
+                    )
                 call.respond(trygdetid.toDto())
             }
         }

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -39,7 +39,7 @@ class TrygdetidService(
         }
 
     private suspend fun tilstandssjekk(behandlingId: UUID, bruker: Bruker, block: suspend () -> Trygdetid): Trygdetid {
-        val kanFastsetteTrygdetid = behandlingKlient.kanBeregnes(behandlingId, bruker, false)
+        val kanFastsetteTrygdetid = behandlingKlient.kanBeregnes(behandlingId, bruker)
         return if (kanFastsetteTrygdetid) {
             block()
         } else {

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -33,15 +33,11 @@ class TrygdetidService(
         beregnetTrygdetid: BeregnetTrygdetid
     ): Trygdetid =
         tilstandssjekk(behandlingId, bruker) {
-            trygdetidFastsatt(behandlingId, bruker)
             trygdetidRepository.oppdaterBeregnetTrygdetid(behandlingId, beregnetTrygdetid)
         }
 
-    private suspend fun trygdetidFastsatt(behandlingId: UUID, bruker: Bruker) =
-        behandlingKlient.fastsettTrygdetid(behandlingId, bruker, true)
-
     private suspend fun tilstandssjekk(behandlingId: UUID, bruker: Bruker, block: suspend () -> Trygdetid): Trygdetid {
-        val kanFastsetteTrygdetid = behandlingKlient.fastsettTrygdetid(behandlingId, bruker, false)
+        val kanFastsetteTrygdetid = behandlingKlient.beregn(behandlingId, bruker, false)
         return if (kanFastsetteTrygdetid) {
             block()
         } else {

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -24,6 +24,7 @@ class TrygdetidService(
         trygdetidGrunnlag: TrygdetidGrunnlag
     ): Trygdetid =
         tilstandssjekk(behandlingId, bruker) {
+            // TODO hvis status er "forbi" trygdetid bør dette sette tilstand tilbake til trygdetid?
             trygdetidRepository.opprettTrygdetidGrunnlag(behandlingId, trygdetidGrunnlag)
         }
 
@@ -33,11 +34,12 @@ class TrygdetidService(
         beregnetTrygdetid: BeregnetTrygdetid
     ): Trygdetid =
         tilstandssjekk(behandlingId, bruker) {
+            // TODO hvis status er "forbi" trygdetid bør dette sette tilstand tilbake til trygdetid?
             trygdetidRepository.oppdaterBeregnetTrygdetid(behandlingId, beregnetTrygdetid)
         }
 
     private suspend fun tilstandssjekk(behandlingId: UUID, bruker: Bruker, block: suspend () -> Trygdetid): Trygdetid {
-        val kanFastsetteTrygdetid = behandlingKlient.beregn(behandlingId, bruker, false)
+        val kanFastsetteTrygdetid = behandlingKlient.kanBeregnes(behandlingId, bruker, false)
         return if (kanFastsetteTrygdetid) {
             block()
         } else {

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/config/ApplicationContext.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/config/ApplicationContext.kt
@@ -17,5 +17,5 @@ class ApplicationContext {
         password = properties.dbPassword
     )
     val behandlingKlient = BehandlingKlient(config, httpClient())
-    val trygdetidService = TrygdetidService(TrygdetidRepository(dataSource))
+    val trygdetidService = TrygdetidService(TrygdetidRepository(dataSource), behandlingKlient)
 }

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
@@ -45,9 +45,9 @@ class BehandlingKlient(config: Config, httpClient: HttpClient) : BehandlingTilga
         }
     }
 
-    suspend fun beregn(behandlingId: UUID, bruker: Bruker, commit: Boolean): Boolean {
+    suspend fun kanBeregnes(behandlingId: UUID, bruker: Bruker, commit: Boolean): Boolean {
         logger.info("Sjekker om behandling med behandlingId=$behandlingId kan beregnes")
-        val resource = Resource(clientId = clientId, url = "$resourceUrl/behandlinger/$behandlingId/trygdetid")
+        val resource = Resource(clientId = clientId, url = "$resourceUrl/behandlinger/$behandlingId/beregn")
 
         val response = when (commit) {
             false -> downstreamResourceClient.get(resource, bruker)

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
@@ -45,21 +45,17 @@ class BehandlingKlient(config: Config, httpClient: HttpClient) : BehandlingTilga
         }
     }
 
-    suspend fun kanBeregnes(behandlingId: UUID, bruker: Bruker, commit: Boolean): Boolean {
+    suspend fun kanBeregnes(behandlingId: UUID, bruker: Bruker): Boolean {
         logger.info("Sjekker om behandling med behandlingId=$behandlingId kan beregnes")
         val resource = Resource(clientId = clientId, url = "$resourceUrl/behandlinger/$behandlingId/beregn")
 
-        val response = when (commit) {
-            false -> downstreamResourceClient.get(resource, bruker)
-            true -> downstreamResourceClient.post(resource, bruker, "{}")
-        }
-
-        return response.mapBoth(
-            success = { true },
-            failure = {
-                logger.info("Behandling med id $behandlingId kan ikke beregnes, commit=$commit")
-                false
-            }
-        )
+        return downstreamResourceClient.get(resource, bruker)
+            .mapBoth(
+                success = { true },
+                failure = {
+                    logger.info("Behandling med id $behandlingId kan ikke beregnes")
+                    false
+                }
+            )
     }
 }

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
@@ -45,7 +45,7 @@ class BehandlingKlient(config: Config, httpClient: HttpClient) : BehandlingTilga
         }
     }
 
-    suspend fun fastsettTrygdetid(behandlingId: UUID, bruker: Bruker, commit: Boolean): Boolean {
+    suspend fun beregn(behandlingId: UUID, bruker: Bruker, commit: Boolean): Boolean {
         logger.info("Sjekker om behandling med behandlingId=$behandlingId kan beregnes")
         val resource = Resource(clientId = clientId, url = "$resourceUrl/behandlinger/$behandlingId/trygdetid")
 

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.ktorobo.AzureAdClient
 import no.nav.etterlatte.libs.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktorobo.Resource
+import no.nav.etterlatte.token.Bruker
 import no.nav.etterlatte.token.Saksbehandler
 import org.slf4j.LoggerFactory
 import java.util.*
@@ -42,5 +43,23 @@ class BehandlingKlient(config: Config, httpClient: HttpClient) : BehandlingTilga
         } catch (e: Exception) {
             throw BehandlingKlientException("Sjekking av tilgang for behandling feilet", e)
         }
+    }
+
+    suspend fun fastsettTrygdetid(behandlingId: UUID, bruker: Bruker, commit: Boolean): Boolean {
+        logger.info("Sjekker om behandling med behandlingId=$behandlingId kan beregnes")
+        val resource = Resource(clientId = clientId, url = "$resourceUrl/behandlinger/$behandlingId/trygdetid")
+
+        val response = when (commit) {
+            false -> downstreamResourceClient.get(resource, bruker)
+            true -> downstreamResourceClient.post(resource, bruker, "{}")
+        }
+
+        return response.mapBoth(
+            success = { true },
+            failure = {
+                logger.info("Behandling med id $behandlingId kan ikke beregnes, commit=$commit")
+                false
+            }
+        )
     }
 }

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TestHelper.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TestHelper.kt
@@ -1,5 +1,6 @@
 package trygdetid
 
+import no.nav.etterlatte.token.Saksbehandler
 import no.nav.etterlatte.trygdetid.BeregnetTrygdetid
 import no.nav.etterlatte.trygdetid.Trygdetid
 import no.nav.etterlatte.trygdetid.TrygdetidGrunnlag
@@ -8,6 +9,8 @@ import no.nav.etterlatte.trygdetid.TrygdetidType
 import java.time.LocalDate
 import java.util.*
 import java.util.UUID.randomUUID
+
+val saksbehandler = Saksbehandler("token", "ident")
 
 fun trygdetid(behandlingId: UUID = randomUUID(), beregnetTrygdetid: BeregnetTrygdetid? = null) = Trygdetid(
     id = randomUUID(),

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TestHelper.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TestHelper.kt
@@ -1,14 +1,23 @@
 package trygdetid
 
 import no.nav.etterlatte.trygdetid.BeregnetTrygdetid
+import no.nav.etterlatte.trygdetid.Trygdetid
 import no.nav.etterlatte.trygdetid.TrygdetidGrunnlag
 import no.nav.etterlatte.trygdetid.TrygdetidPeriode
 import no.nav.etterlatte.trygdetid.TrygdetidType
 import java.time.LocalDate
 import java.util.*
+import java.util.UUID.randomUUID
+
+fun trygdetid(behandlingId: UUID = randomUUID(), beregnetTrygdetid: BeregnetTrygdetid? = null) = Trygdetid(
+    id = randomUUID(),
+    behandlingId = behandlingId,
+    trygdetidGrunnlag = emptyList(),
+    beregnetTrygdetid = beregnetTrygdetid
+)
 
 fun trygdetidGrunnlag(trygdetidId: UUID) = TrygdetidGrunnlag(
-    id = UUID.randomUUID(),
+    id = randomUUID(),
     type = TrygdetidType.NASJONAL,
     bosted = "Norge",
     periode = TrygdetidPeriode(

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
@@ -1,0 +1,183 @@
+package trygdetid
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.token.Saksbehandler
+import no.nav.etterlatte.trygdetid.TrygdetidRepository
+import no.nav.etterlatte.trygdetid.TrygdetidService
+import no.nav.etterlatte.trygdetid.klienter.BehandlingKlient
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID.randomUUID
+
+internal class TrygdetidServiceTest {
+
+    private val repository: TrygdetidRepository = mockk()
+    private val behandlingKlient: BehandlingKlient = mockk()
+    private val service = TrygdetidService(repository, behandlingKlient)
+
+    @BeforeEach
+    fun beforeEach() {
+        coEvery { behandlingKlient.fastsettTrygdetid(any(), any(), false) } returns true
+    }
+
+    @AfterEach
+    fun afterEach() {
+        confirmVerified()
+    }
+
+    @Test
+    fun `skal hente trygdetid`() {
+        val behandlingId = randomUUID()
+        every { repository.hentTrygdetid(any()) } returns trygdetid(behandlingId)
+
+        val trygdetid = service.hentTrygdetid(behandlingId)
+
+        trygdetid shouldNotBe null
+    }
+
+    @Test
+    fun `skal returnere null hvis trygdetid ikke finnes for behandling`() {
+        val behandlingId = randomUUID()
+        every { repository.hentTrygdetid(any()) } returns null
+
+        val trygdetid = service.hentTrygdetid(behandlingId)
+
+        trygdetid shouldBe null
+    }
+
+    @Test
+    fun `skal opprette trygdetid`() {
+        val behandlingId = randomUUID()
+        every { repository.hentTrygdetid(any()) } returns null
+        every { repository.opprettTrygdetid(any()) } returns trygdetid(behandlingId)
+
+        runBlocking {
+            service.opprettTrygdetid(behandlingId, Saksbehandler("token", "ident"))
+        }
+
+        verify { repository.hentTrygdetid(any()) }
+        verify { repository.opprettTrygdetid(any()) }
+        coVerify { behandlingKlient.fastsettTrygdetid(any(), any(), any()) }
+    }
+
+    @Test
+    fun `skal feile ved opprettelse av trygdetid naar det allerede finnes for behandling`() {
+        val behandlingId = randomUUID()
+        every { repository.hentTrygdetid(any()) } returns trygdetid(behandlingId)
+
+        runBlocking {
+            assertThrows<IllegalArgumentException> {
+                service.opprettTrygdetid(behandlingId, Saksbehandler("token", "ident"))
+            }
+        }
+
+        verify { repository.hentTrygdetid(any()) }
+        coVerify { behandlingKlient.fastsettTrygdetid(any(), any(), any()) }
+    }
+
+    @Test
+    fun `skal feile ved opprettelse av trygdetid dersom behandling er i feil tilstand`() {
+        val behandlingId = randomUUID()
+        coEvery { behandlingKlient.fastsettTrygdetid(any(), any(), false) } returns false
+
+        runBlocking {
+            assertThrows<Exception> {
+                service.opprettTrygdetid(behandlingId, Saksbehandler("token", "ident"))
+            }
+        }
+
+        coVerify { behandlingKlient.fastsettTrygdetid(any(), any(), any()) }
+    }
+
+    @Test
+    fun `skal lagre trygdetidsgrunnlag`() {
+        val behandlingId = randomUUID()
+        val trygdetid = trygdetid(behandlingId)
+        val trygdetidGrunnlag = trygdetidGrunnlag(trygdetid.id)
+        every { repository.opprettTrygdetidGrunnlag(any(), any()) } returns trygdetid(behandlingId)
+
+        runBlocking {
+            service.lagreTrygdetidGrunnlag(
+                behandlingId,
+                Saksbehandler("token", "ident"),
+                trygdetidGrunnlag
+            )
+        }
+
+        coVerify { behandlingKlient.fastsettTrygdetid(any(), any(), any()) }
+        coVerify { repository.opprettTrygdetidGrunnlag(any(), any()) }
+    }
+
+    @Test
+    fun `skal feile ved lagring av trygdetidsgrunnlag hvis behandling er i feil tilstand`() {
+        val behandlingId = randomUUID()
+        val trygdetid = trygdetid(behandlingId)
+        val trygdetidGrunnlag = trygdetidGrunnlag(trygdetid.id)
+        coEvery { behandlingKlient.fastsettTrygdetid(any(), any(), false) } returns false
+
+        runBlocking {
+            assertThrows<Exception> {
+                service.lagreTrygdetidGrunnlag(
+                    behandlingId,
+                    Saksbehandler("token", "ident"),
+                    trygdetidGrunnlag
+                )
+            }
+        }
+
+        coVerify { behandlingKlient.fastsettTrygdetid(any(), any(), any()) }
+    }
+
+    @Test
+    fun `skal lagre beregnet trygdetid`() {
+        val behandlingId = randomUUID()
+        val beregnetTrygdetid = beregnetTrygdetid(10, 10, 20)
+        every { repository.oppdaterBeregnetTrygdetid(any(), any()) } returns trygdetid(behandlingId, beregnetTrygdetid)
+        coEvery { behandlingKlient.fastsettTrygdetid(any(), any(), true) } returns true
+
+        runBlocking {
+            service.lagreBeregnetTrygdetid(
+                behandlingId,
+                Saksbehandler("token", "ident"),
+                beregnetTrygdetid
+            )
+        }
+        coVerifyOrder {
+            behandlingKlient.fastsettTrygdetid(any(), any(), false)
+            behandlingKlient.fastsettTrygdetid(any(), any(), true)
+            repository.oppdaterBeregnetTrygdetid(any(), any())
+        }
+    }
+
+    @Test
+    fun `skal feile ved lagring av beregnet trygdetid hvis behandling er i feil tilstand`() {
+        val behandlingId = randomUUID()
+        val beregnetTrygdetid = beregnetTrygdetid(10, 10, 20)
+        coEvery { behandlingKlient.fastsettTrygdetid(any(), any(), false) } returns false
+
+        runBlocking {
+            assertThrows<Exception> {
+                service.lagreBeregnetTrygdetid(
+                    behandlingId,
+                    Saksbehandler("token", "ident"),
+                    beregnetTrygdetid
+                )
+            }
+        }
+
+        coVerify {
+            behandlingKlient.fastsettTrygdetid(any(), any(), false)
+        }
+    }
+}

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
@@ -2,9 +2,9 @@ package trygdetid
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.coVerifyOrder
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
@@ -28,6 +28,7 @@ internal class TrygdetidServiceTest {
 
     @BeforeEach
     fun beforeEach() {
+        clearAllMocks()
         coEvery { behandlingKlient.fastsettTrygdetid(any(), any(), false) } returns true
     }
 
@@ -44,6 +45,8 @@ internal class TrygdetidServiceTest {
         val trygdetid = service.hentTrygdetid(behandlingId)
 
         trygdetid shouldNotBe null
+
+        verify(exactly = 1) { repository.hentTrygdetid(any()) }
     }
 
     @Test
@@ -54,6 +57,8 @@ internal class TrygdetidServiceTest {
         val trygdetid = service.hentTrygdetid(behandlingId)
 
         trygdetid shouldBe null
+
+        verify(exactly = 1) { repository.hentTrygdetid(any()) }
     }
 
     @Test
@@ -66,9 +71,11 @@ internal class TrygdetidServiceTest {
             service.opprettTrygdetid(behandlingId, Saksbehandler("token", "ident"))
         }
 
-        verify { repository.hentTrygdetid(any()) }
-        verify { repository.opprettTrygdetid(any()) }
-        coVerify { behandlingKlient.fastsettTrygdetid(any(), any(), any()) }
+        coVerify(exactly = 1) {
+            behandlingKlient.fastsettTrygdetid(any(), any(), any())
+            repository.hentTrygdetid(any())
+            repository.opprettTrygdetid(any())
+        }
     }
 
     @Test
@@ -82,8 +89,10 @@ internal class TrygdetidServiceTest {
             }
         }
 
-        verify { repository.hentTrygdetid(any()) }
-        coVerify { behandlingKlient.fastsettTrygdetid(any(), any(), any()) }
+        coVerify(exactly = 1) {
+            repository.hentTrygdetid(any())
+            behandlingKlient.fastsettTrygdetid(any(), any(), any())
+        }
     }
 
     @Test
@@ -97,7 +106,7 @@ internal class TrygdetidServiceTest {
             }
         }
 
-        coVerify { behandlingKlient.fastsettTrygdetid(any(), any(), any()) }
+        coVerify(exactly = 1) { behandlingKlient.fastsettTrygdetid(any(), any(), any()) }
     }
 
     @Test
@@ -115,8 +124,10 @@ internal class TrygdetidServiceTest {
             )
         }
 
-        coVerify { behandlingKlient.fastsettTrygdetid(any(), any(), any()) }
-        coVerify { repository.opprettTrygdetidGrunnlag(any(), any()) }
+        coVerify(exactly = 1) {
+            behandlingKlient.fastsettTrygdetid(any(), any(), any())
+            repository.opprettTrygdetidGrunnlag(any(), any())
+        }
     }
 
     @Test
@@ -153,7 +164,7 @@ internal class TrygdetidServiceTest {
                 beregnetTrygdetid
             )
         }
-        coVerifyOrder {
+        coVerify(exactly = 1) {
             behandlingKlient.fastsettTrygdetid(any(), any(), false)
             behandlingKlient.fastsettTrygdetid(any(), any(), true)
             repository.oppdaterBeregnetTrygdetid(any(), any())
@@ -176,7 +187,7 @@ internal class TrygdetidServiceTest {
             }
         }
 
-        coVerify {
+        coVerify(exactly = 1) {
             behandlingKlient.fastsettTrygdetid(any(), any(), false)
         }
     }

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
@@ -29,7 +29,7 @@ internal class TrygdetidServiceTest {
     @BeforeEach
     fun beforeEach() {
         clearAllMocks()
-        coEvery { behandlingKlient.beregn(any(), any(), false) } returns true
+        coEvery { behandlingKlient.kanBeregnes(any(), any(), false) } returns true
     }
 
     @AfterEach
@@ -72,7 +72,7 @@ internal class TrygdetidServiceTest {
         }
 
         coVerify(exactly = 1) {
-            behandlingKlient.beregn(any(), any(), any())
+            behandlingKlient.kanBeregnes(any(), any(), any())
             repository.hentTrygdetid(any())
             repository.opprettTrygdetid(any())
         }
@@ -91,14 +91,14 @@ internal class TrygdetidServiceTest {
 
         coVerify(exactly = 1) {
             repository.hentTrygdetid(any())
-            behandlingKlient.beregn(any(), any(), any())
+            behandlingKlient.kanBeregnes(any(), any(), any())
         }
     }
 
     @Test
     fun `skal feile ved opprettelse av trygdetid dersom behandling er i feil tilstand`() {
         val behandlingId = randomUUID()
-        coEvery { behandlingKlient.beregn(any(), any(), false) } returns false
+        coEvery { behandlingKlient.kanBeregnes(any(), any(), false) } returns false
 
         runBlocking {
             assertThrows<Exception> {
@@ -106,7 +106,7 @@ internal class TrygdetidServiceTest {
             }
         }
 
-        coVerify(exactly = 1) { behandlingKlient.beregn(any(), any(), any()) }
+        coVerify(exactly = 1) { behandlingKlient.kanBeregnes(any(), any(), any()) }
     }
 
     @Test
@@ -125,7 +125,7 @@ internal class TrygdetidServiceTest {
         }
 
         coVerify(exactly = 1) {
-            behandlingKlient.beregn(any(), any(), any())
+            behandlingKlient.kanBeregnes(any(), any(), any())
             repository.opprettTrygdetidGrunnlag(any(), any())
         }
     }
@@ -135,7 +135,7 @@ internal class TrygdetidServiceTest {
         val behandlingId = randomUUID()
         val trygdetid = trygdetid(behandlingId)
         val trygdetidGrunnlag = trygdetidGrunnlag(trygdetid.id)
-        coEvery { behandlingKlient.beregn(any(), any(), false) } returns false
+        coEvery { behandlingKlient.kanBeregnes(any(), any(), false) } returns false
 
         runBlocking {
             assertThrows<Exception> {
@@ -147,7 +147,7 @@ internal class TrygdetidServiceTest {
             }
         }
 
-        coVerify { behandlingKlient.beregn(any(), any(), any()) }
+        coVerify { behandlingKlient.kanBeregnes(any(), any(), any()) }
     }
 
     @Test
@@ -155,7 +155,6 @@ internal class TrygdetidServiceTest {
         val behandlingId = randomUUID()
         val beregnetTrygdetid = beregnetTrygdetid(10, 10, 20)
         every { repository.oppdaterBeregnetTrygdetid(any(), any()) } returns trygdetid(behandlingId, beregnetTrygdetid)
-        coEvery { behandlingKlient.beregn(any(), any(), true) } returns true
 
         runBlocking {
             service.lagreBeregnetTrygdetid(
@@ -165,8 +164,7 @@ internal class TrygdetidServiceTest {
             )
         }
         coVerify(exactly = 1) {
-            behandlingKlient.beregn(any(), any(), false)
-            behandlingKlient.beregn(any(), any(), true)
+            behandlingKlient.kanBeregnes(any(), any(), false)
             repository.oppdaterBeregnetTrygdetid(any(), any())
         }
     }
@@ -175,7 +173,7 @@ internal class TrygdetidServiceTest {
     fun `skal feile ved lagring av beregnet trygdetid hvis behandling er i feil tilstand`() {
         val behandlingId = randomUUID()
         val beregnetTrygdetid = beregnetTrygdetid(10, 10, 20)
-        coEvery { behandlingKlient.beregn(any(), any(), false) } returns false
+        coEvery { behandlingKlient.kanBeregnes(any(), any(), false) } returns false
 
         runBlocking {
             assertThrows<Exception> {
@@ -188,7 +186,7 @@ internal class TrygdetidServiceTest {
         }
 
         coVerify(exactly = 1) {
-            behandlingKlient.beregn(any(), any(), false)
+            behandlingKlient.kanBeregnes(any(), any(), false)
         }
     }
 }

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
@@ -29,7 +29,7 @@ internal class TrygdetidServiceTest {
     @BeforeEach
     fun beforeEach() {
         clearAllMocks()
-        coEvery { behandlingKlient.fastsettTrygdetid(any(), any(), false) } returns true
+        coEvery { behandlingKlient.beregn(any(), any(), false) } returns true
     }
 
     @AfterEach
@@ -72,7 +72,7 @@ internal class TrygdetidServiceTest {
         }
 
         coVerify(exactly = 1) {
-            behandlingKlient.fastsettTrygdetid(any(), any(), any())
+            behandlingKlient.beregn(any(), any(), any())
             repository.hentTrygdetid(any())
             repository.opprettTrygdetid(any())
         }
@@ -91,14 +91,14 @@ internal class TrygdetidServiceTest {
 
         coVerify(exactly = 1) {
             repository.hentTrygdetid(any())
-            behandlingKlient.fastsettTrygdetid(any(), any(), any())
+            behandlingKlient.beregn(any(), any(), any())
         }
     }
 
     @Test
     fun `skal feile ved opprettelse av trygdetid dersom behandling er i feil tilstand`() {
         val behandlingId = randomUUID()
-        coEvery { behandlingKlient.fastsettTrygdetid(any(), any(), false) } returns false
+        coEvery { behandlingKlient.beregn(any(), any(), false) } returns false
 
         runBlocking {
             assertThrows<Exception> {
@@ -106,7 +106,7 @@ internal class TrygdetidServiceTest {
             }
         }
 
-        coVerify(exactly = 1) { behandlingKlient.fastsettTrygdetid(any(), any(), any()) }
+        coVerify(exactly = 1) { behandlingKlient.beregn(any(), any(), any()) }
     }
 
     @Test
@@ -125,7 +125,7 @@ internal class TrygdetidServiceTest {
         }
 
         coVerify(exactly = 1) {
-            behandlingKlient.fastsettTrygdetid(any(), any(), any())
+            behandlingKlient.beregn(any(), any(), any())
             repository.opprettTrygdetidGrunnlag(any(), any())
         }
     }
@@ -135,7 +135,7 @@ internal class TrygdetidServiceTest {
         val behandlingId = randomUUID()
         val trygdetid = trygdetid(behandlingId)
         val trygdetidGrunnlag = trygdetidGrunnlag(trygdetid.id)
-        coEvery { behandlingKlient.fastsettTrygdetid(any(), any(), false) } returns false
+        coEvery { behandlingKlient.beregn(any(), any(), false) } returns false
 
         runBlocking {
             assertThrows<Exception> {
@@ -147,7 +147,7 @@ internal class TrygdetidServiceTest {
             }
         }
 
-        coVerify { behandlingKlient.fastsettTrygdetid(any(), any(), any()) }
+        coVerify { behandlingKlient.beregn(any(), any(), any()) }
     }
 
     @Test
@@ -155,7 +155,7 @@ internal class TrygdetidServiceTest {
         val behandlingId = randomUUID()
         val beregnetTrygdetid = beregnetTrygdetid(10, 10, 20)
         every { repository.oppdaterBeregnetTrygdetid(any(), any()) } returns trygdetid(behandlingId, beregnetTrygdetid)
-        coEvery { behandlingKlient.fastsettTrygdetid(any(), any(), true) } returns true
+        coEvery { behandlingKlient.beregn(any(), any(), true) } returns true
 
         runBlocking {
             service.lagreBeregnetTrygdetid(
@@ -165,8 +165,8 @@ internal class TrygdetidServiceTest {
             )
         }
         coVerify(exactly = 1) {
-            behandlingKlient.fastsettTrygdetid(any(), any(), false)
-            behandlingKlient.fastsettTrygdetid(any(), any(), true)
+            behandlingKlient.beregn(any(), any(), false)
+            behandlingKlient.beregn(any(), any(), true)
             repository.oppdaterBeregnetTrygdetid(any(), any())
         }
     }
@@ -175,7 +175,7 @@ internal class TrygdetidServiceTest {
     fun `skal feile ved lagring av beregnet trygdetid hvis behandling er i feil tilstand`() {
         val behandlingId = randomUUID()
         val beregnetTrygdetid = beregnetTrygdetid(10, 10, 20)
-        coEvery { behandlingKlient.fastsettTrygdetid(any(), any(), false) } returns false
+        coEvery { behandlingKlient.beregn(any(), any(), false) } returns false
 
         runBlocking {
             assertThrows<Exception> {
@@ -188,7 +188,7 @@ internal class TrygdetidServiceTest {
         }
 
         coVerify(exactly = 1) {
-            behandlingKlient.fastsettTrygdetid(any(), any(), false)
+            behandlingKlient.beregn(any(), any(), false)
         }
     }
 }


### PR DESCRIPTION
Sjekker nå at en behandling er i en tilstand hvor den kan beregnes. Det betyr også at det vil være mulig å legge til trygdetid.

Må se litt videre på hvordan vi skal løse eventuelle problemer som oppstår når man har gjort en beregning, men går tilbake og endrer trygdetid. Da må vi tvinge en ny runde gjennom beregning (altså sette status tilbake til VILKAARSVURDERT). Egen oppgave for dette: https://jira.adeo.no/browse/EY-1997