### PR TITLE
Ey 2127 rydde avkorting navngivning

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -9,6 +9,7 @@ import java.util.*
 data class Avkorting(
     val behandlingId: UUID,
     val avkortingGrunnlag: List<AvkortingGrunnlag>,
+    val avkortingsperioder: List<Avkortingsperiode>,
     val avkortetYtelse: List<AvkortetYtelse>
 )
 
@@ -16,11 +17,10 @@ data class AvkortingGrunnlag(
     val periode: Periode,
     val aarsinntekt: Int,
     val spesifikasjon: String,
-    val beregnetAvkorting: List<BeregnetAvkortingGrunnlag>,
     val kilde: Grunnlagsopplysning.Saksbehandler
 )
 
-data class BeregnetAvkortingGrunnlag(
+data class Avkortingsperiode(
     val periode: Periode,
     val avkorting: Int,
     val tidspunkt: Tidspunkt,

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
@@ -19,164 +19,168 @@ class AvkortingRepository(private val dataSource: DataSource) {
 
     fun hentAvkorting(behandlingId: UUID): Avkorting? = using(sessionOf(dataSource)) { session ->
         session.transaction { tx ->
-            hentAvkortingGrunnlag(tx, behandlingId)?.let { avkortingGrunnlag ->
-                val avkortetYtelse = hentAvkortetYtelse(tx, behandlingId)
+            val avkortingGrunnlag = queryOf(
+                "SELECT * FROM avkortinggrunnlag WHERE behandling_id = ?",
+                behandlingId
+            ).let { query -> tx.run(query.map { row -> row.toAvkortinggrunnlag() }.asList) }
+
+            val avkortingsperioder = queryOf(
+                "SELECT * FROM avkortingsperioder WHERE behandling_id = ?",
+                behandlingId
+            ).let { query -> tx.run(query.map { row -> row.toBeregnetAvkortinggrunnlag() }.asList) }
+
+            val avkortetYtelse = queryOf(
+                "SELECT * FROM avkortet_ytelse WHERE behandling_id = ?",
+                behandlingId
+            ).let { query -> tx.run(query.map { row -> row.toAvkortetYtelse() }.asList) }
+
+            if (avkortingGrunnlag.isEmpty()) {
+                null
+            } else {
                 Avkorting(
                     behandlingId = behandlingId,
                     avkortingGrunnlag = avkortingGrunnlag,
+                    avkortingsperioder = avkortingsperioder,
                     avkortetYtelse = avkortetYtelse
                 )
             }
         }
     }
 
-    private fun hentAvkortingGrunnlag(tx: TransactionalSession, behandlingId: UUID): List<AvkortingGrunnlag>? {
-        val beregnetAvkortingGrunnlag = queryOf(
-            "SELECT * FROM beregnet_avkortinggrunnlag WHERE behandling_id = ?",
-            behandlingId
-        ).let { query ->
-            tx.run(query.map { row -> row.toBeregnetAvkortinggrunnlag() }.asList)
-        }
-        return queryOf(
-            "SELECT * FROM avkortinggrunnlag WHERE behandling_id = ?",
-            behandlingId
-        ).let { query ->
-            tx.run(query.map { row -> row.toAvkortinggrunnlag(beregnetAvkortingGrunnlag) }.asList).ifEmpty {
-                null
-            }
-        }
-    }
-
-    private fun hentAvkortetYtelse(tx: TransactionalSession, behandlingId: UUID): List<AvkortetYtelse> {
-        return queryOf(
-            "SELECT * FROM avkortet_ytelse WHERE behandling_id = ?",
-            behandlingId
-        ).let { query ->
-            tx.run(query.map { row -> row.toAvkortetYtelse() }.asList)
-        }
-    }
-
-    fun lagreEllerOppdaterAvkortingGrunnlag(behandlingId: UUID, avkortingGrunnlag: AvkortingGrunnlag): Avkorting {
+    fun lagreEllerOppdaterAvkorting(
+        behandlingId: UUID,
+        avkortingGrunnlag: List<AvkortingGrunnlag>,
+        avkortingsperioder: List<Avkortingsperiode>,
+        avkortetYtelse: List<AvkortetYtelse>
+    ): Avkorting {
         using(sessionOf(dataSource)) { session ->
             session.transaction { tx ->
-                queryOf(
-                    "DELETE FROM beregnet_avkortinggrunnlag WHERE behandling_id = ?",
-                    behandlingId
-                ).let { query ->
-                    tx.run(query.asUpdate)
-                }
-                queryOf(
-                    "DELETE FROM avkortinggrunnlag WHERE behandling_id = ?",
-                    behandlingId
-                ).let { query ->
-                    tx.run(query.asUpdate)
-                }
+                slettAvkorting(behandlingId, tx)
+                lagreAvkortingGrunnlag(behandlingId, avkortingGrunnlag, tx)
+                lagreAvkortingsperioder(behandlingId, avkortingsperioder, tx)
+                lagreAvkortetYtelse(behandlingId, avkortetYtelse, tx)
+            }
+        }
+        return hentAvkortingUtenNullable(behandlingId)
+    }
 
-                val avkortingGrunnlagId = UUID.randomUUID()
-                queryOf(
-                    statement = """
-                        INSERT INTO avkortinggrunnlag(
-                        id, behandling_id, fom, tom, aarsinntekt, gjeldende_aar, spesifikasjon, kilde
-                        ) VALUES (
-                        :id, :behandlingId, :fom, :tom, :aarsinntekt, :gjeldendeAar, :spesifikasjon, :kilde
-                        )
-                    """.trimIndent(),
-                    paramMap = mapOf(
-                        "id" to avkortingGrunnlagId,
-                        "behandlingId" to behandlingId,
-                        "fom" to avkortingGrunnlag.periode.fom.atDay(1),
-                        "tom" to avkortingGrunnlag.periode.tom?.atDay(1),
-                        "aarsinntekt" to avkortingGrunnlag.aarsinntekt,
-                        "spesifikasjon" to avkortingGrunnlag.spesifikasjon,
-                        "kilde" to avkortingGrunnlag.kilde.toJson()
+    private fun slettAvkorting(behandlingId: UUID, tx: TransactionalSession) {
+        queryOf(
+            "DELETE FROM avkortingsperioder WHERE behandling_id = ?",
+            behandlingId
+        ).let { query ->
+            tx.run(query.asUpdate)
+        }
+        queryOf(
+            "DELETE FROM avkortinggrunnlag WHERE behandling_id = ?",
+            behandlingId
+        ).let { query ->
+            tx.run(query.asUpdate)
+        }
+        queryOf(
+            "DELETE FROM avkortet_ytelse WHERE behandling_id = ?",
+            behandlingId
+        ).let { query ->
+            tx.run(query.asUpdate)
+        }
+    }
+
+    private fun lagreAvkortingGrunnlag(
+        behandlingId: UUID,
+        avkortingGrunnlag: List<AvkortingGrunnlag>,
+        tx: TransactionalSession
+    ) = avkortingGrunnlag.forEach {
+        queryOf(
+            statement = """
+                INSERT INTO avkortinggrunnlag(
+                    id, behandling_id, fom, tom, aarsinntekt, gjeldende_aar, spesifikasjon, kilde
+                ) VALUES (
+                    :id, :behandlingId, :fom, :tom, :aarsinntekt, :gjeldendeAar, :spesifikasjon, :kilde
+                )
+            """.trimIndent(),
+            paramMap = mapOf(
+                "id" to UUID.randomUUID(),
+                "behandlingId" to behandlingId,
+                "fom" to it.periode.fom.atDay(1),
+                "tom" to it.periode.tom?.atDay(1),
+                "aarsinntekt" to it.aarsinntekt,
+                "spesifikasjon" to it.spesifikasjon,
+                "kilde" to it.kilde.toJson()
+            )
+        ).let { query -> tx.run(query.asUpdate) }
+    }
+
+    private fun lagreAvkortingsperioder(
+        behandlingId: UUID,
+        avkortingsperioder: List<Avkortingsperiode>,
+        tx: TransactionalSession
+    ) = avkortingsperioder.forEach {
+        queryOf(
+            statement = """
+                INSERT INTO avkortingsperioder(
+                    id, behandling_id, fom, tom, avkorting, tidspunkt, regel_resultat, kilde
+                ) VALUES (
+                    :id, :behandlingId, :fom, :tom, :avkorting,:tidspunkt, :regel_resultat, :kilde
+                )
+            """.trimIndent(),
+            paramMap = mapOf(
+                "id" to UUID.randomUUID(),
+                "behandlingId" to behandlingId,
+                "fom" to it.periode.fom.atDay(1),
+                "tom" to it.periode.tom?.atDay(1),
+                "avkorting" to it.avkorting,
+                "tidspunkt" to it.tidspunkt.toTimestamp(),
+                "regel_resultat" to it.regelResultat.toJson(),
+                "kilde" to it.kilde.toJson()
+            )
+        ).let { query -> tx.run(query.asUpdate) }
+    }
+
+    private fun lagreAvkortetYtelse(
+        behandlingId: UUID,
+        avkortetYtelse: List<AvkortetYtelse>,
+        tx: TransactionalSession
+    ) =
+        avkortetYtelse.forEach {
+            queryOf(
+                statement = """
+                    INSERT INTO avkortet_ytelse(
+                        id, behandling_id, fom, tom, ytelse_etter_avkorting, avkortingsbeloep,
+                        ytelse_foer_avkorting, tidspunkt, regel_resultat, kilde
+                    ) VALUES (
+                        :id, :behandlingId, :fom, :tom,:ytelseEtterAvkorting, :avkortingsbeloep, :ytelseFoerAvkorting,
+                        :tidspunkt, :regel_resultat, :kilde
                     )
-                ).let { tx.run(it.asUpdate) }
-
-                avkortingGrunnlag.beregnetAvkorting.forEach { beregnetAvkorting ->
-                    queryOf(
-                        statement = """
-                        INSERT INTO beregnet_avkortinggrunnlag(
-                        id, avkortinggrunnlag, behandling_id, fom, tom, avkorting, tidspunkt, regel_resultat, kilde
-                        ) VALUES (
-                        :id, :avkortingGrunnlag, :behandlingId, :fom, :tom, :avkorting,
-                        :tidspunkt, :regel_resultat, :kilde
-                        )
-                        """.trimIndent(),
-                        paramMap = mapOf(
-                            "id" to UUID.randomUUID(),
-                            "avkortingGrunnlag" to avkortingGrunnlagId,
-                            "behandlingId" to behandlingId,
-                            "fom" to beregnetAvkorting.periode.fom.atDay(1),
-                            "tom" to beregnetAvkorting.periode.tom?.atDay(1),
-                            "avkorting" to beregnetAvkorting.avkorting,
-                            "tidspunkt" to beregnetAvkorting.tidspunkt.toTimestamp(),
-                            "regel_resultat" to beregnetAvkorting.regelResultat.toJson(),
-                            "kilde" to beregnetAvkorting.kilde.toJson()
-                        )
-                    ).let { tx.run(it.asUpdate) }
-                }
-            }
+                """.trimIndent(),
+                paramMap = mapOf(
+                    "id" to UUID.randomUUID(),
+                    "behandlingId" to behandlingId,
+                    "fom" to it.periode.fom.atDay(1),
+                    "tom" to it.periode.tom?.atDay(1),
+                    "ytelseEtterAvkorting" to it.ytelseEtterAvkorting,
+                    "avkortingsbeloep" to it.avkortingsbeloep,
+                    "ytelseFoerAvkorting" to it.ytelseFoerAvkorting,
+                    "tidspunkt" to it.tidspunkt.toTimestamp(),
+                    "regel_resultat" to it.regelResultat.toJson(),
+                    "kilde" to it.kilde.toJson()
+                )
+            ).let { query -> tx.run(query.asUpdate) }
         }
-        return hentAvkortingUtenNullable(behandlingId)
-    }
-
-    fun lagreEllerOppdaterAvkortetYtelse(behandlingId: UUID, avkortetYtelse: List<AvkortetYtelse>): Avkorting {
-        using(sessionOf(dataSource)) { session ->
-            session.transaction { tx ->
-                queryOf(
-                    "DELETE FROM avkortet_ytelse WHERE behandling_id = ?",
-                    behandlingId
-                ).let { query ->
-                    tx.run(query.asUpdate)
-                }
-
-                avkortetYtelse.forEach {
-                    queryOf(
-                        statement = """
-                        INSERT INTO avkortet_ytelse(
-                        id, behandling_id, fom, tom,
-                         ytelse_etter_avkorting, avkortingsbeloep, ytelse_foer_avkorting,
-                         tidspunkt, regel_resultat, kilde
-                        ) VALUES (
-                        :id, :behandlingId, :fom, :tom,
-                        :ytelseEtterAvkorting, :avkortingsbeloep, :ytelseFoerAvkorting,
-                        :tidspunkt, :regel_resultat, :kilde
-                        )
-                        """.trimIndent(),
-                        paramMap = mapOf(
-                            "id" to UUID.randomUUID(),
-                            "behandlingId" to behandlingId,
-                            "fom" to it.periode.fom.atDay(1),
-                            "tom" to it.periode.tom?.atDay(1),
-                            "ytelseEtterAvkorting" to it.ytelseEtterAvkorting,
-                            "avkortingsbeloep" to it.avkortingsbeloep,
-                            "ytelseFoerAvkorting" to it.ytelseFoerAvkorting,
-                            "tidspunkt" to it.tidspunkt.toTimestamp(),
-                            "regel_resultat" to it.regelResultat.toJson(),
-                            "kilde" to it.kilde.toJson()
-                        )
-                    ).let { query -> tx.run(query.asUpdate) }
-                }
-            }
-        }
-        return hentAvkortingUtenNullable(behandlingId)
-    }
 
     private fun hentAvkortingUtenNullable(behandlingId: UUID): Avkorting =
         hentAvkorting(behandlingId) ?: throw Exception("Uthenting av avkorting for behandling $behandlingId feilet")
 
-    private fun Row.toAvkortinggrunnlag(beregnetAvkorting: List<BeregnetAvkortingGrunnlag>) = AvkortingGrunnlag(
+    private fun Row.toAvkortinggrunnlag() = AvkortingGrunnlag(
         periode = Periode(
             fom = sqlDate("fom").let { YearMonth.from(it.toLocalDate()) },
             tom = sqlDateOrNull("tom")?.let { YearMonth.from(it.toLocalDate()) }
         ),
         aarsinntekt = int("aarsinntekt"),
         spesifikasjon = string("spesifikasjon"),
-        kilde = string("kilde").let { objectMapper.readValue(it) },
-        beregnetAvkorting = beregnetAvkorting
+        kilde = string("kilde").let { objectMapper.readValue(it) }
     )
 
-    private fun Row.toBeregnetAvkortinggrunnlag() = BeregnetAvkortingGrunnlag(
+    private fun Row.toBeregnetAvkortinggrunnlag() = Avkortingsperiode(
         periode = Periode(
             fom = sqlDate("fom").let { YearMonth.from(it.toLocalDate()) },
             tom = sqlDateOrNull("tom")?.let { YearMonth.from(it.toLocalDate()) }

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -74,6 +74,5 @@ fun AvkortingGrunnlagDto.fromDto(bruker: Bruker) = AvkortingGrunnlag(
     periode = Periode(fom = fom, tom = null),
     aarsinntekt = aarsinntekt,
     spesifikasjon = spesifikasjon,
-    kilde = Grunnlagsopplysning.Saksbehandler(bruker.ident(), Tidspunkt.now()),
-    beregnetAvkorting = emptyList()
+    kilde = Grunnlagsopplysning.Saksbehandler(bruker.ident(), Tidspunkt.now())
 )

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
@@ -19,6 +19,10 @@ class BeregningService(
         return beregningRepository.hent(behandlingId)
     }
 
+    fun hentBeregningNonnull(behandlingId: UUID): Beregning {
+        return hentBeregning(behandlingId) ?: throw Exception("Mangler beregning for behandlingId=$behandlingId")
+    }
+
     suspend fun opprettBeregning(behandlingId: UUID, bruker: Bruker): Beregning {
         logger.info("Oppretter beregning for behandlingId=$behandlingId")
         val kanBeregneYtelse = behandlingKlient.beregn(behandlingId, bruker, commit = false)

--- a/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
@@ -60,7 +60,7 @@ class ApplicationContext {
         behandlingKlient = behandlingKlient,
         inntektAvkortingService = InntektAvkortingService,
         avkortingRepository = AvkortingRepository(dataSource),
-        beregningRepository = BeregningRepository(dataSource)
+        beregningService = beregningService
     )
     val regulerAvkortingService = RegulerAvkortingService(avkortingService)
 }

--- a/apps/etterlatte-beregning/src/main/resources/db/migration/V15__rename_beregnet_avkortinggrunnlag.sql
+++ b/apps/etterlatte-beregning/src/main/resources/db/migration/V15__rename_beregnet_avkortinggrunnlag.sql
@@ -1,2 +1,2 @@
-ALTER TABLE beregnet_avkortinggrunnlag RENAME TO avkortingsperioder;
+ALTER TABLE IF EXISTS beregnet_avkortinggrunnlag RENAME TO avkortingsperioder;
 ALTER TABLE avkortingsperioder DROP COLUMN avkortinggrunnlag;

--- a/apps/etterlatte-beregning/src/main/resources/db/migration/V15__rename_beregnet_avkortinggrunnlag.sql
+++ b/apps/etterlatte-beregning/src/main/resources/db/migration/V15__rename_beregnet_avkortinggrunnlag.sql
@@ -1,0 +1,2 @@
+ALTER TABLE beregnet_avkortinggrunnlag RENAME TO avkortingsperioder;
+ALTER TABLE avkortingsperioder DROP COLUMN avkortinggrunnlag;

--- a/apps/etterlatte-beregning/src/main/resources/db/migration/V16__rydde_avkortinggrunnlag.sql
+++ b/apps/etterlatte-beregning/src/main/resources/db/migration/V16__rydde_avkortinggrunnlag.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS avkortinggrunnlag RENAME TO avkortingsgrunnlag ;
+ALTER TABLE avkortingsgrunnlag  DROP COLUMN gjeldende_aar;

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -3,7 +3,7 @@ package no.nav.etterlatte.beregning.regler
 import no.nav.etterlatte.avkorting.AvkortetYtelse
 import no.nav.etterlatte.avkorting.Avkorting
 import no.nav.etterlatte.avkorting.AvkortingGrunnlag
-import no.nav.etterlatte.avkorting.BeregnetAvkortingGrunnlag
+import no.nav.etterlatte.avkorting.Avkortingsperiode
 import no.nav.etterlatte.avkorting.regler.AvkortetYtelseGrunnlag
 import no.nav.etterlatte.avkorting.regler.InntektAvkortingGrunnlag
 import no.nav.etterlatte.beregning.Beregning
@@ -61,29 +61,28 @@ fun avkorting(
 ) = Avkorting(
     behandlingId = behandlingId,
     avkortingGrunnlag = emptyList(),
+    avkortingsperioder = emptyList(),
     avkortetYtelse = emptyList()
 )
 
 fun avkortinggrunnlag(
-    aarsinntekt: Int = 100000,
-    beregnetAvkorting: List<BeregnetAvkortingGrunnlag> = emptyList()
+    aarsinntekt: Int = 100000
 ) = AvkortingGrunnlag(
     periode = Periode(fom = YearMonth.now(), tom = null),
     aarsinntekt = aarsinntekt,
     spesifikasjon = "Spesifikasjon",
-    kilde = Grunnlagsopplysning.Saksbehandler.create("Z123456"),
-    beregnetAvkorting = beregnetAvkorting
+    kilde = Grunnlagsopplysning.Saksbehandler.create("Z123456")
 )
 
 fun inntektAvkortingGrunnlag(inntekt: Int = 500000) = InntektAvkortingGrunnlag(
     inntekt = FaktumNode(verdi = inntekt, "", "")
 )
 
-fun beregnetAvkortingGrunnlag(
+fun avkortingsperiode(
     fom: YearMonth = YearMonth.now(),
     tom: YearMonth? = null,
     avkorting: Int = 10000
-) = BeregnetAvkortingGrunnlag(
+) = Avkortingsperiode(
     Periode(fom = fom, tom = tom),
     avkorting = avkorting,
     tidspunkt = Tidspunkt.now(),

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
@@ -66,13 +66,10 @@ class AvkortingRoutesTest {
 
     @Test
     fun `skal returnere avkorting med avkortingsgrunnlag og beregnet avkorting over flere perioder`() {
-        val avkortingGrunnlag = listOf(
-            avkortinggrunnlag(beregnetAvkorting = listOf()),
-            avkortinggrunnlag(beregnetAvkorting = listOf())
-        )
         every { avkortingService.hentAvkorting(any()) } returns Avkorting(
             behandlingId = UUID.randomUUID(),
-            avkortingGrunnlag = avkortingGrunnlag,
+            avkortingGrunnlag = listOf(avkortinggrunnlag(), avkortinggrunnlag()),
+            avkortingsperioder = emptyList(),
             avkortetYtelse = listOf(
                 avkortetYtelse(100, 1000, periode = Periode(YearMonth.of(2023, 1), YearMonth.of(2023, 1))),
                 avkortetYtelse(200, 2000, periode = Periode(YearMonth.of(2023, 2), YearMonth.of(2023, 2))),

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/InntektAvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/InntektAvkortingServiceTest.kt
@@ -7,7 +7,7 @@ import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import no.nav.etterlatte.avkorting.InntektAvkortingService
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
-import no.nav.etterlatte.beregning.regler.beregnetAvkortingGrunnlag
+import no.nav.etterlatte.beregning.regler.avkortingsperiode
 import no.nav.etterlatte.beregning.regler.beregningsperiode
 import no.nav.etterlatte.grunnbeloep.Grunnbeloep
 import no.nav.etterlatte.grunnbeloep.GrunnbeloepRepository
@@ -64,31 +64,23 @@ class InntektAvkortingServiceTest {
                 datoFOM = YearMonth.of(2023, 4)
             )
         )
-        val avkortingGrunnlag = listOf(
-            avkortinggrunnlag(
-                beregnetAvkorting = listOf(
-                    beregnetAvkortingGrunnlag(
-                        avkorting = 1000,
-                        fom = YearMonth.of(2023, 1),
-                        tom = YearMonth.of(2023, 2)
-                    ),
-                    beregnetAvkortingGrunnlag(
-                        avkorting = 2000,
-                        fom = YearMonth.of(2023, 2)
-                    )
-                )
+        val avkortingsperioder = listOf(
+            avkortingsperiode(
+                avkorting = 1000,
+                fom = YearMonth.of(2023, 1),
+                tom = YearMonth.of(2023, 2)
             ),
-            avkortinggrunnlag(
-                beregnetAvkorting = listOf(
-                    beregnetAvkortingGrunnlag(
-                        avkorting = 3000,
-                        fom = YearMonth.of(2023, 3)
-                    )
-                )
+            avkortingsperiode(
+                avkorting = 2000,
+                fom = YearMonth.of(2023, 2)
+            ),
+            avkortingsperiode(
+                avkorting = 3000,
+                fom = YearMonth.of(2023, 3)
             )
         )
 
-        val avkortetYtelse = InntektAvkortingService.beregnAvkortetYtelse(beregninger, avkortingGrunnlag)
+        val avkortetYtelse = InntektAvkortingService.beregnAvkortetYtelse(beregninger, avkortingsperioder)
 
         avkortetYtelse.size shouldBe 4
         with(avkortetYtelse[0]) {


### PR DESCRIPTION
- Endret navn på BeregnetAvkortingGrunnlag til Avkortingsperiode og flyttet den ut av AvkortingGrunnlag
- Forbedret transaksjonshåndtering ved å lagre hele Avkorting i en public metode og la repo stå for transaksjonen
- Renamet tabeller til å passe ny domenenavn og fjernet ubrukte kolonner