### PR TITLE
EY-2849 Trygdetidservice håndterer flere trygdetider per behandling

### DIFF
--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacadeImplTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacadeImplTest.kt
@@ -35,6 +35,7 @@ import no.nav.etterlatte.libs.common.vedtak.VedtakDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakFattet
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
+import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import no.nav.etterlatte.token.BrukerTokenInfo
@@ -229,7 +230,7 @@ internal class BrevdataFacadeImplTest {
                     avdoedFyllerSeksti = null,
                 ),
             overstyrtNorskPoengaar = null,
-            ident = null,
+            ident = AVDOED_FOEDSELSNUMMER.value,
         )
 
     private fun opprettBeregning() =

--- a/apps/etterlatte-trygdetid-kafka/src/test/kotlin/MigreringHendelserRiverTest.kt
+++ b/apps/etterlatte-trygdetid-kafka/src/test/kotlin/MigreringHendelserRiverTest.kt
@@ -63,7 +63,7 @@ internal class MigreringHendelserRiverTest {
                         avdoedFyllerSeksti = null,
                     ),
                 overstyrtNorskPoengaar = null,
-                ident = null,
+                ident = AVDOED_FOEDSELSNUMMER.value,
             )
         val request =
             MigreringRequest(
@@ -183,7 +183,7 @@ internal class MigreringHendelserRiverTest {
                         avdoedFyllerSeksti = null,
                     ),
                 overstyrtNorskPoengaar = null,
-                ident = null,
+                ident = AVDOED_FOEDSELSNUMMER.value,
             )
         val request =
             MigreringRequest(
@@ -273,7 +273,7 @@ internal class MigreringHendelserRiverTest {
                         avdoedFyllerSeksti = null,
                     ),
                 overstyrtNorskPoengaar = null,
-                ident = null,
+                ident = AVDOED_FOEDSELSNUMMER.value,
             )
         val request =
             MigreringRequest(

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/Trygdetid.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/Trygdetid.kt
@@ -13,7 +13,7 @@ import java.util.UUID.randomUUID
 
 data class Trygdetid(
     val id: UUID = randomUUID(),
-    val ident: String?,
+    val ident: String,
     val sakId: Long,
     val behandlingId: UUID,
     val trygdetidGrunnlag: List<TrygdetidGrunnlag> = emptyList(),

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRepository.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRepository.kt
@@ -89,16 +89,25 @@ class TrygdetidRepository(private val dataSource: DataSource) {
             if (trygdetid.beregnetTrygdetid != null) {
                 oppdaterBeregnetTrygdetid(trygdetid.behandlingId, trygdetid.beregnetTrygdetid, tx)
             }
-        }.let { hentTrygdtidNotNull(trygdetid.behandlingId) }
+        }.let { hentTrygdetidMedIdNotNull(behandlingsId = trygdetid.behandlingId, trygdetidId = trygdetid.id) }
 
     fun oppdaterTrygdetid(
         oppdatertTrygdetid: Trygdetid,
         overstyrt: Boolean = false,
     ): Trygdetid =
         dataSource.transaction { tx ->
-            val gjeldendeTrygdetid = hentTrygdtidNotNull(oppdatertTrygdetid.behandlingId)
+            val gjeldendeTrygdetid =
+                hentTrygdetidMedIdNotNull(
+                    behandlingsId = oppdatertTrygdetid.behandlingId,
+                    trygdetidId = oppdatertTrygdetid.id,
+                )
 
-            oppdaterOverstyrtPoengaar(gjeldendeTrygdetid.id, gjeldendeTrygdetid.behandlingId, oppdatertTrygdetid.overstyrtNorskPoengaar, tx)
+            oppdaterOverstyrtPoengaar(
+                gjeldendeTrygdetid.id,
+                gjeldendeTrygdetid.behandlingId,
+                oppdatertTrygdetid.overstyrtNorskPoengaar,
+                tx,
+            )
 
             // opprett grunnlag
             oppdatertTrygdetid.trygdetidGrunnlag
@@ -127,7 +136,7 @@ class TrygdetidRepository(private val dataSource: DataSource) {
             } else {
                 nullstillBeregnetTrygdetid(oppdatertTrygdetid.behandlingId, tx)
             }
-        }.let { hentTrygdtidNotNull(oppdatertTrygdetid.behandlingId) }
+        }.let { hentTrygdetidMedIdNotNull(oppdatertTrygdetid.behandlingId, oppdatertTrygdetid.id) }
 
     private fun opprettTrygdetid(
         trygdetid: Trygdetid,
@@ -426,9 +435,11 @@ class TrygdetidRepository(private val dataSource: DataSource) {
             )
         }
 
