### PR TITLE
EY-2500 Legger til tilgangssjekk for oppgaveId, refactor oppgaveApi

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -123,6 +123,12 @@ fun Application.module(context: ApplicationContext) {
                 harTilgangTilSak = { sakId, saksbehandlerMedRoller ->
                     tilgangService.harTilgangTilSak(sakId, saksbehandlerMedRoller)
                 }
+                harTilgangTilOppgave = { oppgaveId, saksbehandlerMedRoller ->
+                    tilgangService.harTilgangTilOppgave(
+                        oppgaveId,
+                        saksbehandlerMedRoller
+                    )
+                }
             }
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveDaoMedEndringssporing.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveDaoMedEndringssporing.kt
@@ -5,8 +5,6 @@ import no.nav.etterlatte.behandling.objectMapper
 import no.nav.etterlatte.grunnlagsendring.setJsonb
 import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveNy
 import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveType
-import no.nav.etterlatte.libs.common.oppgaveNy.RedigerFristRequest
-import no.nav.etterlatte.libs.common.oppgaveNy.SaksbehandlerEndringDto
 import no.nav.etterlatte.libs.common.oppgaveNy.Status
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.getTidspunkt
@@ -103,9 +101,9 @@ class OppgaveDaoMedEndringssporingImpl(
         return oppgaveDao.finnOppgaverForStrengtFortroligOgStrengtFortroligUtland(oppgaveTypeTyper)
     }
 
