### PR TITLE
Send til rapid etter attestering skjer no i vedtaksvurdering-kafka, s…

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/AutomatiskBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/AutomatiskBehandlingService.kt
@@ -62,6 +62,6 @@ class AutomatiskBehandlingService(
             behandlingId,
             "Automatisk attestert av ${Fagsaksystem.EY.systemnavn}",
             brukerTokenInfo,
-        ).also { rapidService.sendToRapid(it) }
+        )
     }
 }

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/migrering/AutomatiskBehandlingRoutesKtTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/migrering/AutomatiskBehandlingRoutesKtTest.kt
@@ -145,7 +145,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
                 behandlingKlient.tildelSaksbehandler(any(), any())
                 vedtakService.attesterVedtak(behandlingId, any(), any())
             }
-            coVerify(exactly = 2) {
+            coVerify(exactly = 1) {
                 rapidService.sendToRapid(any())
             }
             coVerify(atLeast = 1) {
@@ -220,7 +220,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
                     behandlingKlient.tildelSaksbehandler(any(), any())
                     vedtakService.attesterVedtak(behandlingId, any(), any())
                 }
-                coVerify(exactly = 2) {
+                coVerify(exactly = 1) {
                     rapidService.sendToRapid(any())
                 }
                 coVerify(atLeast = 1) {
@@ -338,7 +338,6 @@ internal class AutomatiskBehandlingRoutesKtTest {
 
                 coVerify(exactly = 1) {
                     vedtakService.attesterVedtak(behandlingId, any(), any())
-                    rapidService.sendToRapid(any())
                 }
                 coVerify(atLeast = 1) {
                     behandlingKlient.harTilgangTilBehandling(any(), any())


### PR DESCRIPTION
…å det blir dobbelt opp å ha det her i servicen.

Betre å ha det i kafka-appen, for da får vi berika den pakka vi allereie har. Tippar denne kom inn pga mergekrøll.