### PR TITLE
viser alert _kun_ for manuelle / redigerbare brev

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
@@ -68,7 +68,8 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
             <Soeknadsdato mottattDato={soeknadMottattDato} />
 
             <br />
-            {vedtaksbrev?.prosessType !== BrevProsessType.AUTOMATISK && (
+            {(vedtaksbrev?.prosessType === BrevProsessType.MANUELL ||
+              vedtaksbrev?.prosessType === BrevProsessType.REDIGERBAR) && (
               <Alert variant="warning">
                 {manueltBrevKanRedigeres(status)
                   ? 'Kan ikke generere brev automatisk. Du må selv redigere innholdet.'


### PR DESCRIPTION
Slik sjekken var ville et ikke-lastet brev vise advarselen "Dette er et manuelt opprettet brev. Kontroller innholdet nøye før attestering" / "Kan ikke generere brev automatisk. Du må selv redigere innholdet" (avhengig av behandlingsstatus), selv om brevet er automatisk

 løser FAGSYSTEM-295518