### PR TITLE
EY-2981 Vedtaksinfo for pesys

### DIFF
--- a/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
@@ -78,11 +78,29 @@ spec:
     - name: TJENESTEPENSJON_SCOPE
       value: api://dev-fss.pensjonsamhandling.tp-q2/.default
   accessPolicy:
-    inbound:
-      rules:
-        - application: etterlatte-krakend
     outbound:
       rules:
         - application: etterlatte-vedtaksvurdering
       external:
         - host: tp-api-q2.dev-fss-pub.nais.io
+    inbound:
+      rules:
+        - application: etterlatte-krakend
+        - application: pensjon-pen-q1
+          namespace: pensjon-q2
+          cluster: dev-fss
+          permissions:
+            roles:
+              - les-oms-vedtak
+        - application: pensjon-pen-q2
+          namespace: pensjon-q2
+          cluster: dev-fss
+          permissions:
+            roles:
+              - les-oms-vedtak
+        - application: ida
+          namespace: traktor
+          cluster: prod-fss
+          permissions:
+            roles:
+              - les-oms-vedtak

--- a/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
@@ -76,11 +76,17 @@ spec:
     - name: TJENESTEPENSJON_SCOPE
       value: api://prod-fss.pensjonsamhandling.tp/.default
   accessPolicy:
-    inbound:
-      rules:
-        - application: etterlatte-krakend
     outbound:
       rules:
         - application: etterlatte-vedtaksvurdering
       external:
         - host: tp-api.prod-fss-pub.nais.io
+    inbound:
+      rules:
+        - application: etterlatte-krakend
+        - application: pensjon-pen
+          namespace: pensjondeployer
+          cluster: prod-fss
+          permissions:
+            roles:
+              - les-oms-vedtak

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -11,7 +11,6 @@ import no.nav.etterlatte.libs.ktor.restModule
 import no.nav.etterlatte.libs.ktor.setReady
 import no.nav.etterlatte.samordning.ApplicationContext
 import no.nav.etterlatte.samordning.vedtak.samordningVedtakRoute
-import no.nav.security.token.support.core.context.TokenValidationContext
 import org.slf4j.Logger
 
 val sikkerLogg: Logger = sikkerlogger()
@@ -36,7 +35,6 @@ class Server(applicationContext: ApplicationContext) {
                         restModule(
                             sikkerLogg,
                             withMetrics = true,
-                            additionalValidation = validateMaskinportenScope(),
                         ) {
                             samordningVedtakRoute(samordningVedtakService = applicationContext.samordningVedtakService)
                         }
@@ -46,18 +44,4 @@ class Server(applicationContext: ApplicationContext) {
         )
 
     fun run() = setReady().also { engine.start(true) }
-}
-
-fun validateMaskinportenScope(): (TokenValidationContext) -> Boolean {
-    val scopeValidation: (TokenValidationContext) -> Boolean = { ctx ->
-        val scopes =
-            ctx.getClaims("maskinporten")
-                ?.getStringClaim("scope")
-                ?.split(" ")
-                ?: emptyList()
-
-        val allowedScopes = setOf("nav:etterlatteytelser:vedtaksinformasjon.read")
-        scopes.any(allowedScopes::contains)
-    }
-    return scopeValidation
 }

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/CallerContext.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/CallerContext.kt
@@ -1,0 +1,7 @@
+package no.nav.etterlatte.samordning.vedtak
+
+sealed interface CallerContext
+
+data class MaskinportenTpContext(val tpnr: Tjenestepensjonnummer, val organisasjonsnr: String) : CallerContext
+
+object PensjonContext : CallerContext

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtak.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtak.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.samordning.vedtak
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import java.time.LocalDate
 import java.time.YearMonth
 
@@ -35,6 +36,14 @@ enum class SamordningVedtakAarsak {
     ANNET,
 }
 
-class VedtakFeilSakstypeException : RuntimeException()
-
 fun YearMonth.atStartOfMonth(): LocalDate = this.atDay(1)
