### PR TITLE
EY-2414 Samordning-grensesnitt korrigere param-navn

### DIFF
--- a/apps/etterlatte-samordning-vedtak/.nais/apiendpoints.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/apiendpoints.yaml
@@ -21,7 +21,8 @@ spec:
         - fnr
         - tpnr
       queryParams:
-        - virkFom
+        - virkFom  # deprecated
+        - fomDato
       backendHost: http://etterlatte-samordning-vedtak
       backendPath: /api/vedtak
     - path: /samordning/vedtak/{vedtakId}

--- a/apps/etterlatte-samordning-vedtak/README.md
+++ b/apps/etterlatte-samordning-vedtak/README.md
@@ -14,7 +14,8 @@ Det må foreligge et tjenestepensjonsforhold i Tjenestepensjonsregisteret som gj
 
 | Endepunkt                      | Headers        | Responstype         | Beskrivelse                                                                                                                         |
 |:-------------------------------|----------------|---------------------|:------------------------------------------------------------------------------------------------------------------------------------|
-| /api/vedtak?virkFom=YYYY-MM-DD | fnr <br/> tpnr | Samordningsvedtak[] | Henter ut vedtaksinformasjon for gitt person fra og med gitt dato.                                                                  |
+| /api/vedtak?fomDato=YYYY-MM-DD | fnr <br/> tpnr | Samordningsvedtak[] | Henter ut vedtaksinformasjon for gitt person fra og med gitt dato.                                                                  |
+| /api/vedtak?virkFom=YYYY-MM-DD | fnr <br/> tpnr | Samordningsvedtak[] | **DEPRECATED** Henter ut vedtaksinformasjon for gitt person fra og med gitt dato.                                                   |
 | /api/vedtak/{nav-vedtak-id}    | tpnr           | Samordningsvedtak   | Henter ut informasjon om et spesifikt vedtak. VedtaksIDen kommer fra samordningskøen hvor det varsles løpende om vedtak som gjøres. |
 
 | Header | Beskrivelse                      |

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRoute.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRoute.kt
@@ -49,8 +49,9 @@ fun Route.samordningVedtakRoute(
         }
 
         get {
-            val virkFom =
-                call.parameters["virkFom"]?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
+            val fomDato =
+                call.parameters["fomDato"]?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
+                    ?: call.parameters["virkFom"]?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
                     ?: throw ManglerVirkFomException()
 
             val fnr =
@@ -64,7 +65,7 @@ fun Route.samordningVedtakRoute(
             val samordningVedtakDtos =
                 try {
                     samordningVedtakService.hentVedtaksliste(
-                        virkFom = virkFom,
+                        fomDato = fomDato,
                         fnr = Folkeregisteridentifikator.of(fnr),
                         MaskinportenTpContext(
                             tpnr = Tjenestepensjonnummer(tpnummer),
@@ -85,8 +86,9 @@ fun Route.samordningVedtakRoute(
         }
 
         get {
-            val virkFom =
-                call.parameters["virkFom"]?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
+            val fomDato =
+                call.parameters["fomDato"]?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
+                    ?: call.parameters["virkFom"]?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
                     ?: throw ManglerVirkFomException()
 
             val fnr =
@@ -96,7 +98,7 @@ fun Route.samordningVedtakRoute(
             val samordningVedtakDtos =
                 try {
                     samordningVedtakService.hentVedtaksliste(
-                        virkFom = virkFom,
+                        fomDato = fomDato,
                         fnr = Folkeregisteridentifikator.of(fnr),
                         PensjonContext,
                     )

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakService.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakService.kt
@@ -43,18 +43,18 @@ class SamordningVedtakService(
     }
 
     suspend fun hentVedtaksliste(
-        virkFom: LocalDate,
+        fomDato: LocalDate,
         fnr: Folkeregisteridentifikator,
         context: CallerContext,
     ): List<SamordningVedtakDto> {
-        if (context is MaskinportenTpContext && !tjenestepensjonKlient.harTpForholdByDate(fnr.value, context.tpnr, virkFom)
+        if (context is MaskinportenTpContext && !tjenestepensjonKlient.harTpForholdByDate(fnr.value, context.tpnr, fomDato)
         ) {
             logger.info("Avslår forespørsel, manglende/ikke gyldig TP-forhold")
             throw TjenestepensjonManglendeTilgangException("Ikke gyldig tpforhold")
         }
 
         return vedtaksvurderingKlient.hentVedtaksliste(
-            virkFom = virkFom,
+            fomDato = fomDato,
             fnr = fnr.value,
             callerContext = context,
         )

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/VedtaksvurderingKlient.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/VedtaksvurderingKlient.kt
@@ -45,15 +45,15 @@ class VedtaksvurderingKlient(config: Config, private val httpClient: HttpClient)
     }
 
     suspend fun hentVedtaksliste(
-        virkFom: LocalDate,
+        fomDato: LocalDate,
         fnr: String,
         callerContext: CallerContext,
     ): List<VedtakSamordningDto> {
-        logger.info("Henter vedtaksliste, virkFom=$virkFom")
+        logger.info("Henter vedtaksliste, fomDato=$fomDato")
 
         return try {
             httpClient.get {
-                url("$vedtaksvurderingUrl?virkFom=$virkFom")
+                url("$vedtaksvurderingUrl?fomDato=$fomDato")
                 header("fnr", fnr)
                 if (callerContext is MaskinportenTpContext) {
                     header("orgnr", callerContext.organisasjonsnr)

--- a/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRouteTest.kt
+++ b/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRouteTest.kt
@@ -139,7 +139,7 @@ class SamordningVedtakRouteTest {
 
             coEvery {
                 samordningVedtakService.hentVedtaksliste(
-                    virkFom = virkFom,
+                    fomDato = virkFom,
                     fnr = Folkeregisteridentifikator.of(fnr),
                     context =
                         MaskinportenTpContext(
@@ -156,7 +156,7 @@ class SamordningVedtakRouteTest {
 
                 val response =
                     client.get("/api/vedtak") {
-                        parameter("virkFom", virkFom)
+                        parameter("fomDato", virkFom)
                         header("fnr", fnr)
                         header("tpnr", "3010")
                         header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -169,7 +169,7 @@ class SamordningVedtakRouteTest {
                 response.status shouldBe HttpStatusCode.OK
                 coVerify {
                     samordningVedtakService.hentVedtaksliste(
-                        virkFom = virkFom,
+                        fomDato = virkFom,
                         fnr = Folkeregisteridentifikator.of(fnr),
                         any<MaskinportenTpContext>(),
                     )
@@ -209,7 +209,7 @@ class SamordningVedtakRouteTest {
                 val response =
                     client.get("/api/pensjon/vedtak") {
                         header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                        parameter("virkFom", virkFom)
+                        parameter("fomDato", virkFom)
                         header("fnr", fnr)
                     }
 
@@ -227,7 +227,7 @@ class SamordningVedtakRouteTest {
                     client.get("/api/pensjon/vedtak") {
                         header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                         header(HttpHeaders.Authorization, "Bearer ${token()}")
-                        parameter("virkFom", virkFom)
+                        parameter("fomDato", virkFom)
                         header("fnr", fnr)
                     }
 
@@ -239,7 +239,7 @@ class SamordningVedtakRouteTest {
         fun `skal gi 200 med gyldig token inkl rolle`() {
             coEvery {
                 samordningVedtakService.hentVedtaksliste(
-                    virkFom = virkFom,
+                    fomDato = virkFom,
                     fnr = Folkeregisteridentifikator.of(fnr),
                     context = PensjonContext,
                 )
@@ -252,7 +252,7 @@ class SamordningVedtakRouteTest {
 
                 val response =
                     client.get("/api/pensjon/vedtak") {
-                        parameter("virkFom", virkFom)
+                        parameter("fomDato", virkFom)
                         header("fnr", fnr)
                         header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                         header(HttpHeaders.Authorization, "Bearer ${token("les-oms-vedtak")}")
@@ -261,7 +261,7 @@ class SamordningVedtakRouteTest {
                 response.status shouldBe HttpStatusCode.OK
                 coVerify {
                     samordningVedtakService.hentVedtaksliste(
-                        virkFom = virkFom,
+                        fomDato = virkFom,
                         fnr = Folkeregisteridentifikator.of(fnr),
                         PensjonContext,
                     )

--- a/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakServiceTest.kt
+++ b/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakServiceTest.kt
@@ -118,7 +118,7 @@ class SamordningVedtakServiceTest {
 
     @Test
     fun `skal hente to vedtak`() {
-        val virkFom = now().atStartOfMonth()
+        val fomDato = now().atStartOfMonth()
         val vedtakliste =
             listOf(
                 vedtak(
@@ -133,13 +133,13 @@ class SamordningVedtakServiceTest {
                 ),
             )
 
-        coEvery { vedtakKlient.hentVedtaksliste(virkFom, fnr = FNR, MaskinportenTpContext(tpnrSPK, ORGNO)) } returns vedtakliste
-        coEvery { tpKlient.harTpForholdByDate(FNR, tpnr = tpnrSPK, fomDato = virkFom) } returns true
+        coEvery { vedtakKlient.hentVedtaksliste(fomDato, fnr = FNR, MaskinportenTpContext(tpnrSPK, ORGNO)) } returns vedtakliste
+        coEvery { tpKlient.harTpForholdByDate(FNR, tpnr = tpnrSPK, fomDato = fomDato) } returns true
 
         val vedtaksliste =
             runBlocking {
                 samordningVedtakService.hentVedtaksliste(
-                    virkFom,
+                    fomDato,
                     Folkeregisteridentifikator.of(FNR),
                     MaskinportenTpContext(tpnrSPK, ORGNO),
                 )
@@ -147,7 +147,7 @@ class SamordningVedtakServiceTest {
 
         vedtaksliste shouldHaveSize 2
 
-        coVerify { tpKlient.harTpForholdByDate(FNR, tpnr = tpnrSPK, fomDato = virkFom) }
+        coVerify { tpKlient.harTpForholdByDate(FNR, tpnr = tpnrSPK, fomDato = fomDato) }
     }
 }
 

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakBehandlingService.kt
@@ -55,9 +55,9 @@ class VedtakBehandlingService(
 
     fun finnFerdigstilteVedtak(
         fnr: Folkeregisteridentifikator,
-        virkFom: LocalDate,
+        fomDato: LocalDate,
     ): List<Vedtak> {
-        return repository.hentFerdigstilteVedtak(fnr, virkFom)
+        return repository.hentFerdigstilteVedtak(fnr, fomDato)
     }
 
     fun sjekkOmVedtakErLoependePaaDato(

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakBehandlingService.kt
@@ -53,11 +53,8 @@ class VedtakBehandlingService(
 ) {
     private val logger = LoggerFactory.getLogger(VedtakBehandlingService::class.java)
 
-    fun finnFerdigstilteVedtak(
-        fnr: Folkeregisteridentifikator,
-        fomDato: LocalDate,
-    ): List<Vedtak> {
-        return repository.hentFerdigstilteVedtak(fnr, fomDato)
+    fun finnFerdigstilteVedtak(fnr: Folkeregisteridentifikator): List<Vedtak> {
+        return repository.hentFerdigstilteVedtak(fnr)
     }
 
     fun sjekkOmVedtakErLoependePaaDato(

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRepository.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRepository.kt
@@ -24,7 +24,6 @@ import no.nav.etterlatte.libs.database.hentListe
 import no.nav.etterlatte.libs.database.oppdater
 import no.nav.etterlatte.libs.database.transaction
 import java.sql.Date
-import java.time.LocalDate
 import java.time.YearMonth
 import java.util.UUID
 import javax.sql.DataSource
@@ -238,7 +237,6 @@ class VedtaksvurderingRepository(private val datasource: DataSource) : Transacti
 
     fun hentFerdigstilteVedtak(
         fnr: Folkeregisteridentifikator,
-        fomDato: LocalDate,
         tx: TransactionalSession? = null,
     ): List<Vedtak> {
         val hentVedtak = """
@@ -248,12 +246,11 @@ class VedtaksvurderingRepository(private val datasource: DataSource) : Transacti
             FROM vedtak  
             WHERE vedtakstatus in ('TIL_SAMORDNING', 'SAMORDNET', 'IVERKSATT')   
             AND fnr = :fnr
-            AND datoVirkFom >= :fomDato
             """
         return tx.session {
             hentListe(
                 queryString = hentVedtak,
-                params = { mapOf("fnr" to fnr.value, "fomDato" to fomDato) },
+                params = { mapOf("fnr" to fnr.value) },
             ) {
                 val utbetalingsperioder = hentUtbetalingsPerioder(it.long("id"), this)
                 it.toVedtak(utbetalingsperioder)

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRepository.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRepository.kt
@@ -236,12 +236,9 @@ class VedtaksvurderingRepository(private val datasource: DataSource) : Transacti
         }
     }
 
-    /**
-     * TODO vedtakstatus SAMORDNET e.l.?
-     */
     fun hentFerdigstilteVedtak(
         fnr: Folkeregisteridentifikator,
-        virkFom: LocalDate,
+        fomDato: LocalDate,
         tx: TransactionalSession? = null,
     ): List<Vedtak> {
         val hentVedtak = """
@@ -251,12 +248,12 @@ class VedtaksvurderingRepository(private val datasource: DataSource) : Transacti
             FROM vedtak  
             WHERE vedtakstatus in ('TIL_SAMORDNING', 'SAMORDNET', 'IVERKSATT')   
             AND fnr = :fnr
-            AND datoVirkFom >= :virkFom
+            AND datoVirkFom >= :fomDato
             """
         return tx.session {
             hentListe(
                 queryString = hentVedtak,
-                params = { mapOf("fnr" to fnr.value, "virkFom" to virkFom) },
+                params = { mapOf("fnr" to fnr.value, "fomDato" to fomDato) },
             ) {
                 val utbetalingsperioder = hentUtbetalingsPerioder(it.long("id"), this)
                 it.toVedtak(utbetalingsperioder)

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -221,14 +221,14 @@ fun Route.samordningsvedtakRoute(
         }
 
         get {
-            val virkFom =
-                call.parameters["virkFom"]?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
-                    ?: return@get call.respond(HttpStatusCode.BadRequest, "virkFom ikke angitt")
+            val fomDato =
+                call.parameters["fomDato"]?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
+                    ?: return@get call.respond(HttpStatusCode.BadRequest, "fomDato ikke angitt")
             val fnr =
                 call.request.headers["fnr"]?.let { Folkeregisteridentifikator.of(it) }
                     ?: return@get call.respond(HttpStatusCode.BadRequest, "fnr ikke angitt")
 
-            val vedtaksliste = vedtakBehandlingService.finnFerdigstilteVedtak(fnr, virkFom)
+            val vedtaksliste = vedtakBehandlingService.finnFerdigstilteVedtak(fnr, fomDato)
             call.respond(vedtaksliste.map { it.toSamordningsvedtakDto() })
         }
 

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -221,14 +221,13 @@ fun Route.samordningsvedtakRoute(
         }
 
         get {
-            val fomDato =
-                call.parameters["fomDato"]?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
-                    ?: return@get call.respond(HttpStatusCode.BadRequest, "fomDato ikke angitt")
+            call.parameters["fomDato"]?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
+                ?: return@get call.respond(HttpStatusCode.BadRequest, "fomDato ikke angitt")
             val fnr =
                 call.request.headers["fnr"]?.let { Folkeregisteridentifikator.of(it) }
                     ?: return@get call.respond(HttpStatusCode.BadRequest, "fnr ikke angitt")
 
-            val vedtaksliste = vedtakBehandlingService.finnFerdigstilteVedtak(fnr, fomDato)
+            val vedtaksliste = vedtakBehandlingService.finnFerdigstilteVedtak(fnr)
             call.respond(vedtaksliste.map { it.toSamordningsvedtakDto() })
         }
 

--- a/apps/etterlatte-vedtaksvurdering/src/main/resources/db/migration/V24__add_indices.sql
+++ b/apps/etterlatte-vedtaksvurdering/src/main/resources/db/migration/V24__add_indices.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_fnr ON vedtak (fnr);
+CREATE INDEX idx_vedtakid ON utbetalingsperiode (vedtakid);

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/TestHelper.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/TestHelper.kt
@@ -23,6 +23,7 @@ import java.time.Month
 import java.time.YearMonth
 import java.util.UUID
 
+const val FNR_1 = "28098208560"
 const val FNR_2 = "04417103428"
 const val SAKSBEHANDLER_1 = "saksbehandler1"
 const val SAKSBEHANDLER_2 = "saksbehandler2"

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingRepositoryTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingRepositoryTest.kt
@@ -1,7 +1,6 @@
 package vedtaksvurdering
 
 import io.kotest.matchers.comparables.shouldBeGreaterThan
-import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
 import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.TestInstance
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
 import java.math.BigDecimal
-import java.time.LocalDate
 import java.time.Month
 import java.time.YearMonth
 import javax.sql.DataSource
@@ -302,37 +300,37 @@ internal class VedtaksvurderingRepositoryTest {
     }
 
     @Test
-    fun `skal hente vedtak for fnr og fra-og-med angitt dato`() {
-        val soeker1 = SOEKER_FOEDSELSNUMMER
+    fun `skal hente vedtak for fnr`() {
+        val soeker1 = Folkeregisteridentifikator.of(FNR_1)
         val soeker2 = Folkeregisteridentifikator.of(FNR_2)
 
         listOf(
             opprettVedtak(
-                sakId = 1,
+                sakId = 10,
                 soeker = soeker1,
                 virkningstidspunkt = YearMonth.of(2024, Month.JANUARY),
                 status = VedtakStatus.IVERKSATT,
             ),
             opprettVedtak(
-                sakId = 2,
+                sakId = 20,
                 soeker = soeker2,
                 virkningstidspunkt = YearMonth.of(2024, Month.JANUARY),
                 status = VedtakStatus.IVERKSATT,
             ),
             opprettVedtak(
-                sakId = 2,
+                sakId = 20,
                 soeker = soeker2,
                 virkningstidspunkt = YearMonth.of(2024, Month.MARCH),
                 status = VedtakStatus.SAMORDNET,
             ),
             opprettVedtak(
-                sakId = 1,
+                sakId = 10,
                 soeker = soeker1,
                 virkningstidspunkt = YearMonth.of(2024, Month.APRIL),
                 status = VedtakStatus.IVERKSATT,
             ),
             opprettVedtak(
-                sakId = 2,
+                sakId = 20,
                 soeker = soeker2,
                 virkningstidspunkt = YearMonth.of(2024, Month.JUNE),
                 status = VedtakStatus.TIL_SAMORDNING,
@@ -341,16 +339,11 @@ internal class VedtaksvurderingRepositoryTest {
             .map { repository.opprettVedtak(it) }
             .forEach { repository.iverksattVedtak(it.behandlingId) }
 
-        val results = repository.hentFerdigstilteVedtak(soeker2, LocalDate.of(2024, Month.MARCH, 1))
+        val results = repository.hentFerdigstilteVedtak(soeker2)
 
-        results.size shouldBeExactly 2
+        results.size shouldBeExactly 3
         results.forEach {
             it.soeker shouldBe soeker2
-            (it.innhold as VedtakBehandlingInnhold).virkningstidspunkt shouldBeGreaterThanOrEqualTo
-                YearMonth.of(
-                    2024,
-                    Month.MARCH,
-                )
         }
     }
 }


### PR DESCRIPTION
`virkFom` har en mye snevrere betydning enn `fomDato`. Dette endepunktet er bygd over samme idé som det i Pesys, hvor parameteret er kun "_fom_", og det er meningen å gi ut informasjon som gjelder på fra-og-med angitt dato. Med virkFom sier man at det kun skal hentes data der vedtak.virkningstidspunkt >= virkFom, vil med andre ord skippe å gi ut gjeldende sannsynligvis. 

Denne PRen forenkler datauthentingen, med den følge at potensielt _mer_ data hentes ut enn hva som skal gis ut, noe som skyldes mangelen på noe slags vedlikehold av fom/tom ved nye vedtak. Hva som _faktisk_ skal returneres håndteres av EY-2901 #2706 

Med datamengden pr person inntil videre tenker jeg det er rimelig å anta at ytelsen ikke påvirkes enormt av dette i ganske god tid fremover.