### PR TITLE
Endrer flyt for avbryt-knappen for ferdige behandlinger.

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/Behandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/Behandling.tsx
@@ -2,20 +2,26 @@ import { useEffect } from 'react'
 import { Navigate, Route, Routes, useMatch } from 'react-router-dom'
 import { hentBehandling } from '~shared/api/behandling'
 import { GridContainer, MainContent } from '~shared/styled'
-import { addBehandling, resetBehandling, updateVilkaarsvurdering, updateVedtakSammendrag } from '~store/reducers/BehandlingReducer'
+import {
+  addBehandling,
+  resetBehandling,
+  updateVilkaarsvurdering,
+  updateVedtakSammendrag,
+} from '~store/reducers/BehandlingReducer'
 import Spinner from '~shared/Spinner'
 import { StatusBar } from '~shared/statusbar/Statusbar'
 import { useBehandlingRoutes } from './BehandlingRoutes'
 import { StegMeny } from './StegMeny/stegmeny'
 import { SideMeny } from './SideMeny/SideMeny'
-import { useAppDispatch, useAppSelector } from '~store/Store'
+import { useAppDispatch } from '~store/Store'
 import { isFailure, isPendingOrInitial, useApiCall } from '~shared/hooks/useApiCall'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { hentVilkaarsvurdering } from '~shared/api/vilkaarsvurdering'
