### PR TITLE
EY-2949 Rediger behandling etter opprettet brev gir advarsel om mulig utdatert brev

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
@@ -93,7 +93,7 @@ class BrevRepository(private val ds: DataSource) {
             ).asUpdate,
         ).also { require(it == 1) }
 
-        tx.lagreHendelse(id, Status.OPPDATERT, Tidspunkt.now(), payload.toJson())
+        tx.lagreHendelse(id, Status.OPPDATERT, payload.toJson())
             .also { require(it == 1) }
     }
 
@@ -112,7 +112,7 @@ class BrevRepository(private val ds: DataSource) {
             ).asUpdate,
         ).also { require(it == 1) }
 
-        tx.lagreHendelse(id, Status.OPPDATERT, Tidspunkt.now(), payload.toJson())
+        tx.lagreHendelse(id, Status.OPPDATERT, payload.toJson())
             .also { require(it == 1) }
     }
 
@@ -140,7 +140,7 @@ class BrevRepository(private val ds: DataSource) {
             ).asUpdate,
         ).also { require(it == 1) }
 
-        tx.lagreHendelse(id, Status.OPPDATERT, Tidspunkt.now(), mottaker.toJson())
+        tx.lagreHendelse(id, Status.OPPDATERT, mottaker.toJson())
             .also { require(it == 1) }
     }
 
@@ -159,7 +159,7 @@ class BrevRepository(private val ds: DataSource) {
                 ).asUpdate,
             ).also { oppdatert -> require(oppdatert == 1) }
 
-            tx.lagreHendelse(id, Status.FERDIGSTILT, Tidspunkt.now())
+            tx.lagreHendelse(id, Status.FERDIGSTILT)
         }
     }
 
@@ -190,7 +190,7 @@ class BrevRepository(private val ds: DataSource) {
 
     fun settBrevFerdigstilt(id: BrevID) {
         using(sessionOf(ds)) {
-            it.lagreHendelse(id, Status.FERDIGSTILT, Tidspunkt.now())
+            it.lagreHendelse(id, Status.FERDIGSTILT)
         }
     }
 
@@ -264,7 +264,7 @@ class BrevRepository(private val ds: DataSource) {
                 ).asUpdate,
             ).also { oppdatert -> require(oppdatert == 1) }
 
-            tx.lagreHendelse(brevId, Status.JOURNALFOERT, Tidspunkt.now(), journalpostResponse.toJson()) > 0
+            tx.lagreHendelse(brevId, Status.JOURNALFOERT, journalpostResponse.toJson()) > 0
         }
 
     fun hentJournalpostId(brevId: BrevID): String? =
@@ -288,13 +288,19 @@ class BrevRepository(private val ds: DataSource) {
                 ).asUpdate,
             ).also { oppdatert -> require(oppdatert == 1) }
 
-            tx.lagreHendelse(brevId, Status.DISTRIBUERT, Tidspunkt.now(), distResponse.toJson()) > 0
+            tx.lagreHendelse(brevId, Status.DISTRIBUERT, distResponse.toJson()) > 0
         }
 
     private fun Session.lagreHendelse(
         brevId: BrevID,
         status: Status,
-        opprettet: Tidspunkt,
+        payload: String = "{}",
+    ) = lagreHendelse(brevId, status, Tidspunkt.now(), payload)
+
+    private fun Session.lagreHendelse(
+        brevId: BrevID,
+        status: Status,
+        opprettet: Tidspunkt = Tidspunkt.now(),
         payload: String = "{}",
     ) = run(
         queryOf(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
@@ -33,6 +33,7 @@ import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.deserialize
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toTimestamp
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.database.tidspunkt
@@ -92,7 +93,7 @@ class BrevRepository(private val ds: DataSource) {
             ).asUpdate,
         ).also { require(it == 1) }
 
-        tx.lagreHendelse(id, Status.OPPDATERT, payload.toJson())
+        tx.lagreHendelse(id, Status.OPPDATERT, Tidspunkt.now(), payload.toJson())
             .also { require(it == 1) }
     }
 
@@ -111,7 +112,7 @@ class BrevRepository(private val ds: DataSource) {
             ).asUpdate,
         ).also { require(it == 1) }
 
