### PR TITLE
Opprydding avhengigheter

### DIFF
--- a/apps/etterlatte-behandling/build.gradle.kts
+++ b/apps/etterlatte-behandling/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
-    id("etterlatte.kafka")
     id("etterlatte.postgres")
 }
 
@@ -7,6 +6,7 @@ dependencies {
     implementation(project(":libs:saksbehandling-common"))
     implementation(project(":libs:ktor2client-auth-clientcredentials"))
     implementation(project(":libs:ktor2client-onbehalfof"))
+    implementation(project(":libs:etterlatte-kafka"))
     implementation(project(":libs:etterlatte-ktor"))
     implementation(project(":libs:etterlatte-database"))
     implementation(project(":libs:etterlatte-sporingslogg"))
@@ -40,7 +40,6 @@ dependencies {
     implementation(libs.bundles.navfelles.token)
 
     testImplementation(libs.ktor2.clientcontentnegotiation)
-    testImplementation(libs.test.mockk)
     testImplementation(libs.ktor2.clientmock)
     testImplementation(libs.ktor2.servertests)
     testImplementation(libs.kotlinx.coroutinescore)

--- a/apps/etterlatte-behandling/build.gradle.kts
+++ b/apps/etterlatte-behandling/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("etterlatte.common")
     id("etterlatte.postgres")
 }
 

--- a/apps/etterlatte-beregning-kafka/build.gradle.kts
+++ b/apps/etterlatte-beregning-kafka/build.gradle.kts
@@ -17,6 +17,5 @@ dependencies {
     implementation(libs.ktor2.clientjackson)
 
     testImplementation(libs.ktor2.clientmock)
-    testImplementation(libs.test.mockk)
     testImplementation(libs.kotlinx.coroutinescore)
 }

--- a/apps/etterlatte-beregning-kafka/build.gradle.kts
+++ b/apps/etterlatte-beregning-kafka/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("etterlatte.common")
     id("etterlatte.rapids-and-rivers-ktor2")
 }
 

--- a/apps/etterlatte-beregning/build.gradle.kts
+++ b/apps/etterlatte-beregning/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
     implementation(project(":libs:etterlatte-funksjonsbrytere"))
     implementation(project(":libs:etterlatte-vilkaarsvurdering-model"))
 
-    implementation(libs.database.flywaydb)
     implementation(libs.database.kotliquery)
 
     implementation(libs.ktor2.okhttp)
@@ -32,11 +31,8 @@ dependencies {
     implementation(libs.jackson.datatypejsr310)
     implementation(libs.jackson.modulekotlin)
 
-    testImplementation(libs.test.testcontainer.jupiter)
-    testImplementation(libs.test.testcontainer.postgresql)
     testImplementation(libs.navfelles.tokenvalidationktor2)
 
-    testImplementation(libs.test.mockk)
     testImplementation(libs.test.kotest.assertionscore)
     testImplementation(libs.kotlinx.coroutinescore)
     testImplementation(libs.ktor2.servertests)

--- a/apps/etterlatte-brev-api/build.gradle.kts
+++ b/apps/etterlatte-brev-api/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("etterlatte.common")
     id("etterlatte.postgres")
     id("etterlatte.rapids-and-rivers-ktor2")
 }

--- a/apps/etterlatte-brev-api/build.gradle.kts
+++ b/apps/etterlatte-brev-api/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("etterlatte.postgres")
     id("etterlatte.rapids-and-rivers-ktor2")
 }
 
