### PR TITLE
Ey 3158 nullable geografisk tilknytning

### DIFF
--- a/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonService.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonService.kt
@@ -30,6 +30,7 @@ import no.nav.etterlatte.pdl.PdlResponseError
 import no.nav.etterlatte.pdl.mapper.ForeldreansvarHistorikkMapper
 import no.nav.etterlatte.pdl.mapper.GeografiskTilknytningMapper
 import no.nav.etterlatte.pdl.mapper.PersonMapper
+import no.nav.etterlatte.sikkerLogg
 import org.slf4j.LoggerFactory
 
 class PdlForesporselFeilet(message: String) : RuntimeException(message)
@@ -338,6 +339,9 @@ class PersonService(
         return pdlKlient.hentGeografiskTilknytning(request).let {
             if (it.data?.hentGeografiskTilknytning == null) {
                 if (it.errors == null) {
+                    logger.warn("Geografisk tilknytning er null i PDL (fnr=${request.foedselsnummer})")
+                    sikkerLogg.warn("Geografisk tilknytning er null i PDL (fnr=${request.foedselsnummer.value})")
+
                     GeografiskTilknytning(ukjent = true)
                 } else if (it.errors.personIkkeFunnet()) {
                     throw FantIkkePersonException("Fant ikke personen ${request.foedselsnummer}")

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonService.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonService.kt
@@ -337,10 +337,12 @@ class PersonService(
 
         return pdlKlient.hentGeografiskTilknytning(request).let {
             if (it.data?.hentGeografiskTilknytning == null) {
-                val pdlFeil = it.errors?.asFormatertFeil()
-                if (it.errors?.personIkkeFunnet() == true) {
+                if (it.errors == null) {
+                    GeografiskTilknytning(ukjent = true)
+                } else if (it.errors.personIkkeFunnet()) {
                     throw FantIkkePersonException("Fant ikke personen ${request.foedselsnummer}")
                 } else {
+                    val pdlFeil = it.errors.asFormatertFeil()
                     throw PdlForesporselFeilet(
                         "Kunne ikke hente fnr=${request.foedselsnummer} fra PDL: $pdlFeil",
                     )

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonServiceTest.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonServiceTest.kt
@@ -296,6 +296,27 @@ internal class PersonServiceTest {
         assertEquals(tilknytning.geografiskTilknytning(), "0301")
     }
 
+    @Test
+    fun `Bruker uten geografisk tilknytning`() {
+        coEvery { pdlKlient.hentGeografiskTilknytning(any()) } returns
+            PdlGeografiskTilknytningResponse(
+                data =
+                    PdlGeografiskTilknytningData(
+                        null,
+                    ),
+            )
+
+        val tilknytning =
+            runBlocking {
+                personService.hentGeografiskTilknytning(
+                    HentGeografiskTilknytningRequest(TRIVIELL_MIDTPUNKT, SakType.BARNEPENSJON),
+                )
+            }
+
+        assertNotNull(tilknytning)
+        assertTrue(tilknytning.ukjent)
+    }
+
     @ParameterizedTest
     @EnumSource(PdlGradering::class)
     fun `Skal hente gradering for person`(pdlGradering: PdlGradering) {


### PR DESCRIPTION
Når vi begynner med utlandssaker vil vi potensielt få mange brukere som mangler geografiskTilknytning i PDL. Vi må derfor støtte null og heller bruke standard enhet (p.t. Porsgrunn)