### PR TITLE
EY-2169 - legg til støtte for beregningsgrunnlag for institusjonsopphold

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BarnepensjonBeregningsGrunnlag.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BarnepensjonBeregningsGrunnlag.kt
@@ -3,5 +3,6 @@ package no.nav.etterlatte.beregning.grunnlag
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.SoeskenMedIBeregning
 
 data class BarnepensjonBeregningsGrunnlag(
-    val soeskenMedIBeregning: List<SoeskenMedIBeregning>
+    val soeskenMedIBeregning: List<SoeskenMedIBeregning>,
+    val institusjonsopphold: Institusjonsopphold
 )

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlag.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlag.kt
@@ -7,5 +7,6 @@ import java.util.UUID
 data class BeregningsGrunnlag(
     val behandlingId: UUID,
     val kilde: Grunnlagsopplysning.Saksbehandler,
-    val soeskenMedIBeregning: List<SoeskenMedIBeregning>
+    val soeskenMedIBeregning: List<SoeskenMedIBeregning>,
+    val institusjonsopphold: Institusjonsopphold
 )

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagRepository.kt
@@ -35,6 +35,9 @@ class BeregningsGrunnlagRepository(private val dataSource: DataSource) {
                         "soesken_med_i_beregning" to objectMapper.writeValueAsString(
                             beregningsGrunnlag.soeskenMedIBeregning
                         ),
+                        "institusjonsopphold" to objectMapper.writeValueAsString(
+                            beregningsGrunnlag.institusjonsopphold
+                        ),
                         "kilde" to beregningsGrunnlag.kilde.toJson()
 
                     )
