### PR TITLE
Disable deploy av hendelse-samordning til prod inntil videre

### DIFF
--- a/.github/workflows/app-etterlatte-hendelser-samordning.yaml
+++ b/.github/workflows/app-etterlatte-hendelser-samordning.yaml
@@ -44,10 +44,25 @@ jobs:
       contents: 'read'
       id-token: 'write'
 
-  deploy:
+#  deploy:
+#    if: github.event_name != 'pull_request'
+#    needs: build
+#    uses: ./.github/workflows/.deploy.yaml
+#    with:
+#      image: ${{ needs.build.outputs.image }}
+#    secrets: inherit
+
+  deploy-to-dev-gcp:
+    name: dev-gcp
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name != 'pull_request'
     needs: build
-    uses: ./.github/workflows/.deploy.yaml
-    with:
-      image: ${{ needs.build.outputs.image }}
-    secrets: inherit
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: apps/${{ github.workflow }}/.nais/dev.yaml
+          VAR: image=${{ needs.build.outputs.image }}


### PR DESCRIPTION
Det ser ut til å ta litt tid før SAM og dens nye topic går til prod 🤷‍♂️ . Ønsker deploy til dev fortsatt.