### PR TITLE
EY-2784 Ikke låse signatur til første person som åpner brev

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevRoute.kt
@@ -70,6 +70,19 @@ fun Route.vedtaksbrevRoute(
             }
         }
 
+        post("vedtak/ferdigstill") {
+            withBehandlingId(behandlingKlient) { behandlingId ->
+                logger.info("Ferdigstiller vedtaksbrev for behandling (id=$behandlingId)")
+
+                measureTimedValue {
+                    service.ferdigstillVedtaksbrev(behandlingId, brukerTokenInfo)
+                }.also { (_, varighet) ->
+                    logger.info("Ferdigstilling av vedtaksbrev tok ${varighet.toString(DurationUnit.SECONDS, 2)}")
+                    call.respond(HttpStatusCode.OK)
+                }
+            }
+        }
+
         put("payload/tilbakestill") {
             withBehandlingId(behandlingKlient) {
                 val body = call.receive<ResetPayloadRequest>()

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.brev
 
 import no.nav.etterlatte.brev.adresse.AdresseService
 import no.nav.etterlatte.brev.behandling.Behandling
+import no.nav.etterlatte.brev.behandling.ForenkletVedtak
 import no.nav.etterlatte.brev.behandling.SakOgBehandlingService
 import no.nav.etterlatte.brev.brevbaker.BrevbakerRequest
 import no.nav.etterlatte.brev.brevbaker.BrevbakerService
@@ -106,7 +107,47 @@ class VedtaksbrevService(
         val brevRequest = BrevbakerRequest.fra(kode.ferdigstilling, brevData, behandling, avsender)
 
         return brevbaker.genererPdf(brev.id, brevRequest)
-            .also { pdf -> ferdigstillHvisVedtakFattet(brev, behandling, pdf, brukerTokenInfo) }
+            .also { pdf -> lagrePdfHvisVedtakFattet(brev.id, behandling.vedtak, pdf, brukerTokenInfo) }
+    }
+
+    suspend fun ferdigstillVedtaksbrev(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ) {
+        val brev =
+            requireNotNull(hentVedtaksbrev(behandlingId)) {
+                "Fant ingen brev for behandling (id=$behandlingId)"
+            }
+
+        if (brev.status == Status.FERDIGSTILT) {
+            logger.warn("Brev (id=${brev.id}) er allerede ferdigstilt. Avbryter ferdigstilling...")
+            return
+        } else if (!brev.kanEndres()) {
+            throw IllegalStateException("Brev med id=${brev.id} kan ikke ferdigstilles, siden det har status ${brev.status}")
+        }
+
+        val (saksbehandlerIdent, vedtakStatus) =
+            sakOgBehandlingService.hentVedtakSaksbehandlerOgStatus(
+                brev.behandlingId!!,
+                brukerTokenInfo,
+            )
+
+        if (vedtakStatus != VedtakStatus.FATTET_VEDTAK) {
+            throw IllegalStateException(
+                "Vedtak status er $vedtakStatus. Avventer ferdigstilling av brev (id=${brev.id})",
+            )
+        }
+
+        if (!brukerTokenInfo.erSammePerson(saksbehandlerIdent)) {
+            logger.info("Ferdigstiller brev med id=${brev.id}")
+
+            db.settBrevFerdigstilt(brev.id)
+        } else {
+            throw IllegalStateException(
+                "Kan ikke ferdigstille/låse brev når saksbehandler ($saksbehandlerIdent)" +
+                    " og attestant (${brukerTokenInfo.ident()}) er samme person.",
+            )
+        }
     }
 
     suspend fun hentNyttInnhold(
@@ -178,24 +219,24 @@ class VedtaksbrevService(
             MANUELL -> null
         }
 
-    private fun ferdigstillHvisVedtakFattet(
-        brev: Brev,
-        behandling: Behandling,
+    private fun lagrePdfHvisVedtakFattet(
+        brevId: BrevID,
+        vedtak: ForenkletVedtak,
         pdf: Pdf,
         brukerTokenInfo: BrukerTokenInfo,
     ) {
-        if (behandling.vedtak.status != VedtakStatus.FATTET_VEDTAK) {
-            logger.info("Vedtak status er ${behandling.vedtak.status}. Avventer ferdigstilling av brev (id=${brev.id})")
+        if (vedtak.status != VedtakStatus.FATTET_VEDTAK) {
+            logger.info("Vedtak status er ${vedtak.status}. Avventer ferdigstilling av brev (id=$brevId)")
             return
         }
 
-        if (!brukerTokenInfo.erSammePerson(behandling.vedtak.saksbehandlerIdent)) {
-            logger.info("Ferdigstiller brev med id=${brev.id}")
+        if (!brukerTokenInfo.erSammePerson(vedtak.saksbehandlerIdent)) {
+            logger.info("Lagrer PDF for brev med id=$brevId")
 
-            db.lagrePdfOgFerdigstillBrev(brev.id, pdf)
+            db.lagrePdf(brevId, pdf)
         } else {
             logger.warn(
-                "Kan ikke ferdigstille/låse brev når saksbehandler (${behandling.vedtak.saksbehandlerIdent})" +
+                "Kan ikke ferdigstille/låse brev når saksbehandler (${vedtak.saksbehandlerIdent})" +
                     " og attestant (${brukerTokenInfo.ident()}) er samme person.",
             )
         }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/SakOgBehandlingService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/SakOgBehandlingService.kt
@@ -15,6 +15,7 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.vedtak.VedtakDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingDto
 import no.nav.etterlatte.token.BrukerTokenInfo
@@ -66,6 +67,16 @@ class SakOgBehandlingService(
                 brukerTokenInfo,
             )
         }
+
+    suspend fun hentVedtakSaksbehandlerOgStatus(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Pair<String, VedtakStatus> {
+        val vedtakDto = vedtaksvurderingKlient.hentVedtak(behandlingId, brukerTokenInfo)
+        val saksbehandlerIdent = vedtakDto.vedtakFattet?.ansvarligSaksbehandler ?: brukerTokenInfo.ident()
+
+        return Pair(saksbehandlerIdent, vedtakDto.status)
+    }
 
     private suspend fun mapBehandling(
         vedtak: VedtakDto,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
@@ -12,6 +12,7 @@ import no.nav.etterlatte.brev.db.BrevRepository.Queries.OPPDATER_INNHOLD_PAYLOAD
 import no.nav.etterlatte.brev.db.BrevRepository.Queries.OPPDATER_INNHOLD_PAYLOAD_VEDLEGG
 import no.nav.etterlatte.brev.db.BrevRepository.Queries.OPPDATER_MOTTAKER_QUERY
 import no.nav.etterlatte.brev.db.BrevRepository.Queries.OPPRETT_BREV_QUERY
+import no.nav.etterlatte.brev.db.BrevRepository.Queries.OPPRETT_ELLER_OPPDATER_PDF_QUERY
 import no.nav.etterlatte.brev.db.BrevRepository.Queries.OPPRETT_HENDELSE_QUERY
 import no.nav.etterlatte.brev.db.BrevRepository.Queries.OPPRETT_INNHOLD_QUERY
 import no.nav.etterlatte.brev.db.BrevRepository.Queries.OPPRETT_MOTTAKER_QUERY
@@ -165,7 +166,7 @@ class BrevRepository(private val ds: DataSource) {
         using(sessionOf(ds)) {
             it.run(
                 queryOf(
-                    OPPRETT_PDF_QUERY,
+                    OPPRETT_ELLER_OPPDATER_PDF_QUERY,
                     mapOf(
                         "brev_id" to id,
                         "bytes" to pdf.bytes,
@@ -424,6 +425,11 @@ class BrevRepository(private val ds: DataSource) {
         """
 
         const val OPPRETT_PDF_QUERY = """
+            INSERT INTO pdf (brev_id, bytes) 
+            VALUES (:brev_id, :bytes)
+        """
+
+        const val OPPRETT_ELLER_OPPDATER_PDF_QUERY = """
             INSERT INTO pdf (brev_id, bytes) 
             VALUES (:brev_id, :bytes)
             ON CONFLICT (brev_id) DO UPDATE SET bytes = :bytes

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettVedtaksbrevForMigrering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettVedtaksbrevForMigrering.kt
@@ -49,6 +49,7 @@ internal class OpprettVedtaksbrevForMigrering(
             runBlocking {
                 val vedtaksbrev: Brev = service.opprettVedtaksbrev(sakId, behandlingId, brukerTokenInfo)
                 service.genererPdf(vedtaksbrev.id, brukerTokenInfo)
+                service.ferdigstillVedtaksbrev(vedtaksbrev.behandlingId!!, brukerTokenInfo)
             }
             logger.info("Har oppretta vedtaksbrev i sak $sakId")
         } else {

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/db/BrevRepositoryIntegrationTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/db/BrevRepositoryIntegrationTest.kt
@@ -156,6 +156,38 @@ internal class BrevRepositoryIntegrationTest {
     }
 
     @Test
+    fun `Lagring av pdf separat`() {
+        val ulagretBrev = ulagretBrev(behandlingId = UUID.randomUUID())
+        val brev = db.opprettBrev(ulagretBrev)
+
+        brev.status shouldBe Status.OPPRETTET
+
+        db.hentBrevInnhold(brev.id) shouldBe ulagretBrev.innhold
+        db.lagrePdf(brev.id, Pdf(PDF_BYTES))
+
+        val pdf = db.hentPdf(brev.id)!!
+        pdf.bytes.contentEquals(PDF_BYTES) shouldBe true
+
+        val hentetBrev = db.hentBrev(brev.id)
+
+        hentetBrev.status shouldBe Status.OPPRETTET
+    }
+
+    @Test
+    fun `Sette status ferdigstilt`() {
+        val ulagretBrev = ulagretBrev(behandlingId = UUID.randomUUID())
+        val brev = db.opprettBrev(ulagretBrev)
+
+        brev.status shouldBe Status.OPPRETTET
+
+        db.oppdaterPayload(brev.id, Slate())
+        db.settBrevFerdigstilt(brev.id)
+
+        val hentetBrev = db.hentBrev(brev.id)
+        hentetBrev.status shouldBe Status.FERDIGSTILT
+    }
+
+    @Test
     fun `Slett brev`() {
         val behandlingId = UUID.randomUUID()
 

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettVedtaksbrevForMigreringTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettVedtaksbrevForMigreringTest.kt
@@ -1,9 +1,11 @@
 package no.nav.etterlatte.rivers
 
+import io.mockk.Runs
 import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.confirmVerified
+import io.mockk.just
 import io.mockk.mockk
 import no.nav.etterlatte.brev.VedtaksbrevService
 import no.nav.etterlatte.brev.model.Brev
@@ -56,11 +58,13 @@ internal class OpprettVedtaksbrevForMigreringTest {
 
         coEvery { vedtaksbrevService.opprettVedtaksbrev(any(), behandlingId, any()) } returns brev
         coEvery { vedtaksbrevService.genererPdf(brev.id, any()) } returns mockk<Pdf>()
+        coEvery { vedtaksbrevService.ferdigstillVedtaksbrev(brev.behandlingId!!, any()) } just Runs
 
         val inspektoer = testRapid.apply { sendTestMessage(melding.toJson()) }.inspektør
 
         coVerify(exactly = 1) { vedtaksbrevService.opprettVedtaksbrev(any(), behandlingId, any()) }
         coVerify(exactly = 1) { vedtaksbrevService.genererPdf(brev.id, any()) }
+        coVerify(exactly = 1) { vedtaksbrevService.ferdigstillVedtaksbrev(brev.behandlingId!!, any()) }
 
         val meldingSendt = inspektoer.message(0)
         assertEquals(BrevEventTypes.FERDIGSTILT.name, meldingSendt.get(EVENT_NAME_KEY).asText())

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/attesterVedtak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/attesterVedtak.tsx
@@ -6,9 +6,8 @@ import { GeneriskModal } from '~shared/modal/modal'
 import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 import { useNavigate } from 'react-router'
 import { behandlingSkalSendeBrev } from '~components/behandling/felles/utils'
-import { hentVedtaksbrev } from '~shared/api/brev'
+import { ferdigstillVedtaksbrev } from '~shared/api/brev'
 import { isPending, useApiCall } from '~shared/hooks/useApiCall'
-import { BrevStatus } from '~shared/types/Brev'
 import { FlexRow } from '~shared/styled'
 
 export const AttesterVedtak = ({ behandling, kommentar }: { behandling: IDetaljertBehandling; kommentar: string }) => {
@@ -16,7 +15,7 @@ export const AttesterVedtak = ({ behandling, kommentar }: { behandling: IDetalje
   const [modalisOpen, setModalisOpen] = useState(false)
   const skalSendeBrev = behandlingSkalSendeBrev(behandling)
   const [error, setError] = useState<string>()
-  const [hentVedtaksbrevStatus, apiHentVedtaksbrev] = useApiCall(hentVedtaksbrev)
+  const [ferdigstillVedtaksbrevStatus, apiFerdigstillVedtaksbrev] = useApiCall(ferdigstillVedtaksbrev)
   const [attesterVedtakStatus, apiAttesterVedtak] = useApiCall(attesterVedtak)
 
   const settVedtakTilAttestert = () => {
@@ -34,15 +33,14 @@ export const AttesterVedtak = ({ behandling, kommentar }: { behandling: IDetalje
     if (!skalSendeBrev) {
       settVedtakTilAttestert()
     } else {
-      apiHentVedtaksbrev(behandling.id, (vedtaksbrev) => {
-        if (vedtaksbrev.status === BrevStatus.FERDIGSTILT) {
-          settVedtakTilAttestert()
-        } else {
-          setError(`Brev har feil status (${vedtaksbrev.status.toLowerCase()}).
-                    Kan ikke attestere saken. Forsøk å laste siden på nytt.`)
+      apiFerdigstillVedtaksbrev(
+        behandling.id,
+        () => settVedtakTilAttestert(),
+        () => {
+          setError(`Feil oppsto ved ferdigstilling av vedtaksbrevet... Prøv igjen.`)
           setModalisOpen(false)
         }
-      })
+      )
     }
   }
 
@@ -66,7 +64,7 @@ export const AttesterVedtak = ({ behandling, kommentar }: { behandling: IDetalje
         onYesClick={attester}
         setModalisOpen={setModalisOpen}
         open={modalisOpen}
-        loading={isPending(attesterVedtakStatus) || isPending(hentVedtaksbrevStatus)}
+        loading={isPending(attesterVedtakStatus) || isPending(ferdigstillVedtaksbrevStatus)}
       />
     </BeslutningWrapper>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
@@ -17,43 +17,38 @@ import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 import MottakerPanel from '~components/behandling/brev/detaljer/MottakerPanel'
 import ForhaandsvisningBrev from '~components/behandling/brev/ForhaandsvisningBrev'
 import Spinner from '~shared/Spinner'
-import { BrevProsessType } from '~shared/types/Brev'
+import { BrevProsessType, IBrev } from '~shared/types/Brev'
 import RedigerbartBrev from '~components/behandling/brev/RedigerbartBrev'
+import { isFailure, isPending, isPendingOrInitial, useApiCall } from '~shared/hooks/useApiCall'
 
 export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
   const { behandlingId } = useParams()
   const { sakId, soeknadMottattDato, status } = props.behandling
 
-  const [vedtaksbrev, setVedtaksbrev] = useState<any>(undefined)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string>()
+  const [vedtaksbrev, setVedtaksbrev] = useState<IBrev | undefined>(undefined)
+
+  const [hentBrevStatus, hentBrev] = useApiCall(hentVedtaksbrev)
+  const [opprettBrevStatus, opprettNyttVedtaksbrev] = useApiCall(opprettVedtaksbrev)
 
   useEffect(() => {
-    if (!behandlingId || !sakId) return
+    if (!behandlingId || !sakId || !behandlingSkalSendeBrev(props.behandling)) return
 
-    const fetchVedtaksbrev = async () => {
-      if (!behandlingSkalSendeBrev(props.behandling)) {
-        return
+    hentBrev(behandlingId, (brev, statusCode) => {
+      if (statusCode === 200) {
+        setVedtaksbrev(brev)
+      } else if (statusCode === 204) {
+        opprettNyttVedtaksbrev({ sakId, behandlingId }, (nyttBrev) => {
+          setVedtaksbrev(nyttBrev)
+        })
       }
-
-      const brevResponse = await hentVedtaksbrev(behandlingId!!)
-      if (brevResponse.status === 'ok' && brevResponse.statusCode === 200) {
-        setVedtaksbrev(brevResponse.data)
-      } else if (brevResponse.statusCode === 204) {
-        const brevOpprettetResponse = await opprettVedtaksbrev(sakId, behandlingId!!)
-
-        if (brevOpprettetResponse.status === 'ok' && brevOpprettetResponse.statusCode === 201) {
-          setVedtaksbrev(brevOpprettetResponse.data)
-        } else {
-          setError('Oppretting av vedtaksbrev feilet...')
-        }
-      } else {
-        setError('Feil ved henting av brev...')
-      }
-      setLoading(false)
-    }
-    fetchVedtaksbrev()
+    })
   }, [behandlingId, sakId])
+
+  if (isPendingOrInitial(hentBrevStatus)) {
+    return <Spinner visible label="Henter brev ..." />
+  } else if (isPending(opprettBrevStatus)) {
+    return <Spinner visible label="Ingen brev funnet. Oppretter brev ..." />
+  }
 
   return (
     <Content>
@@ -81,17 +76,15 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
           </ContentHeader>
         </Sidebar>
 
-        {loading ? (
-          <SpinnerContainer>
-            <Spinner visible={true} label="Henter brev ..." />
-          </SpinnerContainer>
-        ) : error ? (
-          <ErrorMessage>{error}</ErrorMessage>
-        ) : vedtaksbrev.prosessType === BrevProsessType.AUTOMATISK ? (
-          <ForhaandsvisningBrev brev={vedtaksbrev} />
-        ) : (
-          <RedigerbartBrev brev={vedtaksbrev} kanRedigeres={manueltBrevKanRedigeres(status)} />
-        )}
+        {!!vedtaksbrev &&
+          (vedtaksbrev?.prosessType === BrevProsessType.AUTOMATISK ? (
+            <ForhaandsvisningBrev brev={vedtaksbrev} />
+          ) : (
+            <RedigerbartBrev brev={vedtaksbrev!!} kanRedigeres={manueltBrevKanRedigeres(status)} />
+          ))}
+
+        {isFailure(hentBrevStatus) && <ErrorMessage>Feil ved henting av brev</ErrorMessage>}
+        {isFailure(opprettBrevStatus) && <ErrorMessage>Kunne ikke opprette brev</ErrorMessage>}
       </BrevContent>
 
       <Border />
@@ -102,12 +95,6 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
     </Content>
   )
 }
-
-const SpinnerContainer = styled.div`
-  height: 100%;
-  width: 100%;
-  text-align: center;
-`
 
 const BrevContent = styled.div`
   display: flex;

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
@@ -13,8 +13,11 @@ export const opprettBrevForSak = async (sakId: number): Promise<ApiResponse<IBre
 export const hentVedtaksbrev = async (behandlingId: string): Promise<ApiResponse<IBrev>> =>
   apiClient.get(`/brev/behandling/${behandlingId}/vedtak`)
 
-export const opprettVedtaksbrev = async (sakId: number, behandlingId: string): Promise<ApiResponse<IBrev>> =>
-  apiClient.post(`/brev/behandling/${behandlingId}/vedtak?sakId=${sakId}`, {})
+export const ferdigstillVedtaksbrev = async (behandlingId: string): Promise<ApiResponse<IBrev>> =>
+  apiClient.post(`/brev/behandling/${behandlingId}/vedtak/ferdigstill`, {})
+
+export const opprettVedtaksbrev = async (args: { sakId: number; behandlingId: string }): Promise<ApiResponse<IBrev>> =>
+  apiClient.post(`/brev/behandling/${args.behandlingId}/vedtak?sakId=${args.sakId}`, {})
 
 export const oppdaterMottaker = async (props: {
   brevId: number


### PR DESCRIPTION
Henger sammen med [FAGSYSTEM-295685](https://jira.adeo.no/browse/FAGSYSTEM-295685). 

Sikrer at PDF ikke er låst _før_ vedtaket attesteres. 
Nå lagres PDF dersom status er FATTET_VEDTAK, men brevet får ikke status ferdigstilt før behandling er attestert/godkjent.