### PR TITLE
EY-2504: Hent oppgaver på nytt ved endring i frist eller saksbehandler

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/FilterRad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/FilterRad.tsx
@@ -1,0 +1,143 @@
+import { Button, Select, TextField } from '@navikt/ds-react'
+import React from 'react'
+import styled from 'styled-components'
+import {
+  EnhetFilterKeys,
+  OPPGAVESTATUSFILTER,
+  OppgavestatusFilterKeys,
+  OPPGAVETYPEFILTER,
+  OppgavetypeFilterKeys,
+  SAKSBEHANDLERFILTER,
+  SaksbehandlerFilterKeys,
+  YTELSEFILTER,
+  YtelseFilterKeys,
+  ENHETFILTER,
+  OppgaveKildeFilterKeys,
+  OPPGAVEKILDEFILTER,
+  FRISTFILTER,
+  FristFilterKeys,
+  Filter,
+  initialFilter,
+} from '~components/nyoppgavebenk/Oppgavelistafiltre'
+
+const FilterFlex = styled.div`
+  display: flex;
+  gap: 2rem;
+`
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  margin: 2rem 2rem 2rem 0rem;
+  max-width: 20rem;
+  button:first-child {
+    margin-right: 1rem;
+  }
+`
+
+export const FilterRad = (props: { hentOppgaver: () => void; filter: Filter; setFilter: (filter: Filter) => void }) => {
+  const { hentOppgaver, filter, setFilter } = props
+
+  return (
+    <>
+      <FilterFlex>
+        <TextField
+          label="Fødselsnummer"
+          value={filter.fnrFilter}
+          onChange={(e) => setFilter({ ...filter, fnrFilter: e.target.value })}
+          placeholder={'Søk'}
+          autoComplete="off"
+        />
+        <Select
+          label="Frist"
+          value={filter.fristFilter}
+          onChange={(e) =>
+            setFilter({
+              ...filter,
+              fristFilter: e.target.value as FristFilterKeys,
+            })
+          }
+        >
+          {Object.entries(FRISTFILTER).map(([key, fristBeskrivelse]) => (
+            <option key={key} value={key}>
+              {fristBeskrivelse}
+            </option>
+          ))}
+        </Select>
+        <Select
+          label="Saksbehandler"
+          value={filter.saksbehandlerFilter}
+          onChange={(e) => setFilter({ ...filter, saksbehandlerFilter: e.target.value as SaksbehandlerFilterKeys })}
+        >
+          {Object.entries(SAKSBEHANDLERFILTER).map(([key, beskrivelse]) => (
+            <option key={key} value={key}>
+              {beskrivelse}
+            </option>
+          ))}
+        </Select>
+
+        <Select
+          label="Enhet"
+          value={filter.enhetsFilter}
+          onChange={(e) => setFilter({ ...filter, enhetsFilter: e.target.value as EnhetFilterKeys })}
+        >
+          {Object.entries(ENHETFILTER).map(([enhetsnummer, enhetBeskrivelse]) => (
+            <option key={enhetsnummer} value={enhetsnummer}>
+              {enhetBeskrivelse}
+            </option>
+          ))}
+        </Select>
+        <Select
+          label="Ytelse"
+          value={filter.ytelseFilter}
+          onChange={(e) => setFilter({ ...filter, ytelseFilter: e.target.value as YtelseFilterKeys })}
+        >
+          {Object.entries(YTELSEFILTER).map(([saktype, saktypetekst]) => (
+            <option key={saktype} value={saktype}>
+              {saktypetekst}
+            </option>
+          ))}
+        </Select>
+        <Select
+          label="Oppgavestatus"
+          value={filter.oppgavestatusFilter}
+          onChange={(e) => setFilter({ ...filter, oppgavestatusFilter: e.target.value as OppgavestatusFilterKeys })}
+        >
+          {Object.entries(OPPGAVESTATUSFILTER).map(([status, statusbeskrivelse]) => (
+            <option key={status} value={status}>
+              {statusbeskrivelse}
+            </option>
+          ))}
+        </Select>
+        <Select
+          label="Oppgavetype"
+          value={filter.oppgavetypeFilter}
+          onChange={(e) => setFilter({ ...filter, oppgavetypeFilter: e.target.value as OppgavetypeFilterKeys })}
+        >
+          {Object.entries(OPPGAVETYPEFILTER).map(([type, typebeskrivelse]) => (
+            <option key={type} value={type}>
+              {typebeskrivelse}
+            </option>
+          ))}
+        </Select>
+        <Select
+          label="Kilde"
+          value={filter.oppgavekildeFilter}
+          onChange={(e) => setFilter({ ...filter, oppgavekildeFilter: e.target.value as OppgaveKildeFilterKeys })}
+        >
+          {Object.entries(OPPGAVEKILDEFILTER).map(([type, typebeskrivelse]) => (
+            <option key={type} value={type}>
+              {typebeskrivelse}
+            </option>
+          ))}
+        </Select>
+      </FilterFlex>
+      <ButtonWrapper>
+        <Button onClick={hentOppgaver}>Hent</Button>
+        <Button variant="secondary" onClick={() => setFilter(initialFilter())}>
+          Tilbakestill alle filtre
+        </Button>
+      </ButtonWrapper>
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelista.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelista.tsx
@@ -75,6 +75,7 @@ export const Oppgavelista = (props: { oppgaver: ReadonlyArray<OppgaveDTOny>; hen
   const [fnrFilter, setFnrFilter] = useState<string>('')
   const [page, setPage] = useState<number>(1)
   const [rowsPerPage, setRowsPerPage] = useState<number>(10)
+  const [oppgaveErEndet, setOppgaveErEndret] = useState<boolean>(false)
   const mutableOppgaver = oppgaver.concat()
   const filtrerteOppgaver = filtrerOppgaver(
     enhetsFilter,
@@ -91,9 +92,18 @@ export const Oppgavelista = (props: { oppgaver: ReadonlyArray<OppgaveDTOny>; hen
   let paginerteOppgaver = filtrerteOppgaver
   paginerteOppgaver = paginerteOppgaver.slice((page - 1) * rowsPerPage, page * rowsPerPage)
 
+  const setOppgaveErEndretWrapper = (value: boolean) => setOppgaveErEndret(value)
+
   useEffect(() => {
     if (paginerteOppgaver.length === 0 && filtrerteOppgaver.length > 0) setPage(1)
   }, [paginerteOppgaver, filtrerteOppgaver])
+
+  useEffect(() => {
+    if (oppgaveErEndet) {
+      hentOppgaver()
+      setOppgaveErEndret(false)
+    }
+  }, [oppgaveErEndet])
 
   return (
     <>
@@ -255,9 +265,10 @@ export const Oppgavelista = (props: { oppgaver: ReadonlyArray<OppgaveDTOny>; hen
                             saksbehandler={saksbehandler}
                             oppgaveId={id}
                             sakId={sakId}
+                            setOppgaveErEndret={setOppgaveErEndretWrapper}
                           />
                         ) : (
-                          <TildelSaksbehandler oppgaveId={id} />
+                          <TildelSaksbehandler oppgaveId={id} setOppgaveErEndret={setOppgaveErEndretWrapper} />
                         )}
                       </Table.DataCell>
                       <Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelista.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelista.tsx
@@ -45,8 +45,6 @@ export const Oppgavelista = (props: {
   let paginerteOppgaver = filtrerteOppgaver
   paginerteOppgaver = paginerteOppgaver.slice((page - 1) * rowsPerPage, page * rowsPerPage)
 
-  const setOppgaveErEndretWrapper = (value: boolean) => setOppgaveErEndret(value)
-
   useEffect(() => {
     if (paginerteOppgaver.length === 0 && filtrerteOppgaver.length > 0) setPage(1)
   }, [paginerteOppgaver, filtrerteOppgaver])
@@ -122,10 +120,10 @@ export const Oppgavelista = (props: {
                             saksbehandler={saksbehandler}
                             oppgaveId={id}
                             sakId={sakId}
-                            setOppgaveErEndret={setOppgaveErEndretWrapper}
+                            setOppgaveErEndret={setOppgaveErEndret}
                           />
                         ) : (
-                          <TildelSaksbehandler oppgaveId={id} setOppgaveErEndret={setOppgaveErEndretWrapper} />
+                          <TildelSaksbehandler oppgaveId={id} setOppgaveErEndret={setOppgaveErEndret} />
                         )}
                       </Table.DataCell>
                       <Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelista.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelista.tsx
@@ -40,7 +40,6 @@ export const Oppgavelista = (props: {
 
   const [page, setPage] = useState<number>(1)
   const [rowsPerPage, setRowsPerPage] = useState<number>(10)
-  const [oppgaveErEndet, setOppgaveErEndret] = useState<boolean>(false)
 
   let paginerteOppgaver = filtrerteOppgaver
   paginerteOppgaver = paginerteOppgaver.slice((page - 1) * rowsPerPage, page * rowsPerPage)
@@ -48,13 +47,6 @@ export const Oppgavelista = (props: {
   useEffect(() => {
     if (paginerteOppgaver.length === 0 && filtrerteOppgaver.length > 0) setPage(1)
   }, [paginerteOppgaver, filtrerteOppgaver])
-
-  useEffect(() => {
-    if (oppgaveErEndet) {
-      hentOppgaver()
-      setOppgaveErEndret(false)
-    }
-  }, [oppgaveErEndet])
 
   return (
     <>
@@ -120,10 +112,10 @@ export const Oppgavelista = (props: {
                             saksbehandler={saksbehandler}
                             oppgaveId={id}
                             sakId={sakId}
-                            setOppgaveErEndret={setOppgaveErEndret}
+                            hentOppgaver={hentOppgaver}
                           />
                         ) : (
-                          <TildelSaksbehandler oppgaveId={id} setOppgaveErEndret={setOppgaveErEndret} />
+                          <TildelSaksbehandler oppgaveId={id} hentOppgaver={hentOppgaver} />
                         )}
                       </Table.DataCell>
                       <Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelista.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelista.tsx
@@ -1,46 +1,15 @@
-import { Button, Pagination, Select, Table, TextField } from '@navikt/ds-react'
+import { Pagination, Table } from '@navikt/ds-react'
 import { formaterStringDato } from '~utils/formattering'
 import { TildelSaksbehandler } from '~components/nyoppgavebenk/TildelSaksbehandler'
 import { RedigerSaksbehandler } from '~components/nyoppgavebenk/RedigerSaksbehandler'
 import { OppgaveDTOny } from '~shared/api/oppgaverny'
 import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
-import {
-  EnhetFilterKeys,
-  filtrerOppgaver,
-  OPPGAVESTATUSFILTER,
-  OppgavestatusFilterKeys,
-  OPPGAVETYPEFILTER,
-  OppgavetypeFilterKeys,
-  SAKSBEHANDLERFILTER,
-  SaksbehandlerFilterKeys,
-  YTELSEFILTER,
-  YtelseFilterKeys,
-  ENHETFILTER,
-  OppgaveKildeFilterKeys,
-  OPPGAVEKILDEFILTER,
-  FRISTFILTER,
-  FristFilterKeys,
-} from '~components/nyoppgavebenk/Oppgavelistafiltre'
+import { OPPGAVESTATUSFILTER } from '~components/nyoppgavebenk/Oppgavelistafiltre'
 import { HandlingerForOppgave } from '~components/nyoppgavebenk/HandlingerForOppgave'
 import { OppgavetypeTag, SaktypeTag } from '~components/nyoppgavebenk/Tags'
 import { isBefore } from 'date-fns'
 import SaksoversiktLenke from '~components/oppgavebenken/handlinger/BrukeroversiktKnapp'
-
-const FilterFlex = styled.div`
-  display: flex;
-  gap: 2rem;
-`
-
-const ButtonWrapper = styled.div`
-  display: flex;
-  justify-content: flex-start;
-  margin: 2rem 2rem 2rem 0rem;
-  max-width: 20rem;
-  button:first-child {
-    margin-right: 1rem;
-  }
-`
 
 export const FristWrapper = styled.span<{ fristHarPassert: boolean }>`
   color: ${(p) => p.fristHarPassert && 'var(--a-text-danger)'};
