### PR TITLE
Støtte for å lagre ned flyktningstatus fra Pesys.

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringService.kt
@@ -10,6 +10,7 @@ import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeServi
 import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.Flyktning
 import no.nav.etterlatte.libs.common.behandling.JaNei
 import no.nav.etterlatte.libs.common.behandling.JaNeiMedBegrunnelse
 import no.nav.etterlatte.libs.common.behandling.KommerBarnetTilgode
@@ -65,6 +66,18 @@ class MigreringService(
                     pesys,
                     "Automatisk importert fra Pesys",
                 )
+
+                sakService.oppdaterFlyktning(
+                    sakId = behandling.sak.id,
+                    flyktning =
+                        Flyktning(
+                            erFlyktning = request.flyktningStatus,
+                            virkningstidspunkt = request.foersteVirkningstidspunkt.atDay(1),
+                            begrunnelse = "Automatisk migrert fra Pesys",
+                            kilde = Grunnlagsopplysning.Pesys.create(),
+                        ),
+                )
+
                 val nyopprettaOppgave =
                     requireNotNull(behandlingOgOppgave.oppgave) {
                         "Mangler oppgave for behandling=${behandling.id}. Stopper migrering for pesysId=${request.pesysId}"

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakDao.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.sak
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.objectMapper
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseService
+import no.nav.etterlatte.libs.common.behandling.Flyktning
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Utenlandstilknytning
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
@@ -51,6 +52,21 @@ class SakDao(private val connection: () -> Connection) {
                     "UPDATE sak set utenlandstilknytning = ? where id = ?",
                 )
             statement.setJsonb(1, utenlandstilknytning)
+            statement.setLong(2, sakId)
+            statement.executeUpdate()
+        }
+    }
+
+    fun oppdaterFlyktning(
+        sakId: Long,
+        flyktning: Flyktning,
+    ) {
+        with(connection()) {
+            val statement =
+                prepareStatement(
+                    "UPDATE sak set flyktning = ? where id = ?",
+                )
+            statement.setJsonb(1, flyktning)
             statement.setLong(2, sakId)
             statement.executeUpdate()
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
@@ -13,6 +13,7 @@ import no.nav.etterlatte.common.klienter.SkjermingKlient
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggle
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseService
+import no.nav.etterlatte.libs.common.behandling.Flyktning
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Utenlandstilknytning
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
@@ -74,6 +75,11 @@ interface SakService {
     ): Int
 
     fun hentSakMedUtenlandstilknytning(fnr: String): SakUtenlandstilknytning
+
+    fun oppdaterFlyktning(
+        sakId: Long,
+        flyktning: Flyktning,
+    )
 }
 
 class BrukerManglerSak(message: String) : Exception(message)
@@ -94,6 +100,13 @@ class SakServiceImpl(
         utenlandstilknytning: Utenlandstilknytning,
     ) {
         dao.oppdaterUtenlandstilknytning(sakId, utenlandstilknytning)
+    }
+
+    override fun oppdaterFlyktning(
+        sakId: Long,
+        flyktning: Flyktning,
+    ) {
+        dao.oppdaterFlyktning(sakId, flyktning)
     }
 
     override fun hentSaker(): List<Sak> {

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V75__legg_til_flyktning_status.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V75__legg_til_flyktning_status.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sak ADD COLUMN flyktning JSONB;

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Flyktning.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Flyktning.kt
@@ -1,0 +1,11 @@
+package no.nav.etterlatte.libs.common.behandling
+
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import java.time.LocalDate
+
+data class Flyktning(
+    val erFlyktning: Boolean,
+    val virkningstidspunkt: LocalDate,
+    val begrunnelse: String,
+    val kilde: Grunnlagsopplysning.Kilde,
+)


### PR DESCRIPTION
Samme datagrunnlag blir senere benyttet i trygdetid for å gi 40 års trygdetid. For nå så lagres det kun ned som informasjon på saken. Det er nok ønskelig å hente det ut igjen å vise saksbehandler senere.

EY-3126