### PR TITLE
Fiksar div i migrering

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/AdresseService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/AdresseService.kt
@@ -5,9 +5,9 @@ import kotlinx.coroutines.coroutineScope
 import no.nav.etterlatte.brev.adresse.navansatt.NavansattKlient
 import no.nav.etterlatte.brev.behandling.ForenkletVedtak
 import no.nav.etterlatte.brev.model.Mottaker
-import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.sak.Sak
+import no.nav.etterlatte.token.Fagsaksystem
 import no.nav.pensjon.brevbaker.api.model.Telefonnummer
 
 class AdresseService(
@@ -54,7 +54,7 @@ class AdresseService(
         }
 
     private suspend fun hentSaksbehandlerNavn(navn: String) =
-        if (navn == Vedtaksloesning.PESYS.name) {
+        if (navn == Fagsaksystem.EY.navn) {
             navn
         } else {
             navansattKlient.hentSaksbehandlerInfo(navn).fornavnEtternavn

--- a/apps/etterlatte-migrering/.nais/dev.yaml
+++ b/apps/etterlatte-migrering/.nais/dev.yaml
@@ -72,4 +72,4 @@ spec:
         - application: etterlatte-pdltjenester
       external:
         - host: etterlatte-unleash-api.nav.cloud.nais.io
-        - host: pensjon-pen-proxy-fss-q2.dev-fss-pub.nais.io
+        - host: pensjon-pen-q2.dev.adeo.no

--- a/apps/etterlatte-migrering/.nais/dev.yaml
+++ b/apps/etterlatte-migrering/.nais/dev.yaml
@@ -59,7 +59,7 @@ spec:
     - name: PEN_URL
       value: https://pensjon-pen-q2.dev.adeo.no/pen/springapi
     - name: PEN_CLIENT_ID
-      value: d0883b92-b866-42cd-a216-5a0eec745e05
+      value: ddd52335-cfe8-4ee9-9e68-416a5ab26efa
     - name: ETTERLATTE_PDLTJENESTER_URL
       value: http://etterlatte-pdltjenester
     - name: PDLTJENESTER_AZURE_SCOPE

--- a/apps/etterlatte-migrering/.nais/dev.yaml
+++ b/apps/etterlatte-migrering/.nais/dev.yaml
@@ -72,4 +72,4 @@ spec:
         - application: etterlatte-pdltjenester
       external:
         - host: etterlatte-unleash-api.nav.cloud.nais.io
-        - host: pensjon-pen-q2.dev-fss-pub.nais.io/
+        - host: pensjon-pen-q2.dev-fss-pub.nais.io

--- a/apps/etterlatte-migrering/.nais/dev.yaml
+++ b/apps/etterlatte-migrering/.nais/dev.yaml
@@ -57,7 +57,7 @@ spec:
       #sette tilbake til none senere
       value: earliest
     - name: PEN_URL
-      value: https://pensjon-pen-q2.dev.adeo.no/pen/springapi
+      value: https://pensjon-pen-q2.dev-fss-pub.nais.io/pen/springapi
     - name: PEN_CLIENT_ID
       value: ddd52335-cfe8-4ee9-9e68-416a5ab26efa
     - name: ETTERLATTE_PDLTJENESTER_URL
@@ -72,4 +72,4 @@ spec:
         - application: etterlatte-pdltjenester
       external:
         - host: etterlatte-unleash-api.nav.cloud.nais.io
-        - host: pensjon-pen-q2.dev.adeo.no
+        - host: pensjon-pen-q2.dev-fss-pub.nais.io/

--- a/apps/etterlatte-migrering/.nais/dev.yaml
+++ b/apps/etterlatte-migrering/.nais/dev.yaml
@@ -57,7 +57,7 @@ spec:
       #sette tilbake til none senere
       value: earliest
     - name: PEN_URL
-      value: https://pensjon-pen-proxy-fss-q2.dev-fss-pub.nais.io
+      value: https://pensjon-pen-q2.dev.adeo.no/pen/springapi
     - name: PEN_CLIENT_ID
       value: d0883b92-b866-42cd-a216-5a0eec745e05
     - name: ETTERLATTE_PDLTJENESTER_URL

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/ApplicationContext.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/ApplicationContext.kt
@@ -37,7 +37,8 @@ internal class ApplicationContext {
                 azureAppScope = config.getString("pdl.azure.scope"),
             ),
         )
-    val verifiserer = Verifiserer(pdlKlient = pdlKlient, repository = pesysRepository)
+    val verifiserer =
+        Verifiserer(pdlKlient = pdlKlient, repository = pesysRepository, featureToggleService = featureToggleService)
 }
 
 private fun featureToggleProperties(config: Config) =

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/MigrerSpesifikkSakRiver.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/MigrerSpesifikkSakRiver.kt
@@ -96,6 +96,7 @@ internal class MigrerSpesifikkSakRiver(
 enum class MigreringFeatureToggle(private val key: String) : FeatureToggle {
     SendSakTilMigrering("pensjon-etterlatte.bp-send-sak-til-migrering"),
     OpphoerSakIPesys("opphoer-sak-i-pesys"),
+    VerifiserFoerMigrering("verifiser-foer-migrering"),
     ;
 
     override fun key() = key

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
@@ -1,18 +1,24 @@
 package no.nav.etterlatte.migrering.verifisering
 
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.libs.common.logging.samleExceptions
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.common.pdl.PersonDTO
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.toJson
+import no.nav.etterlatte.migrering.MigreringFeatureToggle
 import no.nav.etterlatte.migrering.Migreringsstatus
 import no.nav.etterlatte.migrering.PesysRepository
 import no.nav.etterlatte.rapidsandrivers.migrering.MigreringRequest
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser
 import org.slf4j.LoggerFactory
 
-internal class Verifiserer(private val pdlKlient: PDLKlient, private val repository: PesysRepository) {
+internal class Verifiserer(
+    private val pdlKlient: PDLKlient,
+    private val repository: PesysRepository,
+    private val featureToggleService: FeatureToggleService,
+) {
     private val sikkerlogg = sikkerlogger()
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -47,12 +53,17 @@ internal class Verifiserer(private val pdlKlient: PDLKlient, private val reposit
     private fun hentPerson(
         rolle: PersonRolle,
         folkeregisteridentifikator: Folkeregisteridentifikator,
-    ): Result<PersonDTO> =
+    ): Result<PersonDTO?> =
         try {
             Result.success(pdlKlient.hentPerson(rolle, folkeregisteridentifikator))
         } catch (e: Exception) {
             sikkerlogg.warn("Fant ikke person $folkeregisteridentifikator med rolle $rolle i PDL", e)
-            Result.failure(FinsIkkeIPDL(rolle, folkeregisteridentifikator))
+            if (featureToggleService.isEnabled(MigreringFeatureToggle.VerifiserFoerMigrering, true)) {
+                Result.failure(FinsIkkeIPDL(rolle, folkeregisteridentifikator))
+            } else {
+                logger.warn("Har skrudd av at vi feiler migreringa hvis verifisering feiler. Fortsetter.")
+                Result.success(null)
+            }
         }
 }
 

--- a/apps/etterlatte-migrering/src/test/kotlin/migrering/MigreringRiverIntegrationTest.kt
+++ b/apps/etterlatte-migrering/src/test/kotlin/migrering/MigreringRiverIntegrationTest.kt
@@ -94,6 +94,7 @@ internal class MigreringRiverIntegrationTest {
                                         } returns mockk()
                                     },
                                     repository,
+                                    featureToggleService,
                                 ),
                         )
                     }
