### PR TITLE
Samordning - benytte lesbar-brukerid for logging av system-til-systemkall internt

### DIFF
--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/LoggingPlugins.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/LoggingPlugins.kt
@@ -50,7 +50,7 @@ val userIdMdcPlugin: RouteScopedPlugin<PluginConfiguration> =
             val user =
                 if (call.request.uri.contains("pensjon")) {
                     when (val bruker = call.brukerTokenInfo) {
-                        is Systembruker -> bruker.sub
+                        is Systembruker -> bruker.jwtTokenClaims?.getStringClaim("azp_name") ?: bruker.sub
                         is Saksbehandler -> "Saksbehandler"
                         else -> "Ukjent"
                     }


### PR DESCRIPTION
Er litt bedre med `dev-fss:pensjon-q2:pensjon-pen-q2` enn `92e4c1d4-d4ba-4849-91ff-caa4dce8d4bb`...