### PR TITLE
Overstyr trygdetid ved feil eller manglende perioder i Pesys

### DIFF
--- a/apps/etterlatte-trygdetid-kafka/src/main/kotlin/MigreringHendelser.kt
+++ b/apps/etterlatte-trygdetid-kafka/src/main/kotlin/MigreringHendelser.kt
@@ -8,6 +8,7 @@ import no.nav.etterlatte.libs.common.trygdetid.DetaljertBeregnetTrygdetidResulta
 import no.nav.etterlatte.libs.common.trygdetid.TrygdetidDto
 import no.nav.etterlatte.libs.common.trygdetid.TrygdetidGrunnlagDto
 import no.nav.etterlatte.libs.common.trygdetid.TrygdetidGrunnlagKildeDto
+import no.nav.etterlatte.rapidsandrivers.migrering.MigreringRequest
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser
 import no.nav.etterlatte.rapidsandrivers.migrering.TRYGDETID_KEY
 import no.nav.etterlatte.rapidsandrivers.migrering.Trygdetidsgrunnlag
@@ -21,12 +22,11 @@ import org.slf4j.LoggerFactory
 import rapidsandrivers.BEHANDLING_ID_KEY
 import rapidsandrivers.HENDELSE_DATA_KEY
 import rapidsandrivers.behandlingId
-import rapidsandrivers.migrering.ListenerMedLogging
-import rapidsandrivers.withFeilhaandtering
+import rapidsandrivers.migrering.ListenerMedLoggingOgFeilhaandtering
 import java.util.UUID
 
 internal class MigreringHendelser(rapidsConnection: RapidsConnection, private val trygdetidService: TrygdetidService) :
-    ListenerMedLogging() {
+    ListenerMedLoggingOgFeilhaandtering(Migreringshendelser.TRYGDETID) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
@@ -41,50 +41,47 @@ internal class MigreringHendelser(rapidsConnection: RapidsConnection, private va
         packet: JsonMessage,
         context: MessageContext,
     ) {
-        withFeilhaandtering(packet, context, Migreringshendelser.TRYGDETID) {
-            val behandlingId = packet.behandlingId
-            logger.info("Mottatt trygdetid-migreringshendelse for behandling $behandlingId")
-            trygdetidService.beregnTrygdetid(behandlingId).also {
-                logger.info("Oppretta trygdetid for behandling $behandlingId")
-            }
-        }.takeIf { it.isSuccess }
-            ?.let {
-                withFeilhaandtering(packet, context, Migreringshendelser.TRYGDETID_GRUNNLAG) {
-                    val behandlingId = packet.behandlingId
-                    val request = packet.hendelseData
-                    logger.info("Oppretter grunnlag for trygdetid for $behandlingId")
+        val behandlingId = packet.behandlingId
+        val request = packet.hendelseData
 
-                    try {
-                        // Oppretter alle trygdetidsperioder og beholder siste beregnede trygdetid
-                        val beregnetTrygdetid =
-                            request.trygdetid.perioder.map { periode ->
-                                trygdetidService.beregnTrygdetidGrunnlag(behandlingId, tilGrunnlag(periode))
-                            }.lastOrNull() ?: it.getOrThrow()
+        logger.info("Mottatt trygdetid-migreringshendelse for behandling $behandlingId")
+        trygdetidService.beregnTrygdetid(behandlingId)
+        logger.info("Opprettet trygdetid for behandling $behandlingId, forsøker å legge til perioder")
 
-                        sendBeregnetTrygdetid(packet, beregnetTrygdetid, context, behandlingId)
-                    } catch (e: Exception) {
-                        logger.warn(
-                            "Problem ved opprettelse av trygdetidsperioder for behandling $behandlingId - overstyrer beregnet trygdetid",
-                            e,
+        val oppdatertTrygdetid: TrygdetidDto =
+            if (request.trygdetid.perioder.isNotEmpty()) {
+                try {
+                    request.trygdetid.perioder.map { periode ->
+                        val grunnlag = tilGrunnlag(periode)
+                        logger.info(
+                            "Forsøker å legge til periode ${grunnlag.periodeFra}-${grunnlag.periodeTil} for behandling $behandlingId",
                         )
-
-                        // TODO - EY-2602 - flere felter trengs - feks utland
-                        val detaljertBeregnetTrygdetid =
-                            DetaljertBeregnetTrygdetidResultat.fraSamletTrygdetidNorge(
-                                request.beregning.anvendtTrygdetid.toInt(),
-                            )
-
-                        val beregnetTrygdetid =
-                            trygdetidService.overstyrBeregnetTrygdetid(
-                                behandlingId,
-                                detaljertBeregnetTrygdetid,
-                            )
-
-                        sendBeregnetTrygdetid(packet, beregnetTrygdetid, context, behandlingId)
-                    }
+                        trygdetidService.beregnTrygdetidGrunnlag(behandlingId, grunnlag)
+                    }.last()
+                } catch (e: Exception) {
+                    logger.warn("Klarte ikke legge til perioder fra Pesys for behandling $behandlingId", e)
+                    overstyrBeregnetTrygdetidNorge(request, behandlingId)
                 }
+            } else {
+                logger.info("Vi mottok ingen trygdetidsperioder fra Pesys for behandling $behandlingId")
+                overstyrBeregnetTrygdetidNorge(request, behandlingId)
             }
+
+        sendBeregnetTrygdetid(packet, oppdatertTrygdetid, context, behandlingId)
     }
+
+    private fun overstyrBeregnetTrygdetidNorge(
+        request: MigreringRequest,
+        behandlingId: UUID,
+    ): TrygdetidDto =
+        // TODO - EY-2602 - flere felter trengs - feks utland
+        trygdetidService.overstyrBeregnetTrygdetid(
+            behandlingId = behandlingId,
+            beregnetTrygdetid =
+                DetaljertBeregnetTrygdetidResultat.fraSamletTrygdetidNorge(
+                    request.beregning.anvendtTrygdetid.toInt(),
+                ).copy(overstyrt = true),
+        ).also { logger.warn("Trygdetid for behandling $behandlingId ble overstyrt med anvendt norsk tt fra Pesys") }
 
     private fun sendBeregnetTrygdetid(
         packet: JsonMessage,

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
@@ -96,7 +96,7 @@ class BehandlingKlient(config: Config, httpClient: HttpClient) : BehandlingTilga
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): Boolean {
-        logger.info("Committer vilkaarsvurdering på behandling med id $behandlingId")
+        logger.info("Committer trygdetid oppdatert på behandling med id $behandlingId")
         val response =
             downstreamResourceClient.post(
                 resource = Resource(clientId = clientId, url = "$resourceUrl/behandlinger/$behandlingId/oppdaterTrygdetid"),


### PR DESCRIPTION
Enkelte migrerte saker får ikke med seg noen trygdetidsinformasjon i migrering: https://gjenny.intern.dev.nav.no/behandling/23e33f63-5c9c-43e2-945a-e349923fccc9/trygdetid

Dersom det ikke er noen perioder, eller noe feiler ved opprettelse av perioder, skal vi overstyre med beregnet verdi.
