### PR TITLE
EY-2331: Kontraktstesting på at signaturen klienten kallar er lik den ruta tilbyr

### DIFF
--- a/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/vilkaarsvurdering/AppBuilder.kt
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/vilkaarsvurdering/AppBuilder.kt
@@ -4,6 +4,7 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import no.nav.etterlatte.libs.common.Miljoevariabler
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
+import no.nav.etterlatte.vilkaarsvurdering.services.EtterlatteHttpClient
 import no.nav.etterlatte.vilkaarsvurdering.services.VilkaarsvurderingServiceImpl
 
 class AppBuilder(props: Miljoevariabler) {
@@ -17,6 +18,6 @@ class AppBuilder(props: Miljoevariabler) {
     private val vilkaarsvurderingUrl = requireNotNull(props["ETTERLATTE_VILKAARSVURDERING_URL"])
 
     fun lagVilkaarsvurderingKlient(): VilkaarsvurderingServiceImpl {
-        return VilkaarsvurderingServiceImpl(vilkaarsvurderingHttpKlient, vilkaarsvurderingUrl)
+        return VilkaarsvurderingServiceImpl(EtterlatteHttpClient(vilkaarsvurderingHttpKlient), vilkaarsvurderingUrl)
     }
 }

--- a/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/vilkaarsvurdering/services/EtterlatteHttpClient.kt
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/vilkaarsvurdering/services/EtterlatteHttpClient.kt
@@ -1,0 +1,16 @@
+package no.nav.etterlatte.vilkaarsvurdering.services
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.post
+
+/*
+Denne klassa fins for å kunne skrive testar på HttpClient-kall
+Utan denne støter vi i skrivande stund på https://github.com/mockk/mockk/issues/944
+Når denne er fiksa, kan vi gjerne gå over til å bruke HttpClient direkte og så slette denne klassa,
+gitt at vi ikkje da støter på https://github.com/mockk/mockk/issues/55 og dens like.
+ */
+class EtterlatteHttpClient(private val httpClient: HttpClient) {
+
+    suspend fun post(urlString: String, block: HttpRequestBuilder.() -> Unit = {}) = httpClient.post(urlString, block)
+}

--- a/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/vilkaarsvurdering/services/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/vilkaarsvurdering/services/VilkaarsvurderingService.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.vilkaarsvurdering.services
 
-import io.ktor.client.HttpClient
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
@@ -16,7 +15,7 @@ interface VilkaarsvurderingService {
     fun migrer(behandlingId: UUID): HttpResponse
 }
 
-class VilkaarsvurderingServiceImpl(private val vilkaarsvurderingKlient: HttpClient, private val url: String) :
+class VilkaarsvurderingServiceImpl(private val vilkaarsvurderingKlient: EtterlatteHttpClient, private val url: String) :
     VilkaarsvurderingService {
     override fun kopierForrigeVilkaarsvurdering(behandlingId: UUID, behandlingViOmregnerFra: UUID) =
         runBlocking {

--- a/libs/etterlatte-kontraktstesting/build.gradle.kts
+++ b/libs/etterlatte-kontraktstesting/build.gradle.kts
@@ -4,22 +4,46 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven {
+        url = uri("https://maven.pkg.github.com/navikt/pensjon-etterlatte-libs")
+        credentials {
+            username = "token"
+            password = System.getenv("GITHUB_TOKEN")
+        }
+    }
 }
 
 dependencies {
     implementation(project(":libs:saksbehandling-common"))
     implementation(project(":libs:etterlatte-ktor"))
+    implementation(project(":libs:etterlatte-database"))
+    implementation(project(":libs:etterlatte-token-model"))
 
     implementation(libs.ktor2.okhttp)
     implementation(libs.ktor2.servercore)
     implementation(libs.ktor2.servercio)
     implementation(libs.ktor2.clientcore)
+    implementation(libs.database.flywaydb)
 
     testImplementation(libs.test.mockk)
     testImplementation(libs.ktor2.servertests)
     testImplementation(libs.test.kotest.assertionscore)
     testImplementation(project(":libs:testdata"))
+    testImplementation(libs.navfelles.mockoauth2server) {
+        exclude("org.slf4j", "slf4j-api")
+    }
+    testImplementation(libs.test.jupiter.api)
+    testImplementation(libs.test.jupiter.params)
+    testImplementation(libs.test.testcontainer.jupiter)
+    testImplementation(libs.test.testcontainer.postgresql)
 
-    implementation(":apps:etterlatte-vilkaarsvurdering")
-    implementation(":apps:etterlatte-vilkaarsvurdering-kafka")
+    implementation(project(":apps:etterlatte-vilkaarsvurdering"))
+    implementation(project(":apps:etterlatte-vilkaarsvurdering-kafka"))
+    implementation(project(":libs:etterlatte-vilkaarsvurdering-model"))
+
+    tasks {
+        withType<Test> {
+            useJUnitPlatform()
+        }
+    }
 }

--- a/libs/etterlatte-kontraktstesting/build.gradle.kts
+++ b/libs/etterlatte-kontraktstesting/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(project(":libs:saksbehandling-common"))
+    implementation(project(":libs:etterlatte-ktor"))
+
+    implementation(libs.ktor2.okhttp)
+    implementation(libs.ktor2.servercore)
+    implementation(libs.ktor2.servercio)
+    implementation(libs.ktor2.clientcore)
+
+    testImplementation(libs.test.mockk)
+    testImplementation(libs.ktor2.servertests)
+    testImplementation(libs.test.kotest.assertionscore)
+    testImplementation(project(":libs:testdata"))
+
+    implementation(":apps:etterlatte-vilkaarsvurdering")
+    implementation(":apps:etterlatte-vilkaarsvurdering-kafka")
+}

--- a/libs/etterlatte-kontraktstesting/src/test/kotlin/RestTestUtils.kt
+++ b/libs/etterlatte-kontraktstesting/src/test/kotlin/RestTestUtils.kt
@@ -7,18 +7,20 @@ private suspend fun ApplicationTestBuilder.verifyKlientOgRouteHarLikSignatur(
     request: Any
 ) {
     val sti = slot<String>()
+    val jsonHeader = header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+    val body = request.toJson()
     verify {
         runBlocking {
             klient.post(capture(sti)) {
-                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                request.toJson()
+                jsonHeader
+                body
             }
         }
     }
 
     client.post(sti.captured) {
-        setBody(request.toJson())
-        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+        setBody(body)
+        jsonHeader
         header(HttpHeaders.Authorization, "Bearer $token")
     }.also { verify { it.status.isSuccess() } }
 }

--- a/libs/etterlatte-kontraktstesting/src/test/kotlin/RestTestUtils.kt
+++ b/libs/etterlatte-kontraktstesting/src/test/kotlin/RestTestUtils.kt
@@ -1,26 +1,25 @@
-import io.ktor.client.HttpClient
+
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.isSuccess
 import io.ktor.server.testing.ApplicationTestBuilder
+import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.libs.common.toJson
+import org.junit.jupiter.api.Assertions
 
-private suspend fun ApplicationTestBuilder.verifyKlientOgRouteHarLikSignaturForPost(
-    klient: HttpClient,
-    request: Any
+fun ApplicationTestBuilder.verifiserAtRutaMatcherDetKlientenKallerForPost(
+    sti: String,
+    request: Any,
+    token: String
 ) {
-    val sti = slot<String>()
-    val jsonHeader = header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-    val body = request.toJson()
-    verify {
-        runBlocking {
-            klient.post(capture(sti)) {
-                jsonHeader
-                body
-            }
-        }
+    runBlocking {
+        client.post(sti) {
+            setBody(request.toJson())
+            header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }.also { Assertions.assertTrue { it.status.isSuccess() } }
     }
-
-    client.post(sti.captured) {
-        setBody(body)
-        jsonHeader
-        header(HttpHeaders.Authorization, "Bearer $token")
-    }.also { verify { it.status.isSuccess() } }
 }

--- a/libs/etterlatte-kontraktstesting/src/test/kotlin/RestTestUtils.kt
+++ b/libs/etterlatte-kontraktstesting/src/test/kotlin/RestTestUtils.kt
@@ -2,7 +2,7 @@ import io.ktor.client.HttpClient
 import io.ktor.server.testing.ApplicationTestBuilder
 import no.nav.etterlatte.libs.common.toJson
 
-private suspend fun ApplicationTestBuilder.verifyKlientOgRouteHarLikSignatur(
+private suspend fun ApplicationTestBuilder.verifyKlientOgRouteHarLikSignaturForPost(
     klient: HttpClient,
     request: Any
 ) {

--- a/libs/etterlatte-kontraktstesting/src/test/kotlin/RestTestUtils.kt
+++ b/libs/etterlatte-kontraktstesting/src/test/kotlin/RestTestUtils.kt
@@ -1,0 +1,24 @@
+import io.ktor.client.HttpClient
+import io.ktor.server.testing.ApplicationTestBuilder
+import no.nav.etterlatte.libs.common.toJson
+
+private suspend fun ApplicationTestBuilder.verifyKlientOgRouteHarLikSignatur(
+    klient: HttpClient,
+    request: Any
+) {
+    val sti = slot<String>()
+    verify {
+        runBlocking {
+            klient.post(capture(sti)) {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                request.toJson()
+            }
+        }
+    }
+
+    client.post(sti.captured) {
+        setBody(request.toJson())
+        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+        header(HttpHeaders.Authorization, "Bearer $token")
+    }.also { verify { it.status.isSuccess() } }
+}

--- a/libs/etterlatte-kontraktstesting/src/test/kotlin/VilkaarsvurderingAPITest.kt
+++ b/libs/etterlatte-kontraktstesting/src/test/kotlin/VilkaarsvurderingAPITest.kt
@@ -1,11 +1,5 @@
 package no.nav.etterlatte
 
-import io.ktor.client.request.header
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
-import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders
-import io.ktor.http.isSuccess
 import io.ktor.server.application.log
 import io.ktor.server.config.HoconApplicationConfig
 import io.ktor.server.testing.ApplicationTestBuilder
@@ -14,8 +8,6 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
-import kotlinx.coroutines.runBlocking
-import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.database.migrate
@@ -29,13 +21,13 @@ import no.nav.etterlatte.vilkaarsvurdering.services.VilkaarsvurderingServiceImpl
 import no.nav.etterlatte.vilkaarsvurdering.vilkaarsvurdering
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
 import testsupport.buildTestApplicationConfigurationForOauth
+import verifiserAtRutaMatcherDetKlientenKallerForPost
 import java.time.YearMonth
 import java.util.*
 import javax.sql.DataSource
@@ -90,7 +82,7 @@ internal class VilkaarsvurderingAPITest {
             }
             val (sti, request) = kallKlient()
             klargjoerRute()
-            verifiserAtRutaMatcherDetKlientenKaller(sti, request)
+            verifiserAtRutaMatcherDetKlientenKallerForPost(sti, request, token)
         }
     }
 
@@ -126,18 +118,5 @@ internal class VilkaarsvurderingAPITest {
         coEvery { klient.post(any(), capture(sti)) } returns mockk()
         klient.oppdaterTotalVurdering(UUID.randomUUID(), request)
         return Pair(sti.captured, request)
-    }
-
-    private fun ApplicationTestBuilder.verifiserAtRutaMatcherDetKlientenKaller(
-        sti: String,
-        request: Any
-    ) {
-        runBlocking {
-            client.post(sti) {
-                setBody(request.toJson())
-                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                header(HttpHeaders.Authorization, "Bearer $token")
-            }.also { assertTrue { it.status.isSuccess() } }
-        }
     }
 }

--- a/libs/etterlatte-kontraktstesting/src/test/kotlin/VilkaarsvurderingAPITest.kt
+++ b/libs/etterlatte-kontraktstesting/src/test/kotlin/VilkaarsvurderingAPITest.kt
@@ -8,7 +8,9 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
 import io.ktor.server.application.log
 import io.ktor.server.config.HoconApplicationConfig
+import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
+import io.mockk.CapturingSlot
 import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.slot
@@ -114,13 +116,20 @@ internal class VilkaarsvurderingAPITest {
                 }
             }
 
-            runBlocking {
-                client.post(sti.captured) {
-                    setBody(request.toJson())
-                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                    header(HttpHeaders.Authorization, "Bearer $token")
-                }.also { assertTrue { it.status.isSuccess() } }
-            }
+            verifiserAtRutaMatcherDetKlientenKaller(sti, request)
+        }
+    }
+
+    private fun ApplicationTestBuilder.verifiserAtRutaMatcherDetKlientenKaller(
+        sti: CapturingSlot<String>,
+        request: Any
+    ) {
+        runBlocking {
+            client.post(sti.captured) {
+                setBody(request.toJson())
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                header(HttpHeaders.Authorization, "Bearer $token")
+            }.also { assertTrue { it.status.isSuccess() } }
         }
     }
 }

