### PR TITLE
Ey 2675 opprydding button wrappers

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
@@ -98,7 +98,6 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
               <Button
                 variant="primary"
                 size="small"
-                className="button"
                 onClick={() =>
                   lagre({ behandlingId: behandling.id, request: { aktivitet: beskrivelse } }, (lagretElement) =>
                     setAktivitetOppfolging(lagretElement)
@@ -142,7 +141,6 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
           <Button
             variant="secondary"
             size="small"
-            className="button"
             as="a"
             href={`${configContext['gosysUrl']}/personoversikt/fnr=${behandling.søker?.foedselsnummer}`}
             target="_blank"
@@ -155,7 +153,7 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
       <Border />
 
       <BehandlingHandlingKnapper>
-        <Button variant="primary" size="medium" onClick={() => next()}>
+        <Button variant="primary" onClick={() => next()}>
           Gå videre
         </Button>
       </BehandlingHandlingKnapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/attestering/godkjenn.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/attestering/godkjenn.tsx
@@ -23,6 +23,7 @@ export const Godkjenn = ({ behandling }: { behandling: IDetaljertBehandling }) =
           autoComplete="off"
         />
       </div>
+      <br />
       <AttesterVedtak behandling={behandling} kommentar={tilbakemeldingFraAttestant} />
     </BeslutningWrapper>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/attesterVedtak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/attesterVedtak.tsx
@@ -1,7 +1,7 @@
 import { Alert, Button } from '@navikt/ds-react'
 import { useState } from 'react'
 import { attesterVedtak } from '~shared/api/behandling'
-import { BeslutningWrapper, ButtonWrapper } from '../styled'
+import { BeslutningWrapper } from '../styled'
 import { GeneriskModal } from '~shared/modal/modal'
 import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 import { useNavigate } from 'react-router'
@@ -9,6 +9,7 @@ import { behandlingSkalSendeBrev } from '~components/behandling/felles/utils'
 import { hentVedtaksbrev } from '~shared/api/brev'
 import { isPending, useApiCall } from '~shared/hooks/useApiCall'
 import { BrevStatus } from '~shared/types/Brev'
+import { FlexRow } from '~shared/styled'
 
 export const AttesterVedtak = ({ behandling, kommentar }: { behandling: IDetaljertBehandling; kommentar: string }) => {
   const navigate = useNavigate()
@@ -52,16 +53,16 @@ export const AttesterVedtak = ({ behandling, kommentar }: { behandling: IDetalje
           {error}
         </Alert>
       )}
-      <ButtonWrapper>
-        <Button variant="primary" size="medium" className="button" onClick={() => setModalisOpen(true)}>
-          {`Iverksett vedtak ${skalSendeBrev ? 'og send brev' : ''}`}
+      <FlexRow>
+        <Button variant="primary" onClick={() => setModalisOpen(true)}>
+          Iverksett vedtak {skalSendeBrev ? 'og send brev' : ''}
         </Button>
-      </ButtonWrapper>
+      </FlexRow>
       <GeneriskModal
         tittel="Er du sikker på at du vil iverksette vedtaket?"
         beskrivelse="Vedtaksbrevet sendes ut automatisk ved iverksettelse"
         tekstKnappJa="Ja, iverksett vedtak"
-        tekstKnappNei=" Nei, gå tilbake"
+        tekstKnappNei="Nei, gå tilbake"
         onYesClick={attester}
         setModalisOpen={setModalisOpen}
         open={modalisOpen}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/underkjennVedtak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/underkjennVedtak.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@navikt/ds-react'
 import { useState } from 'react'
-import { ButtonWrapper } from '../styled'
 import { GeneriskModal } from '~shared/modal/modal'
 import { hentBehandling, underkjennVedtak } from '~shared/api/behandling'
 import { useNavigate } from 'react-router'
@@ -32,11 +31,9 @@ export const UnderkjennVedtak: React.FC<Props> = ({ behandling, kommentar, valgt
 
   return (
     <>
-      <ButtonWrapper>
-        <Button variant="primary" onClick={() => setModalisOpen(true)}>
-          Bekreft og send i retur
-        </Button>
-      </ButtonWrapper>
+      <Button variant="primary" onClick={() => setModalisOpen(true)}>
+        Bekreft og send i retur
+      </Button>
 
       <GeneriskModal
         tittel="Er du sikker på at vil underkjenne vedtak og sende i retur til saksbehandler?"

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/styled.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/styled.tsx
@@ -71,11 +71,3 @@ export const Tekst = styled.div`
 
   color: #3e3832;
 `
-
-export const ButtonWrapper = styled.div`
-  .button {
-    width: 200px;
-    padding: 0.7em 0.5em 0.7em 0.5em;
-    margin-top: 1em;
-  }
-`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
@@ -106,7 +106,7 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
           {visAttesteringsmodal ? (
             <SendTilAttesteringModal />
           ) : (
-            <Button loading={isPending(vedtak)} variant="primary" size="medium" onClick={opprettEllerOppdaterVedtak}>
+            <Button loading={isPending(vedtak)} variant="primary" onClick={opprettEllerOppdaterVedtak}>
               {behandlingSkalSendeBrev(behandling) ? 'Gå videre til brev' : 'Fatt vedtak'}
             </Button>
           )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
@@ -25,6 +25,7 @@ import Soeskenjustering, {
 import Spinner from '~shared/Spinner'
 import { IPdlPerson } from '~shared/types/Person'
 import { InstitusjonsoppholdGrunnlagData } from '~shared/types/Beregning'
+import { Border } from '~components/behandling/soeknadsoversikt/styled'
 
 const BeregningsgrunnlagBarnepensjon = (props: { behandling: IBehandlingReducer }) => {
   const { behandling } = props
@@ -121,6 +122,8 @@ const BeregningsgrunnlagBarnepensjon = (props: { behandling: IBehandlingReducer 
       {manglerSoeskenJustering && <ApiErrorAlert>Søskenjustering er ikke fylt ut </ApiErrorAlert>}
       {isFailure(endreBeregning) && <ApiErrorAlert>Kunne ikke opprette ny beregning</ApiErrorAlert>}
       {isFailure(lagreBeregningsgrunnlag) && <ApiErrorAlert>Kunne ikke lagre beregningsgrunnlag</ApiErrorAlert>}
+
+      <Border />
 
       {behandles ? (
         <BehandlingHandlingKnapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
@@ -126,7 +126,6 @@ const BeregningsgrunnlagBarnepensjon = (props: { behandling: IBehandlingReducer 
         <BehandlingHandlingKnapper>
           <Button
             variant="primary"
-            size="medium"
             onClick={onSubmit}
             loading={isPending(lagreBeregningsgrunnlag) || isPending(endreBeregning)}
           >

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
@@ -22,6 +22,7 @@ import React, { useEffect, useState } from 'react'
 import InstitusjonsoppholdOMS from '~components/behandling/beregningsgrunnlag/InstitusjonsoppholdOMS'
 import { InstitusjonsoppholdGrunnlagData } from '~shared/types/Beregning'
 import { mapListeTilDto } from '~components/behandling/beregningsgrunnlag/PeriodisertBeregningsgrunnlag'
+import { Border } from '~components/behandling/soeknadsoversikt/styled'
 import Spinner from '~shared/Spinner'
 
 const BeregningsgrunnlagOmstillingsstoenad = (props: { behandling: IBehandlingReducer }) => {
@@ -84,6 +85,8 @@ const BeregningsgrunnlagOmstillingsstoenad = (props: { behandling: IBehandlingRe
       </>
       {isFailure(endreBeregning) && <ApiErrorAlert>Kunne ikke opprette ny beregning</ApiErrorAlert>}
       {isFailure(lagreBeregningsgrunnlagOMS) && <ApiErrorAlert>Kunne ikke lagre beregningsgrunnlag</ApiErrorAlert>}
+
+      <Border />
 
       {behandles ? (
         <BehandlingHandlingKnapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
@@ -89,7 +89,6 @@ const BeregningsgrunnlagOmstillingsstoenad = (props: { behandling: IBehandlingRe
         <BehandlingHandlingKnapper>
           <Button
             variant="primary"
-            size="medium"
             onClick={onSubmit}
             loading={isPending(lagreBeregningsgrunnlagOMS) || isPending(endreBeregning)}
           >

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/InstitusjonsoppholdBP.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/InstitusjonsoppholdBP.tsx
@@ -134,6 +134,7 @@ const InstitusjonsoppholdBP = (props: InstitusjonsoppholdProps) => {
       ) : null}
       {behandles && (
         <Button
+          type="button"
           icon={<PlusCircleIcon title="legg til" />}
           iconPosition="left"
           variant="tertiary"

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/InstitusjonsoppholdBP.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/InstitusjonsoppholdBP.tsx
@@ -134,7 +134,6 @@ const InstitusjonsoppholdBP = (props: InstitusjonsoppholdProps) => {
       ) : null}
       {behandles && (
         <Button
-          type="button"
           icon={<PlusCircleIcon title="legg til" />}
           iconPosition="left"
           variant="tertiary"

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/InstitusjonsoppholdOMS.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/InstitusjonsoppholdOMS.tsx
@@ -134,7 +134,6 @@ const InstitusjonsoppholdOMS = (props: InstitusjonsoppholdProps) => {
       ) : null}
       {behandles && (
         <Button
-          type="button"
           icon={<PlusCircleIcon title="legg til" />}
           iconPosition="left"
           variant="tertiary"

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/InstitusjonsoppholdOMS.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/InstitusjonsoppholdOMS.tsx
@@ -134,6 +134,7 @@ const InstitusjonsoppholdOMS = (props: InstitusjonsoppholdProps) => {
       ) : null}
       {behandles && (
         <Button
+          type="button"
           icon={<PlusCircleIcon title="legg til" />}
           iconPosition="left"
           variant="tertiary"

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/institusjonsopphold-styling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/institusjonsopphold-styling.tsx
@@ -3,4 +3,5 @@ import styled from 'styled-components'
 export const InstitusjonsoppholdsWrapper = styled.div`
   padding: 0em 2em;
   max-width: 70em;
+  margin-bottom: 1rem;
 `

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/Soeskenjustering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/Soeskenjustering.tsx
@@ -145,6 +145,7 @@ const Soeskenjustering = (props: SoeskenjusteringProps) => {
           </UstiletListe>
           {behandles && (
             <NyPeriodeButton
+              type="button"
               onClick={() => append(nySoeskengrunnlagPeriode(soesken, addMonths(sisteTom || sisteFom, 1).toString()))}
             >
               Legg til periode

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/Soeskenjustering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/Soeskenjustering.tsx
@@ -145,7 +145,6 @@ const Soeskenjustering = (props: SoeskenjusteringProps) => {
           </UstiletListe>
           {behandles && (
             <NyPeriodeButton
-              type="button"
               onClick={() => append(nySoeskengrunnlagPeriode(soesken, addMonths(sisteTom || sisteFom, 1).toString()))}
             >
               Legg til periode

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/SoeskenjusteringPeriode.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/SoeskenjusteringPeriode.tsx
@@ -84,11 +84,9 @@ const SoeskenjusteringPeriode = (props: SoeskenjusteringPeriodeProps) => {
                       label="Til og med"
                       value={tom.field.value}
                     />
-                    {tom.field.value !== null && tom.field.value !== undefined ? (
-                      <FjernKnapp type="button" onClick={() => tom.field.onChange(undefined)}>
-                        Fjern sluttdato
-                      </FjernKnapp>
-                    ) : null}
+                    {tom.field.value !== null && tom.field.value !== undefined && (
+                      <FjernKnapp onClick={() => tom.field.onChange(undefined)}>Fjern sluttdato</FjernKnapp>
+                    )}
                   </MaanedvelgerMedUtnulling>
                 ) : (
                   <OppdrasSammenLes>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/SoeskenjusteringPeriode.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/SoeskenjusteringPeriode.tsx
@@ -85,7 +85,9 @@ const SoeskenjusteringPeriode = (props: SoeskenjusteringPeriodeProps) => {
                       value={tom.field.value}
                     />
                     {tom.field.value !== null && tom.field.value !== undefined && (
-                      <FjernKnapp onClick={() => tom.field.onChange(undefined)}>Fjern sluttdato</FjernKnapp>
+                      <FjernKnapp type="button" onClick={() => tom.field.onChange(undefined)}>
+                        Fjern sluttdato
+                      </FjernKnapp>
                     )}
                   </MaanedvelgerMedUtnulling>
                 ) : (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
@@ -1,7 +1,7 @@
 import { Content, ContentHeader } from '~shared/styled'
 import { useEffect, useState } from 'react'
 import { Alert, ErrorMessage, Heading } from '@navikt/ds-react'
-import { HeadingWrapper } from '../soeknadsoversikt/styled'
+import { Border, HeadingWrapper } from '../soeknadsoversikt/styled'
 import { BehandlingHandlingKnapper } from '../handlinger/BehandlingHandlingKnapper'
 import { hentVedtaksbrev, opprettVedtaksbrev } from '~shared/api/brev'
 import { useParams } from 'react-router-dom'
@@ -93,11 +93,11 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
         )}
       </BrevContent>
 
-      <BrevContentFooter>
-        <BehandlingHandlingKnapper>
-          {hentBehandlesFraStatus(status) && <SendTilAttesteringModal />}
-        </BehandlingHandlingKnapper>
-      </BrevContentFooter>
+      <Border />
+
+      <BehandlingHandlingKnapper>
+        {hentBehandlesFraStatus(status) && <SendTilAttesteringModal />}
+      </BehandlingHandlingKnapper>
     </Content>
   )
 }
@@ -112,10 +112,6 @@ const BrevContent = styled.div`
   display: flex;
   height: 75vh;
   max-height: 75vh;
-`
-
-const BrevContentFooter = styled.div`
-  border-top: 1px solid #c6c2bf;
 `
 
 const Sidebar = styled.div`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AnnullerBehanding.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AnnullerBehanding.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 import { Alert, Button, ExpansionCard, Heading, Modal } from '@navikt/ds-react'
 import { avbrytBehandling } from '~shared/api/behandling'
 import { useNavigate } from 'react-router'
-import { ButtonWrapper } from '~shared/modal/modal'
 import { IBehandlingStatus, IBehandlingsType } from '~shared/types/IDetaljertBehandling'
 import { hentBehandlesFraStatus } from '~components/behandling/felles/utils'
 import { useBehandling } from '~components/behandling/useBehandling'
@@ -11,6 +10,7 @@ import { isFailure, isPending, useApiCall } from '~shared/hooks/useApiCall'
 import { formaterBehandlingstype } from '~utils/formattering'
 import { ExclamationmarkTriangleFillIcon, XMarkIcon } from '@navikt/aksel-icons'
 import styled from 'styled-components'
+import { FlexRow } from '~shared/styled'
 
 export default function AnnullerBehandling() {
   const navigate = useNavigate()
@@ -84,27 +84,14 @@ export default function AnnullerBehandling() {
         </Modal.Body>
 
         <Modal.Footer>
-          <ButtonWrapper>
-            <Button
-              variant="secondary"
-              size="medium"
-              className="button"
-              onClick={() => setIsOpen(false)}
-              disabled={isPending(status)}
-            >
+          <FlexRow justify={'center'}>
+            <Button variant="secondary" onClick={() => setIsOpen(false)} loading={isPending(status)}>
               Nei, fortsett {formaterBehandlingstype(behandling!!.behandlingType).toLowerCase()}
             </Button>
-            <Button
-              variant="danger"
-              size="medium"
-              className="button"
-              onClick={avbryt}
-              loading={isPending(status)}
-              disabled={isPending(status)}
-            >
+            <Button variant="danger" onClick={avbryt} loading={isPending(status)}>
               Ja, avbryt {formaterBehandlingstype(behandling!!.behandlingType).toLowerCase()}
             </Button>
-          </ButtonWrapper>
+          </FlexRow>
 
           {isFailure(status) && <Alert variant={'error'}>Det oppsto en feil ved avbryting av behandlingen.</Alert>}
         </Modal.Footer>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AvbrytBehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/AvbrytBehandling.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
 import { BodyLong, Button, Heading, Modal } from '@navikt/ds-react'
 import { useNavigate } from 'react-router'
-import { ButtonWrapper } from '~shared/modal/modal'
 import { erFerdigBehandlet } from '~components/behandling/felles/utils'
 import { useBehandling } from '~components/behandling/useBehandling'
+import { FlexRow } from '~shared/styled'
 
 export default function AvbrytBehandling() {
   const navigate = useNavigate()
@@ -11,12 +11,12 @@ export default function AvbrytBehandling() {
   const [isOpen, setIsOpen] = useState(false)
 
   return behandling?.status && erFerdigBehandlet(behandling.status) ? (
-    <Button variant={'tertiary'} className="textButton" onClick={() => navigate('/')}>
+    <Button variant={'tertiary'} onClick={() => navigate('/')}>
       Tilbake til oppgavelisten
     </Button>
   ) : (
     <>
-      <Button variant={'tertiary'} className="textButton" onClick={() => setIsOpen(true)}>
+      <Button variant={'tertiary'} onClick={() => setIsOpen(true)}>
         Avbryt
       </Button>
 
@@ -31,14 +31,14 @@ export default function AvbrytBehandling() {
             Endringene dine er lagret og du kan fortsette der du slapp når du går tilbake til saken.
           </BodyLong>
 
-          <ButtonWrapper>
-            <Button variant="secondary" size="medium" className="button" onClick={() => setIsOpen(false)}>
+          <FlexRow justify={'center'}>
+            <Button variant="secondary" onClick={() => setIsOpen(false)}>
               Nei, fortsett behandling
             </Button>
-            <Button variant="primary" size="medium" className="button" onClick={() => navigate('/')}>
+            <Button variant="primary" onClick={() => navigate('/')}>
               Ja, avbryt
             </Button>
-          </ButtonWrapper>
+          </FlexRow>
         </Modal.Body>
       </Modal>
     </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/BehandlingHandlingKnapper.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/BehandlingHandlingKnapper.tsx
@@ -1,37 +1,18 @@
 import AvbrytBehandling from './AvbrytBehandling'
-import styled from 'styled-components'
 import { Tilbake } from './tilbake'
 import { ReactNode } from 'react'
+import { FlexRow } from '~shared/styled'
 
 export const BehandlingHandlingKnapper = ({ children }: { children: ReactNode }) => {
   return (
-    <KnapperWrapper>
-      <div>
+    <div>
+      <FlexRow justify={'center'} $spacing>
         <Tilbake />
         {children}
-      </div>
-      <AvbrytBehandling />
-    </KnapperWrapper>
+      </FlexRow>
+      <FlexRow justify={'center'}>
+        <AvbrytBehandling />
+      </FlexRow>
+    </div>
   )
 }
-
-export const KnapperWrapper = styled.div`
-  margin: 3em 0em 2em 0em;
-  text-align: center;
-
-  .button {
-    padding-left: 2em;
-    padding-right: 2em;
-    min-width: 200px;
-    margin: 0em 1em 0em 1em;
-  }
-  .textButton {
-    margin-top: 1em;
-    text-decoration: none;
-    cursor: pointer;
-    font-weight: bold;
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/NesteOgTilbake.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/NesteOgTilbake.tsx
@@ -1,27 +1,29 @@
 import { Button } from '@navikt/ds-react'
 import { useBehandlingRoutes } from '../BehandlingRoutes'
 import AvbrytBehandling from './AvbrytBehandling'
-import { KnapperWrapper } from './BehandlingHandlingKnapper'
 import { handlinger } from './typer'
+import { FlexRow } from '~shared/styled'
 
 export const NesteOgTilbake = () => {
   const { next, back, lastPage, firstPage } = useBehandlingRoutes()
 
   return (
-    <KnapperWrapper>
-      <div>
+    <div>
+      <FlexRow justify={'center'} $spacing>
         {!firstPage && (
-          <Button variant="secondary" size="medium" className="button" onClick={back}>
+          <Button variant="secondary" onClick={back}>
             {handlinger.TILBAKE.navn}
           </Button>
         )}
         {!lastPage && (
-          <Button variant="primary" size="medium" className="button" onClick={next}>
+          <Button variant="primary" onClick={next}>
             {handlinger.NESTE.navn}
           </Button>
         )}
-      </div>
-      <AvbrytBehandling />
-    </KnapperWrapper>
+      </FlexRow>
+      <FlexRow justify={'center'}>
+        <AvbrytBehandling />
+      </FlexRow>
+    </div>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/sendTilAttesteringModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/sendTilAttesteringModal.tsx
@@ -1,11 +1,11 @@
-import { Button, Modal, Heading, BodyShort } from '@navikt/ds-react'
+import { BodyShort, Button, Heading, Modal } from '@navikt/ds-react'
 import { useState } from 'react'
 import { handlinger } from './typer'
 import { fattVedtak as fattVedtakApi } from '~shared/api/behandling'
 import { useNavigate, useParams } from 'react-router-dom'
-import { ButtonWrapper } from '~shared/modal/modal'
 import { isFailure, isPending, useApiCall } from '~shared/hooks/useApiCall'
 import { ApiErrorAlert } from '~ErrorBoundary'
+import { FlexRow } from '~shared/styled'
 
 export const SendTilAttesteringModal: React.FC = () => {
   const navigate = useNavigate()
@@ -30,7 +30,7 @@ export const SendTilAttesteringModal: React.FC = () => {
 
   return (
     <>
-      <Button variant="primary" size="medium" className="button" onClick={() => setIsOpen(true)}>
+      <Button variant="primary" onClick={() => setIsOpen(true)}>
         {handlinger.ATTESTERING.navn}
       </Button>
       <Modal
@@ -46,27 +46,19 @@ export const SendTilAttesteringModal: React.FC = () => {
             Er du sikker på at du vil sende vedtaket til attestering?
           </Heading>
           <BodyShort spacing>Når du sender til attestering vil vedtaket låses og du får ikke gjort endringer</BodyShort>
-          <ButtonWrapper>
+          <FlexRow justify={'center'}>
             <Button
               variant="secondary"
-              size="medium"
-              className="button"
               onClick={() => {
                 setIsOpen(false)
               }}
             >
               {handlinger.ATTESTERING_MODAL.NEI.navn}
             </Button>
-            <Button
-              loading={isPending(fattVedtakStatus)}
-              variant="primary"
-              size="medium"
-              className="button"
-              onClick={send}
-            >
+            <Button loading={isPending(fattVedtakStatus)} variant="primary" onClick={send}>
               {handlinger.ATTESTERING_MODAL.JA.navn}
             </Button>
-          </ButtonWrapper>
+          </FlexRow>
           {isFailure(fattVedtakStatus) && <ApiErrorAlert>En feil skjedde under attestering av vedtaket.</ApiErrorAlert>}
         </Modal.Body>
       </Modal>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/start.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/start.tsx
@@ -6,7 +6,7 @@ export const Start = ({ disabled }: { disabled?: boolean }) => {
   const { next } = useBehandlingRoutes()
 
   return (
-    <Button variant="primary" size="medium" className="button" onClick={next} disabled={disabled}>
+    <Button variant="primary" onClick={next} disabled={disabled}>
       {handlinger.START.navn}
     </Button>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/tilbake.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/tilbake.tsx
@@ -8,7 +8,7 @@ export const Tilbake = () => {
   return (
     <>
       {!firstPage && (
-        <Button variant="secondary" size="medium" className="button" onClick={back}>
+        <Button variant="secondary" onClick={back}>
           {handlinger.TILBAKE.navn}
         </Button>
       )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/vilkaarsvurderingKnapper.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/vilkaarsvurderingKnapper.tsx
@@ -24,27 +24,27 @@ export const VilkaarsVurderingKnapper = () => {
           case 'avslag':
             return (
               //TODO - Avslag
-              <Button variant="primary" size="medium" className="button" onClick={() => goto('brev')}>
+              <Button variant="primary" onClick={() => goto('brev')}>
                 {handlinger.VILKAARSVURDERING.AVSLAG.navn}
               </Button>
             )
           case 'uavklart':
             return (
               //TODO - oppdatere sak med Status "satt på vent" og Handlinger "Gjenoppta saken" i oppgavebenken
-              <Button variant="primary" size="medium" className="button" onClick={toggleVentNavn}>
+              <Button variant="primary" onClick={toggleVentNavn}>
                 {ventNavn}
               </Button>
             )
           case 'opphoer':
             return (
-              <Button variant="primary" size="medium" className="button" onClick={next}>
+              <Button variant="primary" onClick={next}>
                 {handlinger.VILKAARSVURDERING.OPPHOER.navn}
               </Button>
             )
           case 'innvilget':
           case 'endring':
             return (
-              <Button variant="primary" size="medium" className="button" onClick={next}>
+              <Button variant="primary" onClick={next}>
                 {handlinger.VILKAARSVURDERING.BEREGNE.navn}
               </Button>
             )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/manueltopphoeroversikt/ManueltOpphoerOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/manueltopphoeroversikt/ManueltOpphoerOversikt.tsx
@@ -135,7 +135,7 @@ export const ManueltOpphoerOversikt = (props: { behandling: IBehandlingReducer }
         </SectionSpacing>
       </MainSection>
       <BehandlingHandlingKnapper>
-        <Button variant="primary" size="medium" loading={loadingBeregning} onClick={lagBeregningOgGaaVidere}>
+        <Button variant="primary" loading={loadingBeregning} onClick={lagBeregningOgGaaVidere}>
           Se over beregning
         </Button>
       </BehandlingHandlingKnapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/personinfo/PersonInfoAdresse.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/personinfo/PersonInfoAdresse.tsx
@@ -1,9 +1,7 @@
-import { useState } from 'react'
-import { TextButton } from './TextButton'
 import { Adressevisning } from '~components/behandling/felles/Adressevisning'
-import { PersonDetailWrapper, Historikk } from '~components/behandling/soeknadsoversikt/styled'
+import { Historikk, PersonDetailWrapper } from '~components/behandling/soeknadsoversikt/styled'
 import { IAdresse } from '~shared/types/IAdresse'
-import { Label } from '@navikt/ds-react'
+import { Label, ReadMore } from '@navikt/ds-react'
 
 type Props = {
   adresser: Readonly<IAdresse[]> | undefined
@@ -12,7 +10,6 @@ type Props = {
 }
 
 export const PersonInfoAdresse = (props: Props) => {
-  const [visAdresseHistorikk, setVisAdresseHistorikk] = useState(false)
   const adresser = props.adresser ? [...props.adresser] : []
 
   const aktivAdresse: IAdresse | undefined = adresser?.find((adresse: IAdresse) => adresse.aktiv)
@@ -39,8 +36,9 @@ export const PersonInfoAdresse = (props: Props) => {
 
       {adresser && props.visHistorikk && (
         <Historikk>
-          <TextButton isOpen={visAdresseHistorikk} setIsOpen={setVisAdresseHistorikk} />
-          {visAdresseHistorikk && <Adressevisning adresser={adresser} soeknadsoversikt={true} />}
+          <ReadMore header={'Historikk'}>
+            <Adressevisning adresser={adresser} soeknadsoversikt={true} />
+          </ReadMore>
         </Historikk>
       )}
     </PersonDetailWrapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/personinfo/TextButton.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/personinfo/TextButton.tsx
@@ -1,5 +1,6 @@
-import styled from 'styled-components'
-import { ChevronUpIcon, ChevronDownIcon } from '@navikt/aksel-icons'
+import { ChevronDownIcon, ChevronUpIcon } from '@navikt/aksel-icons'
+import { Button } from '@navikt/ds-react'
+
 type Props = {
   isOpen: boolean
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>
@@ -7,26 +8,8 @@ type Props = {
 
 export const TextButton: React.FC<Props> = ({ isOpen, setIsOpen }) => {
   return (
-    <TextButtonWrapper onClick={() => setIsOpen(!isOpen)}>
-      <div className="textButton" onClick={() => setIsOpen(!isOpen)}>
-        Historikk {isOpen ? <ChevronUpIcon className="dropdownIcon" /> : <ChevronDownIcon className="dropdownIcon" />}
-      </div>
-    </TextButtonWrapper>
+    <Button variant={'tertiary'} onClick={() => setIsOpen(!isOpen)}>
+      Historikk {isOpen ? <ChevronUpIcon className="dropdownIcon" /> : <ChevronDownIcon className="dropdownIcon" />}
+    </Button>
   )
 }
-
-export const TextButtonWrapper = styled.div`
-  .textButton {
-    display: inline-flex;
-    justify-content: space-between;
-    color: #0067c5;
-    :hover {
-      cursor: pointer;
-    }
-    .dropdownIcon {
-      margin-bottom: 0;
-      margin-left: 0.5em;
-      margin-top: 0.1em;
-    }
-  }
-`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/kommerBarnetTilgode/KommerBarnetTilGodeVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/kommerBarnetTilgode/KommerBarnetTilGodeVurdering.tsx
@@ -82,7 +82,7 @@ export const KommerBarnetTilGodeVurdering = ({
     >
       <div>
         <VurderingsTitle title={'Trenger avklaring'} />
-        <Undertekst gray={false}>
+        <Undertekst $gray={false}>
           Boforholdet er avklart og sannsynliggjort at pensjonen kommer barnet til gode?
         </Undertekst>
         <RadioGroupWrapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/utenlandstilsnitt/UtenlandstilsnittVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/utenlandstilsnitt/UtenlandstilsnittVurdering.tsx
@@ -88,7 +88,7 @@ export const UtenlandstilsnittVurdering = ({
     >
       <>
         <VurderingsTitle title={'Utlandstilknytning'} />
-        <Undertekst gray={false}>Hvilken type sak er dette?</Undertekst>
+        <Undertekst $gray={false}>Hvilken type sak er dette?</Undertekst>
         <RadioGroupWrapper>
           <RadioGroup
             legend=""

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/styled.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/styled.tsx
@@ -97,7 +97,7 @@ export const HeadingWrapper = styled.div`
 `
 
 export const Border = styled.div`
-  border-top: 1px solid #b0b0b0;
+  border-top: 1px solid #ccc;
   margin-bottom: 1em;
 `
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidVisning.tsx
@@ -80,7 +80,7 @@ const TrygdetidVisning = (props: { behandling: IDetaljertBehandling }) => {
 
       {behandles ? (
         <BehandlingHandlingKnapper>
-          <Button variant="primary" size="medium" onClick={next}>
+          <Button variant="primary" onClick={next}>
             Gå videre
           </Button>
         </BehandlingHandlingKnapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/avtaler/TrygdeAvtale.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/avtaler/TrygdeAvtale.tsx
@@ -8,19 +8,20 @@ import { FlexHeader, IconWrapper } from '~components/behandling/soeknadsoversikt
 import Spinner from '~shared/Spinner'
 import {
   hentAlleTrygdetidAvtaleKriterier,
-  TrygdetidAvtale,
-  TrygdetidAvtaleKriteria,
   hentAlleTrygdetidAvtaler,
   hentTrygdeavtaleForBehandling,
-  Trygdeavtale,
-  TrygdetidAvtaleOptions,
   lagreTrygdeavtaleForBehandling,
+  Trygdeavtale,
   TrygdeavtaleRequest,
+  TrygdetidAvtale,
+  TrygdetidAvtaleKriteria,
+  TrygdetidAvtaleOptions,
 } from '~shared/api/trygdetid'
 import { isFailure, isPending, useApiCall } from '~shared/hooks/useApiCall'
 import { IconSize } from '~shared/types/Icon'
-import { Innhold, FormWrapper, FormKnapper } from '../styled'
+import { FormWrapper, Innhold } from '../styled'
 import { TrygdeavtaleVisning } from './TrygdeavtaleVisning'
+import { FlexRow } from '~shared/styled'
 
 interface TrygdetidAvtaleOptionProps {
   defaultBeskrivelse: string
@@ -143,7 +144,7 @@ export const TrygdeAvtale = ({ redigerbar }: Props) => {
         <>
           <TrygdeavtaleVisning avtaler={avtalerListe} kriterier={avtaleKriterierListe} trygdeavtale={trygdeavtale} />
           {redigerbar && (
-            <Button size="small" onClick={rediger} type="button">
+            <Button size="small" onClick={rediger}>
               Rediger
             </Button>
           )}
@@ -204,16 +205,16 @@ export const TrygdeAvtale = ({ redigerbar }: Props) => {
                 </FormWrapper>
               </Rows>
               <Rows>
-                <FormKnapper>
-                  <Button size="small" loading={isPending(lagreTrygdeavtaleRequest)} type="button" onClick={lagre}>
+                <FlexRow $spacing>
+                  <Button size="small" loading={isPending(lagreTrygdeavtaleRequest)} onClick={lagre}>
                     Lagre
                   </Button>
                   {harLagretVerdi && (
-                    <Button size="small" onClick={avbryt} type="button">
+                    <Button size="small" onClick={avbryt}>
                       Avbryt
                     </Button>
                   )}
-                </FormKnapper>
+                </FlexRow>
               </Rows>
             </TrygdeAvtaleForm>
           </Innhold>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/avtaler/TrygdeAvtale.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/avtaler/TrygdeAvtale.tsx
@@ -144,7 +144,7 @@ export const TrygdeAvtale = ({ redigerbar }: Props) => {
         <>
           <TrygdeavtaleVisning avtaler={avtalerListe} kriterier={avtaleKriterierListe} trygdeavtale={trygdeavtale} />
           {redigerbar && (
-            <Button size="small" onClick={rediger}>
+            <Button size="small" onClick={rediger} type="button">
               Rediger
             </Button>
           )}
@@ -206,11 +206,11 @@ export const TrygdeAvtale = ({ redigerbar }: Props) => {
               </Rows>
               <Rows>
                 <FlexRow $spacing>
-                  <Button size="small" loading={isPending(lagreTrygdeavtaleRequest)} onClick={lagre}>
+                  <Button size="small" loading={isPending(lagreTrygdeavtaleRequest)} type="button" onClick={lagre}>
                     Lagre
                   </Button>
                   {harLagretVerdi && (
-                    <Button size="small" onClick={avbryt}>
+                    <Button size="small" onClick={avbryt} type="button">
                       Avbryt
                     </Button>
                   )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/ManueltVilkaar.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/ManueltVilkaar.tsx
@@ -1,8 +1,7 @@
 import {
   Innhold,
-  VilkaarBeskrivelse,
   Title,
-  VilkaarBorder,
+  VilkaarBeskrivelse,
   VilkaarColumn,
   VilkaarInfobokser,
   VilkaarlisteTitle,
@@ -10,12 +9,13 @@ import {
   VilkaarVurderingContainer,
   VilkaarWrapper,
 } from './styled'
-import { Vilkaar, IVilkaarsvurdering, VurderingsResultat } from '~shared/api/vilkaarsvurdering'
+import { IVilkaarsvurdering, Vilkaar, VurderingsResultat } from '~shared/api/vilkaarsvurdering'
 import { Vurdering } from './Vurdering'
 import { StatusIcon, StatusIconProps } from '~shared/icons/statusIcon'
 import { VilkaarGrunnlagsStoette } from './vilkaar/VilkaarGrunnlagsStoette'
 import { Link } from '@navikt/ds-react'
 import { ExternalLinkIcon } from '@navikt/aksel-icons'
+import { Border } from '~components/behandling/soeknadsoversikt/styled'
 
 export interface VilkaarProps {
   vilkaar: Vilkaar
@@ -46,7 +46,7 @@ export const ManueltVilkaar = (props: VilkaarProps) => {
   }
 
   return (
-    <VilkaarBorder id={vilkaar.hovedvilkaar.type}>
+    <>
       <Innhold>
         <VilkaarWrapper>
           <VilkaarInfobokser>
@@ -77,6 +77,8 @@ export const ManueltVilkaar = (props: VilkaarProps) => {
           </VilkaarVurderingColumn>
         </VilkaarWrapper>
       </Innhold>
-    </VilkaarBorder>
+
+      <Border />
+    </>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Resultat.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Resultat.tsx
@@ -8,7 +8,7 @@ import {
   slettTotalVurdering,
   VilkaarsvurderingResultat,
 } from '~shared/api/vilkaarsvurdering'
-import { VilkaarBorder, VilkaarWrapper } from './styled'
+import { VilkaarWrapper } from './styled'
 import { Alert, BodyShort, Button, Heading, Loader, Radio, RadioGroup, Textarea } from '@navikt/ds-react'
 import { svarTilTotalResultat } from './utils'
 import { TrashIcon } from '@navikt/aksel-icons'
@@ -20,6 +20,7 @@ import { useAppDispatch } from '~store/Store'
 import { oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'
 import { IBehandlingStatus, IBehandlingsType } from '~shared/types/IDetaljertBehandling'
 import { SakType } from '~shared/types/sak'
+import { Border } from '~components/behandling/soeknadsoversikt/styled'
 
 type Props = {
   virkningstidspunktDato: string | undefined
@@ -191,7 +192,7 @@ export const Resultat: React.FC<Props> = ({
         </WarningAlert>
       )}
 
-      <VilkaarBorder />
+      <Border />
 
       <BehandlingHandlingKnapper>
         {vilkaarsvurdering.resultat && virkningstidspunktSamsvarer && <VilkaarsVurderingKnapper />}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
@@ -3,7 +3,6 @@ import React, { useEffect } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 import { hentVilkaarsvurdering, opprettVilkaarsvurdering } from '~shared/api/vilkaarsvurdering'
 import { ManueltVilkaar } from './ManueltVilkaar'
-import { VilkaarBorderTop } from './styled'
 import { Resultat } from './Resultat'
 import Spinner from '~shared/Spinner'
 import {
@@ -13,7 +12,7 @@ import {
 } from '~store/reducers/BehandlingReducer'
 import { useAppDispatch } from '~store/Store'
 import { Heading } from '@navikt/ds-react'
-import { HeadingWrapper } from '../soeknadsoversikt/styled'
+import { Border, HeadingWrapper } from '../soeknadsoversikt/styled'
 import { hentBehandlesFraStatus } from '~components/behandling/felles/utils'
 import { isFailure, isInitial, isPending, useApiCall } from '~shared/hooks/useApiCall'
 import { ApiErrorAlert } from '~ErrorBoundary'
@@ -69,7 +68,8 @@ export const Vilkaarsvurdering = (props: { behandling: IBehandlingReducer }) => 
 
       {behandlingId && vilkaarsvurdering && (
         <>
-          <VilkaarBorderTop />
+          <Border />
+
           {vilkaarsvurdering.vilkaar.map((value, index) => (
             <ManueltVilkaar
               key={index}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/styled.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/styled.ts
@@ -1,19 +1,5 @@
 import styled from 'styled-components'
 
-export const VilkaarBorder = styled.div`
-  padding: 1em 0;
-  border-bottom: 1px solid #ccc;
-  left: 0;
-  right: 0;
-`
-
-export const VilkaarBorderTop = styled.div`
-  padding: 1em 0;
-  border-top: 1px solid #ccc;
-  left: 0;
-  right: 0;
-`
-
 export const Innhold = styled.div`
   padding: 0 2em;
 `

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/Klagebehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/Klagebehandling.tsx
@@ -50,12 +50,12 @@ export function Klagebehandling() {
   return (
     <>
       <StatusBar result={personStatus} />
-      <Spinner visible={isPending(fetchKlageStatus)} label="Henter klagebehandling" />
+      <KlageStegmeny />
+      {isPending(fetchKlageStatus) && <Spinner visible label="Henter klagebehandling" />}
 
-      {klage !== null && viHarLastetRiktigKlage ? (
+      {klage !== null && viHarLastetRiktigKlage && (
         <GridContainer>
           <MainContent>
-            <KlageStegmeny />
             <Routes>
               <Route path="formkrav" element={<KlageFormkrav />} />
               <Route path="vurdering" element={<KlageVurdering />} />
@@ -65,7 +65,7 @@ export function Klagebehandling() {
           </MainContent>
           <KlageSidemeny />
         </GridContainer>
-      ) : null}
+      )}
 
       {isFailure(fetchKlageStatus) && <ApiErrorAlert>Kunne ikke hente klagebehandling</ApiErrorAlert>}
     </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/formkrav/KlageFormkrav.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/formkrav/KlageFormkrav.tsx
@@ -1,9 +1,8 @@
 import { Button, Heading, Radio, RadioGroup, Select } from '@navikt/ds-react'
-import { Content, ContentHeader } from '~shared/styled'
+import { Content, ContentHeader, FlexRow } from '~shared/styled'
 import { HeadingWrapper, Innhold } from '~components/behandling/soeknadsoversikt/styled'
 import { useKlage } from '~components/klage/useKlage'
 import { useNavigate } from 'react-router-dom'
-import { KnapperWrapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
 import { isFailure, isPending, isPendingOrInitial, mapSuccess, useApiCall } from '~shared/hooks/useApiCall'
 import { oppdaterFormkravIKlage } from '~shared/api/klage'
 import { JaNei } from '~shared/types/ISvar'
@@ -210,11 +209,11 @@ export function KlageFormkrav() {
 
           <JaNeiRadiogruppe name="erFormkraveneOppfylt" control={control} legend="Er formkravene til klagen oppfylt?" />
         </Innhold>
-        <KnapperWrapper>
+        <FlexRow justify={'center'}>
           <Button type="submit" loading={isPending(lagreFormkravStatus)}>
             Lagre vurdering av formkrav
           </Button>
-        </KnapperWrapper>
+        </FlexRow>
 
         {isFailure(lagreFormkravStatus) ? (
           <ApiErrorAlert>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/oppsummering/KlageOppsummering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/oppsummering/KlageOppsummering.tsx
@@ -1,11 +1,10 @@
 import { BodyShort, Button, Heading } from '@navikt/ds-react'
 import React from 'react'
-import { Content, ContentHeader } from '~shared/styled'
+import { Content, ContentHeader, FlexRow } from '~shared/styled'
 import { HeadingWrapper } from '~components/behandling/soeknadsoversikt/styled'
 import { Innhold } from '~components/klage/styled'
 import { useNavigate } from 'react-router-dom'
 import { useKlage } from '~components/klage/useKlage'
-import { KnapperWrapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
 
 export function KlageOppsummering() {
   const navigate = useNavigate()
@@ -31,14 +30,14 @@ export function KlageOppsummering() {
         <BodyShort>Hvis stadfestelse / delvis omgjøring, vis brevet til KA / bruker med innstilling</BodyShort>
       </Innhold>
 
-      <KnapperWrapper>
+      <FlexRow justify={'center'} $spacing>
         <Button variant="secondary" onClick={() => navigate(`/klage/${klage?.id}/vurdering`)}>
           Gå tilbake
         </Button>
         <Button variant="primary" onClick={() => alert('Vi støtter ikke behandling av klage enda :(')}>
           Send av gårde greier / lag revurdering / ferdigstill klagen
         </Button>
-      </KnapperWrapper>
+      </FlexRow>
     </Content>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/KlageVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/KlageVurdering.tsx
@@ -161,7 +161,7 @@ export function KlageVurdering() {
         ) : null}
 
         <FlexRow justify={'center'}>
-          <Button variant="secondary" onClick={() => navigate(`/klage/${klage?.id}/formkrav`)}>
+          <Button type="button" variant="secondary" onClick={() => navigate(`/klage/${klage?.id}/formkrav`)}>
             Gå tilbake
           </Button>
           <Button loading={isPending(lagreUtfallStatus)} type="submit" variant="primary">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/KlageVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/KlageVurdering.tsx
@@ -1,11 +1,10 @@
 import { BodyShort, Button, Heading, Radio, RadioGroup, Select, Textarea } from '@navikt/ds-react'
 import React from 'react'
-import { Content, ContentHeader } from '~shared/styled'
+import { Content, ContentHeader, FlexRow } from '~shared/styled'
 import { HeadingWrapper } from '~components/behandling/soeknadsoversikt/styled'
 import { Feilmelding, Innhold, VurderingWrapper } from '~components/klage/styled'
 import { useNavigate } from 'react-router-dom'
 import { useKlage } from '~components/klage/useKlage'
-import { KnapperWrapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
 import {
   AARSAKER_OMGJOERING,
   InnstillingTilKabalUtenBrev,
@@ -161,19 +160,14 @@ export function KlageVurdering() {
           </ApiErrorAlert>
         ) : null}
 
-        <KnapperWrapper>
-          <Button
-            className="button"
-            type="button"
-            variant="secondary"
-            onClick={() => navigate(`/klage/${klage?.id}/formkrav`)}
-          >
+        <FlexRow justify={'center'}>
+          <Button variant="secondary" onClick={() => navigate(`/klage/${klage?.id}/formkrav`)}>
             Gå tilbake
           </Button>
-          <Button loading={isPending(lagreUtfallStatus)} type="submit" className="button" variant="primary">
+          <Button loading={isPending(lagreUtfallStatus)} type="submit" variant="primary">
             Send inn vurdering av klagen
           </Button>
-        </KnapperWrapper>
+        </FlexRow>
       </form>
     </Content>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/FilterRad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/FilterRad.tsx
@@ -1,6 +1,5 @@
 import { Button, Select, TextField } from '@navikt/ds-react'
 import React from 'react'
-import styled from 'styled-components'
 import {
   ENHETFILTER,
   EnhetFilterKeys,
@@ -21,28 +20,14 @@ import {
 } from '~components/nyoppgavebenk/Oppgavelistafiltre'
 import { useFeatureEnabledMedDefault } from '~shared/hooks/useFeatureToggle'
 import { FEATURE_TOGGLE_KAN_BRUKE_KLAGE } from '~components/person/OpprettKlage'
-
-const FilterFlex = styled.div`
-  display: flex;
-  gap: 2rem;
-`
-
-const ButtonWrapper = styled.div`
-  display: flex;
-  justify-content: flex-start;
-  margin: 2rem 2rem 2rem 0rem;
-  max-width: 20rem;
-  button:first-child {
-    margin-right: 1rem;
-  }
-`
+import { FlexRow } from '~shared/styled'
 
 export const FilterRad = (props: { hentOppgaver: () => void; filter: Filter; setFilter: (filter: Filter) => void }) => {
   const { hentOppgaver, filter, setFilter } = props
   const kanBrukeKlage = useFeatureEnabledMedDefault(FEATURE_TOGGLE_KAN_BRUKE_KLAGE)
   return (
     <>
-      <FilterFlex>
+      <FlexRow $spacing>
         <TextField
           label="Fødselsnummer"
           value={filter.fnrFilter}
@@ -133,13 +118,14 @@ export const FilterRad = (props: { hentOppgaver: () => void; filter: Filter; set
             </option>
           ))}
         </Select>
-      </FilterFlex>
-      <ButtonWrapper>
+      </FlexRow>
+
+      <FlexRow $spacing>
         <Button onClick={hentOppgaver}>Hent</Button>
         <Button variant="secondary" onClick={() => setFilter(initialFilter())}>
           Tilbakestill alle filtre
         </Button>
-      </ButtonWrapper>
+      </FlexRow>
     </>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/GosysOppgaveModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/GosysOppgaveModal.tsx
@@ -10,6 +10,7 @@ import { OppgaveDTOny } from '~shared/api/oppgaverny'
 import { ConfigContext } from '~clientConfig'
 import { useFeatureEnabledMedDefault } from '~shared/hooks/useFeatureToggle'
 import { FEATURE_TOGGLE_KAN_BRUKE_OPPGAVEBEHANDLING } from '~components/person/journalfoeringsoppgave/BehandleJournalfoeringOppgave'
+import { FlexRow } from '~shared/styled'
 
 const TagRow = styled.div`
   display: flex;
@@ -31,11 +32,6 @@ const BeskrivelseWrapper = styled.div`
   width: 46rem;
 `
 
-const ButtonRow = styled.div`
-  display: flex;
-  gap: 1rem;
-  justify-content: flex-end;
-`
 export const GosysOppgaveModal = ({ oppgave }: { oppgave: OppgaveDTOny }) => {
   const [open, setOpen] = useState(false)
   const { opprettet, frist, status, fnr, gjelder, enhet, saksbehandler, beskrivelse, sakType } = oppgave
@@ -97,7 +93,7 @@ export const GosysOppgaveModal = ({ oppgave }: { oppgave: OppgaveDTOny }) => {
               <BodyShort>{beskrivelse}</BodyShort>
             </div>
           </BeskrivelseWrapper>
-          <ButtonRow>
+          <FlexRow justify={'right'}>
             <Button variant="tertiary" onClick={() => setOpen(false)}>
               Avbryt
             </Button>
@@ -116,7 +112,7 @@ export const GosysOppgaveModal = ({ oppgave }: { oppgave: OppgaveDTOny }) => {
                 Åpne og rediger i Gosys
               </Button>
             )}
-          </ButtonRow>
+          </FlexRow>
         </Modal.Body>
       </Modal>
     </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/FristHandlinger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/FristHandlinger.tsx
@@ -7,13 +7,7 @@ import { formaterStringDato } from '~utils/formattering'
 import { PencilIcon } from '@navikt/aksel-icons'
 import styled from 'styled-components'
 import { add, isBefore } from 'date-fns'
-
-const Buttonwrapper = styled.div`
-  margin: 4rem 1rem 1rem 1rem;
-  button:first-child {
-    margin-right: 1rem;
-  }
-`
+import { FlexRow } from '~shared/styled'
 
 const FristWrapper = styled.span<{ fristHarPassert: boolean; utenKnapp?: boolean }>`
   color: ${(p) => p.fristHarPassert && 'var(--a-text-danger)'};
@@ -83,7 +77,7 @@ export const FristHandlinger = (props: {
               {isSuccess(redigerfristSvar) && <Alert variant="success">Frist er endret</Alert>}
               {isFailure(redigerfristSvar) && <ApiErrorAlert>Kunne ikke lagre ny frist</ApiErrorAlert>}
               {!nyFrist && <Alert variant="warning">Du må velge en måned</Alert>}
-              <Buttonwrapper>
+              <FlexRow>
                 <Button
                   loading={isPending(redigerfristSvar)}
                   disabled={!nyFrist}
@@ -109,7 +103,7 @@ export const FristHandlinger = (props: {
                     Avbryt
                   </Button>
                 )}
-              </Buttonwrapper>
+              </FlexRow>
             </Modal.Body>
           </Modal>
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/OpprettGenerellBehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/OpprettGenerellBehandling.tsx
@@ -5,13 +5,7 @@ import { opprettNyGenerellBehandling } from '~shared/api/generellbehandling'
 import { GenerellBehandlingType, Innholdstyper } from '~shared/types/Generellbehandling'
 import styled from 'styled-components'
 import { ApiErrorAlert } from '~ErrorBoundary'
-
-const ButtonWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  gap: 1em;
-  margin: 2rem 0rem;
-`
+import { FlexRow } from '~shared/styled'
 
 const AlertWrapper = styled(Alert)`
   margin: 2rem 0rem;
@@ -67,7 +61,7 @@ const OpprettGenerellBehandling = (props: { sakId: number }) => {
           {isSuccess(opprettGenBehandlingStatus) && (
             <AlertWrapper variant="success">Behandlingen er opprettet</AlertWrapper>
           )}
-          <ButtonWrapper>
+          <FlexRow justify={'center'}>
             <Button
               onClick={() => opprettGenBehandlingKallWrapper()}
               loading={isPending(opprettGenBehandlingStatus)}
@@ -84,7 +78,7 @@ const OpprettGenerellBehandling = (props: { sakId: number }) => {
             >
               Avbryt
             </Button>
-          </ButtonWrapper>
+          </FlexRow>
         </Modal.Body>
       </Modal>
     </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/SakOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/SakOversikt.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { IBehandlingListe } from './typer'
 import { ManueltOpphoerModal } from './ManueltOpphoerModal'
 import { hentBehandlingerForPerson } from '~shared/api/behandling'
-import { GridContainer } from '~shared/styled'
+import { FlexRow, GridContainer } from '~shared/styled'
 import Spinner from '~shared/Spinner'
 import RelevanteHendelser from '~components/person/uhaandtereHendelser/RelevanteHendelser'
 import { isFailure, isPending, isSuccess, useApiCall } from '~shared/hooks/useApiCall'
@@ -44,11 +44,11 @@ export const SakOversikt = ({ fnr }: { fnr: string }) => {
               <Tag variant={'success'} size={'medium'}>
                 {formaterSakstype(sak!!.sakType)}
               </Tag>
-              <EkstraHandlinger>
+              <FlexRow justify={'right'}>
                 <OpprettKlage sakId={sak!!.id} />
                 <ManueltOpphoerModal sakId={sak!!.id} behandlingliste={behandlingerStatus.data[0].behandlinger} />
                 {kanBrukeGenerllBehandling && <OpprettGenerellBehandling sakId={sak!!.id} />}
-              </EkstraHandlinger>
+              </FlexRow>
             </Heading>
 
             <BodyShort spacing>Denne saken tilhører enhet {sak?.enhet}.</BodyShort>
@@ -87,12 +87,6 @@ const HendelseSidebar = styled.div`
   border-left: 1px solid gray;
   padding: 3em 2rem;
   margin: 0 1em;
-`
-
-const EkstraHandlinger = styled.div`
-  display: flex;
-  flex-direction: row-reverse;
-  gap: 0.5em;
 `
 
 export const HeadingWrapper = styled.div`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrevHandlingerPanel.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrevHandlingerPanel.tsx
@@ -1,10 +1,10 @@
 import { Alert, BodyLong, BodyShort, Button, Heading, Modal, Panel } from '@navikt/ds-react'
 import { BrevStatus, IBrev } from '~shared/types/Brev'
 import { isPending, useApiCall } from '~shared/hooks/useApiCall'
-import { ButtonWrapper } from '~shared/modal/modal'
 import { useState } from 'react'
 import { distribuerBrev, ferdigstillBrev, journalfoerBrev } from '~shared/api/brev'
 import Spinner from '~shared/Spinner'
+import { FlexRow } from '~shared/styled'
 
 interface Props {
   brev: IBrev
@@ -104,14 +104,14 @@ export default function NyttBrevHandlingerPanel({ brev, setKanRedigeres }: Props
                       angres.
                     </BodyLong>
 
-                    <ButtonWrapper>
-                      <Button variant="secondary" size="medium" className="button" onClick={() => setIsOpen(false)}>
+                    <FlexRow justify={'center'}>
+                      <Button variant="secondary" onClick={() => setIsOpen(false)}>
                         Nei, fortsett redigering
                       </Button>
-                      <Button variant="primary" size="medium" className="button" onClick={ferdigstill}>
+                      <Button variant="primary" className="button" onClick={ferdigstill}>
                         Ja, ferdigstill brev
                       </Button>
-                    </ButtonWrapper>
+                    </FlexRow>
                   </>
                 )}
               </Modal.Body>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/RedigerMottakerModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/RedigerMottakerModal.tsx
@@ -5,6 +5,7 @@ import { DocPencilIcon } from '@navikt/aksel-icons'
 import styled, { css } from 'styled-components'
 import { isFailure, isPending, useApiCall } from '~shared/hooks/useApiCall'
 import { oppdaterMottaker } from '~shared/api/brev'
+import { FlexRow } from '~shared/styled'
 
 enum MottakerType {
   PRIVATPERSON = 'PRIVATPERSON',
@@ -196,14 +197,14 @@ export default function RedigerMottakerModal({ brev, oppdater }: Props) {
 
           {isFailure(mottakerStatus) && <Alert variant={'error'}>Kunne ikke oppdatere mottaker...</Alert>}
 
-          <ButtonRow>
+          <FlexRow justify={'right'}>
             <Button variant={'secondary'} disabled={isPending(mottakerStatus)} onClick={avbryt}>
               Avbryt
             </Button>
             <Button variant={'primary'} loading={isPending(mottakerStatus)} onClick={lagre}>
               Lagre
             </Button>
-          </ButtonRow>
+          </FlexRow>
         </Modal.Body>
       </MottakerModal>
     </>
@@ -213,14 +214,6 @@ export default function RedigerMottakerModal({ brev, oppdater }: Props) {
 const MottakerModal = styled(Modal)`
   width: 40rem;
   padding: 3rem;
-`
-
-const ButtonRow = styled.div`
-  text-align: right;
-
-  & > button {
-    margin-left: 1rem;
-  }
 `
 
 const SkjemaGruppe = styled.div<{ inline?: boolean }>`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/dokumentModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/dokumentModal.tsx
@@ -1,15 +1,9 @@
 import { Button, Heading, Modal } from '@navikt/ds-react'
 import { useState } from 'react'
 import { hentDokumentPDF } from '~shared/api/dokument'
-import styled from 'styled-components'
 import Spinner from '~shared/Spinner'
 import { PdfVisning } from '~shared/brev/pdf-visning'
-
-const ButtonRow = styled.div`
-  background: white;
-  width: 100%;
-  text-align: right;
-`
+import { FlexRow } from '~shared/styled'
 
 export default function DokumentModal({
   tittel,
@@ -53,19 +47,21 @@ export default function DokumentModal({
       </Button>
 
       <Modal open={isOpen} onClose={() => setIsOpen(false)}>
-        <Modal.Body>
+        <Modal.Header>
           <Heading spacing level={'2'} size={'medium'}>
             {tittel}
           </Heading>
+        </Modal.Header>
 
+        <Modal.Body>
           <PdfVisning fileUrl={fileURL} error={error} />
           <Spinner visible={!hasLoaded} label="Laster inn PDF" />
 
-          <ButtonRow>
+          <FlexRow justify={'right'}>
             <Button variant={'secondary'} onClick={() => setIsOpen(false)}>
               Lukk
             </Button>
-          </ButtonRow>
+          </FlexRow>
         </Modal.Body>
       </Modal>
     </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/AvbrytBehandleJournalfoeringOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/AvbrytBehandleJournalfoeringOppgave.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router'
 import { useState } from 'react'
 import { BodyLong, Button, Heading, Modal } from '@navikt/ds-react'
-import { ButtonWrapper } from '~shared/modal/modal'
+import { FlexRow } from '~shared/styled'
 
 export default function AvbrytBehandleJournalfoeringOppgave() {
   const navigate = useNavigate()
@@ -9,7 +9,7 @@ export default function AvbrytBehandleJournalfoeringOppgave() {
 
   return (
     <>
-      <Button variant={'tertiary'} className="textButton" onClick={() => setIsOpen(true)}>
+      <Button variant={'tertiary'} onClick={() => setIsOpen(true)}>
         Avbryt
       </Button>
 
@@ -24,14 +24,14 @@ export default function AvbrytBehandleJournalfoeringOppgave() {
             Det du har gjort til nå vil bli slettet og du må starte oppgavebehandlingen på nytt.
           </BodyLong>
 
-          <ButtonWrapper>
-            <Button variant="secondary" size="medium" className="button" onClick={() => setIsOpen(false)}>
+          <FlexRow justify={'center'}>
+            <Button variant="secondary" onClick={() => setIsOpen(false)}>
               Nei, fortsett
             </Button>
-            <Button variant="danger" size="medium" className="button" onClick={() => navigate('/')}>
+            <Button variant="danger" onClick={() => navigate('/')}>
               Ja, avbryt
             </Button>
-          </ButtonWrapper>
+          </FlexRow>
         </Modal.Body>
       </Modal>
     </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/VelgJournalpost.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/VelgJournalpost.tsx
@@ -9,9 +9,9 @@ import { useAppDispatch } from '~store/Store'
 import { settJournalpost } from '~store/reducers/JournalfoeringOppgaveReducer'
 import Spinner from '~shared/Spinner'
 import styled from 'styled-components'
-import { ButtonWrapper } from '~components/behandling/attestering/styled'
 import DokumentModal from '../dokumenter/dokumentModal'
 import { Journalpost } from '~shared/types/Journalpost'
+import { FlexRow } from '~shared/styled'
 
 export default function VelgJournalpost() {
   const { bruker, journalpost } = useJournalfoeringOppgave()
@@ -102,17 +102,17 @@ export default function VelgJournalpost() {
                     <Table.DataCell>{journalpost.journalstatus}</Table.DataCell>
                     <Table.DataCell>{journalpost.journalposttype === 'I' ? 'Inngående' : 'Utgående'}</Table.DataCell>
                     <Table.DataCell>
-                      <ButtonWrapper>
+                      <FlexRow>
                         <DokumentModal
                           tittel={journalpost.tittel}
                           journalpostId={journalpost.journalpostId}
                           dokumentInfoId={journalpost.dokumenter[0].dokumentInfoId}
                         />
-                        &nbsp;
+
                         <Button variant={'primary'} size={'small'} onClick={() => velgJournalpost(journalpost)}>
                           Velg
                         </Button>
-                      </ButtonWrapper>
+                      </FlexRow>
                     </Table.DataCell>
                   </Table.Row>
                 ))}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/kontroll/KontrollerOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/kontroll/KontrollerOppgave.tsx
@@ -4,7 +4,6 @@ import { useJournalfoeringOppgave } from '~components/person/journalfoeringsoppg
 import { useAppDispatch } from '~store/Store'
 import { useNavigate, useParams } from 'react-router-dom'
 import { JaNei } from '~shared/types/ISvar'
-import { KnapperWrapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
 import AvbrytBehandleJournalfoeringOppgave from '~components/person/journalfoeringsoppgave/AvbrytBehandleJournalfoeringOppgave'
 import { formaterFnr, formaterSakstype, formaterStringDato } from '~utils/formattering'
 import { settBehandlingBehov, settBruker, settOppgave, settSamsvar } from '~store/reducers/JournalfoeringOppgaveReducer'
@@ -17,6 +16,7 @@ import { InfoWrapper } from '~components/behandling/soeknadsoversikt/styled'
 import { Info } from '~components/behandling/soeknadsoversikt/Info'
 import { hentSakForPerson } from '~shared/api/behandling'
 import { FormWrapper } from '~components/person/journalfoeringsoppgave/BehandleJournalfoeringOppgave'
+import { FlexRow } from '~shared/styled'
 
 export default function KontrollerOppgave() {
   const { bruker, oppgave, samsvar, journalpost, behandlingBehov } = useJournalfoeringOppgave()
@@ -154,14 +154,16 @@ export default function KontrollerOppgave() {
         </>
       )}
 
-      <KnapperWrapper>
-        <div>
-          <Button variant="primary" className="button" onClick={neste} disabled={!kanGaaVidere}>
+      <div>
+        <FlexRow justify={'center'} $spacing>
+          <Button variant="primary" onClick={neste} disabled={!kanGaaVidere}>
             Neste
           </Button>
-        </div>
-        <AvbrytBehandleJournalfoeringOppgave />
-      </KnapperWrapper>
+        </FlexRow>
+        <FlexRow justify={'center'}>
+          <AvbrytBehandleJournalfoeringOppgave />
+        </FlexRow>
+      </div>
     </FormWrapper>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/nybehandling/OpprettNyBehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/nybehandling/OpprettNyBehandling.tsx
@@ -5,11 +5,11 @@ import PersongalleriOmstillingsstoenad from '~components/person/journalfoeringso
 import { formaterSakstype } from '~utils/formattering'
 import { Button, Heading, Tag } from '@navikt/ds-react'
 import AvbrytBehandleJournalfoeringOppgave from '~components/person/journalfoeringsoppgave/AvbrytBehandleJournalfoeringOppgave'
-import { KnapperWrapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
 import { Navigate, useNavigate } from 'react-router-dom'
 import { FormWrapper } from '~components/person/journalfoeringsoppgave/BehandleJournalfoeringOppgave'
 import styled from 'styled-components'
 import { gyldigPersongalleri } from '~components/person/journalfoeringsoppgave/nybehandling/validator'
+import { FlexRow } from '~shared/styled'
 
 export default function OpprettNyBehandling() {
   const { oppgave, behandlingBehov } = useJournalfoeringOppgave()
@@ -36,23 +36,24 @@ export default function OpprettNyBehandling() {
       {sakType === SakType.OMSTILLINGSSTOENAD && <PersongalleriOmstillingsstoenad />}
       {sakType === SakType.BARNEPENSJON && <PersongalleriBarnepensjon />}
 
-      <KnapperWrapper>
-        <div>
-          <Button variant="secondary" className="button" onClick={tilbake}>
+      <div>
+        <FlexRow justify={'center'} $spacing>
+          <Button variant="secondary" onClick={tilbake}>
             Tilbake
           </Button>
 
           <Button
             variant="primary"
             onClick={neste}
-            className="button"
             disabled={!gyldigPersongalleri(sakType, behandlingBehov?.persongalleri)}
           >
             Neste
           </Button>
-        </div>
-        <AvbrytBehandleJournalfoeringOppgave />
-      </KnapperWrapper>
+        </FlexRow>
+        <FlexRow justify={'center'}>
+          <AvbrytBehandleJournalfoeringOppgave />
+        </FlexRow>
+      </div>
     </FormWrapper>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/oppsummering/FullfoerOppgaveModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/oppsummering/FullfoerOppgaveModal.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react'
 import { Alert, BodyLong, BodyShort, Button, Heading, Modal } from '@navikt/ds-react'
 import { SaktypeTag } from '~components/nyoppgavebenk/Tags'
-import { ButtonWrapper } from '~shared/modal/modal'
 import { OppgaveDTOny } from '~shared/api/oppgaverny'
 import { isPending, isSuccess, useApiCall } from '~shared/hooks/useApiCall'
 import { opprettBehandling } from '~shared/api/behandling'
 import { NyBehandlingRequest } from '~shared/types/IDetaljertBehandling'
 import { useNavigate } from 'react-router-dom'
+import { FlexRow } from '~shared/styled'
 
 interface ModalProps {
   oppgave: OppgaveDTOny
@@ -35,7 +35,7 @@ export default function FullfoerOppgaveModal({ oppgave, behandlingBehov }: Modal
 
   return (
     <>
-      <Button variant="primary" onClick={() => setOpen(true)} className="button">
+      <Button variant="primary" onClick={() => setOpen(true)}>
         Ferdigstill
       </Button>
 
@@ -59,21 +59,14 @@ export default function FullfoerOppgaveModal({ oppgave, behandlingBehov }: Modal
               for denne brukeren.
             </Alert>
           ) : (
-            <ButtonWrapper>
+            <FlexRow justify={'center'}>
               <Button variant="secondary" onClick={() => setOpen(false)} disabled={isPending(status)}>
                 Avbryt
               </Button>
-              <Button
-                variant="primary"
-                size="medium"
-                className="button"
-                onClick={ferdigstill}
-                loading={isPending(status)}
-                disabled={isPending(status)}
-              >
+              <Button variant="primary" onClick={ferdigstill} loading={isPending(status)} disabled={isPending(status)}>
                 Ferdigstill
               </Button>
-            </ButtonWrapper>
+            </FlexRow>
           )}
         </Modal.Body>
       </Modal>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/oppsummering/OppsummeringOppgavebehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/oppsummering/OppsummeringOppgavebehandling.tsx
@@ -1,7 +1,6 @@
 import { Button, Detail, Heading, Tag } from '@navikt/ds-react'
 import { useJournalfoeringOppgave } from '~components/person/journalfoeringsoppgave/useJournalfoeringOppgave'
 import AvbrytBehandleJournalfoeringOppgave from '~components/person/journalfoeringsoppgave/AvbrytBehandleJournalfoeringOppgave'
-import { KnapperWrapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
 import { Navigate, useNavigate } from 'react-router-dom'
 import { Info } from '~components/behandling/soeknadsoversikt/Info'
 import { SakType } from '~shared/types/sak'
@@ -9,6 +8,7 @@ import { formaterSakstype } from '~utils/formattering'
 import { InfoList } from '~components/behandling/soeknadsoversikt/styled'
 import { FormWrapper } from '~components/person/journalfoeringsoppgave/BehandleJournalfoeringOppgave'
 import FullfoerOppgaveModal from '~components/person/journalfoeringsoppgave/oppsummering/FullfoerOppgaveModal'
+import { FlexRow } from '~shared/styled'
 
 export default function OppsummeringOppgavebehandling() {
   const { behandlingBehov, oppgave } = useJournalfoeringOppgave()
@@ -56,16 +56,18 @@ export default function OppsummeringOppgavebehandling() {
         )}
       </InfoList>
 
-      <KnapperWrapper>
-        <div>
-          <Button variant="secondary" size="medium" className="button" onClick={tilbake}>
+      <div>
+        <FlexRow justify={'center'} $spacing>
+          <Button variant="secondary" onClick={tilbake}>
             Tilbake
           </Button>
 
           <FullfoerOppgaveModal oppgave={oppgave!!} behandlingBehov={behandlingBehov!!} />
-        </div>
-        <AvbrytBehandleJournalfoeringOppgave />
-      </KnapperWrapper>
+        </FlexRow>
+        <FlexRow justify={'center'}>
+          <AvbrytBehandleJournalfoeringOppgave />
+        </FlexRow>
+      </div>
     </FormWrapper>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/modal/modal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/modal/modal.tsx
@@ -1,5 +1,5 @@
 import { BodyShort, Button, Heading, Modal } from '@navikt/ds-react'
-import styled from 'styled-components'
+import { FlexRow } from '~shared/styled'
 
 export type Props = {
   tittel: string
@@ -36,36 +36,21 @@ export const GeneriskModal = ({
           {tittel}
         </Heading>
         {beskrivelse && <BodyShort spacing>{beskrivelse}</BodyShort>}
-        <ButtonWrapper>
-          <Button
-            variant="primary"
-            size="medium"
-            className="button"
-            onClick={onYesClick}
-            disabled={!!loading}
-            loading={!!loading}
-          >
+        <FlexRow justify={'center'}>
+          <Button variant="primary" onClick={onYesClick} loading={!!loading}>
             {tekstKnappJa}
           </Button>
           <Button
             variant="secondary"
-            size="medium"
-            className="button"
             onClick={() => {
               setModalisOpen(false)
             }}
-            disabled={!!loading}
+            loading={!!loading}
           >
             {tekstKnappNei}
           </Button>
-        </ButtonWrapper>
+        </FlexRow>
       </Modal.Body>
     </Modal>
   )
 }
-
-export const ButtonWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  gap: 1em;
-`

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/styled.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/styled.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 export const Container = styled.div`
   padding: 2rem;
@@ -64,6 +64,16 @@ export const ContentHeader = styled.div`
   padding: 1em 4em;
 `
 
-export const Header = styled.div`
-  padding: 1em 2em;
+export const FlexRow = styled.div<{
+  justify?: 'left' | 'center' | 'right'
+  $spacing?: boolean
+}>`
+  display: flex;
+  justify-content: ${(props) => props.justify ?? 'left'};
+  gap: 1rem;
+  ${(props) =>
+    props.$spacing &&
+    css`
+      margin-bottom: 1rem;
+    `}
 `


### PR DESCRIPTION
Opprydding i bruk av `Button`, `ButtonWrapper` og borders.

- Byttet ut `ButtonWrapper` med ny `FlexRow` som er vesentlig mer fleksibel (no pun intended) og kan brukes til mer enn bare knapper. 
- Fjernet unødvendig bruk av ~`type="button"` og~ `size="medium"` siden begge disse er default på `<Button>`
- Bruke `<Border>` i stedet for vilkarborder, samt korrigerte farge for å matche alle de andre borders i appen.
- ...med mer...

Har forsøkt å se over så mye som mulig av appen og verifisere at ingenting "brekker" stilmessig, men siden det er vanskelig å gå over 100% av appen, er det er en viss fare for at man må korrigere et par småting fortløpende. 