### PR TITLE
Krever status TRYGDETID_OPPDATERT også ved fast trygdetid

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
@@ -145,12 +145,7 @@ class BehandlingStatusServiceImpl(
         brukerTokenInfo: BrukerTokenInfo,
         dryRun: Boolean,
     ) {
-        hentBehandling(behandlingId).tilBeregnet(
-            !featureToggleService.isEnabled(
-                BehandlingStatusServiceFeatureToggle.BrukFaktiskTrygdetid,
-                false,
-            ),
-        ).lagreEndring(dryRun, brukerTokenInfo.ident())
+        hentBehandling(behandlingId).tilBeregnet().lagreEndring(dryRun, brukerTokenInfo.ident())
     }
 
     override fun settAvkortet(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/AutomatiskRevurdering.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/AutomatiskRevurdering.kt
@@ -53,7 +53,7 @@ data class AutomatiskRevurdering(
 
     override fun tilTrygdetidOppdatert() = endreTilStatus(BehandlingStatus.TRYGDETID_OPPDATERT)
 
-    override fun tilBeregnet(fastTrygdetid: Boolean) = endreTilStatus(BehandlingStatus.BEREGNET)
+    override fun tilBeregnet() = endreTilStatus(BehandlingStatus.BEREGNET)
 
     override fun tilAvkortet() = endreTilStatus(BehandlingStatus.AVKORTET)
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
@@ -137,7 +137,7 @@ sealed class Behandling {
         throw BehandlingStoetterIkkeStatusEndringException(TRYGDETID_OPPDATERT)
     }
 
-    open fun tilBeregnet(fastTrygdetid: Boolean): Behandling {
+    open fun tilBeregnet(): Behandling {
         throw BehandlingStoetterIkkeStatusEndringException(BEREGNET)
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Foerstegangsbehandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Foerstegangsbehandling.kt
@@ -77,23 +77,14 @@ data class Foerstegangsbehandling(
             ),
         ) { endreTilStatus(BehandlingStatus.TRYGDETID_OPPDATERT) }
 
-    override fun tilBeregnet(fastTrygdetid: Boolean): Foerstegangsbehandling =
+    override fun tilBeregnet(): Foerstegangsbehandling =
         hvisTilstandEr(
-            if (fastTrygdetid) {
-                listOf(
-                    BehandlingStatus.VILKAARSVURDERT,
-                    BehandlingStatus.BEREGNET,
-                    BehandlingStatus.AVKORTET,
-                    BehandlingStatus.RETURNERT,
-                )
-            } else {
-                listOf(
-                    BehandlingStatus.TRYGDETID_OPPDATERT,
-                    BehandlingStatus.BEREGNET,
-                    BehandlingStatus.AVKORTET,
-                    BehandlingStatus.RETURNERT,
-                )
-            },
+            listOf(
+                BehandlingStatus.TRYGDETID_OPPDATERT,
+                BehandlingStatus.BEREGNET,
+                BehandlingStatus.AVKORTET,
+                BehandlingStatus.RETURNERT,
+            ),
         ) { endreTilStatus(BehandlingStatus.BEREGNET) }
 
     override fun tilAvkortet(): Foerstegangsbehandling =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ManuellRevurdering.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ManuellRevurdering.kt
@@ -82,9 +82,9 @@ data class ManuellRevurdering(
             ),
         ) { endreTilStatus(BehandlingStatus.TRYGDETID_OPPDATERT) }
 
-    override fun tilBeregnet(fastTrygdetid: Boolean) =
+    override fun tilBeregnet() =
         hvisTilstandEr(
-            if (fastTrygdetid || this.revurderingsaarsak.girOpphoer()) {
+            if (this.revurderingsaarsak.girOpphoer()) {
                 listOf(
                     BehandlingStatus.VILKAARSVURDERT,
                     BehandlingStatus.BEREGNET,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ManueltOpphoer.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ManueltOpphoer.kt
@@ -37,7 +37,7 @@ data class ManueltOpphoer(
     override val kommerBarnetTilgode: KommerBarnetTilgode?
         get() = null
 
-    override fun tilBeregnet(fastTrygdetid: Boolean): ManueltOpphoer =
+    override fun tilBeregnet(): ManueltOpphoer =
         hvisTilstandEr(
             listOf(
                 BehandlingStatus.OPPRETTET,

--- a/apps/etterlatte-behandling/src/test/kotlin/OmregningIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/OmregningIntegrationTest.kt
@@ -100,7 +100,7 @@ class OmregningIntegrationTest : BehandlingIntegrationTest() {
                     .oppdaterVirkningstidspunkt(virkningstidspunkt)
                     .tilVilkaarsvurdert()
                     .tilTrygdetidOppdatert()
-                    .tilBeregnet(false)
+                    .tilBeregnet()
                     .tilFattetVedtak()
                     .tilAttestert()
                     .tilIverksatt()

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingTest.kt
@@ -74,7 +74,7 @@ internal class BehandlingTest {
                 .oppdaterGyldighetsproeving(gyldighetsResultat)
                 .tilVilkaarsvurdert()
                 .tilTrygdetidOppdatert()
-                .tilBeregnet(false)
+                .tilBeregnet()
                 .tilFattetVedtak()
 
         assertThrows<TilstandException.UgyldigTilstand> {
@@ -90,7 +90,7 @@ internal class BehandlingTest {
                 .oppdaterGyldighetsproeving(gyldighetsResultat)
                 .tilVilkaarsvurdert()
                 .tilTrygdetidOppdatert()
-                .tilBeregnet(false)
+                .tilBeregnet()
                 .tilFattetVedtak()
                 .tilAttestert()
                 .tilIverksatt()
@@ -138,7 +138,7 @@ internal class BehandlingTest {
                 .oppdaterGyldighetsproeving(gyldighetsResultat)
                 .tilVilkaarsvurdert()
                 .tilTrygdetidOppdatert()
-                .tilBeregnet(false)
+                .tilBeregnet()
                 .tilFattetVedtak()
                 .tilReturnert()
 
@@ -175,11 +175,11 @@ internal class BehandlingTest {
                 .oppdaterGyldighetsproeving(gyldighetsResultat)
                 .tilVilkaarsvurdert()
                 .tilTrygdetidOppdatert()
-                .tilBeregnet(false)
+                .tilBeregnet()
                 .tilFattetVedtak()
 
         initialBehandling.tilReturnert().tilFattetVedtak()
-        initialBehandling.tilReturnert().tilBeregnet(false)
+        initialBehandling.tilReturnert().tilBeregnet()
         initialBehandling.tilReturnert().tilVilkaarsvurdert()
         initialBehandling.tilReturnert().tilTrygdetidOppdatert()
         initialBehandling.tilReturnert().tilOpprettet()
@@ -193,7 +193,7 @@ internal class BehandlingTest {
                 .oppdaterGyldighetsproeving(gyldighetsResultat)
                 .tilVilkaarsvurdert()
                 .tilTrygdetidOppdatert()
-                .tilBeregnet(false)
+                .tilBeregnet()
                 .tilFattetVedtak()
                 .tilReturnert()
 
@@ -210,7 +210,7 @@ internal class BehandlingTest {
                 .oppdaterGyldighetsproeving(gyldighetsResultat)
                 .tilVilkaarsvurdert()
                 .tilTrygdetidOppdatert()
-                .tilBeregnet(false)
+                .tilBeregnet()
                 .tilFattetVedtak()
                 .tilReturnert()
 
@@ -220,44 +220,23 @@ internal class BehandlingTest {
     }
 
     @Test
-    fun `kan gaa fra VILKAARSVURDERT til BEREGNET ved fast trygdetid`() {
-        behandling
-            .oppdaterVirkningstidspunkt(virkningstidspunkt)
-            .oppdaterGyldighetsproeving(gyldighetsResultat)
-            .tilVilkaarsvurdert()
-            .tilBeregnet(true)
-    }
-
-    @Test
-    fun `kan ikke gaa fra VILKAARSVURDERT til TRYGDETID_OPPRETTET ved fast trygdetid`() {
-        assertThrows<TilstandException.UgyldigTilstand> {
-            behandling
-                .oppdaterVirkningstidspunkt(virkningstidspunkt)
-                .oppdaterGyldighetsproeving(gyldighetsResultat)
-                .tilVilkaarsvurdert()
-                .tilTrygdetidOppdatert()
-                .tilBeregnet(true)
-        }
-    }
-
-    @Test
-    fun `kan gaa fra VILKAARSVURDERT til TRYGDETID_OPPRETTET ved faktisk trygdetid`() {
+    fun `kan gaa fra VILKAARSVURDERT til TRYGDETID_OPPRETTET`() {
         behandling
             .oppdaterVirkningstidspunkt(virkningstidspunkt)
             .oppdaterGyldighetsproeving(gyldighetsResultat)
             .tilVilkaarsvurdert()
             .tilTrygdetidOppdatert()
-            .tilBeregnet(false)
+            .tilBeregnet()
     }
 
     @Test
-    fun `kan ikke gaa fra VILKAARSVURDERT til BEREGNET ved faktisk trygdetid`() {
+    fun `kan ikke gaa fra VILKAARSVURDERT til BEREGNET`() {
         assertThrows<TilstandException.UgyldigTilstand> {
             behandling
                 .oppdaterVirkningstidspunkt(virkningstidspunkt)
                 .oppdaterGyldighetsproeving(gyldighetsResultat)
                 .tilVilkaarsvurdert()
-                .tilBeregnet(false)
+                .tilBeregnet()
         }
     }
 }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/domain/RevurderingTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/domain/RevurderingTest.kt
@@ -45,8 +45,8 @@ internal class RevurderingTest {
             kilde = Vedtaksloesning.GJENNY,
             revurderingInfo = null,
             begrunnelse = null,
-        ).tilVilkaarsvurdert().tilTrygdetidOppdatert().tilBeregnet(false)
-            .tilVilkaarsvurdert().tilTrygdetidOppdatert().tilBeregnet(false).tilFattetVedtak().tilAttestert()
+        ).tilVilkaarsvurdert().tilTrygdetidOppdatert().tilBeregnet()
+            .tilVilkaarsvurdert().tilTrygdetidOppdatert().tilBeregnet().tilFattetVedtak().tilAttestert()
             .tilIverksatt()
     }
 
@@ -57,7 +57,7 @@ internal class RevurderingTest {
         @Test
         fun `kan endre status gjennom gyldig statusendringsflyt`() {
             val actual =
-                revurdering.tilVilkaarsvurdert().tilTrygdetidOppdatert().tilBeregnet(false).tilFattetVedtak()
+                revurdering.tilVilkaarsvurdert().tilTrygdetidOppdatert().tilBeregnet().tilFattetVedtak()
                     .tilAttestert().tilIverksatt()
 
             Assertions.assertEquals(BehandlingStatus.IVERKSATT, actual.status)
@@ -66,7 +66,7 @@ internal class RevurderingTest {
         @Test
         fun `kan endre status gjennom gyldig statusendringsflyt - samordning`() {
             val actual =
-                revurdering.tilVilkaarsvurdert().tilTrygdetidOppdatert().tilBeregnet(false).tilFattetVedtak()
+                revurdering.tilVilkaarsvurdert().tilTrygdetidOppdatert().tilBeregnet().tilFattetVedtak()
                     .tilAttestert().tilTilSamordning().tilSamordnet().tilIverksatt()
 
             Assertions.assertEquals(BehandlingStatus.IVERKSATT, actual.status)
@@ -74,7 +74,7 @@ internal class RevurderingTest {
 
         @Test
         fun `opprettet kan ikke gaa til andre statuser enn vilkaarsvurdert og opprettet`() {
-            assertThrows<TilstandException.UgyldigTilstand> { revurdering.tilBeregnet(false) }
+            assertThrows<TilstandException.UgyldigTilstand> { revurdering.tilBeregnet() }
             assertThrows<TilstandException.UgyldigTilstand> { revurdering.tilFattetVedtak() }
             assertThrows<TilstandException.UgyldigTilstand> { revurdering.tilIverksatt() }
             assertThrows<TilstandException.UgyldigTilstand> { revurdering.tilReturnert() }
@@ -87,7 +87,7 @@ internal class RevurderingTest {
         fun `vilkaarsvurdert kan ikke gaa til andre statuser enn trygdetid oppdatert og opprettet`() {
             val vilkaarsvurdert = revurdering.tilVilkaarsvurdert()
 
-            assertThrows<TilstandException.UgyldigTilstand> { vilkaarsvurdert.tilBeregnet(false) }
+            assertThrows<TilstandException.UgyldigTilstand> { vilkaarsvurdert.tilBeregnet() }
             assertThrows<TilstandException.UgyldigTilstand> { vilkaarsvurdert.tilFattetVedtak() }
             assertThrows<TilstandException.UgyldigTilstand> { vilkaarsvurdert.tilIverksatt() }
             assertThrows<TilstandException.UgyldigTilstand> { vilkaarsvurdert.tilReturnert() }
@@ -107,12 +107,12 @@ internal class RevurderingTest {
             assertDoesNotThrow { trygdetidOppdatert.tilOpprettet() }
             assertDoesNotThrow { trygdetidOppdatert.tilVilkaarsvurdert() }
             assertDoesNotThrow { trygdetidOppdatert.tilTrygdetidOppdatert() }
-            assertDoesNotThrow { trygdetidOppdatert.tilBeregnet(false) }
+            assertDoesNotThrow { trygdetidOppdatert.tilBeregnet() }
         }
 
         @Test
         fun beregnet() {
-            val beregnet = revurdering.tilVilkaarsvurdert().tilTrygdetidOppdatert().tilBeregnet(false)
+            val beregnet = revurdering.tilVilkaarsvurdert().tilTrygdetidOppdatert().tilBeregnet()
 
             assertThrows<TilstandException.UgyldigTilstand> { beregnet.tilReturnert() }
             assertThrows<TilstandException.UgyldigTilstand> { beregnet.tilIverksatt() }
@@ -121,8 +121,8 @@ internal class RevurderingTest {
             assertDoesNotThrow { beregnet.tilVilkaarsvurdert() }
             assertDoesNotThrow { beregnet.tilTrygdetidOppdatert() }
             assertDoesNotThrow { beregnet.tilTrygdetidOppdatert() }
-            assertDoesNotThrow { beregnet.tilBeregnet(false) }
-            assertDoesNotThrow { beregnet.tilBeregnet(false) }
+            assertDoesNotThrow { beregnet.tilBeregnet() }
+            assertDoesNotThrow { beregnet.tilBeregnet() }
             assertDoesNotThrow { beregnet.tilFattetVedtak() }
         }
     }
@@ -150,13 +150,13 @@ internal class RevurderingTest {
 
         @Test
         fun beregnet() {
-            val beregnet = revurdering.tilVilkaarsvurdert().tilTrygdetidOppdatert().tilBeregnet(false)
+            val beregnet = revurdering.tilVilkaarsvurdert().tilTrygdetidOppdatert().tilBeregnet()
             assertKanGaaTilAlleStatuser(beregnet)
         }
 
         @Test
         fun fattet() {
-            val fattet = revurdering.tilVilkaarsvurdert().tilTrygdetidOppdatert().tilBeregnet(false).tilFattetVedtak()
+            val fattet = revurdering.tilVilkaarsvurdert().tilTrygdetidOppdatert().tilBeregnet().tilFattetVedtak()
             assertKanGaaTilAlleStatuser(fattet)
         }
 
@@ -170,7 +170,7 @@ internal class RevurderingTest {
                 BehandlingStatus.TRYGDETID_OPPDATERT,
                 revurdering.tilTrygdetidOppdatert().status,
             )
-            Assertions.assertEquals(BehandlingStatus.BEREGNET, revurdering.tilBeregnet(false).status)
+            Assertions.assertEquals(BehandlingStatus.BEREGNET, revurdering.tilBeregnet().status)
             Assertions.assertEquals(BehandlingStatus.FATTET_VEDTAK, revurdering.tilFattetVedtak().status)
             Assertions.assertEquals(BehandlingStatus.ATTESTERT, revurdering.tilAttestert().status)
             Assertions.assertEquals(BehandlingStatus.RETURNERT, revurdering.tilReturnert().status)


### PR DESCRIPTION
Siden statusen TRYGDETID_OPPDATERT settes når man trykker "Neste" i trygdetidssteget, må denne også tillates i behandling. Dvs, ingen mulighet til å lenger gå direkte fra VILKAARSVURDERT til BEREGNET.