### PR TITLE
EY-2046 Oppdatere testdata for å støtte OMS

### DIFF
--- a/apps/etterlatte-testdata/src/main/kotlin/dolly/DollyClient.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/dolly/DollyClient.kt
@@ -8,6 +8,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
+import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.http.HttpHeaders
 import no.nav.etterlatte.libs.common.objectMapper
@@ -28,6 +29,7 @@ interface DollyClient {
     ): TestGruppeBestillinger
 
     suspend fun hentPersonInfo(identer: List<String>, accessToken: String): List<DollyPersonResponse>
+    suspend fun markerIdentIBruk(ident: String, accessToken: String): DollyIBrukResponse
 }
 
 class DollyClientImpl(config: Config, private val httpClient: HttpClient) : DollyClient {
@@ -76,4 +78,9 @@ class DollyClientImpl(config: Config, private val httpClient: HttpClient) : Doll
         }.let {
             objectMapper.readValue(it.body<JsonNode>()["data"]["hentPersonBolk"].toJson())
         }
+
+    override suspend fun markerIdentIBruk(ident: String, accessToken: String): DollyIBrukResponse =
+        httpClient.put("$dollyUrl/ident/$ident/ibruk?iBruk=true") {
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+        }.body()
 }

--- a/apps/etterlatte-testdata/src/main/kotlin/dolly/Model.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/dolly/Model.kt
@@ -19,13 +19,16 @@ data class HentGruppeResponse(
 data class OpprettGruppeRequest(val navn: String, val hensikt: String)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+data class DollyIBrukResponse(val ident: String, val ibruk: Boolean, val beskrivelse: String, val gruppeId: Long)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class BestillingStatus(val id: Long, val ferdig: Boolean)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class TestGruppeBestillinger(val identer: List<TestGruppeBestilling>)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class TestGruppeBestilling(val ident: String, val bestillingId: List<Long>)
+data class TestGruppeBestilling(val ident: String, val bestillingId: List<Long>, val ibruk: Boolean)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class DollyPersonResponse(val ident: String, val person: DollyPerson)
@@ -55,7 +58,12 @@ data class Foedsel(val foedselsdato: String, val foedselsaar: Int)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Navn(val fornavn: String, val etternavn: String)
 
-data class ForenkletFamilieModell(val avdoed: String, val gjenlevende: String, val barn: List<String>)
+data class ForenkletFamilieModell(
+    val ibruk: Boolean,
+    val avdoed: String,
+    val gjenlevende: String,
+    val barn: List<String>
+)
 
 data class BestillingRequest(
     val helsoesken: Int,

--- a/apps/etterlatte-testdata/src/main/kotlin/testdata/features/dolly/DollyFeature.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/testdata/features/dolly/DollyFeature.kt
@@ -1,6 +1,6 @@
 package no.nav.etterlatte.testdata.features.dolly
 
-import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.server.application.call
 import io.ktor.server.mustache.MustacheContent
@@ -11,20 +11,17 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import no.nav.etterlatte.TestDataFeature
 import no.nav.etterlatte.getClientAccessToken
-import no.nav.etterlatte.libs.common.event.SoeknadInnsendt
-import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.common.toJson
+import no.nav.etterlatte.logger
 import no.nav.etterlatte.navIdentFraToken
 import no.nav.etterlatte.objectMapper
 import no.nav.etterlatte.producer
-import no.nav.etterlatte.testdata.JsonMessage
 import no.nav.etterlatte.testdata.dolly.BestillingRequest
 import no.nav.etterlatte.testdata.dolly.DollyService
 import no.nav.etterlatte.usernameFraToken
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.time.OffsetDateTime
+import testdata.features.soeknad.SoeknadMapper.opprettSoeknadJson
 import java.util.*
 
 class DollyFeature(private val dollyService: DollyService) : TestDataFeature {
@@ -109,20 +106,28 @@ class DollyFeature(private val dollyService: DollyService) : TestDataFeature {
                 try {
                     val noekkel = UUID.randomUUID().toString()
 
-                    val (partisjon, offset) = call.receiveParameters().let {
-                        val soesken: List<String> = objectMapper.readValue(it["soesken"] ?: "[]")
-                        producer.publiser(
-                            noekkel,
-                            opprettSoeknadJson(
-                                gjenlevendeFnr = it["fnrGjenlevende"]!!,
-                                avdoedFnr = it["fnrAvdoed"]!!,
-                                barnFnr = it["fnrBarn"]!!,
-                                soesken = soesken
-                            ),
-                            mapOf("NavIdent" to (navIdentFraToken()!!.toByteArray()))
+                    val request = call.receiveParameters().let {
+                        NySoeknadRequest(
+                            it["type"]!!,
+                            it["avdoed"]!!,
+                            it["gjenlevende"]!!,
+                            objectMapper.readValue(it["barn"] ?: "[]", jacksonTypeRef<List<String>>())
                         )
                     }
+
+                    val (partisjon, offset) = producer.publiser(
+                        noekkel,
+                        opprettSoeknadJson(
+                            type = request.type,
+                            gjenlevendeFnr = request.gjenlevende,
+                            avdoedFnr = request.avdoed,
+                            barn = request.barn
+                        ),
+                        mapOf("NavIdent" to (navIdentFraToken()!!.toByteArray()))
+                    )
                     logger.info("Publiserer melding med partisjon: $partisjon offset: $offset")
+
+                    dollyService.markerSomIBruk(request.avdoed, getClientAccessToken())
 
                     call.respond(SoeknadResponse(200, noekkel).toJson())
                 } catch (e: Exception) {
@@ -139,346 +144,14 @@ class DollyFeature(private val dollyService: DollyService) : TestDataFeature {
         }
 }
 
+data class NySoeknadRequest(
+    val type: String,
+    val avdoed: String,
+    val gjenlevende: String,
+    val barn: List<String> = emptyList()
+)
+
 data class SoeknadResponse(
     val status: Number,
     val noekkel: String
 )
-
-fun opprettSoeknadJson(
-    gjenlevendeFnr: String,
-    avdoedFnr: String,
-    barnFnr: String,
-    soesken: List<String> = emptyList()
-): String {
-    val skjemaInfo = opprettSkjemaInfo(gjenlevendeFnr, barnFnr, avdoedFnr, soesken)
-
-    return JsonMessage.newMessage(
-        mapOf(
-            "@event_name" to SoeknadInnsendt.eventNameBehandlingBehov,
-            "@skjema_info" to objectMapper.readValue<ObjectNode>(skjemaInfo),
-            "@lagret_soeknad_id" to "TEST-${UUID.randomUUID()}",
-            "@template" to "soeknad",
-            "@fnr_soeker" to barnFnr,
-            "@hendelse_gyldig_til" to OffsetDateTime.now().plusMinutes(60L),
-            "@adressebeskyttelse" to "UGRADERT"
-        )
-    ).toJson()
-}
-
-private fun fnrTilBarn(fnr: String, gjenlevende: String, avdoed: String) = """
-    {
-        "fornavn": {
-          "svar": "TEST",
-          "spoersmaal": ""
-        },
-        "etternavn": {
-          "svar": "SOESKEN",
-          "spoersmaal": ""
-        },
-        "foedselsnummer": {
-          "svar": "$fnr",
-          "spoersmaal": ""
-        },
-        "statsborgerskap": {
-          "svar": "Norsk",
-          "spoersmaal": ""
-        },
-        "utenlandsAdresse": {
-          "svar": {
-            "verdi": "NEI",
-            "innhold": "Nei"
-          },
-          "spoersmaal": "",
-          "opplysning": null
-        },
-        "foreldre": [
-          {
-            "fornavn": {
-              "svar": "Levende",
-              "spoersmaal": ""
-            },
-            "etternavn": {
-              "svar": "Testperson",
-              "spoersmaal": ""
-            },
-            "foedselsnummer": {
-              "svar": "$gjenlevende",
-              "spoersmaal": ""
-            },
-            "type": "FORELDER"
-          },
-          {
-            "fornavn": {
-              "svar": "Død",
-              "spoersmaal": ""
-            },
-            "etternavn": {
-              "svar": "Testperson",
-              "spoersmaal": ""
-            },
-            "foedselsnummer": {
-              "svar": "$avdoed",
-              "spoersmaal": ""
-            },
-            "type": "FORELDER"
-          }
-        ],
-        "type": "BARN"
-    }
-""".trimIndent()
-
-fun opprettSkjemaInfo(
-    gjenlevendeFnr: String,
-    barnFnr: String,
-    avdoedFnr: String,
-    soesken: List<String>
-): String {
-    val soeskenString = soesken.joinToString(separator = ",", prefix = "[", postfix = "]") {
-        fnrTilBarn(
-            it,
-            avdoedFnr,
-            gjenlevendeFnr
-        )
-    }
-    val mottatt_dato = Tidspunkt.now().toLocalDatetimeUTC()
-    return """
-    {
-      "imageTag": "ce3542f9645d280bfff9936bdd0e7efc32424de2",
-      "spraak": "nb",
-      "innsender": {
-        "fornavn": {
-          "svar": "DUMMY FORNAVN",
-          "spoersmaal": ""
-        },
-        "etternavn": {
-          "svar": "DUMMY ETTERNAVN",
-          "spoersmaal": ""
-        },
-        "foedselsnummer": {
-          "svar": "$gjenlevendeFnr",
-          "spoersmaal": ""
-        },
-        "type": "INNSENDER"
-      },
-      "harSamtykket": {
-        "svar": true,
-        "spoersmaal": ""
-      },
-      "utbetalingsInformasjon": {
-        "svar": {
-          "verdi": "NORSK",
-          "innhold": "Norsk"
-        },
-        "spoersmaal": "",
-        "opplysning": {
-          "kontonummer": {
-            "svar": {
-              "innhold": "1351.35.13513"
-            },
-            "spoersmaal": ""
-          },
-          "utenlandskBankNavn": null,
-          "utenlandskBankAdresse": null,
-          "iban": null,
-          "swift": null,
-          "skattetrekk": {
-            "svar": {
-              "verdi": "JA",
-              "innhold": "Ja"
-            },
-            "spoersmaal": "",
-            "opplysning": {
-              "svar": {
-                "innhold": "21%"
-              },
-              "spoersmaal": ""
-            }
-          }
-        }
-      },
-      "soeker": {
-        "fornavn": {
-          "svar": "TEST",
-          "spoersmaal": ""
-        },
-        "etternavn": {
-          "svar": "SOEKER",
-          "spoersmaal": ""
-        },
-        "foedselsnummer": {
-          "svar": "$barnFnr",
-          "spoersmaal": ""
-        },
-        "statsborgerskap": {
-          "svar": "Norsk",
-          "spoersmaal": ""
-        },
-        "utenlandsAdresse": {
-          "svar": {
-            "verdi": "NEI",
-            "innhold": "Nei"
-          },
-          "spoersmaal": "",
-          "opplysning": null
-        },
-        "foreldre": [
-          {
-            "fornavn": {
-              "svar": "Levende",
-              "spoersmaal": ""
-            },
-            "etternavn": {
-              "svar": "Testperson",
-              "spoersmaal": ""
-            },
-            "foedselsnummer": {
-              "svar": "$gjenlevendeFnr",
-              "spoersmaal": ""
-            },
-            "type": "FORELDER"
-          },
-          {
-            "fornavn": {
-              "svar": "Død",
-              "spoersmaal": ""
-            },
-            "etternavn": {
-              "svar": "Testperson",
-              "spoersmaal": ""
-            },
-            "foedselsnummer": {
-              "svar": "$avdoedFnr",
-              "spoersmaal": ""
-            },
-            "type": "FORELDER"
-          }
-        ],
-        "verge": {
-          "svar": {
-            "verdi": "NEI",
-            "innhold": "Nei"
-          },
-          "spoersmaal": "",
-          "opplysning": null
-        },
-        "dagligOmsorg": null,
-        "type": "BARN"
-      },
-      "foreldre": [
-        {
-          "fornavn": {
-            "svar": "LEVENDE",
-            "spoersmaal": ""
-          },
-          "etternavn": {
-            "svar": "TESTPERSON",
-            "spoersmaal": ""
-          },
-          "foedselsnummer": {
-            "svar": "$gjenlevendeFnr",
-            "spoersmaal": ""
-          },
-          "adresse": {
-            "svar": "TESTVEIEN 123, 0123 TEST",
-            "spoersmaal": ""
-          },
-          "statsborgerskap": {
-            "svar": "Norge",
-            "spoersmaal": ""
-          },
-          "kontaktinfo": {
-            "telefonnummer": {
-              "svar": {
-                "innhold": "11111111"
-              },
-              "spoersmaal": ""
-            }
-          },
-          "type": "GJENLEVENDE_FORELDER"
-        },
-        {
-          "fornavn": {
-            "svar": "DØD",
-            "spoersmaal": ""
-          },
-          "etternavn": {
-            "svar": "TESTPERSON",
-            "spoersmaal": ""
-          },
-          "foedselsnummer": {
-            "svar": "$avdoedFnr",
-            "spoersmaal": ""
-          },
-          "datoForDoedsfallet": {
-            "svar": {
-              "innhold": "2021-07-27"
-            },
-            "spoersmaal": ""
-          },
-          "statsborgerskap": {
-            "svar": {
-              "innhold": "Norsk"
-            },
-            "spoersmaal": ""
-          },
-          "utenlandsopphold": {
-            "svar": {
-              "verdi": "NEI",
-              "innhold": "Nei"
-            },
-            "spoersmaal": "",
-            "opplysning": []
-          },
-          "doedsaarsakSkyldesYrkesskadeEllerYrkessykdom": {
-            "svar": {
-              "verdi": "NEI",
-              "innhold": "Nei"
-            },
-            "spoersmaal": ""
-          },
-          "naeringsInntekt": {
-            "svar": {
-              "verdi": "JA",
-              "innhold": "Ja"
-            },
-            "spoersmaal": "",
-            "opplysning": {
-              "naeringsinntektPrAarFoerDoedsfall": {
-                "svar": {
-                  "innhold": "150 000"
-                },
-                "spoersmaal": ""
-              },
-              "naeringsinntektVedDoedsfall": {
-                "svar": {
-                  "verdi": "NEI",
-                  "innhold": "Nei"
-                },
-                "spoersmaal": ""
-              }
-            }
-          },
-          "militaertjeneste": {
-            "svar": {
-              "verdi": "JA",
-              "innhold": "Ja"
-            },
-            "spoersmaal": "",
-            "opplysning": {
-              "svar": {
-                "innhold": "1984"
-              },
-              "spoersmaal": ""
-            }
-          },
-          "type": "AVDOED"
-        }
-      ],
-      "soesken": $soeskenString,
-      "versjon": "2",
-      "type": "BARNEPENSJON",
-      "mottattDato": "$mottatt_dato",
-      "template": "barnepensjon_v2"
-    }
-    """.trimIndent()
-}

--- a/apps/etterlatte-testdata/src/main/kotlin/testdata/features/dolly/DollyFeature.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/testdata/features/dolly/DollyFeature.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.testdata.features.dolly
 
 import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.server.application.call
 import io.ktor.server.mustache.MustacheContent
 import io.ktor.server.request.receiveParameters
@@ -12,7 +11,6 @@ import io.ktor.server.routing.post
 import no.nav.etterlatte.TestDataFeature
 import no.nav.etterlatte.getClientAccessToken
 import no.nav.etterlatte.libs.common.toJson
-import no.nav.etterlatte.logger
 import no.nav.etterlatte.navIdentFraToken
 import no.nav.etterlatte.objectMapper
 import no.nav.etterlatte.producer
@@ -111,7 +109,7 @@ class DollyFeature(private val dollyService: DollyService) : TestDataFeature {
                             it["type"]!!,
                             it["avdoed"]!!,
                             it["gjenlevende"]!!,
-                            objectMapper.readValue(it["barn"] ?: "[]", jacksonTypeRef<List<String>>())
+                            objectMapper.readValue(it["barnListe"] ?: "[]", jacksonTypeRef<List<String>>())
                         )
                     }
 

--- a/apps/etterlatte-testdata/src/main/kotlin/testdata/features/soeknad/SoeknadMapper.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/testdata/features/soeknad/SoeknadMapper.kt
@@ -1,0 +1,438 @@
+package testdata.features.soeknad
+
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.etterlatte.libs.common.event.SoeknadInnsendt
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
+import no.nav.etterlatte.logger
+import no.nav.etterlatte.objectMapper
+import no.nav.etterlatte.testdata.JsonMessage
+import java.time.OffsetDateTime
+import java.util.*
+
+object SoeknadMapper {
+    fun opprettSoeknadJson(
+        type: String,
+        gjenlevendeFnr: String,
+        avdoedFnr: String,
+        barn: List<String> = emptyList()
+    ): String {
+        val message = when (type) {
+            "OMSTILLINGSSTOENAD" -> opprettJsonMessageOmstilling(
+                soekerFnr = gjenlevendeFnr,
+                avdoedFnr = avdoedFnr,
+                barn = barn
+            )
+
+            "BARNEPENSJON" -> opprettJsonMessageBarnepensjon(
+                gjenlevendeFnr,
+                avdoedFnr = avdoedFnr,
+                barnFnr = barn.first(),
+                soesken = barn.drop(1)
+            )
+
+            else -> {
+                throw Exception("Ukjent soknad type: '$type'")
+            }
+        }
+
+        return message.toJson().also {
+            logger.info("Opprettet json: \n$it")
+        }
+    }
+
+    private fun opprettJsonMessageBarnepensjon(
+        gjenlevendeFnr: String,
+        barnFnr: String,
+        avdoedFnr: String,
+        soesken: List<String>
+    ): JsonMessage {
+        val mottattDato = Tidspunkt.now().toLocalDatetimeUTC()
+
+        val skjemaInfo = """
+            {
+              "imageTag": "ce3542f9645d280bfff9936bdd0e7efc32424de2",
+              "spraak": "nb",
+              "innsender": ${mapInnsender(gjenlevendeFnr)},
+              "harSamtykket": {"svar": true,"spoersmaal": ""},
+              "utbetalingsInformasjon": ${mapUtbetalingsinfo()},
+              "soeker": ${mapBarn(barnFnr, gjenlevendeFnr, avdoedFnr)},
+              "foreldre": ${mapForeldre(gjenlevendeFnr, avdoedFnr)},
+              "soesken": ${mapBarnListe(soesken, gjenlevendeFnr, avdoedFnr)},
+              "versjon": "2",
+              "type": "BARNEPENSJON",
+              "mottattDato": "$mottattDato",
+              "template": "barnepensjon_v2"
+            }
+        """.trimIndent()
+
+        return JsonMessage.newMessage(
+            mapOf(
+                "@event_name" to SoeknadInnsendt.eventNameBehandlingBehov,
+                "@skjema_info" to objectMapper.readValue<ObjectNode>(skjemaInfo),
+                "@lagret_soeknad_id" to "TEST-${UUID.randomUUID()}",
+                "@template" to "soeknad",
+                "@fnr_soeker" to barnFnr,
+                "@hendelse_gyldig_til" to OffsetDateTime.now().plusMinutes(60L),
+                "@adressebeskyttelse" to "UGRADERT"
+            )
+        )
+    }
+
+    private fun opprettJsonMessageOmstilling(
+        soekerFnr: String,
+        avdoedFnr: String,
+        barn: List<String>
+    ): JsonMessage {
+        val mottattDato = Tidspunkt.now().toLocalDatetimeUTC()
+
+        val skjemaInfo = """
+            {
+              "imageTag": "ce3542f9645d280bfff9936bdd0e7efc32424de2",
+              "spraak": "nb",
+              "innsender": ${mapInnsender(soekerFnr)},
+              "harSamtykket": {"svar": true,"spoersmaal": ""},
+              "utbetalingsInformasjon": ${mapUtbetalingsinfo()},
+              "soeker": ${mapGjenlevnde(soekerFnr)},
+              "avdoed": ${mapAvdoed(avdoedFnr)},
+              "barn": ${mapBarnListe(barn, soekerFnr, avdoedFnr)},
+              "versjon": "1",
+              "type": "OMSTILLINGSSTOENAD",
+              "mottattDato": "$mottattDato",
+              "template": "omstillingsstoenad"
+            }
+        """.trimIndent()
+
+        return JsonMessage.newMessage(
+            mapOf(
+                "@event_name" to SoeknadInnsendt.eventNameInnsendt,
+                "@skjema_info" to objectMapper.readValue<ObjectNode>(skjemaInfo),
+                "@lagret_soeknad_id" to "TEST-${UUID.randomUUID()}",
+                "@template" to "soeknad",
+                "@fnr_soeker" to soekerFnr,
+                "@hendelse_gyldig_til" to OffsetDateTime.now().plusMinutes(60L),
+                "@adressebeskyttelse" to "UGRADERT"
+            )
+        )
+    }
+
+    private fun mapUtbetalingsinfo(): String = """
+        {
+            "svar": {
+              "verdi": "NORSK",
+              "innhold": "Norsk"
+            },
+            "spoersmaal": "",
+            "opplysning": {
+              "kontonummer": {
+                "svar": {
+                  "innhold": "1351.35.13513"
+                },
+                "spoersmaal": ""
+              },
+              "utenlandskBankNavn": null,
+              "utenlandskBankAdresse": null,
+              "iban": null,
+              "swift": null,
+              "skattetrekk": {
+                "svar": {
+                  "verdi": "JA",
+                  "innhold": "Ja"
+                },
+                "spoersmaal": "",
+                "opplysning": {
+                  "svar": {
+                    "innhold": "21%"
+                  },
+                  "spoersmaal": ""
+                }
+              }
+            }
+       }
+    """.trimIndent()
+
+    private fun mapForeldre(gjenlevendeFnr: String, avdoedFnr: String) = """
+        [
+          ${mapGjenlevendeForelder(gjenlevendeFnr)},
+          ${mapAvdoed(avdoedFnr)}
+        ]
+    """.trimIndent()
+
+    private fun mapBarnListe(barnListe: List<String>, gjenlevendeFnr: String, avdoedFnr: String): String =
+        barnListe.joinToString(separator = ",", prefix = "[", postfix = "]") {
+            mapBarn(
+                it,
+                avdoedFnr,
+                gjenlevendeFnr
+            )
+        }
+
+    private fun mapGjenlevnde(fnr: String) = """
+        {
+          "fornavn": {
+            "svar": "LEVENDE",
+            "spoersmaal": ""
+          },
+          "etternavn": {
+            "svar": "TESTPERSON",
+            "spoersmaal": ""
+          },
+          "foedselsnummer": {
+            "svar": "$fnr",
+            "spoersmaal": ""
+          },
+          "adresse": {
+            "svar": "TESTVEIEN 123, 0123 TEST",
+            "spoersmaal": ""
+          },
+          "sivilstatus": {
+            "svar": "GIFT",
+            "spoersmaal": ""
+          },
+          "nySivilstatus": {
+            "svar": {
+              "verdi": "ENSLIG",
+              "innhold": "ENSLIG"
+            },
+            "spoersmaal": ""
+          },
+          "statsborgerskap": {
+            "svar": "Norge",
+            "spoersmaal": ""
+          },
+          "kontaktinfo": {
+            "telefonnummer": {
+              "svar": {
+                "innhold": "11111111"
+              },
+              "spoersmaal": ""
+            }
+          },
+          "andreYtelser": {
+            "kravOmAnnenStonad": {
+              "svar": {
+                "verdi": "NEI",
+                "innhold": "NEI"
+              }
+            },
+            "annenPensjon": {
+              "svar": {
+                "verdi": "NEI",
+                "innhold": "NEI"
+              }
+            },
+            "pensjonUtland": {
+              "svar": {
+                "verdi": "NEI",
+                "innhold": "NEI"
+              }
+            }
+          },
+          "uregistrertEllerVenterBarn": {
+            "svar": {
+              "verdi": "NEI",
+              "innhold": "NEI"
+            }       
+          },
+          "forholdTilAvdoede": {
+            "relasjon": {
+              "svar": {
+                "verdi": "GIFT",
+                "innhold": "GIFT"
+              }
+            }          
+          },
+          "type": "GJENLEVENDE"
+        }
+    """.trimIndent()
+
+    private fun mapAvdoed(fnr: String) = """
+        {
+          "fornavn": {
+            "svar": "DØD",
+            "spoersmaal": ""
+          },
+          "etternavn": {
+            "svar": "TESTPERSON",
+            "spoersmaal": ""
+          },
+          "foedselsnummer": {
+            "svar": "$fnr",
+            "spoersmaal": ""
+          },
+          "datoForDoedsfallet": {
+            "svar": {
+              "innhold": "2021-07-27"
+            },
+            "spoersmaal": ""
+          },
+          "statsborgerskap": {
+            "svar": {
+              "innhold": "Norsk"
+            },
+            "spoersmaal": ""
+          },
+          "utenlandsopphold": {
+            "svar": {
+              "verdi": "NEI",
+              "innhold": "Nei"
+            },
+            "spoersmaal": "",
+            "opplysning": []
+          },
+          "doedsaarsakSkyldesYrkesskadeEllerYrkessykdom": {
+            "svar": {
+              "verdi": "NEI",
+              "innhold": "Nei"
+            },
+            "spoersmaal": ""
+          },
+          "naeringsInntekt": {
+            "svar": {
+              "verdi": "JA",
+              "innhold": "Ja"
+            },
+            "spoersmaal": "",
+            "opplysning": {
+              "naeringsinntektPrAarFoerDoedsfall": {
+                "svar": {
+                  "innhold": "150 000"
+                },
+                "spoersmaal": ""
+              },
+              "naeringsinntektVedDoedsfall": {
+                "svar": {
+                  "verdi": "NEI",
+                  "innhold": "Nei"
+                },
+                "spoersmaal": ""
+              }
+            }
+          },
+          "militaertjeneste": {
+            "svar": {
+              "verdi": "JA",
+              "innhold": "Ja"
+            },
+            "spoersmaal": "",
+            "opplysning": {
+              "svar": {
+                "innhold": "1984"
+              },
+              "spoersmaal": ""
+            }
+          },
+          "type": "AVDOED"
+        }
+    """.trimIndent()
+
+    /*
+    * typer
+    *   "GJENLEVENDE_FORELDER"
+    *   "FORELDER"
+    */
+    private fun mapGjenlevendeForelder(fnr: String) = """
+        {
+          "fornavn": {
+            "svar": "Levende",
+            "spoersmaal": ""
+          },
+          "etternavn": {
+            "svar": "Testperson",
+            "spoersmaal": ""
+          },
+          "foedselsnummer": {
+            "svar": "$fnr",
+            "spoersmaal": ""
+          },
+          "adresse": {
+            "svar": "TESTVEIEN 123, 0123 TEST",
+            "spoersmaal": ""
+          },
+          "statsborgerskap": {
+            "svar": "Norge",
+            "spoersmaal": ""
+          },
+          "kontaktinfo": {
+            "telefonnummer": {
+              "svar": {
+                "innhold": "11111111"
+              },
+              "spoersmaal": ""
+            }
+          },
+          "type": "GJENLEVENDE_FORELDER"
+        }
+    """.trimIndent()
+
+    private fun mapForelder(fnr: String) = """
+        {
+          "fornavn": {
+            "svar": "Levende",
+            "spoersmaal": ""
+          },
+          "etternavn": {
+            "svar": "Testperson",
+            "spoersmaal": ""
+          },
+          "foedselsnummer": {
+            "svar": "$fnr",
+            "spoersmaal": ""
+          },
+          "type": "FORELDER"
+        }
+    """.trimIndent()
+
+    private fun mapBarn(fnr: String, gjenlevende: String, avdoed: String) = """
+        {
+            "fornavn": {
+              "svar": "TEST",
+              "spoersmaal": ""
+            },
+            "etternavn": {
+              "svar": "SOESKEN",
+              "spoersmaal": ""
+            },
+            "foedselsnummer": {
+              "svar": "$fnr",
+              "spoersmaal": ""
+            },
+            "statsborgerskap": {
+              "svar": "Norsk",
+              "spoersmaal": ""
+            },
+            "utenlandsAdresse": {
+              "svar": {
+                "verdi": "NEI",
+                "innhold": "Nei"
+              },
+              "spoersmaal": "",
+              "opplysning": null
+            },
+            "foreldre": [
+              ${mapForelder(gjenlevende)},
+              ${mapForelder(avdoed)}
+            ],
+            "type": "BARN"
+        }
+    """.trimIndent()
+
+    private fun mapInnsender(fnr: String) = """
+          {
+            "fornavn": {
+              "svar": "DUMMY FORNAVN",
+              "spoersmaal": ""
+            },
+            "etternavn": {
+              "svar": "DUMMY ETTERNAVN",
+              "spoersmaal": ""
+            },
+            "foedselsnummer": {
+              "svar": "$fnr",
+              "spoersmaal": ""
+            },
+            "type": "INNSENDER"
+          }
+    """.trimIndent()
+}

--- a/apps/etterlatte-testdata/src/main/resources/templates/dolly/dolly.hbs
+++ b/apps/etterlatte-testdata/src/main/resources/templates/dolly/dolly.hbs
@@ -47,10 +47,9 @@
             <thead>
             <tr>
                 <th>Avdød</th>
-                <th>Gjenlevende (innsender)</th>
+                <th>Gjenlevende</th>
                 <th>Barn</th>
-                <th>Antall Søsken</th>
-                <th></th>
+                <th style="text-align: right">Send søknad</th>
             </tr>
             </thead>
             <tbody>
@@ -101,20 +100,6 @@
                            required
                     />
                 </div>
-
-                <!--<div class="mb-4 col-md-3 form-group">
-                    <label for="halvsoeskenGjenlevende" class="form-label">Halvsøsken (gjenlevende)</label>
-                    <input type="number"
-                           pattern="[0-9]+"
-                           minlength="11"
-                           maxlength="11"
-                           name="halvsoeskenGjenlevende"
-                           id="halvsoeskenGjenlevende"
-                           class="form-control"
-                           value=0
-                           required
-                    />
-                </div>-->
             </div>
 
             <button type="submit" class="btn btn-primary">Opprett ny familie</button>
@@ -168,43 +153,49 @@
             const table = document.querySelector('tbody')
             table.innerHTML = ""
             data.forEach((familie) => {
+                console.log(familie)
+
                 const avdoed = familie.avdoed
                 const gjenlevende = familie.gjenlevende
-                const [barn, ...soesken] = familie.barn
+                const barn = familie.barn
 
                 const tableRow = document.createElement('tr')
 
                 const avdoedTableElement = document.createElement('td')
                 const gjenlevendeTableElement = document.createElement('td')
                 const barnTableElement = document.createElement('td')
-                const antallSoeskenTableElement = document.createElement('td')
                 const buttonTableElement = document.createElement('td')
 
-                const button = document.createElement('button')
-                button.classList.add('btn')
-                button.classList.add('btn-primary')
-                button.innerHTML = 'Send inn søknad for denne familien'
-                button.type = 'button'
-                button.onclick = () => sendSoeknad(avdoed, gjenlevende, barn, soesken)
-
-                avdoedTableElement.innerHTML = avdoed
-                avdoedTableElement.style.width = '200px'
+                if (familie.ibruk) {
+                    avdoedTableElement.innerHTML = `${avdoed} <span class="badge text-bg-warning">Brukt</span>`
+                } else {
+                    avdoedTableElement.innerHTML = avdoed
+                }
+                avdoedTableElement.style.width = '180px'
                 tableRow.appendChild(avdoedTableElement)
 
                 gjenlevendeTableElement.innerHTML = gjenlevende
-                gjenlevendeTableElement.style.width = '300px'
+                gjenlevendeTableElement.style.width = '150px'
                 tableRow.appendChild(gjenlevendeTableElement)
 
-                barnTableElement.innerHTML = barn
-                barnTableElement.style.width = '300px'
+                barnTableElement.innerHTML = `${barn[0]} (m/${(barn.length - 1) ?? '0'} søsken)`
+                barnTableElement.style.width = '200px'
                 tableRow.appendChild(barnTableElement)
 
-                antallSoeskenTableElement.innerHTML = soesken.length ?? '0'
-                antallSoeskenTableElement.style.width = '120px'
-                tableRow.appendChild(antallSoeskenTableElement)
+                const newButton = (type, label, btnClass) => {
+                    const btn = document.createElement('button')
+                    btn.classList.add('btn')
+                    btn.classList.add('me-1')
+                    btn.classList.add(btnClass)
+                    btn.innerHTML = label
+                    btn.type = 'button'
+                    btn.onclick = () => sendSoeknad(type, avdoed, gjenlevende, barn)
+                    return btn
+                }
 
-                buttonTableElement.appendChild(button)
-                buttonTableElement.style.textAlign = 'center'
+                buttonTableElement.appendChild(newButton('BARNEPENSJON', 'BP', 'btn-primary'))
+                buttonTableElement.appendChild(newButton('OMSTILLINGSSTOENAD', 'OMS', 'btn-info'))
+                buttonTableElement.style.textAlign = 'right'
                 buttonTableElement.style.width = '300px'
                 tableRow.appendChild(buttonTableElement)
 
@@ -213,14 +204,14 @@
         })
     }
 
-    const sendSoeknad = async (fnrAvdoed, fnrGjenlevende, fnrBarn, soesken) => {
+    const sendSoeknad = async (type, avdoed, gjenlevende, barn) => {
         soeknadInnsendtAlert.style.display = "none"
         await fetch('dolly/send-soeknad', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded'
             },
-            body: `fnrAvdoed=${fnrAvdoed}&fnrGjenlevende=${fnrGjenlevende}&fnrBarn=${fnrBarn}&soesken=${JSON.stringify(soesken)}`
+            body: `type=${type}&avdoed=${avdoed}&gjenlevende=${gjenlevende}&barnListe=${JSON.stringify(barn)}`
         }).then(res => res.json()).then(data => {
             if ((data.status === 200)) {
                 soeknadInnsendtAlert.firstElementChild.innerHTML = `Søknad er innsendt og registrert med nøkkel: ${data.noekkel}`

--- a/apps/etterlatte-testdata/src/main/resources/templates/dolly/dolly.hbs
+++ b/apps/etterlatte-testdata/src/main/resources/templates/dolly/dolly.hbs
@@ -153,8 +153,6 @@
             const table = document.querySelector('tbody')
             table.innerHTML = ""
             data.forEach((familie) => {
-                console.log(familie)
-
                 const avdoed = familie.avdoed
                 const gjenlevende = familie.gjenlevende
                 const barn = familie.barn


### PR DESCRIPTION
- Legge til egen knapp for å sende OMS-søknad. 
- Tilpasse barn/søsken for å gi mening for begge søknader. 
- Markere avdød som brukt (i Dolly) dersom søknad sendes. 