### PR TITLE
Hotfix: Håndtere avdød som ikke finnes i PDL

### DIFF
--- a/apps/etterlatte-fordeler/src/main/kotlin/fordeler/FordelerKriterier.kt
+++ b/apps/etterlatte-fordeler/src/main/kotlin/fordeler/FordelerKriterier.kt
@@ -33,6 +33,7 @@ enum class FordelerKriterie(val forklaring: String) {
 
     BARN_HAR_FOR_GAMLE_SOESKEN("Det finnes barn av avdøde som er for gamle"),
 
+    AVDOED_FINNES_IKKE_I_PDL("Finner ikke avdød i PDL"),
     AVDOED_HAR_UTVANDRING("Avdød har utvandring"),
     AVDOED_HAR_YRKESSKADE("Avdød er markert med yrkesskade i søknaden"),
     AVDOED_ER_IKKE_REGISTRERT_SOM_DOED("Avdød er ikke registrert som død"),

--- a/apps/etterlatte-fordeler/src/main/kotlin/pdltjenester/PdlTjenesterKlient.kt
+++ b/apps/etterlatte-fordeler/src/main/kotlin/pdltjenester/PdlTjenesterKlient.kt
@@ -13,7 +13,6 @@ import no.nav.etterlatte.libs.common.RetryResult
 import no.nav.etterlatte.libs.common.feilhaandtering.ExceptionResponse
 import no.nav.etterlatte.libs.common.logging.samleExceptions
 import no.nav.etterlatte.libs.common.pdl.AkseptererIkkePersonerUtenIdentException
-import no.nav.etterlatte.libs.common.pdl.FantIkkePersonException
 import no.nav.etterlatte.libs.common.pdl.PdlFeilAarsak
 import no.nav.etterlatte.libs.common.pdl.PdlInternalServerError
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
@@ -25,7 +24,7 @@ import org.slf4j.LoggerFactory
 class PdlTjenesterKlient(private val client: HttpClient, private val apiUrl: String) {
     private val logger = LoggerFactory.getLogger(PdlTjenesterKlient::class.java)
 
-    suspend fun hentPerson(hentPersonRequest: HentPersonRequest): Person {
+    suspend fun hentPerson(hentPersonRequest: HentPersonRequest): Person? {
         logger.info("Henter person med ${hentPersonRequest.foedselsnummer} fra pdltjenester")
         return retry<Person> {
             client.post(apiUrl) {
@@ -51,9 +50,7 @@ class PdlTjenesterKlient(private val client: HttpClient, private val apiUrl: Str
                             throw samleExceptions(it.exceptions + e)
                         }
                     when (feilFraPdl) {
-                        PdlFeilAarsak.FANT_IKKE_PERSON ->
-                            throw FantIkkePersonException()
-
+                        PdlFeilAarsak.FANT_IKKE_PERSON -> null
                         PdlFeilAarsak.INGEN_IDENT_FAMILIERELASJON -> throw AkseptererIkkePersonerUtenIdentException()
                         PdlFeilAarsak.INTERNAL_SERVER_ERROR -> throw PdlInternalServerError()
                     }


### PR DESCRIPTION
**_OBS! Denne PR-en er bare et forslag til løsning. Kom gjerne med andre forslag / innspill._** 

Vi har mottatt en søknad hvor innsender har oppgitt fnr. hvor siste 5 siffer er `00000`. Dette validerer, tross alle reglene i `FoedselsnummerValidator`. 

Søknaden kommer så til `etterlatte-fordeler` hvor det kræsjer siden dette fnr. ikke finnes i PDL. 