### PR TITLE
EY-2297 Justerer beregningsregel for institusjonsopphold

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
@@ -57,13 +57,20 @@ class BeregningsGrunnlagService(
         barnepensjonBeregningsGrunnlag: BarnepensjonBeregningsGrunnlag
     ): Boolean {
         val forrigeGrunnlag = beregningsGrunnlagRepository.finnGrunnlagForBehandling(forrigeIverksatte.id)
+        val revurderingVirk = revurdering.virkningstidspunkt!!.dato.atDay(1)
 
-        // TODO: for periodisert institusjonsopphold må dette sjekkes her i tillegg til søskenjusteringen
-        return erGrunnlagLiktFoerEnDato(
+        val soeskenjusteringErLiktFoerVirk = erGrunnlagLiktFoerEnDato(
             barnepensjonBeregningsGrunnlag.soeskenMedIBeregning,
             forrigeGrunnlag!!.soeskenMedIBeregning,
-            revurdering.virkningstidspunkt!!.dato.atDay(1)
+            revurderingVirk
         )
+        val institusjonsoppholdErLiktFoerVirk = erGrunnlagLiktFoerEnDato(
+            barnepensjonBeregningsGrunnlag.institusjonsopphold ?: emptyList(),
+            forrigeGrunnlag.institusjonsoppholdBeregningsgrunnlag ?: emptyList(),
+            revurderingVirk
+        )
+
+        return soeskenjusteringErLiktFoerVirk && institusjonsoppholdErLiktFoerVirk
     }
 
     suspend fun hentBarnepensjonBeregningsGrunnlag(

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/barnepensjon/Institusjonsoppholdregler.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/barnepensjon/Institusjonsoppholdregler.kt
@@ -3,12 +3,35 @@ package beregning.regler.barnepensjon
 import no.nav.etterlatte.beregning.grunnlag.Prosent
 import no.nav.etterlatte.beregning.regler.barnepensjon.BP_1967_DATO
 import no.nav.etterlatte.beregning.regler.barnepensjon.BarnepensjonGrunnlag
+import no.nav.etterlatte.beregning.regler.barnepensjon.sats.grunnbeloep
 import no.nav.etterlatte.libs.regler.Regel
+import no.nav.etterlatte.libs.regler.RegelMeta
+import no.nav.etterlatte.libs.regler.RegelReferanse
+import no.nav.etterlatte.libs.regler.benytter
 import no.nav.etterlatte.libs.regler.finnFaktumIGrunnlag
+import no.nav.etterlatte.libs.regler.med
+import no.nav.etterlatte.libs.regler.og
+import no.nav.etterlatte.regler.Beregningstall
 
 val institusjonsoppholdRegel: Regel<BarnepensjonGrunnlag, Prosent> =
     finnFaktumIGrunnlag(
         gjelderFra = BP_1967_DATO,
-        beskrivelse = "Finner søkers institusjonsopphold",
+        beskrivelse = "Finner % av G mottaker skal ha for denne institusjonsoppholdytelsen",
         finnFaktum = BarnepensjonGrunnlag::institusjonsopphold
     ) { it?.prosentEtterReduksjon() ?: Prosent.hundre }
+
+val erBrukerIInstitusjon: Regel<BarnepensjonGrunnlag, Boolean> = finnFaktumIGrunnlag(
+    gjelderFra = BP_1967_DATO,
+    beskrivelse = "Finner om bruker har et institusjonsopphold",
+    finnFaktum = BarnepensjonGrunnlag::institusjonsopphold
+) {
+    it != null
+}
+
+val institusjonsoppholdSatsRegel = RegelMeta(
+    gjelderFra = BP_1967_DATO,
+    beskrivelse = "Finner satsen for institusjonsoppholdberegning",
+    regelReferanse = RegelReferanse(id = "Finner sats for bruker, gitt at de skal ha institusjonsoppholdsats")
+) benytter grunnbeloep og institusjonsoppholdRegel med { grunnbeloep, prosent ->
+    Beregningstall.somBroek(prosent).multiply(grunnbeloep.grunnbeloepPerMaaned)
+}


### PR DESCRIPTION
Se [confluence](https://confluence.adeo.no/pages/viewpage.action?pageId=512001934#id-%C2%A7188.Barnepensjonunderoppholdiinstitusjon-Beslutningstre) for illustrasjon av beregningstreet for institusjonsopphold