### PR TITLE
EY-2484: Forenklar og samkøyrer bruken vår at HttpClient, headers og konfig

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/NavAnsattKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/NavAnsattKlient.kt
@@ -10,6 +10,7 @@ import io.ktor.client.request.header
 import io.ktor.http.isSuccess
 import no.nav.etterlatte.behandling.domain.SaksbehandlerEnhet
 import no.nav.etterlatte.behandling.domain.SaksbehandlerTema
+import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.libs.ktor.PingResult
@@ -70,7 +71,7 @@ class NavAnsattKlientImpl(
 
                 val response = client.get("$url/navansatt/$ident/${infoType.urlSuffix}") {
                     header(X_CORRELATION_ID, getXCorrelationId())
-                    header("Nav_Call_Id", getXCorrelationId())
+                    header(NAV_CALL_ID, getXCorrelationId())
                 }
 
                 if (response.status.isSuccess()) {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/NavAnsattKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/NavAnsattKlient.kt
@@ -7,11 +7,11 @@ import io.ktor.client.call.body
 import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.get
 import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.isSuccess
 import no.nav.etterlatte.behandling.domain.SaksbehandlerEnhet
 import no.nav.etterlatte.behandling.domain.SaksbehandlerTema
 import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
-import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.libs.ktor.PingResult
 import no.nav.etterlatte.libs.ktor.Pingable
@@ -70,7 +70,7 @@ class NavAnsattKlientImpl(
                 logger.info("Henter enhet for saksbehandler med ident $ident")
 
                 val response = client.get("$url/navansatt/$ident/${infoType.urlSuffix}") {
-                    header(X_CORRELATION_ID, getXCorrelationId())
+                    header(XCorrelationId, getXCorrelationId())
                     header(NAV_CALL_ID, getXCorrelationId())
                 }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/NavAnsattKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/NavAnsattKlient.kt
@@ -6,13 +6,9 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.get
-import io.ktor.client.request.header
-import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.isSuccess
 import no.nav.etterlatte.behandling.domain.SaksbehandlerEnhet
 import no.nav.etterlatte.behandling.domain.SaksbehandlerTema
-import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
-import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.libs.ktor.PingResult
 import no.nav.etterlatte.libs.ktor.Pingable
 import no.nav.etterlatte.libs.ktor.ping
@@ -69,10 +65,7 @@ class NavAnsattKlientImpl(
             } else {
                 logger.info("Henter enhet for saksbehandler med ident $ident")
 
-                val response = client.get("$url/navansatt/$ident/${infoType.urlSuffix}") {
-                    header(XCorrelationId, getXCorrelationId())
-                    header(NAV_CALL_ID, getXCorrelationId())
-                }
+                val response = client.get("$url/navansatt/$ident/${infoType.urlSuffix}")
 
                 if (response.status.isSuccess()) {
                     response.body<T>()

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/Norg2Klient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/Norg2Klient.kt
@@ -4,18 +4,14 @@ import com.github.benmanes.caffeine.cache.Caffeine
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.ResponseException
-import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.domain.ArbeidsFordelingEnhet
 import no.nav.etterlatte.behandling.domain.ArbeidsFordelingRequest
-import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
-import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import org.slf4j.LoggerFactory
 import java.time.Duration
 
@@ -47,8 +43,6 @@ class Norg2KlientImpl(private val client: HttpClient, private val url: String) :
 
                 runBlocking {
                     val response = client.post("$url/arbeidsfordeling/enheter/bestmatch") {
-                        header(XCorrelationId, getXCorrelationId())
-                        header(NAV_CALL_ID, getXCorrelationId())
                         contentType(ContentType.Application.Json)
                         setBody(request)
                     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/Norg2Klient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/Norg2Klient.kt
@@ -13,6 +13,7 @@ import io.ktor.http.isSuccess
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.domain.ArbeidsFordelingEnhet
 import no.nav.etterlatte.behandling.domain.ArbeidsFordelingRequest
+import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import org.slf4j.LoggerFactory
@@ -47,7 +48,7 @@ class Norg2KlientImpl(private val client: HttpClient, private val url: String) :
                 runBlocking {
                     val response = client.post("$url/arbeidsfordeling/enheter/bestmatch") {
                         header(X_CORRELATION_ID, getXCorrelationId())
-                        header("Nav_Call_Id", getXCorrelationId())
+                        header(NAV_CALL_ID, getXCorrelationId())
                         contentType(ContentType.Application.Json)
                         setBody(request)
                     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/Norg2Klient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/Norg2Klient.kt
@@ -8,13 +8,13 @@ import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.domain.ArbeidsFordelingEnhet
 import no.nav.etterlatte.behandling.domain.ArbeidsFordelingRequest
 import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
-import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import org.slf4j.LoggerFactory
 import java.time.Duration
@@ -47,7 +47,7 @@ class Norg2KlientImpl(private val client: HttpClient, private val url: String) :
 
                 runBlocking {
                     val response = client.post("$url/arbeidsfordeling/enheter/bestmatch") {
-                        header(X_CORRELATION_ID, getXCorrelationId())
+                        header(XCorrelationId, getXCorrelationId())
                         header(NAV_CALL_ID, getXCorrelationId())
                         contentType(ContentType.Application.Json)
                         setBody(request)

--- a/apps/etterlatte-behandling/src/main/kotlin/common/klienter/SkjermingKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/common/klienter/SkjermingKlient.kt
@@ -3,14 +3,10 @@ package no.nav.etterlatte.common.klienter
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.accept
-import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.contentType
-import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
-import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.libs.ktor.PingResult
 import no.nav.etterlatte.libs.ktor.PingResultDown
 import no.nav.etterlatte.libs.ktor.PingResultUp
@@ -26,8 +22,6 @@ class SkjermingKlient(
     suspend fun personErSkjermet(fnr: String): Boolean {
         return httpClient.post("$url/skjermet") {
             accept(ContentType.Application.Json)
-            header(XCorrelationId, getXCorrelationId())
-            header(NAV_CALL_ID, getXCorrelationId())
             contentType(ContentType.Application.Json)
             setBody(SkjermetDataRequestDTO(personident = fnr))
         }.body()
@@ -37,8 +31,6 @@ class SkjermingKlient(
         try {
             val skjermetFalse: Boolean = httpClient.post("$url/skjermet") {
                 accept(ContentType.Application.Json)
-                header(XCorrelationId, getXCorrelationId())
-                header(NAV_CALL_ID, getXCorrelationId())
                 contentType(ContentType.Application.Json)
                 setBody(SkjermetDataRequestDTO(personident = "dummy")) // Det er meningen å sende inn "dummy"
             }.body()

--- a/apps/etterlatte-behandling/src/main/kotlin/common/klienter/SkjermingKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/common/klienter/SkjermingKlient.kt
@@ -8,6 +8,7 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
+import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.libs.ktor.PingResult
@@ -26,7 +27,7 @@ class SkjermingKlient(
         return httpClient.post("$url/skjermet") {
             accept(ContentType.Application.Json)
             header(X_CORRELATION_ID, getXCorrelationId())
-            header("Nav_Call_Id", getXCorrelationId())
+            header(NAV_CALL_ID, getXCorrelationId())
             contentType(ContentType.Application.Json)
             setBody(SkjermetDataRequestDTO(personident = fnr))
         }.body()
@@ -37,7 +38,7 @@ class SkjermingKlient(
             val skjermetFalse: Boolean = httpClient.post("$url/skjermet") {
                 accept(ContentType.Application.Json)
                 header(X_CORRELATION_ID, getXCorrelationId())
-                header("Nav_Call_Id", getXCorrelationId())
+                header(NAV_CALL_ID, getXCorrelationId())
                 contentType(ContentType.Application.Json)
                 setBody(SkjermetDataRequestDTO(personident = "dummy")) // Det er meningen å sende inn "dummy"
             }.body()

--- a/apps/etterlatte-behandling/src/main/kotlin/common/klienter/SkjermingKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/common/klienter/SkjermingKlient.kt
@@ -7,9 +7,9 @@ import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.contentType
 import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
-import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.libs.ktor.PingResult
 import no.nav.etterlatte.libs.ktor.PingResultDown
@@ -26,7 +26,7 @@ class SkjermingKlient(
     suspend fun personErSkjermet(fnr: String): Boolean {
         return httpClient.post("$url/skjermet") {
             accept(ContentType.Application.Json)
-            header(X_CORRELATION_ID, getXCorrelationId())
+            header(XCorrelationId, getXCorrelationId())
             header(NAV_CALL_ID, getXCorrelationId())
             contentType(ContentType.Application.Json)
             setBody(SkjermetDataRequestDTO(personident = fnr))
@@ -37,7 +37,7 @@ class SkjermingKlient(
         try {
             val skjermetFalse: Boolean = httpClient.post("$url/skjermet") {
                 accept(ContentType.Application.Json)
-                header(X_CORRELATION_ID, getXCorrelationId())
+                header(XCorrelationId, getXCorrelationId())
                 header(NAV_CALL_ID, getXCorrelationId())
                 contentType(ContentType.Application.Json)
                 setBody(SkjermetDataRequestDTO(personident = "dummy")) // Det er meningen å sende inn "dummy"

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -7,6 +7,7 @@ import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.serialization.jackson.jackson
 import io.ktor.server.config.HoconApplicationConfig
 import no.nav.etterlatte.brev.BrevService
@@ -34,7 +35,6 @@ import no.nav.etterlatte.brev.grunnlag.GrunnlagKlient
 import no.nav.etterlatte.brev.navansatt.NavansattKlient
 import no.nav.etterlatte.brev.vedtak.VedtaksvurderingKlient
 import no.nav.etterlatte.brev.vedtaksbrevRoute
-import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getCorrelationId
 import no.nav.etterlatte.libs.common.requireEnvValue
 import no.nav.etterlatte.libs.database.DataSourceBuilder
@@ -171,7 +171,7 @@ class ApplicationBuilder {
             }
         }
         defaultRequest {
-            header(X_CORRELATION_ID, getCorrelationId())
+            header(XCorrelationId, getCorrelationId())
         }
     }.also { Runtime.getRuntime().addShutdownHook(Thread { it.close() }) }
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -35,6 +35,7 @@ import no.nav.etterlatte.brev.grunnlag.GrunnlagKlient
 import no.nav.etterlatte.brev.navansatt.NavansattKlient
 import no.nav.etterlatte.brev.vedtak.VedtaksvurderingKlient
 import no.nav.etterlatte.brev.vedtaksbrevRoute
+import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.getCorrelationId
 import no.nav.etterlatte.libs.common.requireEnvValue
 import no.nav.etterlatte.libs.database.DataSourceBuilder
@@ -172,6 +173,7 @@ class ApplicationBuilder {
         }
         defaultRequest {
             header(XCorrelationId, getCorrelationId())
+            header(NAV_CALL_ID, getCorrelationId())
         }
     }.also { Runtime.getRuntime().addShutdownHook(Thread { it.close() }) }
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -2,13 +2,7 @@ package no.nav.etterlatte
 
 import com.typesafe.config.ConfigFactory
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.auth.Auth
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.request.header
-import io.ktor.http.HttpHeaders.XCorrelationId
-import io.ktor.serialization.jackson.jackson
 import io.ktor.server.config.HoconApplicationConfig
 import no.nav.etterlatte.brev.BrevService
 import no.nav.etterlatte.brev.VedtaksbrevService
@@ -35,11 +29,10 @@ import no.nav.etterlatte.brev.grunnlag.GrunnlagKlient
 import no.nav.etterlatte.brev.navansatt.NavansattKlient
 import no.nav.etterlatte.brev.vedtak.VedtaksvurderingKlient
 import no.nav.etterlatte.brev.vedtaksbrevRoute
-import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
-import no.nav.etterlatte.libs.common.logging.getCorrelationId
 import no.nav.etterlatte.libs.common.requireEnvValue
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.database.migrate
+import no.nav.etterlatte.libs.ktor.httpClient
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 import no.nav.etterlatte.libs.ktor.restModule
 import no.nav.etterlatte.libs.ktor.setReady
@@ -155,25 +148,21 @@ class ApplicationBuilder {
 
     fun start() = setReady().also { rapidsConnection.start() }
 
-    private fun httpClient(scope: String? = null, forventStatusSuccess: Boolean = true) = HttpClient(OkHttp) {
-        expectSuccess = forventStatusSuccess
-        install(ContentNegotiation) {
-            jackson() {
-                addMixIn(RenderedJsonLetter.Block::class.java, BrevbakerJSONBlockMixIn::class.java)
-                addMixIn(RenderedJsonLetter.ParagraphContent::class.java, BrevbakerJSONParagraphMixIn::class.java)
-            }
-        }
-        if (scope != null) {
-            install(Auth) {
-                clientCredential {
-                    config = env.toMutableMap()
-                        .apply { put("AZURE_APP_OUTBOUND_SCOPE", requireNotNull(get(scope))) }
+    private fun httpClient(scope: String? = null, forventStatusSuccess: Boolean = true) = httpClient(
+        forventSuksess = forventStatusSuccess,
+        ekstraJacksoninnstillinger = {
+            it.addMixIn(RenderedJsonLetter.Block::class.java, BrevbakerJSONBlockMixIn::class.java)
+            it.addMixIn(RenderedJsonLetter.ParagraphContent::class.java, BrevbakerJSONParagraphMixIn::class.java)
+        },
+        auth = {
+            if (scope != null) {
+                it.install(Auth) {
+                    clientCredential {
+                        config = env.toMutableMap()
+                            .apply { put("AZURE_APP_OUTBOUND_SCOPE", requireNotNull(get(scope))) }
+                    }
                 }
             }
         }
-        defaultRequest {
-            header(XCorrelationId, getCorrelationId())
-            header(NAV_CALL_ID, getCorrelationId())
-        }
-    }.also { Runtime.getRuntime().addShutdownHook(Thread { it.close() }) }
+    )
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/Norg2Klient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/Norg2Klient.kt
@@ -6,9 +6,9 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.isSuccess
-import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import org.slf4j.LoggerFactory
 import java.time.Duration
@@ -34,7 +34,7 @@ class Norg2Klient(
             }
 
             val response = klient.get("$apiUrl/enhet/$enhet") {
-                header(X_CORRELATION_ID, getXCorrelationId())
+                header(XCorrelationId, getXCorrelationId())
             }
 
             if (response.status.isSuccess()) {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/RegoppslagKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/RegoppslagKlient.kt
@@ -6,11 +6,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.get
-import io.ktor.client.request.header
-import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.isSuccess
-import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
-import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.sikkerLogg
 import org.slf4j.LoggerFactory
 import java.time.Duration
@@ -34,10 +30,7 @@ class RegoppslagKlient(
         } else {
             logger.info("Ingen cachet mottakeradresse funnet. Henter fra regoppslag")
 
-            val response = client.get("$url/regoppslag/$ident") {
-                header(XCorrelationId, getXCorrelationId())
-                header(NAV_CALL_ID, getXCorrelationId())
-            }
+            val response = client.get("$url/regoppslag/$ident")
 
             if (response.status.isSuccess()) {
                 response.body<RegoppslagResponseDTO>()

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/RegoppslagKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/RegoppslagKlient.kt
@@ -8,6 +8,7 @@ import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.http.isSuccess
+import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.sikkerLogg
@@ -35,7 +36,7 @@ class RegoppslagKlient(
 
             val response = client.get("$url/regoppslag/$ident") {
                 header(X_CORRELATION_ID, getXCorrelationId())
-                header("Nav_Call_Id", getXCorrelationId())
+                header(NAV_CALL_ID, getXCorrelationId())
             }
 
             if (response.status.isSuccess()) {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/RegoppslagKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/RegoppslagKlient.kt
@@ -7,9 +7,9 @@ import io.ktor.client.call.body
 import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.get
 import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.isSuccess
 import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
-import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.sikkerLogg
 import org.slf4j.LoggerFactory
@@ -35,7 +35,7 @@ class RegoppslagKlient(
             logger.info("Ingen cachet mottakeradresse funnet. Henter fra regoppslag")
 
             val response = client.get("$url/regoppslag/$ident") {
-                header(X_CORRELATION_ID, getXCorrelationId())
+                header(XCorrelationId, getXCorrelationId())
                 header(NAV_CALL_ID, getXCorrelationId())
             }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerKlient.kt
@@ -8,6 +8,7 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
+import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.toJson
@@ -26,7 +27,7 @@ class BrevbakerKlient(private val client: HttpClient, private val apiUrl: String
         measureTimedValue {
             client.post("$apiUrl/etterlatte/pdf") {
                 contentType(ContentType.Application.Json)
-                header("Nav_Call_Id", getXCorrelationId())
+                header(NAV_CALL_ID, getXCorrelationId())
                 setBody(brevRequest.toJsonNode())
             }.body<BrevbakerPdfResponse>()
         }.let { (result, duration) ->
@@ -42,7 +43,7 @@ class BrevbakerKlient(private val client: HttpClient, private val apiUrl: String
         measureTimedValue {
             client.post("$apiUrl/etterlatte/html") {
                 contentType(ContentType.Application.Json)
-                header("Nav_Call_Id", getXCorrelationId())
+                header(NAV_CALL_ID, getXCorrelationId())
                 setBody(brevRequest.toJsonNode())
             }.body<BrevbakerHTMLResponse>()
         }.let { (result, duration) ->
@@ -58,7 +59,7 @@ class BrevbakerKlient(private val client: HttpClient, private val apiUrl: String
         measureTimedValue {
             client.post("$apiUrl/etterlatte/json") {
                 contentType(ContentType.Application.Json)
-                header("Nav_Call_Id", getXCorrelationId())
+                header(NAV_CALL_ID, getXCorrelationId())
                 setBody(brevRequest.toJsonNode())
             }.body<RenderedJsonLetter>()
         }.let { (result, duration) ->

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerKlient.kt
@@ -3,13 +3,10 @@ package no.nav.etterlatte.brev.brevbaker
 import com.fasterxml.jackson.databind.JsonNode
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
-import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
-import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.pensjon.brevbaker.api.model.LetterMetadata
@@ -27,7 +24,6 @@ class BrevbakerKlient(private val client: HttpClient, private val apiUrl: String
         measureTimedValue {
             client.post("$apiUrl/etterlatte/pdf") {
                 contentType(ContentType.Application.Json)
-                header(NAV_CALL_ID, getXCorrelationId())
                 setBody(brevRequest.toJsonNode())
             }.body<BrevbakerPdfResponse>()
         }.let { (result, duration) ->
@@ -43,7 +39,6 @@ class BrevbakerKlient(private val client: HttpClient, private val apiUrl: String
         measureTimedValue {
             client.post("$apiUrl/etterlatte/html") {
                 contentType(ContentType.Application.Json)
-                header(NAV_CALL_ID, getXCorrelationId())
                 setBody(brevRequest.toJsonNode())
             }.body<BrevbakerHTMLResponse>()
         }.let { (result, duration) ->
@@ -59,7 +54,6 @@ class BrevbakerKlient(private val client: HttpClient, private val apiUrl: String
         measureTimedValue {
             client.post("$apiUrl/etterlatte/json") {
                 contentType(ContentType.Application.Json)
-                header(NAV_CALL_ID, getXCorrelationId())
                 setBody(brevRequest.toJsonNode())
             }.body<RenderedJsonLetter>()
         }.let { (result, duration) ->

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/distribusjon/DistribusjonKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/distribusjon/DistribusjonKlient.kt
@@ -8,9 +8,9 @@ import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
-import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import org.slf4j.LoggerFactory
 
@@ -21,7 +21,7 @@ class DistribusjonKlient(private val client: HttpClient, private val url: String
         client.post("$url/distribuerjournalpost") {
             accept(ContentType.Application.Json)
             contentType(ContentType.Application.Json)
-            header(X_CORRELATION_ID, getXCorrelationId())
+            header(XCorrelationId, getXCorrelationId())
             setBody(request)
         }.let {
             when (it.status) {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivKlient.kt
@@ -8,11 +8,11 @@ import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import no.nav.etterlatte.brev.journalpost.JournalpostRequest
 import no.nav.etterlatte.brev.journalpost.JournalpostResponse
-import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import org.slf4j.LoggerFactory
 
@@ -23,7 +23,7 @@ class DokarkivKlient(private val client: HttpClient, private val url: String) {
         client.post("$url?forsoekFerdigstill=$ferdigstill") {
             accept(ContentType.Application.Json)
             contentType(ContentType.Application.Json)
-            header(X_CORRELATION_ID, getXCorrelationId())
+            header(XCorrelationId, getXCorrelationId())
             setBody(request)
         }.body()
     } catch (responseException: ResponseException) {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafClient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafClient.kt
@@ -13,12 +13,12 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.TextContent
 import io.ktor.http.isSuccess
 import no.nav.etterlatte.brev.journalpost.BrukerIdType
 import no.nav.etterlatte.libs.common.RetryResult
-import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.libs.common.retry
 import no.nav.etterlatte.libs.common.toJson
@@ -48,7 +48,7 @@ class SafClient(
         httpClient.get("$baseUrl/rest/hentdokument/$journalpostId/$dokumentInfoId/ARKIV") {
             header("Authorization", "Bearer ${getToken(accessToken)}")
             header("Content-Type", "application/json")
-            header(X_CORRELATION_ID, getXCorrelationId())
+            header(XCorrelationId, getXCorrelationId())
         }.body()
     } catch (ex: Exception) {
         throw JournalpostException("Feil ved kall til hentdokument", ex)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/navansatt/NavansattKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/navansatt/NavansattKlient.kt
@@ -5,12 +5,8 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.get
-import io.ktor.client.request.header
-import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.isSuccess
 import no.nav.etterlatte.brev.adresse.AdresseException
-import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
-import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import org.slf4j.LoggerFactory
 import java.time.Duration
 
@@ -33,10 +29,7 @@ class NavansattKlient(
         } else {
             logger.info("Henter info om saksbehandler med ident $ident")
 
-            val response = client.get("$url/navansatt/$ident") {
-                header(XCorrelationId, getXCorrelationId())
-                header(NAV_CALL_ID, getXCorrelationId())
-            }
+            val response = client.get("$url/navansatt/$ident")
 
             if (response.status.isSuccess()) {
                 response.body<SaksbehandlerInfo>()

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/navansatt/NavansattKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/navansatt/NavansattKlient.kt
@@ -6,10 +6,10 @@ import io.ktor.client.call.body
 import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.get
 import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.isSuccess
 import no.nav.etterlatte.brev.adresse.AdresseException
 import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
-import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import org.slf4j.LoggerFactory
 import java.time.Duration
@@ -34,7 +34,7 @@ class NavansattKlient(
             logger.info("Henter info om saksbehandler med ident $ident")
 
             val response = client.get("$url/navansatt/$ident") {
-                header(X_CORRELATION_ID, getXCorrelationId())
+                header(XCorrelationId, getXCorrelationId())
                 header(NAV_CALL_ID, getXCorrelationId())
             }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/navansatt/NavansattKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/navansatt/NavansattKlient.kt
@@ -8,6 +8,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.http.isSuccess
 import no.nav.etterlatte.brev.adresse.AdresseException
+import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import org.slf4j.LoggerFactory
@@ -34,7 +35,7 @@ class NavansattKlient(
 
             val response = client.get("$url/navansatt/$ident") {
                 header(X_CORRELATION_ID, getXCorrelationId())
-                header("Nav_Call_Id", getXCorrelationId())
+                header(NAV_CALL_ID, getXCorrelationId())
             }
 
             if (response.status.isSuccess()) {

--- a/apps/etterlatte-fordeler/src/main/kotlin/behandling/BehandlingKlient.kt
+++ b/apps/etterlatte-fordeler/src/main/kotlin/behandling/BehandlingKlient.kt
@@ -3,16 +3,12 @@ package no.nav.etterlatte.behandling
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.contentType
 import no.nav.etterlatte.libs.common.FoedselsNummerMedGraderingDTO
 import no.nav.etterlatte.libs.common.behandling.SakType
-import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
-import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 
 class BehandlingKlient(
@@ -23,8 +19,6 @@ class BehandlingKlient(
         return httpClient.post("$url/personer/saker/$sakType") {
             contentType(ContentType.Application.Json)
             setBody(FoedselsNummerMedGraderingDTO(fnr, gradering))
-            header(XCorrelationId, getXCorrelationId())
-            header(NAV_CALL_ID, getXCorrelationId())
         }.body<ObjectNode>()["id"].longValue()
     }
 }

--- a/apps/etterlatte-fordeler/src/main/kotlin/behandling/BehandlingKlient.kt
+++ b/apps/etterlatte-fordeler/src/main/kotlin/behandling/BehandlingKlient.kt
@@ -10,6 +10,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import no.nav.etterlatte.libs.common.FoedselsNummerMedGraderingDTO
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
@@ -23,7 +24,7 @@ class BehandlingKlient(
             contentType(ContentType.Application.Json)
             setBody(FoedselsNummerMedGraderingDTO(fnr, gradering))
             header(X_CORRELATION_ID, getXCorrelationId())
-            header("Nav_Call_Id", getXCorrelationId())
+            header(NAV_CALL_ID, getXCorrelationId())
         }.body<ObjectNode>()["id"].longValue()
     }
 }

--- a/apps/etterlatte-fordeler/src/main/kotlin/behandling/BehandlingKlient.kt
+++ b/apps/etterlatte-fordeler/src/main/kotlin/behandling/BehandlingKlient.kt
@@ -7,11 +7,11 @@ import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.contentType
 import no.nav.etterlatte.libs.common.FoedselsNummerMedGraderingDTO
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
-import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 
@@ -23,7 +23,7 @@ class BehandlingKlient(
         return httpClient.post("$url/personer/saker/$sakType") {
             contentType(ContentType.Application.Json)
             setBody(FoedselsNummerMedGraderingDTO(fnr, gradering))
-            header(X_CORRELATION_ID, getXCorrelationId())
+            header(XCorrelationId, getXCorrelationId())
             header(NAV_CALL_ID, getXCorrelationId())
         }.body<ObjectNode>()["id"].longValue()
     }

--- a/apps/etterlatte-institusjonsopphold/src/main/kotlin/InstitusjonsoppholdKlient.kt
+++ b/apps/etterlatte-institusjonsopphold/src/main/kotlin/InstitusjonsoppholdKlient.kt
@@ -5,12 +5,9 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.contentType
 import kotlinx.coroutines.runBlocking
-import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.NAV_CONSUMER_ID
-import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -20,8 +17,6 @@ class InstitusjonsoppholdKlient(val institusjonsoppholdHttpKlient: HttpClient, v
         runBlocking {
             institusjonsoppholdHttpKlient.get(proxyUrl.plus("/inst2/$oppholdId?Med-Institusjonsinformasjon=true")) {
                 contentType(ContentType.Application.Json)
-                header(XCorrelationId, getXCorrelationId())
-                header(NAV_CALL_ID, getXCorrelationId())
                 header(NAV_CONSUMER_ID, "etterlatte-institusjonsopphold")
             }.body<Institusjonsopphold>()
         }

--- a/apps/etterlatte-institusjonsopphold/src/main/kotlin/InstitusjonsoppholdKlient.kt
+++ b/apps/etterlatte-institusjonsopphold/src/main/kotlin/InstitusjonsoppholdKlient.kt
@@ -5,11 +5,11 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.contentType
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.NAV_CONSUMER_ID
-import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -20,7 +20,7 @@ class InstitusjonsoppholdKlient(val institusjonsoppholdHttpKlient: HttpClient, v
         runBlocking {
             institusjonsoppholdHttpKlient.get(proxyUrl.plus("/inst2/$oppholdId?Med-Institusjonsinformasjon=true")) {
                 contentType(ContentType.Application.Json)
-                header(X_CORRELATION_ID, getXCorrelationId())
+                header(XCorrelationId, getXCorrelationId())
                 header(NAV_CALL_ID, getXCorrelationId())
                 header(NAV_CONSUMER_ID, "etterlatte-institusjonsopphold")
             }.body<Institusjonsopphold>()

--- a/apps/etterlatte-institusjonsopphold/src/main/kotlin/InstitusjonsoppholdKlient.kt
+++ b/apps/etterlatte-institusjonsopphold/src/main/kotlin/InstitusjonsoppholdKlient.kt
@@ -8,6 +8,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
+import no.nav.etterlatte.libs.common.logging.NAV_CONSUMER_ID
 import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import java.time.LocalDate
@@ -21,7 +22,7 @@ class InstitusjonsoppholdKlient(val institusjonsoppholdHttpKlient: HttpClient, v
                 contentType(ContentType.Application.Json)
                 header(X_CORRELATION_ID, getXCorrelationId())
                 header(NAV_CALL_ID, getXCorrelationId())
-                header("Nav-Consumer-Id", "etterlatte-institusjonsopphold")
+                header(NAV_CONSUMER_ID, "etterlatte-institusjonsopphold")
             }.body<Institusjonsopphold>()
         }
 }

--- a/apps/etterlatte-institusjonsopphold/src/main/kotlin/InstitusjonsoppholdKlient.kt
+++ b/apps/etterlatte-institusjonsopphold/src/main/kotlin/InstitusjonsoppholdKlient.kt
@@ -7,6 +7,7 @@ import io.ktor.client.request.header
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import java.time.LocalDate
@@ -19,7 +20,7 @@ class InstitusjonsoppholdKlient(val institusjonsoppholdHttpKlient: HttpClient, v
             institusjonsoppholdHttpKlient.get(proxyUrl.plus("/inst2/$oppholdId?Med-Institusjonsinformasjon=true")) {
                 contentType(ContentType.Application.Json)
                 header(X_CORRELATION_ID, getXCorrelationId())
-                header("Nav_Call_Id", getXCorrelationId())
+                header(NAV_CALL_ID, getXCorrelationId())
                 header("Nav-Consumer-Id", "etterlatte-institusjonsopphold")
             }.body<Institusjonsopphold>()
         }

--- a/apps/etterlatte-testdata/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/Application.kt
@@ -49,6 +49,7 @@ import no.nav.etterlatte.kafka.GcpKafkaConfig
 import no.nav.etterlatte.kafka.LocalKafkaConfig
 import no.nav.etterlatte.kafka.standardProducer
 import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
+import no.nav.etterlatte.libs.common.logging.NAV_CONSUMER_ID
 import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getCorrelationId
 import no.nav.etterlatte.libs.common.objectMapper
@@ -174,7 +175,7 @@ fun httpClient() = HttpClient(OkHttp) {
     defaultRequest {
         header(X_CORRELATION_ID, getCorrelationId())
         header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-        header("Nav-Consumer-Id", "etterlatte-testdata")
+        header(NAV_CONSUMER_ID, "etterlatte-testdata")
         header(NAV_CALL_ID, getCorrelationId())
     }
 }.also { Runtime.getRuntime().addShutdownHook(Thread { it.close() }) }

--- a/apps/etterlatte-testdata/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/Application.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.kafka.GcpKafkaConfig
 import no.nav.etterlatte.kafka.LocalKafkaConfig
 import no.nav.etterlatte.kafka.standardProducer
+import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getCorrelationId
 import no.nav.etterlatte.libs.common.objectMapper
@@ -174,7 +175,7 @@ fun httpClient() = HttpClient(OkHttp) {
         header(X_CORRELATION_ID, getCorrelationId())
         header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
         header("Nav-Consumer-Id", "etterlatte-testdata")
-        header("Nav-Call-Id", getCorrelationId())
+        header(NAV_CALL_ID, getCorrelationId())
     }
 }.also { Runtime.getRuntime().addShutdownHook(Thread { it.close() }) }
 

--- a/apps/etterlatte-testdata/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/Application.kt
@@ -15,6 +15,7 @@ import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.header
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.jackson.JacksonConverter
 import io.ktor.serialization.jackson.jackson
@@ -50,7 +51,6 @@ import no.nav.etterlatte.kafka.LocalKafkaConfig
 import no.nav.etterlatte.kafka.standardProducer
 import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.NAV_CONSUMER_ID
-import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getCorrelationId
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.ktor.metricsModule
@@ -173,7 +173,7 @@ fun httpClient() = HttpClient(OkHttp) {
         register(ContentType.Application.Json, JacksonConverter(objectMapper))
     }
     defaultRequest {
-        header(X_CORRELATION_ID, getCorrelationId())
+        header(XCorrelationId, getCorrelationId())
         header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
         header(NAV_CONSUMER_ID, "etterlatte-testdata")
         header(NAV_CALL_ID, getCorrelationId())

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/KodeverkKlient.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/KodeverkKlient.kt
@@ -8,10 +8,8 @@ import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.http.ContentType
-import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.NAV_CONSUMER_ID
 import org.slf4j.LoggerFactory
-import java.util.*
 
 class KodeverkKlient(config: Config, private val httpKlient: HttpClient) {
     private val logger = LoggerFactory.getLogger(KodeverkKlient::class.java)
@@ -23,7 +21,6 @@ class KodeverkKlient(config: Config, private val httpKlient: HttpClient) {
         httpKlient.get("$url/Landkoder/koder/betydninger?ekskluderUgyldige=false&spraak=nb") {
             accept(ContentType.Application.Json)
             header(NAV_CONSUMER_ID, "etterlatte-trygdetid")
-            header(NAV_CALL_ID, UUID.randomUUID())
         }.body()
     } catch (e: Exception) {
         logger.error("Henting av landkoder feilet", e)

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/KodeverkKlient.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/KodeverkKlient.kt
@@ -8,6 +8,7 @@ import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.http.ContentType
+import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import org.slf4j.LoggerFactory
 import java.util.*
 
@@ -21,7 +22,7 @@ class KodeverkKlient(config: Config, private val httpKlient: HttpClient) {
         httpKlient.get("$url/Landkoder/koder/betydninger?ekskluderUgyldige=false&spraak=nb") {
             accept(ContentType.Application.Json)
             header("Nav-Consumer-Id", "etterlatte-trygdetid")
-            header("Nav-Call-Id", UUID.randomUUID())
+            header(NAV_CALL_ID, UUID.randomUUID())
         }.body()
     } catch (e: Exception) {
         logger.error("Henting av landkoder feilet", e)

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/KodeverkKlient.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/KodeverkKlient.kt
@@ -9,6 +9,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.http.ContentType
 import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
+import no.nav.etterlatte.libs.common.logging.NAV_CONSUMER_ID
 import org.slf4j.LoggerFactory
 import java.util.*
 
@@ -21,7 +22,7 @@ class KodeverkKlient(config: Config, private val httpKlient: HttpClient) {
 
         httpKlient.get("$url/Landkoder/koder/betydninger?ekskluderUgyldige=false&spraak=nb") {
             accept(ContentType.Application.Json)
-            header("Nav-Consumer-Id", "etterlatte-trygdetid")
+            header(NAV_CONSUMER_ID, "etterlatte-trygdetid")
             header(NAV_CALL_ID, UUID.randomUUID())
         }.body()
     } catch (e: Exception) {

--- a/libs/etterlatte-ktor/src/main/kotlin/HttpClient.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/HttpClient.kt
@@ -17,15 +17,13 @@ import no.nav.etterlatte.libs.common.logging.getCorrelationId
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.security.ktor.clientCredential
 
-fun httpClient(forventSuksess: Boolean = false) = httpClientMedAuth(forventSuksess)
-
 fun httpClientClientCredentials(
     azureAppClientId: String,
     azureAppJwk: String,
     azureAppWellKnownUrl: String,
     azureAppScope: String,
     ekstraJacksoninnstillinger: ((o: ObjectMapper) -> Unit) = { }
-) = httpClientMedAuth(
+) = httpClient(
     ekstraJacksoninnstillinger = ekstraJacksoninnstillinger,
     auth = {
         it.install(Auth) {
@@ -42,8 +40,8 @@ fun httpClientClientCredentials(
     forventSuksess = true
 )
 
-private fun httpClientMedAuth(
-    forventSuksess: Boolean,
+fun httpClient(
+    forventSuksess: Boolean = false,
     ekstraJacksoninnstillinger: (o: ObjectMapper) -> Unit = { },
     auth: (cl: HttpClientConfig<OkHttpConfig>) -> Unit? = {}
 ) = HttpClient(OkHttp) {

--- a/libs/etterlatte-ktor/src/main/kotlin/HttpClient.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/HttpClient.kt
@@ -10,6 +10,7 @@ import io.ktor.client.request.header
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.serialization.jackson.JacksonConverter
+import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.getCorrelationId
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.security.ktor.clientCredential
@@ -50,5 +51,6 @@ fun httpClientClientCredentials(
     }
     defaultRequest {
         header(HttpHeaders.XCorrelationId, getCorrelationId())
+        header(NAV_CALL_ID, getCorrelationId())
     }
 }.also { Runtime.getRuntime().addShutdownHook(Thread { it.close() }) }

--- a/libs/etterlatte-ktor/src/main/kotlin/HttpClient.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/HttpClient.kt
@@ -24,6 +24,7 @@ fun httpClient(forventSuksess: Boolean = false) = HttpClient(OkHttp) {
     }
     defaultRequest {
         header(HttpHeaders.XCorrelationId, getCorrelationId())
+        header(NAV_CALL_ID, getCorrelationId())
     }
 }.also { Runtime.getRuntime().addShutdownHook(Thread { it.close() }) }
 

--- a/libs/etterlatte-ktor/src/main/kotlin/HttpClient.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/HttpClient.kt
@@ -2,7 +2,9 @@ package no.nav.etterlatte.libs.ktor
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.engine.okhttp.OkHttpConfig
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
@@ -15,18 +17,7 @@ import no.nav.etterlatte.libs.common.logging.getCorrelationId
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.security.ktor.clientCredential
 
-fun httpClient(forventSuksess: Boolean = false) = HttpClient(OkHttp) {
-    if (forventSuksess) {
-        expectSuccess = true
-    }
-    install(ContentNegotiation) {
-        register(ContentType.Application.Json, JacksonConverter(objectMapper))
-    }
-    defaultRequest {
-        header(HttpHeaders.XCorrelationId, getCorrelationId())
-        header(NAV_CALL_ID, getCorrelationId())
-    }
-}.also { Runtime.getRuntime().addShutdownHook(Thread { it.close() }) }
+fun httpClient(forventSuksess: Boolean = false) = httpClientMedAuth(forventSuksess)
 
 fun httpClientClientCredentials(
     azureAppClientId: String,
@@ -34,22 +25,34 @@ fun httpClientClientCredentials(
     azureAppWellKnownUrl: String,
     azureAppScope: String,
     ekstraJacksoninnstillinger: ((o: ObjectMapper) -> Unit) = { }
+) = httpClientMedAuth(
+    ekstraJacksoninnstillinger = ekstraJacksoninnstillinger,
+    auth = {
+        it.install(Auth) {
+            clientCredential {
+                config = mapOf(
+                    "AZURE_APP_CLIENT_ID" to azureAppClientId,
+                    "AZURE_APP_JWK" to azureAppJwk,
+                    "AZURE_APP_WELL_KNOWN_URL" to azureAppWellKnownUrl,
+                    "AZURE_APP_OUTBOUND_SCOPE" to azureAppScope
+                )
+            }
+        }
+    },
+    forventSuksess = true
+)
+
+private fun httpClientMedAuth(
+    forventSuksess: Boolean,
+    ekstraJacksoninnstillinger: (o: ObjectMapper) -> Unit = { },
+    auth: (cl: HttpClientConfig<OkHttpConfig>) -> Unit? = {}
 ) = HttpClient(OkHttp) {
-    expectSuccess = true
+    expectSuccess = forventSuksess
     install(ContentNegotiation) {
         register(ContentType.Application.Json, JacksonConverter(objectMapper))
         ekstraJacksoninnstillinger(objectMapper)
     }
-    install(Auth) {
-        clientCredential {
-            config = mapOf(
-                "AZURE_APP_CLIENT_ID" to azureAppClientId,
-                "AZURE_APP_JWK" to azureAppJwk,
-                "AZURE_APP_WELL_KNOWN_URL" to azureAppWellKnownUrl,
-                "AZURE_APP_OUTBOUND_SCOPE" to azureAppScope
-            )
-        }
-    }
+    auth.invoke(this)
     defaultRequest {
         header(HttpHeaders.XCorrelationId, getCorrelationId())
         header(NAV_CALL_ID, getCorrelationId())

--- a/libs/etterlatte-ktor/src/main/kotlin/HttpClient.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/HttpClient.kt
@@ -11,8 +11,8 @@ import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.header
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMessageBuilder
 import io.ktor.serialization.jackson.JacksonConverter
-import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.getCorrelationId
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.security.ktor.clientCredential
@@ -43,7 +43,8 @@ fun httpClientClientCredentials(
 fun httpClient(
     forventSuksess: Boolean = false,
     ekstraJacksoninnstillinger: (o: ObjectMapper) -> Unit = { },
-    auth: (cl: HttpClientConfig<OkHttpConfig>) -> Unit? = {}
+    auth: (cl: HttpClientConfig<OkHttpConfig>) -> Unit? = {},
+    ekstraDefaultHeaders: (builder: HttpMessageBuilder) -> Unit = {}
 ) = HttpClient(OkHttp) {
     expectSuccess = forventSuksess
     install(ContentNegotiation) {
@@ -53,6 +54,7 @@ fun httpClient(
     auth.invoke(this)
     defaultRequest {
         header(HttpHeaders.XCorrelationId, getCorrelationId())
-        header(NAV_CALL_ID, getCorrelationId())
+        header("Nav_Call_Id", getCorrelationId())
+        ekstraDefaultHeaders.invoke(this)
     }
 }.also { Runtime.getRuntime().addShutdownHook(Thread { it.close() }) }

--- a/libs/etterlatte-ktor/src/main/kotlin/Ping.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/Ping.kt
@@ -5,14 +5,11 @@ import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders.XCorrelationId
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
-import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.NAV_CONSUMER_ID
-import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import org.slf4j.Logger
 
 suspend fun HttpClient.ping(
@@ -25,8 +22,6 @@ suspend fun HttpClient.ping(
     return try {
         this.get(url) {
             accept(ContentType.Application.Json)
-            header(XCorrelationId, getXCorrelationId())
-            header(NAV_CALL_ID, getXCorrelationId())
             header(NAV_CONSUMER_ID, konsument)
         }
         logger.info("$serviceName svarer OK")

--- a/libs/etterlatte-ktor/src/main/kotlin/Ping.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/Ping.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
 import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
+import no.nav.etterlatte.libs.common.logging.NAV_CONSUMER_ID
 import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import org.slf4j.Logger
@@ -26,7 +27,7 @@ suspend fun HttpClient.ping(
             accept(ContentType.Application.Json)
             header(X_CORRELATION_ID, getXCorrelationId())
             header(NAV_CALL_ID, getXCorrelationId())
-            header("Nav-Consumer-Id", konsument)
+            header(NAV_CONSUMER_ID, konsument)
         }
         logger.info("$serviceName svarer OK")
         PingResultUp(serviceName, endpoint = url, beskrivelse = beskrivelse)

--- a/libs/etterlatte-ktor/src/main/kotlin/Ping.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/Ping.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
+import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import org.slf4j.Logger
@@ -24,7 +25,7 @@ suspend fun HttpClient.ping(
         this.get(url) {
             accept(ContentType.Application.Json)
             header(X_CORRELATION_ID, getXCorrelationId())
-            header("Nav_Call_Id", getXCorrelationId())
+            header(NAV_CALL_ID, getXCorrelationId())
             header("Nav-Consumer-Id", konsument)
         }
         logger.info("$serviceName svarer OK")

--- a/libs/etterlatte-ktor/src/main/kotlin/Ping.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/Ping.kt
@@ -5,13 +5,13 @@ import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders.XCorrelationId
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
 import no.nav.etterlatte.libs.common.logging.NAV_CALL_ID
 import no.nav.etterlatte.libs.common.logging.NAV_CONSUMER_ID
-import no.nav.etterlatte.libs.common.logging.X_CORRELATION_ID
 import no.nav.etterlatte.libs.common.logging.getXCorrelationId
 import org.slf4j.Logger
 
@@ -25,7 +25,7 @@ suspend fun HttpClient.ping(
     return try {
         this.get(url) {
             accept(ContentType.Application.Json)
-            header(X_CORRELATION_ID, getXCorrelationId())
+            header(XCorrelationId, getXCorrelationId())
             header(NAV_CALL_ID, getXCorrelationId())
             header(NAV_CONSUMER_ID, konsument)
         }

--- a/libs/saksbehandling-common/src/main/kotlin/logging/LogUtils.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/logging/LogUtils.kt
@@ -5,6 +5,7 @@ import java.util.*
 
 const val X_CORRELATION_ID: String = "X-Correlation-ID"
 const val CORRELATION_ID: String = "correlation_id"
+const val NAV_CALL_ID: String = "Nav_Call_Id"
 
 fun <T> withLogContext(correlationId: String? = null, kv: Map<String, String> = emptyMap(), block: () -> T): T =
     innerLogContext(correlationId, kv, block)

--- a/libs/saksbehandling-common/src/main/kotlin/logging/LogUtils.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/logging/LogUtils.kt
@@ -6,6 +6,7 @@ import java.util.*
 const val X_CORRELATION_ID: String = "X-Correlation-ID"
 const val CORRELATION_ID: String = "correlation_id"
 const val NAV_CALL_ID: String = "Nav_Call_Id"
+const val NAV_CONSUMER_ID: String = "Nav-Consumer-Id"
 
 fun <T> withLogContext(correlationId: String? = null, kv: Map<String, String> = emptyMap(), block: () -> T): T =
     innerLogContext(correlationId, kv, block)

--- a/libs/saksbehandling-common/src/main/kotlin/logging/LogUtils.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/logging/LogUtils.kt
@@ -3,7 +3,6 @@ package no.nav.etterlatte.libs.common.logging
 import org.slf4j.MDC
 import java.util.*
 
-const val X_CORRELATION_ID: String = "X-Correlation-ID"
 const val CORRELATION_ID: String = "correlation_id"
 const val NAV_CALL_ID: String = "Nav_Call_Id"
 const val NAV_CONSUMER_ID: String = "Nav-Consumer-Id"
@@ -41,4 +40,4 @@ private fun generateCorrelationId() = UUID.randomUUID().toString()
 
 fun getCorrelationId(): String = MDC.get(CORRELATION_ID) ?: generateCorrelationId()
 
-fun getXCorrelationId(): String = MDC.get(X_CORRELATION_ID) ?: generateCorrelationId()
+fun getXCorrelationId(): String = MDC.get("X-Correlation-ID") ?: generateCorrelationId()

--- a/libs/saksbehandling-common/src/main/kotlin/logging/LogUtils.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/logging/LogUtils.kt
@@ -4,7 +4,6 @@ import org.slf4j.MDC
 import java.util.*
 
 const val CORRELATION_ID: String = "correlation_id"
-const val NAV_CALL_ID: String = "Nav_Call_Id"
 const val NAV_CONSUMER_ID: String = "Nav-Consumer-Id"
 
 fun <T> withLogContext(correlationId: String? = null, kv: Map<String, String> = emptyMap(), block: () -> T): T =


### PR DESCRIPTION
Ser ingen grunn til at dette skal variere overalt, så standardiserer