### PR TITLE
EY-2592 Omgjøringer av klager lager en omgjøringsoppgave

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageService.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.behandling.klage
 
 import io.ktor.server.plugins.NotFoundException
-import io.ktor.util.toLowerCasePreservingASCIIRules
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.behandling.klienter.BrevApiKlient
@@ -273,7 +272,7 @@ class KlageServiceImpl(
             sakId = klage.sak.id,
             oppgaveKilde = OppgaveKilde.BEHANDLING,
             oppgaveType = OppgaveType.OMGJOERING,
-            merknad = "Vedtak om ${vedtaketKlagenGjelder.vedtakType?.toString()?.toLowerCasePreservingASCIIRules()} (${
+            merknad = "Vedtak om ${vedtaketKlagenGjelder.vedtakType?.toString()?.lowercase()} (${
                 vedtaketKlagenGjelder.datoAttestert?.format(
                     DateTimeFormatter.ISO_LOCAL_DATE,
                 )

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -288,7 +288,6 @@ class ApplicationContext(
             hendelseDao = hendelseDao,
             oppgaveService = oppgaveService,
             brevApiKlient = brevApiHttpClient,
-            revurderingService = revurderingService,
         )
 
     val tilbakekrevingService =

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelistafiltre.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelistafiltre.tsx
@@ -96,12 +96,13 @@ const OPPGAVETYPEFILTER: Record<OppgavetypeFilterKeys, string> = {
   UTLAND: 'Utland',
   KLAGE: 'Klage',
   TILBAKEKREVING: 'Tilbakekreving',
+  OMGJOERING: 'Omgjøring',
 } as const
 
 export const oppgavetypefilter = (kanBrukeKlage: boolean): Array<[OppgavetypeFilterKeys, string]> => {
   const entries = Object.entries(OPPGAVETYPEFILTER) as Array<[OppgavetypeFilterKeys, string]>
   if (!kanBrukeKlage) {
-    return entries.filter(([key]) => key !== 'KLAGE')
+    return entries.filter(([key]) => key !== 'KLAGE' && key !== 'OMGJOERING')
   }
   return entries
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Tags.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Tags.tsx
@@ -24,6 +24,7 @@ const OPPGAVETYPE_TIL_TAGDATA: Record<Oppgavetype, { variant: Variants; text: st
   GOSYS: { variant: Variants.INFO_FILLED, text: 'Gosys-oppgave' },
   UTLAND: { variant: Variants.ALT2_FILLED, text: 'Utlandsoppgave' },
   KLAGE: { variant: Variants.ALT2, text: 'Klage' },
+  OMGJOERING: { variant: Variants.ALT2, text: 'Omgjøring' },
   TILBAKEKREVING: { variant: Variants.ALT2, text: 'Tilbakekreving' },
 } as const
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Tags.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Tags.tsx
@@ -24,7 +24,7 @@ const OPPGAVETYPE_TIL_TAGDATA: Record<Oppgavetype, { variant: Variants; text: st
   GOSYS: { variant: Variants.INFO_FILLED, text: 'Gosys-oppgave' },
   UTLAND: { variant: Variants.ALT2_FILLED, text: 'Utlandsoppgave' },
   KLAGE: { variant: Variants.ALT2, text: 'Klage' },
-  OMGJOERING: { variant: Variants.ALT2, text: 'Omgjøring' },
+  OMGJOERING: { variant: Variants.ALT2_MODERATE, text: 'Omgjøring' },
   TILBAKEKREVING: { variant: Variants.ALT2, text: 'Tilbakekreving' },
 } as const
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/Tags.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/Tags.tsx
@@ -11,6 +11,7 @@ export enum Variants {
   ALT1_FILLED = 'alt1-filled',
   ALT2 = 'alt2',
   ALT2_FILLED = 'alt2-filled',
+  ALT2_MODERATE = 'alt2-moderate',
   ALT3 = 'alt3',
   ALT3_FILLED = 'alt3-filled',
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaverny.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaverny.ts
@@ -35,6 +35,7 @@ export type Oppgavetype =
   | 'UTLAND'
   | 'KLAGE'
   | 'TILBAKEKREVING'
+  | 'OMGJOERING'
 
 export const erOppgaveRedigerbar = (status: Oppgavestatus): boolean => ['NY', 'UNDER_BEHANDLING'].includes(status)
 

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Klage.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Klage.kt
@@ -72,7 +72,7 @@ data class SendtInnstillingsbrev(
 )
 
 data class KlageResultat(
-    val opprettetRevurderingId: UUID?,
+    val opprettetOppgaveOmgjoeringId: UUID?,
     val sendtInnstillingsbrev: SendtInnstillingsbrev?,
 )
 

--- a/libs/etterlatte-oppgave-model/src/main/kotlin/Oppgave/OppgaveIntern.kt
+++ b/libs/etterlatte-oppgave-model/src/main/kotlin/Oppgave/OppgaveIntern.kt
@@ -101,6 +101,7 @@ enum class OppgaveType {
     UTLAND,
     KLAGE,
     TILBAKEKREVING,
+    OMGJOERING,
 }
 
 data class SaksbehandlerEndringDto(


### PR DESCRIPTION
Siden det ikke bare er standard behandlinger vi skal omgjøre, men også tilbakekrevinger og generelle behandlinger, er det ikke bare å rett frem opprette en revurdering for klagen med en gang. Foreløpig lages bare en oppgave, selve omgjøringen blir håndtert i EY-2739, EY-2740 og EY-2741