### PR TITLE
etterlatte-brev - bruk X_CORRELATION_ID og getXCorrelationId()

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/Norg2Klient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/Norg2Klient.kt
@@ -5,8 +5,11 @@ import com.github.benmanes.caffeine.cache.Caffeine
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.isSuccess
+import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
+import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import org.slf4j.LoggerFactory
 import java.time.Duration
 
@@ -30,7 +33,9 @@ class Norg2Klient(
                 return enhetCache
             }
 
-            val response = klient.get("$apiUrl/enhet/$enhet")
+            val response = klient.get("$apiUrl/enhet/$enhet") {
+                header(X_CORRELATION_ID, getXCorrelationId())
+            }
 
             if (response.status.isSuccess()) {
                 logger.info("Hentet enhet fra Norg2 for enhet $enhet")

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/RegoppslagKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/RegoppslagKlient.kt
@@ -8,6 +8,7 @@ import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.http.isSuccess
+import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.sikkerLogg
 import org.slf4j.LoggerFactory
@@ -33,7 +34,7 @@ class RegoppslagKlient(
             logger.info("Ingen cachet mottakeradresse funnet. Henter fra regoppslag")
 
             val response = client.get("$url/regoppslag/$ident") {
-                header("x_correlation_id", getXCorrelationId())
+                header(X_CORRELATION_ID, getXCorrelationId())
                 header("Nav_Call_Id", getXCorrelationId())
             }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafClient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafClient.kt
@@ -18,12 +18,13 @@ import io.ktor.http.content.TextContent
 import io.ktor.http.isSuccess
 import no.nav.etterlatte.brev.journalpost.BrukerIdType
 import no.nav.etterlatte.libs.common.RetryResult
+import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
+import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.libs.common.retry
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.ktorobo.AzureAdClient
 import no.nav.etterlatte.token.Bruker
 import org.slf4j.LoggerFactory
-import org.slf4j.MDC
 import java.util.*
 
 /*
@@ -48,7 +49,7 @@ class SafClient(
         httpClient.get("$baseUrl/rest/hentdokument/$journalpostId/$dokumentInfoId/ARKIV") {
             header("Authorization", "Bearer ${getToken(accessToken)}")
             header("Content-Type", "application/json")
-            header("X-Correlation-ID", MDC.get("X-Correlation-ID") ?: UUID.randomUUID().toString())
+            header(X_CORRELATION_ID, getXCorrelationId())
         }.body()
     } catch (ex: Exception) {
         throw JournalpostException("Feil ved kall til hentdokument", ex)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/navansatt/NavansattKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/navansatt/NavansattKlient.kt
@@ -8,6 +8,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.http.isSuccess
 import no.nav.etterlatte.brev.adresse.AdresseException
+import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import org.slf4j.LoggerFactory
 import java.time.Duration
@@ -32,7 +33,7 @@ class NavansattKlient(
             logger.info("Henter info om saksbehandler med ident $ident")
 
             val response = client.get("$url/navansatt/$ident") {
-                header("x_correlation_id", getXCorrelationId())
+                header(X_CORRELATION_ID, getXCorrelationId())
                 header("Nav_Call_Id", getXCorrelationId())
             }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/pdf/PdfGeneratorKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/pdf/PdfGeneratorKlient.kt
@@ -7,11 +7,11 @@ import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import no.nav.etterlatte.brev.model.BrevRequest
+import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
+import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.toJson
 import org.slf4j.LoggerFactory
-import org.slf4j.MDC
-import java.util.UUID
 import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 import kotlin.time.measureTimedValue
@@ -26,7 +26,7 @@ class PdfGeneratorKlient(private val client: HttpClient, private val apiUrl: Str
         measureTimedValue {
             client.post("$apiUrl/${brevRequest.brevMalUrl()}") {
                 header("Content-Type", "application/json")
-                header("X-Correlation-ID", MDC.get("X-Correlation-ID") ?: UUID.randomUUID().toString())
+                header(X_CORRELATION_ID, getXCorrelationId())
                 setBody(brevRequest.toJsonNode())
             }.body<ByteArray>()
         }.let { (result, duration) ->


### PR DESCRIPTION
- Noen steder brukte brev litt forskjellige strenger for header navn. Bytt til konstant
- Legg til correlation på Norg2Klient
- Bruk getXCorrelationId() istedenfor MDC.get/generate