-    private fun hentTrygdtidNotNull(behandlingsId: UUID) =
-        hentTrygdetiderForBehandling(behandlingsId).firstOrNull()
-            ?: throw Exception("Fant ikke trygdetid for $behandlingsId")
+    private fun hentTrygdetidMedIdNotNull(
+        behandlingsId: UUID,
+        trygdetidId: UUID,
+    ) = hentTrygdetidMedId(behandlingsId, trygdetidId)
+        ?: throw Exception("Fant ikke trygdetid for $behandlingsId")
 
     private fun Row.toFaktiskTrygdetid(
         totalColumn: String,

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRepository.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRepository.kt
@@ -22,7 +22,18 @@ import java.util.UUID
 import javax.sql.DataSource
 
 class TrygdetidRepository(private val dataSource: DataSource) {
-    fun hentTrygdetid(behandlingId: UUID): Trygdetid? =
+    fun hentTrygdetidMedId(
+        behandlingId: UUID,
+        trygdetidId: UUID,
+    ): Trygdetid? {
+        return hentTrygdetiderForBehandling(behandlingId).find { it.id == trygdetidId }
+    }
+
+    fun hentTrygdetid(behandlingId: UUID): Trygdetid? {
+        return hentTrygdetiderForBehandling(behandlingId).firstOrNull()
+    }
+
+    fun hentTrygdetiderForBehandling(behandlingId: UUID): List<Trygdetid> =
         using(sessionOf(dataSource)) { session ->
             queryOf(
                 statement =
@@ -64,7 +75,7 @@ class TrygdetidRepository(private val dataSource: DataSource) {
                         val trygdetidGrunnlag = hentTrygdetidGrunnlag(trygdetidId)
                         val opplysninger = hentGrunnlagOpplysninger(trygdetidId)
                         row.toTrygdetid(trygdetidGrunnlag, opplysninger)
-                    }.asSingle,
+                    }.asList,
                 )
             }
         }
@@ -416,7 +427,7 @@ class TrygdetidRepository(private val dataSource: DataSource) {
         }
 
     private fun hentTrygdtidNotNull(behandlingsId: UUID) =
