### PR TITLE
EY-2178 Sikre at brev er ferdigstilt før attestering

### DIFF
--- a/apps/etterlatte-brev-api/docker-compose.yml
+++ b/apps/etterlatte-brev-api/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - '9092:9092'
     environment:
       - KAFKA_ENABLE_KRAFT=yes
+      - KAFKA_CFG_NODE_ID=1
       - KAFKA_CFG_PROCESS_ROLES=broker,controller
       - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
       - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/attestering/attestering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/attestering/attestering.tsx
@@ -46,7 +46,6 @@ const TextWrapper = styled.div`
   font-size: 18px;
   font-weight: 600;
   margin: 1em;
-  color: #595959;
 `
 
 const Overskrift = styled.div`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/attesterVedtak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/attesterVedtak.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@navikt/ds-react'
+import { Alert, Button } from '@navikt/ds-react'
 import { useState } from 'react'
 import { attesterVedtak } from '~shared/api/behandling'
 import { BeslutningWrapper, ButtonWrapper } from '../styled'
@@ -6,22 +6,53 @@ import { GeneriskModal } from '~shared/modal/modal'
 import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 import { useNavigate } from 'react-router'
 import { behandlingSkalSendeBrev } from '~components/behandling/felles/utils'
+import { hentVedtaksbrev } from '~shared/api/brev'
+import { isPending, useApiCall } from '~shared/hooks/useApiCall'
 
 export const AttesterVedtak = ({ behandling, kommentar }: { behandling: IDetaljertBehandling; kommentar: string }) => {
   const navigate = useNavigate()
   const [modalisOpen, setModalisOpen] = useState(false)
   const skalSendeBrev = behandlingSkalSendeBrev(behandling)
+  const [vedtaksbrevStatus, fetchVedtaksbrev] = useApiCall(hentVedtaksbrev)
+  const [error, setError] = useState<string>()
 
-  const attester = async () => {
-    attesterVedtak(behandling.id, kommentar).then((response) => {
-      if (response.status === 'ok') {
-        navigate(`/person/${behandling.søker?.foedselsnummer}`)
+  const vedtaksbrevErFerdigstilt = async () => {
+    if (!skalSendeBrev) {
+      return true
+    }
+
+    return fetchVedtaksbrev(behandling.id, (vedtaksbrev) => {
+      if (vedtaksbrev.status === 'FERDIGSTILT') return true
+      else {
+        setError(`
+          Brev har feil status (${vedtaksbrev.status.toLowerCase()}).
+          Kan ikke attestere saken. Forsøk å laste siden på nytt.
+        `)
+        setModalisOpen(false)
+        return false
       }
     })
   }
 
+  const attester = async () => {
+    const erVedtaksbrevFerdigstilt = await vedtaksbrevErFerdigstilt()
+
+    if (erVedtaksbrevFerdigstilt) {
+      attesterVedtak(behandling.id, kommentar).then((response) => {
+        if (response.status === 'ok') {
+          navigate(`/person/${behandling.søker?.foedselsnummer}`)
+        }
+      })
+    }
+  }
+
   return (
     <BeslutningWrapper>
+      {error && (
+        <Alert variant={'error'} style={{ marginTop: '1rem' }}>
+          {error}
+        </Alert>
+      )}
       <ButtonWrapper>
         <Button variant="primary" size="medium" className="button" onClick={() => setModalisOpen(true)}>
           {`Iverksett vedtak ${skalSendeBrev ? 'og send brev' : ''}`}
@@ -35,6 +66,7 @@ export const AttesterVedtak = ({ behandling, kommentar }: { behandling: IDetalje
         onYesClick={attester}
         setModalisOpen={setModalisOpen}
         open={modalisOpen}
+        loading={isPending(vedtaksbrevStatus)}
       />
     </BeslutningWrapper>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/attesterVedtak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/attesterVedtak.tsx
@@ -44,6 +44,9 @@ export const AttesterVedtak = ({ behandling, kommentar }: { behandling: IDetalje
       attesterVedtak(behandling.id, kommentar).then((response) => {
         if (response.status === 'ok') {
           navigate(`/person/${behandling.søker?.foedselsnummer}`)
+        } else {
+          setError(`Ukjent feil oppsto ved attestering av vedtaket... Prøv igjen.`)
+          setModalisOpen(false)
         }
       })
     }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
@@ -54,8 +54,11 @@ export const upsertVedtak = async (behandlingsId: string): Promise<ApiResponse<u
   return apiClient.post(`/vedtak/${behandlingsId}/upsert`, {})
 }
 
-export const attesterVedtak = async (behandlingId: string, kommentar: string): Promise<ApiResponse<unknown>> => {
-  return apiClient.post(`/vedtak/${behandlingId}/attester`, { kommentar })
+export const attesterVedtak = async (args: {
+  behandlingId: string
+  kommentar: string
+}): Promise<ApiResponse<unknown>> => {
+  return apiClient.post(`/vedtak/${args.behandlingId}/attester`, { kommentar: args.kommentar })
 }
 
 export const underkjennVedtak = async (

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
@@ -1,6 +1,7 @@
 import { apiClient, ApiResponse } from './apiClient'
+import { IBrev } from '~shared/types/Brev'
 
-export const hentVedtaksbrev = async (behandlingId: string): Promise<ApiResponse<any>> =>
+export const hentVedtaksbrev = async (behandlingId: string): Promise<ApiResponse<IBrev>> =>
   apiClient.get(`/brev/behandling/${behandlingId}/vedtak`)
 
 export const opprettVedtaksbrev = async (sakId: number, behandlingId: string): Promise<ApiResponse<any>> =>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/modal/modal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/modal/modal.tsx
@@ -9,6 +9,7 @@ export type Props = {
   onYesClick: () => void
   setModalisOpen: React.Dispatch<React.SetStateAction<boolean>>
   open: boolean
+  loading?: boolean
 }
 
 export const GeneriskModal: React.FC<Props> = ({
@@ -19,6 +20,7 @@ export const GeneriskModal: React.FC<Props> = ({
   onYesClick,
   setModalisOpen,
   open,
+  loading,
 }) => {
   return (
     <Modal
@@ -35,7 +37,14 @@ export const GeneriskModal: React.FC<Props> = ({
         </Heading>
         {beskrivelse && <BodyShort spacing>{beskrivelse}</BodyShort>}
         <ButtonWrapper>
-          <Button variant="primary" size="medium" className="button" onClick={onYesClick}>
+          <Button
+            variant="primary"
+            size="medium"
+            className="button"
+            onClick={onYesClick}
+            disabled={!!loading}
+            loading={!!loading}
+          >
             {tekstKnappJa}
           </Button>
           <Button
@@ -45,6 +54,7 @@ export const GeneriskModal: React.FC<Props> = ({
             onClick={() => {
               setModalisOpen(false)
             }}
+            disabled={!!loading}
           >
             {tekstKnappNei}
           </Button>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Brev.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Brev.ts
@@ -2,7 +2,7 @@ export interface IBrev {
   id: number
   behandlingId: string
   tittel: string
-  status: string
+  status: BrevStatus
   mottaker: Mottaker
   erVedtaksbrev: boolean
 }
@@ -23,4 +23,13 @@ export interface Adresse {
   poststed?: string
   landkode?: string
   land?: string
+}
+
+export enum BrevStatus {
+  OPPRETTET = 'OPPRETTET',
+  OPPDATERT = 'OPPDATERT',
+  FERDIGSTILT = 'FERDIGSTILT',
+  JOURNALFOERT = 'JOURNALFOERT',
+  DISTRIBUERT = 'DISTRIBUERT',
+  SLETTET = 'SLETTET',
 }


### PR DESCRIPTION
Verifiserer at vedtaksbrev er ferdigstilt _før_ attestering for å sikre at brev-api ikke havner i CrashLoopBackoff.

Viser nå dette dersom brev har ugyldig status: 
![Screenshot 2023-05-13 at 09 56 46](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/19a792f8-e60d-41c9-bde1-967a3afd9b01)
