### PR TITLE
Nytt endepunkt for å slette trygdetidsgrunnlag

### DIFF
--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/Trygdetid.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/Trygdetid.kt
@@ -26,6 +26,10 @@ data class Trygdetid(
         )
     }
 
+    fun slettTrygdetidGrunnlag(trygdetidGrunnlagId: UUID): Trygdetid = this.copy(
+        trygdetidGrunnlag = this.trygdetidGrunnlag.filter { it.id != trygdetidGrunnlagId }
+    )
+
     fun oppdaterBeregnetTrygdetid(beregnetTrygdetid: BeregnetTrygdetid): Trygdetid {
         return this.copy(beregnetTrygdetid = beregnetTrygdetid)
     }

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
@@ -7,6 +7,7 @@ import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.application
+import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
@@ -24,6 +25,7 @@ import no.nav.etterlatte.libs.common.trygdetid.TrygdetidGrunnlagDto
 import no.nav.etterlatte.libs.common.trygdetid.TrygdetidGrunnlagKildeDto
 import no.nav.etterlatte.libs.common.uuid
 import no.nav.etterlatte.libs.common.withBehandlingId
+import no.nav.etterlatte.libs.common.withParam
 import no.nav.etterlatte.libs.ktor.bruker
 import no.nav.etterlatte.token.Bruker
 import no.nav.etterlatte.trygdetid.klienter.BehandlingKlient
@@ -64,6 +66,16 @@ fun Route.trygdetid(trygdetidService: TrygdetidService, behandlingKlient: Behand
                         trygdetidgrunnlagDto.toTrygdetidGrunnlag(bruker)
                     )
                 call.respond(trygdetid.toDto())
+            }
+        }
+
+        delete("/grunnlag/{trygdetidGrunnlagId}") {
+            withBehandlingId(behandlingKlient) {
+                withParam("trygdetidGrunnlagId") { trygdetidGrunnlagId ->
+                    logger.info("Sletter trygdetidsgrunnlag for behandling $behandlingsId")
+                    val trygdetid = trygdetidService.slettTrygdetidGrunnlag(behandlingsId, trygdetidGrunnlagId, bruker)
+                    call.respond(trygdetid.toDto())
+                }
             }
         }
 

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -56,15 +56,28 @@ class TrygdetidService(
                 trygdetidGrunnlag = trygdetidMedOppdatertTrygdetidGrunnlag.trygdetidGrunnlag
             )
 
-            val oppdatertTrygdetid: Trygdetid =
-                if (nyBeregnetTrygdetid != null) {
-                    trygdetidMedOppdatertTrygdetidGrunnlag.oppdaterBeregnetTrygdetid(nyBeregnetTrygdetid)
-                } else {
-                    trygdetidMedOppdatertTrygdetidGrunnlag.nullstillBeregnetTrygdetid()
+            when (nyBeregnetTrygdetid) {
+                null -> trygdetidMedOppdatertTrygdetidGrunnlag.nullstillBeregnetTrygdetid()
+                else -> trygdetidMedOppdatertTrygdetidGrunnlag.oppdaterBeregnetTrygdetid(nyBeregnetTrygdetid)
+            }.also { nyTrygdetid ->
+                trygdetidRepository.oppdaterTrygdetid(nyTrygdetid).also {
+                    behandlingKlient.settBehandlingStatusVilkaarsvurdert(behandlingId, bruker)
                 }
+            }
+        }
 
-            trygdetidRepository.oppdaterTrygdetid(oppdatertTrygdetid).also {
-                behandlingKlient.settBehandlingStatusVilkaarsvurdert(behandlingId, bruker)
+    suspend fun slettTrygdetidGrunnlag(behandlingId: UUID, trygdetidGrunnlagId: UUID, bruker: Bruker): Trygdetid =
+        tilstandssjekk(behandlingId, bruker) {
+            val trygdetid = trygdetidRepository.hentTrygdetid(behandlingId)?.slettTrygdetidGrunnlag(trygdetidGrunnlagId)
+                ?: throw Exception("Fant ikke gjeldende trygdetid for behandlingId=$behandlingId")
+
+            when (val nyBeregnetTrygdetid = beregnTrygdetidService.beregnTrygdetid(trygdetid.trygdetidGrunnlag)) {
+                null -> trygdetid.nullstillBeregnetTrygdetid()
+                else -> trygdetid.oppdaterBeregnetTrygdetid(nyBeregnetTrygdetid)
+            }.also { nyTrygdetid ->
+                trygdetidRepository.oppdaterTrygdetid(nyTrygdetid).also {
+                    behandlingKlient.settBehandlingStatusVilkaarsvurdert(behandlingId, bruker)
+                }
             }
         }
 
@@ -98,7 +111,11 @@ class TrygdetidService(
     private fun hentOpplysninger(avdoed: Grunnlagsdata<JsonNode>): List<Opplysningsgrunnlag> {
         val foedselsdato = avdoed.hentFoedselsdato()
         val opplysninger = listOf(
-            Opplysningsgrunnlag.ny(TrygdetidOpplysningType.FOEDSELSDATO, foedselsdato?.kilde, foedselsdato?.verdi),
+            Opplysningsgrunnlag.ny(
+                TrygdetidOpplysningType.FOEDSELSDATO,
+                foedselsdato?.kilde,
+                foedselsdato?.verdi
+            ),
             Opplysningsgrunnlag.ny(
                 TrygdetidOpplysningType.FYLT_16,
                 kildeFoedselsnummer(),
@@ -118,7 +135,11 @@ class TrygdetidService(
         return opplysninger
     }
 
-    private suspend fun tilstandssjekk(behandlingId: UUID, bruker: Bruker, block: suspend () -> Trygdetid): Trygdetid {
+    private suspend fun tilstandssjekk(
+        behandlingId: UUID,
+        bruker: Bruker,
+        block: suspend () -> Trygdetid
+    ): Trygdetid {
         val kanFastsetteTrygdetid = behandlingKlient.kanBeregnes(behandlingId, bruker)
         return if (kanFastsetteTrygdetid) {
             block()


### PR DESCRIPTION
Det er litt missbruk av REST spesifikasjonen å sende med det oppdaterte objektet tilbake ved `delete`, men følger "etablert" praksis fra vilkårsvurdering for nå.

- [x] Verifiser funksjonalitet med Mari før merge

EY-2250