### PR TITLE
EY-2295 - ikke åpne for redigering hvis ikke status tillate det - søknadsoversikt

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/boddEllerArbeidetUtlandet/BoddEllerArbeidetUtlandetVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/boddEllerArbeidetUtlandet/BoddEllerArbeidetUtlandetVurdering.tsx
@@ -57,9 +57,13 @@ export const BoddEllerArbeidetUtlandetVurdering = ({
       subtittelKomponent={
         <>
           <BodyShort spacing>Har avdøde bodd eller arbeidet i utlandet?</BodyShort>
-          {boddEllerArbeidetUtlandet?.boddEllerArbeidetUtlandet && (
+          {boddEllerArbeidetUtlandet?.boddEllerArbeidetUtlandet ? (
             <Label as={'p'} size="small" style={{ marginBottom: '32px' }}>
               {JaNeiRec[boddEllerArbeidetUtlandet.boddEllerArbeidetUtlandet ? JaNei.JA : JaNei.NEI]}
+            </Label>
+          ) : (
+            <Label as={'p'} size="small" style={{ marginBottom: '32px' }}>
+              {'Ikke vurdert'}
             </Label>
           )}
         </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/utenlandstilsnitt/UtenlandstilsnittVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/utenlandstilsnitt/UtenlandstilsnittVurdering.tsx
@@ -61,9 +61,13 @@ export const UtenlandstilsnittVurdering = ({
       subtittelKomponent={
         <>
           <BodyShort spacing>Hvilken type sak er dette?</BodyShort>
-          {utenlandstilsnitt?.type && (
+          {utenlandstilsnitt?.type ? (
             <Label as={'p'} size="small" style={{ marginBottom: '32px' }}>
               {UtenlandstilsnittTypeTittel[utenlandstilsnitt.type]}
+            </Label>
+          ) : (
+            <Label as={'p'} size="small" style={{ marginBottom: '32px' }}>
+              {'Ikke vurdert'}
             </Label>
           )}
         </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/vurderingsboks/VurderingsboksWrapper.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/vurderingsboks/VurderingsboksWrapper.tsx
@@ -26,7 +26,7 @@ interface Props {
 }
 
 export const VurderingsboksWrapper = (props: Props) => {
-  const [rediger, setRediger] = useState<boolean>(props.defaultRediger ?? false)
+  const [rediger, setRediger] = useState<boolean>((props.defaultRediger && props.redigerbar) ?? false)
   const [lagrer, setLagrer] = useState(false)
 
   return (


### PR DESCRIPTION
Vi setter defaultRediger til true hvis data mangler. Men det burde ikke kunne overskrive redigerbart som settes fra status.

Så - for de to nye - hvor vi har lagt til kolonner etter saker var fattet så skriv ut "Ikke vurdert" hvis vi er i denne situasjon