### PR TITLE
Bruker redux state stegmeny

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/Behandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/Behandling.tsx
@@ -7,7 +7,7 @@ import { PdlPersonStatusBar } from '~shared/statusbar/Statusbar'
 import { useBehandlingRoutes } from './BehandlingRoutes'
 import { StegMeny } from './StegMeny/stegmeny'
 import { useAppDispatch } from '~store/Store'
-import { mapAllApiResult, useApiCall } from '~shared/hooks/useApiCall'
+import { isSuccess, isPending, isFailure, useApiCall } from '~shared/hooks/useApiCall'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { useBehandling } from '~components/behandling/useBehandling'
 import { BehandlingSidemeny } from '~components/behandling/sidemeny/BehandlingSidemeny'
@@ -34,15 +34,14 @@ export const Behandling = () => {
     }
   }, [behandlingIdFraURL, behandling?.id])
 
-  return mapAllApiResult(
-    fetchBehandlingStatus,
-    <Spinner label="Henter behandling ..." visible />,
-    null,
-    () => <ApiErrorAlert>Kunne ikke hente behandling</ApiErrorAlert>,
-    (hentetBehandling) => (
+  if (isPending(fetchBehandlingStatus)) {
+    return <Spinner label="Henter behandling ..." visible />
+  }
+  if (isSuccess(fetchBehandlingStatus) && behandling != null) {
+    return (
       <>
-        {hentetBehandling.søker && <PdlPersonStatusBar person={hentetBehandling.søker} />}
-        <StegMeny behandling={hentetBehandling} />
+        {behandling.søker && <PdlPersonStatusBar person={behandling.søker} />}
+        <StegMeny behandling={behandling} />
         <GridContainer>
           <MainContent>
             <Routes>
@@ -52,9 +51,13 @@ export const Behandling = () => {
               <Route path="*" element={<Navigate to={behandlingRoutes[0].path} replace />} />
             </Routes>
           </MainContent>
-          <BehandlingSidemeny behandling={hentetBehandling} />
+          <BehandlingSidemeny behandling={behandling} />
         </GridContainer>
       </>
     )
-  )
+  }
+  if (isFailure(fetchBehandlingStatus)) {
+    return <ApiErrorAlert>Kunne ikke hente behandling</ApiErrorAlert>
+  }
+  return null
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/start.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/start.tsx
@@ -7,7 +7,7 @@ export const Start = ({ disabled }: { disabled?: boolean }) => {
 
   return (
     <Button variant="primary" onClick={next} disabled={disabled}>
-      {handlinger.START.navn}
+      {handlinger.NESTE.navn}
     </Button>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/typer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/typer.ts
@@ -1,5 +1,4 @@
 export const handlinger = {
-  START: { id: 'start', navn: 'Neste side' },
   NESTE: { id: 'neste', navn: 'Neste side' },
   TILBAKE: { id: 'tilbake', navn: 'Tilbake' },
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/typer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/typer.ts
@@ -1,5 +1,5 @@
 export const handlinger = {
-  START: { id: 'start', navn: 'Start vilkårsvurdering' },
+  START: { id: 'start', navn: 'Neste side' },
   NESTE: { id: 'neste', navn: 'Neste side' },
   TILBAKE: { id: 'tilbake', navn: 'Tilbake' },
 


### PR DESCRIPTION
- Endrer tilbake til å bruke redux-state for stegmenyen slik at den vises riktig og oppdateres ift redux-state. Dette løser problemet med at stegene ikke ble klikkbare selv om man hadde passert dem i flyten.
- Endrer bruk av `mapAllApiResult` til å sjekke statuser mer manuelt da vi ønsker å sjekke at statusen på requesten er suksess og redux-state i tillegg er satt