### PR TITLE
EY-2526: Forenklar ved å bruke brevprosesstype

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
@@ -19,7 +19,6 @@ import ForhaandsvisningBrev from '~components/behandling/brev/ForhaandsvisningBr
 import Spinner from '~shared/Spinner'
 import { BrevProsessType } from '~shared/types/Brev'
 import RedigerbartBrev from '~components/behandling/brev/RedigerbartBrev'
-import { Revurderingsaarsak } from '~shared/types/Revurderingsaarsak'
 
 export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
   const { behandlingId } = useParams()
@@ -56,25 +55,6 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
     fetchVedtaksbrev()
   }, [behandlingId, sakId])
 
-  const erReadOnly = () => {
-    if (vedtaksbrev.prosessType === BrevProsessType.MANUELL) {
-      return false
-    }
-    if (vedtaksbrev.prosessType === BrevProsessType.AUTOMATISK) {
-      return true
-    }
-    if (!props.behandling.revurderingsaarsak) {
-      return true
-    }
-    const aarsakerMedManueltBrev = [
-      Revurderingsaarsak.OMGJOERING_AV_FARSKAP,
-      Revurderingsaarsak.ADOPSJON,
-      Revurderingsaarsak.FENGSELSOPPHOLD,
-      Revurderingsaarsak.YRKESSKADE,
-    ]
-    return !aarsakerMedManueltBrev.includes(props.behandling.revurderingsaarsak)
-  }
-
   return (
     <Content>
       <BrevContent>
@@ -106,7 +86,7 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
           </SpinnerContainer>
         ) : error ? (
           <ErrorMessage>{error}</ErrorMessage>
-        ) : erReadOnly() ? (
+        ) : vedtaksbrev.prosessType === BrevProsessType.AUTOMATISK ? (
           <ForhaandsvisningBrev brev={vedtaksbrev} />
         ) : (
           <RedigerbartBrev brev={vedtaksbrev} kanRedigeres={manueltBrevKanRedigeres(status)} />


### PR DESCRIPTION
No når vi har brevprosesstypen for redigbart brev, kan vi bruke den direkte heller enn å styre masse med logikk i frontend.

Tanken med `erReadOnly`-metoden var å skilje ut dei breva som kunne redigerast frå dei som ikkje kunne det. No har vi (i den andre EY-2526-PRen) introdusert ein ny brevprosesstype _redigerbar_ for å dekkje dette formålet. Dermed er det berre dei fullautomatiske breva som har typen automatisk, og da kan vi rute kun dei automatiske som read only.