### PR TITLE
behandlingsid -> behandlingId for mer konsekvent navngiving

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -22,7 +22,7 @@ import no.nav.etterlatte.behandling.manueltopphoer.ManueltOpphoerAarsak
 import no.nav.etterlatte.behandling.manueltopphoer.ManueltOpphoerRequest
 import no.nav.etterlatte.behandling.manueltopphoer.ManueltOpphoerService
 import no.nav.etterlatte.inTransaction
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingsBehov
 import no.nav.etterlatte.libs.common.behandling.BoddEllerArbeidetUtlandet
@@ -34,7 +34,7 @@ import no.nav.etterlatte.libs.common.behandling.OpprettAktivitetspliktOppfolging
 import no.nav.etterlatte.libs.common.behandling.Utenlandstilsnitt
 import no.nav.etterlatte.libs.common.behandling.UtenlandstilsnittType
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
-import no.nav.etterlatte.libs.common.behandlingsId
+import no.nav.etterlatte.libs.common.behandlingId
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.gyldigSoeknad.GyldighetsResultat
 import no.nav.etterlatte.libs.common.hentNavidentFraToken
@@ -64,10 +64,10 @@ internal fun Route.behandlingRoutes(
         }
     }
 
-    route("/api/behandling/{$BEHANDLINGSID_CALL_PARAMETER}/") {
+    route("/api/behandling/{$BEHANDLINGID_CALL_PARAMETER}/") {
         get {
             val detaljertBehandlingDTO =
-                behandlingService.hentDetaljertBehandlingMedTilbehoer(behandlingsId, brukerTokenInfo)
+                behandlingService.hentDetaljertBehandlingMedTilbehoer(behandlingId, brukerTokenInfo)
             call.respond(detaljertBehandlingDTO)
         }
 
@@ -78,7 +78,7 @@ internal fun Route.behandlingRoutes(
                     val lagretGyldighetsResultat =
                         inTransaction {
                             gyldighetsproevingService.lagreGyldighetsproeving(
-                                behandlingsId,
+                                behandlingId,
                                 navIdent,
                                 body,
                             )
@@ -98,7 +98,7 @@ internal fun Route.behandlingRoutes(
                         body.svar,
                         body.begrunnelse,
                         Grunnlagsopplysning.Saksbehandler.create(navIdent),
-                        behandlingsId,
+                        behandlingId,
                     )
 
                 try {
@@ -112,15 +112,15 @@ internal fun Route.behandlingRoutes(
 
         route("/manueltopphoer") {
             get {
-                logger.info("Henter manuelt opphør oppsummering for manuelt opphør med id=$behandlingsId")
+                logger.info("Henter manuelt opphør oppsummering for manuelt opphør med id=$behandlingId")
                 when (
                     val opphoerOgBehandlinger =
-                        manueltOpphoerService.hentManueltOpphoerOgAlleIverksatteBehandlingerISak(behandlingsId)
+                        manueltOpphoerService.hentManueltOpphoerOgAlleIverksatteBehandlingerISak(behandlingId)
                 ) {
                     null ->
                         call.respond(
                             HttpStatusCode.NotFound,
-                            "Fant ikke manuelt opphør med id=$behandlingsId",
+                            "Fant ikke manuelt opphør med id=$behandlingId",
                         )
 
                     else -> {
@@ -134,7 +134,7 @@ internal fun Route.behandlingRoutes(
         }
 
         post("/avbryt") {
-            inTransaction { behandlingService.avbrytBehandling(behandlingsId, brukerTokenInfo) }
+            inTransaction { behandlingService.avbrytBehandling(behandlingId, brukerTokenInfo) }
             call.respond(HttpStatusCode.OK)
         }
 
@@ -145,7 +145,7 @@ internal fun Route.behandlingRoutes(
 
                 val erGyldigVirkningstidspunkt =
                     behandlingService.erGyldigVirkningstidspunkt(
-                        behandlingsId,
+                        behandlingId,
                         brukerTokenInfo,
                         body,
                     )
@@ -157,7 +157,7 @@ internal fun Route.behandlingRoutes(
                     val virkningstidspunkt =
                         inTransaction {
                             behandlingService.oppdaterVirkningstidspunkt(
-                                behandlingsId,
+                                behandlingId,
                                 body.dato,
                                 navIdent,
                                 body.begrunnelse!!,
@@ -189,7 +189,7 @@ internal fun Route.behandlingRoutes(
                         )
 
                     inTransaction {
-                        behandlingService.oppdaterUtenlandstilsnitt(behandlingsId, utenlandstilsnitt)
+                        behandlingService.oppdaterUtenlandstilsnitt(behandlingId, utenlandstilsnitt)
                     }
 
                     call.respondText(
@@ -224,7 +224,7 @@ internal fun Route.behandlingRoutes(
 
                     inTransaction {
                         behandlingService.oppdaterBoddEllerArbeidetUtlandet(
-                            behandlingsId,
+                            behandlingId,
                             boddEllerArbeidetUtlandet,
                         )
                     }
@@ -242,7 +242,7 @@ internal fun Route.behandlingRoutes(
 
         route("/aktivitetsplikt") {
             get {
-                val result = aktivitetspliktService.hentAktivitetspliktOppfolging(behandlingsId)
+                val result = aktivitetspliktService.hentAktivitetspliktOppfolging(behandlingId)
                 call.respond(result ?: HttpStatusCode.NoContent)
             }
 
@@ -253,7 +253,7 @@ internal fun Route.behandlingRoutes(
                     try {
                         val result =
                             aktivitetspliktService.lagreAktivitetspliktOppfolging(
-                                behandlingsId,
+                                behandlingId,
                                 oppfolging,
                                 navIdent,
                             )
@@ -267,18 +267,18 @@ internal fun Route.behandlingRoutes(
     }
 
     route("/behandlinger") {
-        route("/{$BEHANDLINGSID_CALL_PARAMETER}") {
+        route("/{$BEHANDLINGID_CALL_PARAMETER}") {
             get {
-                logger.info("Henter detaljert behandling for behandling med id=$behandlingsId")
-                when (val behandling = behandlingService.hentDetaljertBehandling(behandlingsId, brukerTokenInfo)) {
+                logger.info("Henter detaljert behandling for behandling med id=$behandlingId")
+                when (val behandling = behandlingService.hentDetaljertBehandling(behandlingId, brukerTokenInfo)) {
                     is DetaljertBehandling -> call.respond(behandling)
-                    else -> call.respond(HttpStatusCode.NotFound, "Fant ikke behandling med id=$behandlingsId")
+                    else -> call.respond(HttpStatusCode.NotFound, "Fant ikke behandling med id=$behandlingId")
                 }
             }
 
             post("/gyldigfremsatt") {
                 val body = call.receive<GyldighetsResultat>()
-                gyldighetsproevingService.lagreGyldighetsproeving(behandlingsId, body)
+                gyldighetsproevingService.lagreGyldighetsproeving(behandlingId, body)
                 call.respond(HttpStatusCode.OK)
             }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
@@ -10,19 +10,19 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.inTransaction
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
-import no.nav.etterlatte.libs.common.behandlingsId
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.behandlingId
 import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
 import no.nav.etterlatte.tilgangsstyring.kunAttestant
 import no.nav.etterlatte.vedtaksvurdering.VedtakHendelse
 
 internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingStatusService) {
-    route("/behandlinger/{$BEHANDLINGSID_CALL_PARAMETER}") {
+    route("/behandlinger/{$BEHANDLINGID_CALL_PARAMETER}") {
         get("/opprett") {
             // Kalles kun av vilkårsvurdering når total-vurdering slettes
             haandterStatusEndring(call) {
                 inTransaction {
-                    behandlingsstatusService.settOpprettet(behandlingsId)
+                    behandlingsstatusService.settOpprettet(behandlingId)
                 }
             }
         }
@@ -30,7 +30,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
             // Kalles kun av vilkårsvurdering når total-vurdering slettes
             haandterStatusEndring(call) {
                 inTransaction {
-                    behandlingsstatusService.settOpprettet(behandlingsId, false)
+                    behandlingsstatusService.settOpprettet(behandlingId, false)
                 }
             }
         }
@@ -38,14 +38,14 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         get("/vilkaarsvurder") {
             haandterStatusEndring(call) {
                 inTransaction {
-                    behandlingsstatusService.settVilkaarsvurdert(behandlingsId, true)
+                    behandlingsstatusService.settVilkaarsvurdert(behandlingId, true)
                 }
             }
         }
         post("/vilkaarsvurder") {
             haandterStatusEndring(call) {
                 inTransaction {
-                    behandlingsstatusService.settVilkaarsvurdert(behandlingsId, false)
+                    behandlingsstatusService.settVilkaarsvurdert(behandlingId, false)
                 }
             }
         }
@@ -53,14 +53,14 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         get("/oppdaterTrygdetid") {
             haandterStatusEndring(call) {
                 inTransaction {
-                    behandlingsstatusService.settTrygdetidOppdatert(behandlingsId, true)
+                    behandlingsstatusService.settTrygdetidOppdatert(behandlingId, true)
                 }
             }
         }
         post("/oppdaterTrygdetid") {
             haandterStatusEndring(call) {
                 inTransaction {
-                    behandlingsstatusService.settTrygdetidOppdatert(behandlingsId, false)
+                    behandlingsstatusService.settTrygdetidOppdatert(behandlingId, false)
                 }
             }
         }
@@ -68,7 +68,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         get("/beregn") {
             haandterStatusEndring(call) {
                 inTransaction {
-                    behandlingsstatusService.settBeregnet(behandlingsId)
+                    behandlingsstatusService.settBeregnet(behandlingId)
                 }
             }
         }
@@ -76,7 +76,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         post("/beregn") {
             haandterStatusEndring(call) {
                 inTransaction {
-                    behandlingsstatusService.settBeregnet(behandlingsId, false)
+                    behandlingsstatusService.settBeregnet(behandlingId, false)
                 }
             }
         }
@@ -84,7 +84,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         get("/avkort") {
             haandterStatusEndring(call) {
                 inTransaction {
-                    behandlingsstatusService.settAvkortet(behandlingsId)
+                    behandlingsstatusService.settAvkortet(behandlingId)
                 }
             }
         }
@@ -92,7 +92,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         post("/avkort") {
             haandterStatusEndring(call) {
                 inTransaction {
-                    behandlingsstatusService.settAvkortet(behandlingsId, false)
+                    behandlingsstatusService.settAvkortet(behandlingId, false)
                 }
             }
         }
@@ -100,14 +100,14 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         get("/fatteVedtak") {
             haandterStatusEndring(call) {
                 inTransaction {
-                    behandlingsstatusService.sjekkOmKanFatteVedtak(behandlingsId)
+                    behandlingsstatusService.sjekkOmKanFatteVedtak(behandlingId)
                 }
             }
         }
         get("/returner") {
             haandterStatusEndring(call) {
                 inTransaction {
-                    behandlingsstatusService.sjekkOmKanReturnereVedtak(behandlingsId)
+                    behandlingsstatusService.sjekkOmKanReturnereVedtak(behandlingId)
                 }
             }
         }
@@ -116,7 +116,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
             kunAttestant {
                 haandterStatusEndring(call) {
                     inTransaction {
-                        behandlingsstatusService.sjekkOmKanAttestere(behandlingsId)
+                        behandlingsstatusService.sjekkOmKanAttestere(behandlingId)
                     }
                 }
             }
@@ -126,7 +126,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
             val vedtakHendelse = call.receive<VedtakHendelse>()
             haandterStatusEndring(call) {
                 inTransaction {
-                    behandlingsstatusService.settIverksattVedtak(behandlingsId, vedtakHendelse)
+                    behandlingsstatusService.settIverksattVedtak(behandlingId, vedtakHendelse)
                 }
             }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/SjekklisteRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/SjekklisteRoute.kt
@@ -12,26 +12,26 @@ import io.ktor.server.routing.route
 import no.nav.etterlatte.behandling.sjekkliste.OppdaterSjekklisteItem
 import no.nav.etterlatte.behandling.sjekkliste.OppdatertSjekkliste
 import no.nav.etterlatte.behandling.sjekkliste.SjekklisteService
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
-import no.nav.etterlatte.libs.common.behandlingsId
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.behandlingId
 import no.nav.etterlatte.libs.common.kunSaksbehandler
 
 internal fun Route.sjekklisteRoute(sjekklisteService: SjekklisteService) {
-    route("/api/sjekkliste/{$BEHANDLINGSID_CALL_PARAMETER}") {
+    route("/api/sjekkliste/{$BEHANDLINGID_CALL_PARAMETER}") {
         get {
-            val result = sjekklisteService.hentSjekkliste(behandlingsId)
+            val result = sjekklisteService.hentSjekkliste(behandlingId)
             call.respond(result ?: HttpStatusCode.NotFound)
         }
 
         post {
-            val result = sjekklisteService.opprettSjekkliste(behandlingsId)
+            val result = sjekklisteService.opprettSjekkliste(behandlingId)
             call.respond(result)
         }
 
         put {
             kunSaksbehandler {
                 val oppdatering = call.receive<OppdatertSjekkliste>()
-                val result = sjekklisteService.oppdaterSjekkliste(behandlingsId, oppdatering)
+                val result = sjekklisteService.oppdaterSjekkliste(behandlingId, oppdatering)
                 call.respond(result)
             }
         }
@@ -43,7 +43,7 @@ internal fun Route.sjekklisteRoute(sjekklisteService: SjekklisteService) {
 
                 val result =
                     sjekklisteService.oppdaterSjekklisteItem(
-                        behandlingsId,
+                        behandlingId,
                         sjekklisteItemId,
                         oppdatering,
                     )

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etterbetaling/EtterbetalingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etterbetaling/EtterbetalingDao.kt
@@ -42,13 +42,13 @@ class EtterbetalingDao(private val connection: () -> Connection) {
             }
         }
 
-    fun slettEtterbetaling(behandlingsId: UUID) {
+    fun slettEtterbetaling(behandlingId: UUID) {
         with(connection()) {
             val statement =
                 prepareStatement(
                     "DELETE FROM etterbetaling WHERE behandling_id = ?::UUID".trimIndent(),
                 )
-            statement.setObject(1, behandlingsId)
+            statement.setObject(1, behandlingId)
             statement.executeUpdate()
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etterbetaling/EtterbetalingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etterbetaling/EtterbetalingRoutes.kt
@@ -11,9 +11,9 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.put
 import io.ktor.server.routing.route
 import no.nav.etterlatte.inTransaction
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.behandling.Etterbetaling
-import no.nav.etterlatte.libs.common.behandlingsId
+import no.nav.etterlatte.libs.common.behandlingId
 import no.nav.etterlatte.libs.common.medBody
 import java.time.LocalDate
 import java.time.YearMonth
@@ -21,14 +21,14 @@ import java.time.YearMonth
 internal fun Route.etterbetalingRoutes(service: EtterbetalingService) {
     val logger = application.log
 
-    route("/api/behandling/{$BEHANDLINGSID_CALL_PARAMETER}/etterbetaling") {
+    route("/api/behandling/{$BEHANDLINGID_CALL_PARAMETER}/etterbetaling") {
         put {
             medBody<EtterbetalingDTO> { request ->
-                logger.info("Lagrer etterbetaling for behandling $behandlingsId")
+                logger.info("Lagrer etterbetaling for behandling $behandlingId")
                 inTransaction {
                     service.lagreEtterbetaling(
                         Etterbetaling(
-                            behandlingId = behandlingsId,
+                            behandlingId = behandlingId,
                             fra =
                                 requireNotNull(request.fraDato) { "Mangler fradato etterbetaling" }.let {
                                     YearMonth.from(
@@ -49,7 +49,7 @@ internal fun Route.etterbetalingRoutes(service: EtterbetalingService) {
         }
 
         get {
-            when (val etterbetaling = inTransaction { service.hentEtterbetaling(behandlingsId) }) {
+            when (val etterbetaling = inTransaction { service.hentEtterbetaling(behandlingId) }) {
                 null -> call.respond(HttpStatusCode.NoContent)
                 else ->
                     call.respond(
@@ -63,8 +63,8 @@ internal fun Route.etterbetalingRoutes(service: EtterbetalingService) {
         }
 
         delete {
-            logger.info("Sletter etterbetaling for behandling $behandlingsId")
-            inTransaction { service.slettEtterbetaling(behandlingsId) }
+            logger.info("Sletter etterbetaling for behandling $behandlingId")
+            inTransaction { service.slettEtterbetaling(behandlingId) }
             call.respond(HttpStatusCode.OK)
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etterbetaling/EtterbetalingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etterbetaling/EtterbetalingService.kt
@@ -6,7 +6,7 @@ import java.util.UUID
 internal class EtterbetalingService(private val dao: EtterbetalingDao) {
     fun lagreEtterbetaling(etterbetaling: Etterbetaling) = dao.lagreEtterbetaling(etterbetaling)
 
-    fun hentEtterbetaling(behandlingsId: UUID): Etterbetaling? = dao.hentEtterbetaling(behandlingsId)
+    fun hentEtterbetaling(behandlingId: UUID): Etterbetaling? = dao.hentEtterbetaling(behandlingId)
 
-    fun slettEtterbetaling(behandlingsId: UUID) = dao.slettEtterbetaling(behandlingsId)
+    fun slettEtterbetaling(behandlingId: UUID) = dao.slettEtterbetaling(behandlingId)
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringRoutes.kt
@@ -9,8 +9,8 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.put
 import io.ktor.server.routing.route
 import no.nav.etterlatte.inTransaction
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
-import no.nav.etterlatte.libs.common.behandlingsId
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.behandlingId
 import no.nav.etterlatte.libs.common.sak.BehandlingOgSak
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 
@@ -26,8 +26,8 @@ fun Route.migreringRoutes(migreringService: MigreringService) {
                     )
             }
         }
-        put("/{$BEHANDLINGSID_CALL_PARAMETER}/avbryt") {
-            inTransaction { migreringService.avbrytBehandling(behandlingsId, brukerTokenInfo) }
+        put("/{$BEHANDLINGID_CALL_PARAMETER}/avbryt") {
+            inTransaction { migreringService.avbrytBehandling(behandlingId, brukerTokenInfo) }
             call.respond(HttpStatusCode.OK)
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
@@ -10,12 +10,12 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.inTransaction
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.behandling.RevurderingInfo
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
-import no.nav.etterlatte.libs.common.behandlingsId
+import no.nav.etterlatte.libs.common.behandlingId
 import no.nav.etterlatte.libs.common.hentNavidentFraToken
 import no.nav.etterlatte.libs.common.kunSaksbehandler
 import no.nav.etterlatte.libs.common.medBody
@@ -25,15 +25,15 @@ internal fun Route.revurderingRoutes(revurderingService: RevurderingService) {
     val logger = application.log
 
     route("/api/revurdering") {
-        route("{$BEHANDLINGSID_CALL_PARAMETER}") {
+        route("{$BEHANDLINGID_CALL_PARAMETER}") {
             route("revurderinginfo") {
                 post {
                     hentNavidentFraToken { navIdent ->
-                        logger.info("Lagrer revurderinginfo på behandling $behandlingsId")
+                        logger.info("Lagrer revurderinginfo på behandling $behandlingId")
                         medBody<RevurderingInfoDto> {
                             inTransaction {
                                 revurderingService.lagreRevurderingInfo(
-                                    behandlingsId,
+                                    behandlingId,
                                     RevurderingMedBegrunnelse(it.info, it.begrunnelse),
                                     navIdent,
                                 )

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -240,8 +240,8 @@ class RevurderingService(
         )
     }
 
-    private fun behandlingErAvTypenRevurderingOgKanEndres(behandlingsId: UUID) {
-        val behandling = hentBehandling(behandlingsId)
+    private fun behandlingErAvTypenRevurderingOgKanEndres(behandlingId: UUID) {
+        val behandling = hentBehandling(behandlingId)
         if (behandling?.type != BehandlingType.REVURDERING) {
             throw UgyldigBehandlingTypeForRevurdering()
         }
@@ -251,13 +251,13 @@ class RevurderingService(
     }
 
     fun lagreRevurderingInfo(
-        behandlingsId: UUID,
+        behandlingId: UUID,
         revurderingMedBegrunnelse: RevurderingMedBegrunnelse,
         navIdent: String,
     ) {
-        behandlingErAvTypenRevurderingOgKanEndres(behandlingsId)
+        behandlingErAvTypenRevurderingOgKanEndres(behandlingId)
         val kilde = Grunnlagsopplysning.Saksbehandler.create(navIdent)
-        revurderingDao.lagreRevurderingInfo(behandlingsId, revurderingMedBegrunnelse, kilde)
+        revurderingDao.lagreRevurderingInfo(behandlingId, revurderingMedBegrunnelse, kilde)
     }
 
     private fun opprettRevurdering(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/statistikk/StatistikkRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/statistikk/StatistikkRoute.kt
@@ -9,20 +9,20 @@ import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
 import no.nav.etterlatte.behandling.BehandlingService
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.behandling.StatistikkBehandling
-import no.nav.etterlatte.libs.common.behandlingsId
+import no.nav.etterlatte.libs.common.behandlingId
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 
 internal fun Route.statistikkRoutes(behandlingService: BehandlingService) {
     val logger = application.log
 
-    route("/behandlinger/statistikk/{$BEHANDLINGSID_CALL_PARAMETER}") {
+    route("/behandlinger/statistikk/{$BEHANDLINGID_CALL_PARAMETER}") {
         get {
-            logger.info("Henter detaljert behandling for behandling med id=$behandlingsId")
-            when (val behandling = behandlingService.hentStatistikkBehandling(behandlingsId, brukerTokenInfo)) {
+            logger.info("Henter detaljert behandling for behandling med id=$behandlingId")
+            when (val behandling = behandlingService.hentStatistikkBehandling(behandlingId, brukerTokenInfo)) {
                 is StatistikkBehandling -> call.respond(behandling)
-                else -> call.respond(HttpStatusCode.NotFound, "Fant ikke behandling med id=$behandlingsId")
+                else -> call.respond(HttpStatusCode.NotFound, "Fant ikke behandling med id=$behandlingId")
             }
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingRoutes.kt
@@ -9,17 +9,17 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.put
 import io.ktor.server.routing.route
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
-import no.nav.etterlatte.libs.common.behandlingsId
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.behandlingId
 import no.nav.etterlatte.libs.common.medBody
 import no.nav.etterlatte.libs.common.tilbakekreving.Kravgrunnlag
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 
 internal fun Route.tilbakekrevingRoutes(service: TilbakekrevingService) {
-    route("/api/tilbakekreving/{$BEHANDLINGSID_CALL_PARAMETER}") {
+    route("/api/tilbakekreving/{$BEHANDLINGID_CALL_PARAMETER}") {
         get {
             try {
-                call.respond(service.hentTilbakekreving(behandlingsId))
+                call.respond(service.hentTilbakekreving(behandlingId))
             } catch (e: TilbakekrevingFinnesIkkeException) {
                 call.respond(HttpStatusCode.NotFound)
             }
@@ -27,7 +27,7 @@ internal fun Route.tilbakekrevingRoutes(service: TilbakekrevingService) {
         put("/vurdering") {
             val vurdering = call.receive<TilbakekrevingVurdering>()
             try {
-                call.respond(service.lagreVurdering(behandlingsId, vurdering))
+                call.respond(service.lagreVurdering(behandlingId, vurdering))
             } catch (e: TilbakekrevingFinnesIkkeException) {
                 call.respond(HttpStatusCode.NotFound)
             }
@@ -35,7 +35,7 @@ internal fun Route.tilbakekrevingRoutes(service: TilbakekrevingService) {
         put("/perioder") {
             val request = call.receive<TilbakekrevingLagreRequest>()
             try {
-                call.respond(service.lagrePerioder(behandlingsId, request.perioder))
+                call.respond(service.lagrePerioder(behandlingId, request.perioder))
             } catch (e: TilbakekrevingFinnesIkkeException) {
                 call.respond(HttpStatusCode.NotFound)
             }
@@ -44,24 +44,24 @@ internal fun Route.tilbakekrevingRoutes(service: TilbakekrevingService) {
         route("vedtak") {
             post("opprett") {
                 // TODO tilgangsjekk
-                service.opprettVedtak(behandlingsId, brukerTokenInfo)
+                service.opprettVedtak(behandlingId, brukerTokenInfo)
                 call.respond(HttpStatusCode.OK)
             }
             post("fatt") {
                 // TODO tilgangsjekk
-                service.fattVedtak(behandlingsId, brukerTokenInfo)
+                service.fattVedtak(behandlingId, brukerTokenInfo)
                 call.respond(HttpStatusCode.OK)
             }
             post("attester") {
                 // TODO tilgangsjekk
                 val (kommentar) = call.receive<TilbakekrevingAttesterRequest>()
-                service.attesterVedtak(behandlingsId, kommentar, brukerTokenInfo)
+                service.attesterVedtak(behandlingId, kommentar, brukerTokenInfo)
                 call.respond(HttpStatusCode.OK)
             }
             post("underkjenn") {
                 // TODO tilgangsjekk
                 val (kommentar, valgtBegrunnelse) = call.receive<TilbakekrevingUnderkjennRequest>()
-                service.underkjennVedtak(behandlingsId, kommentar, valgtBegrunnelse, brukerTokenInfo)
+                service.underkjennVedtak(behandlingId, kommentar, valgtBegrunnelse, brukerTokenInfo)
                 call.respond(HttpStatusCode.OK)
             }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilgang/TilgangRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilgang/TilgangRoutes.kt
@@ -9,9 +9,9 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.inTransaction
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
-import no.nav.etterlatte.libs.common.behandlingsId
+import no.nav.etterlatte.libs.common.behandlingId
 import no.nav.etterlatte.libs.common.sakId
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.sak.TilgangService
@@ -37,11 +37,11 @@ internal fun Route.tilgangRoutes(tilgangService: TilgangService) {
             call.respond(harTilgang)
         }
 
-        get("/behandling/{$BEHANDLINGSID_CALL_PARAMETER}") {
+        get("/behandling/{$BEHANDLINGID_CALL_PARAMETER}") {
             val harTilgang =
                 harTilgangBrukertypeSjekk(brukerTokenInfo) { _ ->
                     tilgangService.harTilgangTilBehandling(
-                        behandlingsId.toString(),
+                        behandlingId.toString(),
                         Kontekst.get().appUserAsSaksbehandler().saksbehandlerMedRoller,
                     )
                 }

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
@@ -12,11 +12,11 @@ import io.ktor.server.routing.put
 import io.ktor.server.routing.route
 import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.inTransaction
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.OPPGAVEID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.OPPGAVEID_GOSYS_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
-import no.nav.etterlatte.libs.common.behandlingsId
+import no.nav.etterlatte.libs.common.behandlingId
 import no.nav.etterlatte.libs.common.gosysOppgaveId
 import no.nav.etterlatte.libs.common.kunSaksbehandler
 import no.nav.etterlatte.libs.common.kunSystembruker
@@ -55,17 +55,17 @@ internal fun Route.oppgaveRoutes(
             }
         }
 
-        route("behandling/{$BEHANDLINGSID_CALL_PARAMETER}") {
+        route("behandling/{$BEHANDLINGID_CALL_PARAMETER}") {
             get("/hentsaksbehandler") {
                 kunSaksbehandler {
-                    val saksbehandler = inTransaction { service.hentSaksbehandlerForBehandling(behandlingsId) }
+                    val saksbehandler = inTransaction { service.hentSaksbehandlerForBehandling(behandlingId) }
                     call.respond(saksbehandler ?: HttpStatusCode.NoContent)
                 }
             }
 
             get("/oppgaveunderarbeid") {
                 kunSaksbehandler {
-                    val saksbehandler = inTransaction { service.hentSaksbehandlerForOppgaveUnderArbeid(behandlingsId) }
+                    val saksbehandler = inTransaction { service.hentSaksbehandlerForOppgaveUnderArbeid(behandlingId) }
                     call.respond(saksbehandler ?: HttpStatusCode.NoContent)
                 }
             }

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -339,9 +339,9 @@ class OppgaveService(
         )
     }
 
-    fun hentSaksbehandlerForBehandling(behandlingsId: UUID): String? {
+    fun hentSaksbehandlerForBehandling(behandlingId: UUID): String? {
         val oppgaverForBehandlingUtenAttesterting =
-            oppgaveDao.hentOppgaverForReferanse(behandlingsId.toString())
+            oppgaveDao.hentOppgaverForReferanse(behandlingId.toString())
                 .filter {
                     it.type !== OppgaveType.ATTESTERING
                 }
@@ -358,16 +358,16 @@ class OppgaveService(
         return oppgaverForBehandlingFoerstegangs.sortedByDescending { it.opprettet }.firstOrNull()
     }
 
-    fun hentSaksbehandlerForOppgaveUnderArbeid(behandlingsId: UUID): String? {
-        val oppgaverforBehandling = oppgaveDao.hentOppgaverForReferanse(behandlingsId.toString())
+    fun hentSaksbehandlerForOppgaveUnderArbeid(behandlingId: UUID): String? {
+        val oppgaverforBehandling = oppgaveDao.hentOppgaverForReferanse(behandlingId.toString())
         return try {
             val oppgaveUnderbehandling = oppgaverforBehandling.single { it.status == Status.UNDER_BEHANDLING }
             oppgaveUnderbehandling.saksbehandler
         } catch (e: NoSuchElementException) {
-            logger.info("Det må finnes en oppgave under behandling, gjelder behandling: $behandlingsId")
+            logger.info("Det må finnes en oppgave under behandling, gjelder behandling: $behandlingId")
             return null
         } catch (e: IllegalArgumentException) {
-            logger.info("Skal kun ha en oppgave under behandling, gjelder behandling: $behandlingsId")
+            logger.info("Skal kun ha en oppgave under behandling, gjelder behandling: $behandlingId")
             return null
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
@@ -18,7 +18,7 @@ import no.nav.etterlatte.User
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggle
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.inTransaction
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.FoedselsNummerMedGraderingDTO
 import no.nav.etterlatte.libs.common.FoedselsnummerDTO
 import no.nav.etterlatte.libs.common.KLAGEID_CALL_PARAMETER
@@ -78,7 +78,7 @@ val adressebeskyttelsePlugin: RouteScopedPlugin<PluginConfiguration> =
 
             if (bruker is Saksbehandler) {
                 val saksbehandlerGroupIdsByKey = pluginConfig.saksbehandlerGroupIdsByKey
-                val behandlingId = call.parameters[BEHANDLINGSID_CALL_PARAMETER]
+                val behandlingId = call.parameters[BEHANDLINGID_CALL_PARAMETER]
                 if (!behandlingId.isNullOrEmpty()) {
                     if (!pluginConfig.harTilgangBehandling(
                             behandlingId,

--- a/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/beregningkafka/BeregningService.kt
+++ b/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/beregningkafka/BeregningService.kt
@@ -21,10 +21,10 @@ class BeregningService(
 
     fun opprettBeregningsgrunnlagFraForrigeBehandling(
         omregningsId: UUID,
-        forrigeBehandlingsId: UUID,
+        forrigeBehandlingId: UUID,
     ): HttpResponse =
         runBlocking {
-            beregningApp.post("$url/api/beregning/beregningsgrunnlag/$omregningsId/fra/$forrigeBehandlingsId")
+            beregningApp.post("$url/api/beregning/beregningsgrunnlag/$omregningsId/fra/$forrigeBehandlingId")
         }
 
     fun opprettBeregningsgrunnlag(

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -11,7 +11,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.klienter.BehandlingKlient
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.beregning.AvkortetYtelseDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagDto
@@ -28,7 +28,7 @@ fun Route.avkorting(
     avkortingService: AvkortingService,
     behandlingKlient: BehandlingKlient,
 ) {
-    route("/api/beregning/avkorting/{$BEHANDLINGSID_CALL_PARAMETER}") {
+    route("/api/beregning/avkorting/{$BEHANDLINGID_CALL_PARAMETER}") {
         val logger = application.log
 
         get {

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRoutes.kt
@@ -10,7 +10,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.klienter.BehandlingKlient
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.withBehandlingId
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 
@@ -21,7 +21,7 @@ fun Route.beregning(
     route("/api/beregning") {
         val logger = application.log
 
-        get("/{$BEHANDLINGSID_CALL_PARAMETER}") {
+        get("/{$BEHANDLINGID_CALL_PARAMETER}") {
             withBehandlingId(behandlingKlient) {
                 logger.info("Henter beregning med behandlingId=$it")
                 val beregning = beregningService.hentBeregning(it)
@@ -32,7 +32,7 @@ fun Route.beregning(
             }
         }
 
-        post("/{$BEHANDLINGSID_CALL_PARAMETER}") {
+        post("/{$BEHANDLINGID_CALL_PARAMETER}") {
             withBehandlingId(behandlingKlient) {
                 logger.info("Oppretter beregning for behandlingId=$it")
                 val beregning = beregningService.opprettBeregning(it, brukerTokenInfo)
@@ -40,7 +40,7 @@ fun Route.beregning(
             }
         }
 
-        post("/opprettForOpphoer/{$BEHANDLINGSID_CALL_PARAMETER}") {
+        post("/opprettForOpphoer/{$BEHANDLINGID_CALL_PARAMETER}") {
             withBehandlingId(behandlingKlient) {
                 beregningService.opprettForOpphoer(it, brukerTokenInfo)
                 call.respond(HttpStatusCode.OK)

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutes.kt
@@ -10,8 +10,8 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.klienter.BehandlingKlient
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
-import no.nav.etterlatte.libs.common.behandlingsId
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.behandlingId
 import no.nav.etterlatte.libs.common.withBehandlingId
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import org.slf4j.LoggerFactory
@@ -24,8 +24,8 @@ fun Route.beregningsGrunnlag(
     behandlingKlient: BehandlingKlient,
 ) {
     route("/api/beregning/beregningsgrunnlag") {
-        post("/{$BEHANDLINGSID_CALL_PARAMETER}/fra/{forrigeBehandlingId}") {
-            val behandlingId = behandlingsId
+        post("/{$BEHANDLINGID_CALL_PARAMETER}/fra/{forrigeBehandlingId}") {
+            val behandlingId = behandlingId
             val forrigeBehandlingId = call.uuid("forrigeBehandlingId")
 
             beregningsGrunnlagService.dupliserBeregningsGrunnlagBP(behandlingId, forrigeBehandlingId)
@@ -33,7 +33,7 @@ fun Route.beregningsGrunnlag(
             call.respond(HttpStatusCode.NoContent)
         }
 
-        post("/{$BEHANDLINGSID_CALL_PARAMETER}/barnepensjon") {
+        post("/{$BEHANDLINGID_CALL_PARAMETER}/barnepensjon") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 val body = call.receive<BarnepensjonBeregningsGrunnlag>()
 
@@ -49,7 +49,7 @@ fun Route.beregningsGrunnlag(
             }
         }
 
-        post("/{$BEHANDLINGSID_CALL_PARAMETER}/omstillingstoenad") {
+        post("/{$BEHANDLINGID_CALL_PARAMETER}/omstillingstoenad") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 val body = call.receive<OmstillingstoenadBeregningsGrunnlag>()
 
@@ -65,7 +65,7 @@ fun Route.beregningsGrunnlag(
             }
         }
 
-        get("/{$BEHANDLINGSID_CALL_PARAMETER}/barnepensjon") {
+        get("/{$BEHANDLINGID_CALL_PARAMETER}/barnepensjon") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Henter grunnlag for behandling $behandlingId")
                 val grunnlag =
@@ -77,7 +77,7 @@ fun Route.beregningsGrunnlag(
             }
         }
 
-        get("/{$BEHANDLINGSID_CALL_PARAMETER}/omstillingstoenad") {
+        get("/{$BEHANDLINGID_CALL_PARAMETER}/omstillingstoenad") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Henter grunnlag for behandling $behandlingId")
                 val grunnlag =

--- a/apps/etterlatte-beregning/src/main/kotlin/ytelseMedGrunnlag/YtelseMedGrunnlagRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/ytelseMedGrunnlag/YtelseMedGrunnlagRoutes.kt
@@ -9,7 +9,7 @@ import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
 import no.nav.etterlatte.klienter.BehandlingKlient
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.withBehandlingId
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 
@@ -17,7 +17,7 @@ fun Route.ytelseMedGrunnlag(
     ytelseMedGrunnlagService: YtelseMedGrunnlagService,
     behandlingKlient: BehandlingKlient,
 ) {
-    route("/api/beregning/ytelse-med-grunnlag/{$BEHANDLINGSID_CALL_PARAMETER}") {
+    route("/api/beregning/ytelse-med-grunnlag/{$BEHANDLINGID_CALL_PARAMETER}") {
         val logger = application.log
         get {
             withBehandlingId(behandlingKlient) {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevRoute.kt
@@ -10,8 +10,8 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.put
 import io.ktor.server.routing.route
 import no.nav.etterlatte.brev.hentinformasjon.Tilgangssjekker
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
-import no.nav.etterlatte.libs.common.behandlingsId
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.behandlingId
 import no.nav.etterlatte.libs.common.sakId
 import no.nav.etterlatte.libs.common.withBehandlingId
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
@@ -27,7 +27,7 @@ fun Route.vedtaksbrevRoute(
 ) {
     val logger = LoggerFactory.getLogger("no.nav.etterlatte.brev.VedaksbrevRoute")
 
-    route("brev/behandling/{$BEHANDLINGSID_CALL_PARAMETER}") {
+    route("brev/behandling/{$BEHANDLINGID_CALL_PARAMETER}") {
         get("vedtak") {
             withBehandlingId(tilgangssjekker) { behandlingId ->
                 logger.info("Henter vedtaksbrev for behandling (behandlingId=$behandlingId)")
@@ -93,7 +93,7 @@ fun Route.vedtaksbrevRoute(
                 logger.info("Tilbakestiller payload for vedtaksbrev (id=$brevId)")
 
                 measureTimedValue {
-                    service.hentNyttInnhold(sakId, brevId, behandlingsId, brukerTokenInfo)
+                    service.hentNyttInnhold(sakId, brevId, behandlingId, brukerTokenInfo)
                 }.let { (brevPayload, varighet) ->
                     logger.info(
                         "Oppretting av nytt innhold til brev (id=$brevId) tok ${varighet.toString(

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingGrunnlagRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingGrunnlagRoutes.kt
@@ -9,7 +9,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.klienter.BehandlingKlient
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.grunnlag.NyeSaksopplysninger
 import no.nav.etterlatte.libs.common.grunnlag.OppdaterGrunnlagRequest
@@ -27,7 +27,7 @@ fun Route.behandlingGrunnlagRoute(
      *  Dette blir en stegvis endring for å redusere sjansen for at alt brekker.
      *  Sak ID skal fjernes så fort vi har versjonert alt grunnlag i dev/prod med behandlingId
      **/
-    route("sak/{$SAKID_CALL_PARAMETER}/behandling/{$BEHANDLINGSID_CALL_PARAMETER}") {
+    route("sak/{$SAKID_CALL_PARAMETER}/behandling/{$BEHANDLINGID_CALL_PARAMETER}") {
         get {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 when (val opplysningsgrunnlag = grunnlagService.hentOpplysningsgrunnlag(behandlingId)) {

--- a/apps/etterlatte-gyldig-soeknad/src/main/kotlin/gyldigsoeknad/client/BehandlingClient.kt
+++ b/apps/etterlatte-gyldig-soeknad/src/main/kotlin/gyldigsoeknad/client/BehandlingClient.kt
@@ -59,11 +59,11 @@ class BehandlingClient(
     }
 
     fun lagreGyldighetsVurdering(
-        behandlingsId: UUID,
+        behandlingId: UUID,
         gyldighet: GyldighetsResultat,
     ) {
         return runBlocking {
-            sakOgBehandlingApp.post("$url/behandlinger/$behandlingsId/gyldigfremsatt") {
+            sakOgBehandlingApp.post("$url/behandlinger/$behandlingId/gyldigfremsatt") {
                 contentType(ContentType.Application.Json)
                 setBody(gyldighet)
             }.body<String>()

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
@@ -94,7 +94,7 @@ const BeregningsgrunnlagBarnepensjon = (props: { behandling: IBehandlingReducer 
 
       postBeregningsgrunnlag(
         {
-          behandlingsId: behandling.id,
+          behandlingId: behandling.id,
           grunnlag: beregningsgrunnlag,
         },
         () =>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
@@ -72,7 +72,7 @@ const BeregningsgrunnlagOmstillingsstoenad = (props: { behandling: IBehandlingRe
 
     postBeregningsgrunnlag(
       {
-        behandlingsId: behandling.id,
+        behandlingId: behandling.id,
         grunnlag: beregningsgrunnlagOMS,
       },
       () =>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/manueltopphoeroversikt/ManueltOpphoerOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/manueltopphoeroversikt/ManueltOpphoerOversikt.tsx
@@ -54,7 +54,7 @@ export const ManueltOpphoerOversikt = (props: { behandling: IBehandlingReducer }
     setFeilmelding('')
     try {
       await lagreBeregningsGrunnlag({
-        behandlingsId: behandling.id,
+        behandlingId: behandling.id,
         grunnlag: {
           soeskenMedIBeregning: [],
           institusjonsopphold: [],

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlag.tsx
@@ -45,7 +45,7 @@ export const TrygdetidGrunnlag: React.FC<Props> = ({
     if (!behandlingId) throw new Error('Mangler behandlingsid')
     requestLagreTrygdetidgrunnlag(
       {
-        behandlingsId: behandlingId,
+        behandlingId: behandlingId,
         trygdetidgrunnlag: trygdetidgrunnlag,
       },
       (respons) => {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlagListe.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlagListe.tsx
@@ -151,7 +151,7 @@ const PeriodeRow = ({
   const slettGrunnlag = (grunnlagId: string) => {
     slettTrygdetidsgrunnlagRequest(
       {
-        behandlingsId: behandlingId,
+        behandlingId: behandlingId,
         trygdetidGrunnlagId: grunnlagId,
       },
       (oppdatertTrygdetid) => {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/YrkesskadeTrygdetidBP.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/YrkesskadeTrygdetidBP.tsx
@@ -22,13 +22,13 @@ const YrkesskadeTrygdetidBP = () => {
     fetchTrygdetid(behandlingId, (trygdetid: ITrygdetid) => {
       if (trygdetid == null) {
         requestOpprettTrygdetid(behandlingId, () => {
-          requestOpprettYrkesskadeTrygdetidGrunnlag({ behandlingsId: behandlingId })
+          requestOpprettYrkesskadeTrygdetidGrunnlag({ behandlingId })
         })
       } else {
         // Må skrives om når vi gjør om til å støtte utenlands og poeng i inn/ut år (relatert til prorata)
         // Pt sjekker vi regelResultat string i backend (Trygdetid.kt) for å gjøre en "er dette yrkesskade"
         // I mellomtid så vil den bare erstatte en fast 40 år med en ny fast 40 år på samme grunnlag
-        requestOpprettYrkesskadeTrygdetidGrunnlag({ behandlingsId: behandlingId })
+        requestOpprettYrkesskadeTrygdetidGrunnlag({ behandlingId })
       }
     })
   }, [])

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/YrkesskadeTrygdetidOMS.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/YrkesskadeTrygdetidOMS.tsx
@@ -22,13 +22,13 @@ const YrkesskadeTrygdetid = () => {
     fetchTrygdetid(behandlingId, (trygdetid: ITrygdetid) => {
       if (trygdetid == null) {
         requestOpprettTrygdetid(behandlingId, () => {
-          requestOpprettYrkesskadeTrygdetidGrunnlag({ behandlingsId: behandlingId })
+          requestOpprettYrkesskadeTrygdetidGrunnlag({ behandlingId })
         })
       } else {
         // Må skrives om når vi gjør om til å støtte utenlands og poeng i inn/ut år (relatert til prorata)
         // Pt sjekker vi regelResultat string i backend (Trygdetid.kt) for å gjøre en "er dette yrkesskade"
         // I mellomtid så vil den bare erstatte en fast 40 år med en ny fast 40 år på samme grunnlag
-        requestOpprettYrkesskadeTrygdetidGrunnlag({ behandlingsId: behandlingId })
+        requestOpprettYrkesskadeTrygdetidGrunnlag({ behandlingId })
       }
     })
   }, [])

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/avtaler/TrygdeAvtale.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/avtaler/TrygdeAvtale.tsx
@@ -97,7 +97,7 @@ export const TrygdeAvtale = ({ redigerbar }: Props) => {
     if (!behandlingId) throw new Error('Mangler behandlingsid')
     lagreTrygdeavtale(
       {
-        behandlingsId: behandlingId,
+        behandlingId,
         avtaleRequest: {
           avtaleKode: trygdeavtale.avtaleKode,
           avtaleDatoKode: trygdeavtale.avtaleDatoKode,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/behandlingsliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/behandlingsliste.tsx
@@ -16,11 +16,11 @@ import { isFailure, isPending, isSuccess, useApiCall } from '~shared/hooks/useAp
 import Spinner from '~shared/Spinner'
 import { ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons'
 
-const VedtakKolonner = (props: { behandlingsId: string }) => {
+const VedtakKolonner = (props: { behandlingId: string }) => {
   const [vedtak, apiHentVedtaksammendrag] = useApiCall(hentVedtakSammendrag)
 
   useEffect(() => {
-    apiHentVedtaksammendrag(props.behandlingsId)
+    apiHentVedtaksammendrag(props.behandlingId)
   }, [])
 
   const attestertDato = (dato?: string) => {
@@ -110,7 +110,7 @@ export const Behandlingsliste = ({ behandlinger }: { behandlinger: IBehandlingsa
               <Table.DataCell>
                 {behandling.virkningstidspunkt ? formaterStringDato(behandling.virkningstidspunkt!!.dato) : ''}
               </Table.DataCell>
-              <VedtakKolonner behandlingsId={behandling.id} />
+              <VedtakKolonner behandlingId={behandling.id} />
               <Table.DataCell>
                 <Link href={lenkeTilBehandling(behandling)}>Vis behandling</Link>
               </Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/beregning.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/beregning.ts
@@ -20,29 +20,29 @@ export const opprettBeregningForOpphoer = async (behandlingId: string): Promise<
 }
 
 export const lagreBeregningsGrunnlag = async (args: {
-  behandlingsId: string
+  behandlingId: string
   grunnlag: BeregningsGrunnlagPostDto
 }): Promise<ApiResponse<void>> => {
-  return apiClient.post(`/beregning/beregningsgrunnlag/${args.behandlingsId}/barnepensjon`, { ...args.grunnlag })
+  return apiClient.post(`/beregning/beregningsgrunnlag/${args.behandlingId}/barnepensjon`, { ...args.grunnlag })
 }
 
 export const lagreBeregningsGrunnlagOMS = async (args: {
-  behandlingsId: string
+  behandlingId: string
   grunnlag: BeregningsGrunnlagOMSPostDto
 }): Promise<ApiResponse<void>> => {
-  return apiClient.post(`/beregning/beregningsgrunnlag/${args.behandlingsId}/omstillingstoenad`, { ...args.grunnlag })
+  return apiClient.post(`/beregning/beregningsgrunnlag/${args.behandlingId}/omstillingstoenad`, { ...args.grunnlag })
 }
 
 export const hentBeregningsGrunnlag = async (
-  behandlingsId: string
+  behandlingId: string
 ): Promise<ApiResponse<BeregningsGrunnlagDto | null>> => {
-  return apiClient.get<BeregningsGrunnlagDto | null>(`/beregning/beregningsgrunnlag/${behandlingsId}/barnepensjon`)
+  return apiClient.get<BeregningsGrunnlagDto | null>(`/beregning/beregningsgrunnlag/${behandlingId}/barnepensjon`)
 }
 
 export const hentBeregningsGrunnlagOMS = async (
-  behandlingsId: string
+  behandlingId: string
 ): Promise<ApiResponse<BeregningsGrunnlagOMSDto | null>> => {
   return apiClient.get<BeregningsGrunnlagOMSDto | null>(
-    `/beregning/beregningsgrunnlag/${behandlingsId}/omstillingstoenad`
+    `/beregning/beregningsgrunnlag/${behandlingId}/omstillingstoenad`
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
@@ -1,29 +1,29 @@
 import { apiClient, ApiResponse } from '~shared/api/apiClient'
 
-export const hentTrygdetid = async (behandlingsId: string): Promise<ApiResponse<ITrygdetid>> =>
-  apiClient.get<ITrygdetid>(`/trygdetid/${behandlingsId}`)
+export const hentTrygdetid = async (behandlingId: string): Promise<ApiResponse<ITrygdetid>> =>
+  apiClient.get<ITrygdetid>(`/trygdetid/${behandlingId}`)
 
-export const opprettTrygdetid = async (behandlingsId: string): Promise<ApiResponse<ITrygdetid>> =>
-  apiClient.post(`/trygdetid/${behandlingsId}`, {})
+export const opprettTrygdetid = async (behandlingId: string): Promise<ApiResponse<ITrygdetid>> =>
+  apiClient.post(`/trygdetid/${behandlingId}`, {})
 
 export const overstyrTrygdetid = async (overstyring: ITrygdetidOverstyring): Promise<ApiResponse<ITrygdetid>> =>
   apiClient.post(`/trygdetid/${overstyring.behandlingId}/overstyr`, { ...overstyring })
 
 export const lagreYrkesskadeTrygdetidGrunnlag = async (args: {
-  behandlingsId: string
-}): Promise<ApiResponse<ITrygdetid>> => apiClient.post(`/trygdetid/${args.behandlingsId}/grunnlag/yrkesskade`, {})
+  behandlingId: string
+}): Promise<ApiResponse<ITrygdetid>> => apiClient.post(`/trygdetid/${args.behandlingId}/grunnlag/yrkesskade`, {})
 
 export const lagreTrygdetidgrunnlag = async (args: {
-  behandlingsId: string
+  behandlingId: string
   trygdetidgrunnlag: OppdaterTrygdetidGrunnlag
 }): Promise<ApiResponse<ITrygdetid>> =>
-  apiClient.post(`/trygdetid/${args.behandlingsId}/grunnlag`, { ...args.trygdetidgrunnlag })
+  apiClient.post(`/trygdetid/${args.behandlingId}/grunnlag`, { ...args.trygdetidgrunnlag })
 
 export const slettTrygdetidsgrunnlag = async (args: {
-  behandlingsId: string
+  behandlingId: string
   trygdetidGrunnlagId: string
 }): Promise<ApiResponse<ITrygdetid>> =>
-  apiClient.delete<ITrygdetid>(`/trygdetid/${args.behandlingsId}/grunnlag/${args.trygdetidGrunnlagId}`)
+  apiClient.delete<ITrygdetid>(`/trygdetid/${args.behandlingId}/grunnlag/${args.trygdetidGrunnlagId}`)
 
 export const hentAlleLand = async (): Promise<ApiResponse<ILand[]>> =>
   apiClient.get<ILand[]>('/trygdetid/kodeverk/land')
@@ -90,10 +90,10 @@ export const hentTrygdeavtaleForBehandling = async (args: {
 }): Promise<ApiResponse<Trygdeavtale>> => apiClient.get<Trygdeavtale>(`/trygdetid/avtaler/${args.behandlingId}`)
 
 export const lagreTrygdeavtaleForBehandling = async (args: {
-  behandlingsId: string
+  behandlingId: string
   avtaleRequest: TrygdeavtaleRequest
 }): Promise<ApiResponse<Trygdeavtale>> =>
-  apiClient.post<Trygdeavtale>(`/trygdetid/avtaler/${args.behandlingsId}`, { ...args.avtaleRequest })
+  apiClient.post<Trygdeavtale>(`/trygdetid/avtaler/${args.behandlingId}`, { ...args.avtaleRequest })
 
 export interface ITrygdetid {
   id: string

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vedtaksvurdering.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vedtaksvurdering.ts
@@ -2,20 +2,20 @@ import { apiClient, ApiResponse } from './apiClient'
 import { VedtakSammendrag } from '~components/vedtak/typer'
 import { VedtaketKlagenGjelder } from '~shared/types/Klage'
 
-export const hentVedtakSammendrag = async (behandlingsId: string): Promise<ApiResponse<VedtakSammendrag>> => {
-  return apiClient.get(`vedtak/${behandlingsId}/sammendrag`)
+export const hentVedtakSammendrag = async (behandlingId: string): Promise<ApiResponse<VedtakSammendrag>> => {
+  return apiClient.get(`vedtak/${behandlingId}/sammendrag`)
 }
 
 export const hentIverksatteVedtakISak = async (sakId: number): Promise<ApiResponse<Array<VedtaketKlagenGjelder>>> => {
   return apiClient.get(`vedtak/sak/${sakId}/iverksatte`)
 }
 
-export const fattVedtak = async (behandlingsId: string): Promise<ApiResponse<unknown>> => {
-  return apiClient.post(`/vedtak/${behandlingsId}/fattvedtak`, {})
+export const fattVedtak = async (behandlingId: string): Promise<ApiResponse<unknown>> => {
+  return apiClient.post(`/vedtak/${behandlingId}/fattvedtak`, {})
 }
 
-export const upsertVedtak = async (behandlingsId: string): Promise<ApiResponse<unknown>> => {
-  return apiClient.post(`/vedtak/${behandlingsId}/upsert`, {})
+export const upsertVedtak = async (behandlingId: string): Promise<ApiResponse<unknown>> => {
+  return apiClient.post(`/vedtak/${behandlingId}/upsert`, {})
 }
 
 export const attesterVedtak = async (args: {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vilkaarsvurdering.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vilkaarsvurdering.ts
@@ -1,11 +1,11 @@
 import { Kilde } from '~shared/types/kilde'
 import { apiClient, ApiResponse } from './apiClient'
 
-export const hentVilkaarsvurdering = async (behandlingsId: string): Promise<ApiResponse<IVilkaarsvurdering>> =>
-  apiClient.get<IVilkaarsvurdering>(`/vilkaarsvurdering/${behandlingsId}`)
+export const hentVilkaarsvurdering = async (behandlingId: string): Promise<ApiResponse<IVilkaarsvurdering>> =>
+  apiClient.get<IVilkaarsvurdering>(`/vilkaarsvurdering/${behandlingId}`)
 
-export const opprettVilkaarsvurdering = async (behandlingsId: string): Promise<ApiResponse<IVilkaarsvurdering>> =>
-  apiClient.post<IVilkaarsvurdering>(`/vilkaarsvurdering/${behandlingsId}/opprett`, {})
+export const opprettVilkaarsvurdering = async (behandlingId: string): Promise<ApiResponse<IVilkaarsvurdering>> =>
+  apiClient.post<IVilkaarsvurdering>(`/vilkaarsvurdering/${behandlingId}/opprett`, {})
 
 export const vurderVilkaar = async (args: {
   behandlingId: string

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRepository.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRepository.kt
@@ -89,7 +89,7 @@ class TrygdetidRepository(private val dataSource: DataSource) {
             if (trygdetid.beregnetTrygdetid != null) {
                 oppdaterBeregnetTrygdetid(trygdetid.behandlingId, trygdetid.beregnetTrygdetid, tx)
             }
-        }.let { hentTrygdetidMedIdNotNull(behandlingsId = trygdetid.behandlingId, trygdetidId = trygdetid.id) }
+        }.let { hentTrygdetidMedIdNotNull(behandlingId = trygdetid.behandlingId, trygdetidId = trygdetid.id) }
 
     fun oppdaterTrygdetid(
         oppdatertTrygdetid: Trygdetid,
@@ -98,7 +98,7 @@ class TrygdetidRepository(private val dataSource: DataSource) {
         dataSource.transaction { tx ->
             val gjeldendeTrygdetid =
                 hentTrygdetidMedIdNotNull(
-                    behandlingsId = oppdatertTrygdetid.behandlingId,
+                    behandlingId = oppdatertTrygdetid.behandlingId,
                     trygdetidId = oppdatertTrygdetid.id,
                 )
 
@@ -436,10 +436,10 @@ class TrygdetidRepository(private val dataSource: DataSource) {
         }
 
     private fun hentTrygdetidMedIdNotNull(
-        behandlingsId: UUID,
+        behandlingId: UUID,
         trygdetidId: UUID,
-    ) = hentTrygdetidMedId(behandlingsId, trygdetidId)
-        ?: throw Exception("Fant ikke trygdetid for $behandlingsId")
+    ) = hentTrygdetidMedId(behandlingId, trygdetidId)
+        ?: throw Exception("Fant ikke trygdetid for $behandlingId")
 
     private fun Row.toFaktiskTrygdetid(
         totalColumn: String,

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -68,7 +68,7 @@ interface TrygdetidService {
 
     fun overstyrNorskPoengaar(
         trygdetidId: UUID,
-        behandlingsId: UUID,
+        behandlingId: UUID,
         overstyrtNorskPoengaar: Int?,
     ): Trygdetid
 }
@@ -111,10 +111,10 @@ interface GammelTrygdetidServiceMedNy : NyTrygdetidService, TrygdetidService {
 
     override fun overstyrNorskPoengaar(
         trygdetidId: UUID,
-        behandlingsId: UUID,
+        behandlingId: UUID,
         overstyrtNorskPoengaar: Int?,
     ): Trygdetid {
-        return overstyrNorskPoengaaarForTrygdetid(trygdetidId, behandlingsId, overstyrtNorskPoengaar)
+        return overstyrNorskPoengaaarForTrygdetid(trygdetidId, behandlingId, overstyrtNorskPoengaar)
     }
 
     override suspend fun slettTrygdetidGrunnlag(
@@ -184,7 +184,7 @@ interface NyTrygdetidService {
 
     fun overstyrNorskPoengaaarForTrygdetid(
         trygdetidId: UUID,
-        behandlingsId: UUID,
+        behandlingId: UUID,
         overstyrtNorskPoengaar: Int?,
     ): Trygdetid
 
@@ -623,11 +623,11 @@ class TrygdetidServiceImpl(
 
     override fun overstyrNorskPoengaaarForTrygdetid(
         trygdetidId: UUID,
-        behandlingsId: UUID,
+        behandlingId: UUID,
         overstyrtNorskPoengaar: Int?,
     ): Trygdetid {
         val trygdetid =
-            trygdetidRepository.hentTrygdetidMedId(behandlingsId, trygdetidId)
+            trygdetidRepository.hentTrygdetidMedId(behandlingId, trygdetidId)
                 ?: throw GenerellIkkeFunnetException()
 
         return trygdetidRepository.oppdaterTrygdetid(trygdetid.copy(overstyrtNorskPoengaar = overstyrtNorskPoengaar))

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/avtale/AvtaleRoutes.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/avtale/AvtaleRoutes.kt
@@ -10,8 +10,8 @@ import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
-import no.nav.etterlatte.libs.common.behandlingsId
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.behandlingId
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.trygdetid.avtale.Trygdeavtale
@@ -38,11 +38,11 @@ fun Route.avtale(
             call.respond(avtaleService.hentAvtaleKriterier())
         }
 
-        route("{$BEHANDLINGSID_CALL_PARAMETER}") {
+        route("{$BEHANDLINGID_CALL_PARAMETER}") {
             get {
                 withBehandlingId(behandlingKlient) {
-                    logger.info("Henter trygdeavtale for behandling $behandlingsId")
-                    val avtale = avtaleService.hentAvtaleForBehandling(behandlingsId)
+                    logger.info("Henter trygdeavtale for behandling $behandlingId")
+                    val avtale = avtaleService.hentAvtaleForBehandling(behandlingId)
                     if (avtale != null) {
                         call.respond(avtale)
                     } else {
@@ -53,10 +53,10 @@ fun Route.avtale(
 
             post {
                 withBehandlingId(behandlingKlient) {
-                    logger.info("Lagrer trygdeavtale for behandling $behandlingsId")
+                    logger.info("Lagrer trygdeavtale for behandling $behandlingId")
 
                     val trygdeavtaleRequest = call.receive<TrygdeavtaleRequest>()
-                    val avtale = trygdeavtaleRequest.toTrygdeavtale(behandlingsId, brukerTokenInfo)
+                    val avtale = trygdeavtaleRequest.toTrygdeavtale(behandlingId, brukerTokenInfo)
 
                     when (trygdeavtaleRequest.id) {
                         null -> avtaleService.opprettAvtale(avtale)

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/AutomatiskBehandlingRoutes.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/AutomatiskBehandlingRoutes.kt
@@ -7,7 +7,7 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.application
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.sakId
@@ -23,7 +23,7 @@ fun Route.automatiskBehandlingRoutes(
     route("/api/vedtak") {
         val logger = application.log
 
-        post("/{$SAKID_CALL_PARAMETER}/{$BEHANDLINGSID_CALL_PARAMETER}/automatisk") {
+        post("/{$SAKID_CALL_PARAMETER}/{$BEHANDLINGID_CALL_PARAMETER}/automatisk") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Håndterer behandling $behandlingId")
                 val nyttVedtak = service.opprettEllerOppdaterVedtak(behandlingId, brukerTokenInfo)

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -12,7 +12,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.patch
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.sak.VedtakSak
@@ -50,7 +50,7 @@ fun Route.vedtaksvurderingRoute(
             }
         }
 
-        get("/{$BEHANDLINGSID_CALL_PARAMETER}") {
+        get("/{$BEHANDLINGID_CALL_PARAMETER}") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Henter vedtak for behandling $behandlingId")
                 val vedtak = vedtakService.hentVedtak(behandlingId)
@@ -62,7 +62,7 @@ fun Route.vedtaksvurderingRoute(
             }
         }
 
-        get("/{$BEHANDLINGSID_CALL_PARAMETER}/ny") {
+        get("/{$BEHANDLINGID_CALL_PARAMETER}/ny") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Henter vedtak for behandling $behandlingId")
                 val vedtak = vedtakService.hentVedtak(behandlingId)
@@ -74,7 +74,7 @@ fun Route.vedtaksvurderingRoute(
             }
         }
 
-        get("/{$BEHANDLINGSID_CALL_PARAMETER}/sammendrag") {
+        get("/{$BEHANDLINGID_CALL_PARAMETER}/sammendrag") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Henter sammendrag av vedtak for behandling $behandlingId")
                 val vedtaksresultat = vedtakService.hentVedtak(behandlingId)?.toVedtakSammendragDto()
@@ -86,7 +86,7 @@ fun Route.vedtaksvurderingRoute(
             }
         }
 
-        post("/{$BEHANDLINGSID_CALL_PARAMETER}/upsert") {
+        post("/{$BEHANDLINGID_CALL_PARAMETER}/upsert") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Oppretter eller oppdaterer vedtak for behandling $behandlingId")
                 val nyttVedtak = vedtakBehandlingService.opprettEllerOppdaterVedtak(behandlingId, brukerTokenInfo)
@@ -94,7 +94,7 @@ fun Route.vedtaksvurderingRoute(
             }
         }
 
-        post("/{$BEHANDLINGSID_CALL_PARAMETER}/fattvedtak") {
+        post("/{$BEHANDLINGID_CALL_PARAMETER}/fattvedtak") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Fatter vedtak for behandling $behandlingId")
                 val fattetVedtak = vedtakBehandlingService.fattVedtak(behandlingId, brukerTokenInfo)
@@ -103,7 +103,7 @@ fun Route.vedtaksvurderingRoute(
             }
         }
 
-        post("/{$BEHANDLINGSID_CALL_PARAMETER}/attester") {
+        post("/{$BEHANDLINGID_CALL_PARAMETER}/attester") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Attesterer vedtak for behandling $behandlingId")
                 val (kommentar) = call.receive<AttesterVedtakDto>()
@@ -113,7 +113,7 @@ fun Route.vedtaksvurderingRoute(
             }
         }
 
-        post("/{$BEHANDLINGSID_CALL_PARAMETER}/underkjenn") {
+        post("/{$BEHANDLINGID_CALL_PARAMETER}/underkjenn") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Underkjenner vedtak for behandling $behandlingId")
                 val begrunnelse = call.receive<UnderkjennVedtakDto>()
@@ -128,7 +128,7 @@ fun Route.vedtaksvurderingRoute(
             }
         }
 
-        post("/{$BEHANDLINGSID_CALL_PARAMETER}/iverksett") {
+        post("/{$BEHANDLINGID_CALL_PARAMETER}/iverksett") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Iverksetter vedtak for behandling $behandlingId")
                 val vedtak = vedtakBehandlingService.iverksattVedtak(behandlingId, brukerTokenInfo)
@@ -149,7 +149,7 @@ fun Route.vedtaksvurderingRoute(
             }
         }
 
-        patch("/{$BEHANDLINGSID_CALL_PARAMETER}/tilbakestill") {
+        patch("/{$BEHANDLINGID_CALL_PARAMETER}/tilbakestill") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Tilbakestiller ikke iverksatte vedtak for behandling $behandlingId")
                 vedtakBehandlingService.tilbakestillIkkeIverksatteVedtak(behandlingId)

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
@@ -11,7 +11,7 @@ import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarVurderingData
@@ -30,7 +30,7 @@ fun Route.vilkaarsvurdering(
     route("/api/vilkaarsvurdering") {
         val logger = application.log
 
-        get("/{$BEHANDLINGSID_CALL_PARAMETER}") {
+        get("/{$BEHANDLINGID_CALL_PARAMETER}") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Henter vilkårsvurdering for $behandlingId")
                 val vilkaarsvurdering = vilkaarsvurderingService.hentVilkaarsvurdering(behandlingId)
@@ -44,7 +44,7 @@ fun Route.vilkaarsvurdering(
             }
         }
 
-        post("/{$BEHANDLINGSID_CALL_PARAMETER}/opprett") {
+        post("/{$BEHANDLINGID_CALL_PARAMETER}/opprett") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 try {
                     val kopierVedRevurdering =
@@ -73,7 +73,7 @@ fun Route.vilkaarsvurdering(
             }
         }
 
-        post("/{$BEHANDLINGSID_CALL_PARAMETER}/kopier") {
+        post("/{$BEHANDLINGID_CALL_PARAMETER}/kopier") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 val forrigeBehandling = call.receive<OpprettVilkaarsvurderingFraBehandling>().forrigeBehandling
 
@@ -107,7 +107,7 @@ fun Route.vilkaarsvurdering(
             }
         }
 
-        post("/{$BEHANDLINGSID_CALL_PARAMETER}") {
+        post("/{$BEHANDLINGID_CALL_PARAMETER}") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 val vurdertVilkaarDto = call.receive<VurdertVilkaarDto>()
                 val vurdertVilkaar = vurdertVilkaarDto.toVurdertVilkaar(brukerTokenInfo.ident())
@@ -137,7 +137,7 @@ fun Route.vilkaarsvurdering(
             }
         }
 
-        delete("/{$BEHANDLINGSID_CALL_PARAMETER}/{vilkaarId}") {
+        delete("/{$BEHANDLINGID_CALL_PARAMETER}/{vilkaarId}") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 withParam("vilkaarId") { vilkaarId ->
                     logger.info("Sletter vurdering på vilkår $vilkaarId for $behandlingId")
@@ -162,7 +162,7 @@ fun Route.vilkaarsvurdering(
             }
         }
 
-        delete("/{$BEHANDLINGSID_CALL_PARAMETER}") {
+        delete("/{$BEHANDLINGID_CALL_PARAMETER}") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Sletter vilkårsvurdering for $behandlingId")
 
@@ -180,7 +180,7 @@ fun Route.vilkaarsvurdering(
         }
 
         route("/resultat") {
-            post("/{$BEHANDLINGSID_CALL_PARAMETER}") {
+            post("/{$BEHANDLINGID_CALL_PARAMETER}") {
                 withBehandlingId(behandlingKlient) { behandlingId ->
                     val vurdertResultatDto = call.receive<VurdertVilkaarsvurderingResultatDto>()
                     val vurdertResultat =
@@ -207,7 +207,7 @@ fun Route.vilkaarsvurdering(
                 }
             }
 
-            delete("/{$BEHANDLINGSID_CALL_PARAMETER}") {
+            delete("/{$BEHANDLINGID_CALL_PARAMETER}") {
                 withBehandlingId(behandlingKlient) { behandlingId ->
                     logger.info("Sletter vilkårsvurderingsresultat for $behandlingId")
                     try {

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/migrering/MigreringRoutes.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/migrering/MigreringRoutes.kt
@@ -10,7 +10,7 @@ import io.ktor.server.routing.application
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.util.pipeline.PipelineContext
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat
@@ -29,7 +29,7 @@ fun Route.migrering(
     route("/api/vilkaarsvurdering/migrering") {
         val logger = application.log
 
-        post("/{$BEHANDLINGSID_CALL_PARAMETER}") {
+        post("/{$BEHANDLINGID_CALL_PARAMETER}") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Oppretter vilkårsvurdering for migrering for $behandlingId")
                 vilkaarsvurderingService.opprettVilkaarsvurdering(behandlingId, brukerTokenInfo)

--- a/libs/etterlatte-ktor/src/main/kotlin/RouteUtils.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/RouteUtils.kt
@@ -14,23 +14,23 @@ import no.nav.etterlatte.token.Saksbehandler
 import no.nav.etterlatte.token.Systembruker
 import java.util.UUID
 
-const val BEHANDLINGSID_CALL_PARAMETER = "behandlingsid"
+const val BEHANDLINGID_CALL_PARAMETER = "behandlingId"
 const val SAKID_CALL_PARAMETER = "sakId"
 const val OPPGAVEID_CALL_PARAMETER = "oppgaveId"
 const val KLAGEID_CALL_PARAMETER = "klageId"
 const val OPPGAVEID_GOSYS_CALL_PARAMETER = "gosysOppgaveId"
-const val GENERELLBEHANDLINGID_CALL_PARAMETER = "generellbehandlingId"
+const val GENERELLBEHANDLINGID_CALL_PARAMETER = "generellBehandlingId"
 
 inline val PipelineContext<*, ApplicationCall>.generellBehandlingId: UUID
     get() =
         call.parameters[GENERELLBEHANDLINGID_CALL_PARAMETER]?.let { UUID.fromString(it) } ?: throw NullPointerException(
-            "Generellbehandlingid er ikke i path params",
+            "GenerellBehandlingId er ikke i path params",
         )
 
-inline val PipelineContext<*, ApplicationCall>.behandlingsId: UUID
+inline val PipelineContext<*, ApplicationCall>.behandlingId: UUID
     get() =
-        call.parameters[BEHANDLINGSID_CALL_PARAMETER]?.let { UUID.fromString(it) } ?: throw NullPointerException(
-            "BehandlingsId er ikke i path params",
+        call.parameters[BEHANDLINGID_CALL_PARAMETER]?.let { UUID.fromString(it) } ?: throw NullPointerException(
+            "BehandlingId er ikke i path params",
         )
 
 inline val PipelineContext<*, ApplicationCall>.sakId: Long
@@ -60,7 +60,7 @@ inline val PipelineContext<*, ApplicationCall>.klageId: UUID
 suspend inline fun PipelineContext<*, ApplicationCall>.withBehandlingId(
     behandlingTilgangsSjekk: BehandlingTilgangsSjekk,
     onSuccess: (id: UUID) -> Unit,
-) = withParam(BEHANDLINGSID_CALL_PARAMETER) { behandlingId ->
+) = withParam(BEHANDLINGID_CALL_PARAMETER) { behandlingId ->
     when (brukerTokenInfo) {
         is Saksbehandler -> {
             val harTilgangTilBehandling =

--- a/libs/etterlatte-ktor/src/test/kotlin/RestModuleTest.kt
+++ b/libs/etterlatte-ktor/src/test/kotlin/RestModuleTest.kt
@@ -28,7 +28,7 @@ import io.ktor.server.routing.route
 import io.ktor.server.testing.testApplication
 import io.mockk.coEvery
 import io.mockk.mockk
-import no.nav.etterlatte.libs.common.BEHANDLINGSID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.BehandlingTilgangsSjekk
 import no.nav.etterlatte.libs.common.FoedselsnummerDTO
 import no.nav.etterlatte.libs.common.PersonTilgangsSjekk
@@ -346,7 +346,7 @@ class RestModuleTest {
 
     private fun Route.tilgangTestRoute() {
         route("") {
-            get("/behandling/{$BEHANDLINGSID_CALL_PARAMETER}") {
+            get("/behandling/{$BEHANDLINGID_CALL_PARAMETER}") {
                 withBehandlingId(behandlingTilgangsSjekkMock) {
                     call.respond(OK)
                 }


### PR DESCRIPTION
Fjernet "s" fra _behandlingsid_ for å gjøre navngivingen mer konsekvent. 

Gjør også at vi i mange tilfeller kan forenkle objekter i frontend siden vi da kan skrive `{ behandlingId }` i stedet for `{ behandlingsId: behandlingId }`