### PR TITLE
Lagt til støtte for azure token generator i dev for samordning-vedtak

### DIFF
--- a/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
@@ -121,6 +121,12 @@ spec:
           permissions:
             roles:
               - les-oms-vedtak
+        - application: azure-token-generator
+          namespace: aura
+          cluster: dev-gcp
+          permissions:
+            roles:
+              - les-oms-vedtak
     outbound:
       rules:
         - application: etterlatte-vedtaksvurdering


### PR DESCRIPTION
Så kan man bruke https://doc.nais.io/security/auth/azure-ad/usage/#token-generator

(for /pensjon-endepunktet)