-        tx.lagreHendelse(id, Status.OPPDATERT, payload.toJson())
+        tx.lagreHendelse(id, Status.OPPDATERT, Tidspunkt.now(), payload.toJson())
             .also { require(it == 1) }
     }
 
@@ -139,7 +140,7 @@ class BrevRepository(private val ds: DataSource) {
             ).asUpdate,
         ).also { require(it == 1) }
 
-        tx.lagreHendelse(id, Status.OPPDATERT, mottaker.toJson())
+        tx.lagreHendelse(id, Status.OPPDATERT, Tidspunkt.now(), mottaker.toJson())
             .also { require(it == 1) }
     }
 
@@ -158,7 +159,7 @@ class BrevRepository(private val ds: DataSource) {
                 ).asUpdate,
             ).also { oppdatert -> require(oppdatert == 1) }
 
-            tx.lagreHendelse(id, Status.FERDIGSTILT)
+            tx.lagreHendelse(id, Status.FERDIGSTILT, Tidspunkt.now())
         }
     }
 
@@ -189,7 +190,7 @@ class BrevRepository(private val ds: DataSource) {
 
     fun settBrevFerdigstilt(id: BrevID) {
         using(sessionOf(ds)) {
-            it.lagreHendelse(id, Status.FERDIGSTILT)
+            it.lagreHendelse(id, Status.FERDIGSTILT, Tidspunkt.now())
         }
     }
 
@@ -244,7 +245,7 @@ class BrevRepository(private val ds: DataSource) {
                 ).asUpdate,
             ).also { opprettet -> require(opprettet == 1) }
 
-            tx.lagreHendelse(id, Status.OPPRETTET)
+            tx.lagreHendelse(id, Status.OPPRETTET, ulagretBrev.opprettet)
                 .also { oppdatert -> require(oppdatert == 1) }
 
             Brev.fra(id, ulagretBrev)
@@ -263,7 +264,7 @@ class BrevRepository(private val ds: DataSource) {
                 ).asUpdate,
             ).also { oppdatert -> require(oppdatert == 1) }
 
-            tx.lagreHendelse(brevId, Status.JOURNALFOERT, journalpostResponse.toJson()) > 0
+            tx.lagreHendelse(brevId, Status.JOURNALFOERT, Tidspunkt.now(), journalpostResponse.toJson()) > 0
         }
 
     fun hentJournalpostId(brevId: BrevID): String? =
@@ -287,12 +288,13 @@ class BrevRepository(private val ds: DataSource) {
                 ).asUpdate,
             ).also { oppdatert -> require(oppdatert == 1) }
 
-            tx.lagreHendelse(brevId, Status.DISTRIBUERT, distResponse.toJson()) > 0
+            tx.lagreHendelse(brevId, Status.DISTRIBUERT, Tidspunkt.now(), distResponse.toJson()) > 0
         }
 
     private fun Session.lagreHendelse(
         brevId: BrevID,
         status: Status,
+        opprettet: Tidspunkt,
         payload: String = "{}",
     ) = run(
         queryOf(
@@ -301,6 +303,7 @@ class BrevRepository(private val ds: DataSource) {
                 "brev_id" to brevId,
                 "status_id" to status.name,
                 "payload" to payload,
+                "opprettet" to opprettet.toTimestamp(),
             ),
         ).asUpdate,
     )
