### PR TITLE
Eigen modell og eiga route for når statistikk skal hente ut data frå behandling

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -22,6 +22,7 @@ import no.nav.etterlatte.behandling.klage.klageRoutes
 import no.nav.etterlatte.behandling.omregning.migreringRoutes
 import no.nav.etterlatte.behandling.omregning.omregningRoutes
 import no.nav.etterlatte.behandling.revurdering.revurderingRoutes
+import no.nav.etterlatte.behandling.statistikk.statistikkRoutes
 import no.nav.etterlatte.behandling.tilbakekreving.tilbakekrevingRoutes
 import no.nav.etterlatte.behandling.tilgang.tilgangRoutes
 import no.nav.etterlatte.common.DatabaseContext
@@ -119,6 +120,7 @@ fun Application.module(context: ApplicationContext) {
                 oppgaveService = oppgaveService,
                 behandlingService = behandlingService,
             )
+            statistikkRoutes(statistikkService)
             oppgaveRoutes(
                 service = oppgaveService,
                 gosysOppgaveService = gosysOppgaveService,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingHenter.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingHenter.kt
@@ -1,0 +1,37 @@
+package no.nav.etterlatte.behandling
+
+import no.nav.etterlatte.Kontekst
+import no.nav.etterlatte.behandling.domain.Behandling
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
+import no.nav.etterlatte.inTransaction
+import java.util.UUID
+
+class BehandlingHenter(
+    private val behandlingDao: BehandlingDao,
+    private val featureToggleService: FeatureToggleService,
+) {
+    fun hentBehandling(behandlingId: UUID): Behandling? {
+        return inTransaction {
+            hentBehandlingForId(behandlingId)
+        }
+    }
+
+    internal fun hentBehandlingForId(id: UUID) =
+        behandlingDao.hentBehandling(id)?.let { behandling ->
+            listOf(behandling).filterForEnheter().firstOrNull()
+        }
+
+    fun hentBehandlingerISak(sakId: Long): List<Behandling> {
+        return inTransaction {
+            hentBehandlingerForSakId(sakId)
+        }
+    }
+
+    internal fun hentBehandlingerForSakId(sakId: Long) = behandlingDao.alleBehandlingerISak(sakId).filterForEnheter()
+
+    private fun List<Behandling>.filterForEnheter() =
+        this.filterBehandlingerForEnheter(
+            featureToggleService = featureToggleService,
+            user = Kontekst.get().AppUser,
+        )
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
@@ -179,21 +179,13 @@ internal fun Behandling.toDetaljertBehandling(persongalleri: Persongalleri): Det
         id = id,
         sak = sak.id,
         sakType = sak.sakType,
-        behandlingOpprettet = behandlingOpprettet,
-        soeknadMottattDato = mottattDato(),
-        innsender = persongalleri.innsender,
         soeker = persongalleri.soeker,
-        gjenlevende = persongalleri.gjenlevende,
-        avdoed = persongalleri.avdoed,
-        soesken = persongalleri.soesken,
-        status = status,
         behandlingType = type,
         virkningstidspunkt = virkningstidspunkt,
         boddEllerArbeidetUtlandet = boddEllerArbeidetUtlandet,
         revurderingsaarsak = revurderingsaarsak(),
         prosesstype = prosesstype,
         revurderingInfo = revurderingInfo()?.revurderingInfo,
-        enhet = sak.enhet,
     )
 }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/statistikk/StatistikkRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/statistikk/StatistikkRoutes.kt