@@ -15,9 +16,6 @@ dependencies {
 
     implementation("no.nav.pensjon.brevbaker:brevbaker-api-model-common:1.0.2")
 
-    implementation(libs.database.hikaricp)
-    implementation(libs.database.flywaydb)
-    implementation(libs.database.postgresql)
     implementation(libs.database.kotliquery)
 
     implementation(libs.ktor2.servercore)
@@ -39,13 +37,10 @@ dependencies {
     implementation(libs.navfelles.tokenclientcore)
     implementation(libs.navfelles.tokenvalidationktor2)
 
-    testImplementation(libs.test.mockk)
     testImplementation(libs.test.kotest.assertionscore)
     testImplementation(libs.ktor2.clientmock)
     testImplementation(libs.ktor2.servertests)
     testImplementation(libs.kotlinx.coroutinescore)
     testImplementation(libs.navfelles.mockoauth2server)
-    testImplementation(libs.test.testcontainer.jupiter)
-    testImplementation(libs.test.testcontainer.postgresql)
     testImplementation(project(":libs:testdata"))
 }

--- a/apps/etterlatte-egne-ansatte-lytter/build.gradle.kts
+++ b/apps/etterlatte-egne-ansatte-lytter/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.avro)
+    id("etterlatte.common")
     id("etterlatte.rapids-and-rivers-ktor2")
 }
 

--- a/apps/etterlatte-egne-ansatte-lytter/build.gradle.kts
+++ b/apps/etterlatte-egne-ansatte-lytter/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.avro)
     id("etterlatte.rapids-and-rivers-ktor2")
-    id("etterlatte.kafka")
 }
 
 dependencies {
@@ -14,17 +13,15 @@ dependencies {
     implementation(libs.ktor2.servercontentnegotiation)
     implementation(libs.ktor2.calllogging)
     implementation(libs.ktor2.jackson)
+
     implementation(libs.jackson.databind)
     implementation(libs.jackson.modulekotlin)
     implementation(libs.jackson.datatypejsr310)
+
     implementation(libs.kafka.clients)
     implementation(libs.kafka.avro)
     implementation(libs.kafka.avroserializer)
-    implementation(libs.logging.logbackclassic)
 
-    testImplementation(libs.test.jupiter.api)
     testImplementation(libs.kafka.embeddedenv)
-    testImplementation(libs.test.jupiter.engine)
     testImplementation(libs.ktor2.servertests)
-    testImplementation(libs.test.mockk)
 }

--- a/apps/etterlatte-fordeler/build.gradle.kts
+++ b/apps/etterlatte-fordeler/build.gradle.kts
@@ -20,6 +20,5 @@ dependencies {
     implementation(libs.ktor2.jackson)
 
     testImplementation(libs.ktor2.clientmock)
-    testImplementation(libs.test.mockk)
     testImplementation(libs.kotlinx.coroutinescore)
 }

--- a/apps/etterlatte-fordeler/build.gradle.kts
+++ b/apps/etterlatte-fordeler/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("etterlatte.common")
     id("etterlatte.rapids-and-rivers-ktor2")
     id("etterlatte.postgres")
 }

--- a/apps/etterlatte-grunnlag/build.gradle.kts
+++ b/apps/etterlatte-grunnlag/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation(libs.navfelles.tokenclientcore)
     implementation(libs.navfelles.tokenvalidationktor2)
 
-    testImplementation(libs.test.mockk)
     testImplementation(libs.navfelles.mockoauth2server)
     testImplementation(libs.kotlinx.coroutinescore)
     testImplementation(libs.ktor2.servertests)

--- a/apps/etterlatte-grunnlag/build.gradle.kts
+++ b/apps/etterlatte-grunnlag/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("etterlatte.common")
     id("etterlatte.rapids-and-rivers-ktor2")
     id("etterlatte.postgres")
 }