-import { hentVedtakSammendrag } from "~shared/api/vedtaksvurdering";
+import { hentVedtakSammendrag } from '~shared/api/vedtaksvurdering'
+import { useBehandling } from '~components/behandling/useBehandling'
 
 export const Behandling = () => {
-  const behandling = useAppSelector((state) => state.behandlingReducer.behandling)
+  const behandling = useBehandling()
   const dispatch = useAppDispatch()
   const match = useMatch('/behandling/:behandlingId/*')
   const { behandlingRoutes } = useBehandlingRoutes()
@@ -73,10 +79,14 @@ export const Behandling = () => {
       {behandling && <StegMeny behandling={behandling} />}
 
       <Spinner
-        visible={isPendingOrInitial(fetchBehandlingStatus) || isPendingOrInitial(fetchVilkaarsvurderingStatus) || isPendingOrInitial(fetchVedtakStatus)}
+        visible={
+          isPendingOrInitial(fetchBehandlingStatus) ||
+          isPendingOrInitial(fetchVilkaarsvurderingStatus) ||
+          isPendingOrInitial(fetchVedtakStatus)
+        }
         label="Laster"
       />
-      {behandling &&  (
+      {behandling && (
         <GridContainer>
           <MainContent>
             <Routes>
@@ -86,7 +96,7 @@ export const Behandling = () => {
               <Route path="*" element={<Navigate to={behandlingRoutes[0].path} replace />} />
             </Routes>
           </MainContent>
-          <SideMeny behandling={behandling} vedtak={behandling.vedtak}/>
+          <SideMeny behandling={behandling} vedtak={behandling.vedtak} />
         </GridContainer>
       )}
       {isFailure(fetchBehandlingStatus) && <ApiErrorAlert>Kunne ikke hente behandling</ApiErrorAlert>}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
@@ -5,12 +5,12 @@ import { Vilkaarsvurdering } from './vilkaarsvurdering/Vilkaarsvurdering'
 import { Soeknadsoversikt } from './soeknadsoversikt/Soeknadoversikt'
 import Beregningsgrunnlag from './beregningsgrunnlag/Beregningsgrunnlag'
 import { IBehandlingStatus, IBehandlingsType } from '~shared/types/IDetaljertBehandling'
-import { useAppSelector } from '~store/Store'
 import { Vedtaksbrev } from './brev/Vedtaksbrev'
 import { ManueltOpphoerOversikt } from './manueltopphoeroversikt/ManueltOpphoerOversikt'
 import { IBehandlingReducer } from '~store/reducers/BehandlingReducer'
 import { Revurderingsoversikt } from '~components/behandling/revurderingsoversikt/Revurderingsoversikt'
 import { behandlingSkalSendeBrev } from '~components/behandling/felles/utils'
+import { useBehandling } from '~components/behandling/useBehandling'
 
 type behandlingRouteTypes =
   | 'soeknadsoversikt'
@@ -53,7 +53,7 @@ function useRouteNavigation() {
 
 export const useBehandlingRoutes = () => {
   const { currentRoute, goto } = useRouteNavigation()
-  const behandling = useAppSelector((state) => state.behandlingReducer.behandling)
+  const behandling = useBehandling()
 
   const aktuelleRoutes = hentAktuelleRoutes(behandling)
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AnnullerBehanding.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AnnullerBehanding.tsx
@@ -5,17 +5,17 @@ import { annullerBehandling } from '~shared/api/behandling'
 import { useNavigate } from 'react-router'
 import { ApiResponse } from '~shared/api/apiClient'
 import { ButtonWrapper } from '~shared/modal/modal'
-import { useAppSelector } from '~store/Store'
 import { IBehandlingStatus, IBehandlingsType } from '~shared/types/IDetaljertBehandling'
 import { SidebarPanel } from '~components/behandling/SideMeny/SideMeny'
 import { hentBehandlesFraStatus } from '~components/behandling/felles/utils'
+import { useBehandling } from '~components/behandling/useBehandling'
 
 export default function AnnullerBehandling() {
   const navigate = useNavigate()
   const [isOpen, setIsOpen] = useState(false)
   const [error, setError] = useState(false)
 
-  const behandling = useAppSelector((state) => state.behandlingReducer.behandling)
+  const behandling = useBehandling()
   const erFoerstegangsbehandling = behandling?.behandlingType === IBehandlingsType.FØRSTEGANGSBEHANDLING
 
   const behandles = hentBehandlesFraStatus(behandling?.status ?? IBehandlingStatus.IVERKSATT)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AvbrytBehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AvbrytBehandling.tsx
@@ -2,12 +2,19 @@ import { useState } from 'react'
 import { BodyLong, Button, Heading, Modal } from '@navikt/ds-react'
 import { useNavigate } from 'react-router'
 import { ButtonWrapper } from '~shared/modal/modal'
+import { erFerdigBehandlet } from '~components/behandling/felles/utils'
+import { useBehandling } from '~components/behandling/useBehandling'
 
 export default function AvbrytBehandling() {
   const navigate = useNavigate()
+  const behandling = useBehandling()
   const [isOpen, setIsOpen] = useState(false)
 
-  return (
+  return behandling?.status && erFerdigBehandlet(behandling.status) ? (
+    <Button variant={'tertiary'} className="textButton" onClick={() => navigate('/')}>
+      Tilbake til oppgavelisten
+    </Button>
+  ) : (
     <>
       <Button variant={'tertiary'} className="textButton" onClick={() => setIsOpen(true)}>
         Avbryt

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/useBehandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/useBehandling.ts
@@ -1,0 +1,7 @@
+import { useAppSelector } from '~store/Store'
+import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
+import { IBehandlingReducer } from '~store/reducers/BehandlingReducer'
+
+export function useBehandling(): IBehandlingReducer | null {
+  return useAppSelector((state) => state.behandlingReducer.behandling)
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/useBehandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/useBehandling.ts
@@ -1,5 +1,4 @@
 import { useAppSelector } from '~store/Store'
-import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 import { IBehandlingReducer } from '~store/reducers/BehandlingReducer'
 
 export function useBehandling(): IBehandlingReducer | null {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/useVedtaksResultat.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/useVedtaksResultat.ts
@@ -1,6 +1,6 @@
-import { useAppSelector } from '~store/Store'
 import { VilkaarsvurderingResultat } from '~shared/api/vilkaarsvurdering'
 import { IBehandlingsType } from '~shared/types/IDetaljertBehandling'
+import { useBehandling } from '~components/behandling/useBehandling'
 
 // Dette er en midlertidig workaround i frontend fram til vi får noe mer rimelig rundt hva er vedtaksresultat i backend
 // Laget som en felles greie slik at
@@ -9,7 +9,7 @@ import { IBehandlingsType } from '~shared/types/IDetaljertBehandling'
 export type VedtakResultat = 'opphoer' | 'innvilget' | 'avslag' | 'endring' | 'uavklart'
 
 export function useVedtaksResultat(): VedtakResultat {
-  const behandling = useAppSelector((state) => state.behandlingReducer.behandling)
+  const behandling = useBehandling()
   const behandlingType = behandling?.behandlingType
   const vilkaarsresultat = behandling?.vilkårsprøving?.resultat?.utfall
 


### PR DESCRIPTION
Viser nå knappen "Tilbake til oppgavelisten" uten modal dersom behandling er ferdigstilt.

![Screenshot 2023-06-29 at 14 21 50](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1083866/ab23863e-f004-4ad3-a091-498732a722eb)

EY-2363