### PR TITLE
EY-2948: Flere forbedringer på oppdater-grunnlag

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -267,7 +267,7 @@ internal fun Route.behandlingRoutes(
 
         post("/oppdater-grunnlag") {
             inTransaction {
-                behandlingService.oppdaterGrunnlag(behandlingId)
+                behandlingService.oppdaterGrunnlagOgStatus(behandlingId)
             }
             call.respond(HttpStatusCode.OK)
         }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingGrunnlagRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingGrunnlagRoutes.kt
@@ -84,10 +84,12 @@ fun Route.behandlingGrunnlagRoute(
         }
 
         post("oppdater-grunnlag") {
-            withBehandlingId(behandlingKlient) { behandlingId ->
-                val request = call.receive<OppdaterGrunnlagRequest>()
-                grunnlagService.oppdaterGrunnlag(behandlingId, request.sakId, request.sakType)
-                call.respond(HttpStatusCode.OK)
+            kunSystembruker {
+                withBehandlingId(behandlingKlient) { behandlingId ->
+                    val request = call.receive<OppdaterGrunnlagRequest>()
+                    grunnlagService.oppdaterGrunnlag(behandlingId, request.sakId, request.sakType)
+                    call.respond(HttpStatusCode.OK)
+                }
             }
         }
     }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/OpplysningDao.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/OpplysningDao.kt
@@ -10,7 +10,6 @@ import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.database.firstOrNull
 import no.nav.etterlatte.libs.database.singleOrNull
 import no.nav.etterlatte.libs.database.toList
-import org.jetbrains.annotations.TestOnly
 import java.sql.ResultSet
 import java.sql.Types.VARCHAR
 import java.time.YearMonth
@@ -263,7 +262,6 @@ class OpplysningDao(private val datasource: DataSource) {
             }.executeQuery().toList { getLong("sak_id") }.toSet()
         }
 
-    @TestOnly // Kun for testing av dao
     fun hentBehandlingVersjon(behandlingId: UUID): BehandlingGrunnlagVersjon? =
         connection.use {
             it.prepareStatement("SELECT * FROM behandling_versjon WHERE behandling_id = ?::UUID")
@@ -279,7 +277,6 @@ class OpplysningDao(private val datasource: DataSource) {
         }
 }
 