-        hentTrygdetid(behandlingsId)
+        hentTrygdetiderForBehandling(behandlingsId).firstOrNull()
             ?: throw Exception("Fant ikke trygdetid for $behandlingsId")
 
     private fun Row.toFaktiskTrygdetid(

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRepository.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRepository.kt
@@ -512,7 +512,7 @@ class TrygdetidRepository(private val dataSource: DataSource) {
         trygdetidGrunnlag = trygdetidGrunnlag,
         opplysninger = opplysninger,
         overstyrtNorskPoengaar = intOrNull("poengaar_overstyrt"),
-        ident = stringOrNull("ident"),
+        ident = string("ident"),
     )
 
     private fun Row.toTrygdetidGrunnlag() =

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TestHelper.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TestHelper.kt
@@ -59,7 +59,7 @@ fun behandling(
 fun trygdetid(
     behandlingId: UUID = randomUUID(),
     sakId: Long = 1,
-    ident: String? = "en ident",
+    ident: String = "en ident",
     beregnetTrygdetid: DetaljertBeregnetTrygdetid? = null,
     trygdetidGrunnlag: List<TrygdetidGrunnlag> = emptyList(),
     opplysninger: List<Opplysningsgrunnlag> = emptyList(),

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
@@ -25,21 +25,23 @@ import no.nav.etterlatte.libs.common.grunnlag.Opplysning
 import no.nav.etterlatte.libs.common.grunnlag.hentDoedsdato
 import no.nav.etterlatte.libs.common.grunnlag.hentFoedselsdato
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingDto
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.trygdetid.LandNormalisert
+import no.nav.etterlatte.trygdetid.ManglerForrigeTrygdetidMaaReguleresManuelt
 import no.nav.etterlatte.trygdetid.Opplysningsgrunnlag
+import no.nav.etterlatte.trygdetid.TrygdetidAlleredeOpprettetException
 import no.nav.etterlatte.trygdetid.TrygdetidBeregningService
 import no.nav.etterlatte.trygdetid.TrygdetidOpplysningType
-import no.nav.etterlatte.trygdetid.TrygdetidPeriode
 import no.nav.etterlatte.trygdetid.TrygdetidRepository
+import no.nav.etterlatte.trygdetid.TrygdetidService
 import no.nav.etterlatte.trygdetid.TrygdetidServiceImpl
 import no.nav.etterlatte.trygdetid.klienter.BehandlingKlient
 import no.nav.etterlatte.trygdetid.klienter.GrunnlagKlient
 import no.nav.etterlatte.trygdetid.klienter.VilkaarsvuderingKlient
-import no.nav.etterlatte.trygdetid.regler.periode
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -54,7 +56,7 @@ internal class TrygdetidServiceTest {
     private val grunnlagKlient: GrunnlagKlient = mockk()
     private val vilkaarsvurderingKlient: VilkaarsvuderingKlient = mockk()
     private val beregningService: TrygdetidBeregningService = spyk(TrygdetidBeregningService)
-    private val service =
+    private val service: TrygdetidService =
         TrygdetidServiceImpl(
             repository,
             behandlingKlient,
@@ -82,14 +84,14 @@ internal class TrygdetidServiceTest {
 
         every { vilkaarsvurderingDto.isYrkesskade() } returns false
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns vilkaarsvurderingDto
-        coEvery { repository.hentTrygdetid(any()) } returns trygdetid(behandlingId)
+        coEvery { repository.hentTrygdetiderForBehandling(any()) } returns listOf(trygdetid(behandlingId))
 
         val trygdetid = runBlocking { service.hentTrygdetid(behandlingId, saksbehandler) }
 
         trygdetid shouldNotBe null
 
         verify(exactly = 1) {
-            repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetiderForBehandling(behandlingId)
             vilkaarsvurderingDto.isYrkesskade()
         }
 
@@ -101,13 +103,13 @@ internal class TrygdetidServiceTest {
     @Test
     fun `skal returnere null hvis trygdetid ikke finnes for behandling`() {
         val behandlingId = randomUUID()
-        every { repository.hentTrygdetid(any()) } returns null
+        every { repository.hentTrygdetiderForBehandling(any()) } returns emptyList()
 
         val trygdetid = runBlocking { service.hentTrygdetid(behandlingId, saksbehandler) }
 
         trygdetid shouldBe null
 
-        verify(exactly = 1) { repository.hentTrygdetid(behandlingId) }
+        verify(exactly = 1) { repository.hentTrygdetiderForBehandling(behandlingId) }
     }
 
     @Test
@@ -125,7 +127,7 @@ internal class TrygdetidServiceTest {
         val forventetDoedsdato = grunnlag.hentAvdoed().hentDoedsdato()!!.verdi
         val trygdetid = trygdetid(behandlingId, sakId)
 
-        every { repository.hentTrygdetid(any()) } returns null
+        every { repository.hentTrygdetiderForBehandling(any()) } returns emptyList()
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
         coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
         every { repository.opprettTrygdetid(any()) } returns trygdetid
@@ -139,7 +141,7 @@ internal class TrygdetidServiceTest {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
             behandlingKlient.hentBehandling(behandlingId, saksbehandler)
             grunnlagKlient.hentGrunnlag(sakId, behandlingId, saksbehandler)
-            repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetiderForBehandling(behandlingId)
             repository.opprettTrygdetid(
                 withArg { trygdetid ->
                     trygdetid.opplysninger.let { opplysninger ->
@@ -192,13 +194,13 @@ internal class TrygdetidServiceTest {
 
         every { vilkaarsvurderingDto.isYrkesskade() } returns false
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns vilkaarsvurderingDto
-        every { repository.hentTrygdetid(behandlingId) } returns null
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
         coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
             SisteIverksatteBehandling(
                 forrigebehandlingId,
             )
-        every { repository.hentTrygdetid(forrigebehandlingId) } returns trygdetid
+        every { repository.hentTrygdetiderForBehandling(forrigebehandlingId) } returns listOf(trygdetid)
         every { repository.opprettTrygdetid(any()) } returns trygdetid
         coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
 
@@ -208,10 +210,10 @@ internal class TrygdetidServiceTest {
 
         coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
-            repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetiderForBehandling(behandlingId)
             behandlingKlient.hentBehandling(behandlingId, saksbehandler)
             behandlingKlient.hentSisteIverksatteBehandling(sakId, saksbehandler)
-            repository.hentTrygdetid(forrigebehandlingId)
+            repository.hentTrygdetiderForBehandling(forrigebehandlingId)
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
 
             repository.opprettTrygdetid(
@@ -245,13 +247,13 @@ internal class TrygdetidServiceTest {
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
         coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
-        every { repository.hentTrygdetid(behandlingId) } returns null
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
         coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
             SisteIverksatteBehandling(
                 forrigeBehandlingId,
             )
-        every { repository.hentTrygdetid(forrigeBehandlingId) } returns null
+        every { repository.hentTrygdetiderForBehandling(forrigeBehandlingId) } returns emptyList()
         every { repository.opprettTrygdetid(any()) } returns trygdetid
         coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
 
@@ -261,11 +263,11 @@ internal class TrygdetidServiceTest {
 
         coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
-            repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetiderForBehandling(behandlingId)
             behandlingKlient.hentBehandling(behandlingId, saksbehandler)
             behandlingKlient.hentSisteIverksatteBehandling(sakId, saksbehandler)
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
-            repository.hentTrygdetid(forrigeBehandlingId)
+            repository.hentTrygdetiderForBehandling(forrigeBehandlingId)
             grunnlagKlient.hentGrunnlag(any(), any(), any())
 
             repository.opprettTrygdetid(
@@ -295,29 +297,27 @@ internal class TrygdetidServiceTest {
                 every { prosesstype } returns Prosesstype.AUTOMATISK
             }
         val forrigeBehandlingId = randomUUID()
-        every { repository.hentTrygdetid(behandlingId) } returns null
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
         coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
             SisteIverksatteBehandling(
                 forrigeBehandlingId,
             )
-        every { repository.hentTrygdetid(forrigeBehandlingId) } returns null
+        every { repository.hentTrygdetiderForBehandling(forrigeBehandlingId) } returns emptyList()
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
 
         runBlocking {
-            val err =
-                assertThrows<RuntimeException> {
-                    service.opprettTrygdetid(behandlingId, saksbehandler)
-                }
-
-            err.message shouldBe "Forrige trygdetid for ${behandling.id} finnes ikke - må reguleres manuelt"
+            assertThrows<ManglerForrigeTrygdetidMaaReguleresManuelt> {
+                service.opprettTrygdetid(behandlingId, saksbehandler)
+            }
         }
 
         coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
-            repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetiderForBehandling(behandlingId)
             behandlingKlient.hentBehandling(behandlingId, saksbehandler)
             behandlingKlient.hentSisteIverksatteBehandling(sakId, saksbehandler)
-            repository.hentTrygdetid(forrigeBehandlingId)
+            repository.hentTrygdetiderForBehandling(forrigeBehandlingId)
         }
         verify {
             behandling.revurderingsaarsak
@@ -345,14 +345,14 @@ internal class TrygdetidServiceTest {
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
         coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
-        every { repository.hentTrygdetid(behandlingId) } returns null
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
         coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
             SisteIverksatteBehandling(
                 forrigeBehandlingId,
             )
         coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
-        every { repository.hentTrygdetid(forrigeBehandlingId) } returns null
+        every { repository.hentTrygdetiderForBehandling(forrigeBehandlingId) } returns emptyList()
         every { repository.opprettTrygdetid(any()) } returns trygdetid
 
         runBlocking {
@@ -361,11 +361,11 @@ internal class TrygdetidServiceTest {
 
         coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
-            repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetiderForBehandling(behandlingId)
             behandlingKlient.hentBehandling(behandlingId, saksbehandler)
             behandlingKlient.hentSisteIverksatteBehandling(sakId, saksbehandler)
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
-            repository.hentTrygdetid(forrigeBehandlingId)
+            repository.hentTrygdetiderForBehandling(forrigeBehandlingId)
             grunnlagKlient.hentGrunnlag(any(), any(), any())
 
             repository.opprettTrygdetid(
@@ -386,16 +386,16 @@ internal class TrygdetidServiceTest {
     @Test
     fun `skal feile ved opprettelse av trygdetid naar det allerede finnes for behandling`() {
         val behandlingId = randomUUID()
-        every { repository.hentTrygdetid(any()) } returns trygdetid(behandlingId)
+        every { repository.hentTrygdetiderForBehandling(any()) } returns listOf(trygdetid(behandlingId))
 
         runBlocking {
-            assertThrows<IllegalArgumentException> {
+            assertThrows<TrygdetidAlleredeOpprettetException> {
                 service.opprettTrygdetid(behandlingId, saksbehandler)
             }
         }
 
         coVerify(exactly = 1) {
-            repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetiderForBehandling(behandlingId)
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
         }
     }
@@ -417,11 +417,9 @@ internal class TrygdetidServiceTest {
     @Test
     fun `skal lagre nytt trygdetidsgrunnlag`() {
         val behandlingId = randomUUID()
-        val trygdetidGrunnlag =
-            trygdetidGrunnlag().copy(
-                periode = TrygdetidPeriode(LocalDate.now().minusYears(2), LocalDate.now().minusYears(1)),
-            )
-        val eksisterendeTrygdetid = trygdetid(behandlingId)
+        val avdoedIdent = "01478343724"
+        val trygdetidGrunnlag = trygdetidGrunnlag()
+        val eksisterendeTrygdetid = trygdetid(behandlingId, ident = avdoedIdent)
         val vilkaarsvurderingDto = mockk<VilkaarsvurderingDto>()
 
         val grunnlag = mockk<Grunnlag>()
@@ -431,15 +429,28 @@ internal class TrygdetidServiceTest {
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns vilkaarsvurderingDto
         coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
         every { repository.hentTrygdetid(behandlingId) } returns eksisterendeTrygdetid
+        every { repository.hentTrygdetidMedId(behandlingId, eksisterendeTrygdetid.id) } returns eksisterendeTrygdetid
         every { repository.oppdaterTrygdetid(any()) } answers { firstArg() }
         coEvery { behandlingKlient.hentBehandling(any(), any()) } answers { behandling(behandlingId = behandlingId) }
         coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
-        every { grunnlag.hentAvdoed() } returns avdoedGrunnlag
+        every { grunnlag.hentAvdoede() } returns listOf(avdoedGrunnlag)
         every { avdoedGrunnlag[Opplysningstype.FOEDSELSDATO] } answers {
             Opplysning.Konstant(
                 id = randomUUID(),
                 kilde = Grunnlagsopplysning.Saksbehandler("", Tidspunkt.now()),
                 verdi = LocalDate.now().toJsonNode(),
+            )
+        }
+        every { avdoedGrunnlag[Opplysningstype.FOEDSELSNUMMER] } answers {
+            Opplysning.Konstant(
+                id = randomUUID(),
+                kilde =
+                    Grunnlagsopplysning.Pdl(
+                        tidspunktForInnhenting = Tidspunkt.now(),
+                        registersReferanse = null,
+                        opplysningId = null,
+                    ),
+                verdi = Folkeregisteridentifikator.of(avdoedIdent).toJsonNode(),
             )
         }
         every { avdoedGrunnlag[Opplysningstype.DOEDSDATO] } answers {
@@ -460,16 +471,15 @@ internal class TrygdetidServiceTest {
             }
 
         with(trygdetid.trygdetidGrunnlag.first()) {
-            beregnetTrygdetid?.verdi shouldBe Period.of(1, 0, 1)
+            beregnetTrygdetid?.verdi shouldBe Period.of(0, 1, 1)
             beregnetTrygdetid?.regelResultat shouldNotBe null
             beregnetTrygdetid?.tidspunkt shouldNotBe null
         }
 
-        trygdetid.beregnetTrygdetid?.resultat?.samletTrygdetidNorge shouldBe 1
-
         coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
             repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetidMedId(behandlingId, trygdetid.id)
             repository.oppdaterTrygdetid(
                 withArg {
                     it.trygdetidGrunnlag.first().let { tg -> tg.id shouldBe trygdetidGrunnlag.id }
@@ -487,84 +497,8 @@ internal class TrygdetidServiceTest {
         verify {
             avdoedGrunnlag[Opplysningstype.FOEDSELSDATO]
             avdoedGrunnlag[Opplysningstype.DOEDSDATO]
-            grunnlag.hentAvdoed()
-        }
-    }
-
-    @Test
-    fun `skal lagre nytt trygdetidsgrunnlag med overstyrt poengaar`() {
-        val behandlingId = randomUUID()
-        val trygdetidGrunnlag =
-            trygdetidGrunnlag().copy(
-                periode = TrygdetidPeriode(LocalDate.now().minusYears(2), LocalDate.now().minusYears(1)),
-            )
-        val eksisterendeTrygdetid = trygdetid(behandlingId).copy(overstyrtNorskPoengaar = 10)
-        val vilkaarsvurderingDto = mockk<VilkaarsvurderingDto>()
-
-        val grunnlag = mockk<Grunnlag>()
-        val avdoedGrunnlag = mockk<Grunnlagsdata<JsonNode>>()
-
-        every { vilkaarsvurderingDto.isYrkesskade() } returns false
-        coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns vilkaarsvurderingDto
-        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
-        every { repository.hentTrygdetid(behandlingId) } returns eksisterendeTrygdetid
-        every { repository.oppdaterTrygdetid(any()) } answers { firstArg() }
-        coEvery { behandlingKlient.hentBehandling(any(), any()) } answers { behandling(behandlingId = behandlingId) }
-        coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
-        every { grunnlag.hentAvdoed() } returns avdoedGrunnlag
-        every { avdoedGrunnlag[Opplysningstype.FOEDSELSDATO] } answers {
-            Opplysning.Konstant(
-                id = randomUUID(),
-                kilde = Grunnlagsopplysning.Saksbehandler("", Tidspunkt.now()),
-                verdi = LocalDate.now().toJsonNode(),
-            )
-        }
-        every { avdoedGrunnlag[Opplysningstype.DOEDSDATO] } answers {
-            Opplysning.Konstant(
-                id = randomUUID(),
-                kilde = Grunnlagsopplysning.Saksbehandler("", Tidspunkt.now()),
-                verdi = LocalDate.now().toJsonNode(),
-            )
-        }
-
-        val trygdetid =
-            runBlocking {
-                service.lagreTrygdetidGrunnlag(
-                    behandlingId,
-                    saksbehandler,
-                    trygdetidGrunnlag,
-                )
-            }
-
-        with(trygdetid.trygdetidGrunnlag.first()) {
-            beregnetTrygdetid?.verdi shouldBe Period.of(1, 0, 1)
-            beregnetTrygdetid?.regelResultat shouldNotBe null
-            beregnetTrygdetid?.tidspunkt shouldNotBe null
-        }
-
-        trygdetid.beregnetTrygdetid?.resultat?.samletTrygdetidNorge shouldBe 10
-
-        coVerify(exactly = 1) {
-            behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
-            repository.hentTrygdetid(behandlingId)
-            repository.oppdaterTrygdetid(
-                withArg {
-                    it.trygdetidGrunnlag.first().let { tg -> tg.id shouldBe trygdetidGrunnlag.id }
-                },
-            )
-            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
-            beregningService.beregnTrygdetidGrunnlag(any())
-            beregningService.beregnTrygdetid(any(), any(), any(), any())
-            vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any())
-            vilkaarsvurderingDto.isYrkesskade()
-            behandlingKlient.hentBehandling(any(), any())
-            grunnlagKlient.hentGrunnlag(any(), behandlingId, any())
-        }
-
-        verify {
-            avdoedGrunnlag[Opplysningstype.FOEDSELSDATO]
-            avdoedGrunnlag[Opplysningstype.DOEDSDATO]
-            grunnlag.hentAvdoed()
+            avdoedGrunnlag[Opplysningstype.FOEDSELSNUMMER]
+            grunnlag.hentAvdoede()
         }
     }
 
@@ -572,7 +506,10 @@ internal class TrygdetidServiceTest {
     fun `skal oppdatere trygdetidsgrunnlag`() {
         val behandlingId = randomUUID()
         val trygdetidGrunnlag = trygdetidGrunnlag()
-        val eksisterendeTrygdetid = trygdetid(behandlingId, trygdetidGrunnlag = listOf(trygdetidGrunnlag))
+        val avdoedIdent = "01478343724"
+
+        val eksisterendeTrygdetid =
+            trygdetid(behandlingId, trygdetidGrunnlag = listOf(trygdetidGrunnlag), ident = avdoedIdent)
         val endretTrygdetidGrunnlag = trygdetidGrunnlag.copy(bosted = LandNormalisert.NORGE.isoCode)
         val vilkaarsvurderingDto = mockk<VilkaarsvurderingDto>()
 
@@ -581,17 +518,30 @@ internal class TrygdetidServiceTest {
         val avdoedGrunnlag = mockk<Grunnlagsdata<JsonNode>>()
 
         every { repository.hentTrygdetid(behandlingId) } returns eksisterendeTrygdetid
+        every { repository.hentTrygdetidMedId(behandlingId, eksisterendeTrygdetid.id) } returns eksisterendeTrygdetid
         every { repository.oppdaterTrygdetid(any()) } answers { firstArg() }
         every { vilkaarsvurderingDto.isYrkesskade() } returns false
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns vilkaarsvurderingDto
         coEvery { behandlingKlient.hentBehandling(any(), any()) } answers { behandling(behandlingId = behandlingId) }
         coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
-        every { grunnlag.hentAvdoed() } returns avdoedGrunnlag
+        every { grunnlag.hentAvdoede() } returns listOf(avdoedGrunnlag)
         every { avdoedGrunnlag[Opplysningstype.FOEDSELSDATO] } answers {
             Opplysning.Konstant(
                 id = randomUUID(),
                 kilde = Grunnlagsopplysning.Saksbehandler("", Tidspunkt.now()),
                 verdi = LocalDate.now().toJsonNode(),
+            )
+        }
+        every { avdoedGrunnlag[Opplysningstype.FOEDSELSNUMMER] } answers {
+            Opplysning.Konstant(
+                id = randomUUID(),
+                kilde =
+                    Grunnlagsopplysning.Pdl(
+                        tidspunktForInnhenting = Tidspunkt.now(),
+                        registersReferanse = null,
+                        opplysningId = null,
+                    ),
+                verdi = Folkeregisteridentifikator.of(avdoedIdent).toJsonNode(),
             )
         }
         every { avdoedGrunnlag[Opplysningstype.DOEDSDATO] } answers {
@@ -620,6 +570,7 @@ internal class TrygdetidServiceTest {
         coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
             repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetidMedId(behandlingId, eksisterendeTrygdetid.id)
             repository.oppdaterTrygdetid(
                 withArg {
                     it.trygdetidGrunnlag.first().let { tg ->
@@ -640,30 +591,47 @@ internal class TrygdetidServiceTest {
         verify {
             avdoedGrunnlag[Opplysningstype.FOEDSELSDATO]
             avdoedGrunnlag[Opplysningstype.DOEDSDATO]
-            grunnlag.hentAvdoed()
+            avdoedGrunnlag[Opplysningstype.FOEDSELSNUMMER]
+            grunnlag.hentAvdoede()
         }
     }
 
     @Test
     fun `skal slette trygdetidsgrunnlag`() {
         val behandlingId = randomUUID()
+        val avdoedIdent = "01478343724"
         val trygdetidGrunnlag = trygdetidGrunnlag()
-        val eksisterendeTrygdetid = trygdetid(behandlingId, trygdetidGrunnlag = listOf(trygdetidGrunnlag))
+        val eksisterendeTrygdetid =
+            trygdetid(behandlingId, trygdetidGrunnlag = listOf(trygdetidGrunnlag), ident = avdoedIdent)
 
         coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
         val grunnlag = mockk<Grunnlag>()
         val avdoedGrunnlag = mockk<Grunnlagsdata<JsonNode>>()
 
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns listOf(eksisterendeTrygdetid)
         every { repository.hentTrygdetid(behandlingId) } returns eksisterendeTrygdetid
+        every { repository.hentTrygdetidMedId(behandlingId, eksisterendeTrygdetid.id) } returns eksisterendeTrygdetid
         every { repository.oppdaterTrygdetid(any()) } answers { firstArg() }
         coEvery { behandlingKlient.hentBehandling(any(), any()) } answers { behandling(behandlingId = behandlingId) }
         coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns grunnlag
-        every { grunnlag.hentAvdoed() } returns avdoedGrunnlag
+        every { grunnlag.hentAvdoede() } returns listOf(avdoedGrunnlag)
         every { avdoedGrunnlag[Opplysningstype.FOEDSELSDATO] } answers {
             Opplysning.Konstant(
                 id = randomUUID(),
                 kilde = Grunnlagsopplysning.Saksbehandler("", Tidspunkt.now()),
                 verdi = LocalDate.now().toJsonNode(),
+            )
+        }
+        every { avdoedGrunnlag[Opplysningstype.FOEDSELSNUMMER] } answers {
+            Opplysning.Konstant(
+                id = randomUUID(),
+                kilde =
+                    Grunnlagsopplysning.Pdl(
+                        tidspunktForInnhenting = Tidspunkt.now(),
+                        registersReferanse = null,
+                        opplysningId = null,
+                    ),
+                verdi = Folkeregisteridentifikator.of(avdoedIdent).toJsonNode(),
             )
         }
         every { avdoedGrunnlag[Opplysningstype.DOEDSDATO] } answers {
@@ -685,6 +653,7 @@ internal class TrygdetidServiceTest {
         coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
             repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetidMedId(behandlingId, trygdetid.id)
             repository.oppdaterTrygdetid(
                 withArg {
                     it.trygdetidGrunnlag shouldBe emptyList()
@@ -698,7 +667,8 @@ internal class TrygdetidServiceTest {
         verify {
             avdoedGrunnlag[Opplysningstype.FOEDSELSDATO]
             avdoedGrunnlag[Opplysningstype.DOEDSDATO]
-            grunnlag.hentAvdoed()
+            avdoedGrunnlag[Opplysningstype.FOEDSELSNUMMER]
+            grunnlag.hentAvdoede()
         }
     }
 
@@ -706,6 +676,7 @@ internal class TrygdetidServiceTest {
     fun `skal feile ved lagring av trygdetidsgrunnlag hvis behandling er i feil tilstand`() {
         val behandlingId = randomUUID()
         val trygdetidGrunnlag = trygdetidGrunnlag()
+        coEvery { repository.hentTrygdetid(any()) } returns trygdetid(behandlingId)
         coEvery { behandlingKlient.kanOppdatereTrygdetid(any(), any()) } returns false
 
         runBlocking {
@@ -719,6 +690,7 @@ internal class TrygdetidServiceTest {
         }
 
         coVerify { behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler) }
+        coVerify { repository.hentTrygdetid(behandlingId) }
     }
 
     @Test
@@ -746,7 +718,7 @@ internal class TrygdetidServiceTest {
         every { vilkaarsvurderingDto.isYrkesskade() } returns false
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns vilkaarsvurderingDto
         coEvery { behandlingKlient.hentBehandling(behandlingId, saksbehandler) } returns regulering
-        every { repository.hentTrygdetid(forrigeBehandlingId) } returns forrigeTrygdetid
+        every { repository.hentTrygdetiderForBehandling(forrigeBehandlingId) } returns listOf(forrigeTrygdetid)
         every { repository.opprettTrygdetid(any()) } answers { firstArg() }
 
         runBlocking {
@@ -754,7 +726,7 @@ internal class TrygdetidServiceTest {
         }
 
         coVerify(exactly = 1) {
-            repository.hentTrygdetid(forrigeBehandlingId)
+            repository.hentTrygdetiderForBehandling(forrigeBehandlingId)
             behandlingKlient.hentBehandling(behandlingId, saksbehandler)
             repository.opprettTrygdetid(match { it.behandlingId == behandlingId })
             vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any())
@@ -775,8 +747,8 @@ internal class TrygdetidServiceTest {
         every { vilkaarsvurderingDto.isYrkesskade() } returns true
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns vilkaarsvurderingDto
         coEvery {
-            repository.hentTrygdetid(any())
-        } returns trygdetid(behandlingId).copy(beregnetTrygdetid = beregnetYrkesskadeTrygdetid())
+            repository.hentTrygdetiderForBehandling(any())
+        } returns listOf(trygdetid(behandlingId).copy(beregnetTrygdetid = beregnetYrkesskadeTrygdetid()))
 
         val trygdetid = runBlocking { service.hentTrygdetid(behandlingId, saksbehandler) }
 
@@ -784,7 +756,7 @@ internal class TrygdetidServiceTest {
         trygdetid?.beregnetTrygdetid?.resultat?.samletTrygdetidNorge shouldBe 40
 
         verify(exactly = 1) {
-            repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetiderForBehandling(behandlingId)
             vilkaarsvurderingDto.isYrkesskade()
         }
 
@@ -802,8 +774,8 @@ internal class TrygdetidServiceTest {
         every { vilkaarsvurderingDto.isYrkesskade() } returns true
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns vilkaarsvurderingDto
         coEvery {
-            repository.hentTrygdetid(any())
-        } returns trygdetid(behandlingId).copy(beregnetTrygdetid = beregnetTrygdetid(20))
+            repository.hentTrygdetiderForBehandling(any())
+        } returns listOf(trygdetid(behandlingId).copy(beregnetTrygdetid = beregnetTrygdetid(20)))
 
         val trygdetid = runBlocking { service.hentTrygdetid(behandlingId, saksbehandler) }
 
@@ -811,7 +783,7 @@ internal class TrygdetidServiceTest {
         trygdetid?.beregnetTrygdetid shouldBe null
 
         verify(exactly = 1) {
-            repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetiderForBehandling(behandlingId)
             vilkaarsvurderingDto.isYrkesskade()
         }
 
@@ -829,8 +801,8 @@ internal class TrygdetidServiceTest {
         every { vilkaarsvurderingDto.isYrkesskade() } returns false
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns vilkaarsvurderingDto
         coEvery {
-            repository.hentTrygdetid(any())
-        } returns trygdetid(behandlingId).copy(beregnetTrygdetid = beregnetYrkesskadeTrygdetid())
+            repository.hentTrygdetiderForBehandling(any())
+        } returns listOf(trygdetid(behandlingId).copy(beregnetTrygdetid = beregnetYrkesskadeTrygdetid()))
 
         val trygdetid = runBlocking { service.hentTrygdetid(behandlingId, saksbehandler) }
 
@@ -838,7 +810,7 @@ internal class TrygdetidServiceTest {
         trygdetid?.beregnetTrygdetid shouldBe null
 
         verify(exactly = 1) {
-            repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetiderForBehandling(behandlingId)
             vilkaarsvurderingDto.isYrkesskade()
         }
 
@@ -856,8 +828,8 @@ internal class TrygdetidServiceTest {
         every { vilkaarsvurderingDto.isYrkesskade() } returns false
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns vilkaarsvurderingDto
         coEvery {
-            repository.hentTrygdetid(any())
-        } returns trygdetid(behandlingId).copy(beregnetTrygdetid = beregnetTrygdetid(20))
+            repository.hentTrygdetiderForBehandling(any())
+        } returns listOf(trygdetid(behandlingId).copy(beregnetTrygdetid = beregnetTrygdetid(20)))
 
         val trygdetid = runBlocking { service.hentTrygdetid(behandlingId, saksbehandler) }
 
@@ -865,7 +837,7 @@ internal class TrygdetidServiceTest {
         trygdetid?.beregnetTrygdetid?.resultat?.samletTrygdetidNorge shouldBe 20
 
         verify(exactly = 1) {
-            repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetiderForBehandling(behandlingId)
             vilkaarsvurderingDto.isYrkesskade()
         }
 
@@ -884,8 +856,8 @@ internal class TrygdetidServiceTest {
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns vilkaarsvurderingDto
         coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
         every {
-            repository.hentTrygdetid(behandlingId)
-        } returns eksisterendeTrygdetid
+            repository.hentTrygdetiderForBehandling(behandlingId)
+        } returns listOf(eksisterendeTrygdetid)
         every { repository.oppdaterTrygdetid(any()) } answers { firstArg() }
 
         val trygdetid =
@@ -900,7 +872,7 @@ internal class TrygdetidServiceTest {
 
         coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
-            repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetiderForBehandling(behandlingId)
             repository.oppdaterTrygdetid(any())
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
             beregningService.beregnTrygdetidForYrkesskade(any())
@@ -919,8 +891,8 @@ internal class TrygdetidServiceTest {
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns vilkaarsvurderingDto
         coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
         every {
-            repository.hentTrygdetid(behandlingId)
-        } returns eksisterendeTrygdetid.copy(beregnetTrygdetid = beregnetTrygdetid(20))
+            repository.hentTrygdetiderForBehandling(behandlingId)
+        } returns listOf(eksisterendeTrygdetid.copy(beregnetTrygdetid = beregnetTrygdetid(20)))
         every { repository.oppdaterTrygdetid(any()) } answers { firstArg() }
 
         val trygdetid =
@@ -935,7 +907,7 @@ internal class TrygdetidServiceTest {
 
         coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
-            repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetiderForBehandling(behandlingId)
             repository.oppdaterTrygdetid(any())
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
             beregningService.beregnTrygdetidForYrkesskade(any())
@@ -954,8 +926,8 @@ internal class TrygdetidServiceTest {
         coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns vilkaarsvurderingDto
         coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
         every {
-            repository.hentTrygdetid(behandlingId)
-        } returns eksisterendeTrygdetid.copy(beregnetTrygdetid = beregnetYrkesskadeTrygdetid())
+            repository.hentTrygdetiderForBehandling(behandlingId)
+        } returns listOf(eksisterendeTrygdetid.copy(beregnetTrygdetid = beregnetYrkesskadeTrygdetid()))
         every { repository.oppdaterTrygdetid(any()) } answers { firstArg() }
 
         val trygdetid =
@@ -970,7 +942,7 @@ internal class TrygdetidServiceTest {
 
         coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
-            repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetiderForBehandling(behandlingId)
             repository.oppdaterTrygdetid(any())
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
             beregningService.beregnTrygdetidForYrkesskade(any())
@@ -985,7 +957,7 @@ internal class TrygdetidServiceTest {
 
         val eksisterendeTrygdetid = trygdetid(behandlingId)
 
-        coEvery { repository.hentTrygdetid(any()) } returns eksisterendeTrygdetid
+        coEvery { repository.hentTrygdetidMedId(any(), any()) } returns eksisterendeTrygdetid
         coEvery { repository.oppdaterTrygdetid(any(), any()) } returnsArgument 0
 
         val trygdetid =
@@ -997,7 +969,7 @@ internal class TrygdetidServiceTest {
         trygdetid.overstyrtNorskPoengaar shouldBe 10
 
         verify(exactly = 1) {
-            repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetidMedId(any(), any())
             repository.oppdaterTrygdetid(trygdetid, false)
         }
     }

--- a/libs/etterlatte-trygdetid-model/src/main/kotlin/Trygdetid.kt
+++ b/libs/etterlatte-trygdetid-model/src/main/kotlin/Trygdetid.kt
@@ -9,7 +9,7 @@ import java.util.UUID
 
 data class TrygdetidDto(
     val id: UUID,
-    val ident: String?,
+    val ident: String,
     val behandlingId: UUID,
     val beregnetTrygdetid: DetaljertBeregnetTrygdetidDto?,
     val trygdetidGrunnlag: List<TrygdetidGrunnlagDto>,


### PR DESCRIPTION
Setter opp et nytt interface for trygdetidservice, som har metoder som forstår flere trygdetider. Noen av de er ikke helt optimale (f.eks. yrkesskade) men der har vi uansett litt jobb å gjøre for å koble det fra vilkårsvurdering. 

Det nye interfacet brukes til å simulere det gamle interfacet (som fungerer topp så lenge vi kun har en trygdetid per behandling), og testene går fremdeles mot det gamle interfacet. Tenker å flytte testene over når det gamle interfacet fjernes.

Neste steg jeg ser for meg er å sette opp en v2 route for det nye api'et, og så se på å migrere konsumenter (i første omgang sannsynligvis beregning) over på det, for å kunne begynne å håndtere trygdetid til flere avdøde riktig i beregning.