### PR TITLE
Brevene skal signeres med "Fornavn Etternavn", ikke "Etternavn, Fornavn"

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/AdresseService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/AdresseService.kt
@@ -33,14 +33,14 @@ class AdresseService(
 
     suspend fun hentAvsenderOgAttestant(vedtak: ForenkletVedtak): Pair<Avsender, Attestant?> = coroutineScope {
         val avsender = vedtak.saksbehandler.let {
-            val saksbehandlerNavn = async { navansattKlient.hentSaksbehandlerInfo(it.ident).navn }
+            val saksbehandlerNavn = async { navansattKlient.hentSaksbehandlerInfo(it.ident).fornavnEtternavn }
             val saksbehandlerEnhet = async { hentEnhet(it.enhet) }
 
             mapTilAvsender(saksbehandlerEnhet.await(), saksbehandlerNavn.await())
         }
 
         val attestant = vedtak.attestant?.let {
-            val attestantNavn = async { navansattKlient.hentSaksbehandlerInfo(it.ident).navn }
+            val attestantNavn = async { navansattKlient.hentSaksbehandlerInfo(it.ident).fornavnEtternavn }
             val attestantEnhet = async { hentEnhet(it.enhet).navn ?: "NAV" }
 
             Attestant(attestantNavn.await(), attestantEnhet.await())

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/navansatt/SaksbehandlerInfo.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/navansatt/SaksbehandlerInfo.kt
@@ -2,8 +2,10 @@ package no.nav.etterlatte.brev.navansatt
 
 data class SaksbehandlerInfo(
     val ident: String,
-    val navn: String,
+    val navn: String, // active directory displayname
     val fornavn: String,
     val etternavn: String,
     val epost: String
-)
+) {
+    val fornavnEtternavn get() = "$fornavn $etternavn"
+}

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/adresse/AdresseServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/adresse/AdresseServiceTest.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.brev.adresse
 
+import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -48,6 +49,9 @@ internal class AdresseServiceTest {
         val (faktiskAvsender, faktiskAttestant) = runBlocking {
             adresseService.hentAvsenderOgAttestant(vedtak)
         }
+
+        faktiskAvsender.saksbehandler shouldBe "fornavn etternavn"
+        faktiskAttestant?.navn shouldBe "fornavn etternavn"
 
         coVerify(exactly = 1) {
             norg2Mock.hentEnhet(saksbehandler.enhet)

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/navansatt/SaksbehandlerInfoTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/navansatt/SaksbehandlerInfoTest.kt
@@ -1,0 +1,14 @@
+package no.nav.etterlatte.brev.navansatt
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+internal class SaksbehandlerInfoTest {
+
+    @Test
+    fun `Skal returnere navnet paa formatet Fornavn Etternavn`() {
+        SaksbehandlerInfo("Z111111", "Etternavn, Fornavn", "Fornavn", "Etternavn", "fornavn.etternavn@nav.no").let {
+            it.fornavnEtternavn shouldBe "Fornavn Etternavn"
+        }
+    }
+}


### PR DESCRIPTION
I DEV ser det korrekt ut ved å bruke "navn" fra navansatt tjenesten, men i produksjon så får vi formatet "Etternavn, Fornavn" i brevene. 

Ser at feltet "navn" mapper til AD-feltet displayname, som trolig er satt annerledes for disse saksbehandlerene i PROD, så går over til å sette sammen fornavn og etternavn manuelt.

EY-1965