### PR TITLE
Avbryt åpnet og lukket modalen umiddelbart i setting av frist

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/FristHandlinger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/FristHandlinger.tsx
@@ -60,7 +60,7 @@ export const FristHandlinger = (props: {
     <>
       {frist ? (
         <>
-          <Modal open={open} onClose={() => setOpen((x) => !x)} aria-labelledby="modal-heading">
+          <Modal open={open} onClose={() => setOpen(false)} aria-labelledby="modal-heading">
             <Modal.Body>
               <Modal.Header closeButton={false}>
                 <Heading spacing level="2" size="medium" id="modal-heading">


### PR DESCRIPTION
`onClose` kjører tydeligvis etter at state er oppdatert, så du får en elegant 

```
setOpen(false)
// open er nå false
setOpen(open => !open)
// !open er true
```