### PR TITLE
Denne pluginen er markert som deprecated, og github-repoet er arkivert

### DIFF
--- a/apps/etterlatte-tilbakekreving/build.gradle.kts
+++ b/apps/etterlatte-tilbakekreving/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     id("etterlatte.common")
     id("etterlatte.rapids-and-rivers-ktor2")
     id("etterlatte.postgres")
-    alias(libs.plugins.analyze)
 }
 
 dependencies {

--- a/apps/etterlatte-utbetaling/build.gradle.kts
+++ b/apps/etterlatte-utbetaling/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     id("etterlatte.rapids-and-rivers-ktor2")
     id("etterlatte.common")
     id("etterlatte.postgres")
-    alias(libs.plugins.analyze)
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [plugins]
 avro = { id = "com.github.davidmc24.gradle.plugin.avro", version = "1.8.0" }
-analyze = { id = "com.faire.gradle.analyze", version = "1.0.9" }
 cutterslade-analyze = { id = "ca.cutterslade.analyze", version = "1.9.1" }
 
 [versions]


### PR DESCRIPTION
Når no noko gjer at CodeQL-skanninga feilar på å hente avhengnadane her, så er det på tide å rydde opp. Det verkar heller ikkje som vi bruker han til noko bevisst no. Noterer på blokka å sjå på alternativ