### PR TITLE
Endrer expression i alerts.yaml til å bruke gyldige verdier

### DIFF
--- a/alerts.yaml
+++ b/alerts.yaml
@@ -10,9 +10,9 @@ spec:
   - name: alerts
     rules:
     - alert: etterlatte-saksbehandling-error-logg
-      expr: 'sum by (log_app) (max_over_time(logd_messages_total{log_app=~"etterlatte-.*",log_level="Error"}[15m])
+      expr: 'sum by (app) (max_over_time(log_messages_errors{app=~"etterlatte-.*",level="Error"}[15m])
               or vector(0)) -
-             sum by (log_app) (max_over_time(logd_messages_total{log_app=~"etterlatte-.*",log_level="Error"}[15m]
+             sum by (app) (max_over_time(log_messages_errors{app=~"etterlatte-.*",level="Error"}[15m]
              offset 15m) or vector(0)) > 0'
       for: 1s
       annotations:


### PR DESCRIPTION
Ref https://nav-it.slack.com/archives/C01DE3M9YBV/p1684235321138999

Vi har siden 24.05 ikke fått varsler fra logger for saksbehandling i dev eller prod. Denne endringen skal få det til å fungere igjen. 