--- a/apps/etterlatte-gyldig-soeknad/build.gradle.kts
+++ b/apps/etterlatte-gyldig-soeknad/build.gradle.kts
@@ -22,7 +22,6 @@ dependencies {
 
     implementation(libs.navfelles.tokenclientcore)
 
-    testImplementation(libs.test.mockk)
     testImplementation(libs.ktor2.clientmock)
     testImplementation(libs.ktor2.servertests)
     testImplementation(libs.kotlinx.coroutinescore)

--- a/apps/etterlatte-hendelser-pdl/build.gradle.kts
+++ b/apps/etterlatte-hendelser-pdl/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.avro)
-    id("etterlatte.kafka")
+    id("etterlatte.common")
 }
 
 dependencies {
@@ -20,19 +20,17 @@ dependencies {
     implementation(libs.ktor2.servercontentnegotiation)
     implementation(libs.ktor2.calllogging)
     implementation(libs.ktor2.jackson)
+
     implementation(libs.jackson.databind)
     implementation(libs.jackson.modulekotlin)
     implementation(libs.jackson.datatypejsr310)
+
     implementation(libs.kafka.clients)
     implementation(libs.kafka.avro)
     implementation(libs.kafka.avroserializer)
-    implementation(libs.logging.logbackclassic)
 
-    testImplementation(libs.test.jupiter.api)
     testImplementation(libs.kafka.embeddedenv)
-    testImplementation(libs.test.jupiter.engine)
     testImplementation(libs.ktor2.servertests)
-    testImplementation(libs.test.mockk)
     testImplementation(libs.ktor2.clientmock)
 }
 

--- a/apps/etterlatte-institusjonsopphold/build.gradle.kts
+++ b/apps/etterlatte-institusjonsopphold/build.gradle.kts
@@ -18,6 +18,5 @@ dependencies {
     implementation(libs.kafka.avroserializer)
 
     testImplementation(libs.ktor2.clientmock)
-    testImplementation(libs.test.mockk)
     testImplementation(libs.kotlinx.coroutinescore)
 }

--- a/apps/etterlatte-institusjonsopphold/build.gradle.kts
+++ b/apps/etterlatte-institusjonsopphold/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("etterlatte.common")
     id("etterlatte.rapids-and-rivers-ktor2")
 }
 

--- a/apps/etterlatte-migrering/build.gradle.kts
+++ b/apps/etterlatte-migrering/build.gradle.kts
@@ -17,6 +17,5 @@ dependencies {
 
     implementation(libs.ktor2.servercio)
     implementation(libs.database.kotliquery)
-    testImplementation(libs.test.mockk)
     testImplementation(libs.ktor2.servertests)
 }

--- a/apps/etterlatte-oppdater-behandling/build.gradle.kts
+++ b/apps/etterlatte-oppdater-behandling/build.gradle.kts
@@ -17,6 +17,5 @@ dependencies {
     implementation(libs.ktor2.clientjackson)
 
     testImplementation(libs.ktor2.clientmock)
-    testImplementation(libs.test.mockk)
     testImplementation(libs.kotlinx.coroutinescore)
 }

--- a/apps/etterlatte-oppdater-behandling/build.gradle.kts
+++ b/apps/etterlatte-oppdater-behandling/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("etterlatte.common")
     id("etterlatte.rapids-and-rivers-ktor2")
 }
 

--- a/apps/etterlatte-opplysninger-fra-soeknad/build.gradle.kts
+++ b/apps/etterlatte-opplysninger-fra-soeknad/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("etterlatte.common")
     id("etterlatte.rapids-and-rivers-ktor2")
 }
 

--- a/apps/etterlatte-opplysninger-fra-soeknad/build.gradle.kts
+++ b/apps/etterlatte-opplysninger-fra-soeknad/build.gradle.kts
@@ -6,7 +6,6 @@ dependencies {
     implementation(project(":libs:saksbehandling-common"))
     implementation(libs.etterlatte.common)
 
-    testImplementation(libs.test.mockk)
     testImplementation(libs.kotlinx.coroutinescore)
     testImplementation(project(":libs:testdata"))
 }

--- a/apps/etterlatte-pdltjenester/build.gradle.kts
+++ b/apps/etterlatte-pdltjenester/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
     implementation(libs.navfelles.tokenclientcore)
     implementation(libs.navfelles.tokenvalidationktor2)
 
-    testImplementation(libs.test.mockk)
     testImplementation(libs.ktor2.clientmock)
     testImplementation(libs.ktor2.servertests)
     testImplementation(libs.kotlinx.coroutinescore)