@@ -62,32 +31,16 @@ export const HeaderPadding = styled.span`
   padding-left: 20px;
 `
 
-export const Oppgavelista = (props: { oppgaver: ReadonlyArray<OppgaveDTOny>; hentOppgaver: () => void }) => {
-  const { oppgaver, hentOppgaver } = props
+export const Oppgavelista = (props: {
+  oppgaver: ReadonlyArray<OppgaveDTOny>
+  hentOppgaver: () => void
+  filtrerteOppgaver: ReadonlyArray<OppgaveDTOny>
+}) => {
+  const { oppgaver, hentOppgaver, filtrerteOppgaver } = props
 
-  const [saksbehandlerFilter, setSaksbehandlerFilter] = useState<SaksbehandlerFilterKeys>('IkkeTildelt')
-  const [fristFilter, setFristFilter] = useState<FristFilterKeys>('visAlle')
-  const [enhetsFilter, setEnhetsFilter] = useState<EnhetFilterKeys>('visAlle')
-  const [ytelseFilter, setYtelseFilter] = useState<YtelseFilterKeys>('visAlle')
-  const [oppgavestatusFilter, setOppgavestatusFilter] = useState<OppgavestatusFilterKeys>('visAlle')
-  const [oppgavetypeFilter, setOppgavetypeFilter] = useState<OppgavetypeFilterKeys>('visAlle')
-  const [oppgavekildeFilter, setOppgavekildeFilter] = useState<OppgaveKildeFilterKeys>('visAlle')
-  const [fnrFilter, setFnrFilter] = useState<string>('')
   const [page, setPage] = useState<number>(1)
   const [rowsPerPage, setRowsPerPage] = useState<number>(10)
   const [oppgaveErEndet, setOppgaveErEndret] = useState<boolean>(false)
-  const mutableOppgaver = oppgaver.concat()
-  const filtrerteOppgaver = filtrerOppgaver(
-    enhetsFilter,
-    fristFilter,
-    saksbehandlerFilter,
-    ytelseFilter,
-    oppgavestatusFilter,
-    oppgavetypeFilter,
-    oppgavekildeFilter,
-    mutableOppgaver,
-    fnrFilter
-  )
 
   let paginerteOppgaver = filtrerteOppgaver
   paginerteOppgaver = paginerteOppgaver.slice((page - 1) * rowsPerPage, page * rowsPerPage)
@@ -107,102 +60,6 @@ export const Oppgavelista = (props: { oppgaver: ReadonlyArray<OppgaveDTOny>; hen
 
   return (
     <>
-      <FilterFlex>
-        <TextField
-          label="Fødselsnummer"
-          value={fnrFilter}
-          onChange={(e) => setFnrFilter(e.target.value)}
-          placeholder={'Søk'}
-          autoComplete="off"
-        />
-        <Select label="Frist" value={fristFilter} onChange={(e) => setFristFilter(e.target.value as FristFilterKeys)}>
-          {Object.entries(FRISTFILTER).map(([key, fristBeskrivelse]) => (
-            <option key={key} value={key}>
-              {fristBeskrivelse}
-            </option>
-          ))}
-        </Select>
-        <Select
-          label="Saksbehandler"
-          value={saksbehandlerFilter}
-          onChange={(e) => setSaksbehandlerFilter(e.target.value as SaksbehandlerFilterKeys)}
-        >
-          {Object.entries(SAKSBEHANDLERFILTER).map(([key, beskrivelse]) => (
-            <option key={key} value={key}>
-              {beskrivelse}
-            </option>
-          ))}
-        </Select>
-
-        <Select label="Enhet" value={enhetsFilter} onChange={(e) => setEnhetsFilter(e.target.value as EnhetFilterKeys)}>
-          {Object.entries(ENHETFILTER).map(([enhetsnummer, enhetBeskrivelse]) => (
-            <option key={enhetsnummer} value={enhetsnummer}>
-              {enhetBeskrivelse}
-            </option>
-          ))}
-        </Select>
-        <Select
-          label="Ytelse"
-          value={ytelseFilter}
-          onChange={(e) => setYtelseFilter(e.target.value as YtelseFilterKeys)}
-        >
-          {Object.entries(YTELSEFILTER).map(([saktype, saktypetekst]) => (
-            <option key={saktype} value={saktype}>
-              {saktypetekst}
-            </option>
-          ))}
-        </Select>
-        <Select
-          label="Oppgavestatus"
-          value={oppgavestatusFilter}
-          onChange={(e) => setOppgavestatusFilter(e.target.value as OppgavestatusFilterKeys)}
-        >
-          {Object.entries(OPPGAVESTATUSFILTER).map(([status, statusbeskrivelse]) => (
-            <option key={status} value={status}>
-              {statusbeskrivelse}
-            </option>
-          ))}
-        </Select>
-        <Select
-          label="Oppgavetype"
-          value={oppgavetypeFilter}
-          onChange={(e) => setOppgavetypeFilter(e.target.value as OppgavetypeFilterKeys)}
-        >
-          {Object.entries(OPPGAVETYPEFILTER).map(([type, typebeskrivelse]) => (
-            <option key={type} value={type}>
-              {typebeskrivelse}
-            </option>
-          ))}
-        </Select>
-        <Select
-          label="Kilde"
-          value={oppgavekildeFilter}
-          onChange={(e) => setOppgavekildeFilter(e.target.value as OppgaveKildeFilterKeys)}
-        >
-          {Object.entries(OPPGAVEKILDEFILTER).map(([type, typebeskrivelse]) => (
-            <option key={type} value={type}>
-              {typebeskrivelse}
-            </option>
-          ))}
-        </Select>
-      </FilterFlex>
-      <ButtonWrapper>
-        <Button onClick={hentOppgaver}>Hent</Button>
-        <Button
-          variant="secondary"
-          onClick={() => {
-            setSaksbehandlerFilter('visAlle')
-            setOppgavetypeFilter('visAlle')
-            setEnhetsFilter('visAlle')
-            setOppgavestatusFilter('visAlle')
-            setSaksbehandlerFilter('visAlle')
-            setOppgavekildeFilter('visAlle')
-            setFnrFilter('')
-          }}
-        >
-          Tilbakestill alle filtre
-        </Button>
-      </ButtonWrapper>
       {paginerteOppgaver && paginerteOppgaver.length > 0 ? (
         <>
           <Table>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelistafiltre.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelistafiltre.tsx
@@ -170,3 +170,27 @@ export function filtrerOppgaver(
 
   return finnFnrIOppgaver(fnr, fristFiltrert)
 }
+
+export interface Filter {
+  enhetsFilter: EnhetFilterKeys
+  fristFilter: FristFilterKeys
+  saksbehandlerFilter: SaksbehandlerFilterKeys
+  ytelseFilter: YtelseFilterKeys
+  oppgavestatusFilter: OppgavestatusFilterKeys
+  oppgavetypeFilter: OppgavetypeFilterKeys
+  oppgavekildeFilter: OppgaveKildeFilterKeys
+  fnrFilter: string
+}
+
+export const initialFilter = (): Filter => {
+  return {
+    enhetsFilter: 'visAlle',
+    fristFilter: 'visAlle',
+    saksbehandlerFilter: 'IkkeTildelt',
+    ytelseFilter: 'visAlle',
+    oppgavestatusFilter: 'visAlle',
+    oppgavetypeFilter: 'visAlle',
+    oppgavekildeFilter: 'visAlle',
+    fnrFilter: '',
+  }
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/RedigerSaksbehandler.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/RedigerSaksbehandler.tsx
@@ -4,7 +4,7 @@ import { fjernSaksbehandlerApi, byttSaksbehandlerApi, Oppgavestatus, erOppgaveRe
 import { Alert, Button, Loader, Label } from '@navikt/ds-react'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { PencilIcon } from '@navikt/aksel-icons'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { GeneriskModal } from '~shared/modal/modal'
 import styled from 'styled-components'
 
@@ -18,15 +18,22 @@ export const RedigerSaksbehandler = (props: {
   oppgaveId: string
   sakId: number
   status: Oppgavestatus
+  setOppgaveErEndret: (value: boolean) => void
 }) => {
   const [modalIsOpen, setModalIsOpen] = useState(false)
-  const { saksbehandler, oppgaveId, sakId, status } = props
+  const { saksbehandler, oppgaveId, sakId, status, setOppgaveErEndret } = props
   const user = useAppSelector((state) => state.saksbehandlerReducer.saksbehandler)
   const [fjernSaksbehandlerSvar, fjernSaksbehandler] = useApiCall(fjernSaksbehandlerApi)
   const [byttSaksbehandlerSvar, byttSaksbehandler] = useApiCall(byttSaksbehandlerApi)
   const erRedigerbar = erOppgaveRedigerbar(status)
 
   const brukerErSaksbehandler = user.ident === saksbehandler
+
+  useEffect(() => {
+    if (isSuccess(fjernSaksbehandlerSvar) || isSuccess(byttSaksbehandlerSvar)) {
+      setOppgaveErEndret(true)
+    }
+  }, [fjernSaksbehandlerSvar, byttSaksbehandlerSvar])
 
   return (
     <>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/RedigerSaksbehandler.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/RedigerSaksbehandler.tsx
@@ -18,10 +18,10 @@ export const RedigerSaksbehandler = (props: {
   oppgaveId: string
   sakId: number
   status: Oppgavestatus
-  setOppgaveErEndret: (value: boolean) => void
+  hentOppgaver: () => void
 }) => {
   const [modalIsOpen, setModalIsOpen] = useState(false)
-  const { saksbehandler, oppgaveId, sakId, status, setOppgaveErEndret } = props
+  const { saksbehandler, oppgaveId, sakId, status, hentOppgaver } = props
   const user = useAppSelector((state) => state.saksbehandlerReducer.saksbehandler)
   const [fjernSaksbehandlerSvar, fjernSaksbehandler] = useApiCall(fjernSaksbehandlerApi)
   const [byttSaksbehandlerSvar, byttSaksbehandler] = useApiCall(byttSaksbehandlerApi)
@@ -31,7 +31,7 @@ export const RedigerSaksbehandler = (props: {
 
   useEffect(() => {
     if (isSuccess(fjernSaksbehandlerSvar) || isSuccess(byttSaksbehandlerSvar)) {
-      setOppgaveErEndret(true)
+      hentOppgaver()
     }
   }, [fjernSaksbehandlerSvar, byttSaksbehandlerSvar])
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/TildelSaksbehandler.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/TildelSaksbehandler.tsx
@@ -5,14 +5,22 @@ import { ApiErrorAlert } from '~ErrorBoundary'
 import { Button, Loader } from '@navikt/ds-react'
 import { PersonIcon } from '@navikt/aksel-icons'
 import { Alert } from '@navikt/ds-react'
+import { useEffect } from 'react'
 
-export const TildelSaksbehandler = (props: { oppgaveId: string }) => {
-  const { oppgaveId } = props
+export const TildelSaksbehandler = (props: { oppgaveId: string; setOppgaveErEndret: (value: boolean) => void }) => {
+  const { oppgaveId, setOppgaveErEndret } = props
   const user = useAppSelector((state) => state.saksbehandlerReducer.saksbehandler)
   const [tildelSaksbehandlerSvar, tildelSaksbehandler] = useApiCall(tildelSaksbehandlerApi)
   const tildelSaksbehandlerWrapper = () => {
     tildelSaksbehandler({ oppgaveId: oppgaveId, nysaksbehandler: { saksbehandler: user.ident } })
   }
+
+  useEffect(() => {
+    if (isSuccess(tildelSaksbehandlerSvar)) {
+      setOppgaveErEndret(true)
+    }
+  }, [tildelSaksbehandlerSvar])
+
   return (
     <>
       {isPending(tildelSaksbehandlerSvar) && <Loader size="small" title="Setter saksbehandler" />}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/TildelSaksbehandler.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/TildelSaksbehandler.tsx
@@ -7,8 +7,8 @@ import { PersonIcon } from '@navikt/aksel-icons'
 import { Alert } from '@navikt/ds-react'
 import { useEffect } from 'react'
 
-export const TildelSaksbehandler = (props: { oppgaveId: string; setOppgaveErEndret: (value: boolean) => void }) => {
-  const { oppgaveId, setOppgaveErEndret } = props
+export const TildelSaksbehandler = (props: { oppgaveId: string; hentOppgaver: () => void }) => {
+  const { oppgaveId, hentOppgaver } = props
   const user = useAppSelector((state) => state.saksbehandlerReducer.saksbehandler)
   const [tildelSaksbehandlerSvar, tildelSaksbehandler] = useApiCall(tildelSaksbehandlerApi)
   const tildelSaksbehandlerWrapper = () => {
@@ -17,7 +17,7 @@ export const TildelSaksbehandler = (props: { oppgaveId: string; setOppgaveErEndr
 
   useEffect(() => {
     if (isSuccess(tildelSaksbehandlerSvar)) {
-      setOppgaveErEndret(true)
+      hentOppgaver()
     }
   }, [tildelSaksbehandlerSvar])
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/ToggleMinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/ToggleMinOppgaveliste.tsx
@@ -8,6 +8,8 @@ import { hentNyeOppgaver, OppgaveDTOny } from '~shared/api/oppgaverny'
 import Spinner from '~shared/Spinner'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import styled from 'styled-components'
+import { FilterRad } from '~components/nyoppgavebenk/FilterRad'
+import { Filter, filtrerOppgaver, initialFilter } from '~components/nyoppgavebenk/Oppgavelistafiltre'
 
 type OppgavelisteToggle = 'Oppgavelista' | 'MinOppgaveliste'
 const TabsWidth = styled(Tabs)`
@@ -16,6 +18,8 @@ const TabsWidth = styled(Tabs)`
 `
 
 export const ToggleMinOppgaveliste = () => {
+  const [filter, setFilter] = useState<Filter>(initialFilter())
+
   const [oppgaveListeValg, setOppgaveListeValg] = useState<OppgavelisteToggle>('Oppgavelista')
   const [oppgaver, hentOppgaver] = useApiCall(hentNyeOppgaver)
   const [hentedeOppgaver, setHentedeOppgaver] = useState<ReadonlyArray<OppgaveDTOny>>([])
@@ -28,6 +32,20 @@ export const ToggleMinOppgaveliste = () => {
     hentOppgaverWrapper()
   }, [])
 
+  const mutableOppgaver = hentedeOppgaver.concat()
+
+  const filtrerteOppgaver = filtrerOppgaver(
+    filter.enhetsFilter,
+    filter.fristFilter,
+    filter.saksbehandlerFilter,
+    filter.ytelseFilter,
+    filter.oppgavestatusFilter,
+    filter.oppgavetypeFilter,
+    filter.oppgavekildeFilter,
+    mutableOppgaver,
+    filter.fnrFilter
+  )
+
   return (
     <>
       <TabsWidth value={oppgaveListeValg} onChange={(e) => setOppgaveListeValg(e as OppgavelisteToggle)}>
@@ -36,12 +54,20 @@ export const ToggleMinOppgaveliste = () => {
           <Tabs.Tab value="MinOppgaveliste" label="Min oppgaveliste" icon={<PersonIcon />} />
         </Tabs.List>
       </TabsWidth>
+      {oppgaveListeValg === 'Oppgavelista' && (
+        <FilterRad hentOppgaver={hentOppgaverWrapper} filter={filter} setFilter={setFilter} />
+      )}
+
       {isPending(oppgaver) && <Spinner visible={true} label={'Henter nye oppgaver'} />}
       {isFailure(oppgaver) && <ApiErrorAlert>Kunne ikke hente oppgaver</ApiErrorAlert>}
       {isSuccess(oppgaver) && (
         <>
           {oppgaveListeValg === 'Oppgavelista' && (
-            <Oppgavelista oppgaver={hentedeOppgaver} hentOppgaver={hentOppgaverWrapper} />
+            <Oppgavelista
+              oppgaver={hentedeOppgaver}
+              filtrerteOppgaver={filtrerteOppgaver}
+              hentOppgaver={hentOppgaverWrapper}
+            />
           )}
           {oppgaveListeValg === 'MinOppgaveliste' && (
             <MinOppgaveliste oppgaver={hentedeOppgaver} hentOppgaver={hentOppgaverWrapper} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/ToggleMinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/ToggleMinOppgaveliste.tsx
@@ -27,6 +27,7 @@ export const ToggleMinOppgaveliste = () => {
   useEffect(() => {
     hentOppgaverWrapper()
   }, [])
+
   return (
     <>
       <TabsWidth value={oppgaveListeValg} onChange={(e) => setOppgaveListeValg(e as OppgavelisteToggle)}>
@@ -42,7 +43,9 @@ export const ToggleMinOppgaveliste = () => {
           {oppgaveListeValg === 'Oppgavelista' && (
             <Oppgavelista oppgaver={hentedeOppgaver} hentOppgaver={hentOppgaverWrapper} />
           )}
-          {oppgaveListeValg === 'MinOppgaveliste' && <MinOppgaveliste oppgaver={hentedeOppgaver} />}
+          {oppgaveListeValg === 'MinOppgaveliste' && (
+            <MinOppgaveliste oppgaver={hentedeOppgaver} hentOppgaver={hentOppgaverWrapper} />
+          )}
         </>
       )}
     </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/ToggleMinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/ToggleMinOppgaveliste.tsx
@@ -19,15 +19,16 @@ const TabsWidth = styled(Tabs)`
 
 export const ToggleMinOppgaveliste = () => {
   const [filter, setFilter] = useState<Filter>(initialFilter())
-
   const [oppgaveListeValg, setOppgaveListeValg] = useState<OppgavelisteToggle>('Oppgavelista')
   const [oppgaver, hentOppgaver] = useApiCall(hentNyeOppgaver)
   const [hentedeOppgaver, setHentedeOppgaver] = useState<ReadonlyArray<OppgaveDTOny>>([])
+
   const hentOppgaverWrapper = () => {
     hentOppgaver({}, (oppgaver) => {
       setHentedeOppgaver(oppgaver)
     })
   }
+
   useEffect(() => {
     hentOppgaverWrapper()
   }, [])

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/FristHandlinger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/FristHandlinger.tsx
@@ -24,9 +24,9 @@ export const FristHandlinger = (props: {
   status: Oppgavestatus
   orginalFrist: string
   oppgaveId: string
-  setOppgaveErEndret: (value: boolean) => void
+  hentOppgaver: () => void
 }) => {
-  const { orginalFrist, oppgaveId, status, setOppgaveErEndret } = props
+  const { orginalFrist, oppgaveId, status, hentOppgaver } = props
   const [open, setOpen] = useState(false)
   const [frist, setFrist] = useState<string>()
   const [nyFrist, setnyFrist] = useState<Date>(new Date())
@@ -96,14 +96,14 @@ export const FristHandlinger = (props: {
                   <Button
                     variant="secondary"
                     onClick={() => {
-                      setOppgaveErEndret(true)
-                      setOpen(!open)
+                      hentOppgaver()
+                      setOpen(false)
                     }}
                   >
                     Lukk
                   </Button>
                 ) : (
-                  <Button variant="secondary" onClick={() => setOpen(!open)}>
+                  <Button variant="secondary" onClick={() => setOpen(false)}>
                     Avbryt
                   </Button>
                 )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/FristHandlinger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/FristHandlinger.tsx
@@ -20,8 +20,13 @@ const FristWrapper = styled.span<{ fristHarPassert: boolean; utenKnapp?: boolean
   padding: ${(p) => p.utenKnapp && '12px 20px'};
 `
 
-export const FristHandlinger = (props: { status: Oppgavestatus; orginalFrist: string; oppgaveId: string }) => {
-  const { orginalFrist, oppgaveId, status } = props
+export const FristHandlinger = (props: {
+  status: Oppgavestatus
+  orginalFrist: string
+  oppgaveId: string
+  setOppgaveErEndret: (value: boolean) => void
+}) => {
+  const { orginalFrist, oppgaveId, status, setOppgaveErEndret } = props
   const [open, setOpen] = useState(false)
   const [frist, setFrist] = useState<string>()
   const [nyFrist, setnyFrist] = useState<Date>(new Date())
@@ -86,9 +91,22 @@ export const FristHandlinger = (props: { status: Oppgavestatus; orginalFrist: st
                 >
                   Lagre ny frist
                 </Button>
-                <Button variant="secondary" onClick={() => setOpen(!open)}>
-                  {isSuccess(redigerfristSvar) ? 'Lukk' : 'Avbryt'}
-                </Button>
+
+                {isSuccess(redigerfristSvar) ? (
+                  <Button
+                    variant="secondary"
+                    onClick={() => {
+                      setOppgaveErEndret(true)
+                      setOpen(!open)
+                    }}
+                  >
+                    Lukk
+                  </Button>
+                ) : (
+                  <Button variant="secondary" onClick={() => setOpen(!open)}>
+                    Avbryt
+                  </Button>
+                )}
               </Buttonwrapper>
             </Modal.Content>
           </Modal>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/MinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/MinOppgaveliste.tsx
@@ -16,9 +16,10 @@ export const MinOppgaveliste = (props: { oppgaver: ReadonlyArray<OppgaveDTOny>; 
   const { oppgaver, hentOppgaver } = props
   const user = useAppSelector((state) => state.saksbehandlerReducer.saksbehandler)
   const [page, setPage] = useState<number>(1)
-  const mineOppgaver = oppgaver.filter((o) => o.saksbehandler === user.ident)
   const [rowsPerPage, setRowsPerPage] = useState<number>(10)
   const [oppgaveErEndet, setOppgaveErEndret] = useState<boolean>(false)
+
+  const mineOppgaver = oppgaver.filter((o) => o.saksbehandler === user.ident)
 
   let paginerteOppgaver = mineOppgaver
   paginerteOppgaver = paginerteOppgaver.slice((page - 1) * rowsPerPage, page * rowsPerPage)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/MinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/MinOppgaveliste.tsx
@@ -4,7 +4,7 @@ import { Pagination, Table } from '@navikt/ds-react'
 import { formaterStringDato } from '~utils/formattering'
 import { RedigerSaksbehandler } from '~components/nyoppgavebenk/RedigerSaksbehandler'
 import { FristHandlinger } from '~components/nyoppgavebenk/minoppgaveliste/FristHandlinger'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { HandlingerForOppgave } from '~components/nyoppgavebenk/HandlingerForOppgave'
 import { OppgavetypeTag, SaktypeTag } from '~components/nyoppgavebenk/Tags'
 import SaksoversiktLenke from '~components/oppgavebenken/handlinger/BrukeroversiktKnapp'
@@ -17,19 +17,11 @@ export const MinOppgaveliste = (props: { oppgaver: ReadonlyArray<OppgaveDTOny>; 
   const user = useAppSelector((state) => state.saksbehandlerReducer.saksbehandler)
   const [page, setPage] = useState<number>(1)
   const [rowsPerPage, setRowsPerPage] = useState<number>(10)
-  const [oppgaveErEndet, setOppgaveErEndret] = useState<boolean>(false)
 
   const mineOppgaver = oppgaver.filter((o) => o.saksbehandler === user.ident)
 
   let paginerteOppgaver = mineOppgaver
   paginerteOppgaver = paginerteOppgaver.slice((page - 1) * rowsPerPage, page * rowsPerPage)
-
-  useEffect(() => {
-    if (oppgaveErEndet) {
-      hentOppgaver()
-      setOppgaveErEndret(false)
-    }
-  }, [oppgaveErEndet])
 
   return (
     <>
@@ -78,7 +70,7 @@ export const MinOppgaveliste = (props: { oppgaver: ReadonlyArray<OppgaveDTOny>; 
                           status={status}
                           orginalFrist={frist}
                           oppgaveId={id}
-                          setOppgaveErEndret={setOppgaveErEndret}
+                          hentOppgaver={hentOppgaver}
                         />
                       </Table.DataCell>
                       <Table.DataCell>
@@ -100,7 +92,7 @@ export const MinOppgaveliste = (props: { oppgaver: ReadonlyArray<OppgaveDTOny>; 
                             saksbehandler={saksbehandler}
                             oppgaveId={id}
                             sakId={sakId}
-                            setOppgaveErEndret={setOppgaveErEndret}
+                            hentOppgaver={hentOppgaver}
                           />
                         )}
                       </Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/MinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/MinOppgaveliste.tsx
@@ -24,8 +24,6 @@ export const MinOppgaveliste = (props: { oppgaver: ReadonlyArray<OppgaveDTOny>; 
   let paginerteOppgaver = mineOppgaver
   paginerteOppgaver = paginerteOppgaver.slice((page - 1) * rowsPerPage, page * rowsPerPage)
 
-  const setOppgaveErEndretWrapper = (value: boolean) => setOppgaveErEndret(value)
-
   useEffect(() => {
     if (oppgaveErEndet) {
       hentOppgaver()
@@ -80,7 +78,7 @@ export const MinOppgaveliste = (props: { oppgaver: ReadonlyArray<OppgaveDTOny>; 
                           status={status}
                           orginalFrist={frist}
                           oppgaveId={id}
-                          setOppgaveErEndret={setOppgaveErEndretWrapper}
+                          setOppgaveErEndret={setOppgaveErEndret}
                         />
                       </Table.DataCell>
                       <Table.DataCell>
@@ -102,7 +100,7 @@ export const MinOppgaveliste = (props: { oppgaver: ReadonlyArray<OppgaveDTOny>; 
                             saksbehandler={saksbehandler}
                             oppgaveId={id}
                             sakId={sakId}
-                            setOppgaveErEndret={setOppgaveErEndretWrapper}
+                            setOppgaveErEndret={setOppgaveErEndret}
                           />
                         )}
                       </Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/MinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/MinOppgaveliste.tsx
@@ -4,7 +4,7 @@ import { Pagination, Table } from '@navikt/ds-react'
 import { formaterStringDato } from '~utils/formattering'
 import { RedigerSaksbehandler } from '~components/nyoppgavebenk/RedigerSaksbehandler'
 import { FristHandlinger } from '~components/nyoppgavebenk/minoppgaveliste/FristHandlinger'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { HandlingerForOppgave } from '~components/nyoppgavebenk/HandlingerForOppgave'
 import { OppgavetypeTag, SaktypeTag } from '~components/nyoppgavebenk/Tags'
 import SaksoversiktLenke from '~components/oppgavebenken/handlinger/BrukeroversiktKnapp'
@@ -12,14 +12,25 @@ import { PaginationWrapper } from '~components/nyoppgavebenk/Oppgavelista'
 import { OPPGAVESTATUSFILTER } from '~components/nyoppgavebenk/Oppgavelistafiltre'
 import { HeaderPadding } from '~components/nyoppgavebenk/Oppgavelista'
 
-export const MinOppgaveliste = (props: { oppgaver: ReadonlyArray<OppgaveDTOny> }) => {
-  const { oppgaver } = props
+export const MinOppgaveliste = (props: { oppgaver: ReadonlyArray<OppgaveDTOny>; hentOppgaver: () => void }) => {
+  const { oppgaver, hentOppgaver } = props
   const user = useAppSelector((state) => state.saksbehandlerReducer.saksbehandler)
   const [page, setPage] = useState<number>(1)
   const mineOppgaver = oppgaver.filter((o) => o.saksbehandler === user.ident)
   const [rowsPerPage, setRowsPerPage] = useState<number>(10)
+  const [oppgaveErEndet, setOppgaveErEndret] = useState<boolean>(false)
+
   let paginerteOppgaver = mineOppgaver
   paginerteOppgaver = paginerteOppgaver.slice((page - 1) * rowsPerPage, page * rowsPerPage)
+
+  const setOppgaveErEndretWrapper = (value: boolean) => setOppgaveErEndret(value)
+
+  useEffect(() => {
+    if (oppgaveErEndet) {
+      hentOppgaver()
+      setOppgaveErEndret(false)
+    }
+  }, [oppgaveErEndet])
 
   return (
     <>
@@ -64,7 +75,12 @@ export const MinOppgaveliste = (props: { oppgaver: ReadonlyArray<OppgaveDTOny> }
                     <Table.Row key={id}>
                       <Table.HeaderCell>{formaterStringDato(opprettet)}</Table.HeaderCell>
                       <Table.DataCell>
-                        <FristHandlinger status={status} orginalFrist={frist} oppgaveId={id} />
+                        <FristHandlinger
+                          status={status}
+                          orginalFrist={frist}
+                          oppgaveId={id}
+                          setOppgaveErEndret={setOppgaveErEndretWrapper}
+                        />
                       </Table.DataCell>
                       <Table.DataCell>
                         <SaksoversiktLenke fnr={fnr} />
@@ -85,6 +101,7 @@ export const MinOppgaveliste = (props: { oppgaver: ReadonlyArray<OppgaveDTOny> }
                             saksbehandler={saksbehandler}
                             oppgaveId={id}
                             sakId={sakId}
+                            setOppgaveErEndret={setOppgaveErEndretWrapper}
                           />
                         )}
                       </Table.DataCell>


### PR DESCRIPTION
- Henter alle oppgaver på nytt hvis man endrer på frist eller saksbehandler
- Flytter filter ut av oppgavelista for å spare filtervalg ved ny henting av oppgaver. Dette vil også gjøre det lettere å bruke filter på min oppgaveliste hvis det trengs senere.

Burde nok lages en egen alert komponent for å bedre vise frem at saksbehandler er endret.