### PR TITLE
Endrer bruk kjøreplan fra J til N i utbetaling

### DIFF
--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/common/OppdragDefaults.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/common/OppdragDefaults.kt
@@ -12,7 +12,7 @@ object OppdragDefaults {
     const val MOTTAKENDE_KOMPONENTKODE = "OS" // Oppdragsystemet
     const val SAKSBEHANDLER_ID_SYSTEM_ETTERLATTEYTELSER = "EY" // Placeholder for å identifisere
     const val UTBETALINGSFREKVENS = "MND"
-    const val KJOEREPLAN_SAMMEN_MED_NESTE_PLANLAGTE_UTBETALING = "J"
+    const val KJOEREPLAN_SAMMEN_MED_NESTE_PLANLAGTE_UTBETALING = "N"
     const val AKSJONSKODE_OPPDATER = "1"
     val KODEKOMPONENT = OppdragKlassifikasjonskode.BARNEPENSJON_OPTP
     val DATO_OPPDRAG_GJELDER_FOM = LocalDate.EPOCH.toXMLDate()
@@ -27,6 +27,6 @@ object OppdragDefaults {
 
 object OppdragslinjeDefaults {
     const val UTBETALINGSFREKVENS = "MND"
-    const val KJOEREPLAN_SAMMEN_MED_NESTE_PLANLAGTE_UTBETALING = "J"
+    const val KJOEREPLAN_SAMMEN_MED_NESTE_PLANLAGTE_UTBETALING = "N"
     val FRADRAG_ELLER_TILLEGG = TfradragTillegg.T
 }

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/avstemmingsdata/AvstemmingsdataJaxbTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/avstemmingsdata/AvstemmingsdataJaxbTest.kt
@@ -146,7 +146,7 @@ internal class AvstemmingsdataJaxbTest {
                         <sats>10000</sats>
                         <satstypeKode>MND</satstypeKode>
                         <fradragTillegg>T</fradragTillegg>
-                        <brukKjoreplan>J</brukKjoreplan>
+                        <brukKjoreplan>N</brukKjoreplan>
                         <utbetalesTilId>123456</utbetalesTilId>
                         <attestantListe>
                             <attestantId>attestant</attestantId>


### PR DESCRIPTION
Dette for å beregne saker tilbake i tid tidligere enn ved neste månedskjøring.

EY-2057