--- a/apps/etterlatte-statistikk/build.gradle.kts
+++ b/apps/etterlatte-statistikk/build.gradle.kts
@@ -18,7 +18,6 @@ dependencies {
 
     implementation(libs.bundles.jackson)
 
-    testImplementation(libs.test.mockk)
     testImplementation(libs.test.kotest.assertionscore)
     testImplementation(libs.kotlinx.coroutinescore)
 }

--- a/apps/etterlatte-testdata/build.gradle.kts
+++ b/apps/etterlatte-testdata/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
     id("etterlatte.common")
-    id("etterlatte.kafka")
 }
 
 dependencies {
     api(kotlin("reflect"))
 
+    implementation(project(":libs:etterlatte-kafka"))
     implementation(project(":libs:saksbehandling-common"))
     implementation(project(":libs:ktor2client-onbehalfof"))
     implementation(project(":libs:etterlatte-ktor"))
@@ -29,13 +29,5 @@ dependencies {
     implementation(libs.navfelles.tokenclientcore)
     implementation(libs.navfelles.tokenvalidationktor2)
 
-    implementation(libs.logging.logbackclassic)
-    implementation(libs.logging.logstashlogbackencoder) {
-        exclude("com.fasterxml.jackson.core")
-        exclude("com.fasterxml.jackson.dataformat")
-    }
-
-    testImplementation(libs.test.jupiter.root)
-    testImplementation(libs.test.mockk)
     testImplementation(libs.test.kotest.assertionscore)
 }

--- a/apps/etterlatte-tilbakekreving/build.gradle.kts
+++ b/apps/etterlatte-tilbakekreving/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("etterlatte.rapids-and-rivers-ktor2")
+    id("etterlatte.postgres")
     alias(libs.plugins.analyze)
 }
 
@@ -34,19 +35,13 @@ dependencies {
     implementation(libs.jakartabind.api)
     implementation(libs.jakartabind.impl)
 
-    implementation(libs.database.hikaricp)
-    implementation(libs.database.flywaydb)
-    implementation(libs.database.postgresql)
     implementation(libs.database.kotliquery)
 
     testImplementation(libs.ktor2.clientmock)
     testImplementation(libs.ktor2.servertests)
-    testImplementation(libs.test.mockk)
     testImplementation(libs.kotlinx.coroutinescore)
     testImplementation(libs.navfelles.mockoauth2server) {
         exclude("org.slf4j", "slf4j-api")
     }
     testImplementation(libs.test.wiremock)
-    testImplementation(libs.test.testcontainer.jupiter)
-    testImplementation(libs.test.testcontainer.postgresql)
 }

--- a/apps/etterlatte-tilbakekreving/build.gradle.kts
+++ b/apps/etterlatte-tilbakekreving/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("etterlatte.common")
     id("etterlatte.rapids-and-rivers-ktor2")
     id("etterlatte.postgres")
     alias(libs.plugins.analyze)

--- a/apps/etterlatte-trygdetid-kafka/build.gradle.kts
+++ b/apps/etterlatte-trygdetid-kafka/build.gradle.kts
@@ -17,6 +17,5 @@ dependencies {
     implementation(libs.ktor2.clientjackson)
 
     testImplementation(libs.ktor2.clientmock)
-    testImplementation(libs.test.mockk)
     testImplementation(libs.kotlinx.coroutinescore)
 }

--- a/apps/etterlatte-trygdetid-kafka/build.gradle.kts
+++ b/apps/etterlatte-trygdetid-kafka/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("etterlatte.common")
     id("etterlatte.rapids-and-rivers-ktor2")
 }
 

