### PR TITLE
EY-1769 Støtt manuell flyt for revurdering (regulering skal ikke sende brev)

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/DetaljertBehandlingDto.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/DetaljertBehandlingDto.kt
@@ -4,6 +4,7 @@ import no.nav.etterlatte.behandling.hendelse.LagretHendelse
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.KommerBarnetTilgode
+import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -29,7 +30,8 @@ data class DetaljertBehandlingDto(
     val familieforhold: Familieforhold?,
     val behandlingType: BehandlingType,
     val søker: Person?,
-    val kommerBarnetTilgode: KommerBarnetTilgode?
+    val kommerBarnetTilgode: KommerBarnetTilgode?,
+    val revurderingsaarsak: RevurderingAarsak?
 )
 
 data class Familieforhold(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/GenerellBehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/GenerellBehandlingService.kt
@@ -226,7 +226,8 @@ class RealGenerellBehandlingService(
                 hendelser = hendelserIBehandling,
                 familieforhold = Familieforhold(avdoed.await(), gjenlevende.await()),
                 behandlingType = detaljertBehandling.behandlingType,
-                søker = soeker.await()?.opplysning
+                søker = soeker.await()?.opplysning,
+                revurderingsaarsak = detaljertBehandling.revurderingsaarsak
             ).also {
                 gjenlevende.await()?.fnr?.let { loggRequest(bruker, it) }
                 soeker.await()?.fnr?.let { loggRequest(bruker, it) }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingIntegrationTest.kt
@@ -72,7 +72,7 @@ class RevurderingIntegrationTest : BehandlingIntegrationTest() {
     }
 
     @Test
-    fun `hvis featuretoggle er av saa kastes NotImplementedError`() {
+    fun `hvis featuretoggle er av saa kastes NotImplementedError ved opprettelse`() {
         val revurderingFactory = RevurderingFactory(beanFactory.behandlingDao(), beanFactory.hendelseDao())
         val hendelser = beanFactory.behandlingHendelser().nyHendelse
         val featureToggleService = mockk<FeatureToggleService>()

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingRoutesKtTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingRoutesKtTest.kt
@@ -49,7 +49,7 @@ internal class RevurderingRoutesKtTest {
     }
 
     @Test
-    fun `happy case`() {
+    fun `kan opprette en revurdering`() {
         testApplication {
             environment {
                 config = hoconApplicationConfig
@@ -96,7 +96,7 @@ internal class RevurderingRoutesKtTest {
     }
 
     @Test
-    fun `returnerer bad request hvis payloaden er ugyldig`() {
+    fun `returnerer bad request hvis payloaden er ugyldig for opprettelse av en revurdering`() {
         testApplication {
             environment { config = hoconApplicationConfig }
             application { module(beanFactory) }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
@@ -104,5 +104,5 @@ function finnRoutesFoerstegangbehandling(behandling: IBehandlingReducer): Array<
 }
 
 function hentRevurderingRoutes(): Array<behandlingRouteTypes> {
-  return ['revurderingsoversikt', 'vilkaarsvurdering', 'beregningsgrunnlag', 'beregne', 'brev']
+  return ['revurderingsoversikt', 'vilkaarsvurdering', 'beregningsgrunnlag', 'beregne']
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
@@ -11,6 +11,7 @@ import { VilkaarsvurderingResultat } from '~shared/api/vilkaarsvurdering'
 import { ManueltOpphoerOversikt } from './manueltopphoeroversikt/ManueltOpphoerOversikt'
 import { IBehandlingReducer } from '~store/reducers/BehandlingReducer'
 import { Revurderingsoversikt } from '~components/behandling/revurderingsoversikt/Revurderingsoversikt'
+import { behandlingSkalSendeBrev } from '~components/behandling/felles/utils'
 
 type behandlingRouteTypes =
   | 'soeknadsoversikt'
@@ -82,7 +83,7 @@ const hentAktuelleRoutes = (behandling: IBehandlingReducer | null) => {
 
   const soeknadRoutes = finnRoutesFoerstegangbehandling(behandling)
   const manueltOpphoerRoutes: Array<behandlingRouteTypes> = ['opphoeroversikt', 'beregne']
-  const revurderingRoutes = hentRevurderingRoutes()
+  const revurderingRoutes = hentRevurderingRoutes(behandling)
 
   switch (behandling.behandlingType) {
     case IBehandlingsType.MANUELT_OPPHOER:
@@ -103,6 +104,17 @@ function finnRoutesFoerstegangbehandling(behandling: IBehandlingReducer): Array<
   return routes
 }
 
-function hentRevurderingRoutes(): Array<behandlingRouteTypes> {
-  return ['revurderingsoversikt', 'vilkaarsvurdering', 'beregningsgrunnlag', 'beregne']
+function hentRevurderingRoutes(behandling: IBehandlingReducer): Array<behandlingRouteTypes> {
+  const defaultRoutes: Array<behandlingRouteTypes> = [
+    'revurderingsoversikt',
+    'vilkaarsvurdering',
+    'beregningsgrunnlag',
+    'beregne',
+  ]
+
+  if (behandlingSkalSendeBrev(behandling)) {
+    return [...defaultRoutes, 'brev']
+  }
+
+  return defaultRoutes
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
@@ -3,7 +3,7 @@ import { NavLink } from 'react-router-dom'
 import classNames from 'classnames'
 import { Next } from '@navikt/ds-icons'
 import { IBehandlingStatus, IBehandlingsType, IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
-import { kanGaaTilStatus } from '~components/behandling/felles/utils'
+import { behandlingSkalSendeBrev, kanGaaTilStatus } from '~components/behandling/felles/utils'
 
 export const StegMeny = (props: { behandling: IDetaljertBehandling }) => {
   const { behandlingType, status } = props.behandling
@@ -46,7 +46,7 @@ export const StegMeny = (props: { behandling: IDetaljertBehandling }) => {
       <li className={classNames({ disabled: stegErDisabled(IBehandlingStatus.BEREGNET) })}>
         <NavLink to="beregne">Beregning</NavLink>
       </li>
-      {behandlingType !== IBehandlingsType.MANUELT_OPPHOER && (
+      {behandlingSkalSendeBrev(props.behandling) && (
         <>
           <Separator aria-hidden={'true'} />
           <li

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/attesterVedtak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/attesterVedtak.tsx
@@ -4,15 +4,17 @@ import { attesterVedtak } from '~shared/api/behandling'
 import { BeslutningWrapper, ButtonWrapper } from '../styled'
 import { GeneriskModal } from '~shared/modal/modal'
 import { attesterVedtaksbrev } from '~shared/api/brev'
-import { IBehandlingsType, IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
+import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 import { useNavigate } from 'react-router'
+import { behandlingSkalSendeBrev } from '~components/behandling/felles/utils'
 
 export const AttesterVedtak = ({ behandling, kommentar }: { behandling: IDetaljertBehandling; kommentar: string }) => {
   const navigate = useNavigate()
   const [modalisOpen, setModalisOpen] = useState(false)
+  const skalSendeBrev = behandlingSkalSendeBrev(behandling)
 
   const ferdigstillVedtaksbrev = async () => {
-    if (behandling.behandlingType === IBehandlingsType.MANUELT_OPPHOER) {
+    if (!skalSendeBrev) {
       return true
     }
 
@@ -38,7 +40,7 @@ export const AttesterVedtak = ({ behandling, kommentar }: { behandling: IDetalje
     <BeslutningWrapper>
       <ButtonWrapper>
         <Button variant="primary" size="medium" className="button" onClick={() => setModalisOpen(true)}>
-          Iverksett vedtak og send brev
+          {`Iverksett vedtak ${skalSendeBrev ? 'og send brev' : ''}`}
         </Button>
       </ButtonWrapper>
       <GeneriskModal

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.test.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.test.ts
@@ -13,6 +13,7 @@ import { ISaksType } from '~components/behandling/fargetags/saksType'
 import { VurderingsResultat } from '~shared/types/VurderingsResultat'
 import { JaNei } from '~shared/types/ISvar'
 import { KildeType } from '~shared/types/kilde'
+import { Revurderingsaarsak } from '~shared/types/Revurderingsaarsak'
 
 describe('BARNEPENSJON: utfylt søknad er gyldig', () => {
   it('barnepensjon gyldig utfylt', () => {
@@ -133,6 +134,7 @@ const opprettBehandling = (
     hendelser: [],
     behandlingType: IBehandlingsType.FØRSTEGANGSBEHANDLING,
     prosesstype: IProsesstype.MANUELL,
+    revurderingsaarsak: Revurderingsaarsak.REGULERING,
   }
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.ts
@@ -4,6 +4,7 @@ import { IBehandlingStatus, IBehandlingsType, IDetaljertBehandling } from '~shar
 import { IBehandlingsammendrag } from '~components/person/typer'
 import { ISaksType } from '~components/behandling/fargetags/saksType'
 import { JaNei } from '~shared/types/ISvar'
+import { Revurderingsaarsak } from '~shared/types/Revurderingsaarsak'
 
 export function behandlingErUtfylt(behandling: IDetaljertBehandling): boolean {
   const gyldigUtfylt = !!(behandling.gyldighetsprøving && behandling.virkningstidspunkt)
@@ -64,3 +65,18 @@ export const harIngenUavbrutteManuelleOpphoer = (behandlingliste: IBehandlingsam
 
 export const kunIverksatteBehandlinger = (behandlingliste: IBehandlingsammendrag[]): IBehandlingsammendrag[] =>
   behandlingliste.filter((behandling) => behandling.status === IBehandlingStatus.IVERKSATT)
+
+export const behandlingSkalSendeBrev = (behandling: IDetaljertBehandling): boolean => {
+  switch (behandling.behandlingType) {
+    case IBehandlingsType.FØRSTEGANGSBEHANDLING:
+      return true
+    case IBehandlingsType.MANUELT_OPPHOER:
+      return false
+    case IBehandlingsType.REVURDERING:
+      if (behandling.revurderingsaarsak === Revurderingsaarsak.REGULERING) {
+        return false
+      }
+
+      return true
+  }
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/start.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/start.tsx
@@ -2,11 +2,11 @@ import { Button } from '@navikt/ds-react'
 import { useBehandlingRoutes } from '../BehandlingRoutes'
 import { handlinger } from './typer'
 
-export const Start = ({ soeknadGyldigFremsatt }: { soeknadGyldigFremsatt: boolean }) => {
+export const Start = ({ disabled }: { disabled?: boolean }) => {
   const { next } = useBehandlingRoutes()
 
   return (
-    <Button variant="primary" size="medium" className="button" onClick={next} disabled={!soeknadGyldigFremsatt}>
+    <Button variant="primary" size="medium" className="button" onClick={next} disabled={disabled}>
       {handlinger.START.navn}
     </Button>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/Revurderingsoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/Revurderingsoversikt.tsx
@@ -2,12 +2,10 @@ import { Content, ContentHeader } from '~shared/styled'
 import { Heading } from '@navikt/ds-react'
 import { BehandlingHandlingKnapper } from '../handlinger/BehandlingHandlingKnapper'
 import { NesteOgTilbake } from '../handlinger/NesteOgTilbake'
-import { behandlingErUtfylt, hentBehandlesFraStatus } from '../felles/utils'
-import { VurderingsResultat } from '~shared/types/VurderingsResultat'
+import { hentBehandlesFraStatus } from '../felles/utils'
 import Virkningstidspunkt from '~components/behandling/soeknadsoversikt/soeknadoversikt/virkningstidspunkt/Virkningstidspunkt'
 import { Start } from '~components/behandling/handlinger/start'
 import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
-import { Familieforhold } from '~components/behandling/soeknadsoversikt/familieforhold/Familieforhold'
 import { Innhold, Border } from '~components/behandling/soeknadsoversikt/styled'
 import { HeadingWrapper } from '~components/person/saksoversikt'
 
@@ -36,12 +34,9 @@ export const Revurderingsoversikt = (props: { behandling: IDetaljertBehandling }
         />
       </Innhold>
       <Border />
-      <Familieforhold behandling={behandling} />
       {behandles ? (
         <BehandlingHandlingKnapper>
-          {behandlingErUtfylt(behandling) && (
-            <Start soeknadGyldigFremsatt={behandling.gyldighetsprøving?.resultat === VurderingsResultat.OPPFYLT} />
-          )}
+          {<Start disabled={behandling.virkningstidspunkt === null} />}
         </BehandlingHandlingKnapper>
       ) : (
         <NesteOgTilbake />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/Soeknadoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/Soeknadoversikt.tsx
@@ -17,6 +17,7 @@ import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 export const Soeknadsoversikt = (props: { behandling: IDetaljertBehandling }) => {
   const { behandling } = props
   const behandles = hentBehandlesFraStatus(behandling.status)
+  const erGyldigFremsatt = behandling.gyldighetsprøving?.resultat === VurderingsResultat.OPPFYLT
 
   return (
     <Content>
@@ -57,9 +58,7 @@ export const Soeknadsoversikt = (props: { behandling: IDetaljertBehandling }) =>
       <Familieforhold behandling={behandling} />
       {behandles ? (
         <BehandlingHandlingKnapper>
-          {behandlingErUtfylt(behandling) && (
-            <Start soeknadGyldigFremsatt={behandling.gyldighetsprøving?.resultat === VurderingsResultat.OPPFYLT} />
-          )}
+          {behandlingErUtfylt(behandling) && <Start disabled={!erGyldigFremsatt} />}
         </BehandlingHandlingKnapper>
       ) : (
         <NesteOgTilbake />

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IDetaljertBehandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IDetaljertBehandling.ts
@@ -4,6 +4,7 @@ import { KildeSaksbehandler } from '~shared/types/kilde'
 import { IFamilieforhold, IPdlPerson } from '~shared/types/Person'
 import { VurderingsResultat } from '~shared/types/VurderingsResultat'
 import { ISaksType } from '~components/behandling/fargetags/saksType'
+import { Revurderingsaarsak } from '~shared/types/Revurderingsaarsak'
 
 export interface IDetaljertBehandling {
   id: string
@@ -23,6 +24,7 @@ export interface IDetaljertBehandling {
   behandlingType: IBehandlingsType
   søker?: IPdlPerson
   prosesstype: IProsesstype
+  revurderingsaarsak: Revurderingsaarsak | null
 }
 
 export enum IBehandlingsType {


### PR DESCRIPTION
TLDR:: 
* Mulighet for å manuelt revurdere (til å begynne med, kun regulering)
* Revurdering skal ikke vise brev-siden og skal ikke sende brev hvis `årsaken` er regulering