### PR TITLE
Viser liste med revurderingsårsaker basert på sakstype

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
@@ -15,6 +15,7 @@ import no.nav.etterlatte.behandling.domain.toDetaljertBehandling
 import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
+import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.sakId
 
 internal fun Route.revurderingRoutes(
@@ -53,10 +54,13 @@ internal fun Route.revurderingRoutes(
         }
     }
 
-    route("/api/stoettederevurderinger") {
+    route("/api/stoettederevurderinger/{saktype}") {
         get {
+            val sakType = call.parameters["saktype"]?.let { runCatching { SakType.valueOf(it) }.getOrNull() }
+                ?: return@get call.respond(HttpStatusCode.BadRequest, "Ugyldig saktype")
+
             val stoettedeRevurderinger = RevurderingAarsak.values()
-                .filter { it.kanBrukesIMiljo() }
+                .filter { it.kanBrukesIMiljo() && it.gyldigForSakType(sakType) }
                 .map { it.name }
             call.respond(stoettedeRevurderinger)
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
@@ -39,6 +39,12 @@ internal fun Route.revurderingRoutes(
                 return@post
             }
             generellBehandlingService.hentSisteIverksatte(sakId)?.let { forrigeIverksatteBehandling ->
+                val sakType = forrigeIverksatteBehandling.sak.sakType
+                if (!body.aarsak.gyldigForSakType(sakType)) {
+                    call.respond(HttpStatusCode.BadRequest, "${body.aarsak} er ikke støttet for $sakType")
+                    return@post
+                }
+
                 val revurdering = revurderingService.opprettManuellRevurdering(
                     sakId = forrigeIverksatteBehandling.sak.id,
                     forrigeBehandling = forrigeIverksatteBehandling,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/saksoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/saksoversikt.tsx
@@ -35,12 +35,15 @@ export const Saksoversikt = ({ fnr }: { fnr: string | undefined }) => {
   const [hentStoettedeRevurderingerStatus, hentStoettedeRevurderingerFc] = useApiCall(hentStoettedeRevurderinger)
   const [revurderinger, setStoettedeRevurderinger] = useState<Array<Revurderingsaarsak> | undefined>(undefined)
   useEffect(() => {
-    hentStoettedeRevurderingerFc(
-      {},
-      (ans) => setStoettedeRevurderinger(ans),
-      () => {}
-    )
-  }, [])
+    if (behandlingliste.length > 0) {
+      hentStoettedeRevurderingerFc(
+        // TODO saksoversikt burde ha et forhold til saktype uten å måtte se på behandlinger
+        { sakType: behandlingliste[0].sakType },
+        (ans) => setStoettedeRevurderinger(ans),
+        () => {}
+      )
+    }
+  }, [behandlingliste])
 
   useEffect(() => {
     if (!sakId) return resetPersoner

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
@@ -9,6 +9,7 @@ import { apiClient, ApiResponse } from './apiClient'
 import { ManueltOpphoerDetaljer } from '~components/behandling/manueltopphoeroversikt/ManueltOpphoerOversikt'
 import { Grunnlagsendringshendelse } from '~components/person/typer'
 import { Revurderingsaarsak } from '~shared/types/Revurderingsaarsak'
+import { ISaksType } from '~components/behandling/fargetags/saksType'
 
 export const hentBehandlingerForPerson = async (fnr: string): Promise<ApiResponse<any>> => {
   return apiClient.post(`/personer/behandlinger`, { foedselsnummer: fnr })
@@ -99,8 +100,10 @@ export const opprettRevurdering = async (args: {
   })
 }
 
-export const hentStoettedeRevurderinger = async (): Promise<ApiResponse<Array<Revurderingsaarsak>>> => {
-  return apiClient.get(`/stoettederevurderinger`)
+export const hentStoettedeRevurderinger = async (args: {
+  sakType: ISaksType
+}): Promise<ApiResponse<Array<Revurderingsaarsak>>> => {
+  return apiClient.get(`/stoettederevurderinger/${args.sakType}`)
 }
 
 export const lagreUtenlandstilsnitt = async (args: {

--- a/libs/saksbehandling-common/src/main/kotlin/behandling/RevurderingAarsak.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/behandling/RevurderingAarsak.kt
@@ -1,13 +1,21 @@
 package no.nav.etterlatte.libs.common.behandling
 
-enum class RevurderingAarsak(val kanBrukesDev: Boolean, val kanBrukesProd: Boolean) {
-    REGULERING(true, true),
-    ANSVARLIGE_FORELDRE(false, false),
-    SOESKENJUSTERING(true, false),
-    UTLAND(false, false),
-    BARN(false, false),
-    DOEDSFALL(true, false),
-    VERGEMAAL_ELLER_FREMTIDSFULLMAKT(false, false);
+private val SAKTYPE_OMS = listOf(SakType.OMSTILLINGSSTOENAD)
+private val SAKTYPE_BP = listOf(SakType.BARNEPENSJON)
+private val SAKTYPE_BEGGE = SAKTYPE_BP + SAKTYPE_OMS
+
+enum class RevurderingAarsak(
+    val gyldigForSakTyper: List<SakType>,
+    val kanBrukesDev: Boolean,
+    val kanBrukesProd: Boolean
+) {
+    ANSVARLIGE_FORELDRE(SAKTYPE_BP, false, false),
+    SOESKENJUSTERING(SAKTYPE_BP, true, false),
+    UTLAND(SAKTYPE_BP, false, false),
+    BARN(SAKTYPE_BP, false, false),
+    VERGEMAAL_ELLER_FREMTIDSFULLMAKT(SAKTYPE_BP, false, false),
+    REGULERING(SAKTYPE_BEGGE, true, true),
+    DOEDSFALL(SAKTYPE_BEGGE, true, false);
 
     fun kanBrukesIMiljo(): Boolean {
         val env = System.getenv()
@@ -21,6 +29,8 @@ enum class RevurderingAarsak(val kanBrukesDev: Boolean, val kanBrukesProd: Boole
             return this.kanBrukesDev
         }
     }
+
+    fun gyldigForSakType(sakType: SakType): Boolean = gyldigForSakTyper.any { it == sakType }
 }
 
 enum class GcpEnv(val env: String) {

--- a/libs/saksbehandling-common/src/main/kotlin/behandling/RevurderingAarsak.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/behandling/RevurderingAarsak.kt
@@ -2,10 +2,10 @@ package no.nav.etterlatte.libs.common.behandling
 
 private val SAKTYPE_OMS = listOf(SakType.OMSTILLINGSSTOENAD)
 private val SAKTYPE_BP = listOf(SakType.BARNEPENSJON)
-private val SAKTYPE_BEGGE = SAKTYPE_BP + SAKTYPE_OMS
+private val SAKTYPE_BP_OMS = SAKTYPE_BP + SAKTYPE_OMS
 
 enum class RevurderingAarsak(
-    val gyldigForSakTyper: List<SakType>,
+    val gyldigFor: List<SakType>,
     val kanBrukesDev: Boolean,
     val kanBrukesProd: Boolean
 ) {
@@ -14,8 +14,8 @@ enum class RevurderingAarsak(
     UTLAND(SAKTYPE_BP, false, false),
     BARN(SAKTYPE_BP, false, false),
     VERGEMAAL_ELLER_FREMTIDSFULLMAKT(SAKTYPE_BP, false, false),
-    REGULERING(SAKTYPE_BEGGE, true, true),
-    DOEDSFALL(SAKTYPE_BEGGE, true, false);
+    REGULERING(SAKTYPE_BP_OMS, true, true),
+    DOEDSFALL(SAKTYPE_BP_OMS, true, false);
 
     fun kanBrukesIMiljo(): Boolean {
         val env = System.getenv()
@@ -30,7 +30,7 @@ enum class RevurderingAarsak(
         }
     }
 
-    fun gyldigForSakType(sakType: SakType): Boolean = gyldigForSakTyper.any { it == sakType }
+    fun gyldigForSakType(sakType: SakType): Boolean = gyldigFor.any { it == sakType }
 }
 
 enum class GcpEnv(val env: String) {


### PR DESCRIPTION
- Oppdaterer dropdown-liste med gyldige revurderingsårsaker basert på sakstype
- Validerer at en ny revurdering ikke kan opprettes for en revurderingsårsak som ikke er støttet for sakstypen

EY-2262 