### PR TITLE
Forbedre feilmelding når henting av person feiler

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
@@ -4,13 +4,15 @@ import { StatusBar } from '~shared/statusbar/Statusbar'
 import { Container } from '~shared/styled'
 import { SakOversikt } from './SakOversikt'
 import Spinner from '~shared/Spinner'
-import { isFailure, isPending, isSuccess, useApiCall } from '~shared/hooks/useApiCall'
-import { BodyShort, Tabs } from '@navikt/ds-react'
+import { mapApiResult, useApiCall } from '~shared/hooks/useApiCall'
+import { Tabs } from '@navikt/ds-react'
 import { getPerson } from '~shared/api/grunnlag'
 import { GYLDIG_FNR } from '~utils/fnr'
 import NavigerTilbakeMeny from '~components/person/NavigerTilbakeMeny'
 import { BulletListIcon, FileTextIcon } from '@navikt/aksel-icons'
 import { Dokumentoversikt } from './dokumenter/dokumentoversikt'
+import { ApiErrorAlert } from '~ErrorBoundary'
+import { ApiError } from '~shared/api/apiClient'
 
 enum Fane {
   SAKER = 'SAKER',
@@ -29,12 +31,18 @@ export const Person = () => {
     }
   }, [fnr])
 
-  if (isFailure(personStatus)) {
-    return (
-      <Container>
-        <BodyShort>{!GYLDIG_FNR(fnr) ? 'Fødselsnummeret i URLen er ugyldig' : JSON.stringify(personStatus)}</BodyShort>
-      </Container>
-    )
+  const handleError = (error: ApiError) => {
+    if (error.status === 400) {
+      return <ApiErrorAlert>Ugyldig forespørsel. Er fødselsnummeret korrekt?</ApiErrorAlert>
+    } else if (error.status === 404) {
+      return <ApiErrorAlert>Fant ikke person med fødselsnummer {fnr}</ApiErrorAlert>
+    } else {
+      return <ApiErrorAlert>Feil oppsto ved henting av person med fødselsnummer {fnr}</ApiErrorAlert>
+    }
+  }
+
+  if (!GYLDIG_FNR(fnr)) {
+    return <ApiErrorAlert>Fødselsnummeret {fnr} er ugyldig</ApiErrorAlert>
   }
 
   return (
@@ -42,20 +50,26 @@ export const Person = () => {
       <StatusBar result={personStatus} />
       <NavigerTilbakeMeny label="Tilbake til oppgavebenken" path="/" />
 
-      {isPending(personStatus) && <Spinner visible label="Laster personinfo ..." />}
-      {isSuccess(personStatus) && (
-        <Tabs value={fane} onChange={(val) => setFane(val as Fane)}>
-          <Tabs.List>
-            <Tabs.Tab value={Fane.SAKER} label="Sak og behandling" icon={<BulletListIcon title="saker" />} />
-            <Tabs.Tab value={Fane.DOKUMENTER} label="Dokumenter" icon={<FileTextIcon title="dokumenter" />} />
-          </Tabs.List>
-          <Tabs.Panel value={Fane.SAKER}>
-            <SakOversikt fnr={personStatus.data.foedselsnummer} />
-          </Tabs.Panel>
-          <Tabs.Panel value={Fane.DOKUMENTER}>
-            <Dokumentoversikt fnr={personStatus.data.foedselsnummer} />
-          </Tabs.Panel>
-        </Tabs>
+      {mapApiResult(
+        personStatus,
+        <Spinner visible label="Laster personinfo ..." />,
+        (error) => (
+          <Container>{handleError(error)}</Container>
+        ),
+        (person) => (
+          <Tabs value={fane} onChange={(val) => setFane(val as Fane)}>
+            <Tabs.List>
+              <Tabs.Tab value={Fane.SAKER} label="Sak og behandling" icon={<BulletListIcon title="saker" />} />
+              <Tabs.Tab value={Fane.DOKUMENTER} label="Dokumenter" icon={<FileTextIcon title="dokumenter" />} />
+            </Tabs.List>
+            <Tabs.Panel value={Fane.SAKER}>
+              <SakOversikt fnr={person.foedselsnummer} />
+            </Tabs.Panel>
+            <Tabs.Panel value={Fane.DOKUMENTER}>
+              <Dokumentoversikt fnr={person.foedselsnummer} />
+            </Tabs.Panel>
+          </Tabs>
+        )
       )}
     </>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/hooks/useApiCall.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/hooks/useApiCall.ts
@@ -70,9 +70,9 @@ const error = <A = never>(error: ApiError): Result<A> => ({
 export const mapApiResult = <T>(
   result: Result<T>,
   mapInitialOrPending: ReactElement,
-  mapError: (_: ApiError) => ReactElement,
+  mapError: (_: ApiError) => ReactElement | null,
   mapSuccess: (_: T) => ReactElement
-): ReactElement => {
+): ReactElement | null => {
   if (isPendingOrInitial(result)) {
     return mapInitialOrPending
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/statusbar/Statusbar.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/statusbar/Statusbar.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 import { GenderIcon, GenderList } from '../icons/genderIcon'
 import { IPersonResult } from '~components/person/typer'
-import { isPending, isSuccess, Result } from '~shared/hooks/useApiCall'
+import { mapApiResult, Result } from '~shared/hooks/useApiCall'
 import { Link } from '@navikt/ds-react'
 import { KopierbarVerdi } from '~shared/statusbar/kopierbarVerdi'
 import { IPdlPerson } from '~shared/types/Person'
@@ -29,31 +29,37 @@ export const StatusBar = ({ result }: { result: Result<IPersonResult> }) => {
     return GenderList.male
   }
 
-  return (
-    <StatusBarWrapper>
-      {isPending(result) && (
+  return mapApiResult(
+    result,
+    <PersonSkeleton />,
+    () => null,
+    (person) => (
+      <StatusBarWrapper>
         <UserInfo>
-          <SkeletonGenderIcon />
+          <GenderIcon gender={gender(person.foedselsnummer)} />
           <Name>
-            <Skeleton />
+            <Link href={`/person/${person.foedselsnummer}`}>{genererNavn(person)}</Link>
           </Name>
           <Skilletegn>|</Skilletegn>
-          <Skeleton />
+          <KopierbarVerdi value={person.foedselsnummer} />
         </UserInfo>
-      )}
-      {isSuccess(result) && (
-        <UserInfo>
-          <GenderIcon gender={gender(result.data.foedselsnummer)} />
-          <Name>
-            <Link href={`/person/${result.data.foedselsnummer}`}>{genererNavn(result.data)}</Link>
-          </Name>
-          <Skilletegn>|</Skilletegn>
-          <KopierbarVerdi value={result.data.foedselsnummer} />
-        </UserInfo>
-      )}
-    </StatusBarWrapper>
+      </StatusBarWrapper>
+    )
   )
 }
+
+const PersonSkeleton = () => (
+  <StatusBarWrapper>
+    <UserInfo>
+      <SkeletonGenderIcon />
+      <Name>
+        <Skeleton />
+      </Name>
+      <Skilletegn>|</Skilletegn>
+      <Skeleton />
+    </UserInfo>
+  </StatusBarWrapper>
+)
 
 const genererNavn = (personInfo: IPersonResult) => {
   return [personInfo.fornavn, personInfo.mellomnavn, personInfo.etternavn].join(' ')


### PR DESCRIPTION
Dagens feilmelding ved person 404 er ikke veldig tydelig for sb. 

![Screenshot 2023-11-20 at 12 56 57](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/8fc10ae3-2085-4c02-a97b-7658b4c401bc)


Har gjort en mini-oppgradering av feilmeldinger og delt opp i flere typer. 

**404 Not found**
![Screenshot 2023-11-20 at 12 56 13](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/f8f448b2-3849-44e2-bacf-4334f01f80b7)

**400 Bad request**
![Screenshot 2023-11-20 at 12 54 24](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/d2634f25-fcb7-4fc1-957e-72c7772edc9d)

**Fnr. er ikke 11 siffer og kan ikke gjøre kall mot grunnlag**
![Screenshot 2023-11-20 at 12 53 17](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/009471ae-6a40-4627-9d59-dc322979ed75)
