### PR TITLE
EY-2786: Meir robust migrering

### DIFF
--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/migrering/MigreringRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/migrering/MigreringRoutesTest.kt
@@ -12,6 +12,7 @@ import io.ktor.http.contentType
 import io.ktor.serialization.jackson.jackson
 import io.ktor.server.testing.testApplication
 import no.nav.etterlatte.BehandlingIntegrationTest
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.sak.BehandlingOgSak
@@ -72,6 +73,7 @@ class MigreringRoutesTest : BehandlingIntegrationTest() {
                         ),
                     trygdetid = Trygdetid(emptyList()),
                     flyktningStatus = false,
+                    spraak = Spraak.NN,
                 )
 
             val response: BehandlingOgSak =

--- a/apps/etterlatte-beregning-kafka/src/test/kotlin/no/nav/etterlatte/beregningkafka/MigreringHendelserTest.kt
+++ b/apps/etterlatte-beregning-kafka/src/test/kotlin/no/nav/etterlatte/beregningkafka/MigreringHendelserTest.kt
@@ -6,6 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.beregning.BeregningDTO
 import no.nav.etterlatte.libs.common.beregning.Beregningstype
 import no.nav.etterlatte.libs.common.grunnlag.Metadata
@@ -72,6 +73,7 @@ internal class MigreringHendelserTest {
                         g = BigDecimal(100000),
                     ),
                 trygdetid = Trygdetid(emptyList()),
+                spraak = Spraak.NN,
             )
         every { behandlingService.opprettBeregningsgrunnlag(any(), any()) } returns mockk()
         every { behandlingService.beregn(capture(behandlingId)) } returns returnValue

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.brev.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonValue
 import no.nav.etterlatte.brev.adresse.RegoppslagResponseDTO
 import no.nav.etterlatte.brev.behandling.Behandling
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
@@ -11,7 +10,6 @@ import no.nav.etterlatte.libs.common.deserialize
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
-import java.util.Locale
 import java.util.UUID
 
 typealias BrevID = Long
@@ -175,6 +173,7 @@ class BrevProsessTypeFactory(private val featureToggleService: FeatureToggleServ
                     true -> BrevProsessType.REDIGERBAR
                     else -> BrevProsessType.MANUELL
                 }
+
             VedtakType.AVSLAG,
             VedtakType.ENDRING,
             ->
@@ -182,6 +181,7 @@ class BrevProsessTypeFactory(private val featureToggleService: FeatureToggleServ
                     RevurderingAarsak.INNTEKTSENDRING,
                     RevurderingAarsak.ANNEN,
                     -> BrevProsessType.REDIGERBAR
+
                     else -> BrevProsessType.MANUELL
                 }
         }
@@ -219,20 +219,4 @@ class BrevProsessTypeFactory(private val featureToggleService: FeatureToggleServ
             VedtakType.AVSLAG -> BrevProsessType.MANUELL
         }
     }
-}
-
-enum class Spraak(
-    @get:JsonValue val verdi: String,
-) {
-    NB("nb"),
-    NN("nn"),
-    EN("en"),
-    ;
-
-    fun locale(): Locale =
-        when (this) {
-            NB -> Locale.forLanguageTag("no")
-            NN -> Locale.forLanguageTag("no")
-            EN -> Locale.UK
-        }
 }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/MigreringHendelser.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/MigreringHendelser.kt
@@ -13,6 +13,7 @@ import no.nav.etterlatte.rapidsandrivers.migrering.MIGRERING_GRUNNLAG_KEY
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser.LAGRE_GRUNNLAG
 import no.nav.etterlatte.rapidsandrivers.migrering.PERSONGALLERI_KEY
+import no.nav.etterlatte.rapidsandrivers.migrering.hendelseData
 import no.nav.etterlatte.rapidsandrivers.migrering.persongalleri
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
@@ -20,6 +21,7 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import rapidsandrivers.HENDELSE_DATA_KEY
 import rapidsandrivers.SAK_ID_KEY
 import rapidsandrivers.migrering.ListenerMedLoggingOgFeilhaandtering
 import rapidsandrivers.sakId
@@ -38,6 +40,7 @@ class MigreringHendelser(
             validate { it.requireKey(SAK_ID_KEY) }
             validate { it.requireKey(MIGRERING_GRUNNLAG_KEY) }
             validate { it.requireKey(PERSONGALLERI_KEY) }
+            validate { it.requireKey(HENDELSE_DATA_KEY) }
         }.register(this)
     }
 
