### PR TITLE
Refaktorisering vedtak-rivers, del 1: Flyttar det å sende til rapid frå service og ut til route

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakBehandlingService.kt
@@ -10,12 +10,9 @@ import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.common.oppgave.VedtakEndringDTO
 import no.nav.etterlatte.libs.common.oppgave.VedtakOppgaveDTO
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
-import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
 import no.nav.etterlatte.libs.common.rapidsandrivers.REVURDERING_AARSAK
 import no.nav.etterlatte.libs.common.rapidsandrivers.SKAL_SENDE_BREV
-import no.nav.etterlatte.libs.common.rapidsandrivers.TEKNISK_TID_KEY
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.common.tidspunkt.utcKlokke
 import no.nav.etterlatte.libs.common.toObjectNode
 import no.nav.etterlatte.libs.common.vedtak.Attestasjon
@@ -33,7 +30,6 @@ import no.nav.etterlatte.token.BrukerTokenInfo
 import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
 import no.nav.etterlatte.vedtaksvurdering.klienter.BeregningKlient
 import no.nav.etterlatte.vedtaksvurdering.klienter.VilkaarsvurderingKlient
-import no.nav.helse.rapids_rivers.JsonMessage
 import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.time.LocalDate
@@ -45,7 +41,6 @@ class VedtakBehandlingService(
     private val beregningKlient: BeregningKlient,
     private val vilkaarsvurderingKlient: VilkaarsvurderingKlient,
     private val behandlingKlient: BehandlingKlient,
-    private val publiser: (String, UUID) -> Unit,
     private val clock: Clock = utcKlokke(),
 ) {
     private val logger = LoggerFactory.getLogger(VedtakBehandlingService::class.java)
@@ -114,7 +109,7 @@ class VedtakBehandlingService(
     suspend fun fattVedtak(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
-    ): Vedtak {
+    ): VedtakOgRapid {
         logger.info("Fatter vedtak for behandling med behandlingId=$behandlingId")
         val vedtak = hentVedtakNonNull(behandlingId)
 
@@ -125,53 +120,53 @@ class VedtakBehandlingService(
 
         val fattetVedtak =
             repository.inTransaction { tx ->
-                val fattetVedtakIntern =
-                    fattVedtak(
-                        behandlingId,
-                        VedtakFattet(
-                            brukerTokenInfo.ident(),
-                            sak.enhet,
-                            Tidspunkt.now(clock),
-                        ),
-                        tx,
-                    ).also { fattetVedtak ->
-                        runBlocking {
-                            behandlingKlient.fattVedtakBehandling(
-                                brukerTokenInfo = brukerTokenInfo,
-                                vedtakEndringDTO =
-                                    VedtakEndringDTO(
-                                        vedtakOppgaveDTO =
-                                            VedtakOppgaveDTO(
-                                                sakId = sak.id,
-                                                referanse = behandlingId.toString(),
-                                            ),
-                                        vedtakHendelse =
-                                            VedtakHendelse(
-                                                vedtakId = fattetVedtak.id,
-                                                inntruffet = fattetVedtak.vedtakFattet?.tidspunkt!!,
-                                                saksbehandler = fattetVedtak.vedtakFattet.ansvarligSaksbehandler,
-                                            ),
-                                    ),
-                            )
-                        }
+                fattVedtak(
+                    behandlingId,
+                    VedtakFattet(
+                        brukerTokenInfo.ident(),
+                        sak.enhet,
+                        Tidspunkt.now(clock),
+                    ),
+                    tx,
+                ).also { fattetVedtak ->
+                    runBlocking {
+                        behandlingKlient.fattVedtakBehandling(
+                            brukerTokenInfo = brukerTokenInfo,
+                            vedtakEndringDTO =
+                                VedtakEndringDTO(
+                                    vedtakOppgaveDTO =
+                                        VedtakOppgaveDTO(
+                                            sakId = sak.id,
+                                            referanse = behandlingId.toString(),
+                                        ),
+                                    vedtakHendelse =
+                                        VedtakHendelse(
+                                            vedtakId = fattetVedtak.id,
+                                            inntruffet = fattetVedtak.vedtakFattet?.tidspunkt!!,
+                                            saksbehandler = fattetVedtak.vedtakFattet.ansvarligSaksbehandler,
+                                        ),
+                                ),
+                        )
                     }
-                sendToRapid(
-                    vedtakhendelse = VedtakKafkaHendelseType.FATTET,
-                    vedtak = fattetVedtakIntern,
-                    tekniskTid = fattetVedtakIntern.vedtakFattet!!.tidspunkt,
-                    behandlingId = behandlingId,
-                )
-                fattetVedtakIntern
+                }
             }
 
-        return fattetVedtak
+        return VedtakOgRapid(
+            fattetVedtak.toDto(),
+            RapidInfo(
+                vedtakhendelse = VedtakKafkaHendelseType.FATTET,
+                vedtak = fattetVedtak.toDto(),
+                tekniskTid = fattetVedtak.vedtakFattet!!.tidspunkt,
+                behandlingId = behandlingId,
+            ),
+        )
     }
 
     suspend fun attesterVedtak(
         behandlingId: UUID,
         kommentar: String,
         brukerTokenInfo: BrukerTokenInfo,
-    ): Vedtak {
+    ): VedtakOgRapid {
         logger.info("Attesterer vedtak for behandling med behandlingId=$behandlingId")
         val vedtak = hentVedtakNonNull(behandlingId)
 
@@ -221,10 +216,11 @@ class VedtakBehandlingService(
                 attestertVedtak
             }
 
-        try {
-            sendToRapid(
+        return VedtakOgRapid(
+            attestertVedtak.toDto(),
+            RapidInfo(
                 vedtakhendelse = VedtakKafkaHendelseType.ATTESTERT,
-                vedtak = attestertVedtak,
+                vedtak = attestertVedtak.toDto(),
                 tekniskTid = attestertVedtak.attestasjon!!.tidspunkt,
                 behandlingId = behandlingId,
                 extraParams =
@@ -237,18 +233,8 @@ class VedtakBehandlingService(
                         KILDE_KEY to behandling.kilde,
                         REVURDERING_AARSAK to behandling.revurderingsaarsak.toString(),
                     ),
-            )
-        } catch (e: Exception) {
-            logger.error(
-                "Kan ikke sende attestert vedtak på kafka for behandling id: $behandlingId, vedtak: ${vedtak.id} " +
-                    "Saknr: ${sak.id}. Det betyr at vi ikke sender ut brev for vedtaket eller at en utbetaling går til oppdrag. " +
-                    "Denne hendelsen må sendes ut manuelt straks.",
-                e,
-            )
-            throw e
-        }
-
-        return attestertVedtak
+            ),
+        )
     }
 
     private fun RevurderingAarsak?.skalIkkeSendeBrev() = this != null && !utfall.skalSendeBrev
@@ -257,7 +243,7 @@ class VedtakBehandlingService(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         begrunnelse: UnderkjennVedtakDto,
-    ): Vedtak {
+    ): VedtakOgRapid {
         logger.info("Underkjenner vedtak for behandling med behandlingId=$behandlingId")
         val vedtak = hentVedtakNonNull(behandlingId)
 
@@ -287,20 +273,21 @@ class VedtakBehandlingService(
                 underkjentVedtak
             }
 
-        sendToRapid(
-            vedtakhendelse = VedtakKafkaHendelseType.UNDERKJENT,
-            vedtak = underkjentVedtak,
-            tekniskTid = underkjentTid,
-            behandlingId = behandlingId,
+        return VedtakOgRapid(
+            repository.hentVedtak(behandlingId)!!.toDto(),
+            RapidInfo(
+                vedtakhendelse = VedtakKafkaHendelseType.UNDERKJENT,
+                vedtak = underkjentVedtak.toDto(),
+                tekniskTid = underkjentTid,
+                behandlingId = behandlingId,
+            ),
         )
-
-        return repository.hentVedtak(behandlingId)!!
     }
 
     suspend fun iverksattVedtak(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
-    ): Vedtak {
+    ): VedtakOgRapid {
         logger.info("Setter vedtak til iverksatt for behandling med behandlingId=$behandlingId")
         val vedtak = hentVedtakNonNull(behandlingId)
 
@@ -316,14 +303,15 @@ class VedtakBehandlingService(
                 iverksattVedtakLocal
             }
 
-        sendToRapid(
-            vedtakhendelse = VedtakKafkaHendelseType.IVERKSATT,
-            vedtak = iverksattVedtak,
-            tekniskTid = Tidspunkt.now(clock),
-            behandlingId = behandlingId,
+        return VedtakOgRapid(
+            iverksattVedtak.toDto(),
+            RapidInfo(
+                vedtakhendelse = VedtakKafkaHendelseType.IVERKSATT,
+                vedtak = iverksattVedtak.toDto(),
+                tekniskTid = Tidspunkt.now(clock),
+                behandlingId = behandlingId,
+            ),
         )
-
-        return iverksattVedtak
     }
 
     private fun hentVedtakNonNull(behandlingId: UUID): Vedtak {
@@ -534,23 +522,6 @@ class VedtakBehandlingService(
 
     private fun vilkaarsvurderingUtfallNonNull(vilkaarsvurderingUtfall: VilkaarsvurderingUtfall?) =
         requireNotNull(vilkaarsvurderingUtfall) { "Behandling mangler utfall på vilkårsvurdering" }
-
-    private fun sendToRapid(
-        vedtakhendelse: VedtakKafkaHendelseType,
-        vedtak: Vedtak,
-        tekniskTid: Tidspunkt,
-        behandlingId: UUID,
-        extraParams: Map<String, Any> = emptyMap(),
-    ) = publiser(
-        JsonMessage.newMessage(
-            mapOf(
-                EVENT_NAME_KEY to vedtakhendelse.toString(),
-                "vedtak" to vedtak.toDto(),
-                TEKNISK_TID_KEY to tekniskTid.toLocalDatetimeUTC(),
-            ) + extraParams,
-        ).toJson(),
-        behandlingId,
-    )
 
     fun tilbakestillIkkeIverksatteVedtak(behandlingId: UUID): Vedtak? = repository.tilbakestillIkkeIverksatteVedtak(behandlingId)
 

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRapidService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRapidService.kt
@@ -1,0 +1,40 @@
+package no.nav.etterlatte.vedtaksvurdering
+
+import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
+import no.nav.etterlatte.libs.common.rapidsandrivers.TEKNISK_TID_KEY
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
+import no.nav.etterlatte.libs.common.vedtak.VedtakDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseType
+import no.nav.helse.rapids_rivers.JsonMessage
+import java.util.UUID
+
+class VedtaksvurderingRapidService(
+    private val publiser: (String, UUID) -> Unit,
+) {
+    fun sendToRapid(rapidInfo: RapidInfo) =
+        sendToRapid(
+            vedtakhendelse = rapidInfo.vedtakhendelse,
+            vedtak = rapidInfo.vedtak,
+            tekniskTid = rapidInfo.tekniskTid,
+            behandlingId = rapidInfo.behandlingId,
+            extraParams = rapidInfo.extraParams,
+        )
+
+    private fun sendToRapid(
+        vedtakhendelse: VedtakKafkaHendelseType,
+        vedtak: VedtakDto,
+        tekniskTid: Tidspunkt,
+        behandlingId: UUID,
+        extraParams: Map<String, Any> = emptyMap(),
+    ) = publiser(
+        JsonMessage.newMessage(
+            mapOf(
+                EVENT_NAME_KEY to vedtakhendelse.toString(),
+                "vedtak" to vedtak,
+                TEKNISK_TID_KEY to tekniskTid.toLocalDatetimeUTC(),
+            ) + extraParams,
+        ).toJson(),
+        behandlingId,
+    )
+}

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/config/ApplicationBuilder.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/config/ApplicationBuilder.kt
@@ -12,6 +12,7 @@ import no.nav.etterlatte.libs.ktor.restModule
 import no.nav.etterlatte.libs.ktor.setReady
 import no.nav.etterlatte.vedtaksvurdering.VedtakBehandlingService
 import no.nav.etterlatte.vedtaksvurdering.VedtakTilbakekrevingService
+import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingRapidService
 import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingRepository
 import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingService
 import no.nav.etterlatte.vedtaksvurdering.automatiskBehandlingRoutes
@@ -53,8 +54,8 @@ class ApplicationBuilder {
             beregningKlient = BeregningKlientImpl(config, httpClient()),
             vilkaarsvurderingKlient = VilkaarsvurderingKlientImpl(config, httpClient()),
             behandlingKlient = behandlingKlient,
-            publiser = ::publiser,
         )
+    private val vedtaksvurderingRapidService = VedtaksvurderingRapidService(publiser = ::publiser)
     private val vedtakTilbakekrevingService =
         VedtakTilbakekrevingService(
             repository = VedtaksvurderingRepository(dataSource),
@@ -64,8 +65,8 @@ class ApplicationBuilder {
         RapidApplication.Builder(RapidApplication.RapidApplicationConfig.fromEnv(getRapidEnv()))
             .withKtorModule {
                 restModule(sikkerLogg, config = HoconApplicationConfig(config)) {
-                    vedtaksvurderingRoute(vedtaksvurderingService, vedtakBehandlingService, behandlingKlient)
-                    automatiskBehandlingRoutes(vedtakBehandlingService, behandlingKlient)
+                    vedtaksvurderingRoute(vedtaksvurderingService, vedtakBehandlingService, vedtaksvurderingRapidService, behandlingKlient)
+                    automatiskBehandlingRoutes(vedtakBehandlingService, vedtaksvurderingRapidService, behandlingKlient)
                     samordningsvedtakRoute(vedtaksvurderingService, vedtakBehandlingService)
                     tilbakekrevingvedtakRoute(vedtakTilbakekrevingService)
                 }

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingRouteTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingRouteTest.kt
@@ -20,7 +20,9 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import no.nav.etterlatte.libs.common.deserialize
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJson
@@ -41,7 +43,9 @@ import no.nav.etterlatte.vedtaksvurdering.LoependeYtelse
 import no.nav.etterlatte.vedtaksvurdering.UnderkjennVedtakDto
 import no.nav.etterlatte.vedtaksvurdering.VedtakBehandlingInnhold
 import no.nav.etterlatte.vedtaksvurdering.VedtakBehandlingService
+import no.nav.etterlatte.vedtaksvurdering.VedtakOgRapid
 import no.nav.etterlatte.vedtaksvurdering.VedtakTilbakekrevingInnhold
+import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingRapidService
 import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingService
 import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
 import no.nav.etterlatte.vedtaksvurdering.vedtaksvurderingRoute
@@ -64,6 +68,7 @@ internal class VedtaksvurderingRouteTest {
     private val behandlingKlient = mockk<BehandlingKlient>()
     private val vedtaksvurderingService: VedtaksvurderingService = mockk()
     private val vedtakBehandlingService: VedtakBehandlingService = mockk()
+    private val rapidService: VedtaksvurderingRapidService = mockk()
 
     @BeforeAll
     fun before() {
@@ -98,6 +103,7 @@ internal class VedtaksvurderingRouteTest {
                     vedtaksvurderingRoute(
                         vedtaksvurderingService,
                         vedtakBehandlingService,
+                        rapidService,
                         behandlingKlient,
                     )
                 }
@@ -123,6 +129,7 @@ internal class VedtaksvurderingRouteTest {
                     vedtaksvurderingRoute(
                         vedtaksvurderingService,
                         vedtakBehandlingService,
+                        rapidService,
                         behandlingKlient,
                     )
                 }
@@ -154,6 +161,7 @@ internal class VedtaksvurderingRouteTest {
                     vedtaksvurderingRoute(
                         vedtaksvurderingService,
                         vedtakBehandlingService,
+                        rapidService,
                         behandlingKlient,
                     )
                 }
@@ -186,6 +194,7 @@ internal class VedtaksvurderingRouteTest {
                     vedtaksvurderingRoute(
                         vedtaksvurderingService,
                         vedtakBehandlingService,
+                        rapidService,
                         behandlingKlient,
                     )
                 }
@@ -240,6 +249,7 @@ internal class VedtaksvurderingRouteTest {
                     vedtaksvurderingRoute(
                         vedtaksvurderingService,
                         vedtakBehandlingService,
+                        rapidService,
                         behandlingKlient,
                     )
                 }
@@ -296,6 +306,7 @@ internal class VedtaksvurderingRouteTest {
                     vedtaksvurderingRoute(
                         vedtaksvurderingService,
                         vedtakBehandlingService,
+                        rapidService,
                         behandlingKlient,
                     )
                 }
@@ -346,6 +357,7 @@ internal class VedtaksvurderingRouteTest {
                     vedtaksvurderingRoute(
                         vedtaksvurderingService,
                         vedtakBehandlingService,
+                        rapidService,
                         behandlingKlient,
                     )
                 }
@@ -388,6 +400,7 @@ internal class VedtaksvurderingRouteTest {
                     vedtaksvurderingRoute(
                         vedtaksvurderingService,
                         vedtakBehandlingService,
+                        rapidService,
                         behandlingKlient,
                     )
                 }
@@ -424,6 +437,7 @@ internal class VedtaksvurderingRouteTest {
                     vedtaksvurderingRoute(
                         vedtaksvurderingService,
                         vedtakBehandlingService,
+                        rapidService,
                         behandlingKlient,
                     )
                 }
@@ -473,7 +487,8 @@ internal class VedtaksvurderingRouteTest {
                 status = VedtakStatus.FATTET_VEDTAK,
                 vedtakFattet = VedtakFattet(SAKSBEHANDLER_1, ENHET_1, Tidspunkt.now()),
             )
-        coEvery { vedtakBehandlingService.fattVedtak(any(), any()) } returns fattetVedtak
+        coEvery { vedtakBehandlingService.fattVedtak(any(), any()) } returns VedtakOgRapid(fattetVedtak.toDto(), mockk())
+        coEvery { rapidService.sendToRapid(any()) } just runs
 
         testApplication {
             environment { config = applicationConfig }
@@ -482,6 +497,7 @@ internal class VedtaksvurderingRouteTest {
                     vedtaksvurderingRoute(
                         vedtaksvurderingService,
                         vedtakBehandlingService,
+                        rapidService,
                         behandlingKlient,
                     )
                 }
@@ -520,6 +536,7 @@ internal class VedtaksvurderingRouteTest {
             coVerify(exactly = 1) {
                 behandlingKlient.harTilgangTilBehandling(any(), any())
                 vedtakBehandlingService.fattVedtak(any(), match { it.ident() == SAKSBEHANDLER_1 })
+                rapidService.sendToRapid(any())
             }
         }
     }
@@ -533,7 +550,8 @@ internal class VedtaksvurderingRouteTest {
                 vedtakFattet = VedtakFattet(SAKSBEHANDLER_1, ENHET_1, Tidspunkt.now()),
                 attestasjon = Attestasjon(SAKSBEHANDLER_2, ENHET_2, Tidspunkt.now()),
             )
-        coEvery { vedtakBehandlingService.attesterVedtak(any(), any(), any()) } returns attestertVedtak
+        coEvery { vedtakBehandlingService.attesterVedtak(any(), any(), any()) } returns VedtakOgRapid(attestertVedtak.toDto(), mockk())
+        coEvery { rapidService.sendToRapid(any()) } just runs
 
         testApplication {
             environment { config = applicationConfig }
@@ -542,6 +560,7 @@ internal class VedtaksvurderingRouteTest {
                     vedtaksvurderingRoute(
                         vedtaksvurderingService,
                         vedtakBehandlingService,
+                        rapidService,
                         behandlingKlient,
                     )
                 }
@@ -585,6 +604,7 @@ internal class VedtaksvurderingRouteTest {
                     match { it == attestertVedtakKommentar.kommentar },
                     match { it.ident() == SAKSBEHANDLER_1 },
                 )
+                rapidService.sendToRapid(any())
             }
         }
     }
@@ -596,7 +616,9 @@ internal class VedtaksvurderingRouteTest {
                 status = VedtakStatus.RETURNERT,
             )
         val begrunnelse = UnderkjennVedtakDto("Ikke bra nok begrunnet", "Annet")
-        coEvery { vedtakBehandlingService.underkjennVedtak(any(), any(), any()) } returns underkjentVedtak
+        coEvery { vedtakBehandlingService.underkjennVedtak(any(), any(), any()) } returns
+            VedtakOgRapid(underkjentVedtak.toDto(), mockk())
+        coEvery { rapidService.sendToRapid(any()) } just runs
 
         testApplication {
             environment { config = applicationConfig }
@@ -605,6 +627,7 @@ internal class VedtaksvurderingRouteTest {
                     vedtaksvurderingRoute(
                         vedtaksvurderingService,
                         vedtakBehandlingService,
+                        rapidService,
                         behandlingKlient,
                     )
                 }
@@ -648,6 +671,7 @@ internal class VedtaksvurderingRouteTest {
                     match { it.ident() == SAKSBEHANDLER_1 },
                     match { it == begrunnelse },
                 )
+                rapidService.sendToRapid(any())
             }
         }
     }
@@ -667,6 +691,7 @@ internal class VedtaksvurderingRouteTest {
                     vedtaksvurderingRoute(
                         vedtaksvurderingService,
                         vedtakBehandlingService,
+                        rapidService,
                         behandlingKlient,
                     )
                 }

--- a/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/VedtakOgRapid.kt
+++ b/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/VedtakOgRapid.kt
@@ -1,0 +1,16 @@
+package no.nav.etterlatte.vedtaksvurdering
+
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.vedtak.VedtakDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseType
+import java.util.UUID
+
+data class VedtakOgRapid(val vedtak: VedtakDto, val rapidInfo: RapidInfo)
+
+data class RapidInfo(
+    val vedtakhendelse: VedtakKafkaHendelseType,
+    val vedtak: VedtakDto,
+    val tekniskTid: Tidspunkt,
+    val behandlingId: UUID,
+    val extraParams: Map<String, Any> = emptyMap(),
+)


### PR DESCRIPTION
Formålet er å i neste (eller neste-neste) PR å endre på dette for migrering og andre automatiske behandlingar, sånn at meldinga vi der sender med vidare får med seg konteksten vi kom frå. I neste PR kjem eg til å ta bort sendToRapid-kallet for attestering frå AutomatiskeBehandlingerRoutes, og heller flytte denne sendinga over i riverane i vedtaksvurdering-kafka.

Per i dag sender vi heilt nye meldingar ut, og da mistar vi alt av kontekst, som gjer at vi i andre applikasjonar (per no særleg brev-api) må gjera krumspring, der vi helst skulle hatt all konteksten frå den opphavlege meldinga.