### PR TITLE
EY-2567 Lagre versjon for hver behandling

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
@@ -78,7 +78,7 @@ class BehandlingFactory(
                 lagOpplysning(Opplysningstype.SOEKNAD_MOTTATT_DATO, kilde, SoeknadMottattDato(mottattDato).toJsonNode()),
             )
 
-        grunnlagService.leggTilNyeOpplysninger(sak.id, NyeSaksopplysninger(opplysninger))
+        grunnlagService.leggTilNyeOpplysninger(sak.id, behandling.id, NyeSaksopplysninger(opplysninger))
 
         return behandling
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/GrunnlagService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/GrunnlagService.kt
@@ -6,6 +6,7 @@ import no.nav.etterlatte.grunnlagsendring.klienter.GrunnlagKlientImpl
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.grunnlag.NyeSaksopplysninger
 import no.nav.etterlatte.libs.common.grunnlag.Opplysningsbehov
+import java.util.UUID
 
 class GrunnlagService(private val grunnlagKlient: GrunnlagKlientImpl) {
     /**
@@ -20,19 +21,23 @@ class GrunnlagService(private val grunnlagKlient: GrunnlagKlientImpl) {
     ) {
         runBlocking {
             val grunnlagsbehov = grunnlagsbehov(behandling, persongalleri)
-            grunnlagKlient.leggInnNyttGrunnlag(grunnlagsbehov)
+            grunnlagKlient.leggInnNyttGrunnlag(behandling.id, grunnlagsbehov)
         }
     }
 
     fun leggTilNyeOpplysninger(
         sakId: Long,
+        behandlingId: UUID,
         opplysninger: NyeSaksopplysninger,
     ) = runBlocking {
-        grunnlagKlient.lagreNyeSaksopplysninger(sakId, opplysninger)
+        grunnlagKlient.lagreNyeSaksopplysninger(sakId, behandlingId, opplysninger)
     }
 
-    suspend fun hentPersongalleri(sakId: Long): Persongalleri {
-        return grunnlagKlient.hentPersongalleri(sakId)
+    suspend fun hentPersongalleri(
+        sakId: Long,
+        behandlingId: UUID,
+    ): Persongalleri {
+        return grunnlagKlient.hentPersongalleri(sakId, behandlingId)
             ?.opplysning
             ?: throw NoSuchElementException("Persongalleri mangler for sak $sakId")
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/GrunnlagKlient.kt
@@ -14,16 +14,19 @@ import no.nav.etterlatte.libs.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktorobo.Resource
 import no.nav.etterlatte.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 interface GrunnlagKlient {
     suspend fun finnPersonOpplysning(
         sakId: Long,
+        behandlingId: UUID,
         opplysningsType: Opplysningstype,
         brukerTokenInfo: BrukerTokenInfo,
     ): Grunnlagsopplysning<Person>?
 
     suspend fun hentPersongalleri(
         sakId: Long,
+        behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): Grunnlagsopplysning<Persongalleri>?
 }
@@ -41,6 +44,7 @@ class GrunnlagKlientObo(config: Config, httpClient: HttpClient) : GrunnlagKlient
 
     override suspend fun finnPersonOpplysning(
         sakId: Long,
+        behandlingId: UUID,
         opplysningsType: Opplysningstype,
         brukerTokenInfo: BrukerTokenInfo,
     ): Grunnlagsopplysning<Person>? {
@@ -52,7 +56,7 @@ class GrunnlagKlientObo(config: Config, httpClient: HttpClient) : GrunnlagKlient
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/grunnlag/sak/$sakId/$opplysningsType",
+                            url = "$resourceUrl/grunnlag/sak/$sakId/behandling/$behandlingId/$opplysningsType",
                         ),
                     brukerTokenInfo = brukerTokenInfo,
                 )
@@ -70,6 +74,7 @@ class GrunnlagKlientObo(config: Config, httpClient: HttpClient) : GrunnlagKlient
 
     override suspend fun hentPersongalleri(
         sakId: Long,
+        behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): Grunnlagsopplysning<Persongalleri>? {
         try {
@@ -80,7 +85,7 @@ class GrunnlagKlientObo(config: Config, httpClient: HttpClient) : GrunnlagKlient
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/grunnlag/sak/$sakId/${Opplysningstype.PERSONGALLERI_V1}",
+                            url = "$resourceUrl/grunnlag/sak/$sakId/behandling/$behandlingId/${Opplysningstype.PERSONGALLERI_V1}",
                         ),
                     brukerTokenInfo = brukerTokenInfo,
                 )

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
@@ -24,7 +24,7 @@ class OmregningService(
         val forrigeBehandling =
             behandlingService.hentSisteIverksatte(sakId)
                 ?: throw IllegalArgumentException("Fant ikke forrige behandling i sak $sakId")
-        val persongalleri = runBlocking { grunnlagService.hentPersongalleri(sakId) }
+        val persongalleri = runBlocking { grunnlagService.hentPersongalleri(sakId, forrigeBehandling.id) }
         val behandling =
             when (prosessType) {
                 Prosesstype.AUTOMATISK ->

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -174,7 +174,7 @@ class RevurderingServiceImpl(
     ): Revurdering? =
         forrigeBehandling.sjekkEnhet()?.let {
             return if (featureToggleService.isEnabled(RevurderingServiceFeatureToggle.OpprettManuellRevurdering, false)) {
-                val persongalleri = runBlocking { grunnlagService.hentPersongalleri(sakId) }
+                val persongalleri = runBlocking { grunnlagService.hentPersongalleri(sakId, forrigeBehandling.id) }
 
                 opprettRevurdering(
                     sakId = sakId,

--- a/apps/etterlatte-behandling/src/test/kotlin/BehandlingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/BehandlingIntegrationTest.kt
@@ -199,7 +199,7 @@ abstract class BehandlingIntegrationTest {
         HttpClient(MockEngine) {
             engine {
                 addHandler { request ->
-                    if (request.url.fullPath.matches(Regex("api/grunnlag/sak/[0-9]+"))) {
+                    if (request.url.fullPath.matches(Regex("api/grunnlag/sak/[0-9]+/behandling/*"))) {
                         val headers = headersOf("Content-Type" to listOf(ContentType.Application.Json.toString()))
                         respond(Grunnlag.empty().toJson(), headers = headers)
                     } else if (request.url.fullPath.endsWith("/PERSONGALLERI_V1")) {
@@ -418,6 +418,7 @@ abstract class BehandlingIntegrationTest {
 class GrunnlagKlientTest : GrunnlagKlient {
     override suspend fun finnPersonOpplysning(
         sakId: Long,
+        behandlingId: UUID,
         opplysningsType: Opplysningstype,
         brukerTokenInfo: BrukerTokenInfo,
     ): Grunnlagsopplysning<Person> {
@@ -427,6 +428,7 @@ class GrunnlagKlientTest : GrunnlagKlient {
 
     override suspend fun hentPersongalleri(
         sakId: Long,
+        behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): Grunnlagsopplysning<Persongalleri> {
         return Grunnlagsopplysning(

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
@@ -629,8 +629,8 @@ class BehandlingFactoryTest {
             behandlingDaoMock.alleBehandlingerISak(any())
             behandlingHendelserKafkaProducerMock.sendMeldingForHendelseMedDetaljertBehandling(any(), BehandlingHendelseType.OPPRETTET)
             grunnlagService.leggInnNyttGrunnlag(any(), any())
-            grunnlagService.leggTilNyeOpplysninger(sak.id, any())
-            grunnlagService.leggTilNyeOpplysninger(sak.id, any())
+            grunnlagService.leggTilNyeOpplysninger(sak.id, any(), any())
+            grunnlagService.leggTilNyeOpplysninger(sak.id, any(), any())
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
         }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
@@ -443,9 +443,9 @@ class BehandlingServiceImplTest {
         val grunnlagKlient =
             mockk<GrunnlagKlientTest> {
                 coEvery {
-                    finnPersonOpplysning(SAK_ID, opplysningstype, TOKEN)
+                    finnPersonOpplysning(SAK_ID, behandling.id, opplysningstype, TOKEN)
                 } returns grunnlagsopplysningMedPersonopplysning
-                coEvery { hentPersongalleri(any(), any()) } answers { callOriginal() }
+                coEvery { hentPersongalleri(any(), behandling.id, any()) } answers { callOriginal() }
             }
 
         val service =
@@ -776,9 +776,9 @@ class BehandlingServiceImplTest {
         val grunnlagKlient =
             mockk<GrunnlagKlientTest> {
                 coEvery {
-                    finnPersonOpplysning(SAK_ID, Opplysningstype.AVDOED_PDL_V1, TOKEN)
+                    finnPersonOpplysning(SAK_ID, behandling.id, Opplysningstype.AVDOED_PDL_V1, TOKEN)
                 } returns grunnlagsopplysningMedPersonopplysning
-                coEvery { hentPersongalleri(any(), any()) } answers { callOriginal() }
+                coEvery { hentPersongalleri(any(), behandling.id, any()) } answers { callOriginal() }
             }
         return lagRealGenerellBehandlingService(
             behandlingDao =

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingIntegrationTest.kt
@@ -154,7 +154,7 @@ class RevurderingIntegrationTest : BehandlingIntegrationTest() {
             }
 
         verify { grunnlagService.leggInnNyttGrunnlag(revurdering!!, any()) }
-        coVerify { grunnlagService.hentPersongalleri(any()) }
+        coVerify { grunnlagService.hentPersongalleri(any(), any()) }
         verify {
             oppgaveService.opprettNyOppgaveMedSakOgReferanse(
                 revurdering?.id.toString(),
@@ -288,7 +288,7 @@ class RevurderingIntegrationTest : BehandlingIntegrationTest() {
             verify { hendelser.sendMeldingForHendelseMedDetaljertBehandling(any(), BehandlingHendelseType.OPPRETTET) }
             verify { grunnlagService.leggInnNyttGrunnlag(any(), any()) }
             verify { oppgaveService.hentOppgaverForSak(sak.id) }
-            coVerify { grunnlagService.hentPersongalleri(any()) }
+            coVerify { grunnlagService.hentPersongalleri(any(), any()) }
             verify {
                 oppgaveService.opprettNyOppgaveMedSakOgReferanse(
                     revurdering.id.toString(),
@@ -479,7 +479,7 @@ class RevurderingIntegrationTest : BehandlingIntegrationTest() {
                     hendelse.id,
                 )
             assertEquals(revurdering.id, grunnlaghendelse?.behandlingId)
-            coVerify { grunnlagService.hentPersongalleri(any()) }
+            coVerify { grunnlagService.hentPersongalleri(any(), any()) }
             verify { grunnlagService.leggInnNyttGrunnlag(behandling as Behandling, any()) }
             verify { grunnlagService.leggInnNyttGrunnlag(revurdering, any()) }
             verify { oppgaveService.hentOppgaverForSak(sak.id) }

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnBarnepensjonService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnBarnepensjonService.kt
@@ -88,7 +88,7 @@ class BeregnBarnepensjonService(
         behandling: DetaljertBehandling,
         brukerTokenInfo: BrukerTokenInfo,
     ): Beregning {
-        val grunnlag = grunnlagKlient.hentGrunnlag(behandling.sak, brukerTokenInfo)
+        val grunnlag = grunnlagKlient.hentGrunnlag(behandling.sak, behandling.id, brukerTokenInfo)
         val behandlingType = behandling.behandlingType
         val virkningstidspunkt =
             requireNotNull(behandling.virkningstidspunkt?.dato) { "Behandling ${behandling.id} mangler virkningstidspunkt" }

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnOmstillingsstoenadService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnOmstillingsstoenadService.kt
@@ -52,7 +52,7 @@ class BeregnOmstillingsstoenadService(
         behandling: DetaljertBehandling,
         brukerTokenInfo: BrukerTokenInfo,
     ): Beregning {
-        val grunnlag = grunnlagKlient.hentGrunnlag(behandling.sak, brukerTokenInfo)
+        val grunnlag = grunnlagKlient.hentGrunnlag(behandling.sak, behandling.id, brukerTokenInfo)
         val trygdetid =
             trygdetidKlient.hentTrygdetid(behandling.id, brukerTokenInfo) ?: throw Exception(
                 "Forventa å ha trygdetid for behandlingId=${behandling.id}",

--- a/apps/etterlatte-beregning/src/main/kotlin/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/klienter/GrunnlagKlient.kt
@@ -13,10 +13,12 @@ import no.nav.etterlatte.libs.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktorobo.Resource
 import no.nav.etterlatte.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 interface GrunnlagKlient {
     suspend fun hentGrunnlag(
         sakId: Long,
+        behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): Grunnlag
 }
@@ -34,6 +36,7 @@ class GrunnlagKlientImpl(config: Config, httpClient: HttpClient) : GrunnlagKlien
 
     override suspend fun hentGrunnlag(
         sakId: Long,
+        behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): Grunnlag {
         logger.info("Henter grunnlag for sak med sakId = $sakId")
@@ -44,7 +47,7 @@ class GrunnlagKlientImpl(config: Config, httpClient: HttpClient) : GrunnlagKlien
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/api/grunnlag/sak/$sakId",
+                            url = "$resourceUrl/api/grunnlag/sak/$sakId/behandling/$behandlingId",
                         ),
                     brukerTokenInfo = brukerTokenInfo,
                 )

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnBarnepensjonServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnBarnepensjonServiceTest.kt
@@ -82,7 +82,7 @@ internal class BeregnBarnepensjonServiceTest {
         val behandling = mockBehandling(BehandlingType.FØRSTEGANGSBEHANDLING)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery {
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(
                 any(),
@@ -120,7 +120,7 @@ internal class BeregnBarnepensjonServiceTest {
         val behandling = mockBehandling(BehandlingType.FØRSTEGANGSBEHANDLING)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery {
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(
                 any(),
@@ -160,7 +160,7 @@ internal class BeregnBarnepensjonServiceTest {
         val behandling = mockBehandling(BehandlingType.FØRSTEGANGSBEHANDLING)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery {
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(
                 any(),
@@ -200,7 +200,7 @@ internal class BeregnBarnepensjonServiceTest {
         val behandling = mockBehandling(BehandlingType.FØRSTEGANGSBEHANDLING)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery {
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(
                 any(),
@@ -240,7 +240,7 @@ internal class BeregnBarnepensjonServiceTest {
         val behandling = mockBehandling(BehandlingType.FØRSTEGANGSBEHANDLING)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery {
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(
                 any(),
@@ -276,7 +276,7 @@ internal class BeregnBarnepensjonServiceTest {
         val behandling = mockBehandling(BehandlingType.FØRSTEGANGSBEHANDLING)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery {
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(
                 any(),
@@ -313,7 +313,7 @@ internal class BeregnBarnepensjonServiceTest {
         val behandling = mockBehandling(BehandlingType.FØRSTEGANGSBEHANDLING)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery {
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(
                 any(),
@@ -349,7 +349,7 @@ internal class BeregnBarnepensjonServiceTest {
         val behandling = mockBehandling(BehandlingType.FØRSTEGANGSBEHANDLING)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery {
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(
                 any(),
@@ -386,7 +386,7 @@ internal class BeregnBarnepensjonServiceTest {
         val behandling = mockBehandling(BehandlingType.REVURDERING)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery {
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(
                 any(),
@@ -426,7 +426,7 @@ internal class BeregnBarnepensjonServiceTest {
         val behandling = mockBehandling(BehandlingType.REVURDERING)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery {
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(
                 any(),
@@ -467,7 +467,7 @@ internal class BeregnBarnepensjonServiceTest {
         val behandling = mockBehandling(BehandlingType.REVURDERING)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery {
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(
                 any(),
@@ -507,7 +507,7 @@ internal class BeregnBarnepensjonServiceTest {
         val behandling = mockBehandling(BehandlingType.REVURDERING)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery {
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(
                 any(),
@@ -548,7 +548,7 @@ internal class BeregnBarnepensjonServiceTest {
         val behandling = mockBehandling(BehandlingType.MANUELT_OPPHOER)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery {
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(
                 any(),
@@ -584,7 +584,7 @@ internal class BeregnBarnepensjonServiceTest {
         val behandling = mockBehandling(BehandlingType.MANUELT_OPPHOER)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery {
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(
                 any(),
@@ -621,7 +621,7 @@ internal class BeregnBarnepensjonServiceTest {
         val behandling = mockBehandling(BehandlingType.FØRSTEGANGSBEHANDLING)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery {
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(
                 any(),
@@ -676,7 +676,7 @@ internal class BeregnBarnepensjonServiceTest {
     @Test
     fun `skal beregne barnepensjon foerstegangsbehandling - med flere avdøde foreldre og nytt regelverk`() {
         val behandling = mockBehandling(BehandlingType.FØRSTEGANGSBEHANDLING)
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns
             grunnlagMedEkstraAvdoedForelder(LocalDate.of(2023, 11, 12))
         coEvery {
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnOmstillingsstoenadServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnOmstillingsstoenadServiceTest.kt
@@ -60,7 +60,7 @@ internal class BeregnOmstillingsstoenadServiceTest {
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
         val trygdetid = mockTrygdetid(behandling.id)
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery { trygdetidKlient.hentTrygdetid(any(), any()) } returns trygdetid
         coEvery {
             beregningsGrunnlagService.hentOmstillingstoenadBeregningsGrunnlag(
@@ -99,7 +99,7 @@ internal class BeregnOmstillingsstoenadServiceTest {
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
         val trygdetid = mockTrygdetid(behandling.id)
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery { trygdetidKlient.hentTrygdetid(any(), any()) } returns trygdetid
         coEvery {
             beregningsGrunnlagService.hentOmstillingstoenadBeregningsGrunnlag(
@@ -138,7 +138,7 @@ internal class BeregnOmstillingsstoenadServiceTest {
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
         val trygdetid = mockTrygdetid(behandling.id)
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery { trygdetidKlient.hentTrygdetid(any(), any()) } returns trygdetid
         coEvery {
             beregningsGrunnlagService.hentOmstillingstoenadBeregningsGrunnlag(
@@ -177,7 +177,7 @@ internal class BeregnOmstillingsstoenadServiceTest {
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
         val trygdetid = mockTrygdetid(behandling.id)
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns
             mockk {
                 every { resultat?.utfall } returns VilkaarsvurderingUtfall.OPPFYLT
@@ -218,7 +218,7 @@ internal class BeregnOmstillingsstoenadServiceTest {
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
         val trygdetid = mockTrygdetid(behandling.id)
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns
             mockk {
                 every { resultat?.utfall } returns VilkaarsvurderingUtfall.IKKE_OPPFYLT
@@ -258,7 +258,7 @@ internal class BeregnOmstillingsstoenadServiceTest {
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
         val trygdetid = mockTrygdetid(behandling.id)
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery { trygdetidKlient.hentTrygdetid(any(), any()) } returns trygdetid
         coEvery {
             beregningsGrunnlagService.hentOmstillingstoenadBeregningsGrunnlag(
@@ -295,7 +295,7 @@ internal class BeregnOmstillingsstoenadServiceTest {
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
         val trygdetid = mockTrygdetidUtenBeregnetTrygdetid(behandling.id)
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery { trygdetidKlient.hentTrygdetid(any(), any()) } returns trygdetid
         coEvery {
             beregningsGrunnlagService.hentOmstillingstoenadBeregningsGrunnlag(
@@ -316,7 +316,7 @@ internal class BeregnOmstillingsstoenadServiceTest {
         val behandling = mockBehandling(BehandlingType.FØRSTEGANGSBEHANDLING)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery { trygdetidKlient.hentTrygdetid(any(), any()) } returns null
         coEvery {
             beregningsGrunnlagService.hentOmstillingstoenadBeregningsGrunnlag(

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/ReguleringTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/ReguleringTest.kt
@@ -77,7 +77,7 @@ class ReguleringTest {
             GrunnlagTestData(opplysningsmapAvdoedOverrides = avdoedOverrides(virk.atDay(1).minusDays(20)))
                 .hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery {
             beregningsGrunnlagService.hentBarnepensjonBeregningsGrunnlag(
                 any(),

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BehandlingService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BehandlingService.kt
@@ -55,7 +55,7 @@ class BehandlingService(
     ): Behandling =
         coroutineScope {
             val vedtak = async { vedtaksvurderingKlient.hentVedtak(behandlingId, brukerTokenInfo) }
-            val grunnlag = async { grunnlagKlient.hentGrunnlag(sakId, brukerTokenInfo) }
+            val grunnlag = async { grunnlagKlient.hentGrunnlag(sakId, behandlingId, brukerTokenInfo) }
             val sak = async { behandlingKlient.hentSak(sakId, brukerTokenInfo) }
             val vilkaarsvurdering =
                 async { vilkaarsvurderingKlient.hentVilkaarsvurdering(behandlingId, brukerTokenInfo) }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/SoekerService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/SoekerService.kt
@@ -7,5 +7,5 @@ class SoekerService(private val grunnlagKlient: GrunnlagKlient) {
     suspend fun hentSoeker(
         sakId: Long,
         bruker: BrukerTokenInfo,
-    ) = grunnlagKlient.hentGrunnlag(sakId, bruker).mapSoeker()
+    ) = grunnlagKlient.hentGrunnlagForSak(sakId, bruker).mapSoeker()
 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -723,7 +723,7 @@ internal class VedtaksbrevServiceTest {
         ),
         revurderingsaarsak = revurderingsaarsak,
         virkningsdato = YearMonth.of(LocalDate.now().year, LocalDate.now().month),
-        vilkaarsvurdering = VilkaarsvurderingDto(BEHANDLING_ID, emptyList(), YearMonth.now(), null),
+        vilkaarsvurdering = VilkaarsvurderingDto(BEHANDLING_ID, emptyList(), YearMonth.now(), null, 1),
         forrigeUtbetalingsinfo =
             Utbetalingsinfo(
                 1,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/hentinformasjon/BehandlingServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/hentinformasjon/BehandlingServiceTest.kt
@@ -82,7 +82,7 @@ internal class BehandlingServiceTest {
         } throws BehandlingKlientException("har ikke tidligere behandling")
         coEvery { behandlingKlient.hentEtterbetaling(any(), any()) } returns null
         coEvery { vedtaksvurderingKlient.hentVedtak(any(), any()) } returns opprettVedtak()
-        coEvery { grunnlagKlient.hentGrunnlag(SAK_ID, BRUKERTokenInfo) } returns opprettGrunnlag()
+        coEvery { grunnlagKlient.hentGrunnlag(SAK_ID, BEHANDLING_ID, BRUKERTokenInfo) } returns opprettGrunnlag()
         coEvery { beregningKlient.hentBeregning(any(), any()) } returns opprettBeregning()
         coEvery { trygdetidKlient.hentTrygdetid(any(), any()) } returns opprettTrygdetid()
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns opprettVilkaarsvurdering()
@@ -110,7 +110,7 @@ internal class BehandlingServiceTest {
 
         coVerify(exactly = 1) {
             vedtaksvurderingKlient.hentVedtak(BEHANDLING_ID, any())
-            grunnlagKlient.hentGrunnlag(SAK_ID, any())
+            grunnlagKlient.hentGrunnlag(SAK_ID, BEHANDLING_ID, any())
             beregningKlient.hentBeregning(BEHANDLING_ID, any())
         }
     }
@@ -125,7 +125,7 @@ internal class BehandlingServiceTest {
         } returns SisteIverksatteBehandling(UUID.randomUUID())
         coEvery { behandlingKlient.hentEtterbetaling(any(), any()) } returns null
         coEvery { vedtaksvurderingKlient.hentVedtak(any(), any()) } returns opprettVedtak()
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns opprettGrunnlag()
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns opprettGrunnlag()
         coEvery { beregningKlient.hentBeregning(any(), any()) } returns opprettBeregning()
         coEvery { trygdetidKlient.hentTrygdetid(any(), any()) } returns opprettTrygdetid()
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns opprettVilkaarsvurdering()
@@ -146,7 +146,7 @@ internal class BehandlingServiceTest {
 
         coVerify(exactly = 1) {
             vedtaksvurderingKlient.hentVedtak(BEHANDLING_ID, any())
-            grunnlagKlient.hentGrunnlag(SAK_ID, any())
+            grunnlagKlient.hentGrunnlag(SAK_ID, BEHANDLING_ID, any())
             beregningKlient.hentBeregning(BEHANDLING_ID, any())
         }
     }
@@ -161,7 +161,7 @@ internal class BehandlingServiceTest {
         } returns SisteIverksatteBehandling(UUID.randomUUID())
         coEvery { behandlingKlient.hentEtterbetaling(any(), any()) } returns null
         coEvery { vedtaksvurderingKlient.hentVedtak(any(), any()) } returns opprettVedtak()
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns opprettGrunnlag()
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns opprettGrunnlag()
         coEvery { beregningKlient.hentBeregning(any(), any()) } returns opprettBeregningSoeskenjustering()
         coEvery { trygdetidKlient.hentTrygdetid(any(), any()) } returns opprettTrygdetid()
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns opprettVilkaarsvurdering()
@@ -175,7 +175,7 @@ internal class BehandlingServiceTest {
         Assertions.assertTrue(behandling.utbetalingsinfo!!.soeskenjustering)
 
         coVerify(exactly = 1) { vedtaksvurderingKlient.hentVedtak(any(), any()) }
-        coVerify(exactly = 1) { grunnlagKlient.hentGrunnlag(any(), any()) }
+        coVerify(exactly = 1) { grunnlagKlient.hentGrunnlag(SAK_ID, BEHANDLING_ID, any()) }
         coVerify(exactly = 1) { beregningKlient.hentBeregning(any(), any()) }
     }
 

--- a/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
@@ -10,8 +10,9 @@ import no.nav.etterlatte.grunnlag.GrunnlagHendelser
 import no.nav.etterlatte.grunnlag.MigreringHendelser
 import no.nav.etterlatte.grunnlag.OpplysningDao
 import no.nav.etterlatte.grunnlag.RealGrunnlagService
-import no.nav.etterlatte.grunnlag.grunnlagRoute
+import no.nav.etterlatte.grunnlag.behandlingGrunnlagRoute
 import no.nav.etterlatte.grunnlag.personRoute
+import no.nav.etterlatte.grunnlag.sakGrunnlagRoute
 import no.nav.etterlatte.klienter.BehandlingKlientImpl
 import no.nav.etterlatte.klienter.PdlTjenesterKlientImpl
 import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
@@ -63,7 +64,8 @@ class ApplicationBuilder {
             .withKtorModule {
                 restModule(sikkerLogg, routePrefix = "api", config = HoconApplicationConfig(config)) {
                     route("grunnlag") {
-                        grunnlagRoute(grunnlagService, behandlingKlient)
+                        sakGrunnlagRoute(grunnlagService, behandlingKlient)
+                        behandlingGrunnlagRoute(grunnlagService, behandlingKlient)
                         personRoute(grunnlagService, behandlingKlient)
                     }
                 }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagHendelser.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagHendelser.kt
@@ -19,11 +19,13 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import rapidsandrivers.BEHANDLING_ID_KEY
 import rapidsandrivers.FNR_KEY
 import rapidsandrivers.GRUNNLAG_OPPDATERT
 import rapidsandrivers.OPPLYSNING_KEY
 import rapidsandrivers.SAK_ID_KEY
 import rapidsandrivers.migrering.ListenerMedLogging
+import java.util.UUID
 
 class GrunnlagHendelser(
     rapidsConnection: RapidsConnection,
@@ -39,6 +41,7 @@ class GrunnlagHendelser(
             validate { it.interestedIn(FNR_KEY) }
             validate { it.requireKey(OPPLYSNING_KEY) }
             validate { it.requireKey(SAK_ID_KEY) }
+            validate { it.requireKey(BEHANDLING_ID_KEY) }
             validate { it.rejectValue(EVENT_NAME_KEY, GRUNNLAG_OPPDATERT) }
             validate { it.rejectValue(EVENT_NAME_KEY, FEILA) }
             validate { it.rejectValue(VILKAARSVURDERT_KEY, true) }
@@ -54,6 +57,8 @@ class GrunnlagHendelser(
 
         if (eventName == "OPPLYSNING:NY" || opplysningType in OPPLYSNING_TYPER) {
             val sakId = packet[SAK_ID_KEY].asLong()
+            val behandlingId = packet[BEHANDLING_ID_KEY].let { UUID.fromString(it.asText()) }
+
             val opplysninger: List<Grunnlagsopplysning<JsonNode>> =
                 objectMapper.readValue(packet[OPPLYSNING_KEY].toJson())!!
 
@@ -61,11 +66,13 @@ class GrunnlagHendelser(
             if (fnr == null) {
                 grunnlagService.lagreNyeSaksopplysninger(
                     sakId,
+                    behandlingId,
                     opplysninger,
                 )
             } else {
                 grunnlagService.lagreNyePersonopplysninger(
                     sakId,
+                    behandlingId,
                     Folkeregisteridentifikator.of(fnr),
                     opplysninger,
                 )

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagService.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagService.kt
@@ -47,11 +47,13 @@ interface GrunnlagService {
 
     fun lagreNyeSaksopplysninger(
         sak: Long,
+        behandlingId: UUID,
         nyeOpplysninger: List<Grunnlagsopplysning<JsonNode>>,
     )
 
     fun lagreNyePersonopplysninger(
-        sak: Long,
+        sakId: Long,
+        behandlingId: UUID,
         fnr: Folkeregisteridentifikator,
         nyeOpplysninger: List<Grunnlagsopplysning<JsonNode>>,
     )
@@ -64,9 +66,15 @@ interface GrunnlagService {
 
     fun hentPersonerISak(sakId: Long): Map<Folkeregisteridentifikator, PersonMedNavn>?
 
-    suspend fun oppdaterGrunnlag(opplysningsbehov: Opplysningsbehov)
+    suspend fun oppdaterGrunnlag(
+        behandlingId: UUID,
+        opplysningsbehov: Opplysningsbehov,
+    )
 
-    fun hentHistoriskForeldreansvar(sakId: Long): Grunnlagsopplysning<JsonNode>?
+    fun hentHistoriskForeldreansvar(
+        sakId: Long,
+        behandlingId: UUID,
+    ): Grunnlagsopplysning<JsonNode>?
 }
 
 class RealGrunnlagService(
@@ -114,7 +122,10 @@ class RealGrunnlagService(
         }.associateBy { it.fnr }
     }
 
-    override suspend fun oppdaterGrunnlag(opplysningsbehov: Opplysningsbehov) {
+    override suspend fun oppdaterGrunnlag(
+        behandlingId: UUID,
+        opplysningsbehov: Opplysningsbehov,
+    ) {
         val pdlPersondatasGrunnlag =
             coroutineScope {
                 val persongalleri = opplysningsbehov.persongalleri
@@ -225,11 +236,17 @@ class RealGrunnlagService(
                     it.personDto.foedselsnummer.verdi,
                     it.personRolle,
                 )
-            lagreNyePersonopplysninger(opplysningsbehov.sakid, it.personDto.foedselsnummer.verdi, enkenPdlOpplysning)
+            lagreNyePersonopplysninger(
+                opplysningsbehov.sakid,
+                behandlingId,
+                it.personDto.foedselsnummer.verdi,
+                enkenPdlOpplysning,
+            )
         }
 
         lagreNyeSaksopplysninger(
             opplysningsbehov.sakid,
+            behandlingId,
             listOf(opplysningsbehov.persongalleri.tilGrunnlagsopplysning()),
         )
         logger.info("Oppdatert grunnlag for sak ${opplysningsbehov.sakid}")
@@ -253,7 +270,10 @@ class RealGrunnlagService(
         )
     }
 
-    override fun hentHistoriskForeldreansvar(sakId: Long): Grunnlagsopplysning<JsonNode>? {
+    override fun hentHistoriskForeldreansvar(
+        sakId: Long,
+        behandlingId: UUID,
+    ): Grunnlagsopplysning<JsonNode>? {
         val opplysning = opplysningDao.finnNyesteGrunnlag(sakId, Opplysningstype.HISTORISK_FORELDREANSVAR)?.opplysning
         if (opplysning != null) {
             return opplysning
@@ -313,37 +333,48 @@ class RealGrunnlagService(
     }
 
     override fun lagreNyePersonopplysninger(
-        sak: Long,
+        sakId: Long,
+        behandlingId: UUID,
         fnr: Folkeregisteridentifikator,
         nyeOpplysninger: List<Grunnlagsopplysning<JsonNode>>,
     ) {
         logger.info("Oppretter et grunnlag for personopplysninger")
-        val gjeldendeGrunnlag = opplysningDao.finnHendelserIGrunnlag(sak).map { it.opplysning.id }
-
-        for (opplysning in nyeOpplysninger) {
-            if (opplysning.id in gjeldendeGrunnlag) {
-                logger.warn(
-                    "Forsøker å lagre personopplysning ${opplysning.id} i sak $sak men den er allerede gjeldende",
-                )
-            } else {
-                opplysningDao.leggOpplysningTilGrunnlag(sak, opplysning, fnr)
-            }
-        }
+        oppdaterGrunnlagOgVersjon(sakId, behandlingId, fnr, nyeOpplysninger)
     }
 
     override fun lagreNyeSaksopplysninger(
         sak: Long,
+        behandlingId: UUID,
         nyeOpplysninger: List<Grunnlagsopplysning<JsonNode>>,
     ) {
         logger.info("Oppretter et grunnlag for saksopplysninger")
+        oppdaterGrunnlagOgVersjon(sak, behandlingId, fnr = null, nyeOpplysninger)
+    }
+
+    private fun oppdaterGrunnlagOgVersjon(
+        sak: Long,
+        behandlingId: UUID,
+        fnr: Folkeregisteridentifikator?,
+        nyeOpplysninger: List<Grunnlagsopplysning<JsonNode>>,
+    ) {
         val gjeldendeGrunnlag = opplysningDao.finnHendelserIGrunnlag(sak).map { it.opplysning.id }
 
-        for (opplysning in nyeOpplysninger) {
-            if (opplysning.id in gjeldendeGrunnlag) {
-                logger.warn("Forsøker å lagre sakopplysning ${opplysning.id} i sak $sak men den er allerede gjeldende")
-            } else {
-                opplysningDao.leggOpplysningTilGrunnlag(sak, opplysning, null)
-            }
+        val hendelsenummer =
+            nyeOpplysninger.mapNotNull { opplysning ->
+                if (opplysning.id in gjeldendeGrunnlag) {
+                    logger.warn("Forsøker å lagre opplysning ${opplysning.id} i sak $sak men den er allerede gjeldende")
+                    null
+                } else {
+                    opplysningDao.leggOpplysningTilGrunnlag(sak, opplysning, fnr)
+                }
+            }.maxOrNull()
+
+        if (hendelsenummer == null) {
+            logger.warn("Hendelsenummer er null – kan ikke oppdatere versjon for behandling (id=$behandlingId)")
+        } else {
+            // TODO: Hva skal vi gjøre dersom det forsøkes å oppdatere versjon som er låst? Bare hoppe over?
+            logger.info("Setter grunnlag for behandling (id=$behandlingId) til hendelsenummer=$hendelsenummer")
+            opplysningDao.oppdaterVersjonForBehandling(behandlingId, sak, hendelsenummer)
         }
     }
 

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/MigreringHendelser.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/MigreringHendelser.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.grunnlag
 
-import com.fasterxml.jackson.databind.JsonNode
 import no.nav.etterlatte.MigrerSoekerRequest
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
@@ -21,8 +20,10 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import rapidsandrivers.BEHANDLING_ID_KEY
 import rapidsandrivers.HENDELSE_DATA_KEY
 import rapidsandrivers.SAK_ID_KEY
+import rapidsandrivers.behandlingId
 import rapidsandrivers.migrering.ListenerMedLoggingOgFeilhaandtering
 import rapidsandrivers.sakId
 import java.util.UUID
@@ -38,6 +39,7 @@ class MigreringHendelser(
             correlationId()
             eventName(hendelsestype)
             validate { it.requireKey(SAK_ID_KEY) }
+            validate { it.requireKey(BEHANDLING_ID_KEY) }
             validate { it.requireKey(MIGRERING_GRUNNLAG_KEY) }
             validate { it.requireKey(PERSONGALLERI_KEY) }
             validate { it.requireKey(HENDELSE_DATA_KEY) }
@@ -50,11 +52,15 @@ class MigreringHendelser(
     ) {
         logger.info("Mottok grunnlagshendelser for migrering")
         val sakId = packet.sakId
+        val behandlingId = packet.behandlingId
+
         val request =
             objectMapper.treeToValue(packet[MIGRERING_GRUNNLAG_KEY], MigrerSoekerRequest::class.java)
 
-        lagreEnkeltgrunnlag(
+        grunnlagService.lagreNyePersonopplysninger(
             sakId,
+            behandlingId,
+            Folkeregisteridentifikator.of(request.soeker),
             listOf(
                 Grunnlagsopplysning(
                     UUID.randomUUID(),
@@ -71,7 +77,6 @@ class MigreringHendelser(
                     packet.hendelseData.spraak.toJsonNode(),
                 ),
             ),
-            request.soeker,
         )
 
         packet.eventName = Migreringshendelser.VILKAARSVURDER
@@ -79,14 +84,4 @@ class MigreringHendelser(
 
         logger.info("Behandla grunnlagshendelser for migrering for sak $sakId")
     }
-
-    private fun lagreEnkeltgrunnlag(
-        sakId: Long,
-        opplysninger: List<Grunnlagsopplysning<JsonNode>>,
-        fnr: String,
-    ) = grunnlagService.lagreNyePersonopplysninger(
-        sakId,
-        Folkeregisteridentifikator.of(fnr),
-        opplysninger,
-    )
 }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/OpplysningDao.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/OpplysningDao.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.database.singleOrNull
 import no.nav.etterlatte.libs.database.toList
+import org.jetbrains.annotations.TestOnly
 import java.sql.ResultSet
 import java.sql.Types.VARCHAR
 import java.time.YearMonth
@@ -87,7 +88,14 @@ class OpplysningDao(private val datasource: DataSource) {
                 """
                 SELECT sak_id, opplysning_id, kilde, opplysning_type, opplysning, hendelsenummer, fnr, fom, tom
                 FROM grunnlagshendelse hendelse 
-                WHERE hendelse.fnr = ? AND hendelse.opplysning_type = ? AND NOT EXISTS(SELECT 1 FROM grunnlagshendelse annen where annen.fnr = hendelse.fnr AND hendelse.opplysning_type = annen.opplysning_type AND annen.hendelsenummer > hendelse.hendelsenummer)
+                WHERE hendelse.fnr = ? 
+                AND hendelse.opplysning_type = ? 
+                AND NOT EXISTS(
+                    SELECT 1 FROM grunnlagshendelse annen 
+                    where annen.fnr = hendelse.fnr 
+                    AND hendelse.opplysning_type = annen.opplysning_type 
+                    AND annen.hendelsenummer > hendelse.hendelsenummer
+                )
                 """.trimIndent(),
             )
                 .apply {
@@ -105,7 +113,14 @@ class OpplysningDao(private val datasource: DataSource) {
                 """
                 SELECT sak_id, opplysning_id, kilde, opplysning_type, opplysning, hendelsenummer, fnr, fom, tom
                 FROM grunnlagshendelse hendelse 
-                WHERE hendelse.sak_id = ? AND hendelse.opplysning_type = ? AND NOT EXISTS(SELECT 1 FROM grunnlagshendelse annen where annen.sak_id = hendelse.sak_id AND hendelse.opplysning_type = annen.opplysning_type AND annen.hendelsenummer > hendelse.hendelsenummer)
+                WHERE hendelse.sak_id = ? 
+                AND hendelse.opplysning_type = ? 
+                AND NOT EXISTS(
+                    SELECT 1 FROM grunnlagshendelse annen 
+                    WHERE annen.sak_id = hendelse.sak_id 
+                    AND hendelse.opplysning_type = annen.opplysning_type 
+                    AND annen.hendelsenummer > hendelse.hendelsenummer
+                )
                 """.trimIndent(),
             )
                 .apply {
@@ -156,6 +171,32 @@ class OpplysningDao(private val datasource: DataSource) {
                 }.executeQuery().apply { next() }.getLong("hendelsenummer")
         }
 
+    fun oppdaterVersjonForBehandling(
+        behandlingId: UUID,
+        sakId: Long,
+        hendelsenummer: Long,
+    ) = connection.use {
+        it.prepareStatement(
+            """
+            INSERT INTO behandling_versjon (behandling_id, sak_id, hendelsenummer, laast) VALUES (?::UUID, ?, ?, ?) 
+            ON CONFLICT (behandling_id) 
+            DO UPDATE SET hendelsenummer = excluded.hendelsenummer
+            """.trimIndent(),
+        ).apply {
+            setObject(1, behandlingId)
+            setLong(2, sakId)
+            setLong(3, hendelsenummer)
+            setBoolean(4, false)
+        }.executeUpdate().also { require(it > 0) }
+    }
+
+    fun laasGrunnlagVersjonForBehandling(behandlingId: UUID) =
+        connection.use {
+            it.prepareStatement("UPDATE behandling_versjon SET laast = true WHERE behandling_id = ?::UUID")
+                .apply { setObject(1, behandlingId) }
+                .executeUpdate()
+        }
+
     fun finnAllePersongalleriHvorPersonFinnes(fnr: Folkeregisteridentifikator): List<GrunnlagHendelse> =
         connection.use {
             it.prepareStatement(
@@ -184,7 +225,30 @@ class OpplysningDao(private val datasource: DataSource) {
                 setString(2, fnr.value)
             }.executeQuery().toList { getLong("sak_id") }.toSet()
         }
+
+    @TestOnly // Kun for testing av dao
+    fun hentBehandlingVersjon(behandlingId: UUID): BehandlingGrunnlagVersjon? =
+        connection.use {
+            it.prepareStatement("SELECT * FROM behandling_versjon WHERE behandling_id = ?::UUID")
+                .apply { setObject(1, behandlingId) }
+                .executeQuery().singleOrNull {
+                    BehandlingGrunnlagVersjon(
+                        getObject("behandling_id") as UUID,
+                        getLong("sak_id"),
+                        getLong("hendelsenummer"),
+                        getBoolean("laast"),
+                    )
+                }
+        }
 }
+
+@TestOnly // Kun for testing av dao
+data class BehandlingGrunnlagVersjon(
+    val behandlingId: UUID,
+    val sakId: Long,
+    val hendelsenummer: Long,
+    val laast: Boolean,
+)
 
 fun JsonNode?.serialize() = this?.let { objectMapper.writeValueAsString(it) }
 

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/PersonRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/PersonRoutes.kt
@@ -9,6 +9,7 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.hentNavidentFraToken
+import no.nav.etterlatte.libs.common.kunSystembruker
 import no.nav.etterlatte.libs.common.person.InvalidFoedselsnummerException
 import no.nav.etterlatte.libs.common.withFoedselsnummer
 
@@ -25,9 +26,11 @@ fun Route.personRoute(
         }
 
         post("roller") {
-            withFoedselsnummer(behandlingKlient) { fnr ->
-                val personMedSakOgRoller = grunnlagService.hentSakerOgRoller(fnr)
-                call.respond(personMedSakOgRoller)
+            kunSystembruker {
+                withFoedselsnummer(behandlingKlient) { fnr ->
+                    val personMedSakOgRoller = grunnlagService.hentSakerOgRoller(fnr)
+                    call.respond(personMedSakOgRoller)
+                }
             }
         }
 

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/SakGrunnlagRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/SakGrunnlagRoutes.kt
@@ -1,0 +1,49 @@
+package no.nav.etterlatte.grunnlag
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import no.nav.etterlatte.klienter.BehandlingKlient
+import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.sakId
+import no.nav.etterlatte.libs.common.withSakId
+
+fun Route.sakGrunnlagRoute(
+    grunnlagService: GrunnlagService,
+    behandlingKlient: BehandlingKlient,
+) {
+    route("sak/{$SAKID_CALL_PARAMETER}") {
+        get {
+            withSakId(behandlingKlient) { sakId ->
+                when (val opplysningsgrunnlag = grunnlagService.hentOpplysningsgrunnlag(sakId)) {
+                    null -> call.respond(HttpStatusCode.NotFound)
+                    else -> call.respond(opplysningsgrunnlag)
+                }
+            }
+        }
+
+        get("personer/alle") {
+            withSakId(behandlingKlient) { sakId ->
+                when (val personerISak = grunnlagService.hentPersonerISak(sakId)) {
+                    null -> call.respond(HttpStatusCode.NotFound)
+                    else -> call.respond(PersonerISakDto(personerISak))
+                }
+            }
+        }
+    }
+}
+
+private data class PersonerISakDto(
+    val personer: Map<Folkeregisteridentifikator, PersonMedNavn>,
+)
+
+data class PersonMedNavn(
+    val fnr: Folkeregisteridentifikator,
+    val fornavn: String,
+    val etternavn: String,
+    val mellomnavn: String?,
+)

--- a/apps/etterlatte-grunnlag/src/test/kotlin/itest/RapidTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/itest/RapidTest.kt
@@ -26,6 +26,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
+import rapidsandrivers.BEHANDLING_ID_KEY
+import rapidsandrivers.FNR_KEY
+import rapidsandrivers.OPPLYSNING_KEY
+import rapidsandrivers.SAK_ID_KEY
+import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class RapidTest {
@@ -84,9 +89,10 @@ internal class RapidTest {
             JsonMessage.newMessage(
                 mapOf(
                     "@event_name" to "OPPLYSNING:NY",
-                    "opplysning" to listOf(nyOpplysning),
-                    "fnr" to fnr,
-                    "sakId" to 1,
+                    OPPLYSNING_KEY to listOf(nyOpplysning),
+                    FNR_KEY to fnr,
+                    SAK_ID_KEY to 1,
+                    BEHANDLING_ID_KEY to UUID.randomUUID(),
                 ),
             ).toJson()
 
@@ -102,9 +108,10 @@ internal class RapidTest {
             JsonMessage.newMessage(
                 mapOf(
                     "@behov" to Opplysningstype.SOEKER_PDL_V1,
-                    "opplysning" to listOf(nyOpplysning),
-                    "fnr" to fnr,
-                    "sakId" to 1,
+                    OPPLYSNING_KEY to listOf(nyOpplysning),
+                    FNR_KEY to fnr,
+                    SAK_ID_KEY to 1,
+                    BEHANDLING_ID_KEY to UUID.randomUUID(),
                 ),
             ).toJson()
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/GrunnlagForVirkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/GrunnlagForVirkningstidspunkt.tsx
@@ -60,11 +60,11 @@ const AdopsjonGrunnlag = () => {
     )
 
   useEffect(() => {
-    if (!behandling?.sakId) {
+    if (!behandling?.sakId || !behandling.id) {
       return
     }
-    hentForeldreansvar({ sakId: behandling.sakId })
-  }, [behandling?.sakId])
+    hentForeldreansvar({ sakId: behandling.sakId, behandlingId: behandling.id })
+  }, [behandling?.sakId, behandling?.id])
 
   return mapApiResult(
     foreldreansvar,

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/grunnlag.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/grunnlag.ts
@@ -20,8 +20,9 @@ export const getPerson = async (fnr: string): Promise<ApiResponse<IPersonResult>
 
 export const getHistoriskForeldreansvar = (args: {
   sakId: number
+  behandlingId: string
 }): Promise<ApiResponse<Grunnlagsopplysning<Foreldreansvar, KildePdl>>> => {
   return apiClient.get<Grunnlagsopplysning<Foreldreansvar, KildePdl>>(
-    `/grunnlag/sak/${args.sakId}/revurdering/HISTORISK_FORELDREANSVAR`
+    `/grunnlag/sak/${args.sakId}/behandling/${args.behandlingId}/revurdering/HISTORISK_FORELDREANSVAR`
   )
 }

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -93,7 +93,7 @@ class TrygdetidService(
         behandling: DetaljertBehandling,
         brukerTokenInfo: BrukerTokenInfo,
     ): Trygdetid {
-        val avdoed = grunnlagKlient.hentGrunnlag(behandling.sak, brukerTokenInfo).hentAvdoed()
+        val avdoed = grunnlagKlient.hentGrunnlag(behandling.sak, behandling.id, brukerTokenInfo).hentAvdoed()
         val trygdetid =
             Trygdetid(
                 sakId = behandling.sak,
@@ -193,7 +193,7 @@ class TrygdetidService(
     ): DatoerForBehandling {
         val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
 
-        val avdoed = grunnlagKlient.hentGrunnlag(behandling.sak, brukerTokenInfo).hentAvdoed()
+        val avdoed = grunnlagKlient.hentGrunnlag(behandling.sak, behandlingId, brukerTokenInfo).hentAvdoed()
 
         return DatoerForBehandling(
             foedselsDato =

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/GrunnlagKlient.kt
@@ -13,6 +13,7 @@ import no.nav.etterlatte.libs.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktorobo.Resource
 import no.nav.etterlatte.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 class GrunnlagKlientException(override val message: String, override val cause: Throwable) : Exception(message, cause)
 
@@ -27,6 +28,7 @@ class GrunnlagKlient(config: Config, httpClient: HttpClient) {
 
     suspend fun hentGrunnlag(
         sakId: Long,
+        behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): Grunnlag {
         logger.info("Henter grunnlag for sak med sakId = $sakId")
@@ -37,7 +39,7 @@ class GrunnlagKlient(config: Config, httpClient: HttpClient) {
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/api/grunnlag/sak/$sakId",
+                            url = "$resourceUrl/api/grunnlag/sak/$sakId/behandling/$behandlingId",
                         ),
                     brukerTokenInfo = brukerTokenInfo,
                 )

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
@@ -125,7 +125,7 @@ internal class TrygdetidServiceTest {
 
         every { repository.hentTrygdetid(any()) } returns null
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         every { repository.opprettTrygdetid(any()) } returns trygdetid
         coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
 
@@ -136,7 +136,7 @@ internal class TrygdetidServiceTest {
         coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
             behandlingKlient.hentBehandling(behandlingId, saksbehandler)
-            grunnlagKlient.hentGrunnlag(sakId, saksbehandler)
+            grunnlagKlient.hentGrunnlag(sakId, behandlingId, saksbehandler)
             repository.hentTrygdetid(behandlingId)
             repository.opprettTrygdetid(
                 withArg { trygdetid ->
@@ -242,7 +242,7 @@ internal class TrygdetidServiceTest {
         val trygdetid = trygdetid(behandlingId, sakId)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         every { repository.hentTrygdetid(behandlingId) } returns null
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
         coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
@@ -264,7 +264,7 @@ internal class TrygdetidServiceTest {
             behandlingKlient.hentSisteIverksatteBehandling(sakId, saksbehandler)
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
             repository.hentTrygdetid(forrigeBehandlingId)
-            grunnlagKlient.hentGrunnlag(any(), any())
+            grunnlagKlient.hentGrunnlag(any(), any(), any())
 
             repository.opprettTrygdetid(
                 withArg {
@@ -342,7 +342,7 @@ internal class TrygdetidServiceTest {
         val trygdetid = trygdetid(behandlingId, sakId)
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         every { repository.hentTrygdetid(behandlingId) } returns null
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
         coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
@@ -364,7 +364,7 @@ internal class TrygdetidServiceTest {
             behandlingKlient.hentSisteIverksatteBehandling(sakId, saksbehandler)
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
             repository.hentTrygdetid(forrigeBehandlingId)
-            grunnlagKlient.hentGrunnlag(any(), any())
+            grunnlagKlient.hentGrunnlag(any(), any(), any())
 
             repository.opprettTrygdetid(
                 withArg {
@@ -428,7 +428,7 @@ internal class TrygdetidServiceTest {
         every { repository.hentTrygdetid(behandlingId) } returns eksisterendeTrygdetid
         every { repository.oppdaterTrygdetid(any()) } answers { firstArg() }
         coEvery { behandlingKlient.hentBehandling(any(), any()) } answers { behandling(behandlingId = behandlingId) }
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         every { grunnlag.hentAvdoed() } returns avdoedGrunnlag
         every { avdoedGrunnlag[Opplysningstype.FOEDSELSDATO] } answers {
             Opplysning.Konstant(
@@ -474,7 +474,7 @@ internal class TrygdetidServiceTest {
             vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any())
             vilkaarsvurderingDto.isYrkesskade()
             behandlingKlient.hentBehandling(any(), any())
-            grunnlagKlient.hentGrunnlag(any(), any())
+            grunnlagKlient.hentGrunnlag(any(), behandlingId, any())
         }
 
         verify {
@@ -501,7 +501,7 @@ internal class TrygdetidServiceTest {
         every { vilkaarsvurderingDto.isYrkesskade() } returns false
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns vilkaarsvurderingDto
         coEvery { behandlingKlient.hentBehandling(any(), any()) } answers { behandling(behandlingId = behandlingId) }
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         every { grunnlag.hentAvdoed() } returns avdoedGrunnlag
         every { avdoedGrunnlag[Opplysningstype.FOEDSELSDATO] } answers {
             Opplysning.Konstant(
@@ -550,7 +550,7 @@ internal class TrygdetidServiceTest {
             vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any())
             vilkaarsvurderingDto.isYrkesskade()
             behandlingKlient.hentBehandling(any(), any())
-            grunnlagKlient.hentGrunnlag(any(), any())
+            grunnlagKlient.hentGrunnlag(any(), behandlingId, any())
         }
 
         verify {
@@ -573,7 +573,7 @@ internal class TrygdetidServiceTest {
         every { repository.hentTrygdetid(behandlingId) } returns eksisterendeTrygdetid
         every { repository.oppdaterTrygdetid(any()) } answers { firstArg() }
         coEvery { behandlingKlient.hentBehandling(any(), any()) } answers { behandling(behandlingId = behandlingId) }
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         every { grunnlag.hentAvdoed() } returns avdoedGrunnlag
         every { avdoedGrunnlag[Opplysningstype.FOEDSELSDATO] } answers {
             Opplysning.Konstant(
@@ -609,7 +609,7 @@ internal class TrygdetidServiceTest {
             beregningService.beregnTrygdetid(any(), any(), any())
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
             behandlingKlient.hentBehandling(any(), any())
-            grunnlagKlient.hentGrunnlag(any(), any())
+            grunnlagKlient.hentGrunnlag(any(), behandlingId, any())
         }
         verify {
             avdoedGrunnlag[Opplysningstype.FOEDSELSDATO]

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingService.kt
@@ -113,7 +113,9 @@ class VedtaksvurderingService(
     }
 
     /**
-     * TODO: Feilmelding til saksbehandler
+     * TODO:
+     *  - Må sikre at vedtak ikke kan gjennomføres dersom det er diff på versjon
+     *  - Gi forståelig feilmelding til saksbehandler
      **/
     private fun verifiserGrunnlagVersjon(
         vilkaarsvurdering: VilkaarsvurderingDto?,
@@ -122,7 +124,8 @@ class VedtaksvurderingService(
         if (vilkaarsvurdering?.grunnlagVersjon == null || beregningOgAvkorting == null) {
             return
         } else if (vilkaarsvurdering.grunnlagVersjon != beregningOgAvkorting.beregning.grunnlagMetadata.versjon) {
-            throw IllegalStateException("FML...")
+            logger.warn("Ulik versjon av grunnlag i vilkaarsvurdering og beregnin!")
+            return
         }
     }
 

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/Vilkaarsvurdering.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/Vilkaarsvurdering.kt
@@ -23,6 +23,7 @@ data class Vilkaarsvurdering(
             virkningstidspunkt = this.virkningstidspunkt,
             vilkaar = this.vilkaar,
             resultat = this.resultat,
+            grunnlagVersjon = this.grunnlagVersjon,
         )
 }
 

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingService.kt
@@ -241,7 +241,7 @@ class VilkaarsvurderingService(
     ): Pair<DetaljertBehandling, Grunnlag> {
         return coroutineScope {
             val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
-            val grunnlag = async { grunnlagKlient.hentGrunnlag(behandling.sak, brukerTokenInfo) }
+            val grunnlag = async { grunnlagKlient.hentGrunnlag(behandling.sak, behandlingId, brukerTokenInfo) }
 
             Pair(behandling, grunnlag.await())
         }

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/klienter/GrunnlagKlient.kt
@@ -14,10 +14,12 @@ import no.nav.etterlatte.libs.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktorobo.Resource
 import no.nav.etterlatte.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 interface GrunnlagKlient {
     suspend fun hentGrunnlag(
         sakId: Long,
+        behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): Grunnlag
 }
@@ -35,6 +37,7 @@ class GrunnlagKlientImpl(config: Config, httpClient: HttpClient) : GrunnlagKlien
 
     override suspend fun hentGrunnlag(
         sakId: Long,
+        behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): Grunnlag {
         logger.info("Henter grunnlag for sak med sakId=$sakId")
@@ -45,7 +48,7 @@ class GrunnlagKlientImpl(config: Config, httpClient: HttpClient) : GrunnlagKlien
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/grunnlag/sak/$sakId",
+                            url = "$resourceUrl/grunnlag/sak/$sakId/behandling/$behandlingId",
                         ),
                     brukerTokenInfo = brukerTokenInfo,
                 )

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
@@ -94,7 +94,7 @@ internal class VilkaarsvurderingRoutesTest {
         } returns true
         coEvery { behandlingKlient.settBehandlingStatusOpprettet(any(), any(), any()) } returns true
         coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns GrunnlagTestData().hentOpplysningsgrunnlag()
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns GrunnlagTestData().hentOpplysningsgrunnlag()
     }
 
     @AfterEach

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
@@ -83,7 +83,7 @@ internal class VilkaarsvurderingServiceTest {
 
     @BeforeEach
     fun beforeEach() {
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns GrunnlagTestData().hentOpplysningsgrunnlag()
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns GrunnlagTestData().hentOpplysningsgrunnlag()
         coEvery { behandlingKlient.kanSetteBehandlingStatusVilkaarsvurdert(any(), any()) } returns true
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns
             mockk<DetaljertBehandling>().apply {
@@ -190,7 +190,7 @@ internal class VilkaarsvurderingServiceTest {
                 opplysningsmapSakOverrides = mapOf(SOEKNAD_MOTTATT_DATO to soeknadMottattDatoOpplysning),
             ).hentOpplysningsgrunnlag()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
 
         val vilkaarsvurdering =
             runBlocking {
@@ -388,7 +388,7 @@ internal class VilkaarsvurderingServiceTest {
     fun `kan opprette og kopiere vilkaarsvurdering fra forrige behandling`() {
         val grunnlag: Grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
         val nyBehandlingId = UUID.randomUUID()
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery { behandlingKlient.settBehandlingStatusVilkaarsvurdert(any(), any()) } returns true
 
         runBlocking {
@@ -441,7 +441,7 @@ internal class VilkaarsvurderingServiceTest {
         val grunnlag: Grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
         val revurderingId = UUID.randomUUID()
 
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         coEvery { behandlingKlient.settBehandlingStatusVilkaarsvurdert(any(), any()) } returns true
         coEvery { behandlingKlient.hentBehandling(revurderingId, any()) } returns
             mockk {

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/migrering/MigreringTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/migrering/MigreringTest.kt
@@ -102,7 +102,7 @@ class MigreringTest {
         coEvery { behandlingKlient.kanSetteBehandlingStatusVilkaarsvurdert(any(), any()) } returns true
         coEvery { behandlingKlient.hentBehandling(behandlingId, any()) } returns detaljertBehandling()
         coEvery { behandlingKlient.settBehandlingStatusVilkaarsvurdert(behandlingId, any()) } returns true
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns GrunnlagTestData().hentOpplysningsgrunnlag()
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns GrunnlagTestData().hentOpplysningsgrunnlag()
     }
 
     private fun detaljertBehandling() =

--- a/libs/etterlatte-vilkaarsvurdering-model/src/main/kotlin/vilkaarsvurdering/Vilkaarsvurdering.kt
+++ b/libs/etterlatte-vilkaarsvurdering-model/src/main/kotlin/vilkaarsvurdering/Vilkaarsvurdering.kt
@@ -10,6 +10,7 @@ data class VilkaarsvurderingDto(
     val vilkaar: List<Vilkaar>,
     val virkningstidspunkt: YearMonth,
     val resultat: VilkaarsvurderingResultat? = null,
+    val grunnlagVersjon: Long,
 ) {
     fun isYrkesskade() =
         this.vilkaar.filter {


### PR DESCRIPTION
Dette vil bli gjort stegvis. Nå er følgende gjort: 
- Alle endepunkter som skal versjoneres krever nå `behandlingId`
- Lagring av grunnlag krever `behandlingId` og lagrer dette.

Hva gjenstår? 
- Versjonere alle grunnlag i dev og prod.
- Fjerne `sakId` fra alle endepunkter (unntatt de hvor man vil hente _hele_ grunnlaget).
- Skrive om uthenting av grunnlag til å bruke oppgitt versjon.