+
+class VedtakFeilSakstypeException : UgyldigForespoerselException(
+    code = "002-FEIL_SAKSTYPE",
+    detail = "Forespurt informasjon gjeldende ikke-støttet sakstype",
+)
+
+class ManglerTpNrException : UgyldigForespoerselException(
+    code = "001-TPNR-MANGLER",
+    detail = "Forespørselen mangler 'tpnr' header",
+)

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/TjenestepensjonKlient.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/TjenestepensjonKlient.kt
@@ -21,7 +21,7 @@ class TjenestepensjonKlient(config: Config, private val httpClient: HttpClient) 
 
     suspend fun harTpForholdByDate(
         fnr: String,
-        tpnr: String,
+        tpnr: Tjenestepensjonnummer,
         fomDato: LocalDate,
     ): Boolean {
         logger.info("Sjekk om det finnes tjenestepensjonsforhold pr $fomDato for ordning '$tpnr'")
@@ -31,7 +31,7 @@ class TjenestepensjonKlient(config: Config, private val httpClient: HttpClient) 
                 httpClient.get {
                     url("$tjenestepensjonUrl/finnForholdForBruker?datoFom=$fomDato")
                     header("fnr", fnr)
-                    header("tpnr", tpnr)
+                    header("tpnr", tpnr.value)
                 }.body()
             } catch (e: ClientRequestException) {
                 when (e.response.status) {
@@ -47,7 +47,7 @@ class TjenestepensjonKlient(config: Config, private val httpClient: HttpClient) 
 
     suspend fun harTpYtelseOnDate(
         fnr: String,
-        tpnr: String,
+        tpnr: Tjenestepensjonnummer,
         fomDato: LocalDate,
     ): Boolean {
         logger.info("Sjekk om det finnes tjenestepensjonsytelse pr $fomDato for ordning '$tpnr'")
@@ -67,7 +67,7 @@ class TjenestepensjonKlient(config: Config, private val httpClient: HttpClient) 
                 }
             }
 
-        return tpNumre.tpNr.contains(tpnr)
+        return tpNumre.tpNr.contains(tpnr.value)
     }
 }
 

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/VedtaksvurderingKlient.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/VedtaksvurderingKlient.kt
@@ -22,14 +22,16 @@ class VedtaksvurderingKlient(config: Config, private val httpClient: HttpClient)
 
     suspend fun hentVedtak(
         vedtakId: Long,
-        organisasjonsnummer: String,
+        callerContext: CallerContext,
     ): VedtakSamordningDto {
         logger.info("Henter vedtaksvurdering med vedtakId=$vedtakId")
 
         return try {
             httpClient.get {
                 url("$vedtaksvurderingUrl/$vedtakId")
-                header("orgnr", organisasjonsnummer)
+                if (callerContext is MaskinportenTpContext) {
+                    header("orgnr", callerContext.organisasjonsnr)
+                }
             }.body()
         } catch (e: ClientRequestException) {
             when (e.response.status) {
@@ -44,7 +46,7 @@ class VedtaksvurderingKlient(config: Config, private val httpClient: HttpClient)
     suspend fun hentVedtaksliste(
         virkFom: LocalDate,
         fnr: String,
-        organisasjonsnummer: String,
+        callerContext: CallerContext,
     ): List<VedtakSamordningDto> {
         logger.info("Henter vedtaksliste, virkFom=$virkFom")
 
@@ -52,7 +54,9 @@ class VedtaksvurderingKlient(config: Config, private val httpClient: HttpClient)
             httpClient.get {
                 url("$vedtaksvurderingUrl?virkFom=$virkFom")
                 header("fnr", fnr)
-                header("orgnr", organisasjonsnummer)
+                if (callerContext is MaskinportenTpContext) {
+                    header("orgnr", callerContext.organisasjonsnr)
+                }
             }.body()
         } catch (e: ClientRequestException) {
             when (e.response.status) {

--- a/apps/etterlatte-samordning-vedtak/src/main/resources/application.conf
+++ b/apps/etterlatte-samordning-vedtak/src/main/resources/application.conf
@@ -5,6 +5,11 @@ no.nav.security.jwt {
             discoveryurl = ${?MASKINPORTEN_WELL_KNOWN_URL}
             accepted_audience = ${?MASKINPORTEN_CLIENT_ID}
             validation.optional_claims = "aud,nbf,sub"
+        },
+        {
+            issuer_name = azure
+            discoveryurl = ${?AZURE_APP_WELL_KNOWN_URL}
+            accepted_audience = ${?AZURE_APP_CLIENT_ID}
         }
     ]
 }

--- a/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakServiceTest.kt
+++ b/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakServiceTest.kt
@@ -41,6 +41,8 @@ class SamordningVedtakServiceTest {
     private val tpKlient = mockk<TjenestepensjonKlient>()
     private val samordningVedtakService = SamordningVedtakService(vedtakKlient, tpKlient)
 
+    private val tpnrSPK = Tjenestepensjonnummer(TPNR_SPK)
+
     @AfterEach
     fun after() {
         clearAllMocks()
@@ -53,12 +55,14 @@ class SamordningVedtakServiceTest {
                 sakstype = SakType.BARNEPENSJON,
             )
 
-        coEvery { vedtakKlient.hentVedtak(123L, ORGNO) } returns vedtak
-        coEvery { tpKlient.harTpYtelseOnDate(FNR, tpnr = TPNR_SPK, now().atStartOfMonth()) } returns true
+        val callerContext = MaskinportenTpContext(tpnrSPK, ORGNO)
+
+        coEvery { vedtakKlient.hentVedtak(123L, callerContext) } returns vedtak
+        coEvery { tpKlient.harTpYtelseOnDate(FNR, tpnr = tpnrSPK, now().atStartOfMonth()) } returns true
 
         shouldThrow<VedtakFeilSakstypeException> {
             runBlocking {
-                samordningVedtakService.hentVedtak(123L, TPNR_SPK, ORGNO)
+                samordningVedtakService.hentVedtak(123L, callerContext)
             }
         }
     }
@@ -75,12 +79,15 @@ class SamordningVedtakServiceTest {
                         Periode(fom = now().plusMonths(1), tom = null),
                     ),
             )
-        coEvery { vedtakKlient.hentVedtak(456L, ORGNO) } returns vedtak
-        coEvery { tpKlient.harTpYtelseOnDate(FNR, tpnr = TPNR_SPK, now().atStartOfMonth()) } returns true
+        coEvery { vedtakKlient.hentVedtak(456L, MaskinportenTpContext(tpnrSPK, ORGNO)) } returns vedtak
+        coEvery { tpKlient.harTpYtelseOnDate(FNR, tpnr = tpnrSPK, now().atStartOfMonth()) } returns true
 
         val result =
             runBlocking {
-                samordningVedtakService.hentVedtak(456L, TPNR_SPK, ORGNO)
+                samordningVedtakService.hentVedtak(
+                    456L,
+                    MaskinportenTpContext(tpnr = tpnrSPK, organisasjonsnr = ORGNO),
+                )
             }
 
         result.vedtakId shouldBe 456L
@@ -106,7 +113,7 @@ class SamordningVedtakServiceTest {
                 ),
             )
 
-        coVerify { tpKlient.harTpYtelseOnDate(FNR, tpnr = TPNR_SPK, now().atStartOfMonth()) }
+        coVerify { tpKlient.harTpYtelseOnDate(FNR, tpnr = tpnrSPK, now().atStartOfMonth()) }
     }
 
     @Test
@@ -126,22 +133,21 @@ class SamordningVedtakServiceTest {
                 ),
             )
 
