### PR TITLE
EY-1962: Bruke nais-deploy-action og Google Artifactory Registry

### DIFF
--- a/.github/workflows/.build.yaml
+++ b/.github/workflows/.build.yaml
@@ -11,6 +11,9 @@ jobs:
   build-and-publish:
     name: Build & publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     env:
       image: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
       branch-image: ghcr.io/${{ github.repository }}/${{ github.workflow }}

--- a/.github/workflows/.build.yaml
+++ b/.github/workflows/.build.yaml
@@ -41,7 +41,7 @@ jobs:
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           dockerfile: docker/Dockerfile
           docker_context: apps/${{ github.workflow }}/
-          image_suffix: etterlatte-${{ github.workflow }}
+          image_suffix: -${{ github.workflow }}
           tag: ${{ env.GITHUB_REF_SLUG }}
       - name: Print docker tag
         run: echo 'Docker-tag er ${{ steps.docker-build-push.outputs.image }} ' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/.build.yaml
+++ b/.github/workflows/.build.yaml
@@ -41,7 +41,7 @@ jobs:
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           image_suffix: demo
           dockerfile: docker/Dockerfile
-          docker-context: apps/${{ github.workflow }}
+          docker_context: apps/${{ github.workflow }}
           tag: ${{ env.branch-image }}:${{ env.GITHUB_REF_SLUG }}
       - name: Print docker tag
         run: echo 'Docker-tag er ${{ steps.docker-build-push.outputs.image }} ' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/.build.yaml
+++ b/.github/workflows/.build.yaml
@@ -14,9 +14,6 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    env:
-      image: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-      branch-image: ghcr.io/${{ github.repository }}/${{ github.workflow }}
     outputs:
       image: ${{ steps.docker-build-push.outputs.image }}
     steps:
@@ -44,6 +41,7 @@ jobs:
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           dockerfile: docker/Dockerfile
           docker_context: apps/${{ github.workflow }}/
+          image_suffix: etterlatte-${{ github.workflow }}
           tag: ${{ env.GITHUB_REF_SLUG }}
       - name: Print docker tag
         run: echo 'Docker-tag er ${{ steps.docker-build-push.outputs.image }} ' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/.build.yaml
+++ b/.github/workflows/.build.yaml
@@ -41,7 +41,7 @@ jobs:
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           dockerfile: docker/Dockerfile
           docker_context: apps/${{ github.workflow }}/
-          image_suffix: -${{ github.workflow }}
+          image_suffix: ${{ github.workflow }}
           tag: ${{ env.GITHUB_REF_SLUG }}
       - name: Print docker tag
         run: echo 'Docker-tag er ${{ steps.docker-build-push.outputs.image }} ' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/.build.yaml
+++ b/.github/workflows/.build.yaml
@@ -44,7 +44,7 @@ jobs:
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           dockerfile: docker/Dockerfile
           docker_context: apps/${{ github.workflow }}/
-          tag: ${{ env.branch-image }}:${{ env.GITHUB_REF_SLUG }}
+          tag: ${{ env.GITHUB_REF_SLUG }}
       - name: Print docker tag
         run: echo 'Docker-tag er ${{ steps.docker-build-push.outputs.image }} ' >> $GITHUB_STEP_SUMMARY
   snyk:

--- a/.github/workflows/.build.yaml
+++ b/.github/workflows/.build.yaml
@@ -43,7 +43,7 @@ jobs:
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           dockerfile: docker/Dockerfile
-          docker_context: apps/${{ github.workflow }}
+          docker_context: apps/${{ github.workflow }}/
           tag: ${{ env.branch-image }}:${{ env.GITHUB_REF_SLUG }}
       - name: Print docker tag
         run: echo 'Docker-tag er ${{ steps.docker-build-push.outputs.image }} ' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/.build.yaml
+++ b/.github/workflows/.build.yaml
@@ -15,7 +15,7 @@ jobs:
       image: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
       branch-image: ghcr.io/${{ github.repository }}/${{ github.workflow }}
     outputs:
