### PR TITLE
Feature/ey 1784 skal kunne behandle strengt fortrolig og st utland

### DIFF
--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -71,6 +71,8 @@ spec:
       value: http://etterlatte-vedtaksvurdering
     - name: AZUREAD_ATTESTANT_GROUPID
       value: 63f46f74-84a8-4d1c-87a8-78532ab3ae60
+    - name: AZUREAD_FORTROLIG_GROUPID
+      value: ea930b6b-9397-44d9-b9e6-f4cf527a632a
     - name: AZUREAD_SAKSBEHANDLER_GROUPID
       value: 8bb9b8d1-f46a-4ade-8ee8-5895eccdf8cf
     - name: AZUREAD_STRENGT_FORTROLIG_GROUPID

--- a/apps/etterlatte-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-behandling/.nais/prod.yaml
@@ -83,6 +83,8 @@ spec:
       value: 0af3955f-df85-4eb0-b5b2-45bf2c8aeb9e
     - name: AZUREAD_STRENGT_FORTROLIG_GROUPID
       value: ad7b87a6-9180-467c-affc-20a566b0fec0
+    - name: AZUREAD_FORTROLIG_GROUPID
+      value: 9ec6487d-f37a-4aad-a027-cd221c1ac32b
     - name: NORG2_URL
       value: https://norg2.prod-fss-pub.nais.io/norg2/api/v1
     - name: NAVANSATT_URL