@@ -59,6 +62,13 @@ class MigreringHendelser(
                     Opplysningstype.PERSONGALLERI_V1,
                     objectMapper.createObjectNode(),
                     packet.persongalleri.toJsonNode(),
+                ),
+                Grunnlagsopplysning(
+                    UUID.randomUUID(),
+                    Grunnlagsopplysning.Pesys.create(),
+                    Opplysningstype.SPRAAK,
+                    objectMapper.createObjectNode(),
+                    packet.hendelseData.spraak.toJsonNode(),
                 ),
             ),
             request.soeker,

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/Application.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/Application.kt
@@ -1,9 +1,9 @@
 package no.nav.etterlatte
 
-import migrering.FeilendeMigreringLytter
 import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.migrering.ApplicationContext
+import no.nav.etterlatte.migrering.FeilendeMigreringLytter
 import no.nav.etterlatte.migrering.LagreKopling
 import no.nav.etterlatte.migrering.LyttPaaIverksattVedtak
 import no.nav.etterlatte.migrering.MigrerSpesifikkSak

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/FeilendeMigreringLytter.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/FeilendeMigreringLytter.kt
@@ -7,20 +7,25 @@ import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.libs.common.rapidsandrivers.feilendeSteg
 import no.nav.etterlatte.libs.common.rapidsandrivers.feilmelding
+import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.migrering.Migreringsstatus
 import no.nav.etterlatte.migrering.PesysRepository
 import no.nav.etterlatte.rapidsandrivers.EventNames
 import no.nav.etterlatte.rapidsandrivers.migrering.KILDE_KEY
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser
 import no.nav.etterlatte.rapidsandrivers.migrering.PESYS_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.migrering.PesysId
 import no.nav.etterlatte.rapidsandrivers.migrering.hendelseData
 import no.nav.etterlatte.rapidsandrivers.migrering.pesysId
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
+import no.nav.helse.rapids_rivers.toUUID
 import org.slf4j.LoggerFactory
+import rapidsandrivers.BEHANDLING_ID_KEY
 import rapidsandrivers.HENDELSE_DATA_KEY
+import rapidsandrivers.behandlingId
 import rapidsandrivers.migrering.ListenerMedLogging
 
 internal class FeilendeMigreringLytter(rapidsConnection: RapidsConnection, private val repository: PesysRepository) :
