### PR TITLE
EY-2773 Utbedret dok for samordningsvedtak med feilkoder. 

### DIFF
--- a/apps/etterlatte-samordning-vedtak/README.md
+++ b/apps/etterlatte-samordning-vedtak/README.md
@@ -64,6 +64,37 @@ Det må foreligge et tjenestepensjonsforhold i Tjenestepensjonsregisteret som gj
 | dev   | https://etterlatte-samordning-vedtak.ekstern.dev.nav.no |
 | prod  | https://etterlatte-samordning-vedtak.nav.no             |    
 
+## Feilkoder
+
+| Kode                    | HTTP-statuskode | Beskrivelse                                              |
+|-------------------------|-----------------|----------------------------------------------------------|
+| GE-MASKINPORTEN-SCOPE   | 401             | Manglende/feil scope                                     |
+| 001-TPNR-MANGLER        | 400             | Ikke angitt header med gjeldende ordningsnummer          |
+| 002-FNR-MANGLER         | 400             | Ikke angitt header med fødselsnummer det skal spørres på |
+| 003-VIRKFOM-MANGLER     | 400             | Ikke angitt virkFom som query parameter                  |
+| 004-FEIL_SAKSTYPE       | 400             | Etterspurt vedtak som ikke angår omstillingsstønad       |
+| 010-TP-TILGANG          | 403             | Ikke tilgang til TP/etterspurt data                      |
+| 011-TP-FORESPOERSEL     | 400             | Feil ved spørring mot TP                                 |
+| 012-TP-IKKE-FUNNET      | 404             | Kunne ikke finne TP-ressurs                              |
+| 020-VEDTAK-TILGANG      | 403             | Ikke tilgang til vedtak/etterspurt data                  |
+| 021-VEDTAK-FORESPOERSEL | 400             | Feil ved spørring mot vedtak                             |
+| 022-VEDTAK-IKKE-FUNNET  | 404             | Kunne ikke finne vedtaksressurs                          |
+
+### Eksempel-payload ved feil
+
+```
+{
+    "status": 401,
+    "detail": "Har ikke påkrevd scope",
+    "code": "GE-MASKINPORTEN-SCOPE",
+    "meta": {
+        "correlation-id": "30e9a443-f620-4c9e-9547-1bd77d4c86ca",
+        "tidspunkt": "2023-11-06T09:19:35.748618Z"
+    }
+}
+```
+
+
 ## Kom i gang
 
 ### Hvordan kjøre lokalt mot dev-gcp

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtak.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtak.kt
@@ -41,7 +41,7 @@ enum class SamordningVedtakAarsak {
 fun YearMonth.atStartOfMonth(): LocalDate = this.atDay(1)
 
 class VedtakFeilSakstypeException : UgyldigForespoerselException(
-    code = "002-FEIL_SAKSTYPE",
+    code = "004-FEIL_SAKSTYPE",
     detail = "Forespurt informasjon gjeldende ikke-støttet sakstype",
     meta = getMeta(),
 )

--- a/libs/etterlatte-ktor/src/main/kotlin/AuthorizationPlugin.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/AuthorizationPlugin.kt
@@ -4,7 +4,9 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.createRouteScopedPlugin
 import io.ktor.server.application.log
 import io.ktor.server.auth.AuthenticationChecked
-import io.ktor.server.response.respond
+import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
+import no.nav.etterlatte.libs.common.logging.getCorrelationId
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 
 /**
  * Basically straight outta the ktor docs
@@ -22,7 +24,16 @@ val AuthorizationPlugin =
 
                 if (userRoles.intersect(roles).isEmpty()) {
                     application.log.info("Request avslått pga manglende rolle (gyldige: $roles)")
-                    call.respond(HttpStatusCode.Unauthorized, "Har ikke påkrevd rolle ")
+                    throw ForespoerselException(
+                        status = HttpStatusCode.Unauthorized.value,
+                        code = "GE-VALIDATE-ACCESS-ROLE",
+                        detail = "Har ikke påkrevd rolle",
+                        meta =
+                            mapOf(
+                                "correlation-id" to getCorrelationId(),
+                                "tidspunkt" to Tidspunkt.now(),
+                            ),
+                    )
                 }
             }
         }

--- a/libs/etterlatte-ktor/src/main/kotlin/MaskinportenScopeAuthorizationPlugin.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/MaskinportenScopeAuthorizationPlugin.kt
@@ -4,7 +4,9 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.createRouteScopedPlugin
 import io.ktor.server.application.log
 import io.ktor.server.auth.AuthenticationChecked
-import io.ktor.server.response.respond
+import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
+import no.nav.etterlatte.libs.common.logging.getCorrelationId
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 
 val MaskinportenScopeAuthorizationPlugin =
     createRouteScopedPlugin(
@@ -21,7 +23,16 @@ val MaskinportenScopeAuthorizationPlugin =
 
                 if (userScopes.intersect(scopes).isEmpty()) {
                     application.log.info("Request avslått pga manglende scope (gyldige: $scopes)")
-                    call.respond(HttpStatusCode.Unauthorized, "Har ikke påkrevd scope")
+                    throw ForespoerselException(
+                        status = HttpStatusCode.Unauthorized.value,
+                        code = "GE-MASKINPORTEN-SCOPE",
+                        detail = "Har ikke påkrevd scope",
+                        meta =
+                            mapOf(
+                                "correlation-id" to getCorrelationId(),
+                                "tidspunkt" to Tidspunkt.now(),
+                            ),
+                    )
                 }
             }
         }


### PR DESCRIPTION
Auth-plugins kaster feil i stedet for å respondere direkte på call, for å støtte feiltypene i den allmenne feilhåndteringen

Får nå respons à dette ved valideringsfeil av scope:
```
{
    "status": 401,
    "detail": "Har ikke påkrevd scope",
    "code": "GE-MASKINPORTEN-SCOPE",
    "meta": {
        "correlation-id": "30e9a443-f620-4c9e-9547-1bd77d4c86ca",
        "tidspunkt": "2023-11-06T09:19:35.748618Z"
    }
}
```

I stedet for
```
{
    "status": 401,
    "detail": "En ukjent feil oppstod",
    "code": "UNKNOWN_ERROR",
    "meta": null
}
```