### PR TITLE
Ey 2258

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -7,7 +7,6 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.util.*
 
 data class Avkorting(
-    val behandlingId: UUID,
     val avkortingGrunnlag: List<AvkortingGrunnlag>,
     val avkortingsperioder: List<Avkortingsperiode>,
     val avkortetYtelse: List<AvkortetYtelse>
@@ -36,8 +35,7 @@ data class Avkorting(
     )
 
     companion object {
-        fun nyAvkorting(behandlingId: UUID) = Avkorting(
-            behandlingId,
+        fun nyAvkorting() = Avkorting(
             emptyList(),
             emptyList(),
             emptyList()

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -47,8 +47,8 @@ data class AvkortingGrunnlag(
     val id: UUID,
     val periode: Periode,
     val aarsinntekt: Int,
-    val fratrekkInnUt: Int,
-    val relevanteMaaneder: Int,
+    val fratrekkInnAar: Int,
+    val relevanteMaanederInnAar: Int,
     val spesifikasjon: String,
     val kilde: Grunnlagsopplysning.Saksbehandler
 )

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -50,6 +50,7 @@ data class AvkortingGrunnlag(
     val periode: Periode,
     val aarsinntekt: Int,
     val fratrekkInnUt: Int,
+    val relevanteMaaneder: Int,
     val spesifikasjon: String,
     val kilde: Grunnlagsopplysning.Saksbehandler
 )

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
@@ -36,7 +36,6 @@ class AvkortingRepository(private val dataSource: DataSource) {
             null
         } else {
             Avkorting(
-                behandlingId = behandlingId,
                 avkortingGrunnlag = avkortingGrunnlag,
                 avkortingsperioder = avkortingsperioder,
                 avkortetYtelse = avkortetYtelse
@@ -47,14 +46,14 @@ class AvkortingRepository(private val dataSource: DataSource) {
     fun hentAvkortingUtenNullable(behandlingId: UUID): Avkorting =
         hentAvkorting(behandlingId) ?: throw Exception("Uthenting av avkorting for behandling $behandlingId feilet")
 
-    fun lagreAvkorting(avkorting: Avkorting): Avkorting {
+    fun lagreAvkorting(behandlingId: UUID, avkorting: Avkorting): Avkorting {
         dataSource.transaction { tx ->
-            slettAvkorting(avkorting.behandlingId, tx)
-            lagreAvkortingGrunnlag(avkorting.behandlingId, avkorting.avkortingGrunnlag, tx)
-            lagreAvkortingsperioder(avkorting.behandlingId, avkorting.avkortingsperioder, tx)
-            lagreAvkortetYtelse(avkorting.behandlingId, avkorting.avkortetYtelse, tx)
+            slettAvkorting(behandlingId, tx)
+            lagreAvkortingGrunnlag(behandlingId, avkorting.avkortingGrunnlag, tx)
+            lagreAvkortingsperioder(behandlingId, avkorting.avkortingsperioder, tx)
+            lagreAvkortetYtelse(behandlingId, avkorting.avkortetYtelse, tx)
         }
-        return hentAvkortingUtenNullable(avkorting.behandlingId)
+        return hentAvkortingUtenNullable(behandlingId)
     }
     private fun slettAvkorting(behandlingId: UUID, tx: TransactionalSession) {
         queryOf(

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
@@ -86,7 +86,8 @@ class AvkortingRepository(private val dataSource: DataSource) {
                 INSERT INTO avkortingsgrunnlag(
                     id, behandling_id, fom, tom, aarsinntekt, fratrekk_inn_ut, relevante_maaneder, spesifikasjon, kilde
                 ) VALUES (
-                    :id, :behandlingId, :fom, :tom, :aarsinntekt, :fratrekkInnUt, :relevanteMaaneder, :spesifikasjon, :kilde
+                    :id, :behandlingId, :fom, :tom, :aarsinntekt, :fratrekkInnAar, :relevanteMaanederInnAar,
+                     :spesifikasjon, :kilde
                 )
             """.trimIndent(),
             paramMap = mapOf(
@@ -95,8 +96,8 @@ class AvkortingRepository(private val dataSource: DataSource) {
                 "fom" to it.periode.fom.atDay(1),
                 "tom" to it.periode.tom?.atDay(1),
                 "aarsinntekt" to it.aarsinntekt,
-                "fratrekkInnUt" to it.fratrekkInnUt,
-                "relevanteMaaneder" to it.relevanteMaaneder,
+                "fratrekkInnAar" to it.fratrekkInnAar,
+                "relevanteMaanederInnAar" to it.relevanteMaanederInnAar,
                 "spesifikasjon" to it.spesifikasjon,
                 "kilde" to it.kilde.toJson()
             )
@@ -167,8 +168,8 @@ class AvkortingRepository(private val dataSource: DataSource) {
             tom = sqlDateOrNull("tom")?.let { YearMonth.from(it.toLocalDate()) }
         ),
         aarsinntekt = int("aarsinntekt"),
-        fratrekkInnUt = int("fratrekk_inn_ut"),
-        relevanteMaaneder = int("relevante_maaneder"),
+        fratrekkInnAar = int("fratrekk_inn_ut"),
+        relevanteMaanederInnAar = int("relevante_maaneder"),
         spesifikasjon = string("spesifikasjon"),
         kilde = string("kilde").let { objectMapper.readValue(it) }
     )

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
@@ -85,9 +85,9 @@ class AvkortingRepository(private val dataSource: DataSource) {
         queryOf(
             statement = """
                 INSERT INTO avkortingsgrunnlag(
-                    id, behandling_id, fom, tom, aarsinntekt, fratrekk_inn_ut, spesifikasjon, kilde
+                    id, behandling_id, fom, tom, aarsinntekt, fratrekk_inn_ut, relevante_maaneder, spesifikasjon, kilde
                 ) VALUES (
-                    :id, :behandlingId, :fom, :tom, :aarsinntekt, :fratrekkInnUt, :spesifikasjon, :kilde
+                    :id, :behandlingId, :fom, :tom, :aarsinntekt, :fratrekkInnUt, :relevanteMaaneder, :spesifikasjon, :kilde
                 )
             """.trimIndent(),
             paramMap = mapOf(
@@ -97,6 +97,7 @@ class AvkortingRepository(private val dataSource: DataSource) {
                 "tom" to it.periode.tom?.atDay(1),
                 "aarsinntekt" to it.aarsinntekt,
                 "fratrekkInnUt" to it.fratrekkInnUt,
+                "relevanteMaaneder" to it.relevanteMaaneder,
                 "spesifikasjon" to it.spesifikasjon,
                 "kilde" to it.kilde.toJson()
             )
@@ -168,6 +169,7 @@ class AvkortingRepository(private val dataSource: DataSource) {
         ),
         aarsinntekt = int("aarsinntekt"),
         fratrekkInnUt = int("fratrekk_inn_ut"),
+        relevanteMaaneder = int("relevante_maaneder"),
         spesifikasjon = string("spesifikasjon"),
         kilde = string("kilde").let { objectMapper.readValue(it) }
     )

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -60,7 +60,6 @@ fun Route.avkorting(avkortingService: AvkortingService, behandlingKlient: Behand
 }
 
 fun Avkorting.toDto() = AvkortingDto(
-    behandlingId = behandlingId,
     avkortingGrunnlag = avkortingGrunnlag.map { it.toDto() },
     avkortetYtelse = avkortetYtelse.map { it.toDto() }
 )

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -71,6 +71,7 @@ fun AvkortingGrunnlag.toDto() = AvkortingGrunnlagDto(
     tom = periode.tom,
     aarsinntekt = aarsinntekt,
     fratrekkInnUt = fratrekkInnUt,
+    relevanteMaaneder = relevanteMaaneder,
     spesifikasjon = spesifikasjon,
     kilde = AvkortingGrunnlagKildeDto(kilde.tidspunkt.toString(), kilde.ident)
 )
@@ -87,6 +88,7 @@ fun AvkortingGrunnlagDto.fromDto(bruker: Bruker) = AvkortingGrunnlag(
     periode = Periode(fom = fom, tom = tom),
     aarsinntekt = aarsinntekt,
     fratrekkInnUt = fratrekkInnUt,
+    relevanteMaaneder = relevanteMaaneder ?: (12 - fom.monthValue + 1),
     spesifikasjon = spesifikasjon,
     kilde = Grunnlagsopplysning.Saksbehandler(bruker.ident(), Tidspunkt.now())
 )

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -69,8 +69,8 @@ fun AvkortingGrunnlag.toDto() = AvkortingGrunnlagDto(
     fom = periode.fom,
     tom = periode.tom,
     aarsinntekt = aarsinntekt,
-    fratrekkInnUt = fratrekkInnUt,
-    relevanteMaaneder = relevanteMaaneder,
+    fratrekkInnAar = fratrekkInnAar,
+    relevanteMaanederInnAar = relevanteMaanederInnAar,
     spesifikasjon = spesifikasjon,
     kilde = AvkortingGrunnlagKildeDto(kilde.tidspunkt.toString(), kilde.ident)
 )
@@ -86,8 +86,8 @@ fun AvkortingGrunnlagDto.fromDto(bruker: Bruker) = AvkortingGrunnlag(
     id = id,
     periode = Periode(fom = fom, tom = tom),
     aarsinntekt = aarsinntekt,
-    fratrekkInnUt = fratrekkInnUt,
-    relevanteMaaneder = relevanteMaaneder ?: (12 - fom.monthValue + 1),
+    fratrekkInnAar = fratrekkInnAar,
+    relevanteMaanederInnAar = relevanteMaanederInnAar ?: (12 - fom.monthValue + 1),
     spesifikasjon = spesifikasjon,
     kilde = Grunnlagsopplysning.Saksbehandler(bruker.ident(), Tidspunkt.now())
 )

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -37,11 +37,11 @@ class AvkortingService(
     ): Avkorting = tilstandssjekk(behandlingId, bruker) {
         logger.info("Lagre og beregne avkorting og avkortet ytelse for behandlingId=$behandlingId")
 
-        val avkorting = avkortingRepository.hentAvkorting(behandlingId) ?: Avkorting.nyAvkorting(behandlingId)
+        val avkorting = avkortingRepository.hentAvkorting(behandlingId) ?: Avkorting.nyAvkorting()
         val avkortingMedNyttGrunnlag = avkorting.leggTilEllerOppdaterGrunnlag(avkortingGrunnlag)
         val beregnetAvkorting = beregnAvkorting(avkortingMedNyttGrunnlag, behandlingId, bruker)
 
-        val lagretAvkorting = avkortingRepository.lagreAvkorting(beregnetAvkorting)
+        val lagretAvkorting = avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
         behandlingKlient.avkort(behandlingId, bruker, true)
         lagretAvkorting
     }
@@ -56,7 +56,7 @@ class AvkortingService(
         )
         val beregnetAvkorting = beregnAvkorting(nyAvkorting, behandlingId, bruker)
 
-        val lagretAvkorting = avkortingRepository.lagreAvkorting(beregnetAvkorting)
+        val lagretAvkorting = avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
         behandlingKlient.avkort(behandlingId, bruker, true)
         return lagretAvkorting
     }

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/InntektAvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/InntektAvkortingService.kt
@@ -45,8 +45,8 @@ object InntektAvkortingService {
                     FaktumNode(
                         verdi = InntektAvkortingGrunnlag(
                             inntekt = Beregningstall(it.aarsinntekt),
-                            fratrekkInnUt = Beregningstall(it.fratrekkInnUt),
-                            relevanteMaaneder = Beregningstall(it.relevanteMaaneder)
+                            fratrekkInnUt = Beregningstall(it.fratrekkInnAar),
+                            relevanteMaaneder = Beregningstall(it.relevanteMaanederInnAar)
                         ),
                         kilde = it.kilde,
                         beskrivelse = "Forventet årsinntekt"

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/InntektAvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/InntektAvkortingService.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.avkorting
 
+import no.nav.etterlatte.avkorting.regler.InntektAvkortingGrunnlag
 import no.nav.etterlatte.avkorting.regler.PeriodisertAvkortetYtelseGrunnlag
 import no.nav.etterlatte.avkorting.regler.PeriodisertInntektAvkortingGrunnlag
 import no.nav.etterlatte.avkorting.regler.avkorteYtelse
@@ -17,6 +18,7 @@ import no.nav.etterlatte.libs.regler.PeriodisertGrunnlag
 import no.nav.etterlatte.libs.regler.RegelPeriode
 import no.nav.etterlatte.libs.regler.RegelkjoeringResultat
 import no.nav.etterlatte.libs.regler.eksekver
+import no.nav.etterlatte.regler.Beregningstall
 import org.slf4j.LoggerFactory
 import java.lang.IllegalArgumentException
 import java.time.YearMonth
@@ -32,7 +34,7 @@ object InntektAvkortingService {
         logger.info("Beregner inntektsavkorting")
 
         val grunnlag = PeriodisertInntektAvkortingGrunnlag(
-            inntektsperioder = PeriodisertBeregningGrunnlag.lagGrunnlagMedDefaultUtenforPerioder(
+            periodisertInntektAvkortingGrunnlag = PeriodisertBeregningGrunnlag.lagGrunnlagMedDefaultUtenforPerioder(
                 avkortingGrunnlag.map {
                     GrunnlagMedPeriode(
                         data = it,
@@ -41,7 +43,11 @@ object InntektAvkortingService {
                     )
                 }.mapVerdier {
                     FaktumNode(
-                        verdi = it.aarsinntekt,
+                        verdi = InntektAvkortingGrunnlag(
+                            inntekt = Beregningstall(it.aarsinntekt),
+                            fratrekkInnUt = Beregningstall(it.fratrekkInnUt),
+                            relevanteMaaneder = Beregningstall(it.relevanteMaaneder)
+                        ),
                         kilde = it.kilde,
                         beskrivelse = "Forventet årsinntekt"
                     )

--- a/apps/etterlatte-beregning/src/main/resources/db/migration/V19__legge_til_relevante_maaneder_avkortingsgrunnlag.sql
+++ b/apps/etterlatte-beregning/src/main/resources/db/migration/V19__legge_til_relevante_maaneder_avkortingsgrunnlag.sql
@@ -1,0 +1,1 @@
+ALTER TABLE avkortingsgrunnlag ADD COLUMN relevante_maaneder TEXT;

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -6,6 +6,7 @@ import no.nav.etterlatte.avkorting.AvkortingGrunnlag
 import no.nav.etterlatte.avkorting.Avkortingsperiode
 import no.nav.etterlatte.avkorting.regler.AvkortetYtelseGrunnlag
 import no.nav.etterlatte.avkorting.regler.InntektAvkortingGrunnlag
+import no.nav.etterlatte.avkorting.regler.InntektAvkortingGrunnlagWrapper
 import no.nav.etterlatte.beregning.Beregning
 import no.nav.etterlatte.beregning.grunnlag.InstitusjonsoppholdBeregningsgrunnlag
 import no.nav.etterlatte.beregning.regler.barnepensjon.AvdoedForelder
@@ -81,19 +82,34 @@ fun avkorting(
 fun avkortinggrunnlag(
     id: UUID = UUID.randomUUID(),
     aarsinntekt: Int = 100000,
+    fratrekkInnUt: Int = 10000,
+    relevanteMaaneder: Int = 12,
     periode: Periode = Periode(fom = YearMonth.now(), tom = null),
     kilde: Grunnlagsopplysning.Saksbehandler = Grunnlagsopplysning.Saksbehandler.create("Z123456")
 ) = AvkortingGrunnlag(
     id = id,
     periode = periode,
     aarsinntekt = aarsinntekt,
-    fratrekkInnUt = 10000,
+    fratrekkInnUt = fratrekkInnUt,
+    relevanteMaaneder = relevanteMaaneder,
     spesifikasjon = "Spesifikasjon",
     kilde = kilde
 )
 
-fun inntektAvkortingGrunnlag(inntekt: Int = 500000) = InntektAvkortingGrunnlag(
-    inntekt = FaktumNode(verdi = inntekt, "", "")
+fun inntektAvkortingGrunnlag(
+    inntekt: Int = 500000,
+    fratrekkInnUt: Int = 0,
+    relevanteMaaneder: Int = 12
+) = InntektAvkortingGrunnlagWrapper(
+    inntektAvkortingGrunnlag = FaktumNode(
+        verdi = InntektAvkortingGrunnlag(
+            inntekt = Beregningstall(inntekt),
+            fratrekkInnUt = Beregningstall(fratrekkInnUt),
+            relevanteMaaneder = Beregningstall(relevanteMaaneder)
+        ),
+        kilde = "",
+        beskrivelse = ""
+    )
 )
 
 fun avkortingsperiode(

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -88,8 +88,8 @@ fun avkortinggrunnlag(
     id = id,
     periode = periode,
     aarsinntekt = aarsinntekt,
-    fratrekkInnUt = fratrekkInnUt,
-    relevanteMaaneder = relevanteMaaneder,
+    fratrekkInnAar = fratrekkInnUt,
+    relevanteMaanederInnAar = relevanteMaaneder,
     spesifikasjon = "Spesifikasjon",
     kilde = kilde
 )

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -68,12 +68,10 @@ fun Int.toBeregningstall(
 val bruker = Saksbehandler("token", "ident", null)
 
 fun avkorting(
-    behandlingId: UUID = UUID.randomUUID(),
     avkortingGrunnlag: List<AvkortingGrunnlag> = emptyList(),
     avkortingsperioder: List<Avkortingsperiode> = emptyList(),
     avkortetYtelse: List<AvkortetYtelse> = emptyList()
 ) = Avkorting(
-    behandlingId = behandlingId,
     avkortingGrunnlag = avkortingGrunnlag,
     avkortingsperioder = avkortingsperioder,
     avkortetYtelse = avkortetYtelse

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
@@ -54,8 +54,8 @@ internal class AvkortingRepositoryTest {
         val avkortetYtelse = listOf(avkortetYtelse())
 
         avkortingRepository.lagreAvkorting(
+            behandlingId,
             Avkorting(
-                behandlingId,
                 avkortinggrunnlag,
                 avkortingsperioder,
                 avkortetYtelse
@@ -67,15 +67,14 @@ internal class AvkortingRepositoryTest {
         val endretAvkortetYtelse = listOf(avkortetYtelse[0].copy(avkortingsbeloep = 444))
 
         val avkorting = avkortingRepository.lagreAvkorting(
+            behandlingId,
             Avkorting(
-                behandlingId,
                 endretAvkortingGrunnlag,
                 endretAvkortingsperiode,
                 endretAvkortetYtelse
             )
         )
 
-        avkorting.behandlingId shouldBe behandlingId
         avkorting.avkortingGrunnlag.size shouldBe 1
         avkorting.avkortingGrunnlag shouldBe endretAvkortingGrunnlag
         avkorting.avkortingsperioder shouldBe endretAvkortingsperiode

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
@@ -87,13 +87,11 @@ class AvkortingRoutesTest {
             kilde = Grunnlagsopplysning.Saksbehandler("Saksbehandler01", tidspunkt)
         )
         val avkorting = Avkorting(
-            behandlingId = behandlingsId,
             avkortingGrunnlag = mutableListOf(avkortingsgrunnlag),
             avkortingsperioder = mutableListOf(avkortingsperiode()),
             avkortetYtelse = mutableListOf(avkortetYtelse(periode = Periode(fom = dato, tom = dato)))
         )
         val dto = AvkortingDto(
-            behandlingId = behandlingsId,
             avkortingGrunnlag = listOf(
                 AvkortingGrunnlagDto(
                     id = avkortingsgrunnlagId,

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
@@ -12,15 +12,16 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.log
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
-import io.mockk.slot
 import no.nav.etterlatte.avkorting.Avkorting
-import no.nav.etterlatte.avkorting.AvkortingGrunnlag
 import no.nav.etterlatte.avkorting.AvkortingService
 import no.nav.etterlatte.avkorting.avkorting
+import no.nav.etterlatte.avkorting.fromDto
 import no.nav.etterlatte.beregning.regler.avkortetYtelse
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
 import no.nav.etterlatte.beregning.regler.avkortingsperiode
+import no.nav.etterlatte.beregning.regler.bruker
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.beregning.AvkortetYtelseDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingDto
@@ -78,7 +79,7 @@ class AvkortingRoutesTest {
     fun `skal motta og returnere avkorting`() {
         val behandlingsId = UUID.randomUUID()
         val avkortingsgrunnlagId = UUID.randomUUID()
-        val dato = YearMonth.now()
+        val dato = YearMonth.of(2023, 1)
         val tidspunkt = Tidspunkt.now()
         val avkortingsgrunnlag = avkortinggrunnlag(
             id = avkortingsgrunnlagId,
@@ -100,6 +101,7 @@ class AvkortingRoutesTest {
                     tom = dato,
                     aarsinntekt = 100000,
                     fratrekkInnUt = 10000,
+                    relevanteMaaneder = 12,
                     spesifikasjon = "Spesifikasjon",
                     kilde = AvkortingGrunnlagKildeDto(
                         tidspunkt = tidspunkt.toString(),
@@ -116,8 +118,7 @@ class AvkortingRoutesTest {
                 )
             )
         )
-        val avkortingsgrunnlagSlot = slot<AvkortingGrunnlag>()
-        coEvery { avkortingService.lagreAvkorting(any(), any(), capture(avkortingsgrunnlagSlot)) } returns avkorting
+        coEvery { avkortingService.lagreAvkorting(any(), any(), any()) } returns avkorting
 
         testApplication(server.config.httpServer.port()) {
             val response = client.post("/api/beregning/avkorting/$behandlingsId") {
@@ -129,14 +130,42 @@ class AvkortingRoutesTest {
             response.status shouldBe HttpStatusCode.OK
             val result = objectMapper.readValue(response.bodyAsText(), AvkortingDto::class.java)
             result shouldBe dto
-            with(avkortingsgrunnlagSlot.captured) {
-                periode shouldBe avkortingsgrunnlag.periode
-                aarsinntekt shouldBe avkortingsgrunnlag.aarsinntekt
-                fratrekkInnUt shouldBe avkortingsgrunnlag.fratrekkInnUt
-                spesifikasjon shouldBe avkortingsgrunnlag.spesifikasjon
-                kilde.ident shouldBe avkortingsgrunnlag.kilde.ident
+            coVerify {
+                avkortingService.lagreAvkorting(
+                    behandlingsId,
+                    any(),
+                    withArg {
+                        it.periode shouldBe avkortingsgrunnlag.periode
+                        it.aarsinntekt shouldBe avkortingsgrunnlag.aarsinntekt
+                        it.fratrekkInnUt shouldBe avkortingsgrunnlag.fratrekkInnUt
+                        it.relevanteMaaneder shouldBe 12
+                        it.spesifikasjon shouldBe avkortingsgrunnlag.spesifikasjon
+                        it.kilde.ident shouldBe avkortingsgrunnlag.kilde.ident
+                    }
+                )
             }
         }
+    }
+
+    @Test
+    fun `skal regne ut relevant antall maaneder inkludert innevaerende hvis det ikke finnes fra foer`() {
+        val startenAvAaret = AvkortingGrunnlagDto(
+            relevanteMaaneder = null,
+            id = UUID.randomUUID(),
+            fom = YearMonth.of(2023, 1),
+            tom = null,
+            aarsinntekt = 100000,
+            fratrekkInnUt = 10000,
+            spesifikasjon = "Spesifikasjon",
+            kilde = AvkortingGrunnlagKildeDto(
+                tidspunkt = Tidspunkt.now().toString(),
+                ident = "Saksbehandler01"
+            )
+        )
+        val sluttenavAaret = startenAvAaret.copy(fom = YearMonth.of(2023, 12))
+
+        startenAvAaret.fromDto(bruker).relevanteMaaneder shouldBe 12
+        sluttenavAaret.fromDto(bruker).relevanteMaaneder shouldBe 1
     }
 
     private fun testApplication(port: Int, block: suspend ApplicationTestBuilder.() -> Unit) {

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
@@ -98,8 +98,8 @@ class AvkortingRoutesTest {
                     fom = dato,
                     tom = dato,
                     aarsinntekt = 100000,
-                    fratrekkInnUt = 10000,
-                    relevanteMaaneder = 12,
+                    fratrekkInnAar = 10000,
+                    relevanteMaanederInnAar = 12,
                     spesifikasjon = "Spesifikasjon",
                     kilde = AvkortingGrunnlagKildeDto(
                         tidspunkt = tidspunkt.toString(),
@@ -135,8 +135,8 @@ class AvkortingRoutesTest {
                     withArg {
                         it.periode shouldBe avkortingsgrunnlag.periode
                         it.aarsinntekt shouldBe avkortingsgrunnlag.aarsinntekt
-                        it.fratrekkInnUt shouldBe avkortingsgrunnlag.fratrekkInnUt
-                        it.relevanteMaaneder shouldBe 12
+                        it.fratrekkInnAar shouldBe avkortingsgrunnlag.fratrekkInnAar
+                        it.relevanteMaanederInnAar shouldBe 12
                         it.spesifikasjon shouldBe avkortingsgrunnlag.spesifikasjon
                         it.kilde.ident shouldBe avkortingsgrunnlag.kilde.ident
                     }
@@ -148,12 +148,12 @@ class AvkortingRoutesTest {
     @Test
     fun `skal regne ut relevant antall maaneder inkludert innevaerende hvis det ikke finnes fra foer`() {
         val startenAvAaret = AvkortingGrunnlagDto(
-            relevanteMaaneder = null,
+            relevanteMaanederInnAar = null,
             id = UUID.randomUUID(),
             fom = YearMonth.of(2023, 1),
             tom = null,
             aarsinntekt = 100000,
-            fratrekkInnUt = 10000,
+            fratrekkInnAar = 10000,
             spesifikasjon = "Spesifikasjon",
             kilde = AvkortingGrunnlagKildeDto(
                 tidspunkt = Tidspunkt.now().toString(),
@@ -162,8 +162,8 @@ class AvkortingRoutesTest {
         )
         val sluttenavAaret = startenAvAaret.copy(fom = YearMonth.of(2023, 12))
 
-        startenAvAaret.fromDto(bruker).relevanteMaaneder shouldBe 12
-        sluttenavAaret.fromDto(bruker).relevanteMaaneder shouldBe 1
+        startenAvAaret.fromDto(bruker).relevanteMaanederInnAar shouldBe 12
+        sluttenavAaret.fromDto(bruker).relevanteMaanederInnAar shouldBe 1
     }
 
     private fun testApplication(port: Int, block: suspend ApplicationTestBuilder.() -> Unit) {

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -114,7 +114,7 @@ internal class AvkortingServiceTest {
         every { inntektAvkortingService.beregnInntektsavkorting(any(), any()) } returns listOf(nyAvkortingsperiode)
         every { beregningService.hentBeregningNonnull(any()) } returns beregning
         every { inntektAvkortingService.beregnAvkortetYtelse(any(), any(), any()) } returns listOf(nyAvkortetYtelse)
-        every { avkortingRepository.lagreAvkorting(any()) } returns lagretAvkorting
+        every { avkortingRepository.lagreAvkorting(any(), any()) } returns lagretAvkorting
         coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
 
         runBlocking {
@@ -142,6 +142,7 @@ internal class AvkortingServiceTest {
                 listOf(nyAvkortingsperiode)
             )
             avkortingRepository.lagreAvkorting(
+                behandlingId,
                 withArg {
                     with(it.avkortingGrunnlag[0]) {
                         id shouldNotBe avkortinggrunnlag.id
@@ -165,7 +166,6 @@ internal class AvkortingServiceTest {
         val nyAvkortetYtelse = mockk<AvkortetYtelse>()
         val beregning = mockk<Beregningsperiode>()
         val nyAvkorting = Avkorting(
-            behandlingId = behandlingId,
             avkortingGrunnlag = listOf(nyttGrunnlag),
             avkortingsperioder = listOf(nyAvkortingsperiode),
             avkortetYtelse = listOf(nyAvkortetYtelse)
@@ -177,7 +177,7 @@ internal class AvkortingServiceTest {
         every { inntektAvkortingService.beregnInntektsavkorting(any(), any()) } returns listOf(nyAvkortingsperiode)
         every { beregningService.hentBeregningNonnull(any()) } returns beregning(listOf(beregning))
         every { inntektAvkortingService.beregnAvkortetYtelse(any(), any(), any()) } returns listOf(nyAvkortetYtelse)
-        every { avkortingRepository.lagreAvkorting(any()) } returns nyAvkorting
+        every { avkortingRepository.lagreAvkorting(any(), any()) } returns nyAvkorting
         coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
 
         val result = runBlocking {
@@ -196,7 +196,7 @@ internal class AvkortingServiceTest {
                 listOf(beregning),
                 listOf(nyAvkortingsperiode)
             )
-            avkortingRepository.lagreAvkorting(nyAvkorting)
+            avkortingRepository.lagreAvkorting(behandlingId, nyAvkorting)
             behandlingKlient.avkort(behandlingId, bruker, true)
         }
     }
@@ -212,7 +212,6 @@ internal class AvkortingServiceTest {
         val eksisterendeAvkortetYtelse = mockk<AvkortetYtelse>()
 
         val avkorting = Avkorting(
-            behandlingId = behandlingId,
             avkortingGrunnlag = listOf(eksisterendeGrunnlag),
             avkortingsperioder = listOf(eksisterendeAvkortingsperiode),
             avkortetYtelse = listOf(eksisterendeAvkortetYtelse)
@@ -228,7 +227,7 @@ internal class AvkortingServiceTest {
         every { inntektAvkortingService.beregnInntektsavkorting(any(), any()) } returns listOf(nyAvkortingsperiode)
         every { beregningService.hentBeregningNonnull(any()) } returns beregning(listOf(beregning))
         every { inntektAvkortingService.beregnAvkortetYtelse(any(), any(), any()) } returns listOf(nyAvkortetYtelse)
-        every { avkortingRepository.lagreAvkorting(any()) } returns avkorting
+        every { avkortingRepository.lagreAvkorting(any(), any()) } returns avkorting
         coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
 
         val result = runBlocking {
@@ -248,6 +247,7 @@ internal class AvkortingServiceTest {
                 listOf(nyAvkortingsperiode)
             )
             avkortingRepository.lagreAvkorting(
+                behandlingId,
                 withArg {
                     it.avkortingGrunnlag shouldBe listOf(endretGrunnlag)
                     it.avkortingsperioder shouldBe listOf(nyAvkortingsperiode)
@@ -269,7 +269,6 @@ internal class AvkortingServiceTest {
         val eksisterendeAvkortingsperiode = mockk<Avkortingsperiode>()
         val eksisterendeAvkortetYtelse = mockk<AvkortetYtelse>()
         val avkorting = Avkorting(
-            behandlingId = behandlingId,
             avkortingGrunnlag = listOf(eksisterendeGrunnlag),
             avkortingsperioder = listOf(eksisterendeAvkortingsperiode),
             avkortetYtelse = listOf(eksisterendeAvkortetYtelse)
@@ -287,7 +286,7 @@ internal class AvkortingServiceTest {
         every { inntektAvkortingService.beregnInntektsavkorting(any(), any()) } returns listOf(nyeAvkortingsperioder)
         every { beregningService.hentBeregningNonnull(any()) } returns beregning(listOf(beregninger))
         every { inntektAvkortingService.beregnAvkortetYtelse(any(), any(), any()) } returns listOf(nyeAvkortetYtelser)
-        every { avkortingRepository.lagreAvkorting(any()) } returns avkorting
+        every { avkortingRepository.lagreAvkorting(any(), any()) } returns avkorting
         coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
 
         val result = runBlocking {
@@ -314,6 +313,7 @@ internal class AvkortingServiceTest {
                 listOf(nyeAvkortingsperioder)
             )
             avkortingRepository.lagreAvkorting(
+                behandlingId,
                 withArg {
                     it.avkortingGrunnlag[0].periode.tom shouldBe YearMonth.of(2023, 3)
                     it.avkortingGrunnlag[1].periode.tom shouldBe null

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/InntektAvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/InntektAvkortingServiceTest.kt
@@ -41,15 +41,19 @@ class InntektAvkortingServiceTest {
     }
 
     @Test
-    fun `skal beregene avkorting for inntekt til en foerstegangsbehandling`() {
+    fun `skal beregne avkorting for inntekt til en foerstegangsbehandling`() {
         val virkningstidspunkt = YearMonth.of(2023, 1)
         val avkortingGrunnlag = listOf(
             avkortinggrunnlag(
                 aarsinntekt = 300000,
+                fratrekkInnUt = 50000,
+                relevanteMaaneder = 10,
                 periode = Periode(fom = YearMonth.of(2023, 1), tom = YearMonth.of(2023, 3))
             ),
             avkortinggrunnlag(
-                aarsinntekt = 500000,
+                aarsinntekt = 600000,
+                fratrekkInnUt = 100000,
+                relevanteMaaneder = 10,
                 periode = Periode(fom = YearMonth.of(2023, 4), tom = null)
             )
         )
@@ -68,12 +72,12 @@ class InntektAvkortingServiceTest {
             tidspunkt shouldNotBe null
             periode.fom shouldBe YearMonth.of(2023, 4)
             periode.tom shouldBe null
-            avkorting shouldBe 16660
+            avkorting shouldBe 20410
         }
     }
 
     @Test
-    fun `skal ikke tillate aa beregene avkorting for inntekt med feil perioder`() {
+    fun `skal ikke tillate aa beregne avkorting for inntekt med feil perioder`() {
         val virkningstidspunkt = YearMonth.of(2023, 1)
         val avkortingGrunnlag = listOf(
             avkortinggrunnlag(

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -29,13 +29,24 @@ export const AvkortingInntekt = (props: {
     }
   }
   const finnRedigerbartGrunnlag = () => {
-    if (finnesRedigerbartGrunnlag()) {
-      return props.avkortingGrunnlag![props.avkortingGrunnlag!.length - 1]
+    if (props.avkortingGrunnlag) {
+      if (finnesRedigerbartGrunnlag()) {
+        return props.avkortingGrunnlag[props.avkortingGrunnlag.length - 1]
+      }
+      if (props.avkortingGrunnlag.length > 0) {
+        const siste = props.avkortingGrunnlag[props.avkortingGrunnlag.length - 1]
+        return {
+          fom: virkningstidspunkt(),
+          fratrekkInnUt: siste.fratrekkInnUt,
+          relevanteMaaneder: siste.relevanteMaaneder,
+        }
+      }
     }
     return {
       fom: virkningstidspunkt(),
     }
   }
+
   const [inntektGrunnlagForm, setInntektGrunnlagForm] = useState<IAvkortingGrunnlag>(finnRedigerbartGrunnlag())
   const [inntektGrunnlagStatus, requestLagreAvkortingGrunnlag] = useApiCall(lagreAvkortingGrunnlag)
   const [errorTekst, setErrorTekst] = useState<string | null>(null)
@@ -83,7 +94,7 @@ export const AvkortingInntekt = (props: {
           <Table className="table" zebraStripes>
             <Table.Header>
               <Table.HeaderCell>Forventet inntekt</Table.HeaderCell>
-              <Table.HeaderCell>Fratrekk ut/inn</Table.HeaderCell>
+              <Table.HeaderCell>Fratrekk inn/ut</Table.HeaderCell>
               <Table.HeaderCell>F.o.m dato</Table.HeaderCell>
               <Table.HeaderCell>T.o.m dato</Table.HeaderCell>
               <Table.HeaderCell>Spesifikasjon av inntekt</Table.HeaderCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -37,8 +37,8 @@ export const AvkortingInntekt = (props: {
         const siste = props.avkortingGrunnlag[props.avkortingGrunnlag.length - 1]
         return {
           fom: virkningstidspunkt(),
-          fratrekkInnUt: siste.fratrekkInnUt,
-          relevanteMaaneder: siste.relevanteMaaneder,
+          fratrekkInnUt: siste.fratrekkInnAar,
+          relevanteMaaneder: siste.relevanteMaanederInnAar,
         }
       }
     }
@@ -104,7 +104,7 @@ export const AvkortingInntekt = (props: {
               {(props.avkortingGrunnlag ? props.avkortingGrunnlag : []).map((inntektsgrunnlag, index) => (
                 <Table.Row key={index}>
                   <Table.DataCell key="Inntekt">{inntektsgrunnlag.aarsinntekt}</Table.DataCell>
-                  <Table.DataCell key="FratrekkInnUt">{inntektsgrunnlag.fratrekkInnUt}</Table.DataCell>
+                  <Table.DataCell key="FratrekkInnUt">{inntektsgrunnlag.fratrekkInnAar}</Table.DataCell>
                   <Table.DataCell key="InntektFom">{inntektsgrunnlag.fom}</Table.DataCell>
                   <Table.DataCell key="InntektTom">{inntektsgrunnlag.tom}</Table.DataCell>
                   <Table.DataCell key="InntektSpesifikasjon">{inntektsgrunnlag.spesifikasjon}</Table.DataCell>
@@ -148,11 +148,11 @@ export const AvkortingInntekt = (props: {
                   type="text"
                   inputMode="numeric"
                   pattern="[0-9]*"
-                  value={inntektGrunnlagForm.fratrekkInnUt == null ? '0' : inntektGrunnlagForm.fratrekkInnUt}
+                  value={inntektGrunnlagForm.fratrekkInnAar == null ? '0' : inntektGrunnlagForm.fratrekkInnAar}
                   onChange={(e) =>
                     setInntektGrunnlagForm({
                       ...inntektGrunnlagForm,
-                      fratrekkInnUt: e.target.value === '' ? 0 : Number(e.target.value),
+                      fratrekkInnAar: e.target.value === '' ? 0 : Number(e.target.value),
                     })
                   }
                 />

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
@@ -10,6 +10,7 @@ export interface IAvkortingGrunnlag {
   tom?: string
   aarsinntekt?: number
   fratrekkInnUt?: number
+  relevanteMaaneder?: number
   spesifikasjon?: string
   kilde?: {
     tidspunkt: ''

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
@@ -9,8 +9,8 @@ export interface IAvkortingGrunnlag {
   fom?: string
   tom?: string
   aarsinntekt?: number
-  fratrekkInnUt?: number
-  relevanteMaaneder?: number
+  fratrekkInnAar?: number
+  relevanteMaanederInnAar?: number
   spesifikasjon?: string
   kilde?: {
     tidspunkt: ''

--- a/libs/saksbehandling-common/src/main/kotlin/beregning/BeregningDTO.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/beregning/BeregningDTO.kt
@@ -42,6 +42,7 @@ data class AvkortingGrunnlagDto(
     val tom: YearMonth?,
     val aarsinntekt: Int,
     val fratrekkInnUt: Int,
+    val relevanteMaaneder: Int?,
     val spesifikasjon: String,
     val kilde: AvkortingGrunnlagKildeDto?
 )

--- a/libs/saksbehandling-common/src/main/kotlin/beregning/BeregningDTO.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/beregning/BeregningDTO.kt
@@ -31,7 +31,6 @@ data class Beregningsperiode(
 )
 
 data class AvkortingDto(
-    val behandlingId: UUID,
     val avkortingGrunnlag: List<AvkortingGrunnlagDto>,
     val avkortetYtelse: List<AvkortetYtelseDto>
 )

--- a/libs/saksbehandling-common/src/main/kotlin/beregning/BeregningDTO.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/beregning/BeregningDTO.kt
@@ -40,8 +40,8 @@ data class AvkortingGrunnlagDto(
     val fom: YearMonth,
     val tom: YearMonth?,
     val aarsinntekt: Int,
-    val fratrekkInnUt: Int,
-    val relevanteMaaneder: Int?,
+    val fratrekkInnAar: Int,
+    val relevanteMaanederInnAar: Int?,
     val spesifikasjon: String,
     val kilde: AvkortingGrunnlagKildeDto?
 )


### PR DESCRIPTION
- Tilpasse regelkjøringer til beregne avkorting månedlig og ved å utelukke måneder som er før virk
- Nytt felt for relevante måneder i inneværende år
- Kopierer over innUtFratrekk og relevante måneder fra forrige avkortingsgrunnlag i revurdering av inntekt (frontend)

Bugfix
- Ny avkorting ble ikke lagret fordi lagring ble gjort med behandlingsid til forrige behandling
- Fjerner behandlingsId fra Avkorting da det ikke persisteres eller brukes til noe