### PR TITLE
Migrerte saker skal ikke sende brev

### DIFF
--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/services/VedtakService.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/services/VedtakService.kt
@@ -45,7 +45,10 @@ class VedtakServiceImpl(private val vedtakKlient: HttpClient, private val url: S
             vedtakKlient.post("$url/api/vedtak/$behandlingId/attester") {
                 contentType(ContentType.Application.Json)
                 setBody(
-                    AttesterVedtakDto("Automatisk attestert av ${Fagsaksystem.EY.systemnavn}")
+                    AttesterVedtakDto(
+                        kommentar = "Automatisk attestert av ${Fagsaksystem.EY.systemnavn}",
+                        skalSendeBrev = false
+                    )
                 )
             }
                 .body()

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -19,6 +19,7 @@ import no.nav.etterlatte.libs.common.vedtak.LoependeYtelseDTO
 import no.nav.etterlatte.libs.common.withBehandlingId
 import no.nav.etterlatte.libs.common.withSakId
 import no.nav.etterlatte.libs.ktor.bruker
+import no.nav.etterlatte.token.Saksbehandler
 import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
 import java.time.LocalDate
 import java.time.ZonedDateTime
@@ -72,8 +73,14 @@ fun Route.vedtaksvurderingRoute(service: VedtaksvurderingService, behandlingKlie
         post("/{$BEHANDLINGSID_CALL_PARAMETER}/attester") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Attesterer vedtak for behandling $behandlingId")
-                val (kommentar) = call.receive<AttesterVedtakDto>()
-                val attestert = service.attesterVedtak(behandlingId, kommentar, bruker)
+                val (kommentar, skalSendeBrev) = call.receive<AttesterVedtakDto>()
+                if (!skalSendeBrev && bruker is Saksbehandler) {
+                    return@withBehandlingId call.respond(
+                        HttpStatusCode.BadRequest,
+                        "Saksbehandler kan ikke overstyre om brev skal sendes"
+                    )
+                }
+                val attestert = service.attesterVedtak(behandlingId, kommentar, skalSendeBrev, bruker)
 
                 call.respond(attestert.toDto())
             }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
@@ -123,7 +123,7 @@ class VedtaksvurderingService(
         return fattetVedtak
     }
 
-    suspend fun attesterVedtak(behandlingId: UUID, kommentar: String, bruker: Bruker): Vedtak {
+    suspend fun attesterVedtak(behandlingId: UUID, kommentar: String, skalSendeBrev: Boolean, bruker: Bruker): Vedtak {
         logger.info("Attesterer vedtak for behandling med behandlingId=$behandlingId")
         val vedtak = hentVedtakNonNull(behandlingId)
 
@@ -161,7 +161,7 @@ class VedtaksvurderingService(
                 mapOf(
                     SKAL_SENDE_BREV to when (behandling.revurderingsaarsak) {
                         RevurderingAarsak.REGULERING -> false
-                        else -> true
+                        else -> skalSendeBrev
                     },
                     REVURDERING_AARSAK to behandling.revurderingsaarsak.toString()
                 )
@@ -428,5 +428,3 @@ class BehandlingstilstandException(vedtak: Vedtak) :
 
 class UgyldigAttestantException(ident: String) :
     IllegalArgumentException("Saksbehandler og attestant må være to forskjellige personer (ident=$ident)")
-
-class SaksbehandlerManglerEnhetException(message: String) : Exception(message)

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingRouteTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingRouteTest.kt
@@ -350,7 +350,7 @@ internal class VedtaksvurderingRouteTest {
             vedtakFattet = VedtakFattet(SAKSBEHANDLER_1, ENHET_1, Tidspunkt.now()),
             attestasjon = Attestasjon(SAKSBEHANDLER_2, ENHET_2, Tidspunkt.now())
         )
-        coEvery { vedtaksvurderingService.attesterVedtak(any(), any(), any()) } returns attestertVedtak
+        coEvery { vedtaksvurderingService.attesterVedtak(any(), any(), any(), any()) } returns attestertVedtak
 
         testApplication {
             environment { config = applicationConfig }
@@ -390,6 +390,7 @@ internal class VedtaksvurderingRouteTest {
                 vedtaksvurderingService.attesterVedtak(
                     any(),
                     match { it == attestertVedtakKommentar.kommentar },
+                    any(),
                     match { it.ident() == SAKSBEHANDLER_1 }
                 )
             }

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingServiceTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingServiceTest.kt
@@ -330,7 +330,7 @@ internal class VedtaksvurderingServiceTest {
                 opprettVedtak(virkningstidspunkt = virkningstidspunkt, behandlingId = behandlingId)
             )
             service.fattVedtak(behandlingId, gjeldendeSaksbehandler)
-            service.attesterVedtak(behandlingId, KOMMENTAR, attestant)
+            service.attesterVedtak(behandlingId, KOMMENTAR, true, attestant)
         }
 
         attestertVedtak shouldNotBe null
@@ -377,7 +377,7 @@ internal class VedtaksvurderingServiceTest {
             service.fattVedtak(behandlingId, gjeldendeSaksbehandler)
 
             shouldThrow<UgyldigAttestantException> {
-                service.attesterVedtak(behandlingId, KOMMENTAR, gjeldendeSaksbehandler)
+                service.attesterVedtak(behandlingId, KOMMENTAR, true, gjeldendeSaksbehandler)
             }
         }
 
@@ -440,7 +440,7 @@ internal class VedtaksvurderingServiceTest {
                 )
             )
             service.fattVedtak(behandlingId, gjeldendeSaksbehandler)
-            service.attesterVedtak(behandlingId, KOMMENTAR, attestant)
+            service.attesterVedtak(behandlingId, KOMMENTAR, true, attestant)
         }
 
         val hendelse = mutableListOf<String>()
@@ -469,7 +469,7 @@ internal class VedtaksvurderingServiceTest {
             service.fattVedtak(behandlingId, saksbehandler)
 
             assertThrows<BehandlingstilstandException> {
-                service.attesterVedtak(behandlingId, KOMMENTAR, attestant)
+                service.attesterVedtak(behandlingId, KOMMENTAR, true, attestant)
             }
         }
     }
@@ -484,7 +484,7 @@ internal class VedtaksvurderingServiceTest {
             repository.opprettVedtak(opprettVedtak(behandlingId = behandlingId))
 
             assertThrows<VedtakTilstandException> {
-                service.attesterVedtak(behandlingId, KOMMENTAR, saksbehandler)
+                service.attesterVedtak(behandlingId, KOMMENTAR, true, saksbehandler)
             }
         }
     }