-@TestOnly // Kun for testing av dao
 data class BehandlingGrunnlagVersjon(
     val behandlingId: UUID,
     val sakId: Long,

--- a/apps/etterlatte-grunnlag/src/test/kotlin/Utils.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/Utils.kt
@@ -4,8 +4,15 @@ import no.nav.etterlatte.grunnlag.OpplysningDao
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.pdl.OpplysningDTO
+import no.nav.etterlatte.libs.common.pdl.PersonDTO
+import no.nav.etterlatte.libs.common.person.Adresse
+import no.nav.etterlatte.libs.common.person.AdresseType
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.person.Utland
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
+import java.time.LocalDate
 import java.util.UUID
 
 internal fun lagGrunnlagsopplysning(
@@ -53,4 +60,46 @@ internal fun lagGrunnlagHendelse(
         ),
     sakId = sakId,
     hendelseNummer = hendelseNummer,
+)
+
+fun mockPerson() = PersonDTO(
+    fornavn = OpplysningDTO(verdi = "Ola", opplysningsid = null),
+    mellomnavn = OpplysningDTO(verdi = "Mellom", opplysningsid = null),
+    etternavn = OpplysningDTO(verdi = "Nordmann", opplysningsid = null),
+    foedselsnummer = OpplysningDTO(Folkeregisteridentifikator.of("10418305857"), null),
+    foedselsdato = OpplysningDTO(LocalDate.now().minusYears(20), UUID.randomUUID().toString()),
+    foedselsaar = OpplysningDTO(verdi = 2000, opplysningsid = null),
+    foedeland = OpplysningDTO("Norge", UUID.randomUUID().toString()),
+    doedsdato = null,
+    adressebeskyttelse = null,
+    bostedsadresse =
+        listOf(
+            OpplysningDTO(
+                Adresse(
+                    type = AdresseType.VEGADRESSE,
+                    aktiv = true,
+                    coAdresseNavn = "Hos Geir",
+                    adresseLinje1 = "Testveien 4",
+                    adresseLinje2 = null,
+                    adresseLinje3 = null,
+                    postnr = "1234",
+                    poststed = null,
+                    land = "NOR",
+                    kilde = "FREG",
+                    gyldigFraOgMed = Tidspunkt.now().toLocalDatetimeUTC().minusYears(1),
+                    gyldigTilOgMed = null,
+                ),
+                UUID.randomUUID().toString(),
+            ),
+        ),
+    deltBostedsadresse = listOf(),
+    kontaktadresse = listOf(),
+    oppholdsadresse = listOf(),
+    sivilstatus = null,
+    sivilstand = null,
+    statsborgerskap = OpplysningDTO("Norsk", UUID.randomUUID().toString()),
+    utland = OpplysningDTO(Utland(emptyList(), emptyList()), UUID.randomUUID().toString()),
+    familieRelasjon = null,
+    avdoedesBarn = null,
+    vergemaalEllerFremtidsfullmakt = null,
 )

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagServiceTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagServiceTest.kt
@@ -1,11 +1,15 @@
 package no.nav.etterlatte.grunnlag
 
+import com.fasterxml.jackson.databind.JsonNode
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.runBlocking
 import lagGrunnlagHendelse
+import mockPerson
 import no.nav.etterlatte.klienter.PdlTjenesterKlientImpl
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
+import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.Opplysning
@@ -14,6 +18,7 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Navn
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.BOSTEDSADRESSE
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.FOEDELAND
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.FOEDSELSDATO
+import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.FOEDSELSNUMMER
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.NAVN
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.PERSONGALLERI_V1
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.PERSONROLLE
@@ -31,7 +36,9 @@ import no.nav.etterlatte.libs.testdata.grunnlag.INNSENDER_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER2_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.kilde
 import no.nav.etterlatte.libs.testdata.grunnlag.statiskUuid
+import no.nav.etterlatte.pdl.HistorikkForeldreansvar
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -460,7 +467,7 @@ internal class GrunnlagServiceTest {
 
             val soesken = grunnlagService.hentSakerOgRoller(soeskenFnr)
             Assertions.assertEquals(2, soesken.sakerOgRoller.size)
-            Assertions.assertTrue(soesken.sakerOgRoller.all { it.rolle == Saksrolle.SOESKEN })
+            assertTrue(soesken.sakerOgRoller.all { it.rolle == Saksrolle.SOESKEN })
 
             verify(exactly = 1) { opplysningerMock.finnAllePersongalleriHvorPersonFinnes(soeskenFnr) }
         }
@@ -513,5 +520,79 @@ internal class GrunnlagServiceTest {
             Assertions.assertEquals(1, opplysningsgrunnlag.familie.size)
             Assertions.assertEquals(2, opplysningsgrunnlag.hentInnsender().size)
         }
+    }
+
+    @Test
+    fun `Kan oppdatere grunnlag`() {
+        val sakId = 1L
+        val behandlingId = UUID.randomUUID()
+        val sakType = SakType.BARNEPENSJON
+
+        every { opplysningerMock.finnNyesteGrunnlagForSak(any(), PERSONGALLERI_V1) } returns
+            lagGrunnlagHendelse(
+                sakId,
+                1,
+                PERSONGALLERI_V1,
+                id = statiskUuid,
+                verdi = testData.hentPersonGalleri().toJsonNode(),
+                kilde = kilde,
+            )
+
+        every { opplysningerMock.hentAlleGrunnlagForSak(sakId) } returns
+            listOf(
+                lagGrunnlagHendelse(
+                    sakId,
+                    2,
+                    NAVN,
+                    id = statiskUuid,
+                    fnr = INNSENDER_FOEDSELSNUMMER,
+                    verdi = Navn("Per", "Kalle", "Persson").toJsonNode(),
+                    kilde = kilde,
+                ),
+                lagGrunnlagHendelse(
+                    sakId,
+                    3,
+                    PERSONGALLERI_V1,
+                    id = statiskUuid,
+                    verdi = testData.hentPersonGalleri().toJsonNode(),
+                    kilde = kilde,
+                ),
+            )
+
+        every { opplysningerMock.finnHendelserIGrunnlag(sakId) } returns listOf(
+            lagGrunnlagHendelse(
+                sakId,
+                3,
+                PERSONGALLERI_V1,
+                id = statiskUuid,
+                verdi = testData.hentPersonGalleri().toJsonNode(),
+                kilde = kilde,
+            ),
+        )
+
+        val opplysningsperson = mockPerson()
+        every { pdlTjenesterKlientImpl.hentPerson(any(), any(), any()) } returns testData.soeker
+        every { pdlTjenesterKlientImpl.hentOpplysningsperson(any(), any(), any()) } returns opplysningsperson
+        every {
+            pdlTjenesterKlientImpl.hentHistoriskForeldreansvar(any(), any(), any())
+        } returns mockk<HistorikkForeldreansvar>()
+        every {
+            opplysningerMock.hentBehandlingVersjon(behandlingId)
+        } returns BehandlingGrunnlagVersjon(behandlingId, sakId, 12L, false)
+        every {
+            opplysningerMock.leggOpplysningTilGrunnlag(any(), any(), any())
+        } returns 7L
+        every {
+            opplysningerMock.oppdaterVersjonForBehandling(any(), any(), any())
+        } returns 1
+
+        runBlocking { grunnlagService.oppdaterGrunnlag(behandlingId, sakId, sakType) }
+
+        val slot = mutableListOf<Grunnlagsopplysning<JsonNode>>()
+        verify {
+            opplysningerMock.leggOpplysningTilGrunnlag(sakId, capture(slot), opplysningsperson.foedselsnummer.verdi)
+            opplysningerMock.oppdaterVersjonForBehandling(behandlingId, sakId, 7)
+        }
+        assertTrue(slot.filter { oppl -> oppl.opplysningType == FOEDSELSNUMMER }.size > 1)
     }
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/OppdaterGrunnlagModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/OppdaterGrunnlagModal.tsx
@@ -12,14 +12,11 @@ export const FEATURE_TOGGLE_KAN_BRUKE_OPPDATER_GRUNNLAG = 'pensjon-etterlatte.ka
 export default function OppdaterGrunnlagModal() {
   const behandling = useBehandling()
   const [isOpen, setIsOpen] = useState(false)
-
   const featureAktiv = useFeatureEnabledMedDefault(FEATURE_TOGGLE_KAN_BRUKE_OPPDATER_GRUNNLAG, false)
-
   const behandles = behandling != null && hentBehandlesFraStatus(behandling.status)
+  const [oppdatert, apiOppdaterGrunnlag] = useApiCall(oppdaterGrunnlag)
 
   if (!featureAktiv || !behandles) return
-
-  const [oppdatert, apiOppdaterGrunnlag] = useApiCall(oppdaterGrunnlag)
 
   const lagre = () => {
     return apiOppdaterGrunnlag(

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/kommerBarnetTilgode/KommerBarnetTilGodeVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/soeknadoversikt/kommerBarnetTilgode/KommerBarnetTilGodeVurdering.tsx
@@ -1,4 +1,4 @@
-import { Undertekst, VurderingsTitle } from '../../styled'
+import { VurderingsTitle } from '../../styled'
 import styled from 'styled-components'
 import { useState } from 'react'
 import { IBehandlingStatus, IKommerBarnetTilgode } from '~shared/types/IDetaljertBehandling'
@@ -81,9 +81,6 @@ export const KommerBarnetTilGodeVurdering = ({
     >
       <div>
         <VurderingsTitle title="Vurderer du det som sannsynlig at pensjonen kommer barnet tilgode?" />
-        <Undertekst $gray={false}>
-          Boforholdet er avklart og sannsynliggjort at pensjonen kommer barnet til gode?
-        </Undertekst>
         <RadioGroupWrapper>
           <RadioGroup
             legend=""


### PR DESCRIPTION
Kun systembruker kan kalle oppdater-grunnlag i grunnlag. HTTP 403 hvis grunnlag er låst på behandlingen. Test på oppdater grunnlag. Fikser "hooks count"-problem i React (useApiCall ble kalt eller ikke kalt avhengig av status i saken og det funker ikke).