### PR TITLE
EY-2619: Tilpassar migrering til ny oppgåveflyt

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveRoutesNy.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveRoutesNy.kt
@@ -65,11 +65,9 @@ internal fun Route.oppgaveRoutesNy(
 
         route("{$OPPGAVEID_CALL_PARAMETER}") {
             post("tildel-saksbehandler") {
-                kunSaksbehandler {
-                    val saksbehandlerEndringDto = call.receive<SaksbehandlerEndringDto>()
-                    service.tildelSaksbehandler(oppgaveId, saksbehandlerEndringDto.saksbehandler)
-                    call.respond(HttpStatusCode.OK)
-                }
+                val saksbehandlerEndringDto = call.receive<SaksbehandlerEndringDto>()
+                service.tildelSaksbehandler(oppgaveId, saksbehandlerEndringDto.saksbehandler)
+                call.respond(HttpStatusCode.OK)
             }
             post("bytt-saksbehandler") {
                 kunSaksbehandler {

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveRoutesNy.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveRoutesNy.kt
@@ -15,14 +15,17 @@ import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.OPPGAVEID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.OPPGAVEID_GOSYS_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.behandlingsId
 import no.nav.etterlatte.libs.common.gosysOppgaveId
 import no.nav.etterlatte.libs.common.kunSaksbehandler
+import no.nav.etterlatte.libs.common.kunSystembruker
 import no.nav.etterlatte.libs.common.oppgaveId
 import no.nav.etterlatte.libs.common.oppgaveNy.RedigerFristGosysRequest
 import no.nav.etterlatte.libs.common.oppgaveNy.RedigerFristRequest
 import no.nav.etterlatte.libs.common.oppgaveNy.SaksbehandlerEndringDto
 import no.nav.etterlatte.libs.common.oppgaveNy.SaksbehandlerEndringGosysDto
+import no.nav.etterlatte.libs.common.sakId
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.oppgave.GosysOppgaveService
 
@@ -38,6 +41,14 @@ internal fun Route.oppgaveRoutesNy(
                         Kontekst.get().appUserAsSaksbehandler().saksbehandlerMedRoller
                     )
                 )
+            }
+        }
+
+        route("/sak/$SAKID_CALL_PARAMETER") {
+            get("oppgaver") {
+                kunSystembruker {
+                    call.respond(service.hentSakOgOppgaverForSak(sakId))
+                }
             }
         }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveServiceNy.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveny/OppgaveServiceNy.kt
@@ -8,6 +8,7 @@ import no.nav.etterlatte.funksjonsbrytere.FeatureToggle
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveKilde
+import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveListe
 import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveNy
 import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveType
 import no.nav.etterlatte.libs.common.oppgaveNy.Status
@@ -19,9 +20,9 @@ import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
 import no.nav.etterlatte.sak.SakDao
 import no.nav.etterlatte.tilgangsstyring.SaksbehandlerMedRoller
 import no.nav.etterlatte.tilgangsstyring.filterForEnheter
+import no.nav.etterlatte.token.BrukerTokenInfo
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import no.nav.etterlatte.token.BrukerTokenInfo
 import java.util.*
 
 class OppgaveServiceNy(
@@ -342,6 +343,9 @@ class OppgaveServiceNy(
                 oppgaveDaoNy.endreStatusPaaOppgave(it.id, Status.AVBRUTT)
             }
     }
+
+    fun hentSakOgOppgaverForSak(sakId: Long) = inTransaction { sakDao.hentSak(sakId)!! }
+        .let { OppgaveListe(it, hentOppgaverForSak(it.id)) }
 }
 
 fun List<OppgaveNy>.filterOppgaverForEnheter(

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
@@ -103,14 +103,6 @@ internal fun Route.sakWebRoutes(
                     else -> call.respond(FoersteVirkDto(foersteVirk.atDay(1), sakId))
                 }
             }
