### PR TITLE
EY-2015 Legge til Kotliquery og forbedre funksjoner

### DIFF
--- a/apps/etterlatte-brev-api/build.gradle.kts
+++ b/apps/etterlatte-brev-api/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(libs.database.hikaricp)
     implementation(libs.database.flywaydb)
     implementation(libs.database.postgresql)
+    implementation(libs.database.kotliquery)
 
     implementation(libs.ktor2.servercore)
     implementation(libs.ktor2.clientcore)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -98,7 +98,7 @@ class ApplicationBuilder {
     )
     private val norg2Klient = Norg2Klient(env.requireEnvValue("NORG2_URL"), httpClient())
     private val datasource = DataSourceBuilder.createDataSource(env)
-    private val db = BrevRepository.using(datasource)
+    private val db = BrevRepository(datasource)
 
     private val adresseService = AdresseService(norg2Klient, navansattKlient, regoppslagKlient)
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -78,7 +78,7 @@ class BrevService(
             return true
         }
 
-        return db.oppdaterStatus(id, Status.FERDIGSTILT)
+        return db.settBrevFerdigstilt(id)
             .also {
                 if (it) {
                     logger.info("Brev (id=$id) status er satt til ${Status.FERDIGSTILT}")

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
@@ -11,7 +11,6 @@ import no.nav.etterlatte.brev.model.BrevRequestMapper
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.brev.model.UlagretBrev
 import no.nav.etterlatte.brev.pdf.PdfGeneratorKlient
-import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.rivers.VedtakTilJournalfoering
 import no.nav.etterlatte.token.Bruker
 import org.slf4j.LoggerFactory
@@ -65,7 +64,7 @@ class VedtaksbrevService(
             ?: throw IllegalArgumentException("Vedtaksbrev ikke funnet. Avbryter ferdigstilling/attestering.")
 
         return when (vedtaksbrev.status) {
-            in listOf(Status.OPPRETTET, Status.OPPDATERT) -> db.oppdaterStatus(vedtaksbrev.id, Status.FERDIGSTILT)
+            in listOf(Status.OPPRETTET, Status.OPPDATERT) -> db.settBrevFerdigstilt(vedtaksbrev.id)
             Status.FERDIGSTILT -> true // Ignorer hvis brev allerede er ferdigstilt
             else -> throw IllegalArgumentException(
                 "Kan ikke ferdigstille vedtaksbrev (id=${vedtaksbrev.id}) med status ${vedtaksbrev.status}"
@@ -80,9 +79,8 @@ class VedtaksbrevService(
 
         val response = dokarkivService.journalfoer(vedtaksbrev, vedtak)
 
-        db.setJournalpostId(vedtaksbrev.id, response.journalpostId)
-        db.oppdaterStatus(vedtaksbrev.id, Status.JOURNALFOERT, response.toJson())
-            .also { logger.info("Brev med id=${vedtaksbrev.id} markert som ferdigstilt") }
+        db.settBrevJournalfoert(vedtaksbrev.id, response)
+            .also { logger.info("Brev med id=${vedtaksbrev.id} markert som journalført") }
 
         return vedtaksbrev to response
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
@@ -259,7 +259,6 @@ class BrevRepository(private val ds: DataSource) {
         const val OPPRETT_BREV_QUERY = """
             INSERT INTO brev (behandling_id, soeker_fnr, tittel, vedtaksbrev) 
             VALUES (:behandling_id, :soeker_fnr, :tittel, :vedtaksbrev) 
-            RETURNING id
         """
 
         const val OPPRETT_MOTTAKER_QUERY = """

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/distribusjon/DistribusjonService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/distribusjon/DistribusjonService.kt
@@ -3,8 +3,6 @@ package no.nav.etterlatte.brev.distribusjon
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.model.Adresse
-import no.nav.etterlatte.brev.model.Status
-import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.brev.distribusjon.Adresse as DistAdresse
 
 interface DistribusjonService {
@@ -46,10 +44,7 @@ class DistribusjonServiceImpl(
         )
 
         klient.distribuerJournalpost(request)
-            .also {
-                db.setBestillingsId(brevId, it.bestillingsId)
-                db.oppdaterStatus(brevId, Status.DISTRIBUERT, it.toJson())
-            }
-            .let { it.bestillingsId }
+            .also { db.settBrevDistribuert(brevId, it) }
+            .bestillingsId
     }
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -60,7 +60,7 @@ data class Mottaker(
     }
 }
 
-class Brev(
+data class Brev(
     val id: BrevID,
     val behandlingId: UUID,
     val soekerFnr: String,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -194,7 +194,7 @@ internal class VedtaksbrevServiceTest {
                 Brev(2, BEHANDLING_ID, "fnr", "tittel", status, opprettMottaker(), true),
                 Brev(3, BEHANDLING_ID, "fnr", "tittel", Status.FERDIGSTILT, opprettMottaker(), false)
             )
-            every { db.oppdaterStatus(any(), any()) } returns true
+            every { db.settBrevFerdigstilt(any()) } returns true
 
             runBlocking {
                 val ferdigstiltOK = vedtaksbrevService.ferdigstillVedtaksbrev(BEHANDLING_ID)
@@ -204,7 +204,7 @@ internal class VedtaksbrevServiceTest {
 
             verify(exactly = 1) {
                 db.hentBrevForBehandling(BEHANDLING_ID)
-                db.oppdaterStatus(2, Status.FERDIGSTILT)
+                db.settBrevFerdigstilt(2)
             }
 
             verify {
@@ -220,6 +220,7 @@ internal class VedtaksbrevServiceTest {
                 Brev(2, BEHANDLING_ID, "fnr", "tittel", Status.FERDIGSTILT, opprettMottaker(), true),
                 Brev(3, BEHANDLING_ID, "fnr", "tittel", Status.JOURNALFOERT, opprettMottaker(), false)
             )
+            every { db.settBrevFerdigstilt(any()) } returns true
 
             runBlocking {
                 val ferdigstiltOK = vedtaksbrevService.ferdigstillVedtaksbrev(BEHANDLING_ID)
@@ -228,7 +229,7 @@ internal class VedtaksbrevServiceTest {
             }
 
             verify(exactly = 1) { db.hentBrevForBehandling(BEHANDLING_ID) }
-            verify(exactly = 0) { db.oppdaterStatus(any(), any()) }
+            verify(exactly = 0) { db.settBrevFerdigstilt(any()) }
 
             verify {
                 listOf(pdfGenerator, sakOgBehandlingService, adresseService, dokarkivService)
@@ -256,7 +257,7 @@ internal class VedtaksbrevServiceTest {
             }
 
             verify(exactly = 1) { db.hentBrevForBehandling(BEHANDLING_ID) }
-            verify(exactly = 0) { db.oppdaterStatus(any(), any()) }
+            verify(exactly = 0) { db.settBrevFerdigstilt(any()) }
 
             verify {
                 listOf(pdfGenerator, sakOgBehandlingService, adresseService, dokarkivService)
@@ -286,8 +287,7 @@ internal class VedtaksbrevServiceTest {
 
             verify(exactly = 1) {
                 dokarkivService.journalfoer(forventetBrev, vedtak)
-                db.setJournalpostId(forventetBrev.id, response.journalpostId)
-                db.oppdaterStatus(forventetBrev.id, Status.JOURNALFOERT, any())
+                db.settBrevJournalfoert(forventetBrev.id, response)
             }
 
             verify {
@@ -310,7 +310,7 @@ internal class VedtaksbrevServiceTest {
                 }
             }
 
-            verify(exactly = 0) { db.oppdaterStatus(any(), any()) }
+            verify(exactly = 0) { db.settBrevFerdigstilt(any()) }
 
             verify {
                 listOf(pdfGenerator, sakOgBehandlingService, adresseService, dokarkivService)

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/distribusjon/DistribusjonServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/distribusjon/DistribusjonServiceTest.kt
@@ -9,8 +9,6 @@ import io.mockk.slot
 import io.mockk.verify
 import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.model.Adresse
-import no.nav.etterlatte.brev.model.Status
-import no.nav.etterlatte.libs.common.toJson
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -58,10 +56,7 @@ internal class DistribusjonServiceTest {
         assertEquals(tidspunkt, faktiskRequest.distribusjonstidspunkt)
         assertEquals("etterlatte-brev-api", faktiskRequest.dokumentProdApp)
 
-        verify(exactly = 1) {
-            mockDb.setBestillingsId(brevId, bestillingsID)
-            mockDb.oppdaterStatus(brevId, Status.DISTRIBUERT, distribusjonResponse.toJson())
-        }
+        verify(exactly = 1) { mockDb.settBrevDistribuert(brevId, distribusjonResponse) }
     }
 
     private fun opprettAdresse() = Adresse(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/db/BrevRepositoryIntegrationTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/db/BrevRepositoryIntegrationTest.kt
@@ -92,7 +92,11 @@ internal class BrevRepositoryIntegrationTest {
         assertEquals(3, brev3.id)
 
         repeat(10) {
-            db.opprettBrev(ulagretBrev(UUID.randomUUID()))
+            val nyttBrev = ulagretBrev(UUID.randomUUID())
+            val lagretBrev = db.opprettBrev(nyttBrev)
+            val hentetBrev = db.hentBrev(lagretBrev.id)
+
+            assertEquals(lagretBrev, hentetBrev)
         }
 
         assertEquals(3, db.hentBrevForBehandling(behandlingId).size)


### PR DESCRIPTION
Brev har flere tabeller med mange felter. Spørringer mot disse tabellene blir mildt sagt vanskelig å lese uten named parameters. I tillegg er det flere steder hvor det burde kjøres rollback dersom en spørring feiler. Drar derfor inn Kotliquery siden mye av dette er støttet ut av boksen, og det brukes nå i flere av prosjektets apper. 