--- a/apps/etterlatte-trygdetid/build.gradle.kts
+++ b/apps/etterlatte-trygdetid/build.gradle.kts
@@ -21,7 +21,6 @@ dependencies {
     implementation(libs.database.kotliquery)
 
     testImplementation(libs.navfelles.tokenvalidationktor2)
-    testImplementation(libs.test.mockk)
     testImplementation(libs.ktor2.servertests)
     testImplementation(libs.navfelles.mockoauth2server)
     testImplementation(libs.test.kotest.assertionscore)

--- a/apps/etterlatte-utbetaling/build.gradle.kts
+++ b/apps/etterlatte-utbetaling/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("etterlatte.rapids-and-rivers-ktor2")
     id("etterlatte.common")
-    id("etterlatte.kafka")
+    id("etterlatte.postgres")
     alias(libs.plugins.analyze)
 }
 
@@ -11,6 +11,7 @@ dependencies {
     implementation(project(":libs:etterlatte-database"))
     implementation(project(":libs:etterlatte-utbetaling-model"))
     implementation(project(":libs:etterlatte-vedtaksvurdering-model"))
+    implementation(project(":libs:etterlatte-kafka"))
 
     implementation(libs.ktor2.okhttp)
     implementation(libs.ktor2.clientcore)
@@ -25,15 +26,9 @@ dependencies {
     implementation(libs.jakartabind.api)
     implementation(libs.jakartabind.impl)
 
-    implementation(libs.database.hikaricp)
-    implementation(libs.database.flywaydb)
-    implementation(libs.database.postgresql)
     implementation(libs.database.kotliquery)
 
     testImplementation(libs.ktor2.clientmock)
-    testImplementation(libs.test.mockk)
     testImplementation(libs.kotlinx.coroutinescore)
     testImplementation(libs.test.wiremock)
-    testImplementation(libs.test.testcontainer.jupiter)
-    testImplementation(libs.test.testcontainer.postgresql)
 }

--- a/apps/etterlatte-vedtaksvurdering-kafka/build.gradle.kts
+++ b/apps/etterlatte-vedtaksvurdering-kafka/build.gradle.kts
@@ -17,9 +17,7 @@ dependencies {
     implementation(libs.ktor2.clientjackson)
     implementation(libs.ktor2.clientcontentnegotiation)
 
-    testImplementation(libs.test.jupiter.root)
     testImplementation(libs.ktor2.clientmock)
-    testImplementation(libs.test.mockk)
     testImplementation(libs.kotlinx.coroutinescore)
     testImplementation(project(":libs:testdata"))
 }

--- a/apps/etterlatte-vedtaksvurdering-kafka/build.gradle.kts
+++ b/apps/etterlatte-vedtaksvurdering-kafka/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("etterlatte.common")
     id("etterlatte.rapids-and-rivers-ktor2")
 }
 

--- a/apps/etterlatte-vedtaksvurdering/build.gradle.kts
+++ b/apps/etterlatte-vedtaksvurdering/build.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
 
     testImplementation(libs.navfelles.tokenvalidationktor2)
 
-    testImplementation(libs.test.mockk)
     testImplementation(libs.kotlinx.coroutinescore)
     testImplementation(libs.test.kotest.assertionscore)
     testImplementation(libs.ktor2.servertests)

--- a/apps/etterlatte-vilkaarsvurdering-kafka/build.gradle.kts
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
 
     testImplementation(libs.test.jupiter.root)
     testImplementation(libs.ktor2.clientmock)
-    testImplementation(libs.test.mockk)
     testImplementation(libs.kotlinx.coroutinescore)
     testImplementation(project(":libs:testdata"))
 }

--- a/apps/etterlatte-vilkaarsvurdering-kafka/build.gradle.kts
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("etterlatte.common")
     id("etterlatte.rapids-and-rivers-ktor2")
 }
 

--- a/apps/etterlatte-vilkaarsvurdering/build.gradle.kts
+++ b/apps/etterlatte-vilkaarsvurdering/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
 
     testImplementation(libs.navfelles.tokenvalidationktor2)
 