-
-            get("oppgaver") {
-                kunSystembruker {
-                    val oppgaver = inTransaction { sakService.finnSak(sakId)!! }
-                        .let { OppgaveListe(it, oppgaveServiceNy.hentOppgaverForSak(it.id)) }
-                    call.respond(oppgaver)
-                }
-            }
         }
 
         route("/personer/") {

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
@@ -106,7 +106,7 @@ internal fun Route.sakWebRoutes(
 
             get("oppgaver") {
                 kunSystembruker {
-                    val oppgaver = sakService.finnSak(sakId)!!
+                    val oppgaver = inTransaction { sakService.finnSak(sakId)!! }
                         .let { OppgaveListe(it, oppgaveServiceNy.hentOppgaverForSak(it.id)) }
                     call.respond(oppgaver)
                 }

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
@@ -104,8 +104,8 @@ internal fun Route.sakWebRoutes(
                 }
             }
 
-            post("oppgaver") {
-                withFoedselsnummerInternal(tilgangService) { _ ->
+            get("oppgaver") {
+                kunSystembruker {
                     val oppgaver = sakService.finnSak(sakId)!!
                         .let { OppgaveListe(it, oppgaveServiceNy.hentOppgaverForSak(it.id)) }
                     call.respond(oppgaver)

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
@@ -20,8 +20,7 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.SisteIverksatteBehandling
 import no.nav.etterlatte.libs.common.kunSaksbehandler
 import no.nav.etterlatte.libs.common.kunSystembruker
-import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveNy
-import no.nav.etterlatte.libs.common.sak.Sak
+import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveListe
 import no.nav.etterlatte.libs.common.sak.Saker
 import no.nav.etterlatte.libs.common.sakId
 import no.nav.etterlatte.oppgaveny.OppgaveServiceNy
@@ -104,6 +103,14 @@ internal fun Route.sakWebRoutes(
                     else -> call.respond(FoersteVirkDto(foersteVirk.atDay(1), sakId))
                 }
             }
+
+            post("oppgaver") {
+                withFoedselsnummerInternal(tilgangService) { _ ->
+                    val oppgaver = sakService.finnSak(sakId)!!
+                        .let { OppgaveListe(it, oppgaveServiceNy.hentOppgaverForSak(it.id)) }
+                    call.respond(oppgaver)
+                }
+            }
         }
 
         route("/personer/") {
@@ -151,4 +158,3 @@ internal fun Route.sakWebRoutes(
 }
 
 data class FoersteVirkDto(val foersteIverksatteVirkISak: LocalDate, val sakId: Long)
-data class OppgaveListe(val sak: Sak, val oppgaver: List<OppgaveNy>)

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/MigreringHendelser.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/MigreringHendelser.kt
@@ -13,6 +13,7 @@ import rapidsandrivers.BEHANDLING_ID_KEY
 import rapidsandrivers.SAK_ID_KEY
 import rapidsandrivers.behandlingId
 import rapidsandrivers.migrering.ListenerMedLogging
+import rapidsandrivers.sakId
 import rapidsandrivers.withFeilhaandtering
 
 internal class MigreringHendelser(
@@ -35,7 +36,7 @@ internal class MigreringHendelser(
         logger.info("Oppretter, fatter og attesterer vedtak for migrer behandling $behandlingId")
 
         withFeilhaandtering(packet, context, OPPRETT_VEDTAK) {
-            val respons = vedtak.migrer(behandlingId)
+            val respons = vedtak.migrer(packet.sakId, behandlingId)
             logger.info("Opprettet vedtak ${respons.vedtakId} for migrert behandling: $behandlingId")
         }
     }

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/MigreringHendelser.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/MigreringHendelser.kt
@@ -1,10 +1,7 @@
 package no.nav.etterlatte
 
-import no.nav.etterlatte.libs.common.rapidsandrivers.SKAL_SENDE_BREV
 import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
-import no.nav.etterlatte.rapidsandrivers.EventNames
-import no.nav.etterlatte.rapidsandrivers.EventNames.FATT_VEDTAK
 import no.nav.etterlatte.rapidsandrivers.EventNames.OPPRETT_VEDTAK
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser.VEDTAK
 import no.nav.helse.rapids_rivers.JsonMessage
@@ -16,9 +13,7 @@ import rapidsandrivers.BEHANDLING_ID_KEY
 import rapidsandrivers.SAK_ID_KEY
 import rapidsandrivers.behandlingId
 import rapidsandrivers.migrering.ListenerMedLogging
-import rapidsandrivers.sakId
 import rapidsandrivers.withFeilhaandtering
-import java.util.*
 
 internal class MigreringHendelser(
     rapidsConnection: RapidsConnection,
@@ -37,45 +32,11 @@ internal class MigreringHendelser(
 
     override fun haandterPakke(packet: JsonMessage, context: MessageContext) {
         val behandlingId = packet.behandlingId
-        val sakId = packet.sakId
-        logger.info("Oppretter vedtak for migrer behandling $behandlingId")
+        logger.info("Oppretter, fatter og attesterer vedtak for migrer behandling $behandlingId")
 
         withFeilhaandtering(packet, context, OPPRETT_VEDTAK) {
-            val respons = vedtak.upsertVedtak(behandlingId)
+            val respons = vedtak.migrer(behandlingId)
             logger.info("Opprettet vedtak ${respons.vedtakId} for migrert behandling: $behandlingId")
-            packet[SKAL_SENDE_BREV] = false
-        }
-            .takeIf { it.isSuccess }
-            ?.let {
-                fattVedtak(packet, context, behandlingId, sakId)
-                    .takeIf { it.isSuccess }
-                    ?.let { attester(packet, context, behandlingId, sakId) }
-            }
-    }
-
-    private fun fattVedtak(
-        packet: JsonMessage,
-        context: MessageContext,
-        behandlingId: UUID,
-        sakId: Long
-    ) = withFeilhaandtering(packet, context, FATT_VEDTAK) {
-        val fattetVedtak = vedtak.fattVedtak(behandlingId)
-        logger.info(
-            "Fattet vedtak ${fattetVedtak.vedtakId} for sak: $sakId og behandling: $behandlingId"
-        )
-    }
-
-    private fun attester(
-        packet: JsonMessage,
-        context: MessageContext,
-        behandlingId: UUID,
-        sakId: Long
-    ) {
-        withFeilhaandtering(packet, context, EventNames.ATTESTER) {
-            val attestert = vedtak.attesterVedtak(behandlingId)
-            logger.info(
-                "Attesterte vedtak ${attestert.vedtakId} for sak: $sakId og behandling: $behandlingId"
-            )
         }
     }
 }

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/VedtakService.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/VedtakService.kt
@@ -19,7 +19,7 @@ import java.util.*
 interface VedtakService {
     fun harLoependeYtelserFra(sakId: Long, dato: LocalDate): LoependeYtelseDTO
 
-    fun migrer(behandlingId: UUID): VedtakDto
+    fun migrer(sakId: Long, behandlingId: UUID): VedtakDto
     fun upsertVedtak(behandlingId: UUID): VedtakDto
     fun fattVedtak(behandlingId: UUID): VedtakDto
     fun attesterVedtak(behandlingId: UUID): VedtakDto
@@ -33,9 +33,9 @@ class VedtakServiceImpl(private val vedtakKlient: HttpClient, private val url: S
             vedtakKlient.get("$url/api/vedtak/loepende/$sakId?dato=$dato").body()
         }
 
-    override fun migrer(behandlingId: UUID): VedtakDto =
+    override fun migrer(sakId: Long, behandlingId: UUID): VedtakDto =
         runBlocking {
-            vedtakKlient.post("$url/api/vedtak/$behandlingId/migrer").body()
+            vedtakKlient.post("$url/api/vedtak/$sakId/$behandlingId/migrer").body()
         }
 
     override fun upsertVedtak(behandlingId: UUID): VedtakDto =

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/VedtakService.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/VedtakService.kt
@@ -18,6 +18,8 @@ import java.util.*
 
 interface VedtakService {
     fun harLoependeYtelserFra(sakId: Long, dato: LocalDate): LoependeYtelseDTO
+
+    fun migrer(behandlingId: UUID): VedtakDto
     fun upsertVedtak(behandlingId: UUID): VedtakDto
     fun fattVedtak(behandlingId: UUID): VedtakDto
     fun attesterVedtak(behandlingId: UUID): VedtakDto
@@ -29,6 +31,11 @@ class VedtakServiceImpl(private val vedtakKlient: HttpClient, private val url: S
     override fun harLoependeYtelserFra(sakId: Long, dato: LocalDate): LoependeYtelseDTO =
         runBlocking {
             vedtakKlient.get("$url/api/vedtak/loepende/$sakId?dato=$dato").body()
+        }
+
+    override fun migrer(behandlingId: UUID): VedtakDto =
+        runBlocking {
+            vedtakKlient.post("$url/api/vedtak/$behandlingId/migrer").body()
         }
 
     override fun upsertVedtak(behandlingId: UUID): VedtakDto =

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/MigreringHendelserTest.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/MigreringHendelserTest.kt
@@ -57,11 +57,11 @@ class MigreringHendelserTest {
         val vedtakDto = VedtakDto(
             123, VedtakStatus.OPPRETTET, YearMonth.now(), mockk(), mockk(), VedtakType.INNVILGELSE, null, null, listOf()
         )
-        coEvery { vedtakService.migrer(any()) } returns vedtakDto
+        coEvery { vedtakService.migrer(any(), any()) } returns vedtakDto
 
         inspector.sendTestMessage(melding.toJson())
 
-        coVerify { vedtakService.migrer(any()) }
+        coVerify { vedtakService.migrer(any(), any()) }
 
         Assertions.assertEquals(0, inspector.inspektør.size)
     }

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/MigreringHendelserTest.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/MigreringHendelserTest.kt
@@ -57,14 +57,11 @@ class MigreringHendelserTest {
         val vedtakDto = VedtakDto(
             123, VedtakStatus.OPPRETTET, YearMonth.now(), mockk(), mockk(), VedtakType.INNVILGELSE, null, null, listOf()
         )
-        coEvery { vedtakService.upsertVedtak(any()) } returns vedtakDto
-        coEvery { vedtakService.fattVedtak(any()) } returns vedtakDto.copy(status = VedtakStatus.FATTET_VEDTAK)
-        coEvery { vedtakService.attesterVedtak(any()) } returns vedtakDto.copy(status = VedtakStatus.ATTESTERT)
+        coEvery { vedtakService.migrer(any()) } returns vedtakDto
 
         inspector.sendTestMessage(melding.toJson())
 
-        coVerify { vedtakService.fattVedtak(any()) }
-        coVerify { vedtakService.attesterVedtak(any()) }
+        coVerify { vedtakService.migrer(any()) }
 
         Assertions.assertEquals(0, inspector.inspektør.size)
     }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/config/ApplicationBuilder.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/config/ApplicationBuilder.kt
@@ -14,6 +14,7 @@ import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingService
 import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlientImpl
 import no.nav.etterlatte.vedtaksvurdering.klienter.BeregningKlientImpl
 import no.nav.etterlatte.vedtaksvurdering.klienter.VilkaarsvurderingKlientImpl
+import no.nav.etterlatte.vedtaksvurdering.migrering.migreringRoute
 import no.nav.etterlatte.vedtaksvurdering.vedtaksvurderingRoute
 import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helse.rapids_rivers.RapidsConnection
@@ -52,6 +53,7 @@ class ApplicationBuilder {
             .withKtorModule {
                 restModule(sikkerLogg, config = HoconApplicationConfig(config)) {
                     vedtaksvurderingRoute(vedtaksvurderingService, behandlingKlient)
+                    migreringRoute(vedtaksvurderingService, behandlingKlient)
                 }
             }
             .build()

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/klienter/BehandlingKlient.kt
@@ -13,6 +13,7 @@ import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveListe
 import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveNy
+import no.nav.etterlatte.libs.common.oppgaveNy.SaksbehandlerEndringDto
 import no.nav.etterlatte.libs.common.oppgaveNy.VedtakEndringDTO
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -20,6 +21,7 @@ import no.nav.etterlatte.libs.ktorobo.AzureAdClient
 import no.nav.etterlatte.libs.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktorobo.Resource
 import no.nav.etterlatte.token.BrukerTokenInfo
+import no.nav.etterlatte.token.Fagsaksystem
 import no.nav.etterlatte.token.Saksbehandler
 import no.nav.etterlatte.vedtaksvurdering.VedtakHendelse
 import org.slf4j.LoggerFactory
@@ -147,10 +149,10 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
             .post(
                 resource = Resource(
                     clientId = clientId,
-                    url = "$resourceUrl/nyeoppgaver/${oppgaveTilAttestering.id}/tildel-saksbehandler"
+                    url = "$resourceUrl/api/nyeoppgaver/${oppgaveTilAttestering.id}/tildel-saksbehandler"
                 ),
                 brukerTokenInfo = brukerTokenInfo,
-                postBody = {}
+                postBody = SaksbehandlerEndringDto(saksbehandler = Fagsaksystem.EY.navn)
             )
 
         return when (response) {

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/klienter/BehandlingKlient.kt
@@ -63,7 +63,7 @@ interface BehandlingKlient : BehandlingTilgangsSjekk, SakTilgangsSjekk {
     suspend fun iverksett(behandlingId: UUID, brukerTokenInfo: BrukerTokenInfo, vedtakId: Long): Boolean
 
     suspend fun hentOppgaverForSak(sakId: Long, brukerTokenInfo: BrukerTokenInfo): OppgaveListe
-    suspend fun tildelSaksbehandler(oppgaveTilAttestering: List<OppgaveNy>, brukerTokenInfo: BrukerTokenInfo): Boolean
+    suspend fun tildelSaksbehandler(oppgaveTilAttestering: OppgaveNy, brukerTokenInfo: BrukerTokenInfo): Boolean
 }
 
 class BehandlingKlientException(override val message: String, override val cause: Throwable? = null) :
@@ -125,7 +125,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
                 .get(
                     resource = Resource(
                         clientId = clientId,
-                        url = "$resourceUrl/saker/$sakId/oppgaver"
+                        url = "$resourceUrl/api/sak/$sakId/oppgaver"
                     ),
                     brukerTokenInfo = brukerTokenInfo
                 )
@@ -139,7 +139,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
     }
 
     override suspend fun tildelSaksbehandler(
-        oppgaveTilAttestering: List<OppgaveNy>,
+        oppgaveTilAttestering: OppgaveNy,
         brukerTokenInfo: BrukerTokenInfo
     ): Boolean {
         logger.info("Tildeler oppgave $oppgaveTilAttestering til systembruker")
@@ -147,7 +147,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
             .post(
                 resource = Resource(
                     clientId = clientId,
-                    url = "$resourceUrl/nyeoppgaver/$oppgaveTilAttestering/tildel-saksbehandler"
+                    url = "$resourceUrl/nyeoppgaver/${oppgaveTilAttestering.id}/tildel-saksbehandler"
                 ),
                 brukerTokenInfo = brukerTokenInfo,
                 postBody = {}

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/klienter/BehandlingKlient.kt
@@ -127,7 +127,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
                 .get(
                     resource = Resource(
                         clientId = clientId,
-                        url = "$resourceUrl/api/sak/$sakId/oppgaver"
+                        url = "$resourceUrl/api/nyeoppgaver/sak/$sakId/oppgaver"
                     ),
                     brukerTokenInfo = brukerTokenInfo
                 )

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/migrering/MigreringRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/migrering/MigreringRoute.kt
@@ -21,7 +21,7 @@ fun Route.migreringRoute(service: VedtaksvurderingService, behandlingKlient: Beh
     route("/api/vedtak") {
         val logger = application.log
 
-        post("/${SAKID_CALL_PARAMETER}/{$BEHANDLINGSID_CALL_PARAMETER}/migrer") {
+        post("/{$SAKID_CALL_PARAMETER}/{$BEHANDLINGSID_CALL_PARAMETER}/migrer") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Migrerer behandling $behandlingId")
                 val nyttVedtak = service.opprettEllerOppdaterVedtak(behandlingId, brukerTokenInfo)
@@ -35,7 +35,7 @@ fun Route.migreringRoute(service: VedtaksvurderingService, behandlingKlient: Beh
                     .filter { it.referanse == behandlingId.toString() }
                     .filter { it.type == OppgaveType.ATTESTERING }
                     .filterNot { it.erAvsluttet() }
-                behandlingKlient.tildelSaksbehandler(oppgaveTilAttestering, brukerTokenInfo)
+                behandlingKlient.tildelSaksbehandler(oppgaveTilAttestering.first(), brukerTokenInfo)
 
                 logger.info("Attesterer vedtak for behandling $behandlingId")
                 service.attesterVedtak(

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/migrering/MigreringRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/migrering/MigreringRoute.kt
@@ -1,0 +1,51 @@
+package no.nav.etterlatte.vedtaksvurdering.migrering
+
+import io.ktor.server.application.call
+import io.ktor.server.application.log
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.application
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveType
+import no.nav.etterlatte.libs.common.sakId
+import no.nav.etterlatte.libs.common.withBehandlingId
+import no.nav.etterlatte.libs.ktor.brukerTokenInfo
+import no.nav.etterlatte.token.Fagsaksystem
+import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingService
+import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
+
+fun Route.migreringRoute(service: VedtaksvurderingService, behandlingKlient: BehandlingKlient) {
+    route("/api/vedtak") {
+        val logger = application.log
+
+        post("/${SAKID_CALL_PARAMETER}/{$BEHANDLINGSID_CALL_PARAMETER}/migrer") {
+            withBehandlingId(behandlingKlient) { behandlingId ->
+                logger.info("Migrerer behandling $behandlingId")
+                val nyttVedtak = service.opprettEllerOppdaterVedtak(behandlingId, brukerTokenInfo)
+
+                logger.info("Fatter vedtak for behandling $behandlingId")
+                service.fattVedtak(behandlingId, brukerTokenInfo)
+
+                logger.info("Tildeler attesteringsoppgave til systembruker")
+                val oppgaveTilAttestering = behandlingKlient.hentOppgaverForSak(sakId, brukerTokenInfo)
+                    .oppgaver
+                    .filter { it.referanse == behandlingId.toString() }
+                    .filter { it.type == OppgaveType.ATTESTERING }
+                    .filterNot { it.erAvsluttet() }
+                behandlingKlient.tildelSaksbehandler(oppgaveTilAttestering, brukerTokenInfo)
+
+                logger.info("Attesterer vedtak for behandling $behandlingId")
+                service.attesterVedtak(
+                    behandlingId,
+                    "Automatisk attestert av ${Fagsaksystem.EY.systemnavn}",
+                    brukerTokenInfo
+                )
+
+                call.respond(nyttVedtak.toDto())
+            }
+        }
+    }
+}

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/migrering/MigreringRouteKtTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/migrering/MigreringRouteKtTest.kt
@@ -1,0 +1,153 @@
+package no.nav.etterlatte.vedtaksvurdering.migrering
+
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.log
+import io.ktor.server.config.HoconApplicationConfig
+import io.ktor.server.testing.testApplication
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.deserialize
+import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveListe
+import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveNy
+import no.nav.etterlatte.libs.common.oppgaveNy.OppgaveType
+import no.nav.etterlatte.libs.common.oppgaveNy.Status
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.vedtak.VedtakDto
+import no.nav.etterlatte.libs.ktor.AZURE_ISSUER
+import no.nav.etterlatte.libs.ktor.restModule
+import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingService
+import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import testsupport.buildTestApplicationConfigurationForOauth
+import vedtaksvurdering.SAKSBEHANDLER_1
+import vedtaksvurdering.vedtak
+import java.util.*
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class MigreringRouteKtTest {
+
+    private val server = MockOAuth2Server()
+    private lateinit var applicationConfig: HoconApplicationConfig
+    private val behandlingKlient = mockk<BehandlingKlient>()
+    private val vedtaksvurderingService: VedtaksvurderingService = mockk()
+
+    @BeforeAll
+    fun before() {
+        server.start()
+
+        applicationConfig =
+            buildTestApplicationConfigurationForOauth(server.config.httpServer.port(), AZURE_ISSUER, CLIENT_ID)
+    }
+
+    @AfterEach
+    fun afterEach() {
+        confirmVerified()
+        clearAllMocks()
+    }
+
+    @BeforeEach
+    fun beforeEach() {
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+    }
+
+    @AfterAll
+    fun after() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `skal returnere eksisterende vedtaksvurdering`() {
+        testApplication {
+            val opprettetVedtak = vedtak()
+            val behandlingId = UUID.randomUUID()
+            every { runBlocking { vedtaksvurderingService.opprettEllerOppdaterVedtak(any(), any()) } } returns
+                opprettetVedtak
+            every { runBlocking { vedtaksvurderingService.fattVedtak(behandlingId, any()) } } returns opprettetVedtak
+            every { runBlocking { behandlingKlient.hentOppgaverForSak(any(), any()) } } returns OppgaveListe(
+                mockk(),
+                listOf(lagOppgave(behandlingId))
+            )
+            every { runBlocking { behandlingKlient.tildelSaksbehandler(any(), any()) } } returns true
+            every {
+                runBlocking {
+                    vedtaksvurderingService.attesterVedtak(
+                        behandlingId,
+                        any(),
+                        any()
+                    )
+                }
+            } returns opprettetVedtak
+
+            environment { config = applicationConfig }
+            application { restModule(log) { migreringRoute(vedtaksvurderingService, behandlingKlient) } }
+
+            val vedtak = client.post("/api/vedtak/1/$behandlingId/migrer") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                header(HttpHeaders.Authorization, "Bearer $token")
+            }.let {
+                it.status shouldBe HttpStatusCode.OK
+                deserialize<VedtakDto>(it.bodyAsText())
+            }
+
+            Assertions.assertEquals(vedtak.vedtakId, opprettetVedtak.id)
+
+            coVerify(exactly = 1) {
+                vedtaksvurderingService.opprettEllerOppdaterVedtak(behandlingId, any())
+                behandlingKlient.hentOppgaverForSak(1, any())
+                vedtaksvurderingService.fattVedtak(behandlingId, any())
+                behandlingKlient.tildelSaksbehandler(any(), any())
+                vedtaksvurderingService.attesterVedtak(behandlingId, any(), any())
+            }
+            coVerify(atLeast = 1) {
+                behandlingKlient.harTilgangTilBehandling(any(), any())
+            }
+        }
+    }
+
+    private val token: String by lazy {
+        server.issueToken(
+            issuerId = AZURE_ISSUER,
+            audience = CLIENT_ID,
+            claims = mapOf("navn" to "John Doe", "NAVident" to SAKSBEHANDLER_1)
+        ).serialize()
+    }
+
+    private companion object {
+        const val CLIENT_ID = "azure-id for saksbehandler"
+    }
+
+    fun lagOppgave(referanse: UUID) = OppgaveNy(
+        id = UUID.randomUUID(),
+        status = Status.UNDER_BEHANDLING,
+        enhet = "",
+        sakId = 1,
+        kilde = null,
+        type = OppgaveType.ATTESTERING,
+        saksbehandler = null,
+        referanse = referanse.toString(),
+        merknad = null,
+        sakType = SakType.BARNEPENSJON,
+        fnr = null,
+        frist = null,
+        opprettet = Tidspunkt.now()
+    )
+}

--- a/libs/etterlatte-oppgave-model/src/main/kotlin/OppgaveNy/OppgaveNy.kt
+++ b/libs/etterlatte-oppgave-model/src/main/kotlin/OppgaveNy/OppgaveNy.kt
@@ -37,6 +37,8 @@ data class OppgaveNy(
     }
 }
 
+data class OppgaveListe(val sak: Sak, val oppgaver: List<OppgaveNy>)
+
 data class GosysOppgave(
     val id: Long,
     val versjon: Long,


### PR DESCRIPTION
Innsåg med det samme at det byrja å bli veldig mange kall mellom vedtaksvurdering-kafka og vedtaksvurdering, så slo dei saman til eit nytt migrerings-endepunkt.

Tildeler der attesteringsoppgåva til systembrukar.

_Eigentleg_ synes eg det ville vore betre om vi returnerte id-en til den nyoppretta oppgåva heile vegen frå _fattVedtak_, men det vart mykje knot, og eg kjenner meg ganske trygg på at det her blir rett også.

Og så har eg gjort eit bevisst val (som eg innser no at eg burde ha diskutert med nokon _før_ eg gjorde det) om at automatisk behandling i størst mogleg grad skal gjera det samme som ved manuell, sånn at vi opprettar oppgåve, tildeler til systemet og ferdigstiller som om det skulle vore gjort manuelt. Trur det er lurt for ettersporing.