### PR TITLE
EY-2168: Handterer at grunnlag kan vera tomt

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnBarnepensjonService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnBarnepensjonService.kt
@@ -32,6 +32,7 @@ import no.nav.etterlatte.libs.regler.FaktumNode
 import no.nav.etterlatte.libs.regler.KonstantGrunnlag
 import no.nav.etterlatte.libs.regler.RegelPeriode
 import no.nav.etterlatte.libs.regler.RegelkjoeringResultat
+import no.nav.etterlatte.libs.regler.TomtGrunnlag
 import no.nav.etterlatte.libs.regler.eksekver
 import no.nav.etterlatte.libs.regler.finnAnvendteRegler
 import no.nav.etterlatte.regler.Beregningstall
@@ -44,6 +45,7 @@ import java.util.*
 enum class BeregnBarnepensjonServiceFeatureToggle(private val key: String) : FeatureToggle {
     BrukFaktiskTrygdetid("pensjon-etterlatte.bp-bruk-faktisk-trygdetid"),
     BrukInstitusjonsoppholdIBeregning("pensjon-etterlatte.bp-bruk-institusjonsopphold-i-beregning");
+
     override fun key() = key
 }
 
@@ -254,15 +256,19 @@ class BeregnBarnepensjonService(
                 )
             }
         },
