### PR TITLE
EY-2482-Endre-enhet-oppgave

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
@@ -197,8 +197,15 @@ class GrunnlagsendringshendelseService(
         val sakerMedNyEnhet = finnSaker.map {
             SakMedEnhet(it.id, finnEnhetFraGradering(fnr, gradering, it.sakType))
         }
-
+        //In transaction?
         sakService.oppdaterEnhetForSaker(sakerMedNyEnhet)
+        oppdaterEnhetForRelaterteOppgaver(sakerMedNyEnhet)
+    }
+
+    private fun oppdaterEnhetForRelaterteOppgaver(sakerMedNyEnhet: List<SakMedEnhet>) {
+        sakerMedNyEnhet.forEach {
+            oppgaveService.endreEnhetForOppgaverTilknyttetSak(it.id, it.enhet)
+        }
     }
 
     private fun finnEnhetFraGradering(fnr: String, gradering: AdressebeskyttelseGradering, sakType: SakType): String {

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
@@ -197,7 +197,6 @@ class GrunnlagsendringshendelseService(
         val sakerMedNyEnhet = finnSaker.map {
             SakMedEnhet(it.id, finnEnhetFraGradering(fnr, gradering, it.sakType))
         }
-        //In transaction?
         sakService.oppdaterEnhetForSaker(sakerMedNyEnhet)
         oppdaterEnhetForRelaterteOppgaver(sakerMedNyEnhet)
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveDaoMedEndringssporing.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveDaoMedEndringssporing.kt
@@ -92,6 +92,9 @@ class OppgaveDaoMedEndringssporingImpl(
     override fun hentOppgaverForBehandling(behandlingid: String): List<OppgaveNy> {
         return oppgaveDao.hentOppgaverForBehandling(behandlingid)
     }
+    override fun hentOppgaverForSak(sakId: Long): List<OppgaveNy> {
+        return oppgaveDao.hentOppgaverForSak(sakId)
+    }
 
     override fun hentOppgaver(oppgaveTypeTyper: List<OppgaveType>): List<OppgaveNy> {
         return oppgaveDao.hentOppgaver(oppgaveTypeTyper)
@@ -112,6 +115,12 @@ class OppgaveDaoMedEndringssporingImpl(
     override fun endreStatusPaaOppgave(oppgaveId: UUID, oppgaveStatus: Status) {
         lagreEndringerPaaOppgave(oppgaveId) {
             oppgaveDao.endreStatusPaaOppgave(oppgaveId, oppgaveStatus)
+        }
+    }
+
+    override fun endreEnhetPaaOppgave(oppgaveId: UUID, enhet: String) {
+        lagreEndringerPaaOppgave(oppgaveId) {
+            oppgaveDao.endreEnhetPaaOppgave(oppgaveId, enhet)
         }
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveDaoNy.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveDaoNy.kt
@@ -105,7 +105,7 @@ class OppgaveDaoNyImpl(private val connection: () -> Connection) : OppgaveDaoNy 
                     WHERE sak_id = ?
                 """.trimIndent()
             )
-            statement.setString(1, sakId.toString())
+            statement.setLong(1, sakId)
             return statement.executeQuery().toList {
                 asOppgaveNy()
             }.also {

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveServiceNy.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveServiceNy.kt
@@ -200,9 +200,11 @@ class OppgaveServiceNy(
         sakId: Long,
         enhetsID: String
     ) {
-        val oppgaverForbehandling = oppgaveDaoNy.hentOppgaverForSak(sakId)
-        oppgaverForbehandling.forEach {
-            oppgaveDaoNy.endreEnhetPaaOppgave(it.id, enhetsID)
+        inTransaction {
+            val oppgaverForbehandling = oppgaveDaoNy.hentOppgaverForSak(sakId)
+            oppgaverForbehandling.forEach {
+                oppgaveDaoNy.endreEnhetPaaOppgave(it.id, enhetsID)
+            }
         }
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveServiceNy.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveServiceNy.kt
@@ -184,17 +184,28 @@ class OppgaveServiceNy(
         } catch (e: NoSuchElementException) {
             throw BadRequestException(
                 "Det må finnes en oppgave under behandling, gjelder behandling:" +
-                    " ${fattetoppgave.referanse}",
+                        " ${fattetoppgave.referanse}",
                 e
             )
         } catch (e: IllegalArgumentException) {
             throw BadRequestException(
                 "Skal kun ha en oppgave under behandling, gjelder behandling:" +
-                    " ${fattetoppgave.referanse}",
+                        " ${fattetoppgave.referanse}",
                 e
             )
         }
     }
+
+    fun endreEnhetForOppgaverTilknyttetSak(
+        sakId: Long,
+        enhetsID: String
+    ) {
+        val oppgaverForbehandling = oppgaveDaoNy.hentOppgaverForSak(sakId)
+        oppgaverForbehandling.forEach {
+            oppgaveDaoNy.endreEnhetPaaOppgave(it.id, enhetsID)
+        }
+    }
+
 
     fun avbrytOppgaveUnderBehandling(
         behandlingEllerHendelseId: String,
@@ -214,13 +225,13 @@ class OppgaveServiceNy(
         } catch (e: NoSuchElementException) {
             throw BadRequestException(
                 "Det må finnes en oppgave under behandling, gjelder behandling / hendelse med ID:" +
-                    " $behandlingEllerHendelseId}",
+                        " $behandlingEllerHendelseId}",
                 e
             )
         } catch (e: IllegalArgumentException) {
             throw BadRequestException(
                 "Skal kun ha en oppgave under behandling, gjelder behandling / hendelse med ID:" +
-                    " $behandlingEllerHendelseId",
+                        " $behandlingEllerHendelseId",
                 e
             )
         }
@@ -247,13 +258,13 @@ class OppgaveServiceNy(
         } catch (e: NoSuchElementException) {
             throw BadRequestException(
                 "Det må finnes en oppgave under behandling, gjelder behandling / hendelse med ID:" +
-                    " $behandlingEllerHendelseId}",
+                        " $behandlingEllerHendelseId}",
                 e
             )
         } catch (e: IllegalArgumentException) {
             throw BadRequestException(
                 "Skal kun ha en oppgave under behandling, gjelder behandling / hendelse med ID:" +
-                    " $behandlingEllerHendelseId",
+                        " $behandlingEllerHendelseId",
                 e
             )
         }

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
@@ -592,6 +592,7 @@ internal class GrunnlagsendringshendelseServiceTest {
         coEvery { grunnlagClient.hentAlleSakIder(any()) } returns sakIder
         every { adressebeskyttelseDaoMock.oppdaterAdresseBeskyttelse(any(), any()) } returns 1
         every { sakService.finnSaker(fnr) } returns saker
+        every { oppgaveService.endreEnhetForOppgaverTilknyttetSak(any(),any()) } returns Unit
         every {
             sakService.finnEnhetForPersonOgTema(any(), any(), any())
         } returns ArbeidsFordelingEnhet("NAV Familie- og pensjonsytelser Steinkjer", "4817")
@@ -630,6 +631,7 @@ internal class GrunnlagsendringshendelseServiceTest {
         coEvery { grunnlagClient.hentAlleSakIder(any()) } returns sakIder
         every { adressebeskyttelseDaoMock.oppdaterAdresseBeskyttelse(any(), any()) } returns 1
         every { sakService.finnSaker(fnr) } returns saker
+        every { oppgaveService.endreEnhetForOppgaverTilknyttetSak(any(),any()) } returns Unit
         every {
             sakService.finnEnhetForPersonOgTema(any(), any(), any())
         } returns ArbeidsFordelingEnhet("NAV Familie- og pensjonsytelser Steinkjer", "4817")

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
@@ -610,6 +610,9 @@ internal class GrunnlagsendringshendelseServiceTest {
                     adressebeskyttelse.adressebeskyttelseGradering
                 )
             }
+            verify(exactly = 6) {
+                oppgaveService.endreEnhetForOppgaverTilknyttetSak(any(),Enheter.STRENGT_FORTROLIG.enhetNr)
+            }
         }
     }
 
@@ -648,6 +651,9 @@ internal class GrunnlagsendringshendelseServiceTest {
                     it,
                     adressebeskyttelse.adressebeskyttelseGradering
                 )
+            }
+            verify(exactly = 6) {
+                oppgaveService.endreEnhetForOppgaverTilknyttetSak(any(),Enheter.STEINKJER.enhetNr)
             }
         }
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgaveny/OppgaveServiceNyTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgaveny/OppgaveServiceNyTest.kt
@@ -483,6 +483,31 @@ class OppgaveServiceNyTest {
     }
 
     @Test
+    fun `Skal kunne endre enhet for oppgaver tilknyttet sak`() {
+        val opprettetSak = sakDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
+        val nyOppgave = oppgaveServiceNy.opprettNyOppgaveMedSakOgReferanse(
+            "referanse",
+            opprettetSak.id,
+            OppgaveKilde.BEHANDLING,
+            OppgaveType.FOERSTEGANGSBEHANDLING
+        )
+
+        val jwtclaims = JWTClaimsSet.Builder().claim("groups", saksbehandlerRolleDev).build()
+        val saksbehandlerMedRoller = SaksbehandlerMedRoller(
+            Saksbehandler("", "ident", JwtTokenClaims(jwtclaims)),
+            mapOf(AzureGroup.SAKSBEHANDLER to saksbehandlerRolleDev)
+        )
+        val oppgaverUtenEndring = oppgaveServiceNy.finnOppgaverForBruker(saksbehandlerMedRoller)
+        Assertions.assertEquals(1, oppgaverUtenEndring.size)
+        Assertions.assertEquals(Enheter.AALESUND.enhetNr, oppgaverUtenEndring[0].enhet)
+
+        oppgaveServiceNy.endreEnhetForOppgaverTilknyttetSak(opprettetSak.id,Enheter.STEINKJER.enhetNr)
+        val oppgaverMedEndring = oppgaveServiceNy.finnOppgaverForBruker(saksbehandlerMedRoller)
+        Assertions.assertEquals(1, oppgaverMedEndring.size)
+        Assertions.assertEquals(Enheter.STEINKJER.enhetNr, oppgaverMedEndring[0].enhet)
+    }
+
+    @Test
     fun `Skal kun få saker som  er strengt fotrolig tilbake hvis saksbehandler har rolle strengt fortrolig`() {
         val opprettetSak = sakDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
         oppgaveServiceNy.opprettNyOppgaveMedSakOgReferanse(


### PR DESCRIPTION
Endrer enhet på oppgaver når det kommer inn en endringshendelse på adressebeskyttelse

Det gjenstår fortsatt noen caser for enhetsendring som ikke er håndtert av denne PR'en 