### PR TITLE
Fikser problemer med lagring og uthenting av kravdato

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutesDtoer.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutesDtoer.kt
@@ -6,6 +6,7 @@ import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toNorskTid
+import java.time.LocalDate
 import java.time.YearMonth
 import java.util.UUID
 
@@ -32,11 +33,9 @@ data class ManueltOpphoerResponse(val behandlingId: String)
 data class VirkningstidspunktRequest(
     @JsonProperty("dato") private val _dato: String,
     val begrunnelse: String?,
-    @JsonProperty("kravdato") private val _kravdato: String? = null,
+    val kravdato: LocalDate? = null,
 ) {
     val dato: YearMonth = _dato.tilYearMonth()
-    val kravdato: YearMonth?
-        get() = if (_kravdato.isNullOrEmpty()) null else _kravdato.tilYearMonth()
 }
 
 fun String.tilYearMonth(): YearMonth {
@@ -53,6 +52,7 @@ internal data class FastsettVirkningstidspunktResponse(
     val dato: YearMonth,
     val kilde: Grunnlagsopplysning.Saksbehandler,
     val begrunnelse: String,
+    val kravdato: LocalDate?,
 ) {
     companion object {
         fun from(virkningstidspunkt: Virkningstidspunkt) =
@@ -60,6 +60,7 @@ internal data class FastsettVirkningstidspunktResponse(
                 virkningstidspunkt.dato,
                 virkningstidspunkt.kilde,
                 virkningstidspunkt.begrunnelse,
+                virkningstidspunkt.kravdato,
             )
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
@@ -42,6 +42,7 @@ import no.nav.etterlatte.tilgangsstyring.filterForEnheter
 import no.nav.etterlatte.token.BrukerTokenInfo
 import no.nav.etterlatte.vedtaksvurdering.VedtakHendelse
 import org.slf4j.LoggerFactory
+import java.time.LocalDate
 import java.time.YearMonth
 import java.util.UUID
 
@@ -88,7 +89,7 @@ interface BehandlingService {
         virkningstidspunkt: YearMonth,
         ident: String,
         begrunnelse: String,
-        kravdato: YearMonth? = null,
+        kravdato: LocalDate? = null,
     ): Virkningstidspunkt
 
     fun oppdaterBoddEllerArbeidetUtlandet(
@@ -271,7 +272,7 @@ internal class BehandlingServiceImpl(
         if (sakMedUtenlandstilknytning?.utenlandstilknytning != null) {
             if (sakMedUtenlandstilknytning.utenlandstilknytning.type === UtenlandstilknytningType.BOSATT_UTLAND) {
                 val kravdato = request.kravdato ?: throw KravdatoMaaFinnesHvisBosattutland("Kravdato må finnes hvis bosatt utland er valgt")
-                makstidspunktFoerSoeknad = kravdato.minusYears(3)
+                makstidspunktFoerSoeknad = YearMonth.from(kravdato.minusYears(3))
             }
         } else {
             throw VirkningstidspunktMaaHaUtenlandstilknytning(
@@ -429,7 +430,7 @@ internal class BehandlingServiceImpl(
         virkningstidspunkt: YearMonth,
         ident: String,
         begrunnelse: String,
-        kravdato: YearMonth?,
+        kravdato: LocalDate?,
     ): Virkningstidspunkt {
         val behandling =
             hentBehandling(behandlingId) ?: run {

--- a/apps/etterlatte-behandling/src/test/kotlin/VerdikjedeTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/VerdikjedeTest.kt
@@ -231,6 +231,7 @@ class VerdikjedeTest : BehandlingIntegrationTest() {
                         YearMonth.of(2022, 2),
                         Grunnlagsopplysning.Saksbehandler.create("Saksbehandler01"),
                         "En begrunnelse",
+                        null,
                     )
                 assertEquals(expected.dato, it.body<FastsettVirkningstidspunktResponse>().dato)
                 assertEquals(expected.kilde.ident, it.body<FastsettVirkningstidspunktResponse>().kilde.ident)

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoTest.kt
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertAll
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
+import java.time.LocalDate
 import java.time.YearMonth
 import javax.sql.DataSource
 
@@ -524,7 +525,7 @@ internal class BehandlingDaoTest {
 
         val saksbehandler = Grunnlagsopplysning.Saksbehandler.create("navIdent")
         val nyDato = YearMonth.of(2021, 2)
-        val virkningstidspunkt = Virkningstidspunkt(nyDato, saksbehandler, "enBegrunnelse", YearMonth.now())
+        val virkningstidspunkt = Virkningstidspunkt(nyDato, saksbehandler, "enBegrunnelse", LocalDate.now())
         behandling!!.oppdaterVirkningstidspunkt(virkningstidspunkt).let {
             behandlingRepo.lagreNyttVirkningstidspunkt(behandling.id, it.virkningstidspunkt!!)
         }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
@@ -548,7 +548,7 @@ class BehandlingServiceImplTest {
         val bodyVirkningstidspunkt = Tidspunkt.parse("2017-02-01T00:00:00Z")
         val bodyBegrunnelse = "begrunnelse"
         val bodyKravdato = Tidspunkt.parse("2019-02-01T00:00:00Z")
-        val request = VirkningstidspunktRequest(bodyVirkningstidspunkt.toString(), bodyBegrunnelse, bodyKravdato.toString())
+        val request = VirkningstidspunktRequest(bodyVirkningstidspunkt.toString(), bodyBegrunnelse, bodyKravdato.toLocalDate())
         val doedsdato = LocalDate.parse("2014-01-01")
 
         val soeknadMottatt = LocalDateTime.parse("2009-01-01T00:00:00.000000000")

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.test.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.test.ts
@@ -251,5 +251,6 @@ const mockVirkningstidspunkt = (): Virkningstidspunkt => {
       ident: 'Z123456',
     },
     begrunnelse: '',
+    kravdato: null,
   }
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -45,7 +45,7 @@ const Virkningstidspunkt = (props: {
   )
   const [begrunnelse, setBegrunnelse] = useState<string>(behandling.virkningstidspunkt?.begrunnelse ?? '')
   const [kravdato, setKravdato] = useState<Date | null>(
-    behandling.virkningstidspunkt ? new Date(behandling.virkningstidspunkt.kravdato) : null
+    behandling.virkningstidspunkt?.kravdato ? new Date(behandling.virkningstidspunkt.kravdato) : null
   )
 
   const [errorTekst, setErrorTekst] = useState<string>('')
@@ -102,7 +102,7 @@ const Virkningstidspunkt = (props: {
   const reset = (onSuccess?: () => void) => {
     resetToInitial()
     setVirkningstidspunkt(behandling.virkningstidspunkt ? new Date(behandling.virkningstidspunkt.dato) : null)
-    setKravdato(behandling.virkningstidspunkt ? new Date(behandling.virkningstidspunkt.kravdato) : null)
+    setKravdato(behandling.virkningstidspunkt?.kravdato ? new Date(behandling.virkningstidspunkt.kravdato) : null)
     setBegrunnelse(behandling.virkningstidspunkt?.begrunnelse ?? '')
     setErrorTekst('')
     setVurdert(behandling.virkningstidspunkt !== null)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components'
-import { BodyShort, ErrorMessage, Heading, MonthPicker, useMonthpicker } from '@navikt/ds-react'
+import { BodyShort, ErrorMessage, Heading, MonthPicker, useMonthpicker, VStack } from '@navikt/ds-react'
 import React, { useState } from 'react'
 import { oppdaterBehandlingsstatus, oppdaterVirkningstidspunkt } from '~store/reducers/BehandlingReducer'
-import { formaterDatoTilYearMonth, formaterStringDato } from '~utils/formattering'
+import { formaterStringDato } from '~utils/formattering'
 import { fastsettVirkningstidspunkt } from '~shared/api/behandling'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import {
@@ -82,25 +82,18 @@ const Virkningstidspunkt = (props: {
       }
     }
 
-    const harVirkningstidspunktEndretSeg =
-      behandling.virkningstidspunkt?.dato !== formaterDatoTilYearMonth(virkningstidspunkt) ||
-      behandling.virkningstidspunkt?.begrunnelse !== begrunnelse
-    if (harVirkningstidspunktEndretSeg) {
-      return fastsettVirkningstidspunktRequest(
-        { id: behandling.id, dato: virkningstidspunkt, begrunnelse: begrunnelse, kravdato: kravdato },
-        (res) => {
-          dispatch(oppdaterVirkningstidspunkt(res))
-          dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.OPPRETTET))
-          onSuccess?.()
-        },
-        () =>
-          setErrorTekst(
-            'Kunne ikke sette virkningstidspunkt. Last siden på nytt og prøv igjen, meld sak hvis problemet vedvarer'
-          )
-      )
-    } else {
-      onSuccess?.()
-    }
+    return fastsettVirkningstidspunktRequest(
+      { id: behandling.id, dato: virkningstidspunkt, begrunnelse: begrunnelse, kravdato: kravdato },
+      (res) => {
+        dispatch(oppdaterVirkningstidspunkt(res))
+        dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.OPPRETTET))
+        onSuccess?.()
+      },
+      () =>
+        setErrorTekst(
+          'Kunne ikke sette virkningstidspunkt. Last siden på nytt og prøv igjen, meld sak hvis problemet vedvarer'
+        )
+    )
   }
 
   const reset = (onSuccess?: () => void) => {
@@ -133,12 +126,22 @@ const Virkningstidspunkt = (props: {
             <VurderingsboksWrapper
               tittel={tittel}
               subtittelKomponent={
-                <>
-                  <Heading level="3" size="xsmall">
-                    Virkningstidspunkt
-                  </Heading>
-                  <BodyShort spacing>{formaterStringDato(behandling.virkningstidspunkt!!.dato)}</BodyShort>
-                </>
+                <VStack gap="4">
+                  {erBosattUtland && (
+                    <div>
+                      <Heading size="xsmall">Kravdato</Heading>
+                      <BodyShort>
+                        {behandling.virkningstidspunkt!!.kravdato
+                          ? formaterStringDato(behandling.virkningstidspunkt!!.kravdato)
+                          : 'En feil'}
+                      </BodyShort>
+                    </div>
+                  )}
+                  <div>
+                    <Heading size="xsmall">Virkningstidspunkt</Heading>
+                    <BodyShort spacing>{formaterStringDato(behandling.virkningstidspunkt!!.dato)}</BodyShort>
+                  </div>
+                </VStack>
               }
               vurdering={
                 behandling.virkningstidspunkt

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -1,4 +1,3 @@
-import styled from 'styled-components'
 import { BodyShort, ErrorMessage, Heading, MonthPicker, useMonthpicker, VStack } from '@navikt/ds-react'
 import React, { useState } from 'react'
 import { oppdaterBehandlingsstatus, oppdaterVirkningstidspunkt } from '~store/reducers/BehandlingReducer'
@@ -21,7 +20,7 @@ import { VurderingsboksWrapper } from '~components/vurderingsboks/Vurderingsboks
 import { SoeknadsoversiktTextArea } from '~components/behandling/soeknadsoversikt/SoeknadsoversiktTextArea'
 import { hentMinimumsVirkningstidspunkt } from '~components/behandling/virkningstidspunkt/utils'
 import { UseMonthPickerOptions } from '@navikt/ds-react/esm/date/hooks/useMonthPicker'
-import { DatoVelger, formatDateToLocaleDateOrEmptyString } from '~shared/DatoVelger'
+import { DatoVelger } from '~shared/DatoVelger'
 
 export interface Hjemmel {
   lenke: string
@@ -77,10 +76,8 @@ const Virkningstidspunkt = (props: {
     if (begrunnelse.trim().length === 0) {
       return setErrorTekst('Begrunnelsen må fylles ut')
     }
-    if (erBosattUtland) {
-      if (!kravdato) {
-        setErrorTekst('Kravdato kreves på bosatt utland saker')
-      }
+    if (erBosattUtland && !kravdato) {
+      return setErrorTekst('Kravdato kreves på bosatt utland saker')
     }
 
     return fastsettVirkningstidspunktRequest(
@@ -88,10 +85,9 @@ const Virkningstidspunkt = (props: {
         id: behandling.id,
         dato: virkningstidspunkt,
         begrunnelse: begrunnelse,
-        kravdato: formatDateToLocaleDateOrEmptyString(kravdato ?? undefined),
+        kravdato: kravdato,
       },
       (res) => {
-        console.log(kravdato)
         dispatch(oppdaterVirkningstidspunkt(res))
         dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.OPPRETTET))
         onSuccess?.()
@@ -141,7 +137,7 @@ const Virkningstidspunkt = (props: {
                       <BodyShort>
                         {behandling.virkningstidspunkt!!.kravdato
                           ? formaterStringDato(behandling.virkningstidspunkt!!.kravdato)
-                          : 'En feil'}
+                          : ''}
                       </BodyShort>
                     </div>
                   )}
@@ -165,28 +161,26 @@ const Virkningstidspunkt = (props: {
               kommentar={behandling.virkningstidspunkt?.begrunnelse}
               defaultRediger={behandling.virkningstidspunkt === null}
             >
-              <>
+              <VStack gap="4">
                 <VurderingsTitle title={tittel} />
+
                 {erBosattUtland && (
-                  <>
-                    <DatoVelger
-                      label="Kravdato"
-                      onChange={(date) => setKravdato(date ?? null)}
-                      value={kravdato ?? undefined}
-                      fromDate={subYears(new Date(), 18)}
-                      toDate={addYears(new Date(), 2)}
-                    />
-                  </>
+                  <DatoVelger
+                    label="Kravdato"
+                    onChange={(date) => setKravdato(date ?? null)}
+                    value={kravdato ?? undefined}
+                    fromDate={subYears(new Date(), 18)}
+                    toDate={addYears(new Date(), 2)}
+                  />
                 )}
-                <MonthPickerWrapper>
-                  <MonthPicker {...monthpickerProps}>
-                    <MonthPicker.Input label="Virkningstidspunkt" {...inputProps} />
-                  </MonthPicker>
-                </MonthPickerWrapper>
+                <MonthPicker {...monthpickerProps}>
+                  <MonthPicker.Input label="Virkningstidspunkt" {...inputProps} />
+                </MonthPicker>
 
                 <SoeknadsoversiktTextArea value={begrunnelse} onChange={(e) => setBegrunnelse(e.target.value)} />
+
                 {errorTekst !== '' ? <ErrorMessage>{errorTekst}</ErrorMessage> : null}
-              </>
+              </VStack>
             </VurderingsboksWrapper>
           )}
         </VurderingsContainerWrapper>
@@ -194,10 +188,5 @@ const Virkningstidspunkt = (props: {
     </>
   )
 }
-
-const MonthPickerWrapper = styled.div`
-  margin-top: 2rem;
-  margin-bottom: 12px;
-`
 
 export default Virkningstidspunkt

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
@@ -14,6 +14,7 @@ import { InstitusjonsoppholdBegrunnelse } from '~components/person/uhaandtereHen
 import { FoersteVirk, ISak } from '~shared/types/sak'
 import { InstitusjonsoppholdMedKilde } from '~components/person/uhaandtereHendelser/HistoriskeHendelser'
 import { format } from 'date-fns'
+import { DatoFormat } from '~utils/formattering'
 
 export const hentBehandlingerForSak = async (sakId: number): Promise<ApiResponse<SakMedBehandlinger>> => {
   return apiClient.get(`/sak/${sakId}/behandlingerforsak`)
@@ -49,7 +50,7 @@ export const fastsettVirkningstidspunkt = async (args: {
   return apiClient.post(`/behandling/${args.id}/virkningstidspunkt`, {
     dato: args.dato,
     begrunnelse: args.begrunnelse,
-    kravdato: args.kravdato ? format(args.kravdato, 'yyyy-MM-dd') : null,
+    kravdato: args.kravdato ? format(args.kravdato, DatoFormat.AAR_MAANED_DAG) : null,
   })
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
@@ -13,6 +13,7 @@ import { Grunnlagsendringshendelse, GrunnlagsendringsListe, SakMedBehandlinger }
 import { InstitusjonsoppholdBegrunnelse } from '~components/person/uhaandtereHendelser/InstitusjonsoppholdVurderingBegrunnelse'
 import { FoersteVirk, ISak } from '~shared/types/sak'
 import { InstitusjonsoppholdMedKilde } from '~components/person/uhaandtereHendelser/HistoriskeHendelser'
+import { format } from 'date-fns'
 
 export const hentBehandlingerForSak = async (sakId: number): Promise<ApiResponse<SakMedBehandlinger>> => {
   return apiClient.get(`/sak/${sakId}/behandlingerforsak`)
@@ -43,12 +44,12 @@ export const fastsettVirkningstidspunkt = async (args: {
   id: string
   dato: Date
   begrunnelse: string
-  kravdato: string | null
+  kravdato: Date | null
 }): Promise<ApiResponse<Virkningstidspunkt>> => {
   return apiClient.post(`/behandling/${args.id}/virkningstidspunkt`, {
     dato: args.dato,
     begrunnelse: args.begrunnelse,
-    kravdato: args.kravdato,
+    kravdato: args.kravdato ? format(args.kravdato, 'yyyy-MM-dd') : null,
   })
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
@@ -43,7 +43,7 @@ export const fastsettVirkningstidspunkt = async (args: {
   id: string
   dato: Date
   begrunnelse: string
-  kravdato: Date | undefined
+  kravdato: string | null
 }): Promise<ApiResponse<Virkningstidspunkt>> => {
   return apiClient.post(`/behandling/${args.id}/virkningstidspunkt`, {
     dato: args.dato,

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IDetaljertBehandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IDetaljertBehandling.ts
@@ -113,6 +113,7 @@ export interface Virkningstidspunkt {
   dato: string
   kilde: KildeSaksbehandler
   begrunnelse: string
+  kravdato: string
 }
 
 export interface IEtterbetaling {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IDetaljertBehandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IDetaljertBehandling.ts
@@ -113,7 +113,7 @@ export interface Virkningstidspunkt {
   dato: string
   kilde: KildeSaksbehandler
   begrunnelse: string
-  kravdato: string
+  kravdato: string | null
 }
 
 export interface IEtterbetaling {

--- a/libs/saksbehandling-common/src/main/kotlin/behandling/Virkningstidspunkt.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/behandling/Virkningstidspunkt.kt
@@ -8,14 +8,14 @@ data class Virkningstidspunkt(
     val dato: YearMonth,
     val kilde: Grunnlagsopplysning.Saksbehandler,
     val begrunnelse: String,
-    val kravdato: YearMonth? = null,
+    val kravdato: LocalDate? = null,
 ) {
     companion object {
         fun create(
             dato: YearMonth,
             ident: String,
             begrunnelse: String,
-            kravdato: YearMonth? = null,
+            kravdato: LocalDate? = null,
         ) = Virkningstidspunkt(dato, Grunnlagsopplysning.Saksbehandler.create(ident), begrunnelse, kravdato)
     }
 }


### PR DESCRIPTION
- Endrer fra YearMonth til LocalDate siden dette faktisk er en dato
- Fikser slik at verdien vises i behandlingen ved uthenting

Krever at eksisterende behandlinger som har kravdato satt fikses i db før merge.
Kravdato børde nok også ligget et annet sted enn inni Virkningstidspunkt-objektet, men det er en større endring.