### PR TITLE
EY-1968 Lagrer periodiserte opplysninger fra PDL som lister

### DIFF
--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/OpplysningsgrunnlagMapper.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/OpplysningsgrunnlagMapper.kt
@@ -21,12 +21,8 @@ class OpplysningsgrunnlagMapper(
             assert(alleOpplysningerErAvSammeType(hendelser.map { it.opplysning }))
         }
 
-        val opplysning: Opplysning<JsonNode> = if (hendelser.any { it.opplysning.periode != null }) {
-            Opplysning.Periodisert.create(hendelser.map { it.opplysning })
-        } else {
-            hendelser.maxBy { hendelse -> hendelse.hendelseNummer }
-                .let { Opplysning.Konstant.create(it.opplysning) }
-        }
+        val opplysning: Opplysning<JsonNode> = hendelser.maxBy { hendelse -> hendelse.hendelseNummer }
+            .let { Opplysning.Konstant.create(it.opplysning) }
 
         val opplysningstype: Opplysningstype
             get() = hendelser.first().opplysning.opplysningType
@@ -48,9 +44,9 @@ class OpplysningsgrunnlagMapper(
         val opplysninger = grupper.map { GruppertHendelser(it) }
 
         val (personopplysninger, saksopplysninger) = opplysninger.partition { it.fnr !== null }
-        val (søker, familie) = personopplysninger.partition { it.fnr!!.value == persongalleri.soeker }
+        val (soeker, familie) = personopplysninger.partition { it.fnr!!.value == persongalleri.soeker }
 
-        val søkerMap = søker.associateBy({ it.opplysningstype }, { it.opplysning })
+        val soekerMap = soeker.associateBy({ it.opplysningstype }, { it.opplysning })
         val familieMap = familie
             .groupBy { it.fnr }.values
             .map { familiemedlem ->
@@ -59,7 +55,7 @@ class OpplysningsgrunnlagMapper(
         val sakMap = saksopplysninger.associateBy({ it.opplysningstype }, { it.opplysning })
 
         return Grunnlag(
-            soeker = søkerMap,
+            soeker = soekerMap,
             familie = familieMap,
             sak = sakMap,
             metadata = Metadata(sakId, senestVersjon)

--- a/apps/etterlatte-grunnlag/src/main/resources/db/migration/V15__setter_alle_fragmenterte_opplysninger_til_aa_vaere_nyeste_fra_pdl.sql
+++ b/apps/etterlatte-grunnlag/src/main/resources/db/migration/V15__setter_alle_fragmenterte_opplysninger_til_aa_vaere_nyeste_fra_pdl.sql
@@ -1,0 +1,53 @@
+-- Setter opp et midlertidig view som har det nyeste PDL-dokumentet per person per sak, til bruk i utpakking av opplysninger
+CREATE TEMPORARY VIEW pdl_latest AS (select max(hendelsenummer) as siste_hendelse, sak_id, fnr, opplysning::jsonb as opplysning
+                                    from grunnlagshendelse
+                                    where opplysning_type in ('SOEKER_PDL_V1', 'GJENLEVENDE_FORELDER_PDL_V1', 'AVDOED_PDL_V1')
+                                    group by sak_id, fnr, opplysning);
+
+-- BOSTEDSADRESSE
+UPDATE grunnlagshendelse g
+SET opplysning = pdl_latest.opplysning ->> 'bostedsadresse'
+FROM pdl_latest
+WHERE g.opplysning_type = 'BOSTEDSADRESSE'
+  and g.sak_id = pdl_latest.sak_id
+  and g.fnr = pdl_latest.fnr;
+
+-- DELTBOSTEDSADRESSE
+UPDATE grunnlagshendelse g
+SET opplysning = pdl_latest.opplysning ->> 'deltBostedsadresse'
+FROM pdl_latest
+WHERE g.opplysning_type = 'DELTBOSTEDSADRESSE'
+  and g.sak_id = pdl_latest.sak_id
+  and g.fnr = pdl_latest.fnr;
+
+-- KONTAKTADRESSE
+UPDATE grunnlagshendelse g
+SET opplysning = pdl_latest.opplysning ->> 'kontaktadresse'
+FROM pdl_latest
+WHERE g.opplysning_type = 'KONTAKTADRESSE'
+  and g.sak_id = pdl_latest.sak_id
+  and g.fnr = pdl_latest.fnr;
+
+-- OPPHOLDSADRESSE
+UPDATE grunnlagshendelse g
+SET opplysning = pdl_latest.opplysning ->> 'oppholdsadresse'
+FROM pdl_latest
+WHERE g.opplysning_type = 'OPPHOLDSADRESSE'
+  and g.sak_id = pdl_latest.sak_id
+  and g.fnr = pdl_latest.fnr;
+
+-- VERGEMAALELLERFREMTIDSFULLMAKT
+UPDATE grunnlagshendelse g
+SET opplysning = pdl_latest.opplysning ->> 'vergemaalEllerFremtidsfullmakt'
+FROM pdl_latest
+WHERE g.opplysning_type = 'VERGEMAALELLERFREMTIDSFULLMAKT'
+  and g.sak_id = pdl_latest.sak_id
+  and g.fnr = pdl_latest.fnr;
+
+-- SIVILSTAND
+UPDATE grunnlagshendelse g
+SET opplysning = pdl_latest.opplysning ->> 'sivilstand'
+FROM pdl_latest
+WHERE g.opplysning_type = 'SIVILSTAND'
+  and g.sak_id = pdl_latest.sak_id
+  and g.fnr = pdl_latest.fnr;

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagServiceTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagServiceTest.kt
@@ -9,7 +9,6 @@ import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.Opplysning
-import no.nav.etterlatte.libs.common.grunnlag.PeriodisertOpplysning
 import no.nav.etterlatte.libs.common.grunnlag.hentBostedsadresse
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Navn
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.BOSTEDSADRESSE
@@ -19,7 +18,6 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.N
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.PERSONGALLERI_V1
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.PERSONROLLE
 import no.nav.etterlatte.libs.common.objectMapper
-import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.toJson
@@ -34,8 +32,7 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.Month
-import java.time.YearMonth
-import java.util.UUID
+import java.util.*
 
 internal class GrunnlagServiceTest {
     private val opplysningerMock = mockk<OpplysningDao>()
@@ -229,7 +226,6 @@ internal class GrunnlagServiceTest {
             gyldigFraOgMed = LocalDateTime.of(2022, Month.JANUARY, 1, 0, 0),
             gyldigTilOgMed = LocalDateTime.of(2022, Month.JUNE, 1, 0, 0)
         )
-        val uuid2 = UUID.randomUUID()
         val bostedsadresse2 = ADRESSE_DEFAULT.first().copy(
             adresseLinje1 = "AktivAdresse 55",
             gyldigFraOgMed = LocalDateTime.of(2022, Month.JULY, 1, 0, 0),
@@ -242,58 +238,26 @@ internal class GrunnlagServiceTest {
                     kilde = kilde,
                     opplysningType = BOSTEDSADRESSE,
                     meta = objectMapper.createObjectNode(),
-                    opplysning = bostedsadresse1.toJsonNode(),
+                    opplysning = listOf(bostedsadresse1, bostedsadresse2).toJsonNode(),
                     attestering = null,
-                    fnr = testData.soeker.foedselsnummer,
-                    periode = Periode(
-                        fom = bostedsadresse1.gyldigFraOgMed!!.let { YearMonth.of(it.year, it.month) },
-                        tom = bostedsadresse1.gyldigTilOgMed?.let { YearMonth.of(it.year, it.month) }
-                    )
+                    fnr = testData.soeker.foedselsnummer
                 ),
                 sakId = 1,
                 hendelseNummer = 1
-            ),
-            OpplysningDao.GrunnlagHendelse(
-                opplysning = Grunnlagsopplysning(
-                    id = uuid2,
-                    kilde = kilde,
-                    opplysningType = BOSTEDSADRESSE,
-                    meta = objectMapper.createObjectNode(),
-                    opplysning = bostedsadresse2.toJsonNode(),
-                    attestering = null,
-                    fnr = testData.soeker.foedselsnummer,
-                    periode = Periode(
-                        fom = bostedsadresse2.gyldigFraOgMed!!.let { YearMonth.of(it.year, it.month) },
-                        tom = bostedsadresse2.gyldigTilOgMed?.let { YearMonth.of(it.year, it.month) }
-                    )
-                ),
-                sakId = 1,
-                hendelseNummer = 2
             )
         )
 
         every { opplysningerMock.hentAlleGrunnlagForSak(1) } returns grunnlagshendelser
 
         val actual = grunnlagService.hentOpplysningsgrunnlag(1, testData.hentPersonGalleri())
-        val expected = Opplysning.Periodisert(
-            listOf(
-                PeriodisertOpplysning(
-                    uuid1,
-                    kilde = kilde,
-                    verdi = bostedsadresse1,
-                    fom = YearMonth.of(2022, Month.JANUARY),
-                    tom = YearMonth.of(2022, Month.JUNE)
-                ),
-                PeriodisertOpplysning(
-                    uuid2,
-                    kilde = kilde,
-                    verdi = bostedsadresse2,
-                    fom = YearMonth.of(2022, Month.JULY),
-                    tom = YearMonth.of(2022, Month.DECEMBER)
-                )
+        val expected = Opplysning.Konstant(
+            uuid1,
+            kilde = kilde,
+            verdi = listOf(
+                bostedsadresse1,
+                bostedsadresse2
             )
         )
-
         Assertions.assertEquals(expected, actual.soeker.hentBostedsadresse())
     }
 

--- a/libs/saksbehandling-common/src/main/kotlin/grunnlag/Grunnlagsdata.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/grunnlag/Grunnlagsdata.kt
@@ -41,7 +41,6 @@ import no.nav.etterlatte.libs.common.person.UtenlandsoppholdOpplysninger
 import no.nav.etterlatte.libs.common.person.Utland
 import no.nav.etterlatte.libs.common.person.VergemaalEllerFremtidsfullmakt
 import no.nav.etterlatte.libs.common.toJson
-import org.slf4j.LoggerFactory.getLogger
 import java.time.LocalDate
 
 typealias Grunnlagsdata<T> = Map<Opplysningstype, Opplysning<T>>
@@ -57,7 +56,7 @@ fun Grunnlagsdata<JsonNode>.hentDoedsdato() = this.hentKonstantOpplysning<LocalD
 fun Grunnlagsdata<JsonNode>.hentAdressebeskyttelse() =
     this.hentKonstantOpplysning<AdressebeskyttelseGradering>(ADRESSEBESKYTTELSE)
 
-fun Grunnlagsdata<JsonNode>.hentBostedsadresse() = this.hentPeriodisertOpplysning<Adresse>(BOSTEDSADRESSE)
+fun Grunnlagsdata<JsonNode>.hentBostedsadresse() = this.hentKonstantOpplysning<List<Adresse>>(BOSTEDSADRESSE)
 fun Grunnlagsdata<JsonNode>.hentDeltbostedsadresse() = this.hentKonstantOpplysning<List<Adresse>>(DELTBOSTEDSADRESSE)
 fun Grunnlagsdata<JsonNode>.hentKontaktadresse() = this.hentKonstantOpplysning<List<Adresse>>(KONTAKTADRESSE)
 fun Grunnlagsdata<JsonNode>.hentOppholdsadresse() = this.hentKonstantOpplysning<List<Adresse>>(OPPHOLDSADRESSE)
@@ -72,7 +71,7 @@ fun Grunnlagsdata<JsonNode>.hentVergemaalellerfremtidsfullmakt() =
 
 fun Grunnlagsdata<JsonNode>.hentPersonrolle() = this.hentKonstantOpplysning<PersonRolle>(PERSONROLLE)
 fun Grunnlagsdata<JsonNode>.hentUtenlandsopphold() =
-    this.hentPeriodisertOpplysning<UtenlandsoppholdOpplysninger>(UTENLANDSOPPHOLD)
+    this.hentKonstantOpplysning<UtenlandsoppholdOpplysninger>(UTENLANDSOPPHOLD)
 
 fun Grunnlagsdata<JsonNode>.hentUtenlandsadresse() =
     this.hentKonstantOpplysning<Utenlandsadresse>(UTENLANDSADRESSE)
@@ -91,38 +90,5 @@ inline fun <reified T> Grunnlagsdata<JsonNode>.hentKonstantOpplysning(
             grunnlagsdata.kilde,
             objectMapper.readValue(grunnlagsdata.verdi.toJson(), object : TypeReference<T>() {})
         )
-
-        else -> {
-            getLogger(this::class.java).error("Feil skjedde under henting av opplysning: Opplysningen er periodisert")
-            throw RuntimeException("Feil skjedde under henting av opplysning: Opplysningen er periodisert")
-        }
-    }
-}
-
-inline fun <reified T> Grunnlagsdata<JsonNode>.hentPeriodisertOpplysning(
-    opplysningstype: Opplysningstype
-): Opplysning.Periodisert<T>? {
-    val grunnlagsdata = this[opplysningstype] ?: return null
-
-    return when (grunnlagsdata) {
-        is Opplysning.Periodisert -> {
-            Opplysning.Periodisert(
-                perioder = grunnlagsdata.perioder.map {
-                    PeriodisertOpplysning(
-                        id = it.id,
-                        kilde = it.kilde,
-                        verdi = objectMapper.readValue(it.verdi.toJson(), T::class.java),
-                        fom = it.fom,
-                        tom = it.tom
-                    )
-                }
-            )
-        }
-
-        else -> {
-            val err = "Feil skjedde under henting av opplysning $opplysningstype: Opplysningen er Konstant"
-            getLogger(this::class.java).error(err)
-            throw RuntimeException(err)
-        }
     }
 }

--- a/libs/saksbehandling-common/src/main/kotlin/grunnlag/Opplysning.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/grunnlag/Opplysning.kt
@@ -2,10 +2,6 @@ package no.nav.etterlatte.libs.common.grunnlag
 
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import no.nav.etterlatte.libs.common.periode.Periode
-import org.slf4j.LoggerFactory
-import java.time.Month
-import java.time.YearMonth
 import java.util.*
 
 @JsonTypeInfo(
@@ -14,42 +10,9 @@ import java.util.*
     property = "type"
 )
 @JsonSubTypes(
-    JsonSubTypes.Type(value = Opplysning.Periodisert::class, name = "periodisert"),
     JsonSubTypes.Type(value = Opplysning.Konstant::class, name = "konstant")
 )
 sealed class Opplysning<T>(val type: String) {
-    data class Periodisert<T>(
-        val perioder: List<PeriodisertOpplysning<T>>
-    ) : Opplysning<T>("periodisert") {
-        companion object {
-
-            private val logger = LoggerFactory.getLogger(this::class.java)
-            fun <T> create(grunnlagsopplysninger: List<Grunnlagsopplysning<T>>) =
-                Periodisert(
-                    grunnlagsopplysninger.map {
-                        val periode = if (it.periode == null) {
-                            logger.warn(
-                                "Så en periodisert opplysning med id=${it.id} som mangler periode. Setter " +
-                                    "periode som en fiktiv periode fra og med 1900-01 uten til og med"
-                            )
-                            Periode(YearMonth.of(1900, Month.JANUARY), null)
-                        } else {
-                            it.periode
-                        }
-                        PeriodisertOpplysning(
-                            id = it.id,
-                            kilde = it.kilde,
-                            verdi = it.opplysning,
-                            fom = periode.fom,
-                            tom = periode.tom
-                        )
-                    }
-                )
-        }
-
-        /* TODO ai: Midlertidig funksjon for å hente ut data. Skal erstattes av periodisering senere */
-        fun hentSenest() = perioder.lastOrNull()
-    }
 
     data class Konstant<T>(
         val id: UUID,
@@ -65,11 +28,3 @@ sealed class Opplysning<T>(val type: String) {
         }
     }
 }
-
-data class PeriodisertOpplysning<T>(
-    val id: UUID,
-    val kilde: Grunnlagsopplysning.Kilde,
-    val verdi: T,
-    val fom: YearMonth,
-    val tom: YearMonth?
-)

--- a/libs/testdata/src/main/kotlin/grunnlag/TestDataMaps.kt
+++ b/libs/testdata/src/main/kotlin/grunnlag/TestDataMaps.kt
@@ -3,7 +3,6 @@ package no.nav.etterlatte.libs.testdata.grunnlag
 import com.fasterxml.jackson.databind.JsonNode
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.Opplysning
-import no.nav.etterlatte.libs.common.grunnlag.PeriodisertOpplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Navn
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.ADRESSEBESKYTTELSE
@@ -31,7 +30,6 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.testdata.pdl.personTestData
 import java.time.LocalDateTime
-import java.time.YearMonth
 import java.util.UUID.randomUUID
 
 val kilde = Grunnlagsopplysning.Pdl("pdl", Tidspunkt.now(), null, "opplysningsId1")
@@ -69,16 +67,10 @@ internal val soekerTestopplysningerMap: Map<Opplysningstype, Opplysning<JsonNode
     FOEDSELSAAR to Opplysning.Konstant(randomUUID(), kilde, SOEKER_FOEDSELSNUMMER.getBirthDate().year.toJsonNode()),
     FOEDELAND to Opplysning.Konstant(randomUUID(), kilde, "NOR".toJsonNode()),
     ADRESSEBESKYTTELSE to Opplysning.Konstant(randomUUID(), kilde, AdressebeskyttelseGradering.UGRADERT.toJsonNode()),
-    BOSTEDSADRESSE to Opplysning.Periodisert(
-        ADRESSE_DEFAULT.map {
-            PeriodisertOpplysning(
-                randomUUID(),
-                kilde = kilde,
-                verdi = it.toJsonNode(),
-                fom = it.gyldigFraOgMed!!.let { YearMonth.of(it.year, it.month) },
-                tom = it.gyldigFraOgMed?.let { YearMonth.of(it.year, it.month) }
-            )
-        }
+    BOSTEDSADRESSE to Opplysning.Konstant(
+        randomUUID(),
+        kilde = kilde,
+        verdi = ADRESSE_DEFAULT.toJsonNode()
     ),
     STATSBORGERSKAP to Opplysning.Konstant(randomUUID(), kilde, "NOR".toJsonNode()),
     PERSONROLLE to Opplysning.Konstant(randomUUID(), kilde, PersonRolle.BARN.toJsonNode()),
@@ -100,16 +92,10 @@ internal val soeskenTestopplysningerMap: Map<Opplysningstype, Opplysning<JsonNod
     FOEDSELSAAR to Opplysning.Konstant(randomUUID(), kilde, HELSOESKEN_FOEDSELSNUMMER.getBirthDate().year.toJsonNode()),
     FOEDELAND to Opplysning.Konstant(randomUUID(), kilde, "NOR".toJsonNode()),
     ADRESSEBESKYTTELSE to Opplysning.Konstant(randomUUID(), kilde, AdressebeskyttelseGradering.UGRADERT.toJsonNode()),
-    BOSTEDSADRESSE to Opplysning.Periodisert(
-        ADRESSE_DEFAULT.map {
-            PeriodisertOpplysning(
-                randomUUID(),
-                kilde = kilde,
-                verdi = it.toJsonNode(),
-                fom = it.gyldigFraOgMed!!.let { YearMonth.of(it.year, it.month) },
-                tom = it.gyldigFraOgMed?.let { YearMonth.of(it.year, it.month) }
-            )
-        }
+    BOSTEDSADRESSE to Opplysning.Konstant(
+        randomUUID(),
+        kilde = kilde,
+        verdi = ADRESSE_DEFAULT.toJsonNode()
     ),
     STATSBORGERSKAP to Opplysning.Konstant(randomUUID(), kilde, "NOR".toJsonNode()),
     PERSONROLLE to Opplysning.Konstant(randomUUID(), kilde, PersonRolle.BARN.toJsonNode()),
@@ -135,16 +121,10 @@ internal val halvsoeskenTestopplysningerMap: Map<Opplysningstype, Opplysning<Jso
     ),
     FOEDELAND to Opplysning.Konstant(randomUUID(), kilde, "NOR".toJsonNode()),
     ADRESSEBESKYTTELSE to Opplysning.Konstant(randomUUID(), kilde, AdressebeskyttelseGradering.UGRADERT.toJsonNode()),
-    BOSTEDSADRESSE to Opplysning.Periodisert(
-        ADRESSE_DEFAULT.map {
-            PeriodisertOpplysning(
-                randomUUID(),
-                kilde = kilde,
-                verdi = it.toJsonNode(),
-                fom = it.gyldigFraOgMed!!.let { YearMonth.of(it.year, it.month) },
-                tom = it.gyldigFraOgMed?.let { YearMonth.of(it.year, it.month) }
-            )
-        }
+    BOSTEDSADRESSE to Opplysning.Konstant(
+        randomUUID(),
+        kilde = kilde,
+        verdi = ADRESSE_DEFAULT.toJsonNode()
     ),
     STATSBORGERSKAP to Opplysning.Konstant(randomUUID(), kilde, "NOR".toJsonNode()),
     PERSONROLLE to Opplysning.Konstant(randomUUID(), kilde, PersonRolle.BARN.toJsonNode()),
@@ -167,16 +147,10 @@ internal val avdoedTestopplysningerMap: Map<Opplysningstype, Opplysning<JsonNode
     FOEDELAND to Opplysning.Konstant(randomUUID(), kilde, "NOR".toJsonNode()),
     DOEDSDATO to Opplysning.Konstant(randomUUID(), kilde, LocalDateTime.parse("2022-08-17T00:00:00").toJsonNode()),
     ADRESSEBESKYTTELSE to Opplysning.Konstant(randomUUID(), kilde, AdressebeskyttelseGradering.UGRADERT.toJsonNode()),
-    BOSTEDSADRESSE to Opplysning.Periodisert(
-        ADRESSE_DEFAULT.map {
-            PeriodisertOpplysning(
-                randomUUID(),
-                kilde = kilde,
-                verdi = it.toJsonNode(),
-                fom = it.gyldigFraOgMed!!.let { YearMonth.of(it.year, it.month) },
-                tom = it.gyldigFraOgMed?.let { YearMonth.of(it.year, it.month) }
-            )
-        }
+    BOSTEDSADRESSE to Opplysning.Konstant(
+        randomUUID(),
+        kilde = kilde,
+        verdi = ADRESSE_DEFAULT.toJsonNode()
     ),
     SIVILSTATUS to Opplysning.Konstant(randomUUID(), kilde, Sivilstatus.GIFT.toJsonNode()),
     STATSBORGERSKAP to Opplysning.Konstant(randomUUID(), kilde, "NOR".toJsonNode()),
@@ -209,16 +183,10 @@ internal val gjenlevendeTestopplysningerMap: Map<Opplysningstype, Opplysning<Jso
     ),
     FOEDELAND to Opplysning.Konstant(randomUUID(), kilde, "NOR".toJsonNode()),
     ADRESSEBESKYTTELSE to Opplysning.Konstant(randomUUID(), kilde, AdressebeskyttelseGradering.UGRADERT.toJsonNode()),
-    BOSTEDSADRESSE to Opplysning.Periodisert(
-        ADRESSE_DEFAULT.map {
-            PeriodisertOpplysning(
-                randomUUID(),
-                kilde = kilde,
-                verdi = it.toJsonNode(),
-                fom = it.gyldigFraOgMed!!.let { YearMonth.of(it.year, it.month) },
-                tom = it.gyldigFraOgMed?.let { YearMonth.of(it.year, it.month) }
-            )
-        }
+    BOSTEDSADRESSE to Opplysning.Konstant(
+        randomUUID(),
+        kilde = kilde,
+        verdi = ADRESSE_DEFAULT.toJsonNode()
     ),
     SIVILSTATUS to Opplysning.Konstant(randomUUID(), kilde, Sivilstatus.GIFT.toJsonNode()),
     STATSBORGERSKAP to Opplysning.Konstant(randomUUID(), kilde, "NOR".toJsonNode()),

--- a/libs/testdata/src/main/kotlin/pdl/PersonTestData.kt
+++ b/libs/testdata/src/main/kotlin/pdl/PersonTestData.kt
@@ -34,7 +34,7 @@ fun personTestData(
     foedeland = opplysningsmap.hentFoedeland()?.verdi,
     doedsdato = opplysningsmap.hentDoedsdato()?.verdi,
     adressebeskyttelse = opplysningsmap.hentAdressebeskyttelse()?.verdi,
-    bostedsadresse = opplysningsmap.hentBostedsadresse()?.perioder?.map { it.verdi },
+    bostedsadresse = opplysningsmap.hentBostedsadresse()?.verdi,
     deltBostedsadresse = opplysningsmap.hentDeltbostedsadresse()?.verdi,
     kontaktadresse = opplysningsmap.hentKontaktadresse()?.verdi,
     oppholdsadresse = opplysningsmap.hentOppholdsadresse()?.verdi,


### PR DESCRIPTION
Fragmenteringen av opplysningene skaper problemer når vi henter flere ganger fra PDL, siden gamle opplysninger vi har hentet og brukt i en behandling kan være korrigert i en senere behandling. I stedet for å fragmentere opplysningene fra PDL i separate er de nå lagret som lister, slik at vi kan hente nyeste opplysning (evt. <= en hendelsesid som gir oss historisk grunnlag).

Siden vi allerede har lagret disse opplysningene fra PDL fragmentert (også for saker i produksjon) må vi migrere dataene vi har fra før. Dette blir gjort ved å hente siste grunnlag lagret fra PDL, og populere feltene med verdiene derifra i stedet. Dette betyr at vi vil få duplisert informasjon på alle periodiserte opplysninger, men det ser jeg på som et ikke-problem. I produksjon er det til nå bare gjort uthenting av grunnlag 1 gang per sak, så vi risikerer ikke at vi ødelegger historiske data.

Motiverende eksempel for bostedsadresse:
Ved første behandling får vi denne informasjonen:

```
Adresse 1:   |------------>
Adresse 2:           |--------->

```
Dette ble tidligere lagret som to opplysninger (rader) for bostedsadresse, med korresponderende fom / tom.

La oss si at vi har en ny behandling på saken, og henter nytt grunnlag for å få det oppdatert fra PDL. I mellomtiden har PDL gjort en korreksjon, der Adresse 2 ble byttet ut med adresse B med en litt annen fom, og de har nå i tillegg adresse 3:

```
Adresse 1:   |------------>
Adresse B:     |--------->
Adresse 3:               |------>

```
Disse vil også bli lagret som 3 separate bostedsadresser. Problemet oppstår nå når vi prøver å hente ut en periodisert opplysning for adresse på saken. Det er ingen gode måter å filtrere ut det som er korrigert (eller duplett for den saks skyld), så vi henter ut det som er lagret:

```
Adresse 1:   |------------>
Adresse 2:           |--------->
Adresse 1:   |------------>
Adresse B:     |--------->
Adresse 3:               |------>
```

og presenterer dette som en periodisert opplysning. Her har vi dobbelt opp av en adresse, og vi har med en adresse som ikke er riktig for personen.