### PR TITLE
EY-2989 Nytt endepunkt for å hente adressebeskyttelse

### DIFF
--- a/apps/etterlatte-pdltjenester/.nais/dev.yaml
+++ b/apps/etterlatte-pdltjenester/.nais/dev.yaml
@@ -49,6 +49,7 @@ spec:
         - application: etterlatte-fordeler
         - application: etterlatte-gyldig-soeknad
         - application: etterlatte-hendelser-pdl
+        - application: etterlatte-hendelser-joark
         - application: etterlatte-behandling
         - application: etterlatte-grunnlag
         - application: etterlatte-migrering

--- a/apps/etterlatte-pdltjenester/.nais/prod.yaml
+++ b/apps/etterlatte-pdltjenester/.nais/prod.yaml
@@ -49,6 +49,7 @@ spec:
         - application: etterlatte-fordeler
         - application: etterlatte-gyldig-soeknad
         - application: etterlatte-hendelser-pdl
+        - application: etterlatte-hendelser-joark
         - application: etterlatte-behandling
         - application: etterlatte-grunnlag
         - application: etterlatte-migrering

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
@@ -19,6 +19,11 @@ data class PdlFolkeregisterIdentRequest(
     val variables: PdlFolkeregisterIdentVariables,
 )
 
+data class PdlAdressebeskyttelseRequest(
+    val query: String,
+    val variables: PdlAdressebeskyttelseVariables,
+)
+
 data class PdlVariables(
     val ident: String,
     val bostedsadresse: Boolean,
@@ -55,6 +60,10 @@ data class PdlFolkeregisterIdentVariables(
     val historikk: Boolean,
 )
 
+data class PdlAdressebeskyttelseVariables(
+    val ident: String,
+)
+
 data class PdlPersonResponse(
     val data: PdlPersonResponseData? = null,
     val errors: List<PdlResponseError>? = null,
@@ -70,12 +79,21 @@ data class PdlIdentResponse(
     val errors: List<PdlResponseError>? = null,
 )
 
+data class PdlAdressebeskyttelseResponse(
+    val data: PdlAdressebeskyttelseData? = null,
+    val errors: List<PdlResponseError>? = null,
+)
+
 data class PdlFolkegisterIdentData(
     val hentIdenter: PdlFolkeregisterIdentResult? = null,
 )
 
 data class PdlFolkeregisterIdentResult(
     val identer: List<PdlIdenter>,
+)
+
+data class PdlAdressebeskyttelseData(
+    val hentPerson: PdlHentPersonAdressebeskyttelse? = null,
 )
 
 data class PdlIdenter(
@@ -120,6 +138,10 @@ data class PdlHentPersonBolkResult(
     val code: String,
     val ident: String,
     val person: PdlHentPerson? = null,
+)
+
+data class PdlHentPersonAdressebeskyttelse(
+    val adressebeskyttelse: List<PdlAdressebeskyttelse>,
 )
 
 data class PdlHentPerson(

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonRoute.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonRoute.kt
@@ -8,6 +8,7 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.application
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
+import no.nav.etterlatte.libs.common.person.HentAdressebeskyttelseRequest
 import no.nav.etterlatte.libs.common.person.HentFolkeregisterIdenterForAktoerIdBolkRequest
 import no.nav.etterlatte.libs.common.person.HentGeografiskTilknytningRequest
 import no.nav.etterlatte.libs.common.person.HentPdlIdentRequest
@@ -31,6 +32,13 @@ fun Route.personRoute(service: PersonService) {
 
                 service.hentOpplysningsperson(hentPersonRequest).let { call.respond(it) }
             }
+        }
+
+        post("/adressebeskyttelse") {
+            val request = call.receive<HentAdressebeskyttelseRequest>()
+            logger.info("Henter adressebeskyttelse/gradering for fnr=${request.ident}")
+
+            call.respond(service.hentAdressebeskyttelseGradering(request))
         }
     }
 

--- a/apps/etterlatte-pdltjenester/src/main/resources/pdl/hentAdressebeskyttelse.graphql
+++ b/apps/etterlatte-pdltjenester/src/main/resources/pdl/hentAdressebeskyttelse.graphql
@@ -1,0 +1,37 @@
+fragment metadata on Metadata {
+    master
+    historisk
+    opplysningsId
+    endringer {
+        kilde
+        registrert
+        registrertAv
+        systemkilde
+        type
+    }
+}
+
+fragment folkeregistermetadata on Folkeregistermetadata {
+    ajourholdstidspunkt
+    gyldighetstidspunkt
+    opphoerstidspunkt
+    kilde
+    aarsak
+    sekvens
+}
+
+query(
+    $ident: ID!
+) {
+    hentPerson(ident: $ident) {
+        adressebeskyttelse(historikk: false) {
+            folkeregistermetadata {
+                ...folkeregistermetadata
+            }
+            gradering
+            metadata {
+                ...metadata
+            }
+        }
+    }
+}

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/pdl/PdlKlientTest.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/pdl/PdlKlientTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.STOR_SNERK
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.person.HentAdressebeskyttelseRequest
 import no.nav.etterlatte.libs.common.person.HentFolkeregisterIdenterForAktoerIdBolkRequest
 import no.nav.etterlatte.libs.common.person.HentGeografiskTilknytningRequest
 import no.nav.etterlatte.libs.common.person.HentPdlIdentRequest
@@ -133,6 +134,20 @@ internal class PdlKlientTest {
 
             assertEquals("0301", personResponse.data?.hentGeografiskTilknytning?.gtKommune)
             assertEquals(PdlGtType.KOMMUNE, personResponse.data?.hentGeografiskTilknytning?.gtType)
+        }
+    }
+
+    @Test
+    fun `hentAdressebeskyttelse returnerer adressebeskyttelse`() {
+        mockEndpoint("/pdl/adressebeskyttelse.json")
+
+        runBlocking {
+            val response =
+                pdlKlient.hentAdressebeskyttelse(
+                    HentAdressebeskyttelseRequest(PersonIdent(STOR_SNERK.value)),
+                )
+
+            assertEquals(PdlGradering.FORTROLIG, response.data?.hentPerson?.adressebeskyttelse?.single()?.gradering)
         }
     }
 

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonServiceTest.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonServiceTest.kt
@@ -10,6 +10,8 @@ import no.nav.etterlatte.STOR_SNERK
 import no.nav.etterlatte.TRIVIELL_MIDTPUNKT
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.pdl.FantIkkePersonException
+import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
+import no.nav.etterlatte.libs.common.person.HentAdressebeskyttelseRequest
 import no.nav.etterlatte.libs.common.person.HentGeografiskTilknytningRequest
 import no.nav.etterlatte.libs.common.person.HentPdlIdentRequest
 import no.nav.etterlatte.libs.common.person.HentPersonRequest
@@ -19,11 +21,16 @@ import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.mockResponse
 import no.nav.etterlatte.pdl.ParallelleSannheterKlient
+import no.nav.etterlatte.pdl.PdlAdressebeskyttelse
+import no.nav.etterlatte.pdl.PdlAdressebeskyttelseData
+import no.nav.etterlatte.pdl.PdlAdressebeskyttelseResponse
 import no.nav.etterlatte.pdl.PdlGeografiskTilknytning
 import no.nav.etterlatte.pdl.PdlGeografiskTilknytningData
 import no.nav.etterlatte.pdl.PdlGeografiskTilknytningResponse
+import no.nav.etterlatte.pdl.PdlGradering
 import no.nav.etterlatte.pdl.PdlGtType
 import no.nav.etterlatte.pdl.PdlHentPerson
+import no.nav.etterlatte.pdl.PdlHentPersonAdressebeskyttelse
 import no.nav.etterlatte.pdl.PdlIdentResponse
 import no.nav.etterlatte.pdl.PdlKlient
 import no.nav.etterlatte.pdl.PdlPersonResponse
@@ -37,6 +44,8 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.fail
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 
 internal class PersonServiceTest {
     private val pdlKlient = mockk<PdlKlient>()
@@ -280,5 +289,26 @@ internal class PersonServiceTest {
 
         assertEquals(tilknytning.ukjent, false)
         assertEquals(tilknytning.geografiskTilknytning(), "0301")
+    }
+
+    @ParameterizedTest
+    @EnumSource(PdlGradering::class)
+    fun `Skal hente gradering for person`(pdlGradering: PdlGradering) {
+        coEvery { pdlKlient.hentAdressebeskyttelse(any()) } returns
+            PdlAdressebeskyttelseResponse(
+                data =
+                    PdlAdressebeskyttelseData(
+                        PdlHentPersonAdressebeskyttelse(
+                            listOf(PdlAdressebeskyttelse(pdlGradering, null, mockk())),
+                        ),
+                    ),
+            )
+
+        val gradering =
+            runBlocking {
+                personService.hentAdressebeskyttelseGradering(HentAdressebeskyttelseRequest(PersonIdent(TRIVIELL_MIDTPUNKT.value)))
+            }
+
+        assertEquals(AdressebeskyttelseGradering.valueOf(pdlGradering.name), gradering)
     }
 }

--- a/apps/etterlatte-pdltjenester/src/test/resources/pdl/adressebeskyttelse.json
+++ b/apps/etterlatte-pdltjenester/src/test/resources/pdl/adressebeskyttelse.json
@@ -1,0 +1,33 @@
+{
+  "data": {
+    "hentPerson": {
+      "adressebeskyttelse": [
+        {
+          "gradering": "FORTROLIG",
+          "folkeregistermetadata": {
+            "ajourholdstidspunkt": "2021-08-05T15:11:03",
+            "gyldighetstidspunkt": "2021-08-05T15:11:03",
+            "opphoerstidspunkt": null,
+            "kilde": "Dolly",
+            "aarsak": null,
+            "sekvens": null
+          },
+          "metadata": {
+            "master": "FREG",
+            "historisk": false,
+            "opplysningsId": "39317e6c-e98f-4995-8d52-36f9703d1dae",
+            "endringer": [
+              {
+                "kilde": "Dolly",
+                "registrert": "2021-08-05T15:11:03",
+                "registrertAv": "Folkeregisteret",
+                "systemkilde": "FREG",
+                "type": "OPPRETT"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/libs/saksbehandling-common/src/main/kotlin/person/HentPersonRequest.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/person/HentPersonRequest.kt
@@ -14,6 +14,10 @@ data class HentPdlIdentRequest(
     val ident: PersonIdent,
 )
 
+data class HentAdressebeskyttelseRequest(
+    val ident: PersonIdent,
+)
+
 data class PersonIdent
     @JsonCreator
     constructor(

--- a/libs/saksbehandling-common/src/main/kotlin/person/Person.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/person/Person.kt
@@ -191,3 +191,5 @@ enum class AdressebeskyttelseGradering {
         return this == STRENGT_FORTROLIG_UTLAND || this == STRENGT_FORTROLIG || this == FORTROLIG
     }
 }
+
+fun List<AdressebeskyttelseGradering?>.hentPrioritertGradering() = this.filterNotNull().minOrNull() ?: AdressebeskyttelseGradering.UGRADERT

--- a/libs/saksbehandling-common/src/test/kotlin/person/AdressebeskyttelseGraderingTest.kt
+++ b/libs/saksbehandling-common/src/test/kotlin/person/AdressebeskyttelseGraderingTest.kt
@@ -1,0 +1,47 @@
+package person
+
+import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering.FORTROLIG
+import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering.STRENGT_FORTROLIG
+import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND
+import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering.UGRADERT
+import no.nav.etterlatte.libs.common.person.hentPrioritertGradering
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class AdressebeskyttelseGraderingTest {
+    @Test
+    fun `Sjekk enum ordinal value - sikrer prioritering`() {
+        assertEquals(3, UGRADERT.ordinal)
+        assertEquals(2, FORTROLIG.ordinal)
+        assertEquals(1, STRENGT_FORTROLIG.ordinal)
+        assertEquals(0, STRENGT_FORTROLIG_UTLAND.ordinal)
+    }
+
+    @Test
+    fun `Prioritering blir korrekt - UGRADERT`() {
+        val ugradert = listOf(null, UGRADERT, null, null)
+
+        assertEquals(UGRADERT, ugradert.hentPrioritertGradering())
+    }
+
+    @Test
+    fun `Prioritering blir korrekt - FORTROLIG`() {
+        val fortrolig = listOf(null, UGRADERT, null, FORTROLIG)
+
+        assertEquals(FORTROLIG, fortrolig.hentPrioritertGradering())
+    }
+
+    @Test
+    fun `Prioritering blir korrekt - STRENGT_FORTROLIG`() {
+        val strengtFortrolig = listOf(FORTROLIG, UGRADERT, null, STRENGT_FORTROLIG, FORTROLIG)
+
+        assertEquals(STRENGT_FORTROLIG, strengtFortrolig.hentPrioritertGradering())
+    }
+
+    @Test
+    fun `Prioritering blir korrekt - STRENGT_FORTROLIG_UTLAND`() {
+        val strengtFortrolig = listOf(STRENGT_FORTROLIG, UGRADERT, null, STRENGT_FORTROLIG_UTLAND, FORTROLIG)
+
+        assertEquals(STRENGT_FORTROLIG_UTLAND, strengtFortrolig.hentPrioritertGradering())
+    }
+}


### PR DESCRIPTION
Gjøre det mulig å kun hente gradering ifm. opprettelse av nye saker på journalføringshendelser fra Joark .