### PR TITLE
Forsøker på nytt hvis gyldighetsvurdering feiler

### DIFF
--- a/apps/etterlatte-gyldig-soeknad/src/main/kotlin/gyldigsoeknad/barnepensjon/FordeltSoeknadRiver.kt
+++ b/apps/etterlatte-gyldig-soeknad/src/main/kotlin/gyldigsoeknad/barnepensjon/FordeltSoeknadRiver.kt
@@ -68,6 +68,7 @@ internal class FordeltSoeknadRiver(
                 logger.info("Vurdert gyldighet av søknad er fullført")
             } catch (e: Exception) {
                 logger.error("Gyldighetsvurdering av søknad om barnepensjon feilet", e)
+                throw e
             }
         }
 

--- a/apps/etterlatte-gyldig-soeknad/src/main/kotlin/gyldigsoeknad/omstillingsstoenad/InnsendtSoeknadRiver.kt
+++ b/apps/etterlatte-gyldig-soeknad/src/main/kotlin/gyldigsoeknad/omstillingsstoenad/InnsendtSoeknadRiver.kt
@@ -86,6 +86,7 @@ internal class InnsendtSoeknadRiver(
                 logger.info("Vurdert gyldighet av søknad om omstillingsstønad er fullført")
             } catch (e: Exception) {
                 logger.error("Gyldighetsvurdering av søknad om omstillingsstønad feilet", e)
+                throw e
             }
         }
     }


### PR DESCRIPTION
Dersom vi sender inn en søknad og en av oppslagene mot feks behandling feiler, vil det logges en feil, men søknaden må sendes inn på nytt. Burde ikke appen prøve å håndtere meldingen på nytt ved å restarte?