### PR TITLE
EY-2431 Kun sende behandlingId siden kun det brukes

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
@@ -12,7 +12,6 @@ import no.nav.etterlatte.behandling.BehandlingListe
 import no.nav.etterlatte.behandling.GenerellBehandlingService
 import no.nav.etterlatte.behandling.domain.Grunnlagsendringshendelse
 import no.nav.etterlatte.behandling.domain.toBehandlingSammendrag
-import no.nav.etterlatte.behandling.domain.toDetaljertBehandling
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringsListe
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseService
 import no.nav.etterlatte.inTransaction
@@ -50,10 +49,10 @@ internal fun Route.sakSystemRoutes(
 
             get("/behandlinger/sisteIverksatte") {
                 logger.info("Henter siste iverksatte behandling for $sakId")
-                when (val sisteIverksatteBehandling = generellBehandlingService.hentSisteIverksatte(sakId)) {
-                    null -> call.respond(HttpStatusCode.NotFound)
-                    else -> call.respond(sisteIverksatteBehandling.toDetaljertBehandling())
-                }
+
+                val sisteIverksatteBehandling = generellBehandlingService.hentSisteIverksatte(sakId)
+
+                call.respond(sisteIverksatteBehandling?.id ?: HttpStatusCode.NotFound)
             }
         }
     }

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -28,8 +28,8 @@ class AvkortingService(
     ): Avkorting? {
         val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
         if (behandling.behandlingType == BehandlingType.REVURDERING) {
-            val forrigeBehandling = behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, brukerTokenInfo)
-            return kopierAvkorting(behandlingId, forrigeBehandling.id, brukerTokenInfo)
+            val forrigeBehandlingId = behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, brukerTokenInfo)
+            return kopierAvkorting(behandlingId, forrigeBehandlingId, brukerTokenInfo)
         }
         return null
     }

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
@@ -61,12 +61,12 @@ class BeregningService(
         brukerTokenInfo: BrukerTokenInfo,
         behandlingId: UUID
     ) {
-        val sistIverksatte = behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, brukerTokenInfo)
+        val sistIverksatteBehandlingId = behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, brukerTokenInfo)
         val grunnlagDenneBehandlinga =
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(behandlingId, brukerTokenInfo)
         if (grunnlagDenneBehandlinga == null || grunnlagDenneBehandlinga.behandlingId != behandlingId) {
             logger.info("Kopierer beregningsgrunnlag og oppretter beregning for $behandlingId")
-            beregningsGrunnlagService.dupliserBeregningsGrunnlag(behandlingId, sistIverksatte.id)
+            beregningsGrunnlagService.dupliserBeregningsGrunnlag(behandlingId, sistIverksatteBehandlingId)
             opprettBeregning(behandlingId, brukerTokenInfo)
         }
     }

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
@@ -6,7 +6,7 @@ import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
-import java.util.UUID
+import java.util.*
 
 class BeregningsGrunnlagService(
     private val beregningsGrunnlagRepository: BeregningsGrunnlagRepository,
@@ -53,10 +53,10 @@ class BeregningsGrunnlagService(
 
     private fun grunnlagErIkkeEndretFoerVirk(
         revurdering: DetaljertBehandling,
-        forrigeIverksatte: DetaljertBehandling,
+        forrigeIverksatteBehandlingId: UUID,
         barnepensjonBeregningsGrunnlag: BarnepensjonBeregningsGrunnlag
     ): Boolean {
-        val forrigeGrunnlag = beregningsGrunnlagRepository.finnGrunnlagForBehandling(forrigeIverksatte.id)
+        val forrigeGrunnlag = beregningsGrunnlagRepository.finnGrunnlagForBehandling(forrigeIverksatteBehandlingId)
         val revurderingVirk = revurdering.virkningstidspunkt!!.dato.atDay(1)
 
         val soeskenjusteringErLiktFoerVirk = erGrunnlagLiktFoerEnDato(
@@ -86,11 +86,11 @@ class BeregningsGrunnlagService(
         // Det kan hende behandlingen er en revurdering, og da må vi finne forrige grunnlag for saken
         val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
         return if (behandling.behandlingType == BehandlingType.REVURDERING) {
-            val forrigeIverksatteBehandling = behandlingKlient.hentSisteIverksatteBehandling(
+            val forrigeIverksatteBehandlingId = behandlingKlient.hentSisteIverksatteBehandling(
                 behandling.sak,
                 brukerTokenInfo
             )
-            beregningsGrunnlagRepository.finnGrunnlagForBehandling(forrigeIverksatteBehandling.id)
+            beregningsGrunnlagRepository.finnGrunnlagForBehandling(forrigeIverksatteBehandlingId)
         } else {
             null
         }

--- a/apps/etterlatte-beregning/src/main/kotlin/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/klienter/BehandlingKlient.kt
@@ -79,7 +79,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
                     brukerTokenInfo = brukerTokenInfo
                 )
                 .mapBoth(
-                    success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },
+                    success = { UUID.fromString(it.response.toString()) },
                     failure = { throwableErrorMessage -> throw throwableErrorMessage }
                 )
         }.let {

--- a/apps/etterlatte-beregning/src/main/kotlin/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/klienter/BehandlingKlient.kt
@@ -20,7 +20,7 @@ import java.util.*
 interface BehandlingKlient : BehandlingTilgangsSjekk {
     suspend fun hentBehandling(behandlingId: UUID, brukerTokenInfo: BrukerTokenInfo): DetaljertBehandling
 
-    suspend fun hentSisteIverksatteBehandling(sakId: Long, brukerTokenInfo: BrukerTokenInfo): DetaljertBehandling
+    suspend fun hentSisteIverksatteBehandling(sakId: Long, brukerTokenInfo: BrukerTokenInfo): UUID
     suspend fun beregn(behandlingId: UUID, brukerTokenInfo: BrukerTokenInfo, commit: Boolean): Boolean
     suspend fun avkort(behandlingId: UUID, brukerTokenInfo: BrukerTokenInfo, commit: Boolean): Boolean
 }
@@ -68,8 +68,8 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
     override suspend fun hentSisteIverksatteBehandling(
         sakId: Long,
         brukerTokenInfo: BrukerTokenInfo
-    ): DetaljertBehandling {
-        return retry<DetaljertBehandling> {
+    ): UUID {
+        return retry<UUID> {
             downstreamResourceClient
                 .get(
                     resource = Resource(

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.YearMonth
-import java.util.UUID
+import java.util.*
 
 internal class AvkortingServiceTest {
 
@@ -103,9 +103,7 @@ internal class AvkortingServiceTest {
 
             every { avkortingRepository.hentAvkorting(behandlingId) } returns null
             coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-            coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns behandling(
-                forrigeBehandlingId
-            )
+            coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns forrigeBehandlingId
             every { avkortingRepository.hentAvkorting(forrigeBehandlingId) } returns forrigeAvkorting
             every { forrigeAvkorting.kopierAvkorting() } returns kopiertAvkorting
             every { beregningService.hentBeregningNonnull(any()) } returns beregning
@@ -136,7 +134,7 @@ internal class AvkortingServiceTest {
     }
 
     @Nested
-    inner class lagreAvkorting {
+    inner class LagreAvkorting {
 
         @Test
         fun `Foerstegangsbehandling skal opprette og beregne ny avkorting hvis ikke finnes fra foer`() {

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
@@ -113,14 +113,6 @@ internal class BeregningsGrunnlagRoutesTest {
         val idRevurdering = randomUUID()
         val idForrigeIverksatt = randomUUID()
         val sakId = 123L
-        val virkOriginal = Virkningstidspunkt(
-            dato = YearMonth.of(2022, Month.AUGUST),
-            kilde = Grunnlagsopplysning.Saksbehandler(
-                ident = "",
-                tidspunkt = Tidspunkt.now()
-            ),
-            begrunnelse = ""
-        )
         val virkRevurdering = Virkningstidspunkt(
             dato = YearMonth.of(2023, Month.JANUARY),
             kilde = Grunnlagsopplysning.Saksbehandler(
@@ -155,31 +147,7 @@ internal class BeregningsGrunnlagRoutesTest {
             revurderingInfo = null,
             enhet = "1111"
         )
-        coEvery { behandlingKlient.hentSisteIverksatteBehandling(sakId, any()) } returns DetaljertBehandling(
-            id = idForrigeIverksatt,
-            sak = sakId,
-            sakType = SakType.BARNEPENSJON,
-            behandlingOpprettet = LocalDateTime.now().minusMonths(2),
-            sistEndret = LocalDateTime.now().minusMonths(1),
-            soeknadMottattDato = null,
-            innsender = null,
-            soeker = "",
-            gjenlevende = listOf(),
-            avdoed = listOf(),
-            soesken = listOf(),
-            gyldighetsproeving = null,
-            status = BehandlingStatus.IVERKSATT,
-            behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-            virkningstidspunkt = virkOriginal,
-            kommerBarnetTilgode = null,
-            revurderingsaarsak = null,
-            prosesstype = Prosesstype.MANUELL,
-            utenlandstilsnitt = null,
-            boddEllerArbeidetUtlandet = null,
-            revurderingInfo = null,
-            enhet = "1111"
-        )
-
+        coEvery { behandlingKlient.hentSisteIverksatteBehandling(sakId, any()) } returns idForrigeIverksatt
         every { repository.finnGrunnlagForBehandling(idRevurdering) } returns null
         every { repository.finnGrunnlagForBehandling(idForrigeIverksatt) } returns BeregningsGrunnlag(
             behandlingId = idForrigeIverksatt,

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
@@ -132,7 +132,7 @@ internal class BeregningsGrunnlagServiceTest {
                 sakId,
                 any()
             )
-        } returns foerstegangsbehandling
+        } returns foerstegangsbehandling.id
         coEvery { behandlingKlient.hentBehandling(revurdering.id, any()) } returns revurdering
 
         every {
@@ -199,7 +199,7 @@ internal class BeregningsGrunnlagServiceTest {
                 sakId,
                 any()
             )
-        } returns foerstegangsbehandling
+        } returns foerstegangsbehandling.id
         coEvery { behandlingKlient.hentBehandling(revurdering.id, any()) } returns revurdering
 
         every {

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -43,9 +43,12 @@ class TrygdetidService(
 
             BehandlingType.REVURDERING -> {
                 logger.info("Oppretter trygdetid for behandling $behandlingId for revurdering")
-                val forrigeBehandling = behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, brukerTokenInfo)
+                val forrigeBehandlingId = behandlingKlient.hentSisteIverksatteBehandling(
+                    behandling.sak,
+                    brukerTokenInfo
+                )
 
-                when (val forrigeTrygdetid = hentTrygdetid(forrigeBehandling.id)) {
+                when (val forrigeTrygdetid = hentTrygdetid(forrigeBehandlingId)) {
                     null -> opprettTrygdetidForRevurdering(behandling, brukerTokenInfo)
                     else -> kopierSisteTrygdetidberegning(behandling, forrigeTrygdetid)
                 }

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
@@ -62,7 +62,7 @@ class BehandlingKlient(config: Config, httpClient: HttpClient) : BehandlingTilga
             )
     }
 
-    suspend fun hentSisteIverksatteBehandling(sakId: Long, brukerTokenInfo: BrukerTokenInfo): DetaljertBehandling {
+    suspend fun hentSisteIverksatteBehandling(sakId: Long, brukerTokenInfo: BrukerTokenInfo): UUID {
         logger.info("Henter seneste iverksatte behandling for sak med id $sakId")
 
         val response = downstreamResourceClient.get(

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
@@ -71,7 +71,7 @@ class BehandlingKlient(config: Config, httpClient: HttpClient) : BehandlingTilga
         )
 
         return response.mapBoth(
-            success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },
+            success = { UUID.fromString(it.response.toString()) },
             failure = {
                 logger.error("Kunne ikke hente seneste iverksatte behandling for sak med id $sakId")
                 throw it.throwable

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
@@ -150,14 +150,11 @@ internal class TrygdetidServiceTest {
             every { behandlingType } returns BehandlingType.REVURDERING
         }
         val forrigebehandlingId = randomUUID()
-        val forrigeBehandling = mockk<DetaljertBehandling>().apply {
-            every { id } returns forrigebehandlingId
-        }
         val trygdetid = trygdetid(behandlingId, sakId)
 
         every { repository.hentTrygdetid(behandlingId) } returns null
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns forrigeBehandling
+        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns forrigebehandlingId
         every { repository.hentTrygdetid(forrigebehandlingId) } returns trygdetid
         every { repository.opprettTrygdetid(any()) } returns trygdetid
 
@@ -182,7 +179,6 @@ internal class TrygdetidServiceTest {
             behandling.id
             behandling.sak
             behandling.behandlingType
-            forrigeBehandling.id
         }
     }
 
@@ -197,16 +193,13 @@ internal class TrygdetidServiceTest {
             every { revurderingsaarsak } returns RevurderingAarsak.SOESKENJUSTERING
         }
         val forrigeBehandlingId = randomUUID()
-        val forrigeBehandling = mockk<DetaljertBehandling>().apply {
-            every { id } returns forrigeBehandlingId
-        }
         val trygdetid = trygdetid(behandlingId, sakId)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
         every { repository.hentTrygdetid(behandlingId) } returns null
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns forrigeBehandling
+        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns forrigeBehandlingId
         every { repository.hentTrygdetid(forrigeBehandlingId) } returns null
         every { repository.opprettTrygdetid(any()) } returns trygdetid
 
@@ -233,7 +226,6 @@ internal class TrygdetidServiceTest {
             behandling.id
             behandling.sak
             behandling.behandlingType
-            forrigeBehandling.id
         }
     }
 
@@ -249,12 +241,9 @@ internal class TrygdetidServiceTest {
             every { prosesstype } returns Prosesstype.AUTOMATISK
         }
         val forrigeBehandlingId = randomUUID()
-        val forrigeBehandling = mockk<DetaljertBehandling>().apply {
-            every { id } returns forrigeBehandlingId
-        }
         every { repository.hentTrygdetid(behandlingId) } returns null
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns forrigeBehandling
+        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns forrigeBehandlingId
         every { repository.hentTrygdetid(forrigeBehandlingId) } returns null
 
         runBlocking {
@@ -278,7 +267,6 @@ internal class TrygdetidServiceTest {
             behandling.id
             behandling.sak
             behandling.behandlingType
-            forrigeBehandling.id
         }
     }
 
@@ -294,16 +282,13 @@ internal class TrygdetidServiceTest {
             every { prosesstype } returns Prosesstype.MANUELL
         }
         val forrigeBehandlingId = randomUUID()
-        val forrigeBehandling = mockk<DetaljertBehandling>().apply {
-            every { id } returns forrigeBehandlingId
-        }
         val trygdetid = trygdetid(behandlingId, sakId)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
         every { repository.hentTrygdetid(behandlingId) } returns null
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns forrigeBehandling
+        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns forrigeBehandlingId
         every { repository.hentTrygdetid(forrigeBehandlingId) } returns null
         every { repository.opprettTrygdetid(any()) } returns trygdetid
 
@@ -331,7 +316,6 @@ internal class TrygdetidServiceTest {
             behandling.id
             behandling.sak
             behandling.behandlingType
-            forrigeBehandling.id
         }
     }
 

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingService.kt
@@ -152,11 +152,11 @@ class VilkaarsvurderingService(
 
                 BehandlingType.REVURDERING -> {
                     logger.info("Kopierer vilkårsvurdering for behandling $behandlingId fra forrige behandling")
-                    val forrigeBehandling = behandlingKlient.hentSisteIverksatteBehandling(
+                    val forrigeBehandlingId = behandlingKlient.hentSisteIverksatteBehandling(
                         behandling.sak,
                         brukerTokenInfo
                     )
-                    kopierVilkaarsvurdering(behandlingId, forrigeBehandling.id, brukerTokenInfo)
+                    kopierVilkaarsvurdering(behandlingId, forrigeBehandlingId, brukerTokenInfo)
                 }
 
                 BehandlingType.MANUELT_OPPHOER -> throw RuntimeException(

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/klienter/BehandlingKlient.kt
@@ -121,7 +121,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
         )
 
         return response.mapBoth(
-            success = { resource -> resource.response as UUID },
+            success = { UUID.fromString(it.response.toString()) },
             failure = {
                 logger.error("Kunne ikke hente seneste iverksatte behandling for sak med id $sakId")
                 throw it.throwable

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/klienter/BehandlingKlient.kt
@@ -27,7 +27,7 @@ interface BehandlingKlient : BehandlingTilgangsSjekk {
         commit: Boolean
     ): Boolean
     suspend fun settBehandlingStatusVilkaarsvurdert(behandlingId: UUID, brukerTokenInfo: BrukerTokenInfo): Boolean
-    suspend fun hentSisteIverksatteBehandling(sakId: Long, brukerTokenInfo: BrukerTokenInfo): DetaljertBehandling
+    suspend fun hentSisteIverksatteBehandling(sakId: Long, brukerTokenInfo: BrukerTokenInfo): UUID
 }
 
 class BehandlingKlientException(override val message: String, override val cause: Throwable) : Exception(message, cause)
@@ -112,7 +112,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
     override suspend fun hentSisteIverksatteBehandling(
         sakId: Long,
         brukerTokenInfo: BrukerTokenInfo
-    ): DetaljertBehandling {
+    ): UUID {
         logger.info("Henter seneste iverksatte behandling for sak med id $sakId")
 
         val response = downstreamResourceClient.get(
@@ -121,7 +121,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
         )
 
         return response.mapBoth(
-            success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },
+            success = { resource -> resource.response as UUID },
             failure = {
                 logger.error("Kunne ikke hente seneste iverksatte behandling for sak med id $sakId")
                 throw it.throwable

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
@@ -394,9 +394,7 @@ internal class VilkaarsvurderingServiceTest {
             every { revurderingsaarsak } returns RevurderingAarsak.REGULERING
         }
 
-        val detaljertBehandling = mockk<DetaljertBehandling>()
-        every { detaljertBehandling.id } returns uuid
-        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns detaljertBehandling
+        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns uuid
 
         val foerstegangsvilkaar = runBlocking {
             service.opprettVilkaarsvurdering(uuid, brukerTokenInfo)


### PR DESCRIPTION
Siden _kun_ IDen til forrige iverksatte behandling brukes, er det litt unødvendig å sende et detaljert behandlingsobjekt. 
Dersom det skulle vise seg å være behov for andre felter får man heller _lage en DTO med det man trenger..._