### PR TITLE
EY-1824: Hjelpemetode for initialisering av rivers, for å sikre likt oppsett

### DIFF
--- a/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/beregningkafka/MigreringHendelser.kt
+++ b/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/beregningkafka/MigreringHendelser.kt
@@ -6,7 +6,6 @@ import no.nav.etterlatte.beregning.grunnlag.BarnepensjonBeregningsGrunnlag
 import no.nav.etterlatte.beregning.grunnlag.GrunnlagMedPeriode
 import no.nav.etterlatte.libs.common.beregning.BeregningDTO
 import no.nav.etterlatte.libs.common.periode.Periode
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.rapidsandrivers.migrering.MigreringRequest
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser
@@ -14,7 +13,6 @@ import no.nav.etterlatte.rapidsandrivers.migrering.hendelseData
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.BEHANDLING_ID_KEY
 import rapidsandrivers.BEREGNING_KEY
@@ -27,12 +25,10 @@ internal class MigreringHendelser(rapidsConnection: RapidsConnection, private va
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(hendelsestype)
+        initialiserRiver(rapidsConnection, hendelsestype) {
             validate { it.requireKey(BEHANDLING_ID_KEY) }
             validate { it.requireKey(HENDELSE_DATA_KEY) }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/beregningkafka/OmregningHendelser.kt
+++ b/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/beregningkafka/OmregningHendelser.kt
@@ -8,14 +8,11 @@ import no.nav.etterlatte.libs.common.beregning.AvkortingDto
 import no.nav.etterlatte.libs.common.beregning.BeregningDTO
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
-import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.rapidsandrivers.EventNames.BEREGN
 import no.nav.etterlatte.rapidsandrivers.EventNames.OPPRETT_VEDTAK
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import no.nav.helse.rapids_rivers.toUUID
 import org.slf4j.LoggerFactory
 import rapidsandrivers.AVKORTING_KEY
@@ -36,17 +33,13 @@ internal class OmregningHendelser(
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        logger.info("initierer rapid for omregninghendelser")
-        River(rapidsConnection).apply {
-            eventName(hendelsestype)
-
-            correlationId()
+        initialiserRiver(rapidsConnection, hendelsestype) {
             validate { it.requireKey(BEHANDLING_ID_KEY) }
             validate { it.requireKey(SAK_TYPE) }
             validate { it.rejectKey(BEREGNING_KEY) }
             validate { it.requireKey(HENDELSE_DATA_KEY) }
             validate { it.requireKey(BEHANDLING_VI_OMREGNER_FRA_KEY) }
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/DistribuerBrev.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/DistribuerBrev.kt
@@ -6,12 +6,9 @@ import no.nav.etterlatte.brev.distribusjon.DistribusjonService
 import no.nav.etterlatte.brev.distribusjon.DistribusjonsTidspunktType
 import no.nav.etterlatte.brev.distribusjon.DistribusjonsType
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
-import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLogging
 
@@ -23,12 +20,10 @@ internal class DistribuerBrev(
     private val logger = LoggerFactory.getLogger(DistribuerBrev::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(BrevEventTypes.JOURNALFOERT.toString())
+        initialiserRiver(rapidsConnection, BrevEventTypes.JOURNALFOERT.toString()) {
             validate { it.requireKey("brevId", "journalpostId", "distribusjonType") }
             validate { it.rejectKey("bestillingsId") }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrev.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrev.kt
@@ -9,14 +9,11 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.deserialize
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
 import no.nav.etterlatte.libs.common.rapidsandrivers.SKAL_SENDE_BREV
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
-import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.libs.common.sak.VedtakSak
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLogging
 import java.util.UUID
@@ -28,8 +25,7 @@ internal class JournalfoerVedtaksbrev(
     private val logger = LoggerFactory.getLogger(JournalfoerVedtaksbrev::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(BrevEventTypes.FERDIGSTILT.toString())
+        initialiserRiver(rapidsConnection, BrevEventTypes.FERDIGSTILT.toString()) {
             validate { it.requireKey("vedtak") }
             validate { it.requireKey("vedtak.vedtakId") }
             validate { it.requireKey("vedtak.behandling.id") }
@@ -42,8 +38,7 @@ internal class JournalfoerVedtaksbrev(
                 it.rejectValues("vedtak.behandling.type", listOf(BehandlingType.MANUELT_OPPHOER.name))
             }
             validate { it.rejectValue(SKAL_SENDE_BREV, false) }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettVedtaksbrevForMigrering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettVedtaksbrevForMigrering.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.brev.VedtaksbrevService
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.libs.common.Vedtaksloesning
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseType
 import no.nav.etterlatte.rapidsandrivers.migrering.KILDE_KEY
@@ -14,7 +13,6 @@ import no.nav.etterlatte.token.Systembruker
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLoggingOgFeilhaandtering
 import java.util.UUID
@@ -26,13 +24,11 @@ internal class OpprettVedtaksbrevForMigrering(
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(VedtakKafkaHendelseType.ATTESTERT.toString())
+        initialiserRiver(rapidsConnection, VedtakKafkaHendelseType.ATTESTERT.toString()) {
             validate { it.requireKey("vedtak.behandling.id") }
             validate { it.requireKey("vedtak.sak.id") }
             validate { it.interestedIn(KILDE_KEY) }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/VedtaksbrevUnderkjent.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/VedtaksbrevUnderkjent.kt
@@ -2,13 +2,10 @@ package no.nav.etterlatte.rivers
 
 import no.nav.etterlatte.brev.VedtaksbrevService
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
-import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseType
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLogging
 import java.util.UUID
@@ -20,16 +17,14 @@ internal class VedtaksbrevUnderkjent(
     private val logger = LoggerFactory.getLogger(VedtaksbrevUnderkjent::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(VedtakKafkaHendelseType.UNDERKJENT.toString())
+        initialiserRiver(rapidsConnection, VedtakKafkaHendelseType.UNDERKJENT.toString()) {
             validate { it.requireKey("vedtak") }
             validate { it.requireKey("vedtak.vedtakId") }
             validate { it.requireKey("vedtak.behandling.id") }
             validate {
                 it.rejectValues("vedtak.behandling.type", listOf(BehandlingType.MANUELT_OPPHOER.name))
             }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-fordeler/src/main/kotlin/fordeler/Fordeler.kt
+++ b/apps/etterlatte-fordeler/src/main/kotlin/fordeler/Fordeler.kt
@@ -18,14 +18,12 @@ import no.nav.etterlatte.libs.common.rapidsandrivers.GYLDIG_FOR_BEHANDLING_KEY
 import no.nav.etterlatte.libs.common.rapidsandrivers.SAK_TYPE_KEY
 import no.nav.etterlatte.libs.common.rapidsandrivers.SOEKNAD_ID_KEY
 import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
-import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.rapidsandrivers.EventNames
 import no.nav.etterlatte.sikkerLogg
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLogging
 import java.time.OffsetDateTime
@@ -44,8 +42,7 @@ internal class Fordeler(
     private val logger = LoggerFactory.getLogger(Fordeler::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(SoeknadInnsendt.eventNameInnsendt)
+        initialiserRiver(rapidsConnection, SoeknadInnsendt.eventNameInnsendt) {
             validate { it.demandValue(SoeknadInnsendt.skjemaInfoTypeKey, "BARNEPENSJON") }
             validate { it.demandValue(SoeknadInnsendt.skjemaInfoVersjonKey, "2") }
             validate { it.requireKey(SoeknadInnsendt.skjemaInfoKey) }
@@ -57,8 +54,7 @@ internal class Fordeler(
             validate { it.rejectKey(SoeknadInnsendt.dokarkivReturKey) }
             validate { it.rejectKey(GyldigSoeknadVurdert.sakIdKey) }
             validate { it.rejectKey(FordelerFordelt.soeknadFordeltKey) }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagHendelser.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagHendelser.kt
@@ -8,7 +8,6 @@ import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.rapidsandrivers.BEHOV_NAME_KEY
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.rapidsandrivers.EventNames.FEILA
@@ -16,7 +15,6 @@ import no.nav.etterlatte.rapidsandrivers.migrering.VILKAARSVURDERT_KEY
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import rapidsandrivers.FNR_KEY
@@ -32,8 +30,7 @@ class GrunnlagHendelser(
     private val logger: Logger = LoggerFactory.getLogger(GrunnlagHendelser::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            correlationId()
+        initialiserRiverUtenEventName(rapidsConnection) {
             validate { it.interestedIn(EVENT_NAME_KEY) }
             validate { it.interestedIn(BEHOV_NAME_KEY) }
             validate { it.interestedIn(FNR_KEY) }
@@ -42,7 +39,7 @@ class GrunnlagHendelser(
             validate { it.rejectValue(EVENT_NAME_KEY, GRUNNLAG_OPPDATERT) }
             validate { it.rejectValue(EVENT_NAME_KEY, FEILA) }
             validate { it.rejectValue(VILKAARSVURDERT_KEY, true) }
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/MigreringHendelser.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/MigreringHendelser.kt
@@ -6,7 +6,6 @@ import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.rapidsandrivers.migrering.MIGRERING_GRUNNLAG_KEY
@@ -18,7 +17,6 @@ import no.nav.etterlatte.rapidsandrivers.migrering.persongalleri
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import rapidsandrivers.HENDELSE_DATA_KEY
@@ -34,14 +32,12 @@ class MigreringHendelser(
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            correlationId()
-            eventName(hendelsestype)
+        initialiserRiver(rapidsConnection, hendelsestype) {
             validate { it.requireKey(SAK_ID_KEY) }
             validate { it.requireKey(MIGRERING_GRUNNLAG_KEY) }
             validate { it.requireKey(PERSONGALLERI_KEY) }
             validate { it.requireKey(HENDELSE_DATA_KEY) }
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-gyldig-soeknad/src/main/kotlin/gyldigsoeknad/barnepensjon/FordeltSoeknadRiver.kt
+++ b/apps/etterlatte-gyldig-soeknad/src/main/kotlin/gyldigsoeknad/barnepensjon/FordeltSoeknadRiver.kt
@@ -9,12 +9,9 @@ import no.nav.etterlatte.libs.common.event.SoeknadInnsendt
 import no.nav.etterlatte.libs.common.innsendtsoeknad.barnepensjon.Barnepensjon
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.SoeknadType
 import no.nav.etterlatte.libs.common.objectMapper
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
-import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLogging
 
@@ -26,15 +23,12 @@ internal class FordeltSoeknadRiver(
     private val logger = LoggerFactory.getLogger(FordeltSoeknadRiver::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(SoeknadInnsendt.eventNameBehandlingBehov)
-            correlationId()
+        initialiserRiver(rapidsConnection, SoeknadInnsendt.eventNameBehandlingBehov) {
             validate { it.requireKey(FordelerFordelt.skjemaInfoKey) }
             validate { it.demandValue(SoeknadInnsendt.skjemaInfoTypeKey, SoeknadType.BARNEPENSJON.name) }
             validate { it.rejectKey(GyldigSoeknadVurdert.behandlingIdKey) }
             validate { it.rejectValue("trengerManuellJor", true) }
-        }.register(this)
-    }
+        }    }
 
     override fun haandterPakke(
         packet: JsonMessage,

--- a/apps/etterlatte-gyldig-soeknad/src/main/kotlin/gyldigsoeknad/omstillingsstoenad/InnsendtSoeknadRiver.kt
+++ b/apps/etterlatte-gyldig-soeknad/src/main/kotlin/gyldigsoeknad/omstillingsstoenad/InnsendtSoeknadRiver.kt
@@ -12,14 +12,11 @@ import no.nav.etterlatte.libs.common.gyldigSoeknad.VurderingsResultat.KAN_IKKE_V
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.SoeknadType
 import no.nav.etterlatte.libs.common.innsendtsoeknad.omstillingsstoenad.Omstillingsstoenad
 import no.nav.etterlatte.libs.common.objectMapper
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
-import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLogging
 
@@ -30,9 +27,7 @@ internal class InnsendtSoeknadRiver(
     private val logger = LoggerFactory.getLogger(InnsendtSoeknadRiver::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(SoeknadInnsendt.eventNameInnsendt)
-            correlationId()
+        initialiserRiver(rapidsConnection, SoeknadInnsendt.eventNameInnsendt) {
             validate { it.requireKey(SoeknadInnsendt.skjemaInfoKey) }
             validate { it.demandValue(SoeknadInnsendt.skjemaInfoTypeKey, SoeknadType.OMSTILLINGSSTOENAD.name) }
             validate { it.demandValue(SoeknadInnsendt.skjemaInfoVersjonKey, "1") }
@@ -42,7 +37,7 @@ internal class InnsendtSoeknadRiver(
             validate { it.requireKey(SoeknadInnsendt.fnrSoekerKey) }
             validate { it.rejectKey(SoeknadInnsendt.dokarkivReturKey) }
             validate { it.rejectKey(GyldigSoeknadVurdert.behandlingIdKey) }
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/FeilendeMigreringLytter.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/FeilendeMigreringLytter.kt
@@ -3,7 +3,6 @@ package no.nav.etterlatte.migrering
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.rapidsandrivers.FEILENDE_STEG
 import no.nav.etterlatte.libs.common.rapidsandrivers.FEILMELDING_KEY
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.libs.common.rapidsandrivers.feilendeSteg
 import no.nav.etterlatte.libs.common.rapidsandrivers.feilmelding
@@ -18,7 +17,6 @@ import no.nav.etterlatte.rapidsandrivers.migrering.pesysId
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import no.nav.helse.rapids_rivers.toUUID
 import org.slf4j.LoggerFactory
 import rapidsandrivers.BEHANDLING_ID_KEY
@@ -32,8 +30,7 @@ internal class FeilendeMigreringLytter(rapidsConnection: RapidsConnection, priva
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(EventNames.FEILA)
+        initialiserRiver(rapidsConnection, EventNames.FEILA) {
             validate { it.interestedIn(FEILENDE_STEG) }
             validate { it.requireKey(KILDE_KEY) }
             validate { it.requireValue(KILDE_KEY, Vedtaksloesning.PESYS.name) }
@@ -48,8 +45,7 @@ internal class FeilendeMigreringLytter(rapidsConnection: RapidsConnection, priva
                     listOf(Migreringshendelser.VERIFISER, Migreringshendelser.AVBRYT_BEHANDLING),
                 )
             }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/LagreKopling.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/LagreKopling.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.migrering
 
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser
 import no.nav.etterlatte.rapidsandrivers.migrering.PESYS_ID_KEY
@@ -8,7 +7,6 @@ import no.nav.etterlatte.rapidsandrivers.migrering.pesysId
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.BEHANDLING_ID_KEY
 import rapidsandrivers.behandlingId
@@ -19,12 +17,10 @@ internal class LagreKopling(rapidsConnection: RapidsConnection, private val pesy
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(hendelsestype)
-            correlationId()
+        initialiserRiver(rapidsConnection, hendelsestype) {
             validate { it.requireKey(PESYS_ID_KEY) }
             validate { it.requireKey(BEHANDLING_ID_KEY) }
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/LyttPaaIverksattVedtak.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/LyttPaaIverksattVedtak.kt
@@ -3,8 +3,6 @@ package no.nav.etterlatte.migrering
 import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.libs.common.objectMapper
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
-import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.libs.common.utbetaling.UtbetalingResponseDto
 import no.nav.etterlatte.libs.common.utbetaling.UtbetalingStatusDto
 import no.nav.etterlatte.migrering.pen.PenKlient
@@ -14,7 +12,6 @@ import no.nav.etterlatte.utbetaling.common.UTBETALING_RESPONSE
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLoggingOgFeilhaandtering
@@ -28,11 +25,9 @@ internal class LyttPaaIverksattVedtak(
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(EVENT_NAME_OPPDATERT)
+        initialiserRiver(rapidsConnection, EVENT_NAME_OPPDATERT) {
             validate { it.requireKey(UTBETALING_RESPONSE) }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/MigrerSpesifikkSak.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/MigrerSpesifikkSak.kt
@@ -6,7 +6,6 @@ import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.rapidsandrivers.BEHOV_NAME_KEY
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.migrering.pen.BarnepensjonGrunnlagResponse
 import no.nav.etterlatte.migrering.pen.PenKlient
@@ -23,7 +22,6 @@ import no.nav.etterlatte.rapidsandrivers.migrering.pesysId
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.SAK_ID_KEY
 import rapidsandrivers.migrering.ListenerMedLoggingOgFeilhaandtering
@@ -39,11 +37,9 @@ internal class MigrerSpesifikkSak(
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(hendelsestype)
+        initialiserRiver(rapidsConnection, hendelsestype) {
             validate { it.requireKey(SAK_ID_KEY) }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/Migrering.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/Migrering.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.migrering
 
 import kotlinx.coroutines.runBlocking
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.migrering.pen.PenKlient
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser.MIGRER_SPESIFIKK_SAK
@@ -9,7 +8,6 @@ import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser.START_MIG
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLoggingOgFeilhaandtering
 import rapidsandrivers.sakId
@@ -19,10 +17,7 @@ internal class Migrering(rapidsConnection: RapidsConnection, private val penKlie
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(hendelsestype)
-            correlationId()
-        }.register(this)
+        initialiserRiver(rapidsConnection, hendelsestype)
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/PdlHendelser.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/PdlHendelser.kt
@@ -8,12 +8,9 @@ import no.nav.etterlatte.libs.common.pdlhendelse.ForelderBarnRelasjonHendelse
 import no.nav.etterlatte.libs.common.pdlhendelse.SivilstandHendelse
 import no.nav.etterlatte.libs.common.pdlhendelse.UtflyttingsHendelse
 import no.nav.etterlatte.libs.common.pdlhendelse.VergeMaalEllerFremtidsfullmakt
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
-import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLogging
 
@@ -24,14 +21,10 @@ internal class PdlHendelser(
     private val logger = LoggerFactory.getLogger(PdlHendelser::class.java)
 
     init {
-        logger.info("initierer rapid for pdlHendelser")
-        River(rapidsConnection).apply {
-            eventName("PDL:PERSONHENDELSE")
-
-            correlationId()
+        initialiserRiver(rapidsConnection, "PDL:PERSONHENDELSE") {
             validate { it.requireKey("hendelse") }
             validate { it.requireKey("hendelse_data") }
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/migrering/AvbrytBehandlingHvisMigreringFeila.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/migrering/AvbrytBehandlingHvisMigreringFeila.kt
@@ -1,13 +1,10 @@
 package no.nav.etterlatte.migrering
 
 import no.nav.etterlatte.BehandlingService
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
-import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.BEHANDLING_ID_KEY
 import rapidsandrivers.behandlingId
@@ -21,12 +18,9 @@ internal class AvbrytBehandlingHvisMigreringFeila(
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        logger.info("initierer rapid for ${this.javaClass.name}")
-        River(rapidsConnection).apply {
-            eventName(hendelsestype)
-            correlationId()
+        initialiserRiver(rapidsConnection, hendelsestype) {
             validate { it.requireKey(BEHANDLING_ID_KEY) }
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/migrering/MigrerEnEnkeltSak.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/migrering/MigrerEnEnkeltSak.kt
@@ -7,7 +7,6 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.rapidsandrivers.SAK_TYPE_KEY
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.rapidsandrivers.migrering.FNR_KEY
 import no.nav.etterlatte.rapidsandrivers.migrering.MIGRERING_GRUNNLAG_KEY
@@ -18,7 +17,6 @@ import no.nav.etterlatte.rapidsandrivers.migrering.ROLLE_KEY
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.BEHANDLING_ID_KEY
 import rapidsandrivers.HENDELSE_DATA_KEY
@@ -35,17 +33,12 @@ internal class MigrerEnEnkeltSak(
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        logger.info("initierer rapid for migreringshendelser")
-        River(rapidsConnection).apply {
-
-            eventName(hendelsestype)
-
-            correlationId()
+        initialiserRiver(rapidsConnection, hendelsestype) {
             validate { it.rejectKey(BEHANDLING_ID_KEY) }
             validate { it.requireKey(HENDELSE_DATA_KEY) }
             validate { it.requireKey(FNR_KEY) }
             validate { it.rejectKey(OPPLYSNING_KEY) }
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/OmregningsHendelser.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/OmregningsHendelser.kt
@@ -4,14 +4,12 @@ import com.fasterxml.jackson.module.kotlin.treeToValue
 import no.nav.etterlatte.BehandlingService
 import no.nav.etterlatte.libs.common.behandling.Omregningshendelse
 import no.nav.etterlatte.libs.common.objectMapper
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.rapidsandrivers.EventNames.OMREGNINGSHENDELSE
 import no.nav.etterlatte.rapidsandrivers.EventNames.VILKAARSVURDER
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.BEHANDLING_ID_KEY
 import rapidsandrivers.BEHANDLING_VI_OMREGNER_FRA_KEY
@@ -25,14 +23,10 @@ internal class OmregningsHendelser(rapidsConnection: RapidsConnection, private v
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        logger.info("initierer rapid for omregningshendelser")
-        River(rapidsConnection).apply {
-            eventName(hendelsestype)
-
-            correlationId()
+        initialiserRiver(rapidsConnection, hendelsestype) {
             validate { it.rejectKey(BEHANDLING_ID_KEY) }
             validate { it.requireKey(HENDELSE_DATA_KEY) }
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/ReguleringFeilet.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/ReguleringFeilet.kt
@@ -2,13 +2,10 @@ package no.nav.etterlatte.regulering
 
 import no.nav.etterlatte.BehandlingService
 import no.nav.etterlatte.ReguleringFeiletHendelse
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
-import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.rapidsandrivers.EventNames.FEILA
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.SAK_ID_KEY
 import rapidsandrivers.migrering.ListenerMedLogging
@@ -21,12 +18,10 @@ internal class ReguleringFeilet(
     private val logger = LoggerFactory.getLogger(ReguleringFeilet::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(FEILA)
+        initialiserRiver(rapidsConnection, FEILA) {
             validate { it.requireKey(SAK_ID_KEY) }
             validate { it.requireValue("aarsak", "REGULERING") }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/Reguleringsforespoersel.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/Reguleringsforespoersel.kt
@@ -1,14 +1,12 @@
 package no.nav.etterlatte.regulering
 
 import no.nav.etterlatte.BehandlingService
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.rapidsandrivers.EventNames.FINN_LOEPENDE_YTELSER
 import no.nav.etterlatte.rapidsandrivers.EventNames.REGULERING_EVENT_NAME
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.DATO_KEY
 import rapidsandrivers.dato
@@ -23,11 +21,9 @@ internal class Reguleringsforespoersel(
     private val logger = LoggerFactory.getLogger(Reguleringsforespoersel::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(hendelsestype)
+        initialiserRiver(rapidsConnection, hendelsestype) {
             validate { it.requireKey(DATO_KEY) }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/opplysningerfrasoknad/StartUthentingFraSoeknad.kt
+++ b/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/opplysningerfrasoknad/StartUthentingFraSoeknad.kt
@@ -5,12 +5,10 @@ import no.nav.etterlatte.libs.common.event.SoeknadInnsendt
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.SoeknadType
 import no.nav.etterlatte.libs.common.rapidsandrivers.CORRELATION_ID_KEY
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.opplysningerfrasoknad.opplysningsuthenter.Opplysningsuthenter
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLogging
@@ -23,19 +21,18 @@ internal class StartUthentingFraSoeknad(
     private val rapid = rapidsConnection
 
     init {
-        River(rapidsConnection).apply {
+        initialiserRiverUtenEventName(rapidsConnection) {
             validate {
                 it.demandAny(
                     EVENT_NAME_KEY,
                     listOf(SoeknadInnsendt.eventNameInnsendt, SoeknadInnsendt.eventNameBehandlingBehov),
                 )
             }
-            correlationId()
             validate { it.requireKey(GyldigSoeknadVurdert.skjemaInfoKey) }
             validate { it.requireKey(GyldigSoeknadVurdert.sakIdKey) }
             validate { it.requireKey(GyldigSoeknadVurdert.behandlingIdKey) }
             validate { it.requireKey(GyldigSoeknadVurdert.skjemaInfoTypeKey) }
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/BehandlinghendelseRiver.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/BehandlinghendelseRiver.kt
@@ -16,7 +16,6 @@ import no.nav.etterlatte.statistikk.service.StatistikkService
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLogging
 import java.time.LocalDateTime
@@ -35,7 +34,7 @@ class BehandlinghendelseRiver(
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        River(rapidsConnection).apply {
+        initialiserRiverUtenEventName(rapidsConnection) {
             validate { it.demandAny(EVENT_NAME_KEY, behandlingshendelser) }
             validate { it.interestedIn(BehandlingRiverKey.behandlingObjectKey) }
             validate { it.requireKey("behandling.id") }
@@ -46,8 +45,7 @@ class BehandlinghendelseRiver(
             validate { it.requireKey("behandling.status") }
             validate { it.requireKey("behandling.type") }
             validate { it.interestedIn(TEKNISK_TID_KEY) }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/SoeknadStatistikkRiver.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/SoeknadStatistikkRiver.kt
@@ -10,13 +10,11 @@ import no.nav.etterlatte.libs.common.rapidsandrivers.GYLDIG_FOR_BEHANDLING_KEY
 import no.nav.etterlatte.libs.common.rapidsandrivers.SAK_TYPE_KEY
 import no.nav.etterlatte.libs.common.rapidsandrivers.SOEKNAD_ID_KEY
 import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
-import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.rapidsandrivers.EventNames
 import no.nav.etterlatte.statistikk.service.SoeknadStatistikkService
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLogging
 
@@ -27,14 +25,12 @@ class SoeknadStatistikkRiver(
     private val logger = LoggerFactory.getLogger(this.javaClass)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(EventNames.FORDELER_STATISTIKK)
+        initialiserRiver(rapidsConnection, EventNames.FORDELER_STATISTIKK) {
             validate { it.requireKey(SOEKNAD_ID_KEY) }
             validate { it.requireKey(GYLDIG_FOR_BEHANDLING_KEY) }
             validate { it.requireKey(SAK_TYPE_KEY) }
             validate { it.interestedIn(FEILENDE_KRITERIER_KEY) }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/VedtakhendelserRiver.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/VedtakhendelserRiver.kt
@@ -11,7 +11,6 @@ import no.nav.etterlatte.statistikk.service.StatistikkService
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLogging
@@ -31,12 +30,11 @@ class VedtakhendelserRiver(
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        River(rapidsConnection).apply {
+        initialiserRiverUtenEventName(rapidsConnection) {
             validate { it.demandAny(EVENT_NAME_KEY, vedtakshendelser) }
             validate { it.requireKey("vedtak") }
             validate { it.interestedIn(TEKNISK_TID_KEY) }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-trygdetid-kafka/src/main/kotlin/MigreringHendelser.kt
+++ b/apps/etterlatte-trygdetid-kafka/src/main/kotlin/MigreringHendelser.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.trygdetid.kafka
 
 import no.nav.etterlatte.libs.common.Vedtaksloesning
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJson
@@ -18,7 +17,6 @@ import no.nav.etterlatte.trygdetid.TrygdetidType
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.BEHANDLING_ID_KEY
 import rapidsandrivers.HENDELSE_DATA_KEY
@@ -32,15 +30,11 @@ internal class MigreringHendelser(rapidsConnection: RapidsConnection, private va
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        logger.info("initierer rapid for migreringshendelser")
-        River(rapidsConnection).apply {
-            eventName(Migreringshendelser.TRYGDETID)
-
-            correlationId()
+        initialiserRiver(rapidsConnection, Migreringshendelser.TRYGDETID) {
             validate { it.requireKey(BEHANDLING_ID_KEY) }
             validate { it.requireKey(VILKAARSVURDERT_KEY) }
             validate { it.requireKey(HENDELSE_DATA_KEY) }
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/common/Oppgavetrigger.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/common/Oppgavetrigger.kt
@@ -2,8 +2,6 @@ package no.nav.etterlatte.utbetaling.common
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.libs.common.objectMapper
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
-import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.utbetaling.grensesnittavstemming.GrensesnittsavstemmingService
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
@@ -11,7 +9,6 @@ import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.UtbetalingService
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLogging
 
@@ -21,11 +18,9 @@ class Oppgavetrigger(
     private val grensesnittsavstemmingService: GrensesnittsavstemmingService,
 ) : ListenerMedLogging() {
     init {
-        River(rapidsConnection).apply {
-            eventName("okonomi_vedtak_oppgave")
-            correlationId()
+        initialiserRiver(rapidsConnection, "okonomi_vedtak_oppgave") {
             validate { it.interestedIn("oppgave") }
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/VedtakMottaker.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/VedtakMottaker.kt
@@ -2,8 +2,6 @@ package no.nav.etterlatte.utbetaling.iverksetting
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.libs.common.objectMapper
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
-import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.utbetaling.UtbetalingResponseDto
 import no.nav.etterlatte.libs.common.utbetaling.UtbetalingStatusDto
@@ -22,7 +20,6 @@ import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Utbetalingsvedtak
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLogging
 import java.util.UUID
@@ -34,8 +31,7 @@ class VedtakMottaker(
     private val utbetalingService: UtbetalingService,
 ) : ListenerMedLogging() {
     init {
-        River(rapidsConnection).apply {
-            eventName(VedtakKafkaHendelseType.ATTESTERT.toString())
+        initialiserRiver(rapidsConnection, VedtakKafkaHendelseType.ATTESTERT.toString()) {
             validate { it.requireKey("vedtak") }
             validate {
                 it.requireAny(
@@ -43,8 +39,7 @@ class VedtakMottaker(
                     listOf(VedtakType.INNVILGELSE.name, VedtakType.OPPHOER.name, VedtakType.ENDRING.name),
                 )
             }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/LagreIverksattVedtak.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/LagreIverksattVedtak.kt
@@ -3,8 +3,6 @@ package no.nav.etterlatte.vedtaksvurdering.rivers
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.VedtakService
 import no.nav.etterlatte.libs.common.objectMapper
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
-import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.libs.common.utbetaling.UtbetalingResponseDto
 import no.nav.etterlatte.libs.common.utbetaling.UtbetalingStatusDto
 import no.nav.etterlatte.utbetaling.common.EVENT_NAME_OPPDATERT
@@ -12,7 +10,6 @@ import no.nav.etterlatte.utbetaling.common.UTBETALING_RESPONSE
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.migrering.ListenerMedLogging
 
@@ -21,11 +18,9 @@ internal class LagreIverksattVedtak(
     private val vedtaksvurderingService: VedtakService,
 ) : ListenerMedLogging() {
     init {
-        River(rapidsConnection).apply {
-            eventName(EVENT_NAME_OPPDATERT)
+        initialiserRiver(rapidsConnection, EVENT_NAME_OPPDATERT) {
             validate { it.requireKey(UTBETALING_RESPONSE) }
-            correlationId()
-        }.register(this)
+        }
     }
 
     private val logger = LoggerFactory.getLogger(this::class.java)

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/MigreringHendelser.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/MigreringHendelser.kt
@@ -1,12 +1,9 @@
 package no.nav.etterlatte
 
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
-import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser.VEDTAK
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.BEHANDLING_ID_KEY
 import rapidsandrivers.SAK_ID_KEY
@@ -22,12 +19,10 @@ internal class MigreringHendelser(
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(VEDTAK)
+        initialiserRiver(rapidsConnection, VEDTAK) {
             validate { it.requireKey(BEHANDLING_ID_KEY) }
             validate { it.requireKey(SAK_ID_KEY) }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/LoependeYtelserforespoersel.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/LoependeYtelserforespoersel.kt
@@ -3,14 +3,12 @@ package no.nav.etterlatte.regulering
 import no.nav.etterlatte.VedtakService
 import no.nav.etterlatte.libs.common.behandling.Omregningshendelse
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.rapidsandrivers.EventNames.FINN_LOEPENDE_YTELSER
 import no.nav.etterlatte.rapidsandrivers.EventNames.OMREGNINGSHENDELSE
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.DATO_KEY
 import rapidsandrivers.HENDELSE_DATA_KEY
@@ -28,13 +26,11 @@ internal class LoependeYtelserforespoersel(
     private val logger = LoggerFactory.getLogger(LoependeYtelserforespoersel::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(hendelsestype)
+        initialiserRiver(rapidsConnection, hendelsestype) {
             validate { it.requireKey(SAK_ID_KEY) }
             validate { it.requireKey(DATO_KEY) }
             validate { it.requireKey(TILBAKESTILTE_BEHANDLINGER_KEY) }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/OpprettVedtakforespoersel.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/regulering/OpprettVedtakforespoersel.kt
@@ -1,13 +1,10 @@
 package no.nav.etterlatte.regulering
 
 import no.nav.etterlatte.VedtakService
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
-import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.rapidsandrivers.EventNames.OPPRETT_VEDTAK
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.BEHANDLING_ID_KEY
 import rapidsandrivers.DATO_KEY
@@ -24,13 +21,11 @@ internal class OpprettVedtakforespoersel(
     private val logger = LoggerFactory.getLogger(OpprettVedtakforespoersel::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(OPPRETT_VEDTAK)
+        initialiserRiver(rapidsConnection, OPPRETT_VEDTAK) {
             validate { it.requireKey(SAK_ID_KEY) }
             validate { it.requireKey(DATO_KEY) }
             validate { it.requireKey(BEHANDLING_ID_KEY) }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/vilkaarsvurdering/Migrering.kt
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/vilkaarsvurdering/Migrering.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.vilkaarsvurdering
 
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser.VILKAARSVURDER
@@ -9,7 +8,6 @@ import no.nav.etterlatte.vilkaarsvurdering.services.VilkaarsvurderingService
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 import rapidsandrivers.BEHANDLING_ID_KEY
 import rapidsandrivers.behandlingId
@@ -22,12 +20,10 @@ internal class Migrering(
     private val logger = LoggerFactory.getLogger(Migrering::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(hendelsestype)
+        initialiserRiver(rapidsConnection, hendelsestype) {
             validate { it.requireKey(BEHANDLING_ID_KEY) }
             validate { it.rejectKey(VILKAARSVURDERT_KEY) }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/vilkaarsvurdering/Vilkaarsvurder.kt
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/vilkaarsvurdering/Vilkaarsvurder.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.vilkaarsvurdering
 
-import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.rapidsandrivers.EventNames
 import no.nav.etterlatte.rapidsandrivers.EventNames.VILKAARSVURDER
@@ -8,7 +7,6 @@ import no.nav.etterlatte.vilkaarsvurdering.services.VilkaarsvurderingService
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helse.rapids_rivers.River
 import no.nav.helse.rapids_rivers.toUUID
 import org.slf4j.LoggerFactory
 import rapidsandrivers.BEHANDLING_ID_KEY
@@ -25,13 +23,11 @@ internal class Vilkaarsvurder(
     private val logger = LoggerFactory.getLogger(Vilkaarsvurder::class.java)
 
     init {
-        River(rapidsConnection).apply {
-            eventName(hendelsestype)
+        initialiserRiver(rapidsConnection, hendelsestype) {
             validate { it.requireKey(SAK_ID_KEY) }
             validate { it.requireKey(BEHANDLING_ID_KEY) }
             validate { it.requireKey(BEHANDLING_VI_OMREGNER_FRA_KEY) }
-            correlationId()
-        }.register(this)
+        }
     }
 
     override fun haandterPakke(

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/ListenerMedLogging.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/ListenerMedLogging.kt
@@ -2,11 +2,16 @@ package rapidsandrivers.migrering
 
 import no.nav.etterlatte.libs.common.logging.withLogContext
 import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
+import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
+import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
+import org.slf4j.LoggerFactory
 
 abstract class ListenerMedLogging : River.PacketListener {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
     abstract fun haandterPakke(
         packet: JsonMessage,
         context: MessageContext,
@@ -17,5 +22,18 @@ abstract class ListenerMedLogging : River.PacketListener {
         context: MessageContext,
     ) = withLogContext(packet.correlationId) {
         haandterPakke(packet, context)
+    }
+
+    protected fun initialiserRiver(
+        rapidsConnection: RapidsConnection,
+        hendelsestype: String,
+        block: River.() -> Unit = {},
+    ) {
+        logger.info("Initierer river for ${this.javaClass.name}")
+        River(rapidsConnection).apply {
+            eventName(hendelsestype)
+            correlationId()
+            block()
+        }.register(this)
     }
 }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/ListenerMedLogging.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/ListenerMedLogging.kt
@@ -39,7 +39,7 @@ abstract class ListenerMedLogging : River.PacketListener {
         rapidsConnection: RapidsConnection,
         block: River.() -> Unit = {},
     ) {
-        logger.info("Initierer river for ${this.javaClass.name}")
+        logger.info("Initialiserer river for ${this.javaClass.simpleName}")
         River(rapidsConnection).apply {
             correlationId()
             block()

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/ListenerMedLogging.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/ListenerMedLogging.kt
@@ -29,9 +29,18 @@ abstract class ListenerMedLogging : River.PacketListener {
         hendelsestype: String,
         block: River.() -> Unit = {},
     ) {
+        initialiserRiverUtenEventName(rapidsConnection, block = {
+            eventName(hendelsestype)
+            block()
+        })
+    }
+
+    protected fun initialiserRiverUtenEventName(
+        rapidsConnection: RapidsConnection,
+        block: River.() -> Unit = {},
+    ) {
         logger.info("Initierer river for ${this.javaClass.name}")
         River(rapidsConnection).apply {
-            eventName(hendelsestype)
             correlationId()
             block()
         }.register(this)

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/ListenerMedLoggingOgFeilhaandtering.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/ListenerMedLoggingOgFeilhaandtering.kt
@@ -4,10 +4,14 @@ import no.nav.etterlatte.libs.common.logging.withLogContext
 import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
+import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
+import org.slf4j.LoggerFactory
 import rapidsandrivers.withFeilhaandtering
 
 abstract class ListenerMedLoggingOgFeilhaandtering(protected val hendelsestype: String) : River.PacketListener {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
     abstract fun haandterPakke(
         packet: JsonMessage,
         context: MessageContext,
@@ -20,5 +24,16 @@ abstract class ListenerMedLoggingOgFeilhaandtering(protected val hendelsestype: 
         withFeilhaandtering(packet, context, hendelsestype) {
             haandterPakke(packet, context)
         }
+    }
+
+    protected fun initialiserRiver(
+        rapidsConnection: RapidsConnection,
+        block: River.() -> Unit,
+    ) {
+        logger.info("Initierer river for ${this.javaClass.name}")
+        River(rapidsConnection).apply {
+            correlationId()
+            block()
+        }.register(this)
     }
 }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/ListenerMedLoggingOgFeilhaandtering.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/ListenerMedLoggingOgFeilhaandtering.kt
@@ -2,6 +2,7 @@ package rapidsandrivers.migrering
 
 import no.nav.etterlatte.libs.common.logging.withLogContext
 import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
+import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
@@ -28,10 +29,12 @@ abstract class ListenerMedLoggingOgFeilhaandtering(protected val hendelsestype: 
 
     protected fun initialiserRiver(
         rapidsConnection: RapidsConnection,
-        block: River.() -> Unit,
+        hendelsestype: String,
+        block: River.() -> Unit = {},
     ) {
         logger.info("Initierer river for ${this.javaClass.name}")
         River(rapidsConnection).apply {
+            eventName(hendelsestype)
             correlationId()
             block()
         }.register(this)

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/ListenerMedLoggingOgFeilhaandtering.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/ListenerMedLoggingOgFeilhaandtering.kt
@@ -32,7 +32,7 @@ abstract class ListenerMedLoggingOgFeilhaandtering(protected val hendelsestype: 
         hendelsestype: String,
         block: River.() -> Unit = {},
     ) {
-        logger.info("Initierer river for ${this.javaClass.name}")
+        logger.info("Initialiserer river for ${this.javaClass.simpleName}")
         River(rapidsConnection).apply {
             eventName(hendelsestype)
             correlationId()


### PR DESCRIPTION
Gløymte å setje correlationId på ein river i går, så det minna meg på denne ideen.

Synes dagens kode har to problem:

1. Det er fort gjort å gløyme å setje særleg correlationId
2. Vi er inkonsekvente på rekkjefølgje, korvidt vi loggar eller ikkje osv. Ser ingen grunn til at det ikkje kan (og bør) vera likt
3. Det som denne riveren spesifikt er interessert i druknar litt i staffasje

Synes intensjonen for kvar river vart tydelegare etter endringa.