### PR TITLE
Bugfix hent saksbehandler for behandling fra oppgave

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveServiceNy.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveServiceNy.kt
@@ -305,7 +305,7 @@ class OppgaveServiceNy(
         }
 
         val oppgaverForBehandlingUtenAttesterting = oppgaverforBehandling.filter { it.type !== OppgaveType.ATTESTERING }
-        return oppgaverForBehandlingUtenAttesterting.sortedBy { it.opprettet }[0].saksbehandler
+        return oppgaverForBehandlingUtenAttesterting.sortedByDescending { it.opprettet }[0].saksbehandler
     }
 
     private fun lagreOppgave(oppgaveNy: OppgaveNy): OppgaveNy {

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveServiceNy.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveServiceNy.kt
@@ -304,7 +304,8 @@ class OppgaveServiceNy(
             oppgaveDaoNy.hentOppgaverForBehandling(behandlingsId.toString())
         }
 
-        return oppgaverforBehandling.single { it.type === OppgaveType.FOERSTEGANGSBEHANDLING }.saksbehandler
+        val oppgaverForBehandlingUtenAttesterting = oppgaverforBehandling.filter { it.type !== OppgaveType.ATTESTERING }
+        return oppgaverForBehandlingUtenAttesterting.sortedBy { it.opprettet }[0].saksbehandler
     }
 
     private fun lagreOppgave(oppgaveNy: OppgaveNy): OppgaveNy {

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveServiceNy.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveServiceNy.kt
@@ -300,11 +300,11 @@ class OppgaveServiceNy(
     }
 
     fun hentSaksbehandlerForBehandling(behandlingsId: UUID): String? {
-        val oppgaveforBehandling = inTransaction {
+        val oppgaverforBehandling = inTransaction {
             oppgaveDaoNy.hentOppgaverForBehandling(behandlingsId.toString())
-                .single { it.status == Status.UNDER_BEHANDLING || it.status == Status.NY }
         }
-        return oppgaveforBehandling.saksbehandler
+
+        return oppgaverforBehandling.single { it.type === OppgaveType.FOERSTEGANGSBEHANDLING }.saksbehandler
     }
 
     private fun lagreOppgave(oppgaveNy: OppgaveNy): OppgaveNy {

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgaveny/OppgaveServiceNyTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgaveny/OppgaveServiceNyTest.kt
@@ -852,36 +852,6 @@ class OppgaveServiceNyTest {
     }
 
     @Test
-    fun `Skal kunne hente saksbehandler på oppgave for behandling selvom den er underkjent`() {
-        val opprettetSak = sakDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
-        val behandlingId = UUID.randomUUID().toString()
-        val foerstegangsbehandling = oppgaveServiceNy.opprettNyOppgaveMedSakOgReferanse(
-            behandlingId,
-            opprettetSak.id,
-            OppgaveKilde.BEHANDLING,
-            OppgaveType.FOERSTEGANGSBEHANDLING,
-            null
-        )
-        val saksbehandler = "saksbehandler"
-
-        oppgaveServiceNy.tildelSaksbehandler(foerstegangsbehandling.id, saksbehandler)
-
-        val attestertBehandlingsoppgave = oppgaveServiceNy.opprettNyOppgaveMedSakOgReferanse(
-            behandlingId,
-            opprettetSak.id,
-            OppgaveKilde.BEHANDLING,
-            OppgaveType.UNDERKJENT,
-            null
-        )
-        oppgaveServiceNy.tildelSaksbehandler(attestertBehandlingsoppgave.id, "underkjentsaksbehandler")
-
-        val saksbehandlerHentet =
-            oppgaveServiceNy.hentSaksbehandlerForBehandling(UUID.fromString(behandlingId))
-
-        Assertions.assertEquals(saksbehandler, saksbehandlerHentet)
-    }
-
-    @Test
     fun `Får null saksbehandler ved henting på behandling hvis saksbehandler ikke satt`() {
         val opprettetSak = sakDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
         val behandlingId = UUID.randomUUID().toString()

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgaveny/OppgaveServiceNyTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgaveny/OppgaveServiceNyTest.kt
@@ -801,6 +801,27 @@ class OppgaveServiceNyTest {
     }
 
     @Test
+    fun `kan hente saksbehandler på en oppgave fra revurdering`() {
+        val opprettetSak = sakDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
+        val revurderingId = UUID.randomUUID().toString()
+        val nyOppgave = oppgaveServiceNy.opprettNyOppgaveMedSakOgReferanse(
+            revurderingId,
+            opprettetSak.id,
+            OppgaveKilde.BEHANDLING,
+            OppgaveType.REVURDERING,
+            null
+        )
+        val saksbehandler = "saksbehandler"
+
+        oppgaveServiceNy.tildelSaksbehandler(nyOppgave.id, saksbehandler)
+
+        val saksbehandlerHentet =
+            oppgaveServiceNy.hentSaksbehandlerForBehandling(UUID.fromString(revurderingId))
+
+        Assertions.assertEquals(saksbehandler, saksbehandlerHentet)
+    }
+
+    @Test
     fun `Skal kunne hente saksbehandler på oppgave for behandling selvom den er ferdigstilt med attestering`() {
         val opprettetSak = sakDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
         val behandlingId = UUID.randomUUID().toString()

--- a/libs/etterlatte-oppgave-model/src/main/kotlin/OppgaveNy/OppgaveNy.kt
+++ b/libs/etterlatte-oppgave-model/src/main/kotlin/OppgaveNy/OppgaveNy.kt
@@ -25,7 +25,7 @@ data class OppgaveNy(
     val kilde: OppgaveKilde? = null,
     override val type: OppgaveType,
     override val saksbehandler: String? = null,
-    val referanse: String? = null,
+    val referanse: String,
     val merknad: String? = null,
     override val opprettet: Tidspunkt,
     override val sakType: SakType,


### PR DESCRIPTION
Gjør `hentSaksbehandlerForBehandling` mindre streng og sjekker kun på oppgavetype førstegangsbehandling. Hvis ikke vil det feile hvis førstegangsoppgaven er ferdigstilt.