### PR TITLE
EY-2256 Lagre og oppdatere flere enn et avkortingsgrunnlag

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -11,9 +11,42 @@ data class Avkorting(
     val avkortingGrunnlag: List<AvkortingGrunnlag>,
     val avkortingsperioder: List<Avkortingsperiode>,
     val avkortetYtelse: List<AvkortetYtelse>
-)
+) {
+    fun leggTilEllerOppdaterGrunnlag(nyttGrunnlag: AvkortingGrunnlag): Avkorting {
+        val oppdaterteGrunnlag = avkortingGrunnlag
+            .filter { it.id != nyttGrunnlag.id }
+            .map {
+                when (it.periode.tom) {
+                    null -> it.copy(
+                        periode = Periode(fom = it.periode.fom, tom = nyttGrunnlag.periode.fom.minusMonths(1))
+                    )
+
+                    else -> it
+                }
+            } + listOf(nyttGrunnlag)
+        return this.copy(avkortingGrunnlag = oppdaterteGrunnlag)
+    }
+
+    fun oppdaterAvkortingMedNyeBeregninger(
+        nyeAvkortingsperioder: List<Avkortingsperiode>,
+        nyAvkortetYtelse: List<AvkortetYtelse>
+    ): Avkorting = this.copy(
+        avkortingsperioder = nyeAvkortingsperioder,
+        avkortetYtelse = nyAvkortetYtelse
+    )
+
+    companion object {
+        fun nyAvkorting(behandlingId: UUID) = Avkorting(
+            behandlingId,
+            emptyList(),
+            emptyList(),
+            emptyList()
+        )
+    }
+}
 
 data class AvkortingGrunnlag(
+    val id: UUID,
     val periode: Periode,
     val aarsinntekt: Int,
     val fratrekkInnUt: Int,

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
@@ -37,9 +37,9 @@ class AvkortingRepository(private val dataSource: DataSource) {
         } else {
             Avkorting(
                 behandlingId = behandlingId,
-                avkortingGrunnlag = avkortingGrunnlag.toMutableList(),
-                avkortingsperioder = avkortingsperioder.toMutableList(),
-                avkortetYtelse = avkortetYtelse.toMutableList()
+                avkortingGrunnlag = avkortingGrunnlag,
+                avkortingsperioder = avkortingsperioder,
+                avkortetYtelse = avkortetYtelse
             )
         }
     }

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
@@ -37,31 +37,34 @@ class AvkortingRepository(private val dataSource: DataSource) {
         } else {
             Avkorting(
                 behandlingId = behandlingId,
-                avkortingGrunnlag = avkortingGrunnlag,
-                avkortingsperioder = avkortingsperioder,
-                avkortetYtelse = avkortetYtelse
+                avkortingGrunnlag = avkortingGrunnlag.toMutableList(),
+                avkortingsperioder = avkortingsperioder.toMutableList(),
+                avkortetYtelse = avkortetYtelse.toMutableList()
             )
         }
     }
 
-    fun lagreEllerOppdaterAvkorting(
-        behandlingId: UUID,
-        avkortingGrunnlag: List<AvkortingGrunnlag>,
-        avkortingsperioder: List<Avkortingsperiode>,
-        avkortetYtelse: List<AvkortetYtelse>
-    ): Avkorting {
-        dataSource.transaction { tx ->
-            slettAvkorting(behandlingId, tx)
-            lagreAvkortingGrunnlag(behandlingId, avkortingGrunnlag, tx)
-            lagreAvkortingsperioder(behandlingId, avkortingsperioder, tx)
-            lagreAvkortetYtelse(behandlingId, avkortetYtelse, tx)
-        }
-        return hentAvkortingUtenNullable(behandlingId)
-    }
+    fun hentAvkortingUtenNullable(behandlingId: UUID): Avkorting =
+        hentAvkorting(behandlingId) ?: throw Exception("Uthenting av avkorting for behandling $behandlingId feilet")
 
