### PR TITLE
EY-2567 Tabell for å koble behandling til grunnlagsversjon

### DIFF
--- a/apps/etterlatte-grunnlag/src/main/resources/db/migration/V17__versjon_behandling.sql
+++ b/apps/etterlatte-grunnlag/src/main/resources/db/migration/V17__versjon_behandling.sql
@@ -1,0 +1,9 @@
+CREATE TABLE behandling_versjon
+(
+    behandling_id  UUID UNIQUE   NOT NULL,
+    sak_id         BIGINT UNIQUE NOT NULL,
+    hendelsenummer BIGINT        NOT NULL,
+    laast          BOOLEAN       NOT NULL
+);
+
+CREATE INDEX ON behandling_versjon (behandling_id, sak_id);


### PR DESCRIPTION
Oppretter tabell separat slik at det ikke blir krøll i ettertid dersom resten av PR-en (som kommer) skulle feile, og en eventuell revert av koden ikke påvirker flyway. 