### PR TITLE
endre host for at lokal kjøring skal fungere med node 17+

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/vite.config.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/vite.config.ts
@@ -9,11 +9,11 @@ export default defineConfig({
     host: true,
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        target: 'http://0.0.0.0:8080',
         changeOrigin: true,
       },
       '/brev': {
-        target: 'http://localhost:8080',
+        target: 'http://0.0.0.0:8080',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
Node 17+ foretrekker IPv6 og skaper trøbbel med mindre man spesifiserer annet i vite config. 

Ref. https://github.com/vitejs/vite/discussions/7620 