### PR TITLE
EY-2660 Kobler mot etterlatte-proxy for sending av tilbakekrevingsvedtak

### DIFF
--- a/apps/etterlatte-tilbakekreving/.nais/dev.yaml
+++ b/apps/etterlatte-tilbakekreving/.nais/dev.yaml
@@ -54,7 +54,7 @@ spec:
       value: api://dev-gcp.etterlatte.etterlatte-behandling/.default
     - name: ETTERLATTE_PROXY_URL
       value: https://etterlatte-proxy.dev-fss-pub.nais.io/aad
-    - name: ETTERLATTE_PROXY_OUTBOUND_SCOPE
+    - name: ETTERLATTE_PROXY_SCOPE
       value: api://dev-fss.etterlatte.etterlatte-proxy/.default
   accessPolicy:
     outbound:

--- a/apps/etterlatte-tilbakekreving/.nais/dev.yaml
+++ b/apps/etterlatte-tilbakekreving/.nais/dev.yaml
@@ -52,9 +52,14 @@ spec:
       value: http://etterlatte-behandling
     - name: ETTERLATTE_BEHANDLING_SCOPE
       value: api://dev-gcp.etterlatte.etterlatte-behandling/.default
+    - name: ETTERLATTE_PROXY_URL
+      value: https://etterlatte-proxy.dev-fss-pub.nais.io/aad
+    - name: ETTERLATTE_PROXY_OUTBOUND_SCOPE
+      value: api://dev-fss.etterlatte.etterlatte-proxy/.default
   accessPolicy:
     outbound:
       rules:
         - application: etterlatte-behandling
       external:
         - host: etterlatte-unleash-api.nav.cloud.nais.io
+        - host: etterlatte-proxy.dev-fss-pub.nais.io

--- a/apps/etterlatte-tilbakekreving/.run/etterlatte-tilbakekreving.dev-gcp.run.xml
+++ b/apps/etterlatte-tilbakekreving/.run/etterlatte-tilbakekreving.dev-gcp.run.xml
@@ -15,6 +15,8 @@
       <env name="srvpwd" value="passw0rd" />
       <env name="ETTERLATTE_BEHANDLING_SCOPE" value="api://dev-gcp.etterlatte.etterlatte-behandling/.default" />
       <env name="ETTERLATTE_BEHANDLING_URL" value="https://etterlatte-behandling.intern.dev.nav.no" />
+      <env name="ETTERLATTE_PROXY_OUTBOUND_SCOPE" value="api://dev-fss.etterlatte.etterlatte-proxy/.default" />
+      <env name="ETTERLATTE_PROXY_URL" value="https://etterlatte-proxy.dev-fss-pub.nais.io/aad" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="no.nav.etterlatte.ApplicationKt" />
     <module name="pensjon-etterlatte-saksbehandling.apps.etterlatte-tilbakekreving.main" />

--- a/apps/etterlatte-tilbakekreving/.run/etterlatte-tilbakekreving.dev-gcp.run.xml
+++ b/apps/etterlatte-tilbakekreving/.run/etterlatte-tilbakekreving.dev-gcp.run.xml
@@ -15,7 +15,7 @@
       <env name="srvpwd" value="passw0rd" />
       <env name="ETTERLATTE_BEHANDLING_SCOPE" value="api://dev-gcp.etterlatte.etterlatte-behandling/.default" />
       <env name="ETTERLATTE_BEHANDLING_URL" value="https://etterlatte-behandling.intern.dev.nav.no" />
-      <env name="ETTERLATTE_PROXY_OUTBOUND_SCOPE" value="api://dev-fss.etterlatte.etterlatte-proxy/.default" />
+      <env name="ETTERLATTE_PROXY_SCOPE" value="api://dev-fss.etterlatte.etterlatte-proxy/.default" />
       <env name="ETTERLATTE_PROXY_URL" value="https://etterlatte-proxy.dev-fss-pub.nais.io/aad" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="no.nav.etterlatte.ApplicationKt" />

