### PR TITLE
Ey 2368 Regler for restanse og avkorting

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.avkorting
 import com.fasterxml.jackson.databind.JsonNode
 import no.nav.etterlatte.beregning.Beregning
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -35,7 +36,7 @@ data class Avkorting(
     fun beregnAvkortingMedNyttGrunnlag(
         nyttGrunnlag: AvkortingGrunnlag,
         behandlingstype: BehandlingType,
-        virkningstidspunkt: YearMonth,
+        virkningstidspunkt: Virkningstidspunkt,
         beregning: Beregning
     ) = oppdaterMedInntektsgrunnlag(nyttGrunnlag).beregnAvkorting(behandlingstype, virkningstidspunkt, beregning)
 
@@ -59,7 +60,7 @@ data class Avkorting(
 
     fun beregnAvkorting(
         behandlingstype: BehandlingType,
-        virkningstidspunkt: YearMonth,
+        virkningstidspunkt: Virkningstidspunkt,
         beregning: Beregning
     ): Avkorting = if (behandlingstype == BehandlingType.FØRSTEGANGSBEHANDLING) {
         beregnAvkortingForstegangs(virkningstidspunkt, beregning)
@@ -68,14 +69,14 @@ data class Avkorting(
     }
 
     private fun beregnAvkortingForstegangs(
-        virkningstidspunkt: YearMonth,
+        virkningstidspunkt: Virkningstidspunkt,
         beregning: Beregning
     ): Avkorting {
 
         val ytelseFoerAvkorting = beregning.mapTilYtelseFoerAvkorting()
 
         val avkortingsperioder = AvkortingRegelkjoring.beregnInntektsavkorting(
-            Periode(fom = virkningstidspunkt, null),
+            Periode(fom = virkningstidspunkt.dato, tom = null),
             avkortingGrunnlag
         )
 
@@ -97,14 +98,14 @@ data class Avkorting(
         )
     }
 
-    private fun beregnAvkortingRevurdering(virkningstidspunkt: YearMonth, beregning: Beregning): Avkorting {
+    private fun beregnAvkortingRevurdering(virkningstidspunkt: Virkningstidspunkt, beregning: Beregning): Avkorting {
 
         val ytelseFoerAvkorting =
-            this.aarsoppgjoer.ytelseFoerAvkorting.leggTilNyeBeregninger(beregning, virkningstidspunkt)
+            this.aarsoppgjoer.ytelseFoerAvkorting.leggTilNyeBeregninger(beregning, virkningstidspunkt.dato)
 
         val fraFoersteMaaned = Periode(fom = this.foersteMaanedDetteAar(), tom = null)
         val avkortingHeleAaret = AvkortingRegelkjoring.beregnInntektsavkorting(
-            periode = fraFoersteMaaned,
+            fraFoersteMaaned,
             avkortingGrunnlag = listOf(avkortingGrunnlag.last().copy(periode = fraFoersteMaaned))
         )
 

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -20,10 +20,13 @@ data class Avkorting(
         tidligereAvkortetYtelse = aarsoppgjoer.tidligereAvkortetYtelse + avkortetYtelse.map {
             when (it.periode.tom) {
                 null -> it.copy(
+                    type = AvkortetYtelseType.TIDLIGERE,
                     periode = Periode(fom = it.periode.fom, tom = virkningstidspunkt.minusMonths(1))
                 )
 
-                else -> it
+                else -> it.copy(
+                    type = AvkortetYtelseType.TIDLIGERE
+                )
             }
         },
         ytelseFoerAvkorting = aarsoppgjoer.ytelseFoerAvkorting,
@@ -193,11 +196,13 @@ data class Avkortingsperiode(
 data class Restanse(
     val totalRestanse: Int,
     val fordeltRestanse: Int,
+    val tidspunkt: Tidspunkt? = null,
     val regelResultat: JsonNode? = null,
     val kilde: Grunnlagsopplysning.RegelKilde? = null,
 )
 
 data class AvkortetYtelse(
+    val type: AvkortetYtelseType,
     val periode: Periode,
     val ytelseEtterAvkorting: Int,
     val ytelseEtterAvkortingFoerRestanse: Int,
@@ -208,6 +213,7 @@ data class AvkortetYtelse(
     val regelResultat: JsonNode,
     val kilde: Grunnlagsopplysning.RegelKilde
 )
+enum class AvkortetYtelseType { NY, TIDLIGERE, REBEREGNET }
 
 fun Beregning.mapTilYtelseFoerAvkorting() = beregningsperioder.map {
     YtelseFoerAvkorting(

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -11,26 +11,28 @@ import java.time.YearMonth
 import java.util.*
 
 data class Avkorting(
-    val avkortingGrunnlag: List<AvkortingGrunnlag>,
-    val aarsoppgjoer: Aarsoppgjoer,
-    val avkortetYtelse: List<AvkortetYtelse>
+    val avkortingGrunnlag: List<AvkortingGrunnlag> = emptyList(),
+    val aarsoppgjoer: Aarsoppgjoer = Aarsoppgjoer(),
+    val avkortetYtelse: List<AvkortetYtelse> = emptyList()
 ) {
 
-    fun kopierAvkorting(virkningstidspunkt: YearMonth): Avkorting = nyAvkorting(
+    fun kopierAvkorting(virkningstidspunkt: YearMonth): Avkorting = Avkorting(
         avkortingGrunnlag = avkortingGrunnlag.map { it.copy(id = UUID.randomUUID()) },
-        tidligereAvkortetYtelse = aarsoppgjoer.tidligereAvkortetYtelse + avkortetYtelse.map {
-            when (it.periode.tom) {
-                null -> it.copy(
-                    type = AvkortetYtelseType.TIDLIGERE,
-                    periode = Periode(fom = it.periode.fom, tom = virkningstidspunkt.minusMonths(1))
-                )
+        aarsoppgjoer = Aarsoppgjoer(
+            tidligereAvkortetYtelse = aarsoppgjoer.tidligereAvkortetYtelse + avkortetYtelse.map {
+                when (it.periode.tom) {
+                    null -> it.copy(
+                        type = AvkortetYtelseType.TIDLIGERE,
+                        periode = Periode(fom = it.periode.fom, tom = virkningstidspunkt.minusMonths(1))
+                    )
 
-                else -> it.copy(
-                    type = AvkortetYtelseType.TIDLIGERE
-                )
-            }
-        },
-        ytelseFoerAvkorting = aarsoppgjoer.ytelseFoerAvkorting,
+                    else -> it.copy(
+                        type = AvkortetYtelseType.TIDLIGERE
+                    )
+                }
+            },
+            ytelseFoerAvkorting = aarsoppgjoer.ytelseFoerAvkorting,
+        ),
     )
 
     fun beregnAvkortingMedNyttGrunnlag(
@@ -91,7 +93,7 @@ data class Avkorting(
                 ytelseFoerAvkorting = ytelseFoerAvkorting,
                 avkortingsperioder = avkortingsperioder,
                 tidligereAvkortetYtelse = emptyList(),
-                reberegnetAvkortetYtelse = emptyList(),
+                tidligereAvkortetYtelseReberegnet = emptyList(),
                 restanse = null,
             ),
             avkortetYtelse = beregnetAvkortetYtelse
@@ -133,7 +135,7 @@ data class Avkorting(
             aarsoppgjoer = this.aarsoppgjoer.copy(
                 ytelseFoerAvkorting = ytelseFoerAvkorting,
                 avkortingsperioder = avkortingHeleAaret,
-                reberegnetAvkortetYtelse = reberegnetYtelseFoerVirk,
+                tidligereAvkortetYtelseReberegnet = reberegnetYtelseFoerVirk,
                 restanse = restanse
             ),
             avkortetYtelse = avkortetYtelseFraNyVirk
@@ -142,24 +144,6 @@ data class Avkorting(
 
     private fun foersteMaanedDetteAar() = this.aarsoppgjoer.ytelseFoerAvkorting.first().periode.fom
 
-    companion object {
-        fun nyAvkorting(
-            avkortingGrunnlag: List<AvkortingGrunnlag> = emptyList(),
-            ytelseFoerAvkorting: List<YtelseFoerAvkorting> = emptyList(),
-            tidligereAvkortetYtelse: List<AvkortetYtelse> = emptyList(),
-            avkortetYtelse: List<AvkortetYtelse> = emptyList(),
-        ) = Avkorting(
-            avkortingGrunnlag = avkortingGrunnlag,
-            aarsoppgjoer = Aarsoppgjoer(
-                ytelseFoerAvkorting = ytelseFoerAvkorting,
-                avkortingsperioder = emptyList(),
-                tidligereAvkortetYtelse = tidligereAvkortetYtelse,
-                reberegnetAvkortetYtelse = emptyList(),
-                restanse = null,
-            ),
-            avkortetYtelse = avkortetYtelse,
-        )
-    }
 }
 
 data class AvkortingGrunnlag(
@@ -173,11 +157,11 @@ data class AvkortingGrunnlag(
 )
 
 data class Aarsoppgjoer(
-    val ytelseFoerAvkorting: List<YtelseFoerAvkorting>,
-    val avkortingsperioder: List<Avkortingsperiode>,
-    val tidligereAvkortetYtelse: List<AvkortetYtelse>,
-    val reberegnetAvkortetYtelse: List<AvkortetYtelse>,
-    val restanse: Restanse?,
+    val ytelseFoerAvkorting: List<YtelseFoerAvkorting> = emptyList(),
+    val avkortingsperioder: List<Avkortingsperiode> = emptyList(),
+    val tidligereAvkortetYtelse: List<AvkortetYtelse> = emptyList(),
+    val tidligereAvkortetYtelseReberegnet: List<AvkortetYtelse> = emptyList(),
+    val restanse: Restanse? = null,
 )
 
 data class YtelseFoerAvkorting(

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -92,7 +92,7 @@ data class Avkorting(
                 avkortingsperioder = avkortingsperioder,
                 tidligereAvkortetYtelse = emptyList(),
                 reberegnetAvkortetYtelse = emptyList(),
-                restanse = Restanse(totalRestanse = 0, fordeltRestanse = 0),
+                restanse = null,
             ),
             avkortetYtelse = beregnetAvkortetYtelse
         )
@@ -155,7 +155,7 @@ data class Avkorting(
                 avkortingsperioder = emptyList(),
                 tidligereAvkortetYtelse = tidligereAvkortetYtelse,
                 reberegnetAvkortetYtelse = emptyList(),
-                restanse = Restanse(totalRestanse = 0, fordeltRestanse = 0),
+                restanse = null,
             ),
             avkortetYtelse = avkortetYtelse,
         )
@@ -177,7 +177,7 @@ data class Aarsoppgjoer(
     val avkortingsperioder: List<Avkortingsperiode>,
     val tidligereAvkortetYtelse: List<AvkortetYtelse>,
     val reberegnetAvkortetYtelse: List<AvkortetYtelse>,
-    val restanse: Restanse,
+    val restanse: Restanse?,
 )
 
 data class YtelseFoerAvkorting(
@@ -187,6 +187,7 @@ data class YtelseFoerAvkorting(
 )
 
 data class Avkortingsperiode(
+    val id: UUID,
     val periode: Periode,
     val avkorting: Int,
     val tidspunkt: Tidspunkt,
@@ -195,14 +196,16 @@ data class Avkortingsperiode(
 )
 
 data class Restanse(
+    val id: UUID,
     val totalRestanse: Int,
     val fordeltRestanse: Int,
-    val tidspunkt: Tidspunkt? = null,
-    val regelResultat: JsonNode? = null,
-    val kilde: Grunnlagsopplysning.RegelKilde? = null,
+    val tidspunkt: Tidspunkt,
+    val regelResultat: JsonNode,
+    val kilde: Grunnlagsopplysning.RegelKilde,
 )
 
 data class AvkortetYtelse(
+    val id: UUID,
     val type: AvkortetYtelseType,
     val periode: Periode,
     val ytelseEtterAvkorting: Int,

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
@@ -1,18 +1,15 @@
 package no.nav.etterlatte.avkorting
 
-import no.nav.etterlatte.avkorting.regler.FordelRestanseGrunnlag
 import no.nav.etterlatte.avkorting.regler.InntektAvkortingGrunnlag
 import no.nav.etterlatte.avkorting.regler.PeriodisertAvkortetYtelseGrunnlag
 import no.nav.etterlatte.avkorting.regler.PeriodisertInntektAvkortingGrunnlag
-import no.nav.etterlatte.avkorting.regler.PeriodisertRestanseGrunnlag
+import no.nav.etterlatte.avkorting.regler.RestanseGrunnlag
 import no.nav.etterlatte.avkorting.regler.avkortetYtelseMedRestanse
-import no.nav.etterlatte.avkorting.regler.fordeltRestanse
 import no.nav.etterlatte.avkorting.regler.kroneavrundetInntektAvkorting
 import no.nav.etterlatte.avkorting.regler.restanse
 import no.nav.etterlatte.beregning.grunnlag.GrunnlagMedPeriode
 import no.nav.etterlatte.beregning.grunnlag.PeriodisertBeregningGrunnlag
 import no.nav.etterlatte.beregning.grunnlag.mapVerdier
-import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -87,132 +84,39 @@ object AvkortingRegelkjoring {
         }
     }
 
-    // TODO egen fil..
-    fun beregnRestanse(
-        aarsoppgjoerMaaneder: List<AarsoppgjoerMaaned>
-    ): Map<YearMonth, Restanse> {
-        val periode = Periode(fom = aarsoppgjoerMaaneder.first().maaned, tom = aarsoppgjoerMaaneder.last().maaned)
-        val grunnlag = PeriodisertRestanseGrunnlag(
-            tidligereYtelseEtterAvkorting = PeriodisertBeregningGrunnlag.lagGrunnlagMedDefaultUtenforPerioder(
-                aarsoppgjoerMaaneder.map {
-                    GrunnlagMedPeriode(
-                        data = it.faktiskAvkortetYtelse,
-                        fom = it.maaned.atDay(1),
-                        tom = it.maaned.atEndOfMonth()
-                    )
-                }.mapVerdier {
-                    FaktumNode(
-                        verdi = it,
-                        kilde = "", // TODO EY-2368
-                        beskrivelse = "Forventet årsinntekt"
-                    )
-                }
-            ) { _, _, _ -> throw IllegalArgumentException("Noe gikk galt ved uthenting av periodiserte beregninger") },
-            nyForventetYtelseEtterAvkorting = PeriodisertBeregningGrunnlag.lagGrunnlagMedDefaultUtenforPerioder(
-                aarsoppgjoerMaaneder.map {
-                    GrunnlagMedPeriode(
-                        data = it.forventetAvkortetYtelse,
-                        fom = it.maaned.atDay(1),
-                        tom = it.maaned.atEndOfMonth()
-                    )
-                }.mapVerdier {
-                    FaktumNode(
-                        verdi = it,
-                        kilde = "", // TODO EY-2368
-                        beskrivelse = "Forventet årsinntekt"
-                    )
-                }
-            ) { _, _, _ -> throw IllegalArgumentException("Noe gikk galt ved uthenting av periodiserte beregninger") }
-        )
-
-        val resultat = restanse.eksekver(grunnlag, periode.tilRegelPeriode())
-        return when (resultat) {
-            is RegelkjoeringResultat.Suksess -> {
-                resultat.periodiserteResultater.associate {
-                    YearMonth.from(it.periode.fraDato) to
-                            Restanse(
-                                verdi = it.resultat.verdi,
-                                regelResultat = it.toJsonNode(),
-                                kilde = Grunnlagsopplysning.RegelKilde(
-                                    navn = restanse.regelReferanse.id,
-                                    ts = Tidspunkt.now(),
-                                    versjon = it.reglerVersjon
-                                )
-                            )
-                }
-            }
-
-            is RegelkjoeringResultat.UgyldigPeriode ->
-                throw RuntimeException("Ugyldig regler for periode: ${resultat.ugyldigeReglerForPeriode}")
-        }
-    }
-
-    fun beregnFordeltRestanse(virkningstidspunkt: YearMonth, aarsoppgjoer: List<AarsoppgjoerMaaned>): FordeltRestanse {
-        val regelgrunnlag = FordelRestanseGrunnlag(
-            virkningstidspunkt = FaktumNode(
-                verdi = virkningstidspunkt,
-                kilde = "TODO", // TODO EY-2368 kilde - Bytt YearMonth med klasse for å kunne bruke kilde?
-                beskrivelse = "Virkningstidspunkt hvor restanse skal fordeles månedlig fra"
-            ),
-            maanederMedRestanse = FaktumNode(
-                verdi = aarsoppgjoer,
-                kilde = "TODO", // TODO EY-2368 kilde - Hva blir kilde her id til tabell (enten nytt id felt eller ny tabell for å samle)
-                beskrivelse = "All restanse til tidligere måneder i året"
-            )
-        )
-
-        val resultat = fordeltRestanse.eksekver(
-            KonstantGrunnlag(regelgrunnlag),
-            RegelPeriode(fraDato = virkningstidspunkt.atDay(1))
-        )
-        return when (resultat) {
-            is RegelkjoeringResultat.Suksess -> {
-                resultat.periodiserteResultater.map {
-                    FordeltRestanse(
-                        verdi = it.resultat.verdi,
-                        regelResultat = it.toJsonNode(),
-                        kilde = Grunnlagsopplysning.RegelKilde(
-                            navn = fordeltRestanse.regelReferanse.id,
-                            ts = Tidspunkt.now(),
-                            versjon = it.reglerVersjon
-                        )
-                    )
-                }.first()
-            }
-
-            is RegelkjoeringResultat.UgyldigPeriode ->
-                throw RuntimeException("Ugyldig regler for periode: ${resultat.ugyldigeReglerForPeriode}")
-        }
-    }
-
-    fun beregnAvkortetYtelsePaaNytt(aarsoppgjoerMaaneder: List<AarsoppgjoerMaaned>): List<AvkortetYtelse> {
-        val periode = Periode(fom = aarsoppgjoerMaaneder.first().maaned, tom = aarsoppgjoerMaaneder.last().maaned)
-        val avkortetYtelseGrunnlag = PeriodisertAvkortetYtelseGrunnlag(
-            beregningsperioder = maanedligeBeregninger(aarsoppgjoerMaaneder),
-            avkortingsperioder = maanedligeAvkortinger(aarsoppgjoerMaaneder),
-            fordeltRestanse = KonstantGrunnlag(FaktumNode(verdi = 0, kilde = "", beskrivelse = "Tom restanse"))
-        )
-        return beregnAvkortetYtelse(periode, avkortetYtelseGrunnlag)
-    }
-
     fun beregnAvkortetYtelse(
-        periode: Periode,
-        beregningsperioder: List<Beregningsperiode>,
+        virkningstidspunkt: YearMonth,
+        beregningsperioder: List<YtelseFoerAvkorting>,
         avkortingsperioder: List<Avkortingsperiode>,
-        maanedligRestanse: FordeltRestanse? = null
+        restanse: Restanse? = null
     ): List<AvkortetYtelse> {
+        val periode = Periode(fom = virkningstidspunkt, tom = null)
         val regelgrunnlag = PeriodisertAvkortetYtelseGrunnlag(
             beregningsperioder = periodiserteBeregninger(beregningsperioder),
             avkortingsperioder = periodiserteAvkortinger(avkortingsperioder),
             fordeltRestanse = KonstantGrunnlag(
                 FaktumNode(
-                    verdi = maanedligRestanse?.verdi ?: 0,
-                    kilde = maanedligRestanse?.kilde ?: "", // TODO EY-2368 kilde
+                    verdi = restanse?.fordeltRestanse ?: 0,
+                    kilde = restanse?.kilde?: "", // TODO EY-2368 kilde
                     beskrivelse = "Restansebeløp som skal fordeles månedlig"
                 )
             )
         )
         return beregnAvkortetYtelse(periode, regelgrunnlag)
+    }
+
+    fun beregnAvkortetYtelsePaaNytt(
+        virkningstidspunkt: YearMonth,
+        beregninger: List<YtelseFoerAvkorting>,
+        avkortinger: List<Avkortingsperiode>
+    ): List<AvkortetYtelse> {
+        val periode = Periode(fom = beregninger.first().periode.fom, tom = virkningstidspunkt.minusMonths(1))
+        val avkortetYtelseGrunnlag = PeriodisertAvkortetYtelseGrunnlag(
+            beregningsperioder = periodiserteBeregninger(beregninger),
+            avkortingsperioder = periodiserteAvkortinger(avkortinger),
+            fordeltRestanse = KonstantGrunnlag(FaktumNode(verdi = 0, kilde = "", beskrivelse = "Tom restanse"))
+        )
+        return beregnAvkortetYtelse(periode, avkortetYtelseGrunnlag)
     }
 
     private fun beregnAvkortetYtelse(
@@ -252,61 +156,22 @@ object AvkortingRegelkjoring {
         }
     }
 
-    private fun maanedligeBeregninger(
-        aarsoppgjoerMaaneder: List<AarsoppgjoerMaaned>
-    ): PeriodisertGrunnlag<FaktumNode<Int>> =
-        PeriodisertBeregningGrunnlag.lagGrunnlagMedDefaultUtenforPerioder(
-            aarsoppgjoerMaaneder.map {
-                GrunnlagMedPeriode(
-                    data = it,
-                    fom = it.maaned.atDay(1),
-                    tom = it.maaned.atEndOfMonth()
-                )
-            }.mapVerdier {
-                FaktumNode(
-                    verdi = it.beregning,
-                    kilde = "", // TODO EY-2368 kilde
-                    beskrivelse = "Beregnet ytelse før avkorting i måned"
-                )
-            }
-        ) { _, _, _ -> throw IllegalArgumentException("Noe gikk galt ved uthenting av periodiserte beregninger") }
-
-    private fun periodiserteBeregninger(beregninger: List<Beregningsperiode>): PeriodisertGrunnlag<FaktumNode<Int>> =
+    private fun periodiserteBeregninger(beregninger: List<YtelseFoerAvkorting>): PeriodisertGrunnlag<FaktumNode<Int>> =
         PeriodisertBeregningGrunnlag.lagGrunnlagMedDefaultUtenforPerioder(
             beregninger.map {
                 GrunnlagMedPeriode(
                     data = it,
-                    fom = it.datoFOM.atDay(1),
-                    tom = it.datoTOM?.atEndOfMonth()
+                    fom = it.periode.fom.atDay(1),
+                    tom = it.periode.tom?.atEndOfMonth()
                 )
             }.mapVerdier {
                 FaktumNode(
-                    verdi = it.utbetaltBeloep,
-                    kilde = it.kilde
-                        ?: throw IllegalArgumentException("Noe gikk galt ved uthenting av periodiserte beregninger"),
+                    verdi = it.beregning,
+                    kilde = it.beregningsreferanse,
                     beskrivelse = "Beregnet ytelse før avkorting for periode"
                 )
             }
         ) { _, _, _ -> throw IllegalArgumentException("Noe gikk galt ved uthenting av periodiserte beregninger") }
-
-    private fun maanedligeAvkortinger(
-        aarsoppgjoerMaaneder: List<AarsoppgjoerMaaned>
-    ): PeriodisertGrunnlag<FaktumNode<Int>> =
-        PeriodisertBeregningGrunnlag.lagGrunnlagMedDefaultUtenforPerioder(
-            aarsoppgjoerMaaneder.map {
-                GrunnlagMedPeriode(
-                    data = it,
-                    fom = it.maaned.atDay(1),
-                    tom = it.maaned.atEndOfMonth()
-                )
-            }.mapVerdier {
-                FaktumNode(
-                    verdi = it.avkorting,
-                    kilde = "", // TODO EY-2368 kilde
-                    beskrivelse = "Beregnet avkorting i måned"
-                )
-            }
-        ) { _, _, _ -> throw IllegalArgumentException("Noe gikk galt ved uthenting av periodiserte avkortinger") }
 
     private fun periodiserteAvkortinger(avkortingGrunnlag: List<Avkortingsperiode>):
             PeriodisertGrunnlag<FaktumNode<Int>> =
@@ -325,6 +190,76 @@ object AvkortingRegelkjoring {
                 )
             }
         ) { _, _, _ -> throw IllegalArgumentException("Noe gikk galt ved uthenting av periodiserte avkortinger") }
+
+    fun beregnRestanse(
+        foersteMaaned: YearMonth,
+        virkningstidspunkt: YearMonth,
+        tidligereYtelseEtterAvkorting: List<AvkortetYtelse>,
+        nyYtelseEtterAvkorting: List<AvkortetYtelse>
+    ): Restanse {
+
+        val grunnlag = RestanseGrunnlag(
+            FaktumNode(
+                verdi = tidligereYtelseEtterAvkorting
+                    .sprePerMaaned(foersteMaaned, virkningstidspunkt)
+                    .map { it.ytelseEtterAvkorting },
+                kilde = tidligereYtelseEtterAvkorting.map { it.kilde }, // TODO EY-2361 liste med ider
+                beskrivelse = "TODO" // TODO EY-2361
+            ),
+            FaktumNode(
+                verdi = nyYtelseEtterAvkorting
+                    .sprePerMaaned(foersteMaaned, virkningstidspunkt)
+                    .map { it.ytelseEtterAvkorting },
+                kilde = nyYtelseEtterAvkorting.map { it.kilde }, // TODO EY-2361
+                beskrivelse = "TODO" // TODO EY-2361
+            ),
+            virkningstidspunkt = FaktumNode(
+                verdi = virkningstidspunkt,
+                kilde = "TODO", // TODO EY-2368 kilde - Bytt YearMonth med klasse for å kunne bruke kilde?
+                beskrivelse = "Virkningstidspunkt hvor restanse skal fordeles månedlig fra"
+            )
+        )
+
+        val resultat = restanse.eksekver(
+            KonstantGrunnlag(grunnlag),
+            Periode(fom = foersteMaaned, tom = null).tilRegelPeriode()
+        )
+        return when (resultat) {
+            is RegelkjoeringResultat.Suksess -> {
+                val restanseresultat = resultat.periodiserteResultater.first().resultat.verdi
+                Restanse(
+                    totalRestanse = restanseresultat.totalRestanse,
+                    fordeltRestanse = restanseresultat.fordeltRestanse,
+                    regelResultat = resultat.toJsonNode(),
+                    kilde = Grunnlagsopplysning.RegelKilde(
+                        navn = restanse.regelReferanse.id,
+                        ts = Tidspunkt.now(),
+                        versjon = resultat.reglerVersjon,
+                    )
+                )
+            }
+
+            is RegelkjoeringResultat.UgyldigPeriode ->
+                throw RuntimeException("Ugyldig regler for periode: ${resultat.ugyldigeReglerForPeriode}")
+        }
+    }
+
+    private fun List<AvkortetYtelse>.sprePerMaaned(
+        foersteMaaned: YearMonth,
+        virkningstidspunkt: YearMonth
+    ): List<AvkortetYtelse> {
+        val perMaaned = mutableListOf<AvkortetYtelse>()
+        for (maanednr in foersteMaaned.monthValue ..virkningstidspunkt.minusMonths(1).monthValue) {
+            val maaned = YearMonth.of(virkningstidspunkt.year, maanednr)
+            perMaaned.add(avkortetYtelseIMaaned(maaned))
+        }
+        return perMaaned
+    }
+
+    private fun List<AvkortetYtelse>.avkortetYtelseIMaaned(maaned: YearMonth) = this.find {
+        maaned >= it.periode.fom && (it.periode.tom == null || maaned <= it.periode.tom)
+    } ?: throw Exception("Maaned finnes ikke i avkortet ytelse sin periode")
+
 }
 
 fun Periode.tilRegelPeriode(): RegelPeriode = RegelPeriode(

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
@@ -208,17 +208,12 @@ object AvkortingRegelkjoring {
     ): Restanse {
         val grunnlag = RestanseGrunnlag(
             FaktumNode(
-                verdi = tidligereYtelseEtterAvkorting
-                    .sprePerMaaned(foersteMaaned, virkningstidspunkt.dato)
-                    .map { it.ytelseEtterAvkorting },
+                verdi = tidligereYtelseEtterAvkorting.spreYtelsePerMaaned(foersteMaaned, virkningstidspunkt.dato),
                 kilde = tidligereYtelseEtterAvkorting.map { "avkortetYtelse:${it.id}" },
                 beskrivelse = "Ytelse etter avkorting fra tidligere beahndlinge gjeldende år"
-
             ),
             FaktumNode(
-                verdi = nyYtelseEtterAvkorting
-                    .sprePerMaaned(foersteMaaned, virkningstidspunkt.dato)
-                    .map { it.ytelseEtterAvkorting },
+                verdi = nyYtelseEtterAvkorting.spreYtelsePerMaaned(foersteMaaned, virkningstidspunkt.dato),
                 kilde = nyYtelseEtterAvkorting.map { "avkortetYtelse:${it.id}" },
                 beskrivelse = "Reberegnet ytelse etter avkorting før nytt virkningstidspunkt"
             ),
@@ -256,14 +251,14 @@ object AvkortingRegelkjoring {
         }
     }
 
-    private fun List<AvkortetYtelse>.sprePerMaaned(
+    private fun List<AvkortetYtelse>.spreYtelsePerMaaned(
         foersteMaaned: YearMonth,
         virkningstidspunkt: YearMonth
-    ): List<AvkortetYtelse> {
-        val perMaaned = mutableListOf<AvkortetYtelse>()
+    ): List<Int> {
+        val perMaaned = mutableListOf<Int>()
         for (maanednr in foersteMaaned.monthValue..virkningstidspunkt.minusMonths(1).monthValue) {
             val maaned = YearMonth.of(virkningstidspunkt.year, maanednr)
-            perMaaned.add(avkortetYtelseIMaaned(maaned))
+            perMaaned.add(avkortetYtelseIMaaned(maaned).ytelseEtterAvkorting)
         }
         return perMaaned
     }

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
@@ -64,7 +64,7 @@ class AvkortingRepository(private val dataSource: DataSource) {
                     ytelseFoerAvkorting = ytelseFoerAvkorting,
                     avkortingsperioder = avkortingsperioder,
                     tidligereAvkortetYtelse = tidligereAvkortetYtelse,
-                    reberegnetAvkortetYtelse = reberegnetAvkortetYtelse,
+                    tidligereAvkortetYtelseReberegnet = reberegnetAvkortetYtelse,
                     restanse = restanse,
                 ),
                 avkortetYtelse = avkortetYtelse
@@ -83,7 +83,7 @@ class AvkortingRepository(private val dataSource: DataSource) {
                 lagreYtelseFoerAvkorting(behandlingId, ytelseFoerAvkorting, tx)
                 lagreAvkortingsperioder(behandlingId, avkortingsperioder, tx)
                 lagreAvkortetYtelse(behandlingId, tidligereAvkortetYtelse, tx)
-                lagreAvkortetYtelse(behandlingId, reberegnetAvkortetYtelse, tx)
+                lagreAvkortetYtelse(behandlingId, tidligereAvkortetYtelseReberegnet, tx)
                 restanse?.let {lagreRestanse(behandlingId, it, tx) }
             }
             lagreAvkortetYtelse(behandlingId, avkorting.avkortetYtelse, tx)
@@ -219,9 +219,9 @@ class AvkortingRepository(private val dataSource: DataSource) {
             "behandlingId" to behandlingId,
             "total_restanse" to restanse.totalRestanse,
             "fordelt_restanse" to restanse.fordeltRestanse,
-            "tidspunkt" to restanse.tidspunkt?.toTimestamp(),
-            "regel_resultat" to restanse.regelResultat?.toJson(),
-            "kilde" to restanse.kilde?.toJson()
+            "tidspunkt" to restanse.tidspunkt.toTimestamp(),
+            "regel_resultat" to restanse.regelResultat.toJson(),
+            "kilde" to restanse.kilde.toJson()
         )
     ).let { query -> tx.run(query.asUpdate) }
 
@@ -308,7 +308,7 @@ class AvkortingRepository(private val dataSource: DataSource) {
         ytelseEtterAvkorting = int("ytelse_etter_avkorting"),
         avkortingsbeloep = int("avkortingsbeloep"),
         restanse = int("restanse"),
-        ytelseEtterAvkortingFoerRestanse = int("ytelse_etter_Avkorting_uten_restanse"),
+        ytelseEtterAvkortingFoerRestanse = int("ytelse_etter_avkorting_uten_restanse"),
         ytelseFoerAvkorting = int("ytelse_foer_avkorting"),
         tidspunkt = sqlTimestamp("tidspunkt").toTidspunkt(),
         regelResultat = objectMapper.readTree(string("regel_resultat")),

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
@@ -150,6 +150,7 @@ class AvkortingRepository(private val dataSource: DataSource) {
         tx: TransactionalSession
     ) =
         aarsoppgjoer.forEach {
+            // TODO EY-2368 legg til felter regelresultat og kilde for restanse og fordelt restanse
             queryOf(
                 statement = """
                     INSERT INTO avkorting_aarsoppgjoer(
@@ -182,6 +183,7 @@ class AvkortingRepository(private val dataSource: DataSource) {
         tx: TransactionalSession
     ) =
         avkortetYtelse.forEach {
+            // TODO EY-2368 legg til felt ytelseEtterAvkortingFoerRestanse
             queryOf(
                 statement = """
                     INSERT INTO avkortet_ytelse(
@@ -240,7 +242,8 @@ class AvkortingRepository(private val dataSource: DataSource) {
         ytelseEtterAvkorting = int("ytelse_etter_avkorting"),
         avkortingsbeloep = int("avkortingsbeloep"),
         restanse = int("restanse"),
-        ytelseEtterAvkortingFoerRestanse = 0, // TODO EY-2368
+        ytelseEtterAvkortingFoerRestanse = 0,
+        // TODO ytelseEtterAvkortingFoerRestanse = int("ytelse_etter_Avkorting_uten_restanse"),
         ytelseFoerAvkorting = int("ytelse_foer_avkorting"),
         tidspunkt = sqlTimestamp("tidspunkt").toTidspunkt(),
         regelResultat = objectMapper.readTree(string("regel_resultat")),

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -67,9 +67,10 @@ class AvkortingService(
             ?: throw Exception("Fant ikke avkorting for $forrigeBehandlingId")
         val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
         val beregning = beregningService.hentBeregningNonnull(behandlingId)
-        val beregnetAvkorting = forrigeAvkorting.kopierAvkorting().beregnAvkorting(
+        val virkningstidspunkt = behandling.hentVirk()
+        val beregnetAvkorting = forrigeAvkorting.kopierAvkorting(virkningstidspunkt).beregnAvkorting(
             behandling.behandlingType,
-            behandling.hentVirk(),
+            virkningstidspunkt,
             beregning
         )
 

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -41,7 +41,7 @@ class AvkortingService(
     ): Avkorting = tilstandssjekk(behandlingId, brukerTokenInfo) {
         logger.info("Lagre og beregne avkorting og avkortet ytelse for behandlingId=$behandlingId")
 
-        val avkorting = avkortingRepository.hentAvkorting(behandlingId) ?: Avkorting.nyAvkorting()
+        val avkorting = avkortingRepository.hentAvkorting(behandlingId) ?: Avkorting()
         val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
         val beregning = beregningService.hentBeregningNonnull(behandlingId)
         val beregnetAvkorting = avkorting.beregnAvkortingMedNyttGrunnlag(

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -68,7 +68,7 @@ class AvkortingService(
         val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
         val beregning = beregningService.hentBeregningNonnull(behandlingId)
         val virkningstidspunkt = behandling.hentVirk()
-        val beregnetAvkorting = forrigeAvkorting.kopierAvkorting(virkningstidspunkt).beregnAvkorting(
+        val beregnetAvkorting = forrigeAvkorting.kopierAvkorting(virkningstidspunkt.dato).beregnAvkorting(
             behandling.behandlingType,
             virkningstidspunkt,
             beregning
@@ -94,4 +94,4 @@ class AvkortingService(
 }
 
 private fun DetaljertBehandling.hentVirk() =
-    virkningstidspunkt?.dato ?: throw Exception("Mangler virkningstidspunkt for behandling $id")
+    virkningstidspunkt ?: throw Exception("Mangler virkningstidspunkt for behandling $id")

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/AvkortetYtelse.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/AvkortetYtelse.kt
@@ -71,7 +71,7 @@ val avkorteYtelse = RegelMeta(
 val avkortetYtelseMedRestanse = RegelMeta(
     gjelderFra = OMS_GYLDIG_FROM_TEST,
     beskrivelse = "Legger til restanse fra endret avkorting til tidligere måneder",
-    regelReferanse = RegelReferanse(id = "REGEL-AVKORTET-YTELSE-MED-RESTANSE") // TODO EY-2368 Confluence
+    regelReferanse = RegelReferanse(id = "REGEL-AVKORTET-YTELSE-MED-RESTANSE")
 ) benytter avkorteYtelse og fordeltRestanseGrunnlag med { avkorteYtelse, fordeltRestanse ->
     avkorteYtelse.minus(Beregningstall(fordeltRestanse))
         .toInteger()

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/AvkortetYtelse.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/AvkortetYtelse.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.avkorting.regler
 
 import no.nav.etterlatte.beregning.regler.omstillingstoenad.OMS_GYLDIG_FROM_TEST
 import no.nav.etterlatte.libs.regler.FaktumNode
+import no.nav.etterlatte.libs.regler.KonstantGrunnlag
 import no.nav.etterlatte.libs.regler.PeriodisertGrunnlag
 import no.nav.etterlatte.libs.regler.Regel
 import no.nav.etterlatte.libs.regler.RegelMeta
@@ -16,7 +17,8 @@ import kotlin.math.max
 
 data class PeriodisertAvkortetYtelseGrunnlag(
     val beregningsperioder: PeriodisertGrunnlag<FaktumNode<Int>>,
-    val avkortingsperioder: PeriodisertGrunnlag<FaktumNode<Int>>
+    val avkortingsperioder: PeriodisertGrunnlag<FaktumNode<Int>>,
+    val fordeltRestanse: KonstantGrunnlag<FaktumNode<Int>>
 ) : PeriodisertGrunnlag<AvkortetYtelseGrunnlag> {
     override fun finnAlleKnekkpunkter(): Set<LocalDate> {
         return beregningsperioder.finnAlleKnekkpunkter() + avkortingsperioder.finnAlleKnekkpunkter()
@@ -25,14 +27,16 @@ data class PeriodisertAvkortetYtelseGrunnlag(
     override fun finnGrunnlagForPeriode(datoIPeriode: LocalDate): AvkortetYtelseGrunnlag {
         return AvkortetYtelseGrunnlag(
             beregning = beregningsperioder.finnGrunnlagForPeriode(datoIPeriode),
-            avkorting = avkortingsperioder.finnGrunnlagForPeriode(datoIPeriode)
+            avkorting = avkortingsperioder.finnGrunnlagForPeriode(datoIPeriode),
+            fordeltRestanse = fordeltRestanse.finnGrunnlagForPeriode(datoIPeriode)
         )
     }
 }
 
 data class AvkortetYtelseGrunnlag(
     val beregning: FaktumNode<Int>,
-    val avkorting: FaktumNode<Int>
+    val avkorting: FaktumNode<Int>,
+    val fordeltRestanse: FaktumNode<Int>
 )
 
 val beregningsbeloep: Regel<AvkortetYtelseGrunnlag, Int> = finnFaktumIGrunnlag(
@@ -49,13 +53,27 @@ val avkortingsbeloep: Regel<AvkortetYtelseGrunnlag, Int> = finnFaktumIGrunnlag(
     finnFelt = { it }
 )
 
+val fordeltRestanseGrunnlag: Regel<AvkortetYtelseGrunnlag, Int> = finnFaktumIGrunnlag(
+    gjelderFra = OMS_GYLDIG_FROM_TEST,
+    beskrivelse = "Restanse fordelt over gjenværende måneder for gjeldende år",
+    finnFaktum = AvkortetYtelseGrunnlag::fordeltRestanse,
+    finnFelt = { it }
+)
+
 val avkorteYtelse = RegelMeta(
     gjelderFra = OMS_GYLDIG_FROM_TEST,
     beskrivelse = "Finner endelig ytelse ved å trekke avkortingsbeløp fra beregnet ytelse",
     regelReferanse = RegelReferanse(id = "REGEL-AVKORTET-YTELSE")
 ) benytter beregningsbeloep og avkortingsbeloep med { beregningsbeloep, avkortingsbeloep ->
-    Beregningstall(beregningsbeloep)
-        .minus(Beregningstall(avkortingsbeloep))
+    Beregningstall(beregningsbeloep).minus(Beregningstall(avkortingsbeloep))
+}
+
+val avkortetYtelseMedRestanse = RegelMeta(
+    gjelderFra = OMS_GYLDIG_FROM_TEST,
+    beskrivelse = "Legger til restanse fra endret avkorting til tidligere måneder",
+    regelReferanse = RegelReferanse(id = "REGEL-AVKORTET-YTELSE-MED-RESTANSE") // TODO EY-2368 Confluence
+) benytter avkorteYtelse og fordeltRestanseGrunnlag med { avkorteYtelse, fordeltRestanse ->
+    avkorteYtelse.minus(Beregningstall(fordeltRestanse))
         .toInteger()
         .let { max(it, 0) }
 }

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/Restanse.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/Restanse.kt
@@ -1,0 +1,107 @@
+package no.nav.etterlatte.avkorting.regler
+
+import no.nav.etterlatte.avkorting.AarsoppgjoerMaaned
+import no.nav.etterlatte.beregning.regler.omstillingstoenad.OMS_GYLDIG_FROM_TEST
+import no.nav.etterlatte.libs.regler.FaktumNode
+import no.nav.etterlatte.libs.regler.PeriodisertGrunnlag
+import no.nav.etterlatte.libs.regler.Regel
+import no.nav.etterlatte.libs.regler.RegelMeta
+import no.nav.etterlatte.libs.regler.RegelReferanse
+import no.nav.etterlatte.libs.regler.benytter
+import no.nav.etterlatte.libs.regler.finnFaktumIGrunnlag
+import no.nav.etterlatte.libs.regler.med
+import no.nav.etterlatte.libs.regler.og
+import no.nav.etterlatte.regler.Beregningstall
+import java.time.LocalDate
+import java.time.YearMonth
+
+data class PeriodisertRestanseGrunnlag(
+    val tidligereYtelseEtterAvkorting: PeriodisertGrunnlag<FaktumNode<Int>>,
+    val nyForventetYtelseEtterAvkorting: PeriodisertGrunnlag<FaktumNode<Int>>
+) : PeriodisertGrunnlag<RestanseGrunnlag> {
+    override fun finnAlleKnekkpunkter(): Set<LocalDate> =
+        tidligereYtelseEtterAvkorting.finnAlleKnekkpunkter() + nyForventetYtelseEtterAvkorting.finnAlleKnekkpunkter()
+
+    override fun finnGrunnlagForPeriode(datoIPeriode: LocalDate): RestanseGrunnlag =
+        RestanseGrunnlag(
+            tidligereYtelseEtterAvkorting = tidligereYtelseEtterAvkorting.finnGrunnlagForPeriode(datoIPeriode),
+            nyForventetYtelseEtterAvkorting = nyForventetYtelseEtterAvkorting.finnGrunnlagForPeriode(datoIPeriode)
+        )
+
+}
+
+data class RestanseGrunnlag(
+    val tidligereYtelseEtterAvkorting: FaktumNode<Int>,
+    val nyForventetYtelseEtterAvkorting: FaktumNode<Int>
+)
+
+val tidligereYtelse: Regel<RestanseGrunnlag, Int> = finnFaktumIGrunnlag(
+    gjelderFra = OMS_GYLDIG_FROM_TEST,
+    beskrivelse = "Finner tidligere ytelse etter avkorting",
+    finnFaktum = RestanseGrunnlag::tidligereYtelseEtterAvkorting,
+    finnFelt = { it }
+)
+
+val nyYtelse: Regel<RestanseGrunnlag, Int> = finnFaktumIGrunnlag(
+    gjelderFra = OMS_GYLDIG_FROM_TEST,
+    beskrivelse = "Finner ny forventet ytelse etter avkorting",
+    finnFaktum = RestanseGrunnlag::nyForventetYtelseEtterAvkorting,
+    finnFelt = { it }
+)
+
+val restanse = RegelMeta(
+    gjelderFra = OMS_GYLDIG_FROM_TEST,
+    beskrivelse = "Beregner restanse etter endret ytelse etter avkorting på grunn av endret årsinntekt",
+    regelReferanse = RegelReferanse("RESTANSE-INNTEKTSENDRING") // TODO EY-2368 Confluence
+) benytter tidligereYtelse og nyYtelse med { tidligereYtelse, nyYtelse ->
+    Beregningstall(tidligereYtelse).minus(Beregningstall(nyYtelse)).toInteger()
+}
+
+data class FordelRestanseGrunnlag(
+    val virkningstidspunkt: FaktumNode<YearMonth>,
+    val maanederMedRestanse: FaktumNode<List<AarsoppgjoerMaaned>>
+)
+
+val virkningstidspunkt: Regel<FordelRestanseGrunnlag, YearMonth> = finnFaktumIGrunnlag(
+    gjelderFra = OMS_GYLDIG_FROM_TEST,
+    beskrivelse = "Virkningstidspunkt til restanse skal gjelde fra",
+    finnFaktum = FordelRestanseGrunnlag::virkningstidspunkt,
+    finnFelt = { it }
+)
+
+// TODO EY-2368 kilde - Skal hele AarsoppgjoerMaaned med selv om bare restanse.verdi egentlig brukes? Gir kontekst?
+val maanederMedRestanse: Regel<FordelRestanseGrunnlag, List<AarsoppgjoerMaaned>> = finnFaktumIGrunnlag(
+    gjelderFra = OMS_GYLDIG_FROM_TEST,
+    beskrivelse = "Måneder hvor det har forekommet restanse",
+    finnFaktum = FordelRestanseGrunnlag::maanederMedRestanse,
+    finnFelt = { it }
+)
+
+val gjenvaerendeMaaneder = RegelMeta(
+    gjelderFra = OMS_GYLDIG_FROM_TEST,
+    beskrivelse = "Beregner hvor mange måneder som gjenstår i gjeldende år fra nytt virkningstidspunkt",
+    regelReferanse = RegelReferanse("GJENVAERENDE-MAANEDER-FOR-FORDELT-RESTANSE")// TODO EY-2368 Confluence
+) benytter virkningstidspunkt med { virkningstidspunkt ->
+    Beregningstall(12)
+        .minus(Beregningstall(virkningstidspunkt.monthValue))
+        .plus(Beregningstall(1))
+}
+
+val sumRestanse = RegelMeta(
+    gjelderFra = OMS_GYLDIG_FROM_TEST,
+    beskrivelse = "Beregner summen av all restanse fra måneder med restanse",
+    regelReferanse = RegelReferanse("SUMMERT-RESTANSE-INNTEKTSENDRING") // TODO EY-2368 Confluence
+) benytter maanederMedRestanse med { maanederMedRestanse ->
+    Beregningstall(maanederMedRestanse.sumOf {
+        it.restanse
+    })
+}
+
+val fordeltRestanse = RegelMeta(
+    gjelderFra = OMS_GYLDIG_FROM_TEST,
+    beskrivelse = "Fordeler oppsummert restanse over gjenværende måneder av gjeldende år",
+    regelReferanse = RegelReferanse("FORDELT-RESTANSE-INNTEKTSENDRING") // TODO EY-2368 Confluence
+) benytter sumRestanse og gjenvaerendeMaaneder med { sumRestanse, gjenvaerendeMaaneder ->
+    sumRestanse.divide(gjenvaerendeMaaneder).toInteger()
+}
+

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/Restanse.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/Restanse.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.avkorting.regler
 
-import no.nav.etterlatte.avkorting.Restanse
 import no.nav.etterlatte.beregning.regler.omstillingstoenad.OMS_GYLDIG_FROM_TEST
 import no.nav.etterlatte.libs.regler.FaktumNode
 import no.nav.etterlatte.libs.regler.Regel
@@ -42,7 +41,7 @@ val virkningstidspunkt: Regel<RestanseGrunnlag, YearMonth> = finnFaktumIGrunnlag
 val totalRestanse = RegelMeta(
     gjelderFra = OMS_GYLDIG_FROM_TEST,
     beskrivelse = "Beregner restanse etter endret ytelse etter avkorting på grunn av endret årsinntekt",
-    regelReferanse = RegelReferanse("RESTANSE-INNTEKTSENDRING")
+    regelReferanse = RegelReferanse("TOTAL-RESTANSE-INNTEKTSENDRING")
 ) benytter tidligereYtelse og nyYtelse med { tidligereYtelse, nyYtelse ->
     Beregningstall(tidligereYtelse.sum()).minus(Beregningstall(nyYtelse.sum())).toInteger()
 }

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/Restanse.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/Restanse.kt
@@ -70,8 +70,5 @@ val restanse = RegelMeta(
     beskrivelse = "Beregner restanse etter endret ytelse etter avkorting på grunn av endret årsinntekt",
     regelReferanse = RegelReferanse("RESTANSE-INNTEKTSENDRING")
 ) benytter totalRestanse og fordeltRestanse med { totalRestanse, fordeltRestanse ->
-    Restanse(
-        totalRestanse = totalRestanse,
-        fordeltRestanse = fordeltRestanse
-    )
+    totalRestanse to fordeltRestanse
 }

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/Restanse.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/Restanse.kt
@@ -1,9 +1,8 @@
 package no.nav.etterlatte.avkorting.regler
 
-import no.nav.etterlatte.avkorting.AarsoppgjoerMaaned
+import no.nav.etterlatte.avkorting.Restanse
 import no.nav.etterlatte.beregning.regler.omstillingstoenad.OMS_GYLDIG_FROM_TEST
 import no.nav.etterlatte.libs.regler.FaktumNode
-import no.nav.etterlatte.libs.regler.PeriodisertGrunnlag
 import no.nav.etterlatte.libs.regler.Regel
 import no.nav.etterlatte.libs.regler.RegelMeta
 import no.nav.etterlatte.libs.regler.RegelReferanse
@@ -12,70 +11,41 @@ import no.nav.etterlatte.libs.regler.finnFaktumIGrunnlag
 import no.nav.etterlatte.libs.regler.med
 import no.nav.etterlatte.libs.regler.og
 import no.nav.etterlatte.regler.Beregningstall
-import java.time.LocalDate
 import java.time.YearMonth
 
-data class PeriodisertRestanseGrunnlag(
-    val tidligereYtelseEtterAvkorting: PeriodisertGrunnlag<FaktumNode<Int>>,
-    val nyForventetYtelseEtterAvkorting: PeriodisertGrunnlag<FaktumNode<Int>>
-) : PeriodisertGrunnlag<RestanseGrunnlag> {
-    override fun finnAlleKnekkpunkter(): Set<LocalDate> =
-        tidligereYtelseEtterAvkorting.finnAlleKnekkpunkter() + nyForventetYtelseEtterAvkorting.finnAlleKnekkpunkter()
-
-    override fun finnGrunnlagForPeriode(datoIPeriode: LocalDate): RestanseGrunnlag =
-        RestanseGrunnlag(
-            tidligereYtelseEtterAvkorting = tidligereYtelseEtterAvkorting.finnGrunnlagForPeriode(datoIPeriode),
-            nyForventetYtelseEtterAvkorting = nyForventetYtelseEtterAvkorting.finnGrunnlagForPeriode(datoIPeriode)
-        )
-
-}
-
 data class RestanseGrunnlag(
-    val tidligereYtelseEtterAvkorting: FaktumNode<Int>,
-    val nyForventetYtelseEtterAvkorting: FaktumNode<Int>
+    val tidligereYtelseEtterAvkorting: FaktumNode<List<Int>>,
+    val nyForventetYtelseEtterAvkorting: FaktumNode<List<Int>>,
+    val virkningstidspunkt: FaktumNode<YearMonth>,
 )
 
-val tidligereYtelse: Regel<RestanseGrunnlag, Int> = finnFaktumIGrunnlag(
+val tidligereYtelse: Regel<RestanseGrunnlag, List<Int>> = finnFaktumIGrunnlag(
     gjelderFra = OMS_GYLDIG_FROM_TEST,
     beskrivelse = "Finner tidligere ytelse etter avkorting",
     finnFaktum = RestanseGrunnlag::tidligereYtelseEtterAvkorting,
     finnFelt = { it }
 )
 
-val nyYtelse: Regel<RestanseGrunnlag, Int> = finnFaktumIGrunnlag(
+val nyYtelse: Regel<RestanseGrunnlag, List<Int>> = finnFaktumIGrunnlag(
     gjelderFra = OMS_GYLDIG_FROM_TEST,
     beskrivelse = "Finner ny forventet ytelse etter avkorting",
     finnFaktum = RestanseGrunnlag::nyForventetYtelseEtterAvkorting,
     finnFelt = { it }
 )
+val virkningstidspunkt: Regel<RestanseGrunnlag, YearMonth> = finnFaktumIGrunnlag(
+    gjelderFra = OMS_GYLDIG_FROM_TEST,
+    beskrivelse = "Virkningstidspunkt til restanse skal gjelde fra",
+    finnFaktum = RestanseGrunnlag::virkningstidspunkt,
+    finnFelt = { it }
+)
 
-val restanse = RegelMeta(
+val totalRestanse = RegelMeta(
     gjelderFra = OMS_GYLDIG_FROM_TEST,
     beskrivelse = "Beregner restanse etter endret ytelse etter avkorting på grunn av endret årsinntekt",
     regelReferanse = RegelReferanse("RESTANSE-INNTEKTSENDRING") // TODO EY-2368 Confluence
 ) benytter tidligereYtelse og nyYtelse med { tidligereYtelse, nyYtelse ->
-    Beregningstall(tidligereYtelse).minus(Beregningstall(nyYtelse)).toInteger()
+    Beregningstall(tidligereYtelse.sum()).minus(Beregningstall(nyYtelse.sum())).toInteger()
 }
-
-data class FordelRestanseGrunnlag(
-    val virkningstidspunkt: FaktumNode<YearMonth>,
-    val maanederMedRestanse: FaktumNode<List<AarsoppgjoerMaaned>>
-)
-
-val virkningstidspunkt: Regel<FordelRestanseGrunnlag, YearMonth> = finnFaktumIGrunnlag(
-    gjelderFra = OMS_GYLDIG_FROM_TEST,
-    beskrivelse = "Virkningstidspunkt til restanse skal gjelde fra",
-    finnFaktum = FordelRestanseGrunnlag::virkningstidspunkt,
-    finnFelt = { it }
-)
-
-// TODO EY-2368 kilde - Skal hele AarsoppgjoerMaaned med selv om bare restanse.verdi egentlig brukes? Gir kontekst?
-val maanederMedRestanse: Regel<FordelRestanseGrunnlag, List<AarsoppgjoerMaaned>> = finnFaktumIGrunnlag(
-    gjelderFra = OMS_GYLDIG_FROM_TEST,
-    beskrivelse = "Måneder hvor det har forekommet restanse",
-    finnFaktum = FordelRestanseGrunnlag::maanederMedRestanse,
-    finnFelt = { it }
-)
 
 val gjenvaerendeMaaneder = RegelMeta(
     gjelderFra = OMS_GYLDIG_FROM_TEST,
@@ -87,21 +57,21 @@ val gjenvaerendeMaaneder = RegelMeta(
         .plus(Beregningstall(1))
 }
 
-val sumRestanse = RegelMeta(
-    gjelderFra = OMS_GYLDIG_FROM_TEST,
-    beskrivelse = "Beregner summen av all restanse fra måneder med restanse",
-    regelReferanse = RegelReferanse("SUMMERT-RESTANSE-INNTEKTSENDRING") // TODO EY-2368 Confluence
-) benytter maanederMedRestanse med { maanederMedRestanse ->
-    Beregningstall(maanederMedRestanse.sumOf {
-        it.restanse
-    })
-}
-
 val fordeltRestanse = RegelMeta(
     gjelderFra = OMS_GYLDIG_FROM_TEST,
     beskrivelse = "Fordeler oppsummert restanse over gjenværende måneder av gjeldende år",
     regelReferanse = RegelReferanse("FORDELT-RESTANSE-INNTEKTSENDRING") // TODO EY-2368 Confluence
-) benytter sumRestanse og gjenvaerendeMaaneder med { sumRestanse, gjenvaerendeMaaneder ->
-    sumRestanse.divide(gjenvaerendeMaaneder).toInteger()
+) benytter totalRestanse og gjenvaerendeMaaneder med { sumRestanse, gjenvaerendeMaaneder ->
+    Beregningstall(sumRestanse).divide(gjenvaerendeMaaneder).toInteger()
 }
 
+val restanse = RegelMeta(
+    gjelderFra = OMS_GYLDIG_FROM_TEST,
+    beskrivelse = "Beregner restanse etter endret ytelse etter avkorting på grunn av endret årsinntekt",
+    regelReferanse = RegelReferanse("RESTANSE-INNTEKTSENDRING") // TODO EY-2368 Confluence
+) benytter totalRestanse og fordeltRestanse med { totalRestanse, fordeltRestanse ->
+    Restanse(
+        totalRestanse = totalRestanse,
+        fordeltRestanse = fordeltRestanse
+    )
+}

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/Restanse.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/Restanse.kt
@@ -42,7 +42,7 @@ val virkningstidspunkt: Regel<RestanseGrunnlag, YearMonth> = finnFaktumIGrunnlag
 val totalRestanse = RegelMeta(
     gjelderFra = OMS_GYLDIG_FROM_TEST,
     beskrivelse = "Beregner restanse etter endret ytelse etter avkorting på grunn av endret årsinntekt",
-    regelReferanse = RegelReferanse("RESTANSE-INNTEKTSENDRING") // TODO EY-2368 Confluence
+    regelReferanse = RegelReferanse("RESTANSE-INNTEKTSENDRING")
 ) benytter tidligereYtelse og nyYtelse med { tidligereYtelse, nyYtelse ->
     Beregningstall(tidligereYtelse.sum()).minus(Beregningstall(nyYtelse.sum())).toInteger()
 }
@@ -50,7 +50,7 @@ val totalRestanse = RegelMeta(
 val gjenvaerendeMaaneder = RegelMeta(
     gjelderFra = OMS_GYLDIG_FROM_TEST,
     beskrivelse = "Beregner hvor mange måneder som gjenstår i gjeldende år fra nytt virkningstidspunkt",
-    regelReferanse = RegelReferanse("GJENVAERENDE-MAANEDER-FOR-FORDELT-RESTANSE")// TODO EY-2368 Confluence
+    regelReferanse = RegelReferanse("GJENVAERENDE-MAANEDER-FOR-FORDELT-RESTANSE")
 ) benytter virkningstidspunkt med { virkningstidspunkt ->
     Beregningstall(12)
         .minus(Beregningstall(virkningstidspunkt.monthValue))
@@ -60,7 +60,7 @@ val gjenvaerendeMaaneder = RegelMeta(
 val fordeltRestanse = RegelMeta(
     gjelderFra = OMS_GYLDIG_FROM_TEST,
     beskrivelse = "Fordeler oppsummert restanse over gjenværende måneder av gjeldende år",
-    regelReferanse = RegelReferanse("FORDELT-RESTANSE-INNTEKTSENDRING") // TODO EY-2368 Confluence
+    regelReferanse = RegelReferanse("FORDELT-RESTANSE-INNTEKTSENDRING")
 ) benytter totalRestanse og gjenvaerendeMaaneder med { sumRestanse, gjenvaerendeMaaneder ->
     Beregningstall(sumRestanse).divide(gjenvaerendeMaaneder).toInteger()
 }
@@ -68,7 +68,7 @@ val fordeltRestanse = RegelMeta(
 val restanse = RegelMeta(
     gjelderFra = OMS_GYLDIG_FROM_TEST,
     beskrivelse = "Beregner restanse etter endret ytelse etter avkorting på grunn av endret årsinntekt",
-    regelReferanse = RegelReferanse("RESTANSE-INNTEKTSENDRING") // TODO EY-2368 Confluence
+    regelReferanse = RegelReferanse("RESTANSE-INNTEKTSENDRING")
 ) benytter totalRestanse og fordeltRestanse med { totalRestanse, fordeltRestanse ->
     Restanse(
         totalRestanse = totalRestanse,

--- a/apps/etterlatte-beregning/src/main/resources/db/migration/V22__endre_restanse_avkortet_ytelse.sql
+++ b/apps/etterlatte-beregning/src/main/resources/db/migration/V22__endre_restanse_avkortet_ytelse.sql
@@ -1,0 +1,34 @@
+ALTER TABLE avkortet_ytelse
+    ADD COLUMN ytelse_etter_avkorting_uten_restanse BIGINT;
+update avkortet_ytelse
+set ytelse_etter_avkorting_uten_restanse = 0
+where ytelse_etter_avkorting_uten_restanse is null;
+
+ALTER TABLE avkortet_ytelse
+    ADD COLUMN type TEXT;
+update avkortet_ytelse
+set type = 'NY'
+where type is null;
+
+CREATE TABLE avkorting_aarsoppgjoer_ytelse_foer_avkorting
+(
+    id                  UUID   NOT NULL,
+    behandling_id       UUID   NOT NULL,
+    beregning           BIGINT NOT NULL,
+    fom                 Date   NOT NULL,
+    tom                 Date,
+    beregningsreferanse UUID
+);
+
+CREATE TABLE avkorting_aarsoppgjoer_restanse
+(
+    id               UUID   NOT NULL,
+    behandling_id    UUID   NOT NULL,
+    total_restanse   BIGINT NOT NULL,
+    fordelt_restanse BIGINT NOT NULL,
+    tidspunkt        TIMESTAMP,
+    regel_resultat   TEXT,
+    kilde            TEXT
+);
+
+drop table avkorting_aarsoppgjoer;

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -1,10 +1,12 @@
 package no.nav.etterlatte.beregning.regler
 
-import no.nav.etterlatte.avkorting.AarsoppgjoerMaaned
+import no.nav.etterlatte.avkorting.Aarsoppgjoer
 import no.nav.etterlatte.avkorting.AvkortetYtelse
 import no.nav.etterlatte.avkorting.Avkorting
 import no.nav.etterlatte.avkorting.AvkortingGrunnlag
 import no.nav.etterlatte.avkorting.Avkortingsperiode
+import no.nav.etterlatte.avkorting.Restanse
+import no.nav.etterlatte.avkorting.YtelseFoerAvkorting
 import no.nav.etterlatte.avkorting.regler.AvkortetYtelseGrunnlag
 import no.nav.etterlatte.avkorting.regler.InntektAvkortingGrunnlag
 import no.nav.etterlatte.avkorting.regler.InntektAvkortingGrunnlagWrapper
@@ -70,13 +72,12 @@ val bruker = Saksbehandler("token", "ident", null)
 
 fun avkorting(
     avkortingGrunnlag: List<AvkortingGrunnlag> = emptyList(),
+    ytelseFoerAvkorting: List<YtelseFoerAvkorting> = emptyList(),
     avkortingsperioder: List<Avkortingsperiode> = emptyList(),
     avkortetYtelse: List<AvkortetYtelse> = emptyList(),
-    aarsoppgjoer: List<AarsoppgjoerMaaned> = emptyList()
 ) = Avkorting(
     avkortingGrunnlag = avkortingGrunnlag,
-    avkortingsperioder = avkortingsperioder,
-    aarsoppgjoer = aarsoppgjoer,
+    aarsoppgjoer = aarsoppgjoer(ytelseFoerAvkorting, avkortingsperioder),
     avkortetYtelse = avkortetYtelse
 )
 
@@ -111,6 +112,19 @@ fun inntektAvkortingGrunnlag(
         kilde = "",
         beskrivelse = ""
     )
+)
+
+fun aarsoppgjoer(
+    ytelseFoerAvkorting: List<YtelseFoerAvkorting> = emptyList(),
+    avkortingsperioder: List<Avkortingsperiode> = emptyList(),
+    tidligereAvkortetYtelse: List<AvkortetYtelse> = emptyList(),
+    reberegnetAvkortetYtelse: List<AvkortetYtelse> = emptyList(),
+) = Aarsoppgjoer(
+    ytelseFoerAvkorting = ytelseFoerAvkorting,
+    avkortingsperioder = avkortingsperioder,
+    tidligereAvkortetYtelse = tidligereAvkortetYtelse,
+    reberegnetAvkortetYtelse = reberegnetAvkortetYtelse,
+    restanse = Restanse(totalRestanse = 0, fordeltRestanse = 0),
 )
 
 fun avkortingsperiode(
@@ -153,23 +167,6 @@ fun avkortetYtelse(
     kilde = Grunnlagsopplysning.RegelKilde("regelid", Tidspunkt.now(), "1")
 )
 
-fun aarsoppgjoerMaaned(
-    maaned: YearMonth = YearMonth.of(2023, 1),
-    beregning: Int = 0,
-    avkorting: Int = 0,
-    forventetAvkortetYtelse: Int = 0,
-    restanse: Int = 0,
-    fordeltRestanse: Int = 0,
-    faktiskAvkortetYtelse: Int = 0
-) = AarsoppgjoerMaaned(
-    maaned = maaned,
-    beregning = beregning,
-    avkorting = avkorting,
-    forventetAvkortetYtelse = forventetAvkortetYtelse,
-    restanse = restanse,
-    fordeltRestanse = fordeltRestanse,
-    faktiskAvkortetYtelse = faktiskAvkortetYtelse
-)
 
 fun beregning(
     beregninger: List<Beregningsperiode> = listOf(beregningsperiode())

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -125,9 +125,10 @@ fun avkortingsperiode(
     kilde = Grunnlagsopplysning.RegelKilde("regelid", Tidspunkt.now(), "1")
 )
 
-fun avkortetYtelseGrunnlag(beregning: Int, avkorting: Int) = AvkortetYtelseGrunnlag(
+fun avkortetYtelseGrunnlag(beregning: Int, avkorting: Int, fordeltRestanse: Int = 0) = AvkortetYtelseGrunnlag(
     beregning = FaktumNode(verdi = beregning, "", ""),
-    avkorting = FaktumNode(verdi = avkorting, "", "")
+    avkorting = FaktumNode(verdi = avkorting, "", ""),
+    fordeltRestanse = FaktumNode(verdi = fordeltRestanse, "", ""),
 )
 
 fun avkortetYtelse(

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.beregning.regler
 
 import no.nav.etterlatte.avkorting.Aarsoppgjoer
 import no.nav.etterlatte.avkorting.AvkortetYtelse
+import no.nav.etterlatte.avkorting.AvkortetYtelseType
 import no.nav.etterlatte.avkorting.Avkorting
 import no.nav.etterlatte.avkorting.AvkortingGrunnlag
 import no.nav.etterlatte.avkorting.Avkortingsperiode
@@ -119,12 +120,22 @@ fun aarsoppgjoer(
     avkortingsperioder: List<Avkortingsperiode> = emptyList(),
     tidligereAvkortetYtelse: List<AvkortetYtelse> = emptyList(),
     reberegnetAvkortetYtelse: List<AvkortetYtelse> = emptyList(),
+    restanse: Restanse = Restanse(totalRestanse = 0, fordeltRestanse = 0)
 ) = Aarsoppgjoer(
     ytelseFoerAvkorting = ytelseFoerAvkorting,
     avkortingsperioder = avkortingsperioder,
     tidligereAvkortetYtelse = tidligereAvkortetYtelse,
     reberegnetAvkortetYtelse = reberegnetAvkortetYtelse,
-    restanse = Restanse(totalRestanse = 0, fordeltRestanse = 0),
+    restanse = restanse,
+)
+fun ytelseFoerAvkorting(
+    beregning: Int = 100,
+    periode: Periode = Periode(fom = YearMonth.of(2023,1), tom = null),
+    beregningsreferanse: UUID = UUID.randomUUID()
+) = YtelseFoerAvkorting(
+    beregning = beregning,
+    periode = periode,
+    beregningsreferanse = beregningsreferanse
 )
 
 fun avkortingsperiode(
@@ -139,6 +150,17 @@ fun avkortingsperiode(
     kilde = Grunnlagsopplysning.RegelKilde("regelid", Tidspunkt.now(), "1")
 )
 
+fun restanse(
+    totalRestanse: Int = 100,
+    fordeltRestanse: Int = 100
+) = Restanse(
+    totalRestanse = totalRestanse,
+    fordeltRestanse = fordeltRestanse,
+    tidspunkt = Tidspunkt.now(),
+    regelResultat = "".toJsonNode(),
+    kilde = Grunnlagsopplysning.RegelKilde("regelid", Tidspunkt.now(), "1")
+)
+
 fun avkortetYtelseGrunnlag(beregning: Int, avkorting: Int, fordeltRestanse: Int = 0) = AvkortetYtelseGrunnlag(
     beregning = FaktumNode(verdi = beregning, "", ""),
     avkorting = FaktumNode(verdi = avkorting, "", ""),
@@ -146,9 +168,10 @@ fun avkortetYtelseGrunnlag(beregning: Int, avkorting: Int, fordeltRestanse: Int 
 )
 
 fun avkortetYtelse(
-    ytelseEtterAvkorting: Int = 100,
+    type: AvkortetYtelseType = AvkortetYtelseType.NY,
+    ytelseEtterAvkorting: Int = 50,
     restanse: Int = 50,
-    ytelseEtterAvkortingFoerRestanse: Int = 0,
+    ytelseEtterAvkortingFoerRestanse: Int = 100,
     avkortingsbeloep: Int = 200,
     ytelseFoerAvkorting: Int = 300,
     periode: Periode = Periode(
@@ -156,6 +179,7 @@ fun avkortetYtelse(
         tom = null
     )
 ) = AvkortetYtelse(
+    type = type,
     periode = periode,
     ytelseEtterAvkorting = ytelseEtterAvkorting,
     restanse = restanse,

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -126,7 +126,7 @@ fun aarsoppgjoer(
     ytelseFoerAvkorting = ytelseFoerAvkorting,
     avkortingsperioder = avkortingsperioder,
     tidligereAvkortetYtelse = tidligereAvkortetYtelse,
-    reberegnetAvkortetYtelse = reberegnetAvkortetYtelse,
+    tidligereAvkortetYtelseReberegnet = reberegnetAvkortetYtelse,
     restanse = restanse,
 )
 

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -20,6 +20,7 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
 import no.nav.etterlatte.libs.common.beregning.Beregningstype
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -128,9 +129,10 @@ fun aarsoppgjoer(
     reberegnetAvkortetYtelse = reberegnetAvkortetYtelse,
     restanse = restanse,
 )
+
 fun ytelseFoerAvkorting(
     beregning: Int = 100,
-    periode: Periode = Periode(fom = YearMonth.of(2023,1), tom = null),
+    periode: Periode = Periode(fom = YearMonth.of(2023, 1), tom = null),
     beregningsreferanse: UUID = UUID.randomUUID()
 ) = YtelseFoerAvkorting(
     beregning = beregning,
@@ -225,7 +227,7 @@ fun behandling(
     sak: Long = 123,
     sakType: SakType = SakType.OMSTILLINGSSTOENAD,
     behandlingType: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-    virkningstidspunkt: YearMonth = YearMonth.of(2023, 1)
+    virkningstidspunkt: Virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1))
 ) = DetaljertBehandling(
     id = id,
     sak = sak,
@@ -241,7 +243,7 @@ fun behandling(
     gyldighetsproeving = null,
     status = BehandlingStatus.VILKAARSVURDERT,
     behandlingType = behandlingType,
-    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(virkningstidspunkt),
+    virkningstidspunkt = virkningstidspunkt,
     kommerBarnetTilgode = null,
     revurderingsaarsak = null,
     prosesstype = Prosesstype.MANUELL,

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -121,7 +121,7 @@ fun aarsoppgjoer(
     avkortingsperioder: List<Avkortingsperiode> = emptyList(),
     tidligereAvkortetYtelse: List<AvkortetYtelse> = emptyList(),
     reberegnetAvkortetYtelse: List<AvkortetYtelse> = emptyList(),
-    restanse: Restanse = Restanse(totalRestanse = 0, fordeltRestanse = 0)
+    restanse: Restanse? = null
 ) = Aarsoppgjoer(
     ytelseFoerAvkorting = ytelseFoerAvkorting,
     avkortingsperioder = avkortingsperioder,
@@ -145,6 +145,7 @@ fun avkortingsperiode(
     tom: YearMonth? = null,
     avkorting: Int = 10000
 ) = Avkortingsperiode(
+    id = UUID.randomUUID(),
     Periode(fom = fom, tom = tom),
     avkorting = avkorting,
     tidspunkt = Tidspunkt.now(),
@@ -156,6 +157,7 @@ fun restanse(
     totalRestanse: Int = 100,
     fordeltRestanse: Int = 100
 ) = Restanse(
+    id = UUID.randomUUID(),
     totalRestanse = totalRestanse,
     fordeltRestanse = fordeltRestanse,
     tidspunkt = Tidspunkt.now(),
@@ -181,6 +183,7 @@ fun avkortetYtelse(
         tom = null
     )
 ) = AvkortetYtelse(
+    id = UUID.randomUUID(),
     type = type,
     periode = periode,
     ytelseEtterAvkorting = ytelseEtterAvkorting,

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRegelkjoringTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRegelkjoringTest.kt
@@ -8,6 +8,7 @@ import no.nav.etterlatte.beregning.grunnlag.PeriodiseringAvGrunnlagFeil
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
 import no.nav.etterlatte.beregning.regler.avkortingsperiode
 import no.nav.etterlatte.libs.common.periode.Periode
+import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.YearMonth
@@ -17,7 +18,7 @@ class AvkortingRegelkjoringTest {
 
     @Test
     fun `skal beregne avkorting for inntekt til en foerstegangsbehandling`() {
-        val virkningstidspunkt = YearMonth.of(2023, 6)
+        val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 6))
         val avkortingGrunnlag = listOf(
             avkortinggrunnlag(
                 aarsinntekt = 300000,
@@ -34,7 +35,7 @@ class AvkortingRegelkjoringTest {
         )
 
         val avkortingsperioder = AvkortingRegelkjoring.beregnInntektsavkorting(
-            Periode(fom = virkningstidspunkt, tom = null),
+            Periode(fom = virkningstidspunkt.dato, tom = null),
             avkortingGrunnlag
         )
 
@@ -56,7 +57,7 @@ class AvkortingRegelkjoringTest {
 
     @Test
     fun `skal ikke tillate aa beregne avkorting for inntekt med feil perioder`() {
-        val virkningstidspunkt = YearMonth.of(2023, 1)
+        val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1))
         val avkortingGrunnlag = listOf(
             avkortinggrunnlag(
                 aarsinntekt = 300000,
@@ -70,7 +71,7 @@ class AvkortingRegelkjoringTest {
 
         assertThrows<PeriodiseringAvGrunnlagFeil> {
             AvkortingRegelkjoring.beregnInntektsavkorting(
-                Periode(fom = virkningstidspunkt, tom = null),
+                Periode(fom = virkningstidspunkt.dato, tom = null),
                 avkortingGrunnlag
             )
         }
@@ -78,7 +79,7 @@ class AvkortingRegelkjoringTest {
 
     @Test
     fun `skal beregne endelig avkortet ytelse`() {
-        val virkningstidspunkt = YearMonth.of(2023, 1)
+        val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1))
         val beregningsId = UUID.randomUUID()
         val beregninger = listOf(
             YtelseFoerAvkorting(
@@ -153,9 +154,5 @@ class AvkortingRegelkjoringTest {
             ytelseFoerAvkorting shouldBe 10000
         }
     }
-
-    // TODO EY-2368 unittest restanse
-
-    // TODO EY-2368 unittest fordelt restanse
 
 }

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRegelkjoringTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRegelkjoringTest.kt
@@ -109,8 +109,7 @@ class AvkortingRegelkjoringTest {
         val avkortetYtelse = AvkortingRegelkjoring.beregnAvkortetYtelse(
             Periode(fom = virkningstidspunkt, tom = null),
             beregninger,
-            avkortingsperioder,
-            maanedligRestanse = 0
+            avkortingsperioder
         )
 
         avkortetYtelse.size shouldBe 4
@@ -145,4 +144,9 @@ class AvkortingRegelkjoringTest {
             ytelseFoerAvkorting shouldBe 10000
         }
     }
+
+    // TODO EY-2368 unittest restanse
+
+    // TODO EY-2368 unittest fordelt restanse
+
 }

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRegelkjoringTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRegelkjoringTest.kt
@@ -3,14 +3,15 @@ package avkorting
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import no.nav.etterlatte.avkorting.AvkortingRegelkjoring
+import no.nav.etterlatte.avkorting.YtelseFoerAvkorting
 import no.nav.etterlatte.beregning.grunnlag.PeriodiseringAvGrunnlagFeil
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
 import no.nav.etterlatte.beregning.regler.avkortingsperiode
-import no.nav.etterlatte.beregning.regler.beregningsperiode
 import no.nav.etterlatte.libs.common.periode.Periode
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.YearMonth
+import java.util.UUID
 
 class AvkortingRegelkjoringTest {
 
@@ -78,15 +79,23 @@ class AvkortingRegelkjoringTest {
     @Test
     fun `skal beregne endelig avkortet ytelse`() {
         val virkningstidspunkt = YearMonth.of(2023, 1)
+        val beregningsId = UUID.randomUUID()
         val beregninger = listOf(
-            beregningsperiode(
-                utbetaltBeloep = 5000,
-                datoFOM = YearMonth.of(2023, 1),
-                datoTOM = YearMonth.of(2023, 3)
+            YtelseFoerAvkorting(
+                beregning = 5000,
+                Periode(
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 3)
+                ),
+                beregningsreferanse = beregningsId
             ),
-            beregningsperiode(
-                utbetaltBeloep = 10000,
-                datoFOM = YearMonth.of(2023, 4)
+            YtelseFoerAvkorting(
+                beregning = 10000,
+                Periode(
+                    fom = YearMonth.of(2023, 4),
+                    tom = null
+                ),
+                beregningsreferanse = beregningsId
             )
         )
         val avkortingsperioder = listOf(
@@ -107,7 +116,7 @@ class AvkortingRegelkjoringTest {
         )
 
         val avkortetYtelse = AvkortingRegelkjoring.beregnAvkortetYtelse(
-            Periode(fom = virkningstidspunkt, tom = null),
+            virkningstidspunkt,
             beregninger,
             avkortingsperioder
         )

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
@@ -1,14 +1,17 @@
 package avkorting
 
+import io.kotest.assertions.asClue
 import io.kotest.matchers.shouldBe
 import no.nav.etterlatte.avkorting.Aarsoppgjoer
+import no.nav.etterlatte.avkorting.AvkortetYtelseType
 import no.nav.etterlatte.avkorting.Avkorting
 import no.nav.etterlatte.avkorting.AvkortingRepository
-import no.nav.etterlatte.avkorting.Restanse
 import no.nav.etterlatte.beregning.regler.aarsoppgjoer
 import no.nav.etterlatte.beregning.regler.avkortetYtelse
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
 import no.nav.etterlatte.beregning.regler.avkortingsperiode
+import no.nav.etterlatte.beregning.regler.restanse
+import no.nav.etterlatte.beregning.regler.ytelseFoerAvkorting
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.database.migrate
 import org.junit.jupiter.api.AfterAll
@@ -53,39 +56,75 @@ internal class AvkortingRepositoryTest {
     fun `Skal lagre og oppdatere avkorting`() {
         val behandlingId: UUID = UUID.randomUUID()
         val avkortinggrunnlag = listOf(avkortinggrunnlag())
-        val avkortingsperioder = listOf(avkortingsperiode())
+        val aarsoppgjoer = Aarsoppgjoer(
+            ytelseFoerAvkorting = listOf(ytelseFoerAvkorting()),
+            avkortingsperioder = listOf(avkortingsperiode()),
+            tidligereAvkortetYtelse = listOf(avkortetYtelse(type = AvkortetYtelseType.TIDLIGERE)),
+            reberegnetAvkortetYtelse = listOf(avkortetYtelse(type = AvkortetYtelseType.REBEREGNET)),
+            restanse = restanse()
+        )
         val avkortetYtelse = listOf(avkortetYtelse())
 
         avkortingRepository.lagreAvkorting(
             behandlingId,
             Avkorting(
                 avkortingGrunnlag = avkortinggrunnlag,
-                aarsoppgjoer = aarsoppgjoer(avkortingsperioder = avkortingsperioder,),
+                aarsoppgjoer = aarsoppgjoer,
                 avkortetYtelse = avkortetYtelse,
             )
         )
 
         val endretAvkortingGrunnlag = listOf(avkortinggrunnlag[0].copy(spesifikasjon = "Endret"))
-        val endretAvkortingsperiode = listOf(avkortingsperioder[0].copy(avkorting = 333))
-        val endretAvkortetYtelse = listOf(
-            avkortetYtelse[0].copy(
-                avkortingsbeloep = 444,
-                restanse = 100
-            )
-        )
+        val endretYtelseFoerAvkorting = listOf(aarsoppgjoer.ytelseFoerAvkorting[0].copy(beregning = 333))
+        val endretAvkortingsperiode = listOf(aarsoppgjoer.avkortingsperioder[0].copy(avkorting = 333))
+        val endretTidligereAvkortetYtelse = listOf(aarsoppgjoer.tidligereAvkortetYtelse[0].copy(avkortingsbeloep = 444))
+        val endretReberegnetYtelse = listOf(aarsoppgjoer.reberegnetAvkortetYtelse[0].copy(avkortingsbeloep = 444))
+        val endretRestanse = aarsoppgjoer.restanse.copy(totalRestanse = 333)
+        val endretAvkortetYtelse = listOf(avkortetYtelse[0].copy(avkortingsbeloep = 444, restanse = 100))
 
         val avkorting = avkortingRepository.lagreAvkorting(
             behandlingId,
             Avkorting(
                 avkortingGrunnlag = endretAvkortingGrunnlag,
-                aarsoppgjoer = aarsoppgjoer(avkortingsperioder = endretAvkortingsperiode),
+                aarsoppgjoer = aarsoppgjoer(
+                    ytelseFoerAvkorting = endretYtelseFoerAvkorting,
+                    avkortingsperioder = endretAvkortingsperiode,
+                    tidligereAvkortetYtelse = endretTidligereAvkortetYtelse,
+                    reberegnetAvkortetYtelse = endretReberegnetYtelse,
+                    restanse = endretRestanse
+                ),
                 avkortetYtelse = endretAvkortetYtelse
             )
         )
 
-        avkorting.avkortingGrunnlag.size shouldBe 1
-        avkorting.avkortingGrunnlag shouldBe endretAvkortingGrunnlag
-        avkorting.aarsoppgjoer.avkortingsperioder shouldBe endretAvkortingsperiode
-        avkorting.avkortetYtelse shouldBe endretAvkortetYtelse
+        avkorting.avkortingGrunnlag.asClue {
+            it.size shouldBe 1
+            it shouldBe endretAvkortingGrunnlag
+        }
+        with(avkorting.aarsoppgjoer) {
+            avkortingsperioder.asClue {
+                it.size shouldBe 1
+                it shouldBe endretAvkortingsperiode
+            }
+            ytelseFoerAvkorting.asClue {
+                it.size shouldBe 1
+                it shouldBe endretYtelseFoerAvkorting
+            }
+            tidligereAvkortetYtelse.asClue {
+                it.size shouldBe 1
+                it shouldBe endretTidligereAvkortetYtelse
+            }
+            reberegnetAvkortetYtelse.asClue {
+                it.size shouldBe 1
+                it shouldBe endretReberegnetYtelse
+            }
+            restanse.asClue {
+                it shouldBe endretRestanse
+            }
+        }
+        avkorting.avkortetYtelse.asClue {
+            it.size shouldBe 1
+            it shouldBe endretAvkortetYtelse
+        }
     }
 }

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
@@ -60,7 +60,7 @@ internal class AvkortingRepositoryTest {
             ytelseFoerAvkorting = listOf(ytelseFoerAvkorting()),
             avkortingsperioder = listOf(avkortingsperiode()),
             tidligereAvkortetYtelse = listOf(avkortetYtelse(type = AvkortetYtelseType.TIDLIGERE)),
-            reberegnetAvkortetYtelse = listOf(avkortetYtelse(type = AvkortetYtelseType.REBEREGNET)),
+            tidligereAvkortetYtelseReberegnet = listOf(avkortetYtelse(type = AvkortetYtelseType.REBEREGNET)),
             restanse = restanse()
         )
         val avkortetYtelse = listOf(avkortetYtelse())
@@ -78,7 +78,8 @@ internal class AvkortingRepositoryTest {
         val endretYtelseFoerAvkorting = listOf(aarsoppgjoer.ytelseFoerAvkorting[0].copy(beregning = 333))
         val endretAvkortingsperiode = listOf(aarsoppgjoer.avkortingsperioder[0].copy(avkorting = 333))
         val endretTidligereAvkortetYtelse = listOf(aarsoppgjoer.tidligereAvkortetYtelse[0].copy(avkortingsbeloep = 444))
-        val endretReberegnetYtelse = listOf(aarsoppgjoer.reberegnetAvkortetYtelse[0].copy(avkortingsbeloep = 444))
+        val endretReberegnetYtelse =
+            listOf(aarsoppgjoer.tidligereAvkortetYtelseReberegnet[0].copy(avkortingsbeloep = 444))
         val endretRestanse = aarsoppgjoer.restanse!!.copy(totalRestanse = 333)
         val endretAvkortetYtelse = listOf(avkortetYtelse[0].copy(avkortingsbeloep = 444, restanse = 100))
 
@@ -114,7 +115,7 @@ internal class AvkortingRepositoryTest {
                 it.size shouldBe 1
                 it shouldBe endretTidligereAvkortetYtelse
             }
-            reberegnetAvkortetYtelse.asClue {
+            tidligereAvkortetYtelseReberegnet.asClue {
                 it.size shouldBe 1
                 it shouldBe endretReberegnetYtelse
             }

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
@@ -1,9 +1,11 @@
 package avkorting
 
 import io.kotest.matchers.shouldBe
+import no.nav.etterlatte.avkorting.Aarsoppgjoer
 import no.nav.etterlatte.avkorting.Avkorting
 import no.nav.etterlatte.avkorting.AvkortingRepository
-import no.nav.etterlatte.beregning.regler.aarsoppgjoerMaaned
+import no.nav.etterlatte.avkorting.Restanse
+import no.nav.etterlatte.beregning.regler.aarsoppgjoer
 import no.nav.etterlatte.beregning.regler.avkortetYtelse
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
 import no.nav.etterlatte.beregning.regler.avkortingsperiode
@@ -53,15 +55,13 @@ internal class AvkortingRepositoryTest {
         val avkortinggrunnlag = listOf(avkortinggrunnlag())
         val avkortingsperioder = listOf(avkortingsperiode())
         val avkortetYtelse = listOf(avkortetYtelse())
-        val restanseOppgjoer = listOf(aarsoppgjoerMaaned())
 
         avkortingRepository.lagreAvkorting(
             behandlingId,
             Avkorting(
-                avkortinggrunnlag,
-                avkortingsperioder,
-                restanseOppgjoer,
-                avkortetYtelse
+                avkortingGrunnlag = avkortinggrunnlag,
+                aarsoppgjoer = aarsoppgjoer(avkortingsperioder = avkortingsperioder,),
+                avkortetYtelse = avkortetYtelse,
             )
         )
 
@@ -73,21 +73,19 @@ internal class AvkortingRepositoryTest {
                 restanse = 100
             )
         )
-        val endretRestanseOppgjoer = listOf(aarsoppgjoerMaaned(restanse = 555))
 
         val avkorting = avkortingRepository.lagreAvkorting(
             behandlingId,
             Avkorting(
-                endretAvkortingGrunnlag,
-                endretAvkortingsperiode,
-                endretRestanseOppgjoer,
-                endretAvkortetYtelse
+                avkortingGrunnlag = endretAvkortingGrunnlag,
+                aarsoppgjoer = aarsoppgjoer(avkortingsperioder = endretAvkortingsperiode),
+                avkortetYtelse = endretAvkortetYtelse
             )
         )
 
         avkorting.avkortingGrunnlag.size shouldBe 1
         avkorting.avkortingGrunnlag shouldBe endretAvkortingGrunnlag
-        avkorting.avkortingsperioder shouldBe endretAvkortingsperiode
+        avkorting.aarsoppgjoer.avkortingsperioder shouldBe endretAvkortingsperiode
         avkorting.avkortetYtelse shouldBe endretAvkortetYtelse
     }
 }

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
@@ -79,7 +79,7 @@ internal class AvkortingRepositoryTest {
         val endretAvkortingsperiode = listOf(aarsoppgjoer.avkortingsperioder[0].copy(avkorting = 333))
         val endretTidligereAvkortetYtelse = listOf(aarsoppgjoer.tidligereAvkortetYtelse[0].copy(avkortingsbeloep = 444))
         val endretReberegnetYtelse = listOf(aarsoppgjoer.reberegnetAvkortetYtelse[0].copy(avkortingsbeloep = 444))
-        val endretRestanse = aarsoppgjoer.restanse.copy(totalRestanse = 333)
+        val endretRestanse = aarsoppgjoer.restanse!!.copy(totalRestanse = 333)
         val endretAvkortetYtelse = listOf(avkortetYtelse[0].copy(avkortingsbeloep = 444, restanse = 100))
 
         val avkorting = avkortingRepository.lagreAvkorting(

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
@@ -117,7 +117,7 @@ class AvkortingRoutesTest {
                     fom = dato.atDay(1),
                     tom = dato.atEndOfMonth(),
                     avkortingsbeloep = 200,
-                    ytelseEtterAvkorting = 100,
+                    ytelseEtterAvkorting = 50,
                     restanse = 50
                 )
             )

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
@@ -14,10 +14,13 @@ import io.ktor.server.testing.ApplicationTestBuilder
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import no.nav.etterlatte.avkorting.Aarsoppgjoer
 import no.nav.etterlatte.avkorting.Avkorting
 import no.nav.etterlatte.avkorting.AvkortingService
+import no.nav.etterlatte.avkorting.Restanse
 import no.nav.etterlatte.avkorting.avkorting
 import no.nav.etterlatte.avkorting.fromDto
+import no.nav.etterlatte.beregning.regler.aarsoppgjoer
 import no.nav.etterlatte.beregning.regler.avkortetYtelse
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
 import no.nav.etterlatte.beregning.regler.avkortingsperiode
@@ -88,8 +91,9 @@ class AvkortingRoutesTest {
         )
         val avkorting = Avkorting(
             avkortingGrunnlag = listOf(avkortingsgrunnlag),
-            avkortingsperioder = listOf(avkortingsperiode()),
-            aarsoppgjoer = emptyList(),
+            aarsoppgjoer = aarsoppgjoer(
+                avkortingsperioder = listOf(avkortingsperiode()),
+            ),
             avkortetYtelse = listOf(avkortetYtelse(periode = Periode(fom = dato, tom = dato)))
         )
         val dto = AvkortingDto(

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -107,7 +107,7 @@ internal class AvkortingServiceTest {
                 forrigeBehandlingId
             )
             every { avkortingRepository.hentAvkorting(forrigeBehandlingId) } returns forrigeAvkorting
-            every { forrigeAvkorting.kopierAvkorting() } returns kopiertAvkorting
+            every { forrigeAvkorting.kopierAvkorting(any()) } returns kopiertAvkorting
             every { beregningService.hentBeregningNonnull(any()) } returns beregning
             every { kopiertAvkorting.beregnAvkorting(any(), any(), any()) } returns beregnetAvkorting
             every { avkortingRepository.lagreAvkorting(any(), any()) } returns lagretAvkorting
@@ -122,7 +122,7 @@ internal class AvkortingServiceTest {
                 behandlingKlient.hentBehandling(behandlingId, bruker)
                 behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, bruker)
                 avkortingRepository.hentAvkorting(forrigeBehandlingId)
-                forrigeAvkorting.kopierAvkorting()
+                forrigeAvkorting.kopierAvkorting(behandling.virkningstidspunkt!!.dato)
                 beregningService.hentBeregningNonnull(behandlingId)
                 kopiertAvkorting.beregnAvkorting(
                     behandling.behandlingType,

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -21,6 +21,7 @@ import no.nav.etterlatte.beregning.regler.behandling
 import no.nav.etterlatte.beregning.regler.bruker
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -92,7 +93,7 @@ internal class AvkortingServiceTest {
             val behandling = behandling(
                 behandlingType = BehandlingType.REVURDERING,
                 sak = 123L,
-                virkningstidspunkt = YearMonth.of(2023, 1)
+                virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1))
             )
             val forrigeBehandlingId = UUID.randomUUID()
             val forrigeAvkorting = mockk<Avkorting>()
@@ -126,7 +127,7 @@ internal class AvkortingServiceTest {
                 beregningService.hentBeregningNonnull(behandlingId)
                 kopiertAvkorting.beregnAvkorting(
                     behandling.behandlingType,
-                    behandling.virkningstidspunkt!!.dato,
+                    behandling.virkningstidspunkt!!,
                     beregning
                 )
                 avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
@@ -141,10 +142,10 @@ internal class AvkortingServiceTest {
         @Test
         fun `Foerstegangsbehandling skal opprette og beregne ny avkorting hvis ikke finnes fra foer`() {
             val behandlingId = UUID.randomUUID()
-            val virkningsdato = YearMonth.of(2023, 1)
+            val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1))
             val behandling = behandling(
                 behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-                virkningstidspunkt = virkningsdato
+                virkningstidspunkt = virkningstidspunkt
             )
             val nyttGrunnlag = mockk<AvkortingGrunnlag>()
             val beregning = mockk<Beregning>()
@@ -175,7 +176,7 @@ internal class AvkortingServiceTest {
                 nyAvkorting.beregnAvkortingMedNyttGrunnlag(
                     nyttGrunnlag,
                     behandling.behandlingType,
-                    virkningsdato,
+                    virkningstidspunkt,
                     beregning
                 )
                 avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
@@ -186,8 +187,9 @@ internal class AvkortingServiceTest {
         @Test
         fun `Revurdering skal for eksisterende avkorting skal reberegne og lagre avkorting`() {
             val behandlingId = UUID.randomUUID()
-            val virkningsdato = YearMonth.of(2023, 1)
-            val behandling = behandling(behandlingType = BehandlingType.REVURDERING, virkningstidspunkt = virkningsdato)
+            val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1))
+            val behandling =
+                behandling(behandlingType = BehandlingType.REVURDERING, virkningstidspunkt = virkningstidspunkt)
             val endretGrunnlag = mockk<AvkortingGrunnlag>()
             val beregning = mockk<Beregning>()
 
@@ -216,7 +218,7 @@ internal class AvkortingServiceTest {
                 eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(
                     endretGrunnlag,
                     behandling.behandlingType,
-                    virkningsdato,
+                    virkningstidspunkt,
                     beregning
                 )
                 avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -7,7 +7,6 @@ import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkObject
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.avkorting.Avkorting
 import no.nav.etterlatte.avkorting.AvkortingGrunnlag
@@ -140,52 +139,7 @@ internal class AvkortingServiceTest {
     inner class lagreAvkorting {
 
         @Test
-        fun `Foerstegangsbehandling skal opprette og beregne ny avkorting hvis ikke finnes fra foer`() {
-            val behandlingId = UUID.randomUUID()
-            val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1))
-            val behandling = behandling(
-                behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-                virkningstidspunkt = virkningstidspunkt
-            )
-            val nyttGrunnlag = mockk<AvkortingGrunnlag>()
-            val beregning = mockk<Beregning>()
-
-            val nyAvkorting = mockk<Avkorting>()
-            val beregnetAvkorting = mockk<Avkorting>()
-            val lagretAvkorting = mockk<Avkorting>()
-
-            every { avkortingRepository.hentAvkorting(any()) } returns null
-            mockkObject(Avkorting.Companion)
-            every { Avkorting.Companion.nyAvkorting() } returns nyAvkorting
-            coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-            every { beregningService.hentBeregningNonnull(any()) } returns beregning
-            every { nyAvkorting.beregnAvkortingMedNyttGrunnlag(any(), any(), any(), any()) } returns beregnetAvkorting
-            every { avkortingRepository.lagreAvkorting(any(), any()) } returns lagretAvkorting
-            coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
-
-            runBlocking {
-                service.lagreAvkorting(behandlingId, bruker, nyttGrunnlag) shouldBe lagretAvkorting
-            }
-
-            coVerify(exactly = 1) {
-                behandlingKlient.avkort(behandlingId, bruker, false)
-                avkortingRepository.hentAvkorting(behandlingId)
-                Avkorting.nyAvkorting()
-                behandlingKlient.hentBehandling(behandlingId, bruker)
-                beregningService.hentBeregningNonnull(behandlingId)
-                nyAvkorting.beregnAvkortingMedNyttGrunnlag(
-                    nyttGrunnlag,
-                    behandling.behandlingType,
-                    virkningstidspunkt,
-                    beregning
-                )
-                avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
-                behandlingKlient.avkort(behandlingId, bruker, true)
-            }
-        }
-
-        @Test
-        fun `Revurdering skal for eksisterende avkorting skal reberegne og lagre avkorting`() {
+        fun `Skal beregne og lagre avkorting`() {
             val behandlingId = UUID.randomUUID()
             val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1))
             val behandling =

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import no.nav.etterlatte.avkorting.Aarsoppgjoer
 import no.nav.etterlatte.avkorting.AvkortetYtelse
 import no.nav.etterlatte.avkorting.AvkortetYtelseType
 import no.nav.etterlatte.avkorting.Avkorting
@@ -39,14 +40,16 @@ internal class AvkortingTest {
                 )
             )
         )
-        private val avkorting = Avkorting.nyAvkorting(
+        private val avkorting = Avkorting(
             avkortingGrunnlag = listOf(avkortinggrunnlag(), avkortinggrunnlag()),
-            ytelseFoerAvkorting = beregning.mapTilYtelseFoerAvkorting(),
-            tidligereAvkortetYtelse = listOf(
-                avkortetYtelse(
-                    type = AvkortetYtelseType.TIDLIGERE,
-                    periode = Periode(YearMonth.of(2023, 1), YearMonth.of(2023, 1))
-                ),
+            aarsoppgjoer = Aarsoppgjoer(
+                ytelseFoerAvkorting = beregning.mapTilYtelseFoerAvkorting(),
+                tidligereAvkortetYtelse = listOf(
+                    avkortetYtelse(
+                        type = AvkortetYtelseType.TIDLIGERE,
+                        periode = Periode(YearMonth.of(2023, 1), YearMonth.of(2023, 1))
+                    ),
+                )
             ),
             avkortetYtelse = listOf(
                 avkortetYtelse(periode = Periode(YearMonth.of(2023, 2), null)),
@@ -163,7 +166,7 @@ internal class AvkortingTest {
                 )
             )
         )
-        val avkorting = Avkorting.nyAvkorting().oppdaterMedInntektsgrunnlag(
+        val avkorting = Avkorting().oppdaterMedInntektsgrunnlag(
             avkortinggrunnlag(
                 periode = Periode(fom = virkningstidspunkt.dato, tom = null),
                 aarsinntekt = 300000,
@@ -378,7 +381,7 @@ internal class AvkortingTest {
                             AvkortetYtelse::kilde
                         )
                     }
-                    reberegnetAvkortetYtelse.asClue {
+                    tidligereAvkortetYtelseReberegnet.asClue {
                         it.size shouldBe 2
                         it[0].shouldBeEqualToIgnoringFields(
                             avkortetYtelse(

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import no.nav.etterlatte.avkorting.AvkortetYtelse
+import no.nav.etterlatte.avkorting.AvkortetYtelseType
 import no.nav.etterlatte.avkorting.Avkorting
 import no.nav.etterlatte.avkorting.AvkortingGrunnlag
 import no.nav.etterlatte.avkorting.YtelseFoerAvkorting
@@ -41,7 +42,10 @@ internal class AvkortingTest {
             avkortingGrunnlag = listOf(avkortinggrunnlag(), avkortinggrunnlag()),
             ytelseFoerAvkorting = beregning.mapTilYtelseFoerAvkorting(),
             tidligereAvkortetYtelse = listOf(
-                avkortetYtelse(periode = Periode(YearMonth.of(2023, 1), YearMonth.of(2023, 1))),
+                avkortetYtelse(
+                    type = AvkortetYtelseType.TIDLIGERE,
+                    periode = Periode(YearMonth.of(2023, 1), YearMonth.of(2023, 1))
+                ),
             ),
             avkortetYtelse = listOf(
                 avkortetYtelse(periode = Periode(YearMonth.of(2023, 2), null)),
@@ -84,9 +88,11 @@ internal class AvkortingTest {
                 tidligereAvkortetYtelse[1].asClue {
                     it.shouldBeEqualToIgnoringFields(
                         avkorting.avkortetYtelse[0],
-                        AvkortetYtelse::periode
+                        AvkortetYtelse::periode,
+                        AvkortetYtelse::type
                     )
                     it.periode shouldBe Periode(YearMonth.of(2023, 2), virkningstidspunkt.minusMonths(1))
+                    it.type shouldBe AvkortetYtelseType.TIDLIGERE
                 }
             }
         }

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -164,14 +164,14 @@ internal class AvkortingTest {
                     it.shouldContainExactly(
                         aarsoppgjoerMaaned(YearMonth.of(2023, 3), 20902, 9160, 11742, 0, 0, 11742),
                         aarsoppgjoerMaaned(YearMonth.of(2023, 4), 20902, 9160, 11742, 0, 0, 11742),
-                        aarsoppgjoerMaaned(YearMonth.of(2023, 5), 22241, 9026, 13215, 0, 0, 13215),
-                        aarsoppgjoerMaaned(YearMonth.of(2023, 6), 22241, 9026, 13215, 0, 0, 13215),
-                        aarsoppgjoerMaaned(YearMonth.of(2023, 7), 22241, 9026, 13215, 0, 0, 13215),
-                        aarsoppgjoerMaaned(YearMonth.of(2023, 8), 22241, 9026, 13215, 0, 0, 13215),
-                        aarsoppgjoerMaaned(YearMonth.of(2023, 9), 22241, 9026, 13215, 0, 0, 13215),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 5), 22241, 9026, 13215, 0,0, 13215),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 6), 22241, 9026, 13215, 0,0, 13215),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 7), 22241, 9026, 13215, 0,0, 13215),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 8), 22241, 9026, 13215, 0,0, 13215),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 9), 22241, 9026, 13215, 0,0, 13215),
                         aarsoppgjoerMaaned(YearMonth.of(2023, 10), 22241, 9026, 13215, 0, 0, 13215),
-                        aarsoppgjoerMaaned(YearMonth.of(2023, 11), 22241, 9026, 13215, 0, 0, 13215),
-                        aarsoppgjoerMaaned(YearMonth.of(2023, 12), 22241, 9026, 13215, 0, 0, 13215)
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 11), 22241, 9026, 13215, 0,0, 13215),
+                        aarsoppgjoerMaaned(YearMonth.of(2023, 12), 22241, 9026, 13215, 0,0, 13215)
                     )
                 }
             }
@@ -282,7 +282,7 @@ internal class AvkortingTest {
                     nyVirk,
                     beregning
                 )
-                beregnetAvkorting.aarsoppgjoer.asClue {
+                beregnetAvkorting.aarsoppgjoer.let {
                     it.shouldContainExactly(
                         aarsoppgjoerMaaned(YearMonth.of(2023, 3), 20902, 13660, 7242, 4500, 0, 11742),
                         aarsoppgjoerMaaned(YearMonth.of(2023, 4), 20902, 13660, 7242, 4500, 0, 11742),
@@ -295,6 +295,34 @@ internal class AvkortingTest {
                         aarsoppgjoerMaaned(YearMonth.of(2023, 11), 22241, 13526, 8715, 0, 1928, 6787),
                         aarsoppgjoerMaaned(YearMonth.of(2023, 12), 22241, 13526, 8715, 0, 1928, 6787)
                     )
+                }
+            }
+
+            @Test
+            fun `Aarsoppgjoer oppdateres med nye beregninger hvis de har endret seg`() {
+                val beregnetAvkorting = avkortingMedNyInntekt.beregnAvkorting(
+                    BehandlingType.REVURDERING,
+                    nyVirk,
+                    beregning.copy(
+                        beregningsperioder = listOf(
+                            beregningsperiode(
+                                datoFOM = YearMonth.of(2023, 6),
+                                utbetaltBeloep = 23000
+                            )
+                        )
+                    )
+                )
+                beregnetAvkorting.aarsoppgjoer.let {
+                    it[0].beregning shouldBe 20902
+                    it[1].beregning shouldBe 20902
+                    it[2].beregning shouldBe 22241
+                    it[3].beregning shouldBe 23000
+                    it[4].beregning shouldBe 23000
+                    it[5].beregning shouldBe 23000
+                    it[6].beregning shouldBe 23000
+                    it[7].beregning shouldBe 23000
+                    it[8].beregning shouldBe 23000
+                    it[9].beregning shouldBe 23000
                 }
             }
 

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -9,7 +9,6 @@ import no.nav.etterlatte.avkorting.AvkortetYtelse
 import no.nav.etterlatte.avkorting.AvkortetYtelseType
 import no.nav.etterlatte.avkorting.Avkorting
 import no.nav.etterlatte.avkorting.AvkortingGrunnlag
-import no.nav.etterlatte.avkorting.Restanse
 import no.nav.etterlatte.avkorting.YtelseFoerAvkorting
 import no.nav.etterlatte.avkorting.mapTilYtelseFoerAvkorting
 import no.nav.etterlatte.beregning.regler.avkortetYtelse
@@ -242,6 +241,7 @@ internal class AvkortingTest {
                             avkortingsbeloep = 9160,
                             ytelseFoerAvkorting = 20902
                         ),
+                        AvkortetYtelse::id,
                         AvkortetYtelse::tidspunkt,
                         AvkortetYtelse::regelResultat,
                         AvkortetYtelse::kilde
@@ -255,6 +255,7 @@ internal class AvkortingTest {
                             avkortingsbeloep = 9026,
                             ytelseFoerAvkorting = 22241
                         ),
+                        AvkortetYtelse::id,
                         AvkortetYtelse::tidspunkt,
                         AvkortetYtelse::regelResultat,
                         AvkortetYtelse::kilde
@@ -356,6 +357,7 @@ internal class AvkortingTest {
                                 avkortingsbeloep = 9160,
                                 ytelseFoerAvkorting = 20902
                             ),
+                            AvkortetYtelse::id,
                             AvkortetYtelse::tidspunkt,
                             AvkortetYtelse::regelResultat,
                             AvkortetYtelse::kilde
@@ -370,6 +372,7 @@ internal class AvkortingTest {
                                 avkortingsbeloep = 9026,
                                 ytelseFoerAvkorting = 22241
                             ),
+                            AvkortetYtelse::id,
                             AvkortetYtelse::tidspunkt,
                             AvkortetYtelse::regelResultat,
                             AvkortetYtelse::kilde
@@ -387,6 +390,7 @@ internal class AvkortingTest {
                                 avkortingsbeloep = 13660,
                                 ytelseFoerAvkorting = 20902
                             ),
+                            AvkortetYtelse::id,
                             AvkortetYtelse::tidspunkt,
                             AvkortetYtelse::regelResultat,
                             AvkortetYtelse::kilde
@@ -401,18 +405,15 @@ internal class AvkortingTest {
                                 avkortingsbeloep = 13526,
                                 ytelseFoerAvkorting = 22241
                             ),
+                            AvkortetYtelse::id,
                             AvkortetYtelse::tidspunkt,
                             AvkortetYtelse::regelResultat,
                             AvkortetYtelse::kilde
                         )
                     }
                     restanse.asClue {
-                        it.shouldBeEqualToIgnoringFields(
-                            Restanse(13500, 1928),
-                            Restanse::tidspunkt,
-                            Restanse::regelResultat,
-                            Restanse::kilde
-                        )
+                        it!!.totalRestanse shouldBe 13500
+                        it.fordeltRestanse shouldBe 1928
                     }
                 }
             }
@@ -435,6 +436,7 @@ internal class AvkortingTest {
                             avkortingsbeloep = 13526,
                             ytelseFoerAvkorting = 22241
                         ),
+                        AvkortetYtelse::id,
                         AvkortetYtelse::tidspunkt,
                         AvkortetYtelse::regelResultat,
                         AvkortetYtelse::kilde

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/regler/AvkortetYtelseTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/regler/AvkortetYtelseTest.kt
@@ -1,7 +1,7 @@
 package no.nav.etterlatte.beregning.regler.avkorting.regler
 
 import io.kotest.matchers.shouldBe
-import no.nav.etterlatte.avkorting.regler.avkorteYtelse
+import no.nav.etterlatte.avkorting.regler.avkortetYtelseMedRestanse
 import no.nav.etterlatte.beregning.regler.avkortetYtelseGrunnlag
 import no.nav.etterlatte.libs.regler.RegelPeriode
 import org.junit.jupiter.api.Test
@@ -10,7 +10,7 @@ import java.time.LocalDate
 class AvkortetYtelseTest {
     @Test
     fun `avkorteYtelse skal trekke avkortingsbeloep fra beregnet ytelse`() {
-        val avkortetYtelse = avkorteYtelse.anvend(
+        val avkortetYtelse = avkortetYtelseMedRestanse.anvend(
             avkortetYtelseGrunnlag(beregning = 100000, avkorting = 50000),
             RegelPeriode(LocalDate.of(2023, 1, 1))
         )
@@ -19,10 +19,11 @@ class AvkortetYtelseTest {
 
     @Test
     fun `avkorteYtelse skal bli 0 dersom avkortingsbeloep er stoerre enn beregnet ytelse`() {
-        val avkortetYtelse = avkorteYtelse.anvend(
+        val avkortetYtelse = avkortetYtelseMedRestanse.anvend(
             avkortetYtelseGrunnlag(beregning = 50000, avkorting = 100000),
             RegelPeriode(LocalDate.of(2023, 1, 1))
         )
         avkortetYtelse.verdi shouldBe 0
     }
+    // TODO EY-2368 flere tester
 }

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/regler/AvkortetYtelseTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/regler/AvkortetYtelseTest.kt
@@ -25,5 +25,5 @@ class AvkortetYtelseTest {
         )
         avkortetYtelse.verdi shouldBe 0
     }
-    // TODO EY-2368 flere tester
+
 }


### PR DESCRIPTION
Regler
- Implementert regler for å beregne restanse
- Oppdatert regel for avkortetYtelse til å legge til restanse

Skrevet om avkortingsdomene
- Fjerner klasse AarsoppgjoerMaaned
- Lager ny klasse Aarsoppgjoer som holder på alt som behøves for å beregne avkorting og restanse innenfor gjeldende år