### PR TITLE
Nøste opp i intranasaction

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -134,27 +134,25 @@ internal fun Application.module(context: ApplicationContext) {
 
             install(adressebeskyttelsePlugin) {
                 saksbehandlerGroupIdsByKey = context.saksbehandlerGroupIdsByKey
+                // TODO: hvordan få en intransaction på denne tjenesten her? call vs steget før dene må skjer før så enten en egen tjeneste for hooks eller noe annet smart
+                // problemet her er at sakdao tilgang markerer adressebeskyttelse i en intransaction etter finnelelropprettsak så den må være optiona
                 harTilgangBehandling = { behandlingId, saksbehandlerMedRoller ->
-                    inTransaction { tilgangService.harTilgangTilBehandling(behandlingId, saksbehandlerMedRoller) }
+                    tilgangService.harTilgangTilBehandling(behandlingId, saksbehandlerMedRoller)
                 }
                 harTilgangTilSak = { sakId, saksbehandlerMedRoller ->
-                    inTransaction { tilgangService.harTilgangTilSak(sakId, saksbehandlerMedRoller) }
+                    tilgangService.harTilgangTilSak(sakId, saksbehandlerMedRoller)
                 }
                 harTilgangTilOppgave = { oppgaveId, saksbehandlerMedRoller ->
-                    inTransaction {
-                        tilgangService.harTilgangTilOppgave(
-                            oppgaveId,
-                            saksbehandlerMedRoller,
-                        )
-                    }
+                    tilgangService.harTilgangTilOppgave(
+                        oppgaveId,
+                        saksbehandlerMedRoller,
+                    )
                 }
                 harTilgangTilKlage = { klageId, saksbehandlerMedRoller ->
-                    inTransaction {
-                        tilgangService.harTilgangTilKlage(
-                            klageId,
-                            saksbehandlerMedRoller,
-                        )
-                    }
+                    tilgangService.harTilgangTilKlage(
+                        klageId,
+                        saksbehandlerMedRoller,
+                    )
                 }
             }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -134,8 +134,7 @@ internal fun Application.module(context: ApplicationContext) {
 
             install(adressebeskyttelsePlugin) {
                 saksbehandlerGroupIdsByKey = context.saksbehandlerGroupIdsByKey
-                // TODO: hvordan få en intransaction på denne tjenesten her? call vs steget før dene må skjer før så enten en egen tjeneste for hooks eller noe annet smart
-                // problemet her er at sakdao tilgang markerer adressebeskyttelse i en intransaction etter finnelelropprettsak så den må være optiona
+
                 harTilgangBehandling = { behandlingId, saksbehandlerMedRoller ->
                     tilgangService.harTilgangTilBehandling(behandlingId, saksbehandlerMedRoller)
                 }

--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -135,22 +135,26 @@ internal fun Application.module(context: ApplicationContext) {
             install(adressebeskyttelsePlugin) {
                 saksbehandlerGroupIdsByKey = context.saksbehandlerGroupIdsByKey
                 harTilgangBehandling = { behandlingId, saksbehandlerMedRoller ->
-                    tilgangService.harTilgangTilBehandling(behandlingId, saksbehandlerMedRoller)
+                    inTransaction { tilgangService.harTilgangTilBehandling(behandlingId, saksbehandlerMedRoller) }
                 }
                 harTilgangTilSak = { sakId, saksbehandlerMedRoller ->
-                    tilgangService.harTilgangTilSak(sakId, saksbehandlerMedRoller)
+                    inTransaction { tilgangService.harTilgangTilSak(sakId, saksbehandlerMedRoller) }
                 }
                 harTilgangTilOppgave = { oppgaveId, saksbehandlerMedRoller ->
-                    tilgangService.harTilgangTilOppgave(
-                        oppgaveId,
-                        saksbehandlerMedRoller,
-                    )
+                    inTransaction {
+                        tilgangService.harTilgangTilOppgave(
+                            oppgaveId,
+                            saksbehandlerMedRoller,
+                        )
+                    }
                 }
                 harTilgangTilKlage = { klageId, saksbehandlerMedRoller ->
-                    tilgangService.harTilgangTilKlage(
-                        klageId,
-                        saksbehandlerMedRoller,
-                    )
+                    inTransaction {
+                        tilgangService.harTilgangTilKlage(
+                            klageId,
+                            saksbehandlerMedRoller,
+                        )
+                    }
                 }
             }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -76,11 +76,13 @@ internal fun Route.behandlingRoutes(
                 val body = call.receive<JaNeiMedBegrunnelse>()
                 when (
                     val lagretGyldighetsResultat =
-                        gyldighetsproevingService.lagreGyldighetsproeving(
-                            behandlingsId,
-                            navIdent,
-                            body,
-                        )
+                        inTransaction {
+                            gyldighetsproevingService.lagreGyldighetsproeving(
+                                behandlingsId,
+                                navIdent,
+                                body,
+                            )
+                        }
                 ) {
                     null -> call.respond(HttpStatusCode.NotFound)
                     else -> call.respond(HttpStatusCode.OK, lagretGyldighetsResultat)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -100,7 +100,7 @@ internal fun Route.behandlingRoutes(
                     )
 
                 try {
-                    kommerBarnetTilGodeService.lagreKommerBarnetTilgode(kommerBarnetTilgode)
+                    inTransaction { kommerBarnetTilGodeService.lagreKommerBarnetTilgode(kommerBarnetTilgode) }
                     call.respond(HttpStatusCode.OK, kommerBarnetTilgode)
                 } catch (e: TilstandException.UgyldigTilstand) {
                     call.respond(HttpStatusCode.BadRequest, "Kunne ikke endre på feltet")
@@ -287,12 +287,14 @@ internal fun Route.behandlingRoutes(
 
                 when (
                     val behandling =
-                        behandlingFactory.opprettBehandling(
-                            behandlingsBehov.sakId,
-                            behandlingsBehov.persongalleri,
-                            behandlingsBehov.mottattDato,
-                            Vedtaksloesning.GJENNY,
-                        )
+                        inTransaction {
+                            behandlingFactory.opprettBehandling(
+                                behandlingsBehov.sakId,
+                                behandlingsBehov.persongalleri,
+                                behandlingsBehov.mottattDato,
+                                Vedtaksloesning.GJENNY,
+                            )
+                        }
                 ) {
                     null -> call.respond(HttpStatusCode.NotFound)
                     else -> call.respondText(behandling.id.toString())

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -21,6 +21,7 @@ import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeServi
 import no.nav.etterlatte.behandling.manueltopphoer.ManueltOpphoerAarsak
 import no.nav.etterlatte.behandling.manueltopphoer.ManueltOpphoerRequest
 import no.nav.etterlatte.behandling.manueltopphoer.ManueltOpphoerService
+import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingsBehov
@@ -152,12 +153,14 @@ internal fun Route.behandlingRoutes(
 
                 try {
                     val virkningstidspunkt =
-                        behandlingService.oppdaterVirkningstidspunkt(
-                            behandlingsId,
-                            body.dato,
-                            navIdent,
-                            body.begrunnelse!!,
-                        )
+                        inTransaction {
+                            behandlingService.oppdaterVirkningstidspunkt(
+                                behandlingsId,
+                                body.dato,
+                                navIdent,
+                                body.begrunnelse!!,
+                            )
+                        }
 
                     call.respondText(
                         contentType = ContentType.Application.Json,
@@ -183,7 +186,9 @@ internal fun Route.behandlingRoutes(
                             begrunnelse = body.begrunnelse,
                         )
 
-                    behandlingService.oppdaterUtenlandstilsnitt(behandlingsId, utenlandstilsnitt)
+                    inTransaction {
+                        behandlingService.oppdaterUtenlandstilsnitt(behandlingsId, utenlandstilsnitt)
+                    }
 
                     call.respondText(
                         contentType = ContentType.Application.Json,
@@ -215,10 +220,12 @@ internal fun Route.behandlingRoutes(
                             skalSendeKravpakke = body.skalSendeKravpakke,
                         )
 
-                    behandlingService.oppdaterBoddEllerArbeidetUtlandet(
-                        behandlingsId,
-                        boddEllerArbeidetUtlandet,
-                    )
+                    inTransaction {
+                        behandlingService.oppdaterBoddEllerArbeidetUtlandet(
+                            behandlingsId,
+                            boddEllerArbeidetUtlandet,
+                        )
+                    }
 
                     call.respondText(
                         contentType = ContentType.Application.Json,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
@@ -139,6 +139,7 @@ internal class BehandlingServiceImpl(
         return hentBehandlingForId(behandlingId)
     }
 
+    // Sjekk om intransaction kan flyttes ut
     override fun hentBehandlingerISak(sakId: Long): List<Behandling> {
         return inTransaction {
             hentBehandlingerForSakId(sakId)
@@ -146,7 +147,7 @@ internal class BehandlingServiceImpl(
     }
 
     override fun hentSisteIverksatte(sakId: Long): Behandling? {
-        return inTransaction { hentBehandlingerForSakId(sakId) }
+        return hentBehandlingerForSakId(sakId)
             .filter { BehandlingStatus.iverksattEllerAttestert().contains(it.status) }
             .maxByOrNull { it.behandlingOpprettet }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
@@ -277,10 +277,8 @@ internal class BehandlingServiceImpl(
 
                 val hendelserIBehandling = hendelseDao.finnHendelserIBehandling(behandlingId)
                 val kommerBarnetTilgode =
-                    inTransaction {
-                        kommerBarnetTilGodeDao.hentKommerBarnetTilGode(behandlingId)
-                            .takeIf { behandling.sak.sakType == SakType.BARNEPENSJON }
-                    }
+                    kommerBarnetTilGodeDao.hentKommerBarnetTilGode(behandlingId)
+                        .takeIf { behandling.sak.sakType == SakType.BARNEPENSJON }
                 Triple(behandling, kommerBarnetTilgode, hendelserIBehandling)
             }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
@@ -134,16 +134,12 @@ internal class BehandlingServiceImpl(
 
     private fun hentBehandlingerForSakId(sakId: Long) = behandlingDao.alleBehandlingerISak(sakId).filterForEnheter()
 
-    // alle som bruker denne må ha en transaction
     override fun hentBehandling(behandlingId: UUID): Behandling? {
         return hentBehandlingForId(behandlingId)
     }
 
-    // Sjekk om intransaction kan flyttes ut
     override fun hentBehandlingerISak(sakId: Long): List<Behandling> {
-        return inTransaction {
-            hentBehandlingerForSakId(sakId)
-        }
+        return hentBehandlingerForSakId(sakId)
     }
 
     override fun hentSisteIverksatte(sakId: Long): Behandling? {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
@@ -12,7 +12,6 @@ import no.nav.etterlatte.behandling.domain.toStatistikkBehandling
 import no.nav.etterlatte.behandling.etterbetaling.EtterbetalingService
 import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.behandling.hendelse.HendelseType
-import no.nav.etterlatte.behandling.hendelse.LagretHendelse
 import no.nav.etterlatte.behandling.hendelse.registrerVedtakHendelseFelles
 import no.nav.etterlatte.behandling.klienter.GrunnlagKlient
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeDao
@@ -135,10 +134,9 @@ internal class BehandlingServiceImpl(
 
     private fun hentBehandlingerForSakId(sakId: Long) = behandlingDao.alleBehandlingerISak(sakId).filterForEnheter()
 
+    // alle som bruker denne må ha en transaction
     override fun hentBehandling(behandlingId: UUID): Behandling? {
-        return inTransaction {
-            hentBehandlingForId(behandlingId)
-        }
+        return hentBehandlingForId(behandlingId)
     }
 
     override fun hentBehandlingerISak(sakId: Long): List<Behandling> {
@@ -195,7 +193,7 @@ internal class BehandlingServiceImpl(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): StatistikkBehandling? {
-        return hentBehandling(behandlingId)?.let {
+        return inTransaction { hentBehandling(behandlingId) }?.let {
             val persongalleri: Persongalleri =
                 grunnlagKlient.hentPersongalleri(it.sak.id, brukerTokenInfo)
                     ?.opplysning
@@ -209,7 +207,7 @@ internal class BehandlingServiceImpl(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): DetaljertBehandling? {
-        return hentBehandling(behandlingId)?.let {
+        return inTransaction { hentBehandling(behandlingId) }?.let {
             val persongalleri: Persongalleri =
                 grunnlagKlient.hentPersongalleri(it.sak.id, brukerTokenInfo)
                     ?.opplysning
@@ -224,7 +222,7 @@ internal class BehandlingServiceImpl(
         brukerTokenInfo: BrukerTokenInfo,
         opplysningstype: Opplysningstype,
     ): BehandlingMedGrunnlagsopplysninger<Person> {
-        val behandling = requireNotNull(hentBehandling(behandlingId))
+        val behandling = requireNotNull(inTransaction { hentBehandling(behandlingId) })
         val personopplysning = grunnlagKlient.finnPersonOpplysning(behandling.sak.id, opplysningstype, brukerTokenInfo)
 
         return BehandlingMedGrunnlagsopplysninger(
@@ -274,15 +272,19 @@ internal class BehandlingServiceImpl(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): DetaljertBehandlingDto {
-        val behandling =
-            hentBehandling(behandlingId)
-                ?: throw BehandlingFinnesIkkeException("Vi kan ikke hente behandling $behandlingId, sjekk enhet")
-
-        val hendelserIBehandling = hentHendelserIBehandling(behandlingId)
-        val kommerBarnetTilgode =
+        val (behandling, kommerBarnetTilgode, hendelserIBehandling) =
             inTransaction {
-                kommerBarnetTilGodeDao.hentKommerBarnetTilGode(behandlingId)
-                    .takeIf { behandling.sak.sakType == SakType.BARNEPENSJON }
+                val behandling =
+                    hentBehandling(behandlingId)
+                        ?: throw BehandlingFinnesIkkeException("Vi kan ikke hente behandling $behandlingId, sjekk enhet")
+
+                val hendelserIBehandling = hendelseDao.finnHendelserIBehandling(behandlingId)
+                val kommerBarnetTilgode =
+                    inTransaction {
+                        kommerBarnetTilGodeDao.hentKommerBarnetTilGode(behandlingId)
+                            .takeIf { behandling.sak.sakType == SakType.BARNEPENSJON }
+                    }
+                Triple(behandling, kommerBarnetTilgode, hendelserIBehandling)
             }
 
         val sakId = behandling.sak.id
@@ -393,10 +395,8 @@ internal class BehandlingServiceImpl(
         try {
             behandling.oppdaterVirkningstidspunkt(virkningstidspunkt)
                 .also {
-                    inTransaction {
-                        behandlingDao.lagreNyttVirkningstidspunkt(behandlingId, virkningstidspunkt)
-                        behandlingDao.lagreStatus(it)
-                    }
+                    behandlingDao.lagreNyttVirkningstidspunkt(behandlingId, virkningstidspunkt)
+                    behandlingDao.lagreStatus(it)
                 }
         } catch (e: NotImplementedError) {
             logger.error(
@@ -422,10 +422,8 @@ internal class BehandlingServiceImpl(
         try {
             behandling.oppdaterUtenlandstilsnitt(utenlandstilsnitt)
                 .also {
-                    inTransaction {
-                        behandlingDao.lagreUtenlandstilsnitt(behandlingId, utenlandstilsnitt)
-                        behandlingDao.lagreStatus(it)
-                    }
+                    behandlingDao.lagreUtenlandstilsnitt(behandlingId, utenlandstilsnitt)
+                    behandlingDao.lagreStatus(it)
                 }
         } catch (e: NotImplementedError) {
             logger.error(
@@ -451,10 +449,8 @@ internal class BehandlingServiceImpl(
         try {
             behandling.oppdaterBoddEllerArbeidetUtlandnet(boddEllerArbeidetUtlandet)
                 .also {
-                    inTransaction {
-                        behandlingDao.lagreBoddEllerArbeidetUtlandet(behandlingId, boddEllerArbeidetUtlandet)
-                        behandlingDao.lagreStatus(it)
-                    }
+                    behandlingDao.lagreBoddEllerArbeidetUtlandet(behandlingId, boddEllerArbeidetUtlandet)
+                    behandlingDao.lagreStatus(it)
                 }
         } catch (e: NotImplementedError) {
             logger.error(
@@ -462,12 +458,6 @@ internal class BehandlingServiceImpl(
                 e,
             )
             throw e
-        }
-    }
-
-    private fun hentHendelserIBehandling(behandlingId: UUID): List<LagretHendelse> {
-        return inTransaction {
-            hendelseDao.finnHendelserIBehandling(behandlingId)
         }
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
@@ -97,9 +97,7 @@ class BehandlingStatusServiceImpl(
         val behandling = hentBehandling(behandlingId).tilOpprettet()
 
         if (!dryRun) {
-            inTransaction {
-                behandlingDao.lagreStatus(behandling.id, behandling.status, behandling.sistEndret)
-            }
+            behandlingDao.lagreStatus(behandling.id, behandling.status, behandling.sistEndret)
         }
     }
 
@@ -110,9 +108,7 @@ class BehandlingStatusServiceImpl(
         val behandling = hentBehandling(behandlingId).tilVilkaarsvurdert()
 
         if (!dryRun) {
-            inTransaction {
-                behandlingDao.lagreStatus(behandling.id, behandling.status, behandling.sistEndret)
-            }
+            behandlingDao.lagreStatus(behandling.id, behandling.status, behandling.sistEndret)
         }
     }
 
@@ -183,11 +179,9 @@ class BehandlingStatusServiceImpl(
         vedtakHendelse: VedtakHendelse,
     ) {
         val behandling = hentBehandling(behandlingId)
-        inTransaction {
-            lagreNyBehandlingStatus(behandling.tilIverksatt(), Tidspunkt.now().toLocalDatetimeUTC())
-            registrerVedtakHendelse(behandlingId, vedtakHendelse, HendelseType.IVERKSATT)
-            haandterUtland(behandling)
-        }
+        lagreNyBehandlingStatus(behandling.tilIverksatt(), Tidspunkt.now().toLocalDatetimeUTC())
+        registrerVedtakHendelse(behandlingId, vedtakHendelse, HendelseType.IVERKSATT)
+        haandterUtland(behandling)
         if (behandling.type == BehandlingType.REVURDERING) {
             grunnlagsendringshendelseService.settHendelseTilHistorisk(behandlingId)
         }
@@ -233,9 +227,7 @@ class BehandlingStatusServiceImpl(
 
     private fun Behandling.lagreEndring(dryRun: Boolean) {
         if (dryRun) return
-        inTransaction {
-            lagreNyBehandlingStatus(this)
-        }
+        lagreNyBehandlingStatus(this)
     }
 
     private fun lagreNyBehandlingStatus(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingVedtakRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingVedtakRoute.kt
@@ -33,9 +33,11 @@ internal fun Route.behandlingVedtakRoute(
         post {
             val fattVedtak = call.receive<VedtakEndringDTO>()
             val behandling =
-                behandlingService.hentBehandling(
-                    UUID.fromString(fattVedtak.vedtakOppgaveDTO.referanse),
-                )
+                inTransaction {
+                    behandlingService.hentBehandling(
+                        UUID.fromString(fattVedtak.vedtakOppgaveDTO.referanse),
+                    )
+                }
             if (behandling == null) {
                 call.respond(HttpStatusCode.NotFound, "Fant ingen behandling")
             } else {
@@ -70,9 +72,11 @@ internal fun Route.behandlingVedtakRoute(
         post {
             val underkjennVedtakOppgave = call.receive<VedtakEndringDTO>()
             val behandling =
-                behandlingService.hentBehandling(
-                    UUID.fromString(underkjennVedtakOppgave.vedtakOppgaveDTO.referanse),
-                )
+                inTransaction {
+                    behandlingService.hentBehandling(
+                        UUID.fromString(underkjennVedtakOppgave.vedtakOppgaveDTO.referanse),
+                    )
+                }
             if (behandling == null) {
                 call.respond(HttpStatusCode.NotFound, "Fant ingen behandling")
             } else {
@@ -101,9 +105,11 @@ internal fun Route.behandlingVedtakRoute(
         post {
             val attesterVedtakOppgave = call.receive<VedtakEndringDTO>()
             val behandling =
-                behandlingService.hentBehandling(
-                    UUID.fromString(attesterVedtakOppgave.vedtakOppgaveDTO.referanse),
-                )
+                inTransaction {
+                    behandlingService.hentBehandling(
+                        UUID.fromString(attesterVedtakOppgave.vedtakOppgaveDTO.referanse),
+                    )
+                }
             if (behandling == null) {
                 call.respond(HttpStatusCode.NotFound, "Fant ingen behandling")
             } else {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
@@ -9,6 +9,7 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
+import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.behandlingsId
 import no.nav.etterlatte.tilgangsstyring.kunAttestant
@@ -19,77 +20,103 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         get("/opprett") {
             // Kalles kun av vilkårsvurdering når total-vurdering slettes
             haandterStatusEndring(call) {
-                behandlingsstatusService.settOpprettet(behandlingsId)
+                inTransaction {
+                    behandlingsstatusService.settOpprettet(behandlingsId)
+                }
             }
         }
         post("/opprett") {
             // Kalles kun av vilkårsvurdering når total-vurdering slettes
             haandterStatusEndring(call) {
-                behandlingsstatusService.settOpprettet(behandlingsId, false)
+                inTransaction {
+                    behandlingsstatusService.settOpprettet(behandlingsId, false)
+                }
             }
         }
 
         get("/vilkaarsvurder") {
             haandterStatusEndring(call) {
-                behandlingsstatusService.settVilkaarsvurdert(behandlingsId, true)
+                inTransaction {
+                    behandlingsstatusService.settVilkaarsvurdert(behandlingsId, true)
+                }
             }
         }
         post("/vilkaarsvurder") {
             haandterStatusEndring(call) {
-                behandlingsstatusService.settVilkaarsvurdert(behandlingsId, false)
+                inTransaction {
+                    behandlingsstatusService.settVilkaarsvurdert(behandlingsId, false)
+                }
             }
         }
 
         get("/oppdaterTrygdetid") {
             haandterStatusEndring(call) {
-                behandlingsstatusService.settTrygdetidOppdatert(behandlingsId, true)
+                inTransaction {
+                    behandlingsstatusService.settTrygdetidOppdatert(behandlingsId, true)
+                }
             }
         }
         post("/oppdaterTrygdetid") {
             haandterStatusEndring(call) {
-                behandlingsstatusService.settTrygdetidOppdatert(behandlingsId, false)
+                inTransaction {
+                    behandlingsstatusService.settTrygdetidOppdatert(behandlingsId, false)
+                }
             }
         }
 
         get("/beregn") {
             haandterStatusEndring(call) {
-                behandlingsstatusService.settBeregnet(behandlingsId)
+                inTransaction {
+                    behandlingsstatusService.settBeregnet(behandlingsId)
+                }
             }
         }
 
         post("/beregn") {
             haandterStatusEndring(call) {
-                behandlingsstatusService.settBeregnet(behandlingsId, false)
+                inTransaction {
+                    behandlingsstatusService.settBeregnet(behandlingsId, false)
+                }
             }
         }
 
         get("/avkort") {
             haandterStatusEndring(call) {
-                behandlingsstatusService.settAvkortet(behandlingsId)
+                inTransaction {
+                    behandlingsstatusService.settAvkortet(behandlingsId)
+                }
             }
         }
 
         post("/avkort") {
             haandterStatusEndring(call) {
-                behandlingsstatusService.settAvkortet(behandlingsId, false)
+                inTransaction {
+                    behandlingsstatusService.settAvkortet(behandlingsId, false)
+                }
             }
         }
 
         get("/fatteVedtak") {
             haandterStatusEndring(call) {
-                behandlingsstatusService.sjekkOmKanFatteVedtak(behandlingsId)
+                inTransaction {
+                    behandlingsstatusService.sjekkOmKanFatteVedtak(behandlingsId)
+                }
             }
         }
         get("/returner") {
             haandterStatusEndring(call) {
-                behandlingsstatusService.sjekkOmKanReturnereVedtak(behandlingsId)
+                inTransaction {
+                    behandlingsstatusService.sjekkOmKanReturnereVedtak(behandlingsId)
+                }
             }
         }
 
         get("/attester") {
             kunAttestant {
                 haandterStatusEndring(call) {
-                    behandlingsstatusService.sjekkOmKanAttestere(behandlingsId)
+                    inTransaction {
+                        behandlingsstatusService.sjekkOmKanAttestere(behandlingsId)
+                    }
                 }
             }
         }
@@ -97,7 +124,9 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         post("/iverksett") {
             val vedtakHendelse = call.receive<VedtakHendelse>()
             haandterStatusEndring(call) {
-                behandlingsstatusService.settIverksattVedtak(behandlingsId, vedtakHendelse)
+                inTransaction {
+                    behandlingsstatusService.settIverksattVedtak(behandlingsId, vedtakHendelse)
+                }
             }
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/GyldighetsproevingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/GyldighetsproevingService.kt
@@ -47,36 +47,34 @@ class GyldighetsproevingServiceImpl(
         navIdent: String,
         svar: JaNeiMedBegrunnelse,
     ): GyldighetsResultat? {
-        return inTransaction {
-            hentFoerstegangsbehandling(behandlingId)?.let { behandling ->
-                val resultat =
-                    if (svar.erJa()) VurderingsResultat.OPPFYLT else VurderingsResultat.IKKE_OPPFYLT
-                val gyldighetsResultat =
-                    GyldighetsResultat(
-                        resultat = resultat,
-                        vurderinger =
-                            listOf(
-                                VurdertGyldighet(
-                                    navn = GyldighetsTyper.INNSENDER_ER_GJENLEVENDE,
-                                    resultat = resultat,
-                                    basertPaaOpplysninger =
-                                        ManuellVurdering(
-                                            begrunnelse = svar.begrunnelse,
-                                            kilde =
-                                                Grunnlagsopplysning.Saksbehandler(
-                                                    navIdent,
-                                                    Tidspunkt.from(klokke.norskKlokke()),
-                                                ),
-                                        ),
-                                ),
+        return hentFoerstegangsbehandling(behandlingId)?.let { behandling ->
+            val resultat =
+                if (svar.erJa()) VurderingsResultat.OPPFYLT else VurderingsResultat.IKKE_OPPFYLT
+            val gyldighetsResultat =
+                GyldighetsResultat(
+                    resultat = resultat,
+                    vurderinger =
+                        listOf(
+                            VurdertGyldighet(
+                                navn = GyldighetsTyper.INNSENDER_ER_GJENLEVENDE,
+                                resultat = resultat,
+                                basertPaaOpplysninger =
+                                    ManuellVurdering(
+                                        begrunnelse = svar.begrunnelse,
+                                        kilde =
+                                            Grunnlagsopplysning.Saksbehandler(
+                                                navIdent,
+                                                Tidspunkt.from(klokke.norskKlokke()),
+                                            ),
+                                    ),
                             ),
-                        vurdertDato = Tidspunkt(klokke.instant()).toLocalDatetimeNorskTid(),
-                    )
+                        ),
+                    vurdertDato = Tidspunkt(klokke.instant()).toLocalDatetimeNorskTid(),
+                )
 
-                behandling.lagreGyldighetsproeving(gyldighetsResultat)
+            behandling.lagreGyldighetsproeving(gyldighetsResultat)
 
-                gyldighetsResultat
-            }
+            gyldighetsResultat
         }
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
@@ -153,12 +153,10 @@ sealed class Behandling {
         throw BehandlingStoetterIkkeStatusEndringException(AVKORTET)
     }
 
-    // unødvendig?
     open fun tilFattetVedtak(): Behandling {
         throw BehandlingStoetterIkkeStatusEndringException(FATTET_VEDTAK)
     }
 
-    // unødvendig?
     open fun tilAttestert(): Behandling {
         throw BehandlingStoetterIkkeStatusEndringException(ATTESTERT)
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
@@ -153,10 +153,12 @@ sealed class Behandling {
         throw BehandlingStoetterIkkeStatusEndringException(AVKORTET)
     }
 
+    // unødvendig?
     open fun tilFattetVedtak(): Behandling {
         throw BehandlingStoetterIkkeStatusEndringException(FATTET_VEDTAK)
     }
 
+    // unødvendig?
     open fun tilAttestert(): Behandling {
         throw BehandlingStoetterIkkeStatusEndringException(ATTESTERT)
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/kommerbarnettilgode/KommerBarnetTilGodeService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/kommerbarnettilgode/KommerBarnetTilGodeService.kt
@@ -10,13 +10,11 @@ class KommerBarnetTilGodeService(
     private val behandlingDao: BehandlingDao,
 ) {
     fun lagreKommerBarnetTilgode(kommerBarnetTilgode: KommerBarnetTilgode) {
-        inTransaction(true) {
-            kommerBarnetTilgode.behandlingId?.let {
-                behandlingDao.hentBehandling(it)
-                    ?.tilOpprettet()
-                    ?.also { kommerBarnetTilGodeDao.lagreKommerBarnetTilGode(kommerBarnetTilgode) }
-                    ?.also { behandling -> behandlingDao.lagreStatus(behandling) }
-            }
+        kommerBarnetTilgode.behandlingId?.let {
+            behandlingDao.hentBehandling(it)
+                ?.tilOpprettet()
+                ?.also { kommerBarnetTilGodeDao.lagreKommerBarnetTilGode(kommerBarnetTilgode) }
+                ?.also { behandling -> behandlingDao.lagreStatus(behandling) }
         }
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringService.kt
@@ -8,6 +8,7 @@ import no.nav.etterlatte.behandling.GyldighetsproevingService
 import no.nav.etterlatte.behandling.domain.Behandling
 import no.nav.etterlatte.behandling.domain.toStatistikkBehandling
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeService
+import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.JaNei
 import no.nav.etterlatte.libs.common.behandling.JaNeiMedBegrunnelse
@@ -43,12 +44,14 @@ class MigreringService(
                 pesys,
                 JaNeiMedBegrunnelse(JaNei.JA, "Automatisk importert fra Pesys"),
             )
-            behandlingService.oppdaterVirkningstidspunkt(
-                it.id,
-                request.virkningstidspunkt,
-                pesys,
-                "Automatisk importert fra Pesys",
-            )
+            inTransaction {
+                behandlingService.oppdaterVirkningstidspunkt(
+                    it.id,
+                    request.virkningstidspunkt,
+                    pesys,
+                    "Automatisk importert fra Pesys",
+                )
+            }
             val nyopprettaOppgave =
                 oppgaveService.hentOppgaverForSak(it.sak.id).first { o -> o.referanse == it.id.toString() }
             oppgaveService.tildelSaksbehandler(nyopprettaOppgave.id, pesys)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringService.kt
@@ -29,38 +29,38 @@ class MigreringService(
     private val oppgaveService: OppgaveService,
 ) {
     fun migrer(request: MigreringRequest) =
-        opprettSakOgBehandling(request)?.let {
-            val pesys = Vedtaksloesning.PESYS.name
-            kommerBarnetTilGodeService.lagreKommerBarnetTilgode(
-                KommerBarnetTilgode(
-                    JaNei.JA,
-                    "Automatisk importert fra Pesys",
-                    Grunnlagsopplysning.Pesys.create(),
-                    behandlingId = it.id,
-                ),
-            )
-            gyldighetsproevingService.lagreGyldighetsproeving(
-                it.id,
-                pesys,
-                JaNeiMedBegrunnelse(JaNei.JA, "Automatisk importert fra Pesys"),
-            )
-            inTransaction {
+        inTransaction {
+            opprettSakOgBehandling(request)?.let {
+                val pesys = Vedtaksloesning.PESYS.name
+                kommerBarnetTilGodeService.lagreKommerBarnetTilgode(
+                    KommerBarnetTilgode(
+                        JaNei.JA,
+                        "Automatisk importert fra Pesys",
+                        Grunnlagsopplysning.Pesys.create(),
+                        behandlingId = it.id,
+                    ),
+                )
+                gyldighetsproevingService.lagreGyldighetsproeving(
+                    it.id,
+                    pesys,
+                    JaNeiMedBegrunnelse(JaNei.JA, "Automatisk importert fra Pesys"),
+                )
                 behandlingService.oppdaterVirkningstidspunkt(
                     it.id,
                     request.virkningstidspunkt,
                     pesys,
                     "Automatisk importert fra Pesys",
                 )
-            }
-            val nyopprettaOppgave =
-                oppgaveService.hentOppgaverForSak(it.sak.id).first { o -> o.referanse == it.id.toString() }
-            oppgaveService.tildelSaksbehandler(nyopprettaOppgave.id, pesys)
+                val nyopprettaOppgave =
+                    oppgaveService.hentOppgaverForSak(it.sak.id).first { o -> o.referanse == it.id.toString() }
+                oppgaveService.tildelSaksbehandler(nyopprettaOppgave.id, pesys)
 
-            behandlingsHendelser.sendMeldingForHendelseMedDetaljertBehandling(
-                it.toStatistikkBehandling(request.opprettPersongalleri()),
-                BehandlingHendelseType.OPPRETTET,
-            )
-            it
+                behandlingsHendelser.sendMeldingForHendelseMedDetaljertBehandling(
+                    it.toStatistikkBehandling(request.opprettPersongalleri()),
+                    BehandlingHendelseType.OPPRETTET,
+                )
+                it
+            }
         }
 
     private fun opprettSakOgBehandling(request: MigreringRequest): Behandling? =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningRoutes.kt
@@ -6,6 +6,7 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
+import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.behandling.Omregningshendelse
 import no.nav.etterlatte.libs.common.behandling.SakType
 import java.util.UUID
@@ -15,11 +16,13 @@ fun Route.omregningRoutes(omregningService: OmregningService) {
         post {
             val request = call.receive<Omregningshendelse>()
             val (behandlingId, forrigeBehandlingId, sakType) =
-                omregningService.opprettOmregning(
-                    sakId = request.sakId,
-                    fraDato = request.fradato,
-                    prosessType = request.prosesstype,
-                )
+                inTransaction {
+                    omregningService.opprettOmregning(
+                        sakId = request.sakId,
+                        fraDato = request.fradato,
+                        prosessType = request.prosesstype,
+                    )
+                }
             call.respond(OpprettOmregningResponse(behandlingId, forrigeBehandlingId, sakType))
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.behandling.omregning
 
+import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.BehandlingService
 import no.nav.etterlatte.behandling.GrunnlagService
 import no.nav.etterlatte.behandling.revurdering.RevurderingService
@@ -15,7 +16,7 @@ class OmregningService(
     private val grunnlagService: GrunnlagService,
     private val revurderingService: RevurderingService,
 ) {
-    suspend fun opprettOmregning(
+    fun opprettOmregning(
         sakId: Long,
         fraDato: LocalDate,
         prosessType: Prosesstype,
@@ -23,9 +24,7 @@ class OmregningService(
         val forrigeBehandling =
             behandlingService.hentSisteIverksatte(sakId)
                 ?: throw IllegalArgumentException("Fant ikke forrige behandling i sak $sakId")
-
-        val persongalleri = grunnlagService.hentPersongalleri(sakId)
-
+        val persongalleri = runBlocking { grunnlagService.hentPersongalleri(sakId) }
         val behandling =
             when (prosessType) {
                 Prosesstype.AUTOMATISK ->

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
@@ -32,11 +32,13 @@ internal fun Route.revurderingRoutes(revurderingService: RevurderingService) {
                         logger.info("Lagrer revurderinginfo på behandling $behandlingsId")
                         medBody<RevurderingInfoDto> {
                             val fikkLagret =
-                                revurderingService.lagreRevurderingInfo(
-                                    behandlingsId,
-                                    RevurderingMedBegrunnelse(it.info, it.begrunnelse),
-                                    navIdent,
-                                )
+                                inTransaction {
+                                    revurderingService.lagreRevurderingInfo(
+                                        behandlingsId,
+                                        RevurderingMedBegrunnelse(it.info, it.begrunnelse),
+                                        navIdent,
+                                    )
+                                }
                             if (fikkLagret) {
                                 call.respond(HttpStatusCode.NoContent)
                             } else {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
@@ -9,6 +9,7 @@ import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
+import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
@@ -54,14 +55,16 @@ internal fun Route.revurderingRoutes(revurderingService: RevurderingService) {
                     medBody<OpprettRevurderingRequest> { opprettRevurderingRequest ->
 
                         val revurdering =
-                            revurderingService.opprettManuellRevurderingWrapper(
-                                sakId,
-                                opprettRevurderingRequest.aarsak,
-                                opprettRevurderingRequest.paaGrunnAvHendelseId,
-                                opprettRevurderingRequest.begrunnelse,
-                                opprettRevurderingRequest.fritekstAarsak,
-                                saksbehandler,
-                            )
+                            inTransaction {
+                                revurderingService.opprettManuellRevurderingWrapper(
+                                    sakId,
+                                    opprettRevurderingRequest.aarsak,
+                                    opprettRevurderingRequest.paaGrunnAvHendelseId,
+                                    opprettRevurderingRequest.begrunnelse,
+                                    opprettRevurderingRequest.fritekstAarsak,
+                                    saksbehandler,
+                                )
+                            }
 
                         when (revurdering) {
                             null -> call.respond(HttpStatusCode.NotFound)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -248,6 +248,7 @@ class RevurderingServiceImpl(
         return behandling.status.kanEndres()
     }
 
+    // TODO flytte ut intrans her?
     override fun lagreRevurderingInfo(
         behandlingsId: UUID,
         revurderingMedBegrunnelse: RevurderingMedBegrunnelse,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilgang/TilgangRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilgang/TilgangRoutes.kt
@@ -8,6 +8,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.Kontekst
+import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.behandlingsId
@@ -26,10 +27,12 @@ internal fun Route.tilgangRoutes(tilgangService: TilgangService) {
 
             val harTilgang =
                 harTilgangBrukertypeSjekk(brukerTokenInfo) { _ ->
-                    tilgangService.harTilgangTilPerson(
-                        fnr,
-                        Kontekst.get().appUserAsSaksbehandler().saksbehandlerMedRoller,
-                    )
+                    inTransaction {
+                        tilgangService.harTilgangTilPerson(
+                            fnr,
+                            Kontekst.get().appUserAsSaksbehandler().saksbehandlerMedRoller,
+                        )
+                    }
                 }
             call.respond(harTilgang)
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -230,7 +230,7 @@ internal class ApplicationContext(
             revurderingService = revurderingService,
         )
 
-    val tilgangService = TilgangServiceImpl(SakTilgangDao(dataSource))
+    val tilgangService = TilgangServiceImpl(SakTilgangDao { databaseContext().activeTx() })
     val sakService =
         RealSakService(
             sakDao,

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -65,8 +65,8 @@ import no.nav.etterlatte.oppgave.OppgaveService
 import no.nav.etterlatte.oppgaveGosys.GosysOppgaveKlient
 import no.nav.etterlatte.oppgaveGosys.GosysOppgaveKlientImpl
 import no.nav.etterlatte.oppgaveGosys.GosysOppgaveServiceImpl
-import no.nav.etterlatte.sak.RealSakService
 import no.nav.etterlatte.sak.SakDao
+import no.nav.etterlatte.sak.SakServiceImpl
 import no.nav.etterlatte.sak.SakTilgangDao
 import no.nav.etterlatte.sak.TilgangServiceImpl
 import no.nav.etterlatte.tilgangsstyring.AzureGroup
@@ -230,14 +230,13 @@ internal class ApplicationContext(
             revurderingService = revurderingService,
         )
 
-    val tilgangService = TilgangServiceImpl(SakTilgangDao { databaseContext().activeTx() })
+    val tilgangService = TilgangServiceImpl(SakTilgangDao(dataSource))
     val sakService =
-        RealSakService(
+        SakServiceImpl(
             sakDao,
             pdlKlient,
             norg2Klient,
             featureToggleService,
-            tilgangService,
             skjermingKlient,
         )
     val enhetService = EnhetServiceImpl(navAnsattKlient)
@@ -248,7 +247,6 @@ internal class ApplicationContext(
             behandlingService = behandlingService,
             pdlKlient = pdlKlient,
             grunnlagKlient = grunnlagKlient,
-            tilgangService = tilgangService,
             sakService = sakService,
         )
 

--- a/apps/etterlatte-behandling/src/main/kotlin/egenansatt/EgenAnsattRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/egenansatt/EgenAnsattRoute.kt
@@ -9,6 +9,7 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.application
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
+import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.skjermet.EgenAnsattSkjermet
 
 internal fun Route.egenAnsattRoute(egenAnsattService: EgenAnsattService) {
@@ -18,7 +19,9 @@ internal fun Route.egenAnsattRoute(egenAnsattService: EgenAnsattService) {
         post {
             val skjermetHendelse = call.receive<EgenAnsattSkjermet>()
             logger.info("Mottar en egen ansatt hendelse fra skjermingsløsningen")
-            egenAnsattService.haandterSkjerming(skjermetHendelse)
+            inTransaction {
+                egenAnsattService.haandterSkjerming(skjermetHendelse)
+            }
             call.respond(HttpStatusCode.OK)
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/egenansatt/EgenAnsattService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/egenansatt/EgenAnsattService.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.egenansatt
 
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseService
+import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.person.maskerFnr
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.skjermet.EgenAnsattSkjermet
@@ -13,35 +14,37 @@ class EgenAnsattService(private val sakService: SakService, val sikkerLogg: Logg
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     fun haandterSkjerming(skjermetHendelse: EgenAnsattSkjermet) {
-        val saker = sakService.finnSaker(skjermetHendelse.fnr)
-        val sakerMedGradering = sakService.sjekkOmSakerErGradert(saker.map(Sak::id))
-        val sakerSomHarGradering = sakerMedGradering.filter { it.adressebeskyttelseGradering?.erGradert() ?: false }
-        if (sakerSomHarGradering.isNotEmpty()) return
-        if (saker.isEmpty()) {
-            logger.debug(
-                "Fant ingen saker for skjermethendelse fnr: ${skjermetHendelse.fnr.maskerFnr()} " +
-                    "se sikkerlogg og/eller skjekk korrelasjonsid. Selvom dette var forventet," +
-                    " ellers hadde ikke vi fått denne hendelsen",
-            )
-            sikkerLogg.debug("Fant ingen ingen saker for fnr: ${skjermetHendelse.fnr}")
-        }
-
-        val sakerMedNyEnhet =
-            saker.map {
-                GrunnlagsendringshendelseService.SakMedEnhet(
-                    it.id,
-                    if (skjermetHendelse.skjermet) {
-                        Enheter.EGNE_ANSATTE.enhetNr
-                    } else {
-                        sakService.finnEnhetForPersonOgTema(
-                            skjermetHendelse.fnr,
-                            it.sakType.tema,
-                            it.sakType,
-                        ).enhetNr
-                    },
+        inTransaction {
+            val saker = sakService.finnSaker(skjermetHendelse.fnr)
+            val sakerMedGradering = sakService.sjekkOmSakerErGradert(saker.map(Sak::id))
+            val sakerSomHarGradering = sakerMedGradering.filter { it.adressebeskyttelseGradering?.erGradert() ?: false }
+            if (sakerSomHarGradering.isNotEmpty()) return@inTransaction
+            if (saker.isEmpty()) {
+                logger.debug(
+                    "Fant ingen saker for skjermethendelse fnr: ${skjermetHendelse.fnr.maskerFnr()} " +
+                        "se sikkerlogg og/eller skjekk korrelasjonsid. Selvom dette var forventet," +
+                        " ellers hadde ikke vi fått denne hendelsen",
                 )
+                sikkerLogg.debug("Fant ingen ingen saker for fnr: ${skjermetHendelse.fnr}")
             }
-        sakService.oppdaterEnhetForSaker(sakerMedNyEnhet)
-        sakService.markerSakerMedSkjerming(saker.map { it.id }, skjermetHendelse.skjermet)
+
+            val sakerMedNyEnhet =
+                saker.map {
+                    GrunnlagsendringshendelseService.SakMedEnhet(
+                        it.id,
+                        if (skjermetHendelse.skjermet) {
+                            Enheter.EGNE_ANSATTE.enhetNr
+                        } else {
+                            sakService.finnEnhetForPersonOgTema(
+                                skjermetHendelse.fnr,
+                                it.sakType.tema,
+                                it.sakType,
+                            ).enhetNr
+                        },
+                    )
+                }
+            sakService.oppdaterEnhetForSaker(sakerMedNyEnhet)
+            sakService.markerSakerMedSkjerming(saker.map { it.id }, skjermetHendelse.skjermet)
+        }
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/egenansatt/EgenAnsattService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/egenansatt/EgenAnsattService.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.egenansatt
 
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseService
-import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.person.maskerFnr
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.skjermet.EgenAnsattSkjermet
@@ -14,37 +13,35 @@ class EgenAnsattService(private val sakService: SakService, val sikkerLogg: Logg
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     fun haandterSkjerming(skjermetHendelse: EgenAnsattSkjermet) {
-        inTransaction {
-            val saker = sakService.finnSaker(skjermetHendelse.fnr)
-            val sakerMedGradering = sakService.sjekkOmSakerErGradert(saker.map(Sak::id))
-            val sakerSomHarGradering = sakerMedGradering.filter { it.adressebeskyttelseGradering?.erGradert() ?: false }
-            if (sakerSomHarGradering.isNotEmpty()) return@inTransaction
-            if (saker.isEmpty()) {
-                logger.debug(
-                    "Fant ingen saker for skjermethendelse fnr: ${skjermetHendelse.fnr.maskerFnr()} " +
-                        "se sikkerlogg og/eller skjekk korrelasjonsid. Selvom dette var forventet," +
-                        " ellers hadde ikke vi fått denne hendelsen",
-                )
-                sikkerLogg.debug("Fant ingen ingen saker for fnr: ${skjermetHendelse.fnr}")
-            }
-
-            val sakerMedNyEnhet =
-                saker.map {
-                    GrunnlagsendringshendelseService.SakMedEnhet(
-                        it.id,
-                        if (skjermetHendelse.skjermet) {
-                            Enheter.EGNE_ANSATTE.enhetNr
-                        } else {
-                            sakService.finnEnhetForPersonOgTema(
-                                skjermetHendelse.fnr,
-                                it.sakType.tema,
-                                it.sakType,
-                            ).enhetNr
-                        },
-                    )
-                }
-            sakService.oppdaterEnhetForSaker(sakerMedNyEnhet)
-            sakService.markerSakerMedSkjerming(saker.map { it.id }, skjermetHendelse.skjermet)
+        val saker = sakService.finnSaker(skjermetHendelse.fnr)
+        val sakerMedGradering = sakService.sjekkOmSakerErGradert(saker.map(Sak::id))
+        val sakerSomHarGradering = sakerMedGradering.filter { it.adressebeskyttelseGradering?.erGradert() ?: false }
+        if (sakerSomHarGradering.isNotEmpty()) return
+        if (saker.isEmpty()) {
+            logger.debug(
+                "Fant ingen saker for skjermethendelse fnr: ${skjermetHendelse.fnr.maskerFnr()} " +
+                    "se sikkerlogg og/eller skjekk korrelasjonsid. Selvom dette var forventet," +
+                    " ellers hadde ikke vi fått denne hendelsen",
+            )
+            sikkerLogg.debug("Fant ingen ingen saker for fnr: ${skjermetHendelse.fnr}")
         }
+
+        val sakerMedNyEnhet =
+            saker.map {
+                GrunnlagsendringshendelseService.SakMedEnhet(
+                    it.id,
+                    if (skjermetHendelse.skjermet) {
+                        Enheter.EGNE_ANSATTE.enhetNr
+                    } else {
+                        sakService.finnEnhetForPersonOgTema(
+                            skjermetHendelse.fnr,
+                            it.sakType.tema,
+                            it.sakType,
+                        ).enhetNr
+                    },
+                )
+            }
+        sakService.oppdaterEnhetForSaker(sakerMedNyEnhet)
+        sakService.markerSakerMedSkjerming(saker.map { it.id }, skjermetHendelse.skjermet)
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseRoute.kt
@@ -12,6 +12,7 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.behandling.domain.GrunnlagsendringsType
 import no.nav.etterlatte.behandling.domain.Grunnlagsendringshendelse
+import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.institusjonsopphold.InstitusjonsoppholdHendelseBeriket
 import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.pdlhendelse.Adressebeskyttelse
@@ -88,7 +89,7 @@ internal fun Route.grunnlagsendringshendelseRoute(grunnlagsendringshendelseServi
             }
 
             get("/gyldigehendelser") {
-                call.respond(grunnlagsendringshendelseService.hentGyldigeHendelserForSak(sakId))
+                call.respond(inTransaction { grunnlagsendringshendelseService.hentGyldigeHendelserForSak(sakId) })
             }
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
@@ -38,7 +38,6 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.oppgave.OppgaveService
 import no.nav.etterlatte.sak.SakService
-import no.nav.etterlatte.sak.TilgangService
 import no.nav.etterlatte.sikkerLogg
 import no.nav.etterlatte.token.Saksbehandler
 import org.slf4j.LoggerFactory
@@ -50,7 +49,6 @@ class GrunnlagsendringshendelseService(
     private val behandlingService: BehandlingService,
     private val pdlKlient: PdlKlient,
     private val grunnlagKlient: GrunnlagKlient,
-    private val tilgangService: TilgangService,
     private val sakService: SakService,
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
@@ -171,14 +169,16 @@ class GrunnlagsendringshendelseService(
         val gradering = adressebeskyttelse.adressebeskyttelseGradering
         val sakIder = grunnlagKlient.hentAlleSakIder(adressebeskyttelse.fnr)
 
-        inTransaction { oppdaterEnheterForsaker(fnr = adressebeskyttelse.fnr, gradering = gradering) }
+        inTransaction {
+            oppdaterEnheterForsaker(fnr = adressebeskyttelse.fnr, gradering = gradering)
 
-        sakIder.forEach { sakId ->
-            tilgangService.oppdaterAdressebeskyttelse(
-                sakId,
-                gradering,
-            )
-            sikkerLogg.info("Oppdaterte adressebeskyttelse for sakId=$sakId med gradering=$gradering")
+            sakIder.forEach { sakId ->
+                sakService.oppdaterAdressebeskyttelse(
+                    sakId,
+                    gradering,
+                )
+                sikkerLogg.info("Oppdaterte adressebeskyttelse for sakId=$sakId med gradering=$gradering")
+            }
         }
 
         if (sakIder.isNotEmpty() && gradering != AdressebeskyttelseGradering.UGRADERT) {

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
@@ -53,19 +53,15 @@ class GrunnlagsendringshendelseService(
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    fun hentGyldigeHendelserForSak(sakId: Long) =
-        inTransaction {
-            grunnlagsendringshendelseDao.hentGrunnlagsendringshendelserSomErSjekketAvJobb(sakId)
-        }
+    fun hentGyldigeHendelserForSak(sakId: Long) = grunnlagsendringshendelseDao.hentGrunnlagsendringshendelserSomErSjekketAvJobb(sakId)
 
-    fun hentAlleHendelserForSak(sakId: Long) =
-        inTransaction {
-            logger.info("Henter alle relevante hendelser for sak $sakId")
-            grunnlagsendringshendelseDao.hentGrunnlagsendringshendelserMedStatuserISak(
-                sakId,
-                GrunnlagsendringStatus.relevantForSaksbehandler().toList(),
-            )
-        }
+    fun hentAlleHendelserForSak(sakId: Long): List<Grunnlagsendringshendelse> {
+        logger.info("Henter alle relevante hendelser for sak $sakId")
+        return grunnlagsendringshendelseDao.hentGrunnlagsendringshendelserMedStatuserISak(
+            sakId,
+            GrunnlagsendringStatus.relevantForSaksbehandler().toList(),
+        )
+    }
 
     fun hentAlleHendelserForSakAvType(
         sakId: Long,

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutesNy.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutesNy.kt
@@ -47,7 +47,7 @@ internal fun Route.oppgaveRoutes(
         route("/sak/{$SAKID_CALL_PARAMETER}") {
             get("oppgaver") {
                 kunSystembruker {
-                    call.respond(service.hentSakOgOppgaverForSak(sakId))
+                    call.respond(inTransaction { service.hentSakOgOppgaverForSak(sakId) })
                 }
             }
         }
@@ -71,10 +71,12 @@ internal fun Route.oppgaveRoutes(
         route("{$OPPGAVEID_CALL_PARAMETER}") {
             post("tildel-saksbehandler") {
                 val saksbehandlerEndringDto = call.receive<SaksbehandlerEndringDto>()
-                service.tildelSaksbehandler(
-                    oppgaveId,
-                    saksbehandlerEndringDto.saksbehandler,
-                )
+                inTransaction {
+                    service.tildelSaksbehandler(
+                        oppgaveId,
+                        saksbehandlerEndringDto.saksbehandler,
+                    )
+                }
                 call.respond(HttpStatusCode.OK)
             }
             post("bytt-saksbehandler") {

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -228,11 +228,9 @@ class OppgaveService(
         sakId: Long,
         enhetsID: String,
     ) {
-        inTransaction {
-            val oppgaverForSak = oppgaveDao.hentOppgaverForSak(sakId)
-            oppgaverForSak.forEach {
-                oppgaveDao.endreEnhetPaaOppgave(it.id, enhetsID)
-            }
+        val oppgaverForSak = oppgaveDao.hentOppgaverForSak(sakId)
+        oppgaverForSak.forEach {
+            oppgaveDao.endreEnhetPaaOppgave(it.id, enhetsID)
         }
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakDao.kt
@@ -27,14 +27,14 @@ class SakDao(private val connection: () -> Connection) {
     }
 
     fun oppdaterAdresseBeskyttelse(
-        id: Long,
+        sakId: Long,
         adressebeskyttelseGradering: AdressebeskyttelseGradering,
     ): Int {
         with(connection()) {
             val statement = prepareStatement("UPDATE sak SET adressebeskyttelse = ? where id = ?")
             statement.setString(1, adressebeskyttelseGradering.toString())
-            statement.setLong(2, id)
-            return statement.executeUpdate()
+            statement.setLong(2, sakId)
+            return statement.executeUpdate().also { require(it == 1) }
         }
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakDao.kt
@@ -26,6 +26,18 @@ class SakDao(private val connection: () -> Connection) {
         }
     }
 
+    fun oppdaterAdresseBeskyttelse(
+        id: Long,
+        adressebeskyttelseGradering: AdressebeskyttelseGradering,
+    ): Int {
+        with(connection()) {
+            val statement = prepareStatement("UPDATE sak SET adressebeskyttelse = ? where id = ?")
+            statement.setString(1, adressebeskyttelseGradering.toString())
+            statement.setLong(2, id)
+            return statement.executeUpdate()
+        }
+    }
+
     fun hentSaker(): List<Sak> {
         val statement = connection().prepareStatement("SELECT id, sakType, fnr, enhet from sak")
         return statement.executeQuery().toList { this.toSak() }

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
@@ -13,7 +13,6 @@ import no.nav.etterlatte.common.klienter.SkjermingKlient
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggle
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseService
-import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
@@ -89,9 +88,7 @@ class RealSakService(
     }
 
     override fun finnSaker(person: String): List<Sak> {
-        return inTransaction {
-            finnSakerForPerson(person).filterForEnheter()
-        }
+        return finnSakerForPerson(person).filterForEnheter()
     }
 
     override fun slettSak(id: Long) {
@@ -102,9 +99,7 @@ class RealSakService(
         sakIder: List<Long>,
         skjermet: Boolean,
     ) {
-        inTransaction {
-            dao.markerSakerMedSkjerming(sakIder, skjermet)
-        }
+        dao.markerSakerMedSkjerming(sakIder, skjermet)
     }
 
     override fun finnEllerOpprettSak(
@@ -135,27 +130,19 @@ class RealSakService(
                 skjermingKlient.personErSkjermet(fnr)
             }
         if (erSkjermet) {
-            inTransaction {
-                dao.oppdaterEnheterPaaSaker(
-                    listOf(GrunnlagsendringshendelseService.SakMedEnhet(sakId, Enheter.EGNE_ANSATTE.enhetNr)),
-                )
-            }
+            dao.oppdaterEnheterPaaSaker(
+                listOf(GrunnlagsendringshendelseService.SakMedEnhet(sakId, Enheter.EGNE_ANSATTE.enhetNr)),
+            )
         }
-        inTransaction {
-            dao.markerSakerMedSkjerming(sakIder = listOf(sakId), skjermet = erSkjermet)
-        }
+        dao.markerSakerMedSkjerming(sakIder = listOf(sakId), skjermet = erSkjermet)
     }
 
     override fun oppdaterEnhetForSaker(saker: List<GrunnlagsendringshendelseService.SakMedEnhet>) {
-        inTransaction {
-            dao.oppdaterEnheterPaaSaker(saker)
-        }
+        dao.oppdaterEnheterPaaSaker(saker)
     }
 
     override fun sjekkOmSakerErGradert(sakIder: List<Long>): List<SakMedGradering> {
-        return inTransaction {
-            dao.finnSakerMedGraderingOgSkjerming(sakIder)
-        }
+        return dao.finnSakerMedGraderingOgSkjerming(sakIder)
     }
 
     override fun finnSak(

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
@@ -114,13 +114,11 @@ class RealSakService(
         gradering: AdressebeskyttelseGradering?,
     ): Sak {
         val sak =
-            inTransaction {
-                finnSakerForPersonOgType(fnr, type) ?: dao.opprettSak(
-                    fnr,
-                    type,
-                    enhet ?: finnEnhetForPersonOgTema(fnr, type.tema, type).enhetNr,
-                )
-            }
+            finnSakerForPersonOgType(fnr, type) ?: dao.opprettSak(
+                fnr,
+                type,
+                enhet ?: finnEnhetForPersonOgTema(fnr, type.tema, type).enhetNr,
+            )
         this.sjekkSkjerming(fnr = fnr, sakId = sak.id)
         gradering?.let {
             tilgangService.oppdaterAdressebeskyttelse(sak.id, it)

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
@@ -116,7 +116,8 @@ class RealSakService(
             )
         this.sjekkSkjerming(fnr = fnr, sakId = sak.id)
         gradering?.let {
-            tilgangService.oppdaterAdressebeskyttelse(sak.id, it)
+            val updated = tilgangService.oppdaterAdressebeskyttelse(sak.id, it)
+            println(updated)
         }
         return sak
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
@@ -126,10 +126,10 @@ class SakServiceImpl(
     }
 
     override fun oppdaterAdressebeskyttelse(
-        id: Long,
+        sakId: Long,
         adressebeskyttelseGradering: AdressebeskyttelseGradering,
     ): Int {
-        return dao.oppdaterAdresseBeskyttelse(id, adressebeskyttelseGradering)
+        return dao.oppdaterAdresseBeskyttelse(sakId, adressebeskyttelseGradering)
     }
 
     private fun sjekkSkjerming(

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
@@ -62,14 +62,18 @@ interface SakService {
     fun oppdaterEnhetForSaker(saker: List<GrunnlagsendringshendelseService.SakMedEnhet>)
 
     fun sjekkOmSakerErGradert(sakIder: List<Long>): List<SakMedGradering>
+
+    fun oppdaterAdressebeskyttelse(
+        id: Long,
+        adressebeskyttelseGradering: AdressebeskyttelseGradering,
+    ): Int
 }
 
-class RealSakService(
+class SakServiceImpl(
     private val dao: SakDao,
     private val pdlKlient: PdlKlient,
     private val norg2Klient: Norg2Klient,
     private val featureToggleService: FeatureToggleService,
-    private val tilgangService: TilgangService,
     private val skjermingKlient: SkjermingKlient,
 ) : SakService {
     private val logger = LoggerFactory.getLogger(this::class.java)
@@ -116,10 +120,16 @@ class RealSakService(
             )
         this.sjekkSkjerming(fnr = fnr, sakId = sak.id)
         gradering?.let {
-            val updated = tilgangService.oppdaterAdressebeskyttelse(sak.id, it)
-            println(updated)
+            oppdaterAdressebeskyttelse(sak.id, it)
         }
         return sak
+    }
+
+    override fun oppdaterAdressebeskyttelse(
+        id: Long,
+        adressebeskyttelseGradering: AdressebeskyttelseGradering,
+    ): Int {
+        return dao.oppdaterAdresseBeskyttelse(id, adressebeskyttelseGradering)
     }
 
     private fun sjekkSkjerming(

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakTilgangDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakTilgangDao.kt
@@ -5,6 +5,9 @@ import no.nav.etterlatte.libs.database.singleOrNull
 import no.nav.etterlatte.libs.database.toList
 import javax.sql.DataSource
 
+/*
+    Hvis denne skal gjøre skriveoperasjoner MÅ ingen av metodene her være wrappet i en intransaction, da vil skriveoperasjonen bli overskridet av transaksjonen til intransaction
+ */
 class SakTilgangDao(private val datasource: DataSource) {
     fun finnSakerMedGraderingOgSkjerming(fnr: String): List<SakMedGraderingOgSkjermet> {
         datasource.connection.use { connection ->

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakTilgangDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakTilgangDao.kt
@@ -3,12 +3,12 @@ package no.nav.etterlatte.sak
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 import no.nav.etterlatte.libs.database.singleOrNull
 import no.nav.etterlatte.libs.database.toList
-import javax.sql.DataSource
+import java.sql.Connection
 
-class SakTilgangDao(private val datasource: DataSource) {
+class SakTilgangDao(private val connection: () -> Connection) {
     fun finnSakerMedGraderingOgSkjerming(fnr: String): List<SakMedGraderingOgSkjermet> {
-        datasource.connection.use {
-            val statement = it.prepareStatement("SELECT id, adressebeskyttelse, erSkjermet from sak where fnr = ?")
+        with(connection()) {
+            val statement = prepareStatement("SELECT id, adressebeskyttelse, erSkjermet from sak where fnr = ?")
             statement.setString(1, fnr)
             return statement.executeQuery().toList {
                 SakMedGraderingOgSkjermet(
@@ -21,8 +21,8 @@ class SakTilgangDao(private val datasource: DataSource) {
     }
 
     fun hentSakMedGraderingOgSkjerming(id: Long): SakMedGraderingOgSkjermet? {
-        datasource.connection.use {
-            val statement = it.prepareStatement("SELECT id, adressebeskyttelse, erSkjermet from sak where id = ?")
+        with(connection()) {
+            val statement = prepareStatement("SELECT id, adressebeskyttelse, erSkjermet from sak where id = ?")
             statement.setLong(1, id)
             return statement.executeQuery().singleOrNull {
                 SakMedGraderingOgSkjermet(
@@ -38,8 +38,8 @@ class SakTilgangDao(private val datasource: DataSource) {
         id: Long,
         adressebeskyttelseGradering: AdressebeskyttelseGradering,
     ): Int {
-        datasource.connection.use {
-            val statement = it.prepareStatement("UPDATE sak SET adressebeskyttelse = ? where id = ?")
+        with(connection()) {
+            val statement = prepareStatement("UPDATE sak SET adressebeskyttelse = ? where id = ?")
             statement.setString(1, adressebeskyttelseGradering.toString())
             statement.setLong(2, id)
             return statement.executeUpdate()
@@ -47,9 +47,9 @@ class SakTilgangDao(private val datasource: DataSource) {
     }
 
     fun hentSakMedGarderingOgSkjermingPaaBehandling(behandlingId: String): SakMedGraderingOgSkjermet? {
-        datasource.connection.use {
+        with(connection()) {
             val statement =
-                it.prepareStatement(
+                prepareStatement(
                     "SELECT s.id, adressebeskyttelse, erSkjermet FROM behandling b" +
                         " INNER JOIN sak s ON b.sak_id = s.id WHERE b.id = ?::uuid",
                 )
@@ -65,9 +65,9 @@ class SakTilgangDao(private val datasource: DataSource) {
     }
 
     fun hentSakMedGraderingOgSkjermingPaaOppgave(oppgaveId: String): SakMedGraderingOgSkjermet? {
-        datasource.connection.use {
+        with(connection()) {
             val statement =
-                it.prepareStatement(
+                prepareStatement(
                     """
                     SELECT s.id as sak_id, adressebeskyttelse, erskjermet 
                     FROM oppgave o
@@ -90,9 +90,9 @@ class SakTilgangDao(private val datasource: DataSource) {
     }
 
     fun hentSakMedGraderingOgSkjermingPaaKlage(klageId: String): SakMedGraderingOgSkjermet? {
-        datasource.connection.use {
+        with(connection()) {
             val statement =
-                it.prepareStatement(
+                prepareStatement(
                     """
                     SELECT s.id as sak_id, adressebeskyttelse, erskjermet 
                     FROM klage k

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/TilgangService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/TilgangService.kt
@@ -9,11 +9,6 @@ interface TilgangService {
         saksbehandlerMedRoller: SaksbehandlerMedRoller,
     ): Boolean
 
-    fun oppdaterAdressebeskyttelse(
-        id: Long,
-        adressebeskyttelseGradering: AdressebeskyttelseGradering,
-    ): Int
-
     fun harTilgangTilSak(
         sakId: Long,
         saksbehandlerMedRoller: SaksbehandlerMedRoller,
@@ -125,13 +120,5 @@ class TilgangServiceImpl(
             AdressebeskyttelseGradering.UGRADERT -> true
             else -> true
         }
-    }
-
-    override fun oppdaterAdressebeskyttelse(
-        id: Long,
-        adressebeskyttelseGradering: AdressebeskyttelseGradering,
-    ): Int {
-        // TODO: denne fungerer ikke lenger? Tipper alle som har signatur  datasource.connection.use må byttes ut
-        return dao.oppdaterAdresseBeskyttelse(id, adressebeskyttelseGradering)
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/TilgangService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/TilgangService.kt
@@ -131,6 +131,7 @@ class TilgangServiceImpl(
         id: Long,
         adressebeskyttelseGradering: AdressebeskyttelseGradering,
     ): Int {
+        // TODO: denne fungerer ikke lenger? Tipper alle som har signatur  datasource.connection.use må byttes ut
         return dao.oppdaterAdresseBeskyttelse(id, adressebeskyttelseGradering)
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
@@ -17,6 +17,7 @@ import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
 import no.nav.etterlatte.User
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggle
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
+import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.FoedselsNummerMedGraderingDTO
 import no.nav.etterlatte.libs.common.FoedselsnummerDTO
@@ -140,10 +141,12 @@ suspend inline fun PipelineContext<*, ApplicationCall>.withFoedselsnummerInterna
     when (brukerTokenInfo) {
         is Saksbehandler -> {
             val harTilgang =
-                tilgangService.harTilgangTilPerson(
-                    foedselsnummer.value,
-                    Kontekst.get().appUserAsSaksbehandler().saksbehandlerMedRoller,
-                )
+                inTransaction {
+                    tilgangService.harTilgangTilPerson(
+                        foedselsnummer.value,
+                        Kontekst.get().appUserAsSaksbehandler().saksbehandlerMedRoller,
+                    )
+                }
             if (harTilgang) {
                 onSuccess(foedselsnummer)
             } else {
@@ -164,10 +167,12 @@ suspend inline fun PipelineContext<*, ApplicationCall>.withFoedselsnummerAndGrad
     when (brukerTokenInfo) {
         is Saksbehandler -> {
             val harTilgangTilPerson =
-                tilgangService.harTilgangTilPerson(
-                    foedselsnummer.value,
-                    Kontekst.get().appUserAsSaksbehandler().saksbehandlerMedRoller,
-                )
+                inTransaction {
+                    tilgangService.harTilgangTilPerson(
+                        foedselsnummer.value,
+                        Kontekst.get().appUserAsSaksbehandler().saksbehandlerMedRoller,
+                    )
+                }
             if (harTilgangTilPerson) {
                 onSuccess(foedselsnummer, foedselsnummerDTOmedGradering.gradering)
             } else {

--- a/apps/etterlatte-behandling/src/test/kotlin/OmregningIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/OmregningIntegrationTest.kt
@@ -58,21 +58,20 @@ class OmregningIntegrationTest : BehandlingIntegrationTest() {
         private var sakId: Long = 0L
 
         fun opprettSakMedFoerstegangsbehandling(fnr: String): Pair<Sak, Foerstegangsbehandling?> {
-            val sak =
-                inTransaction {
+            return inTransaction {
+                val sak =
                     applicationContext.sakDao.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr)
-                }
 
-            val behandling =
-                applicationContext.behandlingFactory
-                    .opprettBehandling(
-                        sak.id,
-                        persongalleri(),
-                        LocalDateTime.now().toString(),
-                        Vedtaksloesning.GJENNY,
-                    )
-
-            return Pair(sak, behandling as Foerstegangsbehandling)
+                val behandling =
+                    applicationContext.behandlingFactory
+                        .opprettBehandling(
+                            sak.id,
+                            persongalleri(),
+                            LocalDateTime.now().toString(),
+                            Vedtaksloesning.GJENNY,
+                        )
+                Pair(sak, behandling as Foerstegangsbehandling)
+            }
         }
 
         @BeforeEach
@@ -85,9 +84,11 @@ class OmregningIntegrationTest : BehandlingIntegrationTest() {
                     Grunnlagsopplysning.Saksbehandler.create("A0"),
                     behandling!!.id,
                 )
-            applicationContext.kommerBarnetTilGodeService.lagreKommerBarnetTilgode(
-                kommerBarnetTilgode,
-            )
+            inTransaction {
+                applicationContext.kommerBarnetTilGodeService.lagreKommerBarnetTilgode(
+                    kommerBarnetTilgode,
+                )
+            }
 
             sakId = sak.id
 

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
@@ -31,15 +31,14 @@ import no.nav.etterlatte.tilgangsstyring.TILGANG_ROUTE_PATH
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.UUID
 
-// TODO: kan denne endres til per class hvis man har med truncate aftereach?
-@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AdressebeskyttelseTest : BehandlingIntegrationTest() {
-    @BeforeEach
+    @BeforeAll
     fun start() = startServer()
 
     @AfterEach

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.UUID
 
+// TODO: kan denne endres til per class hvis man har med truncate aftereach?
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 class AdressebeskyttelseTest : BehandlingIntegrationTest() {
     @BeforeEach
@@ -375,13 +376,16 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
                 module(applicationContext)
             }
 
-            httpClient.post("/personer/saker/${SakType.BARNEPENSJON}") {
-                addAuthToken(tokenSaksbehandler)
-                contentType(ContentType.Application.Json)
-                setBody(FoedselsNummerMedGraderingDTO(fnr, AdressebeskyttelseGradering.STRENGT_FORTROLIG))
-            }.apply {
-                Assertions.assertEquals(HttpStatusCode.OK, status)
-            }.body<Sak>()
+            val sak =
+                httpClient.post("/personer/saker/${SakType.BARNEPENSJON}") {
+                    addAuthToken(tokenSaksbehandler)
+                    contentType(ContentType.Application.Json)
+                    setBody(FoedselsNummerMedGraderingDTO(fnr, AdressebeskyttelseGradering.STRENGT_FORTROLIG))
+                }.apply {
+                    Assertions.assertEquals(HttpStatusCode.OK, status)
+                }.body<Sak>()
+
+            // Assertions.assertEquals(sak.)
 
             httpClient.post("/personer/saker/${SakType.BARNEPENSJON}") {
                 addAuthToken(tokenSaksbehandler)

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
@@ -390,8 +390,6 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
                     Assertions.assertEquals(HttpStatusCode.OK, status)
                 }.body<Sak>()
 
-            // Assertions.assertEquals(sak.)
-
             httpClient.post("/personer/saker/${SakType.BARNEPENSJON}") {
                 addAuthToken(tokenSaksbehandler)
                 contentType(ContentType.Application.Json)

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
@@ -28,6 +28,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.module
 import no.nav.etterlatte.tilgangsstyring.TILGANG_ROUTE_PATH
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -43,6 +44,11 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
 
     @AfterEach
     fun afterEach() {
+        resetDatabase()
+    }
+
+    @AfterAll
+    fun afterAllTests() {
         afterAll()
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
@@ -1,10 +1,15 @@
 package no.nav.etterlatte.adressebeskyttelse
 
 import com.nimbusds.jwt.JWTClaimsSet
+import io.mockk.mockk
 import no.nav.etterlatte.behandling.BehandlingDao
+import no.nav.etterlatte.behandling.klienter.Norg2Klient
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeDao
 import no.nav.etterlatte.behandling.revurdering.RevurderingDao
 import no.nav.etterlatte.common.Enheter
+import no.nav.etterlatte.common.klienter.PdlKlient
+import no.nav.etterlatte.common.klienter.SkjermingKlient
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
@@ -14,6 +19,8 @@ import no.nav.etterlatte.libs.database.POSTGRES_VERSION
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.opprettBehandling
 import no.nav.etterlatte.sak.SakDao
+import no.nav.etterlatte.sak.SakService
+import no.nav.etterlatte.sak.SakServiceImpl
 import no.nav.etterlatte.sak.SakTilgangDao
 import no.nav.etterlatte.sak.TilgangService
 import no.nav.etterlatte.sak.TilgangServiceImpl
@@ -38,11 +45,16 @@ internal class TilgangServiceTest {
 
     private lateinit var dataSource: DataSource
     private lateinit var tilgangService: TilgangService
+    private lateinit var sakService: SakService
     private lateinit var sakRepo: SakDao
     private lateinit var behandlingRepo: BehandlingDao
     private val strengtfortroligDev = "5ef775f2-61f8-4283-bf3d-8d03f428aa14"
     private val fortroligDev = "ea930b6b-9397-44d9-b9e6-f4cf527a632a"
     private val egenAnsattDev = "dbe4ad45-320b-4e9a-aaa1-73cca4ee124d"
+    private val pdlKlient = mockk<PdlKlient>()
+    private val norg2Klient = mockk<Norg2Klient>()
+    private val featureToggleService = mockk<FeatureToggleService>()
+    private val skjermingKlient = mockk<SkjermingKlient>()
 
     @BeforeAll
     fun beforeAll() {
@@ -57,8 +69,10 @@ internal class TilgangServiceTest {
                 password = postgreSQLContainer.password,
             ).apply { migrate() }
 
-        tilgangService = TilgangServiceImpl(SakTilgangDao { dataSource.connection })
+        tilgangService = TilgangServiceImpl(SakTilgangDao(dataSource))
         sakRepo = SakDao { dataSource.connection }
+
+        sakService = SakServiceImpl(sakRepo, pdlKlient, norg2Klient, featureToggleService, skjermingKlient)
         behandlingRepo =
             BehandlingDao(
                 KommerBarnetTilGodeDao {
@@ -82,8 +96,8 @@ internal class TilgangServiceTest {
                 Saksbehandler("", "ident", null),
                 emptyMap(),
             )
+        sakService.oppdaterAdressebeskyttelse(sakId, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
 
-        tilgangService.oppdaterAdressebeskyttelse(sakId, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
         val opprettBehandling =
             opprettBehandling(
                 type = BehandlingType.FØRSTEGANGSBEHANDLING,
@@ -115,8 +129,8 @@ internal class TilgangServiceTest {
                 Saksbehandler("", "ident", JwtTokenClaims(jwtclaims)),
                 mapOf(AzureGroup.STRENGT_FORTROLIG to strengtfortroligDev),
             )
+        sakService.oppdaterAdressebeskyttelse(sakId, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
 
-        tilgangService.oppdaterAdressebeskyttelse(sakId, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
         val opprettBehandling =
             opprettBehandling(
                 type = BehandlingType.FØRSTEGANGSBEHANDLING,

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
@@ -57,7 +57,7 @@ internal class TilgangServiceTest {
                 password = postgreSQLContainer.password,
             ).apply { migrate() }
 
-        tilgangService = TilgangServiceImpl(SakTilgangDao(dataSource))
+        tilgangService = TilgangServiceImpl(SakTilgangDao { dataSource.connection })
         sakRepo = SakDao { dataSource.connection }
         behandlingRepo =
             BehandlingDao(

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
@@ -10,8 +10,10 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
 import io.ktor.serialization.jackson.JacksonConverter
+import io.ktor.server.application.ApplicationCallPipeline
 import io.ktor.server.application.log
 import io.ktor.server.config.HoconApplicationConfig
+import io.ktor.server.routing.Route
 import io.ktor.server.testing.testApplication
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
@@ -20,15 +22,25 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asContextElement
+import kotlinx.coroutines.withContext
+import no.nav.etterlatte.Context
+import no.nav.etterlatte.DatabaseKontekst
+import no.nav.etterlatte.Kontekst
+import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
 import no.nav.etterlatte.behandling.BehandlingFactory
 import no.nav.etterlatte.behandling.BehandlingService
 import no.nav.etterlatte.behandling.BoddEllerArbeidetUtlandetRequest
+import no.nav.etterlatte.behandling.EnhetService
 import no.nav.etterlatte.behandling.GyldighetsproevingService
 import no.nav.etterlatte.behandling.UtenlandstilsnittRequest
 import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktService
 import no.nav.etterlatte.behandling.behandlingRoutes
+import no.nav.etterlatte.behandling.domain.SaksbehandlerEnhet
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeService
 import no.nav.etterlatte.behandling.manueltopphoer.ManueltOpphoerService
+import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.libs.common.behandling.UtenlandstilsnittType
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -45,6 +57,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import testsupport.buildTestApplicationConfigurationForOauth
+import java.sql.Connection
 import java.time.YearMonth
 import java.util.UUID
 
@@ -61,7 +74,7 @@ internal class BehandlingRoutesTest {
 
     @BeforeAll
     fun before() {
-        mockOAuth2Server.start(1234)
+        mockOAuth2Server.start()
         val httpServer = mockOAuth2Server.config.httpServer
         hoconApplicationConfig = buildTestApplicationConfigurationForOauth(httpServer.port(), AZURE_ISSUER, CLIENT_ID)
     }
@@ -156,7 +169,7 @@ internal class BehandlingRoutesTest {
     }
 
     @Test
-    fun `faar bad request hvis virkningstidspunkt ikke er gyldig`() {
+    fun `Får bad request hvis virkningstidspunkt ikke er gyldig`() {
         val bodyVirkningstidspunkt = Tidspunkt.parse("2017-02-01T00:00:00Z")
         val bodyBegrunnelse = "begrunnelse"
 
@@ -186,6 +199,52 @@ internal class BehandlingRoutesTest {
         }
     }
 
+    class DummyEnhetService : EnhetService {
+        override suspend fun enheterForIdent(ident: String): List<SaksbehandlerEnhet> {
+            return listOf(SaksbehandlerEnhet(id = Enheter.PORSGRUNN.enhetNr, navn = Enheter.PORSGRUNN.navn))
+        }
+
+        override suspend fun harTilgangTilEnhet(
+            ident: String,
+            enhetId: String,
+        ): Boolean {
+            return true
+        }
+    }
+
+    private val user = mockk<SaksbehandlerMedEnheterOgRoller>()
+
+    private fun Route.attachMockContext() {
+        intercept(ApplicationCallPipeline.Call) {
+            val context1 =
+                Context(
+                    user,
+                    object : DatabaseKontekst {
+                        override fun activeTx(): Connection {
+                            throw IllegalArgumentException()
+                        }
+
+                        override fun <T> inTransaction(
+                            gjenbruk: Boolean,
+                            block: () -> T,
+                        ): T {
+                            return block()
+                        }
+                    },
+                )
+
+            withContext(
+                Dispatchers.Default +
+                    Kontekst.asContextElement(
+                        value = context1,
+                    ),
+            ) {
+                proceed()
+            }
+            Kontekst.remove()
+        }
+    }
+
     private fun withTestApplication(block: suspend (client: HttpClient) -> Unit) {
         testApplication {
             environment {
@@ -193,6 +252,7 @@ internal class BehandlingRoutesTest {
             }
             application {
                 restModule(this.log) {
+                    attachMockContext()
                     behandlingRoutes(
                         behandlingService,
                         gyldighetsproevingService,

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
@@ -214,6 +214,7 @@ internal class BehandlingRoutesTest {
 
     private val user = mockk<SaksbehandlerMedEnheterOgRoller>()
 
+    // Felles sted for denne?
     private fun Route.attachMockContext() {
         intercept(ApplicationCallPipeline.Call) {
             val context1 =

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
@@ -37,7 +37,6 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toNorskTid
 import no.nav.etterlatte.libs.ktor.AZURE_ISSUER
 import no.nav.etterlatte.libs.ktor.restModule
-import no.nav.etterlatte.sak.SakService
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
@@ -53,7 +52,6 @@ import java.util.UUID
 internal class BehandlingRoutesTest {
     private val mockOAuth2Server = MockOAuth2Server()
     private lateinit var hoconApplicationConfig: HoconApplicationConfig
-    private val sakService = mockk<SakService>(relaxUnitFun = true)
     private val behandlingService = mockk<BehandlingService>(relaxUnitFun = true)
     private val gyldighetsproevingService = mockk<GyldighetsproevingService>()
     private val kommerBarnetTilGodeService = mockk<KommerBarnetTilGodeService>()

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
@@ -23,6 +23,7 @@ import no.nav.etterlatte.foerstegangsbehandling
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.grunnlagsOpplysningMedPersonopplysning
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseDao
+import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BoddEllerArbeidetUtlandet
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
@@ -688,14 +689,16 @@ class BehandlingServiceImplTest {
                 etterbetalingService = mockk(),
             )
 
-        sut.oppdaterUtenlandstilsnitt(
-            uuid,
-            Utenlandstilsnitt(
-                UtenlandstilsnittType.BOSATT_UTLAND,
-                Grunnlagsopplysning.Saksbehandler.create("ident"),
-                "Test",
-            ),
-        )
+        inTransaction {
+            sut.oppdaterUtenlandstilsnitt(
+                uuid,
+                Utenlandstilsnitt(
+                    UtenlandstilsnittType.BOSATT_UTLAND,
+                    Grunnlagsopplysning.Saksbehandler.create("ident"),
+                    "Test",
+                ),
+            )
+        }
 
         assertEquals(UtenlandstilsnittType.BOSATT_UTLAND, slot.captured.type)
         assertEquals("Test", slot.captured.begrunnelse)
@@ -743,14 +746,16 @@ class BehandlingServiceImplTest {
                 etterbetalingService = mockk(),
             )
 
-        sut.oppdaterBoddEllerArbeidetUtlandet(
-            uuid,
-            BoddEllerArbeidetUtlandet(
-                true,
-                Grunnlagsopplysning.Saksbehandler.create("ident"),
-                "Test",
-            ),
-        )
+        inTransaction {
+            sut.oppdaterBoddEllerArbeidetUtlandet(
+                uuid,
+                BoddEllerArbeidetUtlandet(
+                    true,
+                    Grunnlagsopplysning.Saksbehandler.create("ident"),
+                    "Test",
+                ),
+            )
+        }
 
         assertEquals(true, slot.captured.boddEllerArbeidetUtlandet)
         assertEquals("Test", slot.captured.begrunnelse)

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingStatusServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingStatusServiceTest.kt
@@ -15,6 +15,7 @@ import no.nav.etterlatte.behandling.hendelse.HendelseType
 import no.nav.etterlatte.foerstegangsbehandling
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseService
+import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BoddEllerArbeidetUtlandet
 import no.nav.etterlatte.libs.common.generellbehandling.GenerellBehandling
@@ -83,7 +84,9 @@ internal class BehandlingStatusServiceTest {
                 generellBehandlingService,
             )
 
-        sut.settIverksattVedtak(behandlingId, iverksettVedtak)
+        inTransaction {
+            sut.settIverksattVedtak(behandlingId, iverksettVedtak)
+        }
 
         verify {
             behandlingdao.lagreStatus(behandlingId, BehandlingStatus.IVERKSATT, any())
@@ -147,7 +150,9 @@ internal class BehandlingStatusServiceTest {
                 generellBehandlingService,
             )
 
-        sut.settIverksattVedtak(behandlingId, iverksettVedtak)
+        inTransaction {
+            sut.settIverksattVedtak(behandlingId, iverksettVedtak)
+        }
 
         verify {
             behandlingdao.lagreStatus(behandlingId, BehandlingStatus.IVERKSATT, any())

--- a/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattServiceTest.kt
@@ -23,9 +23,9 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.database.POSTGRES_VERSION
 import no.nav.etterlatte.libs.database.migrate
-import no.nav.etterlatte.sak.RealSakService
 import no.nav.etterlatte.sak.SakDao
 import no.nav.etterlatte.sak.SakService
+import no.nav.etterlatte.sak.SakServiceImpl
 import no.nav.etterlatte.sak.TilgangService
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -73,7 +73,7 @@ internal class EgenAnsattServiceTest {
         sakRepo = SakDao { connection }
         sakService =
             spyk(
-                RealSakService(sakRepo, pdlKlient, norg2Klient, featureToggleService, tilgangService, skjermingKlient),
+                SakServiceImpl(sakRepo, pdlKlient, norg2Klient, featureToggleService, skjermingKlient),
             )
         egenAnsattService = EgenAnsattService(sakService, sikkerLogg)
 

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
@@ -47,8 +47,6 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.oppgave.OppgaveService
 import no.nav.etterlatte.sak.SakService
-import no.nav.etterlatte.sak.SakTilgangDao
-import no.nav.etterlatte.sak.TilgangServiceImpl
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -64,8 +62,6 @@ internal class GrunnlagsendringshendelseServiceTest {
     private val grunnlagshendelsesDao = mockk<GrunnlagsendringshendelseDao>()
     private val pdlService = mockk<PdlKlientImpl>()
     private val grunnlagClient = mockk<GrunnlagKlient>(relaxed = true, relaxUnitFun = true)
-    private val adressebeskyttelseDaoMock = mockk<SakTilgangDao>()
-    private val tilgangServiceImpl = TilgangServiceImpl(adressebeskyttelseDaoMock)
     private val sakService = mockk<SakService>()
     private val oppgaveService = mockk<OppgaveService>()
     private val mockOppgave =
@@ -84,7 +80,6 @@ internal class GrunnlagsendringshendelseServiceTest {
             behandlingService,
             pdlService,
             grunnlagClient,
-            tilgangServiceImpl,
             sakService,
         )
 
@@ -646,7 +641,7 @@ internal class GrunnlagsendringshendelseServiceTest {
             Adressebeskyttelse("1", Endringstype.OPPRETTET, fnr, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
 
         coEvery { grunnlagClient.hentAlleSakIder(any()) } returns sakIder
-        every { adressebeskyttelseDaoMock.oppdaterAdresseBeskyttelse(any(), any()) } returns 1
+        every { sakService.oppdaterAdressebeskyttelse(any(), any()) } returns 1
         every { sakService.finnSaker(fnr) } returns saker
         every { oppgaveService.endreEnhetForOppgaverTilknyttetSak(any(), any()) } returns Unit
         every {
@@ -661,7 +656,7 @@ internal class GrunnlagsendringshendelseServiceTest {
 
         sakIder.forEach {
             verify(exactly = 1) {
-                adressebeskyttelseDaoMock.oppdaterAdresseBeskyttelse(
+                sakService.oppdaterAdressebeskyttelse(
                     it,
                     adressebeskyttelse.adressebeskyttelseGradering,
                 )
@@ -689,7 +684,7 @@ internal class GrunnlagsendringshendelseServiceTest {
             Adressebeskyttelse("1", Endringstype.OPPRETTET, fnr, AdressebeskyttelseGradering.FORTROLIG)
 
         coEvery { grunnlagClient.hentAlleSakIder(any()) } returns sakIder
-        every { adressebeskyttelseDaoMock.oppdaterAdresseBeskyttelse(any(), any()) } returns 1
+        every { sakService.oppdaterAdressebeskyttelse(any(), any()) } returns 1
         every { sakService.finnSaker(fnr) } returns saker
         every { oppgaveService.endreEnhetForOppgaverTilknyttetSak(any(), any()) } returns Unit
         every {
@@ -704,7 +699,7 @@ internal class GrunnlagsendringshendelseServiceTest {
 
         sakIder.forEach {
             verify(exactly = 1) {
-                adressebeskyttelseDaoMock.oppdaterAdresseBeskyttelse(
+                sakService.oppdaterAdressebeskyttelse(
                     it,
                     adressebeskyttelse.adressebeskyttelseGradering,
                 )

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
@@ -50,7 +50,7 @@ internal class OppgaveDaoTest {
         val connection = dataSource.connection
         oppgaveDao = OppgaveDaoImpl { connection }
         sakDao = SakDao { connection }
-        saktilgangDao = SakTilgangDao { dataSource.connection }
+        saktilgangDao = SakTilgangDao(dataSource)
     }
 
     @AfterEach
@@ -101,7 +101,7 @@ internal class OppgaveDaoTest {
         val sakAalesund = sakDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
         val oppgaveNy = lagNyOppgave(sakAalesund)
         oppgaveDao.lagreOppgave(oppgaveNy)
-        saktilgangDao.oppdaterAdresseBeskyttelse(sakAalesund.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
+        sakDao.oppdaterAdresseBeskyttelse(sakAalesund.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
 
         val sakutenbeskyttelse = sakDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
         val oppgaveUtenbeskyttelse = lagNyOppgave(sakutenbeskyttelse)
@@ -116,7 +116,7 @@ internal class OppgaveDaoTest {
         val sakAalesund = sakDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
         val oppgaveNy = lagNyOppgave(sakAalesund)
         oppgaveDao.lagreOppgave(oppgaveNy)
-        saktilgangDao.oppdaterAdresseBeskyttelse(sakAalesund.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
+        sakDao.oppdaterAdresseBeskyttelse(sakAalesund.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
 
         val hentetOppgave =
             oppgaveDao

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
@@ -50,7 +50,7 @@ internal class OppgaveDaoTest {
         val connection = dataSource.connection
         oppgaveDao = OppgaveDaoImpl { connection }
         sakDao = SakDao { connection }
-        saktilgangDao = SakTilgangDao(dataSource)
+        saktilgangDao = SakTilgangDao { dataSource.connection }
     }
 
     @AfterEach

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -86,7 +86,7 @@ internal class OppgaveServiceTest {
         oppgaveDao = OppgaveDaoImpl { connection }
         oppgaveDaoMedEndringssporing = OppgaveDaoMedEndringssporingImpl(oppgaveDao) { connection }
         oppgaveService = OppgaveService(oppgaveDaoMedEndringssporing, sakDao, featureToggleService)
-        saktilgangDao = SakTilgangDao { dataSource.connection }
+        saktilgangDao = SakTilgangDao(dataSource)
     }
 
     val azureGroupToGroupIDMap =
@@ -744,7 +744,7 @@ internal class OppgaveServiceTest {
             null,
         )
 
-        saktilgangDao.oppdaterAdresseBeskyttelse(adressebeskyttetSak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
+        sakDao.oppdaterAdresseBeskyttelse(adressebeskyttetSak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
 
         val saksbehandlerRoller = generateSaksbehandlerMedRoller(AzureGroup.SAKSBEHANDLER)
 
@@ -798,7 +798,7 @@ internal class OppgaveServiceTest {
                 null,
             )
 
-        saktilgangDao.oppdaterAdresseBeskyttelse(adressebeskyttetSak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
+        sakDao.oppdaterAdresseBeskyttelse(adressebeskyttetSak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
         val saksbehandlerMedRollerStrengtFortrolig = generateSaksbehandlerMedRoller(AzureGroup.STRENGT_FORTROLIG)
         val oppgaver = oppgaveService.finnOppgaverForBruker(saksbehandlerMedRollerStrengtFortrolig)
         Assertions.assertEquals(1, oppgaver.size)

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -86,7 +86,7 @@ internal class OppgaveServiceTest {
         oppgaveDao = OppgaveDaoImpl { connection }
         oppgaveDaoMedEndringssporing = OppgaveDaoMedEndringssporingImpl(oppgaveDao) { connection }
         oppgaveService = OppgaveService(oppgaveDaoMedEndringssporing, sakDao, featureToggleService)
-        saktilgangDao = SakTilgangDao(dataSource)
+        saktilgangDao = SakTilgangDao { dataSource.connection }
     }
 
     val azureGroupToGroupIDMap =

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakDaoTest.kt
@@ -38,7 +38,7 @@ internal class SakDaoTest {
             ).apply { migrate() }
         val connection = dataSource.connection
         sakRepo = SakDao { connection }
-        tilgangService = TilgangServiceImpl(SakTilgangDao(dataSource))
+        tilgangService = TilgangServiceImpl(SakTilgangDao { dataSource.connection })
     }
 
     @AfterAll

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakDaoTest.kt
@@ -38,7 +38,7 @@ internal class SakDaoTest {
             ).apply { migrate() }
         val connection = dataSource.connection
         sakRepo = SakDao { connection }
-        tilgangService = TilgangServiceImpl(SakTilgangDao { dataSource.connection })
+        tilgangService = TilgangServiceImpl(SakTilgangDao(dataSource))
     }
 
     @AfterAll

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakServiceTest.kt
@@ -49,7 +49,6 @@ internal class SakServiceTest {
     private val norg2Klient = mockk<Norg2Klient>()
     private val featureToggleService = mockk<FeatureToggleService>()
     private val enhetService = mockk<EnhetService>()
-    private val tilgangService = mockk<TilgangService>()
     private val skjermingKlient = mockk<SkjermingKlient>()
 
     @BeforeEach
@@ -166,7 +165,7 @@ internal class SakServiceTest {
         every { featureToggleService.isEnabled(SakServiceFeatureToggle.FiltrerMedEnhetId, false) } returns true
 
         val service: SakService =
-            RealSakService(sakDao, pdlKlient, norg2Klient, featureToggleService, tilgangService, skjermingKlient)
+            SakServiceImpl(sakDao, pdlKlient, norg2Klient, featureToggleService, skjermingKlient)
 
         val saker = service.finnSaker(TRIVIELL_MIDTPUNKT.value)
 
@@ -198,7 +197,7 @@ internal class SakServiceTest {
         every { featureToggleService.isEnabled(SakServiceFeatureToggle.FiltrerMedEnhetId, false) } returns true
 
         val service: SakService =
-            RealSakService(sakDao, pdlKlient, norg2Klient, featureToggleService, tilgangService, skjermingKlient)
+            SakServiceImpl(sakDao, pdlKlient, norg2Klient, featureToggleService, skjermingKlient)
 
         val saker = service.finnSaker(TRIVIELL_MIDTPUNKT.value)
 
@@ -230,7 +229,7 @@ internal class SakServiceTest {
         every { featureToggleService.isEnabled(SakServiceFeatureToggle.FiltrerMedEnhetId, false) } returns true
 
         val service: SakService =
-            RealSakService(sakDao, pdlKlient, norg2Klient, featureToggleService, tilgangService, skjermingKlient)
+            SakServiceImpl(sakDao, pdlKlient, norg2Klient, featureToggleService, skjermingKlient)
 
         val saker = service.finnSaker(TRIVIELL_MIDTPUNKT.value)
 
@@ -250,7 +249,7 @@ internal class SakServiceTest {
         } throws responseException
 
         val service: SakService =
-            RealSakService(sakDao, pdlKlient, norg2Klient, featureToggleService, tilgangService, skjermingKlient)
+            SakServiceImpl(sakDao, pdlKlient, norg2Klient, featureToggleService, skjermingKlient)
 
         val thrown =
             assertThrows<ResponseException> {
@@ -278,7 +277,7 @@ internal class SakServiceTest {
         every { norg2Klient.hentEnheterForOmraade(SakType.BARNEPENSJON.tema, "0301") } returns emptyList()
 
         val service: SakService =
-            RealSakService(sakDao, pdlKlient, norg2Klient, featureToggleService, tilgangService, skjermingKlient)
+            SakServiceImpl(sakDao, pdlKlient, norg2Klient, featureToggleService, skjermingKlient)
 
         val thrown =
             assertThrows<IngenEnhetFunnetException> {
@@ -316,7 +315,7 @@ internal class SakServiceTest {
             )
 
         val service: SakService =
-            RealSakService(sakDao, pdlKlient, norg2Klient, featureToggleService, tilgangService, skjermingKlient)
+            SakServiceImpl(sakDao, pdlKlient, norg2Klient, featureToggleService, skjermingKlient)
 
         val sak = service.finnEllerOpprettSak(TRIVIELL_MIDTPUNKT.value, SakType.BARNEPENSJON)
 
@@ -359,10 +358,10 @@ internal class SakServiceTest {
             listOf(
                 ArbeidsFordelingEnhet(Enheter.PORSGRUNN.navn, Enheter.PORSGRUNN.enhetNr),
             )
-        every { tilgangService.oppdaterAdressebeskyttelse(any(), any()) } returns 1
+        every { sakDao.oppdaterAdresseBeskyttelse(any(), any()) } returns 1
 
         val service: SakService =
-            RealSakService(sakDao, pdlKlient, norg2Klient, featureToggleService, tilgangService, skjermingKlient)
+            SakServiceImpl(sakDao, pdlKlient, norg2Klient, featureToggleService, skjermingKlient)
 
         val sak =
             service.finnEllerOpprettSak(
@@ -380,7 +379,7 @@ internal class SakServiceTest {
             )
 
         verify(exactly = 1) {
-            tilgangService.oppdaterAdressebeskyttelse(
+            service.oppdaterAdressebeskyttelse(
                 sak.id,
                 AdressebeskyttelseGradering.STRENGT_FORTROLIG,
             )
@@ -416,7 +415,7 @@ internal class SakServiceTest {
         every { featureToggleService.isEnabled(SakServiceFeatureToggle.FiltrerMedEnhetId, false) } returns true
 
         val service: SakService =
-            RealSakService(sakDao, pdlKlient, norg2Klient, featureToggleService, tilgangService, skjermingKlient)
+            SakServiceImpl(sakDao, pdlKlient, norg2Klient, featureToggleService, skjermingKlient)
 
         val saker = service.finnSaker(TRIVIELL_MIDTPUNKT.value)
 
@@ -451,7 +450,7 @@ internal class SakServiceTest {
             )
 
         val service: SakService =
-            RealSakService(sakDao, pdlKlient, norg2Klient, featureToggleService, tilgangService, skjermingKlient)
+            SakServiceImpl(sakDao, pdlKlient, norg2Klient, featureToggleService, skjermingKlient)
         val sak = service.finnEllerOpprettSak(TRIVIELL_MIDTPUNKT.value, SakType.BARNEPENSJON)
 
         sak shouldBe


### PR DESCRIPTION
Merk at det er en liten tradeoff her og det er at saktilgangdao og tilgangservice aldri må ha skriveoperasjoner hvis noen av metodene blir wrappet in en intransaction, da blir oppdatering omitted!
Tenker at det er ok som tradeoff da de fleste oppslag mot tilgangsservice uansett er i en wrapper i starten av routen.
Oppdater gradering er flyttet til sakdao slik at den skjer i en intransaction.

Litt usikker på om jeg burde ha en del 2 der man fjerner "gjenbruk" flagget for transaksjoner.