### PR TITLE
EY-3087 - Mulighet for å pause migrering etter fattet vedtak

### DIFF
--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/Application.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/Application.kt
@@ -8,6 +8,7 @@ import no.nav.etterlatte.migrering.LagreKoblingRiver
 import no.nav.etterlatte.migrering.LyttPaaIverksattVedtakRiver
 import no.nav.etterlatte.migrering.MigrerSpesifikkSakRiver
 import no.nav.etterlatte.migrering.MigreringRiver
+import no.nav.etterlatte.migrering.PauseMigreringRiver
 import no.nav.helse.rapids_rivers.RapidApplication
 import rapidsandrivers.getRapidEnv
 
@@ -33,6 +34,7 @@ internal class Server(private val context: ApplicationContext) {
                     krrKlient,
                 )
                 LagreKoblingRiver(rapidsConnection, pesysRepository)
+                PauseMigreringRiver(rapidsConnection, pesysRepository)
                 LyttPaaIverksattVedtakRiver(rapidsConnection, pesysRepository, penklient, featureToggleService)
                 FeilendeMigreringLytterRiver(rapidsConnection, pesysRepository)
             }.start()

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/MigreringRiver.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/MigreringRiver.kt
@@ -3,9 +3,11 @@ package no.nav.etterlatte.migrering
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
 import no.nav.etterlatte.rapidsandrivers.migrering.LOPENDE_JANUAR_2024_KEY
+import no.nav.etterlatte.rapidsandrivers.migrering.MIGRERING_KJORING_VARIANT
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser.MIGRER_SPESIFIKK_SAK
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser.START_MIGRERING
 import no.nav.etterlatte.rapidsandrivers.migrering.loependeJanuer2024
+import no.nav.etterlatte.rapidsandrivers.migrering.migreringKjoringVariant
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
@@ -23,6 +25,7 @@ internal class MigreringRiver(rapidsConnection: RapidsConnection) :
         initialiserRiver(rapidsConnection, hendelsestype) {
             validate { it.requireKey(SAK_ID_FLERE_KEY) }
             validate { it.requireKey(LOPENDE_JANUAR_2024_KEY) }
+            validate { it.requireKey(MIGRERING_KJORING_VARIANT) }
         }
     }
 
@@ -39,6 +42,7 @@ internal class MigreringRiver(rapidsConnection: RapidsConnection) :
                         EVENT_NAME_KEY to MIGRER_SPESIFIKK_SAK,
                         SAK_ID_KEY to it,
                         LOPENDE_JANUAR_2024_KEY to packet.loependeJanuer2024,
+                        MIGRERING_KJORING_VARIANT to packet.migreringKjoringVariant.name,
                     ),
                 )
             context.publish(melding.toJson())

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/Migreringsstatus.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/Migreringsstatus.kt
@@ -4,6 +4,7 @@ enum class Migreringsstatus {
     HENTA,
     VERIFISERING_FEILA,
     UNDER_MIGRERING,
+    PAUSE,
     FERDIG,
     MIGRERING_FEILA,
     UTBETALING_FEILA,

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/PauseMigreringRiver.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/PauseMigreringRiver.kt
@@ -1,0 +1,31 @@
+package no.nav.etterlatte.migrering
+
+import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser
+import no.nav.etterlatte.rapidsandrivers.migrering.PESYS_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.migrering.pesysId
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.MessageContext
+import no.nav.helse.rapids_rivers.RapidsConnection
+import org.slf4j.LoggerFactory
+import rapidsandrivers.migrering.ListenerMedLoggingOgFeilhaandtering
+
+internal class PauseMigreringRiver(rapidsConnection: RapidsConnection, private val pesysRepository: PesysRepository) :
+    ListenerMedLoggingOgFeilhaandtering(Migreringshendelser.PAUSE) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    init {
+        initialiserRiver(rapidsConnection, hendelsestype) {
+            validate { it.requireKey(PESYS_ID_KEY) }
+        }
+    }
+
+    override fun haandterPakke(
+        packet: JsonMessage,
+        context: MessageContext,
+    ) {
+        val pesysId = packet.pesysId
+        logger.info("migrering har fattet vedtak og skal sette status til pause pesyssak=$pesysId")
+        pesysRepository.oppdaterStatus(pesysId, Migreringsstatus.PAUSE)
+        logger.info("migrering har satt status til pause pesyssak=$pesysId")
+    }
+}

--- a/apps/etterlatte-migrering/src/test/kotlin/migrering/MigreringRiverIntegrationTest.kt
+++ b/apps/etterlatte-migrering/src/test/kotlin/migrering/MigreringRiverIntegrationTest.kt
@@ -275,6 +275,7 @@ internal class MigreringRiverIntegrationTest {
                                     repository,
                                     featureToggleService,
                                 ),
+                            krrKlient = mockk<KrrKlient>().also { coEvery { it.hentDigitalKontaktinformasjon(any()) } returns null },
                         )
                         LagreKoblingRiver(this, repository)
                         PauseMigreringRiver(this, repository)

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/VedtakService.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/VedtakService.kt
@@ -5,11 +5,15 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.patch
 import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.vedtak.LoependeYtelseDTO
 import no.nav.etterlatte.libs.common.vedtak.VedtakDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakNyDto
+import no.nav.etterlatte.rapidsandrivers.migrering.MigreringKjoringVariant
 import no.nav.etterlatte.vedtaksvurdering.VedtakOgRapid
 import java.time.LocalDate
 import java.util.UUID
@@ -24,6 +28,12 @@ interface VedtakService {
         sakId: Long,
         behandlingId: UUID,
     ): VedtakOgRapid
+
+    fun opprettVedtakFattOgAttester(
+        sakId: Long,
+        behandlingId: UUID,
+        kjoringVariant: MigreringKjoringVariant,
+    ): VedtakNyDto
 
     fun tilbakestillVedtak(behandlingId: UUID)
 
