### PR TITLE
EY-2043 - saksbehandler må kunne se enhet på oppgave - frontend

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenken/OppgaveKolonner.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenken/OppgaveKolonner.tsx
@@ -7,12 +7,20 @@ import {
   soeknadTypeFilter,
   statusFilter,
   StatusFilter,
+  enhetFilter,
+  EnhetFilter,
 } from './typer/oppgavebenken'
 import { format } from 'date-fns'
 import { Tag } from '@navikt/ds-react'
 import HandlingerKnapp from './handlinger/HandlingerKnapp'
 import BrukeroversiktLenke from './handlinger/BrukeroversiktKnapp'
 import { tagColors } from '~shared/Tags'
+
+const mapEnhetNavn = (enhet?: EnhetFilter): string => {
+  const navn = (enhet ? enhetFilter[enhet as EnhetFilter]?.navn : undefined) ?? 'Ukjent'
+
+  return navn.includes(' - ') ? navn.substring(0, navn.indexOf(' - ')) : navn
+}
 
 export const kolonner: ReadonlyArray<Column<IOppgave>> = [
   {
@@ -78,6 +86,14 @@ export const kolonner: ReadonlyArray<Column<IOppgave>> = [
       return (
         <span>{oppgaveStatus ? statusFilter[oppgaveStatus as StatusFilter]?.navn ?? oppgaveStatus : 'Ukjent'}</span>
       )
+    },
+  },
+  {
+    Header: 'Enhet',
+    accessor: 'oppgaveEnhet',
+    filter: 'exact',
+    Cell: ({ value: enhet }) => {
+      return <span>{mapEnhetNavn(enhet)}</span>
     },
   },
   {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenken/Oppgavebenken.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenken/Oppgavebenken.tsx
@@ -9,6 +9,7 @@ import {
   OppgaveTypeFilter,
   SoeknadTypeFilter,
   StatusFilter,
+  EnhetFilter,
 } from './typer/oppgavebenken'
 import { Column } from 'react-table'
 import { kolonner } from './OppgaveKolonner'
@@ -90,6 +91,7 @@ const mapOppgaveResponse = (data: OppgaveDTO): IOppgave => ({
   saksbehandler: data.saksbehandler,
   handling: data.handling.toUpperCase() as Handlinger,
   merknad: data.merknad,
+  oppgaveEnhet: data.enhet ? (`E${data.enhet}` as EnhetFilter) : EnhetFilter.INGEN_ENHET,
 })
 
 export default Oppgavebenken

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenken/typer/oppgavebenken.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenken/typer/oppgavebenken.tsx
@@ -10,6 +10,7 @@ export interface IOppgave {
   saksbehandler: string
   handling: Handlinger
   merknad?: string
+  oppgaveEnhet: EnhetFilter
 }
 
 export enum Handlinger {
@@ -62,6 +63,31 @@ export const statusFilter: Record<StatusFilter, IPar> = {
   NY: { id: 'NY', navn: 'Ny' },
   TIL_ATTESTERING: { id: 'TIL_ATTESTERING', navn: 'Til attestering' },
   RETURNERT: { id: 'RETURNERT', navn: 'Returnert' },
+}
+
+export enum EnhetFilter {
+  VELG = 'VELG',
+  INGEN_ENHET = 'INGEN_ENHET',
+  E0001 = 'E0001',
+  E2103 = 'E2103',
+  E4808 = 'E4808',
+  E4815 = 'E4815',
+  E4817 = 'E4817',
+  E4862 = 'E4862',
+  E4883 = 'E4883',
+}
+
+export const enhetFilter: Record<EnhetFilter, IPar> = {
+  VELG: { id: 'VELG', navn: 'Velg' },
+
+  INGEN_ENHET: { id: 'INGEN_ENHET', navn: 'Ingen' },
+  E4815: { id: 'E4815', navn: '4815 - Ålesund' },
+  E4808: { id: 'E4808', navn: '4808 - Porsgrunn' },
+  E4817: { id: 'E4817', navn: '4817 - Steinkjer' },
+  E4862: { id: 'E4862', navn: '4862 - Ålesund Utland' },
+  E0001: { id: 'E0001', navn: '0001 - Utland' },
+  E4883: { id: 'E4883', navn: '4883 - Egne ansatte' },
+  E2103: { id: 'E2103', navn: '2103 - Vikafossen' },
 }
 
 export interface FilterPar {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenken/typer/oppgavefelter.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenken/typer/oppgavefelter.ts
@@ -6,6 +6,8 @@ import {
   SoeknadTypeFilter,
   statusFilter,
   StatusFilter,
+  enhetFilter,
+  EnhetFilter,
 } from './oppgavebenken'
 
 export interface IOppgaveFilter {
@@ -29,6 +31,7 @@ export interface IOppgaveFelter {
   oppgaveType: IOppgaveFelt
   soeknadType: IOppgaveFelt
   oppgaveStatus: IOppgaveFelt
+  oppgaveEnhet: IOppgaveFelt
 }
 
 export enum FeltSortOrder {
@@ -94,6 +97,15 @@ export const initialOppgaveFelter = (): IOppgaveFelter => {
         type: 'select',
         selectedValue: StatusFilter.VELG,
         nedtrekksliste: statusFilter,
+      },
+    },
+    oppgaveEnhet: {
+      noekkel: 'oppgaveEnhet',
+      label: 'Enhet',
+      filter: {
+        type: 'select',
+        selectedValue: EnhetFilter.VELG,
+        nedtrekksliste: enhetFilter,
       },
     },
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaver.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaver.ts
@@ -12,6 +12,7 @@ export interface OppgaveDTO {
   saksbehandler: string
   handling: string
   merknad?: string
+  enhet: string | undefined
 }
 export interface OppgaveResponse {
   oppgaver: ReadonlyArray<OppgaveDTO>


### PR DESCRIPTION
Vis enhets ID i oppgavelisten (ikke full navn - for å spare plass).

La saksbehandler filtrerer listen.

Siden disse er statisk så er denne første runden altid med - og dropdown har alle mulige kjente verdier.

Senere - hadde det vært veldig fint hvis vi kan bare vise de hvis det er flere enn en i resultatsliste og bare har de som er med i dropdown - men - for nå - så er ikke det så lett uten mye omskriving (tror jeg).

![Enheter](https://user-images.githubusercontent.com/49564/233627591-6811a8c5-7bce-463c-9fa2-996a3a1843e5.png)
