### PR TITLE
EY-3170 Vise saksdetaljer (fra journalpost) i dokumentoversikten

### DIFF
--- a/apps/etterlatte-brev-api/src/main/resources/graphql/dokumentoversiktBruker.graphql
+++ b/apps/etterlatte-brev-api/src/main/resources/graphql/dokumentoversiktBruker.graphql
@@ -15,6 +15,11 @@ query(
             journalposttype
             journalstatus
             tema
+            sak {
+                fagsakId
+                fagsaksystem
+                sakstype
+            }
             dokumenter {
                 dokumentInfoId
                 tittel


### PR DESCRIPTION
Mulig dette blir midlertidig siden vi "i teorien" kun skal ha journalposter som tilhører Gjenny og våre saker, men tenkte det er greit å ha hvert fall en periode for å sikre at sakene er tilkoblet riktig.