### PR TITLE
Oppdatert feiltype med rett param

### DIFF
--- a/apps/etterlatte-samordning-vedtak/README.md
+++ b/apps/etterlatte-samordning-vedtak/README.md
@@ -72,7 +72,7 @@ Det må foreligge et tjenestepensjonsforhold i Tjenestepensjonsregisteret som gj
 | GE-MASKINPORTEN-SCOPE   | 401             | Manglende/feil scope                                     |
 | 001-TPNR-MANGLER        | 400             | Ikke angitt header med gjeldende ordningsnummer          |
 | 002-FNR-MANGLER         | 400             | Ikke angitt header med fødselsnummer det skal spørres på |
-| 003-VIRKFOM-MANGLER     | 400             | Ikke angitt virkFom som query parameter                  |
+| 003-FOMDATO-MANGLER     | 400             | Ikke angitt fomDato som query parameter                  |
 | 004-FEIL_SAKSTYPE       | 400             | Etterspurt vedtak som ikke angår omstillingsstønad       |
 | 010-TP-TILGANG          | 403             | Ikke tilgang til TP/etterspurt data                      |
 | 011-TP-FORESPOERSEL     | 400             | Feil ved spørring mot TP                                 |

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtak.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtak.kt
@@ -59,9 +59,9 @@ class ManglerFoedselsnummerException : UgyldigForespoerselException(
     meta = getMeta(),
 )
 
-class ManglerVirkFomException : UgyldigForespoerselException(
-    code = "003-VIRKFOM-MANGLER",
-    detail = "virkFom ikke angitt",
+class ManglerFomDatoException : UgyldigForespoerselException(
+    code = "003-FOMDATO-MANGLER",
+    detail = "fomDato ikke angitt",
     meta = getMeta(),
 )
 

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRoute.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRoute.kt
@@ -52,7 +52,7 @@ fun Route.samordningVedtakRoute(
             val fomDato =
                 call.parameters["fomDato"]?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
                     ?: call.parameters["virkFom"]?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
-                    ?: throw ManglerVirkFomException()
+                    ?: throw ManglerFomDatoException()
 
             val fnr =
                 call.request.headers["fnr"]
@@ -89,7 +89,7 @@ fun Route.samordningVedtakRoute(
             val fomDato =
                 call.parameters["fomDato"]?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
                     ?: call.parameters["virkFom"]?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
-                    ?: throw ManglerVirkFomException()
+                    ?: throw ManglerFomDatoException()
 
             val fnr =
                 call.request.headers["fnr"]


### PR DESCRIPTION
Det opprinnelige `virkFom` var feil (gir annen mening enn fomDato), men vi får støtte det litt til.