### PR TITLE
Ikke map avsenderadresse for brev.

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/AdresseService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/AdresseService.kt
@@ -67,22 +67,11 @@ class AdresseService(
         saksbehandlerNavn: String?,
         attestantNavn: String?,
     ): Avsender {
-        val postadresse = enhet.kontaktinfo?.postadresse
-
         val kontor = enhet.navn ?: "NAV"
-        val adresse =
-            when (postadresse?.type) {
-                "stedsadresse" -> postadresse.let { "${it.gatenavn} ${it.husnummer}${it.husbokstav ?: ""}" }
-                "postboksadresse" -> "Postboks ${postadresse.postboksnummer} ${postadresse.postboksanlegg ?: ""}".trim()
-                else -> throw Exception("Ukjent type postadresse ${postadresse?.type}")
-            }
-        val postnr = postadresse.let { "${it.postnummer} ${it.poststed}" }
         val telefon = enhet.kontaktinfo?.telefonnummer ?: ""
 
         return Avsender(
             kontor = kontor,
-            adresse = adresse,
-            postnummer = postnr,
             telefonnummer = Telefonnummer(telefon),
             saksbehandler = saksbehandlerNavn,
             attestant = attestantNavn,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/Avsender.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/Avsender.kt
@@ -4,8 +4,6 @@ import no.nav.pensjon.brevbaker.api.model.Telefonnummer
 
 data class Avsender(
     val kontor: String,
-    val adresse: String,
-    val postnummer: String,
     val telefonnummer: Telefonnummer,
     val saksbehandler: String?,
     val attestant: String?,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -850,8 +850,6 @@ internal class VedtaksbrevServiceTest {
     private fun opprettAvsender() =
         Avsender(
             kontor = "Nav Porsgrunn",
-            "Etterstad 1",
-            "0556",
             Telefonnummer("55553333"),
             "Sak Saksbehandler",
             "Per Attestant",


### PR DESCRIPTION
Det er ikke alle enheter som har adresse (f. eks 0001), og det benyttes ikke videre i brevet heller.

EY-3190