--- a/apps/etterlatte-tilbakekreving/build.gradle.kts
+++ b/apps/etterlatte-tilbakekreving/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
     alias(libs.plugins.analyze)
 }
 
-val cxfVersion = "4.0.3"
-
 dependencies {
     implementation(project(":libs:saksbehandling-common"))
     implementation(project(":libs:etterlatte-tilbakekreving-model"))

--- a/apps/etterlatte-tilbakekreving/build.gradle.kts
+++ b/apps/etterlatte-tilbakekreving/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     alias(libs.plugins.analyze)
 }
 
+val cxfVersion = "4.0.3"
+
 dependencies {
     implementation(project(":libs:saksbehandling-common"))
     implementation(project(":libs:etterlatte-tilbakekreving-model"))
@@ -47,6 +49,7 @@ dependencies {
         exclude("org.slf4j", "slf4j-api")
     }
     testImplementation(libs.test.wiremock)
+    testImplementation(libs.test.kotest.assertionscore)
     testImplementation(project(":libs:testdata"))
     testImplementation(testFixtures(project(":libs:etterlatte-mq")))
 }

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/Application.kt
@@ -14,6 +14,7 @@ import no.nav.etterlatte.libs.ktor.restModule
 import no.nav.etterlatte.libs.ktor.setReady
 import no.nav.etterlatte.tilbakekreving.config.ApplicationContext
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.testKravgrunnlagRoutes
+import no.nav.etterlatte.tilbakekreving.vedtak.testTilbakekrevingsvedtak
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -39,6 +40,7 @@ class Server(private val context: ApplicationContext) {
                         metricsModule()
                         restModule(sikkerLogg, withMetrics = false) {
                             testKravgrunnlagRoutes(service = context.service)
+                            testTilbakekrevingsvedtak(tilbakekrevingKlient = context.tilbakekrevingKlient)
                         }
                     }
                     connector { port = context.properties.httpPort }

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/config/ApplicationContext.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/config/ApplicationContext.kt
@@ -6,10 +6,11 @@ import no.nav.etterlatte.mq.JmsConnectionFactory
 import no.nav.etterlatte.tilbakekreving.klienter.BehandlingKlient
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.KravgrunnlagConsumer
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.KravgrunnlagService
+import no.nav.etterlatte.tilbakekreving.vedtak.TilbakekrevingKlient
 
