### PR TITLE
Justerer feilhandtering for gjenlevende-søk mot PDL

### DIFF
--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
@@ -26,8 +26,8 @@ internal class Verifiserer(
     fun verifiserRequest(request: MigreringRequest): MigreringRequest {
         val patchedRequest = patchGjenlevendeHvisIkkeOppgitt(request)
         val feil = mutableListOf<Exception>()
-        patchedRequest.onFailure {
-            feil.add(PDLException(it))
+        patchedRequest.onFailure { feilen ->
+            feil.add(PDLException(feilen).also { it.addSuppressed(feilen) })
         }
         patchedRequest.onSuccess {
             feil.addAll(sjekkAtPersonerFinsIPDL(it))
@@ -139,7 +139,7 @@ internal class Verifiserer(
         }
 }
 
-sealed class Verifiseringsfeil(kilde: Throwable? = null) : Exception(cause = kilde)
+sealed class Verifiseringsfeil : Exception()
 
 data class FinsIkkeIPDL(val rolle: PersonRolle, val id: Folkeregisteridentifikator) : Verifiseringsfeil() {
     override val message: String
@@ -166,7 +166,7 @@ object StrengtFortrolig : Verifiseringsfeil() {
         get() = "Skal ikke migrere strengt fortrolig sak"
 }
 
-data class PDLException(val kilde: Throwable) : Verifiseringsfeil(kilde = kilde) {
+data class PDLException(val kilde: Throwable) : Verifiseringsfeil() {
     override val message: String?
         get() = kilde.message
 }

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
@@ -166,4 +166,7 @@ object StrengtFortrolig : Verifiseringsfeil() {
         get() = "Skal ikke migrere strengt fortrolig sak"
 }
 
-data class PDLException(val kilde: Throwable) : Verifiseringsfeil(kilde = kilde)
+data class PDLException(val kilde: Throwable) : Verifiseringsfeil(kilde = kilde) {
+    override val message: String?
+        get() = kilde.message
+}

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
@@ -34,9 +34,9 @@ internal class Verifiserer(
                 request.toJson(),
                 feilendeSteg = Migreringshendelser.VERIFISER,
                 feil = feil.map { it.message }.toJson(),
-                pesysId = patchedRequest.pesysId,
+                pesysId = request.pesysId,
             )
-            repository.oppdaterStatus(patchedRequest.pesysId, Migreringsstatus.VERIFISERING_FEILA)
+            repository.oppdaterStatus(request.pesysId, Migreringsstatus.VERIFISERING_FEILA)
             throw samleExceptions(feil)
         }
         return patchedRequest

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
@@ -96,7 +96,7 @@ internal class Verifiserer(
             return listOf(EnhetUtland(request.enhet.nr))
         }
         if (request.enhet.nr == "2103") {
-            return listOf(Fortrolig)
+            return listOf(StrengtFortrolig)
         }
         request.gjenlevendeForelder!!.let { personer.add(Pair(PersonRolle.GJENLEVENDE, it)) }
 
@@ -161,9 +161,9 @@ data class EnhetUtland(val enhet: String) : Verifiseringsfeil() {
         get() = "Vi har ikke adresse for enhet utland $enhet. Må følges opp snart"
 }
 
-object Fortrolig : Verifiseringsfeil() {
+object StrengtFortrolig : Verifiseringsfeil() {
     override val message: String
-        get() = "Skal ikke migrere fortrolig eller strengt fortrolig sak"
+        get() = "Skal ikke migrere strengt fortrolig sak"
 }
 
 data class PDLException(val kilde: Throwable) : Verifiseringsfeil(kilde = kilde)


### PR DESCRIPTION
Å kaste exception her braut litt med flyten vi hadde lagt opp, så vi får ikkje lagra feil ordentleg. Oppdaterer det så vi får flytta frå henta til verifisering feila som status også for desse