@@ -157,6 +158,7 @@ internal class MigreringRiverIntegrationTest {
                                         } returns mockk()
                                     },
                                     repository,
+                                    featureToggleService,
                                 ),
                         )
                         LagreKoblingRiver(this, repository)
@@ -242,6 +244,7 @@ internal class MigreringRiverIntegrationTest {
                                         } throws IllegalStateException("")
                                     },
                                     repository,
+                                    featureToggleService,
                                 ),
                         )
                     }

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/Trygdetid.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/Trygdetid.kt
@@ -119,7 +119,7 @@ data class TrygdetidPeriode(
     val til: LocalDate,
 ) {
     init {
-        require(fra.isBefore(til) || fra.isEqual(til)) { "Ugyldig periode, fra må være før eller lik til" }
+        require(fra.isBefore(til) || fra.isEqual(til)) { "Ugyldig periode, fra må være før eller lik til. Fra var $fra, til var $til" }
     }
 
     fun overlapperMed(other: TrygdetidPeriode): Boolean {


### PR DESCRIPTION
- Går direkte mot PEN heller enn å gå via proxy, ref diskusjonen på slack: https://nav-it.slack.com/archives/C05MGJ6MZRN/p1698399557225319
- Adresse-oppslaget på systembrukaren _EY_ for å sette inn namn i brevet trynar (naturleg nok). Bruker foreløpig berre EY direkte, men her bør vi som nemnt på demo bytte til noko betre
- Ein del saker i Pesys i test har gjenlevande som ikkje fins i PDL. Innfører funksjonsbrytar for å kunne skru av at verifiseringa er stoppande, for å kunne teste med desse sakene lell
- Viss vi har rare trygdetidsperiodar, logg litt betre