@@ -48,22 +51,23 @@ class BeregningsGrunnlagRepository(private val dataSource: DataSource) {
     companion object {
 
         val lagreGrunnlagQuery = """
-            INSERT INTO bp_beregningsgrunnlag(behandlings_id, soesken_med_i_beregning, kilde)
+            INSERT INTO bp_beregningsgrunnlag(behandlings_id, soesken_med_i_beregning, institusjonsopphold, kilde)
             VALUES(
                 :behandlings_id,
                 :soesken_med_i_beregning,
+                :institusjonsopphold,
                 :kilde
             )
         """.trimMargin()
 
         val oppdaterGrunnlagQuery = """
             UPDATE bp_beregningsgrunnlag
-            SET soesken_med_i_beregning = :soesken_med_i_beregning, kilde = :kilde
+            SET soesken_med_i_beregning = :soesken_med_i_beregning, institusjonsopphold = :institusjonsopphold, kilde = :kilde
             WHERE behandlings_id = :behandlings_id
         """.trimMargin()
 
         val finnGrunnlagForBehandling = """
-            SELECT behandlings_id, soesken_med_i_beregning, kilde
+            SELECT behandlings_id, soesken_med_i_beregning, institusjonsopphold, kilde
             FROM bp_beregningsgrunnlag
             WHERE behandlings_id = :behandlings_id
         """.trimIndent()
@@ -74,6 +78,7 @@ private fun Row.asBeregningsGrunnlag(): BeregningsGrunnlag {
     return BeregningsGrunnlag(
         behandlingId = this.uuid("behandlings_id"),
         soeskenMedIBeregning = objectMapper.readValue(this.string("soesken_med_i_beregning")),
+        institusjonsopphold = objectMapper.readValue(this.string("institusjonsopphold")),
         kilde = objectMapper.readValue(this.string("kilde"))
     )
 }

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
@@ -23,7 +23,8 @@ class BeregningsGrunnlagService(
                 BeregningsGrunnlag(
                     behandlingId = behandlingId,
                     kilde = Grunnlagsopplysning.Saksbehandler.create(bruker.ident()),
-                    soeskenMedIBeregning = barnepensjonBeregningsGrunnlag.soeskenMedIBeregning
+                    soeskenMedIBeregning = barnepensjonBeregningsGrunnlag.soeskenMedIBeregning,
+                    institusjonsopphold = barnepensjonBeregningsGrunnlag.institusjonsopphold
                 )
             )
         }

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/Institusjonsopphold.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/Institusjonsopphold.kt
@@ -1,0 +1,5 @@
+package no.nav.etterlatte.beregning.grunnlag
+
+data class Institusjonsopphold(
+    val institusjonsopphold: Boolean
+)

--- a/apps/etterlatte-beregning/src/main/resources/db/migration/V11__legg_til_institusjons_opphold.sql
+++ b/apps/etterlatte-beregning/src/main/resources/db/migration/V11__legg_til_institusjons_opphold.sql
@@ -1,0 +1,3 @@
+ALTER TABLE bp_beregningsgrunnlag ADD COLUMN institusjonsopphold TEXT;
+
+UPDATE bp_beregningsgrunnlag SET institusjonsopphold = '{"institusjonsopphold":false}'

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnBarnepensjonServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnBarnepensjonServiceTest.kt
@@ -8,6 +8,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.beregning.grunnlag.BeregningsGrunnlag
 import no.nav.etterlatte.beregning.grunnlag.BeregningsGrunnlagService
+import no.nav.etterlatte.beregning.grunnlag.Institusjonsopphold
 import no.nav.etterlatte.beregning.klienter.GrunnlagKlientImpl
 import no.nav.etterlatte.beregning.klienter.VilkaarsvurderingKlient
 import no.nav.etterlatte.beregning.regler.FNR_1
@@ -271,7 +272,8 @@ internal class BeregnBarnepensjonServiceTest {
                     Folkeregisteridentifikator.of(it),
                     skalBrukes = true
                 )
-            }
+            },
+            Institusjonsopphold(false)
         )
 
     private fun mockBehandling(type: BehandlingType, virk: YearMonth = VIRKNINGSTIDSPUNKT_JAN_23): DetaljertBehandling =

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRepositoryIntegrationTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRepositoryIntegrationTest.kt
@@ -3,6 +3,7 @@ package beregning.grunnlag
 import io.mockk.clearAllMocks
 import no.nav.etterlatte.beregning.grunnlag.BeregningsGrunnlag
 import no.nav.etterlatte.beregning.grunnlag.BeregningsGrunnlagRepository
+import no.nav.etterlatte.beregning.grunnlag.Institusjonsopphold
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.SoeskenMedIBeregning
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
@@ -63,6 +64,7 @@ internal class BeregningsGrunnlagRepositoryIntegrationTest {
         val id = UUID.randomUUID()
 
         val soeskenMedIBeregning = listOf(SoeskenMedIBeregning(STOR_SNERK, true))
+        val institusjonsopphold = Institusjonsopphold(false)
 
         repository.lagre(
             BeregningsGrunnlag(
@@ -71,7 +73,8 @@ internal class BeregningsGrunnlagRepositoryIntegrationTest {
                     ident = "Z123456",
                     Tidspunkt.now()
                 ),
-                soeskenMedIBeregning
+                soeskenMedIBeregning,
+                institusjonsopphold
             )
         )
 
@@ -80,6 +83,7 @@ internal class BeregningsGrunnlagRepositoryIntegrationTest {
         assertNotNull(result)
 
         assertEquals(soeskenMedIBeregning, result?.soeskenMedIBeregning)
+        assertEquals(institusjonsopphold, result?.institusjonsopphold)
     }
 
     @Test
@@ -92,6 +96,9 @@ internal class BeregningsGrunnlagRepositoryIntegrationTest {
             SoeskenMedIBeregning(TRIVIELL_MIDTPUNKT, true)
         )
 
+        val initialInstitusjonsopphold = Institusjonsopphold(false)
+        val oppdatertInstitusjonsopphold = Institusjonsopphold(true)
+
         repository.lagre(
             BeregningsGrunnlag(
                 id,
@@ -99,7 +106,8 @@ internal class BeregningsGrunnlagRepositoryIntegrationTest {
                     ident = "Z123456",
                     Tidspunkt.now()
                 ),
-                initialSoeskenMedIBeregning
+                initialSoeskenMedIBeregning,
+                initialInstitusjonsopphold
             )
         )
 
@@ -110,7 +118,8 @@ internal class BeregningsGrunnlagRepositoryIntegrationTest {
                     ident = "Z654321",
                     Tidspunkt.now()
                 ),
-                oppdatertSoeskenMedIBeregning
+                oppdatertSoeskenMedIBeregning,
+                oppdatertInstitusjonsopphold
             )
         )
 
