### PR TITLE
Lar saksbehandler slette gammel og opprette ny vilkårsvurdering.

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
@@ -87,7 +87,7 @@ export const Vilkaarsvurdering = (props: { behandling: IBehandlingReducer }) => 
 
       {behandlingId && vilkaarsvurdering && !isPending(slettVilkaarsvurderingStatus) && (
         <>
-          {visHarGammelVilkaarsvurdering() && (
+          {behandles && visHarGammelVilkaarsvurdering() && (
             <AlertWrapper>
               <Alert variant="info">
                 <BodyLong>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
@@ -64,6 +64,7 @@ export const Vilkaarsvurdering = (props: { behandling: IBehandlingReducer }) => 
 
   const visHarGammelVilkaarsvurdering = () =>
     vilkaarsvurdering &&
+    behandles &&
     !vilkaarsvurderingErPaaNyttRegelverk(vilkaarsvurdering) &&
     behandlingGjelderBarnepensjonPaaNyttRegelverk(behandling)
 
@@ -87,12 +88,13 @@ export const Vilkaarsvurdering = (props: { behandling: IBehandlingReducer }) => 
 
       {behandlingId && vilkaarsvurdering && !isPending(slettVilkaarsvurderingStatus) && (
         <>
-          {behandles && visHarGammelVilkaarsvurdering() && (
+          {visHarGammelVilkaarsvurdering() && (
             <AlertWrapper>
               <Alert variant="info">
                 <BodyLong>
                   Denne behandlingen har automatisk kopiert over en vilkårsvurdering fra gammelt regelverk (før
-                  1.1.2024). For å få oppdaterte vilkår ihht. nytt regelverk må vilkårsvurderingen opprettes på nytt.
+                  1.1.2024). For å få oppdaterte vilkår ihht. nytt regelverk må vilkårsvurderingen opprettes på nytt. Du
+                  kan kopiere ev. begrunnelser fra tidligere behandling.
                 </BodyLong>
                 <Button type="button" variant="secondary" onClick={resetVilkaarsvurdering}>
                   Slett vilkårsvurdering

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
@@ -1,7 +1,7 @@
 import { Content, ContentHeader } from '~shared/styled'
 import React, { useEffect } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
-import { hentVilkaarsvurdering, opprettVilkaarsvurdering } from '~shared/api/vilkaarsvurdering'
+import { hentVilkaarsvurdering, opprettVilkaarsvurdering, slettVilkaarsvurdering } from '~shared/api/vilkaarsvurdering'
 import { ManueltVilkaar } from './ManueltVilkaar'
 import { Resultat } from './Resultat'
 import Spinner from '~shared/Spinner'
@@ -11,12 +11,17 @@ import {
   updateVilkaarsvurdering,
 } from '~store/reducers/BehandlingReducer'
 import { useAppDispatch } from '~store/Store'
-import { Heading } from '@navikt/ds-react'
+import { Alert, BodyLong, Button, Heading } from '@navikt/ds-react'
 import { Border, HeadingWrapper } from '../soeknadsoversikt/styled'
 import { hentBehandlesFraStatus } from '~components/behandling/felles/utils'
 import { isFailure, isInitial, isPending, useApiCall } from '~shared/hooks/useApiCall'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { IBehandlingStatus, IBehandlingsType } from '~shared/types/IDetaljertBehandling'
+import styled from 'styled-components'
+import {
+  behandlingGjelderBarnepensjonPaaNyttRegelverk,
+  vilkaarsvurderingErPaaNyttRegelverk,
+} from '~components/behandling/vilkaarsvurdering/utils'
 
 export const Vilkaarsvurdering = (props: { behandling: IBehandlingReducer }) => {
   const { behandling } = props
@@ -27,6 +32,7 @@ export const Vilkaarsvurdering = (props: { behandling: IBehandlingReducer }) => 
   const vilkaarsvurdering = behandling.vilkårsprøving
   const behandles = hentBehandlesFraStatus(behandling.status)
   const [vilkaarsvurderingStatus, fetchVilkaarsvurdering] = useApiCall(hentVilkaarsvurdering)
+  const [slettVilkaarsvurderingStatus, slettGammelVilkaarsvurdering] = useApiCall(slettVilkaarsvurdering)
   const [opprettNyVilkaarsvurderingStatus, opprettNyVilkaarsvurdering] = useApiCall(opprettVilkaarsvurdering)
 
   useEffect(() => {
@@ -39,7 +45,7 @@ export const Vilkaarsvurdering = (props: { behandling: IBehandlingReducer }) => 
     if (!vilkaarsvurdering) {
       fetchVilkaarsvurdering(behandlingId, (vilkaarsvurdering) => {
         if (vilkaarsvurdering == null) {
-          opprettHvisDenIkkeFinnes(behandlingId)
+          createVilkaarsvurdering(behandlingId, true)
         } else {
           dispatch(updateVilkaarsvurdering(vilkaarsvurdering))
         }
@@ -47,12 +53,25 @@ export const Vilkaarsvurdering = (props: { behandling: IBehandlingReducer }) => 
     }
   }, [behandlingId])
 
-  const opprettHvisDenIkkeFinnes = (behandlingId: string) => {
-    opprettNyVilkaarsvurdering(behandlingId, (vilkaarsvurdering) => {
+  const createVilkaarsvurdering = (behandlingId: string, kopier: boolean) => {
+    opprettNyVilkaarsvurdering({ behandlingId: behandlingId, kopierVedRevurdering: kopier }, (vilkaarsvurdering) => {
       dispatch(updateVilkaarsvurdering(vilkaarsvurdering))
       if (behandling.behandlingType === IBehandlingsType.REVURDERING) {
         dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.VILKAARSVURDERT))
       }
+    })
+  }
+
+  const visHarGammelVilkaarsvurdering = () =>
+    vilkaarsvurdering &&
+    !vilkaarsvurderingErPaaNyttRegelverk(vilkaarsvurdering) &&
+    behandlingGjelderBarnepensjonPaaNyttRegelverk(behandling)
+
+  const resetVilkaarsvurdering = () => {
+    if (!behandlingId) throw new Error('Mangler behandlingsid')
+    slettGammelVilkaarsvurdering(behandlingId, () => {
+      dispatch(updateVilkaarsvurdering(undefined))
+      createVilkaarsvurdering(behandlingId, false)
     })
   }
 
@@ -66,8 +85,25 @@ export const Vilkaarsvurdering = (props: { behandling: IBehandlingReducer }) => 
         </HeadingWrapper>
       </ContentHeader>
 
-      {behandlingId && vilkaarsvurdering && (
+      {behandlingId && vilkaarsvurdering && !isPending(slettVilkaarsvurderingStatus) && (
         <>
+          {visHarGammelVilkaarsvurdering() && (
+            <AlertWrapper>
+              <Alert variant="info">
+                <BodyLong>
+                  Denne behandlingen har automatisk kopiert over en vilkårsvurdering fra gammelt regelverk (før
+                  1.1.2024). For å få oppdaterte vilkår ihht. nytt regelverk må vilkårsvurderingen opprettes på nytt.
+                </BodyLong>
+                <Button type="button" variant="secondary" onClick={resetVilkaarsvurdering}>
+                  Slett vilkårsvurdering
+                </Button>
+              </Alert>
+              {isFailure(slettVilkaarsvurderingStatus) && (
+                <ApiErrorAlert>Klarte ikke slette vilkårsvurderingen</ApiErrorAlert>
+              )}
+            </AlertWrapper>
+          )}
+
           <Border />
 
           {vilkaarsvurdering.vilkaar.map((value, index) => (
@@ -94,6 +130,7 @@ export const Vilkaarsvurdering = (props: { behandling: IBehandlingReducer }) => 
       )}
       {isPending(vilkaarsvurderingStatus) && <Spinner visible={true} label="Henter vilkårsvurdering" />}
       {isPending(opprettNyVilkaarsvurderingStatus) && <Spinner visible={true} label="Oppretter vilkårsvurdering" />}
+      {isPending(slettVilkaarsvurderingStatus) && <Spinner visible={true} label="Sletter vilkårsvurdering" />}
       {isFailure(vilkaarsvurderingStatus) && isInitial(opprettNyVilkaarsvurderingStatus) && (
         <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>
       )}
@@ -107,3 +144,12 @@ export const Vilkaarsvurdering = (props: { behandling: IBehandlingReducer }) => 
     </Content>
   )
 }
+
+const AlertWrapper = styled.div`
+  margin: 1em 0 2em 4em;
+  max-width: 750px;
+
+  button {
+    margin-top: 10px;
+  }
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/utils.test.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/utils.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { IVilkaarsvurdering } from '~shared/api/vilkaarsvurdering'
+import { vilkaarsvurderingErPaaNyttRegelverk } from '~components/behandling/vilkaarsvurdering/utils'
+
+describe('Tester hjelpefunksjoner for vilkårsvurdering', () => {
+  it('barnepensjon vilkaarsvurdering er ikke paa nytt regelverk', () => {
+    const vilkaarsVurderingPaaGammeltRegelverk: IVilkaarsvurdering = {
+      vilkaar: [
+        {
+          hovedvilkaar: {
+            type: 'BP_FORMAAL',
+            tittel: 'Lever barnet?',
+            beskrivelse:
+              'Formålet med barnepensjon er å sikre inntekt for barn når en av foreldrene eller begge er døde. Dette betyr at barnet må være i live for å ha rett på barnepensjon.',
+            spoersmaal: 'Lever barnet det søkes barnepensjon for på virkningstidspunktet?',
+            lovreferanse: {
+              paragraf: '§ 18-1',
+              lenke: 'https://lovdata.no/lov/1997-02-28-19/%C2%A718-3',
+            },
+          },
+          unntaksvilkaar: [],
+          grunnlag: [],
+          id: '6f745fd1-1598-4b0a-96ea-e73d975c2a69',
+        },
+      ],
+      virkningstidspunkt: '2023-11',
+      isYrkesskade: false,
+    }
+
+    expect(vilkaarsvurderingErPaaNyttRegelverk(vilkaarsVurderingPaaGammeltRegelverk)).toBeFalsy()
+  })
+
+  it('barnepensjon vilkaarsvurdering er paa nytt regelverk', () => {
+    const vilkaarsVurderingPaaNyttRegelverk: IVilkaarsvurdering = {
+      vilkaar: [
+        {
+          hovedvilkaar: {
+            type: 'BP_FORMAAL_2024',
+            tittel: 'Lever barnet?',
+            beskrivelse:
+              'Formålet med barnepensjon er å sikre inntekt for barn når en av foreldrene eller begge er døde. Dette betyr at barnet må være i live for å ha rett på barnepensjon.',
+            spoersmaal: 'Lever barnet det søkes barnepensjon for på virkningstidspunktet?',
+            lovreferanse: {
+              paragraf: '§ 18-1',
+              lenke: 'https://lovdata.no/lov/1997-02-28-19/%C2%A718-3',
+            },
+          },
+          unntaksvilkaar: [],
+          grunnlag: [],
+          id: '6f745fd1-1598-4b0a-96ea-e73d975c2a69',
+        },
+      ],
+      virkningstidspunkt: '2023-11',
+      isYrkesskade: false,
+    }
+
+    expect(vilkaarsvurderingErPaaNyttRegelverk(vilkaarsVurderingPaaNyttRegelverk)).toBeTruthy()
+  })
+
+  it('OMS vilkaarsvurdering er ikke paa nytt regelverk', () => {
+    const omsVilkaarsvurdering: IVilkaarsvurdering = {
+      vilkaar: [
+        {
+          hovedvilkaar: {
+            type: 'OMS_FORMAAL',
+            tittel: 'Lever barnet?',
+            beskrivelse:
+              'Formålet med barnepensjon er å sikre inntekt for barn når en av foreldrene eller begge er døde. Dette betyr at barnet må være i live for å ha rett på barnepensjon.',
+            spoersmaal: 'Lever barnet det søkes barnepensjon for på virkningstidspunktet?',
+            lovreferanse: {
+              paragraf: '§ 18-1',
+              lenke: 'https://lovdata.no/lov/1997-02-28-19/%C2%A718-3',
+            },
+          },
+          unntaksvilkaar: [],
+          grunnlag: [],
+          id: '6f745fd1-1598-4b0a-96ea-e73d975c2a69',
+        },
+      ],
+      virkningstidspunkt: '2023-11',
+      isYrkesskade: false,
+    }
+
+    expect(vilkaarsvurderingErPaaNyttRegelverk(omsVilkaarsvurdering)).toBeFalsy()
+  })
+})

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/utils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/utils.ts
@@ -1,6 +1,8 @@
-import { VilkaarsvurderingResultat, VurderingsResultat } from '~shared/api/vilkaarsvurdering'
+import { IVilkaarsvurdering, VilkaarsvurderingResultat, VurderingsResultat } from '~shared/api/vilkaarsvurdering'
 import { ISvar } from '~shared/types/ISvar'
 import { KildeType } from '~shared/types/kilde'
+import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
+import { SakType } from '~shared/types/sak'
 
 export const svarTilTotalResultat = (svar: ISvar) => {
   switch (svar) {
@@ -43,4 +45,19 @@ export function formaterVurderingsResultat(vurderingsResultat?: VurderingsResult
     default:
       return 'Ukjent'
   }
+}
+
+// Siden vi ikke har noen versjonering av vilkårsvurdering p.t. så sjekker vi om det finnes vilkår
+// som kun eksisterer for nytt regelverk på barnepensjon.
+export function vilkaarsvurderingErPaaNyttRegelverk(vilkaarsvurdering: IVilkaarsvurdering): boolean {
+  return vilkaarsvurdering.vilkaar.some(
+    (vilkaar) => vilkaar.hovedvilkaar.type.startsWith('BP') && vilkaar.hovedvilkaar.type.endsWith('2024')
+  )
+}
+
+export function behandlingGjelderBarnepensjonPaaNyttRegelverk(behandling: IDetaljertBehandling): boolean {
+  return (
+    behandling.sakType === SakType.BARNEPENSJON &&
+    new Date(behandling.virkningstidspunkt!!.dato) >= new Date('2024-01-01')
+  )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vilkaarsvurdering.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vilkaarsvurdering.ts
@@ -4,8 +4,17 @@ import { apiClient, ApiResponse } from './apiClient'
 export const hentVilkaarsvurdering = async (behandlingId: string): Promise<ApiResponse<IVilkaarsvurdering>> =>
   apiClient.get<IVilkaarsvurdering>(`/vilkaarsvurdering/${behandlingId}`)
 
-export const opprettVilkaarsvurdering = async (behandlingId: string): Promise<ApiResponse<IVilkaarsvurdering>> =>
-  apiClient.post<IVilkaarsvurdering>(`/vilkaarsvurdering/${behandlingId}/opprett`, {})
+export const opprettVilkaarsvurdering = async (args: {
+  behandlingId: string
+  kopierVedRevurdering: boolean
+}): Promise<ApiResponse<IVilkaarsvurdering>> =>
+  apiClient.post<IVilkaarsvurdering>(
+    `/vilkaarsvurdering/${args.behandlingId}/opprett?kopierVedRevurdering=${args.kopierVedRevurdering}`,
+    {}
+  )
+
+export const slettVilkaarsvurdering = async (behandlingsId: string): Promise<ApiResponse<void>> =>
+  apiClient.delete(`/vilkaarsvurdering/${behandlingsId}`)
 
 export const vurderVilkaar = async (args: {
   behandlingId: string

--- a/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/BehandlingReducer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/BehandlingReducer.ts
@@ -16,7 +16,9 @@ export const addBehandling = createAction<IDetaljertBehandling>('behandling/add'
 export const resetBehandling = createAction('behandling/reset')
 export const oppdaterGyldighetsproeving = createAction<IGyldighetResultat>('behandling/gyldighetsprøving')
 export const oppdaterVirkningstidspunkt = createAction<Virkningstidspunkt>('behandling/virkningstidspunkt')
-export const updateVilkaarsvurdering = createAction<IVilkaarsvurdering>('behandling/update_vilkaarsvurdering')
+export const updateVilkaarsvurdering = createAction<IVilkaarsvurdering | undefined>(
+  'behandling/update_vilkaarsvurdering'
+)
 export const oppdaterKommerBarnetTilgode = createAction<IKommerBarnetTilgode>('behandling/kommerBarnetTilgode')
 export const oppdaterUtenlandstilsnitt = createAction<IUtenlandstilsnitt>('behandling/utenlandstilsnitt')
 export const oppdaterBoddEllerArbeidetUtlandet = createAction<IBoddEllerArbeidetUtlandet>(


### PR DESCRIPTION
Det dukker nå opp en infoboks om at saksbehandler har utdatert vilkårsvurdering, med mulighet til å slette og opprette ny vilkårsvurdering på nytt regelverk.

![Screenshot 2023-10-25 at 21 08 59](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1083866/8ae99d56-e1d5-497c-a717-b0e989748c7e)

EY-2826