### PR TITLE
Ey 2374 restanse detaljer frontend

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -19,19 +19,22 @@ data class Avkorting(
     fun kopierAvkorting(virkningstidspunkt: YearMonth): Avkorting = Avkorting(
         avkortingGrunnlag = avkortingGrunnlag.map { it.copy(id = UUID.randomUUID()) },
         aarsoppgjoer = Aarsoppgjoer(
-            tidligereAvkortetYtelse = aarsoppgjoer.tidligereAvkortetYtelse + avkortetYtelse.map {
-                when (it.periode.tom) {
-                    null -> it.copy(
-                        type = AvkortetYtelseType.TIDLIGERE,
-                        periode = Periode(fom = it.periode.fom, tom = virkningstidspunkt.minusMonths(1))
-                    )
+            tidligereAvkortetYtelse = aarsoppgjoer.tidligereAvkortetYtelse.map { it.copy(id = UUID.randomUUID()) } +
+                    avkortetYtelse.map {
+                        when (it.periode.tom) {
+                            null -> it.copy(
+                                id = UUID.randomUUID(),
+                                type = AvkortetYtelseType.TIDLIGERE,
+                                periode = Periode(fom = it.periode.fom, tom = virkningstidspunkt.minusMonths(1))
+                            )
 
-                    else -> it.copy(
-                        type = AvkortetYtelseType.TIDLIGERE
-                    )
-                }
-            },
-            ytelseFoerAvkorting = aarsoppgjoer.ytelseFoerAvkorting,
+                            else -> it.copy(
+                                id = UUID.randomUUID(),
+                                type = AvkortetYtelseType.TIDLIGERE
+                            )
+                        }
+                    },
+            ytelseFoerAvkorting = aarsoppgjoer.ytelseFoerAvkorting.map { it },
         ),
     )
 
@@ -201,6 +204,7 @@ data class AvkortetYtelse(
     val regelResultat: JsonNode,
     val kilde: Grunnlagsopplysning.RegelKilde
 )
+
 enum class AvkortetYtelseType { NY, TIDLIGERE, REBEREGNET }
 
 fun Beregning.mapTilYtelseFoerAvkorting() = beregningsperioder.map {

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -82,6 +82,7 @@ fun AvkortingGrunnlag.toDto() = AvkortingGrunnlagDto(
 fun AvkortetYtelse.toDto() = AvkortetYtelseDto(
     fom = periode.fom.atDay(1),
     tom = periode.tom?.atEndOfMonth(),
+    ytelseFoerAvkorting = ytelseFoerAvkorting,
     avkortingsbeloep = avkortingsbeloep,
     restanse = restanse,
     ytelseEtterAvkorting = ytelseEtterAvkorting

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
@@ -116,6 +116,7 @@ class AvkortingRoutesTest {
                 AvkortetYtelseDto(
                     fom = dato.atDay(1),
                     tom = dato.atEndOfMonth(),
+                    ytelseFoerAvkorting = 300,
                     avkortingsbeloep = 200,
                     ytelseEtterAvkorting = 50,
                     restanse = 50

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -87,14 +87,20 @@ internal class AvkortingTest {
             with(avkorting.kopierAvkorting(virkningstidspunkt).aarsoppgjoer) {
                 tidligereAvkortetYtelse.size shouldBe 2
                 tidligereAvkortetYtelse[0].asClue {
-                    it shouldBe avkorting.aarsoppgjoer.tidligereAvkortetYtelse[0]
+                    it.shouldBeEqualToIgnoringFields(
+                        avkorting.aarsoppgjoer.tidligereAvkortetYtelse[0],
+                        AvkortetYtelse::id,
+                    )
+                    it.id shouldNotBe avkorting.aarsoppgjoer.tidligereAvkortetYtelse[0].id
                 }
                 tidligereAvkortetYtelse[1].asClue {
                     it.shouldBeEqualToIgnoringFields(
                         avkorting.avkortetYtelse[0],
+                        AvkortetYtelse::id,
                         AvkortetYtelse::periode,
                         AvkortetYtelse::type
                     )
+                    it.id shouldNotBe avkorting.avkortetYtelse[0].id
                     it.periode shouldBe Periode(YearMonth.of(2023, 2), virkningstidspunkt.minusMonths(1))
                     it.type shouldBe AvkortetYtelseType.TIDLIGERE
                 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -92,9 +92,10 @@ export const AvkortingInntekt = (props: {
         Omstillingsstønaden reduseres med 45 prosent av den gjenlevende sin inntekt som på årsbasis overstiger et halvt
         grunnbeløp. Inntekt rundes ned til nærmeste tusen. Det er forventet årsinntekt for hvert kalenderår som skal
         legges til grunn.
-        <br />
-        <br />I innvilgelsesåret skal inntekt opptjent før innvilgelse trekkes fra, og resterende forventet inntekt
-        omgjøres til årsinntekt. På samme måte skal inntekt etter opphør holdes utenfor i opphørsåret.
+      </BodyShort>
+      <BodyShort>
+        I innvilgelsesåret skal inntekt opptjent før innvilgelse trekkes fra, og resterende forventet inntekt omgjøres
+        til årsinntekt. På samme måte skal inntekt etter opphør holdes utenfor i opphørsåret.
       </BodyShort>
 
       {props.avkortingGrunnlag && props.avkortingGrunnlag.length > 0 && (
@@ -113,8 +114,8 @@ export const AvkortingInntekt = (props: {
                   <Table.DataCell key="Inntekt">{inntektsgrunnlag.aarsinntekt}</Table.DataCell>
                   <Table.DataCell key="FratrekkInnUt">{inntektsgrunnlag.fratrekkInnAar}</Table.DataCell>
                   <Table.DataCell key="Periode">
-                    {inntektsgrunnlag.fom ? formaterStringDato(inntektsgrunnlag.fom) : ''} -
-                    {inntektsgrunnlag.tom ? formaterStringDato(inntektsgrunnlag.tom) : ''}
+                    {inntektsgrunnlag.fom && formaterStringDato(inntektsgrunnlag.fom)} -
+                    {inntektsgrunnlag.tom && formaterStringDato(inntektsgrunnlag.tom)}
                   </Table.DataCell>
                   <Table.DataCell key="InntektSpesifikasjon">{inntektsgrunnlag.spesifikasjon}</Table.DataCell>
                   <Table.DataCell key="InntektKilde">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -90,7 +90,11 @@ export const AvkortingInntekt = (props: {
       />
       <BodyShort>
         Omstillingsstønaden reduseres med 45 prosent av den gjenlevende sin inntekt som på årsbasis overstiger et halvt
-        grunnbeløp. Inntekt avrundes til nærmeste tusen.
+        grunnbeløp. Inntekt rundes ned til nærmeste tusen. Det er forventet årsinntekt for hvert kalenderår som skal
+        legges til grunn.
+        <br />
+        <br />I innvilgelsesåret skal inntekt opptjent før innvilgelse trekkes fra, og resterende forventet inntekt
+        omgjøres til årsinntekt. På samme måte skal inntekt etter opphør holdes utenfor i opphørsåret.
       </BodyShort>
 
       {props.avkortingGrunnlag && props.avkortingGrunnlag.length > 0 && (
@@ -99,8 +103,7 @@ export const AvkortingInntekt = (props: {
             <Table.Header>
               <Table.HeaderCell>Forventet inntekt</Table.HeaderCell>
               <Table.HeaderCell>Fratrekk inn år</Table.HeaderCell>
-              <Table.HeaderCell>F.o.m dato</Table.HeaderCell>
-              <Table.HeaderCell>T.o.m dato</Table.HeaderCell>
+              <Table.HeaderCell>Periode</Table.HeaderCell>
               <Table.HeaderCell>Spesifikasjon av inntekt</Table.HeaderCell>
               <Table.HeaderCell>Kilde</Table.HeaderCell>
             </Table.Header>
@@ -109,8 +112,10 @@ export const AvkortingInntekt = (props: {
                 <Table.Row key={index}>
                   <Table.DataCell key="Inntekt">{inntektsgrunnlag.aarsinntekt}</Table.DataCell>
                   <Table.DataCell key="FratrekkInnUt">{inntektsgrunnlag.fratrekkInnAar}</Table.DataCell>
-                  <Table.DataCell key="InntektFom">{inntektsgrunnlag.fom}</Table.DataCell>
-                  <Table.DataCell key="InntektTom">{inntektsgrunnlag.tom}</Table.DataCell>
+                  <Table.DataCell key="Periode">
+                    {inntektsgrunnlag.fom ? formaterStringDato(inntektsgrunnlag.fom) : ''} -
+                    {inntektsgrunnlag.tom ? formaterStringDato(inntektsgrunnlag.tom) : ''}
+                  </Table.DataCell>
                   <Table.DataCell key="InntektSpesifikasjon">{inntektsgrunnlag.spesifikasjon}</Table.DataCell>
                   <Table.DataCell key="InntektKilde">
                     {inntektsgrunnlag.kilde && (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/YtelseEtterAvkorting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/YtelseEtterAvkorting.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { ManglerRegelspesifikasjon } from '~components/behandling/felles/ManglerRegelspesifikasjon'
 import { formaterStringDato } from '~utils/formattering'
+import { YtelseEtterAvkortingDetaljer } from '~components/behandling/avkorting/YtelseEtterAvkortingDetaljer'
 
 export const YtelseEtterAvkorting = (props: { ytelser?: IAvkortetYtelse[] }) => {
   const ytelser = props.ytelser
@@ -18,6 +19,7 @@ export const YtelseEtterAvkorting = (props: { ytelser?: IAvkortetYtelse[] }) => 
           <Table className="table" zebraStripes>
             <Table.Header>
               <Table.Row>
+                <Table.HeaderCell />
                 <Table.HeaderCell>Periode</Table.HeaderCell>
                 <Table.HeaderCell>Avkorting</Table.HeaderCell>
                 <Table.HeaderCell>Restanse</Table.HeaderCell>
@@ -26,7 +28,11 @@ export const YtelseEtterAvkorting = (props: { ytelser?: IAvkortetYtelse[] }) => 
             </Table.Header>
             <Table.Body>
               {ytelser?.map((ytelse, key) => (
-                <Table.Row key={key} shadeOnHover={false}>
+                <Table.ExpandableRow
+                  key={key}
+                  shadeOnHover={false}
+                  content={<YtelseEtterAvkortingDetaljer ytelse={ytelse} />}
+                >
                   <Table.DataCell>
                     {formaterStringDato(ytelse.fom)} - {ytelse.tom ? formaterStringDato(ytelse.tom) : ''}
                   </Table.DataCell>
@@ -35,7 +41,7 @@ export const YtelseEtterAvkorting = (props: { ytelser?: IAvkortetYtelse[] }) => 
                   <Table.DataCell>
                     <ManglerRegelspesifikasjon>{ytelse.ytelseEtterAvkorting} kr</ManglerRegelspesifikasjon>
                   </Table.DataCell>
-                </Table.Row>
+                </Table.ExpandableRow>
               ))}
             </Table.Body>
           </Table>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/YtelseEtterAvkorting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/YtelseEtterAvkorting.tsx
@@ -37,7 +37,11 @@ export const YtelseEtterAvkorting = (props: { ytelser?: IAvkortetYtelse[] }) => 
                     {formaterStringDato(ytelse.fom)} - {ytelse.tom ? formaterStringDato(ytelse.tom) : ''}
                   </Table.DataCell>
                   <Table.DataCell>{ytelse.avkortingsbeloep} kr</Table.DataCell>
-                  <Table.DataCell>{ytelse.restanse} kr</Table.DataCell>
+                  {ytelse.restanse < 0 ? (
+                    <Table.DataCell>+ {ytelse.restanse * -1} kr</Table.DataCell>
+                  ) : (
+                    <Table.DataCell>- {ytelse.restanse} kr</Table.DataCell>
+                  )}
                   <Table.DataCell>
                     <ManglerRegelspesifikasjon>{ytelse.ytelseEtterAvkorting} kr</ManglerRegelspesifikasjon>
                   </Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/YtelseEtterAvkortingDetaljer.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/YtelseEtterAvkortingDetaljer.tsx
@@ -1,0 +1,107 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Border } from '~components/behandling/soeknadsoversikt/styled'
+import { IAvkortetYtelse } from '~shared/types/IAvkorting'
+
+export const YtelseEtterAvkortingDetaljer = (props: { ytelse: IAvkortetYtelse }) => {
+  const ytelse = props.ytelse
+
+  return (
+    <>
+      <Border />
+      <Wrapper>
+        <Regnestykke>
+          <Rad>
+            <Navn>Brutto stønad før avkorting</Navn>
+            <Verdi>{ytelse.ytelseFoerAvkorting} kr</Verdi>
+          </Rad>
+          <Rad>
+            <Navn>Månedlig avkortingsbeløp</Navn>
+            <Operasjon>-</Operasjon>
+            <Verdi>{ytelse.avkortingsbeloep} kr</Verdi>
+          </Rad>
+          {ytelse.restanse < 0 ? (
+            <Rad>
+              <Navn>Månedlig restansebeløp</Navn>
+              <Operasjon>+</Operasjon>
+              <Verdi>{ytelse.restanse * -1} kr</Verdi>
+            </Rad>
+          ) : (
+            <Rad>
+              <Navn>Månedlig restansebeløp</Navn>
+              <Operasjon>-</Operasjon>
+              <Verdi>{ytelse.restanse} kr</Verdi>
+            </Rad>
+          )}
+          <Border />
+          <Rad>
+            <Navn>Brutto stønad etter avkorting og restanse</Navn>
+            <Operasjon>=</Operasjon>
+            <Verdi>
+              <strong>{ytelse.ytelseEtterAvkorting} kr</strong>
+            </Verdi>
+          </Rad>
+        </Regnestykke>
+        <Beskrivelse>
+          <li>
+            <h4>Hvordan fungerer avkorting av en omstillingstønad?</h4>
+            Omstillingsstønaden avkortes med mottakers forventede årsinntekt/12. Er forventet inntekt satt for
+            lavt/høyt, og en eventuell restanse (se under) ikke klarer å hente inn igjen for mye/lite utbetalt stønad,
+            vil dette bli behandlet i et etteroppgjør.
+          </li>
+          <li>
+            <h4>Hva er restanse?</h4>
+            Hvis man fastsetter en ny forventet inntekt for inneværende år, oppstår det en feilutbetaling/etterbetaling,
+            en restanse. Restansen skal fordeles ut over resterende utbetalingsmåneder for inneværende år. Dette gjøres
+            for å minimere etteroppgjøret.
+            <br />
+            <br />
+            Det er antall gjenstående måneder som avgjør hvor stort restansebeløpet blir. Har man f.eks. endret
+            forventet inntekt fra 01.07.2023 og det foreligger en feilutbetaling på 15 000 kroner, skal beløpet fordeles
+            på 6 måneder, og restansebeløpet blir 2 500 kr.
+          </li>
+        </Beskrivelse>
+      </Wrapper>
+    </>
+  )
+}
+
+const Wrapper = styled.div`
+  margin-top: 2em;
+  display: flex;
+
+  font-size: 0.9em;
+`
+
+const Regnestykke = styled.ul``
+
+const Rad = styled.li`
+  margin-bottom: 1.25em;
+  overflow: hidden;
+`
+const Navn = styled.div`
+  float: left;
+  width: 18em;
+`
+const Operasjon = styled.div`
+  float: left;
+  width: 5em;
+`
+const Verdi = styled.div`
+  float: right;
+  width: 5em;
+`
+const Beskrivelse = styled.ul`
+  flex-grow: 1;
+  margin-left: 1em;
+  list-style-type: none;
+  width: 10em;
+
+  h4 {
+    margin: 0;
+  }
+
+  li {
+    margin-bottom: 2em;
+  }
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/YtelseEtterAvkortingDetaljer.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/YtelseEtterAvkortingDetaljer.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { Border } from '~components/behandling/soeknadsoversikt/styled'
 import { IAvkortetYtelse } from '~shared/types/IAvkorting'
+import { BodyShort, ReadMore } from '@navikt/ds-react'
 
 export const YtelseEtterAvkortingDetaljer = (props: { ytelse: IAvkortetYtelse }) => {
   const ytelse = props.ytelse
@@ -10,7 +11,7 @@ export const YtelseEtterAvkortingDetaljer = (props: { ytelse: IAvkortetYtelse })
     <>
       <Border />
       <Wrapper>
-        <Regnestykke>
+        <ul>
           <Rad>
             <Navn>Brutto stønad før avkorting</Navn>
             <Verdi>{ytelse.ytelseFoerAvkorting} kr</Verdi>
@@ -41,24 +42,32 @@ export const YtelseEtterAvkortingDetaljer = (props: { ytelse: IAvkortetYtelse })
               <strong>{ytelse.ytelseEtterAvkorting} kr</strong>
             </Verdi>
           </Rad>
-        </Regnestykke>
+        </ul>
         <Beskrivelse>
           <li>
             <h4>Hvordan fungerer avkorting av en omstillingstønad?</h4>
-            Omstillingsstønaden avkortes med mottakers forventede årsinntekt/12. Er forventet inntekt satt for
-            lavt/høyt, og en eventuell restanse (se under) ikke klarer å hente inn igjen for mye/lite utbetalt stønad,
-            vil dette bli behandlet i et etteroppgjør.
+            <ReadMore header="Les mer">
+              <BodyShort>
+                Omstillingsstønaden avkortes med mottakers forventede årsinntekt/12. Er forventet inntekt satt for
+                lavt/høyt, og en eventuell restanse (se under) ikke klarer å hente inn igjen for mye/lite utbetalt
+                stønad, vil dette bli behandlet i et etteroppgjør.
+              </BodyShort>
+            </ReadMore>
           </li>
           <li>
             <h4>Hva er restanse?</h4>
-            Hvis man fastsetter en ny forventet inntekt for inneværende år, oppstår det en feilutbetaling/etterbetaling,
-            en restanse. Restansen skal fordeles ut over resterende utbetalingsmåneder for inneværende år. Dette gjøres
-            for å minimere etteroppgjøret.
-            <br />
-            <br />
-            Det er antall gjenstående måneder som avgjør hvor stort restansebeløpet blir. Har man f.eks. endret
-            forventet inntekt fra 01.07.2023 og det foreligger en feilutbetaling på 15 000 kroner, skal beløpet fordeles
-            på 6 måneder, og restansebeløpet blir 2 500 kr.
+            <ReadMore header="Les mer">
+              <BodyShort spacing={true}>
+                Hvis man fastsetter en ny forventet inntekt for inneværende år, oppstår det en
+                feilutbetaling/etterbetaling, en restanse. Restansen skal fordeles ut over resterende utbetalingsmåneder
+                for inneværende år. Dette gjøres for å minimere etteroppgjøret.
+              </BodyShort>
+              <BodyShort>
+                Det er antall gjenstående måneder som avgjør hvor stort restansebeløpet blir. Har man f.eks. endret
+                forventet inntekt fra 01.07.2023 og det foreligger en feilutbetaling på 15 000 kroner, skal beløpet
+                fordeles på 6 måneder, og restansebeløpet blir 2 500 kr.
+              </BodyShort>
+            </ReadMore>
           </li>
         </Beskrivelse>
       </Wrapper>
@@ -72,9 +81,6 @@ const Wrapper = styled.div`
 
   font-size: 0.9em;
 `
-
-const Regnestykke = styled.ul``
-
 const Rad = styled.li`
   margin-bottom: 1.25em;
   overflow: hidden;
@@ -91,7 +97,7 @@ const Verdi = styled.div`
   float: right;
   width: 5em;
 `
-const Beskrivelse = styled.ul`
+const Beskrivelse = styled.div`
   flex-grow: 1;
   margin-left: 1em;
   list-style-type: none;

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
@@ -21,6 +21,7 @@ export interface IAvkortingGrunnlag {
 export interface IAvkortetYtelse {
   fom: string
   tom: string
+  ytelseFoerAvkorting: number
   avkortingsbeloep: number
   restanse: number
   ytelseEtterAvkorting: number

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingServiceTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingServiceTest.kt
@@ -883,6 +883,7 @@ internal class VedtaksvurderingServiceTest {
             AvkortetYtelseDto(
                 fom = virkningstidspunkt.atDay(1),
                 tom = null,
+                ytelseFoerAvkorting = 100,
                 ytelseEtterAvkorting = 50,
                 avkortingsbeloep = 50,
                 restanse = 0

--- a/libs/etterlatte-beregning-model/src/main/kotlin/BeregningDTO.kt
+++ b/libs/etterlatte-beregning-model/src/main/kotlin/BeregningDTO.kt
@@ -57,6 +57,7 @@ data class AvkortingGrunnlagKildeDto(
 data class AvkortetYtelseDto(
     val fom: LocalDate,
     val tom: LocalDate?,
+    val ytelseFoerAvkorting: Int,
     val avkortingsbeloep: Int,
     val ytelseEtterAvkorting: Int,
     val restanse: Int


### PR DESCRIPTION
 - Ny komponent for ytelse etter avkorting detaljer for å beskrive hva avkorting og restanse
 - Oppdatere tekst under inntektsavkorting
 
Bugfiks:
 - Fikser feil under kopiering av avkorting ved revurdering må generere nye id'er til tidligereAvkortetYtelse for å ikke få duplicate key