### PR TITLE
Unngår feil i jobbkøyring ved deploy av applikasjon 

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -27,6 +27,7 @@ import no.nav.etterlatte.egenansatt.egenAnsattRoute
 import no.nav.etterlatte.grunnlagsendring.grunnlagsendringshendelseRoute
 import no.nav.etterlatte.institusjonsopphold.InstitusjonsoppholdService
 import no.nav.etterlatte.institusjonsopphold.institusjonsoppholdRoute
+import no.nav.etterlatte.jobs.addShutdownHook
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.restModule
@@ -63,16 +64,8 @@ class Server(private val context: ApplicationContext) {
 
     fun run() = with(context) {
         dataSource.migrate()
-
-        val grunnlagsendringshendelseJobSkedulert = grunnlagsendringshendelseJob.schedule()
+        grunnlagsendringshendelseJob.schedule().also { addShutdownHook(it) }
         setReady().also { engine.start(true) }
-
-        Runtime.getRuntime().addShutdownHook(
-            Thread {
-                grunnlagsendringshendelseJob.setClosedTrue()
-                grunnlagsendringshendelseJobSkedulert.cancel()
-            }
-        )
     }
 }
 

--- a/apps/etterlatte-statistikk/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/Application.kt
@@ -1,17 +1,20 @@
 package no.nav.etterlatte
 
+import no.nav.etterlatte.jobs.addShutdownHook
 import no.nav.etterlatte.statistikk.config.ApplicationContext
+import no.nav.etterlatte.statistikk.config.sikkerLogg
 import no.nav.helse.rapids_rivers.RapidsConnection
 
 fun main() {
     with(ApplicationContext()) {
         jobs(this)
         rapidApplication(this).start()
+        sikkerLogg.info("Sikkerlogg fra etterlatte-statistikk")
     }
 }
 
 fun jobs(applicationContext: ApplicationContext) {
-    applicationContext.maanedligStatistikkJob.schedule()
+    applicationContext.maanedligStatistikkJob.schedule().also { addShutdownHook(it) }
 }
 
 fun rapidApplication(applicationContext: ApplicationContext): RapidsConnection =

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/config/ApplicationContext.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/config/ApplicationContext.kt
@@ -22,11 +22,14 @@ import no.nav.etterlatte.statistikk.service.SoeknadStatistikkServiceImpl
 import no.nav.etterlatte.statistikk.service.StatistikkService
 import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helse.rapids_rivers.RapidsConnection
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import rapidsandrivers.getRapidEnv
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 import javax.sql.DataSource
 
+val sikkerLogg: Logger = LoggerFactory.getLogger("sikkerLogg")
 class ApplicationContext {
     private val env = System.getenv()
     val rapidsConnection: RapidsConnection = RapidApplication.create(getRapidEnv())

--- a/apps/etterlatte-utbetaling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/Application.kt
@@ -1,10 +1,12 @@
 package no.nav.etterlatte
 
+import no.nav.etterlatte.jobs.addShutdownHook
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.utbetaling.config.ApplicationContext
 import no.nav.helse.rapids_rivers.RapidsConnection
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.util.*
 
 val sikkerLogg: Logger = LoggerFactory.getLogger("sikkerLogg")
 
@@ -17,18 +19,20 @@ fun main() {
 }
 
 fun jobs(applicationContext: ApplicationContext) {
+    val jobs = mutableSetOf<Timer>()
     with(applicationContext.grensesnittavstemmingJob) {
-        if (applicationContext.properties.grensesnittavstemmingEnabled) schedule()
+        if (applicationContext.properties.grensesnittavstemmingEnabled) schedule().also { jobs.add(it) }
     }
     with(applicationContext.grensesnittavstemmingJobOMS) {
-        if (applicationContext.properties.grensesnittavstemmingOMSEnabled) schedule()
+        if (applicationContext.properties.grensesnittavstemmingOMSEnabled) schedule().also { jobs.add(it) }
     }
     with(applicationContext.konsistensavstemmingJob) {
-        if (applicationContext.properties.konsistensavstemmingEnabled) schedule()
+        if (applicationContext.properties.konsistensavstemmingEnabled) schedule().also { jobs.add(it) }
     }
     with(applicationContext.konsistensavstemmingJobOMS) {
-        if (applicationContext.properties.konsistensavstemmingOMSEnabled) schedule()
+        if (applicationContext.properties.konsistensavstemmingOMSEnabled) schedule().also { jobs.add(it) }
     }
+    addShutdownHook(jobs)
 }
 
 fun rapidApplication(applicationContext: ApplicationContext): RapidsConnection =

--- a/libs/etterlatte-jobs/src/main/kotlin/jobs/TimerUtils.kt
+++ b/libs/etterlatte-jobs/src/main/kotlin/jobs/TimerUtils.kt
@@ -1,0 +1,60 @@
+package no.nav.etterlatte.jobs
+
+import org.slf4j.Logger
+import java.util.*
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.fixedRateTimer
+
+fun fixedRateCancellableTimer(
+    name: String?,
+    initialDelay: Long,
+    period: Long,
+    logger: Logger,
+    sikkerLogg: Logger,
+    action: TimerTask.() -> Unit
+) = fixedRateTimer(
+    name = name,
+    daemon = true,
+    initialDelay = initialDelay,
+    period = period
+) {
+    run(action, logger, name, sikkerLogg)
+}
+
+fun fixedRateCancellableTimer(
+    name: String?,
+    startAt: Date,
+    period: Long,
+    logger: Logger,
+    sikkerLogg: Logger,
+    action: TimerTask.() -> Unit
+) = fixedRateTimer(
+    name = name,
+    daemon = true,
+    startAt = startAt,
+    period = period
+) {
+    run(action, logger, name, sikkerLogg)
+}
+
+private fun TimerTask.run(action: TimerTask.() -> Unit, logger: Logger, name: String?, sikkerLogg: Logger) = try {
+    action()
+} catch (throwable: Throwable) {
+    if (!shuttingDown.get()) {
+        logger.error("Jobb $name feilet, se sikker logg for stacktrace")
+        sikkerLogg.error("Jobb $name feilet", throwable)
+    } else {
+        logger.info("Jobb $name feilet mens applikasjonen avsluttet, se sikker logg for stacktrace")
+        sikkerLogg.info("Jobb $name feilet mens applikasjonen avsluttet", throwable)
+    }
+}
+
+val shuttingDown: AtomicBoolean = AtomicBoolean(false)
+
+fun addShutdownHook(timers: Set<Timer>) = addShutdownHook(*timers.toTypedArray())
+fun addShutdownHook(vararg timer: Timer) = Runtime.getRuntime().addShutdownHook(
+    Thread {
+        shuttingDown.set(true)
+        timer.forEach { it.cancel() }
+    }
+)


### PR DESCRIPTION
Ved å lytte på shutdown-flagg i det vi plukkar opp feilmeldinga.

Samlar med det samme logikken og sentraliserer dette i etterlatte-jobs-modulen, kjens naturleg at det er der