### PR TITLE
EY-3109 Fjerner rediger-knapp i avkorting og aktivitetsplikt

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
@@ -13,7 +13,7 @@ import Spinner from '~shared/Spinner'
 import { useBehandlingRoutes } from '~components/behandling/BehandlingRoutes'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { AktivitetspliktOppfolging } from '~shared/types/Aktivitetsplikt'
-import { erFerdigBehandlet } from '~components/behandling/felles/utils'
+import { hentBehandlesFraStatus } from '~components/behandling/felles/utils'
 import { handlinger } from '~components/behandling/handlinger/typer'
 
 export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => {
@@ -21,7 +21,7 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
   const { next } = useBehandlingRoutes()
 
   const avdoedesDoedsdato = behandling?.familieforhold?.avdoede?.opplysning?.doedsdato
-  const ferdigBehandlet = erFerdigBehandlet(behandling.status)
+  const redigerbar = hentBehandlesFraStatus(behandling.status)
   const configContext = useContext(ConfigContext)
 
   const [beskrivelse, setBeskrivelse] = useState<string>('')
@@ -76,7 +76,7 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
         {!isPending(hentet) && aktivitetOppfolging && (
           <SpacingWrapper>
             <BodyLong>{aktivitetOppfolging.aktivitet}</BodyLong>
-            {!ferdigBehandlet && (
+            {redigerbar && (
               <Button variant="tertiary" icon={<PencilIcon />} onClick={() => edit()}>
                 Rediger
               </Button>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
@@ -10,17 +10,22 @@ import { YtelseEtterAvkorting } from '~components/behandling/avkorting/YtelseEtt
 import { IBehandlingReducer, oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'
 import { useAppDispatch } from '~store/Store'
 import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
+import { hentBehandlesFraStatus } from '~components/behandling/felles/utils'
 
 export const Avkorting = (props: { behandling: IBehandlingReducer }) => {
   const behandling = props.behandling
   const dispatch = useAppDispatch()
   const [avkortingStatus, hentAvkortingRequest] = useApiCall(hentAvkorting)
   const [avkorting, setAvkorting] = useState<IAvkorting>()
+  const redigerbar = hentBehandlesFraStatus(behandling.status)
 
   useEffect(() => {
     if (!avkorting) {
       hentAvkortingRequest(behandling.id, (res) => {
-        dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.AVKORTET))
+        const avkortingFinnesOgErUnderBehandling = res && redigerbar
+        if (avkortingFinnesOgErUnderBehandling) {
+          dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.AVKORTET))
+        }
         setAvkorting(res)
       })
     }
@@ -33,6 +38,7 @@ export const Avkorting = (props: { behandling: IBehandlingReducer }) => {
           behandling={behandling}
           avkortingGrunnlag={avkorting == null ? [] : avkorting.avkortingGrunnlag}
           setAvkorting={setAvkorting}
+          redigerbar={redigerbar}
         />
       )}
       {avkorting && (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -9,7 +9,6 @@ import { HjemmelLenke } from '~components/behandling/felles/HjemmelLenke'
 import { Info } from '~components/behandling/soeknadsoversikt/Info'
 import { IBehandlingReducer } from '~store/reducers/BehandlingReducer'
 import { PencilIcon } from '@navikt/aksel-icons'
-import { hentBehandlesFraStatus } from '~components/behandling/felles/utils'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { TextButton } from '~components/behandling/soeknadsoversikt/familieforhold/personer/personinfo/TextButton'
 import { OmstillingsstoenadToolTip } from '~components/behandling/beregne/OmstillingsstoenadToolTip'
@@ -17,13 +16,14 @@ import { OmstillingsstoenadToolTip } from '~components/behandling/beregne/Omstil
 export const AvkortingInntekt = (props: {
   behandling: IBehandlingReducer
   avkortingGrunnlag: IAvkortingGrunnlag[]
+  redigerbar: boolean
   setAvkorting: (avkorting: IAvkorting) => void
 }) => {
   const behandling = props.behandling
+  const redigerbar = props.redigerbar
   const avkortingGrunnlag = [...props.avkortingGrunnlag]
   avkortingGrunnlag?.sort((a, b) => new Date(b.fom!).getTime() - new Date(a.fom!).getTime())
 
-  const redigerbar = hentBehandlesFraStatus(behandling.status)
   if (!behandling) throw new Error('Mangler behandling')
 
   const virkningstidspunkt = () => {


### PR DESCRIPTION
- Fjerner redigerknapp i aktivtetsplikt, også når behandlingen har status "FATTET_VEDTAK"
- Oppdaterer behandlingstatus i frontend til AVKORTET kun når vi er i redigeringsmodus og det finnes en avkorting