### PR TITLE
Ey 2314 restanse første utkast

### DIFF
--- a/apps/etterlatte-beregning/.run/etterlatte-beregning.dev-gcp.run.xml
+++ b/apps/etterlatte-beregning/.run/etterlatte-beregning.dev-gcp.run.xml
@@ -13,7 +13,7 @@
       <env name="ETTERLATTE_TRYGDETID_CLIENT_ID" value="8385435e-f3d7-45ec-be59-ebd1c71df735" />
       <env name="ETTERLATTE_TRYGDETID_URL" value="https://etterlatte-trygdetid.intern.dev.nav.no" />
       <env name="ETTERLATTE_VILKAARSVURDERING_CLIENT_ID" value="dev-gcp.etterlatte.etterlatte-vilkaarsvurdering" />
-      <env name="ETTERLATTE_VILKAARSVURDERING_URL" value="http://etterlatte-vilkaarsvurdering" />
+      <env name="ETTERLATTE_VILKAARSVURDERING_URL" value="http://etterlatte-vilkaarsvurdering.intern.dev.nav.no" />
       <env name="NAIS_APP_NAME" value="etterlatte-beregning" />
       <env name="NAIS_CLUSTER_NAME" value="dev-gcp" />
       <env name="ELECTOR_PATH" value="localhost" />

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -2,6 +2,8 @@ package no.nav.etterlatte.avkorting
 
 import com.fasterxml.jackson.databind.JsonNode
 import no.nav.etterlatte.beregning.Beregning
