### PR TITLE
Bytter ut react datepicker med Nav Datepicker 

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/MaanedVelger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/MaanedVelger.tsx
@@ -1,94 +1,36 @@
-import React, { useMemo, useState } from 'react'
-import DatePicker from 'react-datepicker'
-import { CalendarIcon } from '@navikt/aksel-icons'
+import React from 'react'
 import styled from 'styled-components'
-import { Label } from '@navikt/ds-react'
-import { setDefaultOptions } from 'date-fns'
-import { nb } from 'date-fns/locale'
-
-setDefaultOptions({ locale: nb })
-
-const maanedVelgerDefaultProps = {
-  format: 'MMMM yyyy',
-  placeholder: 'Velg måned og år',
-}
+import { MonthPicker, useMonthpicker } from '@navikt/ds-react'
+import { UseMonthPickerOptions } from '@navikt/ds-react/esm/date/hooks/useMonthPicker'
 
 type MaanedVelgerProps = {
   onChange: (date: Date | null) => void
   value?: Date
   label: string
-} & typeof maanedVelgerDefaultProps
+}
 
 const MaanedVelger = (props: MaanedVelgerProps) => {
-  const { format, placeholder, value, onChange, label } = props
-  const [datePicker, setDatepicker] = useState<DatePicker>()
-  const openDatePicker = useMemo(() => {
-    return () => datePicker?.setOpen(true)
-  }, [datePicker])
+  const { value, onChange, label } = props
+
+  const { monthpickerProps, inputProps } = useMonthpicker({
+    onMonthChange: (date: Date) => onChange(date),
+    defaultSelected: value ?? undefined,
+    locale: 'nb',
+  } as UseMonthPickerOptions)
+
+  console.log(value)
 
   return (
-    <>
-      <DatePickerLabel onClick={openDatePicker}>{label}</DatePickerLabel>
-      <Datovelger>
-        <div style={{ textTransform: 'capitalize' }}>
-          <DatePicker
-            ref={(dp) => {
-              if (dp) setDatepicker(dp)
-            }}
-            popperProps={{
-              positionFixed: true,
-            }}
-            dateFormat={format}
-            portalId="root-portal"
-            placeholderText={placeholder}
-            selected={value}
-            locale="nb"
-            onChange={(date: Date) => onChange(date)}
-            autoComplete="off"
-            showMonthYearPicker
-          />
-        </div>
-        <KalenderIkon
-          tabIndex={0}
-          role="button"
-          title="Åpne datovelger"
-          aria-label="Åpne datovelger"
-          onKeyPress={openDatePicker}
-          onClick={openDatePicker}
-        >
-          <CalendarIcon color="white" />
-        </KalenderIkon>
-      </Datovelger>
-    </>
+    <MonthPickerWrapper>
+      <MonthPicker {...monthpickerProps}>
+        <MonthPicker.Input label={label} {...inputProps} />
+      </MonthPicker>
+    </MonthPickerWrapper>
   )
 }
 
-MaanedVelger.defaultProps = maanedVelgerDefaultProps
-
-const KalenderIkon = styled.div`
-  padding: 4px 10px;
-  cursor: pointer;
-  background-color: #0167c5;
-  border: 1px solid #000;
-  border-radius: 0 4px 4px 0;
-  height: 48px;
-  line-height: 42px;
-`
-const DatePickerLabel = styled(Label)`
-  margin-top: 12px;
-`
-
-const Datovelger = styled.div`
-  display: flex;
-  align-items: flex-end;
+const MonthPickerWrapper = styled.div`
   margin-bottom: 12px;
