### PR TITLE
EY-2912 > EY-2924 - lagre overstyring av norsk poengaar > ny felter

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/OverstyrtTrygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/OverstyrtTrygdetid.tsx
@@ -1,0 +1,67 @@
+import { FlexHeader } from '~components/behandling/soeknadsoversikt/familieforhold/styled'
+import { BodyShort, Heading, TextField } from '@navikt/ds-react'
+import styled from 'styled-components'
+import { ITrygdetid } from '~shared/api/trygdetid'
+import { useEffect, useState } from 'react'
+
+interface Props {
+  redigerbar: boolean
+  trygdetid: ITrygdetid
+  overstyrTrygdetidPoengaar: (trygdetid: ITrygdetid) => void
+}
+
+export const OverstyrtTrygdetid = ({ redigerbar, trygdetid, overstyrTrygdetidPoengaar }: Props) => {
+  const [overstyrtNorskPoengaar, setOverstyrtNorskPoengaar] = useState<number | undefined>(undefined)
+
+  useEffect(() => {
+    setOverstyrtNorskPoengaar(trygdetid.overstyrtNorskPoengaar)
+  }, [])
+
+  return (
+    <Overstyrt>
+      <FlexHeader>
+        <Heading size="small" level="4">
+          Norsk poengår
+        </Heading>
+      </FlexHeader>
+      {!redigerbar && (
+        <>
+          <BodyShort>
+            Den avdøde har mindre enn 20 års botid, men har opptjent rett til tilleggspensjon - norsk poengår:
+          </BodyShort>
+          <AntallAar>{trygdetid.overstyrtNorskPoengaar} 12</AntallAar>
+        </>
+      )}
+      {redigerbar && (
+        <>
+          <BodyShort>
+            Hvis den avdøde har mindre enn 20 års botid, men har opptjent rett til tilleggspensjon - så må antall
+            poengår i Norge spesifiseres
+          </BodyShort>
+          <AntallAarFelt
+            value={overstyrtNorskPoengaar}
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            label="Norsk poengår"
+            onChange={(e) => setOverstyrtNorskPoengaar(e.target.value === '' ? undefined : Number(e.target.value))}
+            onBlur={() => overstyrTrygdetidPoengaar({ ...trygdetid, overstyrtNorskPoengaar: overstyrtNorskPoengaar })}
+          />
+        </>
+      )}
+    </Overstyrt>
+  )
+}
+
+const Overstyrt = styled.div`
+  padding: 2em 0 0 0;
+`
+
+const AntallAar = styled(BodyShort)`
+  padding: 1em 0 0 0;
+`
+
+const AntallAarFelt = styled(TextField)`
+  padding: 1em 0 0 0;
+  width: 10em;
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
@@ -7,6 +7,7 @@ import {
   ITrygdetid,
   ITrygdetidGrunnlagType,
   opprettTrygdetid,
+  overstyrTrygdetid,
   sorterLand,
 } from '~shared/api/trygdetid'
 import Spinner from '~shared/Spinner'
@@ -22,6 +23,7 @@ import { IBehandlingStatus, IUtenlandstilsnitt, IUtenlandstilsnittType } from '~
 import { oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'
 import { useAppDispatch } from '~store/Store'
 import { TrygdetidDetaljer } from '~components/behandling/trygdetid/detaljer/TrygdetidDetaljer'
+import { OverstyrtTrygdetid } from './OverstyrtTrygdetid'
 
 interface Props {
   redigerbar: boolean
@@ -37,6 +39,7 @@ export const Trygdetid = ({ redigerbar, utenlandstilsnitt }: Props) => {
   const dispatch = useAppDispatch()
   const [hentTrygdetidRequest, fetchTrygdetid] = useApiCall(hentTrygdetid)
   const [opprettTrygdetidRequest, requestOpprettTrygdetid] = useApiCall(opprettTrygdetid)
+  const [overstyrTrygdetidRequest, requestOverstyrTrygdetid] = useApiCall(overstyrTrygdetid)
   const [hentAlleLandRequest, fetchAlleLand] = useApiCall(hentAlleLand)
   const [trygdetid, setTrygdetid] = useState<ITrygdetid>()
   const [landListe, setLandListe] = useState<ILand[]>()
@@ -44,6 +47,20 @@ export const Trygdetid = ({ redigerbar, utenlandstilsnitt }: Props) => {
   const oppdaterTrygdetid = (trygdetid: ITrygdetid) => {
     setTrygdetid(trygdetid)
     dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.TRYGDETID_OPPDATERT))
+  }
+
+  const overstyrTrygdetidPoengaar = (trygdetid: ITrygdetid) => {
+    if (trygdetid.overstyrtNorskPoengaar) {
+      requestOverstyrTrygdetid(
+        {
+          behandlingId: trygdetid.behandlingId,
+          overstyrtNorskPoengaar: trygdetid.overstyrtNorskPoengaar,
+        },
+        (trygdetid: ITrygdetid) => {
+          oppdaterTrygdetid(trygdetid)
+        }
+      )
+    }
   }
 
   useEffect(() => {
@@ -94,6 +111,11 @@ export const Trygdetid = ({ redigerbar, utenlandstilsnitt }: Props) => {
             trygdetidGrunnlagType={ITrygdetidGrunnlagType.FAKTISK}
             redigerbar={redigerbar}
           />
+          <OverstyrtTrygdetid
+            redigerbar={redigerbar}
+            trygdetid={trygdetid}
+            overstyrTrygdetidPoengaar={overstyrTrygdetidPoengaar}
+          />
           <TrygdetidGrunnlagListe
             trygdetid={trygdetid}
             setTrygdetid={oppdaterTrygdetid}
@@ -112,6 +134,9 @@ export const Trygdetid = ({ redigerbar, utenlandstilsnitt }: Props) => {
       )}
       {isPending(opprettTrygdetidRequest) && <Spinner visible={true} label="Oppretter trygdetid" />}
       {isFailure(hentTrygdetidRequest) && <ApiErrorAlert>En feil har oppstått ved henting av trygdetid</ApiErrorAlert>}
+      {isFailure(overstyrTrygdetidRequest) && (
+        <ApiErrorAlert>En feil har oppstått ved lagring av norsk poengår</ApiErrorAlert>
+      )}
       {isFailure(opprettTrygdetidRequest) && (
         <ApiErrorAlert>En feil har oppstått ved opprettelse av trygdetid</ApiErrorAlert>
       )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
@@ -6,6 +6,9 @@ export const hentTrygdetid = async (behandlingsId: string): Promise<ApiResponse<
 export const opprettTrygdetid = async (behandlingsId: string): Promise<ApiResponse<ITrygdetid>> =>
   apiClient.post(`/trygdetid/${behandlingsId}`, {})
 
+export const overstyrTrygdetid = async (overstyring: ITrygdetidOverstyring): Promise<ApiResponse<ITrygdetid>> =>
+  apiClient.post(`/trygdetid/${overstyring.behandlingId}/overstyr`, { ...overstyring })
+
 export const lagreYrkesskadeTrygdetidGrunnlag = async (args: {
   behandlingsId: string
 }): Promise<ApiResponse<ITrygdetid>> => apiClient.post(`/trygdetid/${args.behandlingsId}/grunnlag/yrkesskade`, {})
@@ -98,6 +101,12 @@ export interface ITrygdetid {
   beregnetTrygdetid?: IDetaljertBeregnetTrygdetid
   trygdetidGrunnlag: ITrygdetidGrunnlag[]
   opplysninger: IGrunnlagOpplysninger
+  overstyrtNorskPoengaar: number | undefined
+}
+
+export interface ITrygdetidOverstyring {
+  behandlingId: string
+  overstyrtNorskPoengaar: number | undefined
 }
 
 export interface IGrunnlagOpplysninger {

--- a/apps/etterlatte-trygdetid-kafka/src/test/kotlin/MigreringHendelserRiverTest.kt
+++ b/apps/etterlatte-trygdetid-kafka/src/test/kotlin/MigreringHendelserRiverTest.kt
@@ -60,6 +60,7 @@ internal class MigreringHendelserRiverTest {
                         avdoedFylteSeksten = null,
                         avdoedFyllerSeksti = null,
                     ),
+                overstyrtNorskPoengaar = null,
             )
         val fnr = Folkeregisteridentifikator.of("12101376212")
         val request =
@@ -179,6 +180,7 @@ internal class MigreringHendelserRiverTest {
                         avdoedFylteSeksten = null,
                         avdoedFyllerSeksti = null,
                     ),
+                overstyrtNorskPoengaar = null,
             )
         val fnr = Folkeregisteridentifikator.of("12101376212")
         val request =
@@ -268,6 +270,7 @@ internal class MigreringHendelserRiverTest {
                         avdoedFylteSeksten = null,
                         avdoedFyllerSeksti = null,
                     ),
+                overstyrtNorskPoengaar = null,
             )
         val fnr = Folkeregisteridentifikator.of("12101376212")
         val request =

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/Trygdetid.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/Trygdetid.kt
@@ -18,6 +18,7 @@ data class Trygdetid(
     val trygdetidGrunnlag: List<TrygdetidGrunnlag> = emptyList(),
     val opplysninger: List<Opplysningsgrunnlag> = emptyList(),
     val beregnetTrygdetid: DetaljertBeregnetTrygdetid? = null,
+    val overstyrtNorskPoengaar: Int? = null,
 ) {
     fun leggTilEllerOppdaterTrygdetidGrunnlag(nyttTrygdetidGrunnlag: TrygdetidGrunnlag): Trygdetid {
         val normalisertNyttTrygdetidGrunnlag = listOf(nyttTrygdetidGrunnlag).normaliser().first()

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidBeregningService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidBeregningService.kt
@@ -12,8 +12,8 @@ import no.nav.etterlatte.libs.regler.eksekver
 import no.nav.etterlatte.trygdetid.regler.TotalTrygdetidGrunnlag
 import no.nav.etterlatte.trygdetid.regler.TrygdetidGrunnlagMedAvdoed
 import no.nav.etterlatte.trygdetid.regler.TrygdetidGrunnlagMedAvdoedGrunnlag
-import no.nav.etterlatte.trygdetid.regler.TrygdetidPeriodMedPoengAar
 import no.nav.etterlatte.trygdetid.regler.TrygdetidPeriodeGrunnlag
+import no.nav.etterlatte.trygdetid.regler.TrygdetidPeriodeMedPoengaar
 import no.nav.etterlatte.trygdetid.regler.beregnDetaljertBeregnetTrygdetid
 import no.nav.etterlatte.trygdetid.regler.beregnTrygdetidForPeriode
 import no.nav.etterlatte.trygdetid.regler.totalTrygdetidYrkesskade
@@ -111,7 +111,7 @@ object TrygdetidBeregningService {
                 periode =
                     FaktumNode(
                         verdi =
-                            TrygdetidPeriodMedPoengAar(
+                            TrygdetidPeriodeMedPoengaar(
                                 fra = trygdetidGrunnlag.periode.fra,
                                 til = trygdetidGrunnlag.periode.til,
                                 poengInnAar = trygdetidGrunnlag.poengInnAar,

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRepository.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRepository.kt
@@ -50,7 +50,8 @@ class TrygdetidRepository(private val dataSource: DataSource) {
                         prorata_broek_nevner,
                         trygdetid_tidspunkt,
                         trygdetid_regelresultat,
-                        beregnet_trygdetid_overstyrt
+                        beregnet_trygdetid_overstyrt,
+                        poengaar_overstyrt
                     FROM trygdetid 
                     WHERE behandling_id = :behandlingId
                     """.trimIndent(),
@@ -84,6 +85,8 @@ class TrygdetidRepository(private val dataSource: DataSource) {
     ): Trygdetid =
         dataSource.transaction { tx ->
             val gjeldendeTrygdetid = hentTrygdtidNotNull(oppdatertTrygdetid.behandlingId)
+
+            oppdaterOverstyrtPoengaar(gjeldendeTrygdetid.behandlingId, oppdatertTrygdetid.overstyrtNorskPoengaar, tx)
 
             // opprett grunnlag
             oppdatertTrygdetid.trygdetidGrunnlag
@@ -249,6 +252,27 @@ class TrygdetidRepository(private val dataSource: DataSource) {
                     "id" to trygdetidGrunnlagId,
                 ),
         ).let { query -> tx.update(query) }
+    }
+
+    private fun oppdaterOverstyrtPoengaar(
+        behandlingId: UUID,
+        overstyrtNorskPoengaar: Int? = null,
+        tx: TransactionalSession,
+    ) {
+        queryOf(
+            statement =
+                """
+                UPDATE trygdetid 
+                  SET poengaar_overstyrt = :overstyrtNorskPoengaar WHERE behandling_id = :behandlingId
+                """.trimIndent(),
+            paramMap =
+                mapOf(
+                    "behandlingId" to behandlingId,
+                    "overstyrtNorskPoengaar" to overstyrtNorskPoengaar,
+                ),
+        ).let { query ->
+            tx.update(query)
+        }
     }
 
     private fun oppdaterBeregnetTrygdetid(
@@ -472,6 +496,7 @@ class TrygdetidRepository(private val dataSource: DataSource) {
             },
         trygdetidGrunnlag = trygdetidGrunnlag,
         opplysninger = opplysninger,
+        overstyrtNorskPoengaar = intOrNull("poengaar_overstyrt"),
     )
 
     private fun Row.toTrygdetidGrunnlag() =

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRepository.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRepository.kt
@@ -86,7 +86,7 @@ class TrygdetidRepository(private val dataSource: DataSource) {
         dataSource.transaction { tx ->
             val gjeldendeTrygdetid = hentTrygdtidNotNull(oppdatertTrygdetid.behandlingId)
 
-            oppdaterOverstyrtPoengaar(gjeldendeTrygdetid.behandlingId, oppdatertTrygdetid.overstyrtNorskPoengaar, tx)
+            oppdaterOverstyrtPoengaar(gjeldendeTrygdetid.id, gjeldendeTrygdetid.behandlingId, oppdatertTrygdetid.overstyrtNorskPoengaar, tx)
 
             // opprett grunnlag
             oppdatertTrygdetid.trygdetidGrunnlag
@@ -255,6 +255,7 @@ class TrygdetidRepository(private val dataSource: DataSource) {
     }
 
     private fun oppdaterOverstyrtPoengaar(
+        id: UUID,
         behandlingId: UUID,
         overstyrtNorskPoengaar: Int? = null,
         tx: TransactionalSession,
@@ -263,10 +264,11 @@ class TrygdetidRepository(private val dataSource: DataSource) {
             statement =
                 """
                 UPDATE trygdetid 
-                  SET poengaar_overstyrt = :overstyrtNorskPoengaar WHERE behandling_id = :behandlingId
+                  SET poengaar_overstyrt = :overstyrtNorskPoengaar WHERE id = :id AND  behandling_id = :behandlingId
                 """.trimIndent(),
             paramMap =
                 mapOf(
+                    "id" to id,
                     "behandlingId" to behandlingId,
                     "overstyrtNorskPoengaar" to overstyrtNorskPoengaar,
                 ),

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
@@ -25,6 +25,7 @@ import no.nav.etterlatte.libs.common.trygdetid.OpplysningsgrunnlagDto
 import no.nav.etterlatte.libs.common.trygdetid.TrygdetidDto
 import no.nav.etterlatte.libs.common.trygdetid.TrygdetidGrunnlagDto
 import no.nav.etterlatte.libs.common.trygdetid.TrygdetidGrunnlagKildeDto
+import no.nav.etterlatte.libs.common.trygdetid.TrygdetidOverstyringDto
 import no.nav.etterlatte.libs.common.uuid
 import no.nav.etterlatte.libs.common.withBehandlingId
 import no.nav.etterlatte.libs.common.withParam
@@ -56,6 +57,20 @@ fun Route.trygdetid(
             withBehandlingId(behandlingKlient) {
                 logger.info("Oppretter trygdetid for behandling $behandlingsId")
                 val trygdetid = trygdetidService.opprettTrygdetid(behandlingsId, brukerTokenInfo)
+                call.respond(trygdetid.toDto())
+            }
+        }
+
+        post("overstyr") {
+            withBehandlingId(behandlingKlient) {
+                logger.info("Oppdater trygdetid (overstyring) for behandling $behandlingsId")
+                val trygdetidOverstyringDto = call.receive<TrygdetidOverstyringDto>()
+
+                val trygdetid =
+                    trygdetidService.overstyrNorskPoengaar(
+                        behandlingsId,
+                        trygdetidOverstyringDto.overstyrtNorskPoengaar,
+                    )
                 call.respond(trygdetid.toDto())
             }
         }

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
@@ -153,6 +153,7 @@ fun Trygdetid.toDto(): TrygdetidDto =
         beregnetTrygdetid = beregnetTrygdetid?.toDto(),
         trygdetidGrunnlag = trygdetidGrunnlag.map { it.toDto() },
         opplysninger = this.opplysninger.toDto(),
+        overstyrtNorskPoengaar = this.overstyrtNorskPoengaar,
     )
 
 private fun DetaljertBeregnetTrygdetid.toDto(): DetaljertBeregnetTrygdetidDto =

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
@@ -68,6 +68,7 @@ fun Route.trygdetid(
 
                 val trygdetid =
                     trygdetidService.overstyrNorskPoengaar(
+                        trygdetidOverstyringDto.id,
                         behandlingsId,
                         trygdetidOverstyringDto.overstyrtNorskPoengaar,
                     )

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -344,12 +344,14 @@ class TrygdetidService(
     }
 
     fun overstyrNorskPoengaar(
+        id: UUID,
         behandlingsId: UUID,
         overstyrtNorskPoengaar: Int?,
     ): Trygdetid {
+        // TODO - EY-2849 - må bruke ID og ikke bare behandlingsId for å hente her
         val trygdetid =
             trygdetidRepository.hentTrygdetid(behandlingsId)
-                ?: throw Exception("Fant ikke gjeldende trygdetid for behandlingId=$behandlingsId")
+                ?: throw Exception("Fant ikke gjeldende trygdetid for id=$id og behandlingId=$behandlingsId")
 
         return trygdetidRepository.oppdaterTrygdetid(trygdetid.copy(overstyrtNorskPoengaar = overstyrtNorskPoengaar))
     }

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -342,4 +342,15 @@ class TrygdetidService(
             trygdetidRepository.oppdaterTrygdetid(nyTrygdetid, true)
         }
     }
+
+    fun overstyrNorskPoengaar(
+        behandlingsId: UUID,
+        overstyrtNorskPoengaar: Int?,
+    ): Trygdetid {
+        val trygdetid =
+            trygdetidRepository.hentTrygdetid(behandlingsId)
+                ?: throw Exception("Fant ikke gjeldende trygdetid for behandlingId=$behandlingsId")
+
+        return trygdetidRepository.oppdaterTrygdetid(trygdetid.copy(overstyrtNorskPoengaar = overstyrtNorskPoengaar))
+    }
 }

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/regler/BeregnTrygdetid.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/regler/BeregnTrygdetid.kt
@@ -26,7 +26,7 @@ import kotlin.math.round
 // TODO dato settes riktig senere
 val TRYGDETID_DATO: LocalDate = LocalDate.of(1900, 1, 1)
 
-data class TrygdetidPeriodMedPoengAar(
+data class TrygdetidPeriodeMedPoengaar(
     val fra: LocalDate,
     val til: LocalDate,
     val poengInnAar: Boolean,
@@ -34,14 +34,14 @@ data class TrygdetidPeriodMedPoengAar(
 )
 
 data class TrygdetidPeriodeGrunnlag(
-    val periode: FaktumNode<TrygdetidPeriodMedPoengAar>,
+    val periode: FaktumNode<TrygdetidPeriodeMedPoengaar>,
 )
 
 data class TotalTrygdetidGrunnlag(
     val beregnetTrygdetidPerioder: FaktumNode<List<Period>>,
 )
 
-val periode: Regel<TrygdetidPeriodeGrunnlag, TrygdetidPeriodMedPoengAar> =
+val periode: Regel<TrygdetidPeriodeGrunnlag, TrygdetidPeriodeMedPoengaar> =
     finnFaktumIGrunnlag(
         gjelderFra = TRYGDETID_DATO,
         beskrivelse = "Finner trygdetidsperiode fra grunnlag",
@@ -55,23 +55,23 @@ val beregnTrygdetidForPeriode =
         beskrivelse = "Beregner trygdetid fra og med periodeFra til og med periodeTil i år, måneder og dager",
         regelReferanse = RegelReferanse(id = "REGEL-TRYGDETID-BEREGNE-PERIODE"),
     ) benytter periode med { periode ->
-        fun TrygdetidPeriodMedPoengAar.erEttPoengAar() = fra.year == til.year && (poengInnAar || poengUtAar)
+        fun TrygdetidPeriodeMedPoengaar.erEttPoengaar() = fra.year == til.year && (poengInnAar || poengUtAar)
 
-        fun TrygdetidPeriodMedPoengAar.poengJustertFra() =
+        fun TrygdetidPeriodeMedPoengaar.poengJustertFra() =
             if (poengInnAar) {
                 fra.with(MonthDay.of(Month.JANUARY, 1))
             } else {
                 fra
             }
 
-        fun TrygdetidPeriodMedPoengAar.poengJustertTil() =
+        fun TrygdetidPeriodeMedPoengaar.poengJustertTil() =
             if (poengUtAar) {
                 til.with(MonthDay.of(Month.DECEMBER, 31))
             } else {
                 til
             }
 
-        if (periode.erEttPoengAar()) {
+        if (periode.erEttPoengaar()) {
             Period.ofYears(1)
         } else {
             Period.between(periode.poengJustertFra(), periode.poengJustertTil().plusDays(1))

--- a/apps/etterlatte-trygdetid/src/main/resources/db/migration/V14__legg_til_overstyrt_poengaar.sql
+++ b/apps/etterlatte-trygdetid/src/main/resources/db/migration/V14__legg_til_overstyrt_poengaar.sql
@@ -1,0 +1,1 @@
+ALTER TABLE trygdetid ADD COLUMN poengaar_overstyrt BIGINT;

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidRepositoryTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidRepositoryTest.kt
@@ -296,6 +296,22 @@ internal class TrygdetidRepositoryTest {
     }
 
     @Test
+    fun `skal oppdatere trygdetid with overstyrt poengaar`() {
+        val behandling = behandlingMock()
+        val opprettetTrygdetid = trygdetid(behandling.id, behandling.sak)
+
+        val trygdetid = repository.opprettTrygdetid(opprettetTrygdetid)
+
+        val trygdetidMedOverstyrtPoengaar =
+            repository.oppdaterTrygdetid(
+                trygdetid.copy(overstyrtNorskPoengaar = 10),
+            )
+
+        trygdetidMedOverstyrtPoengaar shouldNotBe null
+        trygdetidMedOverstyrtPoengaar.overstyrtNorskPoengaar shouldBe 10
+    }
+
+    @Test
     fun `skal nullstille beregnet trygdetid`() {
         val beregnetTrygdetid = beregnetTrygdetid(total = 12, tidspunkt = Tidspunkt.now())
         val behandling = behandlingMock()

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
@@ -894,4 +894,25 @@ internal class TrygdetidServiceTest {
             vilkaarsvurderingDto.isYrkesskade()
         }
     }
+
+    @Test
+    fun `skal oppdater overstyrt poengaar`() {
+        val behandlingId = randomUUID()
+
+        coEvery { repository.hentTrygdetid(any()) } returns trygdetid(behandlingId)
+        coEvery { repository.oppdaterTrygdetid(any(), any()) } returnsArgument 0
+
+        val trygdetid =
+            runBlocking {
+                service.overstyrNorskPoengaar(behandlingId, 10)
+            }
+
+        trygdetid shouldNotBe null
+        trygdetid.overstyrtNorskPoengaar shouldBe 10
+
+        verify(exactly = 1) {
+            repository.hentTrygdetid(behandlingId)
+            repository.oppdaterTrygdetid(trygdetid, false)
+        }
+    }
 }

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
@@ -899,12 +899,14 @@ internal class TrygdetidServiceTest {
     fun `skal oppdater overstyrt poengaar`() {
         val behandlingId = randomUUID()
 
-        coEvery { repository.hentTrygdetid(any()) } returns trygdetid(behandlingId)
+        val eksisterendeTrygdetid = trygdetid(behandlingId)
+
+        coEvery { repository.hentTrygdetid(any()) } returns eksisterendeTrygdetid
         coEvery { repository.oppdaterTrygdetid(any(), any()) } returnsArgument 0
 
         val trygdetid =
             runBlocking {
-                service.overstyrNorskPoengaar(behandlingId, 10)
+                service.overstyrNorskPoengaar(eksisterendeTrygdetid.id, behandlingId, 10)
             }
 
         trygdetid shouldNotBe null

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/regler/BeregnTrygdetidTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/regler/BeregnTrygdetidTest.kt
@@ -16,8 +16,8 @@ import no.nav.etterlatte.trygdetid.TrygdetidType
 import no.nav.etterlatte.trygdetid.regler.TotalTrygdetidGrunnlag
 import no.nav.etterlatte.trygdetid.regler.TrygdetidGrunnlagMedAvdoed
 import no.nav.etterlatte.trygdetid.regler.TrygdetidGrunnlagMedAvdoedGrunnlag
-import no.nav.etterlatte.trygdetid.regler.TrygdetidPeriodMedPoengAar
 import no.nav.etterlatte.trygdetid.regler.TrygdetidPeriodeGrunnlag
+import no.nav.etterlatte.trygdetid.regler.TrygdetidPeriodeMedPoengaar
 import no.nav.etterlatte.trygdetid.regler.beregnAntallAarTotalTrygdetid
 import no.nav.etterlatte.trygdetid.regler.beregnDetaljertBeregnetTrygdetid
 import no.nav.etterlatte.trygdetid.regler.beregnTrygdetidForPeriode
@@ -42,7 +42,7 @@ internal class BeregnTrygdetidTest {
                 periode =
                     FaktumNode(
                         verdi =
-                            TrygdetidPeriodMedPoengAar(
+                            TrygdetidPeriodeMedPoengaar(
                                 fra = LocalDate.of(2023, 1, 1),
                                 til = LocalDate.of(2023, 1, 31),
                                 poengInnAar = false,
@@ -65,7 +65,7 @@ internal class BeregnTrygdetidTest {
                 periode =
                     FaktumNode(
                         verdi =
-                            TrygdetidPeriodMedPoengAar(
+                            TrygdetidPeriodeMedPoengaar(
                                 fra = LocalDate.of(2023, 1, 1),
                                 til = LocalDate.of(2023, 1, 1),
                                 poengInnAar = false,
@@ -88,7 +88,7 @@ internal class BeregnTrygdetidTest {
                 periode =
                     FaktumNode(
                         verdi =
-                            TrygdetidPeriodMedPoengAar(
+                            TrygdetidPeriodeMedPoengaar(
                                 fra = LocalDate.of(2023, 1, 1),
                                 til = LocalDate.of(2024, 2, 1),
                                 poengInnAar = false,
@@ -105,7 +105,7 @@ internal class BeregnTrygdetidTest {
     }
 
     @ParameterizedTest(name = "fra {0} til {1} poengInnAar {2} poengUtAar {3} skal gi periode {4}")
-    @MethodSource("verdierForPoengAarTest")
+    @MethodSource("verdierForPoengaarTest")
     fun `beregnTrygdetidMellomToDatoer skal ta hensyn til poengInnAar og poengUtAar`(
         fra: LocalDate,
         til: LocalDate,
@@ -118,7 +118,7 @@ internal class BeregnTrygdetidTest {
                 periode =
                     FaktumNode(
                         verdi =
-                            TrygdetidPeriodMedPoengAar(
+                            TrygdetidPeriodeMedPoengaar(
                                 fra = fra,
                                 til = til,
                                 poengInnAar = poengInnAar,
@@ -278,7 +278,7 @@ internal class BeregnTrygdetidTest {
 
     companion object {
         @JvmStatic
-        fun verdierForPoengAarTest(): Stream<Arguments> =
+        fun verdierForPoengaarTest(): Stream<Arguments> =
             Stream.of(
                 Arguments.of(LocalDate.of(2023, 5, 10), LocalDate.of(2023, 5, 30), false, false, Period.ofDays(21)),
                 Arguments.of(LocalDate.of(2023, 5, 10), LocalDate.of(2023, 5, 30), false, true, Period.ofYears(1)),

--- a/libs/etterlatte-trygdetid-model/src/main/kotlin/Trygdetid.kt
+++ b/libs/etterlatte-trygdetid-model/src/main/kotlin/Trygdetid.kt
@@ -13,6 +13,12 @@ data class TrygdetidDto(
     val beregnetTrygdetid: DetaljertBeregnetTrygdetidDto?,
     val trygdetidGrunnlag: List<TrygdetidGrunnlagDto>,
     val opplysninger: GrunnlagOpplysningerDto,
+    val overstyrtNorskPoengaar: Int?,
+)
+
+data class TrygdetidOverstyringDto(
+    val behandlingId: UUID,
+    val overstyrtNorskPoengaar: Int?,
 )
 
 data class GrunnlagOpplysningerDto(

--- a/libs/etterlatte-trygdetid-model/src/main/kotlin/Trygdetid.kt
+++ b/libs/etterlatte-trygdetid-model/src/main/kotlin/Trygdetid.kt
@@ -17,6 +17,7 @@ data class TrygdetidDto(
 )
 
 data class TrygdetidOverstyringDto(
+    val id: UUID,
     val behandlingId: UUID,
     val overstyrtNorskPoengaar: Int?,
 )


### PR DESCRIPTION
EY-2924 - "legg til ny felt" del av EY-2912 - for norsk poengår overstyring (er to andre subtasker under 2912 - en for å kun vise det gitt riktig vilkår og en for å bruke verdi i beregningen)