### PR TITLE
EY-2938 Viser prorata brøk i beregningssammendrag for omstillingsstønad

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -113,13 +113,15 @@ export const AvkortingInntekt = (props: {
         <InntektAvkortingTabell>
           <Table className="table" zebraStripes>
             <Table.Header>
-              <Table.HeaderCell>Forventet inntekt Norge</Table.HeaderCell>
-              <Table.HeaderCell>Forventet inntekt utland</Table.HeaderCell>
-              <Table.HeaderCell>Forventet inntekt totalt</Table.HeaderCell>
-              <Table.HeaderCell>Gjenværende måneder</Table.HeaderCell>
-              <Table.HeaderCell>Periode</Table.HeaderCell>
-              <Table.HeaderCell>Spesifikasjon av inntekt</Table.HeaderCell>
-              <Table.HeaderCell>Kilde</Table.HeaderCell>
+              <Table.Row>
+                <Table.HeaderCell>Forventet inntekt Norge</Table.HeaderCell>
+                <Table.HeaderCell>Forventet inntekt utland</Table.HeaderCell>
+                <Table.HeaderCell>Forventet inntekt totalt</Table.HeaderCell>
+                <Table.HeaderCell>Gjenværende måneder</Table.HeaderCell>
+                <Table.HeaderCell>Periode</Table.HeaderCell>
+                <Table.HeaderCell>Spesifikasjon av inntekt</Table.HeaderCell>
+                <Table.HeaderCell>Kilde</Table.HeaderCell>
+              </Table.Row>
             </Table.Header>
             <Table.Body>
               {(visHistorikk ? avkortingGrunnlag : aktivtGrunnlag()).map((inntektsgrunnlag, index) => {
@@ -140,7 +142,7 @@ export const AvkortingInntekt = (props: {
                         {` ${NOK(aarsinntekt)} - ${NOK(fratrekkInnAar)} = ${NOK(forventetInntekt)}`}).
                       </OmstillingsstoenadToolTip>
                     </Table.DataCell>
-                    <Table.DataCell key="Inntekt">
+                    <Table.DataCell key="InntektUtland">
                       {NOK(forventetInntektUtland)}
                       <OmstillingsstoenadToolTip title="Se hva forventet inntekt består av">
                         Forventet inntekt utland beregnes utfra inntekt utland med fratrekk for måneder før innvilgelse.

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BarnepensjonSammendrag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BarnepensjonSammendrag.tsx
@@ -5,19 +5,11 @@ import { formaterDato, formaterStringDato } from '~utils/formattering'
 import { Beregning } from '~shared/types/Beregning'
 import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 import { Barnepensjonberegningssammendrag } from '~components/behandling/beregne/Barnepensjonberegningssammendrag'
-import { IProrataBroek } from '~shared/api/trygdetid'
+import { ProrataBroek } from '~components/behandling/beregne/ProrataBroek'
 
 interface Props {
   behandling: IDetaljertBehandling
   beregning: Beregning
-}
-
-const ProrataBroek = ({ broek }: { broek: IProrataBroek }) => {
-  return (
-    <>
-      {broek.teller} / {broek.nevner}
-    </>
-  )
 }
 
 const BenyttetTrygdetid = ({

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/OmstillingsstoenadSammendrag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/OmstillingsstoenadSammendrag.tsx
@@ -4,6 +4,7 @@ import { compareDesc, lastDayOfMonth } from 'date-fns'
 import { formaterDato, formaterStringDato, NOK } from '~utils/formattering'
 import { Beregning } from '~shared/types/Beregning'
 import { OmstillingsstoenadToolTip } from '~components/behandling/beregne/OmstillingsstoenadToolTip'
+import { ProrataBroek } from '~components/behandling/beregne/ProrataBroek'
 
 interface Props {
   beregning: Beregning
@@ -25,6 +26,7 @@ export const OmstillingsstoenadSammendrag = ({ beregning }: Props) => {
             <Table.HeaderCell>Periode</Table.HeaderCell>
             <Table.HeaderCell>Ytelse</Table.HeaderCell>
             <Table.HeaderCell>Trygdetid</Table.HeaderCell>
+            <Table.HeaderCell>Prorata Brøk</Table.HeaderCell>
             <Table.HeaderCell>Grunnbeløp</Table.HeaderCell>
             <Table.HeaderCell>Brutto stønad før avkorting</Table.HeaderCell>
           </Table.Row>
@@ -39,6 +41,11 @@ export const OmstillingsstoenadSammendrag = ({ beregning }: Props) => {
               </Table.DataCell>
               <Table.DataCell>Omstillingsstønad</Table.DataCell>
               <Table.DataCell>{beregningsperiode.trygdetid} år</Table.DataCell>
+              <Table.DataCell>
+                {beregningsperiode.broek && beregningsperiode.beregningsMetode === 'PRORATA' && (
+                  <ProrataBroek broek={beregningsperiode.broek} />
+                )}
+              </Table.DataCell>
               <Table.DataCell>{NOK(beregningsperiode.grunnbelop)}</Table.DataCell>
               <Table.DataCell>
                 {NOK(beregningsperiode.utbetaltBeloep)}{' '}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/ProrataBroek.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/ProrataBroek.tsx
@@ -1,0 +1,9 @@
+import { IProrataBroek } from '~shared/api/trygdetid'
+
+export const ProrataBroek = ({ broek }: { broek: IProrataBroek }) => {
+  return (
+    <>
+      {broek.teller} / {broek.nevner}
+    </>
+  )
+}


### PR DESCRIPTION
- Viser prorata-brøk i beregningssammendrag for omstillingsstønad på samme måte som i BP.
- Fikser et par små valideringsfeil på Avkorting.