@@ -119,6 +128,7 @@ internal class BeregningsGrunnlagRepositoryIntegrationTest {
         assertNotNull(result)
 
         assertEquals(oppdatertSoeskenMedIBeregning, result?.soeskenMedIBeregning)
+        assertEquals(oppdatertInstitusjonsopphold, result?.institusjonsopphold)
         assertEquals("Z654321", result?.kilde?.ident)
     }
 

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
@@ -83,7 +83,8 @@ internal class BeregningsGrunnlagRoutesTest {
         every { repository.finnGrunnlagForBehandling(any()) } returns BeregningsGrunnlag(
             id,
             Grunnlagsopplysning.Saksbehandler("Z123456", Tidspunkt.now()),
-            emptyList()
+            emptyList(),
+            Institusjonsopphold(false)
         )
 
         testApplication {
@@ -135,7 +136,12 @@ internal class BeregningsGrunnlagRoutesTest {
             client.post("/api/beregning/beregningsgrunnlag/${randomUUID()}/barnepensjon") {
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 header(HttpHeaders.Authorization, "Bearer $token")
-                setBody(BarnepensjonBeregningsGrunnlag(emptyList()))
+                setBody(
+                    BarnepensjonBeregningsGrunnlag(
+                        emptyList(),
+                        Institusjonsopphold(false)
+                    )
+                )
             }.let {
                 it.status shouldBe HttpStatusCode.NotFound
             }
@@ -162,7 +168,12 @@ internal class BeregningsGrunnlagRoutesTest {
             client.post("/api/beregning/beregningsgrunnlag/${randomUUID()}/barnepensjon") {
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 header(HttpHeaders.Authorization, "Bearer $token")
-                setBody(BarnepensjonBeregningsGrunnlag(emptyList()))
+                setBody(
+                    BarnepensjonBeregningsGrunnlag(
+                        emptyList(),
+                        Institusjonsopphold(false)
+                    )
+                )
             }.let {
                 it.status shouldBe HttpStatusCode.NoContent
             }
@@ -189,7 +200,12 @@ internal class BeregningsGrunnlagRoutesTest {
             client.post("/api/beregning/beregningsgrunnlag/${randomUUID()}/barnepensjon") {
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 header(HttpHeaders.Authorization, "Bearer $token")
-                setBody(BarnepensjonBeregningsGrunnlag(emptyList()))
+                setBody(
+                    BarnepensjonBeregningsGrunnlag(
+                        emptyList(),
+                        Institusjonsopphold(false)
+                    )
+                )
             }.let {
                 it.status shouldBe HttpStatusCode.Conflict
             }
@@ -223,7 +239,8 @@ internal class BeregningsGrunnlagRoutesTest {
         every { repository.finnGrunnlagForBehandling(forrige) } returns BeregningsGrunnlag(
             forrige,
             Grunnlagsopplysning.Saksbehandler("Z123456", Tidspunkt.now()),
-            emptyList()
+            emptyList(),
+            Institusjonsopphold(false)
         )
         every { repository.finnGrunnlagForBehandling(nye) } returns null
         every { repository.lagre(any()) } returns true
@@ -274,12 +291,14 @@ internal class BeregningsGrunnlagRoutesTest {
         every { repository.finnGrunnlagForBehandling(forrige) } returns BeregningsGrunnlag(
             forrige,
             Grunnlagsopplysning.Saksbehandler("Z123456", Tidspunkt.now()),
-            emptyList()
+            emptyList(),
+            Institusjonsopphold(false)
         )
         every { repository.finnGrunnlagForBehandling(nye) } returns BeregningsGrunnlag(
             nye,
             Grunnlagsopplysning.Saksbehandler("Z123456", Tidspunkt.now()),
-            emptyList()
+            emptyList(),
+            Institusjonsopphold(false)
         )
         every { repository.lagre(any()) } returns true
 

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.beregning.grunnlag.BarnepensjonBeregningsGrunnlag
 import no.nav.etterlatte.beregning.grunnlag.BeregningsGrunnlag
 import no.nav.etterlatte.beregning.grunnlag.BeregningsGrunnlagRepository
 import no.nav.etterlatte.beregning.grunnlag.BeregningsGrunnlagService
+import no.nav.etterlatte.beregning.grunnlag.Institusjonsopphold
 import no.nav.etterlatte.beregning.klienter.BehandlingKlientImpl
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
@@ -39,6 +40,7 @@ internal class BeregningsGrunnlagServiceTest {
         val soeskenMedIBeregning: List<SoeskenMedIBeregning> = listOf(
             SoeskenMedIBeregning(STOR_SNERK, true)
         )
+        val institusjonsopphold = Institusjonsopphold(false)
 
         val behandling = mockBehandling(SakType.BARNEPENSJON, randomUUID())
 
@@ -50,7 +52,7 @@ internal class BeregningsGrunnlagServiceTest {
         runBlocking {
             beregningsGrunnlagService.lagreBarnepensjonBeregningsGrunnlag(
                 randomUUID(),
-                BarnepensjonBeregningsGrunnlag(soeskenMedIBeregning),
+                BarnepensjonBeregningsGrunnlag(soeskenMedIBeregning, institusjonsopphold),
                 mockk {
                     every { ident() } returns "Z123456"
                 }
@@ -73,7 +75,8 @@ internal class BeregningsGrunnlagServiceTest {
         every { beregningsGrunnlagRepository.finnGrunnlagForBehandling(behandlingsId) } returns BeregningsGrunnlag(
             behandlingsId,
             Grunnlagsopplysning.Saksbehandler("Z123456", Tidspunkt.now()),
-            emptyList()
+            emptyList(),
+            Institusjonsopphold(false)
         )
         every { beregningsGrunnlagRepository.lagre(any()) } returns true
 
@@ -115,7 +118,8 @@ internal class BeregningsGrunnlagServiceTest {
         every { beregningsGrunnlagRepository.finnGrunnlagForBehandling(any()) } returns BeregningsGrunnlag(
             behandlingsId,
             Grunnlagsopplysning.Saksbehandler("Z123456", Tidspunkt.now()),
-            emptyList()
+            emptyList(),
+            Institusjonsopphold(false)
         )
 
         runBlocking {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/manueltopphoeroversikt/ManueltOpphoerOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/manueltopphoeroversikt/ManueltOpphoerOversikt.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { Infoboks } from '~components/behandling/soeknadsoversikt/styled'
 import { BehandlingHandlingKnapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
 import { useEffect, useState } from 'react'
-import { opprettEllerEndreBeregning, lagreSoeskenMedIBeregning } from '~shared/api/beregning'
+import { opprettEllerEndreBeregning, lagreBeregningsGrunnlag } from '~shared/api/beregning'
 import { useBehandlingRoutes } from '~components/behandling/BehandlingRoutes'
 import { Opphoersgrunn, OVERSETTELSER_OPPHOERSGRUNNER } from '~components/person/ManueltOpphoerModal'
 import { hentManueltOpphoerDetaljer } from '~shared/api/behandling'
@@ -17,6 +17,7 @@ import { Child } from '@navikt/ds-icons'
 import differenceInYears from 'date-fns/differenceInYears'
 import { IBehandlingsammendrag } from '~components/person/typer'
 import { IBehandlingReducer } from '~store/reducers/BehandlingReducer'
+import { Institusjonsopphold } from '~shared/types/Beregning'
 
 export interface ManueltOpphoerDetaljer {
   id: string
@@ -52,7 +53,13 @@ export const ManueltOpphoerOversikt = (props: { behandling: IBehandlingReducer }
     setLoadingBeregning(true)
     setFeilmelding('')
     try {
-      await lagreSoeskenMedIBeregning({ behandlingsId: behandling.id, soeskenMedIBeregning: [] })
+      // TODO EY-2170
+      const institusjonsopphold = { institusjonsopphold: false } as Institusjonsopphold
+      await lagreBeregningsGrunnlag({
+        behandlingsId: behandling.id,
+        soeskenMedIBeregning: [],
+        institusjonsopphold: institusjonsopphold,
+      })
       await opprettEllerEndreBeregning(behandling.id)
       behandlingRoutes.next()
     } catch (e) {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/beregning.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/beregning.ts
@@ -1,5 +1,5 @@
 import { apiClient, ApiResponse } from '~shared/api/apiClient'
-import { Beregning, BeregningsGrunnlag, SoeskenMedIBeregning } from '~shared/types/Beregning'
+import { Beregning, BeregningsGrunnlag, Institusjonsopphold, SoeskenMedIBeregning } from '~shared/types/Beregning'
 import { KildeSaksbehandler } from '~shared/types/kilde'
 
 export const hentBeregning = async (behandlingId: string): Promise<ApiResponse<Beregning>> => {
@@ -10,16 +10,18 @@ export const opprettEllerEndreBeregning = async (behandlingId: string): Promise<
   return apiClient.post(`/beregning/${behandlingId}`, {})
 }
 
-export const lagreSoeskenMedIBeregning = async (args: {
+export const lagreBeregningsGrunnlag = async (args: {
   behandlingsId: string
   soeskenMedIBeregning: SoeskenMedIBeregning[]
+  institusjonsopphold: Institusjonsopphold
 }): Promise<ApiResponse<void>> => {
   return apiClient.post(`/beregning/beregningsgrunnlag/${args.behandlingsId}/barnepensjon`, {
     soeskenMedIBeregning: args.soeskenMedIBeregning,
+    institusjonsopphold: args.institusjonsopphold,
   })
 }
 
-export const hentSoeskenjusteringsgrunnlag = async (
+export const hentBeregningsGrunnlag = async (
   behandlingsId: string
 ): Promise<ApiResponse<BeregningsGrunnlag<KildeSaksbehandler> | null>> => {
   return apiClient.get(`/beregning/beregningsgrunnlag/${behandlingsId}/barnepensjon`)

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Beregning.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Beregning.ts
@@ -32,6 +32,7 @@ export interface BeregningsGrunnlag<K> {
   behandlingId: string
   kilde: K
   soeskenMedIBeregning: SoeskenMedIBeregning[]
+  institusjonsopphold: Institusjonsopphold
 }
 
 export interface SoeskenMedIBeregning {
@@ -41,4 +42,9 @@ export interface SoeskenMedIBeregning {
 
 export interface BeregningsGrunnlagData {
   soeskenMedIBeregning: SoeskenMedIBeregning[]
+  institusjonsopphold: Institusjonsopphold
+}
+
+export interface Institusjonsopphold {
+  institusjonsopphold: boolean
 }


### PR DESCRIPTION
Legger til støtte for institusjonsopphold i beregningsgrunnlag.

Initielt - kun en boolean - kan uvtides senere.

Frontend - oppdatere APIet - men sender bare default verdier opp - frontend skal oppdateres i EY-2170.