-
-  input {
-    border-right: none;
-    border-radius: 4px 0 0 4px;
-    height: 48px;
-    text-indent: 4px;
-  }
 `
 
 export default MaanedVelger

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/MaanedVelger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/MaanedVelger.tsx
@@ -18,8 +18,6 @@ const MaanedVelger = (props: MaanedVelgerProps) => {
     locale: 'nb',
   } as UseMonthPickerOptions)
 
-  console.log(value)
-
   return (
     <MonthPickerWrapper>
       <MonthPicker {...monthpickerProps}>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/SoeskenjusteringPeriode.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/SoeskenjusteringPeriode.tsx
@@ -82,7 +82,6 @@ const SoeskenjusteringPeriode = (props: SoeskenjusteringPeriodeProps) => {
                     <MaanedVelger
                       onChange={(val) => tom.field.onChange(val)}
                       label="Til og med"
-                      placeholder="Ingen slutt"
                       value={tom.field.value}
                     />
                     {tom.field.value !== null && tom.field.value !== undefined ? (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlag.tsx
@@ -1,4 +1,4 @@
-import { Button, Label, Select, Textarea, Checkbox, CheckboxGroup } from '@navikt/ds-react'
+import { Button, Select, Textarea, Checkbox, CheckboxGroup } from '@navikt/ds-react'
 import { FormKnapper, FormWrapper, Innhold } from '~components/behandling/trygdetid/styled'
 import { isConflict, isFailure, isPending, useApiCall } from '~shared/hooks/useApiCall'
 import {
@@ -9,12 +9,12 @@ import {
   lagreTrygdetidgrunnlag,
   OppdaterTrygdetidGrunnlag,
 } from '~shared/api/trygdetid'
-import React, { FormEvent, useRef, useState } from 'react'
+import React, { FormEvent, useState } from 'react'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import styled from 'styled-components'
-import DatePicker from 'react-datepicker'
-import { CalendarIcon } from '@navikt/aksel-icons'
 import { useParams } from 'react-router-dom'
+import { format } from 'date-fns'
+import { DatoVelger } from '~shared/DatoVelger'
 
 type Props = {
   eksisterendeGrunnlag: ITrygdetidGrunnlag | undefined
@@ -40,15 +40,6 @@ export const TrygdetidGrunnlag: React.FC<Props> = ({
     eksisterendeGrunnlag ? eksisterendeGrunnlag : initialState(trygdetidGrunnlagType)
   )
   const [trygdetidgrunnlagStatus, requestLagreTrygdetidgrunnlag] = useApiCall(lagreTrygdetidgrunnlag)
-  const fraDatoPickerRef: any = useRef(null)
-  const tilDatoPickerRef: any = useRef(null)
-
-  const toggleDatepicker = (ref: any) => {
-    return () => {
-      ref.current.setOpen(true)
-      ref.current.setFocus()
-    }
-  }
 
   const onSubmit = (e: FormEvent) => {
     e.preventDefault()
@@ -97,62 +88,28 @@ export const TrygdetidGrunnlag: React.FC<Props> = ({
               </Land>
 
               <DatoSection>
-                <Label>Fra dato</Label>
-                <Datovelger>
-                  <DatePicker
-                    ref={fraDatoPickerRef}
-                    dateFormat={'dd.MM.yyyy'}
-                    placeholderText={'dd.mm.åååå'}
-                    selected={trygdetidgrunnlag.periodeFra == null ? null : new Date(trygdetidgrunnlag.periodeFra)}
-                    locale="nb"
-                    autoComplete="off"
-                    onChange={(e) =>
-                      setTrygdetidgrunnlag({
-                        ...trygdetidgrunnlag,
-                        periodeFra: e == null ? '' : e.toISOString().split('T')[0],
-                      })
-                    }
-                  />
-                  <KalenderIkon
-                    tabIndex={0}
-                    onKeyPress={toggleDatepicker(fraDatoPickerRef)}
-                    onClick={toggleDatepicker(fraDatoPickerRef)}
-                    role="button"
-                    title="Åpne datovelger"
-                    aria-label="Åpne datovelger"
-                  >
-                    <CalendarIcon color="white" />
-                  </KalenderIkon>
-                </Datovelger>
+                <DatoVelger
+                  value={trygdetidgrunnlag.periodeFra == null ? null : new Date(trygdetidgrunnlag.periodeFra)}
+                  onChange={(date: Date | null) =>
+                    setTrygdetidgrunnlag({
+                      ...trygdetidgrunnlag,
+                      periodeFra: date == null ? '' : format(date, 'yyyy-MM-dd'),
+                    })
+                  }
+                  label="Fra dato"
+                />
               </DatoSection>
               <DatoSection>
-                <Label>Til dato</Label>
-                <Datovelger>
-                  <DatePicker
-                    ref={tilDatoPickerRef}
-                    dateFormat={'dd.MM.yyyy'}
-                    placeholderText={'dd.mm.åååå'}
-                    selected={trygdetidgrunnlag.periodeTil == null ? null : new Date(trygdetidgrunnlag.periodeTil)}
-                    locale="nb"
-                    autoComplete="off"
-                    onChange={(e) =>
-                      setTrygdetidgrunnlag({
-                        ...trygdetidgrunnlag,
-                        periodeTil: e == null ? '' : e.toISOString().split('T')[0],
-                      })
-                    }
-                  />
-                  <KalenderIkon
-                    tabIndex={0}
-                    onKeyPress={toggleDatepicker(tilDatoPickerRef)}
-                    onClick={toggleDatepicker(tilDatoPickerRef)}
-                    role="button"
-                    title="Åpne datovelger"
-                    aria-label="Åpne datovelger"
-                  >
-                    <CalendarIcon color="white" />
-                  </KalenderIkon>
-                </Datovelger>
+                <DatoVelger
+                  value={trygdetidgrunnlag.periodeTil == null ? null : new Date(trygdetidgrunnlag.periodeTil)}
+                  onChange={(date: Date | null) =>
+                    setTrygdetidgrunnlag({
+                      ...trygdetidgrunnlag,
+                      periodeTil: date == null ? '' : format(date, 'yyyy-MM-dd'),
+                    })
+                  }
+                  label="Til dato"
+                />
               </DatoSection>
             </FormWrapper>
 
@@ -266,30 +223,6 @@ const Rows = styled.div`
 
 const Land = styled.div`
   width: 250px;
-`
-
-const Datovelger = styled.div`
-  display: flex;
-  align-items: flex-start;
-
-  input {
-    border-right: none;
-    border-width: 1px;
-    border-radius: 4px 0 0 4px;
-    width: 160px;
-    height: 48px;
-    text-indent: 4px;
-  }
-`
-
-const KalenderIkon = styled.div`
-  padding: 4px 10px;
-  cursor: pointer;
-  background-color: #0167c5;
-  border: 1px solid #000;
-  border-radius: 0 4px 4px 0;
-  height: 48px;
-  line-height: 42px;
 `
 
 const DatoSection = styled.section`

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/DatoVelger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/DatoVelger.tsx
@@ -1,0 +1,26 @@
+import { DatePicker, useDatepicker } from '@navikt/ds-react'
+import { UseDatepickerOptions } from '@navikt/ds-react/esm/date/hooks/useDatepicker'
+import React from 'react'
+
+export const DatoVelger = ({
+  value,
+  onChange,
+  label,
+}: {
+  value: Date | null
+  onChange: (date: Date | null) => void
+  label: string
+}) => {
+  const { datepickerProps, inputProps } = useDatepicker({
+    onDateChange: (date: Date) => onChange(date),
+    locale: 'nb',
+    inputFormat: 'dd.MM.yyyy',
+    defaultSelected: value,
+  } as UseDatepickerOptions)
+
+  return (
+    <DatePicker {...datepickerProps}>
+      <DatePicker.Input {...inputProps} label={label} />
+    </DatePicker>
+  )
+}


### PR DESCRIPTION
- Bytter ut Datepicker i Maanedvelger og bruker MonthPicker fra komponentbiblioteket istedenfor
- Bytter ut react-datepicker for virkningstidspunkt. Dette tillater at saksbehandler skriver inn dato
- Bytter ut react-datepicker for trygdetid og fikser bug der alle datoer blir -1 dag

React datepicker er ikke fjernet fra repoet siden det fortsatt bruker på gammel oppgaveliste. 
Kan fjernes når det byttes til ny oppgaveliste. 