### PR TITLE
Viser spinner for henting kun når vi laster behandling eller vedtak

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/Behandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/Behandling.tsx
@@ -9,7 +9,7 @@ import { useBehandlingRoutes } from './BehandlingRoutes'
 import { StegMeny } from './StegMeny/stegmeny'
 import { SideMeny } from './SideMeny/SideMeny'
 import { useAppDispatch } from '~store/Store'
-import { isFailure, isPendingOrInitial, useApiCall } from '~shared/hooks/useApiCall'
+import { isFailure, isPending, isPendingOrInitial, useApiCall } from '~shared/hooks/useApiCall'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { hentVedtakSammendrag } from '~shared/api/vedtaksvurdering'
 import { useBehandling } from '~components/behandling/useBehandling'
@@ -65,10 +65,7 @@ export const Behandling = () => {
 
       {behandling && <StegMeny behandling={behandling} />}
 
-      <Spinner
-        visible={isPendingOrInitial(fetchBehandlingStatus) || isPendingOrInitial(fetchVedtakStatus)}
-        label="Laster"
-      />
+      <Spinner visible={isPendingOrInitial(fetchBehandlingStatus) || isPending(fetchVedtakStatus)} label="Laster" />
       {behandling && (
         <GridContainer>
           <MainContent>


### PR DESCRIPTION
Hvis henting av behandling feiler setter vi aldri i gang henting av vedtak. Da har du en feilmelding + en spinner som sier "Laster", men det er ingenting som faktisk laster.

Eksempel:
![Screenshot 2023-08-23 at 12 33 39](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/4296255/36393d57-5a37-46e2-9c0c-062f94138878)
