### PR TITLE
Oppdaget en rar feil hvor trygdetid hevdet å ha overstyrt

### DIFF
--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -603,17 +603,18 @@ class TrygdetidServiceImpl(
             trygdetidRepository.hentTrygdetiderForBehandling(behandlingId).find { it.ident == ident }
                 ?: throw GenerellIkkeFunnetException()
 
-        return trygdetid.copy(
-            trygdetidGrunnlag = emptyList(),
-            beregnetTrygdetid =
-                DetaljertBeregnetTrygdetid(
-                    resultat = beregnetTrygdetid,
-                    tidspunkt = Tidspunkt.now(),
-                    regelResultat = "".toJsonNode(),
-                ),
-        ).also { nyTrygdetid ->
-            trygdetidRepository.oppdaterTrygdetid(nyTrygdetid, true)
-        }
+        val oppdatertTrygdetid =
+            trygdetid.copy(
+                trygdetidGrunnlag = emptyList(),
+                beregnetTrygdetid =
+                    DetaljertBeregnetTrygdetid(
+                        resultat = beregnetTrygdetid,
+                        tidspunkt = Tidspunkt.now(),
+                        regelResultat = "".toJsonNode(),
+                    ),
+            )
+
+        return trygdetidRepository.oppdaterTrygdetid(oppdatertTrygdetid, true)
     }
 
     override suspend fun sjekkGyldighetOgOppdaterBehandlingStatus(


### PR DESCRIPTION
... men databasen sier noe annet.

Lurer på om det kan ha noe med å gjøre at det ble gjort i en also-block.