-      image: ${{ env.image }}
+      image: ${{ steps.docker-build-push.outputs.image }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -31,16 +31,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew :apps:${{ github.workflow }}:build
+
       - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${{ env.image }} --tag ${{ env.branch-image }}:${{ env.GITHUB_REF_SLUG }} -f docker/Dockerfile apps/${{ github.workflow }}
-          docker push ${{ env.image }}
-          docker push ${{ env.branch-image }}:${{ env.GITHUB_REF_SLUG }}
+        uses: nais/docker-build-push@v0
+        id: docker-build-push
+        with:
+          team: etterlatte
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+          image_suffix: demo
+          dockerfile: docker/Dockerfile
+          docker-context: apps/${{ github.workflow }}
+          tag: ${{ env.branch-image }}:${{ env.GITHUB_REF_SLUG }}
       - name: Print docker tag
-        run: echo 'Docker-tag er ${{ env.image }} ' >> $GITHUB_STEP_SUMMARY
+        run: echo 'Docker-tag er ${{ steps.docker-build-push.outputs.image }} ' >> $GITHUB_STEP_SUMMARY
   snyk:
     name: Snyk
     runs-on: ubuntu-latest

--- a/.github/workflows/.build.yaml
+++ b/.github/workflows/.build.yaml
@@ -42,7 +42,6 @@ jobs:
           team: etterlatte
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
-          image_suffix: demo
           dockerfile: docker/Dockerfile
           docker_context: apps/${{ github.workflow }}
           tag: ${{ env.branch-image }}:${{ env.GITHUB_REF_SLUG }}

--- a/.github/workflows/.deploy-main-prod.yaml
+++ b/.github/workflows/.deploy-main-prod.yaml
@@ -9,7 +9,7 @@ on:
         type: string
 
 env:
-  image: ghcr.io/${{ github.repository }}/etterlatte-${{ inputs.applikasjon }}:main
+  image: europe-north1-docker.pkg.dev/nais-management-233d/etterlatte/${{ github.repository }}-etterlatte-${{ inputs.applikasjon }}:main
 
 jobs:
   deploy-main:

--- a/.github/workflows/.deploy-main.yaml
+++ b/.github/workflows/.deploy-main.yaml
@@ -9,7 +9,7 @@ on:
         type: string
 
 env:
-  image: ghcr.io/${{ github.repository }}/etterlatte-${{ inputs.applikasjon }}:main
+  image: europe-north1-docker.pkg.dev/nais-management-233d/etterlatte/${{ github.repository }}-etterlatte-${{ inputs.applikasjon }}:main
 
 jobs:
   deploy-main:

--- a/.github/workflows/.deploy.yaml
+++ b/.github/workflows/.deploy.yaml
@@ -7,25 +7,8 @@ on:
         description: 'Lenke til docker image'
         required: true
         type: string
-      labs:
-        description: 'Om appen skal deployes til labs-gcp (default er false)'
-        required: false
-        type: boolean
 
 jobs:
-  deploy-to-labs-gcp:
-    name: labs-gcp
-    if: ${{ inputs.labs == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: labs-gcp
-          RESOURCE: apps/${{ github.workflow }}/.nais/labs.yaml
-          VAR: image=${{ inputs.image }}
-
   deploy-to-dev-gcp:
     name: dev-gcp
     runs-on: ubuntu-latest

--- a/.github/workflows/app-etterlatte-behandling.yaml
+++ b/.github/workflows/app-etterlatte-behandling.yaml
@@ -56,6 +56,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-beregning-kafka.yaml
+++ b/.github/workflows/app-etterlatte-beregning-kafka.yaml
@@ -39,6 +39,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-beregning.yaml
+++ b/.github/workflows/app-etterlatte-beregning.yaml
@@ -50,6 +50,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-brev-api.yaml
+++ b/.github/workflows/app-etterlatte-brev-api.yaml
@@ -48,6 +48,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-egne-ansatte-lytter.yaml
+++ b/.github/workflows/app-etterlatte-egne-ansatte-lytter.yaml
@@ -38,6 +38,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-fordeler.yaml
+++ b/.github/workflows/app-etterlatte-fordeler.yaml
@@ -40,6 +40,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-grunnlag.yaml
+++ b/.github/workflows/app-etterlatte-grunnlag.yaml
@@ -48,6 +48,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-gyldig-soeknad.yaml
+++ b/.github/workflows/app-etterlatte-gyldig-soeknad.yaml
@@ -40,6 +40,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-hendelser-pdl.yaml
+++ b/.github/workflows/app-etterlatte-hendelser-pdl.yaml
@@ -40,6 +40,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-oppdater-behandling.yaml
+++ b/.github/workflows/app-etterlatte-oppdater-behandling.yaml
@@ -40,6 +40,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-opplysninger-fra-pdl.yaml
+++ b/.github/workflows/app-etterlatte-opplysninger-fra-pdl.yaml
@@ -42,6 +42,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-opplysninger-fra-soeknad.yaml
+++ b/.github/workflows/app-etterlatte-opplysninger-fra-soeknad.yaml
@@ -38,6 +38,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-pdltjenester.yaml
+++ b/.github/workflows/app-etterlatte-pdltjenester.yaml
@@ -46,6 +46,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-saksbehandling-ui.yaml
+++ b/.github/workflows/app-etterlatte-saksbehandling-ui.yaml
@@ -1,9 +1,7 @@
 name: etterlatte-saksbehandling-ui
 
 env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
   APP_NAME: ${{ github.workflow }}
-  branch-image: ghcr.io/${{ github.repository }}/${{ github.workflow }}
 
 on:
   workflow_dispatch: # Allow manually triggered workflow run
@@ -53,6 +51,11 @@ jobs:
     if: github.event_name != 'pull_request'
     name: Build, test and publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    outputs:
+      image: ${{ steps.docker-build-push.outputs.image }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -72,13 +75,16 @@ jobs:
         working-directory: apps/${{ env.APP_NAME }}/client
         run: CI=true yarn test
       - name: Build and publish Docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${{ env.IMAGE }} --tag ${{ env.branch-image }}:${{ env.GITHUB_REF_SLUG }} apps/${{ env.APP_NAME }}
-          docker push ${{ env.IMAGE }}
-          docker push ${{ env.branch-image }}:${{ env.GITHUB_REF_SLUG }}
+        uses: nais/docker-build-push@v0
+        id: docker-build-push
+        with:
+          team: etterlatte
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+          dockerfile: docker/Dockerfile
+          docker_context: apps/${{ github.workflow }}/
+          image_suffix: ${{ github.workflow }}
+          tag: ${{ env.GITHUB_REF_SLUG }}
 
   deploy-to-dev-gcp:
     if: github.event_name != 'pull_request'

--- a/.github/workflows/app-etterlatte-saksbehandling-ui.yaml
+++ b/.github/workflows/app-etterlatte-saksbehandling-ui.yaml
@@ -81,6 +81,7 @@ jobs:
           docker push ${{ env.branch-image }}:${{ env.GITHUB_REF_SLUG }}
 
   deploy-to-dev-gcp:
+    if: github.event_name != 'pull_request'
     name: Deploy to dev-gcp
     needs: build-and-publish
     runs-on: ubuntu-latest

--- a/.github/workflows/app-etterlatte-statistikk.yaml
+++ b/.github/workflows/app-etterlatte-statistikk.yaml
@@ -32,12 +32,11 @@ on:
 
 jobs:
   test:
-    if: github.event_name == 'pull_request'
+    if: github.event_name != 'pull_request'
     uses: ./.github/workflows/.test.yaml
     secrets: inherit
 
   build:
-    if: github.event_name != 'pull_request'
     uses: ./.github/workflows/.build.yaml
     secrets: inherit
 

--- a/.github/workflows/app-etterlatte-statistikk.yaml
+++ b/.github/workflows/app-etterlatte-statistikk.yaml
@@ -41,6 +41,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-statistikk.yaml
+++ b/.github/workflows/app-etterlatte-statistikk.yaml
@@ -32,11 +32,12 @@ on:
 
 jobs:
   test:
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/.test.yaml
     secrets: inherit
 
   build:
+    if: github.event_name != 'pull_request'
     uses: ./.github/workflows/.build.yaml
     secrets: inherit
 

--- a/.github/workflows/app-etterlatte-testdata.yaml
+++ b/.github/workflows/app-etterlatte-testdata.yaml
@@ -29,6 +29,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-tilbakekreving.yaml
+++ b/.github/workflows/app-etterlatte-tilbakekreving.yaml
@@ -42,6 +42,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-trygdetid.yaml
+++ b/.github/workflows/app-etterlatte-trygdetid.yaml
@@ -48,6 +48,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-utbetaling.yaml
+++ b/.github/workflows/app-etterlatte-utbetaling.yaml
@@ -42,6 +42,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-vedtaksvurdering-kafka.yaml
+++ b/.github/workflows/app-etterlatte-vedtaksvurdering-kafka.yaml
@@ -42,6 +42,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-vedtaksvurdering.yaml
+++ b/.github/workflows/app-etterlatte-vedtaksvurdering.yaml
@@ -50,6 +50,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-vilkaarsvurdering-kafka.yaml
+++ b/.github/workflows/app-etterlatte-vilkaarsvurdering-kafka.yaml
@@ -42,6 +42,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/.github/workflows/app-etterlatte-vilkaarsvurdering.yaml
+++ b/.github/workflows/app-etterlatte-vilkaarsvurdering.yaml
@@ -48,6 +48,7 @@ jobs:
     secrets: inherit
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     uses: ./.github/workflows/.deploy.yaml
     with:

--- a/apps/etterlatte-statistikk/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/Application.kt
@@ -7,7 +7,6 @@ fun main() {
     with(ApplicationContext()) {
         jobs(this)
         rapidApplication(this).start()
-        // test
     }
 }
 

--- a/apps/etterlatte-statistikk/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/Application.kt
@@ -7,6 +7,7 @@ fun main() {
     with(ApplicationContext()) {
         jobs(this)
         rapidApplication(this).start()
+        // test
     }
 }
 


### PR DESCRIPTION
Poenget med denne PR-en er todelt:

Først, og primært, å ta i bruk actionen [`nais/docker-build-push`](https://github.com/nais/platform-build-push-sign/blob/main/action.yml), som nais-teamet jobbar med for tida, og som verkar gjennomarbeida og ryddig. Den lager blant anna ein SBOM, og det verkar som det nais-teamet tidlegare har gjort rundt SLSA-tilrettelegging (sjå utfyllande om dét på https://github.com/navikt/familie-ba-sak/pull/3052 ) no er tenkt å skje via denne workflowen, så da får vi mykje gratis ved å ta i bruk den.

I tillegg verkar Google Artifactory Registry å vera raskare enn GHCR, iallfall når imaget uansett skal vidare i Google-sfæra på GCP.