### PR TITLE
Ey 2403 opprydding andre brev

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, useSearchParams } from 'react-router-dom'
 import { StatusBar } from '~shared/statusbar/Statusbar'
 import { Container } from '~shared/styled'
 import { SakOversikt } from './SakOversikt'
@@ -9,19 +9,30 @@ import { Tabs } from '@navikt/ds-react'
 import { getPerson } from '~shared/api/grunnlag'
 import { GYLDIG_FNR } from '~utils/fnr'
 import NavigerTilbakeMeny from '~components/person/NavigerTilbakeMeny'
-import { BulletListIcon, FileTextIcon } from '@navikt/aksel-icons'
+import { BulletListIcon, EnvelopeClosedIcon, FileTextIcon } from '@navikt/aksel-icons'
 import { Dokumentoversikt } from './dokumenter/dokumentoversikt'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { ApiError } from '~shared/api/apiClient'
+import BrevOversikt from '~components/person/brev/BrevOversikt'
 
 enum Fane {
   SAKER = 'SAKER',
   DOKUMENTER = 'DOKUMENTER',
+  BREV = 'BREV',
 }
 
 export const Person = () => {
+  const [search, setSearch] = useSearchParams()
+
   const [personStatus, hentPerson] = useApiCall(getPerson)
-  const [fane, setFane] = useState(Fane.SAKER)
+  const [fane, setFane] = useState(search.get('fane') || Fane.SAKER)
+
+  const velgFane = (value: string) => {
+    const valgtFane = value as Fane
+
+    setSearch({ fane: valgtFane })
+    setFane(valgtFane)
+  }
 
   const { fnr } = useParams()
 
@@ -57,16 +68,29 @@ export const Person = () => {
           <Container>{handleError(error)}</Container>
         ),
         (person) => (
-          <Tabs value={fane} onChange={(val) => setFane(val as Fane)}>
+          <Tabs value={fane} onChange={velgFane}>
             <Tabs.List>
-              <Tabs.Tab value={Fane.SAKER} label="Sak og behandling" icon={<BulletListIcon title="saker" />} />
-              <Tabs.Tab value={Fane.DOKUMENTER} label="Dokumenter" icon={<FileTextIcon title="dokumenter" />} />
+              <Tabs.Tab
+                value={Fane.SAKER}
+                label="Sak og behandling"
+                icon={<BulletListIcon title="Sak og behandling" />}
+              />
+              <Tabs.Tab
+                value={Fane.DOKUMENTER}
+                label="Dokumentoversikt"
+                icon={<FileTextIcon title="Dokumentoversikt" />}
+              />
+              <Tabs.Tab value={Fane.BREV} label="Brev" icon={<EnvelopeClosedIcon title="Brev" />} />
             </Tabs.List>
+
             <Tabs.Panel value={Fane.SAKER}>
               <SakOversikt fnr={person.foedselsnummer} />
             </Tabs.Panel>
             <Tabs.Panel value={Fane.DOKUMENTER}>
               <Dokumentoversikt fnr={person.foedselsnummer} />
+            </Tabs.Panel>
+            <Tabs.Panel value={Fane.BREV}>
+              <BrevOversikt />
             </Tabs.Panel>
           </Tabs>
         )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/SakOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/SakOversikt.tsx
@@ -7,10 +7,9 @@ import { FlexRow, GridContainer } from '~shared/styled'
 import Spinner from '~shared/Spinner'
 import RelevanteHendelser from '~components/person/uhaandtereHendelser/RelevanteHendelser'
 import { isFailure, isPending, isSuccess, useApiCall } from '~shared/hooks/useApiCall'
-import { Alert, BodyShort, Heading, Link, Tag } from '@navikt/ds-react'
+import { Alert, BodyShort, Heading, Tag } from '@navikt/ds-react'
 import { SakType } from '~shared/types/sak'
 import { formaterEnumTilLesbarString, formaterSakstype } from '~utils/formattering'
-import { ExternalLinkIcon } from '@navikt/aksel-icons'
 import { FEATURE_TOGGLE_KAN_BRUKE_KLAGE, OpprettKlage } from '~components/person/OpprettKlage'
 import { useFeatureEnabledMedDefault } from '~shared/hooks/useFeatureToggle'
 import { KlageListe } from '~components/person/KlageListe'
@@ -60,11 +59,6 @@ export const SakOversikt = ({ fnr }: { fnr: string }) => {
             </Heading>
 
             <BodyShort spacing>Denne saken tilhører enhet {sakStatus.data.enhet}.</BodyShort>
-            <BodyShort spacing>
-              <Link href={`/person/${fnr}/sak/${sakStatus.data?.id}/brev`}>
-                Du finner brev tilhørende saken her <ExternalLinkIcon />
-              </Link>
-            </BodyShort>
 
             <hr />
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrevHandlingerPanel.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrevHandlingerPanel.tsx
@@ -1,9 +1,8 @@
-import { Alert, BodyLong, BodyShort, Button, Heading, Modal, Panel } from '@navikt/ds-react'
+import { Alert, BodyLong, Button, Heading, Modal, Panel } from '@navikt/ds-react'
 import { BrevStatus, IBrev } from '~shared/types/Brev'
 import { isPending, useApiCall } from '~shared/hooks/useApiCall'
 import { useState } from 'react'
 import { distribuerBrev, ferdigstillBrev, journalfoerBrev } from '~shared/api/brev'
-import Spinner from '~shared/Spinner'
 import { FlexRow } from '~shared/styled'
 
 interface Props {
@@ -18,7 +17,6 @@ export default function NyttBrevHandlingerPanel({ brev, setKanRedigeres }: Props
   const [journalfoerStatus, apiJournalfoerBrev] = useApiCall(journalfoerBrev)
   const [distribuerStatus, apiDistribuerBrev] = useApiCall(distribuerBrev)
 
-  const [loadingMsg, setLoadingMsg] = useState<string>()
   const [error, setError] = useState<string>()
 
   const handleError = (msg: string) => {
@@ -29,28 +27,26 @@ export default function NyttBrevHandlingerPanel({ brev, setKanRedigeres }: Props
   const ferdigstill = () => {
     setKanRedigeres(false)
 
-    const idPayload = { brevId: brev.id, sakId: brev.sakId }
-
-    setLoadingMsg('Forsøker å ferdigstille brev ...')
-
-    apiFerdigstillBrev(idPayload, journalfoer, () => handleError('Feil oppsto ved ferdigstilling av brev'))
+    apiFerdigstillBrev(
+      {
+        brevId: brev.id,
+        sakId: brev.sakId,
+      },
+      journalfoer,
+      () => handleError('Feil oppsto ved ferdigstilling av brev')
+    )
   }
 
   const journalfoer = () => {
-    setLoadingMsg('... journalfører brevet i dokarkiv ...')
-
     apiJournalfoerBrev({ brevId: brev.id, sakId: brev.sakId }, distribuer, () =>
       handleError('Feil oppsto ved journalføring av brev')
     )
   }
 
   const distribuer = () => {
-    setLoadingMsg('... sender brev til distribusjon ...')
-
     apiDistribuerBrev(
       { brevId: brev.id, sakId: brev.sakId },
       () => {
-        setLoadingMsg('Distribuert OK – laster inn på nytt ...')
         setTimeout(() => window.location.reload(), 2000)
       },
       () => handleError('Feil oppsto ved distribusjon av brev')
@@ -69,56 +65,60 @@ export default function NyttBrevHandlingerPanel({ brev, setKanRedigeres }: Props
 
       {error && <Alert variant="error">{error}</Alert>}
 
-      <BodyShort spacing size="small">
-        {brev.status === BrevStatus.FERDIGSTILT ? (
-          <Button variant="primary" onClick={journalfoer} loading={isPending(journalfoerStatus)}>
-            Journalfør
+      {brev.status === BrevStatus.FERDIGSTILT ? (
+        <Button variant="primary" onClick={journalfoer} loading={isPending(journalfoerStatus)}>
+          Journalfør
+        </Button>
+      ) : brev.status === BrevStatus.JOURNALFOERT ? (
+        <Button variant="primary" onClick={distribuer} loading={isPending(distribuerStatus)}>
+          Distribuer
+        </Button>
+      ) : (
+        <>
+          <Button variant="primary" onClick={() => setIsOpen(true)} loading={isPending(ferdigstillStatus)}>
+            Ferdigstill
           </Button>
-        ) : brev.status === BrevStatus.JOURNALFOERT ? (
-          <Button variant="primary" onClick={distribuer} loading={isPending(distribuerStatus)}>
-            Distribuer
-          </Button>
-        ) : (
-          <>
-            <Button variant="primary" onClick={() => setIsOpen(true)} loading={isPending(ferdigstillStatus)}>
-              Ferdigstill
-            </Button>
 
-            <Modal
-              open={isOpen}
-              onClose={() => setIsOpen(false)}
-              aria-labelledby="modal-heading"
-              className="padding-modal"
-            >
-              <Modal.Body style={{ textAlign: 'center' }}>
-                {loadingMsg ? (
-                  <Spinner visible label={loadingMsg} />
-                ) : (
-                  <>
-                    <Heading level="1" spacing size="medium" id="modal-heading">
-                      Er du sikker på at du vil ferdigstille brevet?
-                    </Heading>
+          <Modal
+            open={isOpen}
+            onClose={() => setIsOpen(false)}
+            aria-labelledby="modal-heading"
+            className="padding-modal"
+          >
+            <Modal.Body style={{ textAlign: 'center' }}>
+              <Heading level="1" spacing size="medium" id="modal-heading">
+                Er du sikker på at du vil ferdigstille brevet?
+              </Heading>
 
-                    <BodyLong spacing>
-                      Når du ferdigstiller brevet vil det bli journalført og distribuert. Denne handlingen kan ikke
-                      angres.
-                    </BodyLong>
+              <BodyLong spacing>
+                Når du ferdigstiller brevet vil det bli journalført og distribuert. Denne handlingen kan ikke angres.
+              </BodyLong>
 
-                    <FlexRow justify="center">
-                      <Button variant="secondary" onClick={() => setIsOpen(false)}>
-                        Nei, fortsett redigering
-                      </Button>
-                      <Button variant="primary" className="button" onClick={ferdigstill}>
-                        Ja, ferdigstill brev
-                      </Button>
-                    </FlexRow>
-                  </>
-                )}
-              </Modal.Body>
-            </Modal>
-          </>
-        )}
-      </BodyShort>
+              <FlexRow justify="center">
+                <Button
+                  variant="secondary"
+                  onClick={() => setIsOpen(false)}
+                  loading={isPending(ferdigstillStatus) || isPending(journalfoerStatus) || isPending(distribuerStatus)}
+                >
+                  Nei, fortsett redigering
+                </Button>
+                <Button
+                  variant="primary"
+                  className="button"
+                  onClick={ferdigstill}
+                  loading={isPending(ferdigstillStatus) || isPending(journalfoerStatus) || isPending(distribuerStatus)}
+                >
+                  Ja, ferdigstill brev
+                </Button>
+              </FlexRow>
+
+              {isPending(ferdigstillStatus) && <Alert variant="info">Forsøker å ferdigstille brev ...</Alert>}
+              {isPending(journalfoerStatus) && <Alert variant="info">... journalfører brevet i dokarkiv ...</Alert>}
+              {isPending(distribuerStatus) && <Alert variant="info">... sender brev til distribusjon ...</Alert>}
+            </Modal.Body>
+          </Modal>
+        </>
+      )}
     </Panel>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrevHandlingerPanel.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrevHandlingerPanel.tsx
@@ -1,9 +1,10 @@
 import { Alert, BodyLong, Button, Heading, Modal, Panel } from '@navikt/ds-react'
 import { BrevStatus, IBrev } from '~shared/types/Brev'
-import { isPending, useApiCall } from '~shared/hooks/useApiCall'
-import { useState } from 'react'
+import { isInitial, isPending, isSuccess, mapAllApiResult, useApiCall } from '~shared/hooks/useApiCall'
+import { useEffect, useState } from 'react'
 import { distribuerBrev, ferdigstillBrev, journalfoerBrev } from '~shared/api/brev'
 import { FlexRow } from '~shared/styled'
+import Spinner from '~shared/Spinner'
 
 interface Props {
   brev: IBrev
@@ -12,17 +13,11 @@ interface Props {
 
 export default function NyttBrevHandlingerPanel({ brev, setKanRedigeres }: Props) {
   const [isOpen, setIsOpen] = useState(false)
+  const [statusModalOpen, setStatusModalOpen] = useState(false)
 
   const [ferdigstillStatus, apiFerdigstillBrev] = useApiCall(ferdigstillBrev)
   const [journalfoerStatus, apiJournalfoerBrev] = useApiCall(journalfoerBrev)
   const [distribuerStatus, apiDistribuerBrev] = useApiCall(distribuerBrev)
-
-  const [error, setError] = useState<string>()
-
-  const handleError = (msg: string) => {
-    setError(msg)
-    setIsOpen(false)
-  }
 
   const ferdigstill = () => {
     setKanRedigeres(false)
@@ -32,38 +27,36 @@ export default function NyttBrevHandlingerPanel({ brev, setKanRedigeres }: Props
         brevId: brev.id,
         sakId: brev.sakId,
       },
-      journalfoer,
-      () => handleError('Feil oppsto ved ferdigstilling av brev')
+      () => journalfoer()
     )
   }
 
   const journalfoer = () => {
-    apiJournalfoerBrev({ brevId: brev.id, sakId: brev.sakId }, distribuer, () =>
-      handleError('Feil oppsto ved journalføring av brev')
-    )
+    apiJournalfoerBrev({ brevId: brev.id, sakId: brev.sakId }, () => distribuer())
   }
 
-  const distribuer = () => {
+  const distribuer = () =>
     apiDistribuerBrev(
       { brevId: brev.id, sakId: brev.sakId },
-      () => {
-        setTimeout(() => window.location.reload(), 2000)
-      },
-      () => handleError('Feil oppsto ved distribusjon av brev')
+      () => void setTimeout(() => window.location.reload(), 2000)
     )
-  }
 
   if (brev.status === BrevStatus.DISTRIBUERT) {
     return null
   }
+
+  useEffect(() => {
+    setStatusModalOpen(
+      isSuccess(distribuerStatus) ||
+        !(isInitial(ferdigstillStatus) && isInitial(journalfoerStatus) && isInitial(distribuerStatus))
+    )
+  }, [ferdigstillStatus, journalfoerStatus, distribuerStatus])
 
   return (
     <Panel>
       <Heading spacing level="2" size="medium">
         Handlinger
       </Heading>
-
-      {error && <Alert variant="error">{error}</Alert>}
 
       {brev.status === BrevStatus.FERDIGSTILT ? (
         <Button variant="primary" onClick={journalfoer} loading={isPending(journalfoerStatus)}>
@@ -74,51 +67,71 @@ export default function NyttBrevHandlingerPanel({ brev, setKanRedigeres }: Props
           Distribuer
         </Button>
       ) : (
-        <>
-          <Button variant="primary" onClick={() => setIsOpen(true)} loading={isPending(ferdigstillStatus)}>
-            Ferdigstill
-          </Button>
-
-          <Modal
-            open={isOpen}
-            onClose={() => setIsOpen(false)}
-            aria-labelledby="modal-heading"
-            className="padding-modal"
-          >
-            <Modal.Body style={{ textAlign: 'center' }}>
-              <Heading level="1" spacing size="medium" id="modal-heading">
-                Er du sikker på at du vil ferdigstille brevet?
-              </Heading>
-
-              <BodyLong spacing>
-                Når du ferdigstiller brevet vil det bli journalført og distribuert. Denne handlingen kan ikke angres.
-              </BodyLong>
-
-              <FlexRow justify="center">
-                <Button
-                  variant="secondary"
-                  onClick={() => setIsOpen(false)}
-                  loading={isPending(ferdigstillStatus) || isPending(journalfoerStatus) || isPending(distribuerStatus)}
-                >
-                  Nei, fortsett redigering
-                </Button>
-                <Button
-                  variant="primary"
-                  className="button"
-                  onClick={ferdigstill}
-                  loading={isPending(ferdigstillStatus) || isPending(journalfoerStatus) || isPending(distribuerStatus)}
-                >
-                  Ja, ferdigstill brev
-                </Button>
-              </FlexRow>
-
-              {isPending(ferdigstillStatus) && <Alert variant="info">Forsøker å ferdigstille brev ...</Alert>}
-              {isPending(journalfoerStatus) && <Alert variant="info">... journalfører brevet i dokarkiv ...</Alert>}
-              {isPending(distribuerStatus) && <Alert variant="info">... sender brev til distribusjon ...</Alert>}
-            </Modal.Body>
-          </Modal>
-        </>
+        <Button variant="primary" onClick={() => setIsOpen(true)} loading={isPending(ferdigstillStatus)}>
+          Ferdigstill
+        </Button>
       )}
+
+      {statusModalOpen && (
+        <Modal open={true} width="medium">
+          {mapAllApiResult(
+            ferdigstillStatus,
+            <Spinner label="Forsøker å ferdigstille brevet ..." visible />,
+            null,
+            () => (
+              <Alert variant="error">Feil oppsto ved ferdigstilling av brevet</Alert>
+            ),
+            () => (
+              <Alert variant="info">Ferdigstilt ok!</Alert>
+            )
+          )}
+
+          {mapAllApiResult(
+            journalfoerStatus,
+            <Spinner label="Journalfører brevet i dokarkiv ..." visible />,
+            null,
+            () => (
+              <Alert variant="error">Feil oppsto ved journalføring av brevet</Alert>
+            ),
+            () => (
+              <Alert variant="info">Journalført ok!</Alert>
+            )
+          )}
+
+          {mapAllApiResult(
+            distribuerStatus,
+            <Spinner label="Sender brev til distribusjon ..." visible />,
+            null,
+            () => (
+              <Alert variant="error">Feil ved sending til distribusjon</Alert>
+            ),
+            () => (
+              <Alert variant="success">Brev sendt til distribusjon. Laster inn brev på nytt...</Alert>
+            )
+          )}
+        </Modal>
+      )}
+
+      <Modal open={isOpen && !statusModalOpen} aria-labelledby="modal-heading" className="padding-modal">
+        <Modal.Body style={{ textAlign: 'center' }}>
+          <Heading level="1" spacing size="medium" id="modal-heading">
+            Er du sikker på at du vil ferdigstille brevet?
+          </Heading>
+
+          <BodyLong spacing>
+            Når du ferdigstiller brevet vil det bli journalført og distribuert. Denne handlingen kan ikke angres.
+          </BodyLong>
+
+          <FlexRow justify="center">
+            <Button variant="secondary" onClick={() => setIsOpen(false)}>
+              Nei, fortsett redigering
+            </Button>
+            <Button variant="primary" className="button" onClick={ferdigstill}>
+              Ja, ferdigstill brev
+            </Button>
+          </FlexRow>
+        </Modal.Body>
+      </Modal>
     </Panel>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/RedigerMottakerModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/RedigerMottakerModal.tsx
@@ -103,7 +103,6 @@ export default function RedigerMottakerModal({ brev, oppdater }: Props) {
                 setMottaker({ ...mottaker, adresse: { ...mottaker.adresse, adresseType: e.target.value } })
               }
               value={mottaker.adresse?.adresseType || ''}
-              required
             >
               <option value="">Velg type</option>
               <option value="NORSKPOSTADRESSE">Norsk postadresse</option>
@@ -121,7 +120,6 @@ export default function RedigerMottakerModal({ brev, oppdater }: Props) {
                 })
               }
               value={mottaker.adresse?.adresselinje1 || ''}
-              required
             />
             <TextField
               label="Adresselinje 2"
@@ -183,7 +181,6 @@ export default function RedigerMottakerModal({ brev, oppdater }: Props) {
               pattern="[A-Z]{2}"
               minLength={2}
               maxLength={2}
-              required
             />
             <TextField
               label="Land"
@@ -194,7 +191,6 @@ export default function RedigerMottakerModal({ brev, oppdater }: Props) {
                 })
               }
               value={mottaker.adresse?.land || ''}
-              required
             />
           </SkjemaGruppe>
 


### PR DESCRIPTION
- "Lagre" valgt fane på person-/saksoversikt. Eksempelvis vil det å gå tilbake et steg vise deg fanen du var i sist. 
- Brev er nå egen fane (se bilde).
- Dokument -> Dokumentoversikt
- Forbedre visning av flyt/status når man ferdigstiller et "annet-brev". Litt jalla løsning, men har ingen andre umiddelbare gode forslag til forbedring siden det er så mange ulike kall mot backend den må gjennom. Se `NyttBrevHandlingerPanel.tsx`


![Screenshot 2023-11-21 at 13 44 20](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/fdbbb791-9c94-44c7-b0fb-f21e19c8b674)
