### PR TITLE
Saksoversikt tilpasset begge ytelser

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingResource.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingResource.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.behandling
 
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import java.time.LocalDateTime
 import java.util.*
@@ -11,6 +12,7 @@ data class BehandlingListe(val behandlinger: List<BehandlingSammendrag>)
 data class BehandlingSammendrag(
     val id: UUID,
     val sak: Long,
+    val sakType: SakType,
     val status: BehandlingStatus,
     val soeknadMottattDato: LocalDateTime?,
     val behandlingOpprettet: LocalDateTime?,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
@@ -154,6 +154,7 @@ internal fun Behandling.toDetaljertBehandling(): DetaljertBehandling {
 fun Behandling.toBehandlingSammendrag() = BehandlingSammendrag(
     id = this.id,
     sak = this.sak.id,
+    sakType = this.sak.sakType,
     status = this.status,
     soeknadMottattDato = if (this is Foerstegangsbehandling) {
         this.soeknadMottattDato

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/behandlingsliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/behandlingsliste.tsx
@@ -1,4 +1,4 @@
-import { Link, Table } from '@navikt/ds-react'
+import { Link, Table, Tag } from '@navikt/ds-react'
 import { AarsaksTyper, BehandlingOgRevurderingsAarsakerType, IBehandlingsammendrag, VedtakSammendrag } from './typer'
 import {
   formaterBehandlingstype,
@@ -12,6 +12,9 @@ import { erFerdigBehandlet } from '~components/behandling/felles/utils'
 import React, { useEffect, useState } from 'react'
 import { Revurderingsaarsak } from '~shared/types/Revurderingsaarsak'
 import { hentVedtakSammendrag } from '~shared/api/vedtaksvurdering'
+import { tagColors } from '~shared/Tags'
+import { INasjonalitetsType } from '~components/behandling/fargetags/nasjonalitetsType'
+import styled from 'styled-components'
 
 const kolonner = [
   'Reg. dato',
@@ -79,7 +82,12 @@ export const Behandlingsliste = ({ behandlinger }: { behandlinger: IBehandlingsa
               </Table.DataCell>
               <Table.DataCell key={`data${behandling.sakType}`}>{formaterSakstype(behandling.sakType)}</Table.DataCell>
               <Table.DataCell key={`data${behandling.behandlingType}`}>
-                {formaterBehandlingstype(behandling.behandlingType)}
+                <BehandlingstypeWrapper>
+                  {formaterBehandlingstype(behandling.behandlingType)}
+                  <Tag variant={tagColors[INasjonalitetsType.NASJONAL]} size={'small'}>
+                    {formaterEnumTilLesbarString(INasjonalitetsType.NASJONAL)}
+                  </Tag>
+                </BehandlingstypeWrapper>
               </Table.DataCell>
               <Table.DataCell key={`data${behandling.aarsak}`}>{mapAarsak(behandling.aarsak)}</Table.DataCell>
               <Table.DataCell key={`data${behandling.status}`}>
@@ -167,3 +175,9 @@ function resultatTekstFoerstegangsbehandling(vilkaarsvurderingResultat?: Vilkaar
       return 'Avslått'
   }
 }
+
+const BehandlingstypeWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 0.5em;
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/behandlingsliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/behandlingsliste.tsx
@@ -1,6 +1,11 @@
 import { Link, Table } from '@navikt/ds-react'
 import { AarsaksTyper, BehandlingOgRevurderingsAarsakerType, IBehandlingsammendrag, VedtakSammendrag } from './typer'
-import { formaterBehandlingstype, formaterEnumTilLesbarString, formaterStringDato } from '~utils/formattering'
+import {
+  formaterBehandlingstype,
+  formaterEnumTilLesbarString,
+  formaterSakstype,
+  formaterStringDato,
+} from '~utils/formattering'
 import { IBehandlingStatus, IBehandlingsType } from '~shared/types/IDetaljertBehandling'
 import { VilkaarsvurderingResultat } from '~shared/api/vilkaarsvurdering'
 import { erFerdigBehandlet } from '~components/behandling/felles/utils'
@@ -8,7 +13,17 @@ import React, { useEffect, useState } from 'react'
 import { Revurderingsaarsak } from '~shared/types/Revurderingsaarsak'
 import { hentVedtakSammendrag } from '~shared/api/vedtaksvurdering'
 
-const colonner = ['Reg. dato', 'Type', 'Årsak', 'Status', 'Virkningstidspunkt', 'Vedtaksdato', 'Resultat', '']
+const kolonner = [
+  'Reg. dato',
+  'Sakstype',
+  'Behandlingstype',
+  'Årsak',
+  'Status',
+  'Virkningstidspunkt',
+  'Vedtaksdato',
+  'Resultat',
+  '',
+]
 
 const VedtaksDato = (props: { behandlingsId: string }) => {
   const [vedtak, setVedtak] = useState<VedtakSammendrag | undefined>(undefined)
@@ -51,7 +66,7 @@ export const Behandlingsliste = ({ behandlinger }: { behandlinger: IBehandlingsa
       <Table zebraStripes>
         <Table.Header>
           <Table.Row>
-            {colonner.map((col) => (
+            {kolonner.map((col) => (
               <Table.HeaderCell key={`header${col}`}>{col}</Table.HeaderCell>
             ))}
           </Table.Row>
@@ -62,6 +77,7 @@ export const Behandlingsliste = ({ behandlinger }: { behandlinger: IBehandlingsa
               <Table.DataCell key={`data${behandling.behandlingOpprettet}`}>
                 {formaterStringDato(behandling.behandlingOpprettet)}
               </Table.DataCell>
+              <Table.DataCell key={`data${behandling.sakType}`}>{formaterSakstype(behandling.sakType)}</Table.DataCell>
               <Table.DataCell key={`data${behandling.behandlingType}`}>
                 {formaterBehandlingstype(behandling.behandlingType)}
               </Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/saksoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/saksoversikt.tsx
@@ -2,12 +2,8 @@ import React, { useEffect, useState } from 'react'
 import { Behandlingsliste } from './behandlingsliste'
 import styled from 'styled-components'
 import { Grunnlagsendringshendelse, GrunnlagsendringsListe, IBehandlingListe, IBehandlingsammendrag } from './typer'
-import { INasjonalitetsType } from '../behandling/fargetags/nasjonalitetsType'
-import { Heading, Tag } from '@navikt/ds-react'
 import { ManueltOpphoerModal } from './ManueltOpphoerModal'
 import { ToKolonner } from '../toKolonner/ToKolonner'
-import { tagColors } from '~shared/Tags'
-import { formaterEnumTilLesbarString } from '~utils/formattering'
 import {
   hentBehandlingerForPerson,
   hentGrunnlagsendringshendelserForPerson,
@@ -124,16 +120,6 @@ export const Saksoversikt = ({ fnr }: { fnr: string | undefined }) => {
       <Spinner visible={!lastetBehandlingliste || !lastetGrunnlagshendelser} label={'Laster'} />
       {lastetBehandlingliste && lastetGrunnlagshendelser && (
         <SaksoversiktWrapper>
-          <HeadingWrapper>
-            <Heading spacing size="xlarge" level="1">
-              Saksoversikt
-            </Heading>
-            <div className="details">
-              <Tag variant={tagColors[INasjonalitetsType.NASJONAL]}>
-                {formaterEnumTilLesbarString(INasjonalitetsType.NASJONAL)}
-              </Tag>
-            </div>
-          </HeadingWrapper>
           <ToKolonner>
             {{
               left: (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/saksoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/saksoversikt.tsx
@@ -126,7 +126,7 @@ export const Saksoversikt = ({ fnr }: { fnr: string | undefined }) => {
         <SaksoversiktWrapper>
           <HeadingWrapper>
             <Heading spacing size="xlarge" level="1">
-              Ytelser
+              Saksoversikt
             </Heading>
             <div className="details">
               <Tag variant={tagColors[INasjonalitetsType.NASJONAL]}>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/saksoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/saksoversikt.tsx
@@ -126,7 +126,7 @@ export const Saksoversikt = ({ fnr }: { fnr: string | undefined }) => {
         <SaksoversiktWrapper>
           <HeadingWrapper>
             <Heading spacing size="xlarge" level="1">
-              Barnepensjon
+              Ytelser
             </Heading>
             <div className="details">
               <Tag variant={tagColors[INasjonalitetsType.NASJONAL]}>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/typer.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/typer.tsx
@@ -1,6 +1,7 @@
 import { VilkaarsvurderingResultat } from '~shared/api/vilkaarsvurdering'
 import { IBehandlingStatus, IBehandlingsType, Virkningstidspunkt } from '~shared/types/IDetaljertBehandling'
 import { Revurderingsaarsak } from '~shared/types/Revurderingsaarsak'
+import { ISaksType } from '~components/behandling/fargetags/saksType'
 
 export interface IPersonResult {
   fornavn: string
@@ -16,6 +17,7 @@ export interface IBehandlingListe {
 export interface IBehandlingsammendrag {
   id: string
   sak: number
+  sakType: ISaksType
   status: IBehandlingStatus
   soeknadMottattDato: string
   behandlingOpprettet: string


### PR DESCRIPTION
Endrer tittel fra `Barnepensjon` til `Saksoversikt` og legger `Sakstype` som en del av behandlingstabellen.

EY-2209

![Skjermbilde 2023-05-19 kl  10 01 47](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/525715/d1d62450-51c3-4ed1-99fe-13509db0d25d)
