### PR TITLE
Fikse caching av tokens i frackend og backend

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/server/package.json
+++ b/apps/etterlatte-saksbehandling-ui/server/package.json
@@ -6,6 +6,7 @@
     "express": "^4.18.2",
     "http-proxy-middleware": "^2.0.6",
     "node-fetch": "^2.6.12",
+    "node-cache": "^5.1.2",
     "prom-client": "^15.0.0",
     "source-map": "~0.7.4",
     "unleash-client": "^5.0.0",

--- a/apps/etterlatte-saksbehandling-ui/server/src/cache/cache-actions.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/cache/cache-actions.ts
@@ -1,0 +1,21 @@
+import tokenCache from './token-cache'
+
+export function flush(): void {
+  tokenCache.flushAll()
+}
+
+export function getTokenInCache(cacheKey: string): [cacheHit: true, value: string] | [cacheHit: false] {
+  const tokenInCache: string | undefined = tokenCache.get(cacheKey)
+  if (tokenInCache) {
+    return [true, tokenInCache]
+  }
+
+  return [false]
+}
+
+export function setTokenInCache(cacheKey: string, access_token: string, expires_in: number): void {
+  if (access_token == null) return
+
+  let calculatedExpiration = (expires_in ?? 65) - 5
+  tokenCache.set(cacheKey, access_token, calculatedExpiration)
+}

--- a/apps/etterlatte-saksbehandling-ui/server/src/cache/index.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/cache/index.ts
@@ -1,0 +1,1 @@
+export * from './cache-actions'

--- a/apps/etterlatte-saksbehandling-ui/server/src/cache/token-cache.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/cache/token-cache.ts
@@ -1,0 +1,5 @@
+import NodeCache from 'node-cache'
+
+const tokenCache = new NodeCache()
+
+export default tokenCache

--- a/apps/etterlatte-saksbehandling-ui/server/src/middleware/getOboToken.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/middleware/getOboToken.ts
@@ -21,7 +21,7 @@ export const getOboToken = async (bearerToken: string, scope: string): Promise<s
   const cacheKey = bearerToken + '.' + scope
 
   const [cacheHit, tokenFromCache] = getTokenInCache(cacheKey)
-  logger.debug('getOboToken: cache hit for scope=' + scope + '? ' + cacheHit)
+  logger.debug(`getOboToken: cache hit for scope=${scope}? ${cacheHit}`)
   if (cacheHit) {
     return tokenFromCache
   }

--- a/apps/etterlatte-saksbehandling-ui/server/yarn.lock
+++ b/apps/etterlatte-saksbehandling-ui/server/yarn.lock
@@ -1899,6 +1899,13 @@ negotiator@0.6.3, negotiator@^0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
+node-cache@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
+  integrity sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==
+  dependencies:
+    clone "2.x"
+
 node-fetch@^2.6.12:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"


### PR DESCRIPTION
Bakgrunn: Under arbeidet med innføringen av requestloggingen så jeg at det ble gjort hyppige oppslag til azure for å få tak i token for det påfølgende kallet til en eller annen app, faktisk 1:1. Har sett nærmere på det nå, og det viser seg å være en kombinasjon av flere ting.

1. `Caffeine`-cachen i `AzureADClient` var satt opp med expiration etter 5 sek. Det er jo ikke en cache som bidrar fryktelig mye sånn i det hele tatt, ikke minst med 2+ pods av hver app også. 
Denne er nå justert til å benytte tokenets faktiske expiration, eventuelt fallback til 5 sek.
2. Caffeine-cachen traff stort sett _aldri_....  fordi frackend produserer nye OBO-tokens hele tiden...    
Løsning: innfører `NodeCache` for dette. 
Takk til Karl Jørgen, ref https://nav-it.slack.com/archives/C6HJFRRMY/p1666176736830649?thread_ts=1666174634.086579&cid=C6HJFRRMY