### PR TITLE
Fjerner klartekst-logging av hele responsen fra Pesys.

### DIFF
--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/PesysRepository.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/PesysRepository.kt
@@ -126,7 +126,7 @@ internal class PesysRepository(private val dataSource: DataSource) : Transaction
                 Feilkjoering.FEILMELDING to feil,
                 Feilkjoering.FEILENDE_STEG to feilendeSteg,
             ),
-            "Lagra feilkjøringsdata for $request.pesysId.id",
+            "Lagra feilkjøringsdata for $pesysId",
         )
     }
 


### PR DESCRIPTION
Inneholder masse fødselsnummer og annen data om bruker og familie.