--- a/libs/etterlatte-kontraktstesting/src/test/kotlin/VilkaarsvurderingAPITest.kt
+++ b/libs/etterlatte-kontraktstesting/src/test/kotlin/VilkaarsvurderingAPITest.kt
@@ -1,0 +1,126 @@
+package no.nav.etterlatte
+
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.isSuccess
+import io.ktor.server.application.log
+import io.ktor.server.config.HoconApplicationConfig
+import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.spyk
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.libs.common.toJson
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
+import no.nav.etterlatte.libs.database.DataSourceBuilder
+import no.nav.etterlatte.libs.database.migrate
+import no.nav.etterlatte.libs.ktor.AZURE_ISSUER
+import no.nav.etterlatte.libs.ktor.restModule
+import no.nav.etterlatte.libs.vilkaarsvurdering.VurdertVilkaarsvurderingResultatDto
+import no.nav.etterlatte.vilkaarsvurdering.Vilkaarsvurdering
+import no.nav.etterlatte.vilkaarsvurdering.VilkaarsvurderingService
+import no.nav.etterlatte.vilkaarsvurdering.klienter.BehandlingKlient
+import no.nav.etterlatte.vilkaarsvurdering.services.VilkaarsvurderingServiceImpl
+import no.nav.etterlatte.vilkaarsvurdering.vilkaarsvurdering
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import testsupport.buildTestApplicationConfigurationForOauth
+import java.time.YearMonth
+import java.util.*
+import javax.sql.DataSource
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class VilkaarsvurderingAPITest {
+
+    private val clientID = "azure-id for saksbehandler"
+
+    @Container
+    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:14")
+    private val server = MockOAuth2Server()
+    private lateinit var hoconApplicationConfig: HoconApplicationConfig
+
+    private lateinit var ds: DataSource
+
+    @BeforeAll
+    fun before() {
+        server.start()
+        val httpServer = server.config.httpServer
+        hoconApplicationConfig = buildTestApplicationConfigurationForOauth(httpServer.port(), AZURE_ISSUER, clientID)
+        postgreSQLContainer.start()
+        ds = DataSourceBuilder.createDataSource(
+            postgreSQLContainer.jdbcUrl,
+            postgreSQLContainer.username,
+            postgreSQLContainer.password
+        ).also { it.migrate() }
+    }
+
+    @AfterAll
+    fun after() {
+        server.shutdown()
+        postgreSQLContainer.stop()
+    }
+
+    private val token: String by lazy {
+        server.issueToken(
+            issuerId = AZURE_ISSUER,
+            audience = clientID,
+            claims = mapOf(
+                "navn" to "John Doe",
+                "NAVident" to "Saksbehandler01"
+            )
+        ).serialize()
+    }
+
+    @Test
+    fun sign() {
+        testApplication {
+            environment {
+                config = hoconApplicationConfig
+            }
+            val vilkaarsvurderingService = mockk<VilkaarsvurderingService>()
+            coEvery { vilkaarsvurderingService.oppdaterTotalVurdering(any(), any(), any()) } returns
+                Vilkaarsvurdering(
+                    behandlingId = UUID.randomUUID(),
+                    grunnlagVersjon = 1,
+                    virkningstidspunkt = YearMonth.now(),
+                    vilkaar = listOf()
+                )
+            val sti = slot<String>()
+
+            val behandlingId: UUID = UUID.randomUUID()
+            val request = VurdertVilkaarsvurderingResultatDto(VilkaarsvurderingUtfall.OPPFYLT, "")
+            val klient = spyk(VilkaarsvurderingServiceImpl(mockk(), ""))
+            coEvery { klient.post(any(), capture(sti)) } returns mockk()
+            klient.oppdaterTotalVurdering(behandlingId, request)
+
+            val behandlingKlient = mockk<BehandlingKlient>()
+            coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+            application {
+                restModule(this.log) {
+                    vilkaarsvurdering(
+                        vilkaarsvurderingService,
+                        behandlingKlient
+                    )
+                }
+            }
+
+            runBlocking {
+                client.post(sti.captured) {
+                    setBody(request.toJson())
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    header(HttpHeaders.Authorization, "Bearer $token")
+                }.also { assertTrue { it.status.isSuccess() } }
+            }
+        }
+    }
+}

