### PR TITLE
EY-2646: Viss vedtaksdato manglar for brev, bruk dagens dato

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/InnvilgetBrevData.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/InnvilgetBrevData.kt
@@ -111,7 +111,7 @@ data class InnvilgetBrevDataEnkel(
                 erEtterbetalingMerEnnTreMaaneder = erEtterbetaling(behandling.utbetalingsinfo.virkningsdato),
                 vedtaksdato =
                     behandling.vedtak.vedtaksdato
-                        ?: throw IllegalStateException("Trenger vedtaksdato, men var null"),
+                        ?: LocalDate.now(),
                 erInstitusjonsopphold =
                     behandling.utbetalingsinfo.beregningsperioder
                         .filter { it.datoFOM.isBefore(LocalDate.now().plusDays(1)) }


### PR DESCRIPTION
Denne datoen blir jo først satt på vedtaket i det saksbehandlar klikkar send til attestering.