### PR TITLE
EY-2982 State for saksbehandler på gjeldende oppgave

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/attestering/attestering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/attestering/attestering.tsx
@@ -3,77 +3,68 @@ import { IBeslutning } from '../types'
 import { Beslutningsvalg } from './beslutningsvalg'
 import { useAppSelector } from '~store/Store'
 import { Alert, BodyShort } from '@navikt/ds-react'
-import { isFailure, isPending, isSuccess, useApiCall } from '~shared/hooks/useApiCall'
-import { hentSaksbehandlerForOppgaveUnderArbeid } from '~shared/api/oppgaver'
 import { useEffect, useState } from 'react'
-import Spinner from '~shared/Spinner'
-import { ApiErrorAlert } from '~ErrorBoundary'
 import { SidebarPanel } from '~shared/components/Sidebar'
 import { VedtakSammendrag } from '~components/vedtak/typer'
+import { useSaksbehandlerGjeldendeOppgave } from '~components/behandling/sidemeny/useSaksbehandlerGjeldendeOppgave'
 
 type Props = {
   setBeslutning: (value: IBeslutning) => void
   beslutning: IBeslutning | undefined
-  behandlingId: string
   vedtak?: VedtakSammendrag
   erFattet: boolean
 }
 
-export const Attestering = ({ setBeslutning, beslutning, behandlingId, vedtak, erFattet }: Props) => {
+export const Attestering = ({ setBeslutning, beslutning, vedtak, erFattet }: Props) => {
   const { lastPage } = useBehandlingRoutes()
   const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.saksbehandler)
-  const [saksbehandlerForOppgave, hentSaksbehandlerForOppgave] = useApiCall(hentSaksbehandlerForOppgaveUnderArbeid)
+  const saksbehandlerForGjeldendeOppgave = useSaksbehandlerGjeldendeOppgave()
   const attestantOgSaksbehandlerErSammePerson = vedtak?.saksbehandlerId === innloggetSaksbehandler.ident
   const [oppgaveErTildeltInnloggetBruker, setOppgaveErTildeltInnloggetBruker] = useState(false)
 
   useEffect(() => {
-    hentSaksbehandlerForOppgave({ behandlingId }, (saksbehandler) => {
-      setOppgaveErTildeltInnloggetBruker(saksbehandler === innloggetSaksbehandler.ident)
-    })
+    setOppgaveErTildeltInnloggetBruker(saksbehandlerForGjeldendeOppgave === innloggetSaksbehandler.ident)
   }, [])
 
   return (
     <SidebarPanel>
-      {isPending(saksbehandlerForOppgave) && <Spinner visible label="Henter oppgave" />}
-      {isFailure(saksbehandlerForOppgave) && <ApiErrorAlert>Kunne ikke hente oppgave for behandling</ApiErrorAlert>}
-      {isSuccess(saksbehandlerForOppgave) &&
-        (oppgaveErTildeltInnloggetBruker ? (
-          <>
-            <Alert variant="info" size="small">
-              Kontroller opplysninger og faglige vurderinger gjort under behandling.
-            </Alert>
-            <br />
-
-            {lastPage ? (
-              <Beslutningsvalg
-                beslutning={beslutning}
-                setBeslutning={setBeslutning}
-                disabled={attestantOgSaksbehandlerErSammePerson}
-              />
-            ) : (
-              <BodyShort size="small" spacing>
-                <i>Se gjennom alle steg før du tar en beslutning.</i>
-              </BodyShort>
-            )}
-
-            {attestantOgSaksbehandlerErSammePerson && (
-              <Alert variant="warning">Du kan ikke attestere en sak som du har saksbehandlet</Alert>
-            )}
-          </>
-        ) : (
-          <Alert variant="warning">
-            {saksbehandlerForOppgave.data ? (
-              <BodyShort>Oppgaven er tildelt {saksbehandlerForOppgave.data}.&nbsp;</BodyShort>
-            ) : (
-              <BodyShort>Oppgaven er ikke tildelt noen.&nbsp;</BodyShort>
-            )}
-            <BodyShort spacing>
-              {erFattet
-                ? 'For å kunne attestere behandlingen, må oppgaven være tildelt deg.'
-                : 'For å kunne fortsette behandling, må oppgaven være tildelt deg.'}
-            </BodyShort>
+      {oppgaveErTildeltInnloggetBruker ? (
+        <>
+          <Alert variant="info" size="small">
+            Kontroller opplysninger og faglige vurderinger gjort under behandling.
           </Alert>
-        ))}
+          <br />
+
+          {lastPage ? (
+            <Beslutningsvalg
+              beslutning={beslutning}
+              setBeslutning={setBeslutning}
+              disabled={attestantOgSaksbehandlerErSammePerson}
+            />
+          ) : (
+            <BodyShort size="small" spacing>
+              <i>Se gjennom alle steg før du tar en beslutning.</i>
+            </BodyShort>
+          )}
+
+          {attestantOgSaksbehandlerErSammePerson && (
+            <Alert variant="warning">Du kan ikke attestere en sak som du har saksbehandlet</Alert>
+          )}
+        </>
+      ) : (
+        <Alert variant="warning">
+          {saksbehandlerForGjeldendeOppgave ? (
+            <BodyShort>Oppgaven er tildelt {saksbehandlerForGjeldendeOppgave}.&nbsp;</BodyShort>
+          ) : (
+            <BodyShort>Oppgaven er ikke tildelt noen.&nbsp;</BodyShort>
+          )}
+          <BodyShort spacing>
+            {erFattet
+              ? 'For å kunne attestere behandlingen, må oppgaven være tildelt deg.'
+              : 'For å kunne fortsette behandling, må oppgaven være tildelt deg.'}
+          </BodyShort>
+        </Alert>
+      )}
     </SidebarPanel>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
@@ -27,7 +27,10 @@ import { updateSjekkliste } from '~store/reducers/SjekklisteReducer'
 import { erFerdigBehandlet } from '~components/behandling/felles/utils'
 import { hentSjekkliste, opprettSjekkliste } from '~shared/api/sjekkliste'
 import { hentSaksbehandlerForOppgaveUnderArbeid } from '~shared/api/oppgaver'
-import { setSaksbehandlerGjeldendeOppgave } from '~store/reducers/SaksbehandlerGjeldendeOppgaveReducer'
+import {
+  resetSaksbehandlerGjeldendeOppgave,
+  setSaksbehandlerGjeldendeOppgave,
+} from '~store/reducers/SaksbehandlerGjeldendeOppgaveReducer'
 
 const finnUtNasjonalitet = (behandling: IBehandlingReducer): UtenlandstilknytningType | null => {
   if (behandling.utenlandstilknytning?.type) {
@@ -79,9 +82,11 @@ export const BehandlingSidemeny = ({ behandling }: { behandling: IBehandlingRedu
   }, [])
 
   useEffect(() => {
-    hentSaksbehandlerForOppgave({ behandlingId: behandling.id }, (saksbehandler) => {
-      dispatch(setSaksbehandlerGjeldendeOppgave(saksbehandler))
-    })
+    hentSaksbehandlerForOppgave(
+      { behandlingId: behandling.id },
+      (saksbehandler) => dispatch(setSaksbehandlerGjeldendeOppgave(saksbehandler)),
+      () => dispatch(resetSaksbehandlerGjeldendeOppgave)
+    )
   }, [behandling.id])
 
   const erFoerstegangsbehandling = behandling.behandlingType === IBehandlingsType.FØRSTEGANGSBEHANDLING

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
@@ -123,7 +123,6 @@ export const BehandlingSidemeny = ({ behandling }: { behandling: IBehandlingRedu
                 <Attestering
                   setBeslutning={setBeslutning}
                   beslutning={beslutning}
-                  behandlingId={behandling.id}
                   vedtak={vedtak}
                   erFattet={behandling.status === IBehandlingStatus.FATTET_VEDTAK}
                 />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/useSaksbehandlerGjeldendeOppgave.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/useSaksbehandlerGjeldendeOppgave.ts
@@ -1,0 +1,5 @@
+import { useAppSelector } from '~store/Store'
+
+export function useSaksbehandlerGjeldendeOppgave(): string | null {
+  return useAppSelector((state) => state.saksbehandlerGjeldendeOppgaveReducer.saksbehandler)
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sjekkliste/Sjekkliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sjekkliste/Sjekkliste.tsx
@@ -27,16 +27,14 @@ import { useAppDispatch, useAppSelector } from '~store/Store'
 import { updateSjekkliste, updateSjekklisteItem } from '~store/reducers/SjekklisteReducer'
 import { PencilIcon } from '@navikt/aksel-icons'
 import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
-import { hentSaksbehandlerForOppgaveUnderArbeid } from '~shared/api/oppgaver'
 import { SakType } from '~shared/types/sak'
+import { useSaksbehandlerGjeldendeOppgave } from '~components/behandling/sidemeny/useSaksbehandlerGjeldendeOppgave'
 
 export const Sjekkliste = ({ behandling }: { behandling: IBehandlingReducer }) => {
   const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.saksbehandler)
   const [redigerbar, setRedigerbar] = useState<boolean>(false)
-  const [saksbehandlerForOppgaveResult, hentSaksbehandlerForOppgave] = useApiCall(
-    hentSaksbehandlerForOppgaveUnderArbeid
-  )
   const [oppgaveErTildeltInnloggetBruker, setOppgaveErTildeltInnloggetBruker] = useState(false)
+  const saksbehandlerGjeldendeOppgave = useSaksbehandlerGjeldendeOppgave()
 
   const dispatch = useAppDispatch()
 
@@ -59,11 +57,9 @@ export const Sjekkliste = ({ behandling }: { behandling: IBehandlingReducer }) =
   const fireOpppdater = useMemo(() => debounce(oppdaterSjekklisteApi, 1500), [])
 
   useEffect(() => {
-    hentSaksbehandlerForOppgave({ behandlingId: behandling.id }, (saksbehandler) => {
-      const erSammeIdent = saksbehandler === innloggetSaksbehandler.ident
-      setOppgaveErTildeltInnloggetBruker(erSammeIdent)
-      setRedigerbar(hentBehandlesFraStatus(behandling.status) && erSammeIdent)
-    })
+    const erSammeIdent = saksbehandlerGjeldendeOppgave === innloggetSaksbehandler.ident
+    setOppgaveErTildeltInnloggetBruker(erSammeIdent)
+    setRedigerbar(hentBehandlesFraStatus(behandling.status) && erSammeIdent)
   }, [])
 
   return (
@@ -77,9 +73,6 @@ export const Sjekkliste = ({ behandling }: { behandling: IBehandlingReducer }) =
       </Heading>
 
       {isFailure(oppdaterSjekklisteResult) && <ApiErrorAlert>Oppdateringen av sjekklista feilet</ApiErrorAlert>}
-      {isFailure(saksbehandlerForOppgaveResult) && (
-        <ApiErrorAlert>Kunne ikke hente saksbehandler gjeldende oppgave</ApiErrorAlert>
-      )}
 
       {sjekkliste && (
         <>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/sidemeny/TilbakekrevingSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/sidemeny/TilbakekrevingSidemeny.tsx
@@ -62,7 +62,6 @@ export function TilbakekrevingSidemeny() {
             <Attestering
               setBeslutning={setBeslutning}
               beslutning={beslutning}
-              behandlingId={tilbakekreving?.id}
               vedtak={vedtak}
               erFattet={tilbakekreving?.status === TilbakekrevingStatus.FATTET_VEDTAK}
             />

--- a/apps/etterlatte-saksbehandling-ui/client/src/store/Store.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/store/Store.tsx
@@ -11,10 +11,12 @@ import { tilbakekrevingReducer } from '~store/reducers/TilbakekrevingReducer'
 import { vedtakReducer } from '~store/reducers/VedtakReducer'
 import { sjekklisteReducer } from '~store/reducers/SjekklisteReducer'
 import { behandlingsidemenyReducer } from '~store/reducers/BehandlingSidemenyReducer'
+import { saksbehandlerGjeldendeOppgaveReducer } from '~store/reducers/SaksbehandlerGjeldendeOppgaveReducer'
 
 const reducer = {
   menuReducer: menuReducer,
   saksbehandlerReducer: saksbehandlerReducer,
+  saksbehandlerGjeldendeOppgaveReducer: saksbehandlerGjeldendeOppgaveReducer,
   behandlingReducer: behandlingReducer,
   behandlingSidemenyReducer: behandlingsidemenyReducer,
   vedtakReducer: vedtakReducer,

--- a/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/SaksbehandlerGjeldendeOppgaveReducer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/SaksbehandlerGjeldendeOppgaveReducer.ts
@@ -1,6 +1,7 @@
 import { createAction, createReducer } from '@reduxjs/toolkit'
 
 export const setSaksbehandlerGjeldendeOppgave = createAction<string | null>('saksbehandlerGjeldendeOppgave/set')
+export const resetSaksbehandlerGjeldendeOppgave = createAction('saksbehandlerGjeldendeOppgave/reset')
 
 const initialState: { saksbehandler: string | null } = {
   saksbehandler: null,
@@ -9,5 +10,8 @@ const initialState: { saksbehandler: string | null } = {
 export const saksbehandlerGjeldendeOppgaveReducer = createReducer(initialState, (builder) => {
   builder.addCase(setSaksbehandlerGjeldendeOppgave, (state, action) => {
     state.saksbehandler = action.payload
+  })
+  builder.addCase(resetSaksbehandlerGjeldendeOppgave, (state) => {
+    state.saksbehandler = null
   })
 })

--- a/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/SaksbehandlerGjeldendeOppgaveReducer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/SaksbehandlerGjeldendeOppgaveReducer.ts
@@ -1,0 +1,13 @@
+import { createAction, createReducer } from '@reduxjs/toolkit'
+
+export const setSaksbehandlerGjeldendeOppgave = createAction<string | null>('saksbehandlerGjeldendeOppgave/set')
+
+const initialState: { saksbehandler: string | null } = {
+  saksbehandler: null,
+}
+
+export const saksbehandlerGjeldendeOppgaveReducer = createReducer(initialState, (builder) => {
+  builder.addCase(setSaksbehandlerGjeldendeOppgave, (state, action) => {
+    state.saksbehandler = action.payload
+  })
+})


### PR DESCRIPTION
Repeterer beskrivelsen fra jira

> Pr nå så gjøres det en sjekk mot "gjeldende oppgave" hver gang sjekkliste-fanen åpnes, for å kunne låse sjekklista for alle andre enn aktuell behandler. Dette medfører litt lag (småkjip brukeropplevelse avhengig av hvor ofte man svitsjer fane), og det bør vurderes forbedring