### PR TITLE
Nokre av systemnamna blir for lange til at det går gjennom i utbetali…

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/AutomatiskBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/AutomatiskBehandlingService.kt
@@ -10,7 +10,6 @@ import java.util.UUID
 
 class AutomatiskBehandlingService(
     val service: VedtakBehandlingService,
-    val rapidService: VedtaksvurderingRapidService,
     val behandlingKlient: BehandlingKlient,
 ) {
     private val logger = LoggerFactory.getLogger(AutomatiskBehandlingService::class.java)
@@ -44,7 +43,7 @@ class AutomatiskBehandlingService(
         logger.info("Håndterer behandling $behandlingId")
         service.opprettEllerOppdaterVedtak(behandlingId, brukerTokenInfo)
         logger.info("Fatter vedtak for behandling $behandlingId")
-        val vedtakOgRapid = service.fattVedtak(behandlingId, brukerTokenInfo)
+        val vedtakOgRapid = service.fattVedtak(behandlingId, brukerTokenInfo, saksbehandler = Fagsaksystem.EY.navn)
 
         logger.info("Tildeler attesteringsoppgave til systembruker")
         val oppgaveTilAttestering =
@@ -67,6 +66,7 @@ class AutomatiskBehandlingService(
             behandlingId,
             "Automatisk attestert av ${Fagsaksystem.EY.systemnavn}",
             brukerTokenInfo,
+            attestant = Fagsaksystem.EY.navn,
         )
     }
 }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakBehandlingService.kt
