### PR TITLE
EY-2650 Litt spacing i bunn av sidebar

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/styled.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/styled.tsx
@@ -42,6 +42,7 @@ export const CollapsibleSidebar = styled.div<{ collapsed: boolean }>`
 
 export const SidebarContent = styled.div<{ collapsed: boolean }>`
   display: ${(props) => (props.collapsed ? 'none' : 'block')};
+  margin-bottom: 4rem;
 `
 
 export const SidebarTools = styled.div`


### PR DESCRIPTION
Gjør at knapp for å avbryte behandling ikke forsvinner dersom dokumentlisten er svært lang

Eksempel: 
![Screenshot 2023-09-07 at 13 50 30](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/b181abb1-9530-4d76-be94-2a5afc1e5045)