--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -79,6 +79,7 @@ fun Application.module(beanFactory: BeanFactory) {
         ) {
             attachContekst(dataSource(), beanFactory)
             sakRoutes(
+                sakServiceAdressebeskyttelse = sakServiceAdressebeskyttelse,
                 sakService = sakService,
                 generellBehandlingService = generellBehandlingService,
                 grunnlagsendringshendelseService = grunnlagsendringshendelseService
@@ -97,13 +98,13 @@ fun Application.module(beanFactory: BeanFactory) {
             oppgaveRoutes(service = beanFactory.oppgaveService())
             grunnlagsendringshendelseRoute(grunnlagsendringshendelseService = grunnlagsendringshendelseService)
             egenAnsattRoute(egenAnsattService = EgenAnsattService(sakService))
-            tilgangRoutes(sakService, sakServiceAdressebeskyttelse)
+            tilgangRoutes(sakServiceAdressebeskyttelse)
             install(adressebeskyttelsePlugin) {
-                behandlingIdHarAdressebeskyttelse = { behandlingId ->
-                    sakServiceAdressebeskyttelse.behandlingHarAdressebeskyttelse(behandlingId)
+                harTilgangBehandling = { behandlingId, saksbehandlerMedRoller ->
+                    sakServiceAdressebeskyttelse.harTilgangTilBehandling(behandlingId, saksbehandlerMedRoller)
                 }
-                sakIdHarAdressebeskyttelse = { sakId ->
-                    sakServiceAdressebeskyttelse.sjekkOmSakHarAdresseBeskyttelse(sakId)
+                harTilgangTilSak = { sakId, saksbehandlerMedRoller ->
+                    sakServiceAdressebeskyttelse.harTilgangTilSak(sakId, saksbehandlerMedRoller)
                 }
             }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/Contekst.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Contekst.kt
@@ -39,7 +39,7 @@ class SystemUser(identifiedBy: TokenValidationContext) : ExternalUser(identified
 
 class Saksbehandler(
     identifiedBy: TokenValidationContext,
-    private val saksbehandlerGroupIdsByKey: Map<String, String?>,
+    private val saksbehandlerGroupIdsByKey: Map<String, String>,
     private val enhetService: EnhetService
 ) :
     ExternalUser(identifiedBy) {
@@ -56,21 +56,28 @@ class Saksbehandler(
     fun harRolleSaksbehandler(): Boolean {
         return identifiedBy.getJwtToken(AZURE_ISSUER).jwtTokenClaims.containsClaim(
             "groups",
-            saksbehandlerGroupIdsByKey["AZUREAD_SAKSBEHANDLER_GROUPID"] ?: ""
+            saksbehandlerGroupIdsByKey["AZUREAD_SAKSBEHANDLER_GROUPID"]
         )
     }
 
     fun harRolleAttestant(): Boolean {
         return identifiedBy.getJwtToken(AZURE_ISSUER).jwtTokenClaims.containsClaim(
             "groups",
-            saksbehandlerGroupIdsByKey["AZUREAD_ATTESTANT_GROUPID"] ?: ""
+            saksbehandlerGroupIdsByKey["AZUREAD_ATTESTANT_GROUPID"]
         )
     }
 
     fun harRolleStrengtFortrolig(): Boolean {
         return identifiedBy.getJwtToken(AZURE_ISSUER).jwtTokenClaims.containsClaim(
             "groups",
-            saksbehandlerGroupIdsByKey["AZUREAD_STRENGT_FORTROLIG_GROUPID"] ?: ""
+            saksbehandlerGroupIdsByKey["AZUREAD_STRENGT_FORTROLIG_GROUPID"]
+        )
+    }
+
+    fun harRolleFortrolig(): Boolean {
+        return identifiedBy.getJwtToken(AZURE_ISSUER).jwtTokenClaims.containsClaim(
+            "groups",
+            saksbehandlerGroupIdsByKey["AZUREAD_FORTROLIG_GROUPID"]
         )
     }
 
@@ -87,7 +94,7 @@ class Kunde(identifiedBy: TokenValidationContext) : ExternalUser(identifiedBy) {
 
 fun decideUser(
     principal: TokenValidationContextPrincipal,
-    saksbehandlerGroupIdsByKey: Map<String, String?>,
+    saksbehandlerGroupIdsByKey: Map<String, String>,
     enhetService: EnhetService
 ): ExternalUser {
     return if (principal.context.issuers.contains("tokenx")) {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilgang/TilgangRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilgang/TilgangRoutes.kt
@@ -7,31 +7,69 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
+import no.nav.etterlatte.SaksbehandlerMedRoller
 import no.nav.etterlatte.TILGANG_ROUTE_PATH
 import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.behandlingsId
 import no.nav.etterlatte.libs.common.sakId
-import no.nav.etterlatte.sak.SakService
+import no.nav.etterlatte.libs.ktor.bruker
 import no.nav.etterlatte.sak.SakServiceAdressebeskyttelse
+import no.nav.etterlatte.token.Bruker
+import no.nav.etterlatte.token.Saksbehandler
+import no.nav.etterlatte.token.SystemBruker
 
-internal fun Route.tilgangRoutes(sakService: SakService, sakServiceAdressebeskyttelse: SakServiceAdressebeskyttelse) {
+internal fun Route.tilgangRoutes(sakServiceAdressebeskyttelse: SakServiceAdressebeskyttelse) {
     route("/$TILGANG_ROUTE_PATH") {
         post("/person") {
             val fnr = call.receive<String>()
-            val harTilgang = !sakService.sjekkOmFnrHarEnSakMedAdresseBeskyttelse(fnr)
+
+            val harTilgang = harTilgangBrukertypeSjekk(
+                bruker = bruker,
+                harTilgang = {
+                    sakServiceAdressebeskyttelse.harTilgangTilPerson(
+                        fnr,
+                        SaksbehandlerMedRoller(bruker as Saksbehandler)
+                    )
+                }
+            )
             call.respond(harTilgang)
         }
 
         get("/behandling/{$BEHANDLINGSID_CALL_PARAMETER}") {
-            val harTilgang =
-                !sakServiceAdressebeskyttelse.behandlingHarAdressebeskyttelse(behandlingsId.toString())
+            val harTilgang = harTilgangBrukertypeSjekk(
+                bruker = bruker,
+                harTilgang = {
+                    sakServiceAdressebeskyttelse.harTilgangTilBehandling(
+                        behandlingsId.toString(),
+                        SaksbehandlerMedRoller(bruker as Saksbehandler)
+                    )
+                }
+            )
+
             call.respond(harTilgang)
         }
 
         get("/sak/{$SAKID_CALL_PARAMETER}") {
-            val harTilgang = !sakService.sjekkOmSakHarAdresseBeskyttelse(sakId)
+            val harTilgang = harTilgangBrukertypeSjekk(
+                bruker = bruker,
+                harTilgang = {
+                    sakServiceAdressebeskyttelse.harTilgangTilSak(
+                        sakId,
+                        SaksbehandlerMedRoller(bruker as Saksbehandler)
+                    )
+                }
+            )
             call.respond(harTilgang)
         }
+    }
+}
+
+fun harTilgangBrukertypeSjekk(bruker: Bruker, harTilgang: () -> Boolean): Boolean {
+    return when (bruker) {
+        is Saksbehandler -> {
+            harTilgang()
+        }
+        is SystemBruker -> true
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
@@ -23,6 +23,7 @@ import no.nav.etterlatte.libs.common.sakId
 import no.nav.etterlatte.libs.common.withFoedselsnummer
 
 internal fun Route.sakRoutes(
+    sakServiceAdressebeskyttelse: SakServiceAdressebeskyttelse,
     sakService: SakService,
     generellBehandlingService: GenerellBehandlingService,
     grunnlagsendringshendelseService: GrunnlagsendringshendelseService
@@ -45,7 +46,7 @@ internal fun Route.sakRoutes(
     post("personer/saker/{type}") {
         val foedselsnummerDTO = call.receive<FoedselsnummerDTO>()
         val fnr = foedselsnummerDTO.foedselsnummer
-        withFoedselsnummer(fnr, sakService) {
+        withFoedselsnummer(fnr, sakServiceAdressebeskyttelse) {
             val type: SakType = enumValueOf(requireNotNull(call.parameters["type"]))
             call.respond(inTransaction { sakService.finnEllerOpprettSak(fnr, type) })
         }
@@ -55,7 +56,7 @@ internal fun Route.sakRoutes(
         post("behandlinger") {
             val foedselsnummerDTO = call.receive<FoedselsnummerDTO>()
             val fnr = foedselsnummerDTO.foedselsnummer
-            withFoedselsnummer(fnr, sakService) {
+            withFoedselsnummer(fnr, sakServiceAdressebeskyttelse) {
                 val behandlinger = sakService.finnSaker(fnr)
                     .map { sak ->
                         generellBehandlingService.hentBehandlingerISak(sak.id).map {
@@ -69,7 +70,7 @@ internal fun Route.sakRoutes(
         post("grunnlagsendringshendelser") {
             val foedselsnummerDTO = call.receive<FoedselsnummerDTO>()
             val fnr = foedselsnummerDTO.foedselsnummer
-            withFoedselsnummer(fnr, sakService) {
+            withFoedselsnummer(fnr, sakServiceAdressebeskyttelse) {
                 call.respond(
                     sakService.finnSaker(fnr).map { sak ->
                         GrunnlagsendringsListe(grunnlagsendringshendelseService.hentAlleHendelserForSak(sak.id))

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakServiceAdressebeskyttelse.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakServiceAdressebeskyttelse.kt
@@ -1,28 +1,81 @@
 package no.nav.etterlatte.sak
 
+import no.nav.etterlatte.SaksbehandlerMedRoller
+import no.nav.etterlatte.libs.common.PersonTilgangsSjekk
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 
-interface SakServiceAdressebeskyttelse {
-    fun behandlingHarAdressebeskyttelse(behandlingId: String): Boolean
+interface SakServiceAdressebeskyttelse : PersonTilgangsSjekk {
+    fun harTilgangTilBehandling(behandlingId: String, saksbehandlerMedRoller: SaksbehandlerMedRoller): Boolean
     fun oppdaterAdressebeskyttelse(id: Long, adressebeskyttelseGradering: AdressebeskyttelseGradering): Int
-    fun sjekkOmSakHarAdresseBeskyttelse(fnr: String): Boolean
+    fun harTilgangTilSak(sakId: Long, saksbehandlerMedRoller: SaksbehandlerMedRoller): Boolean
+    fun harTilgangTilPerson(fnr: String, saksbehandlerMedRoller: SaksbehandlerMedRoller): Boolean
 }
 
-class SakServiceAdressebeskyttelseImpl(private val dao: SakDaoAdressebeskyttelse) : SakServiceAdressebeskyttelse {
+data class SakMedGradering(val id: Long, val adressebeskyttelseGradering: AdressebeskyttelseGradering?)
 
-    private fun finnSakerForPerson(person: String) = dao.finnSaker(person)
-    override fun sjekkOmSakHarAdresseBeskyttelse(fnr: String): Boolean {
-        val sakIder = this.finnSakerForPerson(fnr).map { it.id }
-        return dao.enAvSakeneHarAdresseBeskyttelse(sakIder)
+class SakServiceAdressebeskyttelseImpl(
+    private val dao: SakDaoAdressebeskyttelse,
+    private val saksbehandlereGroupIdsByKey: Map<String, String>
+) : SakServiceAdressebeskyttelse {
+
+    override suspend fun harTilgangTilPerson(
+        foedselsnummer: Folkeregisteridentifikator,
+        bruker: no.nav.etterlatte.token.Saksbehandler
+    ): Boolean {
+        return this.harTilgangTilPerson(foedselsnummer.value, SaksbehandlerMedRoller(bruker))
     }
-    override fun behandlingHarAdressebeskyttelse(behandlingId: String) =
-        dao.sjekkOmBehandlingHarAdressebeskyttelse(behandlingId).harBeskyttelse()
 
-    private fun AdressebeskyttelseGradering?.harBeskyttelse() = when (this) {
-        AdressebeskyttelseGradering.FORTROLIG -> true
-        AdressebeskyttelseGradering.STRENGT_FORTROLIG -> true
-        AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND -> true
-        else -> false
+    override fun harTilgangTilPerson(fnr: String, saksbehandlerMedRoller: SaksbehandlerMedRoller): Boolean {
+        val finnSakerMedGradering = dao.finnSakerMedGradering(fnr)
+        if (finnSakerMedGradering.isEmpty()) {
+            return true
+        }
+        val harRolleStrengtFortrolig = saksbehandlerMedRoller.harRolleStrengtFortrolig(saksbehandlereGroupIdsByKey)
+        val harRolleFortrolig = saksbehandlerMedRoller.harRolleFortrolig(saksbehandlereGroupIdsByKey)
+
+        return finnSakerMedGradering.map {
+            when (it.adressebeskyttelseGradering) {
+                AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND -> harRolleStrengtFortrolig
+                AdressebeskyttelseGradering.STRENGT_FORTROLIG -> harRolleStrengtFortrolig
+                AdressebeskyttelseGradering.FORTROLIG -> harRolleFortrolig
+                AdressebeskyttelseGradering.UGRADERT -> true
+                else -> true
+            }
+        }.all { it }
+    }
+
+    override fun harTilgangTilSak(sakId: Long, saksbehandlerMedRoller: SaksbehandlerMedRoller): Boolean {
+        val harRolleStrengtFortrolig = saksbehandlerMedRoller.harRolleStrengtFortrolig(saksbehandlereGroupIdsByKey)
+        val harRolleFortrolig = saksbehandlerMedRoller.harRolleFortrolig(saksbehandlereGroupIdsByKey)
+
+        val sakMedGradering = dao.hentSakMedGradering(sakId) ?: return true
+        return when (sakMedGradering.adressebeskyttelseGradering) {
+            AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND -> harRolleStrengtFortrolig
+            AdressebeskyttelseGradering.STRENGT_FORTROLIG -> harRolleStrengtFortrolig
+            AdressebeskyttelseGradering.FORTROLIG -> harRolleFortrolig
+            AdressebeskyttelseGradering.UGRADERT -> true
+            else -> true
+        }
+    }
+
+    override fun harTilgangTilBehandling(
+        behandlingId: String,
+        saksbehandlerMedRoller: SaksbehandlerMedRoller
+    ): Boolean {
+        return when (dao.sjekkOmBehandlingHarAdressebeskyttelse(behandlingId)) {
+            AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND -> saksbehandlerMedRoller.harRolleStrengtFortrolig(
+                saksbehandlereGroupIdsByKey
+            )
+            AdressebeskyttelseGradering.STRENGT_FORTROLIG -> saksbehandlerMedRoller.harRolleStrengtFortrolig(
+                saksbehandlereGroupIdsByKey
+            )
+            AdressebeskyttelseGradering.FORTROLIG -> saksbehandlerMedRoller.harRolleFortrolig(
+                saksbehandlereGroupIdsByKey
+            )
+            AdressebeskyttelseGradering.UGRADERT -> true
+            else -> true
+        }
     }
 
     override fun oppdaterAdressebeskyttelse(id: Long, adressebeskyttelseGradering: AdressebeskyttelseGradering): Int {

--- a/apps/etterlatte-behandling/src/test/kotlin/BehandlingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/BehandlingIntegrationTest.kt
@@ -45,6 +45,7 @@ import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.jobs.LeaderElection
 import no.nav.etterlatte.libs.ktor.AZURE_ISSUER
 import no.nav.etterlatte.token.Bruker
+import no.nav.etterlatte.token.Claims
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
@@ -103,8 +104,7 @@ abstract class BehandlingIntegrationTest {
         issueToken(
             mapOf(
                 "navn" to "John Doe",
-                "NAVident" to "Saksbehandler01"
-
+                Claims.NAVident.toString() to "Saksbehandler01"
             )
         )
     }
@@ -113,20 +113,11 @@ abstract class BehandlingIntegrationTest {
         issueToken(
             mapOf(
                 "navn" to "John Doe",
-                "NAVident" to "Saksbehandler01",
+                Claims.NAVident.toString() to "Saksbehandler01",
                 "groups" to listOf(
                     azureAdAttestantClaim,
                     azureAdSaksbehandlerClaim
                 )
-            )
-        )
-    }
-
-    protected val tokenServiceUser: String by lazy {
-        issueToken(
-            mapOf(
-                "NAVident" to "Saksbehandler01",
-                "roles" to listOf("kan-sette-kilde") // TODO hva brukes dette til?
             )
         )
     }
@@ -193,10 +184,12 @@ class TestBeanFactory(
     private val azureAdSaksbehandlerClaim: String,
     private val azureAdAttestantClaim: String
 ) : CommonFactory() {
-    override fun getSaksbehandlerGroupIdsByKey(): Map<String, String?> =
+    override fun getSaksbehandlerGroupIdsByKey(): Map<String, String> =
         mapOf(
             "AZUREAD_ATTESTANT_GROUPID" to azureAdAttestantClaim,
-            "AZUREAD_SAKSBEHANDLER_GROUPID" to azureAdSaksbehandlerClaim
+            "AZUREAD_SAKSBEHANDLER_GROUPID" to azureAdSaksbehandlerClaim,
+            "AZUREAD_STRENGT_FORTROLIG_GROUPID" to "5ef775f2-61f8-4283-bf3d-8d03f428aa14",
+            "AZUREAD_FORTROLIG_GROUPID" to "ea930b6b-9397-44d9-b9e6-f4cf527a632a"
         )
 
     val rapidSingleton: TestProdusent<String, String> by lazy() { TestProdusent() }

--- a/apps/etterlatte-behandling/src/test/kotlin/IntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/IntegrationTest.kt
@@ -87,7 +87,7 @@ class IntegrationTest : BehandlingIntegrationTest() {
 
             assertTrue(beanFactory.featureToggleService().isEnabled(FellesFeatureToggle.NoOperationToggle, false))
 
-            client.get("/saker/$fnr") {
+            client.get("/saker/1") {
                 addAuthToken(tokenSaksbehandler)
             }.apply {
                 assertEquals(HttpStatusCode.NotFound, status)
@@ -110,7 +110,7 @@ class IntegrationTest : BehandlingIntegrationTest() {
             }
 
             val behandlingId = client.post("/behandlinger/foerstegangsbehandling") {
-                addAuthToken(tokenServiceUser)
+                addAuthToken(systemBruker)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody(
                     BehandlingsBehov(
@@ -288,7 +288,7 @@ class IntegrationTest : BehandlingIntegrationTest() {
             }
 
             client.post("/grunnlagsendringshendelse/doedshendelse") {
-                addAuthToken(tokenServiceUser)
+                addAuthToken(systemBruker)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody(Doedshendelse("søker", LocalDate.now(), Endringstype.OPPRETTET))
             }.also {
@@ -296,7 +296,7 @@ class IntegrationTest : BehandlingIntegrationTest() {
             }
 
             client.post("/grunnlagsendringshendelse/doedshendelse") {
-                addAuthToken(tokenServiceUser)
+                addAuthToken(systemBruker)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody(Doedshendelse("søker", LocalDate.now(), Endringstype.OPPRETTET))
             }.also {
@@ -304,7 +304,7 @@ class IntegrationTest : BehandlingIntegrationTest() {
             }
 
             client.post("/grunnlagsendringshendelse/utflyttingshendelse") {
-                addAuthToken(tokenServiceUser)
+                addAuthToken(systemBruker)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody(
                     UtflyttingsHendelse(
@@ -320,7 +320,7 @@ class IntegrationTest : BehandlingIntegrationTest() {
             }
 
             client.post("/grunnlagsendringshendelse/forelderbarnrelasjonhendelse") {
-                addAuthToken(tokenServiceUser)
+                addAuthToken(systemBruker)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody(
                     ForelderBarnRelasjonHendelse(
@@ -337,7 +337,7 @@ class IntegrationTest : BehandlingIntegrationTest() {
             }
 
             val behandlingIdNyFoerstegangsbehandling = client.post("/behandlinger/foerstegangsbehandling") {
-                addAuthToken(tokenServiceUser)
+                addAuthToken(systemBruker)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody(
                     BehandlingsBehov(
@@ -358,20 +358,6 @@ class IntegrationTest : BehandlingIntegrationTest() {
                 assertEquals(HttpStatusCode.OK, it.status)
             }
 
-            client.post("/grunnlagsendringshendelse/adressebeskyttelse") {
-                addAuthToken(tokenServiceUser)
-                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                setBody(
-                    Adressebeskyttelse(
-                        fnr = fnr,
-                        adressebeskyttelseGradering = AdressebeskyttelseGradering.STRENGT_FORTROLIG,
-                        endringstype = Endringstype.OPPRETTET
-                    )
-                )
-            }.also {
-                assertEquals(HttpStatusCode.OK, it.status)
-            }
-
             client.post("/api/behandlinger/${sak.id}/manueltopphoer") {
                 addAuthToken(tokenSaksbehandler)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -388,6 +374,20 @@ class IntegrationTest : BehandlingIntegrationTest() {
             }.also {
                 assertEquals(HttpStatusCode.OK, it.status)
                 it.body<ManueltOpphoerResponse>()
+            }
+
+            client.post("/grunnlagsendringshendelse/adressebeskyttelse") {
+                addAuthToken(systemBruker)
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                setBody(
+                    Adressebeskyttelse(
+                        fnr = fnr,
+                        adressebeskyttelseGradering = AdressebeskyttelseGradering.STRENGT_FORTROLIG,
+                        endringstype = Endringstype.OPPRETTET
+                    )
+                )
+            }.also {
+                assertEquals(HttpStatusCode.OK, it.status)
             }
 
             client.get("/behandlinger/$behandlingId") {

--- a/apps/etterlatte-behandling/src/test/kotlin/OmregningIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/OmregningIntegrationTest.kt
@@ -92,7 +92,7 @@ class OmregningIntegrationTest : BehandlingIntegrationTest() {
                 application { module(beanFactory) }
 
                 val (omregning) = client.post("/omregning") {
-                    addAuthToken(tokenServiceUser)
+                    addAuthToken(systemBruker)
                     header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     setBody(
                         Omregningshendelse(
@@ -135,7 +135,7 @@ class OmregningIntegrationTest : BehandlingIntegrationTest() {
             application { module(beanFactory) }
 
             client.post("/omregning") {
-                addAuthToken(tokenServiceUser)
+                addAuthToken(systemBruker)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody(Omregningshendelse(1, LocalDate.now(), null, Prosesstype.AUTOMATISK))
             }.also {

--- a/apps/etterlatte-behandling/src/test/kotlin/TestApp.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/TestApp.kt
@@ -67,7 +67,9 @@ class LocalAppBeanFactory(
     override fun getSaksbehandlerGroupIdsByKey(): Map<String, String> =
         mapOf(
             "AZUREAD_ATTESTANT_GROUPID" to azureAdAttestantClaim,
-            "AZUREAD_SAKSBEHANDLER_GROUPID" to azureAdSaksbehandlerClaim
+            "AZUREAD_SAKSBEHANDLER_GROUPID" to azureAdSaksbehandlerClaim,
+            "AZUREAD_STRENGT_FORTROLIG_GROUPID" to "5ef775f2-61f8-4283-bf3d-8d03f428aa14",
+            "AZUREAD_FORTROLIG_GROUPID" to "ea930b6b-9397-44d9-b9e6-f4cf527a632a"
         )
 
     override fun dataSource(): DataSource = DataSourceBuilder.createDataSource(jdbcUrl, username, password)

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
@@ -101,7 +101,7 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
             }
 
             client.post("/grunnlagsendringshendelse/adressebeskyttelse") {
-                addAuthToken(tokenServiceUser)
+                addAuthToken(systemBruker)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody(
                     Adressebeskyttelse(
@@ -189,7 +189,7 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
             }
 
             httpClient.post("/grunnlagsendringshendelse/adressebeskyttelse") {
-                addAuthToken(tokenServiceUser)
+                addAuthToken(systemBruker)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody(
                     Adressebeskyttelse(
@@ -275,7 +275,7 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
             Assertions.assertTrue(harTilgang)
 
             client.post("/grunnlagsendringshendelse/adressebeskyttelse") {
-                addAuthToken(tokenServiceUser)
+                addAuthToken(systemBruker)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody(
                     Adressebeskyttelse(
@@ -321,7 +321,7 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
             }.body()
 
             httpClient.post("/grunnlagsendringshendelse/adressebeskyttelse") {
-                addAuthToken(tokenServiceUser)
+                addAuthToken(systemBruker)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody(
                     Adressebeskyttelse(

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingsstatusRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingsstatusRoutesTest.kt
@@ -38,6 +38,9 @@ internal class BehandlingsstatusRoutesTest {
         server.start()
         val httpServer = server.config.httpServer
         hoconApplicationConfig = buildTestApplicationConfigurationForOauth(httpServer.port(), AZURE_ISSUER, CLIENT_ID)
+        every { beanFactory.sakServiceAdressebeskyttelse() } returns mockk {
+            every { harTilgangTilBehandling(any(), any()) } returns true
+        }
     }
 
     @AfterAll

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealGenerellBehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealGenerellBehandlingServiceTest.kt
@@ -361,6 +361,6 @@ class RealGenerellBehandlingServiceTest {
     companion object {
         const val SAK_ID = 1L
         val BEHANDLINGS_ID: UUID = UUID.randomUUID()
-        val TOKEN = Bruker.of("a", "b", null, null)
+        val TOKEN = Bruker.of("a", "b", null, null, null)
     }
 }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingRoutesKtTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingRoutesKtTest.kt
@@ -37,6 +37,10 @@ internal class RevurderingRoutesKtTest {
         server.start()
         val httpServer = server.config.httpServer
         hoconApplicationConfig = buildTestApplicationConfigurationForOauth(httpServer.port(), AZURE_ISSUER, CLIENT_ID)
+        every { beanFactory.sakServiceAdressebeskyttelse() } returns mockk {
+            every { harTilgangTilBehandling(any(), any()) } returns true
+            every { harTilgangTilSak(any(), any()) } returns true
+        }
     }
 
     @AfterAll

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
@@ -53,7 +53,7 @@ internal class GrunnlagsendringshendelseServiceTest {
     private val pdlService = mockk<PdlKlientImpl>()
     private val grunnlagClient = mockk<GrunnlagKlient>(relaxed = true, relaxUnitFun = true)
     private val adressebeskyttelseDaoMock = mockk<SakDaoAdressebeskyttelse>()
-    private val sakServiceAdressebeskyttelse = SakServiceAdressebeskyttelseImpl(adressebeskyttelseDaoMock)
+    private val sakServiceAdressebeskyttelse = SakServiceAdressebeskyttelseImpl(adressebeskyttelseDaoMock, emptyMap())
 
     private val grunnlagsendringshendelseService = GrunnlagsendringshendelseService(
         grunnlagshendelsesDao,

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakDaoTest.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.sak
 
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.libs.common.behandling.SakType
-import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.database.migrate
 import org.junit.jupiter.api.Assertions
@@ -36,55 +35,10 @@ class SakDaoTest {
         ).apply { migrate() }
         val connection = dataSource.connection
         sakRepo = SakDao { connection }
-        sakServiceAdressebeskyttelse = SakServiceAdressebeskyttelseImpl(SakDaoAdressebeskyttelse(dataSource))
-    }
-
-    @Test
-    fun kanSjekkeOmHarStrengtFortroligAdressebeskyttelse() {
-        val opprettSak = sakRepo.opprettSak("fnr", SakType.BARNEPENSJON)
-
-        Assertions.assertFalse(sakRepo.enAvSakeneHarAdresseBeskyttelse(listOf(opprettSak.id)))
-        sakServiceAdressebeskyttelse.oppdaterAdressebeskyttelse(
-            opprettSak.id,
-            AdressebeskyttelseGradering.STRENGT_FORTROLIG
+        sakServiceAdressebeskyttelse = SakServiceAdressebeskyttelseImpl(
+            SakDaoAdressebeskyttelse(dataSource),
+            emptyMap()
         )
-        Assertions.assertTrue(sakRepo.enAvSakeneHarAdresseBeskyttelse(listOf(opprettSak.id)))
-    }
-
-    @Test
-    fun kanSjekkeOmHarStrengtFortroligUtlandAdressebeskyttelse() {
-        val opprettSak = sakRepo.opprettSak("fnr", SakType.BARNEPENSJON)
-
-        Assertions.assertFalse(sakRepo.enAvSakeneHarAdresseBeskyttelse(listOf(opprettSak.id)))
-        sakServiceAdressebeskyttelse.oppdaterAdressebeskyttelse(
-            opprettSak.id,
-            AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND
-        )
-        Assertions.assertTrue(sakRepo.enAvSakeneHarAdresseBeskyttelse(listOf(opprettSak.id)))
-    }
-
-    @Test
-    fun kanSjekkeOmHarFortroligAdressebeskyttelse() {
-        val opprettSak = sakRepo.opprettSak("fnr", SakType.BARNEPENSJON)
-
-        Assertions.assertFalse(sakRepo.enAvSakeneHarAdresseBeskyttelse(listOf(opprettSak.id)))
-        sakServiceAdressebeskyttelse.oppdaterAdressebeskyttelse(
-            opprettSak.id,
-            AdressebeskyttelseGradering.FORTROLIG
-        )
-        Assertions.assertTrue(sakRepo.enAvSakeneHarAdresseBeskyttelse(listOf(opprettSak.id)))
-    }
-
-    @Test
-    fun kanSjekkeUgradertAdressebeskyttlese() {
-        val opprettSak = sakRepo.opprettSak("fnr", SakType.BARNEPENSJON)
-
-        Assertions.assertFalse(sakRepo.enAvSakeneHarAdresseBeskyttelse(listOf(opprettSak.id)))
-        sakServiceAdressebeskyttelse.oppdaterAdressebeskyttelse(
-            opprettSak.id,
-            AdressebeskyttelseGradering.UGRADERT
-        )
-        Assertions.assertFalse(sakRepo.enAvSakeneHarAdresseBeskyttelse(listOf(opprettSak.id)))
     }
 
     @Test

--- a/apps/etterlatte-beregning/build.gradle.kts
+++ b/apps/etterlatte-beregning/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 
     testImplementation(libs.test.testcontainer.jupiter)
     testImplementation(libs.test.testcontainer.postgresql)
+    testImplementation(libs.navfelles.tokenvalidationktor2)
 
     testImplementation(libs.test.mockk)
     testImplementation(libs.test.kotest.assertionscore)

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/TestHelper.kt
@@ -36,4 +36,4 @@ fun Int.toBeregningstall(
     roundingMode: RoundingMode = RoundingMode.UNNECESSARY
 ) = Beregningstall(this).setScale(decimals, roundingMode)
 
-val bruker = Saksbehandler("token", "ident")
+val bruker = Saksbehandler("token", "ident", null)

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -93,7 +93,7 @@ internal class VedtaksbrevServiceTest {
                 vedtaksbrevService.oppdaterVedtaksbrev(
                     SAK_ID,
                     BEHANDLING_ID,
-                    Bruker.of("token", "saksbehandler", null, null)
+                    Bruker.of("token", "saksbehandler", null, null, null)
                 )
             }
 
@@ -132,7 +132,7 @@ internal class VedtaksbrevServiceTest {
                 val brev = vedtaksbrevService.oppdaterVedtaksbrev(
                     SAK_ID,
                     BEHANDLING_ID,
-                    Bruker.of("token", "saksbehandler", null, null)
+                    Bruker.of("token", "saksbehandler", null, null, null)
                 )
 
                 assertNotNull(brev)
@@ -170,7 +170,7 @@ internal class VedtaksbrevServiceTest {
                 vedtaksbrevService.oppdaterVedtaksbrev(
                     123,
                     BEHANDLING_ID,
-                    Bruker.of("token", "saksbehandler", null, null)
+                    Bruker.of("token", "saksbehandler", null, null, null)
                 )
             }
 

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/SakOgBehandlingServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/SakOgBehandlingServiceTest.kt
@@ -199,7 +199,7 @@ internal class SakOgBehandlingServiceTest {
         private val STATISK_UUID = UUID.randomUUID()
         private val BEHANDLING_ID = UUID.randomUUID()
         private const val SAKSBEHANDLER_IDENT = "Z1235"
-        private val BRUKER = Bruker.of("321", SAKSBEHANDLER_IDENT, null, null)
+        private val BRUKER = Bruker.of("321", SAKSBEHANDLER_IDENT, null, null, null)
         private const val ATTESTANT_IDENT = "Z54321"
         private const val SAK_ID = 123L
         private val BREV_BEREGNINGSPERIODE = BrevBeregningsperiode(YearMonth.now().atDay(1), null, 10000, 1, 3063, 10)

--- a/apps/etterlatte-trygdetid/build.gradle.kts
+++ b/apps/etterlatte-trygdetid/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation(libs.ktor2.servercio)
     implementation(libs.database.kotliquery)
 
+    testImplementation(libs.navfelles.tokenvalidationktor2)
     testImplementation(libs.test.mockk)
     testImplementation(libs.ktor2.servertests)
     testImplementation(libs.navfelles.mockoauth2server)

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TestHelper.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TestHelper.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 import java.util.*
 import java.util.UUID.randomUUID
 
-val saksbehandler = Saksbehandler("token", "ident")
+val saksbehandler = Saksbehandler("token", "ident", null)
 
 fun trygdetid(behandlingId: UUID = randomUUID(), beregnetTrygdetid: BeregnetTrygdetid? = null) = Trygdetid(
     id = randomUUID(),

--- a/apps/etterlatte-vedtaksvurdering/build.gradle.kts
+++ b/apps/etterlatte-vedtaksvurdering/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
     implementation(libs.navfelles.tokenvalidationktor2)
     implementation(libs.database.kotliquery)
 
+    testImplementation(libs.navfelles.tokenvalidationktor2)
+
     testImplementation(libs.test.mockk)
     testImplementation(libs.kotlinx.coroutinescore)
     testImplementation(libs.test.kotest.assertionscore)

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/TestHelper.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/TestHelper.kt
@@ -24,8 +24,8 @@ const val SAKSBEHANDLER_2 = "saksbehandler2"
 const val ENHET_1 = "1234"
 const val ENHET_2 = "4321"
 
-val saksbehandler = Saksbehandler("token", SAKSBEHANDLER_1)
-val attestant = Saksbehandler("token", SAKSBEHANDLER_2)
+val saksbehandler = Saksbehandler("token", SAKSBEHANDLER_1, null)
+val attestant = Saksbehandler("token", SAKSBEHANDLER_2, null)
 
 fun opprettVedtak(
     virkningstidspunkt: YearMonth = YearMonth.of(2023, Month.JANUARY),

--- a/apps/etterlatte-vilkaarsvurdering/build.gradle.kts
+++ b/apps/etterlatte-vilkaarsvurdering/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
     implementation(libs.jackson.modulekotlin)
     implementation(libs.database.kotliquery)
 
+    testImplementation(libs.navfelles.tokenvalidationktor2)
+
     testImplementation(libs.test.mockk)
     testImplementation(libs.ktor2.servertests)
     testImplementation(libs.test.kotest.assertionscore)

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
@@ -600,7 +600,7 @@ internal class VilkaarsvurderingRoutesTest {
 
     private companion object {
         val behandlingId: UUID = UUID.randomUUID()
-        val oboToken = Bruker.of("token", "s1", null, null)
+        val oboToken = Bruker.of("token", "s1", null, null, null)
         const val CLIENT_ID = "azure-id for saksbehandler"
     }
 }

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
@@ -58,7 +58,7 @@ internal class VilkaarsvurderingServiceTest {
     private val behandlingKlient = mockk<BehandlingKlient>()
     private val grunnlagKlient = mockk<GrunnlagKlient>()
     private val uuid: UUID = UUID.randomUUID()
-    private val bruker = Bruker.of("token", "s1", null, null)
+    private val bruker = Bruker.of("token", "s1", null, null, null)
 
     @BeforeAll
     fun beforeAll() {

--- a/libs/etterlatte-ktor/src/main/kotlin/TokenUtils.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/TokenUtils.kt
@@ -43,7 +43,8 @@ inline val ApplicationCall.bruker: Bruker
             accessToken = hentAccessToken(this),
             oid = oidSub?.first,
             sub = oidSub?.second,
-            saksbehandler = saksbehandler
+            saksbehandler = saksbehandler,
+            claims = claims
         )
     }
 

--- a/libs/etterlatte-token-model/build.gradle.kts
+++ b/libs/etterlatte-token-model/build.gradle.kts
@@ -9,6 +9,8 @@ repositories {
 }
 
 dependencies {
+    implementation(libs.navfelles.tokenvalidationktor2)
+
     testImplementation(libs.test.jupiter.api)
     testImplementation(libs.test.jupiter.params)
     testRuntimeOnly(libs.test.jupiter.engine)

--- a/libs/etterlatte-token-model/src/main/kotlin/no/nav/etterlatte/token/Bruker.kt
+++ b/libs/etterlatte-token-model/src/main/kotlin/no/nav/etterlatte/token/Bruker.kt
@@ -1,5 +1,7 @@
 package no.nav.etterlatte.token
 
+import no.nav.security.token.support.core.jwt.JwtTokenClaims
+
 sealed class Bruker {
     abstract fun ident(): String
     abstract fun saksbehandlerEnhet(saksbehandlere: Map<String, String>): String
@@ -8,11 +10,17 @@ sealed class Bruker {
 
     companion object {
         private fun erSystembruker(oid: String?, sub: String?) = (oid == sub) && (oid != null)
-        fun of(accessToken: String, saksbehandler: String?, oid: String?, sub: String?): Bruker {
+        fun of(
+            accessToken: String,
+            saksbehandler: String?,
+            oid: String?,
+            sub: String?,
+            claims: JwtTokenClaims?
+        ): Bruker {
             return if (erSystembruker(oid = oid, sub = sub)) {
                 SystemBruker(oid!!, sub!!)
             } else if (saksbehandler != null) {
-                Saksbehandler(accessToken, saksbehandler)
+                Saksbehandler(accessToken, saksbehandler, claims)
             } else {
                 throw Exception(
                     "Er ikke systembruker, og Navident er null i token, sannsynligvis manglende claim NAVident"
@@ -30,13 +38,15 @@ data class SystemBruker(val oid: String, val sub: String) : Bruker() {
     override fun accessToken() = throw NotImplementedError("Kun relevant for saksbehandler")
 }
 
-data class Saksbehandler(val accessToken: String, val ident: String) : Bruker() {
+data class Saksbehandler(val accessToken: String, val ident: String, val jwtTokenClaims: JwtTokenClaims?) : Bruker() {
     override fun ident() = ident
 
     override fun saksbehandlerEnhet(saksbehandlere: Map<String, String>) = saksbehandlere[ident]
         ?: throw SaksbehandlerManglerEnhetException("Saksbehandler $ident mangler enhet fra secret")
 
     override fun accessToken() = accessToken
+
+    fun getClaims() = jwtTokenClaims
 }
 
 enum class Claims {

--- a/libs/etterlatte-token-model/src/test/kotlin/no/nav/etterlatte/token/BrukerTest.kt
+++ b/libs/etterlatte-token-model/src/test/kotlin/no/nav/etterlatte/token/BrukerTest.kt
@@ -8,26 +8,26 @@ internal class BrukerTest {
 
     @Test
     fun `er maskin-til-maskin viss oid og sub er like`() {
-        assertTrue(Bruker.of("a", "b", "c", "c") is SystemBruker)
+        assertTrue(Bruker.of("a", "b", "c", "c", null) is SystemBruker)
     }
 
     @Test
     fun `er ikke maskin-til-maskin viss oid og sub er ulike`() {
-        assertFalse(Bruker.of("a", "b", "c", "d") is SystemBruker)
+        assertFalse(Bruker.of("a", "b", "c", "d", null) is SystemBruker)
     }
 
     @Test
     fun `er ikke maskin-til-maskin viss oid er null, men sub har verdi`() {
-        assertFalse(Bruker.of("a", "b", null, "d") is SystemBruker)
+        assertFalse(Bruker.of("a", "b", null, "d", null) is SystemBruker)
     }
 
     @Test
     fun `er ikke maskin-til-maskin viss sub er null, men oid har verdi`() {
-        assertFalse(Bruker.of("a", "b", "c", null) is SystemBruker)
+        assertFalse(Bruker.of("a", "b", "c", null, null) is SystemBruker)
     }
 
     @Test
     fun `er ikke maskin-til-maskin viss både oid og sub er null`() {
-        assertFalse(Bruker.of("a", "b", null, null) is SystemBruker)
+        assertFalse(Bruker.of("a", "b", null, null, null) is SystemBruker)
     }
 }

--- a/libs/ktor2client-onbehalfof/build.gradle.kts
+++ b/libs/ktor2client-onbehalfof/build.gradle.kts
@@ -25,6 +25,9 @@ dependencies {
     api(libs.cache.caffeine)
     api(project(":libs:etterlatte-token-model"))
 
+    implementation(libs.navfelles.tokenclientcore)
+
+    testImplementation(libs.navfelles.tokenvalidationktor2)
     testImplementation(libs.kotlinx.coroutinestest)
     testImplementation("com.github.tomakehurst:wiremock-jre8:2.35.0")
     testImplementation(libs.test.jupiter.engine)

--- a/libs/ktor2client-onbehalfof/src/test/kotlin/DownstreamResourceClientTest.kt
+++ b/libs/ktor2client-onbehalfof/src/test/kotlin/DownstreamResourceClientTest.kt
@@ -30,7 +30,10 @@ internal class DownstreamResourceClientTest {
         every { runBlocking { azureAdClient.getAccessTokenForResource(any()) } } returns Ok(mockk())
 
         runBlocking {
-            client.get(resource, Bruker.of(accessToken = "a", oid = "b", sub = "b", saksbehandler = null))
+            client.get(
+                resource,
+                Bruker.of(accessToken = "a", oid = "b", sub = "b", saksbehandler = null, claims = null)
+            )
         }
         verify { runBlocking { azureAdClient.getAccessTokenForResource(any()) } }
         verify(exactly = 0) {
@@ -45,7 +48,7 @@ internal class DownstreamResourceClientTest {
         runBlocking {
             client.get(
                 resource,
-                Bruker.of(accessToken = "a", oid = "b", sub = "c", saksbehandler = "s1")
+                Bruker.of(accessToken = "a", oid = "b", sub = "c", saksbehandler = "s1", claims = null)
             )
         }
         verify { runBlocking { azureAdClient.getOnBehalfOfAccessTokenForResource(any(), "a") } }


### PR DESCRIPTION
✅ 

En ting vi må se på senere er konteksten til behandling der man har sin egen impl av bruker som man legger diverse ting og avgjør typen bruker. Kan vi like så godt bruke `call.bruker` der og for å droppe det?
Svar:
https://jira.adeo.no/browse/EY-2013