### PR TITLE
Codescanning klagar på at vi loggar unsanitized input frå LeaderElection

### DIFF
--- a/libs/etterlatte-jobs/src/main/kotlin/jobs/LeaderElection.kt
+++ b/libs/etterlatte-jobs/src/main/kotlin/jobs/LeaderElection.kt
@@ -22,7 +22,7 @@ open class LeaderElection(
                 httpClient.get("http://$electorPath/").bodyAsText().let(objectMapper::readTree).get("name").asText()
             }
         val amLeader = leader == me()
-        logger.info("Current pod: ${me()}. Leader: $leader. Current pod is leader: $amLeader")
+        logger.info("Current pod: ${me()?.sanitize()}. Leader: ${leader.sanitize()}. Current pod is leader: $amLeader")
         return amLeader
     }
 
@@ -30,3 +30,7 @@ open class LeaderElection(
         private val logger = LoggerFactory.getLogger(LeaderElection::class.java)
     }
 }
+
+private val sanitizeRegex = Regex("[A-Za-z0-9.-]+$")
+
+fun String.sanitize() = this.takeIf { it.matches(sanitizeRegex) } ?: "Ugyldig verdi"

--- a/libs/etterlatte-jobs/src/test/kotlin/jobs/LeaderElectionTest.kt
+++ b/libs/etterlatte-jobs/src/test/kotlin/jobs/LeaderElectionTest.kt
@@ -9,6 +9,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.fullPath
 import io.ktor.serialization.jackson.JacksonConverter
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -51,6 +52,14 @@ internal class LeaderElectionTest {
         val httpClient = httpClient(response)
         val leaderElection = LeaderElectionLocalhost(localHostName, httpClient)
         assertFalse(leaderElection.isLeader())
+    }
+
+    @Test
+    fun testsanitize() {
+        Assertions.assertEquals("etterlatte-behandling-696cf4f4b7-tpvhm", "etterlatte-behandling-696cf4f4b7-tpvhm".sanitize())
+        Assertions.assertEquals("127.0.0.1", "127.0.0.1".sanitize())
+        Assertions.assertEquals("Ugyldig verdi", "Guest'%0AUser:'Admin".sanitize())
+        Assertions.assertEquals("Ugyldig verdi", "*!\"#!\"$\"!$!\"#\"!$:::::::".sanitize())
     }
 }
 


### PR DESCRIPTION
Eg trur ikkje det er særleg reell fare, men kan jo fint innføre ein vaskemekanisme også her i backend. Sikkert lettare å løyse det enn å gang på gang markere som falsk positiv uansett