### PR TITLE
Køyre bygg ved endringar i settings.gradle.kts

### DIFF
--- a/.github/workflows/lib-saksbehandling-common.yaml
+++ b/.github/workflows/lib-saksbehandling-common.yaml
@@ -8,12 +8,14 @@ on:
     paths:
       - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
+      - settings.gradle.kts
   pull_request:
     branches:
       - main
     paths:
       - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
+      - settings.gradle.kts
 
 jobs:
   test:


### PR DESCRIPTION
Der definerer vi Kotlin-versjon. Det kan vera endringar i nye versjonar der som er inkompatible med ein plugin eller eit eller anna, så lurt at vi byggjar iallfall noko automatisk ved endringar der for å sjå at det funkar