### PR TITLE
EY-2671 Ta stilling til en klage som er omgjøring

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageRoutes.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.KLAGEID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.behandling.Formkrav
+import no.nav.etterlatte.libs.common.behandling.KlageUtfallUtenBrev
 import no.nav.etterlatte.libs.common.klageId
 import no.nav.etterlatte.libs.common.kunSaksbehandler
 import no.nav.etterlatte.libs.common.medBody
@@ -75,6 +76,19 @@ internal fun Route.klageRoutes(klageService: KlageService, featureToggleService:
                     }
                 }
             }
+
+            put("utfall") {
+                hvisEnabled(KlageFeatureToggle.KanBrukeKlageToggle) {
+                    kunSaksbehandler { saksbehandler ->
+                        medBody<VurdertUtfallDto> { utfall ->
+                            val oppdatertKlage = inTransaction {
+                                klageService.lagreUtfallAvKlage(klageId, utfall.utfall, saksbehandler)
+                            }
+                            call.respond(oppdatertKlage)
+                        }
+                    }
+                }
+            }
         }
 
         get("sak/{$SAKID_CALL_PARAMETER}") {
@@ -89,3 +103,4 @@ internal fun Route.klageRoutes(klageService: KlageService, featureToggleService:
 }
 
 data class VurdereFormkravDto(val formkrav: Formkrav)
+data class VurdertUtfallDto(val utfall: KlageUtfallUtenBrev)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/stegmeny/KlageStegmeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/stegmeny/KlageStegmeny.tsx
@@ -1,13 +1,42 @@
 import { StegMenyWrapper } from '~components/behandling/StegMeny/stegmeny'
 import React from 'react'
 import { KlageNavLenke } from '~components/klage/stegmeny/KlageNavLenke'
+import { useKlage } from '~components/klage/useKlage'
+import { Klage, KlageStatus } from '~shared/types/Klage'
+import { JaNei } from '~shared/types/ISvar'
+
+export function kanVurdereUtfall(klage: Klage | null): boolean {
+  const klageStatus = klage?.status
+
+  switch (klageStatus) {
+    case KlageStatus.UTFALL_VURDERT:
+    case KlageStatus.FORMKRAV_OPPFYLT:
+      return true
+    case KlageStatus.FERDIGSTILT:
+      return klage?.formkrav?.formkrav.erFormkraveneOppfylt === JaNei.JA
+  }
+  return false
+}
+
+export function kanSeOppsummering(klage: Klage | null): boolean {
+  const klageStatus = klage?.status
+  switch (klageStatus) {
+    case KlageStatus.FERDIGSTILT:
+    case KlageStatus.UTFALL_VURDERT:
+    case KlageStatus.FORMKRAV_IKKE_OPPFYLT:
+      return true
+  }
+  return false
+}
 
 export function KlageStegmeny() {
+  const klage = useKlage()
+
   return (
     <StegMenyWrapper>
       <KlageNavLenke path="formkrav" description="Vurder formkrav" enabled={true} />
-      <KlageNavLenke path="vurdering" description="Vurder klagen" enabled={true} />
-      <KlageNavLenke path="oppsummering" description="Oppsummering" enabled={true} />
+      <KlageNavLenke path="vurdering" description="Vurder klagen" enabled={kanVurdereUtfall(klage) || true} />
+      <KlageNavLenke path="oppsummering" description="Oppsummering" enabled={kanSeOppsummering(klage) || true} />
     </StegMenyWrapper>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/styled.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/styled.tsx
@@ -1,5 +1,16 @@
 import styled from 'styled-components'
+import { BodyShort } from '@navikt/ds-react'
 
 export const Innhold = styled.div`
   padding: 2em 2em 2em 4em;
+`
+
+export const VurderingWrapper = styled.div`
+  margin-bottom: 2rem;
+
+  width: 30rem;
+`
+
+export const Feilmelding = styled(BodyShort)`
+  color: var(--a-text-danger);
 `

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/KlageVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/KlageVurdering.tsx
@@ -1,15 +1,93 @@
-import { BodyShort, Button, Heading } from '@navikt/ds-react'
+import { BodyShort, Button, Heading, Radio, RadioGroup, Select, Textarea } from '@navikt/ds-react'
 import React from 'react'
 import { Content, ContentHeader } from '~shared/styled'
 import { HeadingWrapper } from '~components/behandling/soeknadsoversikt/styled'
-import { Innhold } from '~components/klage/styled'
+import { Feilmelding, Innhold, VurderingWrapper } from '~components/klage/styled'
 import { useNavigate } from 'react-router-dom'
 import { useKlage } from '~components/klage/useKlage'
 import { KnapperWrapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
+import {
+  AARSAKER_OMGJOERING,
+  InnstillingTilKabalUtenBrev,
+  KlageUtfallUtenBrev,
+  LOVHJEMLER_KLAGE,
+  Omgjoering,
+  TEKSTER_AARSAK_OMGJOERING,
+  Utfall,
+} from '~shared/types/Klage'
+import { Control, Controller, useForm } from 'react-hook-form'
+import { FieldOrNull } from '~shared/types/util'
+import { isFailure, isPending, useApiCall } from '~shared/hooks/useApiCall'
+import { oppdaterUtfallForKlage } from '~shared/api/klage'
+import { useAppDispatch } from '~store/Store'
+import { addKlage } from '~store/reducers/KlageReducer'
+import { ApiErrorAlert } from '~ErrorBoundary'
+
+type FilledFormDataVurdering = {
+  utfall: Utfall
+  omgjoering?: Omgjoering
+  innstilling?: InnstillingTilKabalUtenBrev
+}
+
+type FormdataVurdering = FieldOrNull<FilledFormDataVurdering>
+
+function erSkjemaUtfylt(skjema: FormdataVurdering): skjema is FilledFormDataVurdering {
+  if (skjema.utfall === null) {
+    return false
+  }
+  if (skjema.utfall === Utfall.OMGJOERING || skjema.utfall === Utfall.DELVIS_OMGJOERING) {
+    const { omgjoering } = skjema
+    if (!omgjoering || !omgjoering.begrunnelse || !omgjoering.grunnForOmgjoering) {
+      return false
+    }
+  }
+  if (skjema.utfall === Utfall.STADFESTE_VEDTAK || skjema.utfall === Utfall.DELVIS_OMGJOERING) {
+    const { innstilling } = skjema
+    if (!innstilling || !innstilling.lovhjemmel || !innstilling.tekst) {
+      return false
+    }
+  }
+  return true
+}
+
+function mapFraFormdataTilKlageUtfall(skjema: FilledFormDataVurdering): KlageUtfallUtenBrev {
+  switch (skjema.utfall) {
+    case Utfall.DELVIS_OMGJOERING:
+      return { utfall: 'DELVIS_OMGJOERING', omgjoering: skjema.omgjoering!!, innstilling: skjema.innstilling!! }
+    case Utfall.OMGJOERING:
+      return { utfall: 'OMGJOERING', omgjoering: skjema.omgjoering!! }
+    case Utfall.STADFESTE_VEDTAK:
+      return { utfall: 'STADFESTE_VEDTAK', innstilling: skjema.innstilling!! }
+  }
+}
 
 export function KlageVurdering() {
   const navigate = useNavigate()
   const klage = useKlage()
+  const [lagreUtfallStatus, lagreUtfall] = useApiCall(oppdaterUtfallForKlage)
+  const dispatch = useAppDispatch()
+
+  const { control, handleSubmit, watch } = useForm<FormdataVurdering>({
+    defaultValues: { utfall: null, omgjoering: null, innstilling: null },
+  })
+
+  const valgtUtfall = watch('utfall')
+
+  function sendInnVurdering(skjema: FormdataVurdering) {
+    if (!klage) {
+      return
+    }
+    if (!erSkjemaUtfylt(skjema)) {
+      // Gjør noe bedre håndtering her
+      return
+    }
+    const utfall = mapFraFormdataTilKlageUtfall(skjema)
+    lagreUtfall({ klageId: klage.id, utfall }, (oppdatertKlage) => {
+      dispatch(addKlage(oppdatertKlage))
+      navigate(`/klage/${klage.id}/oppsummering`)
+    })
+  }
+
   return (
     <Content>
       <ContentHeader>
@@ -20,24 +98,179 @@ export function KlageVurdering() {
         </HeadingWrapper>
       </ContentHeader>
 
-      {/* Se EY-2591 */}
-      <Innhold>
-        <BodyShort>Velg om det er 1. omgjøring 2. delvis omgjøring 3. stadfestelse av vedtaket</BodyShort>
+      <form onSubmit={handleSubmit(sendInnVurdering)}>
+        <Innhold>
+          <VurderingWrapper>
+            <Controller
+              rules={{
+                required: true,
+              }}
+              name="utfall"
+              control={control}
+              render={({ field, fieldState }) => (
+                <>
+                  <RadioGroup legend="Velg utfall" {...field}>
+                    <Radio value={Utfall.OMGJOERING}>Omgjøring av vedtak</Radio>
+                    <Radio value={Utfall.DELVIS_OMGJOERING}>Delvis omgjøring av vedtak</Radio>
+                    <Radio value={Utfall.STADFESTE_VEDTAK}>Stadfeste vedtaket</Radio>
+                  </RadioGroup>
+                  {fieldState.error ? <Feilmelding>Du må velge et utfall for klagen.</Feilmelding> : null}
+                </>
+              )}
+            />
+          </VurderingWrapper>
 
-        <BodyShort>Hvis omgjøring / delvis omgjøring, velg hvorfor fra noen predefinerte grunner</BodyShort>
+          {valgtUtfall === Utfall.STADFESTE_VEDTAK || valgtUtfall === Utfall.DELVIS_OMGJOERING ? (
+            <KlageInnstilling control={control} />
+          ) : null}
 
-        <BodyShort>Hvis stadfestelse / delvis omgjøring, velg hovedparagraf i loven som klagen gjelder</BodyShort>
-        <BodyShort>Hvis stadfestelse / delvis omgjøring, skriv inn innstillingstekst til KA / bruker</BodyShort>
-      </Innhold>
+          {valgtUtfall === Utfall.OMGJOERING || valgtUtfall === Utfall.DELVIS_OMGJOERING ? (
+            <KlageOmgjoering control={control} />
+          ) : null}
+        </Innhold>
 
-      <KnapperWrapper>
-        <Button variant="secondary" onClick={() => navigate(`/klage/${klage?.id}/formkrav`)}>
-          Gå tilbake
-        </Button>
-        <Button variant="primary" onClick={() => navigate(`/klage/${klage?.id}/oppsummering`)}>
-          Send inn vurdering av klagen
-        </Button>
-      </KnapperWrapper>
+        {isFailure(lagreUtfallStatus) ? (
+          <ApiErrorAlert>
+            Kunne ikke lagre utfallet av klagen. Prøv igjen senere, og meld sak hvis problemet vedvarer.
+          </ApiErrorAlert>
+        ) : null}
+
+        <KnapperWrapper>
+          <Button
+            className="button"
+            type="button"
+            variant="secondary"
+            onClick={() => navigate(`/klage/${klage?.id}/formkrav`)}
+          >
+            Gå tilbake
+          </Button>
+          <Button loading={isPending(lagreUtfallStatus)} type="submit" className="button" variant="primary">
+            Send inn vurdering av klagen
+          </Button>
+        </KnapperWrapper>
+      </form>
     </Content>
+  )
+}
+
+function KlageOmgjoering(props: { control: Control<FormdataVurdering> }) {
+  const { control } = props
+
+  return (
+    <>
+      <Heading level="2" size="medium">
+        Omgjøring
+      </Heading>
+
+      <VurderingWrapper>
+        <Controller
+          rules={{
+            required: true,
+            minLength: 1,
+          }}
+          name="omgjoering.grunnForOmgjoering"
+          control={control}
+          render={({ field, fieldState }) => {
+            const { value, ...rest } = field
+            return (
+              <>
+                <Select label="Hvorfor skal saken omgjøres?" value={value ?? ''} {...rest}>
+                  <option value="">Velg grunn</option>
+                  {AARSAKER_OMGJOERING.map((aarsak) => (
+                    <option key={aarsak} value={aarsak}>
+                      {TEKSTER_AARSAK_OMGJOERING[aarsak]}
+                    </option>
+                  ))}
+                </Select>
+                {fieldState.error ? <Feilmelding>Du må velge en årsak for omgjøringen.</Feilmelding> : null}
+              </>
+            )
+          }}
+        />
+      </VurderingWrapper>
+
+      <VurderingWrapper>
+        <Controller
+          rules={{
+            required: true,
+            minLength: 1,
+          }}
+          name="omgjoering.begrunnelse"
+          control={control}
+          render={({ field, fieldState }) => {
+            const { value, ...rest } = field
+            return (
+              <>
+                <Textarea label="Begrunnelse" value={value ?? ''} {...rest} />
+
+                {fieldState.error ? <Feilmelding>Du må gi en begrunnelse for omgjøringen.</Feilmelding> : null}
+              </>
+            )
+          }}
+        />
+      </VurderingWrapper>
+    </>
+  )
+}
+
+function KlageInnstilling(props: { control: Control<FormdataVurdering> }) {
+  const { control } = props
+  return (
+    <>
+      <Heading level="2" size="medium">
+        Innstilling til KA
+      </Heading>
+
+      <BodyShort spacing>Angi hvilken hjemmel klagen hovedsakelig knytter seg til</BodyShort>
+      <VurderingWrapper>
+        <Controller
+          rules={{
+            required: true,
+            minLength: 1,
+          }}
+          name="innstilling.lovhjemmel"
+          control={control}
+          render={({ field, fieldState }) => {
+            const { value, ...rest } = field
+            return (
+              <>
+                <Select label="Hjemmel" value={value ?? ''} {...rest}>
+                  <option value="">Velg hjemmel</option>
+                  {LOVHJEMLER_KLAGE.map((hjemmel) => (
+                    <option key={hjemmel} value={hjemmel}>
+                      {hjemmel}
+                    </option>
+                  ))}
+                </Select>
+                {fieldState.error ? (
+                  <Feilmelding>Du må angi hjemmelen klagen hovedsakelig knytter seg til.</Feilmelding>
+                ) : null}
+              </>
+            )
+          }}
+        />
+      </VurderingWrapper>
+
+      <BodyShort spacing>Skriv innstilling til klagen, som blir med i brev til KA og bruker</BodyShort>
+      <VurderingWrapper>
+        <Controller
+          rules={{
+            required: true,
+            minLength: 1,
+          }}
+          name="innstilling.tekst"
+          control={control}
+          render={({ field, fieldState }) => {
+            const { value, ...rest } = field
+            return (
+              <>
+                <Textarea label="Innstilling til KA" value={value ?? ''} {...rest} />
+                {fieldState.error ? <Feilmelding>Du må skrive en innstillingstekst.</Feilmelding> : null}
+              </>
+            )
+          }}
+        />
+      </VurderingWrapper>
+    </>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/klage.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/klage.ts
@@ -1,5 +1,5 @@
 import { apiClient, ApiResponse } from '~shared/api/apiClient'
-import { Formkrav, Klage } from '~shared/types/Klage'
+import { Formkrav, Klage, KlageUtfallUtenBrev } from '~shared/types/Klage'
 
 export function opprettNyKlage(sakId: number): Promise<ApiResponse<Klage>> {
   return apiClient.post(`/klage/opprett/${sakId}`, {})
@@ -16,4 +16,12 @@ export function hentKlagerISak(sakId: number): Promise<ApiResponse<Array<Klage>>
 export function oppdaterFormkravIKlage(args: { klageId: string; formkrav: Formkrav }): Promise<ApiResponse<Klage>> {
   const { klageId, formkrav } = args
   return apiClient.put(`/klage/${klageId}/formkrav`, { formkrav })
+}
+
+export function oppdaterUtfallForKlage(args: {
+  klageId: string
+  utfall: KlageUtfallUtenBrev
+}): Promise<ApiResponse<Klage>> {
+  const { klageId, utfall } = args
+  return apiClient.put(`/klage/${klageId}/utfall`, { utfall })
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Klage.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Klage.ts
@@ -44,4 +44,111 @@ export interface FormkravMedSaksbehandler {
   formkrav: Formkrav
 }
 
-export type KlageUtfall = {}
+export enum Utfall {
+  OMGJOERING = 'OMGJOERING',
+  DELVIS_OMGJOERING = 'DELVIS_OMGJOERING',
+  STADFESTE_VEDTAK = 'STADFESTE_VEDTAK',
+}
+
+export type KlageUtfall =
+  | {
+      utfall: 'OMGJOERING'
+      omgjoering: Omgjoering
+    }
+  | {
+      utfall: 'DELVIS_OMGJOERING'
+      omgjoering: Omgjoering
+      innstilling: InnstillingTilKabal
+    }
+  | {
+      utfall: 'STADFESTE_VEDTAK'
+      innstilling: InnstillingTilKabal
+    }
+
+export type KlageUtfallUtenBrev =
+  | {
+      utfall: 'OMGJOERING'
+      omgjoering: Omgjoering
+    }
+  | {
+      utfall: 'DELVIS_OMGJOERING'
+      omgjoering: Omgjoering
+      innstilling: InnstillingTilKabalUtenBrev
+    }
+  | {
+      utfall: 'STADFESTE_VEDTAK'
+      innstilling: InnstillingTilKabalUtenBrev
+    }
+
+interface KlageBrevInnstilling {}
+
+interface InnstillingTilKabal {
+  lovhjemmel: string
+  tekst: string
+  brev: KlageBrevInnstilling
+}
+
+export type InnstillingTilKabalUtenBrev = Omit<InnstillingTilKabal, 'brev'>
+
+export interface Omgjoering {
+  grunnForOmgjoering: AarsakOmgjoering
+  begrunnelse: string
+}
+
+export const LOVHJEMLER_KLAGE = [
+  '§ 1-5',
+  '§ 3-5 (trygdetid)',
+  '§ 17-2 (EØS-sammenlegging)',
+  '§ 17-3',
+  '§ 17-4',
+  '§ 17-5',
+  '§ 17-7',
+  '§ 17-8',
+  '§ 17-9',
+  '§ 17-10',
+  '§ 17-11',
+  '§ 17-12',
+  '§ 17-15',
+  '§ 18-2 (EØS-sammenlegging)',
+  '§ 18-3',
+  '§ 18-4',
+  '§ 18-5',
+  '§ 18-10',
+  '§ 21-12',
+  '§ 22-13 3. ledd',
+  '§ 22-13 4. ledd c)',
+  '§ 22-13 7. ledd',
+  '§ 22-15 1. ledd 1. pkt.',
+  '§ 22-15 1. ledd 2. pkt.',
+  '§ 22-15 2. ledd',
+  'Fvl. 33, 2. ledd',
+  'Fvl. 35, 1. ledd c)',
+  'Kapittel 2',
+  'Kapittel 3',
+  'Kapittel 17',
+  'Kapittel 18',
+  'Kapittel 22',
+  'Trygdeavtale',
+  'EØS',
+  'EØS- medlemskap/trygdetid',
+] as const
+
+export const AARSAKER_OMGJOERING = [
+  'FEIL_LOVANVENDELSE',
+  'FEIL_REGELVERKSFORSTAAELSE',
+  'FEIL_ELLER_ENDRET_FAKTA',
+  'PROSESSUELL_FEIL',
+  'SAKEN_HAR_EN_AAPEN_BEHANDLING',
+  'ANNET',
+] as const
+
+export type AarsakOmgjoering = (typeof AARSAKER_OMGJOERING)[number]
+
+export const TEKSTER_AARSAK_OMGJOERING: Record<AarsakOmgjoering, string> = {
+  FEIL_LOVANVENDELSE: 'Feil lovanvendelse',
+  FEIL_REGELVERKSFORSTAAELSE: 'Feil regelverksforståelse',
+  FEIL_ELLER_ENDRET_FAKTA: 'Feil eller endret fakta',
+  PROSESSUELL_FEIL: 'Prosessuell feil',
+  SAKEN_HAR_EN_AAPEN_BEHANDLING: 'Søker / part i saken har en åpen behandling',
+  ANNET: 'Annet',
+} as const

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/util.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/util.ts
@@ -1,0 +1,6 @@
+// På grunn av måten React håndterer controlled vs uncontrolled inputs tror React at input med value=undefined
+// er uncontrolled input. Dette stemmer dårlig med hvordan vi vil bruke skjemaet med f.eks. Partial<FilledFormData>,
+// FieldOrNull gir oss en type der vi kan eksplisitt holde styr på hva som er definert eller ikke
+export type FieldOrNull<T> = {
+  [P in keyof T]: T[P] | null
+}

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Klage.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Klage.kt
@@ -108,7 +108,7 @@ data class Klage(
     }
 }
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "utfall")
 sealed class KlageUtfall {
     abstract val saksbehandler: Grunnlagsopplysning.Saksbehandler
 
@@ -150,7 +150,7 @@ data class InnstillingTilKabalUtenBrev(val lovhjemmel: String, val tekst: String
 // Placeholder for å holde på referansen til klagebrevet
 class KlageBrevInnstilling
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "utfall")
 sealed class KlageUtfallUtenBrev {
     @JsonTypeName("OMGJOERING")
     data class Omgjoering(


### PR DESCRIPTION
Håndteringen av brev i backend kommer i en annen PR, skilte det ut siden det har litt ekstra kompleksitet som er uavklart. Dette betyr at kun ren omgjøring er det utfallet som støttes i denne koden :) 

Noen screenshots fra frontend:
![Screenshot 2023-09-13 at 11 56 53](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/4296255/3d1984e1-e63b-4823-a258-b4ce7a837311)
![Screenshot 2023-09-13 at 11 57 17](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/4296255/9a1c3b13-36ff-4cd6-8e17-811cb461a58a)
