### PR TITLE
EY-2996 Legger til status underkjent i for å kunne attestere

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/brev/TilbakekrevingBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/brev/TilbakekrevingBrev.tsx
@@ -15,9 +15,11 @@ import { useVedtak } from '~components/vedtak/useVedtak'
 import RedigerbartBrev from '~components/behandling/brev/RedigerbartBrev'
 
 export function TilbakekrevingBrev({ tilbakekreving }: { tilbakekreving: TilbakekrevingBehandling }) {
-  const kanAttesteres = [TilbakekrevingStatus.OPPRETTET, TilbakekrevingStatus.UNDER_ARBEID].includes(
-    tilbakekreving.status
-  )
+  const kanAttesteres = [
+    TilbakekrevingStatus.OPPRETTET,
+    TilbakekrevingStatus.UNDER_ARBEID,
+    TilbakekrevingStatus.UNDERKJENT,
+  ].includes(tilbakekreving.status)
   const vedtak = useVedtak()
   const [vedtaksbrev, setVedtaksbrev] = useState<IBrev | undefined>(undefined)
   const [hentBrevStatus, hentBrevRequest] = useApiCall(hentVedtaksbrev)

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Tilbakekreving.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Tilbakekreving.ts
@@ -72,6 +72,7 @@ export enum TilbakekrevingStatus {
   OPPRETTET = 'OPPRETTET',
   UNDER_ARBEID = 'UNDER_ARBEID',
   FATTET_VEDTAK = 'FATTET_VEDTAK',
+  UNDERKJENT = 'UNDERKJENT',
 }
 export enum TilbakekrevingSkyld {
   BRUKER = 'BRUKER',


### PR DESCRIPTION
Dukket opp en liten sak når jeg verifiserte tilbakekreving for BP. Det var ikke mulig å sende en underkjent behandling til attestering pga manglende status.