### PR TITLE
EY-2938 Fikser problem ved lasting av beregning

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
@@ -1,10 +1,9 @@
 import styled from 'styled-components'
-import { isErrorWithCode, useApiCall } from '~shared/hooks/useApiCall'
+import { isErrorWithCode, isPendingOrInitial, useApiCall } from '~shared/hooks/useApiCall'
 import { hentAvkorting } from '~shared/api/avkorting'
 import React, { useEffect, useState } from 'react'
 import { IAvkorting } from '~shared/types/IAvkorting'
 import { AvkortingInntekt } from '~components/behandling/avkorting/AvkortingInntekt'
-import { isPending } from '@reduxjs/toolkit'
 import Spinner from '~shared/Spinner'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { YtelseEtterAvkorting } from '~components/behandling/avkorting/YtelseEtterAvkorting'
@@ -44,8 +43,7 @@ export const Avkorting = (props: { behandling: IBehandlingReducer }) => {
           setAvkorting={setAvkorting}
         />
       )}
-
-      {isPending(avkortingStatus) && <Spinner visible={true} label="Henter avkorting" />}
+      {isPendingOrInitial(avkortingStatus) && <Spinner visible label="Henter avkorting" />}
       {isErrorWithCode(avkortingStatus, 404) && <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>}
     </AvkortingWrapper>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
@@ -73,7 +73,7 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
         </HeadingWrapper>
       </ContentHeader>
 
