### PR TITLE
EY-2058 Setter bruk av kjøreplan avhengig av om det er en regulering

### DIFF
--- a/apps/etterlatte-hendelser-pdl/src/main/kotlin/hendelserpdl/leesah/PersonHendelseFordeler.kt
+++ b/apps/etterlatte-hendelser-pdl/src/main/kotlin/hendelserpdl/leesah/PersonHendelseFordeler.kt
@@ -33,12 +33,12 @@ class PersonHendelseFordeler(
             personhendelse.vergemaalEllerFremtidsfullmakt
         if (vergemaalEllerFremtidsfullmakt?.type in
             listOf(
-                    "ensligMindreaarigAsylsoeker",
-                    "ensligMindreaarigFlyktning",
-                    "mindreaarig",
-                    "midlertidigForMindreaarig",
-                    "forvaltningUtenforVergemaal"
-                )
+                "ensligMindreaarigAsylsoeker",
+                "ensligMindreaarigFlyktning",
+                "mindreaarig",
+                "midlertidigForMindreaarig",
+                "forvaltningUtenforVergemaal"
+            )
         ) {
             try {
                 when (val personnummer = pdlService.hentPdlIdentifikator(personhendelse.personidenter.first())) {

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/Konsistensavstemming.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/Konsistensavstemming.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.utbetaling.avstemming
 
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.utbetaling.grensesnittavstemming.UUIDBase64
+import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.BrukKjoereplan
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Foedselsnummer
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.NavIdent
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.SakId
@@ -34,5 +35,6 @@ data class OppdragslinjeForKonsistensavstemming(
     val tilOgMed: LocalDate?,
     var forrigeUtbetalingslinjeId: UtbetalingslinjeId?,
     val beloep: BigDecimal?,
-    val attestanter: List<NavIdent>
+    val attestanter: List<NavIdent>,
+    val brukKjoereplan: BrukKjoereplan
 )

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingService.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingService.kt
@@ -120,7 +120,8 @@ class KonsistensavstemmingService(
                                 beloep = it.beloep,
                                 attestanter = utbetalingslinjerPerSak
                                     .utbetalingslinjerTilAttestanter[it.id]
-                                    ?: emptyList()
+                                    ?: emptyList(),
+                                brukKjoereplan = it.brukKjoereplan
                             )
                         }
                     )

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/avstemmingsdata/KonsistensavstemmingDataMapper.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/avstemmingsdata/KonsistensavstemmingDataMapper.kt
@@ -112,7 +112,7 @@ internal fun OppdragForKonsistensavstemming.toOppdragdata(): Oppdragsdata {
                     sats = it.beloep
                     satstypeKode = OppdragslinjeDefaults.UTBETALINGSFREKVENS
                     fradragTillegg = OppdragslinjeDefaults.FRADRAG_ELLER_TILLEGG.value()
-                    brukKjoreplan = OppdragslinjeDefaults.KJOEREPLAN_SAMMEN_MED_NESTE_PLANLAGTE_UTBETALING
+                    brukKjoreplan = it.brukKjoereplan.toString()
                     utbetalesTilId = fnr.value
                     attestantListe.addAll(
                         it.attestanter.map {

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/common/OppdragDefaults.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/common/OppdragDefaults.kt
@@ -12,7 +12,6 @@ object OppdragDefaults {
     const val MOTTAKENDE_KOMPONENTKODE = "OS" // Oppdragsystemet
     const val SAKSBEHANDLER_ID_SYSTEM_ETTERLATTEYTELSER = "EY" // Placeholder for å identifisere
     const val UTBETALINGSFREKVENS = "MND"
-    const val KJOEREPLAN_SAMMEN_MED_NESTE_PLANLAGTE_UTBETALING = "N"
     const val AKSJONSKODE_OPPDATER = "1"
     val KODEKOMPONENT = OppdragKlassifikasjonskode.BARNEPENSJON_OPTP
     val DATO_OPPDRAG_GJELDER_FOM = LocalDate.EPOCH.toXMLDate()
@@ -27,6 +26,5 @@ object OppdragDefaults {
 
 object OppdragslinjeDefaults {
     const val UTBETALINGSFREKVENS = "MND"
-    const val KJOEREPLAN_SAMMEN_MED_NESTE_PLANLAGTE_UTBETALING = "N"
     val FRADRAG_ELLER_TILLEGG = TfradragTillegg.T
 }

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/oppdrag/OppdragMapper.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/oppdrag/OppdragMapper.kt
@@ -70,7 +70,7 @@ object OppdragMapper {
                         sats = it.beloep
                         fradragTillegg = OppdragslinjeDefaults.FRADRAG_ELLER_TILLEGG
                         typeSats = OppdragslinjeDefaults.UTBETALINGSFREKVENS
-                        brukKjoreplan = OppdragDefaults.KJOEREPLAN_SAMMEN_MED_NESTE_PLANLAGTE_UTBETALING
+                        brukKjoreplan = it.brukKjoereplan.toString()
                         saksbehId = utbetaling.saksbehandler.value
                         utbetalesTilId = utbetaling.stoenadsmottaker.value
                         henvisning = utbetaling.behandlingId.shortValue.value

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/utbetaling/Utbetaling.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/utbetaling/Utbetaling.kt
@@ -67,8 +67,25 @@ data class Utbetalingslinje(
     val sakId: SakId,
     val periode: PeriodeForUtbetaling,
     val beloep: BigDecimal? = null,
-    val klassifikasjonskode: OppdragKlassifikasjonskode
+    val klassifikasjonskode: OppdragKlassifikasjonskode,
+    val brukKjoereplan: BrukKjoereplan
 )
+
+enum class BrukKjoereplan(private val kode: String) {
+    NESTE_PLANLAGTE_UTBETALING("J"), MED_EN_GANG("N");
+
+    override fun toString(): String {
+        return kode
+    }
+
+    companion object {
+        fun fraKode(kode: String): BrukKjoereplan = when (kode.trim()) {
+            "J", "j" -> NESTE_PLANLAGTE_UTBETALING
+            "N", "n" -> MED_EN_GANG
+            else -> throw IllegalArgumentException("kode $kode er ikke en gjenkjent verdi for bruk_kjoereplan")
+        }
+    }
+}
 
 enum class OppdragKlassifikasjonskode(private val oppdragVerdi: String) {
     BARNEPENSJON_OPTP("BARNEPENSJON-OPTP");

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/utbetaling/UtbetalingDao.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/utbetaling/UtbetalingDao.kt
@@ -76,9 +76,9 @@ class UtbetalingDao(private val dataSource: DataSource) {
         queryOf(
             statement = """
                 INSERT INTO utbetalingslinje(id, type, utbetaling_id, erstatter_id, opprettet, periode_fra, periode_til, 
-                    beloep, sak_id, klassifikasjonskode)
+                    beloep, sak_id, klassifikasjonskode, bruk_kjoereplan)
                 VALUES(:id, :type, :utbetaling_id, :erstatter_id, :opprettet, :periode_fra, :periode_til,  
-                    :beloep, :sak_id, :klassifikasjonskode)
+                    :beloep, :sak_id, :klassifikasjonskode, :bruk_kjoereplan)
             """,
             paramMap = mapOf(
                 "id" to utbetalingslinje.id.value.param(),
@@ -90,7 +90,8 @@ class UtbetalingDao(private val dataSource: DataSource) {
                 "periode_fra" to utbetalingslinje.periode.fra.param(),
                 "periode_til" to utbetalingslinje.periode.til.param(),
                 "beloep" to utbetalingslinje.beloep.param(),
-                "klassifikasjonskode" to utbetalingslinje.klassifikasjonskode.toString().param()
+                "klassifikasjonskode" to utbetalingslinje.klassifikasjonskode.toString().param(),
+                "bruk_kjoereplan" to utbetalingslinje.brukKjoereplan.toString().param()
             )
         ).let { tx.run(it.asUpdate) }
     }
@@ -167,7 +168,7 @@ class UtbetalingDao(private val dataSource: DataSource) {
             queryOf(
                 statement = """
                     SELECT id, type, utbetaling_id, erstatter_id, opprettet, periode_fra, periode_til, beloep, sak_id,
-                        klassifikasjonskode
+                        klassifikasjonskode, bruk_kjoereplan
                     FROM utbetalingslinje 
                     WHERE utbetaling_id = :utbetalingId
                     """,
@@ -182,7 +183,7 @@ class UtbetalingDao(private val dataSource: DataSource) {
         queryOf(
             statement = """
                     SELECT ul.id, ul.type, ul.utbetaling_id, ul.erstatter_id, ul.opprettet, ul.periode_fra, ul.periode_til, ul.beloep, ul.sak_id,
-                        ul.klassifikasjonskode
+                        ul.klassifikasjonskode, ul.bruk_kjoereplan
                     FROM utbetalingslinje as ul 
                     INNER JOIN utbetaling as u
                         ON ul.utbetaling_id = u.id
@@ -377,7 +378,8 @@ class UtbetalingDao(private val dataSource: DataSource) {
                 til = localDateOrNull("periode_til")
             ),
             beloep = bigDecimalOrNull("beloep"),
-            klassifikasjonskode = OppdragKlassifikasjonskode.fraString(string("klassifikasjonskode"))
+            klassifikasjonskode = OppdragKlassifikasjonskode.fraString(string("klassifikasjonskode")),
+            brukKjoereplan = string("bruk_kjoereplan").let { BrukKjoereplan.fraKode(it) }
         )
     }
 

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/utbetaling/UtbetalingMapper.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/utbetaling/UtbetalingMapper.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.utbetaling.iverksetting.utbetaling
 
+import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.utbetaling.common.forsteDagIMaaneden
 import no.nav.etterlatte.utbetaling.common.sisteDagIMaaneden
@@ -16,8 +17,7 @@ class UtbetalingMapper(
     private val utbetalingsperioder = vedtak.pensjonTilUtbetaling.sortedBy { it.periode.fom }
 
     fun opprettUtbetaling(): Utbetaling {
-        if (tidligereUtbetalinger.isEmpty() &&
-            utbetalingsperioder.size == 1 &&
+        if (tidligereUtbetalinger.isEmpty() && utbetalingsperioder.size == 1 &&
             utbetalingsperioder.first().type == UtbetalingsperiodeType.OPPHOER
         ) {
             throw IngenEksisterendeUtbetalingException()
@@ -72,6 +72,10 @@ class UtbetalingMapper(
             klassifikasjonskode = when (saktype) {
                 Saktype.BARNEPENSJON -> OppdragKlassifikasjonskode.BARNEPENSJON_OPTP
                 Saktype.OMSTILLINGSSTOENAD -> TODO("Kanskje det er samme som over men vi kræsjer dette i stedet")
+            },
+            brukKjoereplan = when (vedtak.behandling.revurderingsaarsak) {
+                RevurderingAarsak.REGULERING -> BrukKjoereplan.NESTE_PLANLAGTE_UTBETALING
+                else -> BrukKjoereplan.MED_EN_GANG
             }
         )
     }

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/utbetaling/Utbetalingsvedtak.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/utbetaling/Utbetalingsvedtak.kt
@@ -18,7 +18,11 @@ data class Utbetalingsvedtak(
             Utbetalingsvedtak(
                 vedtakId = vedtak.vedtakId,
                 sak = Sak(vedtak.sak.ident, vedtak.sak.id, Saktype.fraString(vedtak.sak.sakType.toString())),
-                behandling = Behandling(type = vedtak.behandling.type, id = vedtak.behandling.id),
+                behandling = Behandling(
+                    type = vedtak.behandling.type,
+                    id = vedtak.behandling.id,
+                    revurderingsaarsak = vedtak.behandling.revurderingsaarsak
+                ),
                 pensjonTilUtbetaling = vedtak.utbetalingsperioder.map {
                     Utbetalingsperiode(
                         id = it.id!!,

--- a/apps/etterlatte-utbetaling/src/main/resources/db/migration/V14__add_bruk_kjoereplan_to_utbetalingslinje.sql
+++ b/apps/etterlatte-utbetaling/src/main/resources/db/migration/V14__add_bruk_kjoereplan_to_utbetalingslinje.sql
@@ -1,0 +1,5 @@
+alter table utbetalingslinje add column bruk_kjoereplan VARCHAR(20);
+
+update utbetalingslinje set bruk_kjoereplan = 'N';
+
+alter table utbetalingslinje alter column bruk_kjoereplan SET NOT NULL;

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/TestHelper.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/TestHelper.kt
@@ -12,6 +12,7 @@ import no.nav.etterlatte.utbetaling.grensesnittavstemming.UUIDBase64
 import no.nav.etterlatte.utbetaling.iverksetting.oppdrag.OppdragMapper
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Attestasjon
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.BehandlingId
+import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.BrukKjoereplan
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Foedselsnummer
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Kvittering
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.NavIdent
@@ -60,7 +61,8 @@ fun utbetalingsvedtak(
     vedtakId = vedtakId,
     behandling = Behandling(
         id = UUID.randomUUID(),
-        type = BehandlingType.FØRSTEGANGSBEHANDLING
+        type = BehandlingType.FØRSTEGANGSBEHANDLING,
+        revurderingsaarsak = null
     ),
     sak = Sak(
         id = 1,
@@ -173,7 +175,8 @@ fun utbetalingslinje(
     periodeFra: LocalDate = LocalDate.parse("2022-01-01"),
     periodeTil: LocalDate? = null,
     opprettet: Tidspunkt = Tidspunkt.now(),
-    klassifikasjonskode: OppdragKlassifikasjonskode = OppdragKlassifikasjonskode.BARNEPENSJON_OPTP
+    klassifikasjonskode: OppdragKlassifikasjonskode = OppdragKlassifikasjonskode.BARNEPENSJON_OPTP,
+    brukKjoereplan: BrukKjoereplan = BrukKjoereplan.MED_EN_GANG
 ): Utbetalingslinje =
     Utbetalingslinje(
         id = UtbetalingslinjeId(utbetalingslinjeId),
@@ -187,7 +190,8 @@ fun utbetalingslinje(
             til = periodeTil
         ),
         beloep = beloep,
-        klassifikasjonskode = klassifikasjonskode
+        klassifikasjonskode = klassifikasjonskode,
+        brukKjoereplan = brukKjoereplan
     )
 
 fun utbetalingMedOpphoer() = utbetaling(
@@ -243,8 +247,8 @@ fun oppdragslinjeForKonsistensavstemming(
     tilOgMed: LocalDate? = null,
     forrigeUtbetalingslinjeId: Long? = null,
     beloep: BigDecimal = BigDecimal(10000),
-    attestanter: List<NavIdent> = listOf(NavIdent("attestant"))
-
+    attestanter: List<NavIdent> = listOf(NavIdent("attestant")),
+    brukKjoereplan: BrukKjoereplan = BrukKjoereplan.MED_EN_GANG
 ) = OppdragslinjeForKonsistensavstemming(
     id = UtbetalingslinjeId(id),
     opprettet = opprettet,
@@ -252,5 +256,6 @@ fun oppdragslinjeForKonsistensavstemming(
     tilOgMed = tilOgMed,
     forrigeUtbetalingslinjeId = forrigeUtbetalingslinjeId?.let { UtbetalingslinjeId(it) },
     beloep = beloep,
-    attestanter = attestanter
+    attestanter = attestanter,
+    brukKjoereplan = brukKjoereplan
 )

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/Vedtak.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/Vedtak.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.vedtaksvurdering
 
 import com.fasterxml.jackson.databind.node.ObjectNode
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.sak.VedtakSak
@@ -29,7 +30,8 @@ data class OpprettVedtak(
     val beregning: ObjectNode?,
     val avkorting: ObjectNode?,
     val vilkaarsvurdering: ObjectNode?,
-    val utbetalingsperioder: List<Utbetalingsperiode>
+    val utbetalingsperioder: List<Utbetalingsperiode>,
+    val revurderingsaarsak: RevurderingAarsak?
 )
 
 data class Vedtak(
@@ -39,6 +41,7 @@ data class Vedtak(
     val sakType: SakType,
     val behandlingId: UUID,
     val behandlingType: BehandlingType,
+    val revurderingAarsak: RevurderingAarsak?,
     val virkningstidspunkt: YearMonth,
     val status: VedtakStatus,
     val type: VedtakType,
@@ -54,7 +57,7 @@ data class Vedtak(
         status = status,
         virkningstidspunkt = virkningstidspunkt,
         sak = VedtakSak(soeker.value, sakType, sakId),
-        behandling = Behandling(behandlingType, behandlingId),
+        behandling = Behandling(behandlingType, behandlingId, revurderingAarsak),
         type = type,
         utbetalingsperioder = utbetalingsperioder,
         vedtakFattet = vedtakFattet,

--- a/apps/etterlatte-vedtaksvurdering/src/main/resources/db/migration/V21__add_revurdering_aarsak_column.sql
+++ b/apps/etterlatte-vedtaksvurdering/src/main/resources/db/migration/V21__add_revurdering_aarsak_column.sql
@@ -1,0 +1,1 @@
+alter table vedtak add column revurderingsaarsak TEXT;

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/TestHelper.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/TestHelper.kt
@@ -2,6 +2,7 @@ package vedtaksvurdering
 
 import com.fasterxml.jackson.databind.node.ObjectNode
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
@@ -40,6 +41,7 @@ fun opprettVedtak(
     sakType = SakType.BARNEPENSJON,
     behandlingId = behandlingId,
     behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+    revurderingsaarsak = null,
     virkningstidspunkt = virkningstidspunkt,
     type = VedtakType.INNVILGELSE,
     beregning = beregning,
@@ -61,7 +63,8 @@ fun vedtak(
     behandlingId: UUID = UUID.randomUUID(),
     vilkaarsvurdering: ObjectNode? = objectMapper.createObjectNode(),
     beregning: ObjectNode? = objectMapper.createObjectNode(),
-    avkorting: ObjectNode? = objectMapper.createObjectNode()
+    avkorting: ObjectNode? = objectMapper.createObjectNode(),
+    revurderingAarsak: RevurderingAarsak? = null
 ) = Vedtak(
     id = 1L,
     status = VedtakStatus.OPPRETTET,
@@ -82,5 +85,6 @@ fun vedtak(
             beloep = BigDecimal.valueOf(100),
             type = UtbetalingsperiodeType.UTBETALING
         )
-    )
+    ),
+    revurderingAarsak = revurderingAarsak
 )

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtakstidslinjeTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtakstidslinjeTest.kt
@@ -281,6 +281,7 @@ private fun lagVedtak(
             attesterendeEnhet = ENHET_2,
             tidspunkt = datoAttestert
         ),
-        utbetalingsperioder = emptyList()
+        utbetalingsperioder = emptyList(),
+        revurderingAarsak = null
     )
 }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/StandardKeys.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/StandardKeys.kt
@@ -13,6 +13,7 @@ const val SAK_TYPE_KEY = "sak_type"
 const val FEILENDE_KRITERIER_KEY = "feilende_kriterier"
 const val GYLDIG_FOR_BEHANDLING_KEY = "gyldig_for_behandling"
 const val SKAL_SENDE_BREV = "skal_sende_brev"
+const val REVURDERING_AARSAK = "revurdering_aarsak"
 
 fun River.eventName(eventName: String) {
     validate { it.demandValue(EVENT_NAME_KEY, eventName) }

--- a/libs/saksbehandling-common/src/main/kotlin/vedtak/VedtakDto.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/vedtak/VedtakDto.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.libs.common.vedtak
 
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.sak.VedtakSak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.math.BigDecimal
@@ -30,7 +31,8 @@ enum class VedtakStatus {
 
 data class Behandling(
     val type: BehandlingType,
-    val id: UUID
+    val id: UUID,
+    val revurderingsaarsak: RevurderingAarsak? = null
 )
 
 data class Periode(


### PR DESCRIPTION
For å gjøre dette konsekvent må det lagres i databasen og tas med i konsistensavstemmingen. i tilegg så bør det da lagres i vedtaksvurdering, siden det er en egenskap til vedtaket som bør representeres i databasen.

DERMED har vi to migreringer og 20 filer endret for å sette "J" i stedet for "N" hvis vi regulerer 🤠 