### PR TITLE
Minimal dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/distroless/java17
 ENV TZ="Europe/Oslo"
-WORKDIR /app
-COPY build/libs/app.jar app.jar
+COPY build/libs/app.jar /app/app.jar
 EXPOSE 8080
 USER nonroot
+WORKDIR /app
 CMD ["app.jar"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,13 @@
 FROM eclipse-temurin:17-jre-alpine
 
 RUN addgroup -S apprunner && adduser -S apprunner -G apprunner
-RUN chown -R apprunner /app
-USER apprunner
 
 ENV TZ="Europe/Oslo"
 
 COPY build/libs/app.jar /app/app.jar
 WORKDIR /app
+RUN chown -R apprunner /app
+USER apprunner
 
 EXPOSE 8080
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
 FROM gcr.io/distroless/java17
 ENV TZ="Europe/Oslo"
-COPY build/libs/app.jar /app/app.jar
+WORKDIR /app
+COPY build/libs/*.jar ./
+ENV CLASSPATH="/app/WEB-INF/classes:/app/WEB-INF/lib/*"
 EXPOSE 8080
 USER nonroot
-WORKDIR /app
 CMD ["app.jar"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,37 +1,15 @@
-FROM navikt/java:common AS java-common
-
 FROM eclipse-temurin:17-jre-alpine
 
-RUN umask o+r
-
 RUN addgroup -S apprunner && adduser -S apprunner -G apprunner
-
-COPY --chown=apprunner:root --from=java-common /init-scripts /init-scripts
-COPY --chown=apprunner:root --from=java-common /run-java.sh /run-java.sh
-COPY --from=java-common /entrypoint.sh /entrypoint.sh
-COPY --from=java-common /dumb-init /dumb-init
-
-RUN apk add tzdata
-RUN cp /usr/share/zoneinfo/Europe/Oslo /etc/localtime
-RUN echo "Europe/Oslo" > /etc/timezone
-
-ENV LC_ALL="nb_NO.UTF-8"
-ENV LANG="nb_NO.UTF-8"
-ENV TZ="Europe/Oslo"
-ENV APP_BINARY=app
-ENV APP_JAR=app.jar
-ENV MAIN_CLASS="Main"
-ENV CLASSPATH="/app/WEB-INF/classes:/app/WEB-INF/lib/*"
-
-WORKDIR /app
-COPY build/libs/*.jar ./
-
-EXPOSE 8080
-
-RUN apk add --no-cache bash
 RUN chown -R apprunner /app
 USER apprunner
 
-ENTRYPOINT ["/dumb-init", "--", "/entrypoint.sh"]
+ENV TZ="Europe/Oslo"
 
+COPY build/libs/app.jar /app/app.jar
+WORKDIR /app
+
+EXPOSE 8080
+
+CMD ["app.jar"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,7 @@
 FROM gcr.io/distroless/java17
-
 ENV TZ="Europe/Oslo"
-
 WORKDIR /app
 COPY build/libs/app.jar app.jar
-
 EXPOSE 8080
 USER nonroot
 CMD ["app.jar"]
-

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,11 @@
-FROM eclipse-temurin:17-jre-alpine
-
-RUN addgroup -S apprunner && adduser -S apprunner -G apprunner
+FROM gcr.io/distroless/java17
 
 ENV TZ="Europe/Oslo"
 
-COPY build/libs/app.jar /app/app.jar
 WORKDIR /app
-RUN chown -R apprunner /app
-USER apprunner
+COPY build/libs/app.jar app.jar
 
 EXPOSE 8080
-
+USER nonroot
 CMD ["app.jar"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,6 @@ FROM gcr.io/distroless/java17
 ENV TZ="Europe/Oslo"
 WORKDIR /app
 COPY build/libs/*.jar ./
-ENV CLASSPATH="/app/WEB-INF/classes:/app/WEB-INF/lib/*"
 EXPOSE 8080
 USER nonroot
 CMD ["app.jar"]


### PR DESCRIPTION
Dockerfila vi bruker i dag inneheld mykje vi ikkje treng. [baseimages-repoet](https://github.com/navikt/baseimages) er veldig generisk og har mykje, men vi treng nesten ingenting av det. Trur det meste der er mest relevant for on-prem-hosting.

Repoet har også ei åtvaring om 

> 
> Important
> NAIS baseimages are not actively maintained and should be considered deprecated.
> 
> Consider using official images or preferably distroless alternatives.
> 
> Read more in the security playbook: [HERE](https://sikkerhet.nav.no/docs/sikker-utvikling/containere)


Følgjer oppfordringa frå https://sikkerhet.nav.no/docs/sikker-utvikling/containere om å bruke distroless.