### PR TITLE
EY-2317 Oversiktsside for brev + nytt brev side

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -9,6 +9,7 @@ import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.header
 import io.ktor.serialization.jackson.jackson
 import io.ktor.server.config.HoconApplicationConfig
+import no.nav.etterlatte.brev.BrevService
 import no.nav.etterlatte.brev.VedtaksbrevService
 import no.nav.etterlatte.brev.adresse.AdresseService
 import no.nav.etterlatte.brev.adresse.Norg2Klient
@@ -18,6 +19,7 @@ import no.nav.etterlatte.brev.adresse.enhetsregister.BrregService
 import no.nav.etterlatte.brev.behandling.SakOgBehandlingService
 import no.nav.etterlatte.brev.behandlingklient.BehandlingKlient
 import no.nav.etterlatte.brev.beregning.BeregningKlient
+import no.nav.etterlatte.brev.brevRoute
 import no.nav.etterlatte.brev.brevbaker.BrevbakerKlient
 import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.distribusjon.DistribusjonKlient
@@ -111,6 +113,9 @@ class ApplicationBuilder {
         DistribusjonKlient(httpClient("DOKDIST_SCOPE", false), env.requireEnvValue("DOKDIST_URL"))
     private val distribusjonService = DistribusjonServiceImpl(distribusjonKlient, db)
 
+    private val brevService =
+        BrevService(db, sakOgBehandlingService, adresseService, dokarkivService, distribusjonService, brevbaker)
+
     private val vedtaksbrevService =
         VedtaksbrevService(
             db,
@@ -127,6 +132,7 @@ class ApplicationBuilder {
         RapidApplication.Builder(RapidApplication.RapidApplicationConfig.fromEnv(env))
             .withKtorModule {
                 restModule(sikkerLogg, routePrefix = "api", config = HoconApplicationConfig(config)) {
+                    brevRoute(brevService, behandlingKlient)
                     vedtaksbrevRoute(vedtaksbrevService, behandlingKlient)
                     dokumentRoute(journalpostService, behandlingKlient)
                 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
@@ -1,0 +1,131 @@
+package no.nav.etterlatte.brev
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import no.nav.etterlatte.brev.behandlingklient.BehandlingKlient
+import no.nav.etterlatte.brev.model.Slate
+import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.withSakId
+import no.nav.etterlatte.libs.ktor.brukerTokenInfo
+import org.slf4j.LoggerFactory
+import kotlin.time.DurationUnit
+import kotlin.time.ExperimentalTime
+import kotlin.time.measureTimedValue
+
+@OptIn(ExperimentalTime::class)
+fun Route.brevRoute(service: BrevService, behandlingKlient: BehandlingKlient) {
+    val logger = LoggerFactory.getLogger("no.nav.etterlatte.brev.VedaksbrevRoute")
+
+    route("brev/{id}") {
+        get {
+            withSakId(behandlingKlient) {
+                val id = requireNotNull(call.parameters["id"]).toLong()
+
+                call.respond(service.hentBrev(id))
+            }
+        }
+
+        get("pdf") {
+            withSakId(behandlingKlient) {
+                val brevId = requireNotNull(call.parameters["id"]).toLong()
+
+                logger.info("Genererer PDF for brev (id=$brevId)")
+
+                measureTimedValue {
+                    service.genererPdf(brevId, brukerTokenInfo).bytes
+                }.let { (pdf, varighet) ->
+                    logger.info("Oppretting av pdf tok ${varighet.toString(DurationUnit.SECONDS, 2)}")
+                    call.respond(pdf)
+                }
+            }
+        }
+
+        route("payload") {
+            get {
+                withSakId(behandlingKlient) {
+                    val brevId = requireNotNull(call.parameters["id"]).toLong()
+
+                    call.respond(service.hentBrevPayload(brevId) ?: HttpStatusCode.NoContent)
+                }
+            }
+
+            post {
+                withSakId(behandlingKlient) {
+                    val brevId = requireNotNull(call.parameters["id"]).toLong()
+                    val body = call.receive<OppdaterPayloadRequest>()
+
+                    service.lagreBrevPayload(brevId, body.payload)
+                    call.respond(HttpStatusCode.OK)
+                }
+            }
+        }
+
+        post("ferdigstill") {
+            withSakId(behandlingKlient) {
+                val brevId = requireNotNull(call.parameters["id"]).toLong()
+
+                service.ferdigstill(brevId, brukerTokenInfo)
+
+                call.respond(HttpStatusCode.OK)
+            }
+        }
+
+        post("journalfoer") {
+            withSakId(behandlingKlient) {
+                val brevId = requireNotNull(call.parameters["id"]).toLong()
+
+                val journalpostId = service.journalfoer(brevId, brukerTokenInfo)
+
+                call.respond(journalpostId)
+            }
+        }
+
+        post("distribuer") {
+            withSakId(behandlingKlient) {
+                val brevId = requireNotNull(call.parameters["id"]).toLong()
+
+                val journalpostId = service.distribuer(brevId)
+
+                call.respond(journalpostId)
+            }
+        }
+    }
+
+    route("brev/sak/{$SAKID_CALL_PARAMETER}") {
+        get {
+            withSakId(behandlingKlient) { sakId ->
+                logger.info("Henter brev tilknyttet sak=$sakId")
+
+                measureTimedValue {
+                    service.hentBrevForSak(sakId)
+                }.let { (brev, varighet) ->
+                    logger.info("Henting av brev tok ${varighet.toString(DurationUnit.SECONDS, 2)}")
+                    call.respond(brev)
+                }
+            }
+        }
+
+        post {
+            withSakId(behandlingKlient) { sakId ->
+                logger.info("Oppretter nytt brev på sak=$sakId)")
+
+                measureTimedValue {
+                    service.opprettBrev(sakId, brukerTokenInfo)
+                }.let { (brev, varighet) ->
+                    logger.info("Oppretting av brev tok ${varighet.toString(DurationUnit.SECONDS, 2)}")
+                    call.respond(HttpStatusCode.Created, brev)
+                }
+            }
+        }
+    }
+}
+
+data class OppdaterPayloadRequest(
+    val payload: Slate
+)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -1,0 +1,168 @@
+package no.nav.etterlatte.brev
+
+import no.nav.etterlatte.brev.adresse.AdresseService
+import no.nav.etterlatte.brev.behandling.SakOgBehandlingService
+import no.nav.etterlatte.brev.brevbaker.BrevbakerHelpers
+import no.nav.etterlatte.brev.brevbaker.BrevbakerKlient
+import no.nav.etterlatte.brev.brevbaker.BrevbakerRequest
+import no.nav.etterlatte.brev.brevbaker.EtterlatteBrevKode
+import no.nav.etterlatte.brev.brevbaker.LanguageCode
+import no.nav.etterlatte.brev.db.BrevRepository
+import no.nav.etterlatte.brev.distribusjon.DistribusjonService
+import no.nav.etterlatte.brev.distribusjon.DistribusjonsTidspunktType
+import no.nav.etterlatte.brev.distribusjon.DistribusjonsType
+import no.nav.etterlatte.brev.dokarkiv.DokarkivService
+import no.nav.etterlatte.brev.model.Brev
+import no.nav.etterlatte.brev.model.BrevData
+import no.nav.etterlatte.brev.model.BrevID
+import no.nav.etterlatte.brev.model.BrevInnhold
+import no.nav.etterlatte.brev.model.BrevProsessType
+import no.nav.etterlatte.brev.model.ManueltBrevData
+import no.nav.etterlatte.brev.model.OpprettNyttBrev
+import no.nav.etterlatte.brev.model.Pdf
+import no.nav.etterlatte.brev.model.Slate
+import no.nav.etterlatte.brev.model.SlateHelper
+import no.nav.etterlatte.brev.model.Spraak
+import no.nav.etterlatte.brev.model.Status
+import no.nav.etterlatte.token.BrukerTokenInfo
+import org.slf4j.LoggerFactory
+import java.util.*
+
+class BrevService(
+    private val db: BrevRepository,
+    private val sakOgBehandlingService: SakOgBehandlingService,
+    private val adresseService: AdresseService,
+    private val dokarkivService: DokarkivService,
+    private val distribusjonService: DistribusjonService,
+    private val brevbakerKlient: BrevbakerKlient
+) {
+    private val logger = LoggerFactory.getLogger(BrevService::class.java)
+
+    fun hentBrev(id: BrevID): Brev {
+        return db.hentBrev(id)
+    }
+
+    fun hentBrevForSak(sakId: Long): List<Brev> {
+        return db.hentBrevForSak(sakId)
+    }
+
+    suspend fun opprettBrev(sakId: Long, bruker: BrukerTokenInfo): Brev {
+        val sak = sakOgBehandlingService.hentSak(sakId, bruker)
+
+        val mottaker = adresseService.hentMottakerAdresse(sak.ident)
+
+        val nyttBrev = OpprettNyttBrev(
+            sakId = sakId,
+            behandlingId = null,
+            soekerFnr = sak.ident,
+            prosessType = BrevProsessType.MANUELL,
+            mottaker = mottaker,
+            innhold = BrevInnhold("Nytt brev", Spraak.NB, SlateHelper.opprettTomBrevmal())
+        )
+
+        return db.opprettBrev(nyttBrev)
+    }
+
+    fun hentBrevPayload(id: BrevID): Slate? =
+        db.hentBrevPayload(id)
+            .also { logger.info("Hentet payload for brev (id=$id)") }
+
+    fun lagreBrevPayload(id: BrevID, payload: Slate) =
+        db.oppdaterPayload(id, payload)
+            .also { logger.info("Payload for brev (id=$id) oppdatert") }
+
+    suspend fun genererPdf(
+        id: BrevID,
+        bruker: BrukerTokenInfo
+    ): Pdf {
+        val brev = hentBrev(id)
+
+        if (!brev.kanEndres()) {
+            logger.info("Brev har status ${brev.status} - returnerer lagret innhold")
+            return requireNotNull(db.hentPdf(brev.id))
+        }
+
+        val sak = sakOgBehandlingService.hentSak(brev.sakId, bruker)
+        val soeker = sakOgBehandlingService.hentSoeker(brev.sakId, bruker)
+        val avsender = adresseService.hentAvsender(sak, bruker.ident())
+
+        val (brevKode, brevData) = opprettBrevData(brev)
+        val brevRequest = BrevbakerRequest(
+            kode = brevKode,
+            letterData = brevData,
+            felles = BrevbakerHelpers.mapFelles(
+                sakId = brev.sakId,
+                soeker = soeker,
+                avsender = avsender
+            ),
+            language = LanguageCode.spraakToLanguageCode(Spraak.NB) // TODO: fikse spraak
+        )
+
+        return genererPdf(brev.id, brevRequest)
+    }
+
+    suspend fun ferdigstill(id: BrevID, bruker: BrukerTokenInfo) {
+        val brev = hentBrev(id)
+
+        if (brev.status in listOf(Status.OPPRETTET, Status.OPPDATERT)) {
+            val pdf = genererPdf(id, bruker)
+
+            db.lagrePdfOgFerdigstillBrev(id, pdf)
+        } else {
+            throw IllegalStateException("Kan ikke ferdigstille brev (id=$id) med status ${brev.status}")
+        }
+    }
+
+    suspend fun journalfoer(id: BrevID, bruker: BrukerTokenInfo): String {
+        val brev = hentBrev(id)
+
+        if (brev.status != Status.FERDIGSTILT) {
+            throw IllegalStateException("Ugyldig status ${brev.status} på brev (id=${brev.id})")
+        }
+
+        val sak = sakOgBehandlingService.hentSak(brev.sakId, bruker)
+
+        val response = dokarkivService.journalfoer(brev, sak)
+
+        db.settBrevJournalfoert(brev.id, response)
+        logger.info("Brev med id=${brev.id} markert som journalført")
+
+        return response.journalpostId
+    }
+
+    fun distribuer(id: BrevID): String {
+        val brev = hentBrev(id)
+
+        if (brev.status != Status.JOURNALFOERT) {
+            throw IllegalStateException(
+                "Forventet status ${Status.JOURNALFOERT} på brev (id=${brev.id}), men fikk ${brev.status}"
+            )
+        }
+
+        val journalpostId = requireNotNull(db.hentJournalpostId(id)) {
+            "JournalpostID mangler på brev (id=${brev.id}, status=${brev.status})"
+        }
+
+        return distribusjonService.distribuerJournalpost(
+            brevId = brev.id,
+            journalpostId = journalpostId,
+            type = DistribusjonsType.ANNET,
+            tidspunkt = DistribusjonsTidspunktType.KJERNETID,
+            adresse = brev.mottaker.adresse
+        )
+    }
+
+    private fun opprettBrevData(brev: Brev): Pair<EtterlatteBrevKode, BrevData> {
+        val payload = requireNotNull(db.hentBrevPayload(brev.id))
+
+        return Pair(EtterlatteBrevKode.OMS_INNVILGELSE_MANUELL, ManueltBrevData(payload.elements))
+    }
+
+    private suspend fun genererPdf(brevID: BrevID, brevRequest: BrevbakerRequest): Pdf {
+        val brevbakerResponse = brevbakerKlient.genererPdf(brevRequest)
+
+        return Base64.getDecoder().decode(brevbakerResponse.base64pdf)
+            .let { Pdf(it) }
+            .also { logger.info("Generert brev (id=$brevID) med størrelse: ${it.bytes.size}") }
+    }
+}

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevRoute.kt
@@ -2,15 +2,12 @@ package no.nav.etterlatte.brev
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
-import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.brev.behandlingklient.BehandlingKlient
-import no.nav.etterlatte.brev.model.BrevID
-import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.withBehandlingId
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
@@ -61,32 +58,10 @@ fun Route.vedtaksbrevRoute(service: VedtaksbrevService, behandlingKlient: Behand
                 measureTimedValue {
                     service.genererPdf(brevId, brukerTokenInfo).bytes
                 }.let { (pdf, varighet) ->
-                    logger.info("Oppretting av innhold/pdf tok ${varighet.toString(DurationUnit.SECONDS, 2)}")
+                    logger.info("Generering av pdf tok ${varighet.toString(DurationUnit.SECONDS, 2)}")
                     call.respond(pdf)
                 }
             }
         }
-
-        get("vedtak/manuell") {
-            withBehandlingId(behandlingKlient) {
-                val brevId = requireNotNull(call.parameters["brevId"]).toLong()
-
-                call.respond(service.hentManueltBrevPayload(brevId) ?: HttpStatusCode.NoContent)
-            }
-        }
-
-        post("vedtak/manuell") {
-            withBehandlingId(behandlingKlient) {
-                val body = call.receive<OppdaterPayloadRequest>()
-
-                service.lagreManueltBrevPayload(body.id, body.payload)
-                call.respond(HttpStatusCode.OK)
-            }
-        }
     }
 }
-
-data class OppdaterPayloadRequest(
-    val id: BrevID,
-    val payload: Slate
-)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
@@ -20,7 +20,6 @@ import no.nav.etterlatte.brev.model.BrevProsessType.MANUELL
 import no.nav.etterlatte.brev.model.ManueltBrevData
 import no.nav.etterlatte.brev.model.OpprettNyttBrev
 import no.nav.etterlatte.brev.model.Pdf
-import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.brev.model.SlateHelper
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
@@ -88,7 +87,7 @@ class VedtaksbrevService(
             return requireNotNull(db.hentPdf(brev.id))
         }
 
-        val behandling = sakOgBehandlingService.hentBehandling(brev.sakId, brev.behandlingId, brukerTokenInfo)
+        val behandling = sakOgBehandlingService.hentBehandling(brev.sakId, brev.behandlingId!!, brukerTokenInfo)
         val avsender = adresseService.hentAvsender(behandling.vedtak)
 
         val (brevKode, brevData) = opprettBrevData(brev, behandling)
@@ -140,13 +139,6 @@ class VedtaksbrevService(
                     " og attestant (${brukerTokenInfo.ident()}) er samme person."
             )
         }
-    }
-
-    fun hentManueltBrevPayload(id: BrevID): Slate? = db.hentBrevPayload(id)
-
-    fun lagreManueltBrevPayload(id: BrevID, payload: Slate) {
-        db.oppdaterPayload(id, payload)
-            .also { logger.info("Payload for brev (id=$id) oppdatert") }
     }
 
     fun journalfoerVedtaksbrev(vedtaksbrev: Brev, vedtak: VedtakTilJournalfoering): JournalpostResponse {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/SakOgBehandlingService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/SakOgBehandlingService.kt
@@ -22,6 +22,13 @@ class SakOgBehandlingService(
     private val behandlingKlient: BehandlingKlient
 ) {
 
+    suspend fun hentSak(sakId: Long, bruker: BrukerTokenInfo) =
+        behandlingKlient.hentSak(sakId, bruker)
+
+    suspend fun hentSoeker(sakId: Long, bruker: BrukerTokenInfo): Soeker =
+        grunnlagKlient.hentGrunnlag(sakId, bruker)
+            .mapSoeker()
+
     suspend fun hentBehandling(
         sakId: Long,
         behandlingId: UUID,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/journalpost/Journalpost.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/journalpost/Journalpost.kt
@@ -8,7 +8,7 @@ data class JournalpostRequest(
     val journalfoerendeEnhet: String?,
     val avsenderMottaker: AvsenderMottaker,
     val bruker: Bruker,
-    val sak: Sak,
+    val sak: JournalpostSak,
     val eksternReferanseId: String,
     val dokumenter: List<JournalpostDokument>
 )
@@ -32,7 +32,7 @@ data class JournalpostDokument(
     val dokumentvarianter: List<DokumentVariant>
 )
 
-data class Sak(
+data class JournalpostSak(
     val sakstype: Sakstype,
     val fagsakId: String? = null,
     val fagsaksystem: String? = "EY"

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -66,7 +66,7 @@ data class Mottaker(
 data class Brev(
     val id: BrevID,
     val sakId: Long,
-    val behandlingId: UUID,
+    val behandlingId: UUID?,
     val prosessType: BrevProsessType,
     val soekerFnr: String,
     val status: Status,
@@ -99,7 +99,7 @@ data class BrevInnhold(
 
 data class OpprettNyttBrev(
     val sakId: Long,
-    val behandlingId: UUID,
+    val behandlingId: UUID?,
     val soekerFnr: String,
     val prosessType: BrevProsessType,
     val mottaker: Mottaker,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/Slate.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/Slate.kt
@@ -47,5 +47,7 @@ object SlateHelper {
         }.let { deserialize(it) }
     }
 
+    fun opprettTomBrevmal() = deserialize<Slate>(getJsonFile("/maler/tom-brevmal.json"))
+
     private fun getJsonFile(url: String) = javaClass.getResource(url)!!.readText()
 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
@@ -1,0 +1,278 @@
+package no.nav.etterlatte.brev
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.brev.adresse.AdresseService
+import no.nav.etterlatte.brev.behandling.SakOgBehandlingService
+import no.nav.etterlatte.brev.brevbaker.BrevbakerKlient
+import no.nav.etterlatte.brev.db.BrevRepository
+import no.nav.etterlatte.brev.distribusjon.DistribusjonServiceImpl
+import no.nav.etterlatte.brev.distribusjon.DistribusjonsTidspunktType
+import no.nav.etterlatte.brev.distribusjon.DistribusjonsType
+import no.nav.etterlatte.brev.dokarkiv.DokarkivServiceImpl
+import no.nav.etterlatte.brev.journalpost.JournalpostResponse
+import no.nav.etterlatte.brev.model.Adresse
+import no.nav.etterlatte.brev.model.Brev
+import no.nav.etterlatte.brev.model.BrevProsessType
+import no.nav.etterlatte.brev.model.Mottaker
+import no.nav.etterlatte.brev.model.Slate
+import no.nav.etterlatte.brev.model.Status
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.sak.Sak
+import no.nav.etterlatte.token.BrukerTokenInfo
+import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.util.*
+import kotlin.random.Random
+
+internal class BrevServiceTest {
+
+    private val db = mockk<BrevRepository>(relaxed = true)
+    private val brevbaker = mockk<BrevbakerKlient>()
+    private val sakOgBehandlingService = mockk<SakOgBehandlingService>()
+    private val adresseService = mockk<AdresseService>()
+    private val dokarkivService = mockk<DokarkivServiceImpl>()
+    private val distribusjonService = mockk<DistribusjonServiceImpl>()
+
+    private val brevService =
+        BrevService(db, sakOgBehandlingService, adresseService, dokarkivService, distribusjonService, brevbaker)
+
+    private val bruker = BrukerTokenInfo.of(UUID.randomUUID().toString(), "Z123456", null, null, null)
+
+    @BeforeEach
+    fun before() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun after() {
+        confirmVerified(db, sakOgBehandlingService, adresseService, dokarkivService, distribusjonService, brevbaker)
+    }
+
+    @Nested
+    inner class HentingAvBrev {
+        @Test
+        fun `Hent brev med ID`() {
+            every { db.hentBrev(any()) } returns mockk()
+
+            val id = Random.nextLong()
+            val brev = brevService.hentBrev(id)
+            brev shouldNotBe null
+
+            verify {
+                db.hentBrev(id)
+            }
+        }
+
+        @Test
+        fun `Hent brev tilhoerende sak`() {
+            every { db.hentBrevForSak(any()) } returns listOf(
+                opprettBrev(Status.OPPRETTET, BrevProsessType.MANUELL),
+                opprettBrev(Status.OPPRETTET, BrevProsessType.MANUELL),
+                opprettBrev(Status.FERDIGSTILT, BrevProsessType.AUTOMATISK)
+            )
+
+            val sakId = Random.nextLong()
+            val brevListe = brevService.hentBrevForSak(sakId)
+            brevListe.size shouldBe 3
+
+            verify {
+                db.hentBrevForSak(sakId)
+            }
+        }
+    }
+
+    @Nested
+    inner class PayloadManuelleBrev {
+        @Test
+        fun `Hent payload`() {
+            val brev = opprettBrev(Status.OPPRETTET, mockk())
+            every { db.hentBrev(any()) } returns brev
+
+            val payload = Slate(listOf(Slate.Element(Slate.ElementType.PARAGRAPH)))
+            every { db.hentBrevPayload(any()) } returns payload
+
+            val faktiskPayload = runBlocking {
+                brevService.hentBrevPayload(brev.id)
+            }
+
+            faktiskPayload shouldBe payload
+
+            verify {
+                db.hentBrevPayload(brev.id)
+            }
+        }
+
+        @Test
+        fun `Hent payload - finnes ikke`() {
+            val brev = opprettBrev(Status.OPPRETTET, mockk())
+            every { db.hentBrevPayload(any()) } returns null
+
+            runBlocking {
+                Assertions.assertNull(brevService.hentBrevPayload(brev.id))
+            }
+
+            verify {
+                db.hentBrevPayload(brev.id)
+            }
+        }
+    }
+
+    @Nested
+    inner class JournalfoeringAvBrev {
+        @Test
+        fun `Journalfoering fungerer som forventet`() {
+            val brev = opprettBrev(Status.FERDIGSTILT, BrevProsessType.MANUELL)
+            val sak = Sak("ident", SakType.BARNEPENSJON, brev.sakId, "1234")
+            val journalpostResponse = JournalpostResponse("444", journalpostferdigstilt = true)
+
+            coEvery { sakOgBehandlingService.hentSak(any(), any()) } returns sak
+            coEvery { dokarkivService.journalfoer(any<Brev>(), any()) } returns journalpostResponse
+            every { db.hentBrev(any()) } returns brev
+            every { db.settBrevJournalfoert(any(), any()) } returns true
+
+            val faktiskJournalpostId = runBlocking {
+                brevService.journalfoer(brev.id, bruker)
+            }
+
+            faktiskJournalpostId shouldBe journalpostResponse.journalpostId
+
+            verify {
+                db.hentBrev(brev.id)
+                db.settBrevJournalfoert(brev.id, journalpostResponse)
+            }
+            coVerify {
+                sakOgBehandlingService.hentSak(sak.id, bruker)
+                dokarkivService.journalfoer(brev, sak)
+            }
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+            Status::class,
+            mode = EnumSource.Mode.EXCLUDE,
+            names = ["FERDIGSTILT"]
+        )
+        fun `Journalfoering feiler hvis status er feil`(status: Status) {
+            val brev = opprettBrev(status, BrevProsessType.MANUELL)
+            every { db.hentBrev(any()) } returns brev
+
+            runBlocking {
+                assertThrows<IllegalStateException> {
+                    brevService.journalfoer(brev.id, bruker)
+                }
+            }
+
+            verify {
+                db.hentBrev(brev.id)
+            }
+        }
+    }
+
+    @Nested
+    inner class DistribusjonAvBrev {
+        @Test
+        fun `Distribusjon fungerer som forventet`() {
+            val brev = opprettBrev(Status.JOURNALFOERT, BrevProsessType.MANUELL)
+            val journalpostId = "1"
+
+            every { db.hentBrev(any()) } returns brev
+            every { db.hentJournalpostId(any()) } returns journalpostId
+            every { distribusjonService.distribuerJournalpost(any(), any(), any(), any(), any()) } returns "123"
+
+            val bestillingsID = brevService.distribuer(brev.id)
+            bestillingsID shouldBe "123"
+
+            verify {
+                db.hentBrev(brev.id)
+                db.hentJournalpostId(brev.id)
+                distribusjonService.distribuerJournalpost(
+                    brev.id,
+                    journalpostId,
+                    DistribusjonsType.ANNET,
+                    DistribusjonsTidspunktType.KJERNETID,
+                    brev.mottaker.adresse
+                )
+            }
+        }
+
+        @Test
+        fun `Distribusjon avbrytes hvis journalpostId mangler`() {
+            val brev = opprettBrev(Status.JOURNALFOERT, BrevProsessType.MANUELL)
+
+            every { db.hentBrev(any()) } returns brev
+            every { db.hentJournalpostId(any()) } returns null
+
+            assertThrows<IllegalArgumentException> {
+                brevService.distribuer(brev.id)
+            }
+
+            verify {
+                db.hentBrev(brev.id)
+                db.hentJournalpostId(brev.id)
+            }
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+            Status::class,
+            mode = EnumSource.Mode.EXCLUDE,
+            names = ["JOURNALFOERT"]
+        )
+        fun `Distribusjon avbrytes ved feil status`(status: Status) {
+            val brev = opprettBrev(status, BrevProsessType.MANUELL)
+
+            every { db.hentBrev(any()) } returns brev
+
+            assertThrows<IllegalStateException> {
+                brevService.distribuer(brev.id)
+            }
+
+            verify {
+                db.hentBrev(brev.id)
+            }
+        }
+    }
+
+    private fun opprettBrev(
+        status: Status,
+        prosessType: BrevProsessType
+    ) = Brev(
+        id = Random.nextLong(10000),
+        sakId = Random.nextLong(10000),
+        behandlingId = null,
+        prosessType = prosessType,
+        soekerFnr = "fnr",
+        status = status,
+        mottaker = opprettMottaker()
+    )
+
+    private fun opprettMottaker() = Mottaker(
+        "Stor Snerk",
+        foedselsnummer = Foedselsnummer("1234567890"),
+        orgnummer = null,
+        adresse = Adresse(
+            adresseType = "NORSKPOSTADRESSE",
+            adresselinje1 = "Testgaten 13",
+            postnummer = "1234",
+            poststed = "OSLO",
+            land = "Norge",
+            landkode = "NOR"
+        )
+    )
+}

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -29,11 +29,11 @@ import no.nav.etterlatte.brev.journalpost.JournalpostResponse
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Avsender
 import no.nav.etterlatte.brev.model.Brev
+import no.nav.etterlatte.brev.model.BrevID
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.OpprettNyttBrev
 import no.nav.etterlatte.brev.model.Pdf
-import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -49,7 +49,6 @@ import no.nav.pensjon.brevbaker.api.model.LetterMetadata
 import no.nav.pensjon.brevbaker.api.model.Telefonnummer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -229,7 +228,7 @@ internal class VedtaksbrevServiceTest {
             }
 
             coVerify {
-                sakOgBehandlingService.hentBehandling(brev.sakId, brev.behandlingId, SAKSBEHANDLER)
+                sakOgBehandlingService.hentBehandling(brev.sakId, brev.behandlingId!!, SAKSBEHANDLER)
                 adresseService.hentAvsender(any())
                 brevbaker.genererPdf(any())
             }
@@ -255,7 +254,7 @@ internal class VedtaksbrevServiceTest {
             }
 
             coVerify {
-                sakOgBehandlingService.hentBehandling(brev.sakId, brev.behandlingId, ATTESTANT)
+                sakOgBehandlingService.hentBehandling(brev.sakId, brev.behandlingId!!, ATTESTANT)
                 adresseService.hentAvsender(any())
                 brevbaker.genererPdf(any())
             }
@@ -280,7 +279,7 @@ internal class VedtaksbrevServiceTest {
             }
 
             coVerify {
-                sakOgBehandlingService.hentBehandling(brev.sakId, brev.behandlingId, SAKSBEHANDLER)
+                sakOgBehandlingService.hentBehandling(brev.sakId, brev.behandlingId!!, SAKSBEHANDLER)
                 adresseService.hentAvsender(any())
                 brevbaker.genererPdf(any())
             }
@@ -307,7 +306,7 @@ internal class VedtaksbrevServiceTest {
             }
 
             coVerify {
-                sakOgBehandlingService.hentBehandling(brev.sakId, brev.behandlingId, SAKSBEHANDLER)
+                sakOgBehandlingService.hentBehandling(brev.sakId, brev.behandlingId!!, SAKSBEHANDLER)
                 adresseService.hentAvsender(any())
                 brevbaker.genererPdf(any())
             }
@@ -335,7 +334,7 @@ internal class VedtaksbrevServiceTest {
             }
 
             coVerify {
-                sakOgBehandlingService.hentBehandling(brev.sakId, brev.behandlingId, ATTESTANT)
+                sakOgBehandlingService.hentBehandling(brev.sakId, brev.behandlingId!!, ATTESTANT)
                 adresseService.hentAvsender(any())
                 brevbaker.genererPdf(any())
             }
@@ -362,7 +361,7 @@ internal class VedtaksbrevServiceTest {
             }
 
             coVerify {
-                sakOgBehandlingService.hentBehandling(brev.sakId, brev.behandlingId, SAKSBEHANDLER)
+                sakOgBehandlingService.hentBehandling(brev.sakId, brev.behandlingId!!, SAKSBEHANDLER)
                 adresseService.hentAvsender(any())
                 brevbaker.genererPdf(any())
             }
@@ -398,49 +397,13 @@ internal class VedtaksbrevServiceTest {
     }
 
     @Nested
-    inner class PayloadManuelleBrev {
-        @Test
-        fun `Hent payload`() {
-            val brev = opprettBrev(Status.OPPRETTET, mockk())
-            every { db.hentBrev(any()) } returns brev
-
-            val payload = Slate(listOf(Slate.Element(Slate.ElementType.PARAGRAPH)))
-            every { db.hentBrevPayload(any()) } returns payload
-
-            val faktiskPayload = runBlocking {
-                vedtaksbrevService.hentManueltBrevPayload(brev.id)
-            }
-
-            faktiskPayload shouldBe payload
-
-            verify {
-                db.hentBrevPayload(brev.id)
-            }
-        }
-
-        @Test
-        fun `Hent payload - finnes ikke`() {
-            val brev = opprettBrev(Status.OPPRETTET, mockk())
-            every { db.hentBrevPayload(any()) } returns null
-
-            runBlocking {
-                assertNull(vedtaksbrevService.hentManueltBrevPayload(brev.id))
-            }
-
-            verify {
-                db.hentBrevPayload(brev.id)
-            }
-        }
-    }
-
-    @Nested
     inner class JournalfoerVedtaksbrev {
         @Test
         fun `Vedtaksbrev journalfoeres som forventet`() {
             val forventetBrev = opprettBrev(Status.FERDIGSTILT, mockk())
 
             val forventetResponse = JournalpostResponse("1", "OK", "melding", true)
-            every { dokarkivService.journalfoer(any(), any()) } returns forventetResponse
+            every { dokarkivService.journalfoer(any<BrevID>(), any()) } returns forventetResponse
 
             val vedtak = opprettVedtak()
 

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivServiceTest.kt
@@ -16,7 +16,7 @@ import no.nav.etterlatte.brev.journalpost.JournalPostType
 import no.nav.etterlatte.brev.journalpost.JournalpostKoder.Companion.BREV_KODE
 import no.nav.etterlatte.brev.journalpost.JournalpostRequest
 import no.nav.etterlatte.brev.journalpost.JournalpostResponse
-import no.nav.etterlatte.brev.journalpost.Sak
+import no.nav.etterlatte.brev.journalpost.JournalpostSak
 import no.nav.etterlatte.brev.journalpost.Sakstype
 import no.nav.etterlatte.brev.model.BrevInnhold
 import no.nav.etterlatte.brev.model.Pdf
@@ -86,7 +86,7 @@ internal class DokarkivServiceTest {
             journalfoerendeEnhet shouldBe vedtak.ansvarligEnhet
             avsenderMottaker shouldBe AvsenderMottaker(vedtak.sak.ident)
             bruker shouldBe Bruker(vedtak.sak.ident)
-            sak shouldBe Sak(Sakstype.FAGSAK, vedtak.sak.id.toString())
+            sak shouldBe JournalpostSak(Sakstype.FAGSAK, vedtak.sak.id.toString())
             eksternReferanseId shouldBe "${vedtak.behandlingId}.$brevId"
 
             with(dokumenter.single()) {

--- a/apps/etterlatte-saksbehandling-ui/client/src/App.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Routes, Navigate } from 'react-router-dom'
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import '@navikt/ds-css'
 import '@navikt/ds-css-internal'
 import Oppgavebenken from './components/oppgavebenken/Oppgavebenken'
@@ -9,6 +9,8 @@ import useInnloggetSaksbehandler from './shared/hooks/useInnloggetSaksbehandler'
 import nb from 'date-fns/locale/nb'
 import { registerLocale } from 'react-datepicker'
 import ErrorBoundary from '~ErrorBoundary'
+import BrevOversikt from '~components/person/brev/BrevOversikt'
+import NyttBrev from '~components/person/brev/NyttBrev'
 
 function App() {
   const innloggetbrukerHentet = useInnloggetSaksbehandler()
@@ -25,6 +27,8 @@ function App() {
                 <Route path="/" element={<Oppgavebenken />} />
                 <Route path="/oppgavebenken" element={<Oppgavebenken />} />
                 <Route path="/person/:fnr" element={<Person />} />
+                <Route path="/person/:fnr/sak/:sakId/brev" element={<BrevOversikt />} />
+                <Route path="/person/:fnr/sak/:sakId/brev/:brevId" element={<NyttBrev />} />
                 <Route path="/behandling/:behandlingId/*" element={<Behandling />} />
                 <Route path="*" element={<Navigate to="/" replace />} />
               </Routes>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/SlateEditor.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/SlateEditor.tsx
@@ -22,7 +22,7 @@ export default function SlateEditor({ value, onChange, readonly }: EditorProps) 
 
   return (
     <BrevEditor>
-      <Slate editor={editor} onChange={onChange} initialValue={value || []}>
+      <Slate editor={editor} onChange={onChange} initialValue={value}>
         {!readonly && (
           <Toolbar>
             <BlockButton format="heading-two" icon="H2" />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
@@ -88,7 +88,7 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
         ) : vedtaksbrev.prosessType === BrevProsessType.AUTOMATISK ? (
           <ForhaandsvisningBrev brev={vedtaksbrev} />
         ) : (
-          <RedigerbartBrev brev={vedtaksbrev} behandling={props.behandling} />
+          <RedigerbartBrev brev={vedtaksbrev} kanRedigeres={manueltBrevKanRedigeres(status)} />
         )}
       </BrevContent>
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/NavigerTilbakeMeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/NavigerTilbakeMeny.tsx
@@ -1,0 +1,36 @@
+import styled from 'styled-components'
+import { NavLink } from 'react-router-dom'
+import { Back } from '@navikt/ds-icons'
+
+export default function NavigerTilbakeMeny({ label, path }: { label: string; path: string }) {
+  return (
+    <MenyWrapper role="navigation">
+      <Link to={path || '/'}>
+        <Separator /> {label}
+      </Link>
+    </MenyWrapper>
+  )
+}
+
+const Link = styled(NavLink)`
+  margin-left: 1rem;
+  font-weight: 600;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`
+
+const MenyWrapper = styled.ul`
+  display: block;
+  list-style: none;
+  padding: 1em 0;
+  background: #f8f8f8;
+  border-bottom: 1px solid #c6c2bf;
+  box-shadow: 0 5px 10px 0 #ddd;
+`
+
+const Separator = styled(Back)`
+  vertical-align: middle;
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
@@ -8,35 +8,38 @@ import { Dokumentoversikt } from './dokumentoversikt'
 import { Saksoversikt } from './saksoversikt'
 import Spinner from '~shared/Spinner'
 import { isFailure, isPending, isSuccess, useApiCall } from '~shared/hooks/useApiCall'
-import { BodyShort, Label } from '@navikt/ds-react'
+import { BodyShort } from '@navikt/ds-react'
 import { getPerson } from '~shared/api/grunnlag'
 import { GYLDIG_FNR } from '~utils/fnr'
+import NavigerTilbakeMeny from '~components/person/NavigerTilbakeMeny'
 
 export const Person = () => {
   const [personStatus, hentPerson] = useApiCall(getPerson)
 
-  const match = useParams<{ fnr: string }>()
+  const { fnr } = useParams()
 
   useEffect(() => {
-    if (match.fnr) {
-      hentPerson(match.fnr)
+    if (GYLDIG_FNR(fnr)) {
+      hentPerson(fnr!!)
     }
-  }, [match.fnr])
+  }, [fnr])
 
   if (isFailure(personStatus)) {
     return (
       <Container>
-        <BodyShort>
-          {!GYLDIG_FNR(match.fnr) ? 'Fødselsnummeret i URLen er ugyldig' : JSON.stringify(personStatus)}
-        </BodyShort>
+        <BodyShort>{!GYLDIG_FNR(fnr) ? 'Fødselsnummeret i URLen er ugyldig' : JSON.stringify(personStatus)}</BodyShort>
       </Container>
     )
   }
 
   return (
     <>
-      {match.fnr === null && <Label>Kan ikke hente fødselsnummer fra URL</Label>}
-      {isSuccess(personStatus) && <StatusBar theme={StatusBarTheme.gray} personInfo={personStatus.data} />}
+      {isSuccess(personStatus) && (
+        <>
+          <StatusBar theme={StatusBarTheme.gray} personInfo={personStatus.data} />
+          <NavigerTilbakeMeny label={'Tilbake til oppgavebenken'} path={'/'} />
+        </>
+      )}
       {isPending(personStatus) && <Spinner visible={true} label={'Laster'} />}
       {isSuccess(personStatus) && (
         <Container>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/BrevModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/BrevModal.tsx
@@ -1,0 +1,21 @@
+import { Button, Modal } from '@navikt/ds-react'
+import { FilePdfIcon } from '@navikt/aksel-icons'
+import { useState } from 'react'
+import { IBrev } from '~shared/types/Brev'
+import ForhaandsvisningBrev from '~components/behandling/brev/ForhaandsvisningBrev'
+
+export default function BrevModal({ brev }: { brev: IBrev }) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <Button variant={'secondary'} title={'Vis PDF'} icon={<FilePdfIcon />} onClick={() => setOpen(true)} />
+
+      <Modal open={open} onClose={() => setOpen(false)}>
+        <Modal.Content style={{ minWidth: '60rem', paddingTop: '3rem' }}>
+          <ForhaandsvisningBrev brev={brev} />
+        </Modal.Content>
+      </Modal>
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/BrevOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/BrevOversikt.tsx
@@ -1,0 +1,155 @@
+import { isFailure, isPending, isPendingOrInitial, isSuccess, useApiCall } from '~shared/hooks/useApiCall'
+import { hentBrevForSak, opprettBrevForSak } from '~shared/api/brev'
+import { useEffect } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { Alert, Button, Table, Tag } from '@navikt/ds-react'
+import { BrevStatus, IBrev, Mottaker } from '~shared/types/Brev'
+import { DocPencilIcon, ExternalLinkIcon } from '@navikt/aksel-icons'
+import Spinner from '~shared/Spinner'
+import { StatusBar, StatusBarTheme } from '~shared/statusbar/Statusbar'
+import { getPerson } from '~shared/api/grunnlag'
+import { Container } from '~shared/styled'
+import BrevModal from '~components/person/brev/BrevModal'
+
+const mapAdresse = (mottaker: Mottaker) => {
+  const adr = mottaker.adresse
+  const adresselinje = [adr?.adresselinje1, adr?.adresselinje2, adr?.adresselinje3].join(' ')
+  const postlinje = [adr?.postnummer, adr?.poststed, adr?.land].join(' ')
+
+  return `${adresselinje}, ${postlinje}`
+}
+
+const mapStatus = (status: BrevStatus) => status.charAt(0) + status.slice(1).toLowerCase()
+
+const tagColors = (status: BrevStatus) => {
+  switch (status) {
+    case BrevStatus.OPPRETTET:
+    case BrevStatus.OPPDATERT:
+      return 'neutral'
+    case BrevStatus.FERDIGSTILT:
+    case BrevStatus.JOURNALFOERT:
+      return 'info'
+    case BrevStatus.DISTRIBUERT:
+      return 'success'
+    case BrevStatus.SLETTET:
+      return 'neutral'
+  }
+}
+
+const brevKanEndres = (status: BrevStatus) => [BrevStatus.OPPRETTET, BrevStatus.OPPDATERT].includes(status)
+
+const handlingKnapp = (brev: IBrev) => {
+  if (brev.behandlingId && brevKanEndres(brev.status)) {
+    return (
+      <Button
+        as={'a'}
+        href={`/behandling/${brev.behandlingId}/brev`}
+        variant={'secondary'}
+        title={'Gå til behandling'}
+        icon={<ExternalLinkIcon />}
+      />
+    )
+  } else if (!brev.behandlingId && brev.status != BrevStatus.DISTRIBUERT) {
+    return (
+      <Button
+        as={'a'}
+        href={`/person/${brev.soekerFnr}/sak/${brev.sakId}/brev/${brev.id}`}
+        variant={'secondary'}
+        title={'Rediger'}
+        icon={<DocPencilIcon />}
+      />
+    )
+  }
+  return <BrevModal brev={brev} />
+}
+
+export default function BrevOversikt() {
+  const navigate = useNavigate()
+  const { fnr, sakId } = useParams()
+  const [personStatus, hentPerson] = useApiCall(getPerson)
+
+  const [brevListe, hentBrev] = useApiCall(hentBrevForSak)
+  const [nyttBrevStatus, opprettBrev] = useApiCall(opprettBrevForSak)
+
+  useEffect(() => {
+    hentBrev(Number(sakId))
+    hentPerson(fnr!!)
+  }, [])
+
+  const opprettNyttBrevOgRedirect = () => {
+    opprettBrev(Number(sakId), (brev) => {
+      navigate(`/person/${brev.soekerFnr}/sak/${brev.sakId}/brev/${brev.id}`)
+    })
+  }
+
+  return (
+    <>
+      {isSuccess(personStatus) && <StatusBar theme={StatusBarTheme.gray} personInfo={personStatus.data} />}
+
+      <Container>
+        {isPendingOrInitial(brevListe) ? (
+          <Spinner visible label={'Henter brev for sak ...'} />
+        ) : (
+          <Table>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>ID</Table.HeaderCell>
+                <Table.HeaderCell>Status</Table.HeaderCell>
+                <Table.HeaderCell>Type</Table.HeaderCell>
+                <Table.HeaderCell>Navn</Table.HeaderCell>
+                <Table.HeaderCell>Adresse</Table.HeaderCell>
+                <Table.HeaderCell></Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {isFailure(brevListe) && <Alert variant={'error'}>Feil ved henting av brev...</Alert>}
+              {isSuccess(brevListe) &&
+                brevListe.data.map((b) => (
+                  <Table.Row key={b.id}>
+                    <Table.DataCell>{b.id}</Table.DataCell>
+                    <Table.DataCell>
+                      <Tag variant={tagColors(b.status)} size={'medium'}>
+                        {mapStatus(b.status)}
+                      </Tag>
+                    </Table.DataCell>
+                    <Table.DataCell>
+                      {b.behandlingId ? (
+                        <>
+                          Vedtaksbrev{' '}
+                          <Button
+                            variant={'tertiary'}
+                            as={'a'}
+                            href={`/behandling/${b.behandlingId}/brev`}
+                            icon={<ExternalLinkIcon />}
+                            size={'small'}
+                            title={'Gå til behandling'}
+                          />
+                        </>
+                      ) : (
+                        'Annet'
+                      )}
+                    </Table.DataCell>
+                    <Table.DataCell>{b.mottaker.navn}</Table.DataCell>
+                    <Table.DataCell>{mapAdresse(b.mottaker)}</Table.DataCell>
+                    <Table.DataCell>{handlingKnapp(b)}</Table.DataCell>
+                  </Table.Row>
+                ))}
+            </Table.Body>
+          </Table>
+        )}
+      </Container>
+
+      <Container>
+        <Button
+          variant={'primary'}
+          icon={<DocPencilIcon />}
+          iconPosition={'right'}
+          onClick={opprettNyttBrevOgRedirect}
+          loading={isPending(nyttBrevStatus)}
+        >
+          Nytt brev
+        </Button>
+      </Container>
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/BrevStatusPanel.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/BrevStatusPanel.tsx
@@ -1,0 +1,49 @@
+import { BrevStatus, IBrev } from '~shared/types/Brev'
+import { BodyShort, Heading, Label, Panel, Tag } from '@navikt/ds-react'
+
+const mapStatusTilString = (status: BrevStatus) => {
+  switch (status) {
+    case BrevStatus.OPPRETTET:
+      return 'Opprettet'
+    case BrevStatus.OPPDATERT:
+      return 'Oppdatert'
+    case BrevStatus.FERDIGSTILT:
+      return 'Ferdigstilt'
+    case BrevStatus.JOURNALFOERT:
+      return 'Journalført'
+    case BrevStatus.DISTRIBUERT:
+      return 'Distribuert'
+    case BrevStatus.SLETTET:
+      return 'Slettet'
+  }
+}
+
+export default function BrevStatusPanel({ brev }: { brev: IBrev }) {
+  return (
+    <Panel border style={{ margin: '1rem' }}>
+      <Heading size={'medium'} spacing>
+        Oversikt
+      </Heading>
+
+      <BodyShort spacing size={'small'}>
+        <Label>ID:</Label>
+        <br />
+        {brev.id}
+      </BodyShort>
+
+      <BodyShort spacing size={'small'}>
+        <Label>Søker fnr:</Label>
+        <br />
+        {brev.soekerFnr}
+      </BodyShort>
+
+      <BodyShort spacing size={'small'}>
+        <Label>Status:</Label>
+        <br />
+        <Tag variant={'info'} size={'small'}>
+          {mapStatusTilString(brev.status)}
+        </Tag>
+      </BodyShort>
+    </Panel>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrev.tsx
@@ -26,8 +26,6 @@ export default function NyttBrev() {
   }, [])
 
   useEffect(() => {
-    console.log('henter brev')
-
     apiHentBrev({ brevId: Number(brevId), sakId: Number(sakId) }, (brev) => {
       if ([BrevStatus.OPPRETTET, BrevStatus.OPPDATERT].includes(brev.status)) {
         setKanRedigeres(true)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrev.tsx
@@ -1,0 +1,84 @@
+import RedigerbartBrev from '~components/behandling/brev/RedigerbartBrev'
+import { isSuccess, useApiCall } from '~shared/hooks/useApiCall'
+import { useParams } from 'react-router-dom'
+import { hentBrev } from '~shared/api/brev'
+import { useEffect, useState } from 'react'
+import { Column, GridContainer } from '~shared/styled'
+import { StatusBar, StatusBarTheme } from '~shared/statusbar/Statusbar'
+import { getPerson } from '~shared/api/grunnlag'
+import MottakerPanel from '~components/behandling/brev/detaljer/MottakerPanel'
+import NavigerTilbakeMeny from '~components/person/NavigerTilbakeMeny'
+import { BrevStatus } from '~shared/types/Brev'
+import ForhaandsvisningBrev from '~components/behandling/brev/ForhaandsvisningBrev'
+import styled from 'styled-components'
+import NyttBrevHandlingerPanel from '~components/person/brev/NyttBrevHandlingerPanel'
+import BrevStatusPanel from '~components/person/brev/BrevStatusPanel'
+
+export default function NyttBrev() {
+  const { brevId, sakId, fnr } = useParams()
+  const [kanRedigeres, setKanRedigeres] = useState(false)
+
+  const [hentetBrev, apiHentBrev] = useApiCall(hentBrev)
+  const [personStatus, hentPerson] = useApiCall(getPerson)
+
+  useEffect(() => {
+    hentPerson(fnr!!)
+  }, [])
+
+  useEffect(() => {
+    console.log('henter brev')
+
+    apiHentBrev({ brevId: Number(brevId), sakId: Number(sakId) }, (brev) => {
+      if ([BrevStatus.OPPRETTET, BrevStatus.OPPDATERT].includes(brev.status)) {
+        setKanRedigeres(true)
+      } else {
+        setKanRedigeres(false)
+      }
+    })
+  }, [brevId, sakId])
+
+  return (
+    <>
+      {isSuccess(personStatus) && (
+        <>
+          <StatusBar theme={StatusBarTheme.gray} personInfo={personStatus.data} />
+          <NavigerTilbakeMeny label={'Tilbake til brevoversikt'} path={`/person/${fnr}/sak/${sakId}/brev`} />
+        </>
+      )}
+
+      <GridContainer>
+        <Column>
+          {isSuccess(hentetBrev) && (
+            <div style={{ margin: '1rem' }}>
+              <MottakerPanel vedtaksbrev={hentetBrev.data} />
+            </div>
+          )}
+        </Column>
+        <Column>
+          {isSuccess(hentetBrev) &&
+            (hentetBrev.data.status === BrevStatus.DISTRIBUERT ? (
+              <PanelWrapper>
+                <ForhaandsvisningBrev brev={hentetBrev.data} />
+              </PanelWrapper>
+            ) : (
+              <RedigerbartBrev brev={hentetBrev.data} kanRedigeres={kanRedigeres} />
+            ))}
+        </Column>
+        <Column>
+          {isSuccess(hentetBrev) && (
+            <>
+              <BrevStatusPanel brev={hentetBrev.data} />
+              <NyttBrevHandlingerPanel brev={hentetBrev.data} setKanRedigeres={setKanRedigeres} />
+            </>
+          )}
+        </Column>
+      </GridContainer>
+    </>
+  )
+}
+
+const PanelWrapper = styled.div`
+  height: 100%;
+  width: 100%;
+  max-height: 955px;
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrevHandlingerPanel.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrevHandlingerPanel.tsx
@@ -5,7 +5,6 @@ import { ButtonWrapper } from '~shared/modal/modal'
 import { useState } from 'react'
 import { distribuerBrev, ferdigstillBrev, journalfoerBrev } from '~shared/api/brev'
 import Spinner from '~shared/Spinner'
-import { ApiError } from '~shared/api/apiClient'
 
 interface Props {
   brev: IBrev
@@ -22,8 +21,7 @@ export default function NyttBrevHandlingerPanel({ brev, setKanRedigeres }: Props
   const [loadingMsg, setLoadingMsg] = useState<string>()
   const [error, setError] = useState<string>()
 
-  const handleError = (msg: string, err?: ApiError) => {
-    console.error(err)
+  const handleError = (msg: string) => {
     setError(msg)
     setIsOpen(false)
   }
@@ -35,14 +33,14 @@ export default function NyttBrevHandlingerPanel({ brev, setKanRedigeres }: Props
 
     setLoadingMsg('Forsøker å ferdigstille brev ...')
 
-    apiFerdigstillBrev(idPayload, journalfoer, (err) => handleError('Feil oppsto ved ferdigstilling av brev', err))
+    apiFerdigstillBrev(idPayload, journalfoer, () => handleError('Feil oppsto ved ferdigstilling av brev'))
   }
 
   const journalfoer = () => {
     setLoadingMsg('... journalfører brevet i dokarkiv ...')
 
-    apiJournalfoerBrev({ brevId: brev.id, sakId: brev.sakId }, distribuer, (err) =>
-      handleError('Feil oppsto ved journalføring av brev', err)
+    apiJournalfoerBrev({ brevId: brev.id, sakId: brev.sakId }, distribuer, () =>
+      handleError('Feil oppsto ved journalføring av brev')
     )
   }
 
@@ -55,7 +53,7 @@ export default function NyttBrevHandlingerPanel({ brev, setKanRedigeres }: Props
         setLoadingMsg('Distribuert OK – laster inn på nytt ...')
         setTimeout(() => window.location.reload(), 2000)
       },
-      (err) => handleError('Feil oppsto ved distribusjon av brev', err)
+      () => handleError('Feil oppsto ved distribusjon av brev')
     )
   }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrevHandlingerPanel.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrevHandlingerPanel.tsx
@@ -1,0 +1,127 @@
+import { Alert, BodyLong, BodyShort, Button, Heading, Modal, Panel } from '@navikt/ds-react'
+import { BrevStatus, IBrev } from '~shared/types/Brev'
+import { isPending, useApiCall } from '~shared/hooks/useApiCall'
+import { ButtonWrapper } from '~shared/modal/modal'
+import { useState } from 'react'
+import { distribuerBrev, ferdigstillBrev, journalfoerBrev } from '~shared/api/brev'
+import Spinner from '~shared/Spinner'
+import { ApiError } from '~shared/api/apiClient'
+
+interface Props {
+  brev: IBrev
+  setKanRedigeres: (kanRedigeres: boolean) => void
+}
+
+export default function NyttBrevHandlingerPanel({ brev, setKanRedigeres }: Props) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const [ferdigstillStatus, apiFerdigstillBrev] = useApiCall(ferdigstillBrev)
+  const [journalfoerStatus, apiJournalfoerBrev] = useApiCall(journalfoerBrev)
+  const [distribuerStatus, apiDistribuerBrev] = useApiCall(distribuerBrev)
+
+  const [loadingMsg, setLoadingMsg] = useState<string>()
+  const [error, setError] = useState<string>()
+
+  const handleError = (msg: string, err?: ApiError) => {
+    console.error(err)
+    setError(msg)
+    setIsOpen(false)
+  }
+
+  const ferdigstill = () => {
+    setKanRedigeres(false)
+
+    const idPayload = { brevId: brev.id, sakId: brev.sakId }
+
+    setLoadingMsg('Forsøker å ferdigstille brev ...')
+
+    apiFerdigstillBrev(idPayload, journalfoer, (err) => handleError('Feil oppsto ved ferdigstilling av brev', err))
+  }
+
+  const journalfoer = () => {
+    setLoadingMsg('... journalfører brevet i dokarkiv ...')
+
+    apiJournalfoerBrev({ brevId: brev.id, sakId: brev.sakId }, distribuer, (err) =>
+      handleError('Feil oppsto ved journalføring av brev', err)
+    )
+  }
+
+  const distribuer = () => {
+    setLoadingMsg('... sender brev til distribusjon ...')
+
+    apiDistribuerBrev(
+      { brevId: brev.id, sakId: brev.sakId },
+      () => {
+        setLoadingMsg('Distribuert OK – laster inn på nytt ...')
+        setTimeout(() => window.location.reload(), 2000)
+      },
+      (err) => handleError('Feil oppsto ved distribusjon av brev', err)
+    )
+  }
+
+  if (brev.status === BrevStatus.DISTRIBUERT) {
+    return null
+  }
+
+  return (
+    <Panel>
+      <Heading spacing level="2" size={'medium'}>
+        Handlinger
+      </Heading>
+
+      {error && <Alert variant={'error'}>{error}</Alert>}
+
+      <BodyShort spacing size={'small'}>
+        {brev.status === BrevStatus.FERDIGSTILT ? (
+          <Button variant={'primary'} onClick={journalfoer} loading={isPending(journalfoerStatus)}>
+            Journalfør
+          </Button>
+        ) : brev.status === BrevStatus.JOURNALFOERT ? (
+          <Button variant={'primary'} onClick={distribuer} loading={isPending(distribuerStatus)}>
+            Distribuer
+          </Button>
+        ) : (
+          <>
+            <Button variant={'primary'} onClick={() => setIsOpen(true)} loading={isPending(ferdigstillStatus)}>
+              Ferdigstill
+            </Button>
+
+            <Modal
+              open={isOpen}
+              onClose={() => setIsOpen(false)}
+              aria-labelledby="modal-heading"
+              className={'padding-modal'}
+              closeButton={false}
+            >
+              <Modal.Content style={{ textAlign: 'center' }}>
+                {loadingMsg ? (
+                  <Spinner visible label={loadingMsg} />
+                ) : (
+                  <>
+                    <Heading level={'1'} spacing size={'medium'} id="modal-heading">
+                      Er du sikker på at du vil ferdigstille brevet?
+                    </Heading>
+
+                    <BodyLong spacing>
+                      Når du ferdigstiller brevet vil det bli journalført og distribuert. Denne handlingen kan ikke
+                      angres.
+                    </BodyLong>
+
+                    <ButtonWrapper>
+                      <Button variant="secondary" size="medium" className="button" onClick={() => setIsOpen(false)}>
+                        Nei, fortsett redigering
+                      </Button>
+                      <Button variant="primary" size="medium" className="button" onClick={ferdigstill}>
+                        Ja, ferdigstill brev
+                      </Button>
+                    </ButtonWrapper>
+                  </>
+                )}
+              </Modal.Content>
+            </Modal>
+          </>
+        )}
+      </BodyShort>
+    </Panel>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/saksoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/saksoversikt.tsx
@@ -21,6 +21,8 @@ import { isFailure, useApiCall } from '~shared/hooks/useApiCall'
 import { hentPersonerISak } from '~shared/api/grunnlag'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { Revurderingsaarsak } from '~shared/types/Revurderingsaarsak'
+import { BodyShort, Heading, Link } from '@navikt/ds-react'
+import { ExternalLinkIcon } from '@navikt/aksel-icons'
 
 export const Saksoversikt = ({ fnr }: { fnr: string | undefined }) => {
   const [behandlingliste, setBehandlingliste] = useState<IBehandlingsammendrag[]>([])
@@ -142,9 +144,21 @@ export const Saksoversikt = ({ fnr }: { fnr: string | undefined }) => {
             />
           ) : null}
           <div className="behandlinger">
-            <h2>Behandlinger</h2>
+            <Heading size={'large'}>Behandlinger</Heading>
             {behandlingliste !== undefined && <Behandlingsliste behandlinger={behandlingliste} />}
           </div>
+
+          <br />
+          <br />
+
+          <Heading size={'large'} spacing>
+            Brev
+          </Heading>
+          <BodyShort>
+            <Link href={`/person/${fnr}/sak/${sakId}/brev`}>
+              Du finner brev på oversiktssiden her <ExternalLinkIcon />
+            </Link>
+          </BodyShort>
         </SaksoversiktWrapper>
       )}
     </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
@@ -1,24 +1,53 @@
 import { apiClient, ApiResponse } from './apiClient'
 import { IBrev } from '~shared/types/Brev'
 
+export const hentBrev = async (props: { brevId: number; sakId: number }): Promise<ApiResponse<IBrev>> =>
+  apiClient.get(`/brev/${props.brevId}?sakId=${props.sakId}`)
+
+export const hentBrevForSak = async (sakId: number): Promise<ApiResponse<IBrev[]>> =>
+  apiClient.get(`/brev/sak/${sakId}`)
+
+export const opprettBrevForSak = async (sakId: number): Promise<ApiResponse<IBrev>> =>
+  apiClient.post(`/brev/sak/${sakId}`, {})
+
 export const hentVedtaksbrev = async (behandlingId: string): Promise<ApiResponse<IBrev>> =>
   apiClient.get(`/brev/behandling/${behandlingId}/vedtak`)
 
 export const opprettVedtaksbrev = async (sakId: number, behandlingId: string): Promise<ApiResponse<IBrev>> =>
   apiClient.post(`/brev/behandling/${behandlingId}/vedtak?sakId=${sakId}`, {})
 
-export const genererPdf = async (brevId: number, behandlingId: string): Promise<ApiResponse<ArrayBuffer>> =>
-  apiClient.get(`/brev/behandling/${behandlingId}/vedtak/pdf?brevId=${brevId}`)
+export const genererPdf = async (props: {
+  brevId: number
+  sakId?: number
+  behandlingId?: string
+}): Promise<ApiResponse<ArrayBuffer>> => {
+  if (props.behandlingId) {
+    return apiClient.get(`/brev/behandling/${props.behandlingId}/vedtak/pdf?brevId=${props.brevId}`)
+  } else if (props.sakId && !props.behandlingId) {
+    return apiClient.get(`/brev/${props.brevId}/pdf?sakId=${props.sakId}`)
+  } else {
+    throw Error('BehandlingId eller sakId må være satt!')
+  }
+}
 
-export const hentManuellPayload = async (props: { brevId: number; behandlingId: string }): Promise<ApiResponse<any>> =>
-  apiClient.get(`/brev/behandling/${props.behandlingId}/vedtak/manuell?brevId=${props.brevId}`)
+export const hentManuellPayload = async (props: { brevId: number; sakId: number }): Promise<ApiResponse<any>> =>
+  apiClient.get(`/brev/${props.brevId}/payload?sakId=${props.sakId}`)
 
 export const lagreManuellPayload = async (props: {
   brevId: number
-  behandlingId: string
+  sakId: number
   payload: any
 }): Promise<ApiResponse<any>> =>
-  apiClient.post(`/brev/behandling/${props.behandlingId}/vedtak/manuell`, {
+  apiClient.post(`/brev/${props.brevId}/payload?sakId=${props.sakId}`, {
     id: props.brevId,
     payload: props.payload,
   })
+
+export const ferdigstillBrev = async (props: { brevId: number; sakId: number }): Promise<ApiResponse<any>> =>
+  apiClient.post(`/brev/${props.brevId}/ferdigstill?sakId=${props.sakId}`, {})
+
+export const journalfoerBrev = async (props: { brevId: number; sakId: number }): Promise<ApiResponse<any>> =>
+  apiClient.post(`/brev/${props.brevId}/journalfoer?sakId=${props.sakId}`, {})
+
+export const distribuerBrev = async (props: { brevId: number; sakId: number }): Promise<ApiResponse<any>> =>
+  apiClient.post(`/brev/${props.brevId}/distribuer?sakId=${props.sakId}`, {})

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/styled.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/styled.tsx
@@ -11,7 +11,7 @@ export const GridContainer = styled.div`
 `
 
 export const Column = styled.div`
-  min-width: 280px;
+  min-width: 30rem;
   &:nth-child(2) {
     flex-grow: 1;
     border-right: 1px solid #c6c2bf;

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Brev.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Brev.ts
@@ -1,11 +1,11 @@
 export interface IBrev {
   id: number
+  sakId: number
   behandlingId: string
   prosessType: BrevProsessType
-  tittel: string
+  soekerFnr: string
   status: BrevStatus
   mottaker: Mottaker
-  erVedtaksbrev: boolean
 }
 
 export interface Mottaker {


### PR DESCRIPTION
Veldig mye kode, men det fungerer nå. Fortsatt en del som gjenstår, som bl.a. 
- Endre mottaker (herunder hente statsforvalter)
- Endre tittel
- Egne maler for "andre manuelle brev"
- Frontend CSS / styling (litt wonky akkurat nå)
- Kode som er _nesten_ identisk burde slås sammen for å redusere mengde kode. 
- Integrere på en god måte med sak-/personsiden for å gjøre det litt enklere for sb. 

![Screenshot 2023-06-21 at 12 43 50](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/c6cca2b7-4445-4244-b094-b8315decc2b6)
![Screenshot 2023-06-21 at 12 39 36](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/d5445df7-980d-42ec-88d4-2236f0e02567)
![Screenshot 2023-06-21 at 12 39 46](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/876b234a-e4cc-4dea-bf69-027ea3e178f5)
![Screenshot 2023-06-21 at 12 42 51](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/ad21dab2-8665-4538-b2ff-0b16f22fa901)