-      {isPending(beregning) && <Spinner visible label="Laster" />}
+      {isPending(beregning) && <Spinner visible label="Henter beregning" />}
       {isFailure(beregning) && <ApiErrorAlert>Kunne ikke hente beregning</ApiErrorAlert>}
       {isSuccess(beregning) && (
         <BeregningWrapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
@@ -2,7 +2,7 @@ import { Content, ContentHeader, FlexRow } from '~shared/styled'
 import { Border, HeadingWrapper } from '../soeknadsoversikt/styled'
 import { behandlingSkalSendeBrev, hentBehandlesFraStatus } from '../felles/utils'
 import { formaterStringDato } from '~utils/formattering'
-import { formaterVedtaksResultat, useVedtaksResultat } from '../useVedtaksResultat'
+import { useVedtaksResultat } from '../useVedtaksResultat'
 import { useAppDispatch } from '~store/Store'
 import { useBehandlingRoutes } from '../BehandlingRoutes'
 import React, { useEffect, useState } from 'react'
@@ -11,7 +11,7 @@ import { IBehandlingReducer, oppdaterBehandlingsstatus, oppdaterBeregning } from
 import Spinner from '~shared/Spinner'
 import { BehandlingHandlingKnapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
 import { Alert, Button, Heading } from '@navikt/ds-react'
-import { isFailure, isPending, useApiCall } from '~shared/hooks/useApiCall'
+import { isFailure, isPending, isSuccess, useApiCall } from '~shared/hooks/useApiCall'
 import { IBehandlingStatus, IBehandlingsType } from '~shared/types/IDetaljertBehandling'
 import styled from 'styled-components'
 import { NesteOgTilbake } from '../handlinger/NesteOgTilbake'
@@ -26,34 +26,26 @@ import { fattVedtak, upsertVedtak } from '~shared/api/vedtaksvurdering'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { VilkaarsvurderingResultat } from '~shared/api/vilkaarsvurdering'
 import { handlinger } from '~components/behandling/handlinger/typer'
+import { Vilkaarsresultat } from '~components/behandling/felles/Vilkaarsresultat'
 
 export const Beregne = (props: { behandling: IBehandlingReducer }) => {
   const { behandling } = props
   const { next } = useBehandlingRoutes()
-  const beregningFraState = behandling.beregning
   const dispatch = useAppDispatch()
   const [beregning, hentBeregningRequest] = useApiCall(hentBeregning)
   const [vedtak, oppdaterVedtakRequest] = useApiCall(upsertVedtak)
   const [visAttesteringsmodal, setVisAttesteringsmodal] = useState(false)
-
   const virkningstidspunkt = behandling.virkningstidspunkt?.dato
     ? formaterStringDato(behandling.virkningstidspunkt.dato)
     : undefined
   const behandles = hentBehandlesFraStatus(behandling.status)
   const opphoer = behandling.vilkårsprøving?.resultat?.utfall == VilkaarsvurderingResultat.IKKE_OPPFYLT
-
   const vedtaksresultat =
     behandling.behandlingType !== IBehandlingsType.MANUELT_OPPHOER ? useVedtaksResultat() : 'opphoer'
 
   useEffect(() => {
-    const hentBeregning = async () => {
-      if (!opphoer) {
-        hentBeregningRequest(behandling.id, (res) => dispatch(oppdaterBeregning(res)))
-      }
-    }
-
-    if (!beregningFraState && behandling.vilkårsprøving) {
-      void hentBeregning()
+    if (!opphoer) {
+      hentBeregningRequest(behandling.id, (res) => dispatch(oppdaterBeregning(res)))
     }
   }, [])
 
@@ -74,44 +66,48 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
     <Content>
       <ContentHeader>
         <HeadingWrapper>
-          <Heading size="large" level="1">
+          <Heading spacing size="large" level="1">
             Beregning og vedtak
           </Heading>
+          <Vilkaarsresultat vedtaksresultat={vedtaksresultat} virkningstidspunktFormatert={virkningstidspunkt} />
         </HeadingWrapper>
-        <InfoWrapper>
-          <div className="text">
-            Vilkårsresultat: <strong>{formaterVedtaksResultat(vedtaksresultat, virkningstidspunkt)}</strong>
-          </div>
-        </InfoWrapper>
-        {!beregningFraState && !opphoer && !isFailure(beregning) && <Spinner visible label="Laster" />}
-        {isFailure(beregning) && <ApiErrorAlert>Kunne ikke hente beregning</ApiErrorAlert>}
-        {beregningFraState &&
-          !opphoer &&
-          {
-            [Beregningstype.BP]: <BarnepensjonSammendrag behandling={behandling} beregning={beregningFraState} />,
-            [Beregningstype.OMS]: (
-              <>
-                <OmstillingsstoenadSammendrag beregning={beregningFraState} />
-                <Avkorting behandling={behandling} />
-              </>
-            ),
-          }[beregningFraState.type]}
-        {behandlingSkalSendeBrev(behandling.behandlingType, behandling.revurderingsaarsak) ? null : (
-          <InfoAlert variant="info" inline>
-            Det sendes ikke vedtaksbrev for denne behandlingen.
-          </InfoAlert>
-        )}
-        {!opphoer && (
-          <EtterbetalingWrapper>
-            <Etterbetaling
-              behandlingId={behandling.id}
-              lagraEtterbetaling={behandling.etterbetaling}
-              redigerbar={behandles}
-              virkningstidspunkt={virkningstidspunkt}
-            />
-          </EtterbetalingWrapper>
-        )}
       </ContentHeader>
+
+      {isPending(beregning) && <Spinner visible label="Laster" />}
+      {isFailure(beregning) && <ApiErrorAlert>Kunne ikke hente beregning</ApiErrorAlert>}
+      {isSuccess(beregning) && (
+        <BeregningWrapper>
+          {!opphoer &&
+            (() => {
+              switch (beregning.data.type) {
+                case Beregningstype.BP:
+                  return <BarnepensjonSammendrag behandling={behandling} beregning={beregning.data} />
+                case Beregningstype.OMS:
+                  return (
+                    <>
+                      <OmstillingsstoenadSammendrag beregning={beregning.data} />
+                      <Avkorting behandling={behandling} />
+                    </>
+                  )
+              }
+            })()}
+          {behandlingSkalSendeBrev(behandling.behandlingType, behandling.revurderingsaarsak) ? null : (
+            <InfoAlert variant="info" inline>
+              Det sendes ikke vedtaksbrev for denne behandlingen.
+            </InfoAlert>
+          )}
+          {!opphoer && (
+            <EtterbetalingWrapper>
+              <Etterbetaling
+                behandlingId={behandling.id}
+                lagraEtterbetaling={behandling.etterbetaling}
+                redigerbar={behandles}
+                virkningstidspunkt={virkningstidspunkt}
+              />
+            </EtterbetalingWrapper>
+          )}
+        </BeregningWrapper>
+      )}
 
       <Border />
 
@@ -140,16 +136,9 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
   )
 }
 
-const InfoWrapper = styled.div`
-  margin-top: 1em;
-  max-width: 500px;
-
-  .text {
-    margin: 1em 0 5em 0;
-  }
-`
 const EtterbetalingWrapper = styled.div`
   margin-top: 3rem;
+  margin-bottom: 3rem;
   max-width: 500px;
 
   .text {
@@ -159,4 +148,8 @@ const EtterbetalingWrapper = styled.div`
 
 const InfoAlert = styled(Alert).attrs({ variant: 'info' })`
   margin-top: 2rem;
+`
+
+const BeregningWrapper = styled.div`
+  padding: 0 4em;
 `

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Beregningsgrunnlag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Beregningsgrunnlag.tsx
@@ -2,16 +2,17 @@ import { SakType } from '~shared/types/sak'
 import BeregningsgrunnlagBarnepensjon from '~components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon'
 import BeregningsgrunnlagOmstillingsstoenad from '~components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad'
 import { HeadingWrapper } from '~components/behandling/soeknadsoversikt/styled'
-import { BodyShort, Heading } from '@navikt/ds-react'
+import { Heading } from '@navikt/ds-react'
 import { formaterStringDato } from '~utils/formattering'
 import { Content, ContentHeader } from '~shared/styled'
 import { IBehandlingsType, IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
-import { formaterVedtaksResultat, useVedtaksResultat } from '~components/behandling/useVedtaksResultat'
+import { useVedtaksResultat } from '~components/behandling/useVedtaksResultat'
 import { hentOverstyrBeregning } from '~shared/api/beregning'
 import { isSuccess, useApiCall } from '~shared/hooks/useApiCall'
 import { OverstyrBeregning } from '~shared/types/Beregning'
 import { useEffect, useState } from 'react'
 import OverstyrBeregningGrunnlag from './OverstyrBeregningGrunnlag'
+import { Vilkaarsresultat } from '~components/behandling/felles/Vilkaarsresultat'
 
 const Beregningsgrunnlag = (props: { behandling: IDetaljertBehandling }) => {
   const { behandling } = props
@@ -39,9 +40,7 @@ const Beregningsgrunnlag = (props: { behandling: IDetaljertBehandling }) => {
           <Heading spacing size="large" level="1">
             Beregningsgrunnlag
           </Heading>
-          <BodyShort spacing>
-            Vilkårsresultat: <strong>{formaterVedtaksResultat(vedtaksresultat, virkningstidspunkt)}</strong>
-          </BodyShort>
+          <Vilkaarsresultat vedtaksresultat={vedtaksresultat} virkningstidspunktFormatert={virkningstidspunkt} />
         </HeadingWrapper>
       </ContentHeader>
       <>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
@@ -10,6 +10,7 @@ import {
   IBehandlingReducer,
   oppdaterBehandlingsstatus,
   oppdaterBeregingsGrunnlag,
+  oppdaterBeregning,
   resetBeregning,
 } from '~store/reducers/BehandlingReducer'
 import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
@@ -23,6 +24,7 @@ import Soeskenjustering, {
 import Spinner from '~shared/Spinner'
 import { IPdlPerson } from '~shared/types/Person'
 import {
+  Beregning,
   BeregningsMetode,
   BeregningsMetodeBeregningsgrunnlag,
   InstitusjonsoppholdGrunnlagData,
@@ -99,9 +101,10 @@ const BeregningsgrunnlagBarnepensjon = (props: { behandling: IBehandlingReducer 
           grunnlag: beregningsgrunnlag,
         },
         () =>
-          postOpprettEllerEndreBeregning(behandling.id, () => {
+          postOpprettEllerEndreBeregning(behandling.id, (beregning: Beregning) => {
             dispatch(oppdaterBeregingsGrunnlag(beregningsgrunnlag))
             dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.BEREGNET))
+            dispatch(oppdaterBeregning(beregning))
             next()
           })
       )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
@@ -15,12 +15,14 @@ import {
   IBehandlingReducer,
   oppdaterBehandlingsstatus,
   oppdaterBeregingsGrunnlagOMS,
+  oppdaterBeregning,
   resetBeregning,
 } from '~store/reducers/BehandlingReducer'
 import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
 import React, { useEffect, useState } from 'react'
 import InstitusjonsoppholdOMS from '~components/behandling/beregningsgrunnlag/InstitusjonsoppholdOMS'
 import {
+  Beregning,
   BeregningsMetode,
   BeregningsMetodeBeregningsgrunnlag,
   InstitusjonsoppholdGrunnlagData,
@@ -77,9 +79,10 @@ const BeregningsgrunnlagOmstillingsstoenad = (props: { behandling: IBehandlingRe
         grunnlag: beregningsgrunnlagOMS,
       },
       () =>
-        postOpprettEllerEndreBeregning(behandling.id, () => {
+        postOpprettEllerEndreBeregning(behandling.id, (beregning: Beregning) => {
           dispatch(oppdaterBeregingsGrunnlagOMS(beregningsgrunnlagOMS))
           dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.BEREGNET))
+          dispatch(oppdaterBeregning(beregning))
           next()
         })
     )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/Vilkaarsresultat.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/Vilkaarsresultat.tsx
@@ -1,0 +1,15 @@
+import { formaterVedtaksResultat, VedtakResultat } from '~components/behandling/useVedtaksResultat'
+import { BodyShort } from '@navikt/ds-react'
+import React from 'react'
+
+export const Vilkaarsresultat = (props: {
+  vedtaksresultat: VedtakResultat | null
+  virkningstidspunktFormatert: string | undefined
+}) => {
+  return (
+    <BodyShort spacing>
+      Vilkårsresultat:{' '}
+      <strong>{formaterVedtaksResultat(props.vedtaksresultat, props.virkningstidspunktFormatert)}</strong>
+    </BodyShort>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidVisning.tsx
@@ -1,10 +1,10 @@
 import { SakType } from '~shared/types/sak'
 import { Border, HeadingWrapper } from '~components/behandling/soeknadsoversikt/styled'
-import { BodyShort, Button, Heading } from '@navikt/ds-react'
+import { Button, Heading } from '@navikt/ds-react'
 import { formaterStringDato } from '~utils/formattering'
 import { Content, ContentHeader } from '~shared/styled'
 import { IBehandlingStatus, IBehandlingsType, IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
-import { formaterVedtaksResultat, useVedtaksResultat } from '~components/behandling/useVedtaksResultat'
+import { useVedtaksResultat } from '~components/behandling/useVedtaksResultat'
 import { BehandlingHandlingKnapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
 import { NesteOgTilbake } from '~components/behandling/handlinger/NesteOgTilbake'
 import { hentBehandlesFraStatus } from '~components/behandling/felles/utils'
@@ -22,6 +22,7 @@ import { oppdaterStatus } from '~shared/api/trygdetid'
 import { oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'
 import { useAppDispatch } from '~store/Store'
 import { handlinger } from '~components/behandling/handlinger/typer'
+import { Vilkaarsresultat } from '~components/behandling/felles/Vilkaarsresultat'
 
 const featureToggleNameTrygdetid = 'pensjon-etterlatte.bp-bruk-faktisk-trygdetid' as const
 
@@ -69,9 +70,7 @@ const TrygdetidVisning = (props: { behandling: IDetaljertBehandling }) => {
           <Heading spacing size="large" level="1">
             Trygdetid
           </Heading>
-          <BodyShort spacing>
-            Vilkårsresultat: <strong>{formaterVedtaksResultat(vedtaksresultat, virkningstidspunkt)}</strong>
-          </BodyShort>
+          <Vilkaarsresultat vedtaksresultat={vedtaksresultat} virkningstidspunktFormatert={virkningstidspunkt} />
         </HeadingWrapper>
       </ContentHeader>
       {isSuccess(vilkaarsvurdering) &&


### PR DESCRIPTION
- Fikser at beregning ble ikke lastet ved reload av beregningssiden - laster den hver gang beregningssiden vises for å være sikker på at denne er up-to-date
- Endrer på avkorting slik at den viser spinner når den lastes
- Drar ut vilkårsresultat i felles komponent da denne vises på tre ulike steg