### PR TITLE
Setter ikke behandlingsstatus trygdetid ved opphoer

### DIFF
--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -5,6 +5,7 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
+import no.nav.etterlatte.libs.common.behandling.girOpphoer
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsdata
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning.RegelKilde
@@ -241,7 +242,9 @@ class TrygdetidService(
     ): Trygdetid {
         val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
         return kopierSisteTrygdetidberegning(behandling, forrigeBehandlingId, brukerTokenInfo).also {
-            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, brukerTokenInfo)
+            if (!behandling.revurderingsaarsak.girOpphoer()) {
+                behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, brukerTokenInfo)
+            }
         }
     }
 

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -5,7 +5,6 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
-import no.nav.etterlatte.libs.common.behandling.girOpphoer
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsdata
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning.RegelKilde

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -241,11 +241,7 @@ class TrygdetidService(
         brukerTokenInfo: BrukerTokenInfo,
     ): Trygdetid {
         val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
-        return kopierSisteTrygdetidberegning(behandling, forrigeBehandlingId, brukerTokenInfo).also {
-            if (!behandling.revurderingsaarsak.girOpphoer()) {
-                behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, brukerTokenInfo)
-            }
-        }
+        return kopierSisteTrygdetidberegning(behandling, forrigeBehandlingId, brukerTokenInfo)
     }
 
     private suspend fun kopierSisteTrygdetidberegning(

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
@@ -655,6 +655,7 @@ internal class TrygdetidServiceTest {
             mockk<DetaljertBehandling>().apply {
                 every { id } returns behandlingId
                 every { sak } returns sakId
+                every { revurderingsaarsak } returns RevurderingAarsak.ANNEN
             }
 
         val vilkaarsvurderingDto = mockk<VilkaarsvurderingDto>()
@@ -680,6 +681,7 @@ internal class TrygdetidServiceTest {
         verify {
             regulering.id
             regulering.sak
+            regulering.revurderingsaarsak
             vilkaarsvurderingDto.isYrkesskade()
         }
     }

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
@@ -655,7 +655,6 @@ internal class TrygdetidServiceTest {
             mockk<DetaljertBehandling>().apply {
                 every { id } returns behandlingId
                 every { sak } returns sakId
-                every { revurderingsaarsak } returns RevurderingAarsak.ANNEN
             }
 
         val vilkaarsvurderingDto = mockk<VilkaarsvurderingDto>()
@@ -663,7 +662,6 @@ internal class TrygdetidServiceTest {
         every { vilkaarsvurderingDto.isYrkesskade() } returns false
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns vilkaarsvurderingDto
         coEvery { behandlingKlient.hentBehandling(behandlingId, saksbehandler) } returns regulering
-        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
         every { repository.hentTrygdetid(forrigeBehandlingId) } returns forrigeTrygdetid
         every { repository.opprettTrygdetid(any()) } answers { firstArg() }
 
@@ -675,13 +673,11 @@ internal class TrygdetidServiceTest {
             repository.hentTrygdetid(forrigeBehandlingId)
             behandlingKlient.hentBehandling(behandlingId, saksbehandler)
             repository.opprettTrygdetid(match { it.behandlingId == behandlingId })
-            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
             vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any())
         }
         verify {
             regulering.id
             regulering.sak
-            regulering.revurderingsaarsak
             vilkaarsvurderingDto.isYrkesskade()
         }
     }


### PR DESCRIPTION
Ved kopiering av trygdetid når det er opphør, så skal ikke status settes til TRYGDETID_OPPDATERT