### PR TITLE
EY-2595: Samkøyre logikken for å migrere ei sak og den for å migrere alle

### DIFF
--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/Application.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/Application.kt
@@ -19,7 +19,7 @@ internal class Server(private val context: ApplicationContext) {
         dataSource.migrate()
         val rapidEnv = getRapidEnv()
         RapidApplication.create(rapidEnv).also { rapidsConnection ->
-            Migrering(rapidsConnection, pesysRepository, sakmigrerer)
+            Migrering(rapidsConnection, penklient)
             MigrerSpesifikkSak(rapidsConnection, penklient, pesysRepository, sakmigrerer)
         }.start()
     }

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/Migrering.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/Migrering.kt
@@ -1,7 +1,10 @@
 package no.nav.etterlatte.migrering
 
+import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
+import no.nav.etterlatte.migrering.pen.PenKlient
+import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser.MIGRER_SPESIFIKK_SAK
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser.START_MIGRERING
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
@@ -9,12 +12,9 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLoggingOgFeilhaandtering
+import rapidsandrivers.sakId
 
-internal class Migrering(
-    rapidsConnection: RapidsConnection,
-    private val pesysRepository: PesysRepository,
-    private val sakmigrerer: Sakmigrerer
-) :
+internal class Migrering(rapidsConnection: RapidsConnection, private val penKlient: PenKlient) :
     ListenerMedLoggingOgFeilhaandtering(START_MIGRERING) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -25,7 +25,12 @@ internal class Migrering(
         }.register(this)
     }
 
-    override fun haandterPakke(packet: JsonMessage, context: MessageContext) =
-        pesysRepository.hentSaker().also { logger.info("Hentet ${it.size} saker") }
-            .forEach { sakmigrerer.migrerSak(packet, it, context) }
+    override fun haandterPakke(packet: JsonMessage, context: MessageContext) = runBlocking {
+        penKlient.hentAlleSaker()
+    }.also { logger.info("Hentet ${it.size} saker") }
+        .forEach {
+            packet.eventName = MIGRER_SPESIFIKK_SAK
+            packet.sakId = it.id
+            context.publish(packet.toJson())
+        }
 }

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/pen/PenKlient.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/pen/PenKlient.kt
@@ -8,6 +8,7 @@ import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.ktorobo.AzureAdClient
 import no.nav.etterlatte.libs.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktorobo.Resource
+import no.nav.etterlatte.rapidsandrivers.migrering.PesysId
 import no.nav.etterlatte.token.Systembruker
 import org.slf4j.LoggerFactory
 