@@ -49,6 +59,18 @@ class VedtakServiceImpl(private val vedtakKlient: HttpClient, private val url: S
     ): VedtakOgRapid =
         runBlocking {
             vedtakKlient.post("$url/api/vedtak/$sakId/$behandlingId/automatisk").body()
+        }
+
+    override fun opprettVedtakFattOgAttester(
+        sakId: Long,
+        behandlingId: UUID,
+        kjoringVariant: MigreringKjoringVariant,
+    ): VedtakNyDto =
+        runBlocking {
+            vedtakKlient.post("$url/api/vedtak/$sakId/$behandlingId/automatisk/stegvis") {
+                contentType(ContentType.Application.Json)
+                setBody(kjoringVariant.toJson())
+            }.body()
         }
 
     override fun tilbakestillVedtak(behandlingId: UUID) {

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/VedtakService.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/VedtakService.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.vedtak.LoependeYtelseDTO
 import no.nav.etterlatte.libs.common.vedtak.VedtakDto
-import no.nav.etterlatte.libs.common.vedtak.VedtakNyDto
 import no.nav.etterlatte.rapidsandrivers.migrering.MigreringKjoringVariant
 import no.nav.etterlatte.vedtaksvurdering.VedtakOgRapid
 import java.time.LocalDate
@@ -33,7 +32,7 @@ interface VedtakService {
         sakId: Long,
         behandlingId: UUID,
         kjoringVariant: MigreringKjoringVariant,
-    ): VedtakNyDto
+    ): VedtakOgRapid
 
     fun tilbakestillVedtak(behandlingId: UUID)
 
