### PR TITLE
Ytelse blir aldri mindre enn 0 ved avkorting

### DIFF
--- a/apps/etterlatte-beregning/README.md
+++ b/apps/etterlatte-beregning/README.md
@@ -31,7 +31,11 @@ ETTERLATTE_TRYGDETID_CLIENT_ID=8385435e-f3d7-45ec-be59-ebd1c71df735;
 ETTERLATTE_TRYGDETID_URL=https://etterlatte-trygdetid.intern.dev.nav.no;
 ETTERLATTE_VILKAARSVURDERING_CLIENT_ID=dev-gcp.etterlatte.etterlatte-vilkaarsvurdering;
 ETTERLATTE_VILKAARSVURDERING_URL=http://etterlatte-vilkaarsvurdering;
-HTTP_PORT=8080;
+GRUNNLAG_AZURE_SCOPE=api://dev-gcp.etterlatte.etterlatte-grunnlag/.default;
+NAIS_APP_NAME=etterlatte-beregning;
+NAIS_CLUSTER_NAME=dev-gcp;
+ELECTOR_PATH=localhost;
+HTTP_PORT=8089;
 ```
 Legg også til `.env.dev-gcp` som `Env-file` under `Run configurations` i Intellij.
 
@@ -43,7 +47,7 @@ Legg også til `.env.dev-gcp` som `Env-file` under `Run configurations` i Intell
    `./get-secret.sh apps/etterlatte-saksbehandling-ui`
    og legge til følgende linjer nederst i `.env.dev-gcp` fila til saksbehandling-ui.
 ```
-BEREGNING_API_URL=http://host.docker.internal:8088
+BEREGNING_API_URL=http://host.docker.internal:8089
 BEREGNING_API_SCOPE=api://<BEREGNING_CLIENT_ID>/.default // Se .env.dev-gcp fila du opprettet i steg 1.
 ```
 

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/Beregningstall.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/Beregningstall.kt
@@ -87,6 +87,14 @@ class Beregningstall : Comparable<Beregningstall> {
         value.subtract(BigDecimal(subtrahend)).setScale(decimals, roundingMode)
     )
 
+    fun zeroIfNegative(): Beregningstall {
+        return if (this.value < BigDecimal.ZERO) {
+            Beregningstall(BigDecimal.ZERO)
+        } else {
+            this
+        }
+    }
+
     fun setScale(decimals: Int, roundingMode: RoundingMode = AVRUNDING_BEREGNING) =
         Beregningstall(value.setScale(decimals, roundingMode))
 

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/avkorting/AvkortetYtelse.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/avkorting/AvkortetYtelse.kt
@@ -11,6 +11,7 @@ import no.nav.etterlatte.libs.regler.benytter
 import no.nav.etterlatte.libs.regler.finnFaktumIGrunnlag
 import no.nav.etterlatte.libs.regler.med
 import no.nav.etterlatte.libs.regler.og
+import kotlin.math.max
 
 data class AvkortetYtelseGrunnlag(
     val periode: RegelPeriode,
@@ -37,5 +38,8 @@ val avkorteYtelse = RegelMeta(
     beskrivelse = "Finner endelig ytelse ved å trekke avkortingsbeløp fra bruttoytelse",
     regelReferanse = RegelReferanse(id = "TODO")
 ) benytter bruttoYtelse og avkortingsbeloep med { bruttoYtelse, avkortingsbeloep ->
-    Beregningstall(bruttoYtelse).minus(Beregningstall(avkortingsbeloep)).toInteger()
+    Beregningstall(bruttoYtelse)
+        .minus(Beregningstall(avkortingsbeloep))
+        .toInteger()
+        .let { max(it, 0) }
 }

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/avkorting/InntektAvkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/avkorting/InntektAvkorting.kt
@@ -56,7 +56,9 @@ val overstegetInntekt = RegelMeta(
     regelReferanse = RegelReferanse(id = "")
 ) benytter opprundetInntekt og grunnbeloep med { inntekt, grunnbeleop ->
     val halvtGrunnbeloep = Beregningstall(grunnbeleop.grunnbeloep).divide(2)
-    inntekt.minus(halvtGrunnbeloep)
+    inntekt
+        .minus(halvtGrunnbeloep)
+        .zeroIfNegative()
 }
 
 val avkortingFaktor = definerKonstant<InntektAvkortingGrunnlag, Beregningstall>(

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/regler/avkorting/AvkortetYtelseTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/regler/avkorting/AvkortetYtelseTest.kt
@@ -16,4 +16,13 @@ class AvkortetYtelseTest {
         )
         avkortetYtelse.verdi shouldBe 50000
     }
+
+    @Test
+    fun `avkorteYtelse skal bli 0 dersom avkortingsbeloep er stoerre enn bruttoytelse `() {
+        val avkortetYtelse = avkorteYtelse.anvend(
+            avkortetYtelseGrunnlag(bruttoYtelse = 50000, avkorting = 100000),
+            RegelPeriode(LocalDate.of(2023, 1, 1))
+        )
+        avkortetYtelse.verdi shouldBe 0
+    }
 }

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/regler/avkorting/InntektAvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/regler/avkorting/InntektAvkortingTest.kt
@@ -35,6 +35,15 @@ class InntektAvkortingTest {
     }
 
     @Test
+    fun `oversteget inntekt skal gi 0 naar inntekt er mindre en halvt grunnbeloep`() {
+        val overstegetInntekt = overstegetInntekt.anvend(
+            inntektAvkortingGrunnlag(inntekt = 25000),
+            RegelPeriode(LocalDate.of(2023, 1, 1))
+        )
+        overstegetInntekt.verdi.toInteger() shouldBe 0
+    }
+
+    @Test
     fun `avkortingsbeloep er oversteget inntekt ganget med avkortingsfaktor oppdelt i antall maaneder (12)`() {
         val avkortingsbeloep = inntektAvkorting.anvend(
             inntektAvkortingGrunnlag(inntekt = 500000),


### PR DESCRIPTION
Fikser også et tilsvarende problem ved beregning av avkortet beløp dersom inntekt er mindre enn 0.5 * grunnbeløp

EY-1961