### PR TITLE
Endepunkt for å hente samsvar mellom persongalleriet i sak og persongalleri hentet fra PDL

### DIFF
--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingGrunnlagRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingGrunnlagRoutes.kt
@@ -22,11 +22,6 @@ fun Route.behandlingGrunnlagRoute(
     grunnlagService: GrunnlagService,
     behandlingKlient: BehandlingKlient,
 ) {
-    /**
-     * TODO:
-     *  Dette blir en stegvis endring for å redusere sjansen for at alt brekker.
-     *  Sak ID skal fjernes så fort vi har versjonert alt grunnlag i dev/prod med behandlingId
-     **/
     route("/behandling/{$BEHANDLINGID_CALL_PARAMETER}") {
         get {
             withBehandlingId(behandlingKlient) { behandlingId ->

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingGrunnlagRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingGrunnlagRoutes.kt
@@ -10,7 +10,6 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.grunnlag.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
-import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.grunnlag.NyeSaksopplysninger
 import no.nav.etterlatte.libs.common.grunnlag.OppdaterGrunnlagRequest
@@ -104,24 +103,4 @@ fun Route.behandlingGrunnlagRoute(
             }
         }
     }
-}
-
-data class PersongalleriSamsvar(
-    val persongalleri: Persongalleri,
-    val kilde: GenerellKilde,
-    val persongalleriPdl: Persongalleri?,
-    val kildePdl: GenerellKilde?,
-    val problemer: List<MismatchPersongalleri>,
-)
-
-enum class MismatchPersongalleri {
-    MANGLER_GJENLEVENDE,
-    MANGLER_AVDOED,
-    MANGLER_SOESKEN,
-
-    EKSTRA_GJENLEVENDE,
-    EKSTRA_AVDOED,
-    EKSTRA_SOESKEN,
-
-    HAR_PERSONER_UTEN_IDENTER,
 }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingGrunnlagRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingGrunnlagRoutes.kt
@@ -10,6 +10,7 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.grunnlag.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.grunnlag.NyeSaksopplysninger
 import no.nav.etterlatte.libs.common.grunnlag.OppdaterGrunnlagRequest
@@ -88,6 +89,13 @@ fun Route.behandlingGrunnlagRoute(
             }
         }
 
+        get("opplysning/persongalleri-match") {
+            withBehandlingId(behandlingKlient) { behandlingId ->
+                val persongalleri = grunnlagService.hentPersongalleriSamsvar(behandlingId)
+                call.respond(persongalleri)
+            }
+        }
+
         get("personopplysninger") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 val sakstype = SakType.valueOf(call.parameters["sakType"].toString())
@@ -96,4 +104,16 @@ fun Route.behandlingGrunnlagRoute(
             }
         }
     }
+}
+
+data class PersongalleriDto(
+    val persongalleri: Persongalleri,
+    val kilde: GenerellKilde,
+    val persongalleriPdl: Persongalleri,
+    val problemer: List<MismatchPersongalleri>,
+)
+
+enum class MismatchPersongalleri {
+    MANGLER_GJENLEVENDE,
+    MISMATCH,
 }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingGrunnlagRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingGrunnlagRoutes.kt
@@ -89,7 +89,7 @@ fun Route.behandlingGrunnlagRoute(
             }
         }
 
-        get("opplysning/persongalleri-match") {
+        get("opplysning/persongalleri-samsvar") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 val persongalleri = grunnlagService.hentPersongalleriSamsvar(behandlingId)
                 call.respond(persongalleri)
@@ -106,14 +106,22 @@ fun Route.behandlingGrunnlagRoute(
     }
 }
 