@@ -65,7 +64,7 @@ class VedtakServiceImpl(private val vedtakKlient: HttpClient, private val url: S
         sakId: Long,
         behandlingId: UUID,
         kjoringVariant: MigreringKjoringVariant,
-    ): VedtakNyDto =
+    ): VedtakOgRapid =
         runBlocking {
             vedtakKlient.post("$url/api/vedtak/$sakId/$behandlingId/automatisk/stegvis") {
                 contentType(ContentType.Application.Json)

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/MigreringHendelserRiverTest.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/MigreringHendelserRiverTest.kt
@@ -1,28 +1,39 @@
-
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import no.nav.etterlatte.MigreringHendelserRiver
 import no.nav.etterlatte.VedtakService
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
 import no.nav.etterlatte.libs.common.sak.VedtakSak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vedtak.Behandling
-import no.nav.etterlatte.libs.common.vedtak.VedtakDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakInnholdDto
-import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseType
 import no.nav.etterlatte.libs.common.vedtak.VedtakNyDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseType
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
+import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.rapidsandrivers.EventNames
+import no.nav.etterlatte.rapidsandrivers.migrering.AvdoedForelder
+import no.nav.etterlatte.rapidsandrivers.migrering.Beregning
+import no.nav.etterlatte.rapidsandrivers.migrering.BeregningMeta
+import no.nav.etterlatte.rapidsandrivers.migrering.Enhet
+import no.nav.etterlatte.rapidsandrivers.migrering.MIGRERING_KJORING_VARIANT
+import no.nav.etterlatte.rapidsandrivers.migrering.MigreringKjoringVariant
+import no.nav.etterlatte.rapidsandrivers.migrering.MigreringRequest
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser
+import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser.PAUSE
+import no.nav.etterlatte.rapidsandrivers.migrering.PesysId
+import no.nav.etterlatte.rapidsandrivers.migrering.Trygdetid
 import no.nav.etterlatte.vedtaksvurdering.RapidInfo
 import no.nav.etterlatte.vedtaksvurdering.VedtakOgRapid
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import rapidsandrivers.BEHANDLING_ID_KEY
 import rapidsandrivers.SAK_ID_KEY
@@ -41,73 +52,149 @@ class MigreringHendelserRiverTest {
                 mapOf(
                     BEHANDLING_ID_KEY to "a9d42eb9-561f-4320-8bba-2ba600e66e21",
                     SAK_ID_KEY to "1",
+                    MIGRERING_KJORING_VARIANT to MigreringKjoringVariant.FULL_KJORING,
                 ),
             )
         coEvery {
-            vedtakService.opprettVedtakFattOgAttester(any(), any())
+            vedtakService.opprettVedtakFattOgAttester(any(), any(), any())
         } throws RuntimeException("Feila under opprett vedtak")
 
         inspector.sendTestMessage(melding.toJson())
 
-        Assertions.assertEquals(1, inspector.inspektør.size)
+        assertEquals(1, inspector.inspektør.size)
         val sendtMelding = inspector.inspektør.message(0)
-        Assertions.assertEquals(sendtMelding.get(EVENT_NAME_KEY).asText(), EventNames.FEILA)
+        assertEquals(sendtMelding.get(EVENT_NAME_KEY).asText(), EventNames.FEILA)
     }
 
     @Test
     fun `oppretter vedtak, fatter vedtak og attesterer`() {
-        val behandlingId = "a9d42eb9-561f-4320-8bba-2ba600e66e21"
         val melding =
             JsonMessage.newMessage(
                 Migreringshendelser.VEDTAK,
                 mapOf(
                     BEHANDLING_ID_KEY to behandlingId,
                     SAK_ID_KEY to "1",
+                    MIGRERING_KJORING_VARIANT to MigreringKjoringVariant.FULL_KJORING,
                 ),
             )
         val vedtakDto =
-            VedtakDto(
-                123,
-                VedtakStatus.OPPRETTET,
-                YearMonth.now(),
-                VedtakSak("1", SakType.BARNEPENSJON, 1),
-                Behandling(BehandlingType.FØRSTEGANGSBEHANDLING, UUID.fromString(behandlingId)),
-                VedtakType.INNVILGELSE,
-                null,
-                null,
-                listOf(),
-            )
-        coEvery { vedtakService.opprettVedtakFattOgAttester(any(), any()) } returns
-            VedtakOgRapid(
-                vedtakDto,
-                RapidInfo(
-                    vedtakhendelse = VedtakKafkaHendelseType.ATTESTERT,
-                    vedtak =
-                        VedtakNyDto(
-                            123,
-                            UUID.fromString(behandlingId),
-                            VedtakStatus.OPPRETTET,
-                            VedtakSak("1", SakType.BARNEPENSJON, 1),
-                            VedtakType.INNVILGELSE,
-                            null,
-                            null,
-                            VedtakInnholdDto.VedtakBehandlingDto(
-                                YearMonth.now(),
-                                Behandling(BehandlingType.FØRSTEGANGSBEHANDLING, UUID.fromString(behandlingId)),
-                                listOf(),
+            VedtakNyDto(
+                id = 123,
+                behandlingId = UUID.fromString(behandlingId),
+                status = VedtakStatus.OPPRETTET,
+                sak =
+                    VedtakSak(
+                        ident = "ident",
+                        sakType = SakType.BARNEPENSJON,
+                        id = 321L,
+                    ),
+                type = VedtakType.INNVILGELSE,
+                vedtakFattet = null,
+                attestasjon = null,
+                innhold =
+                    VedtakInnholdDto.VedtakBehandlingDto(
+                        virkningstidspunkt = YearMonth.now(),
+                        behandling =
+                            Behandling(
+                                type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                                id = UUID.fromString(behandlingId),
+                                null,
+                                null,
                             ),
-                        ),
-                    tekniskTid = Tidspunkt.now(),
-                    behandlingId = UUID.fromString(behandlingId),
-                ),
+                        utbetalingsperioder = emptyList(),
+                    ),
             )
+        coEvery { vedtakService.opprettVedtakFattOgAttester(any(), any(), any()) } returns vedtakDto
 
         inspector.sendTestMessage(melding.toJson())
 
-        coVerify { vedtakService.opprettVedtakFattOgAttester(any(), any()) }
+        coVerify { vedtakService.opprettVedtakFattOgAttester(any(), any(), any()) }
 
+        assertEquals(0, inspector.inspektør.size)
         val sendtTilRapid = inspector.inspektør.message(0)
-        Assertions.assertEquals(VedtakKafkaHendelseType.ATTESTERT.toString(), sendtTilRapid.get(EVENT_NAME_KEY).textValue())
-        Assertions.assertEquals(sendtTilRapid.get(BEHANDLING_ID_KEY).textValue(), behandlingId)
+        assertEquals(VedtakKafkaHendelseType.ATTESTERT.name, sendtTilRapid.get(EVENT_NAME_KEY).textValue())
+        assertEquals(sendtTilRapid.get(BEHANDLING_ID_KEY).textValue(), behandlingId)
+    }
+
+    @Test
+    fun `Sender hendelse om pause om kjoeringsvariant er pause`() {
+        val melding =
+            JsonMessage.newMessage(
+                Migreringshendelser.VEDTAK,
+                mapOf(
+                    BEHANDLING_ID_KEY to "a9d42eb9-561f-4320-8bba-2ba600e66e21",
+                    SAK_ID_KEY to "1",
+                    MIGRERING_KJORING_VARIANT to MigreringKjoringVariant.MED_PAUSE,
+                ),
+            )
+
+        coEvery { vedtakService.opprettVedtakFattOgAttester(any(), any(), any()) } returns vedtakDto
+
+        inspector.sendTestMessage(melding.toJson())
+
+        coVerify { vedtakService.opprettVedtakFattOgAttester(any(), any(), any()) }
+
+        assertEquals(1, inspector.inspektør.size)
+        val resultat = inspector.inspektør.message(0)
+        assertEquals(PAUSE, resultat.get(EVENT_NAME_KEY).asText())
+    }
+
+    companion object {
+        private val behandlingId = "a9d42eb9-561f-4320-8bba-2ba600e66e21"
+        private val vedtakDto =
+            VedtakNyDto(
+                id = 123,
+                behandlingId = UUID.fromString(behandlingId),
+                status = VedtakStatus.OPPRETTET,
+                sak =
+                    VedtakSak(
+                        ident = "ident",
+                        sakType = SakType.BARNEPENSJON,
+                        id = 321L,
+                    ),
+                type = VedtakType.INNVILGELSE,
+                vedtakFattet = null,
+                attestasjon = null,
+                innhold =
+                    VedtakInnholdDto.VedtakBehandlingDto(
+                        virkningstidspunkt = YearMonth.now(),
+                        behandling =
+                            Behandling(
+                                type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                                id = UUID.fromString(behandlingId),
+                                null,
+                                null,
+                            ),
+                        utbetalingsperioder = emptyList(),
+                    ),
+            )
+
+        private val request =
+            MigreringRequest(
+                pesysId = PesysId(1),
+                enhet = Enhet("4817"),
+                soeker = AVDOED_FOEDSELSNUMMER,
+                avdoedForelder = listOf(AvdoedForelder(AVDOED_FOEDSELSNUMMER, Tidspunkt.now())),
+                gjenlevendeForelder = null,
+                virkningstidspunkt = YearMonth.now(),
+                beregning =
+                    Beregning(
+                        brutto = 1500,
+                        netto = 1500,
+                        anvendtTrygdetid = 40,
+                        datoVirkFom = Tidspunkt.now(),
+                        prorataBroek = null,
+                        g = 100_000,
+                        meta =
+                            BeregningMeta(
+                                beregningsMetodeType = "FOLKETRYGD",
+                                resultatType = "",
+                                resultatKilde = "AUTO",
+                                kravVelgType = "",
+                            ),
+                    ),
+                trygdetid = Trygdetid(emptyList()),
+                spraak = Spraak.NN,
+            )
     }
 }

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/MigreringHendelserRiverTest.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/MigreringHendelserRiverTest.kt
@@ -3,32 +3,23 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import no.nav.etterlatte.MigreringHendelserRiver
 import no.nav.etterlatte.VedtakService
-import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
 import no.nav.etterlatte.libs.common.sak.VedtakSak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vedtak.Behandling
-import no.nav.etterlatte.libs.common.vedtak.VedtakInnholdDto
-import no.nav.etterlatte.libs.common.vedtak.VedtakNyDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakInnholdDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseType
+import no.nav.etterlatte.libs.common.vedtak.VedtakNyDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
-import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.rapidsandrivers.EventNames
-import no.nav.etterlatte.rapidsandrivers.migrering.AvdoedForelder
-import no.nav.etterlatte.rapidsandrivers.migrering.Beregning
-import no.nav.etterlatte.rapidsandrivers.migrering.BeregningMeta
-import no.nav.etterlatte.rapidsandrivers.migrering.Enhet
 import no.nav.etterlatte.rapidsandrivers.migrering.MIGRERING_KJORING_VARIANT
 import no.nav.etterlatte.rapidsandrivers.migrering.MigreringKjoringVariant
-import no.nav.etterlatte.rapidsandrivers.migrering.MigreringRequest
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser
 import no.nav.etterlatte.rapidsandrivers.migrering.Migreringshendelser.PAUSE
-import no.nav.etterlatte.rapidsandrivers.migrering.PesysId
-import no.nav.etterlatte.rapidsandrivers.migrering.Trygdetid
 import no.nav.etterlatte.vedtaksvurdering.RapidInfo
 import no.nav.etterlatte.vedtaksvurdering.VedtakOgRapid
 import no.nav.helse.rapids_rivers.JsonMessage
@@ -77,42 +68,15 @@ class MigreringHendelserRiverTest {
                     MIGRERING_KJORING_VARIANT to MigreringKjoringVariant.FULL_KJORING,
                 ),
             )
-        val vedtakDto =
-            VedtakNyDto(
-                id = 123,
-                behandlingId = UUID.fromString(behandlingId),
-                status = VedtakStatus.OPPRETTET,
-                sak =
-                    VedtakSak(
-                        ident = "ident",
-                        sakType = SakType.BARNEPENSJON,
-                        id = 321L,
-                    ),
-                type = VedtakType.INNVILGELSE,
-                vedtakFattet = null,
-                attestasjon = null,
-                innhold =
-                    VedtakInnholdDto.VedtakBehandlingDto(
-                        virkningstidspunkt = YearMonth.now(),
-                        behandling =
-                            Behandling(
-                                type = BehandlingType.FØRSTEGANGSBEHANDLING,
-                                id = UUID.fromString(behandlingId),
-                                null,
-                                null,
-                            ),
-                        utbetalingsperioder = emptyList(),
-                    ),
-            )
-        coEvery { vedtakService.opprettVedtakFattOgAttester(any(), any(), any()) } returns vedtakDto
+        coEvery { vedtakService.opprettVedtakFattOgAttester(any(), any(), any()) } returns vedtakOgRapid
 
         inspector.sendTestMessage(melding.toJson())
 
         coVerify { vedtakService.opprettVedtakFattOgAttester(any(), any(), any()) }
 
-        assertEquals(0, inspector.inspektør.size)
+        assertEquals(1, inspector.inspektør.size)
         val sendtTilRapid = inspector.inspektør.message(0)
-        assertEquals(VedtakKafkaHendelseType.ATTESTERT.name, sendtTilRapid.get(EVENT_NAME_KEY).textValue())
+        assertEquals(VedtakKafkaHendelseType.ATTESTERT.toString(), sendtTilRapid.get(EVENT_NAME_KEY).textValue())
         assertEquals(sendtTilRapid.get(BEHANDLING_ID_KEY).textValue(), behandlingId)
     }
 
