### PR TITLE
Tilpasser familierelasjonshendelse for omstillingsstønad

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagHelper.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagHelper.kt
@@ -38,7 +38,7 @@ fun Grunnlag.ansvarligeForeldre(saksrolle: Saksrolle, fnr: String) =
                 ?.hentFamilierelasjon()?.verdi?.ansvarligeForeldre
         }
         else -> throw IllegalArgumentException(
-            "Proevde aa finne doedsdato for $saksrolle, men det skal ikke kunne skje D:"
+            "Proevde aa finne ansvarligeForeldre for $saksrolle, men det skal ikke kunne skje D:"
         )
     }
 
@@ -50,8 +50,11 @@ fun Grunnlag.barn(saksrolle: Saksrolle) =
         Saksrolle.GJENLEVENDE -> {
             hentGjenlevende().hentFamilierelasjon()?.verdi?.barn
         }
+        Saksrolle.SOEKER -> {
+            soeker.hentFamilierelasjon()?.verdi?.barn
+        }
         else -> throw IllegalArgumentException(
-            "Proevde aa finne doedsdato for $saksrolle, men det skal ikke kunne skje D:"
+            "Proevde aa finne barn for $saksrolle, men det skal ikke kunne skje D:"
         )
     }
 
@@ -70,7 +73,7 @@ fun Grunnlag.utland(saksrolle: Saksrolle, fnr: String) =
             hentGjenlevende().hentUtland()?.verdi
         }
         else -> throw IllegalArgumentException(
-            "Proevde aa finne doedsdato for $saksrolle, men det skal ikke kunne skje D:"
+            "Proevde aa finne utland for $saksrolle, men det skal ikke kunne skje D:"
         )
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagHelperKtTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagHelperKtTest.kt
@@ -123,7 +123,6 @@ internal class GrunnlagHelperKtTest {
         val gjenlevendesBarn = grunnlag.barn(Saksrolle.GJENLEVENDE)
         assertEquals(barn, avdoedesBarn)
         assertEquals(barn, gjenlevendesBarn)
-        assertThrows<IllegalArgumentException> { grunnlag.barn(Saksrolle.SOEKER) }
         assertThrows<IllegalArgumentException> { grunnlag.barn(Saksrolle.SOESKEN) }
         assertThrows<IllegalArgumentException> { grunnlag.barn(Saksrolle.UKJENT) }
     }


### PR DESCRIPTION
Gjør det mulig å hente ut barn for søker. Dette er relevant å gjøre for omstillingsstønad hvor vi ønsker å sjekke om en mottaker av ytelsen har fått barn.

EY-2223