### PR TITLE
Fikser at barn som ikke har gjenlevende foreldre kan håndteres i fordeler

### DIFF
--- a/apps/etterlatte-fordeler/src/main/kotlin/fordeler/FordelerKriterier.kt
+++ b/apps/etterlatte-fordeler/src/main/kotlin/fordeler/FordelerKriterier.kt
@@ -41,6 +41,7 @@ enum class FordelerKriterie(val forklaring: String) {
     AVDOED_ER_IKKE_FORELDER_TIL_BARN("Avdød er ikke forelder til barnet"),
     AVDOED_HAR_DOEDSDATO_FOR_LANGT_TILBAKE_I_TID("Avdød har dødsdato for langt tilbake i tid"),
 
+    GJENLEVENDE_MANGLER("Søknaden har ingen gjenlevende forelder"),
     GJENLEVENDE_ER_IKKE_BOSATT_I_NORGE("Gjenlevende er ikke bosatt i Norge"),
     GJENLEVENDE_OG_BARN_HAR_IKKE_SAMME_ADRESSE("Gjenlevende har ikke samme adresse som barnet"),
     GJENLEVENDE_HAR_IKKE_FORELDREANSVAR("Gjenlevende har ikke foreldreansvar for barnet"),
@@ -97,18 +98,15 @@ class FordelerKriterier {
         },
 
         // Gjenlevende
+        Kriterie(FordelerKriterie.GJENLEVENDE_MANGLER) { gjenlevende == null },
         Kriterie(FordelerKriterie.GJENLEVENDE_ER_IKKE_BOSATT_I_NORGE) {
-            gjenlevende?.let {
-                ikkeGyldigBostedsAdresseINorge(
-                    gjenlevende
-                )
-            } ?: false
+            gjenlevende == null || ikkeGyldigBostedsAdresseINorge(gjenlevende)
         },
         Kriterie(FordelerKriterie.GJENLEVENDE_OG_BARN_HAR_IKKE_SAMME_ADRESSE) {
-            gjenlevende?.let { gjenlevendeOgBarnHarIkkeSammeAdresse(gjenlevende, barn) } ?: false
+            gjenlevende == null || gjenlevendeOgBarnHarIkkeSammeAdresse(gjenlevende, barn)
         },
         Kriterie(FordelerKriterie.GJENLEVENDE_HAR_IKKE_FORELDREANSVAR) {
-            gjenlevende?.let { gjenlevendeHarIkkeForeldreansvar(barn, gjenlevende) } ?: false
+            gjenlevende == null || gjenlevendeHarIkkeForeldreansvar(barn, gjenlevende)
         },
 
         // Innsender

--- a/apps/etterlatte-fordeler/src/main/kotlin/fordeler/FordelerKriterier.kt
+++ b/apps/etterlatte-fordeler/src/main/kotlin/fordeler/FordelerKriterier.kt
@@ -57,7 +57,7 @@ class FordelerKriterier {
     fun sjekkMotKriterier(
         barn: Person,
         avdoed: Person,
-        gjenlevende: Person,
+        gjenlevende: Person?,
         soeknad: Barnepensjon
     ): FordelerKriterierResultat {
         return fordelerKriterier(barn, avdoed, gjenlevende)
@@ -72,7 +72,7 @@ class FordelerKriterier {
     private fun fordelerKriterier(
         barn: Person,
         avdoed: Person,
-        gjenlevende: Person
+        gjenlevende: Person?
     ) = listOf(
         // Barn (søker)
         Kriterie(FordelerKriterie.BARN_ER_FOR_GAMMELT) { forGammel(barn) },
@@ -97,12 +97,18 @@ class FordelerKriterier {
         },
 
         // Gjenlevende
-        Kriterie(FordelerKriterie.GJENLEVENDE_ER_IKKE_BOSATT_I_NORGE) { ikkeGyldigBostedsAdresseINorge(gjenlevende) },
+        Kriterie(FordelerKriterie.GJENLEVENDE_ER_IKKE_BOSATT_I_NORGE) {
+            gjenlevende?.let {
+                ikkeGyldigBostedsAdresseINorge(
+                    gjenlevende
+                )
+            } ?: false
+        },
         Kriterie(FordelerKriterie.GJENLEVENDE_OG_BARN_HAR_IKKE_SAMME_ADRESSE) {
-            gjenlevendeOgBarnHarIkkeSammeAdresse(gjenlevende, barn)
+            gjenlevende?.let { gjenlevendeOgBarnHarIkkeSammeAdresse(gjenlevende, barn) } ?: false
         },
         Kriterie(FordelerKriterie.GJENLEVENDE_HAR_IKKE_FORELDREANSVAR) {
-            gjenlevendeHarIkkeForeldreansvar(barn, gjenlevende)
+            gjenlevende?.let { gjenlevendeHarIkkeForeldreansvar(barn, gjenlevende) } ?: false
         },
 
         // Innsender

--- a/apps/etterlatte-fordeler/src/test/kotlin/fordeler/FordelerKriterierTest.kt
+++ b/apps/etterlatte-fordeler/src/test/kotlin/fordeler/FordelerKriterierTest.kt
@@ -75,6 +75,35 @@ internal class FordelerKriterierTest {
     }
 
     @Test
+    fun `Gjenlevende mangler`() {
+        val barn = mockPerson(
+            bostedsadresse = mockNorskAdresse(),
+            familieRelasjon = FamilieRelasjon(
+                barn = null,
+                ansvarligeForeldre = null,
+                foreldre = listOf(Folkeregisteridentifikator.of(FNR_2))
+            )
+        )
+        val avdoed = mockPerson(
+            fnr = FNR_2,
+            doedsdato = now().plusMonths(11),
+            bostedsadresse = mockNorskAdresse(
+                gyldigTilOgMed = Tidspunkt.now().toLocalDatetimeUTC().plusMonths(11)
+            ),
+            familieRelasjon = FamilieRelasjon(
+                barn = listOf(barn.foedselsnummer),
+                ansvarligeForeldre = null,
+                foreldre = listOf(Folkeregisteridentifikator.of(FNR_2))
+            )
+        )
+
+        val fordelerResultat =
+            fordelerKriterier.sjekkMotKriterier(barn, avdoed, gjenlevende = null, BARNEPENSJON_SOKNAD)
+
+        assertTrue(fordelerResultat.forklaring.contains(FordelerKriterie.GJENLEVENDE_MANGLER))
+    }
+
+    @Test
     fun `Skal godta bokmaal som spraak`() {
         val barn = mockPerson(
             foedselsaar = now().year - 15,

--- a/apps/etterlatte-fordeler/src/test/kotlin/fordeler/FordelerKriterierTest.kt
+++ b/apps/etterlatte-fordeler/src/test/kotlin/fordeler/FordelerKriterierTest.kt
@@ -423,7 +423,7 @@ internal class FordelerKriterierTest {
     fun `innsender som ikke er forelder er ikke en gyldig kandidat`() {
         val barn = mockPerson()
         val avdoed = mockPerson()
-        val gjenlevende = mockPerson()
+        val gjenlevende = null
 
         val fordelerResultat = fordelerKriterier.sjekkMotKriterier(
             barn,


### PR DESCRIPTION
Det var gjort en antagelse om at det alltid fantes en gjenlevende forelder som kunne slåes opp i pdl. Dette er ikke tilfellet. Det gjøres nå en sjekk på om det finnes gjenlevende foreldre før det gjøres sjekk mot pdl. Videre vil en slik søknad ikke passere da det vil være en annen innsender enn foreldre i slike tilfeller.