### PR TITLE
Sjekkliste - delvis rollback av endringen på når den hentes

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
@@ -95,27 +95,23 @@ export const BehandlingSidemeny = ({ behandling }: { behandling: IBehandlingRedu
   const [opprettSjekklisteResult, opprettSjekklisteForBehandling, resetOpprettSjekkliste] =
     useApiCall(opprettSjekkliste)
 
-  function byttFane(fane: BehandlingFane) {
-    if (fane === BehandlingFane.SJEKKLISTE) {
-      resetSjekklisteResult()
-      resetOpprettSjekkliste()
-      if (behandling && erFoerstegangsbehandling && isInitial(hentSjekklisteResult)) {
-        hentSjekklisteForBehandling(behandling.id, (result, statusCode) => {
-          if (statusCode === 204) {
-            if (!erFerdigBehandlet(behandling.status)) {
-              opprettSjekklisteForBehandling(behandling.id, (nySjekkliste) => {
-                dispatch(updateSjekkliste(nySjekkliste))
-              })
-            }
-          } else {
-            dispatch(updateSjekkliste(result))
+  useEffect(() => {
+    resetSjekklisteResult()
+    resetOpprettSjekkliste()
+    if (behandling && erFoerstegangsbehandling && isInitial(hentSjekklisteResult)) {
+      hentSjekklisteForBehandling(behandling.id, (result, statusCode) => {
+        if (statusCode === 204) {
+          if (!erFerdigBehandlet(behandling.status)) {
+            opprettSjekklisteForBehandling(behandling.id, (nySjekkliste) => {
+              dispatch(updateSjekkliste(nySjekkliste))
+            })
           }
-        })
-      }
+        } else {
+          dispatch(updateSjekkliste(result))
+        }
+      })
     }
-
-    dispatch(visFane(fane))
-  }
+  }, [])
 
   return (
     <Sidebar>
@@ -146,7 +142,7 @@ export const BehandlingSidemeny = ({ behandling }: { behandling: IBehandlingRedu
         <ApiErrorAlert>Kunne ikke hente saksbehandler gjeldende oppgave</ApiErrorAlert>
       )}
       {erFoerstegangsbehandling && (
-        <Tabs value={fane} iconPosition="top" onChange={(val) => byttFane(val as BehandlingFane)}>
+        <Tabs value={fane} iconPosition="top" onChange={(val) => dispatch(visFane(val as BehandlingFane))}>
           <Tabs.List>
             <Tabs.Tab value={BehandlingFane.DOKUMENTER} label="Dokumenter" icon={<FileTextIcon title="dokumenter" />} />
             <Tabs.Tab


### PR DESCRIPTION
Se #2723

Problemet er at når sjekklisten ikke hentes/opprettes før eventuell klikk på fanen, så roter det til for valideringen av sjekklista i modalen "send til attestering". Mulig at det kan ordnes på noe vis med den, men her og nå tenker jeg det kanskje er greiest å (dessverre) gå tilbake til opprinnelig løsning - men beholde 204 istedetfor 404 fra backend da.