@@ -515,10 +515,10 @@ internal class VedtaksvurderingServiceTest {
         runBlocking {
             repository.opprettVedtak(opprettVedtak(behandlingId = behandlingId))
             service.fattVedtak(behandlingId, saksbehandler)
-            service.attesterVedtak(behandlingId, KOMMENTAR, attestant)
+            service.attesterVedtak(behandlingId, KOMMENTAR, true, attestant)
 
             assertThrows<VedtakTilstandException> {
-                service.attesterVedtak(behandlingId, KOMMENTAR, attestant)
+                service.attesterVedtak(behandlingId, KOMMENTAR, true, attestant)
             }
         }
     }
@@ -552,7 +552,7 @@ internal class VedtaksvurderingServiceTest {
                 opprettVedtak(virkningstidspunkt = virkningstidspunkt, behandlingId = behandlingId)
             )
             service.fattVedtak(behandlingId, gjeldendeSaksbehandler)
-            service.attesterVedtak(behandlingId, KOMMENTAR, attestant)
+            service.attesterVedtak(behandlingId, KOMMENTAR, true, attestant)
             service.iverksattVedtak(behandlingId)
         }
 
@@ -603,7 +603,7 @@ internal class VedtaksvurderingServiceTest {
         runBlocking {
             repository.opprettVedtak(opprettVedtak(behandlingId = behandlingId))
             service.fattVedtak(behandlingId, saksbehandler)
-            service.attesterVedtak(behandlingId, KOMMENTAR, attestant)
+            service.attesterVedtak(behandlingId, KOMMENTAR, true, attestant)
             service.iverksattVedtak(behandlingId)
 
             assertThrows<VedtakTilstandException> {
@@ -713,7 +713,7 @@ internal class VedtaksvurderingServiceTest {
         runBlocking {
             repository.opprettVedtak(opprettVedtak(behandlingId = behandlingId))
             service.fattVedtak(behandlingId, saksbehandler)
-            service.attesterVedtak(behandlingId, KOMMENTAR, attestant)
+            service.attesterVedtak(behandlingId, KOMMENTAR, true, attestant)
 
             assertThrows<VedtakTilstandException> {
                 service.underkjennVedtak(behandlingId, attestant, underkjennVedtakBegrunnelse())

--- a/libs/saksbehandling-common/src/main/kotlin/vedtak/VedtakDto.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/vedtak/VedtakDto.kt
@@ -56,7 +56,7 @@ data class Attestasjon(
     val tidspunkt: Tidspunkt
 )
 
-data class AttesterVedtakDto(val kommentar: String)
+data class AttesterVedtakDto(val kommentar: String, val skalSendeBrev: Boolean = true)
 
 data class Utbetalingsperiode(
     val id: Long? = null,


### PR DESCRIPTION
Quickfix, det er kanskje bedre med et eget endepunkt for systembruker som tillater overstyring