### PR TITLE
EY-2043 - saksbehandler må kunne se enhet på oppgave

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
@@ -50,6 +50,7 @@ data class OppgaveDTO(
     val beskrivelse: String,
     val saksbehandler: String,
     val handling: Handling,
+    val enhet: String? = null,
     val merknad: String? = null
 ) {
     companion object {
@@ -57,32 +58,34 @@ data class OppgaveDTO(
             return when (oppgave) {
                 is Oppgave.Grunnlagsendringsoppgave -> OppgaveDTO(
                     behandlingId = null,
-                    sakId = oppgave.sakId,
+                    sakId = oppgave.sak.id,
                     status = BehandlingStatus.OPPRETTET,
                     oppgaveStatus = oppgave.oppgaveStatus,
-                    soeknadType = oppgave.sakType.toString(),
+                    soeknadType = oppgave.sak.sakType.toString(),
                     oppgaveType = oppgave.oppgaveType,
                     regdato = oppgave.registrertDato.toLocalDatetimeUTC().toString(),
                     fristdato = oppgave.fristDato.atStartOfDay().toString(),
-                    fnr = oppgave.fnr.value,
+                    fnr = oppgave.sak.ident,
                     beskrivelse = oppgave.beskrivelse,
                     saksbehandler = "",
-                    handling = oppgave.handling
+                    handling = oppgave.handling,
+                    enhet = oppgave.sak.enhet
                 )
                 is Oppgave.BehandlingOppgave -> OppgaveDTO(
                     behandlingId = oppgave.behandlingId,
-                    sakId = oppgave.sakId,
+                    sakId = oppgave.sak.id,
                     status = oppgave.behandlingStatus,
                     oppgaveStatus = oppgave.oppgaveStatus,
-                    soeknadType = oppgave.sakType.toString(),
+                    soeknadType = oppgave.sak.sakType.toString(),
                     oppgaveType = oppgave.oppgaveType,
                     regdato = oppgave.registrertDato.toLocalDatetimeUTC().toString(),
                     fristdato = oppgave.fristDato.atStartOfDay().toString(),
-                    fnr = oppgave.fnr.value,
+                    fnr = oppgave.sak.ident,
                     beskrivelse = "",
                     saksbehandler = "",
                     handling = oppgave.handling,
-                    merknad = oppgave.merknad
+                    merknad = oppgave.merknad,
+                    enhet = oppgave.sak.enhet
                 )
             }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveServiceImpl.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveServiceImpl.kt
@@ -66,7 +66,7 @@ fun <T : Oppgave> List<T>.filterOppgaverForEnheter(
     user
 ) { item, enheter ->
     when (item) {
-        is Oppgave.BehandlingOppgave -> item.enhet == null || enheter.contains(item.enhet)
+        is Oppgave.BehandlingOppgave -> item.sak.enhet == null || enheter.contains(item.sak.enhet)
         else -> true
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/domain/Oppgave.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/domain/Oppgave.kt
@@ -4,9 +4,8 @@ import no.nav.etterlatte.behandling.OppgaveStatus
 import no.nav.etterlatte.behandling.domain.GrunnlagsendringsType
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
-import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
-import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.time.LocalDate
 import java.util.*
@@ -16,24 +15,19 @@ enum class Handling {
 }
 
 sealed class Oppgave {
-    abstract val sakId: Long
-    abstract val sakType: SakType
+    abstract val sak: Sak
     abstract val registrertDato: Tidspunkt
     abstract val fristDato: LocalDate
-    abstract val fnr: Folkeregisteridentifikator
     abstract val handling: Handling
     abstract val oppgaveStatus: OppgaveStatus
     abstract val oppgaveType: OppgaveType
 
     data class BehandlingOppgave(
-        override val sakId: Long,
-        override val sakType: SakType,
+        override val sak: Sak,
         override val registrertDato: Tidspunkt,
-        override val fnr: Folkeregisteridentifikator,
         val behandlingId: UUID,
         val behandlingsType: BehandlingType,
         val behandlingStatus: BehandlingStatus,
-        val enhet: String?,
         val merknad: String?
     ) : Oppgave() {
         override val oppgaveStatus: OppgaveStatus
@@ -50,10 +44,8 @@ sealed class Oppgave {
     }
 
     data class Grunnlagsendringsoppgave(
-        override val sakId: Long,
-        override val sakType: SakType,
+        override val sak: Sak,
         override val registrertDato: Tidspunkt,
-        override val fnr: Folkeregisteridentifikator,
         val grunnlagsendringsType: GrunnlagsendringsType,
         val gjelderRolle: Saksrolle
     ) : Oppgave() {

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
@@ -111,7 +111,7 @@ internal class OppgaveDaoTest {
         grunnlagsendringshendelsesRepo.opprettGrunnlagsendringshendelse(hendelseIgnorert)
         val oppgaver = oppgaveDao.finnOppgaverFraGrunnlagsendringshendelser()
         assertEquals(oppgaver.size, 1)
-        assertEquals(oppgaver[0].sakId, sakid)
+        assertEquals(oppgaver[0].sak.id, sakid)
     }
 
     @Test
@@ -138,7 +138,7 @@ internal class OppgaveDaoTest {
         val oppgaver = oppgaveDao.finnOppgaverMedStatuser(alleBehandlingsStatuser)
         assertEquals(1, oppgaver.size)
         val oppgave = oppgaver.first() as Oppgave.BehandlingOppgave
-        assertEquals(Enheter.PORSGRUNN.enhetNr, oppgave.enhet)
+        assertEquals(Enheter.PORSGRUNN.enhetNr, oppgave.sak.enhet)
     }
 
     @Test

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -12,6 +12,7 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
+import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.oppgave.domain.Oppgave
 import org.junit.jupiter.api.Test
@@ -20,43 +21,52 @@ import java.util.*
 internal class OppgaveServiceTest {
     private val oppgaveListe: List<Oppgave> = listOf(
         Oppgave.BehandlingOppgave(
-            sakId = 1,
-            sakType = SakType.BARNEPENSJON,
+            sak = Sak(
+                id = 1,
+                sakType = SakType.BARNEPENSJON,
+                ident = TRIVIELL_MIDTPUNKT.value,
+                enhet = null
+            ),
             registrertDato = Tidspunkt.now(),
-            fnr = TRIVIELL_MIDTPUNKT,
             behandlingId = UUID.randomUUID(),
             behandlingsType = BehandlingType.FØRSTEGANGSBEHANDLING,
             behandlingStatus = BehandlingStatus.OPPRETTET,
-            enhet = null,
             merknad = null
         ),
         Oppgave.BehandlingOppgave(
-            sakId = 2,
-            sakType = SakType.BARNEPENSJON,
+            sak = Sak(
+                id = 2,
+                sakType = SakType.BARNEPENSJON,
+                ident = TRIVIELL_MIDTPUNKT.value,
+                enhet = Enheter.PORSGRUNN.enhetNr
+            ),
             registrertDato = Tidspunkt.now(),
-            fnr = TRIVIELL_MIDTPUNKT,
             behandlingId = UUID.randomUUID(),
             behandlingsType = BehandlingType.FØRSTEGANGSBEHANDLING,
             behandlingStatus = BehandlingStatus.OPPRETTET,
-            enhet = Enheter.PORSGRUNN.enhetNr,
             merknad = null
         ),
         Oppgave.BehandlingOppgave(
-            sakId = 3,
-            sakType = SakType.BARNEPENSJON,
+            sak = Sak(
+                id = 3,
+                sakType = SakType.BARNEPENSJON,
+                ident = TRIVIELL_MIDTPUNKT.value,
+                enhet = Enheter.STRENGT_FORTROLIG.enhetNr
+            ),
             registrertDato = Tidspunkt.now(),
-            fnr = TRIVIELL_MIDTPUNKT,
             behandlingId = UUID.randomUUID(),
             behandlingsType = BehandlingType.FØRSTEGANGSBEHANDLING,
             behandlingStatus = BehandlingStatus.OPPRETTET,
-            enhet = Enheter.STRENGT_FORTROLIG.enhetNr,
             merknad = null
         ),
         Oppgave.Grunnlagsendringsoppgave(
-            sakId = 4,
-            sakType = SakType.BARNEPENSJON,
+            sak = Sak(
+                id = 4,
+                sakType = SakType.BARNEPENSJON,
+                ident = TRIVIELL_MIDTPUNKT.value,
+                enhet = null
+            ),
             registrertDato = Tidspunkt.now(),
-            fnr = TRIVIELL_MIDTPUNKT,
             grunnlagsendringsType = GrunnlagsendringsType.FORELDER_BARN_RELASJON,
             gjelderRolle = Saksrolle.SOEKER
         )
@@ -77,6 +87,6 @@ internal class OppgaveServiceTest {
         val filtered = oppgaveListe.filterOppgaverForEnheter(featureToggleService, user)
 
         filtered.size shouldBe 3
-        filtered.filter { it.sakId == 3L }.size shouldBe 0
+        filtered.filter { it.sak.id == 3L }.size shouldBe 0
     }
 }


### PR DESCRIPTION
Saksbehandler må kunne se enhet på oppgave - spesielt hvis de har tilgang til mer enn en enhet.

Dette er kun backend (eksponere enhet på OppgaveDTO).

Tok og fikset det interne Oppgave sealed class tre til å ha hele sak i lik linje til hvordan vi har gjort det med behandlinger.

Frontend fiks tar litt lengre tid - men er lettere å teste når denne er i miljøet :)