### PR TITLE
EY-2401 Viser spesifisert årsak i revurderingsoversikt ved annen revurderingsårsak

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -248,7 +248,7 @@ class RevurderingServiceImpl(
     }
 
     override fun lagreRevurderingInfo(behandlingsId: UUID, info: RevurderingInfo, navIdent: String): Boolean {
-        return inTransaction {
+        return inTransaction(true) {
             if (!kanLagreRevurderingInfo(behandlingsId)) {
                 return@inTransaction false
             }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -286,6 +286,11 @@ class RevurderingServiceImpl(
         fritekstAarsak = fritekstAarsak
     ).let { opprettBehandling ->
         behandlingDao.opprettBehandling(opprettBehandling)
+
+        if (fritekstAarsak != null) {
+            lagreRevurderingsaarsakFritekst(fritekstAarsak, opprettBehandling.id, saksbehandlerIdent)
+        }
+
         forrigeBehandling?.let {
             kommerBarnetTilGodeService.hentKommerBarnetTilGode(it)
                 ?.copy(behandlingId = opprettBehandling.id)
@@ -308,6 +313,15 @@ class RevurderingServiceImpl(
         )
         oppgaveService.tildelSaksbehandler(oppgave.id, saksbehandlerIdent)
         behandlingHendelser.sendMeldingForHendelse(revurdering, BehandlingHendelseType.OPPRETTET)
+    }
+
+    private fun lagreRevurderingsaarsakFritekst(
+        fritekstAarsak: String,
+        behandlingId: UUID,
+        saksbehandlerIdent: String
+    ) {
+        val revurderingInfo = RevurderingInfo.RevurderingAarsakAnnen(fritekstAarsak)
+        lagreRevurderingInfo(behandlingId, revurderingInfo, saksbehandlerIdent)
     }
 
     private fun <T : Behandling> T?.sjekkEnhet() = this?.let { behandling ->

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -287,7 +287,7 @@ class RevurderingServiceImpl(
     ).let { opprettBehandling ->
         behandlingDao.opprettBehandling(opprettBehandling)
 
-        if (fritekstAarsak != null) {
+        fritekstAarsak?.let {
             lagreRevurderingsaarsakFritekst(fritekstAarsak, opprettBehandling.id, saksbehandlerIdent)
         }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/Revurderingsoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/Revurderingsoversikt.tsx
@@ -31,6 +31,8 @@ import { GrunnForSoeskenjustering } from '~components/behandling/revurderingsove
 import { AdoptertAv } from '~components/behandling/revurderingsoversikt/AdoptertAv'
 import { GrunnlagForVirkningstidspunkt } from '~components/behandling/revurderingsoversikt/GrunnlagForVirkningstidspunkt'
 import { OmgjoeringAvFarskap } from '~components/behandling/revurderingsoversikt/OmgjoeringAvFarskap'
+import { hentUndertypeFraBehandling, RevurderingAarsakAnnen } from '~shared/types/RevurderingInfo'
+import { Info } from '~components/behandling/soeknadsoversikt/Info'
 
 const revurderingsaarsakTilTekst = (revurderingsaarsak: Revurderingsaarsak): string =>
   tekstRevurderingsaarsak[revurderingsaarsak]
@@ -75,6 +77,7 @@ export const Revurderingsoversikt = (props: { behandling: IDetaljertBehandling }
     behandling.revurderingsaarsak,
     'Kan ikke starte en revurdering uten en revurderingsårsak'
   )
+  const revurderingInfo = hentUndertypeFraBehandling<RevurderingAarsakAnnen>('ANNEN', behandling)
 
   const [hjemler, beskrivelse] = hjemlerOgBeskrivelse(behandling.sakType, revurderingsaarsak)
   return (
@@ -85,10 +88,17 @@ export const Revurderingsoversikt = (props: { behandling: IDetaljertBehandling }
             Revurdering
           </Heading>
         </HeadingWrapper>
-        <BodyShort>
-          {erOpphoer(revurderingsaarsak) ? 'Opphør' : 'Revurdering'} på grunn av{' '}
-          <Lowercase>{revurderingsaarsakTilTekst(revurderingsaarsak)}</Lowercase>.
-        </BodyShort>
+        {revurderingsaarsak == Revurderingsaarsak.ANNEN ? (
+          <Info
+            label={`Årsak til revurdering (${revurderingsaarsakTilTekst(revurderingsaarsak)})`}
+            tekst={revurderingInfo?.aarsak ?? 'Ikke oppgitt'}
+          />
+        ) : (
+          <BodyShort>
+            {erOpphoer(revurderingsaarsak) ? 'Opphør' : 'Revurdering'} på grunn av{' '}
+            <Lowercase>{revurderingsaarsakTilTekst(revurderingsaarsak)}</Lowercase>.
+          </BodyShort>
+        )}
         {erOpphoer(revurderingsaarsak) ? (
           <Alert variant="warning">
             Gjenny støtter ikke tilbakekreving per dags dato, så opphør må ikke gjennomføres hvis opphøret gjelder fra

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/OpprettNyBehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/OpprettNyBehandling.tsx
@@ -68,7 +68,7 @@ export const OpprettNyBehandling = ({
               <AnnenRevurderingWrapper>
                 <TextField
                   label="Beskriv årsak"
-                  size="small"
+                  size="medium"
                   type="text"
                   value={fritekstgrunn}
                   onChange={(e) => setFritekstgrunn(e.target.value)}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/OpprettNyBehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/OpprettNyBehandling.tsx
@@ -65,13 +65,15 @@ export const OpprettNyBehandling = ({
               })}
             </Select>
             {valgtRevurdering === Revurderingsaarsak.ANNEN && (
-              <TextField
-                label="Beskriv hvorfor"
-                size="small"
-                type="text"
-                value={fritekstgrunn}
-                onChange={(e) => setFritekstgrunn(e.target.value)}
-              />
+              <AnnenRevurderingWrapper>
+                <TextField
+                  label="Beskriv årsak"
+                  size="small"
+                  type="text"
+                  value={fritekstgrunn}
+                  onChange={(e) => setFritekstgrunn(e.target.value)}
+                />
+              </AnnenRevurderingWrapper>
             )}
             <ButtonContainer>
               <Button
@@ -96,4 +98,8 @@ export const OpprettNyBehandling = ({
 
 const OpprettNyBehandlingWrapper = styled.div`
   margin-top: 3rem;
+`
+
+const AnnenRevurderingWrapper = styled.div`
+  margin-top: 1rem;
 `

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/VurderHendelseModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/VurderHendelseModal.tsx
@@ -1,5 +1,5 @@
 import { Alert, BodyShort, Button, Heading, Modal, Select, TextField } from '@navikt/ds-react'
-import { useState } from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 import { opprettRevurdering as opprettRevurderingApi } from '~shared/api/behandling'
 import { isPending, useApiCall } from '~shared/hooks/useApiCall'
@@ -21,6 +21,7 @@ const VurderHendelseModal = (props: Props) => {
   const [valgtAarsak, setValgtAarsak] = useState<Revurderingsaarsak | undefined>(undefined)
   const [opprettRevurderingStatus, opprettRevurdering] = useApiCall(opprettRevurderingApi)
   const [begrunnelse, setBegrunnelse] = useState('')
+  const [fritekstgrunn, setFritekstgrunn] = useState<string>('')
   const navigate = useNavigate()
 
   const onSubmit = () => {
@@ -29,7 +30,13 @@ const VurderHendelseModal = (props: Props) => {
     }
 
     opprettRevurdering(
-      { sakId: props.sakId, aarsak: valgtAarsak, paaGrunnAvHendelseId: valgtHendelse?.id, begrunnelse: begrunnelse },
+      {
+        sakId: props.sakId,
+        aarsak: valgtAarsak,
+        paaGrunnAvHendelseId: valgtHendelse?.id,
+        fritekstAarsak: fritekstgrunn,
+        begrunnelse: begrunnelse,
+      },
       (revurderingId: string) => {
         navigate(`/behandling/${revurderingId}/`)
       },
@@ -68,13 +75,26 @@ const VurderHendelseModal = (props: Props) => {
                   </option>
                 ))}
               </Select>
-              <TextField
-                label="Begrunnelse"
-                size="medium"
-                type="text"
-                value={begrunnelse}
-                onChange={(e) => setBegrunnelse(e.target.value)}
-              />
+              {valgtAarsak === Revurderingsaarsak.ANNEN && (
+                <MarginTop>
+                  <TextField
+                    label="Beskriv årsak"
+                    size="small"
+                    type="text"
+                    value={fritekstgrunn}
+                    onChange={(e) => setFritekstgrunn(e.target.value)}
+                  />
+                </MarginTop>
+              )}
+              <MarginTop>
+                <TextField
+                  label="Begrunnelse"
+                  size="medium"
+                  type="text"
+                  value={begrunnelse}
+                  onChange={(e) => setBegrunnelse(e.target.value)}
+                />
+              </MarginTop>
             </div>
           </ModalContentWrapper>
 
@@ -101,6 +121,10 @@ export const ButtonContainer = styled.div`
   justify-content: flex-end;
   gap: 0.5em;
   padding-top: 2em;
+`
+
+const MarginTop = styled.div`
+  margin-top: 1rem;
 `
 
 export default VurderHendelseModal

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/VurderHendelseModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/VurderHendelseModal.tsx
@@ -79,7 +79,7 @@ const VurderHendelseModal = (props: Props) => {
                 <MarginTop>
                   <TextField
                     label="Beskriv årsak"
-                    size="small"
+                    size="medium"
                     type="text"
                     value={fritekstgrunn}
                     onChange={(e) => setFritekstgrunn(e.target.value)}
@@ -88,7 +88,7 @@ const VurderHendelseModal = (props: Props) => {
               )}
               <MarginTop>
                 <TextField
-                  label="Begrunnelse"
+                  label="Begrunn valget for hendelsen"
                   size="medium"
                   type="text"
                   value={begrunnelse}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/behandlingsliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/behandlingsliste.tsx
@@ -154,6 +154,8 @@ function mapAarsak(aarsak: BehandlingOgRevurderingsAarsakerType) {
       return 'Yrkesskade'
     case Revurderingsaarsak.UT_AV_FENGSEL:
       return 'Ut av fengsel'
+    case Revurderingsaarsak.ANNEN:
+      return 'Annen'
   }
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/RevurderingInfo.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/RevurderingInfo.ts
@@ -12,6 +12,11 @@ export const SOESKENJUSTERING_GRUNNER = [
 
 export type BarnepensjonSoeskenjusteringGrunn = (typeof SOESKENJUSTERING_GRUNNER)[number]
 
+export interface RevurderingAarsakAnnen {
+  type: 'ANNEN'
+  aarsak: string
+}
+
 export interface SoeskenjusteringInfo {
   type: 'SOESKENJUSTERING'
   grunnForSoeskenjustering: BarnepensjonSoeskenjusteringGrunn
@@ -50,6 +55,7 @@ export interface Navn {
 }
 
 export type RevurderingInfo =
+  | RevurderingAarsakAnnen
   | SoeskenjusteringInfo
   | AdopsjonInfo
   | OmgjoeringAvFarskapInfo

--- a/libs/saksbehandling-common/src/main/kotlin/behandling/RevurderingInfo.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/behandling/RevurderingInfo.kt
@@ -17,6 +17,11 @@ enum class BarnepensjonSoeskenjusteringGrunn {
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 sealed class RevurderingInfo {
 
+    @JsonTypeName("ANNEN")
+    data class RevurderingAarsakAnnen(
+        val aarsak: String
+    ) : RevurderingInfo()
+
     @JsonTypeName("SOESKENJUSTERING")
     data class Soeskenjustering(
         val grunnForSoeskenjustering: BarnepensjonSoeskenjusteringGrunn


### PR DESCRIPTION
Legger på fritekst-årsaken i revurderingsoversikten slik at saksbehandlere som åpner den i ettertid kan se hva som ble spesifisert. 

![Skjermbilde 2023-08-31 kl  10 07 16](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/525715/32f96f9e-634a-40c8-a375-5d0f3cdb038f)