-        institusjonsopphold = PeriodisertBeregningGrunnlag.lagGrunnlagMedDefaultUtenforPerioder(
-            beregningsGrunnlag.institusjonsoppholdBeregningsgrunnlag?.mapVerdier { institusjonsopphold ->
-                FaktumNode(
-                    verdi = institusjonsopphold,
-                    kilde = beregningsGrunnlag.kilde,
-                    beskrivelse = "Institusjonsopphold"
-                )
-            } ?: listOf()
-        ) { _, _, _ -> FaktumNode(null, beregningsGrunnlag.kilde, "Institusjonsopphold") }
+        institusjonsopphold = if (featureToggleService.isEnabled(BrukInstitusjonsoppholdIBeregning, false)) {
+            PeriodisertBeregningGrunnlag.lagGrunnlagMedDefaultUtenforPerioder(
+                beregningsGrunnlag.institusjonsoppholdBeregningsgrunnlag?.mapVerdier { institusjonsopphold ->
+                    FaktumNode(
+                        verdi = institusjonsopphold,
+                        kilde = beregningsGrunnlag.kilde,
+                        beskrivelse = "Institusjonsopphold"
+                    )
+                } ?: listOf()
+            ) { _, _, _ -> FaktumNode(null, beregningsGrunnlag.kilde, "Institusjonsopphold") }
+        } else {
+            TomtGrunnlag(FaktumNode(null, beregningsGrunnlag.kilde, "Institusjonsopphold"))
+        }
     )
 
     private fun TrygdetidDto?.hvisKanBrukes() = this.takeIf {

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnBarnepensjonService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnBarnepensjonService.kt
@@ -32,7 +32,6 @@ import no.nav.etterlatte.libs.regler.FaktumNode
 import no.nav.etterlatte.libs.regler.KonstantGrunnlag
 import no.nav.etterlatte.libs.regler.RegelPeriode
 import no.nav.etterlatte.libs.regler.RegelkjoeringResultat
-import no.nav.etterlatte.libs.regler.TomtGrunnlag
 import no.nav.etterlatte.libs.regler.eksekver
 import no.nav.etterlatte.libs.regler.finnAnvendteRegler
 import no.nav.etterlatte.regler.Beregningstall
@@ -267,7 +266,7 @@ class BeregnBarnepensjonService(
                 } ?: listOf()
             ) { _, _, _ -> FaktumNode(null, beregningsGrunnlag.kilde, "Institusjonsopphold") }
         } else {
-            TomtGrunnlag(FaktumNode(null, beregningsGrunnlag.kilde, "Institusjonsopphold"))
+            KonstantGrunnlag(FaktumNode(null, beregningsGrunnlag.kilde, "Institusjonsopphold"))
         }
     )
 

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnBarnepensjonServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnBarnepensjonServiceTest.kt
@@ -447,6 +447,12 @@ internal class BeregnBarnepensjonServiceTest {
         every {
             featureToggleService.isEnabled(BeregnBarnepensjonServiceFeatureToggle.BrukFaktiskTrygdetid, false)
         } returns false
+        every {
+            featureToggleService.isEnabled(
+                BeregnBarnepensjonServiceFeatureToggle.BrukInstitusjonsoppholdIBeregning,
+                false
+            )
+        } returns false
 
         runBlocking {
             val beregning = beregnBarnepensjonService.beregn(behandling, bruker)
@@ -489,6 +495,12 @@ internal class BeregnBarnepensjonServiceTest {
         every {
             featureToggleService.isEnabled(BeregnBarnepensjonServiceFeatureToggle.BrukFaktiskTrygdetid, false)
         } returns true
+        every {
+            featureToggleService.isEnabled(
+                BeregnBarnepensjonServiceFeatureToggle.BrukInstitusjonsoppholdIBeregning,
+                false
+            )
+        } returns false
 
         runBlocking {
             val beregning = beregnBarnepensjonService.beregn(behandling, bruker)
@@ -527,6 +539,12 @@ internal class BeregnBarnepensjonServiceTest {
         coEvery { trygdetidKlient.hentTrygdetid(any(), any()) } returns null
         every {
             featureToggleService.isEnabled(BeregnBarnepensjonServiceFeatureToggle.BrukFaktiskTrygdetid, false)
+        } returns false
+        every {
+            featureToggleService.isEnabled(
+                BeregnBarnepensjonServiceFeatureToggle.BrukInstitusjonsoppholdIBeregning,
+                false
+            )
         } returns false
 
         runBlocking {
@@ -567,6 +585,12 @@ internal class BeregnBarnepensjonServiceTest {
         every {
             featureToggleService.isEnabled(BeregnBarnepensjonServiceFeatureToggle.BrukFaktiskTrygdetid, false)
         } returns true
+        every {
+            featureToggleService.isEnabled(
+                BeregnBarnepensjonServiceFeatureToggle.BrukInstitusjonsoppholdIBeregning,
+                false
+            )
+        } returns false
 
         runBlocking {
             val beregning = beregnBarnepensjonService.beregn(behandling, bruker)

--- a/libs/etterlatte-regler/src/main/kotlin/regler/TomtGrunnlag.kt
+++ b/libs/etterlatte-regler/src/main/kotlin/regler/TomtGrunnlag.kt
@@ -1,0 +1,9 @@
+package no.nav.etterlatte.libs.regler
+
+import java.time.LocalDate
+
+class TomtGrunnlag<T>(private val default: T) : PeriodisertGrunnlag<T> {
+    override fun finnAlleKnekkpunkter(): Set<LocalDate> = setOf()
+
+    override fun finnGrunnlagForPeriode(datoIPeriode: LocalDate) = default
+}

--- a/libs/etterlatte-regler/src/main/kotlin/regler/TomtGrunnlag.kt
+++ b/libs/etterlatte-regler/src/main/kotlin/regler/TomtGrunnlag.kt
@@ -1,9 +1,0 @@
-package no.nav.etterlatte.libs.regler
-
-import java.time.LocalDate
-
-class TomtGrunnlag<T>(private val default: T) : PeriodisertGrunnlag<T> {
-    override fun finnAlleKnekkpunkter(): Set<LocalDate> = setOf()
-
-    override fun finnGrunnlagForPeriode(datoIPeriode: LocalDate) = default
-}


### PR DESCRIPTION
Feilen som kjem:
`no.nav.etterlatte.beregning.grunnlag.PeriodiseringAvGrunnlagFeil$IngenPerioder: Ingen perioder for grunnlaget ble gitt for periodisering at no.nav.etterlatte.beregning.grunnlag.PeriodisertBeregningGrunnlag$Grunnlag.<init>(GrunnlagMedPeriode.kt:45) at no.nav.etterlatte.beregning.grunnlag.PeriodisertBeregningGrunnlag.lagGrunnlagMedDefaultUtenforPerioder(GrunnlagMedPeriode.kt:86) at no.nav.etterlatte.beregning.BeregnBarnepensjonService.opprettBeregningsgrunnlag(BeregnBarnepensjonService.kt:257) at no.nav.etterlatte.beregning.BeregnBarnepensjonService.beregn(BeregnBarnepensjonService.kt:79) at no.nav.etterlatte.beregning.BeregnBarnepensjonService$beregn$1.invokeSuspend(BeregnBarnepensjonService.kt)`