### PR TITLE
Redusere scope for samordning-logging

### DIFF
--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -41,8 +41,8 @@ class Server(applicationContext: ApplicationContext) {
                         ) {
                             samordningVedtakRoute(samordningVedtakService = applicationContext.samordningVedtakService)
                             install(userIdMdcPlugin)
+                            install(serverRequestLoggerPlugin)
                         }
-                        install(serverRequestLoggerPlugin)
                     }
                     connector { port = applicationContext.httpPort }
                 },

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/LoggingPlugins.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/LoggingPlugins.kt
@@ -5,7 +5,6 @@ import io.ktor.server.application.ApplicationCallPipeline
 import io.ktor.server.application.Hook
 import io.ktor.server.application.RouteScopedPlugin
 import io.ktor.server.application.call
-import io.ktor.server.application.createApplicationPlugin
 import io.ktor.server.application.createRouteScopedPlugin
 import io.ktor.server.application.hooks.ResponseSent
 import io.ktor.server.request.httpMethod
@@ -67,7 +66,7 @@ val userIdMdcPlugin: RouteScopedPlugin<PluginConfiguration> =
     }
 
 val serverRequestLoggerPlugin =
-    createApplicationPlugin("ServerRequestLoggingPlugin") {
+    createRouteScopedPlugin("ServerRequestLoggingPlugin") {
         onCall { call ->
             call.attributes.put(loggingPerformed, false)
             call.attributes.put(startTimeAttribute, System.currentTimeMillis())


### PR DESCRIPTION
For ikke å logge `/health/isalive, isready `