### PR TITLE
Fjerner mulighet for redigering av trygdetid og inntekt fom status fattet

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -9,6 +9,7 @@ import { HjemmelLenke } from '~components/behandling/felles/HjemmelLenke'
 import { Info } from '~components/behandling/soeknadsoversikt/Info'
 import { IBehandlingReducer } from '~store/reducers/BehandlingReducer'
 import { PencilIcon } from '@navikt/aksel-icons'
+import { hentBehandlesFraStatus } from '~components/behandling/felles/utils'
 
 export const AvkortingInntekt = (props: {
   behandling: IBehandlingReducer
@@ -16,6 +17,7 @@ export const AvkortingInntekt = (props: {
   setAvkorting: (avkorting: IAvkorting) => void
 }) => {
   const behandling = props.behandling
+  const redigerbar = hentBehandlesFraStatus(behandling.status)
   if (!behandling) throw new Error('Mangler behandling')
 
   const virkningstidspunkt = () => {
@@ -123,101 +125,103 @@ export const AvkortingInntekt = (props: {
           </Table>
         </InntektAvkortingTabell>
       )}
-      <InntektAvkortingForm onSubmit={onSubmit}>
-        <Rows>
-          {formToggle && (
-            <>
-              <FormWrapper>
-                <TextField
-                  label={'Forventet årsinnekt'}
-                  size="medium"
-                  type="text"
-                  inputMode="numeric"
-                  pattern="[0-9]*"
-                  value={inntektGrunnlagForm.aarsinntekt}
-                  onChange={(e) =>
-                    setInntektGrunnlagForm({
-                      ...inntektGrunnlagForm,
-                      aarsinntekt: e.target.value === '' ? undefined : Number(e.target.value),
-                    })
-                  }
-                />
-                <TextField
-                  label={'Fratrekk inn/ut'}
-                  size="medium"
-                  type="text"
-                  inputMode="numeric"
-                  pattern="[0-9]*"
-                  value={inntektGrunnlagForm.fratrekkInnAar == null ? '0' : inntektGrunnlagForm.fratrekkInnAar}
-                  onChange={(e) =>
-                    setInntektGrunnlagForm({
-                      ...inntektGrunnlagForm,
-                      fratrekkInnAar: e.target.value === '' ? 0 : Number(e.target.value),
-                    })
-                  }
-                />
-                <DatoSection>
-                  <Label>F.o.m dato</Label>
-                  <Info label={''} tekst={formaterStringDato(inntektGrunnlagForm.fom!)} />
-                </DatoSection>
-              </FormWrapper>
-              <TextAreaWrapper>
-                <SpesifikasjonLabel>
-                  <Label>Spesifikasjon av inntekt</Label>
-                  <ReadMore header={'Hva regnes som inntekt?'}>
-                    Med inntekt menes all arbeidsinntekt og ytelser som likestilles med arbeidsinntekt. Likestilt med
-                    arbeidsinntekt er dagpenger etter kap 4, sykepenger etter kap 8, stønad ved barns og andre
-                    nærståendes sykdom etter kap 9, arbeidsavklaringspenger etter kap 11, uføretrygd etter kap 12 der
-                    uføregraden er under 100 prosent, svangerskapspenger og foreldrepenger etter kap 14 og
-                    pensjonsytelser etter AFP tilskottloven kapitlene 2 og 3.
-                  </ReadMore>
-                </SpesifikasjonLabel>
-                <textarea
-                  value={inntektGrunnlagForm.spesifikasjon}
-                  onChange={(e) =>
-                    setInntektGrunnlagForm({
-                      ...inntektGrunnlagForm,
-                      spesifikasjon: e.target.value,
-                    })
-                  }
-                />
-              </TextAreaWrapper>
-              {errorTekst == null ? null : <ErrorMessage>{errorTekst}</ErrorMessage>}
-            </>
-          )}
-          <FormKnapper>
-            {formToggle ? (
+      {redigerbar && (
+        <InntektAvkortingForm onSubmit={onSubmit}>
+          <Rows>
+            {formToggle && (
               <>
-                <Button size="small" loading={isPending(inntektGrunnlagStatus)} type="submit">
-                  Lagre
-                </Button>
+                <FormWrapper>
+                  <TextField
+                    label={'Forventet årsinnekt'}
+                    size="medium"
+                    type="text"
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                    value={inntektGrunnlagForm.aarsinntekt}
+                    onChange={(e) =>
+                      setInntektGrunnlagForm({
+                        ...inntektGrunnlagForm,
+                        aarsinntekt: e.target.value === '' ? undefined : Number(e.target.value),
+                      })
+                    }
+                  />
+                  <TextField
+                    label={'Fratrekk inn/ut'}
+                    size="medium"
+                    type="text"
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                    value={inntektGrunnlagForm.fratrekkInnAar == null ? '0' : inntektGrunnlagForm.fratrekkInnAar}
+                    onChange={(e) =>
+                      setInntektGrunnlagForm({
+                        ...inntektGrunnlagForm,
+                        fratrekkInnAar: e.target.value === '' ? 0 : Number(e.target.value),
+                      })
+                    }
+                  />
+                  <DatoSection>
+                    <Label>F.o.m dato</Label>
+                    <Info label={''} tekst={formaterStringDato(inntektGrunnlagForm.fom!)} />
+                  </DatoSection>
+                </FormWrapper>
+                <TextAreaWrapper>
+                  <SpesifikasjonLabel>
+                    <Label>Spesifikasjon av inntekt</Label>
+                    <ReadMore header={'Hva regnes som inntekt?'}>
+                      Med inntekt menes all arbeidsinntekt og ytelser som likestilles med arbeidsinntekt. Likestilt med
+                      arbeidsinntekt er dagpenger etter kap 4, sykepenger etter kap 8, stønad ved barns og andre
+                      nærståendes sykdom etter kap 9, arbeidsavklaringspenger etter kap 11, uføretrygd etter kap 12 der
+                      uføregraden er under 100 prosent, svangerskapspenger og foreldrepenger etter kap 14 og
+                      pensjonsytelser etter AFP tilskottloven kapitlene 2 og 3.
+                    </ReadMore>
+                  </SpesifikasjonLabel>
+                  <textarea
+                    value={inntektGrunnlagForm.spesifikasjon}
+                    onChange={(e) =>
+                      setInntektGrunnlagForm({
+                        ...inntektGrunnlagForm,
+                        spesifikasjon: e.target.value,
+                      })
+                    }
+                  />
+                </TextAreaWrapper>
+                {errorTekst == null ? null : <ErrorMessage>{errorTekst}</ErrorMessage>}
+              </>
+            )}
+            <FormKnapper>
+              {formToggle ? (
+                <>
+                  <Button size="small" loading={isPending(inntektGrunnlagStatus)} type="submit">
+                    Lagre
+                  </Button>
+                  <Button
+                    size="small"
+                    variant="tertiary"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      setFormToggle(false)
+                    }}
+                  >
+                    Avbryt
+                  </Button>
+                </>
+              ) : (
                 <Button
                   size="small"
-                  variant="tertiary"
+                  variant="secondary"
+                  icon={<PencilIcon title="a11y-title" fontSize="1.5rem" />}
                   onClick={(e) => {
                     e.preventDefault()
-                    setFormToggle(false)
+                    setFormToggle(true)
                   }}
                 >
-                  Avbryt
+                  {finnesRedigerbartGrunnlag() ? 'Rediger' : 'Legg til'}
                 </Button>
-              </>
-            ) : (
-              <Button
-                size="small"
-                variant="secondary"
-                icon={<PencilIcon title="a11y-title" fontSize="1.5rem" />}
-                onClick={(e) => {
-                  e.preventDefault()
-                  setFormToggle(true)
-                }}
-              >
-                {finnesRedigerbartGrunnlag() ? 'Rediger' : 'Legg til'}
-              </Button>
-            )}
-          </FormKnapper>
-        </Rows>
-      </InntektAvkortingForm>
+              )}
+            </FormKnapper>
+          </Rows>
+        </InntektAvkortingForm>
+      )}
     </AvkortingInntektWrapper>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
@@ -29,7 +29,7 @@ import Soeskenjustering, {
 const BeregningsgrunnlagBarnepensjon = (props: { behandling: IBehandlingReducer }) => {
   const { behandling } = props
   const { next } = useBehandlingRoutes()
-  const behandles = hentBehandlesFraStatus(behandling?.status)
+  const behandles = hentBehandlesFraStatus(behandling.status)
   const dispatch = useAppDispatch()
   const [lagreSoeskenMedIBeregningStatus, postSoeskenMedIBeregning] = useApiCall(lagreBeregningsGrunnlag)
   const [endreBeregning, postOpprettEllerEndreBeregning] = useApiCall(opprettEllerEndreBeregning)
@@ -90,7 +90,8 @@ const BeregningsgrunnlagBarnepensjon = (props: { behandling: IBehandlingReducer 
   }
   return (
     <>
-      {!isPending(funksjonsbrytere) && (beregnTrygdetid ? <BeregnetTrygdetid /> : <FastTrygdetid />)}
+      {!isPending(funksjonsbrytere) &&
+        (beregnTrygdetid ? <BeregnetTrygdetid redigerbar={behandles} /> : <FastTrygdetid />)}
       <Soeskenjustering
         behandling={behandling}
         onSubmit={(soeskenGrunnlag) => setSoeskenGrunnlagsData(soeskenGrunnlag)}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
@@ -17,7 +17,7 @@ const BeregningsgrunnlagOmstillingsstoenad = (props: { behandling: IDetaljertBeh
   const [beregning, setOpprettEllerEndreBeregning] = useApiCall(opprettEllerEndreBeregning)
   const { next } = useBehandlingRoutes()
   const dispatch = useAppDispatch()
-  const behandles = hentBehandlesFraStatus(behandling?.status)
+  const behandles = hentBehandlesFraStatus(behandling.status)
 
   const oppdaterBeregning = () => {
     dispatch(resetBeregning())
@@ -31,7 +31,7 @@ const BeregningsgrunnlagOmstillingsstoenad = (props: { behandling: IDetaljertBeh
     <>
       {isFailure(beregning) && <ApiErrorAlert>Kunne ikke opprette ny beregning</ApiErrorAlert>}
 
-      <Trygdetid />
+      <Trygdetid redigerbar={behandles} />
       <Border />
 
       {behandles ? (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
@@ -18,7 +18,11 @@ import { useParams } from 'react-router-dom'
 import { Grunnlagopplysninger } from '~components/behandling/trygdetid/Grunnlagopplysninger'
 import { TrygdetidGrunnlagListe } from '~components/behandling/trygdetid/TrygdetidGrunnlagListe'
 
-export const Trygdetid = () => {
+interface Props {
+  redigerbar: boolean
+}
+
+export const Trygdetid: React.FC<Props> = ({ redigerbar }) => {
   const { behandlingId } = useParams()
   const [hentTrygdetidRequest, fetchTrygdetid] = useApiCall(hentTrygdetid)
   const [opprettTrygdetidRequest, requestOpprettTrygdetid] = useApiCall(opprettTrygdetid)
@@ -79,12 +83,14 @@ export const Trygdetid = () => {
             setTrygdetid={setTrygdetid}
             landListe={landListe}
             trygdetidGrunnlagType={ITrygdetidGrunnlagType.FAKTISK}
+            redigerbar={redigerbar}
           />
           <TrygdetidGrunnlagListe
             trygdetid={trygdetid}
             setTrygdetid={setTrygdetid}
             landListe={landListe.filter((land) => land.isoLandkode == 'NOR')}
             trygdetidGrunnlagType={ITrygdetidGrunnlagType.FREMTIDIG}
+            redigerbar={redigerbar}
           />
           <TrygdetidBeregnet trygdetid={trygdetid} setTrygdetid={setTrygdetid} />
         </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlagListe.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlagListe.tsx
@@ -22,6 +22,7 @@ type Props = {
   setTrygdetid: (trygdetid: ITrygdetid) => void
   trygdetidGrunnlagType: ITrygdetidGrunnlagType
   landListe: ILand[]
+  redigerbar: boolean
 }
 
 const initialEndreModusState = {
@@ -34,6 +35,7 @@ export const TrygdetidGrunnlagListe: React.FC<Props> = ({
   setTrygdetid,
   trygdetidGrunnlagType,
   landListe,
+  redigerbar,
 }) => {
   const [endreModus, setEndreModus] = useState(initialEndreModusState)
   const trygdetidGrunnlagListe = trygdetid.trygdetidGrunnlag
@@ -45,6 +47,11 @@ export const TrygdetidGrunnlagListe: React.FC<Props> = ({
     setEndreModus(initialEndreModusState)
     setTrygdetid(trygdetid)
   }
+
+  const leggTilNyPeriodeTilgjengelig =
+    redigerbar &&
+    !endreModus.status &&
+    !(trygdetidGrunnlagType === ITrygdetidGrunnlagType.FREMTIDIG && trygdetidGrunnlagListe.length > 0)
 
   return (
     <GrunnlagListe>
@@ -72,8 +79,12 @@ export const TrygdetidGrunnlagListe: React.FC<Props> = ({
                 <Table.HeaderCell scope={'col'}>Til dato</Table.HeaderCell>
                 <Table.HeaderCell scope={'col'}>{grunnlagTypeTekst} trygdetid</Table.HeaderCell>
                 <Table.HeaderCell scope={'col'}>Kilde</Table.HeaderCell>
-                <Table.HeaderCell scope={'col'}> </Table.HeaderCell>
-                <Table.HeaderCell scope={'col'}> </Table.HeaderCell>
+                {redigerbar && (
+                  <>
+                    <Table.HeaderCell scope={'col'}> </Table.HeaderCell>
+                    <Table.HeaderCell scope={'col'}> </Table.HeaderCell>
+                  </>
+                )}
               </Table.Row>
             </Table.Header>
             <Table.Body>
@@ -88,6 +99,7 @@ export const TrygdetidGrunnlagListe: React.FC<Props> = ({
                     }}
                     landListe={landListe}
                     key={periode.id}
+                    redigerbar={redigerbar}
                   />
                 )
               })}
@@ -106,12 +118,11 @@ export const TrygdetidGrunnlagListe: React.FC<Props> = ({
             landListe={landListe}
           />
         )}
-        {!endreModus.status &&
-          !(trygdetidGrunnlagType === ITrygdetidGrunnlagType.FREMTIDIG && trygdetidGrunnlagListe.length > 0) && (
-            <Button size="small" onClick={() => setEndreModus({ status: true, trygdetidGrunnlagId: '' })}>
-              Legg til ny periode
-            </Button>
-          )}
+        {leggTilNyPeriodeTilgjengelig && (
+          <Button size="small" onClick={() => setEndreModus({ status: true, trygdetidGrunnlagId: '' })}>
+            Legg til ny periode
+          </Button>
+        )}
       </NyEllerOppdatertPeriode>
     </GrunnlagListe>
   )
@@ -123,12 +134,14 @@ const PeriodeRow = ({
   setTrygdetid,
   endrePeriode,
   landListe,
+  redigerbar,
 }: {
   trygdetidGrunnlag: ITrygdetidGrunnlag
   behandlingId: string
   setTrygdetid: (trygdetid: ITrygdetid) => void
   endrePeriode: (trygdetidGrunnlagId: string) => void
   landListe: ILand[]
+  redigerbar: boolean
 }) => {
   const [slettTrygdetidStatus, slettTrygdetidsgrunnlagRequest] = useApiCall(slettTrygdetidsgrunnlag)
 
@@ -172,17 +185,21 @@ const PeriodeRow = ({
         <BodyShort>{trygdetidGrunnlag.kilde.ident}</BodyShort>
         <Detail>{`saksbehandler: ${formaterStringDato(trygdetidGrunnlag.kilde.tidspunkt)}`}</Detail>
       </Table.DataCell>
-      <Table.DataCell>
-        <RedigerWrapper onClick={() => endrePeriode(trygdetidGrunnlag.id)}>Rediger</RedigerWrapper>
-      </Table.DataCell>
-      <Table.DataCell>
-        {isPending(slettTrygdetidStatus) ? (
-          <Spinner visible={true} variant={'neutral'} label="Sletter" margin={'1em'} />
-        ) : (
-          <RedigerWrapper onClick={() => slettGrunnlag(trygdetidGrunnlag.id)}>Slett</RedigerWrapper>
-        )}
-        {isFailure(slettTrygdetidStatus) && <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>}
-      </Table.DataCell>
+      {redigerbar && (
+        <>
+          <Table.DataCell>
+            <RedigerWrapper onClick={() => endrePeriode(trygdetidGrunnlag.id)}>Rediger</RedigerWrapper>
+          </Table.DataCell>
+          <Table.DataCell>
+            {isPending(slettTrygdetidStatus) ? (
+              <Spinner visible={true} variant={'neutral'} label="Sletter" margin={'1em'} />
+            ) : (
+              <RedigerWrapper onClick={() => slettGrunnlag(trygdetidGrunnlag.id)}>Slett</RedigerWrapper>
+            )}
+            {isFailure(slettTrygdetidStatus) && <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>}
+          </Table.DataCell>
+        </>
+      )}
     </Table.ExpandableRow>
   )
 }


### PR DESCRIPTION
Backend har tilstandssjekker for å unngå at det redigeres etter at et vedtak har blitt fattet, men trygdetid og avkorting har tillatt og legge til mer grunnlag i frontend. Fjerner knapper for dette.

EY-2203