### PR TITLE
Konsekvent feilmapping med statuspages

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
@@ -12,6 +12,7 @@ import io.ktor.server.routing.route
 import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.behandlingsId
+import no.nav.etterlatte.libs.ktor.feilhaandtering.ForespoerselException
 import no.nav.etterlatte.tilgangsstyring.kunAttestant
 import no.nav.etterlatte.vedtaksvurdering.VedtakHendelse
 
@@ -149,6 +150,12 @@ private suspend fun haandterStatusEndring(
     runCatching(proevStatusEndring)
         .fold(
             onSuccess = { call.respond(HttpStatusCode.OK, OperasjonGyldig(true)) },
-            onFailure = { call.respond(HttpStatusCode.Conflict, it.message ?: "Statussjekk feilet") },
+            onFailure = { throw BehandlingKanIkkeBytteStatusException() },
         )
 }
+
+class BehandlingKanIkkeBytteStatusException : ForespoerselException(
+    status = HttpStatusCode.Conflict.value,
+    code = "BEHANDLING_HAR_UGYLDIG_STATUS",
+    detail = "Behandlingen kan ikke bytte til ønsket status",
+)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
@@ -12,7 +12,7 @@ import io.ktor.server.routing.route
 import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.behandlingsId
-import no.nav.etterlatte.libs.ktor.feilhaandtering.ForespoerselException
+import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
 import no.nav.etterlatte.tilgangsstyring.kunAttestant
 import no.nav.etterlatte.vedtaksvurdering.VedtakHendelse
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
@@ -4,7 +4,6 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
@@ -178,7 +177,6 @@ internal class BehandlingRoutesTest {
                 }
 
             assertEquals(400, response.status.value)
-            assertEquals("Ugyldig virkningstidspunkt", response.bodyAsText())
         }
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingsstatusRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingsstatusRoutesTest.kt
@@ -147,7 +147,6 @@ internal class BehandlingsstatusRoutesTest {
                 }
 
             assertEquals(HttpStatusCode.Unauthorized, response.status)
-            assertEquals("Mangler attestantrolle", response.bodyAsText())
         }
     }
 

--- a/apps/etterlatte-fordeler/src/main/kotlin/fordeler/FordelerService.kt
+++ b/apps/etterlatte-fordeler/src/main/kotlin/fordeler/FordelerService.kt
@@ -11,8 +11,8 @@ import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.innsendtsoeknad.barnepensjon.Barnepensjon
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.PersonType
+import no.nav.etterlatte.libs.common.pdl.IngenIdentFamilierelasjonException
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
-import no.nav.etterlatte.libs.common.person.FamilieRelasjonManglerIdent
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.HentPersonRequest
@@ -70,7 +70,7 @@ class FordelerService(
                     Vedtaksloesning.PESYS -> IkkeGyldigForBehandling(it.kriterier)
                 }
             }
