### PR TITLE
Logger kun "setter opp" når vi faktisk setter opp Grunnlagsendringshendelsejobben

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseJob.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseJob.kt
@@ -33,6 +33,12 @@ class GrunnlagsendringshendelseJob(
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     fun schedule(): Timer {
+        logger.info(
+            "Setter opp GrunnlagsendringshendelseJob. LeaderElection: ${leaderElection.isLeader()} " +
+                ", initialDelay: ${Duration.of(1, ChronoUnit.MINUTES).toMillis()}" +
+                ", periode: ${periode.toMinutes()}" +
+                ", minutterGamleHendelser: $minutterGamleHendelser "
+        )
         return fixedRateCancellableTimer(
             name = jobbNavn,
             initialDelay = initialDelay,
@@ -40,12 +46,6 @@ class GrunnlagsendringshendelseJob(
             logger = logger,
             sikkerLogg = sikkerLogg
         ) {
-            logger.info(
-                "Setter opp GrunnlagsendringshendelseJob. LeaderElection: ${leaderElection.isLeader()} " +
-                    ", initialDelay: ${Duration.of(1, ChronoUnit.MINUTES).toMillis()}" +
-                    ", periode: ${periode.toMinutes()}" +
-                    ", minutterGamleHendelser: $minutterGamleHendelser "
-            )
             runBlocking {
                 SjekkKlareGrunnlagsendringshendelser(
                     grunnlagsendringshendelseService = grunnlagsendringshendelseService,
@@ -87,7 +87,7 @@ class GrunnlagsendringshendelseJob(
                     }
                 }
             } else {
-                log.info("Ikke leader, saa kjoerer ikke jobb: $jobbNavn.")
+                log.debug("Ikke leader, saa kjoerer ikke jobb: $jobbNavn.")
             }
         }
     }


### PR DESCRIPTION
Setter også debug-nivå på logging av at jobben ikke kjører - det er ikke spesielt interessant å vite at den ikke kjører eksplisitt