@@ -128,73 +92,54 @@ class MigreringHendelserRiverTest {
                 ),
             )
 
-        coEvery { vedtakService.opprettVedtakFattOgAttester(any(), any(), any()) } returns vedtakDto
+        coEvery { vedtakService.opprettVedtakFattOgAttester(any(), any(), any()) } returns vedtakOgRapid
 
         inspector.sendTestMessage(melding.toJson())
 
         coVerify { vedtakService.opprettVedtakFattOgAttester(any(), any(), any()) }
 
-        assertEquals(1, inspector.inspektør.size)
+        assertEquals(2, inspector.inspektør.size)
         val resultat = inspector.inspektør.message(0)
         assertEquals(PAUSE, resultat.get(EVENT_NAME_KEY).asText())
     }
 
     companion object {
         private val behandlingId = "a9d42eb9-561f-4320-8bba-2ba600e66e21"
-        private val vedtakDto =
-            VedtakNyDto(
-                id = 123,
-                behandlingId = UUID.fromString(behandlingId),
-                status = VedtakStatus.OPPRETTET,
-                sak =
-                    VedtakSak(
-                        ident = "ident",
-                        sakType = SakType.BARNEPENSJON,
-                        id = 321L,
-                    ),
-                type = VedtakType.INNVILGELSE,
-                vedtakFattet = null,
-                attestasjon = null,
-                innhold =
-                    VedtakInnholdDto.VedtakBehandlingDto(
-                        virkningstidspunkt = YearMonth.now(),
-                        behandling =
-                            Behandling(
-                                type = BehandlingType.FØRSTEGANGSBEHANDLING,
-                                id = UUID.fromString(behandlingId),
-                                null,
-                                null,
-                            ),
-                        utbetalingsperioder = emptyList(),
-                    ),
+        val vedtakDto =
+            VedtakDto(
+                123,
+                VedtakStatus.OPPRETTET,
+                YearMonth.now(),
+                VedtakSak("1", SakType.BARNEPENSJON, 1),
+                Behandling(BehandlingType.FØRSTEGANGSBEHANDLING, UUID.fromString(behandlingId)),
+                VedtakType.INNVILGELSE,
+                null,
+                null,
+                listOf(),
             )
-
-        private val request =
-            MigreringRequest(
-                pesysId = PesysId(1),
-                enhet = Enhet("4817"),
-                soeker = AVDOED_FOEDSELSNUMMER,
-                avdoedForelder = listOf(AvdoedForelder(AVDOED_FOEDSELSNUMMER, Tidspunkt.now())),
-                gjenlevendeForelder = null,
-                virkningstidspunkt = YearMonth.now(),
-                beregning =
-                    Beregning(
-                        brutto = 1500,
-                        netto = 1500,
-                        anvendtTrygdetid = 40,
-                        datoVirkFom = Tidspunkt.now(),
-                        prorataBroek = null,
-                        g = 100_000,
-                        meta =
-                            BeregningMeta(
-                                beregningsMetodeType = "FOLKETRYGD",
-                                resultatType = "",
-                                resultatKilde = "AUTO",
-                                kravVelgType = "",
+        val vedtakOgRapid =
+            VedtakOgRapid(
+                vedtakDto,
+                RapidInfo(
+                    vedtakhendelse = VedtakKafkaHendelseType.ATTESTERT,
+                    vedtak =
+                        VedtakNyDto(
+                            123,
+                            UUID.fromString(behandlingId),
+                            VedtakStatus.OPPRETTET,
+                            VedtakSak("1", SakType.BARNEPENSJON, 1),
+                            VedtakType.INNVILGELSE,
+                            null,
+                            null,
+                            VedtakInnholdDto.VedtakBehandlingDto(
+                                YearMonth.now(),
+                                Behandling(BehandlingType.FØRSTEGANGSBEHANDLING, UUID.fromString(behandlingId)),
+                                listOf(),
                             ),
-                    ),
-                trygdetid = Trygdetid(emptyList()),
-                spraak = Spraak.NN,
+                        ),
+                    tekniskTid = Tidspunkt.now(),
+                    behandlingId = UUID.fromString(behandlingId),
+                ),
             )
     }
 }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/AutomatiskBehandlingRoutes.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/AutomatiskBehandlingRoutes.kt
@@ -28,7 +28,7 @@ fun Route.automatiskBehandlingRoutes(
                 logger.info("Håndterer behandling $behandlingId")
                 val nyttVedtak =
                     service.vedtakStegvis(behandlingId, sakId, brukerTokenInfo, MigreringKjoringVariant.FULL_KJORING)
-                call.respond(nyttVedtak.toDto())
+                call.respond(nyttVedtak)
             }
         }
 
@@ -37,7 +37,7 @@ fun Route.automatiskBehandlingRoutes(
                 val kjoringVariant = call.receive<MigreringKjoringVariant>()
                 logger.info("Håndterer behandling $behandlingId med kjøringsvariant ${kjoringVariant.name}")
                 val nyttVedtak = service.vedtakStegvis(behandlingId, sakId, brukerTokenInfo, kjoringVariant)
-                call.respond(nyttVedtak.toNyDto())
+                call.respond(nyttVedtak)
             }
         }
     }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/AutomatiskBehandlingRoutes.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/AutomatiskBehandlingRoutes.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.vedtaksvurdering
 
 import io.ktor.server.application.call
 import io.ktor.server.application.log