-        coEvery { vedtakKlient.hentVedtaksliste(virkFom, fnr = FNR, organisasjonsnummer = ORGNO) } returns vedtakliste
-        coEvery { tpKlient.harTpForholdByDate(FNR, tpnr = TPNR_SPK, fomDato = virkFom) } returns true
+        coEvery { vedtakKlient.hentVedtaksliste(virkFom, fnr = FNR, MaskinportenTpContext(tpnrSPK, ORGNO)) } returns vedtakliste
+        coEvery { tpKlient.harTpForholdByDate(FNR, tpnr = tpnrSPK, fomDato = virkFom) } returns true
 
         val vedtaksliste =
             runBlocking {
                 samordningVedtakService.hentVedtaksliste(
                     virkFom,
                     Folkeregisteridentifikator.of(FNR),
-                    Tjenestepensjonnummer(TPNR_SPK),
-                    ORGNO,
+                    MaskinportenTpContext(tpnrSPK, ORGNO),
                 )
             }
 
         vedtaksliste shouldHaveSize 2
 
-        coVerify { tpKlient.harTpForholdByDate(FNR, tpnr = TPNR_SPK, fomDato = virkFom) }
+        coVerify { tpKlient.harTpForholdByDate(FNR, tpnr = tpnrSPK, fomDato = virkFom) }
     }
 }
 

--- a/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/TjenestepensjonKlientTest.kt
+++ b/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/TjenestepensjonKlientTest.kt
@@ -62,7 +62,7 @@ class TjenestepensjonKlientTest {
         val tpKlient = TjenestepensjonKlient(config, httpClient)
 
         runBlocking {
-            tpKlient.harTpForholdByDate("17057554321", "3010", datoHarTpYtelse)
+            tpKlient.harTpForholdByDate("17057554321", tpnr = Tjenestepensjonnummer("3010"), datoHarTpYtelse)
         } shouldBe true
     }
 
