### PR TITLE
NAV call id - forskjellige formater

### DIFF
--- a/libs/etterlatte-ktor/src/main/kotlin/HttpClient.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/HttpClient.kt
@@ -56,6 +56,7 @@ fun httpClient(
         getCorrelationId().let {
             header(HttpHeaders.XCorrelationId, it)
             header("Nav_Call_Id", it)
+            header("Nav-Call-Id", it)
         }
         ekstraDefaultHeaders.invoke(this)
     }


### PR DESCRIPTION
Etter opprydding i EY-2484 så ble vår httpKlient konsistent med bruk av "Nav_Call_Id".

Men det viser seg - noen tjenester forventer "Nav_Call_Id" og noen "Nav-Call-Id".

Det er bare en til header med x-correlation-id - så sender begge varianter.