### PR TITLE
Setter eksplisitt contenttype på opprettbestilling

### DIFF
--- a/apps/etterlatte-testdata/src/main/kotlin/dolly/DollyClient.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/dolly/DollyClient.kt
@@ -10,6 +10,7 @@ import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.toJson
@@ -59,6 +60,7 @@ class DollyClientImpl(config: Config, private val httpClient: HttpClient) : Doll
     override suspend fun opprettBestilling(bestilling: String, gruppeId: Long, accessToken: String): BestillingStatus =
         httpClient.post("$dollyUrl/gruppe/$gruppeId/bestilling") {
             header(HttpHeaders.Authorization, "Bearer $accessToken")
+            header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(objectMapper.readTree(bestilling))
         }.body()
 


### PR DESCRIPTION
For å teste om dette fikser feilen i etterlatte-testdata når du bestiller ny familie