@@ -91,7 +91,7 @@ class TjenestepensjonKlientTest {
         val tpKlient = TjenestepensjonKlient(config, httpClient)
 
         runBlocking {
-            tpKlient.harTpForholdByDate("17057554321", "4100", datoHarIkkeTpYtelse)
+            tpKlient.harTpForholdByDate("17057554321", Tjenestepensjonnummer("4100"), datoHarIkkeTpYtelse)
         } shouldBe false
     }
 
@@ -117,11 +117,11 @@ class TjenestepensjonKlientTest {
         val tpKlient = TjenestepensjonKlient(config, httpClient)
 
         runBlocking {
-            tpKlient.harTpYtelseOnDate("01018012345", "3010", datoHarIkkeTpYtelse)
+            tpKlient.harTpYtelseOnDate("01018012345", Tjenestepensjonnummer("3010"), datoHarIkkeTpYtelse)
         } shouldBe false
 
         runBlocking {
-            tpKlient.harTpYtelseOnDate("01018012345", "3010", datoHarTpYtelse)
+            tpKlient.harTpYtelseOnDate("01018012345", Tjenestepensjonnummer("3010"), datoHarTpYtelse)
         } shouldBe true
     }
 

--- a/apps/etterlatte-samordning-vedtak/src/test/resources/logback-test.xml
+++ b/apps/etterlatte-samordning-vedtak/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/libs/etterlatte-ktor/src/main/kotlin/AuthorizationPlugin.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/AuthorizationPlugin.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.libs.ktor
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.createRouteScopedPlugin
+import io.ktor.server.application.log
 import io.ktor.server.auth.AuthenticationChecked
 import io.ktor.server.response.respond
 
@@ -20,6 +21,7 @@ val AuthorizationPlugin =
                     call.firstValidTokenClaims()?.getAsList("roles") ?: emptyList()
 
                 if (userRoles.intersect(roles).isEmpty()) {
+                    application.log.info("Request avslått pga manglende rolle (gyldige: $roles)")
                     call.respond(HttpStatusCode.Unauthorized, "Har ikke påkrevd rolle ")
                 }
             }

--- a/libs/etterlatte-ktor/src/main/kotlin/MaskinportenScopeAuthorizationPlugin.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/MaskinportenScopeAuthorizationPlugin.kt
@@ -1,0 +1,30 @@
+package no.nav.etterlatte.libs.ktor
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.createRouteScopedPlugin
+import io.ktor.server.auth.AuthenticationChecked
+import io.ktor.server.response.respond
+
+val MaskinportenScopeAuthorizationPlugin =
+    createRouteScopedPlugin(
+        name = "MaskinportenScopeAuthorizationPlugin",
+        createConfiguration = ::MaskinportenScopePluginConfiguration,
+    ) {
+        val scopes = pluginConfig.scopes
+        pluginConfig.apply {
+            on(AuthenticationChecked) { call ->
+                val userScopes =
+                    call.firstValidTokenClaims()?.getStringClaim("scope")
+                        ?.split(" ")
+                        ?: emptyList()
+
+                if (userScopes.intersect(scopes).isEmpty()) {
+                    call.respond(HttpStatusCode.Unauthorized, "Har ikke påkrevd scope")
+                }
+            }
+        }
+    }
+
+class MaskinportenScopePluginConfiguration {
+    var scopes: Set<String> = emptySet()
+}

--- a/libs/etterlatte-ktor/src/main/kotlin/MaskinportenScopeAuthorizationPlugin.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/MaskinportenScopeAuthorizationPlugin.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.libs.ktor
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.createRouteScopedPlugin
+import io.ktor.server.application.log
 import io.ktor.server.auth.AuthenticationChecked
 import io.ktor.server.response.respond
 
@@ -19,6 +20,7 @@ val MaskinportenScopeAuthorizationPlugin =
                         ?: emptyList()
 
                 if (userScopes.intersect(scopes).isEmpty()) {
+                    application.log.info("Request avslått pga manglende scope (gyldige: $scopes)")
                     call.respond(HttpStatusCode.Unauthorized, "Har ikke påkrevd scope")
                 }
             }


### PR DESCRIPTION
Gjenbruker samordningendepunktet, men etablerer egen route fordi
- ikke maskinporten, men azure-token og dermed ikke sjekk på scope, men på rolle
- skippe autorisering av dataoppslag mot TP-registeret hvis != Maskinporten.