### PR TITLE
Skjuler avbryt-dialogen hvis behandlingen ikke er under arbeid

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AnnullerBehanding.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AnnullerBehanding.tsx
@@ -6,8 +6,9 @@ import { useNavigate } from 'react-router'
 import { ApiResponse } from '~shared/api/apiClient'
 import { ButtonWrapper } from '~shared/modal/modal'
 import { useAppSelector } from '~store/Store'
-import { IBehandlingsType } from '~shared/types/IDetaljertBehandling'
+import { IBehandlingStatus, IBehandlingsType } from '~shared/types/IDetaljertBehandling'
 import { SidebarPanel } from '~components/behandling/SideMeny/SideMeny'
+import { hentBehandlesFraStatus } from '~components/behandling/felles/utils'
 
 export default function AnnullerBehandling() {
   const navigate = useNavigate()
@@ -16,6 +17,11 @@ export default function AnnullerBehandling() {
 
   const behandling = useAppSelector((state) => state.behandlingReducer.behandling)
   const erFoerstegangsbehandling = behandling?.behandlingType === IBehandlingsType.FØRSTEGANGSBEHANDLING
+
+  const behandles = hentBehandlesFraStatus(behandling?.status ?? IBehandlingStatus.IVERKSATT)
+  if (!behandles) {
+    return null
+  }
 
   const annuller = () => {
     if (behandling?.id) {


### PR DESCRIPTION
Unngår at den dukker opp i ferdigbehandlede saker som under:

<img width="390" alt="Screenshot 2023-06-14 at 11 50 44" src="https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/4296255/05ae49c0-4a13-4921-b14b-7714d50bc67f">
