### PR TITLE
EY-3056 - Opprettelse av manuell trygdetid manuell migrering

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
@@ -24,6 +24,7 @@ import { useAppDispatch } from '~store/Store'
 import { TrygdetidDetaljer } from '~components/behandling/trygdetid/detaljer/TrygdetidDetaljer'
 import { OverstyrtTrygdetid } from './OverstyrtTrygdetid'
 import { Revurderingaarsak } from '~shared/types/Revurderingaarsak'
+import { TrygdetidManueltOverstyrt } from '~components/behandling/trygdetid/TrygdetidManueltOverstyrt'
 
 interface Props {
   redigerbar: boolean
@@ -88,7 +89,7 @@ export const Trygdetid = ({ redigerbar, behandling, virkningstidspunktEtterNyReg
   if (trygdetid?.beregnetTrygdetid?.resultat.overstyrt) {
     return (
       <TrygdetidWrapper>
-        <div>Skjema for å endre manuell trygdetid kommer her</div>
+        <TrygdetidManueltOverstyrt behandlingId={behandling.id} oppdaterTrygdetid={oppdaterTrygdetid} />
         {trygdetid.beregnetTrygdetid && <TrygdetidDetaljer beregnetTrygdetid={trygdetid.beregnetTrygdetid.resultat} />}
       </TrygdetidWrapper>
     )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
@@ -85,6 +85,15 @@ export const Trygdetid = ({ redigerbar, behandling, virkningstidspunktEtterNyReg
     })
   }, [])
 
+  if (trygdetid?.beregnetTrygdetid?.resultat.overstyrt) {
+    return (
+      <TrygdetidWrapper>
+        <div>Skjema for å endre manuell trygdetid kommer her</div>
+        {trygdetid.beregnetTrygdetid && <TrygdetidDetaljer beregnetTrygdetid={trygdetid.beregnetTrygdetid.resultat} />}
+      </TrygdetidWrapper>
+    )
+  }
+
   return (
     <TrygdetidWrapper>
       {visTrydeavtale(behandling) && <TrygdeAvtale redigerbar={redigerbar} />}
@@ -110,7 +119,6 @@ export const Trygdetid = ({ redigerbar, behandling, virkningstidspunktEtterNyReg
           avtaler skal ikke beregnes sammen.
         </BodyShort>
       </LovtekstMedLenke>
-
       {trygdetid && landListe && (
         <>
           <Grunnlagopplysninger opplysninger={trygdetid.opplysninger} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
@@ -89,8 +89,12 @@ export const Trygdetid = ({ redigerbar, behandling, virkningstidspunktEtterNyReg
   if (trygdetid?.beregnetTrygdetid?.resultat.overstyrt) {
     return (
       <TrygdetidWrapper>
-        <TrygdetidManueltOverstyrt behandlingId={behandling.id} oppdaterTrygdetid={oppdaterTrygdetid} />
-        {trygdetid.beregnetTrygdetid && <TrygdetidDetaljer beregnetTrygdetid={trygdetid.beregnetTrygdetid.resultat} />}
+        <TrygdetidManueltOverstyrt
+          behandlingId={behandling.id}
+          oppdaterTrygdetid={oppdaterTrygdetid}
+          beregnetTrygdetid={trygdetid.beregnetTrygdetid}
+        />
+        <TrygdetidDetaljer beregnetTrygdetid={trygdetid.beregnetTrygdetid.resultat} />
       </TrygdetidWrapper>
     )
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidManueltOverstyrt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidManueltOverstyrt.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react'
+import { Alert, Button, Checkbox, TextField } from '@navikt/ds-react'
+import styled from 'styled-components'
+import { isFailure, isPending, useApiCall } from '~shared/hooks/useApiCall'
+import { ITrygdetid, oppdaterTrygdetidOverstyrtMigrering } from '~shared/api/trygdetid'
+import { InputRow } from '~components/person/journalfoeringsoppgave/nybehandling/OpprettNyBehandling'
+
+export const TrygdetidManueltOverstyrt = ({
+  behandlingId,
+  oppdaterTrygdetid,
+}: {
+  behandlingId: string
+  oppdaterTrygdetid: (trygdetid: ITrygdetid) => void
+}) => {
+  const [anvendtTrygdetid, setAnvendtTrygdetid] = useState<number | undefined>(undefined)
+
+  const [skalHaProrata, setSkalHaProrata] = useState<boolean>(false)
+  const [prorataTeller, setTeller] = useState<number | undefined>(undefined)
+  const [prorataNevner, setNevner] = useState<number | undefined>(undefined)
+
+  const [status, oppdaterTrygdetidRequest] = useApiCall(oppdaterTrygdetidOverstyrtMigrering)
+
+  const lagre = () => {
+    oppdaterTrygdetidRequest(
+      {
+        behandlingId: behandlingId,
+        anvendtTrygdetid: anvendtTrygdetid!!,
+        prorataBroek: skalHaProrata
+          ? {
+              teller: prorataTeller!!,
+              nevner: prorataNevner!!,
+            }
+          : undefined,
+      },
+      (trygdetid) => {
+        oppdaterTrygdetid(trygdetid)
+      }
+    )
+  }
+
+  return (
+    <FormWrapper>
+      <TextField
+        label="Anvendt trygdetid"
+        placeholder="Anvendt trygdetid"
+        value={anvendtTrygdetid || ''}
+        pattern="[0-9]{11}"
+        maxLength={11}
+        onChange={(e) => setAnvendtTrygdetid(Number(e.target.value))}
+      />
+
+      <Checkbox checked={skalHaProrata} onChange={() => setSkalHaProrata(!skalHaProrata)}>
+        Prorata brøk
+      </Checkbox>
+      {skalHaProrata && (
+        <InputRow>
+          <TextField
+            label="Prorata teller"
+            placeholder="Prorata teller"
+            value={prorataTeller || ''}
+            pattern="[0-9]{11}"
+            maxLength={11}
+            onChange={(e) => setTeller(Number(e.target.value))}
+          />
+          <TextField
+            label="Prorata nevner"
+            placeholder="Prorata nevner"
+            value={prorataNevner || ''}
+            pattern="[0-9]{11}"
+            maxLength={11}
+            onChange={(e) => setNevner(Number(e.target.value))}
+          />
+        </InputRow>
+      )}
+
+      <Knapp>
+        <Button
+          variant="secondary"
+          onClick={lagre}
+          loading={isPending(status)}
+          disabled={anvendtTrygdetid == null || (skalHaProrata && (prorataNevner == null || prorataTeller == null))}
+        >
+          Send inn
+        </Button>
+      </Knapp>
+      {isFailure(status) && <Alert variant="error">Det oppsto en feil ved oppdatering av trygdetid.</Alert>}
+    </FormWrapper>
+  )
+}
+
+const FormWrapper = styled.div`
+  width: 10em;
+  display: grid;
+  gap: var(--a-spacing-4);
+`
+const Knapp = styled.div`
+  margin-top: 1em;
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidManueltOverstyrt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidManueltOverstyrt.tsx
@@ -2,21 +2,25 @@ import React, { useState } from 'react'
 import { Alert, Button, Checkbox, TextField } from '@navikt/ds-react'
 import styled from 'styled-components'
 import { isFailure, isPending, useApiCall } from '~shared/hooks/useApiCall'
-import { ITrygdetid, oppdaterTrygdetidOverstyrtMigrering } from '~shared/api/trygdetid'
+import { IDetaljertBeregnetTrygdetid, ITrygdetid, oppdaterTrygdetidOverstyrtMigrering } from '~shared/api/trygdetid'
 import { InputRow } from '~components/person/journalfoeringsoppgave/nybehandling/OpprettNyBehandling'
 
 export const TrygdetidManueltOverstyrt = ({
   behandlingId,
+  beregnetTrygdetid,
   oppdaterTrygdetid,
 }: {
   behandlingId: string
+  beregnetTrygdetid: IDetaljertBeregnetTrygdetid
   oppdaterTrygdetid: (trygdetid: ITrygdetid) => void
 }) => {
-  const [anvendtTrygdetid, setAnvendtTrygdetid] = useState<number | undefined>(undefined)
+  const [anvendtTrygdetid, setAnvendtTrygdetid] = useState<number | undefined>(
+    beregnetTrygdetid.resultat.samletTrygdetidNorge
+  )
 
-  const [skalHaProrata, setSkalHaProrata] = useState<boolean>(false)
-  const [prorataTeller, setTeller] = useState<number | undefined>(undefined)
-  const [prorataNevner, setNevner] = useState<number | undefined>(undefined)
+  const [skalHaProrata, setSkalHaProrata] = useState<boolean>(beregnetTrygdetid.resultat.prorataBroek != null)
+  const [prorataTeller, setTeller] = useState<number | undefined>(beregnetTrygdetid.resultat.prorataBroek?.teller)
+  const [prorataNevner, setNevner] = useState<number | undefined>(beregnetTrygdetid.resultat.prorataBroek?.nevner)
 
   const [status, oppdaterTrygdetidRequest] = useApiCall(oppdaterTrygdetidOverstyrtMigrering)
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/manuelbehandling/ManuellBehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/manuelbehandling/ManuellBehandling.tsx
@@ -12,6 +12,7 @@ import { opprettBehandling } from '~shared/api/behandling'
 import { opprettOverstyrBeregning } from '~shared/api/beregning'
 import { InputRow } from '~components/person/journalfoeringsoppgave/nybehandling/OpprettNyBehandling'
 import { Spraak } from '~shared/types/Brev'
+import { opprettTrygdetidOverstyrtMigrering } from '~shared/api/trygdetid'
 
 export default function ManuellBehandling() {
   const dispatch = useAppDispatch()
@@ -21,7 +22,10 @@ export default function ManuellBehandling() {
   const [erMigrering, setErMigrering] = useState<boolean | null>(null)
 
   const [overstyrBeregningStatus, opprettOverstyrtBeregningReq] = useApiCall(opprettOverstyrBeregning)
-  const [overstyrBeregning, setOverstyrBeregning] = useState<boolean>(true)
+  const [overstyrBeregning, setOverstyrBeregning] = useState<boolean>(false)
+
+  const [overstyrTrygdetidStatus, opprettOverstyrtTrygdetidReq] = useApiCall(opprettTrygdetidOverstyrtMigrering)
+  const [overstyrTrygdetid, setOverstyrTrygdetid] = useState<boolean>(false)
 
   const [pesysId, setPesysId] = useState<number | undefined>(undefined)
 
@@ -40,6 +44,9 @@ export default function ManuellBehandling() {
             behandlingId: nyBehandlingRespons,
             beskrivelse: 'Manuell migrering',
           })
+        }
+        if (overstyrTrygdetid) {
+          opprettOverstyrtTrygdetidReq({ behandlingId: nyBehandlingRespons })
         }
         setNyId(nyBehandlingRespons)
       }
@@ -80,6 +87,10 @@ export default function ManuellBehandling() {
         Skal bruke manuell beregning
       </Checkbox>
 
+      <Checkbox checked={overstyrTrygdetid} onChange={() => setOverstyrTrygdetid(!overstyrTrygdetid)}>
+        Skal bruke manuell trygdetid
+      </Checkbox>
+
       <Select
         label="Hva skal språket/målform være?"
         value={nyBehandlingRequest?.spraak || ''}
@@ -113,7 +124,7 @@ export default function ManuellBehandling() {
         <Button
           variant="secondary"
           onClick={ferdigstill}
-          loading={isPending(status) || isPending(overstyrBeregningStatus)}
+          loading={isPending(status) || isPending(overstyrBeregningStatus) || isPending(overstyrTrygdetidStatus)}
           disabled={erMigrering == null || (erMigrering && pesysId == null)}
         >
           Send inn
@@ -125,6 +136,10 @@ export default function ManuellBehandling() {
       {isPending(overstyrBeregningStatus) && <Alert variant="info">Oppretter overstyrt beregning.</Alert>}
       {isSuccess(overstyrBeregningStatus) && <Alert variant="success">Overstyrt beregning opprettet!</Alert>}
       {isFailure(overstyrBeregningStatus) && <Alert variant="error">Klarte ikke å overstyre beregning.</Alert>}
+
+      {isPending(overstyrTrygdetidStatus) && <Alert variant="info">Oppretter overstyrt trygdetid.</Alert>}
+      {isSuccess(overstyrTrygdetidStatus) && <Alert variant="success">Overstyrt trygdetid opprettet!</Alert>}
+      {isFailure(overstyrTrygdetidStatus) && <Alert variant="error">Klarte ikke å overstyre trygdetid.</Alert>}
     </FormWrapper>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
@@ -117,7 +117,18 @@ export const lagreTrygdeavtaleForBehandling = async (args: {
   apiClient.post<Trygdeavtale>(`/trygdetid/avtaler/${args.behandlingId}`, { ...args.avtaleRequest })
 
 export const opprettTrygdetidOverstyrtMigrering = async (args: { behandlingId: string }): Promise<ApiResponse<void>> =>
-  apiClient.post(`/trygdetid/${args.behandlingId}/migrering/opprett`, {})
+  apiClient.post(`/trygdetid/${args.behandlingId}/migrering/manuell/opprett`, {})
+
+export const oppdaterTrygdetidOverstyrtMigrering = async (args: {
+  behandlingId: string
+  anvendtTrygdetid: number
+  prorataBroek?: IProrataBroek
+}): Promise<ApiResponse<ITrygdetid>> =>
+  apiClient.post(`/trygdetid/${args.behandlingId}/migrering/manuell/lagre`, {
+    samletTrygdetidNorge: args.anvendtTrygdetid,
+    prorataBroek: args.prorataBroek,
+    overstyrt: true,
+  })
 
 export interface ITrygdetid {
   id: string

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
@@ -116,6 +116,9 @@ export const lagreTrygdeavtaleForBehandling = async (args: {
 }): Promise<ApiResponse<Trygdeavtale>> =>
   apiClient.post<Trygdeavtale>(`/trygdetid/avtaler/${args.behandlingId}`, { ...args.avtaleRequest })
 
+export const opprettTrygdetidOverstyrtMigrering = async (args: { behandlingId: string }): Promise<ApiResponse<void>> =>
+  apiClient.post(`/trygdetid/${args.behandlingId}/migrering/opprett`, {})
+
 export interface ITrygdetid {
   id: string
   behandlingId: string

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
@@ -141,11 +141,23 @@ fun Route.trygdetid(
                 }
             }
 
-            post("/opprett") {
+            post("/manuell/opprett") {
                 withBehandlingId(behandlingKlient) {
                     logger.info("Oppretter trygdetid med overstyrt for behandling $behandlingId")
                     trygdetidService.opprettOverstyrtBeregnetTrygdetid(behandlingId, brukerTokenInfo)
                     call.respond(HttpStatusCode.OK)
+                }
+            }
+
+            post("/manuell/lagre") {
+                withBehandlingId(behandlingKlient) {
+                    logger.info("Oppdaterer trygdetid med overstyrt for behandling $behandlingId")
+                    val beregnetTrygdetid = call.receive<DetaljertBeregnetTrygdetidResultat>()
+
+                    val dto = trygdetidService.overstyrBeregnetTrygdetid(behandlingId, beregnetTrygdetid).toDto()
+                    behandlingKlient.settBehandlingStatusTrygdetidOppdatert(dto.behandlingId, brukerTokenInfo)
+
+                    call.respond(dto)
                 }
             }
 

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
@@ -141,6 +141,14 @@ fun Route.trygdetid(
                 }
             }
 
+            post("/opprett") {
+                withBehandlingId(behandlingKlient) {
+                    logger.info("Oppretter trygdetid med overstyrt for behandling $behandlingId")
+                    trygdetidService.opprettOverstyrtBeregnetTrygdetid(behandlingId, brukerTokenInfo)
+                    call.respond(HttpStatusCode.OK)
+                }
+            }
+
             post("/uten_fremtidig") {
                 withBehandlingId(behandlingKlient) {
                     logger.info("Beregn trygdetid uten fremtidig trygdetid for behandling $behandlingId")


### PR DESCRIPTION
- Valgmulighet for å oversytre manuell behandling med manuelt overstyrt trygdetid
- Form og endepunkt for å oppdatere manuelt overstyrt trygdetid

![image](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/18049279/35014aa5-f606-42fc-9c7c-cc57ba4fe44b)
![image](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/18049279/6342ee10-b1ee-4af9-bfa5-8fd993e84ee5)

![image](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/18049279/2e8482f2-7eba-42ef-8836-da68fbf4fcd2)