-data class PersongalleriDto(
+data class PersongalleriSamsvar(
     val persongalleri: Persongalleri,
     val kilde: GenerellKilde,
-    val persongalleriPdl: Persongalleri,
+    val persongalleriPdl: Persongalleri?,
+    val kildePdl: GenerellKilde?,
     val problemer: List<MismatchPersongalleri>,
 )
 
 enum class MismatchPersongalleri {
     MANGLER_GJENLEVENDE,
-    MISMATCH,
+    MANGLER_AVDOED,
+    MANGLER_SOESKEN,
+
+    EKSTRA_GJENLEVENDE,
+    EKSTRA_AVDOED,
+    EKSTRA_SOESKEN,
+
+    HAR_PERSONER_UTEN_IDENTER,
 }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagService.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagService.kt
@@ -103,6 +103,8 @@ interface GrunnlagService {
     fun hentHistoriskForeldreansvar(behandlingId: UUID): Grunnlagsopplysning<JsonNode>?
 
     fun hentVergeadresse(folkeregisteridentifikator: String): BrevMottaker?
+
+    fun hentPersongalleriSamsvar(behandlingId: UUID): MismatchPersongalleri
 }
 
 class RealGrunnlagService(
@@ -292,6 +294,10 @@ class RealGrunnlagService(
     override fun hentVergeadresse(folkeregisteridentifikator: String): BrevMottaker? {
         return persondataKlient.hentAdresseForVerge(folkeregisteridentifikator)
             ?.toBrevMottaker()
+    }
+
+    override fun hentPersongalleriSamsvar(behandlingId: UUID): MismatchPersongalleri {
+        TODO("Not yet implemented")
     }
 
     private fun mapTilRolle(

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagService.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagService.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.grunnlag
 
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.grunnlag.adresse.BrevMottaker
 import no.nav.etterlatte.grunnlag.klienter.PdlTjenesterKlientImpl
 import no.nav.etterlatte.grunnlag.klienter.PersondataKlient
@@ -10,6 +11,7 @@ import no.nav.etterlatte.libs.common.behandling.SakOgRolle
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
 import no.nav.etterlatte.libs.common.deserialize
+import no.nav.etterlatte.libs.common.feilhaandtering.GenerellIkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -21,6 +23,9 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.AVDOED_PDL_V1
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.GJENLEVENDE_FORELDER_PDL_V1
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.INNSENDER_PDL_V1
+import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.INNSENDER_SOEKNAD_V1
+import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.PERSONGALLERI_PDL_V1
+import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.PERSONGALLERI_V1
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.SOEKER_PDL_V1
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.pdl.PersonDTO
@@ -35,6 +40,7 @@ import no.nav.etterlatte.libs.sporingslogg.HttpMethod
 import no.nav.etterlatte.libs.sporingslogg.Sporingslogg
 import no.nav.etterlatte.libs.sporingslogg.Sporingsrequest
 import no.nav.etterlatte.pdl.HistorikkForeldreansvar
+import org.jetbrains.annotations.TestOnly
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
@@ -104,7 +110,7 @@ interface GrunnlagService {
 
     fun hentVergeadresse(folkeregisteridentifikator: String): BrevMottaker?
 
-    fun hentPersongalleriSamsvar(behandlingId: UUID): MismatchPersongalleri
+    fun hentPersongalleriSamsvar(behandlingId: UUID): PersongalleriSamsvar
 }
 
 class RealGrunnlagService(
@@ -296,8 +302,86 @@ class RealGrunnlagService(
             ?.toBrevMottaker()
     }
 
-    override fun hentPersongalleriSamsvar(behandlingId: UUID): MismatchPersongalleri {
-        TODO("Not yet implemented")
+    override fun hentPersongalleriSamsvar(behandlingId: UUID): PersongalleriSamsvar {
+        val grunnlag = opplysningDao.hentAlleGrunnlagForBehandling(behandlingId)
+        val opplysningPersongalleriSak = grunnlag.find { it.opplysning.opplysningType == PERSONGALLERI_V1 }
+        val opplysningPersongalleriPdl = grunnlag.find { it.opplysning.opplysningType == PERSONGALLERI_PDL_V1 }
+        if (opplysningPersongalleriSak == null) {
+            throw GenerellIkkeFunnetException()
+        }
+        val persongalleriISak: Persongalleri = objectMapper.readValue(opplysningPersongalleriSak.opplysning.toJson())
+
+        if (opplysningPersongalleriPdl == null) {
+            logger.info("Fant ikke persongalleri fra PDL for behandling med id=$behandlingId, gjør ingen samsvarsjekk")
+            return PersongalleriSamsvar(
+                persongalleri = persongalleriISak,
+                kilde = opplysningPersongalleriSak.opplysning.kilde.tilGenerellKilde(),
+                persongalleriPdl = null,
+                kildePdl = null,
+                problemer = listOf(),
+            )
+        }
+        val persongalleriPdl: Persongalleri = objectMapper.readValue(opplysningPersongalleriPdl.opplysning.toJson())
+
+        val valideringsfeil =
+            valideringsfeilPersongalleriSakPdl(
+                persongalleriISak = persongalleriISak,
+                persongalleriPdl = persongalleriPdl,
+            )
+
+        return PersongalleriSamsvar(
+            persongalleri = persongalleriISak,
+            kilde = opplysningPersongalleriSak.opplysning.kilde.tilGenerellKilde(),
+            persongalleriPdl = persongalleriPdl,
+            kildePdl = opplysningPersongalleriPdl.opplysning.kilde.tilGenerellKilde(),
+            problemer = valideringsfeil,
+        )
+    }
+
+    @TestOnly
+    fun valideringsfeilPersongalleriSakPdl(
+        persongalleriISak: Persongalleri,
+        persongalleriPdl: Persongalleri,
+    ): List<MismatchPersongalleri> {
+        val forskjellerAvdoede =
+            forskjellerMellomPersonerPdlOgSak(
+                personerPdl = persongalleriPdl.avdoed,
+                personerSak = persongalleriISak.avdoed,
+            )
+        val forskjellerGjenlevende =
+            forskjellerMellomPersonerPdlOgSak(
+                personerPdl = persongalleriPdl.gjenlevende,
+                personerSak = persongalleriISak.gjenlevende,
+            )
+        val forskjellerSoesken =
+            forskjellerMellomPersonerPdlOgSak(
+                personerPdl = persongalleriPdl.soesken,
+                persongalleriISak.soesken,
+            )
+        return listOfNotNull(
+            MismatchPersongalleri.MANGLER_GJENLEVENDE.takeIf { forskjellerGjenlevende.kunPdl.isNotEmpty() },
+            MismatchPersongalleri.MANGLER_AVDOED.takeIf { forskjellerAvdoede.kunPdl.isNotEmpty() },
+            MismatchPersongalleri.MANGLER_SOESKEN.takeIf { forskjellerSoesken.kunPdl.isNotEmpty() },
+            MismatchPersongalleri.EKSTRA_GJENLEVENDE.takeIf { forskjellerGjenlevende.kunSak.isNotEmpty() },
+            MismatchPersongalleri.EKSTRA_AVDOED.takeIf { forskjellerAvdoede.kunSak.isNotEmpty() },
+            MismatchPersongalleri.EKSTRA_SOESKEN.takeIf { forskjellerSoesken.kunSak.isNotEmpty() },
+            MismatchPersongalleri.HAR_PERSONER_UTEN_IDENTER.takeIf { !persongalleriPdl.personerUtenIdent.isNullOrEmpty() },
+        )
+    }
+
+    private fun forskjellerMellomPersonerPdlOgSak(
+        personerPdl: List<String>,
+        personerSak: List<String>,
+    ): ForskjellMellomPersoner {
+        val pdl = personerPdl.toSet()
+        val sak = personerSak.toSet()
+
+        val kunIPdl = pdl subtract sak
+        val kunISak = sak subtract pdl
+        return ForskjellMellomPersoner(
+            kunSak = kunISak.toList(),
+            kunPdl = kunIPdl.toList(),
+        )
     }
 
     private fun mapTilRolle(
@@ -554,3 +638,5 @@ data class GenerellKilde(
     val tidspunkt: Tidspunkt,
     val detalj: String? = null,
 )
+
+data class ForskjellMellomPersoner(val kunSak: List<String>, val kunPdl: List<String>)

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagService.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagService.kt
@@ -23,7 +23,6 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.AVDOED_PDL_V1
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.GJENLEVENDE_FORELDER_PDL_V1
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.INNSENDER_PDL_V1
-import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.INNSENDER_SOEKNAD_V1
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.PERSONGALLERI_PDL_V1
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.PERSONGALLERI_V1
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.SOEKER_PDL_V1

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/PersongalleriSamsvar.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/PersongalleriSamsvar.kt
@@ -1,0 +1,23 @@
+package no.nav.etterlatte.grunnlag
+
+import no.nav.etterlatte.libs.common.behandling.Persongalleri
+
+data class PersongalleriSamsvar(
+    val persongalleri: Persongalleri,
+    val kilde: GenerellKilde,
+    val persongalleriPdl: Persongalleri?,
+    val kildePdl: GenerellKilde?,
+    val problemer: List<MismatchPersongalleri>,
+)
+
+enum class MismatchPersongalleri {
+    MANGLER_GJENLEVENDE,
+    MANGLER_AVDOED,
+    MANGLER_SOESKEN,
+
+    EKSTRA_GJENLEVENDE,
+    EKSTRA_AVDOED,
+    EKSTRA_SOESKEN,
+
+    HAR_PERSONER_UTEN_IDENTER,
+}

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagServiceTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagServiceTest.kt
@@ -668,7 +668,7 @@ internal class GrunnlagServiceTest {
             val persongalleriIngenGjenlevende =
                 Persongalleri(
                     soeker = "",
-                    avdoed = listOf("1"),
+                    gjenlevende = emptyList(),
                 )
             val valideringsfeilPdlEkstraGjenlevende =
                 grunnlagService.valideringsfeilPersongalleriSakPdl(


### PR DESCRIPTION
Tanken er å hente dette som en del av grunnlaget til frontend, og vise avvik hvis det er noen mellom det vi finner i PDL og det som ligger på saken allerede. 

Det er også tenkt at saksbehandler kan "forfremme" persongalleriet fra PDL til å være persongalleriet i saken, slik at de får oppdatert det hvis det er vesentlige feil. Og så kan persongalleriet legges inn ved førstegangsbehandling som vanlig, men ellers så ligger det bare der til saksbehandler oppdaterer (hvis det er behov for det). 

En slik oppdatering vil også oppdatere grunnlag, med påfølgende effekter. 

For denne PR'en skal jeg få skrevet noen tester for logikken, så kommer visning i frontend i en egen pulje. 

Har egentlig lyst til å ta dette med i en mer "beefy" grunnlagshenting for behandlingen, men har det på en egen route foreløpig.