@@ -92,6 +92,7 @@ class VedtakBehandlingService(
     suspend fun fattVedtak(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
+        saksbehandler: String = brukerTokenInfo.ident(),
     ): VedtakOgRapid {
         logger.info("Fatter vedtak for behandling med behandlingId=$behandlingId")
         val vedtak = hentVedtakNonNull(behandlingId)
@@ -109,7 +110,7 @@ class VedtakBehandlingService(
                 fattVedtak(
                     behandlingId,
                     VedtakFattet(
-                        brukerTokenInfo.ident(),
+                        saksbehandler,
                         sak.enhet,
                         Tidspunkt.now(clock),
                     ),
@@ -152,6 +153,7 @@ class VedtakBehandlingService(
         behandlingId: UUID,
         kommentar: String,
         brukerTokenInfo: BrukerTokenInfo,
+        attestant: String = brukerTokenInfo.ident(),
     ): VedtakOgRapid {
         logger.info("Attesterer vedtak for behandling med behandlingId=$behandlingId")
         val vedtak = hentVedtakNonNull(behandlingId)
@@ -170,7 +172,7 @@ class VedtakBehandlingService(
                     repository.attesterVedtak(
                         behandlingId,
                         Attestasjon(
-                            brukerTokenInfo.ident(),
+                            attestant,
                             sak.enhet,
                             Tidspunkt.now(clock),
                         ),

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/config/ApplicationBuilder.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/config/ApplicationBuilder.kt
@@ -78,11 +78,11 @@ class ApplicationBuilder {
         VedtakTilbakekrevingService(
             repository = VedtaksvurderingRepository(dataSource),
         )
-    private val automatiskBehandlingService = AutomatiskBehandlingService(
-        vedtakBehandlingService,
-        vedtaksvurderingRapidService,
-        behandlingKlient
-    )
+    private val automatiskBehandlingService =
+        AutomatiskBehandlingService(
+            vedtakBehandlingService,
+            behandlingKlient,
+        )
 
     private val rapidsConnection =
         RapidApplication.Builder(RapidApplication.RapidApplicationConfig.fromEnv(getRapidEnv()))

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingRouteTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingRouteTest.kt
@@ -487,7 +487,7 @@ internal class VedtaksvurderingRouteTest {
                 status = VedtakStatus.FATTET_VEDTAK,
                 vedtakFattet = VedtakFattet(SAKSBEHANDLER_1, ENHET_1, Tidspunkt.now()),
             )
-        coEvery { vedtakBehandlingService.fattVedtak(any(), any()) } returns VedtakOgRapid(fattetVedtak.toDto(), mockk())
+        coEvery { vedtakBehandlingService.fattVedtak(any(), any(), any()) } returns VedtakOgRapid(fattetVedtak.toDto(), mockk())
         coEvery { rapidService.sendToRapid(any()) } just runs
 
         testApplication {
@@ -535,7 +535,7 @@ internal class VedtaksvurderingRouteTest {
 
             coVerify(exactly = 1) {
                 behandlingKlient.harTilgangTilBehandling(any(), any())
-                vedtakBehandlingService.fattVedtak(any(), match { it.ident() == SAKSBEHANDLER_1 })
+                vedtakBehandlingService.fattVedtak(any(), match { it.ident() == SAKSBEHANDLER_1 }, any())
                 rapidService.sendToRapid(any())
             }
         }
@@ -550,7 +550,10 @@ internal class VedtaksvurderingRouteTest {
                 vedtakFattet = VedtakFattet(SAKSBEHANDLER_1, ENHET_1, Tidspunkt.now()),
                 attestasjon = Attestasjon(SAKSBEHANDLER_2, ENHET_2, Tidspunkt.now()),
             )
-        coEvery { vedtakBehandlingService.attesterVedtak(any(), any(), any()) } returns VedtakOgRapid(attestertVedtak.toDto(), mockk())
+        coEvery { vedtakBehandlingService.attesterVedtak(any(), any(), any(), any()) } returns
+            VedtakOgRapid(
+                attestertVedtak.toDto(), mockk(),
+            )
         coEvery { rapidService.sendToRapid(any()) } just runs
 
         testApplication {
@@ -603,6 +606,7 @@ internal class VedtaksvurderingRouteTest {
                     any(),
                     match { it == attestertVedtakKommentar.kommentar },
                     match { it.ident() == SAKSBEHANDLER_1 },
+                    any(),
                 )
                 rapidService.sendToRapid(any())
             }

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/migrering/AutomatiskBehandlingRoutesKtTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/migrering/AutomatiskBehandlingRoutesKtTest.kt
@@ -31,6 +31,7 @@ import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseType
 import no.nav.etterlatte.libs.ktor.AZURE_ISSUER
 import no.nav.etterlatte.libs.ktor.restModule
 import no.nav.etterlatte.rapidsandrivers.migrering.MigreringKjoringVariant
+import no.nav.etterlatte.token.Fagsaksystem
 import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll
@@ -54,7 +55,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
     private val behandlingKlient = mockk<BehandlingKlient>()
     private val vedtakService: VedtakBehandlingService = mockk()
     private val rapidService: VedtaksvurderingRapidService = mockk()
-    private val automatiskBehandlingService = AutomatiskBehandlingService(vedtakService, rapidService, behandlingKlient)
+    private val automatiskBehandlingService = AutomatiskBehandlingService(vedtakService, behandlingKlient)
 
     @BeforeAll
     fun before() {
@@ -87,7 +88,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
             val behandlingId = UUID.randomUUID()
             coEvery { vedtakService.opprettEllerOppdaterVedtak(any(), any()) } returns
                 opprettetVedtak
-            coEvery { vedtakService.fattVedtak(behandlingId, any()) } returns
+            coEvery { vedtakService.fattVedtak(behandlingId, any(), any()) } returns
                 VedtakOgRapid(
                     opprettetVedtak.toDto(),
                     RapidInfo(
@@ -106,6 +107,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
             coEvery {
                 vedtakService.attesterVedtak(
                     behandlingId,
+                    any(),
                     any(),
                     any(),
                 )
@@ -147,9 +149,9 @@ internal class AutomatiskBehandlingRoutesKtTest {
             coVerify(exactly = 1) {
                 vedtakService.opprettEllerOppdaterVedtak(behandlingId, any())
                 behandlingKlient.hentOppgaverForSak(1, any())
-                vedtakService.fattVedtak(behandlingId, any())
+                vedtakService.fattVedtak(behandlingId, any(), Fagsaksystem.EY.navn)
                 behandlingKlient.tildelSaksbehandler(any(), any())
-                vedtakService.attesterVedtak(behandlingId, any(), any())
+                vedtakService.attesterVedtak(behandlingId, any(), any(), Fagsaksystem.EY.navn)
             }
             coVerify(atLeast = 1) {
                 behandlingKlient.harTilgangTilBehandling(any(), any())
@@ -167,7 +169,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
                 val behandlingId = UUID.randomUUID()
                 coEvery { vedtakService.opprettEllerOppdaterVedtak(any(), any()) } returns
                     opprettetVedtak
-                coEvery { vedtakService.fattVedtak(behandlingId, any()) } returns
+                coEvery { vedtakService.fattVedtak(behandlingId, any(), any()) } returns
                     VedtakOgRapid(
                         opprettetVedtak.toDto(),
                         RapidInfo(
@@ -186,6 +188,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
                 coEvery {
                     vedtakService.attesterVedtak(
                         behandlingId,
+                        any(),
                         any(),
                         any(),
                     )
@@ -229,9 +232,9 @@ internal class AutomatiskBehandlingRoutesKtTest {
                 coVerify(exactly = 1) {
                     vedtakService.opprettEllerOppdaterVedtak(behandlingId, any())
                     behandlingKlient.hentOppgaverForSak(1, any())
-                    vedtakService.fattVedtak(behandlingId, any())
+                    vedtakService.fattVedtak(behandlingId, any(), Fagsaksystem.EY.navn)
                     behandlingKlient.tildelSaksbehandler(any(), any())
-                    vedtakService.attesterVedtak(behandlingId, any(), any())
+                    vedtakService.attesterVedtak(behandlingId, any(), any(), Fagsaksystem.EY.navn)
                 }
                 coVerify(atLeast = 1) {
                     behandlingKlient.harTilgangTilBehandling(any(), any())
@@ -246,7 +249,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
                 val behandlingId = UUID.randomUUID()
                 coEvery { runBlocking { vedtakService.opprettEllerOppdaterVedtak(any(), any()) } } returns
                     opprettetVedtak
-                coEvery { runBlocking { vedtakService.fattVedtak(behandlingId, any()) } } returns
+                coEvery { runBlocking { vedtakService.fattVedtak(behandlingId, any(), any()) } } returns
                     VedtakOgRapid(
                         opprettetVedtak.toDto(),
                         RapidInfo(
@@ -288,7 +291,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
                 coVerify(exactly = 1) {
                     vedtakService.opprettEllerOppdaterVedtak(behandlingId, any())
                     behandlingKlient.hentOppgaverForSak(1, any())
-                    vedtakService.fattVedtak(behandlingId, any())
+                    vedtakService.fattVedtak(behandlingId, any(), Fagsaksystem.EY.navn)
                     behandlingKlient.tildelSaksbehandler(any(), any())
                 }
                 coVerify(atLeast = 1) {
@@ -306,6 +309,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
                     runBlocking {
                         vedtakService.attesterVedtak(
                             behandlingId,
+                            any(),
                             any(),
                             any(),
                         )
@@ -344,7 +348,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
                 assertEquals(respons.vedtak.vedtakId, opprettetVedtak.id)
 
                 coVerify(exactly = 1) {
-                    vedtakService.attesterVedtak(behandlingId, any(), any())
+                    vedtakService.attesterVedtak(behandlingId, any(), any(), Fagsaksystem.EY.navn)
                 }
                 coVerify(atLeast = 1) {
                     behandlingKlient.harTilgangTilBehandling(any(), any())


### PR DESCRIPTION
…ng, som har maksgrense på 32 teikn. Bruker derfor hardkoda systemnamn for systemet når vi fattar og attesterer vedtak, sånn at vi er sikre på at det går gjennom vidare