### PR TITLE
GET-kall kan iblant feile. Legg på automatikk som rekøyrer alle som g…

### DIFF
--- a/libs/ktor2client-onbehalfof/src/main/kotlin/DownstreamResourceClass.kt
+++ b/libs/ktor2client-onbehalfof/src/main/kotlin/DownstreamResourceClass.kt
@@ -17,6 +17,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMessage
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
+import no.nav.etterlatte.libs.common.retryOgPakkUt
 import no.nav.etterlatte.token.BrukerTokenInfo
 import no.nav.etterlatte.token.Systembruker
 import org.slf4j.LoggerFactory
@@ -104,11 +105,12 @@ class DownstreamResourceClient(
         resource: Resource,
         oboAccessToken: AccessToken,
     ): Result<JsonNode?, ThrowableErrorMessage> =
-
         runCatching {
-            httpClient.get(resource.url) {
-                header(HttpHeaders.Authorization, "Bearer ${oboAccessToken.accessToken}")
-                resource.additionalHeaders?.forEach { headers.append(it.key, it.value) }
+            retryOgPakkUt {
+                httpClient.get(resource.url) {
+                    header(HttpHeaders.Authorization, "Bearer ${oboAccessToken.accessToken}")
+                    resource.additionalHeaders?.forEach { headers.append(it.key, it.value) }
+                }
             }
         }
             .mapCatching { response ->

--- a/libs/saksbehandling-common/src/main/kotlin/Retry.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/Retry.kt
@@ -12,6 +12,16 @@ sealed class RetryResult<T> {
     }
 }
 
+suspend fun <T> retryOgPakkUt(
+    times: Int = 2,
+    block: suspend () -> T,
+) = retry(times, block).let {
+    when (it) {
+        is Success -> it.content
+        is Failure -> throw it.samlaExceptions()
+    }
+}
+
 suspend fun <T> retry(
     times: Int = 2,
     block: suspend () -> T,


### PR DESCRIPTION
…år via DownstreamResourceClient automatisk.

Veldig godt mogleg vi bør ha tilsvarande også på andre http-verb, samt på kall direkte til httpclient.