### PR TITLE
Vis kun grunnbeloeps-hendelser i saksoversikt

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/grunnlagshendelser/tekster.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/grunnlagshendelser/tekster.ts
@@ -15,5 +15,5 @@ export const teksterForGrunnlagshendelser: Record<GrunnlagsendringsType, string>
   UTLAND: 'Ut-/innflytting',
   DOEDSDATO: 'Dødsfall',
   VERGEMAAL_ELLER_FREMTIDSFULLMAKT: 'Vergemål',
-  REGULERING: 'Regulering',
+  GRUNNBELOEP: 'Regulering',
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/saksoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/saksoversikt.tsx
@@ -95,6 +95,8 @@ export const Saksoversikt = ({ fnr }: { fnr: string | undefined }) => {
       .filter((behandling) => behandling.behandlingType === IBehandlingsType.REVURDERING)
       .filter((behandling) => !erFerdigBehandlet(behandling.status)).length > 0
 
+  const hendelser = grunnlagshendelser?.filter((hendelse) => hendelse.type === 'GRUNNBELOEP') ?? []
+
   return (
     <>
       <Spinner visible={!lastetBehandlingliste || !lastetGrunnlagshendelser} label={'Laster'} />
@@ -127,7 +129,7 @@ export const Saksoversikt = ({ fnr }: { fnr: string | undefined }) => {
                     </EkstraHandlinger>
                   ) : null}
                   <UhaandterteHendelser
-                    hendelser={[]}
+                    hendelser={hendelser}
                     startRevurdering={() => setVisOpprettRevurderingsmodal(true)}
                     disabled={harAapenRevurdering}
                   />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/typer.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/typer.tsx
@@ -98,7 +98,7 @@ export interface VergemaalEllerFremtidsfullmaktForholdSamsvar {
 }
 
 export interface ReguleringSamsvar {
-  type: 'REGULERING'
+  type: 'GRUNNBELOEP'
   samsvar: boolean
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/uhaandtereHendelser/utils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/uhaandtereHendelser/utils.ts
@@ -1,7 +1,7 @@
 import { GrunnlagsendringsType } from '~components/person/typer'
 
 export const grunnlagsendringsTittel: Record<GrunnlagsendringsType, string> = {
-  REGULERING: 'Regulering feilet',
+  GRUNNBELOEP: 'Regulering feilet',
   DOEDSDATO: 'Dødsdato',
   UTLAND: 'Utlendingsstatus',
   BARN: 'Barn',
@@ -10,7 +10,7 @@ export const grunnlagsendringsTittel: Record<GrunnlagsendringsType, string> = {
 }
 
 export const grunnlagsendringsBeskrivelse: Record<GrunnlagsendringsType, string> = {
-  REGULERING: 'Regulering av pensjonen kunne ikke behandles automatisk. Saken må derfor behandles manuelt',
+  GRUNNBELOEP: 'Regulering av pensjonen kunne ikke behandles automatisk. Saken må derfor behandles manuelt',
   DOEDSDATO: 'Dødsdato',
   UTLAND: 'Utlendingsstatus',
   BARN: 'Barn',
@@ -20,7 +20,7 @@ export const grunnlagsendringsBeskrivelse: Record<GrunnlagsendringsType, string>
 
 export const grunnlagsendringsKilde = (type: GrunnlagsendringsType): string => {
   switch (type) {
-    case 'REGULERING':
+    case 'GRUNNBELOEP':
       return 'Doffen'
     case 'DOEDSDATO':
     case 'UTLAND':


### PR DESCRIPTION
* Vis kun hendelser for når regulering feilet, dette er for att inte påverka produksjon
* Bytt navn på typen for reguleringsamsvar (ref: https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/1279)