-    testImplementation(libs.test.mockk)
     testImplementation(libs.ktor2.servertests)
     testImplementation(libs.test.kotest.assertionscore)
     testImplementation(libs.navfelles.mockoauth2server) {

--- a/buildSrc/src/main/kotlin/etterlatte.common.gradle.kts
+++ b/buildSrc/src/main/kotlin/etterlatte.common.gradle.kts
@@ -22,9 +22,13 @@ dependencies {
     // Logging
     implementation(libs.logging.slf4japi)
     implementation(libs.logging.logbackclassic)
-    implementation(libs.logging.logstashlogbackencoder)
+    implementation(libs.logging.logstashlogbackencoder) {
+        exclude("com.fasterxml.jackson.core")
+        exclude("com.fasterxml.jackson.dataformat")
+    }
 
-    // JUnit Testing
+    // Testing
+    testImplementation(libs.test.mockk)
     testImplementation(libs.test.jupiter.api)
     testImplementation(libs.test.jupiter.params)
     testRuntimeOnly(libs.test.jupiter.engine)
@@ -51,7 +55,7 @@ tasks {
         }
     }
 
-    tasks.withType<Test> {
+    withType<Test> {
         useJUnitPlatform()
         testLogging {
             events(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)

--- a/buildSrc/src/main/kotlin/etterlatte.kafka.gradle.kts
+++ b/buildSrc/src/main/kotlin/etterlatte.kafka.gradle.kts
@@ -1,7 +1,0 @@
-plugins {
-    id("etterlatte.common")
-}
-
-dependencies {
-    implementation(project(":libs:etterlatte-kafka"))
-}

--- a/buildSrc/src/main/kotlin/etterlatte.postgres.gradle.kts
+++ b/buildSrc/src/main/kotlin/etterlatte.postgres.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.accessors.dm.LibrariesForLibs
 val libs = the<LibrariesForLibs>()
 
 plugins {
-    id("etterlatte.common")
+    kotlin("jvm") apply false
 }
 
 repositories {

--- a/buildSrc/src/main/kotlin/etterlatte.rapids-and-rivers-ktor2.gradle.kts
+++ b/buildSrc/src/main/kotlin/etterlatte.rapids-and-rivers-ktor2.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.accessors.dm.LibrariesForLibs
 val libs = the<LibrariesForLibs>()
 
 plugins {
-    id("etterlatte.common")
+    kotlin("jvm") apply false
 }
 
 repositories {

--- a/jobs/start-regulering/build.gradle.kts
+++ b/jobs/start-regulering/build.gradle.kts
@@ -1,18 +1,12 @@
 plugins {
-    id("etterlatte.kafka")
+    id("etterlatte.common")
 }
 
 dependencies {
     api(kotlin("reflect"))
 
-    implementation(libs.logging.logbackclassic)
-    implementation(libs.logging.logstashlogbackencoder) {
-        exclude("com.fasterxml.jackson.core")
-        exclude("com.fasterxml.jackson.dataformat")
-    }
+    implementation(project(":libs:etterlatte-kafka"))
 
     implementation(libs.jackson.core)
     implementation(libs.bundles.jackson)
-
-    testImplementation(libs.test.mockk)
 }

--- a/jobs/test-fordeler/build.gradle.kts
+++ b/jobs/test-fordeler/build.gradle.kts
@@ -1,18 +1,12 @@
 plugins {
-    id("etterlatte.kafka")
+    id("etterlatte.common")
 }
 
 dependencies {
     api(kotlin("reflect"))
 
-    implementation(libs.logging.logbackclassic)
-    implementation(libs.logging.logstashlogbackencoder) {
-        exclude("com.fasterxml.jackson.core")
-        exclude("com.fasterxml.jackson.dataformat")
-    }
+    implementation(project(":libs:etterlatte-kafka"))
 
     implementation(libs.jackson.core)
     implementation(libs.bundles.jackson)
-
-    testImplementation(libs.test.mockk)
 }


### PR DESCRIPTION
- Fjernet `etterlatte.kafka` siden det kun pekte på `:libs:etterlatte-kafka`. 
- Fjernet `etterlatte.common` fra `rapids` og `postgres` plugins/buildSrc. 
- Flyttet div avhengigheter til `etterlatte.common` 