+import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -11,18 +13,24 @@ import java.util.*
 data class Avkorting(
     val avkortingGrunnlag: List<AvkortingGrunnlag>,
     val avkortingsperioder: List<Avkortingsperiode>,
-    val avkortetYtelse: List<AvkortetYtelse>,
-    val aarsoppgjoer: List<Aarsoppgjoer>
+    val aarsoppgjoer: List<AarsoppgjoerMaaned>,
+    val avkortetYtelse: List<AvkortetYtelse>
 ) {
 
     fun kopierAvkorting(): Avkorting = nyAvkorting(
-        avkortingGrunnlag = avkortingGrunnlag.map { it.copy(id = UUID.randomUUID()) }
+        avkortingGrunnlag = avkortingGrunnlag.map { it.copy(id = UUID.randomUUID()) },
+        restanseOppgjoer = this.aarsoppgjoer
     )
 
-    fun beregnAvkortingNyttEllerEndretGrunnlag(
+    fun beregnAvkortingMedNyttGrunnlag(
         nyttGrunnlag: AvkortingGrunnlag,
+        behandlingstype: BehandlingType,
         virkningstidspunkt: YearMonth,
         beregning: Beregning
+    ) = oppdaterMedInntektsgrunnlag(nyttGrunnlag).beregnAvkorting(behandlingstype, virkningstidspunkt, beregning)
+
+    fun oppdaterMedInntektsgrunnlag(
+        nyttGrunnlag: AvkortingGrunnlag
     ): Avkorting {
         val oppdaterteGrunnlag = avkortingGrunnlag
             .filter { it.id != nyttGrunnlag.id }
@@ -35,48 +43,132 @@ data class Avkorting(
                     else -> it
                 }
             } + listOf(nyttGrunnlag)
-        val oppdatertAvkorting = this.copy(avkortingGrunnlag = oppdaterteGrunnlag)
-        return oppdatertAvkorting.beregnAvkorting(virkningstidspunkt, beregning)
+
+        return this.copy(avkortingGrunnlag = oppdaterteGrunnlag)
     }
 
     fun beregnAvkorting(
+        behandlingstype: BehandlingType,
         virkningstidspunkt: YearMonth,
-        beregning: Beregning,
-        forrigeAvkorting: Avkorting? = null
+        beregning: Beregning
+    ): Avkorting = if (behandlingstype == BehandlingType.FØRSTEGANGSBEHANDLING) {
+        beregnAvkortingForstegangs(virkningstidspunkt, beregning)
+    } else {
+        beregnAvkortingRevurdering(virkningstidspunkt, beregning)
+    }
+
+    private fun beregnAvkortingForstegangs(
+        virkningstidspunkt: YearMonth,
+        beregning: Beregning
     ): Avkorting {
-        val beregnetAarsoppgjoer = AvkortingRegelkjoring.beregnAarsoppgjoer(this, virkningstidspunkt, forrigeAvkorting)
-        val beregnetAvkortingsperioder = AvkortingRegelkjoring.beregnInntektsavkorting(
-            Periode(fom = virkningstidspunkt, tom = null),
+        val avkortingsperioder = AvkortingRegelkjoring.beregnInntektsavkorting(
+            periode = Periode(fom = virkningstidspunkt, tom = null),
             avkortingGrunnlag
         )
+
         val beregnetAvkortetYtelse = AvkortingRegelkjoring.beregnAvkortetYtelse(
             Periode(fom = virkningstidspunkt, null),
             beregning.beregningsperioder,
-            beregnetAvkortingsperioder,
-            beregnetAarsoppgjoer.last().restanse
+            avkortingsperioder,
+            0
         )
 
+        val aarsoppgjoer = mutableListOf<AarsoppgjoerMaaned>()
+        for (maanednr in virkningstidspunkt.monthValue..12) {
+            val maaned = YearMonth.of(virkningstidspunkt.year, maanednr)
+            aarsoppgjoer.add(
+                AarsoppgjoerMaaned(
+                    maaned = maaned,
+                    beregning = beregning.beregningsperioder.beregningIMaaned(maaned),
+                    avkorting = avkortingsperioder.avkortingIMaaned(maaned),
+                    forventetAvkortetYtelse = beregnetAvkortetYtelse.avkortetYtelseIMaaned(maaned).ytelseEtterAvkorting,
+                    restanse = 0,
+                    fordeltRestanse = 0,
+                    faktiskAvkortetYtelse = beregnetAvkortetYtelse.avkortetYtelseIMaaned(maaned).ytelseEtterAvkorting
+                )
+            )
+        }
+
         return this.copy(
-            aarsoppgjoer = beregnetAarsoppgjoer.let {
-                val oppgjoerTidligereAar = aarsoppgjoer.filter { it.maaned.year != beregnetAarsoppgjoer[0].maaned.year }
-                oppgjoerTidligereAar + beregnetAarsoppgjoer
-            },
-            avkortingsperioder = beregnetAvkortingsperioder,
+            avkortingsperioder = avkortingsperioder,
+            aarsoppgjoer = aarsoppgjoer,
             avkortetYtelse = beregnetAvkortetYtelse
         )
     }
 
-    fun hentAktiveInntektsgrunnlag(): AvkortingGrunnlag =
-        avkortingGrunnlag.find { it.periode.tom == null } ?: throw Exception("Fant ingen løpende grunnlag")
+    private fun beregnAvkortingRevurdering(
+        virkningstidspunkt: YearMonth,
+        beregning: Beregning
+    ): Avkorting {
+        if (aarsoppgjoer.isEmpty()) {
+            throw IllegalArgumentException("Det må være et oppprettet årsoppgjør for å kunne beregne")
+        }
+
+        val avkortingsperioder = with(aarsoppgjoer.first()) {
+            AvkortingRegelkjoring.beregnInntektsavkorting(
+                periode = Periode(fom = maaned, tom = null),
+                listOf(avkortingGrunnlag.last().copy(periode = Periode(fom = maaned, tom = null)))
+            )
+        }
+
+        val aarsoppgjoerMedNyAvkorting = aarsoppgjoer.map {
+            it.copy(avkorting = avkortingsperioder.avkortingIMaaned(it.maaned))
+        }
+
+        val restanseFoerVirk = aarsoppgjoerMedNyAvkorting.filter { it.maaned < virkningstidspunkt }.map {
+            AvkortingRegelkjoring.beregnRestanse(it)
+        }
+        val aarsoppgjoerMedUtregnetRestanse = aarsoppgjoerMedNyAvkorting.map { aarsoppgjoerMaaned ->
+            if (aarsoppgjoerMaaned.maaned < virkningstidspunkt) {
+                val beregnetRestanse = restanseFoerVirk.oppgjoerIMaaned(aarsoppgjoerMaaned.maaned)
+                aarsoppgjoerMaaned.copy(
+                    forventetAvkortetYtelse = beregnetRestanse.forventetAvkortetYtelse,
+                    restanse = beregnetRestanse.restanse
+                )
+            } else {
+                aarsoppgjoerMaaned
+            }
+        }
+
+        val maanedligRestanse =
+            AvkortingRegelkjoring.beregnFordeltRestanse(virkningstidspunkt, aarsoppgjoerMedUtregnetRestanse)
+
+        val avkortetYtelseFraNyVirk = AvkortingRegelkjoring.beregnAvkortetYtelse(
+            Periode(fom = virkningstidspunkt, null),
+            beregning.beregningsperioder,
+            avkortingsperioder,
+            maanedligRestanse
+        )
+
+        val aarsoppgjoerMedFordeltRestanse = aarsoppgjoerMedUtregnetRestanse.map {
+            if (it.maaned >= virkningstidspunkt) {
+                val avkortetYtelse = avkortetYtelseFraNyVirk.avkortetYtelseIMaaned(it.maaned)
+                it.copy(
+                    forventetAvkortetYtelse = avkortetYtelse.ytelseEtterAvkortingFoerRestanse,
+                    fordeltRestanse = avkortetYtelse.restanse,
+                    faktiskAvkortetYtelse = avkortetYtelse.ytelseEtterAvkorting
+                )
+            } else {
+                it
+            }
+        }
+
+        return this.copy(
+            avkortingsperioder = avkortingsperioder,
+            aarsoppgjoer = aarsoppgjoerMedFordeltRestanse,
+            avkortetYtelse = avkortetYtelseFraNyVirk
+        )
+    }
 
     companion object {
         fun nyAvkorting(
-            avkortingGrunnlag: List<AvkortingGrunnlag> = emptyList()
+            avkortingGrunnlag: List<AvkortingGrunnlag> = emptyList(),
+            restanseOppgjoer: List<AarsoppgjoerMaaned> = emptyList()
         ) = Avkorting(
             avkortingGrunnlag = avkortingGrunnlag,
-            emptyList(),
-            emptyList(),
-            emptyList()
+            avkortingsperioder = emptyList(),
+            aarsoppgjoer = restanseOppgjoer,
+            avkortetYtelse = emptyList()
         )
     }
 }
@@ -99,13 +191,20 @@ data class Avkortingsperiode(
     val kilde: Grunnlagsopplysning.RegelKilde
 )
 
-fun List<Avkortingsperiode>.avkortingIPeriode(maaned: YearMonth) = this.find {
-    maaned >= it.periode.fom && (it.periode.tom == null || maaned <= it.periode.tom)
-}?.avkorting ?: throw Exception("Perioder ny inntektsavkorting stemmer ikke overens med tidligere avkortinger")
+data class AarsoppgjoerMaaned(
+    val maaned: YearMonth,
+    val beregning: Int,
+    val avkorting: Int,
+    val forventetAvkortetYtelse: Int,
+    val restanse: Int, // TODO EY-2368 persistere regelresultat
+    val fordeltRestanse: Int,
+    val faktiskAvkortetYtelse: Int
+)
 
 data class AvkortetYtelse(
     val periode: Periode,
     val ytelseEtterAvkorting: Int,
+    val ytelseEtterAvkortingFoerRestanse: Int, // TODO EY-2368 Legge til i DB
     val restanse: Int = 0,
     val avkortingsbeloep: Int,
     val ytelseFoerAvkorting: Int,
@@ -114,10 +213,18 @@ data class AvkortetYtelse(
     val kilde: Grunnlagsopplysning.RegelKilde
 )
 
-data class Aarsoppgjoer(
-    val maaned: YearMonth,
-    val avkortingForventetInntekt: Int,
-    val tidligereAvkorting: Int,
-    val restanse: Int,
-    val nyAvkorting: Int
-)
+fun List<AvkortetYtelse>.avkortetYtelseIMaaned(maaned: YearMonth) = this.find {
+    maaned >= it.periode.fom && (it.periode.tom == null || maaned <= it.periode.tom)
+} ?: throw Exception("Maaned finnes ikke i avkortet ytelse sin periode")
+
+fun List<Avkortingsperiode>.avkortingIMaaned(maaned: YearMonth) = this.find {
+    maaned >= it.periode.fom && (it.periode.tom == null || maaned <= it.periode.tom)
+}?.avkorting ?: throw Exception("Maaned finnes ikke i avkortingsperioder")
+
+fun List<Beregningsperiode>.beregningIMaaned(maaned: YearMonth) = this.find {
+    maaned >= it.datoFOM && (it.datoTOM == null || maaned <= it.datoTOM)
+}?.utbetaltBeloep ?: throw Exception("Maaned finnes ikke i beregningsperioder")
+
+fun List<AarsoppgjoerMaaned>.oppgjoerIMaaned(maaned: YearMonth) = this.find {
+    it.maaned == maaned
+} ?: throw Exception("Maaned finnes ikke i aarsoppgjoeret")

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -1,17 +1,29 @@
 package no.nav.etterlatte.avkorting
 
 import com.fasterxml.jackson.databind.JsonNode
+import no.nav.etterlatte.beregning.Beregning
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import java.time.YearMonth
 import java.util.*
 
 data class Avkorting(
     val avkortingGrunnlag: List<AvkortingGrunnlag>,
     val avkortingsperioder: List<Avkortingsperiode>,
-    val avkortetYtelse: List<AvkortetYtelse>
+    val avkortetYtelse: List<AvkortetYtelse>,
+    val aarsoppgjoer: List<Aarsoppgjoer>
 ) {
-    fun leggTilEllerOppdaterGrunnlag(nyttGrunnlag: AvkortingGrunnlag): Avkorting {
+
+    fun kopierAvkorting(): Avkorting = nyAvkorting(
+        avkortingGrunnlag = avkortingGrunnlag.map { it.copy(id = UUID.randomUUID()) }
+    )
+
+    fun beregnAvkortingNyttEllerEndretGrunnlag(
+        nyttGrunnlag: AvkortingGrunnlag,
+        virkningstidspunkt: YearMonth,
+        beregning: Beregning
+    ): Avkorting {
         val oppdaterteGrunnlag = avkortingGrunnlag
             .filter { it.id != nyttGrunnlag.id }
             .map {
@@ -23,19 +35,45 @@ data class Avkorting(
                     else -> it
                 }
             } + listOf(nyttGrunnlag)
-        return this.copy(avkortingGrunnlag = oppdaterteGrunnlag)
+        val oppdatertAvkorting = this.copy(avkortingGrunnlag = oppdaterteGrunnlag)
+        return oppdatertAvkorting.beregnAvkorting(virkningstidspunkt, beregning)
     }
 
-    fun oppdaterAvkortingMedNyeBeregninger(
-        nyeAvkortingsperioder: List<Avkortingsperiode>,
-        nyAvkortetYtelse: List<AvkortetYtelse>
-    ): Avkorting = this.copy(
-        avkortingsperioder = nyeAvkortingsperioder,
-        avkortetYtelse = nyAvkortetYtelse
-    )
+    fun beregnAvkorting(
+        virkningstidspunkt: YearMonth,
+        beregning: Beregning,
+        forrigeAvkorting: Avkorting? = null
+    ): Avkorting {
+        val beregnetAarsoppgjoer = AvkortingRegelkjoring.beregnAarsoppgjoer(this, virkningstidspunkt, forrigeAvkorting)
+        val beregnetAvkortingsperioder = AvkortingRegelkjoring.beregnInntektsavkorting(
+            Periode(fom = virkningstidspunkt, tom = null),
+            avkortingGrunnlag
+        )
+        val beregnetAvkortetYtelse = AvkortingRegelkjoring.beregnAvkortetYtelse(
+            Periode(fom = virkningstidspunkt, null),
+            beregning.beregningsperioder,
+            beregnetAvkortingsperioder,
+            beregnetAarsoppgjoer.last().restanse
+        )
+
+        return this.copy(
+            aarsoppgjoer = beregnetAarsoppgjoer.let {
+                val oppgjoerTidligereAar = aarsoppgjoer.filter { it.maaned.year != beregnetAarsoppgjoer[0].maaned.year }
+                oppgjoerTidligereAar + beregnetAarsoppgjoer
+            },
+            avkortingsperioder = beregnetAvkortingsperioder,
+            avkortetYtelse = beregnetAvkortetYtelse
+        )
+    }
+
+    fun hentAktiveInntektsgrunnlag(): AvkortingGrunnlag =
+        avkortingGrunnlag.find { it.periode.tom == null } ?: throw Exception("Fant ingen løpende grunnlag")
 
     companion object {
-        fun nyAvkorting() = Avkorting(
+        fun nyAvkorting(
+            avkortingGrunnlag: List<AvkortingGrunnlag> = emptyList()
+        ) = Avkorting(
+            avkortingGrunnlag = avkortingGrunnlag,
             emptyList(),
             emptyList(),
             emptyList()
@@ -61,12 +99,25 @@ data class Avkortingsperiode(
     val kilde: Grunnlagsopplysning.RegelKilde
 )
 
+fun List<Avkortingsperiode>.avkortingIPeriode(maaned: YearMonth) = this.find {
+    maaned >= it.periode.fom && (it.periode.tom == null || maaned <= it.periode.tom)
+}?.avkorting ?: throw Exception("Perioder ny inntektsavkorting stemmer ikke overens med tidligere avkortinger")
+
 data class AvkortetYtelse(
     val periode: Periode,
     val ytelseEtterAvkorting: Int,
+    val restanse: Int = 0,
     val avkortingsbeloep: Int,
     val ytelseFoerAvkorting: Int,
     val tidspunkt: Tidspunkt,
     val regelResultat: JsonNode,
     val kilde: Grunnlagsopplysning.RegelKilde
+)
+
+data class Aarsoppgjoer(
+    val maaned: YearMonth,
+    val avkortingForventetInntekt: Int,
+    val tidligereAvkorting: Int,
+    val restanse: Int,
+    val nyAvkorting: Int
 )

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -83,6 +83,7 @@ fun AvkortetYtelse.toDto() = AvkortetYtelseDto(
     fom = periode.fom.atDay(1),
     tom = periode.tom?.atEndOfMonth(),
     avkortingsbeloep = avkortingsbeloep,
+    restanse = restanse,
     ytelseEtterAvkorting = ytelseEtterAvkorting
 )
 

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -3,13 +3,13 @@ package no.nav.etterlatte.avkorting
 import no.nav.etterlatte.beregning.BeregningService
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
 import java.util.*
 
 class AvkortingService(
     private val behandlingKlient: BehandlingKlient,
-    private val inntektAvkortingService: InntektAvkortingService,
     private val avkortingRepository: AvkortingRepository,
     private val beregningService: BeregningService
 ) {
@@ -41,8 +41,14 @@ class AvkortingService(
         logger.info("Lagre og beregne avkorting og avkortet ytelse for behandlingId=$behandlingId")
 
         val avkorting = avkortingRepository.hentAvkorting(behandlingId) ?: Avkorting.nyAvkorting()
-        val avkortingMedNyttGrunnlag = avkorting.leggTilEllerOppdaterGrunnlag(avkortingGrunnlag)
-        val beregnetAvkorting = beregnAvkorting(avkortingMedNyttGrunnlag, behandlingId, brukerTokenInfo)
+
+        val virkningstidspunkt = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo).hentVirk()
+        val beregning = beregningService.hentBeregningNonnull(behandlingId)
+        val beregnetAvkorting = avkorting.beregnAvkortingNyttEllerEndretGrunnlag(
+            avkortingGrunnlag,
+            virkningstidspunkt,
+            beregning
+        )
 
         val lagretAvkorting = avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
         behandlingKlient.avkort(behandlingId, brukerTokenInfo, true)
@@ -58,43 +64,23 @@ class AvkortingService(
         val forrigeAvkorting = avkortingRepository.hentAvkorting(forrigeBehandlingId) ?: throw Exception(
             "Fant ikke avkorting for $forrigeBehandlingId"
         )
-        val nyAvkorting = forrigeAvkorting.copy(
-            avkortingGrunnlag = forrigeAvkorting.avkortingGrunnlag.map { it.copy(id = UUID.randomUUID()) }
-        )
-        val beregnetAvkorting = beregnAvkorting(nyAvkorting, behandlingId, brukerTokenInfo)
+        val nyAvkorting = forrigeAvkorting.kopierAvkorting()
+
+        val virkningstidspunkt = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo).hentVirk()
+        val beregning = beregningService.hentBeregningNonnull(behandlingId)
+        val beregnetAvkorting = nyAvkorting.beregnAvkorting(virkningstidspunkt, beregning, forrigeAvkorting)
 
         val lagretAvkorting = avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
         behandlingKlient.avkort(behandlingId, brukerTokenInfo, true)
         return lagretAvkorting
     }
 
-    private suspend fun beregnAvkorting(
-        avkorting: Avkorting,
-        behandlingId: UUID,
-        brukerTokenInfo: BrukerTokenInfo
-    ): Avkorting {
-        val virkningstidspunkt = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo).virkningstidspunkt?.dato
-            ?: throw Exception("Mangler virkningstidspunkt for behandling $behandlingId")
-
-        val avkortingsperioder = inntektAvkortingService.beregnInntektsavkorting(
-            virkningstidspunkt,
-            avkorting.avkortingGrunnlag
-        )
-        val beregning = beregningService.hentBeregningNonnull(behandlingId)
-        val beregnetAvkortetYtelse = inntektAvkortingService.beregnAvkortetYtelse(
-            virkningstidspunkt,
-            beregning.beregningsperioder,
-            avkortingsperioder
-        )
-        return avkorting.oppdaterAvkortingMedNyeBeregninger(avkortingsperioder, beregnetAvkortetYtelse)
-    }
-
     private suspend fun tilstandssjekk(
         behandlingId: UUID,
-        brukerTokenInfo: BrukerTokenInfo,
+        bruker: BrukerTokenInfo,
         block: suspend () -> Avkorting
     ): Avkorting {
-        val kanAvkorte = behandlingKlient.avkort(behandlingId, brukerTokenInfo, commit = false)
+        val kanAvkorte = behandlingKlient.avkort(behandlingId, bruker, commit = false)
         return if (kanAvkorte) {
             block()
         } else {
@@ -102,3 +88,6 @@ class AvkortingService(
         }
     }
 }
+
+private fun DetaljertBehandling.hentVirk() =
+    virkningstidspunkt?.dato ?: throw Exception("Mangler virkningstidspunkt for behandling $id")

--- a/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
@@ -4,7 +4,6 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import no.nav.etterlatte.avkorting.AvkortingRepository
 import no.nav.etterlatte.avkorting.AvkortingService
-import no.nav.etterlatte.avkorting.InntektAvkortingService
 import no.nav.etterlatte.beregning.BeregnBarnepensjonService
 import no.nav.etterlatte.beregning.BeregnOmstillingsstoenadService
 import no.nav.etterlatte.beregning.BeregningRepository
@@ -71,13 +70,13 @@ class ApplicationContext {
         beregnBarnepensjonService = beregnBarnepensjonService,
         beregnOmstillingsstoenadService = beregnOmstillingsstoenadService
     )
+    val avkortingRepository = AvkortingRepository(dataSource)
     val avkortingService = AvkortingService(
         behandlingKlient = behandlingKlient,
-        inntektAvkortingService = InntektAvkortingService,
-        avkortingRepository = AvkortingRepository(dataSource),
+        avkortingRepository = avkortingRepository,
         beregningService = beregningService
     )
     val ytelseMedGrunnlagService = YtelseMedGrunnlagService(
-        avkortingRepository = AvkortingRepository(dataSource)
+        avkortingRepository = avkortingRepository
     )
 }

--- a/apps/etterlatte-beregning/src/main/resources/db/migration/V20__legge_til_restanse_avkortet_ytelse.sql
+++ b/apps/etterlatte-beregning/src/main/resources/db/migration/V20__legge_til_restanse_avkortet_ytelse.sql
@@ -1,0 +1,11 @@
+ALTER TABLE avkortet_ytelse ADD COLUMN restanse BIGINT;
+
+CREATE TABLE avkorting_aarsoppgjoer(
+   id UUID PRIMARY KEY,
+   behandling_id UUID NOT NULL,
+   maaned Date,
+   avkorting_forventet_inntekt BIGINT,
+   tidligere_avkorting BIGINT,
+   restanse BIGINT,
+   ny_avkorting BIGINT
+);

--- a/apps/etterlatte-beregning/src/main/resources/db/migration/V21__legge_til_restanse_avkortet_ytelse.sql
+++ b/apps/etterlatte-beregning/src/main/resources/db/migration/V21__legge_til_restanse_avkortet_ytelse.sql
@@ -4,8 +4,10 @@ CREATE TABLE avkorting_aarsoppgjoer(
    id UUID PRIMARY KEY,
    behandling_id UUID NOT NULL,
    maaned Date,
-   avkorting_forventet_inntekt BIGINT,
-   tidligere_avkorting BIGINT,
+   beregning BIGINT,
+   avkorting BIGINT,
+   forventet_avkortet_ytelse BIGINT,
    restanse BIGINT,
-   ny_avkorting BIGINT
+   fordelt_restanse BIGINT,
+   faktisk_avkortet_ytelse BIGINT
 );

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.beregning.regler
 
+import no.nav.etterlatte.avkorting.Aarsoppgjoer
 import no.nav.etterlatte.avkorting.AvkortetYtelse
 import no.nav.etterlatte.avkorting.Avkorting
 import no.nav.etterlatte.avkorting.AvkortingGrunnlag
@@ -70,11 +71,13 @@ val bruker = Saksbehandler("token", "ident", null)
 fun avkorting(
     avkortingGrunnlag: List<AvkortingGrunnlag> = emptyList(),
     avkortingsperioder: List<Avkortingsperiode> = emptyList(),
-    avkortetYtelse: List<AvkortetYtelse> = emptyList()
+    avkortetYtelse: List<AvkortetYtelse> = emptyList(),
+    aarsoppgjoer: List<Aarsoppgjoer> = emptyList()
 ) = Avkorting(
     avkortingGrunnlag = avkortingGrunnlag,
     avkortingsperioder = avkortingsperioder,
-    avkortetYtelse = avkortetYtelse
+    avkortetYtelse = avkortetYtelse,
+    aarsoppgjoer = aarsoppgjoer
 )
 
 fun avkortinggrunnlag(
@@ -143,6 +146,20 @@ fun avkortetYtelse(
     tidspunkt = Tidspunkt.now(),
     regelResultat = "".toJsonNode(),
     kilde = Grunnlagsopplysning.RegelKilde("regelid", Tidspunkt.now(), "1")
+)
+
+fun aarsoppgjoer(
+    maaned: YearMonth = YearMonth.of(2023, 1),
+    avkortingForventetInntekt: Int = 10000,
+    tidligereAvkorting: Int = 5000,
+    nyAvkorting: Int = 15000,
+    restanse: Int = 5000
+) = Aarsoppgjoer(
+    maaned = maaned,
+    avkortingForventetInntekt = avkortingForventetInntekt,
+    tidligereAvkorting = tidligereAvkorting,
+    nyAvkorting = nyAvkorting,
+    restanse = restanse
 )
 
 fun beregning(

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -1,6 +1,6 @@
 package no.nav.etterlatte.beregning.regler
 
-import no.nav.etterlatte.avkorting.Aarsoppgjoer
+import no.nav.etterlatte.avkorting.AarsoppgjoerMaaned
 import no.nav.etterlatte.avkorting.AvkortetYtelse
 import no.nav.etterlatte.avkorting.Avkorting
 import no.nav.etterlatte.avkorting.AvkortingGrunnlag
@@ -72,12 +72,12 @@ fun avkorting(
     avkortingGrunnlag: List<AvkortingGrunnlag> = emptyList(),
     avkortingsperioder: List<Avkortingsperiode> = emptyList(),
     avkortetYtelse: List<AvkortetYtelse> = emptyList(),
-    aarsoppgjoer: List<Aarsoppgjoer> = emptyList()
+    aarsoppgjoer: List<AarsoppgjoerMaaned> = emptyList()
 ) = Avkorting(
     avkortingGrunnlag = avkortingGrunnlag,
     avkortingsperioder = avkortingsperioder,
-    avkortetYtelse = avkortetYtelse,
-    aarsoppgjoer = aarsoppgjoer
+    aarsoppgjoer = aarsoppgjoer,
+    avkortetYtelse = avkortetYtelse
 )
 
 fun avkortinggrunnlag(
@@ -132,6 +132,8 @@ fun avkortetYtelseGrunnlag(beregning: Int, avkorting: Int) = AvkortetYtelseGrunn
 
 fun avkortetYtelse(
     ytelseEtterAvkorting: Int = 100,
+    restanse: Int = 50,
+    ytelseEtterAvkortingFoerRestanse: Int = 0,
     avkortingsbeloep: Int = 200,
     ytelseFoerAvkorting: Int = 300,
     periode: Periode = Periode(
@@ -141,6 +143,8 @@ fun avkortetYtelse(
 ) = AvkortetYtelse(
     periode = periode,
     ytelseEtterAvkorting = ytelseEtterAvkorting,
+    restanse = restanse,
+    ytelseEtterAvkortingFoerRestanse = ytelseEtterAvkortingFoerRestanse,
     avkortingsbeloep = avkortingsbeloep,
     ytelseFoerAvkorting = ytelseFoerAvkorting,
     tidspunkt = Tidspunkt.now(),
@@ -148,18 +152,22 @@ fun avkortetYtelse(
     kilde = Grunnlagsopplysning.RegelKilde("regelid", Tidspunkt.now(), "1")
 )
 
-fun aarsoppgjoer(
+fun aarsoppgjoerMaaned(
     maaned: YearMonth = YearMonth.of(2023, 1),
-    avkortingForventetInntekt: Int = 10000,
-    tidligereAvkorting: Int = 5000,
-    nyAvkorting: Int = 15000,
-    restanse: Int = 5000
-) = Aarsoppgjoer(
+    beregning: Int = 0,
+    avkorting: Int = 0,
+    forventetAvkortetYtelse: Int = 0,
+    restanse: Int = 0,
+    fordeltRestanse: Int = 0,
+    faktiskAvkortetYtelse: Int = 0
+) = AarsoppgjoerMaaned(
     maaned = maaned,
-    avkortingForventetInntekt = avkortingForventetInntekt,
-    tidligereAvkorting = tidligereAvkorting,
-    nyAvkorting = nyAvkorting,
-    restanse = restanse
+    beregning = beregning,
+    avkorting = avkorting,
+    forventetAvkortetYtelse = forventetAvkortetYtelse,
+    restanse = restanse,
+    fordeltRestanse = fordeltRestanse,
+    faktiskAvkortetYtelse = faktiskAvkortetYtelse
 )
 
 fun beregning(

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRegelkjoringTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRegelkjoringTest.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
-import no.nav.etterlatte.avkorting.InntektAvkortingService
+import no.nav.etterlatte.avkorting.AvkortingRegelkjoring
 import no.nav.etterlatte.beregning.grunnlag.PeriodiseringAvGrunnlagFeil
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
 import no.nav.etterlatte.beregning.regler.avkortingsperiode
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
 import java.time.YearMonth
 
-class InntektAvkortingServiceTest {
+class AvkortingRegelkjoringTest {
 
     @BeforeEach
     fun before() {
@@ -58,7 +58,10 @@ class InntektAvkortingServiceTest {
             )
         )
 
-        val avkortingsperioder = InntektAvkortingService.beregnInntektsavkorting(virkningstidspunkt, avkortingGrunnlag)
+        val avkortingsperioder = AvkortingRegelkjoring.beregnInntektsavkorting(
+            Periode(fom = virkningstidspunkt, tom = null),
+            avkortingGrunnlag
+        )
 
         with(avkortingsperioder[0]) {
             regelResultat shouldNotBe null
@@ -91,7 +94,10 @@ class InntektAvkortingServiceTest {
         )
 
         assertThrows<PeriodiseringAvGrunnlagFeil> {
-            InntektAvkortingService.beregnInntektsavkorting(virkningstidspunkt, avkortingGrunnlag)
+            AvkortingRegelkjoring.beregnInntektsavkorting(
+                Periode(fom = virkningstidspunkt, tom = null),
+                avkortingGrunnlag
+            )
         }
     }
 
@@ -126,10 +132,11 @@ class InntektAvkortingServiceTest {
             )
         )
 
-        val avkortetYtelse = InntektAvkortingService.beregnAvkortetYtelse(
-            virkningstidspunkt,
+        val avkortetYtelse = AvkortingRegelkjoring.beregnAvkortetYtelse(
+            Periode(fom = virkningstidspunkt, tom = null),
             beregninger,
-            avkortingsperioder
+            avkortingsperioder,
+            maanedligRestanse = 0
         )
 
         avkortetYtelse.size shouldBe 4

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRegelkjoringTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRegelkjoringTest.kt
@@ -2,59 +2,33 @@ package avkorting
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.mockk.every
-import io.mockk.mockkObject
-import io.mockk.unmockkObject
 import no.nav.etterlatte.avkorting.AvkortingRegelkjoring
 import no.nav.etterlatte.beregning.grunnlag.PeriodiseringAvGrunnlagFeil
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
 import no.nav.etterlatte.beregning.regler.avkortingsperiode
 import no.nav.etterlatte.beregning.regler.beregningsperiode
-import no.nav.etterlatte.grunnbeloep.Grunnbeloep
-import no.nav.etterlatte.grunnbeloep.GrunnbeloepRepository
 import no.nav.etterlatte.libs.common.periode.Periode
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.math.BigDecimal
 import java.time.YearMonth
 
 class AvkortingRegelkjoringTest {
 
-    @BeforeEach
-    fun before() {
-        mockkObject(GrunnbeloepRepository)
-        every { GrunnbeloepRepository.historiskeGrunnbeloep } returns listOf(
-            Grunnbeloep(
-                dato = YearMonth.of(2022, 5),
-                grunnbeloep = 111477,
-                grunnbeloepPerMaaned = 9290,
-                omregningsfaktor = BigDecimal(1.047726)
-            )
-        )
-    }
-
-    @AfterEach
-    fun after() {
-        unmockkObject(GrunnbeloepRepository)
-    }
-
     @Test
     fun `skal beregne avkorting for inntekt til en foerstegangsbehandling`() {
-        val virkningstidspunkt = YearMonth.of(2023, 1)
+        val virkningstidspunkt = YearMonth.of(2023, 6)
         val avkortingGrunnlag = listOf(
             avkortinggrunnlag(
                 aarsinntekt = 300000,
                 fratrekkInnAar = 50000,
                 relevanteMaanederInnAar = 10,
-                periode = Periode(fom = YearMonth.of(2023, 1), tom = YearMonth.of(2023, 3))
+                periode = Periode(fom = YearMonth.of(2023, 6), tom = YearMonth.of(2023, 8))
             ),
             avkortinggrunnlag(
                 aarsinntekt = 600000,
                 fratrekkInnAar = 100000,
                 relevanteMaanederInnAar = 10,
-                periode = Periode(fom = YearMonth.of(2023, 4), tom = null)
+                periode = Periode(fom = YearMonth.of(2023, 9), tom = null)
             )
         )
 
@@ -66,16 +40,16 @@ class AvkortingRegelkjoringTest {
         with(avkortingsperioder[0]) {
             regelResultat shouldNotBe null
             tidspunkt shouldNotBe null
-            periode.fom shouldBe YearMonth.of(2023, 1)
-            periode.tom shouldBe YearMonth.of(2023, 3)
-            avkorting shouldBe 9160
+            periode.fom shouldBe YearMonth.of(2023, 6)
+            periode.tom shouldBe YearMonth.of(2023, 8)
+            avkorting shouldBe 9026
         }
         with(avkortingsperioder[1]) {
             regelResultat shouldNotBe null
             tidspunkt shouldNotBe null
-            periode.fom shouldBe YearMonth.of(2023, 4)
+            periode.fom shouldBe YearMonth.of(2023, 9)
             periode.tom shouldBe null
-            avkorting shouldBe 20410
+            avkorting shouldBe 20276
         }
     }
 

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
@@ -3,6 +3,7 @@ package avkorting
 import io.kotest.matchers.shouldBe
 import no.nav.etterlatte.avkorting.Avkorting
 import no.nav.etterlatte.avkorting.AvkortingRepository
+import no.nav.etterlatte.beregning.regler.aarsoppgjoer
 import no.nav.etterlatte.beregning.regler.avkortetYtelse
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
 import no.nav.etterlatte.beregning.regler.avkortingsperiode
@@ -52,26 +53,35 @@ internal class AvkortingRepositoryTest {
         val avkortinggrunnlag = listOf(avkortinggrunnlag())
         val avkortingsperioder = listOf(avkortingsperiode())
         val avkortetYtelse = listOf(avkortetYtelse())
+        val aarsoppgjoer = listOf(aarsoppgjoer())
 
         avkortingRepository.lagreAvkorting(
             behandlingId,
             Avkorting(
                 avkortinggrunnlag,
                 avkortingsperioder,
-                avkortetYtelse
+                avkortetYtelse,
+                aarsoppgjoer = aarsoppgjoer
             )
         )
 
         val endretAvkortingGrunnlag = listOf(avkortinggrunnlag[0].copy(spesifikasjon = "Endret"))
         val endretAvkortingsperiode = listOf(avkortingsperioder[0].copy(avkorting = 333))
-        val endretAvkortetYtelse = listOf(avkortetYtelse[0].copy(avkortingsbeloep = 444))
+        val endretAvkortetYtelse = listOf(
+            avkortetYtelse[0].copy(
+                avkortingsbeloep = 444,
+                restanse = 100
+            )
+        )
+        val endretAarsoppgjoer = listOf(aarsoppgjoer(restanse = 555))
 
         val avkorting = avkortingRepository.lagreAvkorting(
             behandlingId,
             Avkorting(
                 endretAvkortingGrunnlag,
                 endretAvkortingsperiode,
-                endretAvkortetYtelse
+                endretAvkortetYtelse,
+                endretAarsoppgjoer
             )
         )
 

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
@@ -3,7 +3,7 @@ package avkorting
 import io.kotest.matchers.shouldBe
 import no.nav.etterlatte.avkorting.Avkorting
 import no.nav.etterlatte.avkorting.AvkortingRepository
-import no.nav.etterlatte.beregning.regler.aarsoppgjoer
+import no.nav.etterlatte.beregning.regler.aarsoppgjoerMaaned
 import no.nav.etterlatte.beregning.regler.avkortetYtelse
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
 import no.nav.etterlatte.beregning.regler.avkortingsperiode
@@ -53,15 +53,15 @@ internal class AvkortingRepositoryTest {
         val avkortinggrunnlag = listOf(avkortinggrunnlag())
         val avkortingsperioder = listOf(avkortingsperiode())
         val avkortetYtelse = listOf(avkortetYtelse())
-        val aarsoppgjoer = listOf(aarsoppgjoer())
+        val restanseOppgjoer = listOf(aarsoppgjoerMaaned())
 
         avkortingRepository.lagreAvkorting(
             behandlingId,
             Avkorting(
                 avkortinggrunnlag,
                 avkortingsperioder,
-                avkortetYtelse,
-                aarsoppgjoer = aarsoppgjoer
+                restanseOppgjoer,
+                avkortetYtelse
             )
         )
 
@@ -73,15 +73,15 @@ internal class AvkortingRepositoryTest {
                 restanse = 100
             )
         )
-        val endretAarsoppgjoer = listOf(aarsoppgjoer(restanse = 555))
+        val endretRestanseOppgjoer = listOf(aarsoppgjoerMaaned(restanse = 555))
 
         val avkorting = avkortingRepository.lagreAvkorting(
             behandlingId,
             Avkorting(
                 endretAvkortingGrunnlag,
                 endretAvkortingsperiode,
-                endretAvkortetYtelse,
-                endretAarsoppgjoer
+                endretRestanseOppgjoer,
+                endretAvkortetYtelse
             )
         )
 

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
@@ -89,8 +89,8 @@ class AvkortingRoutesTest {
         val avkorting = Avkorting(
             avkortingGrunnlag = listOf(avkortingsgrunnlag),
             avkortingsperioder = listOf(avkortingsperiode()),
-            avkortetYtelse = listOf(avkortetYtelse(periode = Periode(fom = dato, tom = dato))),
-            aarsoppgjoer = emptyList()
+            aarsoppgjoer = emptyList(),
+            avkortetYtelse = listOf(avkortetYtelse(periode = Periode(fom = dato, tom = dato)))
         )
         val dto = AvkortingDto(
             avkortingGrunnlag = listOf(
@@ -114,7 +114,7 @@ class AvkortingRoutesTest {
                     tom = dato.atEndOfMonth(),
                     avkortingsbeloep = 200,
                     ytelseEtterAvkorting = 100,
-                    restanse = 0
+                    restanse = 50
                 )
             )
         )

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
@@ -87,9 +87,10 @@ class AvkortingRoutesTest {
             kilde = Grunnlagsopplysning.Saksbehandler("Saksbehandler01", tidspunkt)
         )
         val avkorting = Avkorting(
-            avkortingGrunnlag = mutableListOf(avkortingsgrunnlag),
-            avkortingsperioder = mutableListOf(avkortingsperiode()),
-            avkortetYtelse = mutableListOf(avkortetYtelse(periode = Periode(fom = dato, tom = dato)))
+            avkortingGrunnlag = listOf(avkortingsgrunnlag),
+            avkortingsperioder = listOf(avkortingsperiode()),
+            avkortetYtelse = listOf(avkortetYtelse(periode = Periode(fom = dato, tom = dato))),
+            aarsoppgjoer = emptyList()
         )
         val dto = AvkortingDto(
             avkortingGrunnlag = listOf(
@@ -112,7 +113,8 @@ class AvkortingRoutesTest {
                     fom = dato.atDay(1),
                     tom = dato.atEndOfMonth(),
                     avkortingsbeloep = 200,
-                    ytelseEtterAvkorting = 100
+                    ytelseEtterAvkorting = 100,
+                    restanse = 0
                 )
             )
         )

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -23,6 +23,7 @@ import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.YearMonth
@@ -50,166 +51,193 @@ internal class AvkortingServiceTest {
         confirmVerified()
     }
 
-    @Test
-    fun `Skal hente avkorting`() {
-        val behandlingId = UUID.randomUUID()
-        val avkorting = avkorting()
-        every { avkortingRepository.hentAvkorting(behandlingId) } returns avkorting
+    @Nested
+    inner class HentAvkorting {
 
-        runBlocking {
-            service.hentAvkorting(behandlingId, bruker) shouldBe avkorting
-        }
-        coVerify {
-            avkortingRepository.hentAvkorting(behandlingId)
-        }
-    }
+        @Test
+        fun `Skal hente avkorting`() {
+            val behandlingId = UUID.randomUUID()
+            val avkorting = avkorting()
+            every { avkortingRepository.hentAvkorting(behandlingId) } returns avkorting
 
-    @Test
-    fun `Skal returnere null hvis avkorting ikke finnes`() {
-        val behandlingId = UUID.randomUUID()
-        every { avkortingRepository.hentAvkorting(behandlingId) } returns null
-        val behandling = behandling(behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING)
-        coEvery { behandlingKlient.hentBehandling(behandlingId, bruker) } returns behandling
-
-        runBlocking {
-            service.hentAvkorting(behandlingId, bruker) shouldBe null
-        }
-
-        coVerify {
-            avkortingRepository.hentAvkorting(behandlingId)
-            behandlingKlient.hentBehandling(behandlingId, bruker)
-            behandling.behandlingType
-        }
-    }
-
-    @Test
-    fun `Revurdering skal opprette ny avkorting ved aa kopiere tidligere hvis avkorting ikke finnes fra foer`() {
-        val behandlingId = UUID.randomUUID()
-        val behandling = behandling(
-            behandlingType = BehandlingType.REVURDERING,
-            sak = 123L,
-            virkningstidspunkt = YearMonth.of(2023, 1)
-        )
-        val forrigeBehandlingId = UUID.randomUUID()
-        val forrigeAvkorting = mockk<Avkorting>()
-        val kopiertAvkorting = mockk<Avkorting>()
-        val beregning = mockk<Beregning>()
-        val beregnetAvkorting = mockk<Avkorting>()
-        val lagretAvkorting = mockk<Avkorting>()
-
-        every { avkortingRepository.hentAvkorting(behandlingId) } returns null
-        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns behandling(forrigeBehandlingId)
-        every { avkortingRepository.hentAvkorting(forrigeBehandlingId) } returns forrigeAvkorting
-        every { forrigeAvkorting.kopierAvkorting() } returns kopiertAvkorting
-        every { beregningService.hentBeregningNonnull(any()) } returns beregning
-        every { kopiertAvkorting.beregnAvkorting(any(), any(), any()) } returns beregnetAvkorting
-        every { avkortingRepository.lagreAvkorting(any(), any()) } returns lagretAvkorting
-        coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
-
-        runBlocking {
-            service.hentAvkorting(behandlingId, bruker)
-        }
-
-        coVerify {
-            avkortingRepository.hentAvkorting(behandlingId)
-            behandlingKlient.hentBehandling(behandlingId, bruker)
-            behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, bruker)
-            avkortingRepository.hentAvkorting(forrigeBehandlingId)
-            forrigeAvkorting.kopierAvkorting()
-            beregningService.hentBeregningNonnull(behandlingId)
-            kopiertAvkorting.beregnAvkorting(behandling.virkningstidspunkt!!.dato, beregning, forrigeAvkorting)
-            avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
-            behandlingKlient.avkort(behandlingId, bruker, true)
-        }
-    }
-
-    @Test
-    fun `Skal opprette og beregne ny avkorting hvis ikke finnes fra foer`() {
-        val behandlingId = UUID.randomUUID()
-        val virkningsdato = YearMonth.of(2023, 1)
-        val nyttGrunnlag = mockk<AvkortingGrunnlag>()
-        val nyAvkorting = mockk<Avkorting>()
-        val beregning = mockk<Beregning>()
-        val beregnetAvkorting = mockk<Avkorting>()
-        val lagretAvkorting = mockk<Avkorting>()
-
-        coEvery {
-            behandlingKlient.hentBehandling(any(), any())
-        } returns behandling(virkningstidspunkt = virkningsdato)
-        every { avkortingRepository.hentAvkorting(any()) } returns null
-        mockkObject(Avkorting.Companion)
-        every { Avkorting.Companion.nyAvkorting() } returns nyAvkorting
-        every { beregningService.hentBeregningNonnull(any()) } returns beregning
-        every { nyAvkorting.beregnAvkortingNyttEllerEndretGrunnlag(any(), any(), any()) } returns beregnetAvkorting
-        every { avkortingRepository.lagreAvkorting(any(), any()) } returns lagretAvkorting
-        coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
-
-        runBlocking {
-            service.lagreAvkorting(behandlingId, bruker, nyttGrunnlag) shouldBe lagretAvkorting
-        }
-
-        coVerify(exactly = 1) {
-            behandlingKlient.avkort(behandlingId, bruker, false)
-            behandlingKlient.hentBehandling(behandlingId, bruker)
-            avkortingRepository.hentAvkorting(behandlingId)
-            Avkorting.nyAvkorting()
-            beregningService.hentBeregningNonnull(behandlingId)
-            nyAvkorting.beregnAvkortingNyttEllerEndretGrunnlag(nyttGrunnlag, virkningsdato, beregning)
-            avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
-            behandlingKlient.avkort(behandlingId, bruker, true)
-        }
-    }
-
-    @Test
-    fun `Nytt avkortingsgrunnlag for eksisterende avkorting skal reberegne og lagre avkorting`() {
-        val behandlingId = UUID.randomUUID()
-        val virkningsdato = YearMonth.of(2023, 1)
-        val endretGrunnlag = mockk<AvkortingGrunnlag>()
-        val eksisterendeAvkorting = mockk<Avkorting>()
-        val beregning = mockk<Beregning>()
-        val beregnetAvkorting = mockk<Avkorting>()
-        val lagretAvkorting = mockk<Avkorting>()
-
-        coEvery {
-            behandlingKlient.hentBehandling(any(), any())
-        } returns behandling(virkningstidspunkt = virkningsdato)
-        every { avkortingRepository.hentAvkorting(any()) } returns eksisterendeAvkorting
-        every { beregningService.hentBeregningNonnull(any()) } returns beregning
-        every {
-            eksisterendeAvkorting.beregnAvkortingNyttEllerEndretGrunnlag(any(), any(), any())
-        } returns beregnetAvkorting
-        every { avkortingRepository.lagreAvkorting(any(), any()) } returns lagretAvkorting
-        coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
-
-        runBlocking {
-            service.lagreAvkorting(behandlingId, bruker, endretGrunnlag) shouldBe lagretAvkorting
-        }
-
-        coVerify(exactly = 1) {
-            behandlingKlient.avkort(behandlingId, bruker, false)
-            behandlingKlient.hentBehandling(behandlingId, bruker)
-            avkortingRepository.hentAvkorting(behandlingId)
-            beregningService.hentBeregningNonnull(behandlingId)
-            eksisterendeAvkorting.beregnAvkortingNyttEllerEndretGrunnlag(endretGrunnlag, virkningsdato, beregning)
-            avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
-            behandlingKlient.avkort(behandlingId, bruker, true)
-        }
-    }
-
-    @Test
-    fun `Skal feile ved lagring av avkortinggrunnlag hvis behandling er i feil tilstand`() {
-        val behandlingId = UUID.randomUUID()
-        coEvery { behandlingKlient.avkort(behandlingId, bruker, false) } returns false
-
-        runBlocking {
-            assertThrows<Exception> {
-                service.lagreAvkorting(behandlingId, bruker, avkortinggrunnlag())
+            runBlocking {
+                service.hentAvkorting(behandlingId, bruker) shouldBe avkorting
+            }
+            coVerify {
+                avkortingRepository.hentAvkorting(behandlingId)
             }
         }
 
-        coVerify {
-            behandlingKlient.avkort(behandlingId, bruker, false)
+        @Test
+        fun `Skal returnere null hvis avkorting ikke finnes`() {
+            val behandlingId = UUID.randomUUID()
+            every { avkortingRepository.hentAvkorting(behandlingId) } returns null
+            val behandling = behandling(behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING)
+            coEvery { behandlingKlient.hentBehandling(behandlingId, bruker) } returns behandling
+
+            runBlocking {
+                service.hentAvkorting(behandlingId, bruker) shouldBe null
+            }
+
+            coVerify {
+                avkortingRepository.hentAvkorting(behandlingId)
+                behandlingKlient.hentBehandling(behandlingId, bruker)
+                behandling.behandlingType
+            }
+        }
+
+        @Test
+        fun `Revurdering skal opprette ny avkorting ved aa kopiere tidligere hvis avkorting ikke finnes fra foer`() {
+            val behandlingId = UUID.randomUUID()
+            val behandling = behandling(
+                behandlingType = BehandlingType.REVURDERING,
+                sak = 123L,
+                virkningstidspunkt = YearMonth.of(2023, 1)
+            )
+            val forrigeBehandlingId = UUID.randomUUID()
+            val forrigeAvkorting = mockk<Avkorting>()
+            val kopiertAvkorting = mockk<Avkorting>()
+            val beregning = mockk<Beregning>()
+            val beregnetAvkorting = mockk<Avkorting>()
+            val lagretAvkorting = mockk<Avkorting>()
+
+            every { avkortingRepository.hentAvkorting(behandlingId) } returns null
+            coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+            coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns behandling(
+                forrigeBehandlingId
+            )
+            every { avkortingRepository.hentAvkorting(forrigeBehandlingId) } returns forrigeAvkorting
+            every { forrigeAvkorting.kopierAvkorting() } returns kopiertAvkorting
+            every { beregningService.hentBeregningNonnull(any()) } returns beregning
+            every { kopiertAvkorting.beregnAvkorting(any(), any(), any()) } returns beregnetAvkorting
+            every { avkortingRepository.lagreAvkorting(any(), any()) } returns lagretAvkorting
+            coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
+
+            runBlocking {
+                service.hentAvkorting(behandlingId, bruker)
+            }
+
+            coVerify {
+                avkortingRepository.hentAvkorting(behandlingId)
+                behandlingKlient.hentBehandling(behandlingId, bruker)
+                behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, bruker)
+                avkortingRepository.hentAvkorting(forrigeBehandlingId)
+                forrigeAvkorting.kopierAvkorting()
+                beregningService.hentBeregningNonnull(behandlingId)
+                kopiertAvkorting.beregnAvkorting(
+                    behandling.behandlingType,
+                    behandling.virkningstidspunkt!!.dato,
+                    beregning
+                )
+                avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
+                behandlingKlient.avkort(behandlingId, bruker, true)
+            }
+        }
+    }
+
+    @Nested
+    inner class lagreAvkorting {
+
+        @Test
+        fun `Foerstegangsbehandling skal opprette og beregne ny avkorting hvis ikke finnes fra foer`() {
+            val behandlingId = UUID.randomUUID()
+            val virkningsdato = YearMonth.of(2023, 1)
+            val behandling = behandling(
+                behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                virkningstidspunkt = virkningsdato
+            )
+            val nyttGrunnlag = mockk<AvkortingGrunnlag>()
+            val beregning = mockk<Beregning>()
+
+            val nyAvkorting = mockk<Avkorting>()
+            val beregnetAvkorting = mockk<Avkorting>()
+            val lagretAvkorting = mockk<Avkorting>()
+
+            every { avkortingRepository.hentAvkorting(any()) } returns null
+            mockkObject(Avkorting.Companion)
+            every { Avkorting.Companion.nyAvkorting() } returns nyAvkorting
+            coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+            every { beregningService.hentBeregningNonnull(any()) } returns beregning
+            every { nyAvkorting.beregnAvkortingMedNyttGrunnlag(any(), any(), any(), any()) } returns beregnetAvkorting
+            every { avkortingRepository.lagreAvkorting(any(), any()) } returns lagretAvkorting
+            coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
+
+            runBlocking {
+                service.lagreAvkorting(behandlingId, bruker, nyttGrunnlag) shouldBe lagretAvkorting
+            }
+
+            coVerify(exactly = 1) {
+                behandlingKlient.avkort(behandlingId, bruker, false)
+                avkortingRepository.hentAvkorting(behandlingId)
+                Avkorting.nyAvkorting()
+                behandlingKlient.hentBehandling(behandlingId, bruker)
+                beregningService.hentBeregningNonnull(behandlingId)
+                nyAvkorting.beregnAvkortingMedNyttGrunnlag(
+                    nyttGrunnlag,
+                    behandling.behandlingType,
+                    virkningsdato,
+                    beregning
+                )
+                avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
+                behandlingKlient.avkort(behandlingId, bruker, true)
+            }
+        }
+
+        @Test
+        fun `Revurdering skal for eksisterende avkorting skal reberegne og lagre avkorting`() {
+            val behandlingId = UUID.randomUUID()
+            val virkningsdato = YearMonth.of(2023, 1)
+            val behandling = behandling(behandlingType = BehandlingType.REVURDERING, virkningstidspunkt = virkningsdato)
+            val endretGrunnlag = mockk<AvkortingGrunnlag>()
+            val beregning = mockk<Beregning>()
+
+            val eksisterendeAvkorting = mockk<Avkorting>()
+            val beregnetAvkorting = mockk<Avkorting>()
+            val lagretAvkorting = mockk<Avkorting>()
+
+            every { avkortingRepository.hentAvkorting(any()) } returns eksisterendeAvkorting
+            coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+            every { beregningService.hentBeregningNonnull(any()) } returns beregning
+            every {
+                eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(any(), any(), any(), any())
+            } returns beregnetAvkorting
+            every { avkortingRepository.lagreAvkorting(any(), any()) } returns lagretAvkorting
+            coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
+
+            runBlocking {
+                service.lagreAvkorting(behandlingId, bruker, endretGrunnlag) shouldBe lagretAvkorting
+            }
+
+            coVerify(exactly = 1) {
+                behandlingKlient.avkort(behandlingId, bruker, false)
+                avkortingRepository.hentAvkorting(behandlingId)
+                behandlingKlient.hentBehandling(behandlingId, bruker)
+                beregningService.hentBeregningNonnull(behandlingId)
+                eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(
+                    endretGrunnlag,
+                    behandling.behandlingType,
+                    virkningsdato,
+                    beregning
+                )
+                avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
+                behandlingKlient.avkort(behandlingId, bruker, true)
+            }
+        }
+
+        @Test
+        fun `Skal feile ved lagring av avkortinggrunnlag hvis behandling er i feil tilstand`() {
+            val behandlingId = UUID.randomUUID()
+            coEvery { behandlingKlient.avkort(behandlingId, bruker, false) } returns false
+
+            runBlocking {
+                assertThrows<Exception> {
+                    service.lagreAvkorting(behandlingId, bruker, avkortinggrunnlag())
+                }
+            }
+
+            coVerify {
+                behandlingKlient.avkort(behandlingId, bruker, false)
+            }
         }
     }
 }

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -1,33 +1,26 @@
 package avkorting
 
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import kotlinx.coroutines.runBlocking
-import no.nav.etterlatte.avkorting.AvkortetYtelse
 import no.nav.etterlatte.avkorting.Avkorting
 import no.nav.etterlatte.avkorting.AvkortingGrunnlag
 import no.nav.etterlatte.avkorting.AvkortingRepository
 import no.nav.etterlatte.avkorting.AvkortingService
-import no.nav.etterlatte.avkorting.Avkortingsperiode
-import no.nav.etterlatte.avkorting.InntektAvkortingService
+import no.nav.etterlatte.beregning.Beregning
 import no.nav.etterlatte.beregning.BeregningService
-import no.nav.etterlatte.beregning.regler.avkortetYtelse
 import no.nav.etterlatte.beregning.regler.avkorting
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
-import no.nav.etterlatte.beregning.regler.avkortingsperiode
 import no.nav.etterlatte.beregning.regler.behandling
-import no.nav.etterlatte.beregning.regler.beregning
 import no.nav.etterlatte.beregning.regler.bruker
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
-import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
-import no.nav.etterlatte.libs.common.periode.Periode
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -38,16 +31,18 @@ import java.util.UUID
 internal class AvkortingServiceTest {
 
     private val behandlingKlient: BehandlingKlient = mockk()
-    private val inntektAvkortingService: InntektAvkortingService = mockk()
     private val avkortingRepository: AvkortingRepository = mockk()
     private val beregningService: BeregningService = mockk()
-    private val service =
-        AvkortingService(behandlingKlient, inntektAvkortingService, avkortingRepository, beregningService)
+    private val service = AvkortingService(
+        behandlingKlient,
+        avkortingRepository,
+        beregningService
+    )
 
     @BeforeEach
     fun beforeEach() {
         clearAllMocks()
-        coEvery { behandlingKlient.beregn(any(), any(), any()) } returns true
+        coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
     }
 
     @AfterEach
@@ -56,7 +51,7 @@ internal class AvkortingServiceTest {
     }
 
     @Test
-    fun `skal hente avkorting`() {
+    fun `Skal hente avkorting`() {
         val behandlingId = UUID.randomUUID()
         val avkorting = avkorting()
         every { avkortingRepository.hentAvkorting(behandlingId) } returns avkorting
@@ -70,7 +65,7 @@ internal class AvkortingServiceTest {
     }
 
     @Test
-    fun `skal returnere null hvis avkorting ikke finnes`() {
+    fun `Skal returnere null hvis avkorting ikke finnes`() {
         val behandlingId = UUID.randomUUID()
         every { avkortingRepository.hentAvkorting(behandlingId) } returns null
         val behandling = behandling(behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING)
@@ -88,32 +83,27 @@ internal class AvkortingServiceTest {
     }
 
     @Test
-    fun `skal returnere ny beregnet avkorting med kopierte grunnlag fra forrige avkorting`() {
+    fun `Revurdering skal opprette ny avkorting ved aa kopiere tidligere hvis avkorting ikke finnes fra foer`() {
         val behandlingId = UUID.randomUUID()
-        val sakId = 123L
-        val virkningstidspunkt = YearMonth.of(2023, 1)
         val behandling = behandling(
             behandlingType = BehandlingType.REVURDERING,
-            sak = sakId,
+            sak = 123L,
             virkningstidspunkt = YearMonth.of(2023, 1)
         )
-
         val forrigeBehandlingId = UUID.randomUUID()
-        val forrigeBehandling = behandling(id = forrigeBehandlingId)
-        val avkortinggrunnlag = avkortinggrunnlag(aarsinntekt = 100)
-        val forrigeAvkorting = avkorting(avkortingGrunnlag = listOf(avkortinggrunnlag))
-        val nyAvkortingsperiode = avkortingsperiode()
-        val beregning = beregning()
-        val nyAvkortetYtelse = avkortetYtelse()
+        val forrigeAvkorting = mockk<Avkorting>()
+        val kopiertAvkorting = mockk<Avkorting>()
+        val beregning = mockk<Beregning>()
+        val beregnetAvkorting = mockk<Avkorting>()
         val lagretAvkorting = mockk<Avkorting>()
 
         every { avkortingRepository.hentAvkorting(behandlingId) } returns null
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns forrigeBehandling
+        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns behandling(forrigeBehandlingId)
         every { avkortingRepository.hentAvkorting(forrigeBehandlingId) } returns forrigeAvkorting
-        every { inntektAvkortingService.beregnInntektsavkorting(any(), any()) } returns listOf(nyAvkortingsperiode)
+        every { forrigeAvkorting.kopierAvkorting() } returns kopiertAvkorting
         every { beregningService.hentBeregningNonnull(any()) } returns beregning
-        every { inntektAvkortingService.beregnAvkortetYtelse(any(), any(), any()) } returns listOf(nyAvkortetYtelse)
+        every { kopiertAvkorting.beregnAvkorting(any(), any(), any()) } returns beregnetAvkorting
         every { avkortingRepository.lagreAvkorting(any(), any()) } returns lagretAvkorting
         coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
 
@@ -124,209 +114,91 @@ internal class AvkortingServiceTest {
         coVerify {
             avkortingRepository.hentAvkorting(behandlingId)
             behandlingKlient.hentBehandling(behandlingId, bruker)
-            behandlingKlient.hentSisteIverksatteBehandling(sakId, bruker)
+            behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, bruker)
             avkortingRepository.hentAvkorting(forrigeBehandlingId)
-            inntektAvkortingService.beregnInntektsavkorting(
-                virkningstidspunkt,
-                withArg {
-                    with(it[0]) {
-                        id shouldNotBe avkortinggrunnlag.id
-                        aarsinntekt shouldBe avkortinggrunnlag.aarsinntekt
-                    }
-                }
-            )
+            forrigeAvkorting.kopierAvkorting()
             beregningService.hentBeregningNonnull(behandlingId)
-            inntektAvkortingService.beregnAvkortetYtelse(
-                virkningstidspunkt,
-                beregning.beregningsperioder,
-                listOf(nyAvkortingsperiode)
-            )
-            avkortingRepository.lagreAvkorting(
-                behandlingId,
-                withArg {
-                    with(it.avkortingGrunnlag[0]) {
-                        id shouldNotBe avkortinggrunnlag.id
-                        aarsinntekt shouldBe avkortinggrunnlag.aarsinntekt
-                    }
-                    it.avkortingsperioder shouldBe listOf(nyAvkortingsperiode)
-                    it.avkortetYtelse shouldBe listOf(nyAvkortetYtelse)
-                }
-            )
+            kopiertAvkorting.beregnAvkorting(behandling.virkningstidspunkt!!.dato, beregning, forrigeAvkorting)
+            avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
             behandlingKlient.avkort(behandlingId, bruker, true)
         }
     }
 
     @Test
-    fun `nytt avkortingsgrunnlag for ny avkorting og kjoere regler for avkorting og lagre resultat`() {
+    fun `Skal opprette og beregne ny avkorting hvis ikke finnes fra foer`() {
         val behandlingId = UUID.randomUUID()
-        val virkningstidspunkt = YearMonth.of(2023, 1)
-        val behandling = behandling(virkningstidspunkt = virkningstidspunkt)
+        val virkningsdato = YearMonth.of(2023, 1)
         val nyttGrunnlag = mockk<AvkortingGrunnlag>()
-        val nyAvkortingsperiode = mockk<Avkortingsperiode>()
-        val nyAvkortetYtelse = mockk<AvkortetYtelse>()
-        val beregning = mockk<Beregningsperiode>()
-        val nyAvkorting = Avkorting(
-            avkortingGrunnlag = listOf(nyttGrunnlag),
-            avkortingsperioder = listOf(nyAvkortingsperiode),
-            avkortetYtelse = listOf(nyAvkortetYtelse)
-        )
+        val nyAvkorting = mockk<Avkorting>()
+        val beregning = mockk<Beregning>()
+        val beregnetAvkorting = mockk<Avkorting>()
+        val lagretAvkorting = mockk<Avkorting>()
 
-        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        coEvery {
+            behandlingKlient.hentBehandling(any(), any())
+        } returns behandling(virkningstidspunkt = virkningsdato)
         every { avkortingRepository.hentAvkorting(any()) } returns null
-        coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
-        every { inntektAvkortingService.beregnInntektsavkorting(any(), any()) } returns listOf(nyAvkortingsperiode)
-        every { beregningService.hentBeregningNonnull(any()) } returns beregning(listOf(beregning))
-        every { inntektAvkortingService.beregnAvkortetYtelse(any(), any(), any()) } returns listOf(nyAvkortetYtelse)
-        every { avkortingRepository.lagreAvkorting(any(), any()) } returns nyAvkorting
+        mockkObject(Avkorting.Companion)
+        every { Avkorting.Companion.nyAvkorting() } returns nyAvkorting
+        every { beregningService.hentBeregningNonnull(any()) } returns beregning
+        every { nyAvkorting.beregnAvkortingNyttEllerEndretGrunnlag(any(), any(), any()) } returns beregnetAvkorting
+        every { avkortingRepository.lagreAvkorting(any(), any()) } returns lagretAvkorting
         coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
 
-        val result = runBlocking {
-            service.lagreAvkorting(behandlingId, bruker, nyttGrunnlag)
+        runBlocking {
+            service.lagreAvkorting(behandlingId, bruker, nyttGrunnlag) shouldBe lagretAvkorting
         }
 
-        result shouldBe nyAvkorting
         coVerify(exactly = 1) {
             behandlingKlient.avkort(behandlingId, bruker, false)
             behandlingKlient.hentBehandling(behandlingId, bruker)
             avkortingRepository.hentAvkorting(behandlingId)
-            inntektAvkortingService.beregnInntektsavkorting(virkningstidspunkt, listOf(nyttGrunnlag))
+            Avkorting.nyAvkorting()
             beregningService.hentBeregningNonnull(behandlingId)
-            inntektAvkortingService.beregnAvkortetYtelse(
-                virkningstidspunkt,
-                listOf(beregning),
-                listOf(nyAvkortingsperiode)
-            )
-            avkortingRepository.lagreAvkorting(behandlingId, nyAvkorting)
+            nyAvkorting.beregnAvkortingNyttEllerEndretGrunnlag(nyttGrunnlag, virkningsdato, beregning)
+            avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
             behandlingKlient.avkort(behandlingId, bruker, true)
         }
     }
 
     @Test
-    fun `endret avkortingsgrunnlag for eksisterende avkorting og kjoere regler for avkorting og lagre resultat`() {
+    fun `Nytt avkortingsgrunnlag for eksisterende avkorting skal reberegne og lagre avkorting`() {
         val behandlingId = UUID.randomUUID()
-        val virkningstidspunkt = YearMonth.of(2023, 1)
-        val behandling = behandling(virkningstidspunkt = virkningstidspunkt)
-        val grunnlagId = UUID.randomUUID()
-        val eksisterendeGrunnlag = avkortinggrunnlag(id = grunnlagId)
-        val eksisterendeAvkortingsperiode = mockk<Avkortingsperiode>()
-        val eksisterendeAvkortetYtelse = mockk<AvkortetYtelse>()
+        val virkningsdato = YearMonth.of(2023, 1)
+        val endretGrunnlag = mockk<AvkortingGrunnlag>()
+        val eksisterendeAvkorting = mockk<Avkorting>()
+        val beregning = mockk<Beregning>()
+        val beregnetAvkorting = mockk<Avkorting>()
+        val lagretAvkorting = mockk<Avkorting>()
 
-        val avkorting = Avkorting(
-            avkortingGrunnlag = listOf(eksisterendeGrunnlag),
-            avkortingsperioder = listOf(eksisterendeAvkortingsperiode),
-            avkortetYtelse = listOf(eksisterendeAvkortetYtelse)
-        )
-        val endretGrunnlag = eksisterendeGrunnlag.copy(aarsinntekt = 100)
-        val nyAvkortingsperiode = mockk<Avkortingsperiode>()
-        val nyAvkortetYtelse = mockk<AvkortetYtelse>()
-        val beregning = mockk<Beregningsperiode>()
-
-        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        every { avkortingRepository.hentAvkorting(any()) } returns avkorting
-        coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
-        every { inntektAvkortingService.beregnInntektsavkorting(any(), any()) } returns listOf(nyAvkortingsperiode)
-        every { beregningService.hentBeregningNonnull(any()) } returns beregning(listOf(beregning))
-        every { inntektAvkortingService.beregnAvkortetYtelse(any(), any(), any()) } returns listOf(nyAvkortetYtelse)
-        every { avkortingRepository.lagreAvkorting(any(), any()) } returns avkorting
+        coEvery {
+            behandlingKlient.hentBehandling(any(), any())
+        } returns behandling(virkningstidspunkt = virkningsdato)
+        every { avkortingRepository.hentAvkorting(any()) } returns eksisterendeAvkorting
+        every { beregningService.hentBeregningNonnull(any()) } returns beregning
+        every {
+            eksisterendeAvkorting.beregnAvkortingNyttEllerEndretGrunnlag(any(), any(), any())
+        } returns beregnetAvkorting
+        every { avkortingRepository.lagreAvkorting(any(), any()) } returns lagretAvkorting
         coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
 
-        val result = runBlocking {
-            service.lagreAvkorting(behandlingId, bruker, endretGrunnlag)
+        runBlocking {
+            service.lagreAvkorting(behandlingId, bruker, endretGrunnlag) shouldBe lagretAvkorting
         }
-
-        result shouldBe avkorting
-        coVerify(exactly = 1) {
-            behandlingKlient.avkort(behandlingId, bruker, false)
-            behandlingKlient.hentBehandling(behandlingId, bruker)
-            avkortingRepository.hentAvkorting(behandlingId)
-            inntektAvkortingService.beregnInntektsavkorting(virkningstidspunkt, listOf(endretGrunnlag))
-            beregningService.hentBeregningNonnull(behandlingId)
-            inntektAvkortingService.beregnAvkortetYtelse(
-                virkningstidspunkt,
-                listOf(beregning),
-                listOf(nyAvkortingsperiode)
-            )
-            avkortingRepository.lagreAvkorting(
-                behandlingId,
-                withArg {
-                    it.avkortingGrunnlag shouldBe listOf(endretGrunnlag)
-                    it.avkortingsperioder shouldBe listOf(nyAvkortingsperiode)
-                    it.avkortetYtelse shouldBe listOf(nyAvkortetYtelse)
-                }
-            )
-            behandlingKlient.avkort(behandlingId, bruker, true)
-        }
-    }
-
-    @Test
-    fun `nytt avkortingsgrunnlag for eksisterende avkorting og kjoere regler for avkorting og lagre resultat`() {
-        val behandlingId = UUID.randomUUID()
-        val virkningstidspunkt = YearMonth.of(2023, 1)
-        val behandling = behandling(virkningstidspunkt = virkningstidspunkt)
-        val eksisterendeGrunnlag = avkortinggrunnlag(
-            periode = Periode(fom = YearMonth.of(2023, 1), tom = null)
-        )
-        val eksisterendeAvkortingsperiode = mockk<Avkortingsperiode>()
-        val eksisterendeAvkortetYtelse = mockk<AvkortetYtelse>()
-        val avkorting = Avkorting(
-            avkortingGrunnlag = listOf(eksisterendeGrunnlag),
-            avkortingsperioder = listOf(eksisterendeAvkortingsperiode),
-            avkortetYtelse = listOf(eksisterendeAvkortetYtelse)
-        )
-        val nyttGrunnlag = avkortinggrunnlag(
-            periode = Periode(fom = YearMonth.of(2023, 4), tom = null)
-        )
-        val nyeAvkortingsperioder = mockk<Avkortingsperiode>()
-        val beregninger = mockk<Beregningsperiode>()
-        val nyeAvkortetYtelser = mockk<AvkortetYtelse>()
-
-        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        every { avkortingRepository.hentAvkorting(any()) } returns avkorting
-        coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
-        every { inntektAvkortingService.beregnInntektsavkorting(any(), any()) } returns listOf(nyeAvkortingsperioder)
-        every { beregningService.hentBeregningNonnull(any()) } returns beregning(listOf(beregninger))
-        every { inntektAvkortingService.beregnAvkortetYtelse(any(), any(), any()) } returns listOf(nyeAvkortetYtelser)
-        every { avkortingRepository.lagreAvkorting(any(), any()) } returns avkorting
-        coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
-
-        val result = runBlocking {
-            service.lagreAvkorting(behandlingId, bruker, nyttGrunnlag)
-        }
-
-        result shouldBe avkorting
 
         coVerify(exactly = 1) {
             behandlingKlient.avkort(behandlingId, bruker, false)
             behandlingKlient.hentBehandling(behandlingId, bruker)
             avkortingRepository.hentAvkorting(behandlingId)
-            inntektAvkortingService.beregnInntektsavkorting(
-                virkningstidspunkt,
-                withArg {
-                    it[0].periode.tom shouldBe YearMonth.of(2023, 3)
-                    it[1].periode.tom shouldBe null
-                }
-            )
             beregningService.hentBeregningNonnull(behandlingId)
-            inntektAvkortingService.beregnAvkortetYtelse(
-                virkningstidspunkt,
-                listOf(beregninger),
-                listOf(nyeAvkortingsperioder)
-            )
-            avkortingRepository.lagreAvkorting(
-                behandlingId,
-                withArg {
-                    it.avkortingGrunnlag[0].periode.tom shouldBe YearMonth.of(2023, 3)
-                    it.avkortingGrunnlag[1].periode.tom shouldBe null
-                    it.avkortingsperioder shouldBe listOf(nyeAvkortingsperioder)
-                    it.avkortetYtelse shouldBe listOf(nyeAvkortetYtelser)
-                }
-            )
+            eksisterendeAvkorting.beregnAvkortingNyttEllerEndretGrunnlag(endretGrunnlag, virkningsdato, beregning)
+            avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
             behandlingKlient.avkort(behandlingId, bruker, true)
         }
     }
 
     @Test
-    fun `skal feile ved lagring av avkortinggrunnlag hvis behandling er i feil tilstand`() {
+    fun `Skal feile ved lagring av avkortinggrunnlag hvis behandling er i feil tilstand`() {
         val behandlingId = UUID.randomUUID()
         coEvery { behandlingKlient.avkort(behandlingId, bruker, false) } returns false
 

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -1,0 +1,215 @@
+package avkorting
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
+import no.nav.etterlatte.avkorting.Avkorting
+import no.nav.etterlatte.avkorting.AvkortingRegelkjoring
+import no.nav.etterlatte.beregning.regler.aarsoppgjoer
+import no.nav.etterlatte.beregning.regler.avkortetYtelse
+import no.nav.etterlatte.beregning.regler.avkorting
+import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
+import no.nav.etterlatte.beregning.regler.avkortingsperiode
+import no.nav.etterlatte.beregning.regler.beregning
+import no.nav.etterlatte.libs.common.periode.Periode
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+
+internal class AvkortingTest {
+
+    @BeforeEach
+    fun beforeEach() {
+        mockkObject(AvkortingRegelkjoring)
+    }
+
+    @AfterEach
+    fun afterEach() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `Kopier avkorting lager ny avkorting med tidligere grunnlag med ny id`() {
+        val grunnlag = listOf(avkortinggrunnlag(), avkortinggrunnlag())
+        val kopi = avkorting(avkortingGrunnlag = grunnlag).kopierAvkorting()
+        with(kopi) {
+            with(avkortingGrunnlag) {
+                size shouldBe 2
+                get(0).id shouldNotBe grunnlag[0].id
+                get(1).id shouldNotBe grunnlag[1].id
+            }
+            aarsoppgjoer shouldBe emptyList()
+            avkortingsperioder shouldBe emptyList()
+            avkortetYtelse shouldBe emptyList()
+        }
+    }
+
+    @Test
+    fun `Beregn avkorting med nytt grunnlag legger til og setter til og med paa periode til forrige loepende`() {
+        val foersteGrunnlag = avkortinggrunnlag(
+            periode = Periode(fom = YearMonth.of(2023, 1), tom = YearMonth.of(2023, 3))
+        )
+        val andreGrunnlag = avkortinggrunnlag(periode = Periode(fom = YearMonth.of(2023, 4), tom = null))
+        val nyttGrunnlag = avkortinggrunnlag(periode = Periode(fom = YearMonth.of(2023, 8), tom = null))
+
+        val avkorting = avkorting(
+            avkortingGrunnlag = listOf(foersteGrunnlag, andreGrunnlag)
+        )
+
+        every { AvkortingRegelkjoring.beregnAarsoppgjoer(any(), any(), any()) } returns listOf(aarsoppgjoer())
+        every { AvkortingRegelkjoring.beregnInntektsavkorting(any(), any()) } returns listOf(avkortingsperiode())
+        every { AvkortingRegelkjoring.beregnAvkortetYtelse(any(), any(), any(), any()) } returns listOf(
+            avkortetYtelse()
+        )
+
+        val beregnetAvkorting = avkorting.beregnAvkortingNyttEllerEndretGrunnlag(
+            nyttGrunnlag,
+            YearMonth.of(2023, 8),
+            beregning()
+        )
+
+        with(beregnetAvkorting.avkortingGrunnlag) {
+            size shouldBe 3
+            get(0) shouldBe foersteGrunnlag
+            get(1).id shouldBe andreGrunnlag.id
+            get(1).periode.tom shouldBe YearMonth.of(2023, 7)
+            get(2) shouldBe nyttGrunnlag
+        }
+    }
+
+    @Test
+    fun `Beregn avkorting med endret grunnlag oppdaterer eksisterende loepende grunnlag`() {
+        val foersteGrunnlag = avkortinggrunnlag(
+            periode = Periode(fom = YearMonth.of(2023, 1), tom = YearMonth.of(2023, 3))
+        )
+        val andreGrunnlag = avkortinggrunnlag(
+            aarsinntekt = 1000000,
+            periode = Periode(fom = YearMonth.of(2023, 4), tom = null)
+        )
+        val endretGrunnlag = andreGrunnlag.copy(aarsinntekt = 200000)
+
+        val avkorting = avkorting(
+            avkortingGrunnlag = listOf(foersteGrunnlag, andreGrunnlag)
+        )
+
+        every { AvkortingRegelkjoring.beregnAarsoppgjoer(any(), any(), any()) } returns listOf(aarsoppgjoer())
+        every { AvkortingRegelkjoring.beregnInntektsavkorting(any(), any()) } returns listOf(avkortingsperiode())
+        every { AvkortingRegelkjoring.beregnAvkortetYtelse(any(), any(), any(), any()) } returns listOf(
+            avkortetYtelse()
+        )
+
+        val beregnetAvkorting = avkorting.beregnAvkortingNyttEllerEndretGrunnlag(
+            endretGrunnlag,
+            YearMonth.of(2023, 8),
+            beregning()
+        )
+
+        with(beregnetAvkorting.avkortingGrunnlag) {
+            size shouldBe 2
+            get(0) shouldBe foersteGrunnlag
+            get(1) shouldBe endretGrunnlag
+        }
+    }
+
+    @Test
+    fun `Beregn avkorting beregner avkortingsperioder og avkortet ytelse fra ny virk med restanse fra aarsoppgjoer`() {
+        val virkningstidspunkt = YearMonth.of(2023, 6)
+        val beregning = beregning()
+
+        val avkorting = avkorting(avkortingGrunnlag = listOf(avkortinggrunnlag()))
+
+        val aarsoppgjoer = listOf(aarsoppgjoer(restanse = 1000))
+        val avkortingsperioder = listOf(avkortingsperiode())
+        val avkortetYtelse = listOf(avkortetYtelse())
+
+        every {
+            AvkortingRegelkjoring.beregnAarsoppgjoer(avkorting, virkningstidspunkt)
+        } returns aarsoppgjoer
+        every {
+            AvkortingRegelkjoring.beregnInntektsavkorting(
+                Periode(fom = virkningstidspunkt, tom = null),
+                avkorting.avkortingGrunnlag
+            )
+        } returns avkortingsperioder
+        every {
+            AvkortingRegelkjoring.beregnAvkortetYtelse(
+                Periode(fom = virkningstidspunkt, tom = null),
+                beregning.beregningsperioder,
+                avkortingsperioder,
+                maanedligRestanse = 1000
+            )
+        } returns avkortetYtelse
+
+        val beregnetAvkorting = avkorting.beregnAvkorting(virkningstidspunkt, beregning)
+
+        beregnetAvkorting.avkortingGrunnlag shouldBe avkorting.avkortingGrunnlag
+        beregnetAvkorting.avkortingsperioder shouldBe avkortingsperioder
+        beregnetAvkorting.aarsoppgjoer shouldBe aarsoppgjoer
+        beregnetAvkorting.avkortetYtelse shouldBe avkortetYtelse
+    }
+
+    @Test
+    fun `Beregn avkorting beregner nytt aarsoppgjoer for dette aaret og beholder tidligere aar uendret`() {
+        val nyttAarsoppgjoer = aarsoppgjoer(maaned = YearMonth.of(2023, 1))
+        val tidligereAarsoppgjoer = aarsoppgjoer(maaned = YearMonth.of(2022, 1))
+
+        val avkorting = avkorting(
+            aarsoppgjoer = listOf(tidligereAarsoppgjoer)
+        )
+
+        every { AvkortingRegelkjoring.beregnAarsoppgjoer(any(), any(), any()) } returns listOf(nyttAarsoppgjoer)
+        every { AvkortingRegelkjoring.beregnInntektsavkorting(any(), any()) } returns listOf(avkortingsperiode())
+        every { AvkortingRegelkjoring.beregnAvkortetYtelse(any(), any(), any(), any()) } returns listOf(
+            avkortetYtelse()
+        )
+
+        val beregnetAvkorting = avkorting.beregnAvkorting(YearMonth.of(2023, 6), beregning())
+
+        beregnetAvkorting.aarsoppgjoer shouldBe listOf(tidligereAarsoppgjoer, nyttAarsoppgjoer)
+    }
+
+    @Test
+    fun `Beregn avkorting beregner nytt aarsoppgjoer og erstatter hvis det finnes fra foer`() {
+        val nyttAarsoppgjoer = aarsoppgjoer(maaned = YearMonth.of(2023, 1), restanse = 2000)
+        val tidligereAarsoppgjoer = aarsoppgjoer(maaned = YearMonth.of(2022, 1))
+
+        val avkorting = avkorting(
+            aarsoppgjoer = listOf(
+                aarsoppgjoer(maaned = YearMonth.of(2023, 1), restanse = 1000),
+                tidligereAarsoppgjoer
+            )
+        )
+
+        every { AvkortingRegelkjoring.beregnAarsoppgjoer(any(), any(), any()) } returns listOf(nyttAarsoppgjoer)
+        every { AvkortingRegelkjoring.beregnInntektsavkorting(any(), any()) } returns listOf(avkortingsperiode())
+        every { AvkortingRegelkjoring.beregnAvkortetYtelse(any(), any(), any(), any()) } returns listOf(
+            avkortetYtelse()
+        )
+
+        val beregnetAvkorting = avkorting.beregnAvkorting(YearMonth.of(2023, 6), beregning())
+
+        beregnetAvkorting.aarsoppgjoer shouldBe listOf(tidligereAarsoppgjoer, nyttAarsoppgjoer)
+    }
+
+    @Test
+    fun `Beregn avkorting beregner nytt aarsoppgjoer med tidligere avkorting hvis angitt`() {
+        val virkningstidspunkt = YearMonth.of(2023, 6)
+        val forrigeAvkorting = mockk<Avkorting>()
+        val avkorting = avkorting()
+
+        every { AvkortingRegelkjoring.beregnAarsoppgjoer(any(), any(), any()) } returns listOf(aarsoppgjoer())
+        every { AvkortingRegelkjoring.beregnInntektsavkorting(any(), any()) } returns listOf(avkortingsperiode())
+        every { AvkortingRegelkjoring.beregnAvkortetYtelse(any(), any(), any(), any()) } returns listOf(
+            avkortetYtelse()
+        )
+
+        avkorting.beregnAvkorting(virkningstidspunkt, beregning(), forrigeAvkorting)
+
+        verify { AvkortingRegelkjoring.beregnAarsoppgjoer(avkorting, virkningstidspunkt, forrigeAvkorting) }
+    }
+}

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -1,215 +1,327 @@
 package avkorting
 
+import io.kotest.assertions.asClue
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.mockk.clearAllMocks
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.mockkObject
-import io.mockk.verify
+import no.nav.etterlatte.avkorting.AvkortetYtelse
 import no.nav.etterlatte.avkorting.Avkorting
-import no.nav.etterlatte.avkorting.AvkortingRegelkjoring
-import no.nav.etterlatte.beregning.regler.aarsoppgjoer
+import no.nav.etterlatte.avkorting.AvkortingGrunnlag
+import no.nav.etterlatte.beregning.regler.aarsoppgjoerMaaned
 import no.nav.etterlatte.beregning.regler.avkortetYtelse
 import no.nav.etterlatte.beregning.regler.avkorting
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
-import no.nav.etterlatte.beregning.regler.avkortingsperiode
 import no.nav.etterlatte.beregning.regler.beregning
+import no.nav.etterlatte.beregning.regler.beregningsperiode
+import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.periode.Periode
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.YearMonth
+import java.util.*
 
 internal class AvkortingTest {
 
-    @BeforeEach
-    fun beforeEach() {
-        mockkObject(AvkortingRegelkjoring)
-    }
+    @Nested
+    inner class KopierAvkorting {
 
-    @AfterEach
-    fun afterEach() {
-        clearAllMocks()
-    }
+        private val avkorting = avkorting(
+            avkortingGrunnlag = listOf(avkortinggrunnlag(), avkortinggrunnlag()),
+            aarsoppgjoer = listOf(aarsoppgjoerMaaned())
+        )
 
-    @Test
-    fun `Kopier avkorting lager ny avkorting med tidligere grunnlag med ny id`() {
-        val grunnlag = listOf(avkortinggrunnlag(), avkortinggrunnlag())
-        val kopi = avkorting(avkortingGrunnlag = grunnlag).kopierAvkorting()
-        with(kopi) {
-            with(avkortingGrunnlag) {
-                size shouldBe 2
-                get(0).id shouldNotBe grunnlag[0].id
-                get(1).id shouldNotBe grunnlag[1].id
+        @Test
+        fun `Skal kopiere tidligere grunnlag men erstatte id`() {
+            with(avkorting.kopierAvkorting()) {
+                shouldBeEqualToIgnoringFields(avkorting, Avkorting::avkortingGrunnlag, Avkorting::aarsoppgjoer)
+                with(avkortingGrunnlag) {
+                    size shouldBe 2
+                    get(0).id shouldNotBe avkorting.avkortingGrunnlag[0].id
+                    get(1).id shouldNotBe avkorting.avkortingGrunnlag[1].id
+                }
+                avkortingsperioder shouldBe emptyList()
+                avkortetYtelse shouldBe emptyList()
             }
-            aarsoppgjoer shouldBe emptyList()
-            avkortingsperioder shouldBe emptyList()
-            avkortetYtelse shouldBe emptyList()
+        }
+
+        @Test
+        fun `Skal kopiere aarsoppgjoer`() {
+            avkorting.kopierAvkorting().asClue {
+                it.aarsoppgjoer shouldBe avkorting.aarsoppgjoer
+            }
         }
     }
 
-    @Test
-    fun `Beregn avkorting med nytt grunnlag legger til og setter til og med paa periode til forrige loepende`() {
-        val foersteGrunnlag = avkortinggrunnlag(
+    @Nested
+    inner class OppdaterMedInntektsgrunnlag {
+
+        private val foersteGrunnlag = avkortinggrunnlag(
             periode = Periode(fom = YearMonth.of(2023, 1), tom = YearMonth.of(2023, 3))
         )
-        val andreGrunnlag = avkortinggrunnlag(periode = Periode(fom = YearMonth.of(2023, 4), tom = null))
-        val nyttGrunnlag = avkortinggrunnlag(periode = Periode(fom = YearMonth.of(2023, 8), tom = null))
-
-        val avkorting = avkorting(
-            avkortingGrunnlag = listOf(foersteGrunnlag, andreGrunnlag)
-        )
-
-        every { AvkortingRegelkjoring.beregnAarsoppgjoer(any(), any(), any()) } returns listOf(aarsoppgjoer())
-        every { AvkortingRegelkjoring.beregnInntektsavkorting(any(), any()) } returns listOf(avkortingsperiode())
-        every { AvkortingRegelkjoring.beregnAvkortetYtelse(any(), any(), any(), any()) } returns listOf(
-            avkortetYtelse()
-        )
-
-        val beregnetAvkorting = avkorting.beregnAvkortingNyttEllerEndretGrunnlag(
-            nyttGrunnlag,
-            YearMonth.of(2023, 8),
-            beregning()
-        )
-
-        with(beregnetAvkorting.avkortingGrunnlag) {
-            size shouldBe 3
-            get(0) shouldBe foersteGrunnlag
-            get(1).id shouldBe andreGrunnlag.id
-            get(1).periode.tom shouldBe YearMonth.of(2023, 7)
-            get(2) shouldBe nyttGrunnlag
-        }
-    }
-
-    @Test
-    fun `Beregn avkorting med endret grunnlag oppdaterer eksisterende loepende grunnlag`() {
-        val foersteGrunnlag = avkortinggrunnlag(
-            periode = Periode(fom = YearMonth.of(2023, 1), tom = YearMonth.of(2023, 3))
-        )
-        val andreGrunnlag = avkortinggrunnlag(
+        private val andreGrunnlag = avkortinggrunnlag(
             aarsinntekt = 1000000,
             periode = Periode(fom = YearMonth.of(2023, 4), tom = null)
         )
-        val endretGrunnlag = andreGrunnlag.copy(aarsinntekt = 200000)
 
-        val avkorting = avkorting(
-            avkortingGrunnlag = listOf(foersteGrunnlag, andreGrunnlag)
+        private val avkorting = avkorting(
+            avkortingGrunnlag = listOf(foersteGrunnlag, andreGrunnlag),
+            aarsoppgjoer = listOf(aarsoppgjoerMaaned())
         )
 
-        every { AvkortingRegelkjoring.beregnAarsoppgjoer(any(), any(), any()) } returns listOf(aarsoppgjoer())
-        every { AvkortingRegelkjoring.beregnInntektsavkorting(any(), any()) } returns listOf(avkortingsperiode())
-        every { AvkortingRegelkjoring.beregnAvkortetYtelse(any(), any(), any(), any()) } returns listOf(
-            avkortetYtelse()
-        )
+        @Test
+        fun `Eksisterer det grunnlag med samme id skal eksisterende grunnlag oppdateres uten aa legge til nytt`() {
+            val endretGrunnlag = andreGrunnlag.copy(aarsinntekt = 200000)
 
-        val beregnetAvkorting = avkorting.beregnAvkortingNyttEllerEndretGrunnlag(
-            endretGrunnlag,
-            YearMonth.of(2023, 8),
-            beregning()
-        )
+            val oppdatertAvkorting = avkorting.oppdaterMedInntektsgrunnlag(endretGrunnlag)
 
-        with(beregnetAvkorting.avkortingGrunnlag) {
-            size shouldBe 2
-            get(0) shouldBe foersteGrunnlag
-            get(1) shouldBe endretGrunnlag
+            oppdatertAvkorting.shouldBeEqualToIgnoringFields(avkorting, Avkorting::avkortingGrunnlag)
+            with(oppdatertAvkorting.avkortingGrunnlag) {
+                size shouldBe 2
+                get(0) shouldBe foersteGrunnlag
+                get(1) shouldBe endretGrunnlag
+            }
+        }
+
+        @Test
+        fun `Eksisterer ikke grunnlag skal det legges til og til og med paa periode til siste grunnlag skal settes`() {
+            val nyttGrunnlag = avkortinggrunnlag(periode = Periode(fom = YearMonth.of(2023, 8), tom = null))
+
+            val oppdatertAvkorting = avkorting.oppdaterMedInntektsgrunnlag(nyttGrunnlag)
+
+            oppdatertAvkorting.shouldBeEqualToIgnoringFields(avkorting, Avkorting::avkortingGrunnlag)
+            with(oppdatertAvkorting.avkortingGrunnlag) {
+                size shouldBe 3
+                get(0) shouldBe foersteGrunnlag
+                get(1).shouldBeEqualToIgnoringFields(andreGrunnlag, AvkortingGrunnlag::periode)
+                get(1).periode shouldBe Periode(fom = YearMonth.of(2023, 4), tom = YearMonth.of(2023, 7))
+                get(2) shouldBe nyttGrunnlag
+            }
         }
     }
 
-    @Test
-    fun `Beregn avkorting beregner avkortingsperioder og avkortet ytelse fra ny virk med restanse fra aarsoppgjoer`() {
-        val virkningstidspunkt = YearMonth.of(2023, 6)
-        val beregning = beregning()
+    @Nested
+    inner class BeregnAvkorting {
 
-        val avkorting = avkorting(avkortingGrunnlag = listOf(avkortinggrunnlag()))
-
-        val aarsoppgjoer = listOf(aarsoppgjoer(restanse = 1000))
-        val avkortingsperioder = listOf(avkortingsperiode())
-        val avkortetYtelse = listOf(avkortetYtelse())
-
-        every {
-            AvkortingRegelkjoring.beregnAarsoppgjoer(avkorting, virkningstidspunkt)
-        } returns aarsoppgjoer
-        every {
-            AvkortingRegelkjoring.beregnInntektsavkorting(
-                Periode(fom = virkningstidspunkt, tom = null),
-                avkorting.avkortingGrunnlag
+        private val virkningstidspunkt = YearMonth.of(2023, 3)
+        private val beregning = beregning(
+            beregninger = listOf(
+                beregningsperiode(
+                    datoFOM = virkningstidspunkt,
+                    datoTOM = YearMonth.of(2023, 4),
+                    utbetaltBeloep = 20902
+                ),
+                beregningsperiode(
+                    datoFOM = YearMonth.of(2023, 5),
+                    utbetaltBeloep = 22241
+                )
             )
-        } returns avkortingsperioder
-        every {
-            AvkortingRegelkjoring.beregnAvkortetYtelse(
-                Periode(fom = virkningstidspunkt, tom = null),
-                beregning.beregningsperioder,
-                avkortingsperioder,
-                maanedligRestanse = 1000
-            )
-        } returns avkortetYtelse
-
-        val beregnetAvkorting = avkorting.beregnAvkorting(virkningstidspunkt, beregning)
-
-        beregnetAvkorting.avkortingGrunnlag shouldBe avkorting.avkortingGrunnlag
-        beregnetAvkorting.avkortingsperioder shouldBe avkortingsperioder
-        beregnetAvkorting.aarsoppgjoer shouldBe aarsoppgjoer
-        beregnetAvkorting.avkortetYtelse shouldBe avkortetYtelse
-    }
-
-    @Test
-    fun `Beregn avkorting beregner nytt aarsoppgjoer for dette aaret og beholder tidligere aar uendret`() {
-        val nyttAarsoppgjoer = aarsoppgjoer(maaned = YearMonth.of(2023, 1))
-        val tidligereAarsoppgjoer = aarsoppgjoer(maaned = YearMonth.of(2022, 1))
-
-        val avkorting = avkorting(
-            aarsoppgjoer = listOf(tidligereAarsoppgjoer)
         )
-
-        every { AvkortingRegelkjoring.beregnAarsoppgjoer(any(), any(), any()) } returns listOf(nyttAarsoppgjoer)
-        every { AvkortingRegelkjoring.beregnInntektsavkorting(any(), any()) } returns listOf(avkortingsperiode())
-        every { AvkortingRegelkjoring.beregnAvkortetYtelse(any(), any(), any(), any()) } returns listOf(
-            avkortetYtelse()
-        )
-
-        val beregnetAvkorting = avkorting.beregnAvkorting(YearMonth.of(2023, 6), beregning())
-
-        beregnetAvkorting.aarsoppgjoer shouldBe listOf(tidligereAarsoppgjoer, nyttAarsoppgjoer)
-    }
-
-    @Test
-    fun `Beregn avkorting beregner nytt aarsoppgjoer og erstatter hvis det finnes fra foer`() {
-        val nyttAarsoppgjoer = aarsoppgjoer(maaned = YearMonth.of(2023, 1), restanse = 2000)
-        val tidligereAarsoppgjoer = aarsoppgjoer(maaned = YearMonth.of(2022, 1))
-
-        val avkorting = avkorting(
-            aarsoppgjoer = listOf(
-                aarsoppgjoer(maaned = YearMonth.of(2023, 1), restanse = 1000),
-                tidligereAarsoppgjoer
+        val avkorting = Avkorting.nyAvkorting().oppdaterMedInntektsgrunnlag(
+            avkortinggrunnlag(
+                periode = Periode(fom = virkningstidspunkt, tom = null),
+                aarsinntekt = 300000,
+                fratrekkInnAar = 50000,
+                relevanteMaanederInnAar = 10
             )
         )
 
-        every { AvkortingRegelkjoring.beregnAarsoppgjoer(any(), any(), any()) } returns listOf(nyttAarsoppgjoer)
-        every { AvkortingRegelkjoring.beregnInntektsavkorting(any(), any()) } returns listOf(avkortingsperiode())
-        every { AvkortingRegelkjoring.beregnAvkortetYtelse(any(), any(), any(), any()) } returns listOf(
-            avkortetYtelse()
-        )
+        @Nested
+        inner class Foerstegangs {
 
-        val beregnetAvkorting = avkorting.beregnAvkorting(YearMonth.of(2023, 6), beregning())
+            @Test
+            fun `Skal beregne avkortingsperioder fra og med virkningstidspunkt`() {
+                val beregnetAvkorting = avkorting.beregnAvkorting(
+                    BehandlingType.FØRSTEGANGSBEHANDLING,
+                    virkningstidspunkt,
+                    beregning
+                )
+                beregnetAvkorting.avkortingsperioder.asClue {
+                    it.size shouldBe 2
+                    it[0].asClue { avkortingsperiode ->
+                        avkortingsperiode.periode shouldBe Periode(
+                            fom = virkningstidspunkt,
+                            tom = YearMonth.of(2023, 4)
+                        )
+                        avkortingsperiode.avkorting shouldBe 9160
+                    }
+                    it[1].asClue { avkortingsperiode ->
+                        avkortingsperiode.periode shouldBe Periode(fom = YearMonth.of(2023, 5), tom = null)
+                        avkortingsperiode.avkorting shouldBe 9026
+                    }
+                }
+            }
 
-        beregnetAvkorting.aarsoppgjoer shouldBe listOf(tidligereAarsoppgjoer, nyttAarsoppgjoer)
-    }
+            @Test
+            fun `Aarsoppgjoer skal vaere opprettet uten noen restanse`() {
+                val beregnetAvkorting = avkorting.beregnAvkorting(
+                    BehandlingType.FØRSTEGANGSBEHANDLING,
+                    virkningstidspunkt,
+                    beregning
+                )
+                beregnetAvkorting.aarsoppgjoer.asClue {
+                    it.shouldContainExactly(
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 3), 20902, 9160, 11742, 0, 0, 11742),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 4), 20902, 9160, 11742, 0, 0, 11742),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 5), 22241, 9026, 13215, 0, 0, 13215),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 6), 22241, 9026, 13215, 0, 0, 13215),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 7), 22241, 9026, 13215, 0, 0, 13215),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 8), 22241, 9026, 13215, 0, 0, 13215),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 9), 22241, 9026, 13215, 0, 0, 13215),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 10), 22241, 9026, 13215, 0, 0, 13215),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 11), 22241, 9026, 13215, 0, 0, 13215),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 12), 22241, 9026, 13215, 0, 0, 13215)
+                    )
+                }
+            }
 
-    @Test
-    fun `Beregn avkorting beregner nytt aarsoppgjoer med tidligere avkorting hvis angitt`() {
-        val virkningstidspunkt = YearMonth.of(2023, 6)
-        val forrigeAvkorting = mockk<Avkorting>()
-        val avkorting = avkorting()
+            @Test
+            fun `Skal beregne ytelse etter avkorting fra virkningstidspunkt`() {
+                val beregnetAvkorting = avkorting.beregnAvkorting(
+                    BehandlingType.FØRSTEGANGSBEHANDLING,
+                    virkningstidspunkt,
+                    beregning
+                )
+                with(beregnetAvkorting.avkortetYtelse) {
+                    size shouldBe 2
+                    get(0).shouldBeEqualToIgnoringFields(
+                        avkortetYtelse(
+                            periode = Periode(fom = virkningstidspunkt, tom = YearMonth.of(2023, 4)),
+                            ytelseEtterAvkorting = 11742,
+                            ytelseEtterAvkortingFoerRestanse = 11742,
+                            restanse = 0,
+                            avkortingsbeloep = 9160,
+                            ytelseFoerAvkorting = 20902
+                        ),
+                        AvkortetYtelse::tidspunkt,
+                        AvkortetYtelse::regelResultat,
+                        AvkortetYtelse::kilde
+                    )
+                    get(1).shouldBeEqualToIgnoringFields(
+                        avkortetYtelse(
+                            periode = Periode(fom = YearMonth.of(2023, 5), tom = null),
+                            ytelseEtterAvkorting = 13215,
+                            ytelseEtterAvkortingFoerRestanse = 13215,
+                            restanse = 0,
+                            avkortingsbeloep = 9026,
+                            ytelseFoerAvkorting = 22241
+                        ),
+                        AvkortetYtelse::tidspunkt,
+                        AvkortetYtelse::regelResultat,
+                        AvkortetYtelse::kilde
+                    )
+                }
+            }
+        }
 
-        every { AvkortingRegelkjoring.beregnAarsoppgjoer(any(), any(), any()) } returns listOf(aarsoppgjoer())
-        every { AvkortingRegelkjoring.beregnInntektsavkorting(any(), any()) } returns listOf(avkortingsperiode())
-        every { AvkortingRegelkjoring.beregnAvkortetYtelse(any(), any(), any(), any()) } returns listOf(
-            avkortetYtelse()
-        )
+        @Nested
+        inner class Revurdering {
 
-        avkorting.beregnAvkorting(virkningstidspunkt, beregning(), forrigeAvkorting)
+            private val nyVirk = YearMonth.of(2023, 6)
+            private val avkortingMedNyInntekt = avkorting.copy(
+                aarsoppgjoer = listOf(
+                    aarsoppgjoerMaaned(YearMonth.of(2023, 3), 20902, 9160, 11742, 0, 0, 11742),
+                    aarsoppgjoerMaaned(YearMonth.of(2023, 4), 20902, 9160, 11742, 0, 0, 11742),
+                    aarsoppgjoerMaaned(YearMonth.of(2023, 5), 22241, 9026, 13215, 0, 0, 13215),
+                    aarsoppgjoerMaaned(YearMonth.of(2023, 6), 22241, 9026, 13215, 0, 0, 13215),
+                    aarsoppgjoerMaaned(YearMonth.of(2023, 7), 22241, 9026, 13215, 0, 0, 13215),
+                    aarsoppgjoerMaaned(YearMonth.of(2023, 8), 22241, 9026, 13215, 0, 0, 13215),
+                    aarsoppgjoerMaaned(YearMonth.of(2023, 9), 22241, 9026, 13215, 0, 0, 13215),
+                    aarsoppgjoerMaaned(YearMonth.of(2023, 10), 22241, 9026, 13215, 0, 0, 13215),
+                    aarsoppgjoerMaaned(YearMonth.of(2023, 11), 22241, 9026, 13215, 0, 0, 13215),
+                    aarsoppgjoerMaaned(YearMonth.of(2023, 12), 22241, 9026, 13215, 0, 0, 13215)
+                )
+            ).oppdaterMedInntektsgrunnlag(
+                nyttGrunnlag = avkorting.avkortingGrunnlag.first().copy(
+                    id = UUID.randomUUID(),
+                    aarsinntekt = 400000
+                )
+            )
 
-        verify { AvkortingRegelkjoring.beregnAarsoppgjoer(avkorting, virkningstidspunkt, forrigeAvkorting) }
+            @Test
+            fun `Skal ikke kunne beregne uten et opprettet aarsoppjoer`() {
+                assertThrows<IllegalArgumentException> {
+                    avkorting(
+                        aarsoppgjoer = emptyList()
+                    ).beregnAvkorting(
+                        BehandlingType.REVURDERING,
+                        YearMonth.of(2023, 1),
+                        beregning()
+                    )
+                }
+            }
+
+            @Test
+            fun `Skal beregne avkortingsperioder fra og med foerste maaned i aarsoppgjoer med nytt inntektsgrunnlag`() {
+                val beregnetAvkorting = avkortingMedNyInntekt.beregnAvkorting(
+                    BehandlingType.REVURDERING,
+                    nyVirk,
+                    beregning
+                )
+                beregnetAvkorting.avkortingsperioder.asClue {
+                    it.size shouldBe 2
+                    it[0].asClue { avkortingsperiode ->
+                        avkortingsperiode.periode shouldBe Periode(
+                            fom = virkningstidspunkt,
+                            tom = YearMonth.of(2023, 4)
+                        )
+                        avkortingsperiode.avkorting shouldBe 13660
+                    }
+                    it[1].asClue { avkortingsperiode ->
+                        avkortingsperiode.periode shouldBe Periode(fom = YearMonth.of(2023, 5), tom = null)
+                        avkortingsperiode.avkorting shouldBe 13526
+                    }
+                }
+            }
+
+            @Test
+            fun `Aarsoppgjoer beregner restanse foer ny virk og fordele utover resterende maaneder etter ny virk`() {
+                val beregnetAvkorting = avkortingMedNyInntekt.beregnAvkorting(
+                    BehandlingType.REVURDERING,
+                    nyVirk,
+                    beregning
+                )
+                beregnetAvkorting.aarsoppgjoer.asClue {
+                    it.shouldContainExactly(
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 3), 20902, 13660, 7242, 4500, 0, 11742),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 4), 20902, 13660, 7242, 4500, 0, 11742),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 5), 22241, 13526, 8715, 4500, 0, 13215),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 6), 22241, 13526, 8715, 0, 1928, 6787),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 7), 22241, 13526, 8715, 0, 1928, 6787),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 8), 22241, 13526, 8715, 0, 1928, 6787),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 9), 22241, 13526, 8715, 0, 1928, 6787),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 10), 22241, 13526, 8715, 0, 1928, 6787),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 11), 22241, 13526, 8715, 0, 1928, 6787),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 12), 22241, 13526, 8715, 0, 1928, 6787)
+                    )
+                }
+            }
+
+            @Test
+            fun `Skal beregne ytelse etter avkorting og restanse fra nytt virkningstidspunkt`() {
+                val beregnetAvkorting = avkortingMedNyInntekt.beregnAvkorting(
+                    BehandlingType.REVURDERING,
+                    nyVirk,
+                    beregning
+                )
+                beregnetAvkorting.avkortetYtelse.asClue {
+                    it.size shouldBe 1
+                    it[0].shouldBeEqualToIgnoringFields(
+                        avkortetYtelse(
+                            periode = Periode(fom = nyVirk, tom = null),
+                            ytelseEtterAvkorting = 6787,
+                            ytelseEtterAvkortingFoerRestanse = 8715,
+                            restanse = 1928,
+                            avkortingsbeloep = 13526,
+                            ytelseFoerAvkorting = 22241
+                        ),
+                        AvkortetYtelse::tidspunkt,
+                        AvkortetYtelse::regelResultat,
+                        AvkortetYtelse::kilde
+                    )
+                }
+            }
+        }
     }
 }

--- a/apps/etterlatte-beregning/src/test/kotlin/ytelseMedGrunnlag/YtelseMedGrunnlagServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/ytelseMedGrunnlag/YtelseMedGrunnlagServiceTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 import java.time.YearMonth
 import java.util.UUID
 
-internal class BruttoYtelseServiceTest {
+internal class YtelseMedGrunnlagServiceTest {
 
     private val avkortingRepository = mockk<AvkortingRepository>()
     private val service = YtelseMedGrunnlagService(avkortingRepository)
@@ -76,7 +76,7 @@ internal class BruttoYtelseServiceTest {
             grunnbelop shouldBe 111477
             grunnbelopMnd shouldBe 9290
         }
-        with(ytelse!!.perioder[1]) {
+        with(ytelse.perioder[1]) {
             periode shouldBe Periode(fom = YearMonth.of(2023, 4), tom = YearMonth.of(2023, 5))
             ytelseEtterAvkorting shouldBe 17000
             ytelseFoerAvkorting shouldBe 20000
@@ -86,7 +86,7 @@ internal class BruttoYtelseServiceTest {
             grunnbelop shouldBe 111477
             grunnbelopMnd shouldBe 9290
         }
-        with(ytelse!!.perioder[2]) {
+        with(ytelse.perioder[2]) {
             periode shouldBe Periode(fom = YearMonth.of(2023, 6), tom = null)
             ytelseEtterAvkorting shouldBe 17000
             ytelseFoerAvkorting shouldBe 21000

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -2,7 +2,7 @@ import { BodyShort, Button, ErrorMessage, Heading, Label, ReadMore, Table, TextF
 import styled from 'styled-components'
 import React, { FormEvent, useState } from 'react'
 import { IAvkorting, IAvkortingGrunnlag } from '~shared/types/IAvkorting'
-import { isPending, useApiCall } from '~shared/hooks/useApiCall'
+import { isFailure, isPending, useApiCall } from '~shared/hooks/useApiCall'
 import { lagreAvkortingGrunnlag } from '~shared/api/avkorting'
 import { formaterStringDato } from '~utils/formattering'
 import { HjemmelLenke } from '~components/behandling/felles/HjemmelLenke'
@@ -10,6 +10,7 @@ import { Info } from '~components/behandling/soeknadsoversikt/Info'
 import { IBehandlingReducer } from '~store/reducers/BehandlingReducer'
 import { PencilIcon } from '@navikt/aksel-icons'
 import { hentBehandlesFraStatus } from '~components/behandling/felles/utils'
+import { ApiErrorAlert } from '~ErrorBoundary'
 
 export const AvkortingInntekt = (props: {
   behandling: IBehandlingReducer
@@ -30,7 +31,7 @@ export const AvkortingInntekt = (props: {
       return siste.fom === behandling.virkningstidspunkt?.dato
     }
   }
-  const finnRedigerbartGrunnlag = () => {
+  const finnRedigerbartGrunnlag = (): IAvkortingGrunnlag => {
     if (props.avkortingGrunnlag) {
       if (finnesRedigerbartGrunnlag()) {
         return props.avkortingGrunnlag[props.avkortingGrunnlag.length - 1]
@@ -39,13 +40,14 @@ export const AvkortingInntekt = (props: {
         const siste = props.avkortingGrunnlag[props.avkortingGrunnlag.length - 1]
         return {
           fom: virkningstidspunkt(),
-          fratrekkInnUt: siste.fratrekkInnAar,
-          relevanteMaaneder: siste.relevanteMaanederInnAar,
+          fratrekkInnAar: siste.fratrekkInnAar,
+          relevanteMaanederInnAar: siste.relevanteMaanederInnAar,
         }
       }
     }
     return {
       fom: virkningstidspunkt(),
+      fratrekkInnAar: 0,
     }
   }
 
@@ -96,7 +98,7 @@ export const AvkortingInntekt = (props: {
           <Table className="table" zebraStripes>
             <Table.Header>
               <Table.HeaderCell>Forventet inntekt</Table.HeaderCell>
-              <Table.HeaderCell>Fratrekk inn/ut</Table.HeaderCell>
+              <Table.HeaderCell>Fratrekk inn år</Table.HeaderCell>
               <Table.HeaderCell>F.o.m dato</Table.HeaderCell>
               <Table.HeaderCell>T.o.m dato</Table.HeaderCell>
               <Table.HeaderCell>Spesifikasjon av inntekt</Table.HeaderCell>
@@ -151,11 +153,11 @@ export const AvkortingInntekt = (props: {
                     type="text"
                     inputMode="numeric"
                     pattern="[0-9]*"
-                    value={inntektGrunnlagForm.fratrekkInnAar == null ? '0' : inntektGrunnlagForm.fratrekkInnAar}
+                    value={inntektGrunnlagForm.fratrekkInnAar}
                     onChange={(e) =>
                       setInntektGrunnlagForm({
                         ...inntektGrunnlagForm,
-                        fratrekkInnAar: e.target.value === '' ? 0 : Number(e.target.value),
+                        fratrekkInnAar: Number(e.target.value),
                       })
                     }
                   />
@@ -222,6 +224,7 @@ export const AvkortingInntekt = (props: {
           </Rows>
         </InntektAvkortingForm>
       )}
+      {isFailure(inntektGrunnlagStatus) && <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>}
     </AvkortingInntektWrapper>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/YtelseEtterAvkorting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/YtelseEtterAvkorting.tsx
@@ -20,6 +20,7 @@ export const YtelseEtterAvkorting = (props: { ytelser?: IAvkortetYtelse[] }) => 
               <Table.Row>
                 <Table.HeaderCell>Periode</Table.HeaderCell>
                 <Table.HeaderCell>Avkorting</Table.HeaderCell>
+                <Table.HeaderCell>Restanse</Table.HeaderCell>
                 <Table.HeaderCell>Brutto stønad etter avkorting</Table.HeaderCell>
               </Table.Row>
             </Table.Header>
@@ -30,6 +31,7 @@ export const YtelseEtterAvkorting = (props: { ytelser?: IAvkortetYtelse[] }) => 
                     {formaterStringDato(ytelse.fom)} - {ytelse.tom ? formaterStringDato(ytelse.tom) : ''}
                   </Table.DataCell>
                   <Table.DataCell>{ytelse.avkortingsbeloep} kr</Table.DataCell>
+                  <Table.DataCell>{ytelse.restanse} kr</Table.DataCell>
                   <Table.DataCell>
                     <ManglerRegelspesifikasjon>{ytelse.ytelseEtterAvkorting} kr</ManglerRegelspesifikasjon>
                   </Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
@@ -22,5 +22,6 @@ export interface IAvkortetYtelse {
   fom: string
   tom: string
   avkortingsbeloep: number
+  restanse: number
   ytelseEtterAvkorting: number
 }

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingServiceTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingServiceTest.kt
@@ -887,7 +887,8 @@ internal class VedtaksvurderingServiceTest {
                 fom = virkningstidspunkt.atDay(1),
                 tom = null,
                 ytelseEtterAvkorting = 50,
-                avkortingsbeloep = 50
+                avkortingsbeloep = 50,
+                restanse = 0
             )
         )
     }

--- a/libs/etterlatte-beregning-model/src/main/kotlin/BeregningDTO.kt
+++ b/libs/etterlatte-beregning-model/src/main/kotlin/BeregningDTO.kt
@@ -58,7 +58,8 @@ data class AvkortetYtelseDto(
     val fom: LocalDate,
     val tom: LocalDate?,
     val avkortingsbeloep: Int,
-    val ytelseEtterAvkorting: Int
+    val ytelseEtterAvkorting: Int,
+    val restanse: Int
 )
 
 data class YtelseMedGrunnlagDto(


### PR DESCRIPTION
- Ny tabell i db for å lagre årsoppgjør for avkorting og restanse
- Metode for beregne årsoppgjøret og månedlig restanse (uten regelkjøring enn så lenge)
- flyttet domenelogikk fra AvkortingService til Avkorting
- Div rydding og renaming
- Fikset bug i AvkortingIntekst.tsx etter renaming av relevanteMaanederInnAar og fratrekkInnAar
