### PR TITLE
Rettet en feil på visning av Institusjonsopphold 

### DIFF
--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRepositoryIntegrationTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRepositoryIntegrationTest.kt
@@ -2,6 +2,7 @@ package beregning.grunnlag
 
 import io.mockk.clearAllMocks
 import no.nav.etterlatte.beregning.grunnlag.BeregningsGrunnlag
+import no.nav.etterlatte.beregning.grunnlag.BeregningsGrunnlagOMS
 import no.nav.etterlatte.beregning.grunnlag.BeregningsGrunnlagRepository
 import no.nav.etterlatte.beregning.grunnlag.GrunnlagMedPeriode
 import no.nav.etterlatte.beregning.grunnlag.InstitusjonsoppholdBeregningsgrunnlag
@@ -100,6 +101,37 @@ internal class BeregningsGrunnlagRepositoryIntegrationTest {
     }
 
     @Test
+    fun `Opprettelse fungerer for OMS`() {
+        val id = UUID.randomUUID()
+
+        val institusjonsoppholdBeregningsgrunnlag =
+            listOf(
+                GrunnlagMedPeriode(
+                    fom = LocalDate.of(2022, 8, 1),
+                    tom = null,
+                    data = InstitusjonsoppholdBeregningsgrunnlag(Reduksjon.NEI_KORT_OPPHOLD)
+                )
+            )
+
+        repository.lagreOMS(
+            BeregningsGrunnlagOMS(
+                id,
+                Grunnlagsopplysning.Saksbehandler(
+                    ident = "Z123456",
+                    Tidspunkt.now()
+                ),
+                institusjonsoppholdBeregningsgrunnlag
+            )
+        )
+
+        val result = repository.finnOmstillingstoenadGrunnlagForBehandling(id)
+
+        assertNotNull(result)
+
+        assertEquals(institusjonsoppholdBeregningsgrunnlag, result?.institusjonsoppholdBeregningsgrunnlag)
+    }
+
+    @Test
     fun `Oppdatering fungerer`() {
         val id = UUID.randomUUID()
 
@@ -155,6 +187,57 @@ internal class BeregningsGrunnlagRepositoryIntegrationTest {
         assertNotNull(result)
 
         assertEquals(oppdatertSoeskenMedIBeregning, result?.soeskenMedIBeregning)
+        assertEquals(oppdatertInstitusjonsoppholdBeregningsgrunnlag, result?.institusjonsoppholdBeregningsgrunnlag)
+        assertEquals("Z654321", result?.kilde?.ident)
+    }
+
+    @Test
+    fun `Oppdatering fungerer for OMS`() {
+        val id = UUID.randomUUID()
+
+        val initialInstitusjonsoppholdBeregningsgrunnlag =
+            listOf(
+                GrunnlagMedPeriode(
+                    fom = LocalDate.of(2022, 8, 1),
+                    tom = null,
+                    data = InstitusjonsoppholdBeregningsgrunnlag(Reduksjon.NEI_KORT_OPPHOLD)
+                )
+            )
+        val oppdatertInstitusjonsoppholdBeregningsgrunnlag =
+            listOf(
+                GrunnlagMedPeriode(
+                    fom = LocalDate.of(2022, 8, 1),
+                    tom = null,
+                    data = InstitusjonsoppholdBeregningsgrunnlag(Reduksjon.JA_VANLIG)
+                )
+            )
+
+        repository.lagreOMS(
+            BeregningsGrunnlagOMS(
+                id,
+                Grunnlagsopplysning.Saksbehandler(
+                    ident = "Z123456",
+                    Tidspunkt.now()
+                ),
+                initialInstitusjonsoppholdBeregningsgrunnlag
+            )
+        )
+
+        repository.lagreOMS(
+            BeregningsGrunnlagOMS(
+                id,
+                Grunnlagsopplysning.Saksbehandler(
+                    ident = "Z654321",
+                    Tidspunkt.now()
+                ),
+                oppdatertInstitusjonsoppholdBeregningsgrunnlag
+            )
+        )
+
+        val result = repository.finnOmstillingstoenadGrunnlagForBehandling(id)
+
+        assertNotNull(result)
+
         assertEquals(oppdatertInstitusjonsoppholdBeregningsgrunnlag, result?.institusjonsoppholdBeregningsgrunnlag)
         assertEquals("Z654321", result?.kilde?.ident)
     }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
@@ -22,6 +22,7 @@ import React, { useEffect, useState } from 'react'
 import InstitusjonsoppholdOMS from '~components/behandling/beregningsgrunnlag/InstitusjonsoppholdOMS'
 import { InstitusjonsoppholdGrunnlagData } from '~shared/types/Beregning'
 import { mapListeTilDto } from '~components/behandling/beregningsgrunnlag/PeriodisertBeregningsgrunnlag'
+import Spinner from '~shared/Spinner'
 
 const BeregningsgrunnlagOmstillingsstoenad = (props: { behandling: IBehandlingReducer }) => {
   const { behandling } = props
@@ -29,7 +30,6 @@ const BeregningsgrunnlagOmstillingsstoenad = (props: { behandling: IBehandlingRe
   const dispatch = useAppDispatch()
   const behandles = hentBehandlesFraStatus(behandling.status)
   const [beregningsgrunnlag, fetchBeregningsgrunnlag] = useApiCall(hentBeregningsGrunnlagOMS)
-  const [visInstitusjonsopphold, setVisInstitusjonsopphold] = useState<boolean>(false)
   const [lagreBeregningsgrunnlagOMS, postBeregningsgrunnlag] = useApiCall(lagreBeregningsGrunnlagOMS)
   const [endreBeregning, postOpprettEllerEndreBeregning] = useApiCall(opprettEllerEndreBeregning)
   const [institusjonsoppholdsGrunnlagData, setInstitusjonsoppholdsGrunnlagData] =
@@ -46,7 +46,6 @@ const BeregningsgrunnlagOmstillingsstoenad = (props: { behandling: IBehandlingRe
         )
       }
     })
-    setVisInstitusjonsopphold(true)
   }, [])
 
   const onSubmit = () => {
@@ -73,13 +72,19 @@ const BeregningsgrunnlagOmstillingsstoenad = (props: { behandling: IBehandlingRe
 
   return (
     <>
+      <>
+        {isSuccess(beregningsgrunnlag) && (
+          <InstitusjonsoppholdOMS
+            behandling={behandling}
+            onSubmit={(institusjonsoppholdGrunnlag) => setInstitusjonsoppholdsGrunnlagData(institusjonsoppholdGrunnlag)}
+          />
+        )}
+        <Spinner visible={isPending(beregningsgrunnlag)} label={'Henter beregningsgrunnlag'} />
+        {isFailure(beregningsgrunnlag) && <ApiErrorAlert>Beregningsgrunnlag kan ikke hentes</ApiErrorAlert>}
+      </>
       {isFailure(endreBeregning) && <ApiErrorAlert>Kunne ikke opprette ny beregning</ApiErrorAlert>}
-      {visInstitusjonsopphold && isSuccess(beregningsgrunnlag) && (
-        <InstitusjonsoppholdOMS
-          behandling={behandling}
-          onSubmit={(institusjonsoppholdGrunnlag) => setInstitusjonsoppholdsGrunnlagData(institusjonsoppholdGrunnlag)}
-        />
-      )}
+      {isFailure(lagreBeregningsgrunnlagOMS) && <ApiErrorAlert>Kunne ikke lagre beregningsgrunnlag</ApiErrorAlert>}
+
       {behandles ? (
         <BehandlingHandlingKnapper>
           <Button

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/InstitusjonsoppholdOMS.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/InstitusjonsoppholdOMS.tsx
@@ -34,7 +34,7 @@ const InstitusjonsoppholdOMS = (props: InstitusjonsoppholdProps) => {
     institusjonsOppholdForm: InstitusjonsoppholdGrunnlagData
   }>({
     defaultValues: {
-      institusjonsOppholdForm: mapListeFraDto(behandling.beregningsGrunnlag?.institusjonsopphold ?? []),
+      institusjonsOppholdForm: mapListeFraDto(behandling.beregningsGrunnlagOMS?.institusjonsopphold ?? []),
     },
   })
 
@@ -64,8 +64,8 @@ const InstitusjonsoppholdOMS = (props: InstitusjonsoppholdProps) => {
 
   return (
     <InstitusjonsoppholdsWrapper>
-      {(behandling.beregningsGrunnlag?.institusjonsopphold &&
-        behandling.beregningsGrunnlag?.institusjonsopphold?.length > 0) ||
+      {(behandling.beregningsGrunnlagOMS?.institusjonsopphold &&
+        behandling.beregningsGrunnlagOMS?.institusjonsopphold?.length > 0) ||
       behandles ? (
         <>
           <LovtekstMedLenke


### PR DESCRIPTION
Rettet en feil på visning av Institusjonsopphold når man navigerer tilbake til Beregningsgrunnlag for OMS.

Rettelsen gjelder kun endringene i InstitusjonsoppholdOMS.tsx.
Endret i tillegg litt på BeregningsgrunnlagOmstillinsstoenad for å få en likere implementasjon som for BP + la til 2 tester