### PR TITLE
EY-2901 Korrigert logikk for samordningsperioder

### DIFF
--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakService.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakService.kt
@@ -7,6 +7,7 @@ import no.nav.etterlatte.libs.common.beregning.AvkortingDto
 import no.nav.etterlatte.libs.common.beregning.BeregningDTO
 import no.nav.etterlatte.libs.common.deserialize
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
 import no.nav.etterlatte.libs.common.vedtak.VedtakSamordningDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import org.slf4j.LoggerFactory
@@ -75,7 +76,7 @@ class SamordningVedtakService(
             anvendtTrygdetid = beregning?.beregningsperioder?.first()?.trygdetid ?: 0,
             perioder =
                 avkorting?.avkortetYtelse
-                    ?.map { it.toSamordningVedtakPeriode() }
+                    ?.map { it.toSamordningVedtakPeriode(this.utbetalingsperioder) }
                     ?.sortedBy { it.fom }
                     ?: emptyList(),
         )
@@ -99,10 +100,12 @@ class SamordningVedtakService(
         }.name
     }
 
-    private fun AvkortetYtelseDto.toSamordningVedtakPeriode(): SamordningVedtakPeriode {
+    private fun AvkortetYtelseDto.toSamordningVedtakPeriode(utbetalingsperioder: List<Utbetalingsperiode>): SamordningVedtakPeriode {
+        val justertPeriode = utbetalingsperioder.first { this.fom == it.periode.fom }
+
         return SamordningVedtakPeriode(
             fom = fom.atStartOfMonth(),
-            tom = tom?.atEndOfMonth(),
+            tom = justertPeriode.periode.tom?.atEndOfMonth(),
             omstillingsstoenadBrutto = ytelseFoerAvkorting,
             omstillingsstoenadNetto = ytelseEtterAvkorting,
         )

--- a/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakServiceTest.kt
+++ b/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakServiceTest.kt
@@ -25,11 +25,13 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vedtak.Behandling
 import no.nav.etterlatte.libs.common.vedtak.Periode
 import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
+import no.nav.etterlatte.libs.common.vedtak.UtbetalingsperiodeType
 import no.nav.etterlatte.libs.common.vedtak.VedtakSamordningDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
 import java.time.YearMonth.now
 import java.util.UUID
 
@@ -70,14 +72,22 @@ class SamordningVedtakServiceTest {
 
     @Test
     fun `skal mappe vedtak med to perioder, hvor nr 1 er lukket og nr 2 er aapen`() {
+        val periodeFirst = Periode(fom = now(), tom = now())
+        val periodeSecond = Periode(fom = now().plusMonths(1), tom = null)
+
         val vedtak =
             vedtak(
                 vedtakId = 456L,
                 beregning = beregning(trygdetid = 32),
                 avkorting =
                     avkorting(
-                        Periode(fom = now(), tom = now()),
-                        Periode(fom = now().plusMonths(1), tom = null),
+                        periodeFirst,
+                        periodeSecond,
+                    ),
+                utbetalingsperioder =
+                    listOf(
+                        Utbetalingsperiode(id = 1, periodeFirst, beloep = BigDecimal(2500), type = UtbetalingsperiodeType.UTBETALING),
+                        Utbetalingsperiode(id = 2, periodeSecond, beloep = BigDecimal(2800), type = UtbetalingsperiodeType.UTBETALING),
                     ),
             )
         coEvery { vedtakKlient.hentVedtak(456L, MaskinportenTpContext(tpnrSPK, ORGNO)) } returns vedtak

--- a/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakServiceTest.kt
+++ b/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakServiceTest.kt
@@ -24,6 +24,7 @@ import no.nav.etterlatte.libs.common.sak.VedtakSak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vedtak.Behandling
 import no.nav.etterlatte.libs.common.vedtak.Periode
+import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
 import no.nav.etterlatte.libs.common.vedtak.VedtakSamordningDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
@@ -156,6 +157,7 @@ fun vedtak(
     sakstype: SakType = SakType.OMSTILLINGSSTOENAD,
     beregning: BeregningDTO? = null,
     avkorting: AvkortingDto? = null,
+    utbetalingsperioder: List<Utbetalingsperiode> = emptyList(),
 ): VedtakSamordningDto =
     VedtakSamordningDto(
         vedtakId = vedtakId ?: 5678L,
@@ -167,6 +169,7 @@ fun vedtak(
         type = VedtakType.INNVILGELSE,
         vedtakFattet = null,
         attestasjon = null,
+        utbetalingsperioder = utbetalingsperioder,
         beregning = beregning?.let { objectMapper.valueToTree(it) },
         avkorting = avkorting?.let { objectMapper.valueToTree(it) },
     )

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakBehandlingService.kt
@@ -48,10 +48,6 @@ class VedtakBehandlingService(
 ) {
     private val logger = LoggerFactory.getLogger(VedtakBehandlingService::class.java)
 
-    fun finnFerdigstilteVedtak(fnr: Folkeregisteridentifikator): List<Vedtak> {
-        return repository.hentFerdigstilteVedtak(fnr)
-    }
-
     fun sjekkOmVedtakErLoependePaaDato(
         sakId: Long,
         dato: LocalDate,

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakSamordningService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakSamordningService.kt
@@ -1,0 +1,74 @@
+package no.nav.etterlatte.vedtaksvurdering
+
+import no.nav.etterlatte.libs.common.beregning.AvkortetYtelseDto
+import no.nav.etterlatte.libs.common.beregning.AvkortingDto
+import no.nav.etterlatte.libs.common.deserialize
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.sak.VedtakSak
+import no.nav.etterlatte.libs.common.vedtak.Behandling
+import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
+import no.nav.etterlatte.libs.common.vedtak.VedtakSamordningDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakSamordningPeriode
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+import java.time.YearMonth
+
+class VedtakSamordningService(private val repository: VedtaksvurderingRepository) {
+    private val logger = LoggerFactory.getLogger(VedtakSamordningService::class.java)
+
+    fun hentVedtak(vedtakId: Long): VedtakSamordningDto? {
+        logger.debug("Henter vedtak med id=$vedtakId")
+        return repository.hentVedtak(vedtakId)?.toSamordningsvedtakDto()
+    }
+
+    fun hentVedtaksliste(
+        fnr: Folkeregisteridentifikator,
+        fomDato: LocalDate,
+    ): List<VedtakSamordningDto> {
+        logger.debug("Henter og sammenstiller vedtaksliste")
+        val vedtaksliste = repository.hentFerdigstilteVedtak(fnr)
+        val tidslinjeJustert =
+            Vedtakstidslinje(vedtaksliste)
+                .sammenstill(YearMonth.of(fomDato.year, fomDato.month))
+        return tidslinjeJustert.map { it.toSamordningsvedtakDto() }
+    }
+}
+
+private fun Vedtak.toSamordningsvedtakDto(): VedtakSamordningDto {
+    val innhold = innhold as VedtakBehandlingInnhold
+    val avkorting = innhold.avkorting?.let { deserialize<AvkortingDto>(it.toString()) }
+
+    return VedtakSamordningDto(
+        vedtakId = id,
+        fnr = soeker.value,
+        status = status,
+        sak = VedtakSak(soeker.value, sakType, sakId),
+        type = type,
+        vedtakFattet = vedtakFattet,
+        attestasjon = attestasjon,
+        behandling =
+            Behandling(
+                innhold.behandlingType,
+                behandlingId,
+                innhold.revurderingAarsak,
+                innhold.revurderingInfo,
+            ),
+        virkningstidspunkt = innhold.virkningstidspunkt,
+        beregning = innhold.beregning,
+        perioder =
+            avkorting?.avkortetYtelse
+                ?.map { it.toSamordningVedtakPeriode(innhold.utbetalingsperioder) }
+                ?: emptyList(),
+    )
+}
+
+private fun AvkortetYtelseDto.toSamordningVedtakPeriode(utbetalingsperioder: List<Utbetalingsperiode>): VedtakSamordningPeriode {
+    val justertPeriode = utbetalingsperioder.first { this.fom == it.periode.fom }
+
+    return VedtakSamordningPeriode(
+        fom = fom,
+        tom = justertPeriode.periode.tom,
+        ytelseFoerAvkorting = ytelseFoerAvkorting,
+        ytelseEtterAvkorting = ytelseEtterAvkorting,
+    )
+}

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/Vedtakstidslinje.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/Vedtakstidslinje.kt
@@ -59,7 +59,7 @@ class Vedtakstidslinje(private val vedtak: List<Vedtak>) {
         }
 
         return vedtakByVirkningsdato
-            .filter { (k, _) -> k.tom == null || k.tom!!.isAfter(fomDato) }
+            .filter { (k, _) -> k.tom == null || k.tom == fomDato || k.tom!!.isAfter(fomDato) }
             .map { (k, v) -> v.kopier(k) }
             .sortedBy { it.virkningstidspunkt }
     }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/Vedtakstidslinje.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/Vedtakstidslinje.kt
@@ -59,8 +59,8 @@ class Vedtakstidslinje(private val vedtak: List<Vedtak>) {
         }
 
         return vedtakByVirkningsdato
-            .filter { (k, _) -> k.tom == null || k.tom == fomDato || k.tom!!.isAfter(fomDato) }
-            .map { (k, v) -> v.kopier(k) }
+            .filter { (periode, _) -> periode.tom == null || periode.tom == fomDato || periode.tom!!.isAfter(fomDato) }
+            .map { (periode, vedtak) -> vedtak.kopier(periode) }
             .sortedBy { it.virkningstidspunkt }
     }
 

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -340,6 +340,7 @@ private fun Vedtak.toSamordningsvedtakDto(): VedtakSamordningDto {
                 innhold.revurderingInfo,
             ),
         virkningstidspunkt = innhold.virkningstidspunkt,
+        utbetalingsperioder = innhold.utbetalingsperioder,
         beregning = innhold.beregning,
         avkorting = innhold.avkorting,
     )

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/config/ApplicationBuilder.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/config/ApplicationBuilder.kt
@@ -15,6 +15,7 @@ import no.nav.etterlatte.libs.ktor.restModule
 import no.nav.etterlatte.libs.ktor.setReady
 import no.nav.etterlatte.vedtaksvurdering.AutomatiskBehandlingService
 import no.nav.etterlatte.vedtaksvurdering.VedtakBehandlingService
+import no.nav.etterlatte.vedtaksvurdering.VedtakSamordningService
 import no.nav.etterlatte.vedtaksvurdering.VedtakTilbakekrevingService
 import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingRapidService
 import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingRepository
@@ -78,6 +79,10 @@ class ApplicationBuilder {
         VedtakTilbakekrevingService(
             repository = VedtaksvurderingRepository(dataSource),
         )
+    private val vedtakSamordningService =
+        VedtakSamordningService(
+            repository = VedtaksvurderingRepository(dataSource),
+        )
     private val automatiskBehandlingService =
         AutomatiskBehandlingService(
             vedtakBehandlingService,
@@ -90,7 +95,7 @@ class ApplicationBuilder {
                 restModule(sikkerLogg, config = HoconApplicationConfig(config)) {
                     vedtaksvurderingRoute(vedtaksvurderingService, vedtakBehandlingService, vedtaksvurderingRapidService, behandlingKlient)
                     automatiskBehandlingRoutes(automatiskBehandlingService, behandlingKlient)
-                    samordningsvedtakRoute(vedtaksvurderingService, vedtakBehandlingService)
+                    samordningsvedtakRoute(vedtakSamordningService)
                     tilbakekrevingvedtakRoute(vedtakTilbakekrevingService, behandlingKlient)
                 }
             }

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/SamordningsvedtakRouteTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/SamordningsvedtakRouteTest.kt
@@ -14,6 +14,8 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.mockk
+import no.nav.etterlatte.libs.common.beregning.AvkortingDto
+import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.ktor.AZURE_ISSUER
 import no.nav.etterlatte.libs.ktor.restModule
 import no.nav.etterlatte.vedtaksvurdering.VedtakBehandlingService
@@ -71,7 +73,17 @@ class SamordningsvedtakRouteTest {
 
     @Test
     fun `skal returnere vedtak naar token har noedvendig rolle og vedtak eksisterer`() {
-        coEvery { vedtaksvurderingService.hentVedtak(1234) } returns vedtak()
+        coEvery { vedtaksvurderingService.hentVedtak(1234) } returns
+            vedtak(
+                avkorting =
+                    objectMapper.valueToTree(
+                        AvkortingDto(
+                            avkortingGrunnlag = emptyList(),
+                            avkortetYtelse = emptyList(),
+                            tidligereAvkortetYtelse = emptyList(),
+                        ),
+                    ),
+            )
 
         testApplication {
             environment { config = applicationConfig }

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/TestHelper.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/TestHelper.kt
@@ -94,6 +94,7 @@ fun vedtak(
     avkorting: ObjectNode? = objectMapper.createObjectNode(),
     revurderingAarsak: Revurderingaarsak? = null,
     status: VedtakStatus = VedtakStatus.OPPRETTET,
+    vedtakFattet: VedtakFattet? = null,
     utbetalingsperioder: List<Utbetalingsperiode>? = null,
 ) = Vedtak(
     id = 1L,
@@ -103,6 +104,7 @@ fun vedtak(
     sakType = SakType.BARNEPENSJON,
     behandlingId = behandlingId,
     type = VedtakType.INNVILGELSE,
+    vedtakFattet = vedtakFattet,
     innhold =
         VedtakBehandlingInnhold(
             behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtakSamordningServiceTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtakSamordningServiceTest.kt
@@ -1,0 +1,144 @@
+package vedtaksvurdering
+
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.etterlatte.libs.common.beregning.AvkortetYtelseDto
+import no.nav.etterlatte.libs.common.beregning.AvkortingDto
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.vedtak.Periode
+import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
+import no.nav.etterlatte.libs.common.vedtak.UtbetalingsperiodeType
+import no.nav.etterlatte.libs.common.vedtak.VedtakFattet
+import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
+import no.nav.etterlatte.vedtaksvurdering.VedtakSamordningService
+import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingRepository
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.Month
+import java.time.YearMonth
+
+class VedtakSamordningServiceTest {
+    private val vedtakRepository: VedtaksvurderingRepository = mockk()
+    private val samordningService = VedtakSamordningService(vedtakRepository)
+
+    @Test
+    fun `skal hente vedtak`() {
+        every { vedtakRepository.hentVedtak(1234) } returns
+            vedtak(
+                status = VedtakStatus.IVERKSATT,
+                avkorting =
+                    objectMapper.valueToTree(
+                        AvkortingDto(
+                            avkortingGrunnlag = emptyList(),
+                            avkortetYtelse = emptyList(),
+                            tidligereAvkortetYtelse = emptyList(),
+                        ),
+                    ),
+            )
+
+        val resultat = samordningService.hentVedtak(1234)!!
+
+        verify { vedtakRepository.hentVedtak(1234) }
+
+        resultat.status shouldBeEqual VedtakStatus.IVERKSATT
+        resultat.perioder shouldBeEqual emptyList()
+    }
+
+    @Test
+    fun `Skal hente sammenstilt tidslinje av vedtakslista`() {
+        val virkFom2024Januar = YearMonth.of(2024, Month.JANUARY)
+        val virkFom2024Februar = YearMonth.of(2024, Month.FEBRUARY)
+
+        every { vedtakRepository.hentFerdigstilteVedtak(Folkeregisteridentifikator.of(FNR_2)) } returns
+            listOf(
+                vedtak(
+                    status = VedtakStatus.IVERKSATT,
+                    virkningstidspunkt = virkFom2024Januar,
+                    vedtakFattet =
+                        VedtakFattet(
+                            "SBH", "1014", Tidspunkt.parse("2023-12-05T14:20:50Z"),
+                        ),
+                    utbetalingsperioder =
+                        listOf(
+                            Utbetalingsperiode(
+                                periode = Periode(virkFom2024Januar, null),
+                                beloep = BigDecimal(2500),
+                                type = UtbetalingsperiodeType.UTBETALING,
+                            ),
+                        ),
+                    avkorting =
+                        objectMapper.valueToTree(
+                            avkortingDto(fom = virkFom2024Januar, ytelseFoer = 3000, ytelseEtter = 2500),
+                        ),
+                ),
+                vedtak(
+                    status = VedtakStatus.IVERKSATT,
+                    virkningstidspunkt = virkFom2024Februar,
+                    vedtakFattet =
+                        VedtakFattet(
+                            "SBH", "1014", Tidspunkt.parse("2024-01-11T09:43:04Z"),
+                        ),
+                    utbetalingsperioder =
+                        listOf(
+                            Utbetalingsperiode(
+                                periode = Periode(virkFom2024Februar, null),
+                                beloep = BigDecimal(2500),
+                                type = UtbetalingsperiodeType.UTBETALING,
+                            ),
+                        ),
+                    avkorting =
+                        objectMapper.valueToTree(
+                            avkortingDto(fom = virkFom2024Februar, ytelseFoer = 3200, ytelseEtter = 2900),
+                        ),
+                ),
+            )
+
+        val resultat =
+            samordningService.hentVedtaksliste(
+                Folkeregisteridentifikator.of(FNR_2),
+                fomDato = LocalDate.of(2024, Month.JANUARY, 1),
+            )
+
+        verify { vedtakRepository.hentFerdigstilteVedtak(Folkeregisteridentifikator.of(FNR_2)) }
+
+        assertAll(
+            { resultat shouldHaveSize 2 },
+            { resultat[0].virkningstidspunkt shouldBe virkFom2024Januar },
+            { resultat[0].perioder shouldHaveSize 1 },
+            { resultat[0].perioder[0].fom shouldBe virkFom2024Januar },
+            { resultat[0].perioder[0].tom shouldBe virkFom2024Januar },
+            { resultat[1].virkningstidspunkt shouldBe virkFom2024Februar },
+            { resultat[1].perioder shouldHaveSize 1 },
+            { resultat[1].perioder[0].fom shouldBe virkFom2024Februar },
+            { resultat[1].perioder[0].tom shouldBe null },
+        )
+    }
+
+    private fun avkortingDto(
+        fom: YearMonth,
+        ytelseFoer: Int,
+        ytelseEtter: Int,
+    ) = AvkortingDto(
+        avkortingGrunnlag = emptyList(),
+        avkortetYtelse =
+            listOf(
+                AvkortetYtelseDto(
+                    fom = fom,
+                    tom = null,
+                    ytelseFoerAvkorting = ytelseFoer,
+                    ytelseEtterAvkorting = ytelseEtter,
+                    avkortingsbeloep = ytelseEtter - ytelseFoer,
+                    restanse = 0,
+                ),
+            ),
+        tidligereAvkortetYtelse = emptyList(),
+    )
+}

--- a/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/VedtakDto.kt
+++ b/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/VedtakDto.kt
@@ -130,8 +130,14 @@ data class VedtakSamordningDto(
     val vedtakFattet: VedtakFattet?,
     val attestasjon: Attestasjon?,
     val beregning: ObjectNode?,
-    val avkorting: ObjectNode?,
-    val utbetalingsperioder: List<Utbetalingsperiode>,
+    val perioder: List<VedtakSamordningPeriode>,
+)
+
+data class VedtakSamordningPeriode(
+    val fom: YearMonth,
+    val tom: YearMonth?,
+    val ytelseFoerAvkorting: Int,
+    val ytelseEtterAvkorting: Int,
 )
 
 data class TilbakekrevingVedtakDto(

--- a/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/VedtakDto.kt
+++ b/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/VedtakDto.kt
@@ -131,6 +131,7 @@ data class VedtakSamordningDto(
     val attestasjon: Attestasjon?,
     val beregning: ObjectNode?,
     val avkorting: ObjectNode?,
+    val utbetalingsperioder: List<Utbetalingsperiode>,
 )
 
 data class TilbakekrevingVedtakDto(


### PR DESCRIPTION
Opprinnelig bug er at tidslinja korrigerer _utbetalingsperiodene_, mens det i samordning-vedtak er _avkortingsperiodene_ som er førende. Er en serie av commits her, som da i første omgang korrigerer dette i samordning-vedtak, men så har jeg flyttet denne logikken til vedtaksvurdering, og deretter til en egen service der da det etterhvert ble en del samordningsrelatert kode.