### PR TITLE
EY-2346: Ryddar i service-laget i behandling

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -96,7 +96,7 @@ fun Application.module(context: ApplicationContext) {
             )
             behandlingRoutes(
                 behandlingService = behandlingService,
-                foerstegangsbehandlingService = foerstegangsbehandlingService,
+                gyldighetsproevingService = gyldighetsproevingService,
                 manueltOpphoerService = manueltOpphoerService,
                 kommerBarnetTilGodeService = kommerBarnetTilGodeService,
                 behandlingFactory = behandlingFactory

--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -98,7 +98,8 @@ fun Application.module(context: ApplicationContext) {
                 behandlingService = behandlingService,
                 foerstegangsbehandlingService = foerstegangsbehandlingService,
                 manueltOpphoerService = manueltOpphoerService,
-                kommerBarnetTilGodeService = kommerBarnetTilGodeService
+                kommerBarnetTilGodeService = kommerBarnetTilGodeService,
+                behandlingFactory = behandlingFactory
             )
             revurderingRoutes(
                 revurderingService = revurderingService,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
@@ -1,0 +1,144 @@
+package no.nav.etterlatte.behandling
+
+import no.nav.etterlatte.Kontekst
+import no.nav.etterlatte.behandling.domain.Behandling
+import no.nav.etterlatte.behandling.domain.Foerstegangsbehandling
+import no.nav.etterlatte.behandling.domain.OpprettBehandling
+import no.nav.etterlatte.behandling.domain.toBehandlingOpprettet
+import no.nav.etterlatte.behandling.hendelse.HendelseDao
+import no.nav.etterlatte.behandling.revurdering.RevurderingService
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
+import no.nav.etterlatte.inTransaction
+import no.nav.etterlatte.libs.common.Vedtaksloesning
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
+import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.Persongalleri
+import no.nav.etterlatte.libs.common.behandling.Prosesstype
+import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.sak.Sak
+import no.nav.etterlatte.oppgaveny.OppgaveServiceNy
+import no.nav.etterlatte.oppgaveny.OppgaveType
+import no.nav.etterlatte.sak.SakDao
+import no.nav.etterlatte.sak.filterSakerForEnheter
+import org.slf4j.LoggerFactory
+import java.time.LocalDateTime
+import java.util.*
+
+class BehandlingFactory(
+    private val oppgaveService: OppgaveServiceNy,
+    private val grunnlagService: GrunnlagService,
+    private val revurderingService: RevurderingService,
+    private val sakDao: SakDao,
+    private val behandlingDao: BehandlingDao,
+    private val hendelseDao: HendelseDao,
+    private val behandlingHendelser: BehandlingHendelserKafkaProducer,
+    private val featureToggleService: FeatureToggleService
+) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    fun opprettBehandling(
+        sakId: Long,
+        persongalleri: Persongalleri,
+        mottattDato: String?,
+        kilde: Vedtaksloesning
+    ): Behandling? {
+        logger.info("Starter behandling i sak $sakId")
+        val sak = inTransaction {
+            requireNotNull(
+                sakDao.hentSak(sakId)?.let {
+                    listOf(it).filterSakerForEnheter(featureToggleService, Kontekst.get().AppUser).firstOrNull()
+                }
+            ) {
+                "Fant ingen sak med id=$sakId!"
+            }
+        }
+        val harBehandlingerForSak = inTransaction {
+            behandlingDao.alleBehandlingerISak(sak.id)
+        }
+
+        val harIverksattEllerAttestertBehandling = harBehandlingerForSak.filter { behandling ->
+            BehandlingStatus.iverksattEllerAttestert().find { it == behandling.status } != null
+        }
+        return if (harIverksattEllerAttestertBehandling.isNotEmpty()) {
+            revurderingService.opprettRevurdering(
+                sakId,
+                persongalleri,
+                harIverksattEllerAttestertBehandling.maxBy { it.behandlingOpprettet }.id,
+                mottattDato,
+                Prosesstype.AUTOMATISK,
+                Vedtaksloesning.GJENNY,
+                "Oppdatert søknad",
+                RevurderingAarsak.NY_SOEKNAD
+            )
+        } else {
+            val harBehandlingUnderbehandling = harBehandlingerForSak.filter { behandling ->
+                BehandlingStatus.underBehandling().find { it == behandling.status } != null
+            }
+            opprettFoerstegangsbehandling(harBehandlingUnderbehandling, sak, persongalleri, mottattDato)
+        }
+    }
+
+    private fun opprettFoerstegangsbehandling(
+        harBehandlingUnderbehandling: List<Behandling>,
+        sak: Sak,
+        persongalleri: Persongalleri,
+        mottattDato: String?
+    ): Foerstegangsbehandling? {
+        return inTransaction {
+            harBehandlingUnderbehandling.forEach {
+                behandlingDao.lagreStatus(it.id, BehandlingStatus.AVBRUTT, LocalDateTime.now())
+            }
+
+            OpprettBehandling(
+                type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                sakId = sak.id,
+                status = BehandlingStatus.OPPRETTET,
+                soeknadMottattDato = mottattDato?.let { LocalDateTime.parse(it) },
+                persongalleri = persongalleri,
+                kilde = Vedtaksloesning.GJENNY,
+                merknad = opprettMerknad(sak, persongalleri)
+            ).let { opprettBehandling ->
+                behandlingDao.opprettBehandling(opprettBehandling)
+                hendelseDao.behandlingOpprettet(opprettBehandling.toBehandlingOpprettet())
+
+                logger.info("Opprettet behandling ${opprettBehandling.id} i sak ${opprettBehandling.sakId}")
+
+                hentBehandling(opprettBehandling.id)
+            }.also { behandling ->
+                behandling?.let {
+                    grunnlagService.leggInnNyttGrunnlag(it)
+                    oppgaveService.opprettNyOppgaveMedSakOgReferanse(
+                        referanse = behandling.id.toString(),
+                        sakId = sak.id,
+                        oppgaveType = OppgaveType.FOERSTEGANGSBEHANDLING
+                    )
+                    behandlingHendelser.sendMeldingForHendelse(it, BehandlingHendelseType.OPPRETTET)
+                }
+            }
+        }
+    }
+
+    fun hentBehandling(id: UUID): Foerstegangsbehandling? =
+        (behandlingDao.hentBehandling(id) as? Foerstegangsbehandling)?.sjekkEnhet()
+
+    private fun opprettMerknad(sak: Sak, persongalleri: Persongalleri): String? {
+        return if (persongalleri.soesken.isEmpty()) {
+            null
+        } else if (sak.sakType == SakType.BARNEPENSJON) {
+            "${persongalleri.soesken.size} søsken"
+        } else if (sak.sakType == SakType.OMSTILLINGSSTOENAD) {
+            val barnUnder20 = persongalleri.soesken.count { Folkeregisteridentifikator.of(it).getAge() < 20 }
+
+            "$barnUnder20 barn u/20år"
+        } else {
+            null
+        }
+    }
+    private fun Foerstegangsbehandling?.sjekkEnhet() = this?.let { behandling ->
+        listOf(behandling).filterBehandlingerForEnheter(
+            featureToggleService,
+            Kontekst.get().AppUser
+        ).firstOrNull()
+    }
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -45,7 +45,8 @@ internal fun Route.behandlingRoutes(
     behandlingService: BehandlingService,
     foerstegangsbehandlingService: FoerstegangsbehandlingService,
     kommerBarnetTilGodeService: KommerBarnetTilGodeService,
-    manueltOpphoerService: ManueltOpphoerService
+    manueltOpphoerService: ManueltOpphoerService,
+    behandlingFactory: BehandlingFactory
 ) {
     val logger = application.log
     route("/api/behandling/{$BEHANDLINGSID_CALL_PARAMETER}/") {
@@ -230,7 +231,7 @@ internal fun Route.behandlingRoutes(
                 val behandlingsBehov = call.receive<BehandlingsBehov>()
 
                 when (
-                    val behandling = foerstegangsbehandlingService.opprettBehandling(
+                    val behandling = behandlingFactory.opprettBehandling(
                         behandlingsBehov.sak,
                         behandlingsBehov.persongalleri,
                         behandlingsBehov.mottattDato,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -16,7 +16,6 @@ import io.ktor.server.routing.route
 import no.nav.etterlatte.behandling.domain.ManueltOpphoer
 import no.nav.etterlatte.behandling.domain.TilstandException
 import no.nav.etterlatte.behandling.domain.toBehandlingSammendrag
-import no.nav.etterlatte.behandling.foerstegangsbehandling.FoerstegangsbehandlingService
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeService
 import no.nav.etterlatte.behandling.manueltopphoer.ManueltOpphoerAarsak
 import no.nav.etterlatte.behandling.manueltopphoer.ManueltOpphoerRequest
@@ -43,7 +42,7 @@ import java.util.*
 
 internal fun Route.behandlingRoutes(
     behandlingService: BehandlingService,
-    foerstegangsbehandlingService: FoerstegangsbehandlingService,
+    gyldighetsproevingService: GyldighetsproevingService,
     kommerBarnetTilGodeService: KommerBarnetTilGodeService,
     manueltOpphoerService: ManueltOpphoerService,
     behandlingFactory: BehandlingFactory
@@ -60,7 +59,7 @@ internal fun Route.behandlingRoutes(
             hentNavidentFraToken { navIdent ->
                 val body = call.receive<JaNeiMedBegrunnelse>()
                 when (
-                    val lagretGyldighetsResultat = foerstegangsbehandlingService.lagreGyldighetsproeving(
+                    val lagretGyldighetsResultat = gyldighetsproevingService.lagreGyldighetsproeving(
                         behandlingsId,
                         navIdent,
                         body
@@ -221,7 +220,7 @@ internal fun Route.behandlingRoutes(
 
             post("/gyldigfremsatt") {
                 val body = call.receive<GyldighetsResultat>()
-                foerstegangsbehandlingService.lagreGyldighetsproeving(behandlingsId, body)
+                gyldighetsproevingService.lagreGyldighetsproeving(behandlingsId, body)
                 call.respond(HttpStatusCode.OK)
             }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
@@ -146,7 +146,7 @@ class BehandlingServiceImpl(
         return hentBehandling(behandlingId)?.toDetaljertBehandling()
     }
 
-    private suspend fun hentBehandlingMedEnkelPersonopplysning(
+    internal suspend fun hentBehandlingMedEnkelPersonopplysning(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         opplysningstype: Opplysningstype

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
@@ -72,18 +72,11 @@ interface BehandlingService {
         boddEllerArbeidetUtlandet: BoddEllerArbeidetUtlandet
     )
 
-    fun hentHendelserIBehandling(behandlingId: UUID): List<LagretHendelse>
     fun hentDetaljertBehandling(behandlingId: UUID): DetaljertBehandling?
     suspend fun hentDetaljertBehandlingMedTilbehoer(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo
     ): DetaljertBehandlingDto
-
-    suspend fun hentBehandlingMedEnkelPersonopplysning(
-        behandlingId: UUID,
-        brukerTokenInfo: BrukerTokenInfo,
-        opplysningstype: Opplysningstype
-    ): BehandlingMedGrunnlagsopplysninger<Person>
 
     suspend fun erGyldigVirkningstidspunkt(
         behandlingId: UUID,
@@ -153,7 +146,7 @@ class BehandlingServiceImpl(
         return hentBehandling(behandlingId)?.toDetaljertBehandling()
     }
 
-    override suspend fun hentBehandlingMedEnkelPersonopplysning(
+    private suspend fun hentBehandlingMedEnkelPersonopplysning(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         opplysningstype: Opplysningstype
@@ -383,7 +376,7 @@ class BehandlingServiceImpl(
         }
     }
 
-    override fun hentHendelserIBehandling(behandlingId: UUID): List<LagretHendelse> {
+    private fun hentHendelserIBehandling(behandlingId: UUID): List<LagretHendelse> {
         return inTransaction {
             hendelseDao.finnHendelserIBehandling(behandlingId)
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/GyldighetsproevingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/GyldighetsproevingService.kt
@@ -1,9 +1,7 @@
-package no.nav.etterlatte.behandling.foerstegangsbehandling
+package no.nav.etterlatte.behandling
 
 import no.nav.etterlatte.Kontekst
-import no.nav.etterlatte.behandling.BehandlingDao
 import no.nav.etterlatte.behandling.domain.Foerstegangsbehandling
-import no.nav.etterlatte.behandling.filterBehandlingerForEnheter
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.behandling.JaNeiMedBegrunnelse
@@ -21,7 +19,7 @@ import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.util.*
 
-interface FoerstegangsbehandlingService {
+interface GyldighetsproevingService {
 
     fun lagreGyldighetsproeving(
         behandlingId: UUID,
@@ -32,12 +30,12 @@ interface FoerstegangsbehandlingService {
     fun lagreGyldighetsproeving(behandlingId: UUID, gyldighetsproeving: GyldighetsResultat)
 }
 
-class FoerstegangsbehandlingServiceImpl(
+class GyldighetsproevingServiceImpl(
     private val behandlingDao: BehandlingDao,
     private val featureToggleService: FeatureToggleService,
     private val klokke: Clock = utcKlokke()
-) : FoerstegangsbehandlingService {
-    private val logger = LoggerFactory.getLogger(FoerstegangsbehandlingServiceImpl::class.java)
+) : GyldighetsproevingService {
+    private val logger = LoggerFactory.getLogger(GyldighetsproevingServiceImpl::class.java)
 
     internal fun hentBehandling(id: UUID): Foerstegangsbehandling? =
         (behandlingDao.hentBehandling(id) as? Foerstegangsbehandling)?.sjekkEnhet()

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/GyldighetsproevingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/GyldighetsproevingService.kt
@@ -37,7 +37,7 @@ class GyldighetsproevingServiceImpl(
 ) : GyldighetsproevingService {
     private val logger = LoggerFactory.getLogger(GyldighetsproevingServiceImpl::class.java)
 
-    internal fun hentBehandling(id: UUID): Foerstegangsbehandling? =
+    internal fun hentFoerstegangsbehandling(id: UUID): Foerstegangsbehandling? =
         (behandlingDao.hentBehandling(id) as? Foerstegangsbehandling)?.sjekkEnhet()
 
     override fun lagreGyldighetsproeving(
@@ -46,7 +46,7 @@ class GyldighetsproevingServiceImpl(
         svar: JaNeiMedBegrunnelse
     ): GyldighetsResultat? {
         return inTransaction {
-            hentBehandling(behandlingId)?.let { behandling ->
+            hentFoerstegangsbehandling(behandlingId)?.let { behandling ->
                 val resultat =
                     if (svar.erJa()) VurderingsResultat.OPPFYLT else VurderingsResultat.IKKE_OPPFYLT
                 val gyldighetsResultat = GyldighetsResultat(
@@ -76,7 +76,7 @@ class GyldighetsproevingServiceImpl(
 
     override fun lagreGyldighetsproeving(behandlingId: UUID, gyldighetsproeving: GyldighetsResultat) {
         inTransaction {
-            hentBehandling(behandlingId)?.lagreGyldighetsproeving(gyldighetsproeving)
+            hentFoerstegangsbehandling(behandlingId)?.lagreGyldighetsproeving(gyldighetsproeving)
         }
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
@@ -74,7 +74,7 @@ class FoerstegangsbehandlingServiceImpl(
 ) : FoerstegangsbehandlingService {
     private val logger = LoggerFactory.getLogger(FoerstegangsbehandlingServiceImpl::class.java)
 
-    fun hentBehandling(id: UUID): Foerstegangsbehandling? =
+    internal fun hentBehandling(id: UUID): Foerstegangsbehandling? =
         (behandlingDao.hentBehandling(id) as? Foerstegangsbehandling)?.sjekkEnhet()
 
     override fun hentFoerstegangsbehandling(behandling: UUID): Foerstegangsbehandling? {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
@@ -44,7 +44,6 @@ import java.time.LocalDateTime
 import java.util.*
 
 interface FoerstegangsbehandlingService {
-    fun hentFoerstegangsbehandling(behandling: UUID): Foerstegangsbehandling?
     fun opprettBehandling(
         sakId: Long,
         persongalleri: Persongalleri,
@@ -76,12 +75,6 @@ class FoerstegangsbehandlingServiceImpl(
 
     internal fun hentBehandling(id: UUID): Foerstegangsbehandling? =
         (behandlingDao.hentBehandling(id) as? Foerstegangsbehandling)?.sjekkEnhet()
-
-    override fun hentFoerstegangsbehandling(behandling: UUID): Foerstegangsbehandling? {
-        return inTransaction {
-            hentBehandling(behandling)
-        }
-    }
 
     override fun opprettBehandling(
         sakId: Long,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/foerstegangsbehandling/FoerstegangsbehandlingService.kt
@@ -59,13 +59,6 @@ interface FoerstegangsbehandlingService {
     ): GyldighetsResultat?
 
     fun lagreGyldighetsproeving(behandlingId: UUID, gyldighetsproeving: GyldighetsResultat)
-    fun settOpprettet(behandlingId: UUID, dryRun: Boolean = true)
-    fun settVilkaarsvurdert(behandlingId: UUID, dryRun: Boolean = true)
-    fun settBeregnet(behandlingId: UUID, dryRun: Boolean = true)
-    fun settFattetVedtak(behandlingId: UUID, dryRun: Boolean = true)
-    fun settAttestert(behandlingId: UUID, dryRun: Boolean = true)
-    fun settReturnert(behandlingId: UUID, dryRun: Boolean = true)
-    fun settIverksatt(behandlingId: UUID, dryRun: Boolean = true)
 }
 
 class FoerstegangsbehandlingServiceImpl(
@@ -218,56 +211,6 @@ class FoerstegangsbehandlingServiceImpl(
                 behandlingDao.lagreGyldighetsproving(it)
                 logger.info("behandling ${it.id} i sak: ${it.sak.id} er gyldighetsprøvd. Saktype: ${it.sak.sakType}")
             }
-    }
-
-    override fun settOpprettet(behandlingId: UUID, dryRun: Boolean) {
-        hentBehandling(behandlingId)?.tilOpprettet()?.lagreEndring(dryRun)
-    }
-
-    override fun settVilkaarsvurdert(behandlingId: UUID, dryRun: Boolean) {
-        val behandling = hentFoerstegangsbehandling(behandlingId)?.tilVilkaarsvurdert()
-
-        if (!dryRun) {
-            inTransaction {
-                behandling?.let {
-                    behandlingDao.lagreStatus(it.id, it.status, it.sistEndret)
-                }
-            }
-        }
-    }
-
-    override fun settBeregnet(behandlingId: UUID, dryRun: Boolean) {
-        hentFoerstegangsbehandling(behandlingId)?.tilBeregnet()?.lagreEndring(dryRun)
-    }
-
-    override fun settFattetVedtak(behandlingId: UUID, dryRun: Boolean) {
-        hentFoerstegangsbehandling(behandlingId)?.tilFattetVedtak()?.lagreEndring(dryRun)
-    }
-
-    override fun settAttestert(behandlingId: UUID, dryRun: Boolean) {
-        hentFoerstegangsbehandling(behandlingId)?.tilAttestert()?.lagreEndring(dryRun)
-    }
-
-    override fun settReturnert(behandlingId: UUID, dryRun: Boolean) {
-        hentFoerstegangsbehandling(behandlingId)?.tilReturnert()?.lagreEndring(dryRun)
-    }
-
-    override fun settIverksatt(behandlingId: UUID, dryRun: Boolean) {
-        hentFoerstegangsbehandling(behandlingId)?.tilIverksatt()?.lagreEndring(dryRun)
-    }
-
-    private fun Foerstegangsbehandling.lagreEndring(dryRun: Boolean) {
-        if (dryRun) return
-
-        lagreNyBehandlingStatus(this)
-    }
-
-    private fun lagreNyBehandlingStatus(behandling: Foerstegangsbehandling) {
-        inTransaction {
-            behandling.let {
-                behandlingDao.lagreStatus(it.id, it.status, it.sistEndret)
-            }
-        }
     }
 
     private fun opprettMerknad(sak: Sak, persongalleri: Persongalleri): String? {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringService.kt
@@ -4,8 +4,8 @@ import no.nav.etterlatte.behandling.BehandlingFactory
 import no.nav.etterlatte.behandling.BehandlingHendelseType
 import no.nav.etterlatte.behandling.BehandlingHendelserKafkaProducer
 import no.nav.etterlatte.behandling.BehandlingService
+import no.nav.etterlatte.behandling.GyldighetsproevingService
 import no.nav.etterlatte.behandling.domain.Behandling
-import no.nav.etterlatte.behandling.foerstegangsbehandling.FoerstegangsbehandlingService
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeService
 import no.nav.etterlatte.behandling.migrering.MigreringRepository
 import no.nav.etterlatte.libs.common.Vedtaksloesning
@@ -19,7 +19,7 @@ import no.nav.etterlatte.sak.SakService
 
 class MigreringService(
     private val sakService: SakService,
-    private val foerstegangsBehandlingService: FoerstegangsbehandlingService,
+    private val gyldighetsproevingService: GyldighetsproevingService,
     private val behandlingFactory: BehandlingFactory,
     private val kommerBarnetTilGodeService: KommerBarnetTilGodeService,
     private val behandlingsHendelser: BehandlingHendelserKafkaProducer,
@@ -36,7 +36,7 @@ class MigreringService(
                 behandlingId = it.id
             )
         )
-        foerstegangsBehandlingService.lagreGyldighetsproeving(
+        gyldighetsproevingService.lagreGyldighetsproeving(
             it.id,
             pesys,
             JaNeiMedBegrunnelse(JaNei.JA, "Automatisk importert fra Pesys")

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringService.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.behandling.omregning
 
+import no.nav.etterlatte.behandling.BehandlingFactory
 import no.nav.etterlatte.behandling.BehandlingHendelseType
 import no.nav.etterlatte.behandling.BehandlingHendelserKafkaProducer
 import no.nav.etterlatte.behandling.BehandlingService
@@ -19,6 +20,7 @@ import no.nav.etterlatte.sak.SakService
 class MigreringService(
     private val sakService: SakService,
     private val foerstegangsBehandlingService: FoerstegangsbehandlingService,
+    private val behandlingFactory: BehandlingFactory,
     private val kommerBarnetTilGodeService: KommerBarnetTilGodeService,
     private val behandlingsHendelser: BehandlingHendelserKafkaProducer,
     private val migreringRepository: MigreringRepository,
@@ -51,7 +53,7 @@ class MigreringService(
     }
 
     private fun opprettSakOgBehandling(request: MigreringRequest): Behandling? =
-        foerstegangsBehandlingService.opprettBehandling(
+        behandlingFactory.opprettBehandling(
             finnEllerOpprettSak(request).id,
             request.persongalleri,
             null,

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -173,13 +173,7 @@ class ApplicationContext(
 
     val foerstegangsbehandlingService =
         FoerstegangsbehandlingServiceImpl(
-            oppgaveService = oppgaveServiceNy,
-            grunnlagService = grunnlagsService,
-            revurderingService = revurderingService,
-            sakDao = sakDao,
             behandlingDao = behandlingDao,
-            hendelseDao = hendelseDao,
-            behandlingHendelser = behandlingsHendelser,
             featureToggleService = featureToggleService
         )
 

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -4,6 +4,7 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import io.ktor.client.HttpClient
 import no.nav.etterlatte.behandling.BehandlingDao
+import no.nav.etterlatte.behandling.BehandlingFactory
 import no.nav.etterlatte.behandling.BehandlingServiceImpl
 import no.nav.etterlatte.behandling.BehandlingStatusServiceImpl
 import no.nav.etterlatte.behandling.BehandlingsHendelserKafkaProducerImpl
@@ -221,13 +222,25 @@ class ApplicationContext(
     val behandlingsStatusService =
         BehandlingStatusServiceImpl(behandlingDao, behandlingService, grunnlagsendringshendelseService)
 
+    val behandlingFactory = BehandlingFactory(
+        oppgaveService = oppgaveServiceNy,
+        grunnlagService = grunnlagsService,
+        revurderingService = revurderingService,
+        sakDao = sakDao,
+        behandlingDao = behandlingDao,
+        hendelseDao = hendelseDao,
+        behandlingHendelser = behandlingsHendelser,
+        featureToggleService = featureToggleService
+    )
+
     val migreringService = MigreringService(
         sakService = sakService,
         foerstegangsBehandlingService = foerstegangsbehandlingService,
         behandlingsHendelser = behandlingsHendelser,
         migreringRepository = MigreringRepository(dataSource),
         behandlingService = behandlingService,
-        kommerBarnetTilGodeService = kommerBarnetTilGodeService
+        kommerBarnetTilGodeService = kommerBarnetTilGodeService,
+        behandlingFactory = behandlingFactory
     )
 
     // Job

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -10,7 +10,7 @@ import no.nav.etterlatte.behandling.BehandlingStatusServiceImpl
 import no.nav.etterlatte.behandling.BehandlingsHendelserKafkaProducerImpl
 import no.nav.etterlatte.behandling.EnhetServiceImpl
 import no.nav.etterlatte.behandling.GrunnlagService
-import no.nav.etterlatte.behandling.foerstegangsbehandling.FoerstegangsbehandlingServiceImpl
+import no.nav.etterlatte.behandling.GyldighetsproevingServiceImpl
 import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.behandling.klienter.GrunnlagKlient
 import no.nav.etterlatte.behandling.klienter.GrunnlagKlientObo
@@ -171,8 +171,8 @@ class ApplicationContext(
             kommerBarnetTilGodeService = kommerBarnetTilGodeService
         )
 
-    val foerstegangsbehandlingService =
-        FoerstegangsbehandlingServiceImpl(
+    val gyldighetsproevingService =
+        GyldighetsproevingServiceImpl(
             behandlingDao = behandlingDao,
             featureToggleService = featureToggleService
         )
@@ -229,7 +229,7 @@ class ApplicationContext(
 
     val migreringService = MigreringService(
         sakService = sakService,
-        foerstegangsBehandlingService = foerstegangsbehandlingService,
+        gyldighetsproevingService = gyldighetsproevingService,
         behandlingsHendelser = behandlingsHendelser,
         migreringRepository = MigreringRepository(dataSource),
         behandlingService = behandlingService,

--- a/apps/etterlatte-behandling/src/test/kotlin/OmregningIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/OmregningIntegrationTest.kt
@@ -66,7 +66,7 @@ class OmregningIntegrationTest : BehandlingIntegrationTest() {
                 applicationContext.sakDao.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr)
             }
 
-            val behandling = applicationContext.foerstegangsbehandlingService
+            val behandling = applicationContext.behandlingFactory
                 .opprettBehandling(
                     sak.id,
                     persongalleri(),

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
@@ -1,0 +1,523 @@
+package behandling
+
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import no.nav.etterlatte.Context
+import no.nav.etterlatte.DatabaseKontekst
+import no.nav.etterlatte.Kontekst
+import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
+import no.nav.etterlatte.behandling.BehandlingDao
+import no.nav.etterlatte.behandling.BehandlingFactory
+import no.nav.etterlatte.behandling.BehandlingHendelseType
+import no.nav.etterlatte.behandling.BehandlingHendelserKafkaProducer
+import no.nav.etterlatte.behandling.BehandlingServiceFeatureToggle
+import no.nav.etterlatte.behandling.GrunnlagService
+import no.nav.etterlatte.behandling.domain.Foerstegangsbehandling
+import no.nav.etterlatte.behandling.domain.OpprettBehandling
+import no.nav.etterlatte.behandling.domain.Revurdering
+import no.nav.etterlatte.behandling.hendelse.HendelseDao
+import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeService
+import no.nav.etterlatte.behandling.revurdering.RevurderingServiceImpl
+import no.nav.etterlatte.common.Enheter
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
+import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseDao
+import no.nav.etterlatte.libs.common.Vedtaksloesning
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
+import no.nav.etterlatte.libs.common.behandling.JaNei
+import no.nav.etterlatte.libs.common.behandling.KommerBarnetTilgode
+import no.nav.etterlatte.libs.common.behandling.Persongalleri
+import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import no.nav.etterlatte.libs.common.sak.Sak
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
+import no.nav.etterlatte.oppgaveny.OppgaveServiceNy
+import no.nav.etterlatte.oppgaveny.OppgaveType
+import no.nav.etterlatte.oppgaveny.opprettNyOppgaveMedReferanseOgSak
+import no.nav.etterlatte.revurdering
+import no.nav.etterlatte.sak.SakDao
+import no.nav.etterlatte.sak.SakServiceFeatureToggle
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.sql.Connection
+import java.time.YearMonth
+import java.util.*
+
+class BehandlingFactoryTest {
+
+    private val user = mockk<SaksbehandlerMedEnheterOgRoller>()
+    private val sakDaoMock = mockk<SakDao>()
+    private val behandlingDaoMock = mockk<BehandlingDao>()
+    private val hendelseDaoMock = mockk<HendelseDao>()
+    private val behandlingHendelserKafkaProducerMock = mockk<BehandlingHendelserKafkaProducer>()
+    private val featureToggleService = mockk<FeatureToggleService>()
+    private val grunnlagsendringshendelseDao = mockk<GrunnlagsendringshendelseDao>()
+    private val grunnlagService = mockk<GrunnlagService>()
+    private val oppgaveService = mockk<OppgaveServiceNy>()
+    private val mockOppgave = opprettNyOppgaveMedReferanseOgSak(
+        "behandling",
+        Sak("ident", SakType.BARNEPENSJON, 1L, Enheter.AALESUND.enhetNr),
+        OppgaveType.FOERSTEGANGSBEHANDLING
+    )
+    private val kommerBarnetTilGodeService = mockk<KommerBarnetTilGodeService>().also {
+        every { it.hentKommerBarnetTilGode(any()) } returns null
+    }
+    private val revurderingService = RevurderingServiceImpl(
+        oppgaveService,
+        grunnlagService,
+        behandlingHendelserKafkaProducerMock,
+        featureToggleService,
+        behandlingDaoMock,
+        hendelseDaoMock,
+        grunnlagsendringshendelseDao,
+        kommerBarnetTilGodeService
+    )
+    private val behandlingFactory = BehandlingFactory(
+        oppgaveService,
+        grunnlagService,
+        revurderingService,
+        sakDaoMock,
+        behandlingDaoMock,
+        hendelseDaoMock,
+        behandlingHendelserKafkaProducerMock,
+        featureToggleService
+    )
+
+    @BeforeEach
+    fun before() {
+        Kontekst.set(
+            Context(
+                user,
+                object : DatabaseKontekst {
+                    override fun activeTx(): Connection {
+                        throw IllegalArgumentException()
+                    }
+
+                    override fun <T> inTransaction(gjenbruk: Boolean, block: () -> T): T {
+                        return block()
+                    }
+                }
+            )
+        )
+    }
+
+    @AfterEach
+    fun after() {
+        confirmVerified(sakDaoMock, behandlingDaoMock, hendelseDaoMock, behandlingHendelserKafkaProducerMock)
+        clearAllMocks()
+    }
+
+    @Test
+    fun startBehandling() {
+        val behandlingOpprettes = slot<OpprettBehandling>()
+        val behandlingHentes = slot<UUID>()
+        val datoNaa = Tidspunkt.now().toLocalDatetimeUTC()
+
+        every { featureToggleService.isEnabled(BehandlingServiceFeatureToggle.FiltrerMedEnhetId, false) } returns false
+        every { featureToggleService.isEnabled(SakServiceFeatureToggle.FiltrerMedEnhetId, false) } returns false
+
+        val opprettetBehandling = Foerstegangsbehandling(
+            id = UUID.randomUUID(),
+            sak = Sak(
+                ident = "Soeker",
+                sakType = SakType.BARNEPENSJON,
+                id = 1,
+                enhet = Enheter.defaultEnhet.enhetNr
+            ),
+            behandlingOpprettet = datoNaa,
+            sistEndret = datoNaa,
+            status = BehandlingStatus.OPPRETTET,
+            soeknadMottattDato = Tidspunkt.now().toLocalDatetimeUTC(),
+            persongalleri = Persongalleri(
+                "Innsender",
+                "Soeker",
+                listOf("Gjenlevende"),
+                listOf("Avdoed"),
+                emptyList()
+            ),
+            gyldighetsproeving = null,
+            virkningstidspunkt = Virkningstidspunkt(
+                YearMonth.of(2022, 1),
+                Grunnlagsopplysning.Saksbehandler.create("ident"),
+                "begrunnelse"
+            ),
+            utenlandstilsnitt = null,
+            boddEllerArbeidetUtlandet = null,
+            kommerBarnetTilgode = null,
+            kilde = Vedtaksloesning.GJENNY
+        )
+
+        val persongalleri = Persongalleri(
+            "Soeker",
+            "Innsender",
+            emptyList(),
+            listOf("Avdoed"),
+            listOf("Gjenlevende")
+        )
+
+        every { sakDaoMock.hentSak(any()) } returns opprettetBehandling.sak
+        every { behandlingDaoMock.opprettBehandling(capture(behandlingOpprettes)) } returns Unit
+        every { behandlingDaoMock.hentBehandling(capture(behandlingHentes)) } returns opprettetBehandling
+        every { hendelseDaoMock.behandlingOpprettet(any()) } returns Unit
+        every { behandlingDaoMock.lagreGyldighetsproving(any()) } returns Unit
+        every { behandlingDaoMock.alleBehandlingerISak(any()) } returns listOf(opprettetBehandling)
+        every { behandlingDaoMock.lagreStatus(any(), any(), any()) } returns Unit
+        every { behandlingHendelserKafkaProducerMock.sendMeldingForHendelse(any(), any()) } returns Unit
+        every { grunnlagService.leggInnNyttGrunnlag(any()) } returns Unit
+        every { oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any()) } returns mockOppgave
+
+        val resultat = behandlingFactory.opprettBehandling(
+            1,
+            persongalleri,
+            datoNaa.toString(),
+            Vedtaksloesning.GJENNY
+        )!!
+
+        Assertions.assertEquals(opprettetBehandling, resultat)
+        Assertions.assertEquals(opprettetBehandling.persongalleri.avdoed, resultat.persongalleri.avdoed)
+        Assertions.assertEquals(opprettetBehandling.sak, resultat.sak)
+        Assertions.assertEquals(opprettetBehandling.id, resultat.id)
+        Assertions.assertEquals(opprettetBehandling.persongalleri.soeker, resultat.persongalleri.soeker)
+        Assertions.assertEquals(opprettetBehandling.behandlingOpprettet, resultat.behandlingOpprettet)
+        Assertions.assertEquals(1, behandlingOpprettes.captured.sakId)
+        Assertions.assertEquals(behandlingHentes.captured, behandlingOpprettes.captured.id)
+
+        verify(exactly = 1) {
+            sakDaoMock.hentSak(any())
+            behandlingDaoMock.hentBehandling(any())
+            behandlingDaoMock.opprettBehandling(any())
+            hendelseDaoMock.behandlingOpprettet(any())
+            behandlingDaoMock.alleBehandlingerISak(any())
+            behandlingDaoMock.lagreStatus(any(), any(), any())
+            behandlingHendelserKafkaProducerMock.sendMeldingForHendelse(any(), BehandlingHendelseType.OPPRETTET)
+            grunnlagService.leggInnNyttGrunnlag(any())
+            oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any())
+            oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `skal opprette kun foerstegangsbehandling hvis det ikke finnes noen tidligere behandlinger`() {
+        val behandlingOpprettes = slot<OpprettBehandling>()
+        val behandlingHentes = slot<UUID>()
+        val datoNaa = Tidspunkt.now().toLocalDatetimeUTC()
+
+        every { featureToggleService.isEnabled(BehandlingServiceFeatureToggle.FiltrerMedEnhetId, false) } returns false
+        every { featureToggleService.isEnabled(SakServiceFeatureToggle.FiltrerMedEnhetId, false) } returns false
+
+        val opprettetBehandling = Foerstegangsbehandling(
+            id = UUID.randomUUID(),
+            sak = Sak(
+                ident = "Soeker",
+                sakType = SakType.BARNEPENSJON,
+                id = 1,
+                enhet = Enheter.defaultEnhet.enhetNr
+            ),
+            behandlingOpprettet = datoNaa,
+            sistEndret = datoNaa,
+            status = BehandlingStatus.OPPRETTET,
+            soeknadMottattDato = Tidspunkt.now().toLocalDatetimeUTC(),
+            persongalleri = Persongalleri(
+                "Innsender",
+                "Soeker",
+                listOf("Gjenlevende"),
+                listOf("Avdoed"),
+                emptyList()
+            ),
+            gyldighetsproeving = null,
+            virkningstidspunkt = Virkningstidspunkt(
+                YearMonth.of(2022, 1),
+                Grunnlagsopplysning.Saksbehandler.create("ident"),
+                "begrunnelse"
+            ),
+            utenlandstilsnitt = null,
+            boddEllerArbeidetUtlandet = null,
+            kommerBarnetTilgode = null,
+            kilde = Vedtaksloesning.GJENNY
+        )
+
+        val persongalleri = Persongalleri(
+            "Soeker",
+            "Innsender",
+            emptyList(),
+            listOf("Avdoed"),
+            listOf("Gjenlevende")
+        )
+
+        every { sakDaoMock.hentSak(any()) } returns opprettetBehandling.sak
+        every { behandlingDaoMock.opprettBehandling(capture(behandlingOpprettes)) } returns Unit
+        every { behandlingDaoMock.hentBehandling(capture(behandlingHentes)) } returns opprettetBehandling
+        every { behandlingDaoMock.alleBehandlingerISak(any()) } returns emptyList()
+        every { hendelseDaoMock.behandlingOpprettet(any()) } returns Unit
+        every { behandlingHendelserKafkaProducerMock.sendMeldingForHendelse(any(), any()) } returns Unit
+        every { grunnlagService.leggInnNyttGrunnlag(any()) } returns Unit
+        every { oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any()) } returns mockOppgave
+
+        val foerstegangsbehandling = behandlingFactory.opprettBehandling(
+            1,
+            persongalleri,
+            datoNaa.toString(),
+            Vedtaksloesning.GJENNY
+        )!!
+
+        Assertions.assertTrue(foerstegangsbehandling is Foerstegangsbehandling)
+
+        verify(exactly = 1) {
+            sakDaoMock.hentSak(any())
+            behandlingDaoMock.hentBehandling(any())
+            behandlingDaoMock.opprettBehandling(any())
+            hendelseDaoMock.behandlingOpprettet(any())
+            behandlingDaoMock.alleBehandlingerISak(any())
+            behandlingHendelserKafkaProducerMock.sendMeldingForHendelse(any(), any())
+            grunnlagService.leggInnNyttGrunnlag(any())
+            oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any())
+            oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `skal avbryte behandling hvis under behandling og opprette en ny`() {
+        val behandlingOpprettes = slot<OpprettBehandling>()
+        val behandlingHentes = slot<UUID>()
+        val datoNaa = Tidspunkt.now().toLocalDatetimeUTC()
+
+        every {
+            featureToggleService.isEnabled(BehandlingServiceFeatureToggle.FiltrerMedEnhetId, false)
+        } returns false
+        every { featureToggleService.isEnabled(SakServiceFeatureToggle.FiltrerMedEnhetId, false) } returns false
+
+        val underArbeidBehandling = Foerstegangsbehandling(
+            id = UUID.randomUUID(),
+            sak = Sak(
+                ident = "Soeker",
+                sakType = SakType.BARNEPENSJON,
+                id = 1,
+                enhet = Enheter.defaultEnhet.enhetNr
+            ),
+            behandlingOpprettet = datoNaa,
+            sistEndret = datoNaa,
+            status = BehandlingStatus.OPPRETTET,
+            soeknadMottattDato = Tidspunkt.now().toLocalDatetimeUTC(),
+            persongalleri = Persongalleri(
+                "Innsender",
+                "Soeker",
+                listOf("Gjenlevende"),
+                listOf("Avdoed"),
+                emptyList()
+            ),
+            gyldighetsproeving = null,
+            virkningstidspunkt = Virkningstidspunkt(
+                YearMonth.of(2022, 1),
+                Grunnlagsopplysning.Saksbehandler.create("ident"),
+                "begrunnelse"
+            ),
+            utenlandstilsnitt = null,
+            boddEllerArbeidetUtlandet = null,
+            kommerBarnetTilgode = null,
+            kilde = Vedtaksloesning.GJENNY
+        )
+
+        val persongalleri = Persongalleri(
+            "Soeker",
+            "Innsender",
+            emptyList(),
+            listOf("Avdoed"),
+            listOf("Gjenlevende")
+        )
+
+        every { sakDaoMock.hentSak(any()) } returns underArbeidBehandling.sak
+        every { behandlingDaoMock.opprettBehandling(capture(behandlingOpprettes)) } returns Unit
+        every { behandlingDaoMock.hentBehandling(capture(behandlingHentes)) } returns underArbeidBehandling
+        every {
+            behandlingDaoMock.alleBehandlingerISak(any())
+        } returns emptyList()
+        every { behandlingDaoMock.lagreStatus(any(), any(), any()) } returns Unit
+        every { hendelseDaoMock.behandlingOpprettet(any()) } returns Unit
+        every { behandlingHendelserKafkaProducerMock.sendMeldingForHendelse(any(), any()) } returns Unit
+        every { grunnlagService.leggInnNyttGrunnlag(any()) } returns Unit
+        every { oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any()) } returns mockOppgave
+
+        val foerstegangsbehandling = behandlingFactory.opprettBehandling(
+            1,
+            persongalleri,
+            datoNaa.toString(),
+            Vedtaksloesning.GJENNY
+        )!!
+
+        Assertions.assertTrue(foerstegangsbehandling is Foerstegangsbehandling)
+
+        every {
+            behandlingDaoMock.alleBehandlingerISak(any())
+        } returns listOf(underArbeidBehandling)
+
+        val nyfoerstegangsbehandling = behandlingFactory.opprettBehandling(
+            1,
+            persongalleri,
+            datoNaa.toString(),
+            Vedtaksloesning.GJENNY
+        )
+        Assertions.assertTrue(nyfoerstegangsbehandling is Foerstegangsbehandling)
+
+        verify(exactly = 2) {
+            sakDaoMock.hentSak(any())
+            behandlingDaoMock.hentBehandling(any())
+            behandlingDaoMock.opprettBehandling(any())
+            hendelseDaoMock.behandlingOpprettet(any())
+            behandlingDaoMock.alleBehandlingerISak(any())
+            behandlingHendelserKafkaProducerMock.sendMeldingForHendelse(any(), any())
+            grunnlagService.leggInnNyttGrunnlag(any())
+            oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any())
+            oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any())
+        }
+        verify {
+            behandlingDaoMock.lagreStatus(any(), BehandlingStatus.AVBRUTT, any())
+        }
+    }
+
+    @Test
+    fun `skal lage ny behandling som revurdering hvis behandling er satt til iverksatt`() {
+        val behandlingOpprettes = slot<OpprettBehandling>()
+        val behandlingHentes = slot<UUID>()
+        val datoNaa = Tidspunkt.now().toLocalDatetimeUTC()
+
+        every {
+            featureToggleService.isEnabled(BehandlingServiceFeatureToggle.FiltrerMedEnhetId, false)
+        } returns false
+        every { featureToggleService.isEnabled(SakServiceFeatureToggle.FiltrerMedEnhetId, false) } returns false
+
+        val nyBehandling = Foerstegangsbehandling(
+            id = UUID.randomUUID(),
+            sak = Sak(
+                ident = "Soeker",
+                sakType = SakType.BARNEPENSJON,
+                id = 1,
+                enhet = Enheter.defaultEnhet.enhetNr
+            ),
+            behandlingOpprettet = datoNaa,
+            sistEndret = datoNaa,
+            status = BehandlingStatus.OPPRETTET,
+            soeknadMottattDato = Tidspunkt.now().toLocalDatetimeUTC(),
+            persongalleri = Persongalleri(
+                "Innsender",
+                "Soeker",
+                listOf("Gjenlevende"),
+                listOf("Avdoed"),
+                emptyList()
+            ),
+            gyldighetsproeving = null,
+            virkningstidspunkt = Virkningstidspunkt(
+                YearMonth.of(2022, 1),
+                Grunnlagsopplysning.Saksbehandler.create("ident"),
+                "begrunnelse"
+            ),
+            utenlandstilsnitt = null,
+            boddEllerArbeidetUtlandet = null,
+            kommerBarnetTilgode = null,
+            kilde = Vedtaksloesning.GJENNY
+        )
+
+        val persongalleri = Persongalleri(
+            "Soeker",
+            "Innsender",
+            emptyList(),
+            listOf("Avdoed"),
+            listOf("Gjenlevende")
+        )
+
+        every { sakDaoMock.hentSak(any()) } returns nyBehandling.sak
+        every { behandlingDaoMock.opprettBehandling(capture(behandlingOpprettes)) } returns Unit
+        every { behandlingDaoMock.hentBehandling(capture(behandlingHentes)) } returns nyBehandling
+        every {
+            behandlingDaoMock.alleBehandlingerISak(any())
+        } returns emptyList()
+        every { behandlingDaoMock.lagreStatus(any(), any(), any()) } returns Unit
+        every { hendelseDaoMock.behandlingOpprettet(any()) } returns Unit
+        every { behandlingHendelserKafkaProducerMock.sendMeldingForHendelse(any(), any()) } returns Unit
+        every { grunnlagService.leggInnNyttGrunnlag(any()) } returns Unit
+        every { oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any()) } returns mockOppgave
+
+        val foerstegangsbehandling = behandlingFactory.opprettBehandling(
+            1,
+            persongalleri,
+            datoNaa.toString(),
+            Vedtaksloesning.GJENNY
+        )!!
+
+        Assertions.assertTrue(foerstegangsbehandling is Foerstegangsbehandling)
+
+        val iverksattBehandlingId = UUID.randomUUID()
+        val iverksattBehandling = Foerstegangsbehandling(
+            id = iverksattBehandlingId,
+            sak = Sak(
+                ident = "Soeker",
+                sakType = SakType.BARNEPENSJON,
+                id = 1,
+                enhet = Enheter.defaultEnhet.enhetNr
+            ),
+            behandlingOpprettet = datoNaa,
+            sistEndret = datoNaa,
+            status = BehandlingStatus.IVERKSATT,
+            soeknadMottattDato = Tidspunkt.now().toLocalDatetimeUTC(),
+            persongalleri = Persongalleri(
+                "Innsender",
+                "Soeker",
+                listOf("Gjenlevende"),
+                listOf("Avdoed"),
+                emptyList()
+            ),
+            gyldighetsproeving = null,
+            virkningstidspunkt = Virkningstidspunkt(
+                YearMonth.of(2022, 1),
+                Grunnlagsopplysning.Saksbehandler.create("ident"),
+                "begrunnelse"
+            ),
+            utenlandstilsnitt = null,
+            boddEllerArbeidetUtlandet = null,
+            kommerBarnetTilgode = KommerBarnetTilgode(
+                JaNei.JA,
+                "",
+                Grunnlagsopplysning.Saksbehandler.create("saksbehandler"),
+                iverksattBehandlingId
+            ),
+            kilde = Vedtaksloesning.GJENNY
+        )
+
+        every {
+            behandlingDaoMock.alleBehandlingerISak(any())
+        } returns listOf(iverksattBehandling)
+
+        every { behandlingDaoMock.hentBehandling(any()) } returns revurdering(
+            sakId = 1,
+            revurderingAarsak = RevurderingAarsak.NY_SOEKNAD,
+            enhet = Enheter.defaultEnhet.enhetNr
+        )
+
+        val revurderingsBehandling = behandlingFactory.opprettBehandling(
+            1,
+            persongalleri,
+            datoNaa.toString(),
+            Vedtaksloesning.GJENNY
+        )
+        Assertions.assertTrue(revurderingsBehandling is Revurdering)
+        verify {
+            grunnlagService.leggInnNyttGrunnlag(any())
+        }
+        verify(exactly = 2) {
+            sakDaoMock.hentSak(any())
+            behandlingDaoMock.hentBehandling(any())
+            behandlingDaoMock.opprettBehandling(any())
+            hendelseDaoMock.behandlingOpprettet(any())
+            behandlingDaoMock.alleBehandlingerISak(any())
+            behandlingHendelserKafkaProducerMock.sendMeldingForHendelse(any(), any())
+            oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any())
+        }
+    }
+}

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
@@ -23,9 +23,9 @@ import io.mockk.verify
 import no.nav.etterlatte.behandling.BehandlingFactory
 import no.nav.etterlatte.behandling.BehandlingService
 import no.nav.etterlatte.behandling.BoddEllerArbeidetUtlandetRequest
+import no.nav.etterlatte.behandling.GyldighetsproevingService
 import no.nav.etterlatte.behandling.UtenlandstilsnittRequest
 import no.nav.etterlatte.behandling.behandlingRoutes
-import no.nav.etterlatte.behandling.foerstegangsbehandling.FoerstegangsbehandlingService
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeService
 import no.nav.etterlatte.behandling.manueltopphoer.ManueltOpphoerService
 import no.nav.etterlatte.libs.common.behandling.UtenlandstilsnittType
@@ -53,7 +53,7 @@ internal class BehandlingRoutesTest {
     private val mockOAuth2Server = MockOAuth2Server()
     private lateinit var hoconApplicationConfig: HoconApplicationConfig
     private val behandlingService = mockk<BehandlingService>(relaxUnitFun = true)
-    private val foerstegangsbehandlingService = mockk<FoerstegangsbehandlingService>()
+    private val gyldighetsproevingService = mockk<GyldighetsproevingService>()
     private val kommerBarnetTilGodeService = mockk<KommerBarnetTilGodeService>()
     private val manueltOpphoerService = mockk<ManueltOpphoerService>()
     private val behandlingFactory = mockk<BehandlingFactory>()
@@ -189,7 +189,7 @@ internal class BehandlingRoutesTest {
                 restModule(this.log) {
                     behandlingRoutes(
                         behandlingService,
-                        foerstegangsbehandlingService,
+                        gyldighetsproevingService,
                         kommerBarnetTilGodeService,
                         manueltOpphoerService,
                         behandlingFactory

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
@@ -20,6 +20,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import no.nav.etterlatte.behandling.BehandlingFactory
 import no.nav.etterlatte.behandling.BehandlingService
 import no.nav.etterlatte.behandling.BoddEllerArbeidetUtlandetRequest
 import no.nav.etterlatte.behandling.UtenlandstilsnittRequest
@@ -55,6 +56,7 @@ internal class BehandlingRoutesTest {
     private val foerstegangsbehandlingService = mockk<FoerstegangsbehandlingService>()
     private val kommerBarnetTilGodeService = mockk<KommerBarnetTilGodeService>()
     private val manueltOpphoerService = mockk<ManueltOpphoerService>()
+    private val behandlingFactory = mockk<BehandlingFactory>()
 
     @BeforeAll
     fun before() {
@@ -189,7 +191,8 @@ internal class BehandlingRoutesTest {
                         behandlingService,
                         foerstegangsbehandlingService,
                         kommerBarnetTilGodeService,
-                        manueltOpphoerService
+                        manueltOpphoerService,
+                        behandlingFactory
                     )
                 }
             }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/FoerstegangsbehandlingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/FoerstegangsbehandlingServiceImplTest.kt
@@ -166,7 +166,7 @@ internal class FoerstegangsbehandlingServiceImplTest {
             kilde = Vedtaksloesning.GJENNY
         )
 
-        assertEquals("Soeker", behandlingsService.hentFoerstegangsbehandling(id)!!.persongalleri.innsender)
+        assertEquals("Soeker", behandlingsService.hentBehandling(id)!!.persongalleri.innsender)
 
         verify(exactly = 1) { behandlingDaoMock.hentBehandling(id) }
     }
@@ -672,7 +672,7 @@ internal class FoerstegangsbehandlingServiceImplTest {
             kilde = Vedtaksloesning.GJENNY
         )
 
-        assertEquals("Soeker", behandlingsService.hentFoerstegangsbehandling(id)!!.persongalleri.innsender)
+        assertEquals("Soeker", behandlingsService.hentBehandling(id)!!.persongalleri.innsender)
 
         verify(exactly = 1) { behandlingDaoMock.hentBehandling(id) }
     }
@@ -720,7 +720,7 @@ internal class FoerstegangsbehandlingServiceImplTest {
             kilde = Vedtaksloesning.GJENNY
         )
 
-        assertEquals("Soeker", behandlingsService.hentFoerstegangsbehandling(id)!!.persongalleri.innsender)
+        assertEquals("Soeker", behandlingsService.hentBehandling(id)!!.persongalleri.innsender)
 
         verify(exactly = 1) { behandlingDaoMock.hentBehandling(id) }
     }
@@ -768,7 +768,7 @@ internal class FoerstegangsbehandlingServiceImplTest {
             kilde = Vedtaksloesning.GJENNY
         )
 
-        assertNull(behandlingsService.hentFoerstegangsbehandling(id))
+        assertNull(behandlingsService.hentBehandling(id))
 
         verify(exactly = 1) { behandlingDaoMock.hentBehandling(id) }
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/FoerstegangsbehandlingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/FoerstegangsbehandlingServiceImplTest.kt
@@ -6,15 +6,12 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.verify
 import no.nav.etterlatte.Context
 import no.nav.etterlatte.DatabaseKontekst
 import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
 import no.nav.etterlatte.behandling.domain.Foerstegangsbehandling
-import no.nav.etterlatte.behandling.domain.OpprettBehandling
-import no.nav.etterlatte.behandling.domain.Revurdering
 import no.nav.etterlatte.behandling.foerstegangsbehandling.FoerstegangsbehandlingServiceImpl
 import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeService
@@ -26,10 +23,8 @@ import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.JaNei
 import no.nav.etterlatte.libs.common.behandling.JaNeiMedBegrunnelse
-import no.nav.etterlatte.libs.common.behandling.KommerBarnetTilgode
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
-import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -44,16 +39,11 @@ import no.nav.etterlatte.libs.common.tidspunkt.fixedNorskTid
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeNorskTid
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.oppgaveny.OppgaveServiceNy
-import no.nav.etterlatte.oppgaveny.OppgaveType
-import no.nav.etterlatte.oppgaveny.opprettNyOppgaveMedReferanseOgSak
 import no.nav.etterlatte.persongalleri
-import no.nav.etterlatte.revurdering
 import no.nav.etterlatte.sak.SakDao
-import no.nav.etterlatte.sak.SakServiceFeatureToggle
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.sql.Connection
@@ -72,11 +62,6 @@ internal class FoerstegangsbehandlingServiceImplTest {
     private val grunnlagsendringshendelseDao = mockk<GrunnlagsendringshendelseDao>()
     private val grunnlagService = mockk<GrunnlagService>()
     private val oppgaveService = mockk<OppgaveServiceNy>()
-    private val mockOppgave = opprettNyOppgaveMedReferanseOgSak(
-        "behandling",
-        Sak("ident", SakType.BARNEPENSJON, 1L, Enheter.AALESUND.enhetNr),
-        OppgaveType.FOERSTEGANGSBEHANDLING
-    )
     private val kommerBarnetTilGodeService = mockk<KommerBarnetTilGodeService>().also {
         every { it.hentKommerBarnetTilGode(any()) } returns null
     }
@@ -169,412 +154,6 @@ internal class FoerstegangsbehandlingServiceImplTest {
         assertEquals("Soeker", behandlingsService.hentBehandling(id)!!.persongalleri.innsender)
 
         verify(exactly = 1) { behandlingDaoMock.hentBehandling(id) }
-    }
-
-    @Test
-    fun startBehandling() {
-        val behandlingOpprettes = slot<OpprettBehandling>()
-        val behandlingHentes = slot<UUID>()
-        val datoNaa = Tidspunkt.now().toLocalDatetimeUTC()
-
-        every { featureToggleService.isEnabled(BehandlingServiceFeatureToggle.FiltrerMedEnhetId, false) } returns false
-        every { featureToggleService.isEnabled(SakServiceFeatureToggle.FiltrerMedEnhetId, false) } returns false
-
-        val opprettetBehandling = Foerstegangsbehandling(
-            id = UUID.randomUUID(),
-            sak = Sak(
-                ident = "Soeker",
-                sakType = SakType.BARNEPENSJON,
-                id = 1,
-                enhet = Enheter.defaultEnhet.enhetNr
-            ),
-            behandlingOpprettet = datoNaa,
-            sistEndret = datoNaa,
-            status = BehandlingStatus.OPPRETTET,
-            soeknadMottattDato = Tidspunkt.now().toLocalDatetimeUTC(),
-            persongalleri = Persongalleri(
-                "Innsender",
-                "Soeker",
-                listOf("Gjenlevende"),
-                listOf("Avdoed"),
-                emptyList()
-            ),
-            gyldighetsproeving = null,
-            virkningstidspunkt = Virkningstidspunkt(
-                YearMonth.of(2022, 1),
-                Grunnlagsopplysning.Saksbehandler.create("ident"),
-                "begrunnelse"
-            ),
-            utenlandstilsnitt = null,
-            boddEllerArbeidetUtlandet = null,
-            kommerBarnetTilgode = null,
-            kilde = Vedtaksloesning.GJENNY
-        )
-
-        val persongalleri = Persongalleri(
-            "Soeker",
-            "Innsender",
-            emptyList(),
-            listOf("Avdoed"),
-            listOf("Gjenlevende")
-        )
-
-        every { sakDaoMock.hentSak(any()) } returns opprettetBehandling.sak
-        every { behandlingDaoMock.opprettBehandling(capture(behandlingOpprettes)) } returns Unit
-        every { behandlingDaoMock.hentBehandling(capture(behandlingHentes)) } returns opprettetBehandling
-        every { hendelseDaoMock.behandlingOpprettet(any()) } returns Unit
-        every { behandlingDaoMock.lagreGyldighetsproving(any()) } returns Unit
-        every { behandlingDaoMock.alleBehandlingerISak(any()) } returns listOf(opprettetBehandling)
-        every { behandlingDaoMock.lagreStatus(any(), any(), any()) } returns Unit
-        every { behandlingHendelserKafkaProducerMock.sendMeldingForHendelse(any(), any()) } returns Unit
-        every { grunnlagService.leggInnNyttGrunnlag(any()) } returns Unit
-        every { oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any()) } returns mockOppgave
-
-        val resultat = behandlingsService.opprettBehandling(
-            1,
-            persongalleri,
-            datoNaa.toString(),
-            Vedtaksloesning.GJENNY
-        )!!
-
-        assertEquals(opprettetBehandling, resultat)
-        assertEquals(opprettetBehandling.persongalleri.avdoed, resultat.persongalleri.avdoed)
-        assertEquals(opprettetBehandling.sak, resultat.sak)
-        assertEquals(opprettetBehandling.id, resultat.id)
-        assertEquals(opprettetBehandling.persongalleri.soeker, resultat.persongalleri.soeker)
-        assertEquals(opprettetBehandling.behandlingOpprettet, resultat.behandlingOpprettet)
-        assertEquals(1, behandlingOpprettes.captured.sakId)
-        assertEquals(behandlingHentes.captured, behandlingOpprettes.captured.id)
-
-        verify(exactly = 1) {
-            sakDaoMock.hentSak(any())
-            behandlingDaoMock.hentBehandling(any())
-            behandlingDaoMock.opprettBehandling(any())
-            hendelseDaoMock.behandlingOpprettet(any())
-            behandlingDaoMock.alleBehandlingerISak(any())
-            behandlingDaoMock.lagreStatus(any(), any(), any())
-            behandlingHendelserKafkaProducerMock.sendMeldingForHendelse(any(), BehandlingHendelseType.OPPRETTET)
-            grunnlagService.leggInnNyttGrunnlag(any())
-            oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any())
-            oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any())
-        }
-    }
-
-    @Test
-    fun `skal opprette kun foerstegangsbehandling hvis det ikke finnes noen tidligere behandlinger`() {
-        val behandlingOpprettes = slot<OpprettBehandling>()
-        val behandlingHentes = slot<UUID>()
-        val datoNaa = Tidspunkt.now().toLocalDatetimeUTC()
-
-        every { featureToggleService.isEnabled(BehandlingServiceFeatureToggle.FiltrerMedEnhetId, false) } returns false
-        every { featureToggleService.isEnabled(SakServiceFeatureToggle.FiltrerMedEnhetId, false) } returns false
-
-        val opprettetBehandling = Foerstegangsbehandling(
-            id = UUID.randomUUID(),
-            sak = Sak(
-                ident = "Soeker",
-                sakType = SakType.BARNEPENSJON,
-                id = 1,
-                enhet = Enheter.defaultEnhet.enhetNr
-            ),
-            behandlingOpprettet = datoNaa,
-            sistEndret = datoNaa,
-            status = BehandlingStatus.OPPRETTET,
-            soeknadMottattDato = Tidspunkt.now().toLocalDatetimeUTC(),
-            persongalleri = Persongalleri(
-                "Innsender",
-                "Soeker",
-                listOf("Gjenlevende"),
-                listOf("Avdoed"),
-                emptyList()
-            ),
-            gyldighetsproeving = null,
-            virkningstidspunkt = Virkningstidspunkt(
-                YearMonth.of(2022, 1),
-                Grunnlagsopplysning.Saksbehandler.create("ident"),
-                "begrunnelse"
-            ),
-            utenlandstilsnitt = null,
-            boddEllerArbeidetUtlandet = null,
-            kommerBarnetTilgode = null,
-            kilde = Vedtaksloesning.GJENNY
-        )
-
-        val persongalleri = Persongalleri(
-            "Soeker",
-            "Innsender",
-            emptyList(),
-            listOf("Avdoed"),
-            listOf("Gjenlevende")
-        )
-
-        every { sakDaoMock.hentSak(any()) } returns opprettetBehandling.sak
-        every { behandlingDaoMock.opprettBehandling(capture(behandlingOpprettes)) } returns Unit
-        every { behandlingDaoMock.hentBehandling(capture(behandlingHentes)) } returns opprettetBehandling
-        every { behandlingDaoMock.alleBehandlingerISak(any()) } returns emptyList()
-        every { hendelseDaoMock.behandlingOpprettet(any()) } returns Unit
-        every { behandlingHendelserKafkaProducerMock.sendMeldingForHendelse(any(), any()) } returns Unit
-        every { grunnlagService.leggInnNyttGrunnlag(any()) } returns Unit
-        every { oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any()) } returns mockOppgave
-
-        val foerstegangsbehandling = behandlingsService.opprettBehandling(
-            1,
-            persongalleri,
-            datoNaa.toString(),
-            Vedtaksloesning.GJENNY
-        )!!
-
-        assertTrue(foerstegangsbehandling is Foerstegangsbehandling)
-
-        verify(exactly = 1) {
-            sakDaoMock.hentSak(any())
-            behandlingDaoMock.hentBehandling(any())
-            behandlingDaoMock.opprettBehandling(any())
-            hendelseDaoMock.behandlingOpprettet(any())
-            behandlingDaoMock.alleBehandlingerISak(any())
-            behandlingHendelserKafkaProducerMock.sendMeldingForHendelse(any(), any())
-            grunnlagService.leggInnNyttGrunnlag(any())
-            oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any())
-            oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any())
-        }
-    }
-
-    @Test
-    fun `skal avbryte behandling hvis under behandling og opprette en ny`() {
-        val behandlingOpprettes = slot<OpprettBehandling>()
-        val behandlingHentes = slot<UUID>()
-        val datoNaa = Tidspunkt.now().toLocalDatetimeUTC()
-
-        every {
-            featureToggleService.isEnabled(BehandlingServiceFeatureToggle.FiltrerMedEnhetId, false)
-        } returns false
-        every { featureToggleService.isEnabled(SakServiceFeatureToggle.FiltrerMedEnhetId, false) } returns false
-
-        val underArbeidBehandling = Foerstegangsbehandling(
-            id = UUID.randomUUID(),
-            sak = Sak(
-                ident = "Soeker",
-                sakType = SakType.BARNEPENSJON,
-                id = 1,
-                enhet = Enheter.defaultEnhet.enhetNr
-            ),
-            behandlingOpprettet = datoNaa,
-            sistEndret = datoNaa,
-            status = BehandlingStatus.OPPRETTET,
-            soeknadMottattDato = Tidspunkt.now().toLocalDatetimeUTC(),
-            persongalleri = Persongalleri(
-                "Innsender",
-                "Soeker",
-                listOf("Gjenlevende"),
-                listOf("Avdoed"),
-                emptyList()
-            ),
-            gyldighetsproeving = null,
-            virkningstidspunkt = Virkningstidspunkt(
-                YearMonth.of(2022, 1),
-                Grunnlagsopplysning.Saksbehandler.create("ident"),
-                "begrunnelse"
-            ),
-            utenlandstilsnitt = null,
-            boddEllerArbeidetUtlandet = null,
-            kommerBarnetTilgode = null,
-            kilde = Vedtaksloesning.GJENNY
-        )
-
-        val persongalleri = Persongalleri(
-            "Soeker",
-            "Innsender",
-            emptyList(),
-            listOf("Avdoed"),
-            listOf("Gjenlevende")
-        )
-
-        every { sakDaoMock.hentSak(any()) } returns underArbeidBehandling.sak
-        every { behandlingDaoMock.opprettBehandling(capture(behandlingOpprettes)) } returns Unit
-        every { behandlingDaoMock.hentBehandling(capture(behandlingHentes)) } returns underArbeidBehandling
-        every {
-            behandlingDaoMock.alleBehandlingerISak(any())
-        } returns emptyList()
-        every { behandlingDaoMock.lagreStatus(any(), any(), any()) } returns Unit
-        every { hendelseDaoMock.behandlingOpprettet(any()) } returns Unit
-        every { behandlingHendelserKafkaProducerMock.sendMeldingForHendelse(any(), any()) } returns Unit
-        every { grunnlagService.leggInnNyttGrunnlag(any()) } returns Unit
-        every { oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any()) } returns mockOppgave
-
-        val foerstegangsbehandling = behandlingsService.opprettBehandling(
-            1,
-            persongalleri,
-            datoNaa.toString(),
-            Vedtaksloesning.GJENNY
-        )!!
-
-        assertTrue(foerstegangsbehandling is Foerstegangsbehandling)
-
-        every {
-            behandlingDaoMock.alleBehandlingerISak(any())
-        } returns listOf(underArbeidBehandling)
-
-        val nyfoerstegangsbehandling = behandlingsService.opprettBehandling(
-            1,
-            persongalleri,
-            datoNaa.toString(),
-            Vedtaksloesning.GJENNY
-        )
-        assertTrue(nyfoerstegangsbehandling is Foerstegangsbehandling)
-
-        verify(exactly = 2) {
-            sakDaoMock.hentSak(any())
-            behandlingDaoMock.hentBehandling(any())
-            behandlingDaoMock.opprettBehandling(any())
-            hendelseDaoMock.behandlingOpprettet(any())
-            behandlingDaoMock.alleBehandlingerISak(any())
-            behandlingHendelserKafkaProducerMock.sendMeldingForHendelse(any(), any())
-            grunnlagService.leggInnNyttGrunnlag(any())
-            oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any())
-            oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any())
-        }
-        verify {
-            behandlingDaoMock.lagreStatus(any(), BehandlingStatus.AVBRUTT, any())
-        }
-    }
-
-    @Test
-    fun `skal lage ny behandling som revurdering hvis behandling er satt til iverksatt`() {
-        val behandlingOpprettes = slot<OpprettBehandling>()
-        val behandlingHentes = slot<UUID>()
-        val datoNaa = Tidspunkt.now().toLocalDatetimeUTC()
-
-        every {
-            featureToggleService.isEnabled(BehandlingServiceFeatureToggle.FiltrerMedEnhetId, false)
-        } returns false
-        every { featureToggleService.isEnabled(SakServiceFeatureToggle.FiltrerMedEnhetId, false) } returns false
-
-        val nyBehandling = Foerstegangsbehandling(
-            id = UUID.randomUUID(),
-            sak = Sak(
-                ident = "Soeker",
-                sakType = SakType.BARNEPENSJON,
-                id = 1,
-                enhet = Enheter.defaultEnhet.enhetNr
-            ),
-            behandlingOpprettet = datoNaa,
-            sistEndret = datoNaa,
-            status = BehandlingStatus.OPPRETTET,
-            soeknadMottattDato = Tidspunkt.now().toLocalDatetimeUTC(),
-            persongalleri = Persongalleri(
-                "Innsender",
-                "Soeker",
-                listOf("Gjenlevende"),
-                listOf("Avdoed"),
-                emptyList()
-            ),
-            gyldighetsproeving = null,
-            virkningstidspunkt = Virkningstidspunkt(
-                YearMonth.of(2022, 1),
-                Grunnlagsopplysning.Saksbehandler.create("ident"),
-                "begrunnelse"
-            ),
-            utenlandstilsnitt = null,
-            boddEllerArbeidetUtlandet = null,
-            kommerBarnetTilgode = null,
-            kilde = Vedtaksloesning.GJENNY
-        )
-
-        val persongalleri = Persongalleri(
-            "Soeker",
-            "Innsender",
-            emptyList(),
-            listOf("Avdoed"),
-            listOf("Gjenlevende")
-        )
-
-        every { sakDaoMock.hentSak(any()) } returns nyBehandling.sak
-        every { behandlingDaoMock.opprettBehandling(capture(behandlingOpprettes)) } returns Unit
-        every { behandlingDaoMock.hentBehandling(capture(behandlingHentes)) } returns nyBehandling
-        every {
-            behandlingDaoMock.alleBehandlingerISak(any())
-        } returns emptyList()
-        every { behandlingDaoMock.lagreStatus(any(), any(), any()) } returns Unit
-        every { hendelseDaoMock.behandlingOpprettet(any()) } returns Unit
-        every { behandlingHendelserKafkaProducerMock.sendMeldingForHendelse(any(), any()) } returns Unit
-        every { grunnlagService.leggInnNyttGrunnlag(any()) } returns Unit
-        every { oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any()) } returns mockOppgave
-
-        val foerstegangsbehandling = behandlingsService.opprettBehandling(
-            1,
-            persongalleri,
-            datoNaa.toString(),
-            Vedtaksloesning.GJENNY
-        )!!
-
-        assertTrue(foerstegangsbehandling is Foerstegangsbehandling)
-
-        val iverksattBehandlingId = UUID.randomUUID()
-        val iverksattBehandling = Foerstegangsbehandling(
-            id = iverksattBehandlingId,
-            sak = Sak(
-                ident = "Soeker",
-                sakType = SakType.BARNEPENSJON,
-                id = 1,
-                enhet = Enheter.defaultEnhet.enhetNr
-            ),
-            behandlingOpprettet = datoNaa,
-            sistEndret = datoNaa,
-            status = BehandlingStatus.IVERKSATT,
-            soeknadMottattDato = Tidspunkt.now().toLocalDatetimeUTC(),
-            persongalleri = Persongalleri(
-                "Innsender",
-                "Soeker",
-                listOf("Gjenlevende"),
-                listOf("Avdoed"),
-                emptyList()
-            ),
-            gyldighetsproeving = null,
-            virkningstidspunkt = Virkningstidspunkt(
-                YearMonth.of(2022, 1),
-                Grunnlagsopplysning.Saksbehandler.create("ident"),
-                "begrunnelse"
-            ),
-            utenlandstilsnitt = null,
-            boddEllerArbeidetUtlandet = null,
-            kommerBarnetTilgode = KommerBarnetTilgode(
-                JaNei.JA,
-                "",
-                Grunnlagsopplysning.Saksbehandler.create("saksbehandler"),
-                iverksattBehandlingId
-            ),
-            kilde = Vedtaksloesning.GJENNY
-        )
-
-        every {
-            behandlingDaoMock.alleBehandlingerISak(any())
-        } returns listOf(iverksattBehandling)
-
-        every { behandlingDaoMock.hentBehandling(any()) } returns revurdering(
-            sakId = 1,
-            revurderingAarsak = RevurderingAarsak.NY_SOEKNAD,
-            enhet = Enheter.defaultEnhet.enhetNr
-        )
-
-        val revurderingsBehandling = behandlingsService.opprettBehandling(
-            1,
-            persongalleri,
-            datoNaa.toString(),
-            Vedtaksloesning.GJENNY
-        )
-        assertTrue(revurderingsBehandling is Revurdering)
-        verify {
-            grunnlagService.leggInnNyttGrunnlag(any())
-        }
-        verify(exactly = 2) {
-            sakDaoMock.hentSak(any())
-            behandlingDaoMock.hentBehandling(any())
-            behandlingDaoMock.opprettBehandling(any())
-            hendelseDaoMock.behandlingOpprettet(any())
-            behandlingDaoMock.alleBehandlingerISak(any())
-            behandlingHendelserKafkaProducerMock.sendMeldingForHendelse(any(), any())
-            oppgaveService.opprettNyOppgaveMedSakOgReferanse(any(), any(), any())
-        }
     }
 
     @Test

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/FoerstegangsbehandlingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/FoerstegangsbehandlingServiceImplTest.kt
@@ -77,13 +77,7 @@ internal class FoerstegangsbehandlingServiceImplTest {
     )
     private val naaTid = Tidspunkt.now()
     private val behandlingsService = FoerstegangsbehandlingServiceImpl(
-        oppgaveService,
-        grunnlagService,
-        revurderingService,
-        sakDaoMock,
         behandlingDaoMock,
-        hendelseDaoMock,
-        behandlingHendelserKafkaProducerMock,
         featureToggleService,
         naaTid.fixedNorskTid()
     )

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/GyldighetsproevingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/GyldighetsproevingServiceImplTest.kt
@@ -12,7 +12,6 @@ import no.nav.etterlatte.DatabaseKontekst
 import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
 import no.nav.etterlatte.behandling.domain.Foerstegangsbehandling
-import no.nav.etterlatte.behandling.foerstegangsbehandling.FoerstegangsbehandlingServiceImpl
 import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeService
 import no.nav.etterlatte.behandling.revurdering.RevurderingServiceImpl
@@ -51,7 +50,7 @@ import java.time.LocalDateTime
 import java.time.YearMonth
 import java.util.*
 
-internal class FoerstegangsbehandlingServiceImplTest {
+internal class GyldighetsproevingServiceImplTest {
 
     private val user = mockk<SaksbehandlerMedEnheterOgRoller>()
     private val sakDaoMock = mockk<SakDao>()
@@ -76,7 +75,7 @@ internal class FoerstegangsbehandlingServiceImplTest {
         kommerBarnetTilGodeService
     )
     private val naaTid = Tidspunkt.now()
-    private val behandlingsService = FoerstegangsbehandlingServiceImpl(
+    private val behandlingsService = GyldighetsproevingServiceImpl(
         behandlingDaoMock,
         featureToggleService,
         naaTid.fixedNorskTid()

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/GyldighetsproevingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/GyldighetsproevingServiceImplTest.kt
@@ -13,11 +13,8 @@ import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
 import no.nav.etterlatte.behandling.domain.Foerstegangsbehandling
 import no.nav.etterlatte.behandling.hendelse.HendelseDao
-import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeService
-import no.nav.etterlatte.behandling.revurdering.RevurderingServiceImpl
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
-import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseDao
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.JaNei
@@ -37,7 +34,6 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.fixedNorskTid
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeNorskTid
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
-import no.nav.etterlatte.oppgaveny.OppgaveServiceNy
 import no.nav.etterlatte.persongalleri
 import no.nav.etterlatte.sak.SakDao
 import org.junit.jupiter.api.AfterEach
@@ -58,22 +54,6 @@ internal class GyldighetsproevingServiceImplTest {
     private val hendelseDaoMock = mockk<HendelseDao>()
     private val behandlingHendelserKafkaProducerMock = mockk<BehandlingHendelserKafkaProducer>()
     private val featureToggleService = mockk<FeatureToggleService>()
-    private val grunnlagsendringshendelseDao = mockk<GrunnlagsendringshendelseDao>()
-    private val grunnlagService = mockk<GrunnlagService>()
-    private val oppgaveService = mockk<OppgaveServiceNy>()
-    private val kommerBarnetTilGodeService = mockk<KommerBarnetTilGodeService>().also {
-        every { it.hentKommerBarnetTilGode(any()) } returns null
-    }
-    private val revurderingService = RevurderingServiceImpl(
-        oppgaveService,
-        grunnlagService,
-        behandlingHendelserKafkaProducerMock,
-        featureToggleService,
-        behandlingDaoMock,
-        hendelseDaoMock,
-        grunnlagsendringshendelseDao,
-        kommerBarnetTilGodeService
-    )
     private val naaTid = Tidspunkt.now()
     private val behandlingsService = GyldighetsproevingServiceImpl(
         behandlingDaoMock,

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/GyldighetsproevingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/GyldighetsproevingServiceImplTest.kt
@@ -124,7 +124,7 @@ internal class GyldighetsproevingServiceImplTest {
             kilde = Vedtaksloesning.GJENNY
         )
 
-        assertEquals("Soeker", behandlingsService.hentBehandling(id)!!.persongalleri.innsender)
+        assertEquals("Soeker", behandlingsService.hentFoerstegangsbehandling(id)!!.persongalleri.innsender)
 
         verify(exactly = 1) { behandlingDaoMock.hentBehandling(id) }
     }
@@ -224,7 +224,7 @@ internal class GyldighetsproevingServiceImplTest {
             kilde = Vedtaksloesning.GJENNY
         )
 
-        assertEquals("Soeker", behandlingsService.hentBehandling(id)!!.persongalleri.innsender)
+        assertEquals("Soeker", behandlingsService.hentFoerstegangsbehandling(id)!!.persongalleri.innsender)
 
         verify(exactly = 1) { behandlingDaoMock.hentBehandling(id) }
     }
@@ -272,7 +272,7 @@ internal class GyldighetsproevingServiceImplTest {
             kilde = Vedtaksloesning.GJENNY
         )
 
-        assertEquals("Soeker", behandlingsService.hentBehandling(id)!!.persongalleri.innsender)
+        assertEquals("Soeker", behandlingsService.hentFoerstegangsbehandling(id)!!.persongalleri.innsender)
 
         verify(exactly = 1) { behandlingDaoMock.hentBehandling(id) }
     }
@@ -320,7 +320,7 @@ internal class GyldighetsproevingServiceImplTest {
             kilde = Vedtaksloesning.GJENNY
         )
 
-        assertNull(behandlingsService.hentBehandling(id))
+        assertNull(behandlingsService.hentFoerstegangsbehandling(id))
 
         verify(exactly = 1) { behandlingDaoMock.hentBehandling(id) }
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingIntegrationTest.kt
@@ -8,6 +8,7 @@ import io.mockk.verify
 import no.nav.etterlatte.BehandlingIntegrationTest
 import no.nav.etterlatte.Context
 import no.nav.etterlatte.Kontekst
+import no.nav.etterlatte.behandling.BehandlingFactory
 import no.nav.etterlatte.behandling.BehandlingHendelseType
 import no.nav.etterlatte.behandling.BehandlingServiceFeatureToggle
 import no.nav.etterlatte.behandling.domain.Foerstegangsbehandling
@@ -16,7 +17,6 @@ import no.nav.etterlatte.behandling.domain.GrunnlagsendringsType
 import no.nav.etterlatte.behandling.domain.Grunnlagsendringshendelse
 import no.nav.etterlatte.behandling.domain.Revurdering
 import no.nav.etterlatte.behandling.domain.SamsvarMellomKildeOgGrunnlag
-import no.nav.etterlatte.behandling.foerstegangsbehandling.FoerstegangsbehandlingServiceImpl
 import no.nav.etterlatte.common.DatabaseContext
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
@@ -67,13 +67,12 @@ class RevurderingIntegrationTest : BehandlingIntegrationTest() {
 
     fun opprettSakMedFoerstegangsbehandling(
         fnr: String,
-        foerstegangsbehandlingService: FoerstegangsbehandlingServiceImpl? = null
+        behandlingFactory: BehandlingFactory? = null
     ): Pair<Sak, Foerstegangsbehandling?> {
         val sak = inTransaction {
             applicationContext.sakDao.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr)
         }
-        val forstegangsService = foerstegangsbehandlingService ?: applicationContext.foerstegangsbehandlingService
-        val behandling = forstegangsService
+        val behandling = (behandlingFactory ?: applicationContext.behandlingFactory)
             .opprettBehandling(
                 sak.id,
                 persongalleri(),
@@ -351,8 +350,8 @@ class RevurderingIntegrationTest : BehandlingIntegrationTest() {
                 applicationContext.kommerBarnetTilGodeService
             )
 
-        val foerstegangsbehandlingService =
-            FoerstegangsbehandlingServiceImpl(
+        val behandlingFactory =
+            BehandlingFactory(
                 oppgaveService = oppgaveService,
                 grunnlagService = grunnlagService,
                 revurderingService = revurderingService,
@@ -363,7 +362,7 @@ class RevurderingIntegrationTest : BehandlingIntegrationTest() {
                 featureToggleService = featureToggleService
             )
 
-        val (sak, behandling) = opprettSakMedFoerstegangsbehandling(fnr, foerstegangsbehandlingService)
+        val (sak, behandling) = opprettSakMedFoerstegangsbehandling(fnr, behandlingFactory)
 
         assertNotNull(behandling)
 


### PR DESCRIPTION
- Oppretting av behandling er mykje logikk, og malplassert der han ligg i dag. Synes denne fortener sin eigen factory no
- Mykje i `FoerstegangsbehandlingService` var ubrukt. Det som endte opp med å vera der etter alt ubrukt var sletta og oppretting var trekt ut, var gyldighetsprøving-konseptet, så reindyrka den klassa for det formålet

Denne PR-en skal ikkje ha nokre funksjonelle endringar/konsekvensar, det er kun refaktorisering