### PR TITLE
Kobler revurderinger på grunn av hendelser sammen

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/GenerellBehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/GenerellBehandlingService.kt
@@ -141,7 +141,7 @@ class RealGenerellBehandlingService(
             behandlingDao.avbrytBehandling(behandlingId).also {
                 hendelseDao.behandlingAvbrutt(behandling, saksbehandler)
             }.also {
-                grunnlagsendringshendelseDao.aapneGrunnlagsendringshendelserForBehandlingId(behandlingId)
+                grunnlagsendringshendelseDao.kobleGrunnlagsendringshendelserFraBehandlingId(behandlingId)
             }
         }
         runBlocking {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
@@ -34,7 +34,8 @@ class OmregningService(
                 sakId = sakId,
                 forrigeBehandling = forrigeBehandling,
                 revurderingAarsak = RevurderingAarsak.REGULERING,
-                kilde = Vedtaksloesning.GJENNY
+                kilde = Vedtaksloesning.GJENNY,
+                paaGrunnAvHendelse = null
             )
         } ?: throw Exception("Opprettelse av revurdering feilet for $sakId")
         return Triple(behandling.id, forrigeBehandling.id, behandling.sak.sakType)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
@@ -17,6 +17,7 @@ import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.sakId
+import java.util.UUID
 
 internal fun Route.revurderingRoutes(
     revurderingService: RevurderingService,
@@ -49,7 +50,8 @@ internal fun Route.revurderingRoutes(
                     sakId = forrigeIverksatteBehandling.sak.id,
                     forrigeBehandling = forrigeIverksatteBehandling,
                     revurderingAarsak = body.aarsak,
-                    kilde = Vedtaksloesning.GJENNY
+                    kilde = Vedtaksloesning.GJENNY,
+                    paaGrunnAvHendelse = body.paaGrunnAvHendelseId
                 )
 
                 when (revurdering) {
@@ -73,4 +75,4 @@ internal fun Route.revurderingRoutes(
     }
 }
 
-data class OpprettRevurderingRequest(val aarsak: RevurderingAarsak)
+data class OpprettRevurderingRequest(val aarsak: RevurderingAarsak, val paaGrunnAvHendelseId: UUID? = null)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
@@ -46,12 +46,21 @@ internal fun Route.revurderingRoutes(
                     return@post
                 }
 
+                val paaGrunnAvHendelseId = try {
+                    body.paaGrunnAvHendelseId?.let { UUID.fromString(it) }
+                } catch (e: Exception) {
+                    return@post call.respond(
+                        HttpStatusCode.BadRequest,
+                        "${body.paaGrunnAvHendelseId} er ikke en gyldig UUID"
+                    )
+                }
+
                 val revurdering = revurderingService.opprettManuellRevurdering(
                     sakId = forrigeIverksatteBehandling.sak.id,
                     forrigeBehandling = forrigeIverksatteBehandling,
                     revurderingAarsak = body.aarsak,
                     kilde = Vedtaksloesning.GJENNY,
-                    paaGrunnAvHendelse = body.paaGrunnAvHendelseId
+                    paaGrunnAvHendelse = paaGrunnAvHendelseId
                 )
 
                 when (revurdering) {
@@ -75,4 +84,4 @@ internal fun Route.revurderingRoutes(
     }
 }
 
-data class OpprettRevurderingRequest(val aarsak: RevurderingAarsak, val paaGrunnAvHendelseId: UUID? = null)
+data class OpprettRevurderingRequest(val aarsak: RevurderingAarsak, val paaGrunnAvHendelseId: String? = null)

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -140,6 +140,7 @@ class ApplicationContext(
         behandlingDao = behandlingDao,
         behandlingHendelser = behandlingsHendelser.hendelserKanal,
         hendelseDao = hendelseDao,
+        grunnlagsendringshendelseDao = grunnlagsendringshendelseDao,
         vedtakKlient = vedtakKlientObo,
         grunnlagKlient = grunnlagKlientObo,
         sporingslogg = sporingslogg,

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseDao.kt
@@ -107,6 +107,23 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
         }
     }
 
