### PR TITLE
Fjerner ports-parametere som ikke er støttet i nais

### DIFF
--- a/apps/etterlatte-tilbakekreving/.nais/dev.yaml
+++ b/apps/etterlatte-tilbakekreving/.nais/dev.yaml
@@ -66,8 +66,6 @@ spec:
       external:
         - host: b27apvl222.preprod.local
           ports:
-            - name: mq
-              port: 1413
-              protocol: TCP
+            - port: 1413
         - host: etterlatte-unleash-api.nav.cloud.nais.io
         - host: etterlatte-proxy.dev-fss-pub.nais.io

--- a/apps/etterlatte-tilbakekreving/.nais/prod.yaml
+++ b/apps/etterlatte-tilbakekreving/.nais/prod.yaml
@@ -74,8 +74,6 @@ spec:
       external:
         - host: mpls04.adeo.no
           ports:
-            - name: mq
-              port: 1414
-              protocol: TCP
+            - port: 1414
         - host: etterlatte-unleash-api.nav.cloud.nais.io
         - host: etterlatte-proxy.prod-fss-pub.nais.io

--- a/apps/etterlatte-utbetaling/.nais/dev.yaml
+++ b/apps/etterlatte-utbetaling/.nais/dev.yaml
@@ -72,7 +72,5 @@ spec:
       external:
         - host: b27apvl222.preprod.local
           ports:
-            - name: mq
-              port: 1413
-              protocol: TCP
+            - port: 1413
         - host: etterlatte-unleash-api.nav.cloud.nais.io

--- a/apps/etterlatte-utbetaling/.nais/prod.yaml
+++ b/apps/etterlatte-utbetaling/.nais/prod.yaml
@@ -82,7 +82,5 @@ spec:
       external:
         - host: mpls04.adeo.no
           ports:
-            - name: mq
-              port: 1414
-              protocol: TCP
+            - port: 1414
         - host: etterlatte-unleash-api.nav.cloud.nais.io


### PR DESCRIPTION
`name` og `protocol` er ikke (lenger?) støttet: https://docs.nais.io/nais-application/application/#accesspolicyoutboundexternalportsport

Vi får feil i loggene så lenge disse ligger i configen.