### PR TITLE
TrygdetidKlient kan få null hvis response er 204

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnOmstillingsstoenadService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnOmstillingsstoenadService.kt
@@ -42,7 +42,9 @@ class BeregnOmstillingsstoenadService(
 
     suspend fun beregn(behandling: DetaljertBehandling, bruker: Bruker): Beregning {
         val grunnlag = grunnlagKlient.hentGrunnlag(behandling.sak, bruker)
-        val trygdetid = trygdetidKlient.hentTrygdetid(behandling.id, bruker)
+        val trygdetid = trygdetidKlient.hentTrygdetid(behandling.id, bruker) ?: throw Exception(
+            "Forventa å ha trygdetid for behandlingId=${behandling.id}"
+        )
         val behandlingType = behandling.behandlingType
         val virkningstidspunkt = requireNotNull(behandling.virkningstidspunkt?.dato)
         val beregningsgrunnlag = opprettBeregningsgrunnlagOmstillingsstoenad(trygdetid)

--- a/apps/etterlatte-beregning/src/main/kotlin/klienter/TrygdetidKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/klienter/TrygdetidKlient.kt
@@ -29,9 +29,9 @@ class TrygdetidKlient(config: Config, httpClient: HttpClient) {
     suspend fun hentTrygdetid(
         behandlingId: UUID,
         bruker: Bruker
-    ): TrygdetidDto {
+    ): TrygdetidDto? {
         logger.info("Henter trygdetid med behandlingid $behandlingId")
-        return retry<TrygdetidDto> {
+        return retry<TrygdetidDto?> {
             downstreamResourceClient
                 .get(
                     resource = Resource(
@@ -41,7 +41,7 @@ class TrygdetidKlient(config: Config, httpClient: HttpClient) {
                     bruker = bruker
                 )
                 .mapBoth(
-                    success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },
+                    success = { resource -> resource.response?.let { objectMapper.readValue(it.toString()) } },
                     failure = { throwableErrorMessage -> throw throwableErrorMessage }
                 )
         }.let {

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnOmstillingsstoenadServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnOmstillingsstoenadServiceTest.kt
@@ -181,6 +181,21 @@ internal class BeregnOmstillingsstoenadServiceTest {
         }
     }
 
+    @Test
+    fun `skal feile hvis trygdetid ikke finnes`() {
+        val behandling = mockBehandling(BehandlingType.FØRSTEGANGSBEHANDLING)
+        val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
+
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { trygdetidKlient.hentTrygdetid(any(), any()) } returns null
+
+        runBlocking {
+            assertThrows<Exception> {
+                beregnOmstillingsstoenadService.beregn(behandling, bruker)
+            }
+        }
+    }
+
     private fun mockBehandling(type: BehandlingType, virk: YearMonth = VIRKNINGSTIDSPUNKT_JAN_23): DetaljertBehandling =
         mockk<DetaljertBehandling>().apply {
             every { id } returns randomUUID()


### PR DESCRIPTION
Med eksisterende klient - så ender vi opp å returnere en TrygdetidDto men med verdi null.

Denne endring gjør at vi sier det ved å endre fra TrygdetidDto til TrygdetidDto?
