### PR TITLE
Fiks outbound for saksbehandling-ui

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/.nais/dev.yaml
+++ b/apps/etterlatte-saksbehandling-ui/.nais/dev.yaml
@@ -87,7 +87,7 @@ spec:
     outbound:
       external:
         - host: navikt.github.io
-        - host: https://login.microsoftonline.com
+        - host: login.microsoftonline.com
         - host: graph.microsoft.com
         - host: unleash.nais.io
       rules:

--- a/apps/etterlatte-saksbehandling-ui/.nais/prod.yaml
+++ b/apps/etterlatte-saksbehandling-ui/.nais/prod.yaml
@@ -86,7 +86,7 @@ spec:
     outbound:
       external:
         - host: navikt.github.io
-        - host: https://login.microsoftonline.com
+        - host: login.microsoftonline.com
         - host: graph.microsoft.com
         - host: unleash.nais.io
       rules:


### PR DESCRIPTION
Frontend har sluttet å deploye, og klager på at host ikke passerer regex-sjekk.

https://github.com/navikt/pensjon-etterlatte-saksbehandling/actions/runs/5185458336/jobs/9345428892

```
Error: Status: failure: nais.io/v1alpha1, Kind=Application, Namespace=etterlatte, Name=etterlatte-saksbehandling-ui: Application.nais.io "etterlatte-saksbehandling-ui" is invalid: spec.accessPolicy.outbound.external[1].host: Invalid value: "https://login.microsoftonline.com/": spec.accessPolicy.outbound.external[1].host in body should match '^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$' (total of 1 errors)
Error: fatal: deployment failed
```

Verifisert OK i DEV: https://github.com/navikt/pensjon-etterlatte-saksbehandling/actions/runs/5185743271