### PR TITLE
Flytter virkningstidspunkt og setter titteler

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/utenlandstilknytning/UtenlandstilknytningVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/utenlandstilknytning/UtenlandstilknytningVurdering.tsx
@@ -1,8 +1,8 @@
 import { IBehandlingStatus, IUtenlandstilknytning, UtenlandstilknytningType } from '~shared/types/IDetaljertBehandling'
 import { VurderingsboksWrapper } from '~components/vurderingsboks/VurderingsboksWrapper'
-import { BodyShort, Label, Radio, RadioGroup } from '@navikt/ds-react'
+import { Label, Radio, RadioGroup } from '@navikt/ds-react'
 import { RadioGroupWrapper } from '~components/behandling/vilkaarsvurdering/Vurdering'
-import { Undertekst, VurderingsTitle } from '../styled'
+import { VurderingsTitle } from '../styled'
 import { SoeknadsoversiktTextArea } from '../SoeknadsoversiktTextArea'
 import { useAppDispatch } from '~store/Store'
 import { useState } from 'react'
@@ -35,6 +35,8 @@ export const UtenlandstilknytningVurdering = ({
   const [begrunnelse, setBegrunnelse] = useState<string>(utenlandstilknytning?.begrunnelse || '')
   const [setUtenlandstilknytningStatus, setUtenlandstilknytning, resetToInitial] = useApiCall(lagreUtenlandstilknytning)
 
+  const tittel = 'Hvilken type sak er dette?'
+
   const lagre = (onSuccess?: () => void) => {
     !svar ? setRadioError('Du må velge et svar') : setRadioError('')
 
@@ -57,10 +59,9 @@ export const UtenlandstilknytningVurdering = ({
 
   return (
     <VurderingsboksWrapper
-      tittel=""
+      tittel={tittel}
       subtittelKomponent={
         <>
-          <BodyShort spacing>Hvilken type sak er dette?</BodyShort>
           {utenlandstilknytning?.type ? (
             <Label as="p" size="small" style={{ marginBottom: '32px' }}>
               {UtenlandstilknytningTypeTittel[utenlandstilknytning.type]}
@@ -87,8 +88,7 @@ export const UtenlandstilknytningVurdering = ({
       defaultRediger={utenlandstilknytning === null}
     >
       <>
-        <VurderingsTitle title="Utlandstilknytning" />
-        <Undertekst $gray={false}>Hvilken type sak er dette?</Undertekst>
+        <VurderingsTitle title={tittel} />
         <RadioGroupWrapper>
           <RadioGroup
             legend=""

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -1,16 +1,21 @@
 import styled from 'styled-components'
-import { ErrorMessage, MonthPicker, useMonthpicker } from '@navikt/ds-react'
+import { BodyShort, ErrorMessage, Heading, MonthPicker, useMonthpicker } from '@navikt/ds-react'
 import React, { useState } from 'react'
 import { oppdaterBehandlingsstatus, oppdaterVirkningstidspunkt } from '~store/reducers/BehandlingReducer'
 import { formaterDatoTilYearMonth, formaterStringDato } from '~utils/formattering'
 import { fastsettVirkningstidspunkt } from '~shared/api/behandling'
 import { useApiCall } from '~shared/hooks/useApiCall'
-import { Beskrivelse, InfobokserWrapper, InfoWrapper, VurderingsContainerWrapper } from '../soeknadsoversikt/styled'
+import {
+  Beskrivelse,
+  InfobokserWrapper,
+  InfoWrapper,
+  VurderingsContainerWrapper,
+  VurderingsTitle,
+} from '../soeknadsoversikt/styled'
 import { useAppDispatch } from '~store/Store'
 import { IBehandlingStatus, IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 import { addMonths, addYears, subYears } from 'date-fns'
 import { LovtekstMedLenke } from '../soeknadsoversikt/LovtekstMedLenke'
-import { Info } from '../soeknadsoversikt/Info'
 import { LeggTilVurderingButton } from '~components/behandling/soeknadsoversikt/LeggTilVurderingButton'
 import { VurderingsboksWrapper } from '~components/vurderingsboks/VurderingsboksWrapper'
 import { SoeknadsoversiktTextArea } from '~components/behandling/soeknadsoversikt/SoeknadsoversiktTextArea'
@@ -46,6 +51,7 @@ const Virkningstidspunkt = (props: {
   const [kravdato, setKravdato] = useState<Date | undefined>(undefined)
 
   const avdoedDoedsdato = behandling.familieforhold?.avdoede?.opplysning?.doedsdato
+  const tittel = 'Hva er virkningstidspunkt for behandlingen?'
 
   const { monthpickerProps, inputProps } = useMonthpicker({
     fromDate: hentMinimumsVirkningstidspunkt(
@@ -116,17 +122,7 @@ const Virkningstidspunkt = (props: {
         <div>
           <Beskrivelse>{props.beskrivelse}</Beskrivelse>
           <InfobokserWrapper>
-            <InfoWrapper>
-              {props.children?.info}
-              <Info
-                label="Virkningstidspunkt"
-                tekst={
-                  behandling.virkningstidspunkt
-                    ? formaterStringDato(behandling.virkningstidspunkt.dato)
-                    : 'Ikke vurdert'
-                }
-              />
-            </InfoWrapper>
+            <InfoWrapper>{props.children?.info}</InfoWrapper>
           </InfobokserWrapper>
         </div>
 
@@ -135,7 +131,15 @@ const Virkningstidspunkt = (props: {
             <LeggTilVurderingButton onClick={() => setVurdert(true)}>Legg til vurdering</LeggTilVurderingButton>
           ) : (
             <VurderingsboksWrapper
-              tittel=""
+              tittel={tittel}
+              subtittelKomponent={
+                <>
+                  <Heading level="3" size="xsmall">
+                    Virkningstidspunkt
+                  </Heading>
+                  <BodyShort spacing>{formaterStringDato(behandling.virkningstidspunkt!!.dato)}</BodyShort>
+                </>
+              }
               vurdering={
                 behandling.virkningstidspunkt
                   ? {
@@ -151,6 +155,7 @@ const Virkningstidspunkt = (props: {
               defaultRediger={behandling.virkningstidspunkt === null}
             >
               <>
+                <VurderingsTitle title={tittel} />
                 {erBosattUtland && (
                   <>
                     <DatoVelger


### PR DESCRIPTION
Noen forberedelser ifm en fiks som kommer senere på kravdato

- Flytter verdien som er satt for virkningstidspunkt ut fra "grunnlagskolonnen" og inn i vurderingskolonnen. 
- Setter header på vurderingene som manglet dette i søknadsoversikt