### PR TITLE
EY-2583: SQL for overgangen frå gamal til ny innvilgelsesmal

### DIFF
--- a/apps/etterlatte-brev-api/src/test/resources/db.migration/automatisk-til-redigerbart-brev.sql
+++ b/apps/etterlatte-brev-api/src/test/resources/db.migration/automatisk-til-redigerbart-brev.sql
@@ -1,0 +1,27 @@
+begin transaction;
+with ids as (
+    select distinct b.id
+    from brev b
+             inner join hendelse h on b.id = h.brev_id
+    where b.id not in (select distinct brev_id
+                       from hendelse
+                       where status_id in ('FERDIGSTILT', 'JOURNALFOERT', 'DISTRIBUERT'))
+      and b.prosess_type = 'AUTOMATISK'
+)
+update innhold set payload='[]' where brev_id in (select id from ids);
+
+with ids as (
+    select distinct b.id
+    from brev b
+             inner join hendelse h on b.id = h.brev_id
+    where b.id not in (select distinct brev_id
+                       from hendelse
+                       where status_id in ('FERDIGSTILT', 'JOURNALFOERT', 'DISTRIBUERT'))
+      and b.prosess_type = 'AUTOMATISK'
+)
+
+
+update brev set prosess_type = 'REDIGERBAR' where id in (select id from ids);
+
+
+commit transaction;

--- a/apps/etterlatte-brev-api/src/test/resources/db.migration/automatisk-til-redigerbart-brev.sql
+++ b/apps/etterlatte-brev-api/src/test/resources/db.migration/automatisk-til-redigerbart-brev.sql
@@ -3,10 +3,12 @@ with ids as (
     select distinct b.id
     from brev b
              inner join hendelse h on b.id = h.brev_id
+    inner join innhold i on b.id = i.brev_id
     where b.id not in (select distinct brev_id
                        from hendelse
                        where status_id in ('FERDIGSTILT', 'JOURNALFOERT', 'DISTRIBUERT'))
       and b.prosess_type = 'AUTOMATISK'
+    and i.tittel = 'Vedtak om innvilgelse'
 )
 update innhold set payload='[]' where brev_id in (select id from ids);
 
@@ -14,10 +16,12 @@ with ids as (
     select distinct b.id
     from brev b
              inner join hendelse h on b.id = h.brev_id
+             inner join innhold i on b.id = i.brev_id
     where b.id not in (select distinct brev_id
                        from hendelse
                        where status_id in ('FERDIGSTILT', 'JOURNALFOERT', 'DISTRIBUERT'))
       and b.prosess_type = 'AUTOMATISK'
+      and i.tittel = 'Vedtak om innvilgelse'
 )
 
 


### PR DESCRIPTION
Usikker på om vi bør køyre denne SQL-en direkte som han er, men trur det skal vera trygt. select-en kan vi uansett bruke for å sjekke ståa.