--- a/libs/etterlatte-kontraktstesting/src/test/kotlin/VilkaarsvurderingAPITest.kt
+++ b/libs/etterlatte-kontraktstesting/src/test/kotlin/VilkaarsvurderingAPITest.kt
@@ -10,7 +10,6 @@ import io.ktor.server.application.log
 import io.ktor.server.config.HoconApplicationConfig
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
-import io.mockk.CapturingSlot
 import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.slot
@@ -89,43 +88,52 @@ internal class VilkaarsvurderingAPITest {
             environment {
                 config = hoconApplicationConfig
             }
-            val vilkaarsvurderingService = mockk<VilkaarsvurderingService>()
-            coEvery { vilkaarsvurderingService.oppdaterTotalVurdering(any(), any(), any()) } returns
-                Vilkaarsvurdering(
-                    behandlingId = UUID.randomUUID(),
-                    grunnlagVersjon = 1,
-                    virkningstidspunkt = YearMonth.now(),
-                    vilkaar = listOf()
-                )
-            val sti = slot<String>()
-
-            val behandlingId: UUID = UUID.randomUUID()
-            val request = VurdertVilkaarsvurderingResultatDto(VilkaarsvurderingUtfall.OPPFYLT, "")
-            val klient = spyk(VilkaarsvurderingServiceImpl(mockk(), ""))
-            coEvery { klient.post(any(), capture(sti)) } returns mockk()
-            klient.oppdaterTotalVurdering(behandlingId, request)
-
-            val behandlingKlient = mockk<BehandlingKlient>()
-            coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
-            application {
-                restModule(this.log) {
-                    vilkaarsvurdering(
-                        vilkaarsvurderingService,
-                        behandlingKlient
-                    )
-                }
-            }
-
+            val (sti, request) = kallKlient()
+            klargjoerRute()
             verifiserAtRutaMatcherDetKlientenKaller(sti, request)
         }
     }
 
