### PR TITLE
Logikken for om vi skulle la brukar redigere brev eller ikkje var både kompleks og feil 

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
@@ -57,14 +57,18 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
   }, [behandlingId, sakId])
 
   const erReadOnly = () => {
-    return (
-      vedtaksbrev.prosessType === BrevProsessType.AUTOMATISK &&
-      !(
-        props.behandling.revurderingsaarsak != null &&
-        props.behandling.revurderingsaarsak in
-          [Revurderingsaarsak.OMGJOERING_AV_FARSKAP, Revurderingsaarsak.ADOPSJON, Revurderingsaarsak.FENGSELSOPPHOLD]
-      )
-    )
+    if (vedtaksbrev.prosessType === BrevProsessType.MANUELL) {
+      return false
+    }
+    if (!props.behandling.revurderingsaarsak) {
+      return true
+    }
+    const aarsakerMedManueltBrev = [
+      Revurderingsaarsak.OMGJOERING_AV_FARSKAP,
+      Revurderingsaarsak.ADOPSJON,
+      Revurderingsaarsak.FENGSELSOPPHOLD,
+    ]
+    return !aarsakerMedManueltBrev.includes(props.behandling.revurderingsaarsak)
   }
 
   return (


### PR DESCRIPTION
(ikkje alle med brevprosesstype automatisk skal vera readonly lenger). Gjekk derfor for å forenkle med det samme, så vi har betre kontroll framover