### PR TITLE
EY-2204 - fjern sjekk mot SakServiceFeatureToggle.OpprettMedEnhetId

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
@@ -20,7 +20,6 @@ import no.nav.etterlatte.libs.common.sak.Sak
 import org.slf4j.LoggerFactory
 
 enum class SakServiceFeatureToggle(private val key: String) : FeatureToggle {
-    OpprettMedEnhetId("pensjon-etterlatte.opprett-sak-med-enhet-id"),
     FiltrerMedEnhetId("pensjon-etterlatte.filtrer-saker-med-enhet-id");
 
     override fun key() = key
@@ -88,11 +87,7 @@ class RealSakService(
             finnSakerForPersonOgType(fnr, type) ?: dao.opprettSak(
                 fnr,
                 type,
-                if (featureToggleService.isEnabled(SakServiceFeatureToggle.OpprettMedEnhetId, false)) {
-                    enhet ?: finnEnhetForPersonOgTema(fnr, type.tema, type).enhetNr
-                } else {
-                    null
-                }
+                enhet ?: finnEnhetForPersonOgTema(fnr, type.tema, type).enhetNr
             )
         }
         gradering?.let {

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakServiceTest.kt
@@ -217,7 +217,6 @@ internal class SakServiceTest {
         val responseException = ResponseException(mockk(), "Oops")
 
         every { sakDao.finnSaker(TRIVIELL_MIDTPUNKT.value) } returns emptyList()
-        every { featureToggleService.isEnabled(SakServiceFeatureToggle.OpprettMedEnhetId, false) } returns true
         every {
             pdlKlient.hentGeografiskTilknytning(TRIVIELL_MIDTPUNKT.value, SakType.BARNEPENSJON)
         } throws responseException
@@ -234,7 +233,6 @@ internal class SakServiceTest {
         thrown.message shouldContain "Oops"
 
         verify(exactly = 1) { sakDao.finnSaker(TRIVIELL_MIDTPUNKT.value) }
-        verify(exactly = 1) { featureToggleService.isEnabled(SakServiceFeatureToggle.OpprettMedEnhetId, false) }
         verify(exactly = 1) { pdlKlient.hentGeografiskTilknytning(TRIVIELL_MIDTPUNKT.value, SakType.BARNEPENSJON) }
         verify {
             listOf(norg2Klient) wasNot Called
@@ -244,7 +242,6 @@ internal class SakServiceTest {
     @Test
     fun `finnEllerOpprettSak feiler hvis NORG2 ikke finner geografisk tilknytning`() {
         every { sakDao.finnSaker(TRIVIELL_MIDTPUNKT.value) } returns emptyList()
-        every { featureToggleService.isEnabled(SakServiceFeatureToggle.OpprettMedEnhetId, false) } returns true
         every {
             pdlKlient.hentGeografiskTilknytning(TRIVIELL_MIDTPUNKT.value, SakType.BARNEPENSJON)
         } returns GeografiskTilknytning(kommune = "0301", ukjent = false)
@@ -260,7 +257,6 @@ internal class SakServiceTest {
         thrown.omraade shouldBe "0301"
 
         verify(exactly = 1) { sakDao.finnSaker(TRIVIELL_MIDTPUNKT.value) }
-        verify(exactly = 1) { featureToggleService.isEnabled(SakServiceFeatureToggle.OpprettMedEnhetId, false) }
         verify(exactly = 1) { pdlKlient.hentGeografiskTilknytning(TRIVIELL_MIDTPUNKT.value, SakType.BARNEPENSJON) }
         verify(exactly = 1) { norg2Klient.hentEnheterForOmraade(SakType.BARNEPENSJON.tema, "0301") }
     }
@@ -276,7 +272,6 @@ internal class SakServiceTest {
             sakType = SakType.BARNEPENSJON,
             enhet = Enheter.PORSGRUNN.enhetNr
         )
-        every { featureToggleService.isEnabled(SakServiceFeatureToggle.OpprettMedEnhetId, false) } returns true
         every {
             pdlKlient.hentGeografiskTilknytning(TRIVIELL_MIDTPUNKT.value, SakType.BARNEPENSJON)
         } returns GeografiskTilknytning(kommune = "0301", ukjent = false)
@@ -296,7 +291,6 @@ internal class SakServiceTest {
         )
 
         verify(exactly = 1) { sakDao.finnSaker(TRIVIELL_MIDTPUNKT.value) }
-        verify(exactly = 1) { featureToggleService.isEnabled(SakServiceFeatureToggle.OpprettMedEnhetId, false) }
         verify(exactly = 1) { pdlKlient.hentGeografiskTilknytning(TRIVIELL_MIDTPUNKT.value, SakType.BARNEPENSJON) }
         verify(exactly = 1) { norg2Klient.hentEnheterForOmraade(SakType.BARNEPENSJON.tema, "0301") }
         verify(exactly = 1) {
@@ -316,7 +310,6 @@ internal class SakServiceTest {
             sakType = SakType.BARNEPENSJON,
             enhet = Enheter.PORSGRUNN.enhetNr
         )
-        every { featureToggleService.isEnabled(SakServiceFeatureToggle.OpprettMedEnhetId, false) } returns true
         every {
             pdlKlient.hentGeografiskTilknytning(TRIVIELL_MIDTPUNKT.value, SakType.BARNEPENSJON)
         } returns GeografiskTilknytning(kommune = "0301", ukjent = false)
@@ -347,43 +340,10 @@ internal class SakServiceTest {
             )
         }
         verify(exactly = 1) { sakDao.finnSaker(TRIVIELL_MIDTPUNKT.value) }
-        verify(exactly = 1) { featureToggleService.isEnabled(SakServiceFeatureToggle.OpprettMedEnhetId, false) }
         verify(exactly = 1) { pdlKlient.hentGeografiskTilknytning(TRIVIELL_MIDTPUNKT.value, SakType.BARNEPENSJON) }
         verify(exactly = 1) { norg2Klient.hentEnheterForOmraade(SakType.BARNEPENSJON.tema, "0301") }
         verify(exactly = 1) {
             sakDao.opprettSak(TRIVIELL_MIDTPUNKT.value, SakType.BARNEPENSJON, Enheter.PORSGRUNN.enhetNr)
-        }
-    }
-
-    @Test
-    fun `finnEllerOpprettSak lagre uten enhet - feature disabled`() {
-        every { sakDao.finnSaker(TRIVIELL_MIDTPUNKT.value) } returns emptyList()
-        every {
-            sakDao.opprettSak(TRIVIELL_MIDTPUNKT.value, SakType.BARNEPENSJON, null)
-        } returns Sak(
-            id = 1,
-            ident = TRIVIELL_MIDTPUNKT.value,
-            sakType = SakType.BARNEPENSJON,
-            enhet = null
-        )
-        every { featureToggleService.isEnabled(SakServiceFeatureToggle.OpprettMedEnhetId, false) } returns false
-
-        val service: SakService = RealSakService(sakDao, pdlKlient, norg2Klient, featureToggleService, tilgangService)
-
-        val sak = service.finnEllerOpprettSak(TRIVIELL_MIDTPUNKT.value, SakType.BARNEPENSJON)
-
-        sak shouldBe Sak(
-            ident = TRIVIELL_MIDTPUNKT.value,
-            sakType = SakType.BARNEPENSJON,
-            id = 1,
-            enhet = null
-        )
-
-        verify(exactly = 1) { sakDao.finnSaker(TRIVIELL_MIDTPUNKT.value) }
-        verify(exactly = 1) { featureToggleService.isEnabled(SakServiceFeatureToggle.OpprettMedEnhetId, false) }
-        verify(exactly = 1) { sakDao.opprettSak(TRIVIELL_MIDTPUNKT.value, SakType.BARNEPENSJON, null) }
-        verify {
-            listOf(pdlKlient, norg2Klient) wasNot Called
         }
     }
 


### PR DESCRIPTION
Den skal altid være på fremover - så trenger ikke en bryter lenger.

Denne setter ikke enhet til "not null" - har laget jira EY-2205 for det.