### PR TITLE
EY-2493 Håndterer hendelser og oppgaver når vi gjør noe med de

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
@@ -25,12 +25,15 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Utenlandstilsnitt
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
+import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveKilde
+import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveType
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.Person
 import no.nav.etterlatte.libs.sporingslogg.Decision
 import no.nav.etterlatte.libs.sporingslogg.HttpMethod
 import no.nav.etterlatte.libs.sporingslogg.Sporingslogg
 import no.nav.etterlatte.libs.sporingslogg.Sporingsrequest
+import no.nav.etterlatte.oppgaveny.OppgaveServiceNy
 import no.nav.etterlatte.tilgangsstyring.filterForEnheter
 import no.nav.etterlatte.token.BrukerTokenInfo
 import no.nav.etterlatte.vedtaksvurdering.VedtakHendelse
@@ -96,7 +99,9 @@ class BehandlingServiceImpl(
     private val grunnlagKlient: GrunnlagKlient,
     private val sporingslogg: Sporingslogg,
     private val featureToggleService: FeatureToggleService,
-    private val kommerBarnetTilGodeDao: KommerBarnetTilGodeDao
+    private val kommerBarnetTilGodeDao: KommerBarnetTilGodeDao,
+    private val oppgaveServiceNy: OppgaveServiceNy,
+    private val kanBrukeNyOppgaveliste: Boolean
 ) : BehandlingService {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -135,8 +140,37 @@ class BehandlingServiceImpl(
             }
 
             behandlingDao.avbrytBehandling(behandlingId).also {
+                val hendelserKnyttetTilBehandling =
+                    grunnlagsendringshendelseDao.hentGrunnlagsendringshendelseSomErTattMedIBehandling(behandlingId)
+                try {
+                    oppgaveServiceNy.avbrytOppgaveUnderBehandling(behandlingId.toString())
+
+                    hendelserKnyttetTilBehandling.forEach { hendelse ->
+                        oppgaveServiceNy.opprettNyOppgaveMedSakOgReferanse(
+                            referanse = hendelse.id.toString(),
+                            sakId = behandling.sak.id,
+                            oppgaveKilde = OppgaveKilde.HENDELSE,
+                            oppgaveType = OppgaveType.VURDER_KONSEKVENS
+                        )
+                    }
+                } catch (e: Exception) {
+                    if (kanBrukeNyOppgaveliste) {
+                        logger.error(
+                            "En feil oppstod nunder ryddingen i oppgavene til behandling / hendelse når" +
+                                "vi avbrøt en behandling, og vi får dermed ikke avbrutt riktig",
+                            e
+                        )
+                        throw e
+                    } else {
+                        logger.error(
+                            "En feil oppstod nunder ryddingen i oppgavene til behandling / hendelse når" +
+                                "vi avbrøt en behandling, men ny oppgaveliste er ikke i bruk og feilen ignorerers",
+                            e
+                        )
+                    }
+                }
+
                 hendelseDao.behandlingAvbrutt(behandling, saksbehandler)
-            }.also {
                 grunnlagsendringshendelseDao.kobleGrunnlagsendringshendelserFraBehandlingId(behandlingId)
             }
             behandlingHendelser.sendMeldingForHendelse(behandling, BehandlingHendelseType.AVBRUTT)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingVedtakRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingVedtakRoute.kt
@@ -76,7 +76,7 @@ internal fun Route.behandlingVedtakRoute(
                     behandlingsstatusService.settAttestertVedtak(behandling, attesterVedtakOppgave.vedtakHendelse)
                     if (kanBrukeNyOppgaveliste) {
                         oppgaveService.ferdigStillOppgaveUnderBehandling(
-                            attesterVedtakOppgave.vedtakOppgaveDTO
+                            attesterVedtakOppgave.vedtakOppgaveDTO.referanse
                         )
                     }
                 }

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -158,7 +158,9 @@ class ApplicationContext(
         grunnlagKlient = grunnlagKlientObo,
         sporingslogg = sporingslogg,
         featureToggleService = featureToggleService,
-        kommerBarnetTilGodeDao = kommerBarnetTilGodeDao
+        kommerBarnetTilGodeDao = kommerBarnetTilGodeDao,
+        oppgaveServiceNy = oppgaveServiceNy,
+        kanBrukeNyOppgaveliste = kanBrukeNyOppgaveliste
     )
 
     val kommerBarnetTilGodeService =
@@ -175,7 +177,8 @@ class ApplicationContext(
             grunnlagsendringshendelseDao = grunnlagsendringshendelseDao,
             kommerBarnetTilGodeService = kommerBarnetTilGodeService,
             revurderingDao = revurderingDao,
-            behandlingService = behandlingService
+            behandlingService = behandlingService,
+            kanBrukeNyOppgaveliste = kanBrukeNyOppgaveliste
         )
 
     val gyldighetsproevingService =

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseDao.kt
@@ -267,6 +267,25 @@ class GrunnlagsendringshendelseDao(val connection: () -> Connection) {
             kommentar = getString("kommentar")
         )
     }
+
+    fun hentGrunnlagsendringshendelseSomErTattMedIBehandling(behandlingId: UUID): List<Grunnlagsendringshendelse> {
+        with(connection()) {
+            prepareStatement(
+                """
+                SELECT id, sak_id, type, opprettet, status, behandling_id, hendelse_gjelder_rolle, 
+                        samsvar_mellom_pdl_og_grunnlag, gjelder_person, kommentar
+                    FROM grunnlagsendringshendelse
+                    WHERE behandling_id = ?
+                """.trimIndent()
+            )
+                .let {
+                    it.setObject(1, behandlingId)
+                    return it.executeQuery().toList {
+                        asGrunnlagsendringshendelse()
+                    }
+                }
+        }
+    }
 }
 
 inline fun <reified T> PreparedStatement.setJsonb(parameterIndex: Int, jsonb: T): PreparedStatement {

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
@@ -80,6 +80,11 @@ class GrunnlagsendringshendelseService(
 
         inTransaction {
             grunnlagsendringshendelseDao.lukkGrunnlagsendringStatus(hendelse = hendelse)
+            try {
+                oppgaveService.ferdigStillOppgaveUnderBehandling(hendelse.id.toString())
+            } catch (e: Exception) {
+                // TODO sjekk her om ny oppgaveliste er in action, og fiks dat shit
+            }
         }
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgaveny/OppgaveServiceNyTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgaveny/OppgaveServiceNyTest.kt
@@ -473,7 +473,7 @@ class OppgaveServiceNyTest {
         )
 
         oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(oppgave.id, "saksbehandler01"))
-        oppgaveServiceNy.ferdigStillOppgaveUnderBehandling(VedtakOppgaveDTO(opprettetSak.id, behandlingsref))
+        oppgaveServiceNy.ferdigStillOppgaveUnderBehandling(behandlingsref)
         val ferdigstiltOppgave = oppgaveServiceNy.hentOppgave(oppgave.id)
         Assertions.assertEquals(Status.FERDIGSTILT, ferdigstiltOppgave?.status)
     }


### PR DESCRIPTION
Når vi lukker en hendelse eller oppretter en revurdering som en konsekvens av en hendelse, blir hendelsen i seg selv lukket.

For tilfellene der vi har opprettet revurderinger på grunn av hendelser, der disse revurderingene blir avbrutt, tar vi å lager nye oppgaver for disse hendelsene, som må lukkes manuelt eller bli tatt med i en annen revurdering.

I tillegg avbryter vi behandlingsoppgaven når vi avbryter en behandling