@@ -313,6 +316,7 @@ class BrevRepository(private val ds: DataSource) {
             soekerFnr = row.string("soeker_fnr"),
             prosessType = BrevProsessType.valueOf(row.string("prosess_type")),
             status = row.string("status_id").let { Status.valueOf(it) },
+            statusEndret = row.tidspunkt("hendelse_opprettet"),
             opprettet = row.tidspunkt("opprettet"),
             mottaker =
                 Mottaker(
@@ -356,7 +360,9 @@ class BrevRepository(private val ds: DataSource) {
     // language=SQL
     private object Queries {
         const val HENT_BREV_QUERY = """
-            SELECT b.id, b.sak_id, b.behandling_id, b.prosess_type, b.soeker_fnr, b.opprettet, h.status_id, m.*
+            SELECT 
+                b.id, b.sak_id, b.behandling_id, b.prosess_type, b.soeker_fnr, b.opprettet, h.status_id, 
+                h.opprettet as hendelse_opprettet, m.*
             FROM brev b
             INNER JOIN mottaker m on b.id = m.brev_id
             INNER JOIN hendelse h on b.id = h.brev_id
@@ -369,7 +375,9 @@ class BrevRepository(private val ds: DataSource) {
         """
 
         const val HENT_BREV_FOR_BEHANDLING_QUERY = """
-            SELECT b.id, b.sak_id, b.behandling_id, b.prosess_type, b.soeker_fnr, h.status_id, b.opprettet, m.*
+            SELECT 
+                b.id, b.sak_id, b.behandling_id, b.prosess_type, b.soeker_fnr, h.status_id, b.opprettet, 
+                h.opprettet as hendelse_opprettet, m.*
             FROM brev b
             INNER JOIN mottaker m on b.id = m.brev_id
             INNER JOIN hendelse h on b.id = h.brev_id
@@ -382,7 +390,9 @@ class BrevRepository(private val ds: DataSource) {
         """
 
         const val HENT_BREV_FOR_SAK_QUERY = """
-            SELECT b.id, b.sak_id, b.behandling_id, b.prosess_type, b.soeker_fnr, h.status_id, b.opprettet, m.*
+            SELECT 
+                b.id, b.sak_id, b.behandling_id, b.prosess_type, b.soeker_fnr, h.status_id, b.opprettet, 
+                h.opprettet as hendelse_opprettet, m.*
             FROM brev b
             INNER JOIN mottaker m on b.id = m.brev_id
             INNER JOIN hendelse h on b.id = h.brev_id
@@ -456,8 +466,8 @@ class BrevRepository(private val ds: DataSource) {
         """
 
         const val OPPRETT_HENDELSE_QUERY = """
-            INSERT INTO hendelse (brev_id, status_id, payload) 
-            VALUES (:brev_id, :status_id, :payload)
+            INSERT INTO hendelse (brev_id, status_id, payload, opprettet) 
+            VALUES (:brev_id, :status_id, :payload, :opprettet)
         """
     }
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -6,7 +6,6 @@ import no.nav.etterlatte.brev.behandling.Beregningsperiode
 import no.nav.etterlatte.brev.behandling.Trygdetidsperiode
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.common.toJson
 import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import no.nav.pensjon.brevbaker.api.model.Kroner
 import org.apache.pdfbox.Loader
@@ -194,9 +193,4 @@ data class EtterbetalingBrev(
             )
         }
     }
-}
-
-fun main() {
-    val tidspunkt = Tidspunkt.now()
-    println(tidspunkt.toJson())
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -6,6 +6,7 @@ import no.nav.etterlatte.brev.behandling.Beregningsperiode
 import no.nav.etterlatte.brev.behandling.Trygdetidsperiode
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.toJson
 import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import no.nav.pensjon.brevbaker.api.model.Kroner
 import org.apache.pdfbox.Loader
@@ -83,6 +84,7 @@ data class Brev(
     val prosessType: BrevProsessType,
     val soekerFnr: String,
     val status: Status,
+    val statusEndret: Tidspunkt,
     val opprettet: Tidspunkt,
     val mottaker: Mottaker,
 ) {
@@ -99,6 +101,7 @@ data class Brev(
             prosessType = opprettNyttBrev.prosessType,
             soekerFnr = opprettNyttBrev.soekerFnr,
             status = opprettNyttBrev.status,
+            statusEndret = opprettNyttBrev.opprettet,
             mottaker = opprettNyttBrev.mottaker,
             opprettet = opprettNyttBrev.opprettet,
         )
@@ -191,4 +194,9 @@ data class EtterbetalingBrev(
             )
         }
     }
