### PR TITLE
EY-2537: Snyk klagar på manglande sanitize av fnr- og tpnr-parametra …

### DIFF
--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRoute.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRoute.kt
@@ -8,6 +8,7 @@ import io.ktor.server.response.respondNullable
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.ktor.hentTokenClaims
 import java.time.LocalDate
 
@@ -65,8 +66,8 @@ fun Route.samordningVedtakRoute(samordningVedtakService: SamordningVedtakService
                 try {
                     samordningVedtakService.hentVedtaksliste(
                         virkFom = virkFom,
-                        fnr = fnr,
-                        tpnr = tpnummer,
+                        fnr = Folkeregisteridentifikator.of(fnr),
+                        tpnr = Tjenestepensjonnummer(tpnummer),
                         organisasjonsnummer = call.orgNummer,
                     )
                 } catch (e: TjenestepensjonManglendeTilgangException) {

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakService.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakService.kt
@@ -6,6 +6,7 @@ import no.nav.etterlatte.libs.common.beregning.AvkortetYtelseDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingDto
 import no.nav.etterlatte.libs.common.beregning.BeregningDTO
 import no.nav.etterlatte.libs.common.deserialize
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.vedtak.VedtakSamordningDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import java.time.LocalDate
@@ -39,17 +40,17 @@ class SamordningVedtakService(
 
     suspend fun hentVedtaksliste(
         virkFom: LocalDate,
-        fnr: String,
-        tpnr: String,
+        fnr: Folkeregisteridentifikator,
+        tpnr: Tjenestepensjonnummer,
         organisasjonsnummer: String,
     ): List<SamordningVedtakDto> {
-        if (!tjenestepensjonKlient.harTpForholdByDate(fnr, tpnr, virkFom)) {
+        if (!tjenestepensjonKlient.harTpForholdByDate(fnr.value, tpnr.value, virkFom)) {
             throw TjenestepensjonManglendeTilgangException("Ikke gyldig tpforhold")
         }
 
         return vedtaksvurderingKlient.hentVedtaksliste(
             virkFom = virkFom,
-            fnr = fnr,
+            fnr = fnr.value,
             organisasjonsnummer = organisasjonsnummer,
         )
             .map { it.mapSamordningsvedtak() }

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/Tjenestepensjon.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/Tjenestepensjon.kt
@@ -20,6 +20,12 @@ data class SamhandlerYtelseDto(
     val datoYtelseIverksattTom: LocalDate? = null,
 )
 
+data class Tjenestepensjonnummer(val value: String) {
+    init {
+        require(value == value.replace(Regex("[^0-9]"), ""))
+    }
+}
+
 class TjenestepensjonManglendeTilgangException(override val message: String, cause: Throwable? = null) : Exception(message, cause)
 
 class TjenestepensjonUgyldigForesporselException(override val message: String, cause: Throwable?) : Exception(message, cause)

--- a/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRouteTest.kt
+++ b/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRouteTest.kt
@@ -17,6 +17,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.mockk
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.ktor.restModule
 import no.nav.etterlatte.validateMaskinportenScope
 import no.nav.security.mock.oauth2.MockOAuth2Server
@@ -117,13 +118,13 @@ class SamordningVedtakRouteTest {
     @Test
     fun `skal gi 200 med gyldig token inkl scope - hent vedtaksliste med virkfom og fnr`() {
         val virkFom = LocalDate.now()
-        val fnr = "01015012345"
+        val fnr = "01448203510"
 
         coEvery {
             samordningVedtakService.hentVedtaksliste(
                 virkFom = virkFom,
-                fnr = fnr,
-                tpnr = "3010",
+                fnr = Folkeregisteridentifikator.of(fnr),
+                tpnr = Tjenestepensjonnummer("3010"),
                 organisasjonsnummer = any<String>(),
             )
         } returns
@@ -149,8 +150,8 @@ class SamordningVedtakRouteTest {
             coVerify {
                 samordningVedtakService.hentVedtaksliste(
                     virkFom = virkFom,
-                    fnr = fnr,
-                    tpnr = "3010",
+                    fnr = Folkeregisteridentifikator.of(fnr),
+                    tpnr = Tjenestepensjonnummer("3010"),
                     organisasjonsnummer = any<String>(),
                 )
             }

--- a/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakServiceTest.kt
+++ b/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakServiceTest.kt
@@ -19,6 +19,7 @@ import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
 import no.nav.etterlatte.libs.common.beregning.Beregningstype
 import no.nav.etterlatte.libs.common.grunnlag.Metadata
 import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.sak.VedtakSak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vedtak.Behandling
@@ -130,7 +131,12 @@ class SamordningVedtakServiceTest {
 
         val vedtaksliste =
             runBlocking {
-                samordningVedtakService.hentVedtaksliste(virkFom, FNR, TPNR_SPK, ORGNO)
+                samordningVedtakService.hentVedtaksliste(
+                    virkFom,
+                    Folkeregisteridentifikator.of(FNR),
+                    Tjenestepensjonnummer(TPNR_SPK),
+                    ORGNO,
+                )
             }
 
         vedtaksliste shouldHaveSize 2


### PR DESCRIPTION
…for samordning, og det er jo eit poeng. Her veit vi jo eigentleg ein del om formatet, så vi kan like godt bruke objekt for dei heller enn string uansett