### PR TITLE
Legger sjekk av trygdetidsberegning bak feature-toggle

### DIFF
--- a/apps/etterlatte-trygdetid/.run/etterlatte-trygdetid.dev-gcp.run.xml
+++ b/apps/etterlatte-trygdetid/.run/etterlatte-trygdetid.dev-gcp.run.xml
@@ -3,6 +3,7 @@
     <envs>
       <env name="HTTP_PORT" value="8088" />
       <env name="LOGBACK_APPENDER" value="STDOUT" />
+      <env name="NAIS_APP_NAME" value="etterlatte-trygdetid" />
       <env name="DB_JDBC_URL" value="jdbc:postgresql://localhost:5434/postgres" />
       <env name="DB_PASSWORD" value="postgres" />
       <env name="DB_USERNAME" value="postgres" />

--- a/apps/etterlatte-trygdetid/build.gradle.kts
+++ b/apps/etterlatte-trygdetid/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(project(":libs:etterlatte-database"))
     implementation(project(":libs:etterlatte-trygdetid-model"))
     implementation(project(":libs:ktor2client-onbehalfof"))
+    implementation(project(":libs:etterlatte-funksjonsbrytere"))
 
     implementation(libs.ktor2.servercio)
     implementation(libs.database.kotliquery)

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -2,6 +2,8 @@ package no.nav.etterlatte.trygdetid
 
 import com.fasterxml.jackson.databind.JsonNode
 import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggle
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
@@ -27,6 +29,13 @@ import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.time.temporal.TemporalAdjusters
 import java.util.UUID
+
+enum class TrygdetidFeatureToggle(private val key: String) : FeatureToggle {
+    BrukFaktiskTrygdetid("pensjon-etterlatte.bp-bruk-faktisk-trygdetid"),
+    ;
+
+    override fun key() = key
+}
 
 interface TrygdetidService {
     suspend fun hentTrygdetid(
@@ -226,6 +235,7 @@ class TrygdetidServiceImpl(
     private val grunnlagKlient: GrunnlagKlient,
     private val vilkaarsvurderingKlient: VilkaarsvuderingKlient,
     private val beregnTrygdetidService: TrygdetidBeregningService,
+    private val featureToggleService: FeatureToggleService,
 ) : GammelTrygdetidServiceMedNy {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -614,12 +624,21 @@ class TrygdetidServiceImpl(
             val trygdetider = trygdetidRepository.hentTrygdetiderForBehandling(behandlingId)
             val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
 
-            if (trygdetider.isEmpty()) {
-                throw IngenTrygdetidFunnetForAvdoede()
-            }
+            val brukFaktiskTrygdetid =
+                featureToggleService.isEnabled(
+                    TrygdetidFeatureToggle.BrukFaktiskTrygdetid,
+                    false,
+                )
+            logger.info("BrukFaktiskTrygdetid = $brukFaktiskTrygdetid")
 
-            if (trygdetider.any { it.beregnetTrygdetid == null }) {
-                throw TrygdetidManglerBeregning()
+            if (brukFaktiskTrygdetid) {
+                if (trygdetider.isEmpty()) {
+                    throw IngenTrygdetidFunnetForAvdoede()
+                }
+
+                if (trygdetider.any { it.beregnetTrygdetid == null }) {
+                    throw TrygdetidManglerBeregning()
+                }
             }
 
             // Dersom forrige steg (vilkårsvurdering) har blitt endret vil statusen være VILKAARSVURDERT. Når man

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/config/ApplicationContext.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/config/ApplicationContext.kt
@@ -2,6 +2,8 @@ package no.nav.etterlatte.trygdetid.config
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggleProperties
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.ktor.httpClient
 import no.nav.etterlatte.trygdetid.KodeverkService
@@ -35,7 +37,15 @@ class ApplicationContext {
             grunnlagKlient = grunnlagKlient,
             vilkaarsvurderingKlient = vilkaarsvurderingKlient,
             beregnTrygdetidService = TrygdetidBeregningService,
+            featureToggleService = FeatureToggleService.initialiser(featureToggleProperties(config)),
         )
     private val avtaleRepository = AvtaleRepository(dataSource)
     val avtaleService = AvtaleService(avtaleRepository)
 }
+
+private fun featureToggleProperties(config: Config) =
+    FeatureToggleProperties(
+        applicationName = config.getString("funksjonsbrytere.unleash.applicationName"),
+        host = config.getString("funksjonsbrytere.unleash.host"),
+        apiKey = config.getString("funksjonsbrytere.unleash.token"),
+    )

--- a/apps/etterlatte-trygdetid/src/main/resources/application.conf
+++ b/apps/etterlatte-trygdetid/src/main/resources/application.conf
@@ -22,3 +22,7 @@ vilkaarsvurdering.client.id = ${?ETTERLATTE_VILKAARSVURDERING_CLIENT_ID}
 vilkaarsvurdering.resource.url = ${?ETTERLATTE_VILKAARSVURDERING_URL}
 
 kodeverk.resource.url = ${?KODEVERK_URL}
+
+funksjonsbrytere.unleash.applicationName = ${?NAIS_APP_NAME}
+funksjonsbrytere.unleash.host = ${?UNLEASH_SERVER_API_URL}
+funksjonsbrytere.unleash.token = ${?UNLEASH_SERVER_API_TOKEN}


### PR DESCRIPTION
Ikke mulig å behandle saker forbi trygdetid i produksjon fordi det ikke finnes trygdetidsberegninger på fast trygdetid. Legger sjekkene bak feature-toggle inntil trygdetid skrus på i produksjon.