### PR TITLE
EY-2643 Legger til avbryt-knapp på omstillingsstønad-behandlinger

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/SideMeny/SideMeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/SideMeny/SideMeny.tsx
@@ -12,7 +12,6 @@ import { IBehandlingInfo } from '~components/behandling/SideMeny/types'
 import { Dokumentoversikt } from '~components/person/dokumentoversikt'
 import styled from 'styled-components'
 import AnnullerBehandling from '~components/behandling/handlinger/AnnullerBehanding'
-import { SakType } from '~shared/types/sak'
 import { VedtakSammendrag } from '~components/vedtak/typer'
 import { ChevronLeftDoubleIcon, ChevronRightDoubleIcon } from '@navikt/aksel-icons'
 
@@ -70,7 +69,7 @@ export const SideMeny = (props: { behandling: IDetaljertBehandling; vedtak: Vedt
           <Dokumentoversikt fnr={behandling.søker.foedselsnummer} liten />
         )}
 
-        {behandling.sakType == SakType.BARNEPENSJON && <AnnullerBehandling />}
+        <AnnullerBehandling />
       </SidebarContent>
     </CollapsibleSidebar>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AnnullerBehanding.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AnnullerBehanding.tsx
@@ -9,6 +9,7 @@ import { IBehandlingStatus, IBehandlingsType } from '~shared/types/IDetaljertBeh
 import { SidebarPanel } from '~components/behandling/SideMeny/SideMeny'
 import { hentBehandlesFraStatus } from '~components/behandling/felles/utils'
 import { useBehandling } from '~components/behandling/useBehandling'
+import { SakType } from '~shared/types/sak'
 
 export default function AnnullerBehandling() {
   const navigate = useNavigate()
@@ -17,9 +18,11 @@ export default function AnnullerBehandling() {
 
   const behandling = useBehandling()
   const erFoerstegangsbehandling = behandling?.behandlingType === IBehandlingsType.FØRSTEGANGSBEHANDLING
+  const erFoerstegangsbehandlingOgOmstillingsstoenad =
+    behandling?.sakType == SakType.OMSTILLINGSSTOENAD && erFoerstegangsbehandling
 
   const behandles = hentBehandlesFraStatus(behandling?.status ?? IBehandlingStatus.IVERKSATT)
-  if (!behandles) {
+  if (!behandles || erFoerstegangsbehandlingOgOmstillingsstoenad) {
     return null
   }
 


### PR DESCRIPTION
Legger til avbryt-knapp for revurderinger på Omstillingsstønad. Avbryte førstegangsbehandling her gir ikke mening slik det gjør for barnepensjon da vi ikke har pesys som fallback. 