@@ -1,0 +1,30 @@
+package no.nav.etterlatte.behandling.statistikk
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.application.log
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.application
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.behandling.BehandlingForStatistikk
+import no.nav.etterlatte.libs.common.behandlingsId
+import no.nav.etterlatte.libs.ktor.brukerTokenInfo
+
+internal fun Route.statistikkRoutes(statistikkService: StatistikkService) {
+    val logger = application.log
+
+    route("/behandlinger/statistikk") {
+        route("/{$BEHANDLINGSID_CALL_PARAMETER}") {
+            get {
+                logger.info("Henter detaljert behandling for behandling med id=$behandlingsId")
+                when (val behandling = statistikkService.hentDetaljertBehandling(behandlingsId, brukerTokenInfo)) {
+                    is BehandlingForStatistikk -> call.respond(behandling)
+                    else -> call.respond(HttpStatusCode.NotFound, "Fant ikke behandling med id=$behandlingsId")
+                }
+            }
+        }
+    }
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/statistikk/StatistikkService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/statistikk/StatistikkService.kt
@@ -29,7 +29,6 @@ internal class StatistikkService(
 private fun Behandling.toBehandlingForStatistikk(persongalleri: Persongalleri) =
     BehandlingForStatistikk(
         id = id,
-        sak = sak.id,
         sakType = sak.sakType,
         behandlingOpprettet = behandlingOpprettet,
         soeknadMottattDato = mottattDato(),
@@ -39,11 +38,7 @@ private fun Behandling.toBehandlingForStatistikk(persongalleri: Persongalleri) =
         avdoed = persongalleri.avdoed,
         soesken = persongalleri.soesken,
         status = status,
-        behandlingType = type,
-        virkningstidspunkt = virkningstidspunkt,
-        boddEllerArbeidetUtlandet = boddEllerArbeidetUtlandet,
         revurderingsaarsak = revurderingsaarsak(),
         prosesstype = prosesstype,
-        revurderingInfo = revurderingInfo()?.revurderingInfo,
         enhet = sak.enhet,
     )

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/statistikk/StatistikkService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/statistikk/StatistikkService.kt
@@ -1,0 +1,49 @@
+package no.nav.etterlatte.behandling.statistikk
+
+import no.nav.etterlatte.behandling.BehandlingHenter
+import no.nav.etterlatte.behandling.domain.Behandling
+import no.nav.etterlatte.behandling.klienter.GrunnlagKlient
+import no.nav.etterlatte.libs.common.behandling.BehandlingForStatistikk
+import no.nav.etterlatte.libs.common.behandling.Persongalleri
+import no.nav.etterlatte.token.BrukerTokenInfo
+import java.util.UUID
+
+internal class StatistikkService(
+    private val grunnlagKlient: GrunnlagKlient,
+    private val behandlingHenter: BehandlingHenter,
+) {
+    suspend fun hentDetaljertBehandling(
+        behandlingsId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): BehandlingForStatistikk? =
+        behandlingHenter.hentBehandling(behandlingsId)?.let {
+            val persongalleri: Persongalleri =
+                grunnlagKlient.hentPersongalleri(it.sak.id, brukerTokenInfo)
+                    ?.opplysning
+                    ?: throw NoSuchElementException("Persongalleri mangler for sak ${it.sak.id}")
+
+            it.toBehandlingForStatistikk(persongalleri)
+        }
+}
+
+private fun Behandling.toBehandlingForStatistikk(persongalleri: Persongalleri) =
+    BehandlingForStatistikk(
+        id = id,
+        sak = sak.id,
+        sakType = sak.sakType,
+        behandlingOpprettet = behandlingOpprettet,
+        soeknadMottattDato = mottattDato(),
+        innsender = persongalleri.innsender,
+        soeker = persongalleri.soeker,
+        gjenlevende = persongalleri.gjenlevende,
+        avdoed = persongalleri.avdoed,
+        soesken = persongalleri.soesken,
+        status = status,
+        behandlingType = type,
+        virkningstidspunkt = virkningstidspunkt,
+        boddEllerArbeidetUtlandet = boddEllerArbeidetUtlandet,
+        revurderingsaarsak = revurderingsaarsak(),
+        prosesstype = prosesstype,
+        revurderingInfo = revurderingInfo()?.revurderingInfo,
+        enhet = sak.enhet,
+    )

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -5,6 +5,7 @@ import com.typesafe.config.ConfigFactory
 import io.ktor.client.HttpClient
 import no.nav.etterlatte.behandling.BehandlingDao
 import no.nav.etterlatte.behandling.BehandlingFactory
+import no.nav.etterlatte.behandling.BehandlingHenter
 import no.nav.etterlatte.behandling.BehandlingServiceImpl
 import no.nav.etterlatte.behandling.BehandlingStatusServiceImpl
 import no.nav.etterlatte.behandling.BehandlingsHendelserKafkaProducerImpl
@@ -171,7 +172,8 @@ class ApplicationContext(
     val generellBehandlingService = GenerellBehandlingService(generellbehandlingDao)
     val oppgaveService = OppgaveService(oppgaveDaoEndringer, sakDao, featureToggleService)
     val gosysOppgaveService = GosysOppgaveServiceImpl(gosysOppgaveKlient, pdlKlient, featureToggleService)
-    val behandlingService =
+    internal val behandlingHenter = BehandlingHenter(behandlingDao, featureToggleService)
+    internal val behandlingService =
         BehandlingServiceImpl(
             behandlingDao = behandlingDao,
             behandlingHendelser = behandlingsHendelser,
@@ -179,9 +181,9 @@ class ApplicationContext(
             grunnlagsendringshendelseDao = grunnlagsendringshendelseDao,
             grunnlagKlient = grunnlagKlientObo,
             sporingslogg = sporingslogg,
-            featureToggleService = featureToggleService,
             kommerBarnetTilGodeDao = kommerBarnetTilGodeDao,
             oppgaveService = oppgaveService,
+            behandlingHenter = behandlingHenter,
         )
 
     val kommerBarnetTilGodeService =

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -34,6 +34,7 @@ import no.nav.etterlatte.behandling.omregning.MigreringService
 import no.nav.etterlatte.behandling.omregning.OmregningService
 import no.nav.etterlatte.behandling.revurdering.RevurderingDao
 import no.nav.etterlatte.behandling.revurdering.RevurderingServiceImpl
+import no.nav.etterlatte.behandling.statistikk.StatistikkService
 import no.nav.etterlatte.behandling.tilbakekreving.TilbakekrevingDao
 import no.nav.etterlatte.behandling.tilbakekreving.TilbakekrevingService
 import no.nav.etterlatte.common.klienter.PdlKlientImpl
@@ -183,6 +184,11 @@ class ApplicationContext(
             sporingslogg = sporingslogg,
             kommerBarnetTilGodeDao = kommerBarnetTilGodeDao,
             oppgaveService = oppgaveService,
+            behandlingHenter = behandlingHenter,
+        )
+    internal val statistikkService =
+        StatistikkService(
+            grunnlagKlient = grunnlagKlientObo,
             behandlingHenter = behandlingHenter,
         )
 

--- a/apps/etterlatte-behandling/src/test/kotlin/VerdikjedeTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/VerdikjedeTest.kt
@@ -182,7 +182,6 @@ class VerdikjedeTest : BehandlingIntegrationTest() {
                 assertEquals(HttpStatusCode.OK, it.status)
                 val behandling: DetaljertBehandling = it.body()
                 assertNotNull(behandling.id)
-                assertEquals("innsender", behandling.innsender)
             }
 
             client.post("/api/behandling/$behandlingId/virkningstidspunkt") {
@@ -368,7 +367,6 @@ class VerdikjedeTest : BehandlingIntegrationTest() {
                 val behandling = it.body<DetaljertBehandling>()
 
                 assertEquals(HttpStatusCode.OK, it.status)
-                assertEquals(BehandlingStatus.IVERKSATT, behandling.status)
             }
 
             client.post("/grunnlagsendringshendelse/doedshendelse") {

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
@@ -97,9 +97,9 @@ class BehandlingServiceImplTest {
                 hendelseDao = hendelserMock,
                 grunnlagKlient = mockk(),
                 sporingslogg = mockk(),
-                featureToggleService = featureToggleService,
                 kommerBarnetTilGodeDao = mockk(),
                 oppgaveService = mockk(),
+                behandlingHenter = BehandlingHenter(behandlingDaoMock, featureToggleService),
             )
 
         val behandlinger = sut.hentBehandlingerISak(1)
@@ -578,9 +578,9 @@ class BehandlingServiceImplTest {
                 hendelseDao = hendelserMock,
                 grunnlagKlient = mockk(),
                 sporingslogg = mockk(),
-                featureToggleService = featureToggleService,
                 kommerBarnetTilGodeDao = mockk(),
                 oppgaveService = mockk(),
+                behandlingHenter = BehandlingHenter(behandlingDaoMock, featureToggleService),
             )
 
         val behandlinger = sut.hentBehandlingerISak(1)
@@ -625,9 +625,9 @@ class BehandlingServiceImplTest {
                 hendelseDao = hendelserMock,
                 grunnlagKlient = mockk(),
                 sporingslogg = mockk(),
-                featureToggleService = featureToggleService,
                 kommerBarnetTilGodeDao = mockk(),
                 oppgaveService = mockk(),
+                behandlingHenter = BehandlingHenter(behandlingDaoMock, featureToggleService),
             )
 
         val behandlinger = sut.hentBehandlingerISak(1)
@@ -670,9 +670,9 @@ class BehandlingServiceImplTest {
                 hendelseDao = mockk(),
                 grunnlagKlient = mockk(),
                 sporingslogg = mockk(),
-                featureToggleService = featureToggleService,
                 kommerBarnetTilGodeDao = mockk(),
                 oppgaveService = mockk(),
+                behandlingHenter = BehandlingHenter(behandlingDaoMock, featureToggleService),
             )
 
         sut.oppdaterUtenlandstilsnitt(
@@ -724,9 +724,9 @@ class BehandlingServiceImplTest {
                 mockk(),
                 mockk(),
                 mockk(),
-                featureToggleService,
                 kommerBarnetTilGodeDao = mockk(),
                 oppgaveService = mockk(),
+                behandlingHenter = BehandlingHenter(behandlingDaoMock, featureToggleService),
             )
 
         sut.oppdaterBoddEllerArbeidetUtlandet(
@@ -792,9 +792,9 @@ class BehandlingServiceImplTest {
             hendelseDao = hendelseDao ?: mockk(),
             grunnlagKlient = grunnlagKlient ?: mockk(),
             sporingslogg = mockk(),
-            featureToggleService = featureToggleService,
             kommerBarnetTilGodeDao = mockk(),
             oppgaveService = oppgaveService,
+            behandlingHenter = BehandlingHenter(behandlingDao ?: mockk(), featureToggleService),
         )
 
     companion object {

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -15,7 +15,6 @@ import no.nav.etterlatte.avkorting.regler.InntektAvkortingGrunnlagWrapper
 import no.nav.etterlatte.beregning.Beregning
 import no.nav.etterlatte.beregning.grunnlag.InstitusjonsoppholdBeregningsgrunnlag
 import no.nav.etterlatte.beregning.regler.barnepensjon.BarnepensjonGrunnlag
-import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
@@ -38,7 +37,6 @@ import no.nav.etterlatte.regler.Beregningstall
 import no.nav.etterlatte.token.Saksbehandler
 import java.math.RoundingMode
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.YearMonth
 import java.util.UUID
 
@@ -261,19 +259,11 @@ fun behandling(
     id = id,
     sak = sak,
     sakType = sakType,
-    behandlingOpprettet = LocalDateTime.now(),
-    soeknadMottattDato = null,
-    innsender = null,
     soeker = "12312312321",
-    gjenlevende = listOf(),
-    avdoed = listOf(),
-    soesken = listOf(),
-    status = BehandlingStatus.TRYGDETID_OPPDATERT,
     behandlingType = behandlingType,
     virkningstidspunkt = virkningstidspunkt,
     revurderingsaarsak = null,
     prosesstype = Prosesstype.MANUELL,
     boddEllerArbeidetUtlandet = null,
     revurderingInfo = null,
-    enhet = "1111",
 )

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
@@ -20,7 +20,6 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.etterlatte.klienter.BehandlingKlient
-import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
@@ -38,7 +37,6 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import testsupport.buildTestApplicationConfigurationForOauth
-import java.time.LocalDateTime
 import java.time.Month
 import java.time.YearMonth
 import java.util.UUID.randomUUID
@@ -72,21 +70,13 @@ internal class BeregningsGrunnlagRoutesTest {
                 id = randomUUID(),
                 sak = 123,
                 sakType = SakType.BARNEPENSJON,
-                behandlingOpprettet = LocalDateTime.now(),
-                soeknadMottattDato = null,
-                innsender = null,
                 soeker = "diam",
-                gjenlevende = listOf(),
-                avdoed = listOf(),
-                soesken = listOf(),
-                status = BehandlingStatus.TRYGDETID_OPPDATERT,
                 behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
                 virkningstidspunkt = null,
                 revurderingsaarsak = null,
                 prosesstype = Prosesstype.MANUELL,
                 boddEllerArbeidetUtlandet = null,
                 revurderingInfo = null,
-                enhet = "1111",
             )
 
         every { repository.finnBarnepensjonGrunnlagForBehandling(any()) } returns null
@@ -126,21 +116,13 @@ internal class BeregningsGrunnlagRoutesTest {
                 id = randomUUID(),
                 sak = sakId,
                 sakType = SakType.BARNEPENSJON,
-                behandlingOpprettet = LocalDateTime.now(),
-                soeknadMottattDato = null,
-                innsender = null,
                 soeker = "",
-                gjenlevende = listOf(),
-                avdoed = listOf(),
-                soesken = listOf(),
-                status = BehandlingStatus.TRYGDETID_OPPDATERT,
                 behandlingType = BehandlingType.REVURDERING,
                 virkningstidspunkt = virkRevurdering,
                 revurderingsaarsak = null,
                 prosesstype = Prosesstype.MANUELL,
                 boddEllerArbeidetUtlandet = null,
                 revurderingInfo = null,
-                enhet = "1111",
             )
         coEvery {
             behandlingKlient.hentSisteIverksatteBehandling(sakId, any())
@@ -266,14 +248,7 @@ internal class BeregningsGrunnlagRoutesTest {
                 id = randomUUID(),
                 sak = 123,
                 sakType = SakType.BARNEPENSJON,
-                behandlingOpprettet = LocalDateTime.now(),
-                soeknadMottattDato = null,
-                innsender = null,
                 soeker = "diam",
-                gjenlevende = listOf(),
-                avdoed = listOf(),
-                soesken = listOf(),
-                status = BehandlingStatus.TRYGDETID_OPPDATERT,
                 behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
                 virkningstidspunkt =
                     Virkningstidspunkt(
@@ -289,7 +264,6 @@ internal class BeregningsGrunnlagRoutesTest {
                 prosesstype = Prosesstype.MANUELL,
                 boddEllerArbeidetUtlandet = null,
                 revurderingInfo = null,
-                enhet = "1111",
             )
 
         testApplication {
@@ -329,14 +303,7 @@ internal class BeregningsGrunnlagRoutesTest {
                 id = randomUUID(),
                 sak = 123,
                 sakType = SakType.BARNEPENSJON,
-                behandlingOpprettet = LocalDateTime.now(),
-                soeknadMottattDato = null,
-                innsender = null,
                 soeker = "diam",
-                gjenlevende = listOf(),
-                avdoed = listOf(),
-                soesken = listOf(),
-                status = BehandlingStatus.TRYGDETID_OPPDATERT,
                 behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
                 virkningstidspunkt =
                     Virkningstidspunkt(
@@ -352,7 +319,6 @@ internal class BeregningsGrunnlagRoutesTest {
                 prosesstype = Prosesstype.MANUELL,
                 boddEllerArbeidetUtlandet = null,
                 revurderingInfo = null,
-                enhet = "1111",
             )
 
         testApplication {

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/clients/BehandlingKlient.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/clients/BehandlingKlient.kt
@@ -3,14 +3,14 @@ package no.nav.etterlatte.statistikk.clients
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
-import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
+import no.nav.etterlatte.libs.common.behandling.BehandlingForStatistikk
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import java.util.UUID
 
 interface BehandlingKlient {
     suspend fun hentPersongalleri(behandlingId: UUID): Persongalleri
 
-    suspend fun hentDetaljertBehandling(behandlingId: UUID): DetaljertBehandling
+    suspend fun hentDetaljertBehandling(behandlingId: UUID): BehandlingForStatistikk
 }
 
 class BehandlingKlientImpl(
@@ -21,9 +21,9 @@ class BehandlingKlientImpl(
         return hentDetaljertBehandling(behandlingId).toPersongalleri()
     }
 
-    override suspend fun hentDetaljertBehandling(behandlingId: UUID): DetaljertBehandling {
+    override suspend fun hentDetaljertBehandling(behandlingId: UUID): BehandlingForStatistikk {
         return try {
-            behandlingHttpClient.get("$behandlingUrl/behandlinger/$behandlingId")
+            behandlingHttpClient.get("$behandlingUrl/behandlinger/statistikk/$behandlingId")
                 .body()
         } catch (e: Exception) {
             throw KunneIkkeHenteFraBehandling("Kunne ikke hente behandling med id $behandlingId fra Behandling", e)
@@ -33,7 +33,7 @@ class BehandlingKlientImpl(
 
 class KunneIkkeHenteFraBehandling(message: String, cause: Exception) : Exception(message, cause)
 
-fun DetaljertBehandling.toPersongalleri() =
+fun BehandlingForStatistikk.toPersongalleri() =
     Persongalleri(
         soeker = this.soeker,
         innsender = this.innsender,

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/service/StatistikkService.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/service/StatistikkService.kt
@@ -1,8 +1,8 @@
 package no.nav.etterlatte.statistikk.service
 
 import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.libs.common.behandling.BehandlingForStatistikk
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
-import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
@@ -158,7 +158,7 @@ class StatistikkService(
     private fun behandlingResultatFraVedtak(
         vedtak: VedtakDto,
         vedtakHendelse: VedtakHendelse,
-        detaljertBehandling: DetaljertBehandling,
+        detaljertBehandling: BehandlingForStatistikk,
     ): BehandlingResultat? {
         if (detaljertBehandling.status == BehandlingStatus.AVBRUTT) {
             return BehandlingResultat.AVBRUTT
@@ -315,14 +315,14 @@ enum class VedtakHendelse {
     IVERKSATT,
 }
 
-internal fun DetaljertBehandling.sakYtelsesgruppe(): SakYtelsesgruppe? =
+internal fun BehandlingForStatistikk.sakYtelsesgruppe(): SakYtelsesgruppe? =
     when (this.sakType to this.avdoed?.size) {
         SakType.BARNEPENSJON to 1 -> SakYtelsesgruppe.EN_AVDOED_FORELDER
         SakType.BARNEPENSJON to 2 -> SakYtelsesgruppe.FORELDRELOES
         else -> null
     }
 
-internal fun DetaljertBehandling.behandlingMetode(attestasjon: Attestasjon?): BehandlingMetode =
+internal fun BehandlingForStatistikk.behandlingMetode(attestasjon: Attestasjon?): BehandlingMetode =
     when (this.prosesstype) {
         Prosesstype.MANUELL ->
             if (attestasjon != null) {

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/service/StatistikkServiceTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/service/StatistikkServiceTest.kt
@@ -7,9 +7,9 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.etterlatte.libs.common.behandling.BehandlingForStatistikk
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
-import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -71,7 +71,7 @@ class StatistikkServiceTest {
         every { stoenadRepo.lagreStoenadsrad(any()) } returnsArgument 0
         every { sakRepo.lagreRad(any()) } returnsArgument 0
         coEvery { behandlingKlient.hentDetaljertBehandling(behandlingId) } returns
-            DetaljertBehandling(
+            BehandlingForStatistikk(
                 id = behandlingId,
                 sak = sakId,
                 sakType = SakType.BARNEPENSJON,
@@ -162,7 +162,7 @@ class StatistikkServiceTest {
         every { stoenadRepo.lagreStoenadsrad(any()) } returnsArgument 0
         every { sakRepo.lagreRad(any()) } returnsArgument 0
         coEvery { behandlingKlient.hentDetaljertBehandling(behandlingId) } returns
-            DetaljertBehandling(
+            BehandlingForStatistikk(
                 id = behandlingId,
                 sak = sakId,
                 sakType = SakType.OMSTILLINGSSTOENAD,
@@ -258,7 +258,7 @@ class StatistikkServiceTest {
         every { sakRepo.lagreRad(any()) } returnsArgument 0
 
         coEvery { behandlingKlient.hentDetaljertBehandling(behandlingId) } returns
-            DetaljertBehandling(
+            BehandlingForStatistikk(
                 id = behandlingId,
                 sak = sakId,
                 sakType = SakType.BARNEPENSJON,

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/service/StatistikkServiceTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/service/StatistikkServiceTest.kt
@@ -73,7 +73,6 @@ class StatistikkServiceTest {
         coEvery { behandlingKlient.hentDetaljertBehandling(behandlingId) } returns
             BehandlingForStatistikk(
                 id = behandlingId,
-                sak = sakId,
                 sakType = SakType.BARNEPENSJON,
                 behandlingOpprettet = Tidspunkt.now().toLocalDatetimeUTC(),
                 soeknadMottattDato = null,
@@ -83,11 +82,7 @@ class StatistikkServiceTest {
                 avdoed = listOf(),
                 soesken = listOf(),
                 status = BehandlingStatus.FATTET_VEDTAK,
-                behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-                virkningstidspunkt = null,
-                boddEllerArbeidetUtlandet = null,
                 revurderingsaarsak = null,
-                revurderingInfo = null,
                 prosesstype = Prosesstype.MANUELL,
                 enhet = "1111",
             )
@@ -164,7 +159,6 @@ class StatistikkServiceTest {
         coEvery { behandlingKlient.hentDetaljertBehandling(behandlingId) } returns
             BehandlingForStatistikk(
                 id = behandlingId,
-                sak = sakId,
                 sakType = SakType.OMSTILLINGSSTOENAD,
                 behandlingOpprettet = Tidspunkt.now().toLocalDatetimeUTC(),
                 soeknadMottattDato = null,
@@ -174,11 +168,7 @@ class StatistikkServiceTest {
                 avdoed = listOf(),
                 soesken = listOf(),
                 status = BehandlingStatus.FATTET_VEDTAK,
-                behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-                virkningstidspunkt = null,
-                boddEllerArbeidetUtlandet = null,
                 revurderingsaarsak = null,
-                revurderingInfo = null,
                 prosesstype = Prosesstype.MANUELL,
                 enhet = "1111",
             )
@@ -260,7 +250,6 @@ class StatistikkServiceTest {
         coEvery { behandlingKlient.hentDetaljertBehandling(behandlingId) } returns
             BehandlingForStatistikk(
                 id = behandlingId,
-                sak = sakId,
                 sakType = SakType.BARNEPENSJON,
                 behandlingOpprettet = Tidspunkt.now().toLocalDatetimeUTC(),
                 soeknadMottattDato = null,
@@ -270,12 +259,8 @@ class StatistikkServiceTest {
                 avdoed = listOf("32132132132"),
                 soesken = listOf(),
                 status = BehandlingStatus.OPPRETTET,
-                behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-                virkningstidspunkt = null,
-                boddEllerArbeidetUtlandet = null,
                 revurderingsaarsak = null,
                 prosesstype = Prosesstype.MANUELL,
-                revurderingInfo = null,
                 enhet = "1111",
             )
 

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TestHelper.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TestHelper.kt
@@ -1,6 +1,5 @@
 package trygdetid
 
-import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
@@ -21,7 +20,6 @@ import no.nav.etterlatte.trygdetid.TrygdetidGrunnlag
 import no.nav.etterlatte.trygdetid.TrygdetidPeriode
 import no.nav.etterlatte.trygdetid.TrygdetidType
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.Period
 import java.util.UUID
 import java.util.UUID.randomUUID
@@ -37,21 +35,13 @@ fun behandling(
     id = behandlingId,
     sak = sakId,
     sakType = SakType.BARNEPENSJON,
-    behandlingOpprettet = LocalDateTime.now(),
-    soeknadMottattDato = null,
-    innsender = null,
     soeker = "",
-    gjenlevende = null,
-    avdoed = null,
-    soesken = null,
-    status = BehandlingStatus.VILKAARSVURDERT,
     behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
     virkningstidspunkt = null,
     boddEllerArbeidetUtlandet = null,
     revurderingsaarsak = null,
     revurderingInfo = null,
     prosesstype = Prosesstype.AUTOMATISK,
-    enhet = "",
 )
 
 fun trygdetid(

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingServiceTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingServiceTest.kt
@@ -13,7 +13,6 @@ import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import kotliquery.queryOf
-import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
@@ -33,7 +32,6 @@ import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
 import no.nav.etterlatte.libs.common.rapidsandrivers.SKAL_SENDE_BREV
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.common.vedtak.KafkaHendelseType
 import no.nav.etterlatte.libs.common.vedtak.VedtakFattet
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
@@ -64,9 +62,7 @@ import vedtaksvurdering.SAKSBEHANDLER_1
 import vedtaksvurdering.attestant
 import vedtaksvurdering.opprettVedtak
 import vedtaksvurdering.saksbehandler
-import java.lang.RuntimeException
 import java.math.BigDecimal
-import java.time.LocalDateTime
 import java.time.Month
 import java.time.YearMonth
 import java.util.UUID
@@ -605,19 +601,11 @@ internal class VedtaksvurderingServiceTest {
                 sakType = SakType.BARNEPENSJON,
                 behandlingType = BehandlingType.REVURDERING,
                 revurderingsaarsak = RevurderingAarsak.REGULERING,
-                behandlingOpprettet = Tidspunkt.now().toLocalDatetimeUTC(),
-                soeknadMottattDato = null,
-                innsender = null,
                 soeker = FNR_1,
-                gjenlevende = listOf(),
-                avdoed = listOf(),
-                soesken = listOf(),
-                status = BehandlingStatus.VILKAARSVURDERT,
                 virkningstidspunkt = null,
                 boddEllerArbeidetUtlandet = null,
                 prosesstype = Prosesstype.MANUELL,
                 revurderingInfo = null,
-                enhet = "1111",
             )
         coEvery { behandlingKlientMock.hentSak(any(), any()) } returns
             Sak(
@@ -1125,14 +1113,7 @@ internal class VedtaksvurderingServiceTest {
             id = behandlingId,
             sak = sakId,
             sakType = saktype,
-            behandlingOpprettet = LocalDateTime.now(),
-            soeknadMottattDato = LocalDateTime.now(),
-            innsender = null,
             soeker = FNR_1,
-            gjenlevende = listOf(),
-            avdoed = listOf(),
-            soesken = listOf(),
-            status = BehandlingStatus.OPPRETTET,
             behandlingType =
                 if (revurderingAarsak == null) {
                     BehandlingType.FØRSTEGANGSBEHANDLING
@@ -1149,7 +1130,6 @@ internal class VedtaksvurderingServiceTest {
             revurderingsaarsak = revurderingAarsak,
             revurderingInfo = revurderingInfo,
             prosesstype = Prosesstype.MANUELL,
-            enhet = "1111",
         )
 
     private companion object {

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/BehandlingForStatistikk.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/BehandlingForStatistikk.kt
@@ -5,21 +5,16 @@ import java.util.UUID
 
 data class BehandlingForStatistikk(
     val id: UUID,
-    val sak: Long,
     val sakType: SakType,
-    val behandlingOpprettet: LocalDateTime, // kun statistikk
-    val soeknadMottattDato: LocalDateTime?, // kun statistikk
-    val innsender: String?, // kun statistikk
-    val soeker: String, // statistikk og vedtak
-    val gjenlevende: List<String>?, // kun statistikk
-    val avdoed: List<String>?, // kun statistikk
-    val soesken: List<String>?, // kun statistikk
-    val status: BehandlingStatus, // kun statistikk
-    val behandlingType: BehandlingType,
-    val virkningstidspunkt: Virkningstidspunkt?,
-    val boddEllerArbeidetUtlandet: BoddEllerArbeidetUtlandet?,
+    val behandlingOpprettet: LocalDateTime,
+    val soeknadMottattDato: LocalDateTime?,
+    val innsender: String?,
+    val soeker: String,
+    val gjenlevende: List<String>?,
+    val avdoed: List<String>?,
+    val soesken: List<String>?,
+    val status: BehandlingStatus,
     val revurderingsaarsak: RevurderingAarsak? = null,
-    val revurderingInfo: RevurderingInfo?,
-    val prosesstype: Prosesstype, // statistikk og trygdetid
-    val enhet: String, // kun statistikk
+    val prosesstype: Prosesstype,
+    val enhet: String,
 )

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/BehandlingForStatistikk.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/BehandlingForStatistikk.kt
@@ -1,0 +1,25 @@
+package no.nav.etterlatte.libs.common.behandling
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class BehandlingForStatistikk(
+    val id: UUID,
+    val sak: Long,
+    val sakType: SakType,
+    val behandlingOpprettet: LocalDateTime, // kun statistikk
+    val soeknadMottattDato: LocalDateTime?, // kun statistikk
+    val innsender: String?, // kun statistikk
+    val soeker: String, // statistikk og vedtak
+    val gjenlevende: List<String>?, // kun statistikk
+    val avdoed: List<String>?, // kun statistikk
+    val soesken: List<String>?, // kun statistikk
+    val status: BehandlingStatus, // kun statistikk
+    val behandlingType: BehandlingType,
+    val virkningstidspunkt: Virkningstidspunkt?,
+    val boddEllerArbeidetUtlandet: BoddEllerArbeidetUtlandet?,
+    val revurderingsaarsak: RevurderingAarsak? = null,
+    val revurderingInfo: RevurderingInfo?,
+    val prosesstype: Prosesstype, // statistikk og trygdetid
+    val enhet: String, // kun statistikk
+)

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/DetaljertBehandling.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/DetaljertBehandling.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.libs.common.behandling
 
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
-import java.time.LocalDateTime
 import java.util.UUID
 
 /**
@@ -14,21 +13,13 @@ data class DetaljertBehandling(
     val id: UUID,
     val sak: Long,
     val sakType: SakType,
-    val behandlingOpprettet: LocalDateTime, // kun statistikk
-    val soeknadMottattDato: LocalDateTime?, // kun statistikk
-    val innsender: String?, // kun statistikk
     val soeker: String, // statistikk og vedtak
-    val gjenlevende: List<String>?, // kun statistikk
-    val avdoed: List<String>?, // kun statistikk
-    val soesken: List<String>?, // kun statistikk
-    val status: BehandlingStatus, // kun statistikk
     val behandlingType: BehandlingType,
     val virkningstidspunkt: Virkningstidspunkt?,
     val boddEllerArbeidetUtlandet: BoddEllerArbeidetUtlandet?,
     val revurderingsaarsak: RevurderingAarsak? = null,
     val revurderingInfo: RevurderingInfo?,
     val prosesstype: Prosesstype, // statistikk og trygdetid
-    val enhet: String, // kun statistikk
 ) {
     fun kanVedta(type: VedtakType): Boolean {
         if (revurderingsaarsak.girOpphoer() && type != VedtakType.OPPHOER) {

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/DetaljertBehandling.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/DetaljertBehandling.kt
@@ -3,12 +3,6 @@ package no.nav.etterlatte.libs.common.behandling
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import java.util.UUID
 
-/**
- * TODO:
- *  8 av 18 felter her brukes KUN av statistikk.
- *  Burde kanskje vurdere om statistikk skulle hatt sin egen BehandlingDTO...?
- *  Eventuelt om vi kan fjerne og heller kalle på grunnlag fra statistikk?
- **/
 data class DetaljertBehandling(
     val id: UUID,
     val sak: Long,

--- a/libs/etterlatte-behandling-model/src/test/kotlin/no/nav/etterlatte/libs/common/behandling/DetaljertBehandlingTest.kt
+++ b/libs/etterlatte-behandling-model/src/test/kotlin/no/nav/etterlatte/libs/common/behandling/DetaljertBehandlingTest.kt
@@ -3,7 +3,6 @@ package no.nav.etterlatte.libs.common.behandling
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import java.time.LocalDateTime
 import java.util.UUID
 
 class DetaljertBehandlingTest {
@@ -32,20 +31,12 @@ class DetaljertBehandlingTest {
             id = UUID.randomUUID(),
             sak = 1L,
             sakType = SakType.BARNEPENSJON,
-            behandlingOpprettet = LocalDateTime.now(),
-            soeknadMottattDato = LocalDateTime.now(),
-            innsender = null,
             soeker = "123",
-            gjenlevende = listOf(),
-            avdoed = listOf(),
-            soesken = listOf(),
-            status = BehandlingStatus.OPPRETTET,
             behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
             virkningstidspunkt = null,
             boddEllerArbeidetUtlandet = null,
             revurderingsaarsak = revurderingsaarsak,
             prosesstype = Prosesstype.MANUELL,
             revurderingInfo = null,
-            enhet = "1111",
         )
 }


### PR DESCRIPTION
DetaljertBehandling-dataklassa hadde masse felt som kun var brukt til statistikk. Med det gjer det at vi for alle andre høve hentar ut og sender over mykje data vi ikkje trenger, og det er ikkje så enkelt å sjå kva som faktisk blir brukt til kva.