### PR TITLE
Gå over fra Q1 til Q2 i brev-api

### DIFF
--- a/apps/etterlatte-brev-api/.nais/dev.yaml
+++ b/apps/etterlatte-brev-api/.nais/dev.yaml
@@ -58,17 +58,17 @@ spec:
     - name: NORG2_URL
       value: https://norg2.dev-fss-pub.nais.io/norg2/api/v1
     - name: SAF_BASE_URL
-      value: https://saf.dev-fss-pub.nais.io
+      value: https://saf-q2.dev-fss-pub.nais.io
     - name: SAF_SCOPE
-      value: api://dev-fss.teamdokumenthandtering.saf-q1/.default
+      value: api://dev-fss.teamdokumenthandtering.saf/.default
     - name: DOKARKIV_URL
-      value: https://dokarkiv.dev-fss-pub.nais.io/rest/journalpostapi/v1/journalpost
+      value: https://dokarkiv-q2.dev-fss-pub.nais.io/rest/journalpostapi/v1/journalpost
     - name: DOKARKIV_SCOPE
-      value: api://dev-fss.teamdokumenthandtering.dokarkiv-q1/.default
+      value: api://dev-fss.teamdokumenthandtering.dokarkiv/.default
     - name: DOKDIST_URL
-      value: https://dokdistfordeling-q1.dev-fss-pub.nais.io/rest/v1
+      value: https://dokdistfordeling.dev-fss-pub.nais.io/rest/v1
     - name: DOKDIST_SCOPE
-      value: api://dev-fss.teamdokumenthandtering.saf-q1/.default
+      value: api://dev-fss.teamdokumenthandtering.saf/.default
     - name: NAVANSATT_URL
       value: https://navansatt.dev-fss-pub.nais.io
     - name: KAFKA_RAPID_TOPIC
@@ -120,9 +120,9 @@ spec:
       external:
         - host: etterlatte-proxy.dev-fss-pub.nais.io
         - host: norg2.dev-fss-pub.nais.io
-        - host: saf.dev-fss-pub.nais.io
-        - host: dokarkiv.dev-fss-pub.nais.io
-        - host: dokdistfordeling-q1.dev-fss-pub.nais.io
+        - host: saf-q2.dev-fss-pub.nais.io
+        - host: dokarkiv-q2.dev-fss-pub.nais.io
+        - host: dokdistfordeling.dev-fss-pub.nais.io
         - host: data.brreg.no
         - host: navansatt.dev-fss-pub.nais.io
         - host: pensjon-brevbaker.intern.dev.nav.no

--- a/apps/etterlatte-brev-api/.run/etterlatte-brev-api.dev-gcp.run.xml
+++ b/apps/etterlatte-brev-api/.run/etterlatte-brev-api.dev-gcp.run.xml
@@ -4,10 +4,10 @@
       <env name="BRREG_URL" value="https://data.brreg.no" />
       <env name="DB_JDBC_URL" value="jdbc:postgresql://host.docker.internal:5435/postgres" />
       <env name="DB_USERNAME" value="postgres" />
-      <env name="DOKARKIV_SCOPE" value="api://dev-fss.teamdokumenthandtering.dokarkiv-q1/.default" />
-      <env name="DOKARKIV_URL" value="https://dokarkiv.dev-fss-pub.nais.io/rest/journalpostapi/v1/journalpost" />
-      <env name="DOKDIST_SCOPE" value="api://dev-fss.teamdokumenthandtering.saf-q1/.default" />
-      <env name="DOKDIST_URL" value="https://dokdistfordeling-q1.dev-fss-pub.nais.io/rest/v1" />
+      <env name="DOKARKIV_SCOPE" value="api://dev-fss.teamdokumenthandtering.dokarkiv/.default" />
+      <env name="DOKARKIV_URL" value="https://dokarkiv-q2.dev-fss-pub.nais.io/rest/journalpostapi/v1/journalpost" />
+      <env name="DOKDIST_SCOPE" value="api://dev-fss.teamdokumenthandtering.saf/.default" />
+      <env name="DOKDIST_URL" value="https://dokdistfordeling.dev-fss-pub.nais.io/rest/v1" />
       <env name="ETTERLATTE_BEHANDLING_CLIENT_ID" value="59967ac8-009c-492e-a618-e5a0f6b3e4e4" />
       <env name="ETTERLATTE_BEHANDLING_URL" value="https://etterlatte-behandling.intern.dev.nav.no" />
       <env name="ETTERLATTE_BEREGNING_CLIENT_ID" value="b07cf335-11fb-4efa-bd46-11f51afd5052" />


### PR DESCRIPTION
Ingresser i dev-fss er ikke konsekvente, så dokdist _uten_ `-q2` tilsvarer `q2`, og motsatt på de andre. Flotte greier! 