### PR TITLE
EY-2189 - endring i enum verdier samt ekspoenere i behandling sammendrag

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingResource.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingResource.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.behandling
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.behandling.Utenlandstilsnitt
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import java.time.LocalDateTime
 import java.util.*
@@ -18,5 +19,6 @@ data class BehandlingSammendrag(
     val behandlingOpprettet: LocalDateTime?,
     val behandlingType: BehandlingType,
     val aarsak: String?,
-    val virkningstidspunkt: Virkningstidspunkt?
+    val virkningstidspunkt: Virkningstidspunkt?,
+    val utenlandstilsnitt: Utenlandstilsnitt?
 )

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
@@ -178,5 +178,6 @@ fun Behandling.toBehandlingSammendrag() = BehandlingSammendrag(
         is Revurdering -> this.revurderingsaarsak?.name ?: "REVURDERING"
         is ManueltOpphoer -> "MANUELT_OPPHOER"
     },
-    virkningstidspunkt = this.virkningstidspunkt
+    virkningstidspunkt = this.virkningstidspunkt,
+    utenlandstilsnitt = this.utenlandstilsnitt
 )

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoIntegrationTest.kt
@@ -224,7 +224,7 @@ internal class BehandlingDaoIntegrationTest {
         behandlingRepo.lagreUtenlandstilsnitt(
             opprettetBehandling.id,
             Utenlandstilsnitt(
-                UtenlandstilsnittType.UTLAND_BOSATT_UTLAND,
+                UtenlandstilsnittType.BOSATT_UTLAND,
                 Grunnlagsopplysning.Saksbehandler.create("navIdent"),
                 "Test"
             )
@@ -233,7 +233,7 @@ internal class BehandlingDaoIntegrationTest {
         val lagretBehandling =
             requireNotNull(behandlingRepo.hentBehandling(opprettBehandling.id)) as Foerstegangsbehandling
 
-        assertEquals(UtenlandstilsnittType.UTLAND_BOSATT_UTLAND, lagretBehandling.utenlandstilsnitt?.type)
+        assertEquals(UtenlandstilsnittType.BOSATT_UTLAND, lagretBehandling.utenlandstilsnitt?.type)
         assertEquals("Test", lagretBehandling.utenlandstilsnitt?.begrunnelse)
         assertEquals("navIdent", lagretBehandling.utenlandstilsnitt?.kilde?.ident)
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
@@ -80,7 +80,7 @@ internal class BehandlingRoutesTest {
             val response = client.post("/api/behandling/$behandlingId/utenlandstilsnitt") {
                 header(HttpHeaders.Authorization, "Bearer $token")
                 contentType(ContentType.Application.Json)
-                setBody(UtenlandstilsnittRequest(UtenlandstilsnittType.UTLAND_BOSATT_UTLAND, "Test"))
+                setBody(UtenlandstilsnittRequest(UtenlandstilsnittType.BOSATT_UTLAND, "Test"))
             }
 
             assertEquals(200, response.status.value)

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealGenerellBehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealGenerellBehandlingServiceTest.kt
@@ -461,13 +461,13 @@ class RealGenerellBehandlingServiceTest {
         sut.oppdaterUtenlandstilsnitt(
             uuid,
             Utenlandstilsnitt(
-                UtenlandstilsnittType.UTLAND_BOSATT_UTLAND,
+                UtenlandstilsnittType.BOSATT_UTLAND,
                 Grunnlagsopplysning.Saksbehandler.create("ident"),
                 "Test"
             )
         )
 
-        assertEquals(UtenlandstilsnittType.UTLAND_BOSATT_UTLAND, slot.captured.type)
+        assertEquals(UtenlandstilsnittType.BOSATT_UTLAND, slot.captured.type)
         assertEquals("Test", slot.captured.begrunnelse)
         assertEquals("ident", slot.captured.kilde.ident)
     }

--- a/libs/saksbehandling-common/src/main/kotlin/behandling/Utenlandstilsnitt.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/behandling/Utenlandstilsnitt.kt
@@ -10,6 +10,6 @@ data class Utenlandstilsnitt(
 
 enum class UtenlandstilsnittType {
     NASJONAL,
-    UTLAND_BOSATT_NORGE,
-    UTLAND_BOSATT_UTLAND
+    UTLANDSTILSNITT,
+    BOSATT_UTLAND
 }


### PR DESCRIPTION
Fag har kommet med ny sett av verdier for Utenlandstilsnitt enum samt bedt om at det er synlig i saksoversikt for person som bruker behandling sammendrag - så må settes der og.