### PR TITLE
Liten forbedring av get-secret.sh

### DIFF
--- a/get-secret.sh
+++ b/get-secret.sh
@@ -13,6 +13,15 @@ error() {
     exit;
 }
 
+validateGitIgnore() {
+  ROOT_DIR=$(pwd | sed "s/saksbehandling.*/saksbehandling/")
+  CONTAINS_IGNORE_ENV=$(cat $ROOT_DIR/.gitignore | grep '.env')
+
+  if [[ -z "$CONTAINS_IGNORE_ENV" ]]; then
+    error ".gitignore does not contain entry for .env files!"
+  fi
+}
+
 userIsAuthenticated() {
   nais device status | grep -q -i "naisdevice status: Disconnected" &> /dev/null
   if [ $? -eq 0 ]; then # Grep returns 0 if there is a match
@@ -22,6 +31,12 @@ userIsAuthenticated() {
   gcloud auth print-identity-token &> /dev/null
   if [ $? -gt 0 ]; then
     error "Not logged into gcloud... Please run:\n\n\t$ gcloud auth login"
+  fi
+
+  CURRENT_CONTEXT=$(kubectl config current-context)
+
+  if [ "$CURRENT_CONTEXT" != "dev-gcp" ]; then
+      error "Current context is $CURRENT_CONTEXT, but should be 'dev-gcp'"
   fi
 
   # Only continue if user is able to read secrets from gcp/kubernetes
@@ -36,13 +51,20 @@ userIsAuthenticated() {
 
 validateAppDir() {
   if [[ -z "$1" ]]; then
-    error "You must supply a dir where secrets should be added.\n\n\tExample:\tget-secret.sh apps/<my-application>\n"
+    ALL_APPS_DIR=$(pwd | sed "s/saksbehandling.*/saksbehandling\/apps/")
+    AVAILABLE_APPS=$(ls $ALL_APPS_DIR)
+
+    error "You must supply app name. \n\nAvailable apps are: \n$AVAILABLE_APPS"
   fi
 
-  APP_DIR=$1
+  APP_NAME=$1
+  APP_DIR=$(pwd | sed "s/saksbehandling.*/saksbehandling\/apps\/$APP_NAME/")
 
   if [ ! -d "$APP_DIR" ]; then
-    error "Directory '$APP_DIR' does not exist!"
+    ALL_APPS_DIR=$(pwd | sed "s/saksbehandling.*/saksbehandling\/apps/")
+    AVAILABLE_APPS=$(ls $ALL_APPS_DIR)
+
+    error "Directory '$APP_DIR' does not exist! \n\nAvailable app dirs are: \n$AVAILABLE_APPS"
   else
     info "Found directory '$APP_DIR'."
   fi
@@ -62,7 +84,7 @@ userHasJq() {
   fi
 }
 
-getAzureadSecretName() {
+getLocalSecretName() {
   info "Checking if app contains config for azuread secret"
 
   AZUREAD_FILE_PATH=$(find $APP_DIR -iname "azuread-etterlatte*")
@@ -70,13 +92,32 @@ getAzureadSecretName() {
     error "No azuread secret file found in dir '$APP_DIR'. Please ensure it follows this format:\n\n\t.nais/azuread-etterlatte-<APP_NAME>-lokal.yaml"
   fi
 
-  SECRET_NAME=$(grep "secretName" $AZUREAD_FILE_PATH | awk '{print $2}')
+  AZURE_SECRET_NAME=$(grep "secretName" $AZUREAD_FILE_PATH | awk '{print $2}')
 
-  if [ -z "$SECRET_NAME" ]; then
+  if [ -z "$AZURE_SECRET_NAME" ]; then
     error "Field 'secretName' not found in file '$AZUREAD_FILE_PATH'"
   fi
+}
 
-  info "Found secret with name '$SECRET_NAME' in file path: '$AZUREAD_FILE_PATH'"
+getRemoteSecretName() {
+  info "Checking kubernetes for secret for $APP_NAME"
+
+  AZURE_SECRET_NAME=$(kubectl get secrets | grep "azure-$APP_NAME" | awk '{print $1}')
+  if [ -z "$AZURE_SECRET_NAME" ]; then
+    error "No azuread secret found for app name $APP_NAME"
+  fi
+}
+
+getAzureadSecretName() {
+  read -p "Do you want to use 'local' secret (default=remote)? [y/N] " USE_LOKAL_SECRET
+
+  if [ "$USE_LOKAL_SECRET" == "y" ]; then
+    getLocalSecretName
+  else
+    getRemoteSecretName
+  fi
+
+  info "Found secret with name '$AZURE_SECRET_NAME'"
 }
 
 addSecretToEnvFile() {
@@ -90,26 +131,28 @@ addSecretToEnvFile() {
   info "Fetching secrets from kubernetes"
 
   if [ "$USING_WONDERWALL" == "y" ]; then
-    info "Adding wonderwall keys to .env file"
-
-    kubectl -n etterlatte get secret $SECRET_NAME -o json \
+    kubectl -n etterlatte get secret $AZURE_SECRET_NAME -o json \
         | jq -r '.data | map_values(@base64d)
           | .["WONDERWALL_OPENID_CLIENT_ID"] = .AZURE_APP_CLIENT_ID
           | .["WONDERWALL_OPENID_CLIENT_JWK"] = .AZURE_APP_JWK
           | .["WONDERWALL_OPENID_WELL_KNOWN_URL"] = .AZURE_APP_WELL_KNOWN_URL
           | to_entries[] | (.key | ascii_upcase) +"=" + .value' \
         | sed -r "s/^(WONDERWALL_OPENID_CLIENT_JWK)=(\{.*\})$/\1='\2'/g" \
-        > ./$APP_DIR/.env.dev-gcp
+        > $APP_DIR/.env.dev-gcp
   else
-    kubectl -n etterlatte get secret $SECRET_NAME -o json \
+    kubectl -n etterlatte get secret $AZURE_SECRET_NAME -o json \
         | jq -r '.data | map_values(@base64d) | to_entries[] | (.key | ascii_upcase) +"=" + .value' \
-        > ./$APP_DIR/.env.dev-gcp
+        > $APP_DIR/.env.dev-gcp
   fi
+
+  info ".env.dev-gcp created with valid secrets"
 }
 
 info "==============="
 info "Starting script ..."
 info "==============="
+
+validateGitIgnore
 
 # Ensure user is authenticated
 userIsAuthenticated


### PR DESCRIPTION
- Sjekker at .gitignore inneholder .env
- Sjekker at context er **dev-gcp**
- Forenkle input (kan nå skrive _kun_ appnavn, eks: etterlatte-brev-api)
- Scriptet kan kjøres hvor som helst i prosjektet. 
- Støtter uthenting av secrets som ikke er av typen "lokal". Gjør det mulig å kjøre `lokal front -> lokal backend -> dev backend`.