### PR TITLE
EY-2960 Fikse feil i form inntektsavkorting - spesifikasjon av inntekt

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -45,10 +45,12 @@ export const AvkortingInntekt = (props: {
         fratrekkInnAar: nyligste.fratrekkInnAar,
         fratrekkInnAarUtland: nyligste.fratrekkInnAarUtland,
         relevanteMaanederInnAar: nyligste.relevanteMaanederInnAar,
+        spesifikasjon: nyligste.spesifikasjon,
       }
     }
     return {
       fom: virkningstidspunkt(),
+      spesifikasjon: '',
     }
   }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
@@ -14,7 +14,7 @@ export interface IAvkortingGrunnlag {
   relevanteMaanederInnAar?: number
   inntektUtland?: number
   fratrekkInnAarUtland?: number
-  spesifikasjon?: string
+  spesifikasjon: string
   kilde?: {
     tidspunkt: ''
     ident: ''


### PR DESCRIPTION
- spesifikasjon av inntekt er ikke optional og settes som tom streng by default avkorting frontend