### PR TITLE
EY-2651 Fikse redirect til saksoversikt + tekster

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AnnullerBehanding.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AnnullerBehanding.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { Alert, BodyLong, Button, Heading, Modal } from '@navikt/ds-react'
 import { avbrytBehandling } from '~shared/api/behandling'
 import { useNavigate } from 'react-router'
@@ -27,15 +27,13 @@ export default function AnnullerBehandling() {
   }
 
   const avbryt = () => {
-    if (behandling?.id) {
-      avbrytBehandlingen(behandling.id, () => {
-        if (behandling.søker?.foedselsnummer) {
-          navigate(`/person/${behandling.søker?.foedselsnummer}`)
-        } else {
-          window.location.reload() // Bare refresh behandling
-        }
-      })
-    }
+    avbrytBehandlingen(behandling!!.id, () => {
+      if (behandling?.søker?.foedselsnummer) {
+        navigate(`/person/${behandling.søker?.foedselsnummer}`)
+      } else {
+        window.location.reload() // Bare refresh behandling
+      }
+    })
   }
 
   return (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AnnullerBehanding.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AnnullerBehanding.tsx
@@ -63,8 +63,7 @@ export default function AnnullerBehandling() {
           </Heading>
           <BodyLong spacing>
             {erFoerstegangsbehandling
-              ? 'Behandlingen blir avbrutt og kan ikke behandles videre i Gjenny. Saken må annulleres fra ' +
-                'saksoversikten og deretter opprettes på nytt i Pesys.'
+              ? 'Saken blir annullert og kan ikke behandles videre i Gjenny. Saken må manuelt opprettes på nytt i Pesys.'
               : 'Behandlingen blir avsluttet og kan opprettes på nytt.'}
           </BodyLong>
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AnnullerBehanding.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AnnullerBehanding.tsx
@@ -1,20 +1,20 @@
-import { useState } from 'react'
-import { BodyLong, Button, Heading, Modal } from '@navikt/ds-react'
-import { WarningText } from '~shared/styled'
-import { annullerBehandling } from '~shared/api/behandling'
+import React, { useState } from 'react'
+import { Alert, BodyLong, Button, Heading, Modal } from '@navikt/ds-react'
+import { avbrytBehandling } from '~shared/api/behandling'
 import { useNavigate } from 'react-router'
-import { ApiResponse } from '~shared/api/apiClient'
 import { ButtonWrapper } from '~shared/modal/modal'
 import { IBehandlingStatus, IBehandlingsType } from '~shared/types/IDetaljertBehandling'
 import { SidebarPanel } from '~components/behandling/SideMeny/SideMeny'
 import { hentBehandlesFraStatus } from '~components/behandling/felles/utils'
 import { useBehandling } from '~components/behandling/useBehandling'
 import { SakType } from '~shared/types/sak'
+import { isFailure, isPending, useApiCall } from '~shared/hooks/useApiCall'
+import { formaterBehandlingstype } from '~utils/formattering'
 
 export default function AnnullerBehandling() {
   const navigate = useNavigate()
   const [isOpen, setIsOpen] = useState(false)
-  const [error, setError] = useState(false)
+  const [status, avbrytBehandlingen] = useApiCall(avbrytBehandling)
 
   const behandling = useBehandling()
   const erFoerstegangsbehandling = behandling?.behandlingType === IBehandlingsType.FØRSTEGANGSBEHANDLING
@@ -26,13 +26,13 @@ export default function AnnullerBehandling() {
     return null
   }
 
-  const annuller = () => {
+  const avbryt = () => {
     if (behandling?.id) {
-      annullerBehandling(behandling.id).then((response: ApiResponse<any>) => {
-        if (response.status === 'ok') {
-          navigate('/')
+      avbrytBehandlingen(behandling.id, () => {
+        if (behandling.søker?.foedselsnummer) {
+          navigate(`/person/${behandling.søker?.foedselsnummer}`)
         } else {
-          setError(true)
+          window.location.reload() // Bare refresh behandling
         }
       })
     }
@@ -42,37 +42,31 @@ export default function AnnullerBehandling() {
     <>
       <SidebarPanel>
         <Heading size={'small'} spacing>
-          {erFoerstegangsbehandling ? 'Annullering av saken' : 'Avbryte behandling'}.
+          Avbryt {formaterBehandlingstype(behandling!!.behandlingType).toLowerCase()}
         </Heading>
 
         <BodyLong spacing size={'small'}>
-          Dersom behandlingen ikke kan behandles i Gjenny må
-          {erFoerstegangsbehandling ? ' saken annulleres' : ' den avbrytes'}.
+          {erFoerstegangsbehandling
+            ? 'Hvis denne behandlingen ikke kan behandles i Gjenny må sak og behandling avbrytes.'
+            : 'Hvis denne behandlingen er uaktuell, kan du avbryte den her.'}
         </BodyLong>
 
         <div className="flex">
           <Button variant={'danger'} size={'xsmall'} className="textButton" onClick={() => setIsOpen(true)}>
-            {erFoerstegangsbehandling ? 'Avbryt behandling og annuller saken' : 'Avbryt behandling'}
+            Avbryt {formaterBehandlingstype(behandling!!.behandlingType).toLowerCase()}
           </Button>
         </div>
       </SidebarPanel>
 
-      <Modal
-        open={isOpen}
-        onClose={() => {
-          setIsOpen(false)
-          setError(false)
-        }}
-        aria-labelledby="modal-heading"
-        className={'padding-modal'}
-      >
+      <Modal open={isOpen} onClose={() => setIsOpen(false)} aria-labelledby="modal-heading" className={'padding-modal'}>
         <Modal.Body style={{ textAlign: 'center' }}>
           <Heading level={'1'} spacing size={'medium'} id="modal-heading">
             Er du sikker på at du vil avbryte behandlingen?
           </Heading>
           <BodyLong spacing>
             {erFoerstegangsbehandling
-              ? 'Saken blir annullert og kan ikke behandles videre i Gjenny. Saken må manuelt opprettes på nytt i Pesys.'
+              ? 'Behandlingen blir avbrutt og kan ikke behandles videre i Gjenny. Saken må annulleres fra ' +
+                'saksoversikten og deretter opprettes på nytt i Pesys.'
               : 'Behandlingen blir avsluttet og kan opprettes på nytt.'}
           </BodyLong>
 
@@ -81,18 +75,24 @@ export default function AnnullerBehandling() {
               variant="secondary"
               size="medium"
               className="button"
-              onClick={() => {
-                setIsOpen(false)
-                setError(false)
-              }}
+              onClick={() => setIsOpen(false)}
+              disabled={isPending(status)}
             >
-              Nei, fortsett behandling
+              Nei, fortsett {formaterBehandlingstype(behandling!!.behandlingType).toLowerCase()}
             </Button>
-            <Button variant="danger" size="medium" className="button" onClick={annuller}>
-              {erFoerstegangsbehandling ? 'Ja, avbryt behandling og annuller saken' : 'Ja, avbryt behandling'}
+            <Button
+              variant="danger"
+              size="medium"
+              className="button"
+              onClick={avbryt}
+              loading={isPending(status)}
+              disabled={isPending(status)}
+            >
+              Ja, avbryt {formaterBehandlingstype(behandling!!.behandlingType).toLowerCase()}
             </Button>
           </ButtonWrapper>
-          {error && <WarningText>Det oppsto en feil ved avbryting av behandlingen.</WarningText>}
+
+          {isFailure(status) && <Alert variant={'error'}>Det oppsto en feil ved avbryting av behandlingen.</Alert>}
         </Modal.Body>
       </Modal>
     </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
@@ -32,7 +32,7 @@ export const hentBehandling = async (id: string): Promise<ApiResponse<IDetaljert
   return apiClient.get(`/behandling/${id}`)
 }
 
-export const annullerBehandling = async (id: string): Promise<ApiResponse<unknown>> => {
+export const avbrytBehandling = async (id: string): Promise<ApiResponse<unknown>> => {
   return apiClient.post(`/behandling/${id}/avbryt`, {})
 }
 


### PR DESCRIPTION
Redirecte SB til saksoversikten i stedet for oppgavelisten. 

Litt pynting på tekster, men her må det gjøres mer arbeid. Avventer nye tekster fra design. Kommer i egen sak. 