### PR TITLE
Fikser nøstet transaksjon + navn i call-parameter

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -178,16 +178,16 @@ class RevurderingServiceImpl(
             return if (featureToggleService.isEnabled(RevurderingServiceFeatureToggle.OpprettManuellRevurdering, false)) {
                 val persongalleri = runBlocking { grunnlagService.hentPersongalleri(sakId) }
 
-                inTransaction {
+                inTransaction(gjenbruk = true) {
                     opprettRevurdering(
-                        sakId,
-                        persongalleri,
-                        forrigeBehandling.id,
-                        Tidspunkt.now().toLocalDatetimeUTC().toString(),
-                        Prosesstype.MANUELL,
-                        Vedtaksloesning.GJENNY,
-                        null,
-                        revurderingAarsak,
+                        sakId = sakId,
+                        persongalleri = persongalleri,
+                        forrigeBehandling = forrigeBehandling.id,
+                        mottattDato = Tidspunkt.now().toLocalDatetimeUTC().toString(),
+                        prosessType = Prosesstype.MANUELL,
+                        kilde = Vedtaksloesning.GJENNY,
+                        merknad = null,
+                        revurderingAarsak = revurderingAarsak,
                         virkningstidspunkt = null,
                         begrunnelse = begrunnelse,
                         fritekstAarsak = fritekstAarsak,
@@ -231,15 +231,15 @@ class RevurderingServiceImpl(
     ) = forrigeBehandling.sjekkEnhet()?.let {
         inTransaction {
             opprettRevurdering(
-                sakId,
-                persongalleri,
-                forrigeBehandling.id,
-                mottattDato,
-                Prosesstype.AUTOMATISK,
-                kilde,
-                merknad,
-                revurderingAarsak,
-                virkningstidspunkt?.tilVirkningstidspunkt("Opprettet automatisk"),
+                sakId = sakId,
+                persongalleri = persongalleri,
+                forrigeBehandling = forrigeBehandling.id,
+                mottattDato = mottattDato,
+                prosessType = Prosesstype.AUTOMATISK,
+                kilde = kilde,
+                merknad = merknad,
+                revurderingAarsak = revurderingAarsak,
+                virkningstidspunkt = virkningstidspunkt?.tilVirkningstidspunkt("Opprettet automatisk"),
                 begrunnelse = begrunnelse ?: "Automatisk revurdering - ${revurderingAarsak.name.lowercase()}",
                 saksbehandlerIdent = Fagsaksystem.EY.navn,
             )


### PR DESCRIPTION
Når vi har en klage som er omgjøring vil vi opprette en revurdering for de -- så revurdering må støtte nøstede transaksjoner :) 