### PR TITLE
Legg til antall oppgaver som saksbehandler har

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/ToggleMinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/ToggleMinOppgaveliste.tsx
@@ -14,7 +14,7 @@ import { useAppSelector } from '~store/Store'
 
 type OppgavelisteToggle = 'Oppgavelista' | 'MinOppgaveliste'
 const TabsWidth = styled(Tabs)`
-  max-width: 22em;
+  max-width: fit-content;
   margin-bottom: 2rem;
 `
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/ToggleMinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/ToggleMinOppgaveliste.tsx
@@ -10,10 +10,11 @@ import { ApiErrorAlert } from '~ErrorBoundary'
 import styled from 'styled-components'
 import { FilterRad } from '~components/nyoppgavebenk/FilterRad'
 import { Filter, filtrerOppgaver, initialFilter } from '~components/nyoppgavebenk/Oppgavelistafiltre'
+import { useAppSelector } from '~store/Store'
 
 type OppgavelisteToggle = 'Oppgavelista' | 'MinOppgaveliste'
 const TabsWidth = styled(Tabs)`
-  max-width: 20em;
+  max-width: 22em;
   margin-bottom: 2rem;
 `
 
@@ -22,6 +23,9 @@ export const ToggleMinOppgaveliste = () => {
   const [oppgaveListeValg, setOppgaveListeValg] = useState<OppgavelisteToggle>('Oppgavelista')
   const [oppgaver, hentOppgaver] = useApiCall(hentNyeOppgaver)
   const [hentedeOppgaver, setHentedeOppgaver] = useState<ReadonlyArray<OppgaveDTOny>>([])
+  const user = useAppSelector((state) => state.saksbehandlerReducer.saksbehandler)
+
+  const mineOppgaver = hentedeOppgaver.filter((o) => o.saksbehandler === user.ident)
 
   const hentOppgaverWrapper = () => {
     hentOppgaver({}, (oppgaver) => {
@@ -52,7 +56,7 @@ export const ToggleMinOppgaveliste = () => {
       <TabsWidth value={oppgaveListeValg} onChange={(e) => setOppgaveListeValg(e as OppgavelisteToggle)}>
         <Tabs.List>
           <Tabs.Tab value="Oppgavelista" label="Oppgavelisten" icon={<InboxIcon />} />
-          <Tabs.Tab value="MinOppgaveliste" label="Min oppgaveliste" icon={<PersonIcon />} />
+          <Tabs.Tab value="MinOppgaveliste" label={`Min oppgaveliste (${mineOppgaver.length})`} icon={<PersonIcon />} />
         </Tabs.List>
       </TabsWidth>
       {oppgaveListeValg === 'Oppgavelista' && (
@@ -71,7 +75,7 @@ export const ToggleMinOppgaveliste = () => {
             />
           )}
           {oppgaveListeValg === 'MinOppgaveliste' && (
-            <MinOppgaveliste oppgaver={hentedeOppgaver} hentOppgaver={hentOppgaverWrapper} />
+            <MinOppgaveliste oppgaver={mineOppgaver} hentOppgaver={hentOppgaverWrapper} />
           )}
         </>
       )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/MinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/MinOppgaveliste.tsx
@@ -1,5 +1,4 @@
 import { OppgaveDTOny } from '~shared/api/oppgaverny'
-import { useAppSelector } from '~store/Store'
 import { Pagination, Table } from '@navikt/ds-react'
 import { formaterStringDato } from '~utils/formattering'
 import { RedigerSaksbehandler } from '~components/nyoppgavebenk/RedigerSaksbehandler'
@@ -14,13 +13,10 @@ import { HeaderPadding } from '~components/nyoppgavebenk/Oppgavelista'
 
 export const MinOppgaveliste = (props: { oppgaver: ReadonlyArray<OppgaveDTOny>; hentOppgaver: () => void }) => {
   const { oppgaver, hentOppgaver } = props
-  const user = useAppSelector((state) => state.saksbehandlerReducer.saksbehandler)
   const [page, setPage] = useState<number>(1)
   const [rowsPerPage, setRowsPerPage] = useState<number>(10)
 
-  const mineOppgaver = oppgaver.filter((o) => o.saksbehandler === user.ident)
-
-  let paginerteOppgaver = mineOppgaver
+  let paginerteOppgaver = oppgaver
   paginerteOppgaver = paginerteOppgaver.slice((page - 1) * rowsPerPage, page * rowsPerPage)
 
   return (
@@ -113,12 +109,12 @@ export const MinOppgaveliste = (props: { oppgaver: ReadonlyArray<OppgaveDTOny>; 
             <Pagination
               page={page}
               onPageChange={setPage}
-              count={Math.ceil(mineOppgaver.length / rowsPerPage)}
+              count={Math.ceil(oppgaver.length / rowsPerPage)}
               size="small"
             />
             <p>
               Viser {(page - 1) * rowsPerPage + 1} - {(page - 1) * rowsPerPage + paginerteOppgaver.length} av{' '}
-              {mineOppgaver.length} oppgaver
+              {oppgaver.length} oppgaver
             </p>
             <select
               value={rowsPerPage}


### PR DESCRIPTION
Viser antall oppgaver saksbehandler har under mine oppgaver. 
Gjør det enklere å se at en oppgave legges til under mine oppgaver.

![minoppgavelistenumber](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/17142094/2a930608-a815-4f6c-85f9-1af7bc7cdd58)
_PS. Skrivefeilen som er i videoen er fikset_
