### PR TITLE
Logge vedtaksID ved forespørsel mot SAM

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakBehandlingService.kt
@@ -310,10 +310,10 @@ class VedtakBehandlingService(
         )
 
         if (!samKlient.samordneVedtak(tilSamordningVedtakLocal, brukerTokenInfo)) {
-            logger.info("Svar fra samordning: ikke nødvendig å vente [behandlingId=$behandlingId]")
+            logger.info("Svar fra samordning: ikke nødvendig å vente for vedtak=${vedtak.id} [behandlingId=$behandlingId]")
             return samordnetVedtak(behandlingId, brukerTokenInfo, tilSamordningVedtakLocal)
         } else {
-            logger.info("Svar fra samordning: må vente [behandlingId=$behandlingId]")
+            logger.info("Svar fra samordning: må vente for vedtak=${vedtak.id} [behandlingId=$behandlingId]")
         }
 
         return tilSamordningVedtakLocal


### PR DESCRIPTION
Og for å kunne noenlunde lett finne IDen når man trenger å poste melding via testdata for å shortcircuite den lange verdikjeden (a feature in the making)