### PR TITLE
EY-2421 - sett opp brev for BP revurdering annen

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapper.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapper.kt
@@ -73,6 +73,7 @@ class BrevDataMapper(private val featureToggleService: FeatureToggleService) {
                                 )
                             RevurderingAarsak.YRKESSKADE ->
                                 BrevkodePar(BARNEPENSJON_REVURDERING_YRKESSKADE, BARNEPENSJON_REVURDERING_ENDRING)
+                            RevurderingAarsak.ANNEN -> BrevkodePar(TOM_MAL, BARNEPENSJON_REVURDERING_ENDRING)
 
                             else -> TODO("Revurderingsbrev for ${behandling.revurderingsaarsak} er ikke støttet")
                         }
@@ -148,6 +149,7 @@ class BrevDataMapper(private val featureToggleService: FeatureToggleService) {
                             RevurderingAarsak.UT_AV_FENGSEL -> UtAvFengselBrevdata.fra(behandling)
                             RevurderingAarsak.INSTITUSJONSOPPHOLD -> InstitusjonsoppholdRevurderingBrevdata.fra(behandling)
                             RevurderingAarsak.YRKESSKADE -> YrkesskadeRevurderingBrevdata.fra(behandling)
+                            RevurderingAarsak.ANNEN -> ManueltBrevData(emptyList())
                             else -> TODO("Revurderingsbrev for ${behandling.revurderingsaarsak} er ikke støttet")
                         }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -203,6 +203,7 @@ class BrevProsessTypeFactory(private val featureToggleService: FeatureToggleServ
                     RevurderingAarsak.FENGSELSOPPHOLD -> BrevProsessType.REDIGERBAR
                     RevurderingAarsak.UT_AV_FENGSEL -> BrevProsessType.REDIGERBAR
                     RevurderingAarsak.YRKESSKADE -> BrevProsessType.REDIGERBAR
+                    RevurderingAarsak.ANNEN -> BrevProsessType.REDIGERBAR
                     else -> BrevProsessType.MANUELL
                 }
 


### PR DESCRIPTION
OMS revurdering annen er helt ytelsesagnostisk frem til brev.

I brev har de brukt TOM_MAL og OMS_REVURDERING_ENDRING, manuelt og redigerbart

Setter opp BP med TOM_MAL og BARNEPENSJON_REVURDERING_ENDRING, manuelt og redigerbart.