### PR TITLE
EY-2960 - Bedre tilstandshåndtering av avkorting

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -18,8 +18,10 @@ data class Avkorting(
     val avkortetYtelseForrigeVedtak: List<AvkortetYtelse> = emptyList(),
 ) {
     /*
-     * Årsoppgjør inneholder ytelsen sine perioder for hele år og for behandlinger/vedtak er det kun
-     * virknigstidspunkt og fremover som er relevant.
+     * avkortetYtelseFraVirkningstidspunkt - Årsoppgjør inneholder ytelsen sine perioder for hele år
+     * og for behandlinger/vedtak er det kun virknigstidspunkt og fremover som er relevant.
+     *
+     * avkortetYtelseForrigeVedtak - brukes til å sammenligne med beløper til nye beregna perioder under behandlingen
      */
     fun medYtelseFraOgMedVirkningstidspunkt(
         virkningstidspunkt: YearMonth,

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -47,7 +47,7 @@ fun Route.avkorting(
                 logger.info("Lagre avkorting for behandlingId=$it")
                 val avkortingGrunnlag = call.receive<AvkortingGrunnlagDto>()
                 val avkorting =
-                    avkortingService.lagreAvkorting(
+                    avkortingService.beregnAvkortingMedNyttGrunnlag(
                         it,
                         brukerTokenInfo,
                         avkortingGrunnlag.fromDto(brukerTokenInfo),

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -28,7 +28,14 @@ class AvkortingService(
         val eksisterendeAvkorting = avkortingRepository.hentAvkorting(behandling.id)
 
         if (behandling.behandlingType == BehandlingType.FØRSTEGANGSBEHANDLING) {
-            return eksisterendeAvkorting?.let { avkortingMedTillegg(it, behandling) }
+            return eksisterendeAvkorting?.let {
+                if (behandling.status == BehandlingStatus.BEREGNET) {
+                    val reberegnetAvkorting = reberegnOgLagreAvkorting(behandling.id, eksisterendeAvkorting, brukerTokenInfo)
+                    avkortingMedTillegg(reberegnetAvkorting, behandling)
+                } else {
+                    avkortingMedTillegg(eksisterendeAvkorting, behandling)
+                }
+            }
         }
 
         val forrigeAvkorting = hentAvkortingForrigeBehandling(behandling.sak, brukerTokenInfo)

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -2,8 +2,11 @@ package no.nav.etterlatte.avkorting
 
 import no.nav.etterlatte.beregning.BeregningService
 import no.nav.etterlatte.klienter.BehandlingKlient
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
+import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
+import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
 import java.util.UUID
@@ -19,88 +22,124 @@ class AvkortingService(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): Avkorting? {
+        tilstandssjekk(behandlingId, brukerTokenInfo)
         logger.info("Henter avkorting for behandlingId=$behandlingId")
         val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
+        val eksisterendeAvkorting = avkortingRepository.hentAvkorting(behandling.id)
 
-        return if (behandling.behandlingType == BehandlingType.FØRSTEGANGSBEHANDLING) {
-            hentAvkorting(behandling)
+        if (behandling.behandlingType == BehandlingType.FØRSTEGANGSBEHANDLING) {
+            return eksisterendeAvkorting?.let { avkortingMedTillegg(it, behandling) }
+        }
+
+        val forrigeAvkorting = hentAvkortingForrigeBehandling(behandling.sak, brukerTokenInfo)
+        return if (eksisterendeAvkorting == null) {
+            val nyAvkorting = kopierOgReberegnAvkorting(behandling.id, forrigeAvkorting, brukerTokenInfo)
+            avkortingMedTillegg(nyAvkorting, behandling, forrigeAvkorting)
+        } else if (behandling.status == BehandlingStatus.BEREGNET) {
+            val reberegnetAvkorting = reberegnOgLagreAvkorting(behandling.id, eksisterendeAvkorting, brukerTokenInfo)
+            avkortingMedTillegg(reberegnetAvkorting, behandling, forrigeAvkorting)
         } else {
-            val forrigeBehandlingId = behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, brukerTokenInfo).id
-            val forrigeAvkorting = hentForrigeAvkorting(forrigeBehandlingId)
-            return hentAvkorting(behandling, forrigeAvkorting)
-                ?: kopierAvkorting(behandling, forrigeAvkorting, brukerTokenInfo)
+            avkortingMedTillegg(eksisterendeAvkorting, behandling, forrigeAvkorting)
         }
     }
 
-    suspend fun lagreAvkorting(
+    suspend fun beregnAvkortingMedNyttGrunnlag(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         avkortingGrunnlag: AvkortingGrunnlag,
-    ): Avkorting =
-        tilstandssjekk(behandlingId, brukerTokenInfo) {
-            logger.info("Lagre og beregne avkorting og avkortet ytelse for behandlingId=$behandlingId")
+    ): Avkorting {
+        tilstandssjekk(behandlingId, brukerTokenInfo)
+        logger.info("Lagre og beregne avkorting og avkortet ytelse for behandlingId=$behandlingId")
 
-            val avkorting = avkortingRepository.hentAvkorting(behandlingId) ?: Avkorting()
-            val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
-            val beregning = beregningService.hentBeregningNonnull(behandlingId)
-            val beregnetAvkorting =
-                avkorting.beregnAvkortingMedNyttGrunnlag(
-                    avkortingGrunnlag,
-                    behandling.behandlingType,
-                    beregning,
+        val avkorting = avkortingRepository.hentAvkorting(behandlingId) ?: Avkorting()
+        val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
+        val beregning = beregningService.hentBeregningNonnull(behandlingId)
+        val beregnetAvkorting =
+            avkorting.beregnAvkortingMedNyttGrunnlag(
+                avkortingGrunnlag,
+                behandling.behandlingType,
+                beregning,
+            )
+
+        avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
+        val lagretAvkorting =
+            if (behandling.behandlingType == BehandlingType.FØRSTEGANGSBEHANDLING) {
+                avkortingMedTillegg(hentAvkortingNonNull(behandling.id), behandling)
+            } else {
+                val forrigeAvkorting = hentAvkortingForrigeBehandling(behandling.sak, brukerTokenInfo)
+                avkortingMedTillegg(
+                    hentAvkortingNonNull(behandling.id),
+                    behandling,
+                    forrigeAvkorting,
                 )
+            }
 
-            avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
-            val lagretAvkorting =
-                if (behandling.behandlingType == BehandlingType.FØRSTEGANGSBEHANDLING) {
-                    hentAvkortingNonNull(behandling)
-                } else {
-                    val forrigeBehandlingId = behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, brukerTokenInfo).id
-                    val forrigeAvkorting = hentForrigeAvkorting(forrigeBehandlingId)
-                    hentAvkortingNonNull(behandling, forrigeAvkorting)
-                }
+        behandlingKlient.avkort(behandlingId, brukerTokenInfo, true)
+        return lagretAvkorting
+    }
 
-            behandlingKlient.avkort(behandlingId, brukerTokenInfo, true)
-            lagretAvkorting
-        }
-
+    /*
+     * Brukes ved automatisk regulering
+     */
     suspend fun kopierAvkorting(
         behandlingId: UUID,
         forrigeBehandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): Avkorting {
+        tilstandssjekk(behandlingId, brukerTokenInfo)
         logger.info("Kopierer avkorting fra forrige behandling med behandlingId=$forrigeBehandlingId")
         val forrigeAvkorting = hentForrigeAvkorting(forrigeBehandlingId)
         val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
-        return kopierAvkorting(behandling, forrigeAvkorting, brukerTokenInfo)
+        return kopierOgReberegnAvkorting(behandling.id, forrigeAvkorting, brukerTokenInfo)
     }
 
-    private suspend fun kopierAvkorting(
-        behandling: DetaljertBehandling,
+    private suspend fun kopierOgReberegnAvkorting(
+        behandlingId: UUID,
         forrigeAvkorting: Avkorting,
         brukerTokenInfo: BrukerTokenInfo,
     ): Avkorting {
-        val beregning = beregningService.hentBeregningNonnull(behandling.id)
-        val beregnetAvkorting = forrigeAvkorting.kopierAvkorting().beregnAvkortingRevurdering(beregning)
-        avkortingRepository.lagreAvkorting(behandling.id, beregnetAvkorting)
-        val lagretAvkorting = hentAvkortingNonNull(behandling, forrigeAvkorting)
-        behandlingKlient.avkort(behandling.id, brukerTokenInfo, true)
+        val kopiertAvkorting = forrigeAvkorting.kopierAvkorting()
+        return reberegnOgLagreAvkorting(behandlingId, kopiertAvkorting, brukerTokenInfo)
+    }
+
+    private suspend fun reberegnOgLagreAvkorting(
+        behandlingId: UUID,
+        avkorting: Avkorting,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Avkorting {
+        val beregning = beregningService.hentBeregningNonnull(behandlingId)
+        val beregnetAvkorting = avkorting.beregnAvkortingRevurdering(beregning)
+        avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
+        val lagretAvkorting = hentAvkortingNonNull(behandlingId)
+        behandlingKlient.avkort(behandlingId, brukerTokenInfo, true)
         return lagretAvkorting
     }
 
-    private fun hentAvkortingNonNull(
-        behandling: DetaljertBehandling,
-        forrigeAvkorting: Avkorting? = null,
-    ) = hentAvkorting(behandling, forrigeAvkorting)
-        ?: throw Exception("Uthenting av avkorting for behandling ${behandling.id} feilet")
+    private fun hentAvkortingNonNull(behandlingId: UUID) =
+        avkortingRepository.hentAvkorting(behandlingId)
+            ?: throw AvkortingFinnesIkkeException(behandlingId)
 
-    private fun hentAvkorting(
+    private fun avkortingMedTillegg(
+        avkorting: Avkorting,
         behandling: DetaljertBehandling,
         forrigeAvkorting: Avkorting? = null,
-    ) = avkortingRepository.hentAvkorting(behandling.id)?.medYtelseFraOgMedVirkningstidspunkt(
-        behandling.hentVirk().dato,
-        forrigeAvkorting,
-    )
+    ): Avkorting {
+        // Forrige behandling er forrige iverksatte som da vil være seg selv eller nyere hvis status er iverksatte
+        val forrigeBehandling =
+            when (behandling.status) {
+                BehandlingStatus.IVERKSATT -> null
+                else -> forrigeAvkorting
+            }
+        return avkorting.medYtelseFraOgMedVirkningstidspunkt(behandling.hentVirk().dato, forrigeBehandling)
+    }
+
+    private suspend fun hentAvkortingForrigeBehandling(
+        sakId: Long,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Avkorting {
+        val forrigeBehandlingId = behandlingKlient.hentSisteIverksatteBehandling(sakId, brukerTokenInfo).id
+        return hentForrigeAvkorting(forrigeBehandlingId)
+    }
 
     private fun hentForrigeAvkorting(forrigeBehandlingId: UUID): Avkorting =
         avkortingRepository.hentAvkorting(forrigeBehandlingId)
@@ -109,15 +148,22 @@ class AvkortingService(
     private suspend fun tilstandssjekk(
         behandlingId: UUID,
         bruker: BrukerTokenInfo,
-        block: suspend () -> Avkorting,
-    ): Avkorting {
+    ) {
         val kanAvkorte = behandlingKlient.avkort(behandlingId, bruker, commit = false)
-        return if (kanAvkorte) {
-            block()
-        } else {
-            throw Exception("Kan ikke avkorte da behandlingen er i feil tilstand")
+        if (!kanAvkorte) {
+            throw AvkortingBehandlingFeilStatus(behandlingId)
         }
     }
 }
 
 private fun DetaljertBehandling.hentVirk() = virkningstidspunkt ?: throw Exception("Mangler virkningstidspunkt for behandling $id")
+
+class AvkortingFinnesIkkeException(behandlingId: UUID) : IkkeFunnetException(
+    code = "AVKORTING_IKKE_FUNNET",
+    detail = "Uthenting av avkorting for behandling $behandlingId finnes ikke",
+)
+
+class AvkortingBehandlingFeilStatus(behandlingId: UUID) : IkkeTillattException(
+    code = "BEHANDLING_FEIL_STATUS_FOR_AVKORTING",
+    detail = "Kan ikke avkorte da behandling med id=$behandlingId har feil status",
+)

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -22,7 +22,6 @@ class AvkortingService(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): Avkorting? {
-        tilstandssjekk(behandlingId, brukerTokenInfo)
         logger.info("Henter avkorting for behandlingId=$behandlingId")
         val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
         val eksisterendeAvkorting = avkortingRepository.hentAvkorting(behandling.id)
@@ -114,6 +113,7 @@ class AvkortingService(
         avkorting: Avkorting,
         brukerTokenInfo: BrukerTokenInfo,
     ): Avkorting {
+        tilstandssjekk(behandlingId, brukerTokenInfo)
         val beregning = beregningService.hentBeregningNonnull(behandlingId)
         val beregnetAvkorting = avkorting.beregnAvkortingRevurdering(beregning)
         avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -284,6 +284,7 @@ fun behandling(
     sakType: SakType = SakType.OMSTILLINGSSTOENAD,
     behandlingType: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
     virkningstidspunkt: Virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1)),
+    status: BehandlingStatus = BehandlingStatus.BEREGNET,
 ) = DetaljertBehandling(
     id = id,
     sak = sak,
@@ -295,7 +296,7 @@ fun behandling(
     gjenlevende = listOf(),
     avdoed = listOf(),
     soesken = listOf(),
-    status = BehandlingStatus.TRYGDETID_OPPDATERT,
+    status = status,
     behandlingType = behandlingType,
     virkningstidspunkt = virkningstidspunkt,
     revurderingsaarsak = null,

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
@@ -161,7 +161,7 @@ class AvkortingRoutesTest {
                         ),
                     ),
             )
-        coEvery { avkortingService.lagreAvkorting(any(), any(), any()) } returns avkorting
+        coEvery { avkortingService.beregnAvkortingMedNyttGrunnlag(any(), any(), any()) } returns avkorting
 
         testApplication(server.config.httpServer.port()) {
             val response =
@@ -175,7 +175,7 @@ class AvkortingRoutesTest {
             val result = objectMapper.readValue(response.bodyAsText(), AvkortingDto::class.java)
             result shouldBe dto
             coVerify {
-                avkortingService.lagreAvkorting(
+                avkortingService.beregnAvkortingMedNyttGrunnlag(
                     behandlingsId,
                     any(),
                     withArg {

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -71,7 +71,6 @@ internal class AvkortingServiceTest {
             }
 
             coVerify {
-                behandlingKlient.avkort(behandlingId, bruker, false)
                 avkortingRepository.hentAvkorting(behandlingId)
                 behandlingKlient.hentBehandling(behandlingId, bruker)
                 behandling.behandlingType
@@ -97,7 +96,6 @@ internal class AvkortingServiceTest {
                 service.hentAvkorting(behandlingId, bruker) shouldBe avkorting
             }
             coVerify {
-                behandlingKlient.avkort(behandlingId, bruker, false)
                 behandlingKlient.hentBehandling(behandlingId, bruker)
                 avkortingRepository.hentAvkorting(behandlingId)
                 avkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2023, 1))
@@ -173,7 +171,6 @@ internal class AvkortingServiceTest {
             }
 
             coVerify(exactly = 1) {
-                behandlingKlient.avkort(behandlingId, bruker, false)
                 behandlingKlient.hentBehandling(behandlingId, bruker)
                 avkortingRepository.hentAvkorting(behandlingId)
                 behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, bruker)
@@ -212,7 +209,6 @@ internal class AvkortingServiceTest {
             }
 
             coVerify(exactly = 1) {
-                behandlingKlient.avkort(behandlingId, bruker, false)
                 behandlingKlient.hentBehandling(behandlingId, bruker)
                 avkortingRepository.hentAvkorting(behandlingId)
                 behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, bruker)

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -18,6 +18,7 @@ import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
 import no.nav.etterlatte.beregning.regler.behandling
 import no.nav.etterlatte.beregning.regler.bruker
 import no.nav.etterlatte.klienter.BehandlingKlient
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SisteIverksatteBehandling
 import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
@@ -54,7 +55,7 @@ internal class AvkortingServiceTest {
     @Nested
     inner class HentAvkorting {
         @Test
-        fun `Skal hente avkorting med loepende ytelse`() {
+        fun `Skal hente avkorting med ytelse`() {
             val behandlingId = UUID.randomUUID()
             val behandling =
                 behandling(
@@ -71,6 +72,7 @@ internal class AvkortingServiceTest {
                 service.hentAvkorting(behandlingId, bruker) shouldBe avkorting
             }
             coVerify {
+                behandlingKlient.avkort(behandlingId, bruker, false)
                 behandlingKlient.hentBehandling(behandlingId, bruker)
                 avkortingRepository.hentAvkorting(behandlingId)
                 avkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2023, 1))
@@ -78,7 +80,7 @@ internal class AvkortingServiceTest {
         }
 
         @Test
-        fun `Skal returnere null hvis avkorting ikke finnes`() {
+        fun `Skal returnere null hvis avkorting ikke finnes for en foerstegangsbehandling`() {
             val behandlingId = UUID.randomUUID()
             val behandling =
                 behandling(
@@ -93,9 +95,88 @@ internal class AvkortingServiceTest {
             }
 
             coVerify {
+                behandlingKlient.avkort(behandlingId, bruker, false)
                 avkortingRepository.hentAvkorting(behandlingId)
                 behandlingKlient.hentBehandling(behandlingId, bruker)
                 behandling.behandlingType
+            }
+        }
+
+        @Test
+        fun `Revurdering skal returnere eksisterende avkorting hvis allerede beregnet`() {
+            val behandlingId = UUID.randomUUID()
+            val behandlingStatusEtterBeregnet = BehandlingStatus.AVKORTET
+            val behandling =
+                behandling(
+                    id = behandlingId,
+                    status = behandlingStatusEtterBeregnet,
+                    behandlingType = BehandlingType.REVURDERING,
+                    sak = 123L,
+                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1)),
+                )
+            val forrigeBehandlingId = UUID.randomUUID()
+            val eksisterendeAvkorting = mockk<Avkorting>()
+            val forrigeAvkorting = mockk<Avkorting>()
+
+            coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+            coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
+                SisteIverksatteBehandling(
+                    forrigeBehandlingId,
+                )
+            every { avkortingRepository.hentAvkorting(behandlingId) } returns eksisterendeAvkorting
+            every { avkortingRepository.hentAvkorting(forrigeBehandlingId) } returns forrigeAvkorting
+            every { eksisterendeAvkorting.medYtelseFraOgMedVirkningstidspunkt(any(), any()) } returns eksisterendeAvkorting
+
+            runBlocking {
+                service.hentAvkorting(behandlingId, bruker)
+            }
+
+            coVerify(exactly = 1) {
+                behandlingKlient.avkort(behandlingId, bruker, false)
+                behandlingKlient.hentBehandling(behandlingId, bruker)
+                avkortingRepository.hentAvkorting(behandlingId)
+                behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, bruker)
+                avkortingRepository.hentAvkorting(forrigeBehandlingId)
+                eksisterendeAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2023, 1), forrigeAvkorting)
+            }
+        }
+
+        @Test
+        fun `Revurdering skal for iverksatt behandling IKKE legge til avkortinginfo fra forrige behandling`() {
+            val behandlingId = UUID.randomUUID()
+            val behandlingStatusEtterBeregnet = BehandlingStatus.IVERKSATT
+            val behandling =
+                behandling(
+                    id = behandlingId,
+                    status = behandlingStatusEtterBeregnet,
+                    behandlingType = BehandlingType.REVURDERING,
+                    sak = 123L,
+                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1)),
+                )
+            val forrigeBehandlingId = UUID.randomUUID()
+            val eksisterendeAvkorting = mockk<Avkorting>()
+            val forrigeAvkorting = mockk<Avkorting>()
+
+            coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+            coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
+                SisteIverksatteBehandling(
+                    forrigeBehandlingId,
+                )
+            every { avkortingRepository.hentAvkorting(behandlingId) } returns eksisterendeAvkorting
+            every { avkortingRepository.hentAvkorting(forrigeBehandlingId) } returns forrigeAvkorting
+            every { eksisterendeAvkorting.medYtelseFraOgMedVirkningstidspunkt(any(), any()) } returns eksisterendeAvkorting
+
+            runBlocking {
+                service.hentAvkorting(behandlingId, bruker)
+            }
+
+            coVerify(exactly = 1) {
+                behandlingKlient.avkort(behandlingId, bruker, false)
+                behandlingKlient.hentBehandling(behandlingId, bruker)
+                avkortingRepository.hentAvkorting(behandlingId)
+                behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, bruker)
+                avkortingRepository.hentAvkorting(forrigeBehandlingId)
+                eksisterendeAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2023, 1), null)
             }
         }
 
@@ -135,6 +216,7 @@ internal class AvkortingServiceTest {
             }
 
             coVerify(exactly = 1) {
+                behandlingKlient.avkort(behandlingId, bruker, false)
                 behandlingKlient.hentBehandling(behandlingId, bruker)
                 behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, bruker)
                 avkortingRepository.hentAvkorting(forrigeBehandlingId)
@@ -142,6 +224,58 @@ internal class AvkortingServiceTest {
                 forrigeAvkorting.kopierAvkorting()
                 kopiertAvkorting.beregnAvkortingRevurdering(beregning)
                 avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
+                lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2023, 1), forrigeAvkorting)
+                behandlingKlient.avkort(behandlingId, bruker, true)
+            }
+            coVerify(exactly = 2) {
+                avkortingRepository.hentAvkorting(behandlingId)
+            }
+        }
+
+        @Test
+        fun `Revurdering skal reberegne avkorting hvis beregning er beregnet paa nytt`() {
+            val behandlingId = UUID.randomUUID()
+            val behandlingBeregnetStatus = BehandlingStatus.BEREGNET
+            val behandling =
+                behandling(
+                    id = behandlingId,
+                    status = behandlingBeregnetStatus,
+                    behandlingType = BehandlingType.REVURDERING,
+                    sak = 123L,
+                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1)),
+                )
+            val forrigeBehandlingId = UUID.randomUUID()
+            val eksisterendeAvkorting = mockk<Avkorting>()
+            val forrigeAvkorting = mockk<Avkorting>()
+            val beregning = mockk<Beregning>()
+            val reberegnetAvkorting = mockk<Avkorting>()
+            val lagretAvkorting = mockk<Avkorting>()
+
+            coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+            coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
+                SisteIverksatteBehandling(
+                    forrigeBehandlingId,
+                )
+            every { avkortingRepository.hentAvkorting(behandlingId) } returns eksisterendeAvkorting andThen lagretAvkorting
+            every { avkortingRepository.hentAvkorting(forrigeBehandlingId) } returns forrigeAvkorting
+            every { beregningService.hentBeregningNonnull(any()) } returns beregning
+            every { eksisterendeAvkorting.beregnAvkortingRevurdering(any()) } returns reberegnetAvkorting
+            every { avkortingRepository.lagreAvkorting(any(), any()) } returns Unit
+            every { lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(any(), any()) } returns lagretAvkorting
+            coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
+
+            runBlocking {
+                service.hentAvkorting(behandlingId, bruker)
+            }
+
+            coVerify(exactly = 1) {
+                behandlingKlient.avkort(behandlingId, bruker, false)
+                behandlingKlient.hentBehandling(behandlingId, bruker)
+                behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, bruker)
+                avkortingRepository.hentAvkorting(forrigeBehandlingId)
+                beregningService.hentBeregningNonnull(behandlingId)
+                eksisterendeAvkorting.beregnAvkortingRevurdering(beregning)
+                avkortingRepository.lagreAvkorting(behandlingId, reberegnetAvkorting)
                 lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2023, 1), forrigeAvkorting)
                 behandlingKlient.avkort(behandlingId, bruker, true)
             }
@@ -181,7 +315,7 @@ internal class AvkortingServiceTest {
             every { lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(any()) } returns lagretAvkorting
 
             runBlocking {
-                service.lagreAvkorting(behandlingId, bruker, endretGrunnlag) shouldBe lagretAvkorting
+                service.beregnAvkortingMedNyttGrunnlag(behandlingId, bruker, endretGrunnlag) shouldBe lagretAvkorting
             }
 
             coVerify(exactly = 1) {
@@ -232,7 +366,7 @@ internal class AvkortingServiceTest {
             coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
 
             runBlocking {
-                service.lagreAvkorting(revurderingId, bruker, endretGrunnlag) shouldBe lagretAvkorting
+                service.beregnAvkortingMedNyttGrunnlag(revurderingId, bruker, endretGrunnlag) shouldBe lagretAvkorting
             }
 
             coVerify(exactly = 1) {
@@ -262,7 +396,7 @@ internal class AvkortingServiceTest {
 
             runBlocking {
                 assertThrows<Exception> {
-                    service.lagreAvkorting(behandlingId, bruker, avkortinggrunnlag())
+                    service.beregnAvkortingMedNyttGrunnlag(behandlingId, bruker, avkortinggrunnlag())
                 }
             }
 


### PR DESCRIPTION
- Sjekker at behandling har riktig status for bruk av avkorting
- Behandling med status BEREGNET trigger ny beregning av avkorting da beregning er oppdatert
- Behandling med status IVERKSATT lar være å legge til info om forrige behandling fordi den henter forrige iverksatte som da vil være seg selv eller nyere
- Mer spesifik bruk av exception
- Generell rydding av kode og flere tester