### PR TITLE
Ingen feilmelding ved 404 fra avkorting

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { isErrorWithCode, isPendingOrInitial, useApiCall } from '~shared/hooks/useApiCall'
+import { isFailure, isPendingOrInitial, useApiCall } from '~shared/hooks/useApiCall'
 import { hentAvkorting } from '~shared/api/avkorting'
 import React, { useEffect, useState } from 'react'
 import { IAvkorting } from '~shared/types/IAvkorting'
@@ -44,7 +44,9 @@ export const Avkorting = (props: { behandling: IBehandlingReducer }) => {
         />
       )}
       {isPendingOrInitial(avkortingStatus) && <Spinner visible label="Henter avkorting" />}
-      {isErrorWithCode(avkortingStatus, 404) && <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>}
+      {isFailure(avkortingStatus) && avkortingStatus.error.status !== 404 && (
+        <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>
+      )}
     </AvkortingWrapper>
   )
 }


### PR DESCRIPTION
Det skal ikke vises noen 404-feil når det ikke finnes avkorting. Da returnerer backend 404 som er en gyldig status i dette tilfellet.