### PR TITLE
Ikke sjekke Maskinporten-scope dersom auth uansett ikke har validert token(s)

### DIFF
--- a/libs/etterlatte-ktor/src/main/kotlin/MaskinportenScopeAuthorizationPlugin.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/MaskinportenScopeAuthorizationPlugin.kt
@@ -16,23 +16,25 @@ val MaskinportenScopeAuthorizationPlugin =
         val scopes = pluginConfig.scopes
         pluginConfig.apply {
             on(AuthenticationChecked) { call ->
-                val userScopes =
-                    call.firstValidTokenClaims()?.getStringClaim("scope")
-                        ?.split(" ")
-                        ?: emptyList()
+                call.firstValidTokenClaims()?.let { token ->
+                    val userScopes =
+                        token.getStringClaim("scope")
+                            ?.split(" ")
+                            ?: emptyList()
 
-                if (userScopes.intersect(scopes).isEmpty()) {
-                    application.log.info("Request avslått pga manglende scope (gyldige: $scopes)")
-                    throw ForespoerselException(
-                        status = HttpStatusCode.Unauthorized.value,
-                        code = "GE-MASKINPORTEN-SCOPE",
-                        detail = "Har ikke påkrevd scope",
-                        meta =
-                            mapOf(
-                                "correlation-id" to getCorrelationId(),
-                                "tidspunkt" to Tidspunkt.now(),
-                            ),
-                    )
+                    if (userScopes.intersect(scopes).isEmpty()) {
+                        application.log.info("Request avslått pga manglende scope (gyldige: $scopes)")
+                        throw ForespoerselException(
+                            status = HttpStatusCode.Unauthorized.value,
+                            code = "GE-MASKINPORTEN-SCOPE",
+                            detail = "Har ikke påkrevd scope",
+                            meta =
+                                mapOf(
+                                    "correlation-id" to getCorrelationId(),
+                                    "tidspunkt" to Tidspunkt.now(),
+                                ),
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fikk litt feil info i responsen som følge av dette dersom man forsøkte med et utløpt token. Fremdeles 401, men "pga manglende scope" noe som jo ikke er riktig.