### PR TITLE
Returner oppgåve tilbake frå opprett behandling, og i migrering tildele akkurat denne oppgåva heller enn å grave bakover

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
@@ -22,6 +22,7 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.SoeknadMottattDato
 import no.nav.etterlatte.libs.common.gyldigSoeknad.GyldighetsResultat
 import no.nav.etterlatte.libs.common.gyldigSoeknad.VurderingsResultat
+import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
@@ -58,7 +59,7 @@ class BehandlingFactory(
                 opprettBehandling(
                     sak.id, request.persongalleri, request.mottattDato, Vedtaksloesning.GJENNY,
                 ) ?: throw IllegalStateException("Kunne ikke opprette behandling")
-            }
+            }.behandling
 
         val gyldighetsvurdering =
             GyldighetsResultat(
@@ -75,7 +76,11 @@ class BehandlingFactory(
         val opplysninger =
             listOf(
                 lagOpplysning(Opplysningstype.SPRAAK, kilde, request.spraak.toJsonNode()),
-                lagOpplysning(Opplysningstype.SOEKNAD_MOTTATT_DATO, kilde, SoeknadMottattDato(mottattDato).toJsonNode()),
+                lagOpplysning(
+                    Opplysningstype.SOEKNAD_MOTTATT_DATO,
+                    kilde,
+                    SoeknadMottattDato(mottattDato).toJsonNode(),
+                ),
             )
 
         grunnlagService.leggTilNyeOpplysninger(sak.id, behandling.id, NyeSaksopplysninger(opplysninger))
@@ -88,7 +93,7 @@ class BehandlingFactory(
         persongalleri: Persongalleri,
         mottattDato: String?,
         kilde: Vedtaksloesning,
-    ): Behandling? {
+    ): BehandlingOgOppgave? {
         logger.info("Starter behandling i sak $sakId")
 
         val sak =
@@ -112,26 +117,25 @@ class BehandlingFactory(
                 mottattDato = mottattDato,
                 kilde = kilde,
                 revurderingAarsak = RevurderingAarsak.NY_SOEKNAD,
-            )
+            )?.let { BehandlingOgOppgave(it, null) }
         } else {
             val harBehandlingUnderbehandling =
                 harBehandlingerForSak.filter { behandling ->
                     BehandlingStatus.underBehandling().find { it == behandling.status } != null
                 }
-            opprettFoerstegangsbehandling(harBehandlingUnderbehandling, sak, mottattDato, kilde)
-                .also { behandling ->
-                    behandling?.let {
-                        grunnlagService.leggInnNyttGrunnlag(it, persongalleri)
-                        oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(
-                            referanse = behandling.id.toString(),
-                            sakId = sak.id,
-                        )
-                        behandlingHendelser.sendMeldingForHendelseMedDetaljertBehandling(
-                            it.toStatistikkBehandling(persongalleri),
-                            BehandlingHendelseType.OPPRETTET,
-                        )
-                    }
-                }
+            val behandling =
+                opprettFoerstegangsbehandling(harBehandlingUnderbehandling, sak, mottattDato, kilde) ?: return null
+            grunnlagService.leggInnNyttGrunnlag(behandling, persongalleri)
+            val oppgave =
+                oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(
+                    referanse = behandling.id.toString(),
+                    sakId = sak.id,
+                )
+            behandlingHendelser.sendMeldingForHendelseMedDetaljertBehandling(
+                behandling.toStatistikkBehandling(persongalleri),
+                BehandlingHendelseType.OPPRETTET,
+            )
+            return BehandlingOgOppgave(behandling, oppgave)
         }
     }
 
@@ -170,3 +174,5 @@ class BehandlingFactory(
             ).firstOrNull()
         }
 }
+
+data class BehandlingOgOppgave(val behandling: Behandling, val oppgave: OppgaveIntern?)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -296,7 +296,7 @@ internal fun Route.behandlingRoutes(
                                 behandlingsBehov.mottattDato,
                                 Vedtaksloesning.GJENNY,
                             )
-                        }
+                        }?.behandling
                 ) {
                     null -> call.respond(HttpStatusCode.NotFound)
                     else -> call.respondText(behandling.id.toString())

--- a/apps/etterlatte-behandling/src/test/kotlin/OmregningIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/OmregningIntegrationTest.kt
@@ -69,7 +69,7 @@ class OmregningIntegrationTest : BehandlingIntegrationTest() {
                             persongalleri(),
                             LocalDateTime.now().toString(),
                             Vedtaksloesning.GJENNY,
-                        )
+                        )?.behandling
                 Pair(sak, behandling as Foerstegangsbehandling)
             }
         }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
@@ -205,7 +205,7 @@ class BehandlingFactoryTest {
                 persongalleri,
                 datoNaa.toString(),
                 Vedtaksloesning.GJENNY,
-            )!!
+            )!!.behandling
 
         Assertions.assertEquals(opprettetBehandling, resultat)
         Assertions.assertEquals(opprettetBehandling.sak, resultat.sak)
@@ -289,7 +289,7 @@ class BehandlingFactoryTest {
                 persongalleri,
                 datoNaa.toString(),
                 Vedtaksloesning.GJENNY,
-            )!!
+            )!!.behandling
 
         Assertions.assertTrue(foerstegangsbehandling is Foerstegangsbehandling)
 
@@ -376,7 +376,7 @@ class BehandlingFactoryTest {
                 persongalleri,
                 datoNaa.toString(),
                 Vedtaksloesning.GJENNY,
-            )!!
+            )!!.behandling
 
         Assertions.assertTrue(foerstegangsbehandling is Foerstegangsbehandling)
 
@@ -390,7 +390,7 @@ class BehandlingFactoryTest {
                 persongalleri,
                 datoNaa.toString(),
                 Vedtaksloesning.GJENNY,
-            )
+            )?.behandling
         Assertions.assertTrue(nyfoerstegangsbehandling is Foerstegangsbehandling)
 
         verify(exactly = 2) {
@@ -483,7 +483,7 @@ class BehandlingFactoryTest {
                 persongalleri,
                 datoNaa.toString(),
                 Vedtaksloesning.GJENNY,
-            )!!
+            )!!.behandling
 
         Assertions.assertTrue(foerstegangsbehandling is Foerstegangsbehandling)
 
@@ -538,7 +538,7 @@ class BehandlingFactoryTest {
                 persongalleri,
                 datoNaa.toString(),
                 Vedtaksloesning.GJENNY,
-            )
+            )?.behandling
         Assertions.assertTrue(revurderingsBehandling is Revurdering)
         verify {
             grunnlagService.leggInnNyttGrunnlag(any(), any())

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingIntegrationTest.kt
@@ -93,7 +93,7 @@ class RevurderingIntegrationTest : BehandlingIntegrationTest() {
                         LocalDateTime.now().toString(),
                         Vedtaksloesning.GJENNY,
                     )
-            }
+            }?.behandling
 
         return Pair(sak, behandling as Foerstegangsbehandling)
     }


### PR DESCRIPTION
Hovudpoenget i denne PR-en er å gå frå 

```
val nyopprettaOppgave =
                    oppgaveService.hentOppgaverForSak(it.sak.id).first { o -> o.referanse == it.id.toString() }
```

til 
`                val nyopprettaOppgave = requireNotNull(behandlingOgOppgave.oppgave)`