### PR TITLE
EY-1973 Sikre annen respons ved 403 Forbidden på journalposter

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/DokumentRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/DokumentRoute.kt
@@ -19,8 +19,13 @@ fun Route.dokumentRoute(safService: SafService, behandlingKlient: BehandlingKlie
             val foedselsnummerDTO = call.receive<FoedselsnummerDTO>()
             val fnr = foedselsnummerDTO.foedselsnummer
             withFoedselsnummer(fnr, behandlingKlient) { foedselsnummer ->
-                val innhold = safService.hentDokumenter(foedselsnummer.value, BrukerIdType.FNR, bruker.accessToken())
-                call.respond(innhold)
+                val result = safService.hentDokumenter(foedselsnummer.value, BrukerIdType.FNR, bruker)
+
+                if (result.error == null) {
+                    call.respond(result.journalposter)
+                } else {
+                    call.respond(result.error.statusCode, result.error.message)
+                }
             }
         }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/Model.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/Model.kt
@@ -1,6 +1,17 @@
 package no.nav.etterlatte.brev.dokument
 
+import io.ktor.http.HttpStatusCode
 import no.nav.etterlatte.brev.journalpost.BrukerIdType
+
+data class HentJournalposterResult(
+    val journalposter: List<Journalpost> = emptyList(),
+    val error: Error? = null
+) {
+    data class Error(
+        val statusCode: HttpStatusCode = HttpStatusCode.InternalServerError,
+        val message: String
+    )
+}
 
 data class JournalpostResponse(
     val data: DokumentoversiktBruker? = null,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafService.kt
@@ -1,9 +1,10 @@
 package no.nav.etterlatte.brev.dokument
 
 import no.nav.etterlatte.brev.journalpost.BrukerIdType
+import no.nav.etterlatte.token.Bruker
 
 interface SafService {
-    suspend fun hentDokumenter(fnr: String, idType: BrukerIdType, accessToken: String): JournalpostResponse
+    suspend fun hentDokumenter(fnr: String, idType: BrukerIdType, bruker: Bruker): HentJournalposterResult
 
     suspend fun hentDokumentPDF(
         journalpostId: String,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/dokument/DokumentRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/dokument/DokumentRouteTest.kt
@@ -20,7 +20,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
-import no.nav.etterlatte.brev.dokument.JournalpostResponse
+import no.nav.etterlatte.brev.dokument.HentJournalposterResult
 import no.nav.etterlatte.brev.dokument.SafClient
 import no.nav.etterlatte.brev.dokument.dokumentRoute
 import no.nav.etterlatte.brev.journalpost.BrukerIdType
@@ -63,7 +63,7 @@ internal class DokumentRouteTest {
 
     @Test
     fun `Endepunkt for uthenting av alle dokumenter tilknyttet brukeren`() {
-        coEvery { journalpostService.hentDokumenter(any(), any(), any()) } returns JournalpostResponse(null, null)
+        coEvery { journalpostService.hentDokumenter(any(), any(), any()) } returns HentJournalposterResult()
         coEvery { behandlingKlient.harTilgangTilPerson(any(), any()) } returns true
 
         val token = accessToken
@@ -95,7 +95,7 @@ internal class DokumentRouteTest {
             assertEquals(HttpStatusCode.OK, response.status)
         }
 
-        coVerify(exactly = 1) { journalpostService.hentDokumenter(fnr, BrukerIdType.FNR, token) }
+        coVerify(exactly = 1) { journalpostService.hentDokumenter(fnr, BrukerIdType.FNR, any()) }
     }
 
     @Test

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Brev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Brev.tsx
@@ -57,7 +57,7 @@ export const Brev = (props: { behandling: IDetaljertBehandling }) => {
 
     hentDokumenter(fnr)
       .then((res) => {
-        if (res.status === 'ok') setInnkommendeBrevListe(res.data.data.dokumentoversiktBruker.journalposter)
+        if (res.status === 'ok') setInnkommendeBrevListe(res.data)
         else throw Error(res.error)
       })
       .catch(() => setInnkommendeError(true))

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/types.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/types.ts
@@ -11,15 +11,6 @@ export enum PersonStatus {
   ETTERLATT = 'Etterlatt',
 }
 
-export interface JournalpostResponse {
-  data: {
-    dokumentoversiktBruker: {
-      journalposter: Journalpost[]
-    }
-  }
-  errors: any
-}
-
 export interface Journalpost {
   journalpostId: string
   tittel: string

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumentoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumentoversikt.tsx
@@ -19,7 +19,7 @@ export const Dokumentoversikt = (props: { fnr: string; liten?: boolean }) => {
       const res = await hentDokumenter(props.fnr)
 
       if (res.status === 'ok') {
-        setDokumenter(res.data.data.dokumentoversiktBruker.journalposter)
+        setDokumenter(res.data)
         setDokumenterHentet(true)
       } else {
         setError(true)

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/dokument.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/dokument.ts
@@ -1,7 +1,7 @@
-import { JournalpostResponse } from '~components/behandling/types'
+import { Journalpost } from '~components/behandling/types'
 import { apiClient, ApiResponse } from './apiClient'
 
-export const hentDokumenter = async (fnr: string): Promise<ApiResponse<JournalpostResponse>> =>
+export const hentDokumenter = async (fnr: string): Promise<ApiResponse<Journalpost[]>> =>
   apiClient.post(`/dokumenter`, { foedselsnummer: fnr })
 
 export const hentDokumentPDF = async (journalpostId: string, dokumentInfoId: string): Promise<ApiResponse<Blob>> =>


### PR DESCRIPTION
Bare en kjapp fiks for å fjerne 403 error fra loggene. Skal justeres litt mer, men må se hva vi får i respons først siden objektet vi har i dag tydeligvis ikke håndterer 403 error. 