### PR TITLE
Støtte for flere trygdetidsperioder

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
@@ -17,6 +17,7 @@ import styled from 'styled-components'
 import { BodyShort } from '@navikt/ds-react'
 import { useParams } from 'react-router-dom'
 import { Grunnlagopplysninger } from '~components/behandling/trygdetid/Grunnlagopplysninger'
+import { TrygdetidGrunnlagListe } from '~components/behandling/trygdetid/TrygdetidGrunnlagListe'
 
 export const Trygdetid = () => {
   const { behandlingId } = useParams()
@@ -73,6 +74,23 @@ export const Trygdetid = () => {
       {trygdetid && landListe && (
         <>
           <Grunnlagopplysninger opplysninger={trygdetid.opplysninger} />
+
+          <br />
+          <TrygdetidGrunnlagListe
+            trygdetid={trygdetid}
+            setTrygdetid={setTrygdetid}
+            landListe={landListe}
+            trygdetidGrunnlagType={ITrygdetidGrunnlagType.FAKTISK}
+          />
+          <br />
+          <TrygdetidGrunnlagListe
+            trygdetid={trygdetid}
+            setTrygdetid={setTrygdetid}
+            landListe={landListe}
+            trygdetidGrunnlagType={ITrygdetidGrunnlagType.FREMTIDIG}
+          />
+          <br />
+          <br />
           <TrygdetidGrunnlag
             trygdetid={trygdetid}
             setTrygdetid={setTrygdetid}
@@ -102,5 +120,5 @@ export const Trygdetid = () => {
 }
 const TrygdetidWrapper = styled.div`
   padding: 0 4em;
-  max-width: 52em;
+  max-width: 69em;
 `

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react'
-import { TrygdetidGrunnlag } from '~components/behandling/trygdetid/TrygdetidGrunnlag'
 import { isFailure, isPending, useApiCall } from '~shared/hooks/useApiCall'
 import {
   hentAlleLand,
@@ -75,33 +74,17 @@ export const Trygdetid = () => {
         <>
           <Grunnlagopplysninger opplysninger={trygdetid.opplysninger} />
 
-          <br />
           <TrygdetidGrunnlagListe
             trygdetid={trygdetid}
             setTrygdetid={setTrygdetid}
             landListe={landListe}
             trygdetidGrunnlagType={ITrygdetidGrunnlagType.FAKTISK}
           />
-          <br />
           <TrygdetidGrunnlagListe
             trygdetid={trygdetid}
             setTrygdetid={setTrygdetid}
             landListe={landListe}
             trygdetidGrunnlagType={ITrygdetidGrunnlagType.FREMTIDIG}
-          />
-          <br />
-          <br />
-          <TrygdetidGrunnlag
-            trygdetid={trygdetid}
-            setTrygdetid={setTrygdetid}
-            trygdetidGrunnlagType={ITrygdetidGrunnlagType.FAKTISK}
-            landListe={landListe}
-          />
-          <TrygdetidGrunnlag
-            trygdetid={trygdetid}
-            setTrygdetid={setTrygdetid}
-            trygdetidGrunnlagType={ITrygdetidGrunnlagType.FREMTIDIG}
-            landListe={landListe}
           />
           <TrygdetidBeregnet trygdetid={trygdetid} setTrygdetid={setTrygdetid} />
         </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlag.tsx
@@ -1,4 +1,4 @@
-import { Button, Heading, Label, Select, Textarea } from '@navikt/ds-react'
+import { Button, Label, Select, Textarea } from '@navikt/ds-react'
 import { FormKnapper, FormWrapper, Innhold } from '~components/behandling/trygdetid/styled'
 import { isFailure, isPending, useApiCall } from '~shared/hooks/useApiCall'
 import {
@@ -14,12 +14,11 @@ import styled from 'styled-components'
 import DatePicker from 'react-datepicker'
 import { Calender } from '@navikt/ds-icons'
 import { useParams } from 'react-router-dom'
-import { Info } from '~components/behandling/soeknadsoversikt/Info'
-import { formaterStringDato } from '~utils/formattering'
 
 type Props = {
-  trygdetid: ITrygdetid
+  eksisterendeGrunnlag: ITrygdetidGrunnlag | undefined
   setTrygdetid: (trygdetid: ITrygdetid) => void
+  avbryt: () => void
   trygdetidGrunnlagType: ITrygdetidGrunnlagType
   landListe: ILand[]
 }
@@ -35,9 +34,14 @@ const initialState = (type: ITrygdetidGrunnlagType) => {
   }
 }
 
-export const TrygdetidGrunnlag: React.FC<Props> = ({ trygdetid, setTrygdetid, trygdetidGrunnlagType, landListe }) => {
+export const TrygdetidGrunnlag: React.FC<Props> = ({
+  eksisterendeGrunnlag,
+  setTrygdetid,
+  avbryt,
+  trygdetidGrunnlagType,
+  landListe,
+}) => {
   const { behandlingId } = useParams()
-  const eksisterendeGrunnlag = trygdetid.trygdetidGrunnlag.find((grunnlag) => grunnlag.type === trygdetidGrunnlagType)
   const [trygdetidgrunnlag, setTrygdetidgrunnlag] = useState<ITrygdetidGrunnlag>(
     eksisterendeGrunnlag ? eksisterendeGrunnlag : initialState(trygdetidGrunnlagType)
   )
@@ -54,9 +58,6 @@ export const TrygdetidGrunnlag: React.FC<Props> = ({ trygdetid, setTrygdetid, tr
     }
   }
 
-  const beregnetTrygdetid = eksisterendeGrunnlag?.beregnet
-    ? `${eksisterendeGrunnlag.beregnet.aar} år ${eksisterendeGrunnlag.beregnet.maaneder} måneder ${eksisterendeGrunnlag.beregnet.dager} dager`
-    : '-'
   const onSubmit = (e: FormEvent) => {
     e.preventDefault()
     if (!behandlingId) throw new Error('Mangler behandlingsid')
@@ -77,26 +78,6 @@ export const TrygdetidGrunnlag: React.FC<Props> = ({ trygdetid, setTrygdetid, tr
 
   return (
     <TrygdetidGrunnlagWrapper>
-      {
-        {
-          [ITrygdetidGrunnlagType.FAKTISK]: (
-            <>
-              <Heading spacing size="small" level="3">
-                Faktisk trygdetid
-              </Heading>
-              <p>Legg til trygdetid fra avdøde var 16 år frem til hen døde.</p>
-            </>
-          ),
-          [ITrygdetidGrunnlagType.FREMTIDIG]: (
-            <>
-              <Heading spacing size="small" level="3">
-                Fremtidig trygdetid
-              </Heading>
-              <p>Legg til trygdetid fra dødsdato til og med kalenderåret avdøde hadde blitt 66 år.</p>
-            </>
-          ),
-        }[trygdetidGrunnlagType]
-      }
       <Innhold>
         <TrygdetidForm onSubmit={onSubmit}>
           <Rows>
@@ -181,25 +162,6 @@ export const TrygdetidGrunnlag: React.FC<Props> = ({ trygdetid, setTrygdetid, tr
                   </KalenderIkon>
                 </Datovelger>
               </DatoSection>
-              <TrygdetidBeregnet>
-                <Label>
-                  {trygdetidGrunnlagType === ITrygdetidGrunnlagType.FREMTIDIG
-                    ? 'Fremtidig trygdetid'
-                    : 'Faktisk trygdetid'}
-                </Label>
-                <div>{beregnetTrygdetid}</div>
-              </TrygdetidBeregnet>
-              {eksisterendeGrunnlag && (
-                <Kilde>
-                  <Label>Kilde</Label>
-
-                  <Info
-                    tekst={eksisterendeGrunnlag.kilde.ident}
-                    label={''}
-                    undertekst={`saksbehandler: ${formaterStringDato(eksisterendeGrunnlag.kilde.tidspunkt)}`}
-                  />
-                </Kilde>
-              )}
             </FormWrapper>
 
             <FormWrapper>
@@ -220,6 +182,15 @@ export const TrygdetidGrunnlag: React.FC<Props> = ({ trygdetid, setTrygdetid, tr
             <FormKnapper>
               <Button size="small" loading={isPending(trygdetidgrunnlagStatus)} type="submit">
                 Lagre
+              </Button>
+              <Button
+                size="small"
+                onClick={(event) => {
+                  event.preventDefault()
+                  avbryt()
+                }}
+              >
+                Avbryt
               </Button>
             </FormKnapper>
           </Rows>
@@ -245,18 +216,6 @@ const Rows = styled.div`
 
 const Land = styled.div`
   width: 250px;
-`
-
-const Kilde = styled.div`
-  width: 250px;
-  display: grid;
-  gap: 0.5em;
-`
-
-const TrygdetidBeregnet = styled.div`
-  width: 220px;
-  display: grid;
-  gap: 0.5em;
 `
 
 const Datovelger = styled.div`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlag.tsx
@@ -7,6 +7,7 @@ import {
   ITrygdetidGrunnlag,
   ITrygdetidGrunnlagType,
   lagreTrygdetidgrunnlag,
+  OppdaterTrygdetidGrunnlag,
 } from '~shared/api/trygdetid'
 import React, { FormEvent, useRef, useState } from 'react'
 import { ApiErrorAlert } from '~ErrorBoundary'
@@ -24,14 +25,7 @@ type Props = {
 }
 
 const initialState = (type: ITrygdetidGrunnlagType) => {
-  return {
-    type: type,
-    bosted: '',
-    kilde: {
-      tidspunkt: '',
-      ident: '',
-    },
-  }
+  return { type: type, bosted: '' }
 }
 
 export const TrygdetidGrunnlag: React.FC<Props> = ({
@@ -42,7 +36,7 @@ export const TrygdetidGrunnlag: React.FC<Props> = ({
   landListe,
 }) => {
   const { behandlingId } = useParams()
-  const [trygdetidgrunnlag, setTrygdetidgrunnlag] = useState<ITrygdetidGrunnlag>(
+  const [trygdetidgrunnlag, setTrygdetidgrunnlag] = useState<OppdaterTrygdetidGrunnlag>(
     eksisterendeGrunnlag ? eksisterendeGrunnlag : initialState(trygdetidGrunnlagType)
   )
   const [trygdetidgrunnlagStatus, requestLagreTrygdetidgrunnlag] = useApiCall(lagreTrygdetidgrunnlag)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlagListe.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlagListe.tsx
@@ -39,7 +39,7 @@ export const TrygdetidGrunnlagListe: React.FC<Props> = ({
   const [endreModus, setEndreModus] = useState(initialEndreModusState)
   const trygdetidGrunnlagListe = trygdetid.trygdetidGrunnlag
     .filter((tg) => tg.type == trygdetidGrunnlagType)
-    .sort((a, b) => (a.periodeFra > b.periodeFra ? 1 : -1))
+    .sort((a, b) => (a.periodeFra!! > b.periodeFra!! ? 1 : -1))
   const grunnlagTypeTekst = trygdetidGrunnlagType == ITrygdetidGrunnlagType.FAKTISK ? 'Faktisk' : 'Fremtidig'
 
   const oppdaterStateOgSettTrygdetid = (trygdetid: ITrygdetid) => {
@@ -88,6 +88,7 @@ export const TrygdetidGrunnlagListe: React.FC<Props> = ({
                       setEndreModus({ status: true, trygdetidGrunnlagId: trygdetidGrunnlagId })
                     }}
                     landListe={landListe}
+                    key={periode.id}
                   />
                 )
               })}
@@ -151,7 +152,6 @@ const PeriodeRow = ({
   return (
     <Table.ExpandableRow
       expansionDisabled={!trygdetidGrunnlag.begrunnelse}
-      key={trygdetidGrunnlag.id}
       content={
         <div>
           <Heading size={'small'}>Begrunnelse</Heading>
@@ -160,7 +160,7 @@ const PeriodeRow = ({
       }
     >
       <Table.DataCell>
-        {landListe.find((land) => land.isoLandkode == trygdetidGrunnlag.bosted).beskrivelse.tekst}
+        {landListe.find((land) => land.isoLandkode == trygdetidGrunnlag.bosted)?.beskrivelse?.tekst}
       </Table.DataCell>
       <Table.DataCell>
         <Datofelt>{formaterStringDato(trygdetidGrunnlag.periodeFra!!)}</Datofelt>
@@ -181,7 +181,7 @@ const PeriodeRow = ({
       </Table.DataCell>
       <Table.DataCell>
         {isPending(slettTrygdetidStatus) ? (
-          <Spinner visible="true" variant={'neutral'} label="Sletter" margin={'1em'} />
+          <Spinner visible={true} variant={'neutral'} label="Sletter" margin={'1em'} />
         ) : (
           <RedigerWrapper onClick={() => slettGrunnlag(trygdetidGrunnlag.id!!)}>Slett</RedigerWrapper>
         )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlagListe.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlagListe.tsx
@@ -38,7 +38,7 @@ export const TrygdetidGrunnlagListe: React.FC<Props> = ({
   const [endreModus, setEndreModus] = useState(initialEndreModusState)
   const trygdetidGrunnlagListe = trygdetid.trygdetidGrunnlag
     .filter((tg) => tg.type == trygdetidGrunnlagType)
-    .sort((a, b) => (a.periodeFra!! > b.periodeFra!! ? 1 : -1))
+    .sort((a, b) => (a.periodeFra > b.periodeFra ? 1 : -1))
   const grunnlagTypeTekst = trygdetidGrunnlagType == ITrygdetidGrunnlagType.FAKTISK ? 'Faktisk' : 'Fremtidig'
 
   const oppdaterStateOgSettTrygdetid = (trygdetid: ITrygdetid) => {
@@ -162,10 +162,10 @@ const PeriodeRow = ({
         {landListe.find((land) => land.isoLandkode == trygdetidGrunnlag.bosted)?.beskrivelse?.tekst}
       </Table.DataCell>
       <Table.DataCell>
-        <Datofelt>{formaterStringDato(trygdetidGrunnlag.periodeFra!!)}</Datofelt>
+        <Datofelt>{formaterStringDato(trygdetidGrunnlag.periodeFra)}</Datofelt>
       </Table.DataCell>
       <Table.DataCell>
-        <Datofelt>{formaterStringDato(trygdetidGrunnlag.periodeTil!!)}</Datofelt>
+        <Datofelt>{formaterStringDato(trygdetidGrunnlag.periodeTil)}</Datofelt>
       </Table.DataCell>
       <Table.DataCell>{beregnetTrygdetid}</Table.DataCell>
       <Table.DataCell>
@@ -173,13 +173,13 @@ const PeriodeRow = ({
         <Detail>{`saksbehandler: ${formaterStringDato(trygdetidGrunnlag.kilde.tidspunkt)}`}</Detail>
       </Table.DataCell>
       <Table.DataCell>
-        <RedigerWrapper onClick={() => endrePeriode(trygdetidGrunnlag.id!!)}>Rediger</RedigerWrapper>
+        <RedigerWrapper onClick={() => endrePeriode(trygdetidGrunnlag.id)}>Rediger</RedigerWrapper>
       </Table.DataCell>
       <Table.DataCell>
         {isPending(slettTrygdetidStatus) ? (
           <Spinner visible={true} variant={'neutral'} label="Sletter" margin={'1em'} />
         ) : (
-          <RedigerWrapper onClick={() => slettGrunnlag(trygdetidGrunnlag.id!!)}>Slett</RedigerWrapper>
+          <RedigerWrapper onClick={() => slettGrunnlag(trygdetidGrunnlag.id)}>Slett</RedigerWrapper>
         )}
         {isFailure(slettTrygdetidStatus) && <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>}
       </Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlagListe.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlagListe.tsx
@@ -1,0 +1,149 @@
+import {
+  ILand,
+  ITrygdetid,
+  ITrygdetidGrunnlag,
+  ITrygdetidGrunnlagType,
+  slettTrygdetidsgrunnlag,
+} from '~shared/api/trygdetid'
+import { FlexHeader, IconWrapper, TableWrapper } from '~components/behandling/soeknadsoversikt/familieforhold/styled'
+import { IconSize } from '~shared/types/Icon'
+import { Button, Heading, Table } from '@navikt/ds-react'
+import { CalendarIcon } from '@navikt/aksel-icons'
+import { Info } from '~components/behandling/soeknadsoversikt/Info'
+import { formaterStringDato } from '~utils/formattering'
+import React from 'react'
+import styled from 'styled-components'
+import { useApiCall } from '~shared/hooks/useApiCall'
+
+type Props = {
+  trygdetid: ITrygdetid
+  setTrygdetid: (trygdetid: ITrygdetid) => void
+  trygdetidGrunnlagType: ITrygdetidGrunnlagType
+  landListe: ILand[]
+}
+
+export const TrygdetidGrunnlagListe: React.FC<Props> = ({
+  trygdetid,
+  setTrygdetid,
+  trygdetidGrunnlagType,
+  landListe,
+}) => {
+  const [nyTrygdetid, slettTrygdetidsgrunnlagRequest] = useApiCall(slettTrygdetidsgrunnlag)
+  const trygdetidGrunnlagListe = trygdetid.trygdetidGrunnlag.filter((tg) => tg.type == trygdetidGrunnlagType)
+  const grunnlagTypeTekst = trygdetidGrunnlagType == ITrygdetidGrunnlagType.FAKTISK ? 'Faktisk' : 'Fremtidig'
+
+  const slettTrygdetid = (grunnlagId: string) => {
+    slettTrygdetidsgrunnlagRequest(
+      {
+        behandlingsId: trygdetid.behandlingId,
+        trygdetidGrunnlagId: grunnlagId,
+      },
+      (oppdatertTrygdetid) => {
+        setTrygdetid(oppdatertTrygdetid)
+      }
+    )
+  }
+
+  return (
+    <div>
+      <FlexHeader>
+        <IconWrapper>
+          <CalendarIcon fontSize={IconSize.DEFAULT} />
+        </IconWrapper>
+        <Heading size={'small'} level={'3'}>
+          {grunnlagTypeTekst} trygdetid
+        </Heading>
+      </FlexHeader>
+      {trygdetidGrunnlagListe.length ? (
+        <TableWrapper>
+          <Table size={'medium'}>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell />
+                <Table.HeaderCell scope={'col'}>Land</Table.HeaderCell>
+                <Table.HeaderCell scope={'col'}>Fra dato</Table.HeaderCell>
+                <Table.HeaderCell scope={'col'}>Til dato</Table.HeaderCell>
+                <Table.HeaderCell scope={'col'}>{grunnlagTypeTekst} trygdetid</Table.HeaderCell>
+                <Table.HeaderCell scope={'col'}>Kilde</Table.HeaderCell>
+                <Table.HeaderCell scope={'col'}> </Table.HeaderCell>
+                <Table.HeaderCell scope={'col'}> </Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {trygdetidGrunnlagListe.map((periode) => {
+                return <PeriodeRow trygdetidGrunnlag={periode} slettGrunnlag={slettTrygdetid} landListe={landListe} />
+              })}
+            </Table.Body>
+          </Table>
+        </TableWrapper>
+      ) : (
+        <p>Ingen perioder registert</p>
+      )}
+
+      <NyPeriode>
+        <Button size="small">Legg til ny periode</Button>
+      </NyPeriode>
+    </div>
+  )
+}
+
+const PeriodeRow = ({
+  trygdetidGrunnlag,
+  slettGrunnlag,
+  landListe,
+}: {
+  trygdetidGrunnlag: ITrygdetidGrunnlag
+  slettGrunnlag: (grunnlagId: string) => void
+  landListe: ILand[]
+}) => {
+  const beregnetTrygdetid = trygdetidGrunnlag?.beregnet
+    ? `${trygdetidGrunnlag.beregnet.aar} år ${trygdetidGrunnlag.beregnet.maaneder} måneder ${trygdetidGrunnlag.beregnet.dager} dager`
+    : '-'
+
+  return (
+    <Table.ExpandableRow key={trygdetidGrunnlag.id} content="Her kommer beskrivelse.">
+      <Table.DataCell>
+        {landListe.find((land) => land.isoLandkode == trygdetidGrunnlag.bosted).beskrivelse.tekst}
+      </Table.DataCell>
+      <Table.DataCell>
+        <Datofelt>{formaterStringDato(trygdetidGrunnlag.periodeFra!!)}</Datofelt>
+      </Table.DataCell>
+      <Table.DataCell>
+        <Datofelt>{formaterStringDato(trygdetidGrunnlag.periodeTil!!)}</Datofelt>
+      </Table.DataCell>
+      <Table.DataCell>{beregnetTrygdetid}</Table.DataCell>
+      <Table.DataCell>
+        <Info
+          tekst={trygdetidGrunnlag.kilde.ident}
+          label={''}
+          undertekst={`saksbehandler: ${formaterStringDato(trygdetidGrunnlag.kilde.tidspunkt)}`}
+        />
+      </Table.DataCell>
+      <Table.DataCell>
+        <RedigerWrapper>Rediger</RedigerWrapper>
+      </Table.DataCell>
+      <Table.DataCell>
+        <RedigerWrapper onClick={() => slettGrunnlag(trygdetidGrunnlag.id!!)}>Slett</RedigerWrapper>
+      </Table.DataCell>
+    </Table.ExpandableRow>
+  )
+}
+
+const Datofelt = styled.div`
+  width: 5em;
+`
+
+const RedigerWrapper = styled.div`
+  display: inline-flex;
+  float: left;
+  cursor: pointer;
+  color: #0067c5;
+
+  &:hover {
+    text-decoration-line: underline;
+  }
+`
+
+const NyPeriode = styled.div`
+  margin-top: 1em;
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlagListe.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlagListe.tsx
@@ -7,9 +7,8 @@ import {
 } from '~shared/api/trygdetid'
 import { FlexHeader, IconWrapper, TableWrapper } from '~components/behandling/soeknadsoversikt/familieforhold/styled'
 import { IconSize } from '~shared/types/Icon'
-import { Button, Heading, Table } from '@navikt/ds-react'
+import { BodyShort, Button, Detail, Heading, Table } from '@navikt/ds-react'
 import { CalendarIcon } from '@navikt/aksel-icons'
-import { Info } from '~components/behandling/soeknadsoversikt/Info'
 import { formaterStringDato } from '~utils/formattering'
 import React, { useState } from 'react'
 import styled from 'styled-components'
@@ -170,11 +169,8 @@ const PeriodeRow = ({
       </Table.DataCell>
       <Table.DataCell>{beregnetTrygdetid}</Table.DataCell>
       <Table.DataCell>
-        <Info
-          tekst={trygdetidGrunnlag.kilde.ident}
-          label={''}
-          undertekst={`saksbehandler: ${formaterStringDato(trygdetidGrunnlag.kilde.tidspunkt)}`}
-        />
+        <BodyShort>{trygdetidGrunnlag.kilde.ident}</BodyShort>
+        <Detail>{`saksbehandler: ${formaterStringDato(trygdetidGrunnlag.kilde.tidspunkt)}`}</Detail>
       </Table.DataCell>
       <Table.DataCell>
         <RedigerWrapper onClick={() => endrePeriode(trygdetidGrunnlag.id!!)}>Rediger</RedigerWrapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlagListe.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlagListe.tsx
@@ -37,7 +37,9 @@ export const TrygdetidGrunnlagListe: React.FC<Props> = ({
   landListe,
 }) => {
   const [endreModus, setEndreModus] = useState(initialEndreModusState)
-  const trygdetidGrunnlagListe = trygdetid.trygdetidGrunnlag.filter((tg) => tg.type == trygdetidGrunnlagType)
+  const trygdetidGrunnlagListe = trygdetid.trygdetidGrunnlag
+    .filter((tg) => tg.type == trygdetidGrunnlagType)
+    .sort((a, b) => (a.periodeFra > b.periodeFra ? 1 : -1))
   const grunnlagTypeTekst = trygdetidGrunnlagType == ITrygdetidGrunnlagType.FAKTISK ? 'Faktisk' : 'Fremtidig'
 
   const oppdaterStateOgSettTrygdetid = (trygdetid: ITrygdetid) => {
@@ -83,7 +85,6 @@ export const TrygdetidGrunnlagListe: React.FC<Props> = ({
                     behandlingId={trygdetid.behandlingId}
                     setTrygdetid={setTrygdetid}
                     endrePeriode={(trygdetidGrunnlagId) => {
-                      console.log('Endrer periode: ' + trygdetidGrunnlagId)
                       setEndreModus({ status: true, trygdetidGrunnlagId: trygdetidGrunnlagId })
                     }}
                     landListe={landListe}
@@ -148,7 +149,16 @@ const PeriodeRow = ({
     : '-'
 
   return (
-    <Table.ExpandableRow key={trygdetidGrunnlag.id} content="Her kommer beskrivelse.">
+    <Table.ExpandableRow
+      expansionDisabled={!trygdetidGrunnlag.begrunnelse}
+      key={trygdetidGrunnlag.id}
+      content={
+        <div>
+          <Heading size={'small'}>Begrunnelse</Heading>
+          {trygdetidGrunnlag.begrunnelse}
+        </div>
+      }
+    >
       <Table.DataCell>
         {landListe.find((land) => land.isoLandkode == trygdetidGrunnlag.bosted).beskrivelse.tekst}
       </Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/styled.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/styled.tsx
@@ -14,4 +14,7 @@ export const FormKnapper = styled.div`
   margin-top: 1rem;
   margin-right: 1em;
   gap: 1rem;
+  button {
+    margin-right: 1em;
+  }
 `

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
@@ -12,6 +12,12 @@ export const lagreTrygdetidgrunnlag = async (args: {
 }): Promise<ApiResponse<ITrygdetid>> =>
   apiClient.post(`/trygdetid/${args.behandlingsId}/grunnlag`, { ...args.trygdetidgrunnlag })
 
+export const slettTrygdetidsgrunnlag = async (args: {
+  behandlingsId: string
+  trygdetidGrunnlagId: string
+}): Promise<ApiResponse<ITrygdetid>> =>
+  apiClient.delete<ITrygdetid>(`/trygdetid/${args.behandlingsId}/grunnlag/${args.trygdetidGrunnlagId}`)
+
 export const hentAlleLand = async (): Promise<ApiResponse<ILand[]>> =>
   apiClient.get<ILand[]>('/trygdetid/kodeverk/land')
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
@@ -8,7 +8,7 @@ export const opprettTrygdetid = async (behandlingsId: string): Promise<ApiRespon
 
 export const lagreTrygdetidgrunnlag = async (args: {
   behandlingsId: string
-  trygdetidgrunnlag: ITrygdetidGrunnlag
+  trygdetidgrunnlag: OppdaterTrygdetidGrunnlag
 }): Promise<ApiResponse<ITrygdetid>> =>
   apiClient.post(`/trygdetid/${args.behandlingsId}/grunnlag`, { ...args.trygdetidgrunnlag })
 
@@ -49,16 +49,25 @@ export interface IBeregnetTrygdetid {
 }
 
 export interface ITrygdetidGrunnlag {
-  id?: string
+  id: string
   type: ITrygdetidGrunnlagType
   bosted: string
-  periodeFra?: string
-  periodeTil?: string
+  periodeFra: string
+  periodeTil: string
   beregnet?: IBeregnetTrygdetidGrunnlag
   kilde: {
     tidspunkt: string
     ident: string
   }
+  begrunnelse?: string
+}
+
+export interface OppdaterTrygdetidGrunnlag {
+  id?: string
+  type: ITrygdetidGrunnlagType
+  bosted: string
+  periodeFra?: string
+  periodeTil?: string
   begrunnelse?: string
 }
 


### PR DESCRIPTION
Lagt til støtte for å vise en liste av perioder, legge til, endre og slette trygdetidsperioder.

Det er nok et par UX-forbedringer man kan gjøre her, men tenkte å la Mari/Julie for teste litt før jeg gjør for mange finjusteringer.

![Screenshot 2023-06-05 at 13 16 31](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1083866/916e2d1b-dcb8-4848-a21c-deca15f6a41a)

Hvis man trykker "Legg til periode" får man den gamle komponenten opp
![Screenshot 2023-06-05 at 13 22 58](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1083866/74c6e303-4e27-4e02-ac9d-51273b06f6e9)