-    override fun settNySaksbehandler(saksbehandlerEndringDto: SaksbehandlerEndringDto) {
-        lagreEndringerPaaOppgave(saksbehandlerEndringDto.oppgaveId) {
-            oppgaveDao.settNySaksbehandler(saksbehandlerEndringDto)
+    override fun settNySaksbehandler(oppgaveId: UUID, saksbehandler: String) {
+        lagreEndringerPaaOppgave(oppgaveId) {
+            oppgaveDao.settNySaksbehandler(oppgaveId, saksbehandler)
         }
     }
 
@@ -121,9 +119,9 @@ class OppgaveDaoMedEndringssporingImpl(
         }
     }
 
-    override fun redigerFrist(redigerFristRequest: RedigerFristRequest) {
-        lagreEndringerPaaOppgave(redigerFristRequest.oppgaveId) {
-            oppgaveDao.redigerFrist(redigerFristRequest)
+    override fun redigerFrist(oppgaveId: UUID, frist: Tidspunkt) {
+        lagreEndringerPaaOppgave(oppgaveId) {
+            oppgaveDao.redigerFrist(oppgaveId, frist)
         }
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveRoutesNy.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveRoutesNy.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.oppgaveny
 
+import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.request.receive
@@ -10,10 +11,9 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.put
 import io.ktor.server.routing.route
 import no.nav.etterlatte.Kontekst
-import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.OPPGAVEID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.kunSaksbehandler
-import no.nav.etterlatte.libs.common.oppgaveNy.FjernSaksbehandlerRequest
-import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveNy
+import no.nav.etterlatte.libs.common.oppgaveId
 import no.nav.etterlatte.libs.common.oppgaveNy.RedigerFristRequest
 import no.nav.etterlatte.libs.common.oppgaveNy.SaksbehandlerEndringDto
 
@@ -22,7 +22,7 @@ internal fun Route.oppgaveRoutesNy(
     kanBrukeNyOppgaveliste: Boolean
 ) {
     route("/api/nyeoppgaver") {
-        get("/hent") {
+        get {
             kunSaksbehandler {
                 if (kanBrukeNyOppgaveliste) {
                     call.respond(
@@ -34,57 +34,51 @@ internal fun Route.oppgaveRoutesNy(
             }
         }
 
-        post("tildel-saksbehandler/{$SAKID_CALL_PARAMETER}") {
-            kunSaksbehandler {
-                if (kanBrukeNyOppgaveliste) {
-                    val saksbehandlerEndringDto = call.receive<SaksbehandlerEndringDto>()
-                    service.tildelSaksbehandler(saksbehandlerEndringDto)
-                    call.respond(HttpStatusCode.OK)
-                } else {
-                    call.respond(HttpStatusCode.NotImplemented)
+        route("{$OPPGAVEID_CALL_PARAMETER}") {
+            post("tildel-saksbehandler") {
+                kunSaksbehandler {
+                    if (kanBrukeNyOppgaveliste) {
+                        val saksbehandlerEndringDto = call.receive<SaksbehandlerEndringDto>()
+                        service.tildelSaksbehandler(oppgaveId, saksbehandlerEndringDto.saksbehandler)
+                        call.respond(HttpStatusCode.OK)
+                    } else {
+                        call.respond(HttpStatusCode.NotImplemented)
+                    }
                 }
             }
-        }
-        post("bytt-saksbehandler/{$SAKID_CALL_PARAMETER}") {
-            kunSaksbehandler {
-                if (kanBrukeNyOppgaveliste) {
-                    val saksbehandlerEndringDto = call.receive<SaksbehandlerEndringDto>()
-                    service.byttSaksbehandler(saksbehandlerEndringDto)
-                    call.respond(HttpStatusCode.OK)
-                } else {
-                    call.respond(HttpStatusCode.NotImplemented)
+            post("bytt-saksbehandler") {
+                kunSaksbehandler {
+                    if (kanBrukeNyOppgaveliste) {
+                        val saksbehandlerEndringDto = call.receive<SaksbehandlerEndringDto>()
+                        service.byttSaksbehandler(oppgaveId, saksbehandlerEndringDto.saksbehandler)
+                        call.respond(HttpStatusCode.OK)
+                    } else {
+                        call.respond(HttpStatusCode.NotImplemented)
+                    }
                 }
             }
-        }
-        post("fjern-saksbehandler/{$SAKID_CALL_PARAMETER}") {
-            kunSaksbehandler {
-                if (kanBrukeNyOppgaveliste) {
-                    val fjernSaksbehandlerRequest = call.receive<FjernSaksbehandlerRequest>()
-                    service.fjernSaksbehandler(fjernSaksbehandlerRequest)
-                    call.respond(HttpStatusCode.OK)
-                } else {
-                    call.respond(HttpStatusCode.NotImplemented)
+            route("saksbehandler", HttpMethod.Delete) {
+                handle {
+                    kunSaksbehandler {
+                        if (kanBrukeNyOppgaveliste) {
+                            service.fjernSaksbehandler(oppgaveId)
+                            call.respond(HttpStatusCode.OK)
+                        } else {
+                            call.respond(HttpStatusCode.NotImplemented)
+                        }
+                    }
                 }
             }
-        }
-        put("/rediger-frist/{$SAKID_CALL_PARAMETER}") {
-            kunSaksbehandler {
-                if (kanBrukeNyOppgaveliste) {
-                    val redigerFrist = call.receive<RedigerFristRequest>()
-                    service.redigerFrist(redigerFrist)
-                    call.respond(HttpStatusCode.OK)
-                } else {
-                    call.respond(HttpStatusCode.NotImplemented)
+            put("frist") {
+                kunSaksbehandler {
+                    if (kanBrukeNyOppgaveliste) {
+                        val redigerFrist = call.receive<RedigerFristRequest>()
+                        service.redigerFrist(oppgaveId, redigerFrist.frist)
+                        call.respond(HttpStatusCode.OK)
+                    } else {
+                        call.respond(HttpStatusCode.NotImplemented)
+                    }
                 }
-            }
-        }
-        post("/lagre") {
-            if (kanBrukeNyOppgaveliste) {
-                val oppgave = call.receive<OppgaveNy>()
-                // service.lagreOppgave(oppgave)
-                call.respond(HttpStatusCode.Created)
-            } else {
-                call.respond(HttpStatusCode.Forbidden)
             }
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakTilgangDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakTilgangDao.kt
@@ -60,4 +60,27 @@ class SakTilgangDao(private val datasource: DataSource) {
             }
         }
     }
+
+    fun hentSakMedGraderingOgSkjermingPaaOppgave(oppgaveId: String): SakMedGraderingOgSkjermet? {
+        datasource.connection.use {
+            val statement = it.prepareStatement(
+                """
+                SELECT s.id as sak_id, adressebeskyttelse, erskjermet 
+                FROM oppgave o
+                INNER JOIN Sak s on o.sak_id = s.id
+                WHERE o.id = ?::uuid
+                """.trimIndent()
+            )
+            statement.setString(1, oppgaveId)
+            return statement.executeQuery().singleOrNull {
+                SakMedGraderingOgSkjermet(
+                    id = getLong("sak_id"),
+                    adressebeskyttelseGradering = getString("adressebeskyttelse")?.let {
+                        AdressebeskyttelseGradering.valueOf(it)
+                    },
+                    erSkjermet = getBoolean("erskjermet")
+                )
+            }
+        }
+    }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/TilgangService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/TilgangService.kt
@@ -8,6 +8,7 @@ interface TilgangService {
     fun oppdaterAdressebeskyttelse(id: Long, adressebeskyttelseGradering: AdressebeskyttelseGradering): Int
     fun harTilgangTilSak(sakId: Long, saksbehandlerMedRoller: SaksbehandlerMedRoller): Boolean
     fun harTilgangTilPerson(fnr: String, saksbehandlerMedRoller: SaksbehandlerMedRoller): Boolean
+    fun harTilgangTilOppgave(oppgaveId: String, saksbehandlerMedRoller: SaksbehandlerMedRoller): Boolean
 }
 
 data class SakMedGraderingOgSkjermet(
@@ -33,6 +34,11 @@ class TilgangServiceImpl(
         return finnSakerMedGradering.map {
             harTilgangSjekker(it, saksbehandlerMedRoller)
         }.all { it }
+    }
+
+    override fun harTilgangTilOppgave(oppgaveId: String, saksbehandlerMedRoller: SaksbehandlerMedRoller): Boolean {
+        val sakMedGraderingOgSkjermet = dao.hentSakMedGraderingOgSkjermingPaaOppgave(oppgaveId) ?: return true
+        return harTilgangSjekker(sakMedGraderingOgSkjermet, saksbehandlerMedRoller)
     }
 
     override fun harTilgangTilSak(sakId: Long, saksbehandlerMedRoller: SaksbehandlerMedRoller): Boolean {

--- a/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
@@ -20,6 +20,7 @@ import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.FoedselsNummerMedGraderingDTO
 import no.nav.etterlatte.libs.common.FoedselsnummerDTO
+import no.nav.etterlatte.libs.common.OPPGAVEID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
@@ -32,6 +33,8 @@ class PluginConfiguration {
     var harTilgangBehandling: (behandlingId: String, saksbehandlerMedRoller: SaksbehandlerMedRoller)
     -> Boolean = { _, _ -> false }
     var harTilgangTilSak: (sakId: Long, saksbehandlerMedRoller: SaksbehandlerMedRoller)
+    -> Boolean = { _, _ -> false }
+    var harTilgangTilOppgave: (oppgaveId: String, saksbehandlerMedRoller: SaksbehandlerMedRoller)
     -> Boolean = { _, _ -> false }
     var saksbehandlerGroupIdsByKey: Map<AzureGroup, String> = emptyMap()
 }
@@ -85,6 +88,18 @@ val adressebeskyttelsePlugin: RouteScopedPlugin<PluginConfiguration> = createRou
             if (!sakId.isNullOrEmpty()) {
                 if (!pluginConfig.harTilgangTilSak(
                         sakId.toLong(),
+                        SaksbehandlerMedRoller(bruker, saksbehandlerGroupIdsByKey)
+                    )
+                ) {
+                    call.respond(HttpStatusCode.NotFound)
+                }
+                return@on
+            }
+
+            val oppgaveId = call.parameters[OPPGAVEID_CALL_PARAMETER]
+            if (!oppgaveId.isNullOrEmpty()) {
+                if (!pluginConfig.harTilgangTilOppgave(
+                        oppgaveId,
                         SaksbehandlerMedRoller(bruker, saksbehandlerGroupIdsByKey)
                     )
                 ) {

--- a/apps/etterlatte-behandling/src/test/kotlin/IntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/IntegrationTest.kt
@@ -138,17 +138,17 @@ class IntegrationTest : BehandlingIntegrationTest() {
                 it.body<DetaljertBehandling>()
             }
 
-            val oppgaver: List<OppgaveNy> = client.get("/api/nyeoppgaver/hent") {
+            val oppgaver: List<OppgaveNy> = client.get("/api/nyeoppgaver") {
                 addAuthToken(tokenSaksbehandler)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
             }.also {
                 assertEquals(HttpStatusCode.OK, it.status)
             }.body()
             val oppgaverforbehandling = oppgaver.filter { it.referanse == behandlingId.toString() }
-            client.post("/api/nyeoppgaver/tildel-saksbehandler/${sak.id}") {
+            client.post("/api/nyeoppgaver/${oppgaverforbehandling[0].id}/tildel-saksbehandler/") {
                 addAuthToken(tokenSaksbehandler)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                setBody(SaksbehandlerEndringDto(oppgaverforbehandling[0].id, "Saksbehandler01"))
+                setBody(SaksbehandlerEndringDto("Saksbehandler01"))
             }.also {
                 assertEquals(HttpStatusCode.OK, it.status)
             }
@@ -278,17 +278,17 @@ class IntegrationTest : BehandlingIntegrationTest() {
                 assertEquals(HttpStatusCode.OK, it.status)
             }
 
-            val oppgaveroppgaveliste: List<OppgaveNy> = client.get("/api/nyeoppgaver/hent") {
+            val oppgaveroppgaveliste: List<OppgaveNy> = client.get("/api/nyeoppgaver") {
                 addAuthToken(tokenAttestant)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
             }.also {
                 assertEquals(HttpStatusCode.OK, it.status)
             }.body()
             val oppgaverforattestant = oppgaveroppgaveliste.filter { it.referanse == behandlingId.toString() }
-            client.post("/api/nyeoppgaver/tildel-saksbehandler/${sak.id}") {
+            client.post("/api/nyeoppgaver/${oppgaverforattestant[0].id}/tildel-saksbehandler") {
                 addAuthToken(tokenAttestant)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                setBody(SaksbehandlerEndringDto(oppgaverforattestant[0].id, "Saksbehandler02"))
+                setBody(SaksbehandlerEndringDto("Saksbehandler02"))
             }.also {
                 assertEquals(HttpStatusCode.OK, it.status)
             }
@@ -419,7 +419,7 @@ class IntegrationTest : BehandlingIntegrationTest() {
                 UUID.fromString(it.body())
             }
 
-            val oppgaverTo: List<OppgaveNy> = client.get("/api/nyeoppgaver/hent") {
+            val oppgaverTo: List<OppgaveNy> = client.get("/api/nyeoppgaver") {
                 addAuthToken(tokenSaksbehandler)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
             }.also {
@@ -429,10 +429,10 @@ class IntegrationTest : BehandlingIntegrationTest() {
                 it.referanse == behandlingIdNyFoerstegangsbehandling.toString()
             }
 
-            client.post("/api/nyeoppgaver/tildel-saksbehandler/${sak.id}") {
+            client.post("/api/nyeoppgaver/${oppgaveForNyFoerstegangsbehandling[0].id}/tildel-saksbehandler") {
                 addAuthToken(tokenSaksbehandler)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                setBody(SaksbehandlerEndringDto(oppgaveForNyFoerstegangsbehandling[0].id, "Saksbehandler01"))
+                setBody(SaksbehandlerEndringDto("Saksbehandler01"))
             }.also {
                 assertEquals(HttpStatusCode.OK, it.status)
             }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingIntegrationTest.kt
@@ -32,7 +32,6 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
 import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveType
-import no.nav.etterlatte.libs.common.oppgaveNy.SaksbehandlerEndringDto
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
@@ -422,10 +421,8 @@ class RevurderingIntegrationTest : BehandlingIntegrationTest() {
         }
 
         applicationContext.oppgaveServiceNy.tildelSaksbehandler(
-            SaksbehandlerEndringDto(
-                oppgaveId = oppgave.id,
-                saksbehandler = saksbehandlerIdent
-            )
+            oppgaveId = oppgave.id,
+            saksbehandler = saksbehandlerIdent
         )
 
         val revurdering = revurderingService.opprettManuellRevurderingWrapper(

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgaveny/OppgaveDaoNyTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgaveny/OppgaveDaoNyTest.kt
@@ -5,7 +5,6 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveNy
 import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveType
-import no.nav.etterlatte.libs.common.oppgaveNy.SaksbehandlerEndringDto
 import no.nav.etterlatte.libs.common.oppgaveNy.Status
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 import no.nav.etterlatte.libs.common.sak.Sak
@@ -91,7 +90,7 @@ internal class OppgaveDaoNyTest {
         oppgaveDaoNy.lagreOppgave(oppgaveNy)
 
         val nySaksbehandler = "nysaksbehandler"
-        oppgaveDaoNy.settNySaksbehandler(SaksbehandlerEndringDto(oppgaveNy.id, nySaksbehandler))
+        oppgaveDaoNy.settNySaksbehandler(oppgaveNy.id, nySaksbehandler)
         val hentOppgave = oppgaveDaoNy.hentOppgave(oppgaveNy.id)
         assertEquals(nySaksbehandler, hentOppgave?.saksbehandler)
         assertEquals(Status.UNDER_BEHANDLING, hentOppgave?.status)

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgaveny/OppgaveServiceNyTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgaveny/OppgaveServiceNyTest.kt
@@ -13,11 +13,8 @@ import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.funksjonsbrytere.DummyFeatureToggleService
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.libs.common.behandling.SakType
-import no.nav.etterlatte.libs.common.oppgaveNy.FjernSaksbehandlerRequest
 import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveType
-import no.nav.etterlatte.libs.common.oppgaveNy.RedigerFristRequest
-import no.nav.etterlatte.libs.common.oppgaveNy.SaksbehandlerEndringDto
 import no.nav.etterlatte.libs.common.oppgaveNy.Status
 import no.nav.etterlatte.libs.common.oppgaveNy.VedtakOppgaveDTO
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
@@ -121,7 +118,7 @@ class OppgaveServiceNyTest {
             OppgaveType.FOERSTEGANGSBEHANDLING
         )
         val nysaksbehandler = "nysaksbehandler"
-        oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(nyOppgave.id, nysaksbehandler))
+        oppgaveServiceNy.tildelSaksbehandler(nyOppgave.id, nysaksbehandler)
 
         val oppgaveMedNySaksbehandler = oppgaveServiceNy.hentOppgave(nyOppgave.id)
         Assertions.assertEquals(nysaksbehandler, oppgaveMedNySaksbehandler?.saksbehandler)
@@ -137,9 +134,9 @@ class OppgaveServiceNyTest {
             OppgaveType.FOERSTEGANGSBEHANDLING
         )
         val nysaksbehandler = "nysaksbehandler"
-        oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(nyOppgave.id, nysaksbehandler))
+        oppgaveServiceNy.tildelSaksbehandler(nyOppgave.id, nysaksbehandler)
         val err = assertThrows<BadRequestException> {
-            oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(nyOppgave.id, "enda en"))
+            oppgaveServiceNy.tildelSaksbehandler(nyOppgave.id, "enda en")
         }
         Assertions.assertTrue(err.message!!.startsWith("Oppgaven har allerede en saksbehandler"))
     }
@@ -148,7 +145,7 @@ class OppgaveServiceNyTest {
     fun `skal ikke kunne tildele hvis oppgaven ikke finnes`() {
         val nysaksbehandler = "nysaksbehandler"
         val err = assertThrows<NotFoundException> {
-            oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(UUID.randomUUID(), nysaksbehandler))
+            oppgaveServiceNy.tildelSaksbehandler(UUID.randomUUID(), nysaksbehandler)
         }
         Assertions.assertTrue(err.message!!.startsWith("Oppgaven finnes ikke"))
     }
@@ -165,7 +162,7 @@ class OppgaveServiceNyTest {
         oppgaveDaoNy.endreStatusPaaOppgave(nyOppgave.id, Status.FERDIGSTILT)
         val nysaksbehandler = "nysaksbehandler"
         assertThrows<IllegalStateException> {
-            oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(nyOppgave.id, nysaksbehandler))
+            oppgaveServiceNy.tildelSaksbehandler(nyOppgave.id, nysaksbehandler)
         }
     }
 
@@ -179,7 +176,7 @@ class OppgaveServiceNyTest {
             OppgaveType.FOERSTEGANGSBEHANDLING
         )
         val nysaksbehandler = "nysaksbehandler"
-        oppgaveServiceNy.byttSaksbehandler(SaksbehandlerEndringDto(nyOppgave.id, nysaksbehandler))
+        oppgaveServiceNy.byttSaksbehandler(nyOppgave.id, nysaksbehandler)
 
         val oppgaveMedNySaksbehandler = oppgaveServiceNy.hentOppgave(nyOppgave.id)
         Assertions.assertEquals(nysaksbehandler, oppgaveMedNySaksbehandler?.saksbehandler)
@@ -197,7 +194,7 @@ class OppgaveServiceNyTest {
         oppgaveDaoNy.endreStatusPaaOppgave(nyOppgave.id, Status.FERDIGSTILT)
         val nysaksbehandler = "nysaksbehandler"
         assertThrows<IllegalStateException> {
-            oppgaveServiceNy.byttSaksbehandler(SaksbehandlerEndringDto(nyOppgave.id, nysaksbehandler))
+            oppgaveServiceNy.byttSaksbehandler(nyOppgave.id, nysaksbehandler)
         }
         val oppgaveMedNySaksbehandler = oppgaveServiceNy.hentOppgave(nyOppgave.id)
         Assertions.assertEquals(nyOppgave.saksbehandler, oppgaveMedNySaksbehandler?.saksbehandler)
@@ -230,7 +227,7 @@ class OppgaveServiceNyTest {
     fun `skal ikke kunne bytte saksbehandler på en ikke eksisterende sak`() {
         val nysaksbehandler = "nysaksbehandler"
         val err = assertThrows<NotFoundException> {
-            oppgaveServiceNy.byttSaksbehandler(SaksbehandlerEndringDto(UUID.randomUUID(), nysaksbehandler))
+            oppgaveServiceNy.byttSaksbehandler(UUID.randomUUID(), nysaksbehandler)
         }
         Assertions.assertTrue(err.message!!.startsWith("Oppgaven finnes ikke"))
     }
@@ -245,8 +242,8 @@ class OppgaveServiceNyTest {
             OppgaveType.FOERSTEGANGSBEHANDLING
         )
         val nysaksbehandler = "nysaksbehandler"
-        oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(nyOppgave.id, nysaksbehandler))
-        oppgaveServiceNy.fjernSaksbehandler(FjernSaksbehandlerRequest(nyOppgave.id))
+        oppgaveServiceNy.tildelSaksbehandler(nyOppgave.id, nysaksbehandler)
+        oppgaveServiceNy.fjernSaksbehandler(nyOppgave.id)
         val oppgaveUtenSaksbehandler = oppgaveServiceNy.hentOppgave(nyOppgave.id)
         Assertions.assertNotNull(oppgaveUtenSaksbehandler?.id)
         Assertions.assertNull(oppgaveUtenSaksbehandler?.saksbehandler)
@@ -263,7 +260,7 @@ class OppgaveServiceNyTest {
             OppgaveType.FOERSTEGANGSBEHANDLING
         )
         val err = assertThrows<BadRequestException> {
-            oppgaveServiceNy.fjernSaksbehandler(FjernSaksbehandlerRequest(nyOppgave.id))
+            oppgaveServiceNy.fjernSaksbehandler(nyOppgave.id)
         }
         Assertions.assertTrue(err.message!!.startsWith("Oppgaven har ingen saksbehandler"))
     }
@@ -278,10 +275,10 @@ class OppgaveServiceNyTest {
             OppgaveType.FOERSTEGANGSBEHANDLING
         )
         val saksbehandler = "saksbehandler"
-        oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(nyOppgave.id, saksbehandler))
+        oppgaveServiceNy.tildelSaksbehandler(nyOppgave.id, saksbehandler)
         oppgaveDaoNy.endreStatusPaaOppgave(nyOppgave.id, Status.FERDIGSTILT)
         assertThrows<IllegalStateException> {
-            oppgaveServiceNy.fjernSaksbehandler(FjernSaksbehandlerRequest(nyOppgave.id))
+            oppgaveServiceNy.fjernSaksbehandler(nyOppgave.id)
         }
         val lagretOppgave = oppgaveServiceNy.hentOppgave(nyOppgave.id)
 
@@ -297,9 +294,9 @@ class OppgaveServiceNyTest {
             OppgaveKilde.BEHANDLING,
             OppgaveType.FOERSTEGANGSBEHANDLING
         )
-        oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(nyOppgave.id, "nysaksbehandler"))
+        oppgaveServiceNy.tildelSaksbehandler(nyOppgave.id, "nysaksbehandler")
         val nyFrist = Tidspunkt.now().toLocalDatetimeUTC().plusMonths(4L).toTidspunkt()
-        oppgaveServiceNy.redigerFrist(RedigerFristRequest(nyOppgave.id, nyFrist))
+        oppgaveServiceNy.redigerFrist(nyOppgave.id, nyFrist)
         val oppgaveMedNyFrist = oppgaveServiceNy.hentOppgave(nyOppgave.id)
         Assertions.assertEquals(nyFrist, oppgaveMedNyFrist?.frist)
     }
@@ -313,11 +310,11 @@ class OppgaveServiceNyTest {
             OppgaveKilde.BEHANDLING,
             OppgaveType.FOERSTEGANGSBEHANDLING
         )
-        oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(nyOppgave.id, "nysaksbehandler"))
+        oppgaveServiceNy.tildelSaksbehandler(nyOppgave.id, "nysaksbehandler")
         val nyFrist = Tidspunkt.now().toLocalDatetimeUTC().minusMonths(1L).toTidspunkt()
 
         val err = assertThrows<BadRequestException> {
-            oppgaveServiceNy.redigerFrist(RedigerFristRequest(nyOppgave.id, nyFrist))
+            oppgaveServiceNy.redigerFrist(nyOppgave.id, nyFrist)
         }
 
         Assertions.assertTrue(err.message!!.startsWith("Tidspunkt tilbake i tid id: "))
@@ -336,10 +333,8 @@ class OppgaveServiceNyTest {
         oppgaveDaoNy.endreStatusPaaOppgave(nyOppgave.id, Status.FERDIGSTILT)
         assertThrows<IllegalStateException> {
             oppgaveServiceNy.redigerFrist(
-                redigerFristRequest = RedigerFristRequest(
-                    oppgaveId = nyOppgave.id,
-                    frist = Tidspunkt.now().toLocalDatetimeUTC().plusMonths(1L).toTidspunkt()
-                )
+                oppgaveId = nyOppgave.id,
+                frist = Tidspunkt.now().toLocalDatetimeUTC().plusMonths(1L).toTidspunkt()
             )
         }
         val lagretOppgave = oppgaveServiceNy.hentOppgave(nyOppgave.id)
@@ -357,7 +352,7 @@ class OppgaveServiceNyTest {
             OppgaveType.FOERSTEGANGSBEHANDLING
         )
 
-        oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(nyOppgave.id, "saksbehandler"))
+        oppgaveServiceNy.tildelSaksbehandler(nyOppgave.id, "saksbehandler")
 
         val vedtakOppgaveDTO = oppgaveServiceNy.lukkOppgaveUnderbehandlingOgLagNyMedType(
             VedtakOppgaveDTO(opprettetSak.id, referanse),
@@ -428,8 +423,8 @@ class OppgaveServiceNyTest {
             OppgaveKilde.BEHANDLING,
             OppgaveType.FOERSTEGANGSBEHANDLING
         )
-        oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(oppgaveEn.id, "saksbehandler"))
-        oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(oppgaveTo.id, "saksbehandler"))
+        oppgaveServiceNy.tildelSaksbehandler(oppgaveEn.id, "saksbehandler")
+        oppgaveServiceNy.tildelSaksbehandler(oppgaveTo.id, "saksbehandler")
 
         val err = assertThrows<BadRequestException> {
             oppgaveServiceNy.lukkOppgaveUnderbehandlingOgLagNyMedType(
@@ -446,7 +441,7 @@ class OppgaveServiceNyTest {
     @Test
     fun `kan ikke fjerne saksbehandler hvis oppgaven ikke finnes`() {
         val err = assertThrows<NotFoundException> {
-            oppgaveServiceNy.fjernSaksbehandler(FjernSaksbehandlerRequest(UUID.randomUUID()))
+            oppgaveServiceNy.fjernSaksbehandler(UUID.randomUUID())
         }
         Assertions.assertTrue(err.message!!.startsWith("Oppgaven finnes ikke"))
     }
@@ -553,7 +548,7 @@ class OppgaveServiceNyTest {
             OppgaveType.FOERSTEGANGSBEHANDLING
         )
         val nysaksbehandler = "nysaksbehandler"
-        oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(nyOppgave.id, nysaksbehandler))
+        oppgaveServiceNy.tildelSaksbehandler(nyOppgave.id, nysaksbehandler)
 
         val oppgaveMedNySaksbehandler = oppgaveServiceNy.hentOppgave(nyOppgave.id)
         Assertions.assertEquals(nysaksbehandler, oppgaveMedNySaksbehandler?.saksbehandler)
@@ -578,7 +573,7 @@ class OppgaveServiceNyTest {
             OppgaveType.FOERSTEGANGSBEHANDLING
         )
 
-        oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(oppgave.id, "saksbehandler01"))
+        oppgaveServiceNy.tildelSaksbehandler(oppgave.id, "saksbehandler01")
         oppgaveServiceNy.ferdigStillOppgaveUnderBehandling(behandlingsref)
         val ferdigstiltOppgave = oppgaveServiceNy.hentOppgave(oppgave.id)
         Assertions.assertEquals(Status.FERDIGSTILT, ferdigstiltOppgave?.status)
@@ -594,7 +589,7 @@ class OppgaveServiceNyTest {
             OppgaveKilde.BEHANDLING,
             OppgaveType.FOERSTEGANGSBEHANDLING
         )
-        oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(oppgaveSomSkalBliAvbrutt.id, "saksbehandler01"))
+        oppgaveServiceNy.tildelSaksbehandler(oppgaveSomSkalBliAvbrutt.id, "saksbehandler01")
 
         oppgaveServiceNy.opprettFoerstegangsbehandlingsOppgaveForInnsendSoeknad(behandlingsref, opprettetSak.id)
 
@@ -631,7 +626,7 @@ class OppgaveServiceNyTest {
             OppgaveType.FOERSTEGANGSBEHANDLING
         )
         val saksbehandlerid = "saksbehandler01"
-        oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(oppgaveAalesund.id, saksbehandlerid))
+        oppgaveServiceNy.tildelSaksbehandler(oppgaveAalesund.id, saksbehandlerid)
 
         val saksteinskjer = sakDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.STEINKJER.enhetNr)
         val behrefsteinkjer = UUID.randomUUID().toString()
@@ -642,7 +637,7 @@ class OppgaveServiceNyTest {
             OppgaveType.FOERSTEGANGSBEHANDLING
         )
 
-        oppgaveServiceNy.tildelSaksbehandler(SaksbehandlerEndringDto(oppgavesteinskjer.id, saksbehandlerid))
+        oppgaveServiceNy.tildelSaksbehandler(oppgavesteinskjer.id, saksbehandlerid)
 
         val jwtclaims = JWTClaimsSet.Builder().claim("groups", saksbehandlerRolleDev).build()
         val saksbehandlerMedRoller = SaksbehandlerMedRoller(

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelista.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelista.tsx
@@ -233,7 +233,7 @@ export const Oppgavelista = (props: { oppgaver: ReadonlyArray<OppgaveDTOny>; hen
                             sakId={sakId}
                           />
                         ) : (
-                          <TildelSaksbehandler oppgaveId={id} sakId={sakId} />
+                          <TildelSaksbehandler oppgaveId={id} />
                         )}
                       </Table.DataCell>
                       <Table.DataCell>{sakType && <SaktypeTag sakType={sakType} />}</Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/RedigerSaksbehandler.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/RedigerSaksbehandler.tsx
@@ -74,8 +74,8 @@ export const RedigerSaksbehandler = (props: {
                 tekstKnappNei="Nei"
                 onYesClick={() =>
                   byttSaksbehandler({
-                    nysaksbehandler: { oppgaveId: oppgaveId, saksbehandler: user.ident },
-                    sakId: sakId,
+                    oppgaveId: oppgaveId,
+                    nysaksbehandler: { saksbehandler: user.ident },
                   })
                 }
                 setModalisOpen={setModalIsOpen}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/TildelSaksbehandler.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/TildelSaksbehandler.tsx
@@ -6,12 +6,12 @@ import { Button, Loader } from '@navikt/ds-react'
 import { PersonIcon } from '@navikt/aksel-icons'
 import { Alert } from '@navikt/ds-react'
 
-export const TildelSaksbehandler = (props: { oppgaveId: string; sakId: number }) => {
-  const { oppgaveId, sakId } = props
+export const TildelSaksbehandler = (props: { oppgaveId: string }) => {
+  const { oppgaveId } = props
   const user = useAppSelector((state) => state.saksbehandlerReducer.saksbehandler)
   const [tildelSaksbehandlerSvar, tildelSaksbehandler] = useApiCall(tildelSaksbehandlerApi)
   const tildelSaksbehandlerWrapper = () => {
-    tildelSaksbehandler({ nysaksbehandler: { oppgaveId: oppgaveId, saksbehandler: user.ident }, sakId: sakId })
+    tildelSaksbehandler({ oppgaveId: oppgaveId, nysaksbehandler: { saksbehandler: user.ident } })
   }
   return (
     <>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/FristHandlinger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/FristHandlinger.tsx
@@ -16,8 +16,8 @@ const Buttonwrapper = styled.div`
   }
 `
 
-export const FristHandlinger = (props: { status: Oppgavestatus; frist: string; oppgaveId: string; sakId: number }) => {
-  const { frist, oppgaveId, sakId, status } = props
+export const FristHandlinger = (props: { status: Oppgavestatus; frist: string; oppgaveId: string }) => {
+  const { frist, oppgaveId, status } = props
   const [open, setOpen] = useState(false)
   const [nyFrist, setnyFrist] = useState<Date>(new Date())
   const [redigerfristSvar, redigerFrist, resetredigerFristApi] = useApiCall(redigerFristApi)
@@ -68,7 +68,7 @@ export const FristHandlinger = (props: { status: Oppgavestatus; frist: string; o
                   loading={isPending(redigerfristSvar)}
                   disabled={!nyFrist}
                   onClick={() => {
-                    redigerFrist({ redigerFristRequest: { oppgaveId: oppgaveId, frist: nyFrist }, sakId: sakId })
+                    redigerFrist({ oppgaveId, redigerFristRequest: { frist: nyFrist } })
                   }}
                 >
                   Lagre ny frist

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/MinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/MinOppgaveliste.tsx
@@ -57,7 +57,7 @@ export const MinOppgaveliste = (props: { oppgaver: ReadonlyArray<OppgaveDTOny> }
                     <Table.Row key={id}>
                       <Table.HeaderCell>{formaterStringDato(opprettet)}</Table.HeaderCell>
                       <Table.DataCell>
-                        <FristHandlinger status={status} frist={frist} oppgaveId={id} sakId={sakId} />
+                        <FristHandlinger status={status} frist={frist} oppgaveId={id} />
                       </Table.DataCell>
                       <Table.DataCell>
                         <SaksoversiktLenke fnr={fnr} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaverny.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaverny.ts
@@ -31,34 +31,31 @@ export type Oppgavetype =
 
 export const erOppgaveRedigerbar = (status: Oppgavestatus): boolean => ['NY', 'UNDER_BEHANDLING'].includes(status)
 
-export const hentNyeOppgaver = async (): Promise<ApiResponse<OppgaveDTOny[]>> => apiClient.get('/nyeoppgaver/hent')
+export const hentNyeOppgaver = async (): Promise<ApiResponse<OppgaveDTOny[]>> => apiClient.get('/nyeoppgaver')
 
 export interface SaksbehandlerEndringDto {
-  oppgaveId: string
   saksbehandler: string
 }
 
 export const tildelSaksbehandlerApi = async (args: {
+  oppgaveId: string
   nysaksbehandler: SaksbehandlerEndringDto
-  sakId: number
 }): Promise<ApiResponse<void>> =>
-  apiClient.post(`/nyeoppgaver/tildel-saksbehandler/${args.sakId}`, { ...args.nysaksbehandler })
+  apiClient.post(`/nyeoppgaver/${args.oppgaveId}/tildel-saksbehandler`, { ...args.nysaksbehandler })
 
 export const byttSaksbehandlerApi = async (args: {
+  oppgaveId: string
   nysaksbehandler: SaksbehandlerEndringDto
-  sakId: number
 }): Promise<ApiResponse<void>> =>
-  apiClient.post(`/nyeoppgaver/bytt-saksbehandler/${args.sakId}`, { ...args.nysaksbehandler })
+  apiClient.post(`/nyeoppgaver/${args.oppgaveId}/bytt-saksbehandler`, { ...args.nysaksbehandler })
 
 export const fjernSaksbehandlerApi = async (args: { oppgaveId: string; sakId: number }): Promise<ApiResponse<void>> =>
-  apiClient.post(`/nyeoppgaver/fjern-saksbehandler/${args.sakId}`, { oppgaveId: args.oppgaveId })
+  apiClient.delete(`/nyeoppgaver/${args.oppgaveId}/saksbehandler`)
 
 export interface RedigerFristRequest {
-  oppgaveId: string
   frist: Date
 }
 export const redigerFristApi = async (args: {
+  oppgaveId: string
   redigerFristRequest: RedigerFristRequest
-  sakId: number
-}): Promise<ApiResponse<void>> =>
-  apiClient.put(`/nyeoppgaver/rediger-frist/${args.sakId}`, { ...args.redigerFristRequest })
+}): Promise<ApiResponse<void>> => apiClient.put(`/nyeoppgaver/${args.oppgaveId}/frist`, { ...args.redigerFristRequest })

--- a/apps/etterlatte-saksbehandling-ui/server/src/index.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/index.ts
@@ -74,11 +74,7 @@ if (isDev) {
       '/api/grunnlagsendringshendelse/:sakid/institusjon',
       '/api/sak/:sakid',
       '/api/institusjonsoppholdbegrunnelse/:sakid',
-      '/api/nyeoppgaver/hent',
-      '/api/nyeoppgaver/tildel-saksbehandler/:sakid',
-      '/api/nyeoppgaver/bytt-saksbehandler/:sakid',
-      '/api/nyeoppgaver/fjern-saksbehandler/:sakid',
-      '/api/nyeoppgaver/rediger-frist/:sakid',
+      '/api/nyeoppgaver',
     ],
     tokenMiddleware(ApiConfig.behandling.scope),
     proxy(ApiConfig.behandling.url)

--- a/libs/etterlatte-ktor/src/main/kotlin/RouteUtils.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/RouteUtils.kt
@@ -17,6 +17,7 @@ import java.util.*
 
 const val BEHANDLINGSID_CALL_PARAMETER = "behandlingsid"
 const val SAKID_CALL_PARAMETER = "sakId"
+const val OPPGAVEID_CALL_PARAMETER = "oppgaveId"
 
 inline val PipelineContext<*, ApplicationCall>.behandlingsId: UUID
     get() = call.parameters[BEHANDLINGSID_CALL_PARAMETER]?.let { UUID.fromString(it) } ?: throw NullPointerException(
@@ -27,6 +28,11 @@ inline val PipelineContext<*, ApplicationCall>.sakId: Long
     get() = call.parameters[SAKID_CALL_PARAMETER]?.toLong() ?: throw NullPointerException(
         "SakId er ikke i path params"
     )
+
+inline val PipelineContext<*, ApplicationCall>.oppgaveId: UUID
+    get() = requireNotNull(call.parameters[OPPGAVEID_CALL_PARAMETER]?.let { UUID.fromString(it) }) {
+        "OppgaveId er ikke i path params"
+    }
 
 suspend inline fun PipelineContext<*, ApplicationCall>.withBehandlingId(
     behandlingTilgangsSjekk: BehandlingTilgangsSjekk,

--- a/libs/etterlatte-oppgave-model/src/main/kotlin/OppgaveNy/OppgaveNy.kt
+++ b/libs/etterlatte-oppgave-model/src/main/kotlin/OppgaveNy/OppgaveNy.kt
@@ -62,16 +62,10 @@ enum class OppgaveType {
 }
 
 data class SaksbehandlerEndringDto(
-    val oppgaveId: UUID,
     val saksbehandler: String
 )
 
-data class FjernSaksbehandlerRequest(
-    val oppgaveId: UUID
-)
-
 data class RedigerFristRequest(
-    val oppgaveId: UUID,
     val frist: Tidspunkt
 )
 


### PR DESCRIPTION
Bruken av sakId i parameter gjorde at man kunne lyve til API'et: Saksbehandler A har tilgang til enhet 1234, men ikke enhet 6767 som behandler skjermede saker. Hvis det ligger en oppgave O på enhet 6767 kan saksbehandler da endre på den uten tilgang, ved å sende requests av typen "/api/nyeoppgaver/tildel-saksbehandler/1234" med en referanse til oppgave O i request-body.

Sjekken på tilgang går på sakId som sendes med i parameteret, men det ble ikke validert mot den faktiske saken oppgaven ligger på.

I stedet for å legge på en slik sjekk er dette en omskrivning av oppgaveApi'et til å heller basere seg på id'er sendt i call params, og legge på en tilgangssjekk mot oppgaveId'en i stedet. Brukte også anledningen til å skrive det litt mer REST-aktig