### PR TITLE
Endrer referansen vi oppdaterer til å være på klageID

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageDao.kt
@@ -23,7 +23,7 @@ interface KlageDao {
     fun hentKlagerISak(sakId: Long): List<Klage>
 
     fun oppdaterKabalStatus(
-        sakId: Long,
+        klageId: UUID,
         kabalrespons: Kabalrespons,
     )
 }
@@ -90,7 +90,7 @@ class KlageDaoImpl(private val connection: () -> Connection) : KlageDao {
     }
 
     override fun oppdaterKabalStatus(
-        sakId: Long,
+        klageId: UUID,
         kabalrespons: Kabalrespons,
     ) {
         with(connection()) {
@@ -99,12 +99,12 @@ class KlageDaoImpl(private val connection: () -> Connection) : KlageDao {
                     """
                     UPDATE klage
                     SET kabalstatus = ?, kabalresultat = ?
-                    WHERE sak_id = ?
+                    WHERE id = ?
                     """.trimIndent(),
                 )
             statement.setString(1, kabalrespons.kabalStatus.name)
             statement.setString(2, kabalrespons.resultat.name)
-            statement.setObject(3, sakId)
+            statement.setObject(3, klageId)
             statement.executeUpdate()
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageRoutes.kt
@@ -21,6 +21,7 @@ import no.nav.etterlatte.libs.common.behandling.Kabalrespons
 import no.nav.etterlatte.libs.common.behandling.KlageUtfallUtenBrev
 import no.nav.etterlatte.libs.common.klageId
 import no.nav.etterlatte.libs.common.kunSaksbehandler
+import no.nav.etterlatte.libs.common.kunSystembruker
 import no.nav.etterlatte.libs.common.medBody
 import no.nav.etterlatte.libs.common.sakId
 
@@ -99,6 +100,19 @@ internal fun Route.klageRoutes(
                     }
                 }
             }
+
+            patch("kabalstatus") {
+                hvisEnabled(KlageFeatureToggle.KanBrukeKlageToggle) {
+                    kunSystembruker {
+                        medBody<Kabalrespons> {
+                            inTransaction {
+                                klageService.oppdaterKabalStatus(klageId, it)
+                            }
+                            call.respond(HttpStatusCode.OK)
+                        }
+                    }
+                }
+            }
         }
 
         get("sak/{$SAKID_CALL_PARAMETER}") {
@@ -108,17 +122,6 @@ internal fun Route.klageRoutes(
                         klageService.hentKlagerISak(sakId)
                     }
                 call.respond(klager)
-            }
-        }
-
-        patch("{$KLAGEID_CALL_PARAMETER}/kabalstatus") {
-            hvisEnabled(KlageFeatureToggle.KanBrukeKlageToggle) {
-                medBody<Kabalrespons> {
-                    inTransaction {
-                        klageService.oppdaterKabalStatus(sakId, it)
-                    }
-                    call.respond(HttpStatusCode.OK)
-                }
             }
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageService.kt
@@ -43,7 +43,7 @@ interface KlageService {
     ): Klage
 
     fun oppdaterKabalStatus(
-        sakId: Long,
+        klageId: UUID,
         kabalrespons: Kabalrespons,
     )
 }
@@ -177,7 +177,7 @@ class KlageServiceImpl(
     }
 
     override fun oppdaterKabalStatus(
-        sakId: Long,
+        klageId: UUID,
         kabalrespons: Kabalrespons,
-    ) = klageDao.oppdaterKabalStatus(sakId, kabalrespons)
+    ) = klageDao.oppdaterKabalStatus(klageId, kabalrespons)
 }

--- a/apps/etterlatte-klage/src/main/kotlin/no/nav/etterlatte/klage/BehandlingKlient.kt
+++ b/apps/etterlatte-klage/src/main/kotlin/no/nav/etterlatte/klage/BehandlingKlient.kt
@@ -48,6 +48,8 @@ class BehandlingKlient(val behandlingHttpClient: HttpClient, val resourceUrl: St
                             requireNotNull(klageHendelse.detaljer.klagebehandlingAvsluttet).utfall.tilResultat(),
                         )
 
+                    // TODO: Se på hvordan vi håndterer anke -- det burde nok sette et eget flagg
+                    //  og ikke overstyre første status
                     BehandlingEventType.ANKEBEHANDLING_OPPRETTET ->
                         Kabalrespons(
                             KabalStatus.OPPRETTET,
@@ -77,7 +79,7 @@ class BehandlingKlient(val behandlingHttpClient: HttpClient, val resourceUrl: St
                 }
 
             behandlingHttpClient.patch(
-                "$resourceUrl/klage/${klageHendelse.kildeReferanse}/kabalstatus",
+                "$resourceUrl/api/klage/${klageHendelse.kildeReferanse}/kabalstatus",
             ) {
                 contentType(ContentType.Application.Json)
                 setBody(body)


### PR DESCRIPTION
Legger også inn /api/ i request-url'en, og samler endepunktene. Setter også oppdatering av kabalstatus bak sjekk på at det kun er systembrukere som kan oppdatere