### PR TITLE
OppgaveStatus som ord og ordlyd for endring av saksbehandler

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelista.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelista.tsx
@@ -239,7 +239,9 @@ export const Oppgavelista = (props: { oppgaver: ReadonlyArray<OppgaveDTOny>; hen
                       </Table.DataCell>
                       <Table.DataCell>{sakType && <SaktypeTag sakType={sakType} />}</Table.DataCell>
                       <Table.DataCell>{merknad}</Table.DataCell>
-                      <Table.DataCell>{status}</Table.DataCell>
+                      <Table.DataCell>
+                        {<span>{status ? OPPGAVESTATUSFILTER[status] ?? status : 'Ukjent'}</span>}
+                      </Table.DataCell>
                       <Table.DataCell>{enhet}</Table.DataCell>
                       <Table.DataCell>
                         {saksbehandler ? (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/RedigerSaksbehandler.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/RedigerSaksbehandler.tsx
@@ -69,8 +69,8 @@ export const RedigerSaksbehandler = (props: {
               )}
               <GeneriskModal
                 tittel="Endre saksbehandler"
-                beskrivelse={`Ønsker du å fjerne ${saksbehandler} og sette deg som saksbehandler?`}
-                tekstKnappJa="Ja, sett meg som saksbehandler"
+                beskrivelse={`Vil du overta oppgaven til ${saksbehandler}?`}
+                tekstKnappJa="Ja, overta oppgaven"
                 tekstKnappNei="Nei"
                 onYesClick={() =>
                   byttSaksbehandler({

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/MinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/MinOppgaveliste.tsx
@@ -9,6 +9,7 @@ import { HandlingerForOppgave } from '~components/nyoppgavebenk/HandlingerForOpp
 import { OppgavetypeTag, SaktypeTag } from '~components/nyoppgavebenk/Tags'
 import SaksoversiktLenke from '~components/oppgavebenken/handlinger/BrukeroversiktKnapp'
 import { PaginationWrapper } from '~components/nyoppgavebenk/Oppgavelista'
+import { OPPGAVESTATUSFILTER } from '~components/nyoppgavebenk/Oppgavelistafiltre'
 
 export const MinOppgaveliste = (props: { oppgaver: ReadonlyArray<OppgaveDTOny> }) => {
   const { oppgaver } = props
@@ -68,7 +69,9 @@ export const MinOppgaveliste = (props: { oppgaver: ReadonlyArray<OppgaveDTOny> }
                       </Table.DataCell>
                       <Table.DataCell>{sakType && <SaktypeTag sakType={sakType} />}</Table.DataCell>
                       <Table.DataCell>{merknad}</Table.DataCell>
-                      <Table.DataCell>{status}</Table.DataCell>
+                      <Table.DataCell>
+                        {<span>{status ? OPPGAVESTATUSFILTER[status] ?? status : 'Ukjent'}</span>}
+                      </Table.DataCell>
                       <Table.DataCell>{enhet}</Table.DataCell>
                       <Table.DataCell>
                         {saksbehandler && (


### PR DESCRIPTION
- Oppgavestatus hentes nå fra filter istedenfor å være enum
- Endret ordlyd for endring av saksbehandler