+    fun lagreAvkorting(avkorting: Avkorting): Avkorting {
+        dataSource.transaction { tx ->
+            slettAvkorting(avkorting.behandlingId, tx)
+            lagreAvkortingGrunnlag(avkorting.behandlingId, avkorting.avkortingGrunnlag, tx)
+            lagreAvkortingsperioder(avkorting.behandlingId, avkorting.avkortingsperioder, tx)
+            lagreAvkortetYtelse(avkorting.behandlingId, avkorting.avkortetYtelse, tx)
+        }
+        return hentAvkortingUtenNullable(avkorting.behandlingId)
+    }
     private fun slettAvkorting(behandlingId: UUID, tx: TransactionalSession) {
         queryOf(
             "DELETE FROM avkortingsperioder WHERE behandling_id = ?",
+            behandlingId
+        ).let { query ->
+            tx.run(query.asUpdate)
+        }
+        queryOf(
+            "DELETE FROM avkortet_ytelse WHERE behandling_id  = ?",
             behandlingId
         ).let { query ->
             tx.run(query.asUpdate)
@@ -72,19 +75,13 @@ class AvkortingRepository(private val dataSource: DataSource) {
         ).let { query ->
             tx.run(query.asUpdate)
         }
-        queryOf(
-            "DELETE FROM avkortet_ytelse WHERE behandling_id = ?",
-            behandlingId
-        ).let { query ->
-            tx.run(query.asUpdate)
-        }
     }
 
     private fun lagreAvkortingGrunnlag(
         behandlingId: UUID,
-        avkortingGrunnlag: List<AvkortingGrunnlag>,
+        avkortingsgrunnlag: List<AvkortingGrunnlag>,
         tx: TransactionalSession
-    ) = avkortingGrunnlag.forEach {
+    ) = avkortingsgrunnlag.forEach {
         queryOf(
             statement = """
                 INSERT INTO avkortingsgrunnlag(
@@ -94,7 +91,7 @@ class AvkortingRepository(private val dataSource: DataSource) {
                 )
             """.trimIndent(),
             paramMap = mapOf(
-                "id" to UUID.randomUUID(),
+                "id" to it.id,
                 "behandlingId" to behandlingId,
                 "fom" to it.periode.fom.atDay(1),
                 "tom" to it.periode.tom?.atDay(1),
@@ -163,10 +160,8 @@ class AvkortingRepository(private val dataSource: DataSource) {
             ).let { query -> tx.run(query.asUpdate) }
         }
 
-    private fun hentAvkortingUtenNullable(behandlingId: UUID): Avkorting =
-        hentAvkorting(behandlingId) ?: throw Exception("Uthenting av avkorting for behandling $behandlingId feilet")
-
     private fun Row.toAvkortingsgrunnlag() = AvkortingGrunnlag(
+        id = uuid("id"),
         periode = Periode(
             fom = sqlDate("fom").let { YearMonth.from(it.toLocalDate()) },
             tom = sqlDateOrNull("tom")?.let { YearMonth.from(it.toLocalDate()) }

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -66,6 +66,7 @@ fun Avkorting.toDto() = AvkortingDto(
 )
 
 fun AvkortingGrunnlag.toDto() = AvkortingGrunnlagDto(
+    id = id,
     fom = periode.fom,
     tom = periode.tom,
     aarsinntekt = aarsinntekt,
@@ -82,6 +83,7 @@ fun AvkortetYtelse.toDto() = AvkortetYtelseDto(
 )
 
 fun AvkortingGrunnlagDto.fromDto(bruker: Bruker) = AvkortingGrunnlag(
+    id = id,
     periode = Periode(fom = fom, tom = tom),
     aarsinntekt = aarsinntekt,
     fratrekkInnUt = fratrekkInnUt,

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/InntektAvkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/InntektAvkorting.kt
@@ -4,6 +4,7 @@ import no.nav.etterlatte.beregning.regler.omstillingstoenad.OMS_GYLDIG_FROM_TEST
 import no.nav.etterlatte.grunnbeloep.Grunnbeloep
 import no.nav.etterlatte.grunnbeloep.GrunnbeloepRepository
 import no.nav.etterlatte.libs.regler.FaktumNode
+import no.nav.etterlatte.libs.regler.PeriodisertGrunnlag
 import no.nav.etterlatte.libs.regler.Regel
 import no.nav.etterlatte.libs.regler.RegelMeta
 import no.nav.etterlatte.libs.regler.RegelReferanse
@@ -15,10 +16,25 @@ import no.nav.etterlatte.libs.regler.og
 import no.nav.etterlatte.libs.regler.velgNyesteGyldige
 import no.nav.etterlatte.regler.Beregningstall
 import java.math.RoundingMode
+import java.time.LocalDate
 
 data class InntektAvkortingGrunnlag(
     val inntekt: FaktumNode<Int>
 )
+
+data class PeriodisertInntektAvkortingGrunnlag(
+    val inntektsperioder: PeriodisertGrunnlag<FaktumNode<Int>>
+) : PeriodisertGrunnlag<InntektAvkortingGrunnlag> {
+    override fun finnAlleKnekkpunkter(): Set<LocalDate> {
+        return inntektsperioder.finnAlleKnekkpunkter()
+    }
+
+    override fun finnGrunnlagForPeriode(datoIPeriode: LocalDate): InntektAvkortingGrunnlag {
+        return InntektAvkortingGrunnlag(
+            inntektsperioder.finnGrunnlagForPeriode(datoIPeriode)
+        )
+    }
+}
 
 val historiskeGrunnbeloep = GrunnbeloepRepository.historiskeGrunnbeloep.map { grunnbeloep ->
     val grunnbeloepGyldigFra = grunnbeloep.dato.atDay(1)

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -72,10 +72,12 @@ fun avkorting(
 )
 
 fun avkortinggrunnlag(
+    id: UUID = UUID.randomUUID(),
     aarsinntekt: Int = 100000,
     periode: Periode = Periode(fom = YearMonth.now(), tom = null),
     kilde: Grunnlagsopplysning.Saksbehandler = Grunnlagsopplysning.Saksbehandler.create("Z123456")
 ) = AvkortingGrunnlag(
+    id = id,
     periode = periode,
     aarsinntekt = aarsinntekt,
     fratrekkInnUt = 10000,

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -10,6 +10,11 @@ import no.nav.etterlatte.beregning.Beregning
 import no.nav.etterlatte.beregning.grunnlag.InstitusjonsoppholdBeregningsgrunnlag
 import no.nav.etterlatte.beregning.regler.barnepensjon.AvdoedForelder
 import no.nav.etterlatte.beregning.regler.barnepensjon.BarnepensjonGrunnlag
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
+import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
+import no.nav.etterlatte.libs.common.behandling.Prosesstype
+import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
 import no.nav.etterlatte.libs.common.beregning.Beregningstype
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -21,11 +26,13 @@ import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.common.toObjectNode
 import no.nav.etterlatte.libs.regler.FaktumNode
 import no.nav.etterlatte.libs.regler.RegelPeriode
+import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.kilde
 import no.nav.etterlatte.regler.Beregningstall
 import no.nav.etterlatte.token.Saksbehandler
 import java.math.RoundingMode
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.YearMonth
 import java.util.*
 
@@ -150,4 +157,33 @@ fun beregningsperiode(
     regelResultat = mapOf("regel" to "resultat").toObjectNode(),
     regelVersjon = "1",
     kilde = Grunnlagsopplysning.RegelKilde("regelid", Tidspunkt.now(), "1")
+)
+
+fun behandling(
+    id: UUID = UUID.randomUUID(),
+    sak: Long = 123,
+    sakType: SakType = SakType.OMSTILLINGSSTOENAD,
+    behandlingType: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+    virkningstidspunkt: YearMonth = YearMonth.of(2023, 1)
+) = DetaljertBehandling(
+    id = id,
+    sak = sak,
+    sakType = sakType,
+    behandlingOpprettet = LocalDateTime.now(),
+    sistEndret = LocalDateTime.now(),
+    soeknadMottattDato = null,
+    innsender = null,
+    soeker = "diam",
+    gjenlevende = listOf(),
+    avdoed = listOf(),
+    soesken = listOf(),
+    gyldighetsproeving = null,
+    status = BehandlingStatus.VILKAARSVURDERT,
+    behandlingType = behandlingType,
+    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(virkningstidspunkt),
+    kommerBarnetTilgode = null,
+    revurderingsaarsak = null,
+    prosesstype = Prosesstype.MANUELL,
+    utenlandstilsnitt = null,
+    boddEllerArbeidetUtlandet = null
 )

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
@@ -1,6 +1,7 @@
 package avkorting
 
 import io.kotest.matchers.shouldBe
+import no.nav.etterlatte.avkorting.Avkorting
 import no.nav.etterlatte.avkorting.AvkortingRepository
 import no.nav.etterlatte.beregning.regler.avkortetYtelse
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
@@ -48,29 +49,34 @@ internal class AvkortingRepositoryTest {
     @Test
     fun `Skal lagre og oppdatere avkorting`() {
         val behandlingId: UUID = UUID.randomUUID()
-        val avkortinggrunnlag = listOf(avkortinggrunnlag())
-        val avkortingsperioder = listOf(avkortingsperiode())
-        val avkortetYtelse = listOf(avkortetYtelse())
+        val avkortinggrunnlag = mutableListOf(avkortinggrunnlag())
+        val avkortingsperioder = mutableListOf(avkortingsperiode())
+        val avkortetYtelse = mutableListOf(avkortetYtelse())
 
-        avkortingRepository.lagreEllerOppdaterAvkorting(
-            behandlingId,
-            avkortinggrunnlag,
-            avkortingsperioder,
-            avkortetYtelse
+        avkortingRepository.lagreAvkorting(
+            Avkorting(
+                behandlingId,
+                avkortinggrunnlag,
+                avkortingsperioder,
+                avkortetYtelse
+            )
         )
 
-        val endretAvkortingGrunnlag = listOf(avkortinggrunnlag[0].copy(spesifikasjon = "Endret"))
-        val endretAvkortingsperiode = listOf(avkortingsperioder[0].copy(avkorting = 333))
-        val endretAvkortetYtelse = listOf(avkortetYtelse[0].copy(avkortingsbeloep = 444))
+        val endretAvkortingGrunnlag = mutableListOf(avkortinggrunnlag[0].copy(spesifikasjon = "Endret"))
+        val endretAvkortingsperiode = mutableListOf(avkortingsperioder[0].copy(avkorting = 333))
+        val endretAvkortetYtelse = mutableListOf(avkortetYtelse[0].copy(avkortingsbeloep = 444))
 
-        val avkorting = avkortingRepository.lagreEllerOppdaterAvkorting(
-            behandlingId,
-            endretAvkortingGrunnlag,
-            endretAvkortingsperiode,
-            endretAvkortetYtelse
+        val avkorting = avkortingRepository.lagreAvkorting(
+            Avkorting(
+                behandlingId,
+                endretAvkortingGrunnlag,
+                endretAvkortingsperiode,
+                endretAvkortetYtelse
+            )
         )
 
         avkorting.behandlingId shouldBe behandlingId
+        avkorting.avkortingGrunnlag.size shouldBe 1
         avkorting.avkortingGrunnlag shouldBe endretAvkortingGrunnlag
         avkorting.avkortingsperioder shouldBe endretAvkortingsperiode
         avkorting.avkortetYtelse shouldBe endretAvkortetYtelse

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
@@ -49,9 +49,9 @@ internal class AvkortingRepositoryTest {
     @Test
     fun `Skal lagre og oppdatere avkorting`() {
         val behandlingId: UUID = UUID.randomUUID()
-        val avkortinggrunnlag = mutableListOf(avkortinggrunnlag())
-        val avkortingsperioder = mutableListOf(avkortingsperiode())
-        val avkortetYtelse = mutableListOf(avkortetYtelse())
+        val avkortinggrunnlag = listOf(avkortinggrunnlag())
+        val avkortingsperioder = listOf(avkortingsperiode())
+        val avkortetYtelse = listOf(avkortetYtelse())
 
         avkortingRepository.lagreAvkorting(
             Avkorting(
@@ -62,9 +62,9 @@ internal class AvkortingRepositoryTest {
             )
         )
 
-        val endretAvkortingGrunnlag = mutableListOf(avkortinggrunnlag[0].copy(spesifikasjon = "Endret"))
-        val endretAvkortingsperiode = mutableListOf(avkortingsperioder[0].copy(avkorting = 333))
-        val endretAvkortetYtelse = mutableListOf(avkortetYtelse[0].copy(avkortingsbeloep = 444))
+        val endretAvkortingGrunnlag = listOf(avkortinggrunnlag[0].copy(spesifikasjon = "Endret"))
+        val endretAvkortingsperiode = listOf(avkortingsperioder[0].copy(avkorting = 333))
+        val endretAvkortetYtelse = listOf(avkortetYtelse[0].copy(avkortingsbeloep = 444))
 
         val avkorting = avkortingRepository.lagreAvkorting(
             Avkorting(

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
@@ -77,22 +77,25 @@ class AvkortingRoutesTest {
     @Test
     fun `skal motta og returnere avkorting`() {
         val behandlingsId = UUID.randomUUID()
+        val avkortingsgrunnlagId = UUID.randomUUID()
         val dato = YearMonth.now()
         val tidspunkt = Tidspunkt.now()
         val avkortingsgrunnlag = avkortinggrunnlag(
+            id = avkortingsgrunnlagId,
             periode = Periode(fom = dato, tom = dato),
             kilde = Grunnlagsopplysning.Saksbehandler("Saksbehandler01", tidspunkt)
         )
         val avkorting = Avkorting(
             behandlingId = behandlingsId,
-            avkortingGrunnlag = listOf(avkortingsgrunnlag),
-            avkortingsperioder = listOf(avkortingsperiode()),
-            avkortetYtelse = listOf(avkortetYtelse(periode = Periode(fom = dato, tom = dato)))
+            avkortingGrunnlag = mutableListOf(avkortingsgrunnlag),
+            avkortingsperioder = mutableListOf(avkortingsperiode()),
+            avkortetYtelse = mutableListOf(avkortetYtelse(periode = Periode(fom = dato, tom = dato)))
         )
         val dto = AvkortingDto(
             behandlingId = behandlingsId,
             avkortingGrunnlag = listOf(
                 AvkortingGrunnlagDto(
+                    id = avkortingsgrunnlagId,
                     fom = dato,
                     tom = dato,
                     aarsinntekt = 100000,

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -1,32 +1,38 @@
 package avkorting
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.avkorting.AvkortetYtelse
 import no.nav.etterlatte.avkorting.Avkorting
+import no.nav.etterlatte.avkorting.AvkortingGrunnlag
 import no.nav.etterlatte.avkorting.AvkortingRepository
 import no.nav.etterlatte.avkorting.AvkortingService
+import no.nav.etterlatte.avkorting.Avkortingsperiode
 import no.nav.etterlatte.avkorting.InntektAvkortingService
 import no.nav.etterlatte.beregning.BeregningService
-import no.nav.etterlatte.beregning.regler.avkortetYtelse
 import no.nav.etterlatte.beregning.regler.avkorting
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
-import no.nav.etterlatte.beregning.regler.avkortingsperiode
 import no.nav.etterlatte.beregning.regler.beregning
-import no.nav.etterlatte.beregning.regler.beregningsperiode
 import no.nav.etterlatte.beregning.regler.bruker
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
+import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
+import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
+import no.nav.etterlatte.libs.common.periode.Periode
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.YearMonth
 import java.util.UUID
 
 internal class AvkortingServiceTest {
@@ -35,8 +41,9 @@ internal class AvkortingServiceTest {
     private val inntektAvkortingService: InntektAvkortingService = mockk()
     private val avkortingRepository: AvkortingRepository = mockk()
     private val beregningService: BeregningService = mockk()
-    private val service =
+    private val service = spyk(
         AvkortingService(behandlingKlient, inntektAvkortingService, avkortingRepository, beregningService)
+    )
 
     @BeforeEach
     fun beforeEach() {
@@ -59,6 +66,7 @@ internal class AvkortingServiceTest {
             service.hentAvkorting(behandlingId, bruker) shouldBe avkorting
         }
         coVerify {
+            service.hentAvkorting(any(), any())
             avkortingRepository.hentAvkorting(behandlingId)
         }
     }
@@ -67,7 +75,7 @@ internal class AvkortingServiceTest {
     fun `skal returnere null hvis avkorting ikke finnes`() {
         val behandlingId = UUID.randomUUID()
         every { avkortingRepository.hentAvkorting(behandlingId) } returns null
-        val behandling = mockk<DetaljertBehandling>().apply {
+        val behandling = mockk<DetaljertBehandling>() {
             every { behandlingType } returns BehandlingType.FØRSTEGANGSBEHANDLING
         }
         coEvery { behandlingKlient.hentBehandling(behandlingId, bruker) } returns behandling
@@ -76,6 +84,7 @@ internal class AvkortingServiceTest {
             service.hentAvkorting(behandlingId, bruker) shouldBe null
         }
         coVerify {
+            service.hentAvkorting(any(), any())
             avkortingRepository.hentAvkorting(behandlingId)
             behandlingKlient.hentBehandling(behandlingId, bruker)
             behandling.behandlingType
@@ -86,49 +95,34 @@ internal class AvkortingServiceTest {
     fun `skal returnere kopi av forrige avkorting hvis avkorting ikke finnes for en revurdering`() {
         val behandlingId = UUID.randomUUID()
         val sakId = 123L
-        val behandling = mockk<DetaljertBehandling>().apply {
+        val behandling = mockk<DetaljertBehandling>() {
             every { behandlingType } returns BehandlingType.REVURDERING
             every { sak } returns sakId
         }
         val forrigeBehandlingId = UUID.randomUUID()
-        val forrigeBehandling = mockk<DetaljertBehandling>().apply {
+        val forrigeBehandling = mockk<DetaljertBehandling>() {
             every { id } returns forrigeBehandlingId
         }
-        val avkortinggrunnlag = avkortinggrunnlag()
-        val forrigeAvkorting = mockk<Avkorting>().apply {
-            every { avkortingGrunnlag } returns listOf(avkortinggrunnlag)
-        }
-        val avkortingsperioder = listOf(avkortingsperiode())
-        val beregninger = listOf(beregningsperiode())
-        val avkortetYtelse = listOf(avkortetYtelse())
+        val avkortinggrunnlag =
+            listOf(avkortinggrunnlag(aarsinntekt = 100), avkortinggrunnlag(aarsinntekt = 200))
+        val forrigeAvkorting = avkorting(avkortingGrunnlag = avkortinggrunnlag)
+        val nyAvkorting = mockk<Avkorting>()
 
         every { avkortingRepository.hentAvkorting(behandlingId) } returns null
         coEvery { behandlingKlient.hentBehandling(behandlingId, bruker) } returns behandling
-
         coEvery { behandlingKlient.hentSisteIverksatteBehandling(sakId, bruker) } returns forrigeBehandling
         every { avkortingRepository.hentAvkorting(forrigeBehandlingId) } returns forrigeAvkorting
-
-        coEvery { behandlingKlient.avkort(behandlingId, bruker, false) } returns true
-        every { inntektAvkortingService.beregnInntektsavkorting(avkortinggrunnlag) } returns avkortingsperioder
-        every { beregningService.hentBeregningNonnull(behandlingId) } returns beregning(beregninger)
-        every {
-            inntektAvkortingService.beregnAvkortetYtelse(beregninger, avkortingsperioder)
-        } returns avkortetYtelse
-        every {
-            avkortingRepository.lagreEllerOppdaterAvkorting(
-                behandlingId,
-                listOf(avkortinggrunnlag),
-                avkortingsperioder,
-                avkortetYtelse
-            )
-        } returns mockk()
-        coEvery { behandlingKlient.avkort(behandlingId, bruker, true) } returns true
+        coEvery { service.lagreAvkorting(any(), any(), any()) } returns mockk()
+        every { avkortingRepository.hentAvkortingUtenNullable(behandlingId) } returns nyAvkorting
 
         runBlocking {
-            service.hentAvkorting(behandlingId, bruker)
+            service.hentAvkorting(behandlingId, bruker) shouldBe nyAvkorting
         }
 
         coVerify {
+            service.hentAvkorting(any(), any())
+            service.kopierAvkorting(any(), any(), any())
+
             avkortingRepository.hentAvkorting(behandlingId)
             behandlingKlient.hentBehandling(behandlingId, bruker)
             behandling.behandlingType
@@ -136,61 +130,210 @@ internal class AvkortingServiceTest {
             behandlingKlient.hentSisteIverksatteBehandling(sakId, bruker)
             forrigeBehandling.id
             avkortingRepository.hentAvkorting(forrigeBehandlingId)
-            forrigeAvkorting.avkortingGrunnlag
-            behandlingKlient.avkort(behandlingId, bruker, false)
-            inntektAvkortingService.beregnInntektsavkorting(avkortinggrunnlag)
-            beregningService.hentBeregningNonnull(behandlingId)
-            inntektAvkortingService.beregnAvkortetYtelse(beregninger, avkortingsperioder)
-            avkortingRepository.lagreEllerOppdaterAvkorting(
+
+            service.lagreAvkorting(
                 behandlingId,
-                listOf(avkortinggrunnlag),
-                avkortingsperioder,
-                avkortetYtelse
+                bruker,
+                withArg {
+                    it.aarsinntekt shouldBe avkortinggrunnlag[0].aarsinntekt
+                    it.id shouldNotBe avkortinggrunnlag[0].id
+                }
+            )
+            service.lagreAvkorting(
+                behandlingId,
+                bruker,
+                withArg {
+                    it.aarsinntekt shouldBe avkortinggrunnlag[1].aarsinntekt
+                    it.id shouldNotBe avkortinggrunnlag[1].id
+                }
+            )
+            avkortingRepository.hentAvkortingUtenNullable(behandlingId)
+        }
+    }
+
+    @Test
+    fun `nytt avkortingsgrunnlag for ny avkorting og kjoere regler for avkorting og lagre resultat`() {
+        val behandlingId = UUID.randomUUID()
+        val virkningstidspunktMock = Virkningstidspunkt(
+            dato = YearMonth.of(2023, 1),
+            mockk(),
+            ""
+        )
+        val behandling = mockk<DetaljertBehandling>() {
+            every { virkningstidspunkt } returns virkningstidspunktMock
+        }
+        val nyttGrunnlag = mockk<AvkortingGrunnlag>()
+        val nyAvkortingsperiode = mockk<Avkortingsperiode>()
+        val nyAvkortetYtelse = mockk<AvkortetYtelse>()
+        val beregning = mockk<Beregningsperiode>()
+        val nyAvkorting = Avkorting(
+            behandlingId = behandlingId,
+            avkortingGrunnlag = listOf(nyttGrunnlag),
+            avkortingsperioder = listOf(nyAvkortingsperiode),
+            avkortetYtelse = listOf(nyAvkortetYtelse)
+        )
+
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        every { avkortingRepository.hentAvkorting(any()) } returns null
+        coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
+        every { inntektAvkortingService.beregnInntektsavkorting(any(), any()) } returns listOf(nyAvkortingsperiode)
+        every { beregningService.hentBeregningNonnull(any()) } returns beregning(listOf(beregning))
+        every { inntektAvkortingService.beregnAvkortetYtelse(any(), any(), any()) } returns listOf(nyAvkortetYtelse)
+        every { avkortingRepository.lagreAvkorting(any()) } returns nyAvkorting
+        coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
+
+        val result = runBlocking {
+            service.lagreAvkorting(behandlingId, bruker, nyttGrunnlag)
+        }
+
+        result shouldBe nyAvkorting
+        coVerify(exactly = 1) {
+            service.lagreAvkorting(any(), any(), any())
+            behandlingKlient.avkort(behandlingId, bruker, false)
+            behandlingKlient.hentBehandling(behandlingId, bruker)
+            behandling.virkningstidspunkt
+            avkortingRepository.hentAvkorting(behandlingId)
+            inntektAvkortingService.beregnInntektsavkorting(virkningstidspunktMock.dato, listOf(nyttGrunnlag))
+            beregningService.hentBeregningNonnull(behandlingId)
+            inntektAvkortingService.beregnAvkortetYtelse(
+                virkningstidspunktMock.dato,
+                listOf(beregning),
+                listOf(nyAvkortingsperiode)
+            )
+            avkortingRepository.lagreAvkorting(nyAvkorting)
+            behandlingKlient.avkort(behandlingId, bruker, true)
+        }
+    }
+
+    @Test
+    fun `endret avkortingsgrunnlag for eksisterende avkorting og kjoere regler for avkorting og lagre resultat`() {
+        val behandlingId = UUID.randomUUID()
+        val virkningstidspunktMock = Virkningstidspunkt(dato = YearMonth.of(2023, 1), mockk(), "")
+        val behandling = mockk<DetaljertBehandling>() {
+            every { virkningstidspunkt } returns virkningstidspunktMock
+        }
+        val grunnlagId = UUID.randomUUID()
+        val eksisterendeGrunnlag = avkortinggrunnlag(id = grunnlagId)
+        val eksisterendeAvkortingsperiode = mockk<Avkortingsperiode>()
+        val eksisterendeAvkortetYtelse = mockk<AvkortetYtelse>()
+
+        val avkorting = Avkorting(
+            behandlingId = behandlingId,
+            avkortingGrunnlag = listOf(eksisterendeGrunnlag),
+            avkortingsperioder = listOf(eksisterendeAvkortingsperiode),
+            avkortetYtelse = listOf(eksisterendeAvkortetYtelse)
+        )
+        val endretGrunnlag = eksisterendeGrunnlag.copy(aarsinntekt = 100)
+        val nyAvkortingsperiode = mockk<Avkortingsperiode>()
+        val nyAvkortetYtelse = mockk<AvkortetYtelse>()
+        val beregning = mockk<Beregningsperiode>()
+
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        every { avkortingRepository.hentAvkorting(any()) } returns avkorting
+        coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
+        every { inntektAvkortingService.beregnInntektsavkorting(any(), any()) } returns listOf(nyAvkortingsperiode)
+        every { beregningService.hentBeregningNonnull(any()) } returns beregning(listOf(beregning))
+        every { inntektAvkortingService.beregnAvkortetYtelse(any(), any(), any()) } returns listOf(nyAvkortetYtelse)
+        every { avkortingRepository.lagreAvkorting(any()) } returns avkorting
+        coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
+
+        val result = runBlocking {
+            service.lagreAvkorting(behandlingId, bruker, endretGrunnlag)
+        }
+
+        result shouldBe avkorting
+        coVerify(exactly = 1) {
+            service.lagreAvkorting(any(), any(), any())
+            behandlingKlient.avkort(behandlingId, bruker, false)
+            behandlingKlient.hentBehandling(behandlingId, bruker)
+            behandling.virkningstidspunkt
+            avkortingRepository.hentAvkorting(behandlingId)
+            inntektAvkortingService.beregnInntektsavkorting(virkningstidspunktMock.dato, listOf(endretGrunnlag))
+            beregningService.hentBeregningNonnull(behandlingId)
+            inntektAvkortingService.beregnAvkortetYtelse(
+                virkningstidspunktMock.dato,
+                listOf(beregning),
+                listOf(nyAvkortingsperiode)
+            )
+            avkortingRepository.lagreAvkorting(
+                withArg {
+                    it.avkortingGrunnlag shouldBe listOf(endretGrunnlag)
+                    it.avkortingsperioder shouldBe listOf(nyAvkortingsperiode)
+                    it.avkortetYtelse shouldBe listOf(nyAvkortetYtelse)
+                }
             )
             behandlingKlient.avkort(behandlingId, bruker, true)
         }
     }
 
     @Test
-    fun `skal kjoere regler for avkorting og lagre resultat`() {
+    fun `nytt avkortingsgrunnlag for eksisterende avkorting og kjoere regler for avkorting og lagre resultat`() {
         val behandlingId = UUID.randomUUID()
-        val avkorting = avkorting()
-        val avkortinggrunnlag = avkortinggrunnlag()
-        val avkortingsperioder = listOf(avkortingsperiode())
-        val beregninger = listOf(beregningsperiode())
-        val avkortetYtelse = listOf(avkortetYtelse())
 
-        coEvery { behandlingKlient.avkort(behandlingId, bruker, false) } returns true
-        every { inntektAvkortingService.beregnInntektsavkorting(avkortinggrunnlag) } returns avkortingsperioder
-        every { beregningService.hentBeregningNonnull(behandlingId) } returns beregning(beregninger)
-        every {
-            inntektAvkortingService.beregnAvkortetYtelse(beregninger, avkortingsperioder)
-        } returns avkortetYtelse
-        every {
-            avkortingRepository.lagreEllerOppdaterAvkorting(
-                behandlingId,
-                listOf(avkortinggrunnlag),
-                avkortingsperioder,
-                avkortetYtelse
-            )
-        } returns avkorting
-        coEvery { behandlingKlient.avkort(behandlingId, bruker, true) } returns true
+        val virkningstidspunktMock = Virkningstidspunkt(dato = YearMonth.of(2023, 1), mockk(), "")
+        val behandling = mockk<DetaljertBehandling>() {
+            every { virkningstidspunkt } returns virkningstidspunktMock
+        }
+        val eksisterendeGrunnlag = avkortinggrunnlag(
+            periode = Periode(fom = YearMonth.of(2023, 1), tom = null)
+        )
+        val eksisterendeAvkortingsperiode = mockk<Avkortingsperiode>()
+        val eksisterendeAvkortetYtelse = mockk<AvkortetYtelse>()
+
+        val avkorting = Avkorting(
+            behandlingId = behandlingId,
+            avkortingGrunnlag = listOf(eksisterendeGrunnlag),
+            avkortingsperioder = listOf(eksisterendeAvkortingsperiode),
+            avkortetYtelse = listOf(eksisterendeAvkortetYtelse)
+        )
+        val nyttGrunnlag = avkortinggrunnlag(
+            periode = Periode(fom = YearMonth.of(2023, 4), tom = null)
+        )
+        val nyeAvkortingsperioder = mockk<Avkortingsperiode>()
+        val nyeAvkortetYtelser = mockk<AvkortetYtelse>()
+        val beregninger = mockk<Beregningsperiode>()
+
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        every { avkortingRepository.hentAvkorting(any()) } returns avkorting
+        coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
+        every { inntektAvkortingService.beregnInntektsavkorting(any(), any()) } returns listOf(nyeAvkortingsperioder)
+        every { beregningService.hentBeregningNonnull(any()) } returns beregning(listOf(beregninger))
+        every { inntektAvkortingService.beregnAvkortetYtelse(any(), any(), any()) } returns listOf(nyeAvkortetYtelser)
+        every { avkortingRepository.lagreAvkorting(any()) } returns avkorting
+        coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
 
         val result = runBlocking {
-            service.lagreAvkorting(behandlingId, bruker, avkortinggrunnlag)
+            service.lagreAvkorting(behandlingId, bruker, nyttGrunnlag)
         }
 
         result shouldBe avkorting
+
         coVerify(exactly = 1) {
+            service.lagreAvkorting(any(), any(), any())
             behandlingKlient.avkort(behandlingId, bruker, false)
-            inntektAvkortingService.beregnInntektsavkorting(avkortinggrunnlag)
+            behandlingKlient.hentBehandling(behandlingId, bruker)
+            avkortingRepository.hentAvkorting(behandlingId)
+            behandling.virkningstidspunkt
+            inntektAvkortingService.beregnInntektsavkorting(
+                virkningstidspunktMock.dato,
+                withArg {
+                    it[0].periode.tom shouldBe YearMonth.of(2023, 3)
+                    it[1].periode.tom shouldBe null
+                }
+            )
             beregningService.hentBeregningNonnull(behandlingId)
-            inntektAvkortingService.beregnAvkortetYtelse(beregninger, avkortingsperioder)
-            avkortingRepository.lagreEllerOppdaterAvkorting(
-                behandlingId,
-                listOf(avkortinggrunnlag),
-                avkortingsperioder,
-                avkortetYtelse
+            inntektAvkortingService.beregnAvkortetYtelse(
+                virkningstidspunktMock.dato,
+                listOf(beregninger),
+                listOf(nyeAvkortingsperioder)
+            )
+            avkortingRepository.lagreAvkorting(
+                withArg {
+                    it.avkortingGrunnlag[0].periode.tom shouldBe YearMonth.of(2023, 3)
+                    it.avkortingGrunnlag[1].periode.tom shouldBe null
+                    it.avkortingsperioder shouldBe listOf(nyeAvkortingsperioder)
+                    it.avkortetYtelse shouldBe listOf(nyeAvkortetYtelser)
+                }
             )
             behandlingKlient.avkort(behandlingId, bruker, true)
         }
@@ -208,6 +351,7 @@ internal class AvkortingServiceTest {
         }
 
         coVerify {
+            service.lagreAvkorting(any(), any(), any())
             behandlingKlient.avkort(behandlingId, bruker, false)
         }
     }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -22,13 +22,21 @@ export const AvkortingInntekt = (props: {
     if (!behandling.virkningstidspunkt) throw new Error('Mangler virkningstidspunkt')
     return behandling.virkningstidspunkt.dato
   }
-  const [inntektGrunnlagForm, setInntektGrunnlagForm] = useState<IAvkortingGrunnlag>(
-    props.avkortingGrunnlag
-      ? props.avkortingGrunnlag[props.avkortingGrunnlag.length - 1]
-      : {
-          fom: virkningstidspunkt(),
-        }
-  )
+  const finnesRedigerbartGrunnlag = () => {
+    if (props.avkortingGrunnlag) {
+      const siste = props.avkortingGrunnlag[props.avkortingGrunnlag.length - 1]
+      return siste.fom === behandling.virkningstidspunkt?.dato
+    }
+  }
+  const finnRedigerbartGrunnlag = () => {
+    if (finnesRedigerbartGrunnlag()) {
+      return props.avkortingGrunnlag![props.avkortingGrunnlag!.length - 1]
+    }
+    return {
+      fom: virkningstidspunkt(),
+    }
+  }
+  const [inntektGrunnlagForm, setInntektGrunnlagForm] = useState<IAvkortingGrunnlag>(finnRedigerbartGrunnlag())
   const [inntektGrunnlagStatus, requestLagreAvkortingGrunnlag] = useApiCall(lagreAvkortingGrunnlag)
   const [errorTekst, setErrorTekst] = useState<string | null>(null)
 
@@ -48,7 +56,7 @@ export const AvkortingInntekt = (props: {
         avkortingGrunnlag: inntektGrunnlagForm,
       },
       (respons) => {
-        const nyttAvkortingGrunnlag = respons.avkortingGrunnlag[0]
+        const nyttAvkortingGrunnlag = respons.avkortingGrunnlag[respons.avkortingGrunnlag.length - 1]
         nyttAvkortingGrunnlag && setInntektGrunnlagForm(nyttAvkortingGrunnlag)
         props.setAvkorting(respons)
         setFormToggle(false)
@@ -133,7 +141,7 @@ export const AvkortingInntekt = (props: {
                   onChange={(e) =>
                     setInntektGrunnlagForm({
                       ...inntektGrunnlagForm,
-                      fratrekkInnUt: e.target.value === '' ? undefined : Number(e.target.value),
+                      fratrekkInnUt: e.target.value === '' ? 0 : Number(e.target.value),
                     })
                   }
                 />
@@ -193,7 +201,7 @@ export const AvkortingInntekt = (props: {
                   setFormToggle(true)
                 }}
               >
-                Legg til / rediger
+                {finnesRedigerbartGrunnlag() ? 'Rediger' : 'Legg til'}
               </Button>
             )}
           </FormKnapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
@@ -5,6 +5,7 @@ export interface IAvkorting {
 }
 
 export interface IAvkortingGrunnlag {
+  id?: string
   fom?: string
   tom?: string
   aarsinntekt?: number

--- a/libs/saksbehandling-common/src/main/kotlin/beregning/BeregningDTO.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/beregning/BeregningDTO.kt
@@ -37,6 +37,7 @@ data class AvkortingDto(
 )
 
 data class AvkortingGrunnlagDto(
+    val id: UUID = UUID.randomUUID(),
     val fom: YearMonth,
     val tom: YearMonth?,
     val aarsinntekt: Int,


### PR DESCRIPTION
- Regelberegning for avkorting endret til å bruke virknignstidspunkt og periodisert grunnlag slik at revurdering kun beregner sende inn flere grunnlag men kun beregne fra virkningstidspunkt og fremover
- Lagt til domenelogikk for å sjekke om mottat grunnlag finnes fra før og oppdatere eller legge til hvis ikke finnes fra før
- I frontend legge til ny inntekt hvis det ikke finnes fra før fra nytt virkningstidspunkt redigere hvis det finnes fra før
- Forbedre opprettelse av ny avkorting ved revurdering