### PR TITLE
EY-2595: Verkar som sakid i pesys er long, så endrar til det i kva vi får frå dei

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringRepository.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringRepository.kt
@@ -12,7 +12,7 @@ class MigreringRepository(private val connection: () -> Connection) {
     fun lagreKoplingTilPesyssaka(pesysSakId: PesysId, sakId: Long) = inTransaction {
         connection().prepareStatement("INSERT INTO pesyskopling(pesys_id,sak_id) VALUES(?, ?)")
             .also {
-                it.setString(1, pesysSakId.id)
+                it.setLong(1, pesysSakId.id)
                 it.setLong(2, sakId)
                 it.executeUpdate()
             }

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V51__pesysid_som_long.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V51__pesysid_som_long.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pesyskopling ALTER COLUMN pesys_id TYPE BIGINT USING (pesys_id::bigint)

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/migrering/MigreringRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/migrering/MigreringRoutesTest.kt
@@ -55,7 +55,7 @@ class MigreringRoutesTest : BehandlingIntegrationTest() {
             application { module(applicationContext) }
             val fnr = Folkeregisteridentifikator.of("08071272487")
             val request = MigreringRequest(
-                pesysId = PesysId("1"),
+                pesysId = PesysId(1),
                 enhet = Enhet("4817"),
                 soeker = fnr,
                 avdoedForelder = listOf(AvdoedForelder(fnr, Tidspunkt.now())),

--- a/apps/etterlatte-beregning-kafka/src/test/kotlin/no/nav/etterlatte/beregningkafka/MigreringHendelserTest.kt
+++ b/apps/etterlatte-beregning-kafka/src/test/kotlin/no/nav/etterlatte/beregningkafka/MigreringHendelserTest.kt
@@ -54,7 +54,7 @@ internal class MigreringHendelserTest {
 
         val fnr = Folkeregisteridentifikator.of("12101376212")
         val request = MigreringRequest(
-            pesysId = PesysId("1"),
+            pesysId = PesysId(1),
             enhet = Enhet("4817"),
             soeker = fnr,
             avdoedForelder = listOf(AvdoedForelder(fnr, Tidspunkt.now())),

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/pen/PenModellTilVaarModell.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/pen/PenModellTilVaarModell.kt
@@ -17,7 +17,7 @@ import java.util.*
 fun BarnepensjonGrunnlagResponse.tilVaarModell(): Pesyssak {
     val pesyssak = Pesyssak(
         id = UUID.randomUUID(),
-        pesysId = PesysId(sakId.toString()),
+        pesysId = PesysId(sakId),
         enhet = Enhet(enhet),
         soeker = Folkeregisteridentifikator.of(soeker),
         gjenlevendeForelder = gjenlevendeForelder?.let { Folkeregisteridentifikator.of(it) },

--- a/apps/etterlatte-migrering/src/test/kotlin/migrering/MigreringIntegrationTest.kt
+++ b/apps/etterlatte-migrering/src/test/kotlin/migrering/MigreringIntegrationTest.kt
@@ -65,7 +65,7 @@ class MigreringIntegrationTest {
             val syntetiskFnr = "19078504903"
             val sakInn = Pesyssak(
                 UUID.randomUUID(),
-                PesysId("4"),
+                PesysId(4),
                 Enhet("4808"),
                 Folkeregisteridentifikator.of(syntetiskFnr),
                 Folkeregisteridentifikator.of(syntetiskFnr),
@@ -103,7 +103,7 @@ class MigreringIntegrationTest {
             val melding1 = inspector.inspektør.message(0)
 
             val request = objectMapper.readValue(melding1.get("request").asText(), MigreringRequest::class.java)
-            assertEquals(PesysId("4"), request.pesysId)
+            assertEquals(PesysId(4), request.pesysId)
             assertEquals(sakInn.soeker, request.soeker)
         }
     }
@@ -139,7 +139,7 @@ class MigreringIntegrationTest {
             )
             with(repository.hentSaker()) {
                 assertEquals(1, size)
-                assertEquals(get(0).pesysId.id, "22974139")
+                assertEquals(get(0).pesysId.id, 22974139)
                 assertEquals(get(0).virkningstidspunkt, YearMonth.of(2023, Month.SEPTEMBER))
             }
         }

--- a/apps/etterlatte-trygdetid-kafka/src/test/kotlin/MigreringHendelserTest.kt
+++ b/apps/etterlatte-trygdetid-kafka/src/test/kotlin/MigreringHendelserTest.kt
@@ -55,7 +55,7 @@ internal class MigreringHendelserTest {
         )
         val fnr = Folkeregisteridentifikator.of("12101376212")
         val request = MigreringRequest(
-            pesysId = PesysId("1"),
+            pesysId = PesysId(1),
             enhet = Enhet("4817"),
             soeker = fnr,
             avdoedForelder = listOf(AvdoedForelder(fnr, Tidspunkt.now())),
@@ -146,7 +146,7 @@ internal class MigreringHendelserTest {
         )
         val fnr = Folkeregisteridentifikator.of("12101376212")
         val request = MigreringRequest(
-            pesysId = PesysId("1"),
+            pesysId = PesysId(1),
             enhet = Enhet("4817"),
             soeker = fnr,
             avdoedForelder = listOf(AvdoedForelder(fnr, Tidspunkt.now())),

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/MigreringRequest.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/MigreringRequest.kt
@@ -31,7 +31,7 @@ data class AvdoedForelder(
     val yrkesskade: Boolean = false
 )
 
-data class PesysId(val id: String)
+data class PesysId(val id: Long)
 
 data class Enhet(val nr: String)
 


### PR DESCRIPTION
Prøver å stykke opp endringane i migrering i så små og isolerte bitar som mogleg, denne går kun på å endre datatypen for sakid som vi får frå pesys

Ref https://github.com/navikt/pesys/blob/4e37118c3addd920308691f5d2b0329380d8a583/pen-app/src/main/java/no/nav/pensjon/pen_app/domain/barnepensjon/response/BarnepensjonGrunnlagResponse.kt#L9C1-L9C1