-class ApplicationContext {
-    val properties = ApplicationProperties.fromEnv(System.getenv())
-
+class ApplicationContext(
+    val properties: ApplicationProperties = ApplicationProperties.fromEnv(System.getenv()),
+) {
     var jmsConnectionFactory =
         JmsConnectionFactory(
             hostname = properties.mqHost,
@@ -33,9 +34,21 @@ class ApplicationContext {
                 ),
         )
 
+    val tilbakekrevingKlient =
+        TilbakekrevingKlient(
+            url = properties.proxyUrl,
+            httpClient =
+                httpClientClientCredentials(
+                    azureAppClientId = properties.azureAppClientId,
+                    azureAppJwk = properties.azureAppJwk,
+                    azureAppWellKnownUrl = properties.azureAppWellKnownUrl,
+                    azureAppScope = properties.behandlingScope,
+                ),
+        )
+
     val service = KravgrunnlagService(behandlingKlient)
 
-    var kravgrunnlagConsumer =
+    val kravgrunnlagConsumer =
         KravgrunnlagConsumer(
             connectionFactory = jmsConnectionFactory,
             queue = properties.mqKravgrunnlagQueue,

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/config/ApplicationContext.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/config/ApplicationContext.kt
@@ -42,7 +42,7 @@ class ApplicationContext(
                     azureAppClientId = properties.azureAppClientId,
                     azureAppJwk = properties.azureAppJwk,
                     azureAppWellKnownUrl = properties.azureAppWellKnownUrl,
-                    azureAppScope = properties.behandlingScope,
+                    azureAppScope = properties.proxyScope,
                 ),
         )
 

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/config/ApplicationProperties.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/config/ApplicationProperties.kt
@@ -14,6 +14,8 @@ data class ApplicationProperties(
     val azureAppWellKnownUrl: String,
     val behandlingUrl: String,
     val behandlingScope: String,
+    val proxyUrl: String,
+    val proxyScope: String,
 ) {
     companion object {
         fun fromEnv(env: Map<String, String>) =
@@ -32,6 +34,8 @@ data class ApplicationProperties(
                     azureAppWellKnownUrl = value("AZURE_APP_WELL_KNOWN_URL"),
                     behandlingUrl = value("ETTERLATTE_BEHANDLING_URL"),
                     behandlingScope = value("ETTERLATTE_BEHANDLING_SCOPE"),
+                    proxyUrl = value("ETTERLATTE_PROXY_URL"),
+                    proxyScope = value("ETTERLATTE_PROXY_OUTBOUND_SCOPE"),
                 )
             }
 

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/config/ApplicationProperties.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/config/ApplicationProperties.kt
@@ -35,7 +35,7 @@ data class ApplicationProperties(
                     behandlingUrl = value("ETTERLATTE_BEHANDLING_URL"),
                     behandlingScope = value("ETTERLATTE_BEHANDLING_SCOPE"),
                     proxyUrl = value("ETTERLATTE_PROXY_URL"),
-                    proxyScope = value("ETTERLATTE_PROXY_OUTBOUND_SCOPE"),
+                    proxyScope = value("ETTERLATTE_PROXY_SCOPE"),
                 )
             }
 

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumer.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumer.kt
@@ -16,6 +16,9 @@ class KravgrunnlagConsumer(
     private val queue: String,
     private val kravgrunnlagService: KravgrunnlagService,
 ) : MessageListener {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val sikkerLogg: Logger = sikkerlogger()
+
     fun start() =
         connectionFactory.start(
             listener = exceptionListener(),
@@ -46,9 +49,4 @@ class KravgrunnlagConsumer(
         }
 
     private fun Message.deliveryCount() = this.getLongProperty("JMSXDeliveryCount")
-
-    companion object {
-        private val logger = LoggerFactory.getLogger(KravgrunnlagConsumer::class.java)
-        private val sikkerLogg: Logger = sikkerlogger()
-    }
 }

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/vedtak/TestVedtakRoutes.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/vedtak/TestVedtakRoutes.kt
@@ -1,0 +1,20 @@
+package no.nav.etterlatte.tilbakekreving.vedtak
+
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import no.nav.etterlatte.libs.common.tilbakekreving.VedtakId
+
+/**
+ * Denne brukes kun for å teste at oppsettet via proxyen fungerer. Fjernes senere.
+ */
+fun Route.testTilbakekrevingsvedtak(tilbakekrevingKlient: TilbakekrevingKlient) {
+    route("tilbakekrevingsvedtak") {
+        post {
+            tilbakekrevingKlient.sendTilbakekrevingsvedtak(Tilbakekrevingsvedtak(VedtakId(1)))
+            call.respond("OK")
+        }
+    }
+}

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/vedtak/TilbakekrevingKlient.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/vedtak/TilbakekrevingKlient.kt
@@ -16,6 +16,7 @@ import no.nav.okonomi.tilbakekrevingservice.TilbakekrevingsvedtakResponse
 import no.nav.tilbakekreving.tilbakekrevingsvedtak.vedtak.v1.TilbakekrevingsvedtakDto
 import org.slf4j.LoggerFactory
 
+// TODO Modellen her utvides når vi kommer så langt
 data class Tilbakekrevingsvedtak(val vedtakId: VedtakId)
 
 class TilbakekrevingKlient(private val url: String, private val httpClient: HttpClient) {

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/vedtak/TilbakekrevingKlient.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/vedtak/TilbakekrevingKlient.kt
@@ -1,0 +1,88 @@
+package no.nav.etterlatte.tilbakekreving.vedtak
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.coroutines.runBlocking
+import net.logstash.logback.argument.StructuredArguments.kv
+import no.nav.etterlatte.libs.common.logging.sikkerlogger
+import no.nav.etterlatte.libs.common.tilbakekreving.VedtakId
+import no.nav.etterlatte.libs.common.toJson
+import no.nav.okonomi.tilbakekrevingservice.TilbakekrevingsvedtakRequest
+import no.nav.okonomi.tilbakekrevingservice.TilbakekrevingsvedtakResponse
+import no.nav.tilbakekreving.tilbakekrevingsvedtak.vedtak.v1.TilbakekrevingsvedtakDto
+import org.slf4j.LoggerFactory
+
+data class Tilbakekrevingsvedtak(val vedtakId: VedtakId)
+
+class TilbakekrevingKlient(private val url: String, private val httpClient: HttpClient) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val sikkerLogg = sikkerlogger()
+
+    fun sendTilbakekrevingsvedtak(tilbakekrevingsvedtak: Tilbakekrevingsvedtak) {
+        logger.info("Sender tilbakekrevingsvedtak ${tilbakekrevingsvedtak.vedtakId} til tilbakekrevingskomponenten")
+        val request = toTilbakekrevingsvedtakRequest(tilbakekrevingsvedtak)
+
+        val response =
+            runBlocking {
+                val httpResponse =
+                    httpClient.post("$url/tilbakekreving/tilbakekrevingsvedtak") {
+                        contentType(ContentType.Application.Json)
+                        setBody(request.toJson())
+                    }
+
+                httpResponse.body<TilbakekrevingsvedtakResponse>()
+            }
+
+        return kontrollerResponse(response)
+    }
+
+    private fun toTilbakekrevingsvedtakRequest(tilbakekrevingsvedtak: Tilbakekrevingsvedtak): TilbakekrevingsvedtakRequest {
+        return TilbakekrevingsvedtakRequest().apply {
+            setTilbakekrevingsvedtak(
+                TilbakekrevingsvedtakDto().apply {
+                    vedtakId = tilbakekrevingsvedtak.vedtakId.value.toBigInteger()
+                    // TODO utvid denne
+                },
+            )
+        }
+    }
+
+    private fun kontrollerResponse(response: TilbakekrevingsvedtakResponse) {
+        return when (val alvorlighetsgrad = Alvorlighetsgrad.fromString(response.mmel.alvorlighetsgrad)) {
+            Alvorlighetsgrad.OK,
+            Alvorlighetsgrad.OK_MED_VARSEL,
+            -> Unit
+            Alvorlighetsgrad.ALVORLIG_FEIL,
+            Alvorlighetsgrad.SQL_FEIL,
+            -> {
+                val err = "Tilbakekrevingsvedtak feilet med alvorlighetsgrad $alvorlighetsgrad"
+                sikkerLogg.error(err, kv("response", response.toJson()))
+                throw Exception(err)
+            }
+        }
+    }
+
+    enum class Alvorlighetsgrad(val value: String) {
+        OK("00"),
+
+        /** En varselmelding følger med */
+        OK_MED_VARSEL("04"),
+
+        /** Alvorlig feil som logges og stopper behandling av aktuelt tilfelle*/
+        ALVORLIG_FEIL("08"),
+        SQL_FEIL("12"),
+        ;
+
+        override fun toString() = value
+
+        companion object {
+            fun fromString(string: String): Alvorlighetsgrad {
+                return enumValues<Alvorlighetsgrad>().first { it.value == string }
+            }
+        }
+    }
+}

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgunnlagJaxbTest.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgunnlagJaxbTest.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.tilbakekreving.kravgrunnlag
 
+import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.testsupport.readFile
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -10,7 +11,11 @@ internal class KravgunnlagJaxbTest {
     @Test
     fun `skal lese og mappe kravgrunnlag fra tilbakekrevingskomponenten`() {
         val kravgrunnlagXml = readFile("/kravgrunnlag.xml")
+
         val kravgrunnlag = KravgrunnlagJaxb.toDetaljertKravgrunnlagDto(kravgrunnlagXml)
+
+        val json = kravgrunnlag.toJson()
+        println(json)
 
         assertNotNull(kravgrunnlag)
         assertEquals(BigInteger.valueOf(302004), kravgrunnlag.kravgrunnlagId)

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgunnlagJaxbTest.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgunnlagJaxbTest.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.tilbakekreving.kravgrunnlag
 
-import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.testsupport.readFile
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -13,9 +12,6 @@ internal class KravgunnlagJaxbTest {
         val kravgrunnlagXml = readFile("/kravgrunnlag.xml")
 
         val kravgrunnlag = KravgrunnlagJaxb.toDetaljertKravgrunnlagDto(kravgrunnlagXml)
-
-        val json = kravgrunnlag.toJson()
-        println(json)
 
         assertNotNull(kravgrunnlag)
         assertEquals(BigInteger.valueOf(302004), kravgrunnlag.kravgrunnlagId)

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/vedtak/TilbakekrevingKlientTest.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/vedtak/TilbakekrevingKlientTest.kt
@@ -1,0 +1,80 @@
+package tilbakekreving.vedtak
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.fullPath
+import io.ktor.http.headersOf
+import io.ktor.serialization.jackson.JacksonConverter
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.tilbakekreving.VedtakId
+import no.nav.etterlatte.libs.common.toJson
+import no.nav.etterlatte.tilbakekreving.vedtak.TilbakekrevingKlient
+import no.nav.etterlatte.tilbakekreving.vedtak.Tilbakekrevingsvedtak
+import no.nav.okonomi.tilbakekrevingservice.TilbakekrevingsvedtakResponse
+import no.nav.tilbakekreving.typer.v1.MmelDto
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class TilbakekrevingKlientTest {
+    @Test
+    fun `skal kunne sende tilbakekrevingvedtak og haandtere ok fra tilbakekrevingskomponenten`() {
+        val response =
+            TilbakekrevingsvedtakResponse().apply {
+                mmel = MmelDto().apply { alvorlighetsgrad = "00" }
+            }
+
+        val httpClient = mockedHttpClient("/tilbakekreving/tilbakekrevingsvedtak", HttpMethod.Post, response)
+        val tilbakekrevingKlient = TilbakekrevingKlient("", httpClient)
+
+        val tilbakekrevingsvedtak = Tilbakekrevingsvedtak(vedtakId = VedtakId(1))
+        tilbakekrevingKlient.sendTilbakekrevingsvedtak(tilbakekrevingsvedtak)
+    }
+
+    @Test
+    fun `skal kunne sende tilbakekrevingvedtak og haandtere feilmelding fra tilbakekrevingskomponenten`() {
+        val response =
+            TilbakekrevingsvedtakResponse().apply {
+                mmel = MmelDto().apply { alvorlighetsgrad = "08" }
+            }
+
+        val httpClient = mockedHttpClient("/tilbakekreving/tilbakekrevingsvedtak", HttpMethod.Post, response)
+        val tilbakekrevingKlient = TilbakekrevingKlient("", httpClient)
+
+        val tilbakekrevingsvedtak = Tilbakekrevingsvedtak(vedtakId = VedtakId(1))
+
+        assertThrows<Exception>("Tilbakekrevingsvedtak feilet med alvorlighetsgrad 08") {
+            tilbakekrevingKlient.sendTilbakekrevingsvedtak(tilbakekrevingsvedtak)
+        }
+    }
+
+    private fun mockedHttpClient(
+        url: String,
+        method: HttpMethod,
+        response: Any,
+    ): HttpClient =
+        HttpClient(MockEngine) {
+            expectSuccess = true
+            install(ContentNegotiation) {
+                register(ContentType.Application.Json, JacksonConverter(objectMapper))
+            }
+
+            engine {
+                addHandler { request ->
+                    when {
+                        request.url.fullPath == url && request.method == method ->
+                            respond(
+                                response.toJson(),
+                                HttpStatusCode.OK,
+                                headersOf("Content-Type" to listOf(ContentType.Application.Json.toString())),
+                            )
+                        else -> error("Unhandled ${request.url.fullPath}")
+                    }
+                }
+            }
+        }
+}


### PR DESCRIPTION
Sender tilbakekrevingsvedtak via `etterlatte-proxy` til soap-tjenesten for tilbakekreving som ligger on-prem.