+    fun aapneGrunnlagsendringshendelserForBehandlingId(behandlingId: UUID) {
+        with(connection()) {
+            prepareStatement(
+                """
+                    UPDATE grunnlagsendringshendelse
+                    SET kommentar = null,
+                        status = ?
+                    WHERE behandling_id = ?
+                """.trimIndent()
+            ).use {
+                it.setString(1, GrunnlagsendringStatus.SJEKKET_AV_JOBB.toString())
+                it.setObject(2, behandlingId)
+                it.executeUpdate()
+            }
+        }
+    }
+
     fun settBehandlingIdForTattMedIBehandling(
         grlaghendelseId: UUID,
         behandlingId: UUID
@@ -122,7 +139,7 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
             ).use {
                 it.setObject(1, behandlingId)
                 it.setObject(2, grlaghendelseId)
-                it.setString(3, GrunnlagsendringStatus.TATT_MED_I_BEHANDLING.name)
+                it.setString(3, GrunnlagsendringStatus.SJEKKET_AV_JOBB.name)
                 it.executeUpdate()
             }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseDao.kt
@@ -107,13 +107,14 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
         }
     }
 
-    fun aapneGrunnlagsendringshendelserForBehandlingId(behandlingId: UUID) {
+    fun kobleGrunnlagsendringshendelserFraBehandlingId(behandlingId: UUID) {
         with(connection()) {
             prepareStatement(
                 """
                     UPDATE grunnlagsendringshendelse
                     SET kommentar = null,
-                        status = ?
+                        status = ?,
+                        behandling_id = null 
                     WHERE behandling_id = ?
                 """.trimIndent()
             ).use {
@@ -132,14 +133,16 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
             prepareStatement(
                 """
                    UPDATE grunnlagsendringshendelse
-                   SET behandling_id = ?
+                   SET behandling_id = ?,
+                   status = ?
                    WHERE id = ?
                    AND status = ?
                 """.trimIndent()
             ).use {
                 it.setObject(1, behandlingId)
-                it.setObject(2, grlaghendelseId)
-                it.setString(3, GrunnlagsendringStatus.SJEKKET_AV_JOBB.name)
+                it.setString(2, GrunnlagsendringStatus.TATT_MED_I_BEHANDLING.name)
+                it.setObject(3, grlaghendelseId)
+                it.setString(4, GrunnlagsendringStatus.SJEKKET_AV_JOBB.name)
                 it.executeUpdate()
             }
         }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealGenerellBehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealGenerellBehandlingServiceTest.kt
@@ -21,6 +21,7 @@ import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.foerstegangsbehandling
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.grunnlagsOpplysningMedPersonopplysning
+import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseDao
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BoddEllerArbeidetUtlandet
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
@@ -82,13 +83,14 @@ class RealGenerellBehandlingServiceTest {
         every { featureToggleService.isEnabled(BehandlingServiceFeatureToggle.FiltrerMedEnhetId, false) } returns false
 
         val sut = RealGenerellBehandlingService(
-            behandlingDaoMock,
-            hendleseskanal,
-            hendelserMock,
-            mockk(),
-            mockk(),
-            mockk(),
-            featureToggleService
+            behandlingDao = behandlingDaoMock,
+            behandlingHendelser = hendleseskanal,
+            grunnlagsendringshendelseDao = mockk(),
+            hendelseDao = hendelserMock,
+            vedtakKlient = mockk(),
+            grunnlagKlient = mockk(),
+            sporingslogg = mockk(),
+            featureToggleService = featureToggleService
         )
 
         val behandlinger = sut.hentBehandlingerISak(1)
@@ -367,13 +369,14 @@ class RealGenerellBehandlingServiceTest {
         every { featureToggleService.isEnabled(BehandlingServiceFeatureToggle.FiltrerMedEnhetId, false) } returns true
 
         val sut = RealGenerellBehandlingService(
-            behandlingDaoMock,
-            hendleseskanal,
-            hendelserMock,
-            mockk(),
-            mockk(),
-            mockk(),
-            featureToggleService
+            behandlingDao = behandlingDaoMock,
+            behandlingHendelser = hendleseskanal,
+            grunnlagsendringshendelseDao = mockk(),
+            hendelseDao = hendelserMock,
+            vedtakKlient = mockk(),
+            grunnlagKlient = mockk(),
+            sporingslogg = mockk(),
+            featureToggleService = featureToggleService
         )
 
         val behandlinger = sut.hentBehandlingerISak(1)
@@ -409,13 +412,14 @@ class RealGenerellBehandlingServiceTest {
         every { featureToggleService.isEnabled(BehandlingServiceFeatureToggle.FiltrerMedEnhetId, false) } returns true
 
         val sut = RealGenerellBehandlingService(
-            behandlingDaoMock,
-            hendleseskanal,
-            hendelserMock,
-            mockk(),
-            mockk(),
-            mockk(),
-            featureToggleService
+            behandlingDao = behandlingDaoMock,
+            behandlingHendelser = hendleseskanal,
+            grunnlagsendringshendelseDao = mockk(),
+            hendelseDao = hendelserMock,
+            vedtakKlient = mockk(),
+            grunnlagKlient = mockk(),
+            sporingslogg = mockk(),
+            featureToggleService = featureToggleService
         )
 
         val behandlinger = sut.hentBehandlingerISak(1)
@@ -450,13 +454,14 @@ class RealGenerellBehandlingServiceTest {
         every { featureToggleService.isEnabled(BehandlingServiceFeatureToggle.FiltrerMedEnhetId, false) } returns true
 
         val sut = RealGenerellBehandlingService(
-            behandlingDaoMock,
-            mockk(),
-            mockk(),
-            mockk(),
-            mockk(),
-            mockk(),
-            featureToggleService
+            behandlingDao = behandlingDaoMock,
+            behandlingHendelser = mockk(),
+            grunnlagsendringshendelseDao = mockk(),
+            hendelseDao = mockk(),
+            vedtakKlient = mockk(),
+            grunnlagKlient = mockk(),
+            sporingslogg = mockk(),
+            featureToggleService = featureToggleService
         )
 
         sut.oppdaterUtenlandstilsnitt(
@@ -556,16 +561,18 @@ class RealGenerellBehandlingServiceTest {
         behandlingDao: BehandlingDao? = null,
         hendelseKanal: BehandlingHendelserKanal? = null,
         hendelseDao: HendelseDao? = null,
+        grunnlagsendringshendelseDao: GrunnlagsendringshendelseDao = mockk(relaxed = true),
         grunnlagKlient: GrunnlagKlient? = null,
         featureToggleService: FeatureToggleService
     ): RealGenerellBehandlingService = RealGenerellBehandlingService(
         behandlingDao = behandlingDao ?: mockk(),
         behandlingHendelser = hendelseKanal ?: mockk(),
+        grunnlagsendringshendelseDao = grunnlagsendringshendelseDao,
         hendelseDao = hendelseDao ?: mockk(),
-        mockk(),
-        grunnlagKlient ?: mockk(),
-        mockk(),
-        featureToggleService
+        vedtakKlient = mockk(),
+        grunnlagKlient = grunnlagKlient ?: mockk(),
+        sporingslogg = mockk(),
+        featureToggleService = featureToggleService
     )
 
     companion object {

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealGenerellBehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealGenerellBehandlingServiceTest.kt
@@ -560,6 +560,7 @@ class RealGenerellBehandlingServiceTest {
             mockk(),
             mockk(),
             mockk(),
+            mockk(),
             featureToggleService
         )
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingIntegrationTest.kt
@@ -90,7 +90,8 @@ class RevurderingIntegrationTest : BehandlingIntegrationTest() {
                 sakId = sak.id,
                 forrigeBehandling = behandling!!,
                 revurderingAarsak = RevurderingAarsak.REGULERING,
-                kilde = Vedtaksloesning.GJENNY
+                kilde = Vedtaksloesning.GJENNY,
+                paaGrunnAvHendelse = null
             )
 
         inTransaction {
@@ -140,7 +141,8 @@ class RevurderingIntegrationTest : BehandlingIntegrationTest() {
                 sakId = sak.id,
                 forrigeBehandling = behandling!!,
                 revurderingAarsak = RevurderingAarsak.REGULERING,
-                kilde = Vedtaksloesning.GJENNY
+                kilde = Vedtaksloesning.GJENNY,
+                paaGrunnAvHendelse = null
             )
         )
     }
@@ -202,7 +204,8 @@ class RevurderingIntegrationTest : BehandlingIntegrationTest() {
                 sakId = sak.id,
                 forrigeBehandling = behandling!!,
                 revurderingAarsak = RevurderingAarsak.REGULERING,
-                kilde = Vedtaksloesning.GJENNY
+                kilde = Vedtaksloesning.GJENNY,
+                paaGrunnAvHendelse = hendelse.id
             )
 
         inTransaction {

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseDaoTest.kt
@@ -326,7 +326,7 @@ internal class GrunnlagsendringshendelseDaoTest {
                 sakId = sak1,
                 fnr = grunnlagsinformasjonDoedshendelse().avdoedFnr,
                 type = grunnlagsendringstype,
-                status = GrunnlagsendringStatus.TATT_MED_I_BEHANDLING,
+                status = GrunnlagsendringStatus.SJEKKET_AV_JOBB,
                 samsvarMellomKildeOgGrunnlag = null
             )
         ).forEach {

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseDaoTest.kt
@@ -3,13 +3,18 @@ package no.nav.etterlatte.grunnlagsendring
 import no.nav.etterlatte.behandling.BehandlingDao
 import no.nav.etterlatte.behandling.domain.GrunnlagsendringStatus
 import no.nav.etterlatte.behandling.domain.GrunnlagsendringsType
+import no.nav.etterlatte.behandling.domain.OpprettBehandling
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.grunnlagsendringshendelseMedSamsvar
 import no.nav.etterlatte.grunnlagsinformasjonDoedshendelse
 import no.nav.etterlatte.grunnlagsinformasjonForelderBarnRelasjonHendelse
 import no.nav.etterlatte.grunnlagsinformasjonUtflyttingshendelse
 import no.nav.etterlatte.ikkeSamsvarMellomPdlOgGrunnlagDoed
+import no.nav.etterlatte.libs.common.Vedtaksloesning
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.Persongalleri
+import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -22,6 +27,9 @@ import no.nav.etterlatte.samsvarMellomPdlOgGrunnlagDoed
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -335,6 +343,89 @@ internal class GrunnlagsendringshendelseDaoTest {
         grunnlagsendringshendelsesRepo.settBehandlingIdForTattMedIBehandling(hendelseId, opprettBehandling.id)
         val lagretHendelse = grunnlagsendringshendelsesRepo.hentGrunnlagsendringshendelse(hendelseId)
         assertEquals(opprettBehandling.id, lagretHendelse?.behandlingId)
+    }
+
+    @Test
+    fun `kobleGrunnlagsendringshendelserFraBehandlingId skal oppdatere riktige grunnlagsendringshendelser`() {
+        val sak1 = sakRepo.opprettSak("1", SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr).id
+        val sak2 = sakRepo.opprettSak("2", SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr).id
+
+        val behandling1 = OpprettBehandling(
+            type = BehandlingType.REVURDERING,
+            sakId = sak1,
+            status = BehandlingStatus.OPPRETTET,
+            persongalleri = Persongalleri(
+                soeker = "12312312312",
+                innsender = null,
+                soesken = listOf(),
+                avdoed = listOf(),
+                gjenlevende = listOf()
+            ),
+            soeknadMottattDato = null,
+            kommerBarnetTilgode = null,
+            virkningstidspunkt = null,
+            revurderingsAarsak = RevurderingAarsak.SOESKENJUSTERING,
+            opphoerAarsaker = listOf(),
+            fritekstAarsak = null,
+            prosesstype = Prosesstype.MANUELL,
+            kilde = Vedtaksloesning.GJENNY,
+            merknad = null
+        )
+        val behandling2 = behandling1.copy(sakId = sak2)
+        assertNotEquals(behandling1.id, behandling2.id)
+
+        behandlingRepo.opprettBehandling(
+            behandling = behandling1
+        )
+        behandlingRepo.opprettBehandling(behandling = behandling2)
+
+        val id1 = UUID.randomUUID()
+        val id2 = UUID.randomUUID()
+        val id3 = UUID.randomUUID()
+        val doedsdato = LocalDate.of(2022, 7, 21)
+        val samsvarMellomPdlOgGrunnlag = ikkeSamsvarMellomPdlOgGrunnlagDoed(doedsdato)
+        val fnrDoedshendelse = grunnlagsinformasjonDoedshendelse().avdoedFnr
+
+        listOf(
+            grunnlagsendringshendelseMedSamsvar(
+                id = id1,
+                sakId = sak1,
+                fnr = fnrDoedshendelse,
+                samsvarMellomKildeOgGrunnlag = samsvarMellomPdlOgGrunnlag,
+                status = GrunnlagsendringStatus.SJEKKET_AV_JOBB
+            ),
+            grunnlagsendringshendelseMedSamsvar(
+                id = id2,
+                sakId = sak1,
+                fnr = fnrDoedshendelse,
+                samsvarMellomKildeOgGrunnlag = samsvarMellomPdlOgGrunnlag,
+                status = GrunnlagsendringStatus.SJEKKET_AV_JOBB
+            ),
+            grunnlagsendringshendelseMedSamsvar(
+                id = id3,
+                sakId = sak2,
+                fnr = fnrDoedshendelse,
+                samsvarMellomKildeOgGrunnlag = samsvarMellomPdlOgGrunnlag,
+                status = GrunnlagsendringStatus.SJEKKET_AV_JOBB
+            )
+        ).forEach {
+            grunnlagsendringshendelsesRepo.opprettGrunnlagsendringshendelse(it)
+        }
+
+        grunnlagsendringshendelsesRepo.settBehandlingIdForTattMedIBehandling(id1, behandling1.id)
+        grunnlagsendringshendelsesRepo.settBehandlingIdForTattMedIBehandling(id3, behandling2.id)
+
+        grunnlagsendringshendelsesRepo.kobleGrunnlagsendringshendelserFraBehandlingId(behandling1.id)
+
+        val hendelse1 = grunnlagsendringshendelsesRepo.hentGrunnlagsendringshendelse(id1)
+        val hendelse2 = grunnlagsendringshendelsesRepo.hentGrunnlagsendringshendelse(id2)
+        val hendelse3 = grunnlagsendringshendelsesRepo.hentGrunnlagsendringshendelse(id3)
+
+        assertEquals(GrunnlagsendringStatus.SJEKKET_AV_JOBB, hendelse1?.status)
+        assertNull(hendelse1?.behandlingId)
+        assertEquals(GrunnlagsendringStatus.SJEKKET_AV_JOBB, hendelse2?.status)
+        assertEquals(GrunnlagsendringStatus.TATT_MED_I_BEHANDLING, hendelse3?.status)
+        assertNotNull(hendelse3?.behandlingId)
     }
 
     @Test

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/OpprettRevurderingModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/OpprettRevurderingModal.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { opprettRevurdering as opprettRevurderingApi } from '~shared/api/behandling'
 import { isPending, useApiCall } from '~shared/hooks/useApiCall'
 import { Grunnlagsendringshendelse } from '~components/person/typer'
-import { Revurderingsaarsak } from '~shared/types/Revurderingsaarsak'
+import { Revurderingsaarsak, tekstRevurderingsaarsak } from '~shared/types/Revurderingsaarsak'
 import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 import { useNavigate } from 'react-router-dom'
 
@@ -12,7 +12,7 @@ type Props = {
   open: boolean
   setOpen: (value: boolean) => void
   sakId: number
-  revurderinger: Array<string>
+  revurderinger: Array<Revurderingsaarsak>
   valgtHendelse?: Grunnlagsendringshendelse
 }
 const OpprettRevurderingModal = (props: Props) => {
@@ -59,7 +59,7 @@ const OpprettRevurderingModal = (props: Props) => {
                 <option value={''}>Velg en årsak</option>
                 {revurderinger.map((aarsak) => (
                   <option value={aarsak} key={aarsak}>
-                    {aarsak}
+                    {tekstRevurderingsaarsak[aarsak]}
                   </option>
                 ))}
               </Select>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/OpprettRevurderingModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/OpprettRevurderingModal.tsx
@@ -13,10 +13,10 @@ type Props = {
   setOpen: (value: boolean) => void
   sakId: number
   revurderinger: Array<string>
-  valgtHendelse: Grunnlagsendringshendelse
+  valgtHendelse?: Grunnlagsendringshendelse
 }
 const OpprettRevurderingModal = (props: Props) => {
-  const { revurderinger } = props
+  const { revurderinger, valgtHendelse } = props
   const [error, setError] = useState<string | null>(null)
   const [valgtAarsak, setValgtAarsak] = useState<Revurderingsaarsak | undefined>(undefined)
   const [opprettRevurderingStatus, opprettRevurdering] = useApiCall(opprettRevurderingApi)
@@ -28,7 +28,7 @@ const OpprettRevurderingModal = (props: Props) => {
     }
 
     opprettRevurdering(
-      { sakId: props.sakId, aarsak: valgtAarsak },
+      { sakId: props.sakId, aarsak: valgtAarsak, paaGrunnAvHendelseId: valgtHendelse?.id },
       (revurdering: IDetaljertBehandling) => {
         navigate(`/behandling/${revurdering.id}/`)
       },

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
@@ -94,6 +94,7 @@ export const lagreBegrunnelseKommerBarnetTilgode = async (args: {
 export const opprettRevurdering = async (args: {
   sakId: number
   aarsak: Revurderingsaarsak
+  paaGrunnAvHendelseId?: string
 }): Promise<ApiResponse<IDetaljertBehandling>> => {
   return apiClient.post(`/revurdering/${args.sakId}`, {
     aarsak: args.aarsak,


### PR DESCRIPTION
Det betyr at når du oppretter en revurdering på grunn av en hendelse kobler vi hendelsen på behandlingen, slik at den forsvinner fra oppgavelisten.

Hvis behandlingen avbrytes kobles hendelsen i fra igjen, slik at den dukker opp i oppgavelisten / saksoversikten igjen.

Mangler fiksing av tester på flyten når man avbryter en behandling som har hendelse(r) koblet opp