### PR TITLE
EY-1876 - filtrere oppgaveliste utifra enhet til saksbehandler

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -111,7 +111,8 @@ private fun Route.attachContekst(ds: DataSource, beanFactory: BeanFactory) {
             Context(
                 AppUser = decideUser(
                     call.principal() ?: throw Exception("Ingen bruker funnet i jwt token"),
-                    beanFactory.getSaksbehandlerGroupIdsByKey()
+                    beanFactory.getSaksbehandlerGroupIdsByKey(),
+                    beanFactory.enhetService()
                 ),
                 databasecontxt = DatabaseContext(ds)
             )

--- a/apps/etterlatte-behandling/src/main/kotlin/config/BeanFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/BeanFactory.kt
@@ -118,7 +118,7 @@ abstract class CommonFactory : BeanFactory {
     }
 
     private val oppgaveService: OppgaveService by lazy {
-        OppgaveServiceImpl(oppgaveDao())
+        OppgaveServiceImpl(oppgaveDao(), featureToggleService())
     }
 
     private val oppgaveDao: OppgaveDao by lazy {

--- a/apps/etterlatte-behandling/src/main/kotlin/config/BeanFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/BeanFactory.kt
@@ -7,6 +7,8 @@ import no.nav.etterlatte.behandling.BehandlingDao
 import no.nav.etterlatte.behandling.BehandlingStatusService
 import no.nav.etterlatte.behandling.BehandlingStatusServiceImpl
 import no.nav.etterlatte.behandling.BehandlingsHendelser
+import no.nav.etterlatte.behandling.EnhetService
+import no.nav.etterlatte.behandling.EnhetServiceImpl
 import no.nav.etterlatte.behandling.GenerellBehandlingService
 import no.nav.etterlatte.behandling.RealGenerellBehandlingService
 import no.nav.etterlatte.behandling.foerstegangsbehandling.FoerstegangsbehandlingFactory
@@ -91,6 +93,7 @@ interface BeanFactory {
     fun featureToggleService(): FeatureToggleService
     fun norg2HttpClient(): Norg2Klient
     fun navAnsattKlient(): NavAnsattKlient
+    fun enhetService(): EnhetService
 }
 
 abstract class CommonFactory : BeanFactory {
@@ -307,5 +310,9 @@ class EnvBasedBeanFactory(private val env: Map<String, String>) : CommonFactory(
             ),
             env.getValue("NAVANSATT_URL")
         )
+    }
+
+    override fun enhetService(): EnhetService {
+        return EnhetServiceImpl(navAnsattKlient())
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDao.kt
@@ -31,7 +31,7 @@ class OppgaveDao(private val connection: () -> Connection) {
         with(connection()) {
             val stmt = prepareStatement(
                 """
-                |SELECT b.id, b.sak_id, soeknad_mottatt_dato, fnr, sakType, status, behandling_opprettet,
+                |SELECT b.id, b.sak_id, soeknad_mottatt_dato, fnr, sakType, enhet, status, behandling_opprettet,
                 |behandlingstype, soesken, b.prosesstype, adressebeskyttelse
                 |FROM behandling b INNER JOIN sak s ON b.sak_id = s.id 
                 |WHERE ((adressebeskyttelse = ?) OR (adressebeskyttelse = ?)) 
@@ -56,7 +56,8 @@ class OppgaveDao(private val connection: () -> Connection) {
                     fnr = Folkeregisteridentifikator.of(getString("fnr")),
                     registrertDato = mottattDato,
                     behandlingsType = BehandlingType.valueOf(getString("behandlingstype")),
-                    antallSoesken = antallSoesken(getString("soesken"))
+                    antallSoesken = antallSoesken(getString("soesken")),
+                    enhet = getString("enhet").takeIf { !wasNull() }
                 )
             }
         }
@@ -68,7 +69,7 @@ class OppgaveDao(private val connection: () -> Connection) {
         with(connection()) {
             val stmt = prepareStatement(
                 """
-                |SELECT b.id, b.sak_id, soeknad_mottatt_dato, fnr, sakType, status, behandling_opprettet,
+                |SELECT b.id, b.sak_id, soeknad_mottatt_dato, fnr, sakType, enhet, status, behandling_opprettet,
                 |behandlingstype, soesken, b.prosesstype, adressebeskyttelse
                 |FROM behandling b INNER JOIN sak s ON b.sak_id = s.id 
                 |WHERE status = ANY(?) AND (b.prosesstype is NULL OR b.prosesstype != ?)
@@ -94,7 +95,8 @@ class OppgaveDao(private val connection: () -> Connection) {
                     fnr = Folkeregisteridentifikator.of(getString("fnr")),
                     registrertDato = mottattDato,
                     behandlingsType = BehandlingType.valueOf(getString("behandlingstype")),
-                    antallSoesken = antallSoesken(getString("soesken"))
+                    antallSoesken = antallSoesken(getString("soesken")),
+                    enhet = getString("enhet").takeIf { !wasNull() }
                 )
             }.also {
                 logger.info(

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveServiceImpl.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveServiceImpl.kt
@@ -39,6 +39,18 @@ class OppgaveServiceImpl(private val oppgaveDao: OppgaveDao) : OppgaveService {
                 oppgaveDao.finnOppgaverMedStatuser(aktuelleStatuserForRoller) +
                     oppgaveDao.finnOppgaverFraGrunnlagsendringshendelser()
             }.sortedByDescending { it.registrertDato }
+        }.filterForEnheter(bruker)
+    }
+
+    private fun List<Oppgave>.filterForEnheter(bruker: Saksbehandler) =
+        filterOppgaverForEnheter(this, bruker.enheter().map { it.id })
+
+    fun filterOppgaverForEnheter(oppgaver: List<Oppgave>, enheter: List<String>): List<Oppgave> {
+        return oppgaver.filter { oppgave ->
+            when (oppgave) {
+                is Oppgave.BehandlingOppgave -> oppgave.enhet == null || enheter.contains(oppgave.enhet)
+                else -> true
+            }
         }
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/domain/Oppgave.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/domain/Oppgave.kt
@@ -33,7 +33,8 @@ sealed class Oppgave {
         val behandlingId: UUID,
         val behandlingsType: BehandlingType,
         val behandlingStatus: BehandlingStatus,
-        val antallSoesken: Int
+        val antallSoesken: Int,
+        val enhet: String?
     ) : Oppgave() {
         override val oppgaveStatus: OppgaveStatus
             get() = OppgaveStatus.from(behandlingStatus)

--- a/apps/etterlatte-behandling/src/test/kotlin/BehandlingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/BehandlingIntegrationTest.kt
@@ -12,6 +12,8 @@ import io.ktor.http.fullPath
 import io.ktor.http.headersOf
 import io.ktor.serialization.jackson.JacksonConverter
 import io.ktor.server.config.HoconApplicationConfig
+import no.nav.etterlatte.behandling.EnhetService
+import no.nav.etterlatte.behandling.EnhetServiceImpl
 import no.nav.etterlatte.behandling.domain.ArbeidsFordelingEnhet
 import no.nav.etterlatte.behandling.domain.Foerstegangsbehandling
 import no.nav.etterlatte.behandling.domain.SaksbehandlerEnhet
@@ -325,5 +327,9 @@ class TestBeanFactory(
 
     override fun navAnsattKlient(): NavAnsattKlient {
         return NavAnsattKlientTest()
+    }
+
+    override fun enhetService(): EnhetService {
+        return EnhetServiceImpl(navAnsattKlient())
     }
 }

--- a/apps/etterlatte-behandling/src/test/kotlin/TestApp.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/TestApp.kt
@@ -8,6 +8,8 @@ import io.ktor.http.ContentType
 import io.ktor.http.fullPath
 import io.ktor.http.headersOf
 import io.ktor.serialization.jackson.JacksonConverter
+import no.nav.etterlatte.behandling.EnhetService
+import no.nav.etterlatte.behandling.EnhetServiceImpl
 import no.nav.etterlatte.behandling.klienter.GrunnlagKlient
 import no.nav.etterlatte.behandling.klienter.NavAnsattKlient
 import no.nav.etterlatte.behandling.klienter.Norg2Klient
@@ -145,5 +147,9 @@ class LocalAppBeanFactory(
 
     override fun navAnsattKlient(): NavAnsattKlient {
         return NavAnsattKlientTest()
+    }
+
+    override fun enhetService(): EnhetService {
+        return EnhetServiceImpl(navAnsattKlient())
     }
 }

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
@@ -7,6 +7,7 @@ import no.nav.etterlatte.behandling.domain.GrunnlagsendringStatus
 import no.nav.etterlatte.behandling.domain.GrunnlagsendringsType
 import no.nav.etterlatte.behandling.domain.Grunnlagsendringshendelse
 import no.nav.etterlatte.behandling.domain.OpprettBehandling
+import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseDao
 import no.nav.etterlatte.grunnlagsendring.samsvarDoedsdatoer
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
@@ -124,6 +125,18 @@ internal class OppgaveDaoTest {
         val oppgaver = oppgaveDao.finnOppgaverMedStatuser(listOf(BehandlingStatus.OPPRETTET))
         assertEquals(1, oppgaver.size)
         assertEquals(manuel.id, (oppgaver[0] as Oppgave.BehandlingOppgave).behandlingId)
+    }
+
+    @Test
+    fun `enhet er tilgjengelig hvis det er tilgjengelig paa sak`() {
+        val fnr = TRIVIELL_MIDTPUNKT.value
+        val sak = sakDao.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.DEFAULT.enhetNr)
+        behandlingDao.opprettBehandling(lagRegulering(Prosesstype.MANUELL, fnr, sak.id))
+        val alleBehandlingsStatuser = BehandlingStatus.values().asList()
+        val oppgaver = oppgaveDao.finnOppgaverMedStatuser(alleBehandlingsStatuser)
+        assertEquals(1, oppgaver.size)
+        val oppgave = oppgaver.first() as Oppgave.BehandlingOppgave
+        assertEquals(Enheter.DEFAULT.enhetNr, oppgave.enhet)
     }
 
     @Test

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -1,10 +1,12 @@
 package no.nav.etterlatte.oppgave
 
 import io.kotest.matchers.shouldBe
+import io.mockk.every
 import io.mockk.mockk
 import no.nav.etterlatte.TRIVIELL_MIDTPUNKT
 import no.nav.etterlatte.behandling.domain.GrunnlagsendringsType
 import no.nav.etterlatte.common.Enheter
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -15,55 +17,59 @@ import org.junit.jupiter.api.Test
 import java.util.*
 
 internal class OppgaveServiceTest {
+    private val oppgaveListe: List<Oppgave> = listOf(
+        Oppgave.BehandlingOppgave(
+            sakId = 1,
+            sakType = SakType.BARNEPENSJON,
+            registrertDato = Tidspunkt.now(),
+            fnr = TRIVIELL_MIDTPUNKT,
+            behandlingId = UUID.randomUUID(),
+            behandlingsType = BehandlingType.FØRSTEGANGSBEHANDLING,
+            behandlingStatus = BehandlingStatus.OPPRETTET,
+            antallSoesken = 1,
+            enhet = null
+        ),
+        Oppgave.BehandlingOppgave(
+            sakId = 2,
+            sakType = SakType.BARNEPENSJON,
+            registrertDato = Tidspunkt.now(),
+            fnr = TRIVIELL_MIDTPUNKT,
+            behandlingId = UUID.randomUUID(),
+            behandlingsType = BehandlingType.FØRSTEGANGSBEHANDLING,
+            behandlingStatus = BehandlingStatus.OPPRETTET,
+            antallSoesken = 1,
+            enhet = Enheter.DEFAULT.enhetNr
+        ),
+        Oppgave.BehandlingOppgave(
+            sakId = 3,
+            sakType = SakType.BARNEPENSJON,
+            registrertDato = Tidspunkt.now(),
+            fnr = TRIVIELL_MIDTPUNKT,
+            behandlingId = UUID.randomUUID(),
+            behandlingsType = BehandlingType.FØRSTEGANGSBEHANDLING,
+            behandlingStatus = BehandlingStatus.OPPRETTET,
+            antallSoesken = 1,
+            enhet = Enheter.STRENGT_FORTROLIG.enhetNr
+        ),
+        Oppgave.Grunnlagsendringsoppgave(
+            sakId = 4,
+            sakType = SakType.BARNEPENSJON,
+            registrertDato = Tidspunkt.now(),
+            fnr = TRIVIELL_MIDTPUNKT,
+            grunnlagsendringsType = GrunnlagsendringsType.FORELDER_BARN_RELASJON,
+            gjelderRolle = Saksrolle.SOEKER
+        )
+    )
+
     @Test
     fun `filter oppgaveliste for enheter`() {
-        val oppgaveListe: List<Oppgave> = listOf(
-            Oppgave.BehandlingOppgave(
-                sakId = 1,
-                sakType = SakType.BARNEPENSJON,
-                registrertDato = Tidspunkt.now(),
-                fnr = TRIVIELL_MIDTPUNKT,
-                behandlingId = UUID.randomUUID(),
-                behandlingsType = BehandlingType.FØRSTEGANGSBEHANDLING,
-                behandlingStatus = BehandlingStatus.OPPRETTET,
-                antallSoesken = 1,
-                enhet = null
-            ),
-            Oppgave.BehandlingOppgave(
-                sakId = 2,
-                sakType = SakType.BARNEPENSJON,
-                registrertDato = Tidspunkt.now(),
-                fnr = TRIVIELL_MIDTPUNKT,
-                behandlingId = UUID.randomUUID(),
-                behandlingsType = BehandlingType.FØRSTEGANGSBEHANDLING,
-                behandlingStatus = BehandlingStatus.OPPRETTET,
-                antallSoesken = 1,
-                enhet = Enheter.DEFAULT.enhetNr
-            ),
-            Oppgave.BehandlingOppgave(
-                sakId = 3,
-                sakType = SakType.BARNEPENSJON,
-                registrertDato = Tidspunkt.now(),
-                fnr = TRIVIELL_MIDTPUNKT,
-                behandlingId = UUID.randomUUID(),
-                behandlingsType = BehandlingType.FØRSTEGANGSBEHANDLING,
-                behandlingStatus = BehandlingStatus.OPPRETTET,
-                antallSoesken = 1,
-                enhet = Enheter.STRENGT_FORTROLIG.enhetNr
-            ),
-            Oppgave.Grunnlagsendringsoppgave(
-                sakId = 4,
-                sakType = SakType.BARNEPENSJON,
-                registrertDato = Tidspunkt.now(),
-                fnr = TRIVIELL_MIDTPUNKT,
-                grunnlagsendringsType = GrunnlagsendringsType.FORELDER_BARN_RELASJON,
-                gjelderRolle = Saksrolle.SOEKER
-            )
-        )
-
         val enhetsListe = listOf(Enheter.DEFAULT.enhetNr, Enheter.EGNE_ANSATTE.enhetNr)
 
-        val service = OppgaveServiceImpl(mockk())
+        val featureToggleService = mockk<FeatureToggleService>()
+
+        every { featureToggleService.isEnabled(any(), false) } returns true
+
+        val service = OppgaveServiceImpl(mockk(), featureToggleService)
 
         val filtered = service.filterOppgaverForEnheter(oppgaveListe, enhetsListe)
 

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -1,0 +1,73 @@
+package no.nav.etterlatte.oppgave
+
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import no.nav.etterlatte.TRIVIELL_MIDTPUNKT
+import no.nav.etterlatte.behandling.domain.GrunnlagsendringsType
+import no.nav.etterlatte.common.Enheter
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
+import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.behandling.Saksrolle
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.oppgave.domain.Oppgave
+import org.junit.jupiter.api.Test
+import java.util.*
+
+internal class OppgaveServiceTest {
+    @Test
+    fun `filter oppgaveliste for enheter`() {
+        val oppgaveListe: List<Oppgave> = listOf(
+            Oppgave.BehandlingOppgave(
+                sakId = 1,
+                sakType = SakType.BARNEPENSJON,
+                registrertDato = Tidspunkt.now(),
+                fnr = TRIVIELL_MIDTPUNKT,
+                behandlingId = UUID.randomUUID(),
+                behandlingsType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                behandlingStatus = BehandlingStatus.OPPRETTET,
+                antallSoesken = 1,
+                enhet = null
+            ),
+            Oppgave.BehandlingOppgave(
+                sakId = 2,
+                sakType = SakType.BARNEPENSJON,
+                registrertDato = Tidspunkt.now(),
+                fnr = TRIVIELL_MIDTPUNKT,
+                behandlingId = UUID.randomUUID(),
+                behandlingsType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                behandlingStatus = BehandlingStatus.OPPRETTET,
+                antallSoesken = 1,
+                enhet = Enheter.DEFAULT.enhetNr
+            ),
+            Oppgave.BehandlingOppgave(
+                sakId = 3,
+                sakType = SakType.BARNEPENSJON,
+                registrertDato = Tidspunkt.now(),
+                fnr = TRIVIELL_MIDTPUNKT,
+                behandlingId = UUID.randomUUID(),
+                behandlingsType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                behandlingStatus = BehandlingStatus.OPPRETTET,
+                antallSoesken = 1,
+                enhet = Enheter.STRENGT_FORTROLIG.enhetNr
+            ),
+            Oppgave.Grunnlagsendringsoppgave(
+                sakId = 4,
+                sakType = SakType.BARNEPENSJON,
+                registrertDato = Tidspunkt.now(),
+                fnr = TRIVIELL_MIDTPUNKT,
+                grunnlagsendringsType = GrunnlagsendringsType.FORELDER_BARN_RELASJON,
+                gjelderRolle = Saksrolle.SOEKER
+            )
+        )
+
+        val enhetsListe = listOf(Enheter.DEFAULT.enhetNr, Enheter.EGNE_ANSATTE.enhetNr)
+
+        val service = OppgaveServiceImpl(mockk())
+
+        val filtered = service.filterOppgaverForEnheter(oppgaveListe, enhetsListe)
+
+        filtered.size shouldBe 3
+        filtered.filter { it.sakId == 3L }.size shouldBe 0
+    }
+}


### PR DESCRIPTION
EnhetService skal gi enheter til en saksbehandler cachet med 15 min.

Den gjøres tilgjengelig på saksbehandler men med en slags lazy (hentes først når den trengs).

I første omgang prøver vi å filtrere oppgaverlisten.

- Er det ikke BehandlingOppgave - så er det ikke filtrert bort.
- Er det BehandlingOppgave med null enhet - så er det ikke filtrert bort (eksisterende data fra før sak ruting)
- Ellers skal det filtreres etter enheter saksbehandleren har.