### PR TITLE
EY-2431 Ikke fange flere exceptions i én + retry

### DIFF
--- a/apps/etterlatte-hendelser-pdl/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-hendelser-pdl/src/main/kotlin/Application.kt
@@ -24,7 +24,7 @@ fun main() {
     Server(context).run()
 }
 
-class Server(val context: ApplicationContext) {
+class Server(private val context: ApplicationContext) {
     private val engine = embeddedServer(
         factory = CIO,
         environment = applicationEngineEnvironment {

--- a/apps/etterlatte-hendelser-pdl/src/main/kotlin/hendelserpdl/config/ApplicationContext.kt
+++ b/apps/etterlatte-hendelser-pdl/src/main/kotlin/hendelserpdl/config/ApplicationContext.kt
@@ -11,8 +11,9 @@ import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 import no.nav.person.pdl.leesah.Personhendelse
 
 class ApplicationContext(
-    val env: Map<String, String> = System.getenv(),
-    val pdlKlient: PdlKlient = PdlKlient(
+    private val env: Map<String, String> = System.getenv(),
+
+    private val pdlKlient: PdlKlient = PdlKlient(
         httpClient = httpClientClientCredentials(
             azureAppClientId = env.requireEnvValue("AZURE_APP_CLIENT_ID"),
             azureAppJwk = env.requireEnvValue("AZURE_APP_JWK"),


### PR DESCRIPTION
Vi får ofte "feil" fra **etterlatte-hendelser-pdl** som følge av timeout e.l. mot PDL. 

Legger derfor til `Retry` og skiller exceptions slik at vi ikke fanger ident-error og hendelsesobjekter vi ikke kan håndtere i én og samme try-catch. 