### PR TITLE
Overstyrer med både anvendt TT og prorata

### DIFF
--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -583,12 +583,14 @@ class TrygdetidServiceImpl(
             trygdetidRepository.hentTrygdetiderForBehandling(behandlingId).find { it.ident == ident }
                 ?: throw GenerellIkkeFunnetException()
 
-        return trygdetid.oppdaterBeregnetTrygdetid(
-            DetaljertBeregnetTrygdetid(
-                resultat = beregnetTrygdetid,
-                tidspunkt = Tidspunkt.now(),
-                regelResultat = "".toJsonNode(),
-            ),
+        return trygdetid.copy(
+            trygdetidGrunnlag = emptyList(),
+            beregnetTrygdetid =
+                DetaljertBeregnetTrygdetid(
+                    resultat = beregnetTrygdetid,
+                    tidspunkt = Tidspunkt.now(),
+                    regelResultat = "".toJsonNode(),
+                ),
         ).also { nyTrygdetid ->
             trygdetidRepository.oppdaterTrygdetid(nyTrygdetid, true)
         }

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidServiceTest.kt
@@ -10,6 +10,7 @@ import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
@@ -32,12 +33,14 @@ import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.common.trygdetid.DetaljertBeregnetTrygdetidResultat
 import no.nav.etterlatte.libs.common.trygdetid.FaktiskTrygdetid
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingDto
+import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.trygdetid.BeregnetTrygdetidGrunnlag
 import no.nav.etterlatte.trygdetid.DetaljertBeregnetTrygdetid
 import no.nav.etterlatte.trygdetid.LandNormalisert
 import no.nav.etterlatte.trygdetid.ManglerForrigeTrygdetidMaaReguleresManuelt
 import no.nav.etterlatte.trygdetid.Opplysningsgrunnlag
+import no.nav.etterlatte.trygdetid.Trygdetid
 import no.nav.etterlatte.trygdetid.TrygdetidAlleredeOpprettetException
 import no.nav.etterlatte.trygdetid.TrygdetidBeregningService
 import no.nav.etterlatte.trygdetid.TrygdetidGrunnlag
@@ -494,9 +497,8 @@ internal class TrygdetidServiceTest {
     @Test
     fun `skal lagre nytt trygdetidsgrunnlag`() {
         val behandlingId = randomUUID()
-        val avdoedIdent = "01478343724"
         val trygdetidGrunnlag = trygdetidGrunnlag()
-        val eksisterendeTrygdetid = trygdetid(behandlingId, ident = avdoedIdent)
+        val eksisterendeTrygdetid = trygdetid(behandlingId, ident = AVDOED_FOEDSELSNUMMER.value)
         val vilkaarsvurderingDto = mockk<VilkaarsvurderingDto>()
 
         val grunnlag = mockk<Grunnlag>()
@@ -527,7 +529,7 @@ internal class TrygdetidServiceTest {
                         registersReferanse = null,
                         opplysningId = null,
                     ),
-                verdi = Folkeregisteridentifikator.of(avdoedIdent).toJsonNode(),
+                verdi = Folkeregisteridentifikator.of(AVDOED_FOEDSELSNUMMER.value).toJsonNode(),
             )
         }
         every { avdoedGrunnlag[Opplysningstype.DOEDSDATO] } answers {
@@ -582,13 +584,11 @@ internal class TrygdetidServiceTest {
     @Test
     fun `skal lagre nytt trygdetidsgrunnlag med overstyrt poengaar`() {
         val behandlingId = randomUUID()
-        val avdoedIdent = "01478343724"
-
         val trygdetidGrunnlag =
             trygdetidGrunnlag().copy(
                 periode = TrygdetidPeriode(LocalDate.now().minusYears(2), LocalDate.now().minusYears(1)),
             )
-        val eksisterendeTrygdetid = trygdetid(behandlingId, ident = avdoedIdent).copy(overstyrtNorskPoengaar = 10)
+        val eksisterendeTrygdetid = trygdetid(behandlingId, ident = AVDOED_FOEDSELSNUMMER.value).copy(overstyrtNorskPoengaar = 10)
         val vilkaarsvurderingDto = mockk<VilkaarsvurderingDto>()
 
         val grunnlag = mockk<Grunnlag>()
@@ -619,7 +619,7 @@ internal class TrygdetidServiceTest {
                         registersReferanse = null,
                         opplysningId = null,
                     ),
-                verdi = Folkeregisteridentifikator.of(avdoedIdent).toJsonNode(),
+                verdi = Folkeregisteridentifikator.of(AVDOED_FOEDSELSNUMMER.value).toJsonNode(),
             )
         }
         every { avdoedGrunnlag[Opplysningstype.DOEDSDATO] } answers {
@@ -675,10 +675,8 @@ internal class TrygdetidServiceTest {
     fun `skal oppdatere trygdetidsgrunnlag`() {
         val behandlingId = randomUUID()
         val trygdetidGrunnlag = trygdetidGrunnlag()
-        val avdoedIdent = "01478343724"
-
         val eksisterendeTrygdetid =
-            trygdetid(behandlingId, trygdetidGrunnlag = listOf(trygdetidGrunnlag), ident = avdoedIdent)
+            trygdetid(behandlingId, trygdetidGrunnlag = listOf(trygdetidGrunnlag), ident = AVDOED_FOEDSELSNUMMER.value)
         val endretTrygdetidGrunnlag = trygdetidGrunnlag.copy(bosted = LandNormalisert.NORGE.isoCode)
         val vilkaarsvurderingDto = mockk<VilkaarsvurderingDto>()
 
@@ -710,7 +708,7 @@ internal class TrygdetidServiceTest {
                         registersReferanse = null,
                         opplysningId = null,
                     ),
-                verdi = Folkeregisteridentifikator.of(avdoedIdent).toJsonNode(),
+                verdi = Folkeregisteridentifikator.of(AVDOED_FOEDSELSNUMMER.value).toJsonNode(),
             )
         }
         every { avdoedGrunnlag[Opplysningstype.DOEDSDATO] } answers {
@@ -768,10 +766,9 @@ internal class TrygdetidServiceTest {
     @Test
     fun `skal slette trygdetidsgrunnlag`() {
         val behandlingId = randomUUID()
-        val avdoedIdent = "01478343724"
         val trygdetidGrunnlag = trygdetidGrunnlag()
         val eksisterendeTrygdetid =
-            trygdetid(behandlingId, trygdetidGrunnlag = listOf(trygdetidGrunnlag), ident = avdoedIdent)
+            trygdetid(behandlingId, trygdetidGrunnlag = listOf(trygdetidGrunnlag), ident = AVDOED_FOEDSELSNUMMER.value)
 
         coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
         val grunnlag = mockk<Grunnlag>()
@@ -800,7 +797,7 @@ internal class TrygdetidServiceTest {
                         registersReferanse = null,
                         opplysningId = null,
                     ),
-                verdi = Folkeregisteridentifikator.of(avdoedIdent).toJsonNode(),
+                verdi = Folkeregisteridentifikator.of(AVDOED_FOEDSELSNUMMER.value).toJsonNode(),
             )
         }
         every { avdoedGrunnlag[Opplysningstype.DOEDSDATO] } answers {
@@ -838,6 +835,36 @@ internal class TrygdetidServiceTest {
             avdoedGrunnlag[Opplysningstype.DOEDSDATO]
             avdoedGrunnlag[Opplysningstype.FOEDSELSNUMMER]
             grunnlag.hentAvdoede()
+        }
+    }
+
+    @Test
+    fun `skal overstyre beregnet trygdetid og slette grunnlaget`() {
+        val behandlingId = randomUUID()
+        val trygdetidGrunnlag = trygdetidGrunnlag()
+        val eksisterendeTrygdetid =
+            trygdetid(
+                behandlingId,
+                trygdetidGrunnlag = listOf(trygdetidGrunnlag),
+                ident = AVDOED_FOEDSELSNUMMER.value,
+                beregnetTrygdetid = beregnetTrygdetid(35, Tidspunkt.now()),
+            )
+        val oppdatertTrygdetidCaptured = slot<Trygdetid>()
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+        coEvery { repository.hentTrygdetid(behandlingId) } returns eksisterendeTrygdetid
+        coEvery { repository.hentTrygdetiderForBehandling(behandlingId) } returns listOf(eksisterendeTrygdetid)
+        coEvery { repository.oppdaterTrygdetid(capture(oppdatertTrygdetidCaptured), true) } returns eksisterendeTrygdetid
+
+        service.overstyrBeregnetTrygdetid(behandlingId, beregnetTrygdetid(25, Tidspunkt.now()).resultat)
+
+        coVerify(exactly = 1) {
+            repository.hentTrygdetid(behandlingId)
+            repository.hentTrygdetiderForBehandling(behandlingId)
+            repository.oppdaterTrygdetid(oppdatertTrygdetidCaptured.captured, true)
+        }
+        with(oppdatertTrygdetidCaptured.captured) {
+            this.trygdetidGrunnlag.size shouldBe 0
+            this.beregnetTrygdetid?.resultat?.samletTrygdetidNorge shouldBe 25
         }
     }
 

--- a/libs/etterlatte-trygdetid-model/src/main/kotlin/Trygdetid.kt
+++ b/libs/etterlatte-trygdetid-model/src/main/kotlin/Trygdetid.kt
@@ -86,17 +86,31 @@ data class DetaljertBeregnetTrygdetidResultat(
     val overstyrt: Boolean,
 ) {
     companion object {
-        fun fraSamletTrygdetidNorge(verdi: Int) =
+        fun fraSamletTrygdetidNorge(anvendtTrygdetid: Int) =
             DetaljertBeregnetTrygdetidResultat(
                 faktiskTrygdetidNorge = null,
                 faktiskTrygdetidTeoretisk = null,
                 fremtidigTrygdetidNorge = null,
                 fremtidigTrygdetidTeoretisk = null,
-                samletTrygdetidNorge = verdi,
+                samletTrygdetidNorge = anvendtTrygdetid,
                 samletTrygdetidTeoretisk = null,
                 prorataBroek = null,
-                overstyrt = false,
+                overstyrt = true,
             )
+
+        fun fraSamletTrygdetidProrata(
+            anvendtTrygdetid: Int,
+            prorataBroek: IntBroek?,
+        ) = DetaljertBeregnetTrygdetidResultat(
+            faktiskTrygdetidNorge = null,
+            faktiskTrygdetidTeoretisk = null,
+            fremtidigTrygdetidNorge = null,
+            fremtidigTrygdetidTeoretisk = null,
+            samletTrygdetidNorge = null,
+            samletTrygdetidTeoretisk = anvendtTrygdetid,
+            prorataBroek = prorataBroek,
+            overstyrt = true,
+        )
     }
 }
 


### PR DESCRIPTION
Rydder opp i overstyringen slik at grunnlaget (som er feil) også slettes fra trygdetidsobjektet.

EY-3008