### PR TITLE
EY-1714 Skru om til SAM+TP Q1 for verdikjedetest samordning (m eksterne)

### DIFF
--- a/apps/etterlatte-hendelser-samordning/.nais/dev.yaml
+++ b/apps/etterlatte-hendelser-samordning/.nais/dev.yaml
@@ -35,7 +35,7 @@ spec:
     - name: SAMORDNINGVEDTAK_HENDELSE_GROUP_ID
       value: "etterlatte-v1"
     - name: SAMORDNINGVEDTAK_HENDELSE_TOPIC
-      value: "pensjonsamhandling.sam-vedtak-samhandlersvar-q2"
+      value: "pensjonsamhandling.sam-vedtak-samhandlersvar-q1"
   envFrom:
     - secret: my-application-unleash-api-token
   accessPolicy:

--- a/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
@@ -82,9 +82,9 @@ spec:
     - name: ETTERLATTE_VEDTAKSVURDERING_SCOPE
       value: api://dev-gcp.etterlatte.etterlatte-vedtaksvurdering/.default
     - name: TJENESTEPENSJON_URL
-      value: https://tp-api-q2.dev-fss-pub.nais.io
+      value: https://tp-api-q1.dev-fss-pub.nais.io
     - name: TJENESTEPENSJON_SCOPE
-      value: api://dev-fss.pensjonsamhandling.tp-q2/.default
+      value: api://dev-fss.pensjonsamhandling.tp-q1/.default
     - name: ROLLE_PENSJONSAKSBEHANDLER
       value: 8bb9b8d1-f46a-4ade-8ee8-5895eccdf8cf
   accessPolicy:
@@ -125,4 +125,4 @@ spec:
       rules:
         - application: etterlatte-vedtaksvurdering
       external:
-        - host: tp-api-q2.dev-fss-pub.nais.io
+        - host: tp-api-q1.dev-fss-pub.nais.io

--- a/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
@@ -67,9 +67,9 @@ spec:
     - name: BEHANDLING_AZURE_SCOPE
       value: api://dev-gcp.etterlatte.etterlatte-behandling/.default
     - name: SAMORDNEVEDTAK_URL
-      value: https://sam-q2.dev-fss-pub.nais.io
+      value: https://sam-q1.dev-fss-pub.nais.io
     - name: SAMORDNEVEDTAK_AZURE_SCOPE
-      value: api://dev-fss.pensjonsamhandling.sam-q2/.default
+      value: api://dev-fss.pensjonsamhandling.sam-q1/.default
   envFrom:
     - secret: my-application-unleash-api-token
   accessPolicy:
@@ -94,4 +94,4 @@ spec:
         - application: etterlatte-behandling
       external:
         - host: etterlatte-unleash-api.nav.cloud.nais.io
-        - host: sam-q2.dev-fss-pub.nais.io
+        - host: sam-q1.dev-fss-pub.nais.io

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/klienter/SamKlient.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/klienter/SamKlient.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.vedtaksvurdering.klienter
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.typesafe.config.Config
+import io.getunleash.UnleashContext
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.ResponseException
@@ -48,6 +49,10 @@ class SamKlientImpl(
         if (!featureToggleService.isEnabled(
                 toggleId = SamordneVedtakFeatureToggle.SamordneVedtakMedSamToggle,
                 defaultValue = false,
+                context =
+                    UnleashContext.builder()
+                        .userId(brukerTokenInfo.ident())
+                        .build(),
             )
         ) {
             return false


### PR DESCRIPTION
ref https://nav-it.slack.com/archives/C063E3VAP24/p1700039680332509

Bakgrunn: TP-ordningene er koblet opp mot Q1. Nå er jo det et delt miljø med både prodkopi og synttestdata, men Gjenny får bare en tynn melding tilbake med 
```
vedtaksid
fagsystemkode
ytelseskode
```