+}
+
+fun main() {
+    val tidspunkt = Tidspunkt.now()
+    println(tidspunkt.toJson())
 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
@@ -233,6 +233,7 @@ internal class BrevRouteTest {
             prosessType = BrevProsessType.AUTOMATISK,
             soekerFnr = "soeker_fnr",
             status = Status.OPPRETTET,
+            statusEndret = Tidspunkt.now(),
             opprettet = Tidspunkt.now(),
             mottaker =
                 Mottaker(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
@@ -284,6 +284,7 @@ internal class BrevServiceTest {
         prosessType = prosessType,
         soekerFnr = "fnr",
         status = status,
+        statusEndret = Tidspunkt.now(),
         opprettet = Tidspunkt.now(),
         mottaker = opprettMottaker(),
     )

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
@@ -257,6 +257,7 @@ internal class VedtaksbrevRouteTest {
             "soeker_fnr",
             Status.OPPRETTET,
             Tidspunkt.now(),
+            Tidspunkt.now(),
             Mottaker(
                 "Stor Snerk",
                 STOR_SNERK,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -741,6 +741,7 @@ internal class VedtaksbrevServiceTest {
                     "fnr",
                     status,
                     Tidspunkt.now(),
+                    Tidspunkt.now(),
                     opprettMottaker(),
                 )
 
@@ -767,6 +768,7 @@ internal class VedtaksbrevServiceTest {
         prosessType = prosessType,
         soekerFnr = "fnr",
         status = status,
+        Tidspunkt.now(),
         Tidspunkt.now(),
         mottaker = opprettMottaker(),
     )

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiverTest.kt
@@ -60,6 +60,7 @@ internal class JournalfoerVedtaksbrevRiverTest {
                 "fnr",
                 Status.FERDIGSTILT,
                 Tidspunkt.now(),
+                Tidspunkt.now(),
                 mottaker = mockk(),
             )
         val response = JournalpostResponse("1234", null, null, true, emptyList())
@@ -101,6 +102,7 @@ internal class JournalfoerVedtaksbrevRiverTest {
                 BrevProsessType.AUTOMATISK,
                 "fnr",
                 Status.JOURNALFOERT,
+                Tidspunkt.now(),
                 Tidspunkt.now(),
                 mottaker = mockk(),
             )

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
@@ -151,6 +151,7 @@ internal class OpprettJournalfoerOgDistribuer {
             soekerFnr = "123",
             status = Status.FERDIGSTILT,
             Tidspunkt.now(),
+            Tidspunkt.now(),
             mottaker =
                 Mottaker(
                     "Marte Kirkerud",

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettVedtaksbrevForMigreringRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettVedtaksbrevForMigreringRiverTest.kt
@@ -102,6 +102,7 @@ internal class OpprettVedtaksbrevForMigreringRiverTest {
             "fnr",
             Status.FERDIGSTILT,
             Tidspunkt.now(),
+            Tidspunkt.now(),
             mottaker = mockk(),
         )
 

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/VedtaksbrevUnderkjentRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/VedtaksbrevUnderkjentRiverTest.kt
@@ -121,6 +121,7 @@ internal class VedtaksbrevUnderkjentRiverTest {
             "fnr",
             Status.JOURNALFOERT,
             Tidspunkt.now(),
+            Tidspunkt.now(),
             mottaker = mockk(),
         )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
@@ -34,7 +34,7 @@ const formaterTidspunkt = (dato: Date) => format(new Date(dato), 'HH:mm:ss').toS
 interface RedigerbartBrevProps {
   brev: IBrev
   kanRedigeres: boolean
-  lukkAdvarselBehandlingEndret: () => void
+  lukkAdvarselBehandlingEndret?: () => void
 }
 
 export default function RedigerbartBrev({ brev, kanRedigeres, lukkAdvarselBehandlingEndret }: RedigerbartBrevProps) {
@@ -69,7 +69,7 @@ export default function RedigerbartBrev({ brev, kanRedigeres, lukkAdvarselBehand
         setContent(payload.hoveddel)
         setVedlegg(payload.vedlegg)
         setLagretStatus({ lagret: true, beskrivelse: `Lagret kl. ${formaterTidspunkt(new Date())}` })
-        lukkAdvarselBehandlingEndret()
+        if (lukkAdvarselBehandlingEndret) lukkAdvarselBehandlingEndret()
       }
     )
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
@@ -59,6 +59,7 @@ export default function RedigerbartBrev({ brev, kanRedigeres, lukkAdvarselBehand
   const lagre = () => {
     apiLagreManuellPayload({ brevId: brev.id, sakId: brev.sakId, payload: content, payload_vedlegg: vedlegg }, () => {
       setLagretStatus({ lagret: true, beskrivelse: `Lagret kl. ${formaterTidspunkt(new Date())}` })
+      if (lukkAdvarselBehandlingEndret) lukkAdvarselBehandlingEndret()
     })
   }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
@@ -34,9 +34,10 @@ const formaterTidspunkt = (dato: Date) => format(new Date(dato), 'HH:mm:ss').toS
 interface RedigerbartBrevProps {
   brev: IBrev
   kanRedigeres: boolean
+  lukkAdvarselBehandlingEndret: () => void
 }
 
-export default function RedigerbartBrev({ brev, kanRedigeres }: RedigerbartBrevProps) {
+export default function RedigerbartBrev({ brev, kanRedigeres, lukkAdvarselBehandlingEndret }: RedigerbartBrevProps) {
   const [fane, setFane] = useState<string>(kanRedigeres ? ManueltBrevFane.REDIGER : ManueltBrevFane.FORHAANDSVIS)
   const [content, setContent] = useState<any[]>([])
   const [vedlegg, setVedlegg] = useState<any[]>([])
@@ -68,6 +69,7 @@ export default function RedigerbartBrev({ brev, kanRedigeres }: RedigerbartBrevP
         setContent(payload.hoveddel)
         setVedlegg(payload.vedlegg)
         setLagretStatus({ lagret: true, beskrivelse: `Lagret kl. ${formaterTidspunkt(new Date())}` })
+        lukkAdvarselBehandlingEndret()
       }
     )
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
@@ -35,7 +35,7 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
   const { sakId, soeknadMottattDato, status } = props.behandling
 
   const [vedtaksbrev, setVedtaksbrev] = useState<IBrev | undefined>(undefined)
-  const [visAdvarselBehandlingEndret, setVisAdvarselBehandlingEndret] = useState<boolean>(false)
+  const [visAdvarselBehandlingEndret, setVisAdvarselBehandlingEndret] = useState(false)
 
   const [hentBrevStatus, hentBrev] = useApiCall(hentVedtaksbrev)
   const [opprettBrevStatus, opprettNyttVedtaksbrev] = useApiCall(opprettVedtaksbrev)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
@@ -12,6 +12,7 @@ import {
   behandlingSkalSendeBrev,
   hentBehandlesFraStatus,
   manueltBrevKanRedigeres,
+  sisteBehandlingHendelse,
 } from '~components/behandling/felles/utils'
 import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 import MottakerPanel from '~components/behandling/brev/detaljer/MottakerPanel'
@@ -23,16 +24,45 @@ import { isFailure, isPending, isPendingOrInitial, useApiCall } from '~shared/ho
 
 import { fattVedtak } from '~shared/api/vedtaksvurdering'
 import { SjekklisteValideringErrorSummary } from '~components/behandling/sjekkliste/SjekklisteValideringErrorSummary'
-import { IHendelseType } from '~shared/types/IHendelse'
+import { IHendelse } from '~shared/types/IHendelse'
+import { oppdaterBehandling, resetBehandling } from '~store/reducers/BehandlingReducer'
+import { hentBehandling } from '~shared/api/behandling'
+import { useAppDispatch } from '~store/Store'
 
 export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
   const { behandlingId } = useParams()
+  const dispatch = useAppDispatch()
   const { sakId, soeknadMottattDato, status } = props.behandling
 
   const [vedtaksbrev, setVedtaksbrev] = useState<IBrev | undefined>(undefined)
+  const [visAdvarselBehandlingEndret, setVisAdvarselBehandlingEndret] = useState<boolean>(false)
 
   const [hentBrevStatus, hentBrev] = useApiCall(hentVedtaksbrev)
   const [opprettBrevStatus, opprettNyttVedtaksbrev] = useApiCall(opprettVedtaksbrev)
+  const [, fetchBehandling] = useApiCall(hentBehandling)
+
+  const behandlingRedigertEtterOpprettetBrev = (vedtaksbrev: IBrev, hendelser: IHendelse[]) => {
+    const hendelse = sisteBehandlingHendelse(hendelser)
+    return new Date(hendelse.opprettet).getTime() > new Date(vedtaksbrev.statusEndret).getTime()
+  }
+
+  const lukkAdvarselBehandlingEndret = () => {
+    setVisAdvarselBehandlingEndret(false)
+  }
+
+  // Opppdaterer behandling for å sikre at siste hendelser er på plass
+  useEffect(() => {
+    if (behandlingId && vedtaksbrev) {
+      fetchBehandling(
+        behandlingId,
+        (behandling) => {
+          dispatch(oppdaterBehandling(behandling))
+          setVisAdvarselBehandlingEndret(behandlingRedigertEtterOpprettetBrev(vedtaksbrev, behandling.hendelser))
+        },
+        () => dispatch(resetBehandling())
+      )
+    }
+  }, [vedtaksbrev])
 
   useEffect(() => {
     if (
@@ -59,23 +89,6 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
     return <Spinner visible label="Ingen brev funnet. Oppretter brev ..." />
   }
 
-  const behandlingRedigertEtterOpprettetBrev = props.behandling.hendelser.find((hendelse) => {
-    if (!vedtaksbrev) return false
-
-    const erBehandlingshendelse = [
-      IHendelseType.BEHANDLING_OPPRETTET,
-      IHendelseType.BEHANDLING_VILKAARSVURDERT,
-      IHendelseType.BEHANDLING_TRYGDETID_OPPDATERT,
-      IHendelseType.BEHANDLING_BEREGNET,
-      IHendelseType.BEHANDLING_AVKORTET,
-    ].includes(hendelse.hendelse)
-
-    const hendelseErEtterBrevOpprettelse =
-      new Date(vedtaksbrev.opprettet).getTime() < new Date(hendelse.opprettet).getTime()
-
-    return erBehandlingshendelse && hendelseErEtterBrevOpprettelse
-  })
-
   return (
     <Content>
       <BrevContent>
@@ -91,16 +104,17 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
             <br />
             {(vedtaksbrev?.prosessType === BrevProsessType.MANUELL ||
               vedtaksbrev?.prosessType === BrevProsessType.REDIGERBAR) && (
-              <Alert variant="warning">
+              <WarningAlert>
                 {manueltBrevKanRedigeres(status)
                   ? 'Kan ikke generere brev automatisk. Du må selv redigere innholdet.'
                   : 'Dette er et manuelt opprettet brev. Kontroller innholdet nøye før attestering.'}
-              </Alert>
+              </WarningAlert>
             )}
-            {behandlingRedigertEtterOpprettetBrev && (
-              <Alert variant="warning">
-                Behandling er redigert etter brev ble opprettet. Brev bør derfor tilbakestilles..
-              </Alert>
+            {visAdvarselBehandlingEndret && (
+              <WarningAlert>
+                Behandling er redigert etter brevet ble opprettet. Gå gjennom brevet og vurder om det bør tilbakestilles
+                for å få oppdaterte verdier fra behandlingen.
+              </WarningAlert>
             )}
             <br />
             {vedtaksbrev && (
@@ -117,7 +131,11 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
           (vedtaksbrev?.prosessType === BrevProsessType.AUTOMATISK ? (
             <ForhaandsvisningBrev brev={vedtaksbrev} />
           ) : (
-            <RedigerbartBrev brev={vedtaksbrev!!} kanRedigeres={manueltBrevKanRedigeres(status)} />
+            <RedigerbartBrev
+              brev={vedtaksbrev!!}
+              kanRedigeres={manueltBrevKanRedigeres(status)}
+              lukkAdvarselBehandlingEndret={lukkAdvarselBehandlingEndret}
+            />
           ))}
 
         {isFailure(hentBrevStatus) && <ErrorMessage>Feil ved henting av brev</ErrorMessage>}
@@ -148,4 +166,8 @@ const Sidebar = styled.div`
   min-width: 40%;
   width: 40%;
   border-right: 1px solid #c6c2bf;
+`
+
+const WarningAlert = styled(Alert).attrs({ variant: 'warning' })`
+  margin-bottom: 1em;
 `

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.ts
@@ -5,6 +5,7 @@ import { IBehandlingsammendrag } from '~components/person/typer'
 import { SakType } from '~shared/types/sak'
 import { JaNei } from '~shared/types/ISvar'
 import { Revurderingaarsak } from '~shared/types/Revurderingaarsak'
+import { IHendelse, IHendelseType } from '~shared/types/IHendelse'
 
 export function behandlingErUtfylt(behandling: IDetaljertBehandling): boolean {
   const gyldigUtfylt = !!(
@@ -37,6 +38,7 @@ export const hentGyldigeNavigeringsStatuser = (status: IBehandlingStatus) => {
     IBehandlingStatus.VILKAARSVURDERT,
     IBehandlingStatus.TRYGDETID_OPPDATERT,
     IBehandlingStatus.BEREGNET,
+    IBehandlingStatus.AVKORTET,
     IBehandlingStatus.FATTET_VEDTAK,
     IBehandlingStatus.ATTESTERT,
   ]
@@ -108,4 +110,20 @@ export const manueltBrevKanRedigeres = (status: IBehandlingStatus): boolean => {
 export function requireNotNull<T>(value: T | null, message: string): T {
   if (!!value) return value
   else throw Error(message)
+}
+
+export const sisteBehandlingHendelse = (hendelser: IHendelse[]): IHendelse => {
+  const hendelserSortert = hendelser
+    .filter((hendelse) =>
+      [
+        IHendelseType.BEHANDLING_OPPRETTET,
+        IHendelseType.BEHANDLING_VILKAARSVURDERT,
+        IHendelseType.BEHANDLING_TRYGDETID_OPPDATERT,
+        IHendelseType.BEHANDLING_BEREGNET,
+        IHendelseType.BEHANDLING_AVKORTET,
+      ].includes(hendelse.hendelse)
+    )
+    .sort((a, b) => (a.opprettet > b.opprettet ? 1 : -1))
+
+  return hendelserSortert[hendelserSortert.length - 1]
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Brev.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Brev.ts
@@ -5,6 +5,7 @@ export interface IBrev {
   prosessType: BrevProsessType
   soekerFnr: string
   status: BrevStatus
+  statusEndret: string
   mottaker: Mottaker
   opprettet: string
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/BehandlingReducer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/BehandlingReducer.ts
@@ -19,6 +19,7 @@ import { RevurderingInfo } from '~shared/types/RevurderingInfo'
 
 export const setBehandling = createAction<IDetaljertBehandling>('behandling/set')
 export const resetBehandling = createAction('behandling/reset')
+export const oppdaterBehandling = createAction<IDetaljertBehandling>('behandling/oppdater')
 export const oppdaterGyldighetsproeving = createAction<IGyldighetResultat>('behandling/gyldighetsproeving')
 export const oppdaterVirkningstidspunkt = createAction<Virkningstidspunkt>('behandling/virkningstidspunkt')
 export const updateVilkaarsvurdering = createAction<IVilkaarsvurdering | undefined>(
@@ -58,6 +59,9 @@ const initialState: { behandling: IBehandlingReducer | null } = {
 export const behandlingReducer = createReducer(initialState, (builder) => {
   builder.addCase(setBehandling, (state, action) => {
     state.behandling = action.payload
+  })
+  builder.addCase(oppdaterBehandling, (state, action) => {
+    state.behandling = { ...state.behandling, ...action.payload }
   })
   builder.addCase(updateVilkaarsvurdering, (state, action) => {
     state.behandling!!.vilkårsprøving = action.payload


### PR DESCRIPTION
Videreføring av sjekken som ble gjort tidligere for å finne ut om en behandling har blitt endret etter at brev sist ble opprettet / lagret, men med noen endringer:
- Lagt på felt i vedtaksbrev `statusEndret` som gir hvilket tidspunkt siste statushendelse i brev oppsto. Dette endres feks hver gang et brev tilbakestilles, eller lagres.
- Når det trykkes på `Tilbakestill`, vil advarselen om at brevet er utdatert fjernes.
- Henter behandling når man går inn på brev for å sikre at vi har alle hendelser. 

![Skjermbilde 2023-11-09 kl  21 34 46](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/525715/f0322bd7-0e52-4756-b753-c6543777ccd1)
