### PR TITLE
Loggar feilande valideringar i rivers

### DIFF
--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/ListenerMedLogging.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/ListenerMedLogging.kt
@@ -1,16 +1,19 @@
 package rapidsandrivers.migrering
 
+import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.common.logging.withLogContext
 import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
+import no.nav.helse.rapids_rivers.MessageProblems
 import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
 
 abstract class ListenerMedLogging : River.PacketListener {
     private val logger = LoggerFactory.getLogger(this::class.java)
+    private val sikkerlogg = sikkerlogger()
 
     abstract fun haandterPakke(
         packet: JsonMessage,
@@ -22,6 +25,14 @@ abstract class ListenerMedLogging : River.PacketListener {
         context: MessageContext,
     ) = withLogContext(packet.correlationId) {
         haandterPakke(packet, context)
+    }
+
+    override fun onError(
+        problems: MessageProblems,
+        context: MessageContext,
+    ) {
+        sikkerlogg.warn("Plukka ikke opp meldinga i ${context.rapidName()} fordi ${problems.toExtendedReport()}")
+        super.onError(problems, context)
     }
 
     protected fun initialiserRiver(

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/ListenerMedLoggingOgFeilhaandtering.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/migrering/ListenerMedLoggingOgFeilhaandtering.kt
@@ -1,10 +1,12 @@
 package rapidsandrivers.migrering
 
+import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.common.logging.withLogContext
 import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
+import no.nav.helse.rapids_rivers.MessageProblems
 import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import org.slf4j.LoggerFactory
@@ -12,6 +14,7 @@ import rapidsandrivers.withFeilhaandtering
 
 abstract class ListenerMedLoggingOgFeilhaandtering(protected val hendelsestype: String) : River.PacketListener {
     private val logger = LoggerFactory.getLogger(this::class.java)
+    private val sikkerlogg = sikkerlogger()
 
     abstract fun haandterPakke(
         packet: JsonMessage,
@@ -25,6 +28,14 @@ abstract class ListenerMedLoggingOgFeilhaandtering(protected val hendelsestype: 
         withFeilhaandtering(packet, context, hendelsestype) {
             haandterPakke(packet, context)
         }
+    }
+
+    override fun onError(
+        problems: MessageProblems,
+        context: MessageContext,
+    ) {
+        sikkerlogg.warn("Plukka ikke opp meldinga i ${context.rapidName()} fordi ${problems.toExtendedReport()}")
+        super.onError(problems, context)
     }
 
     protected fun initialiserRiver(


### PR DESCRIPTION
Merk at desse ikkje slår til viss eventnames er feil, som i grunn er bra, da slepp vi veldig mange falske positive