### PR TITLE
EY-2440 - reverser logikk i frontend for prorata

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlag.tsx
@@ -161,10 +161,10 @@ export const TrygdetidGrunnlag: React.FC<Props> = ({
 
                   <Prorata
                     legend="Prorata"
-                    value={[trygdetidgrunnlag.prorata ? 'PRORATA' : ''].filter((val) => val !== '')}
+                    value={[!trygdetidgrunnlag.prorata ? 'IKKEPRORATA' : ''].filter((val) => val !== '')}
                   >
                     <Checkbox
-                      value="PRORATA"
+                      value="IKKEPRORATA"
                       key={`prorata-${trygdetidGrunnlagType}`}
                       onChange={() => {
                         setTrygdetidgrunnlag({
@@ -173,7 +173,7 @@ export const TrygdetidGrunnlag: React.FC<Props> = ({
                         })
                       }}
                     >
-                      Med i prorata
+                      Ikke med i prorata
                     </Checkbox>
                   </Prorata>
                 </>


### PR DESCRIPTION
Beholder prorata som verdi i backend - men saksbehandlere er mer vant til valget "Ikke med i prorata" i grensesnittet - så reverser logikken der.