+import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.application
@@ -9,16 +10,14 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
-import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.sakId
 import no.nav.etterlatte.libs.common.withBehandlingId
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
-import no.nav.etterlatte.token.Fagsaksystem
+import no.nav.etterlatte.rapidsandrivers.migrering.MigreringKjoringVariant
 import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
 
 fun Route.automatiskBehandlingRoutes(
-    service: VedtakBehandlingService,
-    rapidService: VedtaksvurderingRapidService,
+    service: AutomatiskBehandlingService,
     behandlingKlient: BehandlingKlient,
 ) {
     route("/api/vedtak") {
@@ -27,30 +26,18 @@ fun Route.automatiskBehandlingRoutes(
         post("/{$SAKID_CALL_PARAMETER}/{$BEHANDLINGID_CALL_PARAMETER}/automatisk") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Håndterer behandling $behandlingId")
-                service.opprettEllerOppdaterVedtak(behandlingId, brukerTokenInfo)
+                val nyttVedtak =
+                    service.vedtakStegvis(behandlingId, sakId, brukerTokenInfo, MigreringKjoringVariant.FULL_KJORING)
+                call.respond(nyttVedtak.toDto())
+            }
+        }
 
-                logger.info("Fatter vedtak for behandling $behandlingId")
-                service.fattVedtak(behandlingId, brukerTokenInfo).also { rapidService.sendToRapid(it) }
-
-                logger.info("Tildeler attesteringsoppgave til systembruker")
-                val oppgaveTilAttestering =
-                    behandlingKlient.hentOppgaverForSak(sakId, brukerTokenInfo)
-                        .oppgaver
-                        .filter { it.referanse == behandlingId.toString() }
-                        .filter { it.type == OppgaveType.ATTESTERING }
-                        .filterNot { it.erAvsluttet() }
-                        .first()
-                behandlingKlient.tildelSaksbehandler(oppgaveTilAttestering, brukerTokenInfo)
-
-                logger.info("Attesterer vedtak for behandling $behandlingId")
-                val attestert =
-                    service.attesterVedtak(
-                        behandlingId,
-                        "Automatisk attestert av ${Fagsaksystem.EY.systemnavn}",
-                        brukerTokenInfo,
-                    )
-
-                call.respond(attestert)
+        post("/{$SAKID_CALL_PARAMETER}/{$BEHANDLINGID_CALL_PARAMETER}/automatisk/stegvis") {
+            withBehandlingId(behandlingKlient) { behandlingId ->
+                val kjoringVariant = call.receive<MigreringKjoringVariant>()
+                logger.info("Håndterer behandling $behandlingId med kjøringsvariant ${kjoringVariant.name}")
+                val nyttVedtak = service.vedtakStegvis(behandlingId, sakId, brukerTokenInfo, kjoringVariant)
+                call.respond(nyttVedtak.toNyDto())
             }
         }
     }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/AutomatiskBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/AutomatiskBehandlingService.kt
