### PR TITLE
Samordning - korrigert rollesjekk ved OBO-token

### DIFF
--- a/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
@@ -85,6 +85,8 @@ spec:
       value: https://tp-api-q2.dev-fss-pub.nais.io
     - name: TJENESTEPENSJON_SCOPE
       value: api://dev-fss.pensjonsamhandling.tp-q2/.default
+    - name: ROLLE_PENSJONSAKSBEHANDLER
+      value: 8bb9b8d1-f46a-4ade-8ee8-5895eccdf8cf
   accessPolicy:
     inbound:
       rules:

--- a/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
@@ -83,6 +83,8 @@ spec:
       value: https://tp-api.prod-fss-pub.nais.io
     - name: TJENESTEPENSJON_SCOPE
       value: api://prod-fss.pensjonsamhandling.tp/.default
+    - name: ROLLE_PENSJONSAKSBEHANDLER
+      value: 0af3955f-df85-4eb0-b5b2-45bf2c8aeb9e
   accessPolicy:
     inbound:
       rules:

--- a/apps/etterlatte-samordning-vedtak/.run/etterlatte-samordning-vedtak.dev-gcp.run.xml
+++ b/apps/etterlatte-samordning-vedtak/.run/etterlatte-samordning-vedtak.dev-gcp.run.xml
@@ -5,6 +5,7 @@
       <env name="ETTERLATTE_VEDTAKSVURDERING_SCOPE" value="api://dev-gcp.etterlatte.etterlatte-vedtaksvurdering/.default" />
       <env name="TJENESTEPENSJON_URL" value="https://tp-api-q2.dev-fss-pub.nais.io" />
       <env name="TJENESTEPENSJON_SCOPE" value="api://dev-fss.pensjonsamhandling.tp-q2/.default" />
+      <env name="ROLLE_PENSJONSAKSBEHANDLER" value="8bb9b8d1-f46a-4ade-8ee8-5895eccdf8cf" />
       <env name="HTTP_PORT" value="8094" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="no.nav.etterlatte.ApplicationKt" />

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -39,7 +39,10 @@ class Server(applicationContext: ApplicationContext) {
                             sikkerLogg,
                             withMetrics = true,
                         ) {
-                            samordningVedtakRoute(samordningVedtakService = applicationContext.samordningVedtakService)
+                            samordningVedtakRoute(
+                                samordningVedtakService = applicationContext.samordningVedtakService,
+                                config = applicationContext.config,
+                            )
                             install(userIdMdcPlugin)
                             install(serverRequestLoggerPlugin)
                         }

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRoute.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRoute.kt
@@ -106,6 +106,12 @@ fun Route.samordningVedtakRoute(
 
             call.respond(samordningVedtakDtos)
         }
+
+        get("/ping") {
+            call.respond(
+                getMeta(),
+            )
+        }
     }
 }
 

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRoute.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRoute.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.samordning.vedtak
 
+import com.typesafe.config.Config
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
@@ -15,7 +16,10 @@ import no.nav.etterlatte.libs.ktor.MaskinportenScopeAuthorizationPlugin
 import no.nav.etterlatte.libs.ktor.hentTokenClaims
 import java.time.LocalDate
 
-fun Route.samordningVedtakRoute(samordningVedtakService: SamordningVedtakService) {
+fun Route.samordningVedtakRoute(
+    samordningVedtakService: SamordningVedtakService,
+    config: Config,
+) {
     route("api/vedtak") {
         install(MaskinportenScopeAuthorizationPlugin) {
             scopes = setOf("nav:etterlatteytelser:vedtaksinformasjon.read")
@@ -77,7 +81,7 @@ fun Route.samordningVedtakRoute(samordningVedtakService: SamordningVedtakService
 
     route("api/pensjon/vedtak") {
         install(AuthorizationPlugin) {
-            roles = setOf("les-oms-vedtak")
+            roles = setOf("les-oms-vedtak", config.getString("roller.pensjon-saksbehandler"))
         }
 
         get {

--- a/apps/etterlatte-samordning-vedtak/src/main/resources/application.conf
+++ b/apps/etterlatte-samordning-vedtak/src/main/resources/application.conf
@@ -30,3 +30,7 @@ tjenestepensjon {
     outbound = ${?TJENESTEPENSJON_SCOPE}
     client_id = ${?AZURE_APP_CLIENT_ID}
 }
+
+roller {
+    pensjon-saksbehandler = ${?ROLLE_PENSJONSAKSBEHANDLER}
+}

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/SamordningsvedtakRouteTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/SamordningsvedtakRouteTest.kt
@@ -92,7 +92,12 @@ class SamordningsvedtakRouteTest {
         server.issueToken(
             issuerId = AZURE_ISSUER,
             audience = CLIENT_ID,
-            claims = mapOf("roles" to roles),
+            claims =
+                mapOf(
+                    "roles" to roles,
+                    "sub" to "pensjon-pen",
+                    "oid" to "pensjon-pen",
+                ),
         ).serialize()
 
     private companion object {

--- a/libs/etterlatte-ktor/src/main/kotlin/AuthorizationPlugin.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/AuthorizationPlugin.kt
@@ -19,10 +19,8 @@ val AuthorizationPlugin =
         val roles = pluginConfig.roles
         pluginConfig.apply {
             on(AuthenticationChecked) { call ->
-                val userRoles =
-                    call.firstValidTokenClaims()?.getAsList("roles") ?: emptyList()
-
-                if (userRoles.intersect(roles).isEmpty()) {
+                val roller = call.brukerTokenInfo.roller
+                if (roller.intersect(roles).isEmpty()) {
                     application.log.info("Request avslått pga manglende rolle (gyldige: $roles)")
                     throw ForespoerselException(
                         status = HttpStatusCode.Unauthorized.value,


### PR DESCRIPTION
Opprinnelig løsning antok (feilaktig) at obo-tokens også får custom-role, men nei - naisdok'en er ganske tydelig egentlig.

Dette er i kontekst av at tjenesten kalles fra PSAK (saksbehandlerløsningen) _via_ backend PEN