@@ -30,11 +35,13 @@ internal class FeilendeMigreringLytter(rapidsConnection: RapidsConnection, priva
     init {
         River(rapidsConnection).apply {
             eventName(EventNames.FEILA)
-            validate { it.requireKey(FEILENDE_STEG) }
+            validate { it.interestedIn(FEILENDE_STEG) }
             validate { it.requireKey(KILDE_KEY) }
             validate { it.requireValue(KILDE_KEY, Vedtaksloesning.PESYS.name) }
-            validate { it.requireKey(PESYS_ID_KEY) }
-            validate { it.requireKey(HENDELSE_DATA_KEY) }
+            validate { it.interestedIn("vedtak.behandling.id") }
+            validate { it.interestedIn(BEHANDLING_ID_KEY) }
+            validate { it.interestedIn(PESYS_ID_KEY) }
+            validate { it.interestedIn(HENDELSE_DATA_KEY) }
             validate { it.requireKey(FEILMELDING_KEY) }
             validate { it.rejectValue(FEILENDE_STEG, Migreringshendelser.VERIFISER) }
             correlationId()
@@ -45,8 +52,30 @@ internal class FeilendeMigreringLytter(rapidsConnection: RapidsConnection, priva
         packet: JsonMessage,
         context: MessageContext,
     ) {
-        logger.warn("Migrering av pesyssak ${packet.pesysId} feila")
-        repository.lagreFeilkjoering(packet.hendelseData, feil = packet.feilmelding, feilendeSteg = packet.feilendeSteg)
-        repository.oppdaterStatus(packet.pesysId, Migreringsstatus.MIGRERING_FEILA)
+        val pesysId = finnPesysId(packet)
+
+        logger.warn("Migrering av pesyssak $pesysId feila")
+        repository.lagreFeilkjoering(
+            request =
+                packet.takeIf { it.harVerdi(HENDELSE_DATA_KEY) }?.hendelseData?.toJson()
+                    ?: "Har ikke requestobjektet tilgjengelig for logging",
+            feilendeSteg = packet.feilendeSteg,
+            feil = packet.feilmelding,
+            pesysId = pesysId,
+        )
+        repository.oppdaterStatus(pesysId, Migreringsstatus.MIGRERING_FEILA)
     }
+
+    private fun finnPesysId(packet: JsonMessage): PesysId =
+        if (packet.harVerdi(PESYS_ID_KEY)) {
+            packet.pesysId
+        } else if (packet.harVerdi(BEHANDLING_ID_KEY)) {
+            repository.hentPesysId(packet.behandlingId)!!.pesysId
+        } else if (packet.harVerdi("vedtak.behandling.id")) {
+            repository.hentPesysId(packet["vedtak.behandling.id"].asText().toUUID())!!.pesysId
+        } else {
+            throw IllegalArgumentException("Manglar pesys-identifikator, kan ikke kjøre feilhåndtering")
+        }
 }
+
+private fun JsonMessage.harVerdi(key: String) = this[key].toString().isNotEmpty()

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/FeilendeMigreringLytter.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/FeilendeMigreringLytter.kt
@@ -1,4 +1,4 @@
-package migrering
+package no.nav.etterlatte.migrering
 
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.rapidsandrivers.FEILENDE_STEG
@@ -8,8 +8,6 @@ import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.libs.common.rapidsandrivers.feilendeSteg
 import no.nav.etterlatte.libs.common.rapidsandrivers.feilmelding
 import no.nav.etterlatte.libs.common.toJson
-import no.nav.etterlatte.migrering.Migreringsstatus
-import no.nav.etterlatte.migrering.PesysRepository
 import no.nav.etterlatte.rapidsandrivers.EventNames
 import no.nav.etterlatte.rapidsandrivers.migrering.KILDE_KEY
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/LyttPaaIverksattVedtak.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/LyttPaaIverksattVedtak.kt
@@ -61,9 +61,11 @@ internal class LyttPaaIverksattVedtak(
                 pesysRepository.oppdaterStatus(behandling.pesysId, Migreringsstatus.FERDIG)
                 runBlocking { penKlient.opphoerSak(behandling.pesysId) }
             }
-
-            else -> {
-                logger.warn("Fikk respons med status ${respons.status} for ${respons.behandlingId}")
+            UtbetalingStatusDto.MOTTATT, UtbetalingStatusDto.SENDT -> {
+                logger.info("Fikk respons fra utbetaling med status ${respons.status} for ${respons.behandlingId}")
+            }
+            UtbetalingStatusDto.AVVIST, UtbetalingStatusDto.FEILET -> {
+                logger.warn("Fikk respons fra utbetaling med status ${respons.status} for ${respons.behandlingId}")
                 pesysRepository.oppdaterStatus(behandling.pesysId, Migreringsstatus.UTBETALING_FEILA)
             }
         }

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/MigrerSpesifikkSak.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/MigrerSpesifikkSak.kt
@@ -51,7 +51,7 @@ internal class MigrerSpesifikkSak(
         context: MessageContext,
     ) {
         val sakId = packet.sakId
-        if (pesysRepository.hentStatus(sakId) != null) {
+        if (pesysRepository.hentStatus(sakId) == Migreringsstatus.FERDIG) {
             logger.info("Har allerede migrert sak $sakId. Avbryter.")
             return
         }

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/PesysRepository.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/PesysRepository.kt
@@ -7,7 +7,6 @@ import no.nav.etterlatte.libs.database.hent
 import no.nav.etterlatte.libs.database.oppdater
 import no.nav.etterlatte.libs.database.opprett
 import no.nav.etterlatte.libs.database.transaction
-import no.nav.etterlatte.rapidsandrivers.migrering.MigreringRequest
 import no.nav.etterlatte.rapidsandrivers.migrering.PesysId
 import java.util.UUID
 import javax.sql.DataSource
@@ -89,10 +88,11 @@ internal class PesysRepository(private val dataSource: DataSource) : Transaction
     }
 
     fun lagreFeilkjoering(
-        request: MigreringRequest,
+        request: String,
         tx: TransactionalSession? = null,
         feilendeSteg: String,
         feil: String,
+        pesysId: PesysId,
     ) = tx.session {
         opprett(
             """
@@ -112,7 +112,7 @@ internal class PesysRepository(private val dataSource: DataSource) : Transaction
                 )""",
             mapOf(
                 Feilkjoering.ID to UUID.randomUUID(),
-                Feilkjoering.PESYS_ID to request.pesysId.id,
+                Feilkjoering.PESYS_ID to pesysId.id,
                 Feilkjoering.REQUEST to request.toJson(),
                 Feilkjoering.FEILMELDING to feil,
                 Feilkjoering.FEILENDE_STEG to feilendeSteg,

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/Pesyssak.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/Pesyssak.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.migrering
 
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.rapidsandrivers.migrering.AvdoedForelder
 import no.nav.etterlatte.rapidsandrivers.migrering.Beregning
@@ -20,6 +21,7 @@ data class Pesyssak(
     val beregning: Beregning,
     val trygdetid: Trygdetid,
     val flyktningStatus: Boolean,
+    val spraak: Spraak,
 ) {
     fun tilMigreringsrequest() =
         MigreringRequest(
@@ -33,5 +35,6 @@ data class Pesyssak(
             beregning = beregning,
             trygdetid = trygdetid,
             flyktningStatus = flyktningStatus,
+            spraak = spraak,
         )
 }

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/pen/PenModellTilVaarModell.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/pen/PenModellTilVaarModell.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.migrering.pen
 
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.migrering.Pesyssak
@@ -52,6 +53,7 @@ fun BarnepensjonGrunnlagResponse.tilVaarModell(): Pesyssak {
                     listOf(), // TODO: Parse ordentleg
                 ),
             flyktningStatus = false, // TODO
+            spraak = Spraak.NB, // TODO
         )
     return pesyssak
 }

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
@@ -23,9 +23,10 @@ internal class Verifiserer(private val pdlKlient: PDLKlient, private val reposit
                 "Sak ${request.pesysId} har ufullstendige data i PDL, kan ikke migrere. Se sikkerlogg for detaljer",
             )
             repository.lagreFeilkjoering(
-                request,
-                feil = feil.map { it.message }.toJson(),
+                request.toJson(),
                 feilendeSteg = Migreringshendelser.VERIFISER,
+                feil = feil.map { it.message }.toJson(),
+                pesysId = request.pesysId,
             )
             repository.oppdaterStatus(request.pesysId, Migreringsstatus.VERIFISERING_FEILA)
             throw samleExceptions(feil)

--- a/apps/etterlatte-migrering/src/test/kotlin/migrering/FeilendeMigreringLytterTest.kt
+++ b/apps/etterlatte-migrering/src/test/kotlin/migrering/FeilendeMigreringLytterTest.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.migrering
 import io.ktor.server.testing.testApplication
 import io.mockk.every
 import io.mockk.spyk
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
@@ -79,6 +80,7 @@ class FeilendeMigreringLytterTest {
                         ),
                     trygdetid = Trygdetid(perioder = listOf()),
                     flyktningStatus = false,
+                    spraak = Spraak.NN,
                 )
             repository.lagrePesyssak(pesyssak)
 
@@ -135,6 +137,7 @@ class FeilendeMigreringLytterTest {
                         ),
                     trygdetid = Trygdetid(perioder = listOf()),
                     flyktningStatus = false,
+                    spraak = Spraak.NN,
                 )
             repository.lagrePesyssak(pesyssak)
             repository.lagreKoplingTilBehandling(behandlingId, pesysid)

--- a/apps/etterlatte-migrering/src/test/kotlin/migrering/FeilendeMigreringLytterTest.kt
+++ b/apps/etterlatte-migrering/src/test/kotlin/migrering/FeilendeMigreringLytterTest.kt
@@ -1,4 +1,4 @@
-package migrering
+package no.nav.etterlatte.migrering
 
 import io.ktor.server.testing.testApplication
 import io.mockk.every
@@ -10,10 +10,6 @@ import no.nav.etterlatte.libs.common.rapidsandrivers.FEILENDE_STEG
 import no.nav.etterlatte.libs.common.rapidsandrivers.FEILMELDING_KEY
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.database.POSTGRES_VERSION
-import no.nav.etterlatte.migrering.Migreringsstatus
-import no.nav.etterlatte.migrering.PesysRepository
-import no.nav.etterlatte.migrering.Pesyskopling
-import no.nav.etterlatte.migrering.Pesyssak
 import no.nav.etterlatte.opprettInMemoryDatabase
 import no.nav.etterlatte.rapidsandrivers.EventNames
 import no.nav.etterlatte.rapidsandrivers.migrering.Beregning

--- a/apps/etterlatte-migrering/src/test/resources/attesteringsfeil.json
+++ b/apps/etterlatte-migrering/src/test/resources/attesteringsfeil.json
@@ -1,0 +1,65 @@
+{
+  "@event_name": "FEILA",
+    "vedtak": {
+    "vedtakId": 1350,
+    "status": "ATTESTERT",
+    "virkningstidspunkt": "2023-05",
+    "sak": {
+      "ident": "06470791932",
+      "sakType": "BARNEPENSJON",
+      "id": 756
+    },
+    "behandling": {
+      "type": "FØRSTEGANGSBEHANDLING",
+      "id": "bd8e7578-01fe-4e3e-b560-daf859c45c5f",
+      "revurderingsaarsak": null,
+      "revurderingInfo": null
+    },
+    "type": "INNVILGELSE",
+    "vedtakFattet": {
+      "ansvarligSaksbehandler": "EY",
+      "ansvarligEnhet": "4808",
+      "tidspunkt": "2023-10-03T08:13:43.517531Z"
+    },
+    "attestasjon": {
+      "attestant": "EY",
+      "attesterendeEnhet": "4808",
+      "tidspunkt": "2023-10-03T08:13:43.847096Z"
+    },
+    "utbetalingsperioder": [
+      {
+        "id": 1419,
+        "periode": {
+          "fom": "2023-05",
+          "tom": "2023-09"
+        },
+        "beloep": 3954,
+        "type": "UTBETALING"
+      },
+      {
+        "id": 1420,
+        "periode": {
+          "fom": "2023-10",
+          "tom": null
+        },
+        "beloep": 9885,
+        "type": "UTBETALING"
+      }
+    ]
+  },
+  "teknisk_tid": "2023-10-03T08:13:43.847096",
+  "skal_sende_brev": true,
+  "kilde": "PESYS",
+  "revurdering_aarsak": "null",
+  "@id": "53921457-eac3-4007-8226-b8db83b81a4e",
+  "@opprettet": "2023-10-03T10:13:44.254562362",
+  "system_read_count": 1,
+  "system_participating_services": [],
+  "feilende_steg": "OPPRETTET",
+  "feilmelding": "java.lang.IllegalArgumentException: Sak",
+  "@forårsaket_av": {
+    "id": "1b0c3fd0-5cee-44db-b169-f3abfb8f307e",
+    "opprettet": "2023-10-03T10:13:43.910051689",
+    "event_name": "VEDTAK:ATTESTERT"
+  }
+}

--- a/apps/etterlatte-trygdetid-kafka/src/test/kotlin/MigreringHendelserTest.kt
+++ b/apps/etterlatte-trygdetid-kafka/src/test/kotlin/MigreringHendelserTest.kt
@@ -3,6 +3,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -124,6 +125,7 @@ internal class MigreringHendelserTest {
                             ),
                         ),
                     ),
+                spraak = Spraak.NN,
             )
         every { trygdetidService.beregnTrygdetid(capture(behandlingId)) } returns mockk()
         every {
@@ -195,6 +197,7 @@ internal class MigreringHendelserTest {
                         g = BigDecimal(100000),
                     ),
                 trygdetid = Trygdetid(emptyList()),
+                spraak = Spraak.NN,
             )
         every { trygdetidService.beregnTrygdetid(capture(behandlingId)) } returns trygdetidDto
         every { trygdetidService.beregnTrygdetidGrunnlag(any(), any()) } returns trygdetidDto

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/MigreringRequest.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/MigreringRequest.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.rapidsandrivers.migrering
 
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
@@ -18,6 +19,7 @@ data class MigreringRequest(
     val beregning: Beregning,
     val trygdetid: Trygdetid,
     val flyktningStatus: Boolean = false,
+    val spraak: Spraak,
 ) {
     fun opprettPersongalleri() =
         Persongalleri(

--- a/libs/saksbehandling-common/src/main/kotlin/Spraak.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/Spraak.kt
@@ -1,0 +1,11 @@
+package no.nav.etterlatte.brev.model
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class Spraak(
+    @get:JsonValue val verdi: String,
+) {
+    NB("nb"),
+    NN("nn"),
+    EN("en"),
+}


### PR DESCRIPTION
- Tar høgde for at det kan feile i stega etter fattet vedtak, kor vi manglar data frå den originale pakka
- Tar med språk i requesten, sia dette trengs når vi skal lage brev
- Opnar for å migrere sak fleire gongar, for å forenkle testing