@@ -1,0 +1,64 @@
+package no.nav.etterlatte.vedtaksvurdering
+
+import no.nav.etterlatte.libs.common.oppgave.OppgaveType
+import no.nav.etterlatte.rapidsandrivers.migrering.MigreringKjoringVariant
+import no.nav.etterlatte.token.BrukerTokenInfo
+import no.nav.etterlatte.token.Fagsaksystem
+import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+class AutomatiskBehandlingService(
+    val service: VedtakBehandlingService,
+    val behandlingKlient: BehandlingKlient,
+) {
+    private val logger = LoggerFactory.getLogger(AutomatiskBehandlingService::class.java)
+
+    suspend fun vedtakStegvis(
+        behandlingId: UUID,
+        sakId: Long,
+        brukerTokenInfo: BrukerTokenInfo,
+        kjoringVariant: MigreringKjoringVariant,
+    ): Vedtak =
+        when (kjoringVariant) {
+            MigreringKjoringVariant.FULL_KJORING -> {
+                opprettOgFattVedtak(behandlingId, sakId, brukerTokenInfo)
+                attesterVedtak(behandlingId, brukerTokenInfo)
+            }
+            MigreringKjoringVariant.MED_PAUSE -> opprettOgFattVedtak(behandlingId, sakId, brukerTokenInfo)
+            MigreringKjoringVariant.FORTSETT_ETTER_PAUSE -> attesterVedtak(behandlingId, brukerTokenInfo)
+        }
+
+    private suspend fun opprettOgFattVedtak(
+        behandlingId: UUID,
+        sakId: Long,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Vedtak {
+        logger.info("Fatter vedtak for behandling $behandlingId")
+        val vedtak = service.opprettEllerOppdaterVedtak(behandlingId, brukerTokenInfo)
+        service.fattVedtak(behandlingId, brukerTokenInfo)
+
+        logger.info("Tildeler attesteringsoppgave til systembruker")
+        val oppgaveTilAttestering =
+            behandlingKlient.hentOppgaverForSak(sakId, brukerTokenInfo)
+                .oppgaver
+                .filter { it.referanse == behandlingId.toString() }
+                .filter { it.type == OppgaveType.ATTESTERING }
+                .filterNot { it.erAvsluttet() }
+                .first()
+        behandlingKlient.tildelSaksbehandler(oppgaveTilAttestering, brukerTokenInfo)
+        return vedtak
+    }
+
+    private suspend fun attesterVedtak(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Vedtak {
+        logger.info("Attesterer vedtak for behandling $behandlingId")
+        return service.attesterVedtak(
+            behandlingId,
+            "Automatisk attestert av ${Fagsaksystem.EY.systemnavn}",
+            brukerTokenInfo,
+        )
+    }
+}

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/config/ApplicationBuilder.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/config/ApplicationBuilder.kt
@@ -13,6 +13,7 @@ import no.nav.etterlatte.libs.ktor.httpClient
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 import no.nav.etterlatte.libs.ktor.restModule
 import no.nav.etterlatte.libs.ktor.setReady
+import no.nav.etterlatte.vedtaksvurdering.AutomatiskBehandlingService
 import no.nav.etterlatte.vedtaksvurdering.VedtakBehandlingService
 import no.nav.etterlatte.vedtaksvurdering.VedtakTilbakekrevingService
 import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingRapidService
@@ -77,13 +78,18 @@ class ApplicationBuilder {
         VedtakTilbakekrevingService(
             repository = VedtaksvurderingRepository(dataSource),
         )
+    private val automatiskBehandlingService = AutomatiskBehandlingService(
+        vedtakBehandlingService,
+        vedtaksvurderingRapidService,
+        behandlingKlient
+    )
 
     private val rapidsConnection =
         RapidApplication.Builder(RapidApplication.RapidApplicationConfig.fromEnv(getRapidEnv()))
             .withKtorModule {
                 restModule(sikkerLogg, config = HoconApplicationConfig(config)) {
                     vedtaksvurderingRoute(vedtaksvurderingService, vedtakBehandlingService, vedtaksvurderingRapidService, behandlingKlient)
-                    automatiskBehandlingRoutes(vedtakBehandlingService, vedtaksvurderingRapidService, behandlingKlient)
+                    automatiskBehandlingRoutes(automatiskBehandlingService, behandlingKlient)
                     samordningsvedtakRoute(vedtaksvurderingService, vedtakBehandlingService)
                     tilbakekrevingvedtakRoute(vedtakTilbakekrevingService, behandlingKlient)
                 }

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/migrering/AutomatiskBehandlingRoutesKtTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/migrering/AutomatiskBehandlingRoutesKtTest.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.vedtaksvurdering
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.header
 import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
@@ -24,16 +25,22 @@ import no.nav.etterlatte.libs.common.oppgave.OppgaveListe
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.oppgave.Status
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.toJson
+import no.nav.etterlatte.libs.common.vedtak.VedtakDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakNyDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseType
 import no.nav.etterlatte.libs.ktor.AZURE_ISSUER
 import no.nav.etterlatte.libs.ktor.restModule
+import no.nav.etterlatte.rapidsandrivers.migrering.MigreringKjoringVariant
 import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import testsupport.buildTestApplicationConfigurationForOauth
@@ -46,9 +53,10 @@ internal class AutomatiskBehandlingRoutesKtTest {
     private val server = MockOAuth2Server()
     private lateinit var applicationConfig: HoconApplicationConfig
     private val behandlingKlient = mockk<BehandlingKlient>()
-    private val service: VedtakBehandlingService = mockk()
+    private val vedtakService: VedtakBehandlingService = mockk()
     private val rapidService: VedtaksvurderingRapidService = mockk()
-
+    private val automatiskBehandlingService = AutomatiskBehandlingService(vedtakService, rapidService, behandlingKlient)
+    
     @BeforeAll
     fun before() {
         server.start()
@@ -78,9 +86,9 @@ internal class AutomatiskBehandlingRoutesKtTest {
         testApplication {
             val opprettetVedtak = vedtak()
             val behandlingId = UUID.randomUUID()
-            coEvery { service.opprettEllerOppdaterVedtak(any(), any()) } returns
+            coEvery { vedtakService.opprettEllerOppdaterVedtak(any(), any()) } returns
                 opprettetVedtak
-            coEvery { service.fattVedtak(behandlingId, any()) } returns
+            coEvery { vedtakService.fattVedtak(behandlingId, any()) } returns
                 VedtakOgRapid(
                     opprettetVedtak.toDto(),
                     mockk(),
@@ -92,7 +100,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
                 )
             coEvery { behandlingKlient.tildelSaksbehandler(any(), any()) } returns true
             coEvery {
-                service.attesterVedtak(
+                vedtakService.attesterVedtak(
                     behandlingId,
                     any(),
                     any(),
@@ -105,15 +113,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
             coEvery { rapidService.sendToRapid(any()) } just runs
 
             environment { config = applicationConfig }
-            application {
-                restModule(log) {
-                    automatiskBehandlingRoutes(
-                        service,
-                        rapidService,
-                        behandlingKlient,
-                    )
-                }
-            }
+            application { restModule(log) { automatiskBehandlingRoutes(automatiskBehandlingService, behandlingKlient) } }
 
             val vedtak =
                 client.post("/api/vedtak/1/$behandlingId/automatisk") {
@@ -124,21 +124,158 @@ internal class AutomatiskBehandlingRoutesKtTest {
                     deserialize<VedtakOgRapid>(it.bodyAsText())
                 }
 
-            Assertions.assertEquals(vedtak.vedtak.vedtakId, opprettetVedtak.id)
-            Assertions.assertEquals(vedtak.rapidInfo1.vedtakhendelse, VedtakKafkaHendelseType.ATTESTERT)
+            assertEquals(vedtak.vedtak.vedtakId, opprettetVedtak.id)
+            assertEquals(vedtak.rapidInfo1.vedtakhendelse, VedtakKafkaHendelseType.ATTESTERT)
 
             coVerify(exactly = 1) {
-                service.opprettEllerOppdaterVedtak(behandlingId, any())
+                vedtakService.opprettEllerOppdaterVedtak(behandlingId, any())
                 behandlingKlient.hentOppgaverForSak(1, any())
-                service.fattVedtak(behandlingId, any())
+                vedtakService.fattVedtak(behandlingId, any())
                 behandlingKlient.tildelSaksbehandler(any(), any())
-                service.attesterVedtak(behandlingId, any(), any())
+                vedtakService.attesterVedtak(behandlingId, any(), any())
             }
             coVerify(exactly = 1) {
                 rapidService.sendToRapid(any())
             }
             coVerify(atLeast = 1) {
                 behandlingKlient.harTilgangTilBehandling(any(), any())
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Skal stegvis opprette vedtak, fatte vedtak og attestere")
+    inner class StegvisAutomatiskBehandling {
+        @Test
+        fun `Full kjoring skal skal opprette vedtak, fatte vedtak og attestere`() {
+            testApplication {
+                val opprettetVedtak = vedtak()
+                val behandlingId = UUID.randomUUID()
+                every { runBlocking { vedtakService.opprettEllerOppdaterVedtak(any(), any()) } } returns
+                    opprettetVedtak
+                every { runBlocking { vedtakService.fattVedtak(behandlingId, any()) } } returns opprettetVedtak
+                every { runBlocking { behandlingKlient.hentOppgaverForSak(any(), any()) } } returns
+                    OppgaveListe(
+                        mockk(),
+                        listOf(lagOppgave(behandlingId)),
+                    )
+                every { runBlocking { behandlingKlient.tildelSaksbehandler(any(), any()) } } returns true
+                every {
+                    runBlocking {
+                        vedtakService.attesterVedtak(
+                            behandlingId,
+                            any(),
+                            any(),
+                        )
+                    }
+                } returns opprettetVedtak
+
+                environment { config = applicationConfig }
+                application { restModule(log) { automatiskBehandlingRoutes(automatiskBehandlingService, behandlingKlient) } }
+
+                val vedtak =
+                    client.post("/api/vedtak/1/$behandlingId/automatisk/stegvis") {
+                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        header(HttpHeaders.Authorization, "Bearer $token")
+                        setBody(MigreringKjoringVariant.FULL_KJORING.toJson())
+                    }.let {
+                        it.status shouldBe HttpStatusCode.OK
+                        deserialize<VedtakNyDto>(it.bodyAsText())
+                    }
+
+                assertEquals(vedtak.id, opprettetVedtak.id)
+
+                coVerify(exactly = 1) {
+                    vedtakService.opprettEllerOppdaterVedtak(behandlingId, any())
+                    behandlingKlient.hentOppgaverForSak(1, any())
+                    vedtakService.fattVedtak(behandlingId, any())
+                    behandlingKlient.tildelSaksbehandler(any(), any())
+                    vedtakService.attesterVedtak(behandlingId, any(), any())
+                }
+                coVerify(atLeast = 1) {
+                    behandlingKlient.harTilgangTilBehandling(any(), any())
+                }
+            }
+        }
+
+        @Test
+        fun `Med pause skal skal opprette vedtak og fatte vedtak`() {
+            testApplication {
+                val opprettetVedtak = vedtak()
+                val behandlingId = UUID.randomUUID()
+                every { runBlocking { vedtakService.opprettEllerOppdaterVedtak(any(), any()) } } returns
+                    opprettetVedtak
+                every { runBlocking { vedtakService.fattVedtak(behandlingId, any()) } } returns opprettetVedtak
+                every { runBlocking { behandlingKlient.hentOppgaverForSak(any(), any()) } } returns
+                    OppgaveListe(
+                        mockk(),
+                        listOf(lagOppgave(behandlingId)),
+                    )
+                every { runBlocking { behandlingKlient.tildelSaksbehandler(any(), any()) } } returns true
+
+                environment { config = applicationConfig }
+                application { restModule(log) { automatiskBehandlingRoutes(automatiskBehandlingService, behandlingKlient) } }
+
+                val vedtak =
+                    client.post("/api/vedtak/1/$behandlingId/automatisk/stegvis") {
+                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        header(HttpHeaders.Authorization, "Bearer $token")
+                        setBody(MigreringKjoringVariant.MED_PAUSE.toJson())
+                    }.let {
+                        it.status shouldBe HttpStatusCode.OK
+                        deserialize<VedtakNyDto>(it.bodyAsText())
+                    }
+
+                assertEquals(vedtak.id, opprettetVedtak.id)
+
+                coVerify(exactly = 1) {
+                    vedtakService.opprettEllerOppdaterVedtak(behandlingId, any())
+                    behandlingKlient.hentOppgaverForSak(1, any())
+                    vedtakService.fattVedtak(behandlingId, any())
+                    behandlingKlient.tildelSaksbehandler(any(), any())
+                }
+                coVerify(atLeast = 1) {
+                    behandlingKlient.harTilgangTilBehandling(any(), any())
+                }
+            }
+        }
+
+        @Test
+        fun `Fortsett etter pause skal attestere vedtak`() {
+            testApplication {
+                val opprettetVedtak = vedtak()
+                val behandlingId = UUID.randomUUID()
+                every {
+                    runBlocking {
+                        vedtakService.attesterVedtak(
+                            behandlingId,
+                            any(),
+                            any(),
+                        )
+                    }
+                } returns opprettetVedtak
+
+                environment { config = applicationConfig }
+                application { restModule(log) { automatiskBehandlingRoutes(automatiskBehandlingService, behandlingKlient) } }
+
+                val vedtak =
+                    client.post("/api/vedtak/1/$behandlingId/automatisk/stegvis") {
+                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        header(HttpHeaders.Authorization, "Bearer $token")
+                        setBody(MigreringKjoringVariant.FORTSETT_ETTER_PAUSE.toJson())
+                    }.let {
+                        it.status shouldBe HttpStatusCode.OK
+                        deserialize<VedtakNyDto>(it.bodyAsText())
+                    }
+
+                assertEquals(vedtak.id, opprettetVedtak.id)
+
+                coVerify(exactly = 1) {
+                    vedtakService.attesterVedtak(behandlingId, any(), any())
+                }
+                coVerify(atLeast = 1) {
+                    behandlingKlient.harTilgangTilBehandling(any(), any())
+                }
             }
         }
     }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/MigreringRequest.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/MigreringRequest.kt
@@ -8,6 +8,12 @@ import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.time.YearMonth
 
+enum class MigreringKjoringVariant {
+    FULL_KJORING,
+    MED_PAUSE,
+    FORTSETT_ETTER_PAUSE,
+}
+
 data class MigreringRequest(
     val pesysId: PesysId,
     val enhet: Enhet,

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/Migreringshendelser.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/Migreringshendelser.kt
@@ -15,6 +15,7 @@ object Migreringshendelser {
     const val TRYGDETID = "${PREFIX}TRYGDETID"
     const val TRYGDETID_GRUNNLAG = "${PREFIX}TRYGDETID_GRUNNLAG"
     const val VEDTAK = "${PREFIX}VEDTAK"
+    const val PAUSE = "${PREFIX}PAUSE"
     const val IVERKSATT = "${PREFIX}IVERKSATT"
     const val AVBRYT_BEHANDLING = "${PREFIX}AVBRYT_BEHANDLING"
 }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/PesysKeys.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/PesysKeys.kt
@@ -15,6 +15,7 @@ const val PERSONGALLERI_KEY = "persongalleri"
 const val PESYS_ID_KEY = "pesysId"
 const val KILDE_KEY = "kilde"
 const val LOPENDE_JANUAR_2024_KEY = "lopendeJanuar2024"
+const val MIGRERING_KJORING_VARIANT = "migreringKjoringVariant"
 const val BREV_OPPRETTA_MIGRERING = "brev_oppretta_migrering"
 
 var JsonMessage.hendelseData: MigreringRequest
@@ -45,4 +46,10 @@ var JsonMessage.kilde: Vedtaksloesning
     get() = objectMapper.treeToValue(this[KILDE_KEY], Vedtaksloesning::class.java)
     set(name) {
         this[KILDE_KEY] = name
+    }
+
+var JsonMessage.migreringKjoringVariant: MigreringKjoringVariant
+    get() = objectMapper.treeToValue(this[MIGRERING_KJORING_VARIANT], MigreringKjoringVariant::class.java)
+    set(name) {
+        this[MIGRERING_KJORING_VARIANT] = name
     }


### PR DESCRIPTION
- Ny migreringsstatus PAUSE
- Ny verdi på meldinger "migreringKjoringVariant" og tilhørende Enum MigreringKjoringVariant
- MigrerRiver og MigrerSpesifikkSakRiver vil kreve kjøringsvariant
- Vedtak Kafka vil kjøre deler av vedtaksløpet basert på kjøringsvariant (full kjøring, frem til fatting fra og med attester)
- Ny River PauseMigreringRiver for å oppdatere status på migrering når vedtak er fattet under migrering av type MED_PAUSE
- MigrerSpesifikkSakRiver går direkte til vedtak hvis kjøringsvariant er FORTSETT_ETTER_PAUSE