-        } catch (e: FamilieRelasjonManglerIdent) {
+        } catch (e: IngenIdentFamilierelasjonException) {
             logger.warn(
                 "Fikk en familierelasjon som mangler ident fra PDL. Disse tilfellene støtter vi ikke per nå." +
                     " Se sikkerlogg for detaljer",
@@ -78,7 +78,7 @@ class FordelerService(
             sikkerLogg.info("Søknad ${event.soeknadId} har en familierelasjon som mangler ident", e)
 
             if (featureToggleService.isEnabled(FordelerFeatureToggle.ManuellJournalfoering, false)) {
-                FordelerResultat.TrengerManuellJournalfoering(e.message)
+                FordelerResultat.TrengerManuellJournalfoering(e.detail)
             } else {
                 IkkeGyldigForBehandling(listOf(FordelerKriterie.FAMILIERELASJON_MANGLER_IDENT))
             }
@@ -87,7 +87,10 @@ class FordelerService(
         }
     }
 
-    private fun fordelSoeknad(event: FordelerEvent, tillatAlleScenarier: Boolean): Fordeling {
+    private fun fordelSoeknad(
+        event: FordelerEvent,
+        tillatAlleScenarier: Boolean,
+    ): Fordeling {
         val eksisterendeFordeling = finnEksisterendeFordeling(event.soeknadId)
         logger.debug("Eksisterende fordeling: ${eksisterendeFordeling?.fordeltTil?.name}")
         if (eksisterendeFordeling == null) {
@@ -112,7 +115,10 @@ class FordelerService(
         fordelerRepository.lagreFordeling(FordeltTransient(soeknadId, fordeltTil.name, kriterier.map { it.name }))
     }
 
-    private fun nyFordeling(event: FordelerEvent, tillatAlleScenarier: Boolean): Fordeling =
+    private fun nyFordeling(
+        event: FordelerEvent,
+        tillatAlleScenarier: Boolean,
+    ): Fordeling =
         runBlocking {
             val soeknad: Barnepensjon = event.soeknad
             val barn = pdlTjenesterKlient.hentPerson(hentBarnRequest(soeknad))

--- a/apps/etterlatte-fordeler/src/main/kotlin/pdltjenester/PdlTjenesterKlient.kt
+++ b/apps/etterlatte-fordeler/src/main/kotlin/pdltjenester/PdlTjenesterKlient.kt
@@ -10,10 +10,11 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType.Application.Json
 import io.ktor.http.contentType
 import no.nav.etterlatte.libs.common.RetryResult
+import no.nav.etterlatte.libs.common.feilhaandtering.ExceptionResponse
 import no.nav.etterlatte.libs.common.logging.samleExceptions
-import no.nav.etterlatte.libs.common.pdl.PdlFeil
+import no.nav.etterlatte.libs.common.pdl.FantIkkePersonException
+import no.nav.etterlatte.libs.common.pdl.IngenIdentFamilierelasjonException
 import no.nav.etterlatte.libs.common.pdl.PdlFeilAarsak
-import no.nav.etterlatte.libs.common.person.FamilieRelasjonManglerIdent
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.HentPersonRequest
 import no.nav.etterlatte.libs.common.person.Person
@@ -43,18 +44,16 @@ class PdlTjenesterKlient(private val client: HttpClient, private val apiUrl: Str
                         }
                     val feilFraPdl =
                         try {
-                            response.body<PdlFeil>()
+                            val feil = response.body<ExceptionResponse>()
+                            enumValueOf<PdlFeilAarsak>(feil.code!!)
                         } catch (e: Exception) {
                             throw samleExceptions(it.exceptions + e)
                         }
-                    when (feilFraPdl.aarsak) {
+                    when (feilFraPdl) {
                         PdlFeilAarsak.FANT_IKKE_PERSON ->
-                            throw PersonFinnesIkkeException(hentPersonRequest.foedselsnummer)
+                            throw FantIkkePersonException()
 
-                        PdlFeilAarsak.INGEN_IDENT_FAMILIERELASJON -> throw FamilieRelasjonManglerIdent(
-                            "${hentPersonRequest.foedselsnummer} har en person i persongalleriet som " +
-                                "mangler ident: ${feilFraPdl.detaljer}",
-                        )
+                        PdlFeilAarsak.INGEN_IDENT_FAMILIERELASJON -> throw IngenIdentFamilierelasjonException()
                     }
                 }
             }

--- a/apps/etterlatte-fordeler/src/test/kotlin/fordeler/FordelerServiceTest.kt
+++ b/apps/etterlatte-fordeler/src/test/kotlin/fordeler/FordelerServiceTest.kt
@@ -10,8 +10,8 @@ import no.nav.etterlatte.FNR_3
 import no.nav.etterlatte.behandling.BehandlingKlient
 import no.nav.etterlatte.fordeler.FordelerKriterie.AVDOED_ER_IKKE_REGISTRERT_SOM_DOED
 import no.nav.etterlatte.funksjonsbrytere.DummyFeatureToggleService
+import no.nav.etterlatte.libs.common.pdl.IngenIdentFamilierelasjonException
 import no.nav.etterlatte.libs.common.person.FamilieRelasjon
-import no.nav.etterlatte.libs.common.person.FamilieRelasjonManglerIdent
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.mockNorskAdresse
@@ -319,7 +319,7 @@ internal class FordelerServiceTest {
     fun `legger til manuell journalfoering hvis en av personer i persongalleriet mangler ident`() {
         every { fordelerRepo.finnFordeling(any()) } returns null
         every { fordelerRepo.lagreFordeling(any()) } returns Unit
-        coEvery { pdlTjenesterKlient.hentPerson(any()) } throws FamilieRelasjonManglerIdent("")
+        coEvery { pdlTjenesterKlient.hentPerson(any()) } throws IngenIdentFamilierelasjonException()
         dummyFeatureToggleService.settBryter(FordelerFeatureToggle.ManuellJournalfoering, true)
 
         val resultat = fordelerService.sjekkGyldighetForBehandling(fordelerEvent())

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/FamilieRelasjonMapper.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/FamilieRelasjonMapper.kt
@@ -1,7 +1,7 @@
 package no.nav.etterlatte.pdl.mapper
 
+import no.nav.etterlatte.libs.common.pdl.IngenIdentFamilierelasjonException
 import no.nav.etterlatte.libs.common.person.FamilieRelasjon
-import no.nav.etterlatte.libs.common.person.FamilieRelasjonManglerIdent
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.pdl.PdlForelderBarnRelasjonRolle
@@ -24,7 +24,7 @@ object FamilieRelasjonMapper {
                             ?.mapValues { it.value.maxByOrNull { fa -> fa.metadata.sisteRegistrertDato() } }
                             ?.map {
                                 it.value?.ansvarlig?.let { Folkeregisteridentifikator.of(it) }
-                                    ?: throw FamilieRelasjonManglerIdent("${it.value} mangler ident")
+                                    ?: throw IngenIdentFamilierelasjonException("${it.value} mangler ident")
                             }
 
                     else -> null
@@ -38,7 +38,7 @@ object FamilieRelasjonMapper {
                             ?.mapValues { it.value.maxByOrNull { fbr -> fbr.metadata.sisteRegistrertDato() } }
                             ?.map {
                                 it.value?.relatertPersonsIdent?.let { Folkeregisteridentifikator.of(it) }
-                                    ?: throw FamilieRelasjonManglerIdent("${it.value} mangler ident")
+                                    ?: throw IngenIdentFamilierelasjonException("${it.value} mangler ident")
                             }
 
                     else -> null
@@ -52,7 +52,7 @@ object FamilieRelasjonMapper {
                             ?.mapValues { it.value.maxByOrNull { fbr -> fbr.metadata.sisteRegistrertDato() } }
                             ?.map {
                                 it.value?.relatertPersonsIdent?.let { Folkeregisteridentifikator.of(it) }
-                                    ?: throw FamilieRelasjonManglerIdent("${it.value} mangler ident")
+                                    ?: throw IngenIdentFamilierelasjonException("${it.value} mangler ident")
                             }
 
                     else -> null

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/ForeldreansvarHistorikkMapper.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/ForeldreansvarHistorikkMapper.kt
@@ -1,6 +1,6 @@
 package no.nav.etterlatte.pdl.mapper
 
-import no.nav.etterlatte.libs.common.person.FamilieRelasjonManglerIdent
+import no.nav.etterlatte.libs.common.pdl.IngenIdentFamilierelasjonException
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.pdl.ForeldreansvarPeriode
 import no.nav.etterlatte.pdl.HistorikkForeldreansvar
@@ -10,7 +10,7 @@ import no.nav.etterlatte.pdl.PdlHistorikkForeldreansvar
 object ForeldreansvarHistorikkMapper {
     fun mapForeldreAnsvar(pdlData: PdlHistorikkForeldreansvar): HistorikkForeldreansvar {
         if (pdlData.foreldreansvar.any { it.ansvarligUtenIdentifikator != null }) {
-            throw FamilieRelasjonManglerIdent(
+            throw IngenIdentFamilierelasjonException(
                 "Har en ansvarlig forelder som mangler ident i historikken for foreldreansvar.",
             )
         }
@@ -35,7 +35,7 @@ object ForeldreansvarHistorikkMapper {
                 .mapValues { it.value.maxByOrNull { fbr -> fbr.metadata.sisteRegistrertDato() } }
                 .map {
                     it.value?.relatertPersonsIdent?.let { Folkeregisteridentifikator.of(it) }
-                        ?: throw FamilieRelasjonManglerIdent("${it.value} mangler ident")
+                        ?: throw IngenIdentFamilierelasjonException("${it.value} mangler ident")
                 }
         return HistorikkForeldreansvar(
             ansvarligeForeldre = foreldreansvar,

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonRoute.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonRoute.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.person
 
-import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.application.log
 import io.ktor.server.request.receive
@@ -9,9 +8,6 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.application
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
-import no.nav.etterlatte.libs.common.pdl.PdlFeil
-import no.nav.etterlatte.libs.common.pdl.PdlFeilAarsak
-import no.nav.etterlatte.libs.common.person.FamilieRelasjonManglerIdent
 import no.nav.etterlatte.libs.common.person.HentFolkeregisterIdenterForAktoerIdBolkRequest
 import no.nav.etterlatte.libs.common.person.HentGeografiskTilknytningRequest
 import no.nav.etterlatte.libs.common.person.HentPdlIdentRequest
@@ -25,13 +21,7 @@ fun Route.personRoute(service: PersonService) {
             val hentPersonRequest = call.receive<HentPersonRequest>()
             logger.info("Henter person med fnr=${hentPersonRequest.foedselsnummer}")
 
-            try {
-                service.hentPerson(hentPersonRequest).let { call.respond(it) }
-            } catch (e: PdlFantIkkePerson) {
-                call.respond(HttpStatusCode.NotFound, e.tilPdlFeil())
-            } catch (e: FamilieRelasjonManglerIdent) {
-                call.respond(HttpStatusCode.InternalServerError, e.tilPdlFeil())
-            }
+            service.hentPerson(hentPersonRequest).let { call.respond(it) }
         }
 
         route("/v2") {
@@ -39,13 +29,7 @@ fun Route.personRoute(service: PersonService) {
                 val hentPersonRequest = call.receive<HentPersonRequest>()
                 logger.info("Henter personopplysning med fnr=${hentPersonRequest.foedselsnummer}")
 
-                try {
-                    service.hentOpplysningsperson(hentPersonRequest).let { call.respond(it) }
-                } catch (e: PdlFantIkkePerson) {
-                    call.respond(HttpStatusCode.NotFound, e.tilPdlFeil())
-                } catch (e: FamilieRelasjonManglerIdent) {
-                    call.respond(HttpStatusCode.InternalServerError, e.tilPdlFeil())
-                }
+                service.hentOpplysningsperson(hentPersonRequest).let { call.respond(it) }
             }
         }
     }
@@ -57,11 +41,7 @@ fun Route.personRoute(service: PersonService) {
             val hentPdlIdentRequest = call.receive<HentPdlIdentRequest>()
             logger.info("Henter identer for ident=${hentPdlIdentRequest.ident}")
 
-            try {
-                service.hentPdlIdentifikator(hentPdlIdentRequest).let { call.respond(it) }
-            } catch (e: PdlFantIkkePerson) {
-                call.respond(HttpStatusCode.NotFound)
-            }
+            service.hentPdlIdentifikator(hentPdlIdentRequest).let { call.respond(it) }
         }
     }
 
@@ -69,13 +49,9 @@ fun Route.personRoute(service: PersonService) {
         post {
             val personIdenterForAktoerIdRequest = call.receive<HentFolkeregisterIdenterForAktoerIdBolkRequest>()
 
-            try {
-                service.hentFolkeregisterIdenterForAktoerIdBolk(
-                    personIdenterForAktoerIdRequest,
-                ).let { call.respond(it) }
-            } catch (e: PdlFantIkkePerson) {
-                call.respond(HttpStatusCode.NotFound)
-            }
+            service.hentFolkeregisterIdenterForAktoerIdBolk(
+                personIdenterForAktoerIdRequest,
+            ).let { call.respond(it) }
         }
     }
 
@@ -86,11 +62,7 @@ fun Route.personRoute(service: PersonService) {
             val hentGeografiskTilknytningRequest = call.receive<HentGeografiskTilknytningRequest>()
             logger.info("Henter geografisk tilknytning med fnr=${hentGeografiskTilknytningRequest.foedselsnummer}")
 
-            try {
-                service.hentGeografiskTilknytning(hentGeografiskTilknytningRequest).let { call.respond(it) }
-            } catch (e: PdlFantIkkePerson) {
-                call.respond(HttpStatusCode.NotFound)
-            }
+            service.hentGeografiskTilknytning(hentGeografiskTilknytningRequest).let { call.respond(it) }
         }
     }
 
@@ -100,17 +72,7 @@ fun Route.personRoute(service: PersonService) {
         post {
             val identRequest = call.receive<HentPersonRequest>()
             logger.info("Henter historikk for foreldreansvar for person med fnr=${identRequest.foedselsnummer}")
-            try {
-                service.hentHistorikkForeldreansvar(identRequest).let { call.respond(it) }
-            } catch (e: PdlFantIkkePerson) {
-                call.respond(HttpStatusCode.NotFound, e.tilPdlFeil())
-            } catch (e: FamilieRelasjonManglerIdent) {
-                call.respond(HttpStatusCode.InternalServerError, e.tilPdlFeil())
-            }
+            service.hentHistorikkForeldreansvar(identRequest).let { call.respond(it) }
         }
     }
 }
-
-fun PdlFantIkkePerson.tilPdlFeil(): PdlFeil = PdlFeil(aarsak = PdlFeilAarsak.FANT_IKKE_PERSON, detaljer = this.message)
-
-fun FamilieRelasjonManglerIdent.tilPdlFeil(): PdlFeil = PdlFeil(aarsak = PdlFeilAarsak.INGEN_IDENT_FAMILIERELASJON, detaljer = this.message)

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonService.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonService.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.person
 
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.pdl.FantIkkePersonException
 import no.nav.etterlatte.libs.common.pdl.PersonDTO
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.GeografiskTilknytning
@@ -24,8 +25,6 @@ import org.slf4j.LoggerFactory
 
 class PdlForesporselFeilet(message: String) : RuntimeException(message)
 
-class PdlFantIkkePerson(message: String) : RuntimeException(message)
-
 class PersonService(
     private val pdlKlient: PdlKlient,
     private val ppsKlient: ParallelleSannheterKlient,
@@ -39,7 +38,7 @@ class PersonService(
             if (it.data?.hentPerson == null) {
                 val pdlFeil = it.errors?.asFormatertFeil()
                 if (it.errors?.personIkkeFunnet() == true) {
-                    throw PdlFantIkkePerson("Fant ikke personen ${request.foedselsnummer}")
+                    throw FantIkkePersonException("Fant ikke personen ${request.foedselsnummer}")
                 } else {
                     throw PdlForesporselFeilet(
                         "Kunne ikke hente person med fnr=${request.foedselsnummer} fra PDL: $pdlFeil",
@@ -72,7 +71,7 @@ class PersonService(
                 if (it.data?.hentPerson == null) {
                     val pdlFeil = it.errors?.asFormatertFeil()
                     if (it.errors?.personIkkeFunnet() == true) {
-                        throw PdlFantIkkePerson("Fant ikke personen $fnr")
+                        throw FantIkkePersonException("Fant ikke personen $fnr")
                     } else {
                         throw PdlForesporselFeilet(
                             "Kunne ikke hente person med fnr=$fnr fra PDL: $pdlFeil",
@@ -91,7 +90,7 @@ class PersonService(
             if (it.data?.hentPerson == null) {
                 val pdlFeil = it.errors?.asFormatertFeil()
                 if (it.errors?.personIkkeFunnet() == true) {
-                    throw PdlFantIkkePerson("Fant ikke personen ${request.foedselsnummer}")
+                    throw FantIkkePersonException("Fant ikke personen ${request.foedselsnummer}")
                 } else {
                     throw PdlForesporselFeilet(
                         "Kunne ikke hente opplysninger for ${request.foedselsnummer} fra PDL: $pdlFeil",
@@ -115,7 +114,7 @@ class PersonService(
             if (identResponse.data?.hentIdenter == null) {
                 val pdlFeil = identResponse.errors?.asFormatertFeil()
                 if (identResponse.errors?.personIkkeFunnet() == true) {
-                    throw PdlFantIkkePerson("Fant ikke personen ${request.ident}")
+                    throw FantIkkePersonException("Fant ikke personen ${request.ident}")
                 } else {
                     throw PdlForesporselFeilet(
                         "Kunne ikke hente pdlidentifkator " +
@@ -165,7 +164,7 @@ class PersonService(
             if (it.data?.hentGeografiskTilknytning == null) {
                 val pdlFeil = it.errors?.asFormatertFeil()
                 if (it.errors?.personIkkeFunnet() == true) {
-                    throw PdlFantIkkePerson("Fant ikke personen ${request.foedselsnummer}")
+                    throw FantIkkePersonException("Fant ikke personen ${request.foedselsnummer}")
                 } else {
                     throw PdlForesporselFeilet(
                         "Kunne ikke hente fnr=${request.foedselsnummer} fra PDL: $pdlFeil",

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonRouteTest.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonRouteTest.kt
@@ -3,7 +3,6 @@ package no.nav.etterlatte.person
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -211,7 +210,6 @@ class PersonRouteTest {
                 }
 
             assertEquals(HttpStatusCode.InternalServerError, response.status)
-            assertEquals("En intern feil har oppstått", response.bodyAsText())
             coVerify { personService.hentPerson(any()) }
             confirmVerified(personService)
         }
@@ -244,7 +242,6 @@ class PersonRouteTest {
                 }
 
             assertEquals(HttpStatusCode.InternalServerError, response.status)
-            assertEquals("En intern feil har oppstått", response.bodyAsText())
             coVerify { personService.hentPdlIdentifikator(any()) }
             confirmVerified(personService)
         }

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonServiceTest.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonServiceTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.STOR_SNERK
 import no.nav.etterlatte.TRIVIELL_MIDTPUNKT
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.pdl.FantIkkePersonException
 import no.nav.etterlatte.libs.common.person.HentGeografiskTilknytningRequest
 import no.nav.etterlatte.libs.common.person.HentPdlIdentRequest
 import no.nav.etterlatte.libs.common.person.HentPersonRequest
@@ -213,7 +214,7 @@ internal class PersonServiceTest {
         coEvery { pdlKlient.hentPerson(any()) } returns mockResponse("/pdl/person_ikke_funnet.json")
 
         runBlocking {
-            assertThrows<PdlFantIkkePerson> {
+            assertThrows<FantIkkePersonException> {
                 personService.hentPerson(HentPersonRequest(STOR_SNERK, rolle = PersonRolle.BARN, SakType.BARNEPENSJON))
             }
         }
@@ -255,7 +256,7 @@ internal class PersonServiceTest {
     fun `finner ikke folkeregisterident`() {
         coEvery { pdlKlient.hentPdlIdentifikator(any()) } returns mockResponse("/pdl/ident_ikke_funnet.json")
         runBlocking {
-            assertThrows<PdlFantIkkePerson> {
+            assertThrows<FantIkkePersonException> {
                 personService.hentPdlIdentifikator(HentPdlIdentRequest(PersonIdent("1234")))
             }
         }

--- a/apps/etterlatte-saksbehandling-ui/client/src/Versioncheck.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/Versioncheck.tsx
@@ -15,7 +15,7 @@ const Versioncheck = () => {
     let timeoutReload: null | number = null
     intervalVersionCheck = window.setInterval(() => {
       hentClientConfig().then((res) => {
-        if (res.status === 'ok') {
+        if (res.ok) {
           const fetchedAppversion = res.data.cachebuster
           if (appVersion && fetchedAppversion !== appVersion) {
             setIsOutdated(true)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/attesterYtelse.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/attesterYtelse.tsx
@@ -22,8 +22,12 @@ export const AttesterYtelse = ({ behandling, kommentar }: { behandling: IDetalje
     apiAttesterVedtak(
       { behandlingId: behandling.id, kommentar },
       () => navigate(`/person/${behandling.søker?.foedselsnummer}`),
-      () => {
-        setError(`Ukjent feil oppsto ved attestering av vedtaket... Prøv igjen.`)
+      (error) => {
+        if (error.code === 'ATTESTANT_OG_SAKSBEHANDLER_ER_SAMME_PERSON') {
+          setError('Vedtaket er allerede fattet av deg. Du kan ikke attestere dine egne vedtak.')
+        } else {
+          setError(`En feil opptod ved attestering av vedtaket: ${error.detail}.`)
+        }
         setModalisOpen(false)
       }
     )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
@@ -40,7 +40,7 @@ export const Avkorting = (props: { behandling: IBehandlingReducer }) => {
       )}
 
       {isPending(avkortingStatus) && <Spinner visible={true} label="Henter avkorting" />}
-      {isFailure(avkortingStatus) && avkortingStatus.error.statusCode !== 404 && (
+      {isFailure(avkortingStatus) && avkortingStatus.error.status !== 404 && (
         <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>
       )}
     </AvkortingWrapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
@@ -99,7 +99,7 @@ export const Vilkaarsvurdering = (props: { behandling: IBehandlingReducer }) => 
       )}
       {isFailure(opprettNyVilkaarsvurderingStatus) && (
         <ApiErrorAlert>
-          {opprettNyVilkaarsvurderingStatus.error.statusCode === 412
+          {opprettNyVilkaarsvurderingStatus.error.status === 412
             ? 'Virkningstidspunkt og kommer søker tilgode må avklares før vilkårsvurdering kan starte'
             : 'En feil har oppstått'}
         </ApiErrorAlert>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/ManueltOpphoerModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/ManueltOpphoerModal.tsx
@@ -80,7 +80,7 @@ export const ManueltOpphoerModal = ({
     setLoading(true)
     const kjenteAarsaker = selectedGrunner.filter((grunn) => grunn !== 'ANNET')
     const res = await sendInnManueltOpphoer(sakId, kjenteAarsaker, grunn)
-    if (res.status === 'ok') {
+    if (res.ok) {
       navigate(`/behandling/${res.data.behandlingId}/`)
     } else {
       setFeilmelding('Kunne ikke annullere denne saken nå. Prøv igjen senere, eller meld det som feil i systemet.')

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/OpprettNyRevurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/OpprettNyRevurdering.tsx
@@ -32,7 +32,7 @@ export const OpprettNyRevurdering = ({
       },
       (err) => {
         setError('En feil skjedde ved opprettelse av revurderingen. Prøv igjen senere.')
-        console.error(`Feil ved opprettelse av revurdering, status: ${err.status} err: ${err.error}`)
+        console.error(`Feil ved opprettelse av revurdering, status: ${err.status} err: ${err.detail}`)
       }
     )
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/behandlingsliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/behandlingsliste.tsx
@@ -43,7 +43,7 @@ const VedtakKolonner = (props: { behandlingsId: string }) => {
       )}
       {isFailure(vedtak) && (
         <ExclamationmarkTriangleFillIcon
-          title={vedtak.error.error || 'Feil oppsto ved henting av sammendrag for behandling'}
+          title={vedtak.error.detail || 'Feil oppsto ved henting av sammendrag for behandling'}
         />
       )}
     </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/dokumentModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/dokumentModal.tsx
@@ -24,10 +24,10 @@ export default function DokumentModal({
 
     hentDokumentPDF({ journalpostId, dokumentInfoId })
       .then((res) => {
-        if (res.status === 'ok') {
+        if (res.ok) {
           return new Blob([res.data], { type: 'application/pdf' })
         } else {
-          throw Error(res.error)
+          throw Error(res.detail)
         }
       })
       .then((file) => URL.createObjectURL(file!!))

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/BehandleJournalfoeringOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/BehandleJournalfoeringOppgave.tsx
@@ -24,7 +24,7 @@ export default function BehandleJournalfoeringOppgave() {
   useEffect(() => {
     if (GYLDIG_FNR(bruker)) {
       hentPerson(bruker!!, undefined, (error) => {
-        if (error.statusCode === 404) {
+        if (error.status === 404) {
           // TODO: Avventer design på hvordan vi skal håndtere visning av brukere som ikke finnes i vårt system
         }
       })

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/uhaandtereHendelser/UhaandtertHendelse.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/uhaandtereHendelser/UhaandtertHendelse.tsx
@@ -36,7 +36,7 @@ const UhaandtertHendelse = (props: {
         location.reload()
       },
       (err) => {
-        console.error(`Feil status: ${err.status} error: ${err.error}`)
+        console.error(`Feil status: ${err.status} error: ${err.detail}`)
       }
     )
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/header/Search.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/header/Search.tsx
@@ -2,8 +2,8 @@ import styled from 'styled-components'
 import { BodyShort, Loader, Search as SearchField } from '@navikt/ds-react'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { ANavRed, AGray900, ABlue500 } from '@navikt/ds-tokens/dist/tokens'
-import { XMarkOctagonIcon, InformationSquareIcon } from '@navikt/aksel-icons'
+import { ABlue500, AGray900, ANavRed } from '@navikt/ds-tokens/dist/tokens'
+import { InformationSquareIcon, XMarkOctagonIcon } from '@navikt/aksel-icons'
 import { isFailure, isPending, isSuccess, useApiCall } from '~shared/hooks/useApiCall'
 import { getPerson } from '~shared/api/grunnlag'
 import { GYLDIG_FNR } from '~utils/fnr'
@@ -120,7 +120,7 @@ export const Search = () => {
 }
 
 const feilmelding = (error: ApiError) => {
-  if (error.statusCode === 404) {
+  if (error.status === 404) {
     return 'Fant ingen data i Gjenny'
   } else {
     return 'En feil har skjedd'

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/hooks/useApiCall.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/hooks/useApiCall.ts
@@ -6,7 +6,7 @@ export function useApiCall<T, U>(
 ): [
   Result<U>,
   (args: T, onSuccess?: (result: U, statusCode: number) => void, onError?: (error: ApiError) => void) => void,
-  () => void,
+  () => void
 ] {
   const [apiResult, setApiResult] = useState<Result<U>>(initial)
 
@@ -16,9 +16,9 @@ export function useApiCall<T, U>(
         setApiResult(pending)
 
         const res = await fn(args)
-        if (res.status === 'ok') {
+        if (res.ok) {
           setApiResult(success(res.data))
-          onSuccess?.(res.data, res.statusCode)
+          onSuccess?.(res.data, res.status)
         } else {
           setApiResult(error(res))
           onError?.(res)
@@ -46,7 +46,7 @@ export const isPending = (result: Result<unknown>): result is Pending => result.
 export const isSuccess = <T>(result: Result<T>): result is Success<T> => result.status === 'success'
 export const isFailure = (result: Result<unknown>): result is Error<ApiError> => result.status === 'error'
 export const isConflict = (result: Result<unknown>): result is Error<ApiError> =>
-  result.status === 'error' && result.error.statusCode == 409
+  result.status === 'error' && result.error.status === 409
 export const isInitial = (result: Result<unknown>): result is Initial => result.status === 'initial'
 export const isPendingOrInitial = (result: Result<unknown>): result is Initial | Pending =>
   isPending(result) || isInitial(result)

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
@@ -6,6 +6,7 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.RevurderingAarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.common.oppgave.VedtakEndringDTO
 import no.nav.etterlatte.libs.common.oppgave.VedtakOppgaveDTO
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
@@ -27,7 +28,6 @@ import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingDto
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
-import no.nav.etterlatte.libs.ktor.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.rapidsandrivers.migrering.KILDE_KEY
 import no.nav.etterlatte.token.BrukerTokenInfo
 import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
@@ -27,6 +27,7 @@ import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingDto
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
+import no.nav.etterlatte.libs.ktor.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.rapidsandrivers.migrering.KILDE_KEY
 import no.nav.etterlatte.token.BrukerTokenInfo
 import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
@@ -565,4 +566,7 @@ class OpphoersrevurderingErIkkeOpphoersvedtakException(revurderingAarsak: Revurd
     )
 
 class UgyldigAttestantException(ident: String) :
-    IllegalArgumentException("Saksbehandler og attestant må være to forskjellige personer (ident=$ident)")
+    IkkeTillattException(
+        code = "ATTESTANT_OG_SAKSBEHANDLER_ER_SAMME_PERSON",
+        detail = "Saksbehandler og attestant må være to forskjellige personer (ident=$ident)",
+    )

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingRouteTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingRouteTest.kt
@@ -113,7 +113,6 @@ internal class VedtaksvurderingRouteTest {
                 }
 
             response.status shouldBe HttpStatusCode.InternalServerError
-            response.bodyAsText() shouldBe "En intern feil har oppstått"
         }
 
         coVerify(exactly = 1) {

--- a/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/ForespoerselExceptions.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/ForespoerselExceptions.kt
@@ -1,0 +1,45 @@
+package no.nav.etterlatte.libs.ktor.feilhaandtering
+
+import io.ktor.http.HttpStatusCode
+
+open class ForespoerselException(
+    open val status: Int,
+    open val code: String,
+    open val detail: String,
+    open val meta: Map<String, Any>? = null,
+    override val cause: Throwable? = null,
+) : Exception(detail, cause) {
+    fun noMeta(): ForespoerselException {
+        return ForespoerselException(status = status, code = code, detail = detail, cause = cause)
+    }
+
+    fun somExceptionResponse(): ExceptionResponse {
+        return ExceptionResponse(
+            status = status,
+            detail = detail,
+            code = code,
+            meta = meta,
+        )
+    }
+}
+
+open class UgyldigForespoerselException(
+    override val code: String,
+    override val detail: String,
+    override val meta: Map<String, Any>? = null,
+    override val cause: Throwable? = null,
+) : ForespoerselException(HttpStatusCode.BadRequest.value, code = code, detail = detail, meta = meta, cause = cause)
+
+open class IkkeFunnetException(
+    override val code: String,
+    override val detail: String,
+    override val meta: Map<String, Any>? = null,
+    override val cause: Throwable? = null,
+) : ForespoerselException(status = HttpStatusCode.NotFound.value, code = code, detail = detail, meta = meta, cause = cause)
+
+open class IkkeTillattException(
+    override val code: String,
+    override val detail: String,
+    override val meta: Map<String, Any>? = null,
+    override val cause: Throwable? = null,
+) : ForespoerselException(status = HttpStatusCode.Forbidden.value, code = code, detail = detail, meta = meta, cause = cause)

--- a/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/InternfeilException.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/InternfeilException.kt
@@ -1,0 +1,17 @@
+package no.nav.etterlatte.libs.ktor.feilhaandtering
+
+import io.ktor.http.HttpStatusCode
+
+open class InternfeilException(
+    open val detail: String,
+    override val cause: Throwable? = null,
+) : Exception(detail, cause) {
+    fun somJsonRespons(): ExceptionResponse {
+        return ExceptionResponse(
+            status = HttpStatusCode.InternalServerError.value,
+            detail = detail,
+            code = "INTERNAL_SERVER_ERROR",
+            meta = null,
+        )
+    }
+}

--- a/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
@@ -6,23 +6,17 @@ import io.ktor.server.application.log
 import io.ktor.server.plugins.statuspages.StatusPagesConfig
 import io.ktor.server.response.respond
 import isProd
+import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
+import no.nav.etterlatte.libs.common.feilhaandtering.GenerellIkkeFunnetException
+import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
+import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.ktor.erDeserialiseringsException
 import org.slf4j.Logger
 
-data class ExceptionResponse(
-    val status: Int,
-    val detail: String,
-    val code: String?,
-    val meta: Map<String, Any>?,
-)
-
 class StatusPagesKonfigurasjon(private val sikkerLogg: Logger) {
-    // Håndteringen på statuscodes er risky å ta med i første omgang
-    // HttpStatusCode.allStatusCodes.filter { it.value in 400..499 }.toTypedArray()
-    private val statusCodes4xx = emptyArray<HttpStatusCode>()
-
-    // HttpStatusCode.allStatusCodes.filter { it.value in 500..599 }.toTypedArray()
-    private val statusCodes5xx = emptyArray<HttpStatusCode>()
+    private val statusCodes4xx = HttpStatusCode.allStatusCodes.filter { it.value in 400..499 }.toTypedArray()
+    private val statusCodes5xx = HttpStatusCode.allStatusCodes.filter { it.value in 500..599 }.toTypedArray()
 
     val config: StatusPagesConfig.() -> Unit = {
         exception<Throwable> { call, cause ->
@@ -46,10 +40,7 @@ class StatusPagesKonfigurasjon(private val sikkerLogg: Logger) {
         }
         status(*statusCodes4xx) { call, code ->
             when (code) {
-                HttpStatusCode.NotFound ->
-                    IkkeFunnetException("NOT_FOUND", "Ressursen ble ikke funnet").respond(
-                        call,
-                    )
+                HttpStatusCode.NotFound -> GenerellIkkeFunnetException()
 
                 HttpStatusCode.BadRequest ->
                     UgyldigForespoerselException(

--- a/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
@@ -40,7 +40,7 @@ class StatusPagesKonfigurasjon(private val sikkerLogg: Logger) {
         }
         status(*statusCodes4xx) { call, code ->
             when (code) {
-                HttpStatusCode.NotFound -> GenerellIkkeFunnetException()
+                HttpStatusCode.NotFound -> GenerellIkkeFunnetException().respond(call)
 
                 HttpStatusCode.BadRequest ->
                     UgyldigForespoerselException(

--- a/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
@@ -3,7 +3,6 @@ package no.nav.etterlatte.libs.ktor.feilhaandtering
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.log
-import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.NotFoundException
 import io.ktor.server.plugins.statuspages.StatusPagesConfig
 import io.ktor.server.response.respond
@@ -39,17 +38,6 @@ class StatusPagesKonfigurasjon(private val sikkerLogg: Logger) {
                         IkkeFunnetException(
                             code = "NOT_FOUND",
                             detail = cause.message ?: "Fant ikke ressursen",
-                            cause = cause,
-                        )
-                    call.application.log.loggForespoerselException(wrapped)
-                    wrapped.respond(call)
-                }
-
-                is BadRequestException -> {
-                    val wrapped =
-                        UgyldigForespoerselException(
-                            code = "BAD_REQUEST",
-                            detail = "Forespørselen er ugyldig",
                             cause = cause,
                         )
                     call.application.log.loggForespoerselException(wrapped)

--- a/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
@@ -1,0 +1,123 @@
+package no.nav.etterlatte.libs.ktor.feilhaandtering
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.log
+import io.ktor.server.plugins.statuspages.StatusPagesConfig
+import io.ktor.server.response.respond
+import isProd
+import no.nav.etterlatte.libs.ktor.erDeserialiseringsException
+import org.slf4j.Logger
+
+data class ExceptionResponse(
+    val status: Int,
+    val detail: String,
+    val code: String?,
+    val meta: Map<String, Any>?,
+)
+
+class StatusPagesKonfigurasjon(private val sikkerLogg: Logger) {
+    private val statusCodes4xx = HttpStatusCode.allStatusCodes.filter { it.value in 400..499 }.toTypedArray()
+    private val statusCodes5xx = HttpStatusCode.allStatusCodes.filter { it.value in 500..599 }.toTypedArray()
+
+    val config: StatusPagesConfig.() -> Unit = {
+        exception<Throwable> { call, cause ->
+            when (cause) {
+                is ForespoerselException -> {
+                    call.application.log.loggForespoerselException(cause)
+                    cause.respond(call)
+                }
+
+                is InternfeilException -> {
+                    call.application.log.loggInternfeilException(cause)
+                    cause.respond(call)
+                }
+
+                else -> {
+                    val mappetFeil = InternfeilException("En feil har skjedd.", cause)
+                    call.application.log.loggInternfeilException(mappetFeil)
+                    mappetFeil.respond(call)
+                }
+            }
+        }
+        status(*statusCodes4xx) { call, code ->
+            when (code) {
+                HttpStatusCode.NotFound ->
+                    IkkeFunnetException("NOT_FOUND", "Ressursen ble ikke funnet").respond(
+                        call,
+                    )
+
+                HttpStatusCode.BadRequest ->
+                    UgyldigForespoerselException(
+                        "BAD_REQUEST",
+                        "Forespørselen er ugyldig",
+                    ).respond(call)
+
+                HttpStatusCode.Forbidden ->
+                    IkkeTillattException(
+                        "FORBIDDEN",
+                        "Forespørselen er ikke tillatt",
+                    ).respond(call)
+
+                else ->
+                    ForespoerselException(
+                        status = code.value,
+                        code = "UNKNOWN_ERROR",
+                        detail = "En ukjent feil oppstod",
+                    )
+                        .respond(call)
+            }
+        }
+
+        status(*statusCodes5xx) { call, code ->
+            // Maskerer alle interne feil som 500 internal server error
+            val feil = InternfeilException("Ukjent feil")
+            if (code !== HttpStatusCode.InternalServerError) {
+                call.application.log.error(
+                    "Et endepunkt returnerte en ikke-500 5xx-respons ($code). Maskerer som 500.",
+                    feil,
+                )
+            } else {
+                call.application.log.error("Et endepunkt returnerte en 500-respons", feil)
+            }
+            feil.respond(call)
+        }
+    }
+
+    private fun Logger.loggInternfeilException(cause: InternfeilException) {
+        if (cause.erDeserialiseringsException() && isProd()) {
+            sikkerLogg.error("En feil har oppstått ved deserialisering", cause)
+            this.error(
+                "En feil har oppstått ved deserialisering. Se sikkerlogg for mer detaljer.",
+            )
+        } else {
+            this.error("En intern feil oppstod i et endepunkt. Svarer frontend med 500-feil", cause)
+        }
+    }
+
+    private fun Logger.loggForespoerselException(cause: ForespoerselException) {
+        if (cause.erDeserialiseringsException() && isProd()) {
+            sikkerLogg.info("En feil har oppstått ved deserialisering", cause)
+            this.info(
+                "En feil har oppstått ved deserialisering i et endepunkt. Se sikkerlogg for mer detaljer. " +
+                    "Feilen fikk status ${cause.status} til frontend.",
+            )
+        }
+        // Logger ikke meta, siden det kan inneholde identiferende informasjon
+        this.info("En forespørselsfeil oppstod i et endepunkt", cause.noMeta())
+    }
+
+    private suspend fun ForespoerselException.respond(call: ApplicationCall) {
+        call.respond(
+            HttpStatusCode.fromValue(this.status),
+            this.somExceptionResponse(),
+        )
+    }
+
+    private suspend fun InternfeilException.respond(call: ApplicationCall) {
+        call.respond(
+            HttpStatusCode.InternalServerError,
+            this.somJsonRespons(),
+        )
+    }
+}

--- a/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
@@ -17,8 +17,12 @@ data class ExceptionResponse(
 )
 
 class StatusPagesKonfigurasjon(private val sikkerLogg: Logger) {
-    private val statusCodes4xx = HttpStatusCode.allStatusCodes.filter { it.value in 400..499 }.toTypedArray()
-    private val statusCodes5xx = HttpStatusCode.allStatusCodes.filter { it.value in 500..599 }.toTypedArray()
+    // Håndteringen på statuscodes er risky å ta med i første omgang
+    // HttpStatusCode.allStatusCodes.filter { it.value in 400..499 }.toTypedArray()
+    private val statusCodes4xx = emptyArray<HttpStatusCode>()
+
+    // HttpStatusCode.allStatusCodes.filter { it.value in 500..599 }.toTypedArray()
+    private val statusCodes5xx = emptyArray<HttpStatusCode>()
 
     val config: StatusPagesConfig.() -> Unit = {
         exception<Throwable> { call, cause ->

--- a/libs/etterlatte-ktor/src/test/kotlin/RestModuleTest.kt
+++ b/libs/etterlatte-ktor/src/test/kotlin/RestModuleTest.kt
@@ -34,14 +34,14 @@ import no.nav.etterlatte.libs.common.FoedselsnummerDTO
 import no.nav.etterlatte.libs.common.PersonTilgangsSjekk
 import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.SakTilgangsSjekk
+import no.nav.etterlatte.libs.common.feilhaandtering.ExceptionResponse
+import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
+import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.withBehandlingId
 import no.nav.etterlatte.libs.common.withFoedselsnummer
 import no.nav.etterlatte.libs.common.withSakId
-import no.nav.etterlatte.libs.ktor.feilhaandtering.ExceptionResponse
-import no.nav.etterlatte.libs.ktor.feilhaandtering.IkkeFunnetException
-import no.nav.etterlatte.libs.ktor.feilhaandtering.InternfeilException
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -270,7 +270,7 @@ class RestModuleTest {
                     routesMedForskjelligeFeil()
                 }
             }
-            val cli =
+            val client =
                 createClient {
                     install(ContentNegotiation) {
                         register(ContentType.Application.Json, JacksonConverter(objectMapper))
@@ -278,7 +278,7 @@ class RestModuleTest {
                     install(httpClient())
                 }
 
-            cli.get("ikke_funnet/exception") {
+            client.get("ikke_funnet/exception") {
                 header(HttpHeaders.Authorization, "Bearer $token")
                 header(HttpHeaders.Accept, ContentType.Application.Json)
             }.also {
@@ -287,15 +287,15 @@ class RestModuleTest {
                 assertEquals(NotFound.value, body.status)
             }
 
-//            cli.get("ikke_funnet/status") {
-//                header(HttpHeaders.Authorization, "Bearer $token")
-//                header(HttpHeaders.Accept, ContentType.Application.Json)
-//            }.also {
-//                val body = it.body<ExceptionResponse>()
-//                assertEquals(NotFound.value, body.status)
-//                assertEquals("NOT_FOUND", body.code)
-//            }
-            cli.get("intern/vilkaarlig") {
+            client.get("ikke_funnet/status") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+                header(HttpHeaders.Accept, ContentType.Application.Json)
+            }.also {
+                val body = it.body<ExceptionResponse>()
+                assertEquals(NotFound.value, body.status)
+                assertEquals("NOT_FOUND", body.code)
+            }
+            client.get("intern/vilkaarlig") {
                 header(HttpHeaders.Authorization, "Bearer $token")
                 header(HttpHeaders.Accept, ContentType.Application.Json)
             }.also {
@@ -303,7 +303,7 @@ class RestModuleTest {
                 assertEquals(InternalServerError.value, bodyMapped.status)
             }
 
-            cli.get("intern/exception") {
+            client.get("intern/exception") {
                 header(HttpHeaders.Authorization, "Bearer $token")
                 header(HttpHeaders.Accept, ContentType.Application.Json)
             }.also {
@@ -311,13 +311,13 @@ class RestModuleTest {
                 assertEquals(InternalServerError.value, bodyMapped.status)
             }
 
-//            cli.get("intern/status") {
-//                header(HttpHeaders.Authorization, "Bearer $token")
-//                header(HttpHeaders.Accept, ContentType.Application.Json)
-//            }.also {
-//                val bodyMapped = it.body<ExceptionResponse>()
-//                assertEquals(InternalServerError.value, bodyMapped.status)
-//            }
+            client.get("intern/status") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+                header(HttpHeaders.Accept, ContentType.Application.Json)
+            }.also {
+                val bodyMapped = it.body<ExceptionResponse>()
+                assertEquals(InternalServerError.value, bodyMapped.status)
+            }
         }
     }
 

--- a/libs/etterlatte-ktor/src/test/kotlin/RestModuleTest.kt
+++ b/libs/etterlatte-ktor/src/test/kotlin/RestModuleTest.kt
@@ -287,14 +287,14 @@ class RestModuleTest {
                 assertEquals(NotFound.value, body.status)
             }
 
-            cli.get("ikke_funnet/status") {
-                header(HttpHeaders.Authorization, "Bearer $token")
-                header(HttpHeaders.Accept, ContentType.Application.Json)
-            }.also {
-                val body = it.body<ExceptionResponse>()
-                assertEquals(NotFound.value, body.status)
-                assertEquals("NOT_FOUND", body.code)
-            }
+//            cli.get("ikke_funnet/status") {
+//                header(HttpHeaders.Authorization, "Bearer $token")
+//                header(HttpHeaders.Accept, ContentType.Application.Json)
+//            }.also {
+//                val body = it.body<ExceptionResponse>()
+//                assertEquals(NotFound.value, body.status)
+//                assertEquals("NOT_FOUND", body.code)
+//            }
             cli.get("intern/vilkaarlig") {
                 header(HttpHeaders.Authorization, "Bearer $token")
                 header(HttpHeaders.Accept, ContentType.Application.Json)
@@ -311,13 +311,13 @@ class RestModuleTest {
                 assertEquals(InternalServerError.value, bodyMapped.status)
             }
 
-            cli.get("intern/status") {
-                header(HttpHeaders.Authorization, "Bearer $token")
-                header(HttpHeaders.Accept, ContentType.Application.Json)
-            }.also {
-                val bodyMapped = it.body<ExceptionResponse>()
-                assertEquals(InternalServerError.value, bodyMapped.status)
-            }
+//            cli.get("intern/status") {
+//                header(HttpHeaders.Authorization, "Bearer $token")
+//                header(HttpHeaders.Accept, ContentType.Application.Json)
+//            }.also {
+//                val bodyMapped = it.body<ExceptionResponse>()
+//                assertEquals(InternalServerError.value, bodyMapped.status)
+//            }
         }
     }
 

--- a/libs/etterlatte-pdl-model/src/main/kotlin/pdl/PdlFeil.kt
+++ b/libs/etterlatte-pdl-model/src/main/kotlin/pdl/PdlFeil.kt
@@ -1,8 +1,21 @@
 package no.nav.etterlatte.libs.common.pdl
 
-data class PdlFeil(val aarsak: PdlFeilAarsak, val detaljer: String?)
+import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
+import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
 
 enum class PdlFeilAarsak {
     FANT_IKKE_PERSON,
     INGEN_IDENT_FAMILIERELASJON,
 }
+
+class FantIkkePersonException(override val detail: String = "Fant ikke forespurt person i PDL") : IkkeFunnetException(
+    code = PdlFeilAarsak.FANT_IKKE_PERSON.name,
+    detail = detail,
+)
+
+class IngenIdentFamilierelasjonException(override val detail: String = "En person i familierelasjon mangler ident") :
+    ForespoerselException(
+        status = 400,
+        code = PdlFeilAarsak.INGEN_IDENT_FAMILIERELASJON.name,
+        detail = detail,
+    )

--- a/libs/saksbehandling-common/src/main/kotlin/feilhaandtering/ExceptionResponse.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/feilhaandtering/ExceptionResponse.kt
@@ -1,0 +1,8 @@
+package no.nav.etterlatte.libs.common.feilhaandtering
+
+data class ExceptionResponse(
+    val status: Int,
+    val detail: String,
+    val code: String?,
+    val meta: Map<String, Any>?,
+)

--- a/libs/saksbehandling-common/src/main/kotlin/feilhaandtering/ForespoerselException.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/feilhaandtering/ForespoerselException.kt
@@ -1,6 +1,4 @@
-package no.nav.etterlatte.libs.ktor.feilhaandtering
-
-import io.ktor.http.HttpStatusCode
+package no.nav.etterlatte.libs.common.feilhaandtering
 
 open class ForespoerselException(
     open val status: Int,
@@ -28,18 +26,24 @@ open class UgyldigForespoerselException(
     override val detail: String,
     override val meta: Map<String, Any>? = null,
     override val cause: Throwable? = null,
-) : ForespoerselException(HttpStatusCode.BadRequest.value, code = code, detail = detail, meta = meta, cause = cause)
+) : ForespoerselException(status = 400, code = code, detail = detail, meta = meta, cause = cause)
 
 open class IkkeFunnetException(
     override val code: String,
     override val detail: String,
     override val meta: Map<String, Any>? = null,
     override val cause: Throwable? = null,
-) : ForespoerselException(status = HttpStatusCode.NotFound.value, code = code, detail = detail, meta = meta, cause = cause)
+) : ForespoerselException(status = 404, code = code, detail = detail, meta = meta, cause = cause)
+
+/**
+ * Brukes felles alle steder der vi ikke vil lekke noe informasjon om vi faktisk har funnet noe eller ikke ref.
+ * informasjonssikring
+ */
+class GenerellIkkeFunnetException : IkkeFunnetException(code = "NOT_FOUND", detail = "Kunne ikke finne ønsket ressurs")
 
 open class IkkeTillattException(
     override val code: String,
     override val detail: String,
     override val meta: Map<String, Any>? = null,
     override val cause: Throwable? = null,
-) : ForespoerselException(status = HttpStatusCode.Forbidden.value, code = code, detail = detail, meta = meta, cause = cause)
+) : ForespoerselException(status = 403, code = code, detail = detail, meta = meta, cause = cause)

--- a/libs/saksbehandling-common/src/main/kotlin/feilhaandtering/InternfeilException.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/feilhaandtering/InternfeilException.kt
@@ -1,6 +1,4 @@
-package no.nav.etterlatte.libs.ktor.feilhaandtering
-
-import io.ktor.http.HttpStatusCode
+package no.nav.etterlatte.libs.common.feilhaandtering
 
 open class InternfeilException(
     open val detail: String,
@@ -8,7 +6,7 @@ open class InternfeilException(
 ) : Exception(detail, cause) {
     fun somJsonRespons(): ExceptionResponse {
         return ExceptionResponse(
-            status = HttpStatusCode.InternalServerError.value,
+            status = 500,
             detail = detail,
             code = "INTERNAL_SERVER_ERROR",
             meta = null,

--- a/libs/saksbehandling-common/src/main/kotlin/person/Person.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/person/Person.kt
@@ -180,9 +180,6 @@ fun List<Adresse>.aktiv(): Adresse? = firstOrNull { it.aktiv }
 fun List<Adresse>.nyeste(inkluderInaktiv: Boolean = false): Adresse? =
     sortedByDescending { it.gyldigFraOgMed }.firstOrNull { if (inkluderInaktiv) true else it.gyldigTilOgMed == null }
 
-class FamilieRelasjonManglerIdent(override val message: String, override val cause: Throwable? = null) :
-    Exception(message, cause)
-
 enum class AdressebeskyttelseGradering {
     STRENGT_FORTROLIG_UTLAND,
     STRENGT_FORTROLIG,


### PR DESCRIPTION
Alle kastede exceptions og responser med responskoder 400 <= kode <= 599 blir mappet til en json-response, på formatet

```
{
  "status": number, // Http-koden for feilen
  "detail": string, // En menneskelig lesbar feilmelding
  "code": string | undefined, // En feilkode for feilen (se vedtaksvurderingsservice / attesterytelse for eksempelbruk
  "meta": Record<string, any> | undefined // et map som inneholder eventuell ekstrainformasjon til bruk i frontend. Logges ikke
}
```

Det trenger ikke noe ekstra jobb for å ta dette inn, men for å dra nytte av spesifikke feilkoder må man subklasse ForespoerselException og sette en kode man vil bruke i frontend. Igjen, se vedtaksvurderingsservice / attesterytelse for et eksempel på hvordan dette kan gjøres.

Det er muligens hensiktsmessig å ikke ha med statuscode-delen av dette i første omgang, siden vi vil overskrive dagens oppførsel hvis man ville returnere noe spesifikt, annet enn bare statuskoden 