+    private fun ApplicationTestBuilder.klargjoerRute() {
+        val vilkaarsvurderingService = mockk<VilkaarsvurderingService>()
+            .also {
+                coEvery { it.oppdaterTotalVurdering(any(), any(), any()) } returns
+                    Vilkaarsvurdering(
+                        behandlingId = UUID.randomUUID(),
+                        grunnlagVersjon = 1,
+                        virkningstidspunkt = YearMonth.now(),
+                        vilkaar = listOf()
+                    )
+            }
+
+        val behandlingKlient = mockk<BehandlingKlient>().also {
+            coEvery { it.harTilgangTilBehandling(any(), any()) } returns true
+        }
+        application {
+            restModule(this.log) {
+                vilkaarsvurdering(
+                    vilkaarsvurderingService,
+                    behandlingKlient
+                )
+            }
+        }
+    }
+
+    private fun kallKlient(): Pair<String, VurdertVilkaarsvurderingResultatDto> {
+        val sti = slot<String>()
+        val request = VurdertVilkaarsvurderingResultatDto(VilkaarsvurderingUtfall.OPPFYLT, "")
+        val klient = spyk(VilkaarsvurderingServiceImpl(mockk(), ""))
+        coEvery { klient.post(any(), capture(sti)) } returns mockk()
+        klient.oppdaterTotalVurdering(UUID.randomUUID(), request)
+        return Pair(sti.captured, request)
+    }
+
     private fun ApplicationTestBuilder.verifiserAtRutaMatcherDetKlientenKaller(
-        sti: CapturingSlot<String>,
+        sti: String,
         request: Any
     ) {
         runBlocking {
-            client.post(sti.captured) {
+            client.post(sti) {
                 setBody(request.toJson())
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 header(HttpHeaders.Authorization, "Bearer $token")

--- a/libs/etterlatte-kontraktstesting/src/test/kotlin/VilkaarsvurderingAPITest.kt
+++ b/libs/etterlatte-kontraktstesting/src/test/kotlin/VilkaarsvurderingAPITest.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte
 
+import io.ktor.client.HttpClient
 import io.ktor.server.application.log
 import io.ktor.server.config.HoconApplicationConfig
 import io.ktor.server.testing.ApplicationTestBuilder
@@ -8,12 +9,10 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
-import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.AZURE_ISSUER
 import no.nav.etterlatte.libs.ktor.restModule
-import no.nav.etterlatte.libs.vilkaarsvurdering.VurdertVilkaarsvurderingResultatDto
 import no.nav.etterlatte.vilkaarsvurdering.Vilkaarsvurdering
 import no.nav.etterlatte.vilkaarsvurdering.VilkaarsvurderingService
 import no.nav.etterlatte.vilkaarsvurdering.klienter.BehandlingKlient
@@ -82,7 +81,7 @@ internal class VilkaarsvurderingAPITest {
             }
             val (sti, request) = kallKlient()
             klargjoerRute()
-            verifiserAtRutaMatcherDetKlientenKallerForPost(sti, request, token)
+            verifiserAtRutaMatcherDetKlientenKallerForPost(sti.toString(), request, token)
         }
     }
 
@@ -111,12 +110,12 @@ internal class VilkaarsvurderingAPITest {
         }
     }
 
-    private fun kallKlient(): Pair<String, VurdertVilkaarsvurderingResultatDto> {
-        val sti = slot<String>()
-        val request = VurdertVilkaarsvurderingResultatDto(VilkaarsvurderingUtfall.OPPFYLT, "")
-        val klient = spyk(VilkaarsvurderingServiceImpl(mockk(), ""))
-        coEvery { klient.post(any(), capture(sti)) } returns mockk()
-        klient.oppdaterTotalVurdering(UUID.randomUUID(), request)
-        return Pair(sti.captured, request)
+    private fun kallKlient(): Pair<UUID, Any> {
+        val sti = slot<UUID>()
+        val httpClient = mockk<HttpClient>()
+        val klient = spyk(VilkaarsvurderingServiceImpl(httpClient, ""))
+        coEvery { klient.migrer(capture(sti)) } returns mockk()
+        klient.migrer(UUID.randomUUID())
+        return Pair(sti.captured, "{}")
     }
 }

--- a/libs/etterlatte-kontraktstesting/src/test/kotlin/VilkaarsvurderingAPITest.kt
+++ b/libs/etterlatte-kontraktstesting/src/test/kotlin/VilkaarsvurderingAPITest.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte
 
 import io.ktor.client.HttpClient
+import io.ktor.client.request.post
 import io.ktor.server.application.log
 import io.ktor.server.config.HoconApplicationConfig
 import io.ktor.server.testing.ApplicationTestBuilder
@@ -110,11 +111,11 @@ internal class VilkaarsvurderingAPITest {
         }
     }
 
