### PR TITLE
fjerne constraint på sakId i behandling_versjon

### DIFF
--- a/apps/etterlatte-grunnlag/src/main/resources/db/migration/V18__fjerne_unique_constraint.sql
+++ b/apps/etterlatte-grunnlag/src/main/resources/db/migration/V18__fjerne_unique_constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE behandling_versjon DROP CONSTRAINT behandling_versjon_sak_id_key;


### PR DESCRIPTION
Unique constraint som ikke skulle vært der. Sak kan ha flere behandlinger, så unique sak_id blir feil. 