### PR TITLE
EY-2917 Hente grunnlag med behandlingId

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
@@ -78,7 +78,7 @@ class BehandlingFactory(
                 lagOpplysning(Opplysningstype.SOEKNAD_MOTTATT_DATO, kilde, SoeknadMottattDato(mottattDato).toJsonNode()),
             )
 
-        grunnlagService.leggTilNyeOpplysninger(sak.id, behandling.id, NyeSaksopplysninger(opplysninger))
+        grunnlagService.leggTilNyeOpplysninger(behandling.id, NyeSaksopplysninger(sak.id, opplysninger))
 
         return behandling
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/GrunnlagService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/GrunnlagService.kt
@@ -26,11 +26,10 @@ class GrunnlagService(private val grunnlagKlient: GrunnlagKlientImpl) {
     }
 
     fun leggTilNyeOpplysninger(
-        sakId: Long,
         behandlingId: UUID,
         opplysninger: NyeSaksopplysninger,
     ) = runBlocking {
-        grunnlagKlient.lagreNyeSaksopplysninger(sakId, behandlingId, opplysninger)
+        grunnlagKlient.lagreNyeSaksopplysninger(opplysninger.sakId, behandlingId, opplysninger)
     }
 
     suspend fun hentPersongalleri(
@@ -47,7 +46,7 @@ class GrunnlagService(private val grunnlagKlient: GrunnlagKlientImpl) {
         persongalleri: Persongalleri,
     ): Opplysningsbehov {
         return Opplysningsbehov(
-            sakid = behandling.sak.id,
+            sakId = behandling.sak.id,
             sakType = behandling.sak.sakType,
             persongalleri = persongalleri,
         )

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/klienter/GrunnlagKlient.kt
@@ -54,7 +54,7 @@ class GrunnlagKlientImpl(
         opplysningsbehov: Opplysningsbehov,
     ) {
         return grunnlagHttpClient
-            .post("$url/grunnlag/sak/${opplysningsbehov.sakid}/behandling/$behandlingId/oppdater-grunnlag") {
+            .post("$url/grunnlag/sak/${opplysningsbehov.sakId}/behandling/$behandlingId/oppdater-grunnlag") {
                 accept(ContentType.Application.Json)
                 contentType(ContentType.Application.Json)
                 setBody(opplysningsbehov)

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
@@ -626,8 +626,8 @@ class BehandlingFactoryTest {
             behandlingDaoMock.alleBehandlingerISak(any())
             behandlingHendelserKafkaProducerMock.sendMeldingForHendelseMedDetaljertBehandling(any(), BehandlingHendelseType.OPPRETTET)
             grunnlagService.leggInnNyttGrunnlag(any(), any())
-            grunnlagService.leggTilNyeOpplysninger(sak.id, any(), any())
-            grunnlagService.leggTilNyeOpplysninger(sak.id, any(), any())
+            grunnlagService.leggTilNyeOpplysninger(any(), any())
+            grunnlagService.leggTilNyeOpplysninger(any(), any())
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
         }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
@@ -437,7 +437,7 @@ class BehandlingServiceImplTest {
         val grunnlagKlient =
             mockk<GrunnlagKlientTest> {
                 coEvery {
-                    finnPersonOpplysning(SAK_ID, behandling.id, opplysningstype, TOKEN)
+                    finnPersonOpplysning(behandling.sak.id, behandling.id, opplysningstype, TOKEN)
                 } returns grunnlagsopplysningMedPersonopplysning
                 coEvery { hentPersongalleri(any(), behandling.id, any()) } answers { callOriginal() }
             }
@@ -770,7 +770,7 @@ class BehandlingServiceImplTest {
         val grunnlagKlient =
             mockk<GrunnlagKlientTest> {
                 coEvery {
-                    finnPersonOpplysning(SAK_ID, behandling.id, Opplysningstype.AVDOED_PDL_V1, TOKEN)
+                    finnPersonOpplysning(behandling.sak.id, behandling.id, Opplysningstype.AVDOED_PDL_V1, TOKEN)
                 } returns grunnlagsopplysningMedPersonopplysning
                 coEvery { hentPersongalleri(any(), behandling.id, any()) } answers { callOriginal() }
             }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingGrunnlagRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingGrunnlagRoutes.kt
@@ -11,13 +11,11 @@ import io.ktor.server.routing.route
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
-import no.nav.etterlatte.libs.common.behandlingsId
 import no.nav.etterlatte.libs.common.grunnlag.NyeSaksopplysninger
 import no.nav.etterlatte.libs.common.grunnlag.Opplysningsbehov
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.kunSystembruker
-import no.nav.etterlatte.libs.common.sakId
-import no.nav.etterlatte.libs.common.withSakId
+import no.nav.etterlatte.libs.common.withBehandlingId
 
 fun Route.behandlingGrunnlagRoute(
     grunnlagService: GrunnlagService,
@@ -30,8 +28,8 @@ fun Route.behandlingGrunnlagRoute(
      **/
     route("sak/{$SAKID_CALL_PARAMETER}/behandling/{$BEHANDLINGSID_CALL_PARAMETER}") {
         get {
-            withSakId(behandlingKlient) { sakId ->
-                when (val opplysningsgrunnlag = grunnlagService.hentOpplysningsgrunnlag(sakId)) {
+            withBehandlingId(behandlingKlient) { behandlingId ->
+                when (val opplysningsgrunnlag = grunnlagService.hentOpplysningsgrunnlag(behandlingId)) {
                     null -> call.respond(HttpStatusCode.NotFound)
                     else -> call.respond(opplysningsgrunnlag)
                 }
@@ -39,9 +37,9 @@ fun Route.behandlingGrunnlagRoute(
         }
 
         get("{opplysningType}") {
-            withSakId(behandlingKlient) { sakId ->
+            withBehandlingId(behandlingKlient) { behandlingId ->
                 val opplysningstype = Opplysningstype.valueOf(call.parameters["opplysningType"].toString())
-                val grunnlag = grunnlagService.hentGrunnlagAvType(sakId, opplysningstype)
+                val grunnlag = grunnlagService.hentGrunnlagAvType(behandlingId, opplysningstype)
 
                 if (grunnlag != null) {
                     call.respond(grunnlag)
@@ -53,9 +51,9 @@ fun Route.behandlingGrunnlagRoute(
             }
         }
 
-        get("revurdering/${Opplysningstype.HISTORISK_FORELDREANSVAR.name}") {
-            withSakId(behandlingKlient) { sakId ->
-                when (val historisk = grunnlagService.hentHistoriskForeldreansvar(sakId, behandlingsId)) {
+        get("revurdering/${Opplysningstype.HISTORISK_FORELDREANSVAR}") {
+            withBehandlingId(behandlingKlient) { behandlingId ->
+                when (val historisk = grunnlagService.hentHistoriskForeldreansvar(behandlingId)) {
                     null -> call.respond(HttpStatusCode.NotFound)
                     else -> call.respond(historisk)
                 }
@@ -63,18 +61,22 @@ fun Route.behandlingGrunnlagRoute(
         }
 
         post("nye-opplysninger") {
-            withSakId(behandlingKlient) {
+            withBehandlingId(behandlingKlient) { behandlingId ->
                 val opplysningsbehov = call.receive<NyeSaksopplysninger>()
-                grunnlagService.lagreNyeSaksopplysninger(sakId, behandlingsId, opplysningsbehov.opplysninger)
+                grunnlagService.lagreNyeSaksopplysninger(
+                    opplysningsbehov.sakId,
+                    behandlingId,
+                    opplysningsbehov.opplysninger,
+                )
                 call.respond(HttpStatusCode.OK)
             }
         }
 
         post("oppdater-grunnlag") {
             kunSystembruker {
-                withSakId(behandlingKlient) {
+                withBehandlingId(behandlingKlient) { behandlingId ->
                     val opplysningsbehov = call.receive<Opplysningsbehov>()
-                    grunnlagService.oppdaterGrunnlag(behandlingsId, opplysningsbehov)
+                    grunnlagService.oppdaterGrunnlag(behandlingId, opplysningsbehov)
                     call.respond(HttpStatusCode.OK)
                 }
             }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagService.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagService.kt
@@ -36,7 +36,7 @@ import java.util.UUID
 
 interface GrunnlagService {
     fun hentGrunnlagAvType(
-        sak: Long,
+        behandlingId: UUID,
         opplysningstype: Opplysningstype,
     ): Grunnlagsopplysning<JsonNode>?
 
@@ -46,7 +46,7 @@ interface GrunnlagService {
     ): NavnOpplysningDTO?
 
     fun lagreNyeSaksopplysninger(
-        sak: Long,
+        sakId: Long,
         behandlingId: UUID,
         nyeOpplysninger: List<Grunnlagsopplysning<JsonNode>>,
     )
@@ -58,7 +58,9 @@ interface GrunnlagService {
         nyeOpplysninger: List<Grunnlagsopplysning<JsonNode>>,
     )
 
-    fun hentOpplysningsgrunnlag(sak: Long): Grunnlag?
+    fun hentOpplysningsgrunnlagForSak(sakId: Long): Grunnlag?
+
+    fun hentOpplysningsgrunnlag(behandlingId: UUID): Grunnlag?
 
     fun hentSakerOgRoller(fnr: Folkeregisteridentifikator): PersonMedSakerOgRoller
 
@@ -83,10 +85,7 @@ interface GrunnlagService {
         opplysningsbehov: Opplysningsbehov,
     )
 
-    fun hentHistoriskForeldreansvar(
-        sakId: Long,
-        behandlingId: UUID,
-    ): Grunnlagsopplysning<JsonNode>?
+    fun hentHistoriskForeldreansvar(behandlingId: UUID): Grunnlagsopplysning<JsonNode>?
 }
 
 class RealGrunnlagService(
@@ -96,17 +95,32 @@ class RealGrunnlagService(
 ) : GrunnlagService {
     private val logger = LoggerFactory.getLogger(RealGrunnlagService::class.java)
 
-    override fun hentOpplysningsgrunnlag(sak: Long): Grunnlag? {
-        val persongalleriJsonNode = opplysningDao.finnNyesteGrunnlag(sak, Opplysningstype.PERSONGALLERI_V1)?.opplysning
+    override fun hentOpplysningsgrunnlagForSak(sakId: Long): Grunnlag? {
+        val persongalleriJsonNode =
+            opplysningDao.finnNyesteGrunnlagForSak(sakId, Opplysningstype.PERSONGALLERI_V1)?.opplysning
 
         if (persongalleriJsonNode == null) {
-            logger.info("Klarte ikke å hente ut grunnlag for sak $sak. Fant ikke persongalleri")
+            logger.info("Klarte ikke å hente ut grunnlag for sak $sakId. Fant ikke persongalleri")
             return null
         }
         val persongalleri = objectMapper.readValue(persongalleriJsonNode.opplysning.toJson(), Persongalleri::class.java)
-        val grunnlag = opplysningDao.hentAlleGrunnlagForSak(sak)
+        val grunnlag = opplysningDao.hentAlleGrunnlagForSak(sakId)
 
-        return OpplysningsgrunnlagMapper(grunnlag, sak, persongalleri).hentGrunnlag()
+        return OpplysningsgrunnlagMapper(grunnlag, persongalleri).hentGrunnlag()
+    }
+
+    override fun hentOpplysningsgrunnlag(behandlingId: UUID): Grunnlag? {
+        val persongalleriJsonNode =
+            opplysningDao.finnNyesteGrunnlagForBehandling(behandlingId, Opplysningstype.PERSONGALLERI_V1)?.opplysning
+
+        if (persongalleriJsonNode == null) {
+            logger.info("Klarte ikke å hente ut grunnlag for behandling (id=$behandlingId). Fant ikke persongalleri")
+            return null
+        }
+        val persongalleri = objectMapper.readValue(persongalleriJsonNode.opplysning.toJson(), Persongalleri::class.java)
+        val grunnlag = opplysningDao.hentAlleGrunnlagForBehandling(behandlingId)
+
+        return OpplysningsgrunnlagMapper(grunnlag, persongalleri).hentGrunnlag()
     }
 
     override fun hentSakerOgRoller(fnr: Folkeregisteridentifikator): PersonMedSakerOgRoller {
@@ -122,7 +136,7 @@ class RealGrunnlagService(
     override fun hentAlleSakerForFnr(fnr: Folkeregisteridentifikator): Set<Long> = opplysningDao.finnAlleSakerForPerson(fnr)
 
     override fun hentPersonerISak(sakId: Long): Map<Folkeregisteridentifikator, PersonMedNavn>? {
-        val grunnlag = hentOpplysningsgrunnlag(sakId) ?: return null
+        val grunnlag = hentOpplysningsgrunnlagForSak(sakId) ?: return null
 
         val personer = listOf(grunnlag.soeker) + grunnlag.familie
         return personer.mapNotNull {
@@ -252,7 +266,7 @@ class RealGrunnlagService(
                     it.personRolle,
                 )
             lagreNyePersonopplysninger(
-                opplysningsbehov.sakid,
+                opplysningsbehov.sakId,
                 behandlingId,
                 it.personDto.foedselsnummer.verdi,
                 enkenPdlOpplysning,
@@ -260,11 +274,11 @@ class RealGrunnlagService(
         }
 
         lagreNyeSaksopplysninger(
-            opplysningsbehov.sakid,
+            opplysningsbehov.sakId,
             behandlingId,
             listOf(opplysningsbehov.persongalleri.tilGrunnlagsopplysning()),
         )
-        logger.info("Oppdatert grunnlag for sak ${opplysningsbehov.sakid}")
+        logger.info("Oppdatert grunnlag (sakId=${opplysningsbehov.sakId}, behandlingId=$behandlingId)")
     }
 
     private fun Persongalleri.tilGrunnlagsopplysning(): Grunnlagsopplysning<JsonNode> {
@@ -285,15 +299,15 @@ class RealGrunnlagService(
         )
     }
 
-    override fun hentHistoriskForeldreansvar(
-        sakId: Long,
-        behandlingId: UUID,
-    ): Grunnlagsopplysning<JsonNode>? {
-        val opplysning = opplysningDao.finnNyesteGrunnlag(sakId, Opplysningstype.HISTORISK_FORELDREANSVAR)?.opplysning
-        if (opplysning != null) {
-            return opplysning
+    override fun hentHistoriskForeldreansvar(behandlingId: UUID): Grunnlagsopplysning<JsonNode>? {
+        val grunnlagshendelse =
+            opplysningDao.finnNyesteGrunnlagForBehandling(behandlingId, Opplysningstype.HISTORISK_FORELDREANSVAR)
+
+        if (grunnlagshendelse?.opplysning != null) {
+            return grunnlagshendelse.opplysning
         }
-        val grunnlag = hentOpplysningsgrunnlag(sakId)
+
+        val grunnlag = hentOpplysningsgrunnlag(behandlingId)
         val soekerFnr = grunnlag?.soeker?.hentFoedselsnummer()?.verdi ?: return null
         val historiskForeldreansvar =
             pdltjenesterKlient.hentHistoriskForeldreansvar(
@@ -302,7 +316,12 @@ class RealGrunnlagService(
                 SakType.BARNEPENSJON,
             )
                 .tilGrunnlagsopplysning(soekerFnr)
-        opplysningDao.leggOpplysningTilGrunnlag(sakId, historiskForeldreansvar, soekerFnr)
+
+        val hendelsenummer =
+            opplysningDao.leggOpplysningTilGrunnlag(grunnlag.metadata.sakId, historiskForeldreansvar, soekerFnr)
+
+        opplysningDao.oppdaterVersjonForBehandling(behandlingId, grunnlag.metadata.sakId, hendelsenummer)
+
         return historiskForeldreansvar
     }
 
@@ -319,10 +338,10 @@ class RealGrunnlagService(
         }
 
     override fun hentGrunnlagAvType(
-        sak: Long,
+        behandlingId: UUID,
         opplysningstype: Opplysningstype,
     ): Grunnlagsopplysning<JsonNode>? {
-        return opplysningDao.finnNyesteGrunnlag(sak, opplysningstype)?.opplysning
+        return opplysningDao.finnNyesteGrunnlagForBehandling(behandlingId, opplysningstype)?.opplysning
     }
 
     override fun hentOpplysningstypeNavnFraFnr(
@@ -358,12 +377,12 @@ class RealGrunnlagService(
     }
 
     override fun lagreNyeSaksopplysninger(
-        sak: Long,
+        sakId: Long,
         behandlingId: UUID,
         nyeOpplysninger: List<Grunnlagsopplysning<JsonNode>>,
     ) {
         logger.info("Oppretter et grunnlag for saksopplysninger")
-        oppdaterGrunnlagOgVersjon(sak, behandlingId, fnr = null, nyeOpplysninger)
+        oppdaterGrunnlagOgVersjon(sakId, behandlingId, fnr = null, nyeOpplysninger)
     }
 
     private fun oppdaterGrunnlagOgVersjon(
@@ -373,6 +392,12 @@ class RealGrunnlagService(
         nyeOpplysninger: List<Grunnlagsopplysning<JsonNode>>,
     ) {
         val gjeldendeGrunnlag = opplysningDao.finnHendelserIGrunnlag(sak).map { it.opplysning.id }
+
+        val versjon = opplysningDao.hentBehandlingVersjon(behandlingId)
+        if (versjon?.laast ?: false) {
+            logger.warn("Grunnlag låst for behandling (id=$behandlingId). Avbryter oppdatering av grunnlaget...")
+            return
+        }
 
         val hendelsenummer =
             nyeOpplysninger.mapNotNull { opplysning ->
@@ -385,9 +410,8 @@ class RealGrunnlagService(
             }.maxOrNull()
 
         if (hendelsenummer == null) {
-            logger.warn("Hendelsenummer er null – kan ikke oppdatere versjon for behandling (id=$behandlingId)")
+            logger.error("Hendelsenummer er null – kan ikke oppdatere versjon for behandling (id=$behandlingId)")
         } else {
-            // TODO: Hva skal vi gjøre dersom det forsøkes å oppdatere versjon som er låst? Bare hoppe over?
             logger.info("Setter grunnlag for behandling (id=$behandlingId) til hendelsenummer=$hendelsenummer")
             opplysningDao.oppdaterVersjonForBehandling(behandlingId, sak, hendelsenummer)
         }
@@ -399,14 +423,18 @@ class RealGrunnlagService(
         behandlingId: UUID,
         laasVersjon: Boolean,
     ) {
-        val grunnlag = hentOpplysningsgrunnlag(sakId)
+        val grunnlag = hentOpplysningsgrunnlagForSak(sakId)
         if (grunnlag == null) {
             logger.warn("Ingen grunnlag funnet for sak=$sakId - kan ikke sette versjon for behandlingId=$behandlingId")
             return
         }
 
-        val hendelsenummer = grunnlag.metadata.versjon
+        val versjonErLaast = opplysningDao.hentBehandlingVersjon(behandlingId)?.laast ?: false
+        if (versjonErLaast) {
+            throw IllegalStateException("Kan ikke oppdatere versjon som er låst (behandlingId=$behandlingId)")
+        }
 
+        val hendelsenummer = grunnlag.metadata.versjon
         val oppdatertOK = opplysningDao.oppdaterVersjonForBehandling(behandlingId, sakId, hendelsenummer) > 0
         if (oppdatertOK) {
             logger.info("Versjon satt til hendelsenummer=$hendelsenummer (sakId=$sakId, id=$behandlingId)")

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/OpplysningsgrunnlagMapper.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/OpplysningsgrunnlagMapper.kt
@@ -11,7 +11,6 @@ import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 
 class OpplysningsgrunnlagMapper(
     private val grunnlaghendelser: List<OpplysningDao.GrunnlagHendelse>,
-    private val sakId: Long,
     private val persongalleri: Persongalleri,
 ) {
     private data class GruppertHendelser(
@@ -54,6 +53,8 @@ class OpplysningsgrunnlagMapper(
                     familiemedlem.associateBy({ it.opplysningstype }, { it.opplysning })
                 }
         val sakMap = saksopplysninger.associateBy({ it.opplysningstype }, { it.opplysning })
+
+        val sakId = grunnlaghendelser.first().sakId
 
         return Grunnlag(
             soeker = soekerMap,

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/SakGrunnlagRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/SakGrunnlagRoutes.kt
@@ -18,7 +18,7 @@ fun Route.sakGrunnlagRoute(
     route("sak/{$SAKID_CALL_PARAMETER}") {
         get {
             withSakId(behandlingKlient) { sakId ->
-                when (val opplysningsgrunnlag = grunnlagService.hentOpplysningsgrunnlag(sakId)) {
+                when (val opplysningsgrunnlag = grunnlagService.hentOpplysningsgrunnlagForSak(sakId)) {
                     null -> call.respond(HttpStatusCode.NotFound)
                     else -> call.respond(opplysningsgrunnlag)
                 }
@@ -36,7 +36,7 @@ fun Route.sakGrunnlagRoute(
     }
 }
 
-private data class PersonerISakDto(
+data class PersonerISakDto(
     val personer: Map<Folkeregisteridentifikator, PersonMedNavn>,
 )
 

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagServiceTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagServiceTest.kt
@@ -51,7 +51,7 @@ internal class GrunnlagServiceTest {
 
     @BeforeAll
     fun beforeAll() {
-        every { opplysningerMock.finnNyesteGrunnlag(1, PERSONGALLERI_V1) } returns
+        every { opplysningerMock.finnNyesteGrunnlagForBehandling(any(), PERSONGALLERI_V1) } returns
             lagGrunnlagHendelse(
                 1,
                 4,
@@ -116,7 +116,7 @@ internal class GrunnlagServiceTest {
 
             every { opplysningerMock.hentAlleGrunnlagForSak(1) } returns grunnlagshendelser
 
-            val actual = grunnlagService.hentOpplysningsgrunnlag(1)!!
+            val actual = grunnlagService.hentOpplysningsgrunnlagForSak(1)!!
             val expected =
                 mapOf(
                     NAVN to Opplysning.Konstant(statiskUuid, kilde, nyttNavn.toJsonNode()),
@@ -133,7 +133,7 @@ internal class GrunnlagServiceTest {
 
             every { opplysningerMock.hentAlleGrunnlagForSak(1) } returns grunnlagshendelser
 
-            val actual = grunnlagService.hentOpplysningsgrunnlag(1)!!
+            val actual = grunnlagService.hentOpplysningsgrunnlagForSak(1)!!
             val expected =
                 mapOf(
                     NAVN to Opplysning.Konstant(statiskUuid, kilde, nyttNavn.toJsonNode()),
@@ -151,7 +151,7 @@ internal class GrunnlagServiceTest {
 
             every { opplysningerMock.hentAlleGrunnlagForSak(1) } returns grunnlagshendelser
 
-            val actual = grunnlagService.hentOpplysningsgrunnlag(1)!!
+            val actual = grunnlagService.hentOpplysningsgrunnlagForSak(1)!!
             val expected =
                 mapOf(
                     NAVN to Opplysning.Konstant(statiskUuid, kilde, nyttNavn.toJsonNode()),
@@ -169,7 +169,7 @@ internal class GrunnlagServiceTest {
 
             every { opplysningerMock.hentAlleGrunnlagForSak(1) } returns grunnlagshendelser
 
-            val actual = grunnlagService.hentOpplysningsgrunnlag(1)!!
+            val actual = grunnlagService.hentOpplysningsgrunnlagForSak(1)!!
             val expected =
                 mapOf(
                     NAVN to Opplysning.Konstant(statiskUuid, kilde, nyttNavn.toJsonNode()),
@@ -212,14 +212,14 @@ internal class GrunnlagServiceTest {
 
             Assertions.assertEquals(
                 1,
-                grunnlagService.hentOpplysningsgrunnlag(1)!!.soeker.values.size,
+                grunnlagService.hentOpplysningsgrunnlagForSak(1)!!.soeker.values.size,
             )
         }
 
         @Test
         fun `tar alltid seneste versjon av samme opplysning`() {
             every { opplysningerMock.hentAlleGrunnlagForSak(1) } returns grunnlagshendelser
-            val opplysningsgrunnlag = grunnlagService.hentOpplysningsgrunnlag(1)!!
+            val opplysningsgrunnlag = grunnlagService.hentOpplysningsgrunnlagForSak(1)!!
 
             Assertions.assertEquals(
                 2,
@@ -267,7 +267,7 @@ internal class GrunnlagServiceTest {
 
         every { opplysningerMock.hentAlleGrunnlagForSak(1) } returns grunnlagshendelser
 
-        val actual = grunnlagService.hentOpplysningsgrunnlag(1)!!
+        val actual = grunnlagService.hentOpplysningsgrunnlagForSak(1)!!
         val expected =
             Opplysning.Konstant(
                 uuid1,
@@ -283,7 +283,7 @@ internal class GrunnlagServiceTest {
 
     @Test
     fun `kan hente og mappe opplysningsgrunnlag`() {
-        every { opplysningerMock.finnNyesteGrunnlag(1, PERSONGALLERI_V1) } returns
+        every { opplysningerMock.finnNyesteGrunnlagForSak(any<Long>(), PERSONGALLERI_V1) } returns
             lagGrunnlagHendelse(
                 1,
                 1,
@@ -294,7 +294,7 @@ internal class GrunnlagServiceTest {
                 kilde = kilde,
             )
 
-        every { opplysningerMock.hentAlleGrunnlagForSak(1) } returns
+        every { opplysningerMock.hentAlleGrunnlagForSak(any<Long>()) } returns
             listOf(
                 lagGrunnlagHendelse(
                     1,
@@ -324,7 +324,7 @@ internal class GrunnlagServiceTest {
                 ),
             )
 
-        val opplysningsgrunnlag = grunnlagService.hentOpplysningsgrunnlag(1)!!
+        val opplysningsgrunnlag = grunnlagService.hentOpplysningsgrunnlagForSak(1)!!
 
         Assertions.assertEquals(1, opplysningsgrunnlag.sak.size)
         Assertions.assertEquals(2, opplysningsgrunnlag.soeker.size)
@@ -467,7 +467,7 @@ internal class GrunnlagServiceTest {
 
         @Test
         fun `Kan mappe og hente innsender`() {
-            every { opplysningerMock.finnNyesteGrunnlag(1, PERSONGALLERI_V1) } returns
+            every { opplysningerMock.finnNyesteGrunnlagForBehandling(any(), PERSONGALLERI_V1) } returns
                 lagGrunnlagHendelse(
                     1,
                     1,
@@ -507,7 +507,7 @@ internal class GrunnlagServiceTest {
                     ),
                 )
 
-            val opplysningsgrunnlag = grunnlagService.hentOpplysningsgrunnlag(1)!!
+            val opplysningsgrunnlag = grunnlagService.hentOpplysningsgrunnlagForSak(1)!!
 
             Assertions.assertEquals(1, opplysningsgrunnlag.sak.size)
             Assertions.assertEquals(1, opplysningsgrunnlag.familie.size)

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/SakGrunnlagRoutesKtTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/SakGrunnlagRoutesKtTest.kt
@@ -1,0 +1,201 @@
+package no.nav.etterlatte.grunnlag
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.jackson.jackson
+import io.ktor.server.application.log
+import io.ktor.server.config.HoconApplicationConfig
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.mockk.Called
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.etterlatte.klienter.BehandlingKlient
+import no.nav.etterlatte.libs.common.serialize
+import no.nav.etterlatte.libs.ktor.AZURE_ISSUER
+import no.nav.etterlatte.libs.ktor.restModule
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
+import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import testsupport.buildTestApplicationConfigurationForOauth
+import java.util.UUID
+import kotlin.random.Random
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class SakGrunnlagRoutesKtTest {
+    private val grunnlagService = mockk<GrunnlagService>()
+    private val behandlingKlient = mockk<BehandlingKlient>()
+    private val server = MockOAuth2Server()
+    private lateinit var hoconApplicationConfig: HoconApplicationConfig
+
+    companion object {
+        private const val CLIENT_ID = "CLIENT_ID"
+    }
+
+    @BeforeAll
+    fun before() {
+        server.start()
+        val httpServer = server.config.httpServer
+        hoconApplicationConfig = buildTestApplicationConfigurationForOauth(httpServer.port(), AZURE_ISSUER, CLIENT_ID)
+    }
+
+    @AfterEach
+    fun afterEach() {
+        confirmVerified(grunnlagService, behandlingKlient)
+        clearAllMocks()
+    }
+
+    @AfterAll
+    fun after() {
+        server.shutdown()
+    }
+
+    private val token by lazy {
+        server.issueToken(
+            issuerId = AZURE_ISSUER,
+            audience = CLIENT_ID,
+            claims =
+                mapOf(
+                    "navn" to "Per Persson",
+                    "NAVident" to "Saksbehandler01",
+                ),
+        ).serialize()
+    }
+
+    private val systemBruker: String by lazy {
+        val mittsystem = UUID.randomUUID().toString()
+        server.issueToken(
+            issuerId = AZURE_ISSUER,
+            audience = CLIENT_ID,
+            claims =
+                mapOf(
+                    "sub" to mittsystem,
+                    "oid" to mittsystem,
+                ),
+        ).serialize()
+    }
+
+    @Test
+    fun `returnerer 401 uten gyldig token`() {
+        val sakId = Random.nextLong()
+
+        testApplication {
+            val response = createHttpClient().get("api/grunnlag/sak/$sakId")
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+        coVerify(exactly = 1) { behandlingKlient wasNot Called }
+    }
+
+    @Test
+    fun `returnerer 404 hvis grunnlag ikke finnes`() {
+        val sakId = Random.nextLong()
+
+        every { grunnlagService.hentOpplysningsgrunnlagForSak(any()) } returns null
+        coEvery { behandlingKlient.harTilgangTilSak(any(), any()) } returns true
+
+        testApplication {
+            val response =
+                createHttpClient().get("api/grunnlag/sak/$sakId") {
+                    headers {
+                        append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        append(HttpHeaders.Authorization, "Bearer $token")
+                    }
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+        verify(exactly = 1) { grunnlagService.hentOpplysningsgrunnlagForSak(any()) }
+        coVerify(exactly = 1) { behandlingKlient.harTilgangTilSak(any(), any()) }
+    }
+
+    @Test
+    fun `Hent grunnlag for sak`() {
+        val sakId = Random.nextLong()
+        val testData = GrunnlagTestData().hentOpplysningsgrunnlag()
+
+        every { grunnlagService.hentOpplysningsgrunnlagForSak(any()) } returns testData
+        coEvery { behandlingKlient.harTilgangTilSak(any(), any()) } returns true
+
+        testApplication {
+            val response =
+                createHttpClient().get("api/grunnlag/sak/$sakId") {
+                    headers {
+                        append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        append(HttpHeaders.Authorization, "Bearer $token")
+                    }
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(serialize(testData), response.body<String>())
+        }
+
+        verify(exactly = 1) { grunnlagService.hentOpplysningsgrunnlagForSak(sakId) }
+        coVerify(exactly = 1) { behandlingKlient.harTilgangTilSak(sakId, any()) }
+    }
+
+    @Test
+    fun `Hent alle personer i sak`() {
+        val sakId = Random.nextLong()
+        val testData =
+            mapOf(
+                SOEKER_FOEDSELSNUMMER to PersonMedNavn(SOEKER_FOEDSELSNUMMER, "John", "Doe", null),
+            )
+
+        every { grunnlagService.hentPersonerISak(any()) } returns testData
+        coEvery { behandlingKlient.harTilgangTilSak(any(), any()) } returns true
+
+        testApplication {
+            val response =
+                createHttpClient().get("api/grunnlag/sak/$sakId/personer/alle") {
+                    headers {
+                        append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        append(HttpHeaders.Authorization, "Bearer $token")
+                    }
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(serialize(PersonerISakDto(testData)), response.body<String>())
+        }
+
+        verify(exactly = 1) { grunnlagService.hentPersonerISak(sakId) }
+        coVerify(exactly = 1) { behandlingKlient.harTilgangTilSak(sakId, any()) }
+    }
+
+    private fun ApplicationTestBuilder.createHttpClient(): HttpClient {
+        environment {
+            config = hoconApplicationConfig
+        }
+        application {
+            restModule(this.log, routePrefix = "api/grunnlag") {
+                sakGrunnlagRoute(grunnlagService, behandlingKlient)
+            }
+        }
+
+        return createClient {
+            install(ContentNegotiation) {
+                jackson { registerModule(JavaTimeModule()) }
+            }
+        }
+    }
+}

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/grunnlag/Opplysningsbehov.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/grunnlag/Opplysningsbehov.kt
@@ -4,7 +4,7 @@ import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.SakType
 
 data class Opplysningsbehov(
-    val sakid: Long,
+    val sakId: Long,
     val sakType: SakType,
     val persongalleri: Persongalleri,
 )

--- a/libs/saksbehandling-common/src/main/kotlin/grunnlag/NyeSaksopplysninger.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/grunnlag/NyeSaksopplysninger.kt
@@ -3,5 +3,6 @@ package no.nav.etterlatte.libs.common.grunnlag
 import com.fasterxml.jackson.databind.JsonNode
 
 data class NyeSaksopplysninger(
+    val sakId: Long,
     val opplysninger: List<Grunnlagsopplysning<JsonNode>>,
 )


### PR DESCRIPTION
Hovedsaklig henter man nå ut grunnlag basert på siste versjon tilknyttet `behandlingId`. 
Noen steder hvor man fortsatt henter på `sakId` for å sikre at man får komplett historikk. 

Gjenstår å rydde i endepunkter og funksjoner brukt ifm. versjonering av eksisterende data, men det fjernes når dette har fått kjøre litt og vi ser at det fungerer som det skal. 