-    private fun kallKlient(): Pair<UUID, Any> {
-        val sti = slot<UUID>()
+    private fun kallKlient(): Pair<String, Any> {
+        val sti = slot<String>()
         val httpClient = mockk<HttpClient>()
         val klient = spyk(VilkaarsvurderingServiceImpl(httpClient, ""))
-        coEvery { klient.migrer(capture(sti)) } returns mockk()
+        coEvery { httpClient.post(capture(sti), {}) } returns mockk()
         klient.migrer(UUID.randomUUID())
         return Pair(sti.captured, "{}")
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,6 +36,7 @@ include(
     "libs:etterlatte-ktor",
     "libs:etterlatte-jobs",
     "libs:etterlatte-kafka",
+    "libs:etterlatte-kontraktstesting",
     "libs:etterlatte-pdl-model",
     "libs:etterlatte-institusjonsopphold-model",
     "libs:testdata",


### PR DESCRIPTION
Oppfølgar til https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/1259

Denne er ein variant av alternativ 2 derifrå, det vi gjer her er i grunn ein heimesnekra og forenkla variant av det eit kontraktstestingsverktyg som Pact gjer.

Vi introduserer ein ny modul som er tenkt å ha avhengnad til alt og alle, og det er her testane er tenkt å liggje.


Fordelane med denne tilnærminga er at vi ikkje endrar prodkode, samt at testkoden blir ganske rett fram.
Ulempa er at denne nye modulen får massivt med avhengnadar, men sia det berre er testkode er eg ikkje sikker på at det gjer så mykje.