### PR TITLE
EY-2263: Fiks byggejobbar som ikkje lyttar på eigen kode

### DIFF
--- a/.github/workflows/app-etterlatte-beregning-kafka.yaml
+++ b/.github/workflows/app-etterlatte-beregning-kafka.yaml
@@ -15,6 +15,7 @@ on:
     branches:
       - main
     paths:
+      - apps/etterlatte-beregning-kafka/**
       - libs/saksbehandling-common/**
       - libs/ktor2client-auth-clientcredentials/**
       - libs/rapidsandrivers-extras/**
@@ -23,7 +24,9 @@ on:
     branches:
       - main
     paths:
+      - apps/etterlatte-beregning-kafka/**
       - libs/saksbehandling-common/**
+      - libs/ktor2client-auth-clientcredentials/**
       - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
 

--- a/.github/workflows/app-etterlatte-trygdetid-kafka.yaml
+++ b/.github/workflows/app-etterlatte-trygdetid-kafka.yaml
@@ -15,6 +15,7 @@ on:
     branches:
       - main
     paths:
+      - apps/etterlatte-trygdetid-kafka/**
       - libs/saksbehandling-common/**
       - libs/ktor2client-auth-clientcredentials/**
       - libs/rapidsandrivers-extras/**
@@ -23,7 +24,9 @@ on:
     branches:
       - main
     paths:
+      - apps/etterlatte-trygdetid-kafka/**
       - libs/saksbehandling-common/**
+      - libs/ktor2client-auth-clientcredentials/**
       - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
 

--- a/.github/workflows/lib-etterlatte-institusjonsopphold-model.yaml
+++ b/.github/workflows/lib-etterlatte-institusjonsopphold-model.yaml
@@ -1,0 +1,22 @@
+name: etterlatte-institusjonsopphold-model
+
+on:
+  workflow_dispatch: # Allow manually triggered workflow run
+  push:
+    branches:
+      - main
+    paths:
+      - libs/etterlatte-institusjonsopphold-model/**
+      - gradle/libs.versions.toml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - libs/etterlatte-institusjonsopphold-model/**
+      - gradle/libs.versions.toml
+
+jobs:
+  test:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/.lib-test.yaml
+    secrets: inherit

--- a/.github/workflows/lib-etterlatte-token-model.yaml
+++ b/.github/workflows/lib-etterlatte-token-model.yaml
@@ -1,0 +1,22 @@
+name: etterlatte-token-model
+
+on:
+  workflow_dispatch: # Allow manually triggered workflow run
+  push:
+    branches:
+      - main
+    paths:
+      - libs/etterlatte-token-model/**
+      - gradle/libs.versions.toml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - libs/etterlatte-token-model/**
+      - gradle/libs.versions.toml
+
+jobs:
+  test:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/.lib-test.yaml
+    secrets: inherit

--- a/.github/workflows/lib-etterlatte-vilkaarsvurdering-model.yaml
+++ b/.github/workflows/lib-etterlatte-vilkaarsvurdering-model.yaml
@@ -1,0 +1,22 @@
+name: etterlatte-vilkaarsvurdering-model
+
+on:
+  workflow_dispatch: # Allow manually triggered workflow run
+  push:
+    branches:
+      - main
+    paths:
+      - libs/etterlatte-vilkaarsvurdering-model/**
+      - gradle/libs.versions.toml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - libs/etterlatte-vilkaarsvurdering-model/**
+      - gradle/libs.versions.toml
+
+jobs:
+  test:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/.lib-test.yaml
+    secrets: inherit


### PR DESCRIPTION
For beregning-kafka og trygdetid-kafka hadde vi visst ikkje fått med at byggejobben må køyre når koden i sjølve modulen blir endra.

Fiksar med det samme byggejobbar for eit par ganske nye libs