### PR TITLE
EY-3063: Henter data for visning av bakgrunn for gyldighetsvurdering fra grunnlag

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/Foreldreansvar.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/Foreldreansvar.tsx
@@ -5,15 +5,15 @@ import { IPdlPerson, Persongalleri } from '~shared/types/Person'
 import { KildePdl } from '~shared/types/kilde'
 
 interface Props {
-  persongalleri: Grunnlagsopplysning<Persongalleri, KildePdl>
-  gjenlevende: Grunnlagsopplysning<IPdlPerson, KildePdl> | undefined
+  persongalleriGrunnlag: Grunnlagsopplysning<Persongalleri, KildePdl>
+  gjenlevendeGrunnlag: Grunnlagsopplysning<IPdlPerson, KildePdl> | undefined
 }
 
-export const Foreldreansvar = ({ persongalleri, gjenlevende }: Props) => {
-  const oppfylt = persongalleri.opplysning.innsender == gjenlevende?.opplysning.foedselsnummer
-  const navn = oppfylt
-    ? [gjenlevende?.opplysning.fornavn, gjenlevende?.opplysning.mellomnavn, gjenlevende?.opplysning.etternavn].join(' ')
-    : 'Ukjent'
+export const Foreldreansvar = ({ persongalleriGrunnlag, gjenlevendeGrunnlag }: Props) => {
+  const persongalleri = persongalleriGrunnlag.opplysning
+  const gjenlevende = gjenlevendeGrunnlag?.opplysning
+  const oppfylt = persongalleri.innsender == gjenlevende?.foedselsnummer
+  const navn = oppfylt ? [gjenlevende?.fornavn, gjenlevende?.mellomnavn, gjenlevende?.etternavn].join(' ') : 'Ukjent'
   const label = 'Foreldreansvar'
   const tekst = settTekst(oppfylt)
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/Foreldreansvar.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/Foreldreansvar.tsx
@@ -7,14 +7,23 @@ import { KildePdl } from '~shared/types/kilde'
 interface Props {
   persongalleriGrunnlag: Grunnlagsopplysning<Persongalleri, KildePdl>
   gjenlevendeGrunnlag: Grunnlagsopplysning<IPdlPerson, KildePdl> | undefined
+  harKildePesys: Boolean
 }
 
-export const Foreldreansvar = ({ persongalleriGrunnlag, gjenlevendeGrunnlag }: Props) => {
+export const Foreldreansvar = ({ persongalleriGrunnlag, gjenlevendeGrunnlag, harKildePesys }: Props) => {
+  const label = 'Foreldreansvar'
+  if (harKildePesys) {
+    return (
+      <InfoWrapper>
+        <Info tekst="Ukjent" undertekst="Mangler info" label={label} />
+      </InfoWrapper>
+    )
+  }
+
   const persongalleri = persongalleriGrunnlag.opplysning
   const gjenlevende = gjenlevendeGrunnlag?.opplysning
   const oppfylt = persongalleri.innsender == gjenlevende?.foedselsnummer
   const navn = oppfylt ? [gjenlevende?.fornavn, gjenlevende?.mellomnavn, gjenlevende?.etternavn].join(' ') : 'Ukjent'
-  const label = 'Foreldreansvar'
   const tekst = settTekst(oppfylt)
 
   function settTekst(oppfylt: Boolean): string {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/Foreldreansvar.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/Foreldreansvar.tsx
@@ -1,25 +1,27 @@
-import { IGyldighetproving } from '~shared/types/IDetaljertBehandling'
-import { VurderingsResultat } from '~shared/types/VurderingsResultat'
 import { InfoWrapper } from '../../styled'
 import { Info } from '../../Info'
+import { Grunnlagsopplysning } from '~shared/types/grunnlag'
+import { IPdlPerson, Persongalleri } from '~shared/types/Person'
+import { KildePdl } from '~shared/types/kilde'
 
 interface Props {
-  innsenderHarForeldreansvar: IGyldighetproving | undefined
+  persongalleri: Grunnlagsopplysning<Persongalleri, KildePdl>
+  gjenlevende: Grunnlagsopplysning<IPdlPerson, KildePdl> | undefined
 }
 
-export const Foreldreansvar = ({ innsenderHarForeldreansvar }: Props) => {
-  const navn =
-    innsenderHarForeldreansvar?.resultat === VurderingsResultat.OPPFYLT
-      ? innsenderHarForeldreansvar?.basertPaaOpplysninger?.innsender?.navn
-      : undefined
+export const Foreldreansvar = ({ persongalleri, gjenlevende }: Props) => {
+  const oppfylt = persongalleri.opplysning.innsender == gjenlevende?.opplysning.foedselsnummer
+  const navn = oppfylt
+    ? [gjenlevende?.opplysning.fornavn, gjenlevende?.opplysning.mellomnavn, gjenlevende?.opplysning.etternavn].join(' ')
+    : 'Ukjent'
   const label = 'Foreldreansvar'
-  const tekst = settTekst(innsenderHarForeldreansvar?.resultat)
+  const tekst = settTekst(oppfylt)
 
-  function settTekst(vurdering: VurderingsResultat | undefined): string {
-    switch (vurdering) {
-      case VurderingsResultat.OPPFYLT:
+  function settTekst(oppfylt: Boolean): string {
+    switch (oppfylt) {
+      case true:
         return ''
-      case VurderingsResultat.IKKE_OPPFYLT:
+      case false:
         return 'Innsender har ikke foreldreansvar'
       default:
         return 'Mangler info'

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/GyldigFramsattBarnepensjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/GyldigFramsattBarnepensjon.tsx
@@ -1,9 +1,4 @@
-import {
-  GyldigFramsattType,
-  IDetaljertBehandling,
-  IGyldighetproving,
-  IGyldighetResultat,
-} from '~shared/types/IDetaljertBehandling'
+import { IDetaljertBehandling, IGyldighetResultat } from '~shared/types/IDetaljertBehandling'
 import { LovtekstMedLenke } from '~components/behandling/soeknadsoversikt/LovtekstMedLenke'
 import {
   Beskrivelse,
@@ -16,6 +11,9 @@ import { Verger } from '~components/behandling/soeknadsoversikt/gyldigFramsattSo
 import { GyldigFramsattVurdering } from '~components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/GyldigFramsattVurdering'
 import { behandlingErRedigerbar } from '~components/behandling/felles/utils'
 import { StatusIconProps } from '~shared/icons/statusIcon'
+import { useEffect } from 'react'
+import { isSuccess, useApiCall } from '~shared/hooks/useApiCall'
+import { getPersongalleriFraPdl } from '~shared/api/grunnlag'
 
 export const GyldigFramsattBarnepensjon = ({
   behandling,
@@ -31,48 +29,53 @@ export const GyldigFramsattBarnepensjon = ({
   }
 
   const redigerbar = behandlingErRedigerbar(behandling.status)
-  const innsenderHarForeldreansvar = gyldigFramsatt.vurderinger.find(
-    (g: IGyldighetproving) => g.navn === GyldigFramsattType.HAR_FORELDREANSVAR_FOR_BARNET
-  )
-  const innsenderErForelder = gyldigFramsatt.vurderinger.find(
-    (g: IGyldighetproving) => g.navn === GyldigFramsattType.INNSENDER_ER_FORELDER
-  )
+  const [personGalleriPdl, getPersonGalleriPdl] = useApiCall(getPersongalleriFraPdl)
+  useEffect(() => {
+    getPersonGalleriPdl({ sakId: behandling.sakId, behandlingId: behandling.id })
+  }, [behandling.sakId, behandling.id])
 
   return (
-    <LovtekstMedLenke
-      tittel="Vurdering - søknad gyldig fremsatt"
-      hjemler={[
-        {
-          lenke: 'https://lovdata.no/lov/1997-02-28-19/§22-13',
-          tittel: 'Folketrygdloven § 22-13 første ledd og tilhørende rundskriv',
-        },
-        { lenke: 'https://lovdata.no/lov/2010-03-26-9/§9', tittel: 'Vergemålsloven § 9, § 16 og § 19' },
-        {
-          lenke: 'https://lovdata.no/pro/rundskriv/a45-01-02/ARTIKKEL_45',
-          tittel: 'Forordning 987/2009 artikkel 45 nr. 4',
-        },
-      ]}
-      status={gyldigFremsattTilStatusIcon}
-    >
-      <div>
-        <Beskrivelse>
-          Den som har rett til ytelsen må sette frem krav (forelder/verge hvis under 18 år). Om annet må fullmakt ligge
-          i saken. Søknaden må være signert og vise hva det søkes om, og den må settes fram i bostedslandet eller i det
-          landet vedkommende sist var medlem.
-        </Beskrivelse>
-        <InfobokserWrapper>
-          <Innsender innsenderErForelder={innsenderErForelder} />
-          <Foreldreansvar innsenderHarForeldreansvar={innsenderHarForeldreansvar} />
-          <Verger behandlingId={behandling.id} sakId={behandling.sakId} />
-        </InfobokserWrapper>
-      </div>
-      <VurderingsContainerWrapper>
-        <GyldigFramsattVurdering
-          behandlingId={behandling.id}
-          gyldigFramsatt={behandling.gyldighetsprøving}
-          redigerbar={redigerbar}
-        />
-      </VurderingsContainerWrapper>
-    </LovtekstMedLenke>
+    <>
+      {isSuccess(personGalleriPdl) && (
+        <LovtekstMedLenke
+          tittel="Vurdering - søknad gyldig fremsatt"
+          hjemler={[
+            {
+              lenke: 'https://lovdata.no/lov/1997-02-28-19/§22-13',
+              tittel: 'Folketrygdloven § 22-13 første ledd og tilhørende rundskriv',
+            },
+            { lenke: 'https://lovdata.no/lov/2010-03-26-9/§9', tittel: 'Vergemålsloven § 9, § 16 og § 19' },
+            {
+              lenke: 'https://lovdata.no/pro/rundskriv/a45-01-02/ARTIKKEL_45',
+              tittel: 'Forordning 987/2009 artikkel 45 nr. 4',
+            },
+          ]}
+          status={gyldigFremsattTilStatusIcon}
+        >
+          <div>
+            <Beskrivelse>
+              Den som har rett til ytelsen må sette frem krav (forelder/verge hvis under 18 år). Om annet må fullmakt
+              ligge i saken. Søknaden må være signert og vise hva det søkes om, og den må settes fram i bostedslandet
+              eller i det landet vedkommende sist var medlem.
+            </Beskrivelse>
+            <InfobokserWrapper>
+              <Innsender persongalleri={personGalleriPdl.data} gjenlevende={behandling.familieforhold?.gjenlevende} />
+              <Foreldreansvar
+                persongalleri={personGalleriPdl.data}
+                gjenlevende={behandling.familieforhold?.gjenlevende}
+              />
+              <Verger behandlingId={behandling.id} sakId={behandling.sakId} />
+            </InfobokserWrapper>
+          </div>
+          <VurderingsContainerWrapper>
+            <GyldigFramsattVurdering
+              behandlingId={behandling.id}
+              gyldigFramsatt={behandling.gyldighetsprøving}
+              redigerbar={redigerbar}
+            />
+          </VurderingsContainerWrapper>
+        </LovtekstMedLenke>
+      )}
+    </>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/GyldigFramsattBarnepensjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/GyldigFramsattBarnepensjon.tsx
@@ -13,7 +13,7 @@ import { behandlingErRedigerbar } from '~components/behandling/felles/utils'
 import { StatusIconProps } from '~shared/icons/statusIcon'
 import { useEffect } from 'react'
 import { isSuccess, useApiCall } from '~shared/hooks/useApiCall'
-import { getPersongalleriFraPdl } from '~shared/api/grunnlag'
+import { getPersongalleriFraSoeknad } from '~shared/api/grunnlag'
 
 export const GyldigFramsattBarnepensjon = ({
   behandling,
@@ -29,14 +29,14 @@ export const GyldigFramsattBarnepensjon = ({
   }
 
   const redigerbar = behandlingErRedigerbar(behandling.status)
-  const [personGalleriPdl, getPersonGalleriPdl] = useApiCall(getPersongalleriFraPdl)
+  const [personGalleriSoeknad, getPersonGalleriSoeknad] = useApiCall(getPersongalleriFraSoeknad)
   useEffect(() => {
-    getPersonGalleriPdl({ sakId: behandling.sakId, behandlingId: behandling.id })
+    getPersonGalleriSoeknad({ sakId: behandling.sakId, behandlingId: behandling.id })
   }, [behandling.sakId, behandling.id])
 
   return (
     <>
-      {isSuccess(personGalleriPdl) && (
+      {isSuccess(personGalleriSoeknad) && (
         <LovtekstMedLenke
           tittel="Vurdering - søknad gyldig fremsatt"
           hjemler={[
@@ -59,9 +59,12 @@ export const GyldigFramsattBarnepensjon = ({
               eller i det landet vedkommende sist var medlem.
             </Beskrivelse>
             <InfobokserWrapper>
-              <Innsender persongalleri={personGalleriPdl.data} gjenlevende={behandling.familieforhold?.gjenlevende} />
+              <Innsender
+                persongalleri={personGalleriSoeknad.data}
+                gjenlevende={behandling.familieforhold?.gjenlevende}
+              />
               <Foreldreansvar
-                persongalleri={personGalleriPdl.data}
+                persongalleri={personGalleriSoeknad.data}
                 gjenlevende={behandling.familieforhold?.gjenlevende}
               />
               <Verger behandlingId={behandling.id} sakId={behandling.sakId} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/GyldigFramsattBarnepensjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/GyldigFramsattBarnepensjon.tsx
@@ -60,12 +60,12 @@ export const GyldigFramsattBarnepensjon = ({
             </Beskrivelse>
             <InfobokserWrapper>
               <Innsender
-                persongalleri={personGalleriSoeknad.data}
-                gjenlevende={behandling.familieforhold?.gjenlevende}
+                persongalleriGrunnlag={personGalleriSoeknad.data}
+                gjenlevendeGrunnlag={behandling.familieforhold?.gjenlevende}
               />
               <Foreldreansvar
-                persongalleri={personGalleriSoeknad.data}
-                gjenlevende={behandling.familieforhold?.gjenlevende}
+                persongalleriGrunnlag={personGalleriSoeknad.data}
+                gjenlevendeGrunnlag={behandling.familieforhold?.gjenlevende}
               />
               <Verger behandlingId={behandling.id} sakId={behandling.sakId} />
             </InfobokserWrapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/GyldigFramsattBarnepensjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/GyldigFramsattBarnepensjon.tsx
@@ -1,4 +1,4 @@
-import { IDetaljertBehandling, IGyldighetResultat } from '~shared/types/IDetaljertBehandling'
+import { GyldigFramsattType, IDetaljertBehandling, IGyldighetResultat } from '~shared/types/IDetaljertBehandling'
 import { LovtekstMedLenke } from '~components/behandling/soeknadsoversikt/LovtekstMedLenke'
 import {
   Beskrivelse,
@@ -8,7 +8,10 @@ import {
 import { Innsender } from '~components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/Innsender'
 import { Foreldreansvar } from '~components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/Foreldreansvar'
 import { Verger } from '~components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/Verger'
-import { GyldigFramsattVurdering } from '~components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/GyldigFramsattVurdering'
+import {
+  finnVurdering,
+  GyldigFramsattVurdering,
+} from '~components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/GyldigFramsattVurdering'
 import { behandlingErRedigerbar } from '~components/behandling/felles/utils'
 import { StatusIconProps } from '~shared/icons/statusIcon'
 import { useEffect } from 'react'
@@ -33,6 +36,8 @@ export const GyldigFramsattBarnepensjon = ({
   useEffect(() => {
     getPersonGalleriSoeknad({ sakId: behandling.sakId, behandlingId: behandling.id })
   }, [behandling.sakId, behandling.id])
+  const manuellVurdering = finnVurdering(gyldigFramsatt, GyldigFramsattType.MANUELL_VURDERING)?.basertPaaOpplysninger
+  const harKildePesys = manuellVurdering?.kilde?.ident == 'PESYS'
 
   return (
     <>
@@ -60,10 +65,12 @@ export const GyldigFramsattBarnepensjon = ({
             </Beskrivelse>
             <InfobokserWrapper>
               <Innsender
+                harKildePesys={harKildePesys}
                 persongalleriGrunnlag={personGalleriSoeknad.data}
                 gjenlevendeGrunnlag={behandling.familieforhold?.gjenlevende}
               />
               <Foreldreansvar
+                harKildePesys={harKildePesys}
                 persongalleriGrunnlag={personGalleriSoeknad.data}
                 gjenlevendeGrunnlag={behandling.familieforhold?.gjenlevende}
               />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/GyldigFramsattVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/GyldigFramsattVurdering.tsx
@@ -138,7 +138,7 @@ export const GyldigFramsattVurdering = ({
   )
 }
 
-function finnVurdering(gyldigFramsatt: IGyldighetResultat | undefined, type: GyldigFramsattType) {
+export function finnVurdering(gyldigFramsatt: IGyldighetResultat | undefined, type: GyldigFramsattType) {
   return gyldigFramsatt?.vurderinger.find((g: IGyldighetproving) => g.navn === type)
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/Innsender.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/Innsender.tsx
@@ -1,25 +1,27 @@
-import { IGyldighetproving } from '~shared/types/IDetaljertBehandling'
-import { VurderingsResultat } from '~shared/types/VurderingsResultat'
 import { InfoWrapper } from '../../styled'
 import { Info } from '../../Info'
+import { IPdlPerson, Persongalleri } from '~shared/types/Person'
+import { Grunnlagsopplysning } from '~shared/types/grunnlag'
+import { KildePdl } from '~shared/types/kilde'
 
 interface Props {
-  innsenderErForelder: IGyldighetproving | undefined
+  persongalleri: Grunnlagsopplysning<Persongalleri, KildePdl>
+  gjenlevende: Grunnlagsopplysning<IPdlPerson, KildePdl> | undefined
 }
 
-export const Innsender = ({ innsenderErForelder }: Props) => {
-  const navn =
-    innsenderErForelder?.resultat === VurderingsResultat.KAN_IKKE_VURDERE_PGA_MANGLENDE_OPPLYSNING
-      ? undefined
-      : innsenderErForelder?.basertPaaOpplysninger?.innsender?.navn
+export const Innsender = ({ persongalleri, gjenlevende }: Props) => {
+  const oppfylt = persongalleri.opplysning.innsender == gjenlevende?.opplysning.foedselsnummer
+  const navn = oppfylt
+    ? [gjenlevende?.opplysning.fornavn, gjenlevende?.opplysning.mellomnavn, gjenlevende?.opplysning.etternavn].join(' ')
+    : 'Ukjent'
   const label = 'Innsender'
-  const tekst = settTekst(innsenderErForelder?.resultat)
+  const tekst = settTekst(oppfylt)
 
-  function settTekst(vurdering: VurderingsResultat | undefined): string {
+  function settTekst(vurdering: Boolean): string {
     switch (vurdering) {
-      case VurderingsResultat.OPPFYLT:
+      case true:
         return '(gjenlevende forelder)'
-      case VurderingsResultat.IKKE_OPPFYLT:
+      case false:
         return 'Ikke gjenlevende forelder'
       default:
         return 'Mangler info'

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/Innsender.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/Innsender.tsx
@@ -5,15 +5,14 @@ import { Grunnlagsopplysning } from '~shared/types/grunnlag'
 import { KildePdl } from '~shared/types/kilde'
 
 interface Props {
-  persongalleri: Grunnlagsopplysning<Persongalleri, KildePdl>
-  gjenlevende: Grunnlagsopplysning<IPdlPerson, KildePdl> | undefined
+  persongalleriGrunnlag: Grunnlagsopplysning<Persongalleri, KildePdl>
+  gjenlevendeGrunnlag: Grunnlagsopplysning<IPdlPerson, KildePdl> | undefined
 }
 
-export const Innsender = ({ persongalleri, gjenlevende }: Props) => {
-  const oppfylt = persongalleri.opplysning.innsender == gjenlevende?.opplysning.foedselsnummer
-  const navn = oppfylt
-    ? [gjenlevende?.opplysning.fornavn, gjenlevende?.opplysning.mellomnavn, gjenlevende?.opplysning.etternavn].join(' ')
-    : 'Ukjent'
+export const Innsender = ({ persongalleriGrunnlag, gjenlevendeGrunnlag }: Props) => {
+  const gjenlevende = gjenlevendeGrunnlag?.opplysning
+  const oppfylt = persongalleriGrunnlag.opplysning.innsender == gjenlevende?.foedselsnummer
+  const navn = oppfylt ? [gjenlevende?.fornavn, gjenlevende?.mellomnavn, gjenlevende?.etternavn].join(' ') : 'Ukjent'
   const label = 'Innsender'
   const tekst = settTekst(oppfylt)
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/Innsender.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/Innsender.tsx
@@ -7,14 +7,28 @@ import { KildePdl } from '~shared/types/kilde'
 interface Props {
   persongalleriGrunnlag: Grunnlagsopplysning<Persongalleri, KildePdl>
   gjenlevendeGrunnlag: Grunnlagsopplysning<IPdlPerson, KildePdl> | undefined
+  harKildePesys: Boolean
 }
 
-export const Innsender = ({ persongalleriGrunnlag, gjenlevendeGrunnlag }: Props) => {
+export const Innsender = ({ persongalleriGrunnlag, gjenlevendeGrunnlag, harKildePesys }: Props) => {
+  const label = 'Innsender'
+  if (harKildePesys) {
+    return (
+      <InfoWrapper>
+        <Info tekst="Ukjent" undertekst="Mangler info" label={label} />
+      </InfoWrapper>
+    )
+  }
   const gjenlevende = gjenlevendeGrunnlag?.opplysning
   const oppfylt = persongalleriGrunnlag.opplysning.innsender == gjenlevende?.foedselsnummer
   const navn = oppfylt ? [gjenlevende?.fornavn, gjenlevende?.mellomnavn, gjenlevende?.etternavn].join(' ') : 'Ukjent'
-  const label = 'Innsender'
   const tekst = settTekst(oppfylt)
+
+  return (
+    <InfoWrapper>
+      <Info tekst={navn ?? 'Ukjent'} undertekst={tekst} label={label} />
+    </InfoWrapper>
+  )
 
   function settTekst(vurdering: Boolean): string {
     switch (vurdering) {
@@ -26,10 +40,4 @@ export const Innsender = ({ persongalleriGrunnlag, gjenlevendeGrunnlag }: Props)
         return 'Mangler info'
     }
   }
-
-  return (
-    <InfoWrapper>
-      <Info tekst={navn ?? 'Ukjent'} undertekst={tekst} label={label} />
-    </InfoWrapper>
-  )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/grunnlag.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/grunnlag.ts
@@ -3,7 +3,7 @@ import { Grunnlagsopplysning, PersonMedNavn, Personopplysninger } from '~shared/
 import { IPersonResult } from '~components/person/typer'
 import { Foreldreansvar } from '~shared/types/Foreldreansvar'
 import { KildePdl, KildePersondata } from '~shared/types/kilde'
-import { IPdlPerson } from '~shared/types/Person'
+import { IPdlPerson, Persongalleri } from '~shared/types/Person'
 import { Mottaker } from '~shared/types/Brev'
 
 export const hentPersonerISak = async (sakId: number): Promise<ApiResponse<PersonerISakResponse>> => {
@@ -55,4 +55,11 @@ export const hentPersonopplysningerForBehandling = async (
   behandlingId: string
 ): Promise<ApiResponse<Personopplysninger>> => {
   return apiClient.get<Personopplysninger>(`/grunnlag/behandling/${behandlingId}/personopplysninger`)
+}
+
+export const getPersongalleriFraPdl = async (args: {
+  sakId: number
+  behandlingId: string
+}): Promise<ApiResponse<Grunnlagsopplysning<Persongalleri, KildePdl>>> => {
+  return apiClient.get(`/grunnlag/behandling/${args.behandlingId}/PERSONGALLERI_PDL_V1`)
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/grunnlag.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/grunnlag.ts
@@ -63,3 +63,10 @@ export const getPersongalleriFraPdl = async (args: {
 }): Promise<ApiResponse<Grunnlagsopplysning<Persongalleri, KildePdl>>> => {
   return apiClient.get(`/grunnlag/behandling/${args.behandlingId}/PERSONGALLERI_PDL_V1`)
 }
+
+export const getPersongalleriFraSoeknad = async (args: {
+  sakId: number
+  behandlingId: string
+}): Promise<ApiResponse<Grunnlagsopplysning<Persongalleri, KildePdl>>> => {
+  return apiClient.get(`/grunnlag/behandling/${args.behandlingId}/PERSONGALLERI_V1`)
+}


### PR DESCRIPTION
Dette blir riktig når persongalleriet sin gjenlevende hentes fra søkers ansvarlige foreldre i PDL. Tror jeg