### PR TITLE
EY-2645: Ved migrering skal vi sende brev, 

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
@@ -28,7 +28,6 @@ import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingDto
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import no.nav.etterlatte.token.BrukerTokenInfo
-import no.nav.etterlatte.token.Systembruker
 import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
 import no.nav.etterlatte.vedtaksvurdering.klienter.BeregningKlient
 import no.nav.etterlatte.vedtaksvurdering.klienter.VilkaarsvurderingKlient
@@ -195,7 +194,6 @@ class VedtaksvurderingService(
                 mapOf(
                     SKAL_SENDE_BREV to when {
                         behandling.revurderingsaarsak.skalIkkeSendeBrev() -> false
-                        brukerTokenInfo is Systembruker -> false
                         else -> true
                     },
                     REVURDERING_AARSAK to behandling.revurderingsaarsak.toString()


### PR DESCRIPTION
… sia det blir omrekning til nytt regelverk, så da må brukar få veta om det.

Kjens uansett fint å gå bort frå automatikken om at systembrukar ikkje skal kunne generere brev, den kjens litt vilkårleg og sårbar, så da er det betre at vi får typa det opp mot forretnignslogikken vår