@@ -18,6 +19,22 @@ class PenKlient(config: Config, pen: HttpClient) {
 
     private val clientId = config.getString("pen.client.id")
     private val resourceUrl = config.getString("pen.client.url")
+    suspend fun hentAlleSaker(): List<PesysId> {
+        logger.info("Henter alle saker fra PEN")
+
+        return downstreamResourceClient
+            .get(
+                resource = Resource(
+                    clientId = clientId,
+                    url = "$resourceUrl/barnepensjon-migrering/saker"
+                ),
+                brukerTokenInfo = Systembruker(oid = "TODO", sub = "TODO")
+            )
+            .mapBoth(
+                success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },
+                failure = { errorResponse -> throw errorResponse }
+            )
+    }
     suspend fun hentSak(sakid: Long): BarnepensjonGrunnlagResponse {
         logger.info("Henter sak $sakid fra PEN")
 

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/pen/PenKlient.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/pen/PenKlient.kt
@@ -19,21 +19,9 @@ class PenKlient(config: Config, pen: HttpClient) {
 
     private val clientId = config.getString("pen.client.id")
     private val resourceUrl = config.getString("pen.client.url")
-    suspend fun hentAlleSaker(): List<PesysId> {
-        logger.info("Henter alle saker fra PEN")
-
-        return downstreamResourceClient
-            .get(
-                resource = Resource(
-                    clientId = clientId,
-                    url = "$resourceUrl/barnepensjon-migrering/saker"
-                ),
-                brukerTokenInfo = Systembruker(oid = "TODO", sub = "TODO")
-            )
-            .mapBoth(
-                success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },
-                failure = { errorResponse -> throw errorResponse }
-            )
+    fun hentAlleSaker(): List<PesysId> {
+        // TODO i EY-2599: Kople opp mot PEN/Pesys her
+        return listOf()
     }
     suspend fun hentSak(sakid: Long): BarnepensjonGrunnlagResponse {
         logger.info("Henter sak $sakid fra PEN")

--- a/apps/etterlatte-migrering/src/test/kotlin/migrering/MigreringIntegrationTest.kt
+++ b/apps/etterlatte-migrering/src/test/kotlin/migrering/MigreringIntegrationTest.kt
@@ -9,18 +9,14 @@ import no.nav.etterlatte.funksjonsbrytere.DummyFeatureToggleService
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
-import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.database.POSTGRES_VERSION
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.migrering.pen.BarnepensjonGrunnlagResponse
 import no.nav.etterlatte.migrering.pen.PenKlient
-import no.nav.etterlatte.rapidsandrivers.migrering.Beregning
-import no.nav.etterlatte.rapidsandrivers.migrering.Enhet
 import no.nav.etterlatte.rapidsandrivers.migrering.MigreringRequest
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser
 import no.nav.etterlatte.rapidsandrivers.migrering.PesysId
-import no.nav.etterlatte.rapidsandrivers.migrering.Trygdetid
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import org.junit.jupiter.api.AfterEach
@@ -30,10 +26,8 @@ import org.junit.jupiter.api.Test
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
 import rapidsandrivers.SAK_ID_KEY
-import java.math.BigDecimal
 import java.time.Month
 import java.time.YearMonth
-import java.util.*
 import javax.sql.DataSource
 
 class MigreringIntegrationTest {
@@ -59,61 +53,11 @@ class MigreringIntegrationTest {
     fun stop() = postgreSQLContainer.stop()
 
     @Test
-    fun `skal sende migreringsmelding for hver enkelt sak`() {
-        testApplication {
-            val repository = PesysRepository(datasource)
-            val syntetiskFnr = "19078504903"
-            val sakInn = Pesyssak(
-                UUID.randomUUID(),
-                PesysId(4),
-                Enhet("4808"),
-                Folkeregisteridentifikator.of(syntetiskFnr),
-                Folkeregisteridentifikator.of(syntetiskFnr),
-                emptyList(),
-                YearMonth.now(),
-                YearMonth.now().minusYears(10),
-                Beregning(
-                    brutto = BigDecimal(1000),
-                    netto = BigDecimal(1000),
-                    anvendtTrygdetid = BigDecimal(40),
-                    datoVirkFom = Tidspunkt.now(),
-                    g = BigDecimal(100000)
-                ),
-                Trygdetid(emptyList()),
-                false
-            )
-            repository.lagrePesyssak(sakInn)
-            val featureToggleService = DummyFeatureToggleService().also {
-                it.settBryter(MigreringFeatureToggle.SendSakTilMigrering, true)
-            }
-            val inspector = TestRapid()
-                .apply {
-                    Migrering(
-                        this,
-                        repository,
-                        sakmigrerer = Sakmigrerer(repository, featureToggleService)
-                    )
-                }
-
-            val melding = JsonMessage.newMessage(
-                mapOf(EVENT_NAME_KEY to Migreringshendelser.START_MIGRERING)
-            )
-            inspector.sendTestMessage(melding.toJson())
-
-            val melding1 = inspector.inspektør.message(0)
-
-            val request = objectMapper.readValue(melding1.get("request").asText(), MigreringRequest::class.java)
-            assertEquals(PesysId(4), request.pesysId)
-            assertEquals(sakInn.soeker, request.soeker)
-        }
-    }
-
-    @Test
     fun `kan ta imot og handtere respons fra PEN`() {
         testApplication {
             val repository = PesysRepository(datasource)
             val featureToggleService = DummyFeatureToggleService().also {
-                it.settBryter(MigreringFeatureToggle.SendSakTilMigrering, false)
+                it.settBryter(MigreringFeatureToggle.SendSakTilMigrering, true)
             }
             val responsFraPEN = objectMapper.readValue<BarnepensjonGrunnlagResponse>(
                 this::class.java.getResource("/penrespons.json")!!.readText()
@@ -142,6 +86,12 @@ class MigreringIntegrationTest {
                 assertEquals(get(0).pesysId.id, 22974139)
                 assertEquals(get(0).virkningstidspunkt, YearMonth.of(2023, Month.SEPTEMBER))
             }
+
+            val melding1 = inspector.inspektør.message(0)
+
+            val request = objectMapper.readValue(melding1.get("request").asText(), MigreringRequest::class.java)
+            assertEquals(PesysId(22974139), request.pesysId)
+            assertEquals(Folkeregisteridentifikator.of("06421594773"), request.soeker)
         }
     }
 }


### PR DESCRIPTION
Bruker tilsvarande konsept som for migrering (sjå `Reguleringsforespørsel`) - migrér alle hentar først oversikt over alle saker som skal migrerast, og køyrer så ut separat migrering per sak.