### PR TITLE
Forbedring av fnr-validering + støtte tomrom i søk (fnr/sak)

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelistafiltre.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Oppgavelistafiltre.tsx
@@ -140,7 +140,7 @@ function filtrerOppgavekilde(oppgaveKildeFilterKeys: OppgaveKildeFilterKeys, opp
 
 function finnFnrIOppgaver(fnr: string, oppgaver: OppgaveDTO[]): OppgaveDTO[] {
   if (fnr && fnr.length > 0) {
-    return oppgaver.filter((o) => o.fnr.includes(fnr))
+    return oppgaver.filter((o) => o.fnr.includes(fnr.trim()))
   } else {
     return oppgaver
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
@@ -7,7 +7,7 @@ import Spinner from '~shared/Spinner'
 import { mapApiResult, useApiCall } from '~shared/hooks/useApiCall'
 import { Tabs } from '@navikt/ds-react'
 import { getPerson } from '~shared/api/grunnlag'
-import { fnrErGyldig } from '~utils/fnr'
+import { fnrHarGyldigFormat } from '~utils/fnr'
 import NavigerTilbakeMeny from '~components/person/NavigerTilbakeMeny'
 import { BulletListIcon, EnvelopeClosedIcon, FileTextIcon } from '@navikt/aksel-icons'
 import { Dokumentoversikt } from './dokumenter/dokumentoversikt'
@@ -39,7 +39,7 @@ export const Person = () => {
   const { fnr } = useParams()
 
   useEffect(() => {
-    if (fnrErGyldig(fnr)) {
+    if (fnrHarGyldigFormat(fnr)) {
       hentPerson(fnr!!)
       hentSak(fnr!!)
     }
@@ -55,8 +55,8 @@ export const Person = () => {
     }
   }
 
-  if (!fnrErGyldig(fnr)) {
-    return <ApiErrorAlert>Fødselsnummeret {fnr} er ugyldig</ApiErrorAlert>
+  if (!fnrHarGyldigFormat(fnr)) {
+    return <ApiErrorAlert>Fødselsnummeret {fnr} har et ugyldig format (ikke 11 siffer)</ApiErrorAlert>
   }
 
   return (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
@@ -7,7 +7,7 @@ import Spinner from '~shared/Spinner'
 import { mapApiResult, useApiCall } from '~shared/hooks/useApiCall'
 import { Tabs } from '@navikt/ds-react'
 import { getPerson } from '~shared/api/grunnlag'
-import { GYLDIG_FNR } from '~utils/fnr'
+import { fnrErGyldig } from '~utils/fnr'
 import NavigerTilbakeMeny from '~components/person/NavigerTilbakeMeny'
 import { BulletListIcon, EnvelopeClosedIcon, FileTextIcon } from '@navikt/aksel-icons'
 import { Dokumentoversikt } from './dokumenter/dokumentoversikt'
@@ -39,7 +39,7 @@ export const Person = () => {
   const { fnr } = useParams()
 
   useEffect(() => {
-    if (GYLDIG_FNR(fnr)) {
+    if (fnrErGyldig(fnr)) {
       hentPerson(fnr!!)
       hentSak(fnr!!)
     }
@@ -55,7 +55,7 @@ export const Person = () => {
     }
   }
 
-  if (!GYLDIG_FNR(fnr)) {
+  if (!fnrErGyldig(fnr)) {
     return <ApiErrorAlert>Fødselsnummeret {fnr} er ugyldig</ApiErrorAlert>
   }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/VelgJournalpost.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/VelgJournalpost.tsx
@@ -1,7 +1,7 @@
 import { isFailure, isPending, isSuccess, mapApiResult, useApiCall } from '~shared/hooks/useApiCall'
 import { hentDokumenter, hentDokumentPDF, hentJournalpost } from '~shared/api/dokument'
 import React, { useEffect, useState } from 'react'
-import { GYLDIG_FNR } from '~utils/fnr'
+import { fnrErGyldig } from '~utils/fnr'
 import { Button, Detail, Heading, Link, Panel, Table } from '@navikt/ds-react'
 import { useJournalfoeringOppgave } from '~components/person/journalfoeringsoppgave/useJournalfoeringOppgave'
 import { formaterStringDato } from '~utils/formattering'
@@ -30,7 +30,7 @@ export default function VelgJournalpost({ journalpostId }: { journalpostId: stri
   }
 
   useEffect(() => {
-    if (GYLDIG_FNR(bruker) && !journalpost) {
+    if (fnrErGyldig(bruker) && !journalpost) {
       if (journalpostId) {
         apiHentJournalpost(journalpostId, (journalpost) => {
           velgJournalpost(journalpost)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/VelgJournalpost.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/VelgJournalpost.tsx
@@ -1,7 +1,7 @@
 import { isFailure, isPending, isSuccess, mapApiResult, useApiCall } from '~shared/hooks/useApiCall'
 import { hentDokumenter, hentDokumentPDF, hentJournalpost } from '~shared/api/dokument'
 import React, { useEffect, useState } from 'react'
-import { fnrErGyldig } from '~utils/fnr'
+import { fnrHarGyldigFormat } from '~utils/fnr'
 import { Button, Detail, Heading, Link, Panel, Table } from '@navikt/ds-react'
 import { useJournalfoeringOppgave } from '~components/person/journalfoeringsoppgave/useJournalfoeringOppgave'
 import { formaterStringDato } from '~utils/formattering'
@@ -30,7 +30,7 @@ export default function VelgJournalpost({ journalpostId }: { journalpostId: stri
   }
 
   useEffect(() => {
-    if (fnrErGyldig(bruker) && !journalpost) {
+    if (fnrHarGyldigFormat(bruker) && !journalpost) {
       if (journalpostId) {
         apiHentJournalpost(journalpostId, (journalpost) => {
           velgJournalpost(journalpost)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/nybehandling/validator.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/nybehandling/validator.ts
@@ -1,4 +1,4 @@
-import { GYLDIG_FNR } from '~utils/fnr'
+import { fnrErGyldig } from '~utils/fnr'
 import { SakType } from '~shared/types/sak'
 import { NyBehandlingRequest } from '~shared/types/IDetaljertBehandling'
 
@@ -16,8 +16,8 @@ const gyldigPersongalleri = (request: NyBehandlingRequest) => {
     return false
   }
 
-  const avdoede = persongalleri.avdoed?.filter((fnr) => GYLDIG_FNR(fnr)) || []
-  const gjenlevende = persongalleri.gjenlevende?.filter((fnr) => GYLDIG_FNR(fnr)) || []
+  const avdoede = persongalleri.avdoed?.filter((fnr) => fnrErGyldig(fnr)) || []
+  const gjenlevende = persongalleri.gjenlevende?.filter((fnr) => fnrErGyldig(fnr)) || []
   const antallGjenlevOgAvdoed = avdoede.length + gjenlevende.length
 
   let gyldigGjenlevOgAvdoed = false
@@ -27,7 +27,7 @@ const gyldigPersongalleri = (request: NyBehandlingRequest) => {
     gyldigGjenlevOgAvdoed = antallGjenlevOgAvdoed === 1
   }
 
-  const gyldigInnsender = !persongalleri.innsender || GYLDIG_FNR(persongalleri.innsender)
+  const gyldigInnsender = !persongalleri.innsender || fnrErGyldig(persongalleri.innsender)
 
-  return GYLDIG_FNR(persongalleri.soeker) && gyldigGjenlevOgAvdoed && gyldigInnsender
+  return fnrErGyldig(persongalleri.soeker) && gyldigGjenlevOgAvdoed && gyldigInnsender
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/index.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/index.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client'
 import './index.css'
 import App from './App'
 import { Provider } from 'react-redux'
-import { store } from './store/Store'
+import { store } from '~store/Store'
 import { setupWindowOnError } from '~utils/logger'
 
 setupWindowOnError()

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/header/Search.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/header/Search.tsx
@@ -6,7 +6,7 @@ import { ABlue500, AGray900, ANavRed } from '@navikt/ds-tokens/dist/tokens'
 import { InformationSquareIcon, XMarkOctagonIcon } from '@navikt/aksel-icons'
 import { isFailure, isPending, isSuccess, useApiCall } from '~shared/hooks/useApiCall'
 import { getPerson } from '~shared/api/grunnlag'
-import { fnrErGyldig } from '~utils/fnr'
+import { fnrHarGyldigFormat } from '~utils/fnr'
 import { ApiError } from '~shared/api/apiClient'
 import { hentSak } from '~shared/api/behandling'
 
@@ -17,7 +17,7 @@ export const Search = () => {
   const [personStatus, hentPerson, reset] = useApiCall(getPerson)
   const [funnetSak, finnSak, resetSakSoek] = useApiCall(hentSak)
 
-  const gyldigInputFnr = fnrErGyldig(searchInput)
+  const gyldigInputFnr = fnrHarGyldigFormat(searchInput)
   const gyldigInputSakId = /^\d{1,10}$/.test(searchInput ?? '')
   const avgjoerSoek = () => {
     if (gyldigInputFnr) {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/header/Search.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/header/Search.tsx
@@ -6,7 +6,7 @@ import { ABlue500, AGray900, ANavRed } from '@navikt/ds-tokens/dist/tokens'
 import { InformationSquareIcon, XMarkOctagonIcon } from '@navikt/aksel-icons'
 import { isFailure, isPending, isSuccess, useApiCall } from '~shared/hooks/useApiCall'
 import { getPerson } from '~shared/api/grunnlag'
-import { GYLDIG_FNR } from '~utils/fnr'
+import { fnrErGyldig } from '~utils/fnr'
 import { ApiError } from '~shared/api/apiClient'
 import { hentSak } from '~shared/api/behandling'
 
@@ -17,7 +17,7 @@ export const Search = () => {
   const [personStatus, hentPerson, reset] = useApiCall(getPerson)
   const [funnetSak, finnSak, resetSakSoek] = useApiCall(hentSak)
 
-  const gyldigInputFnr = GYLDIG_FNR(searchInput)
+  const gyldigInputFnr = fnrErGyldig(searchInput)
   const gyldigInputSakId = /^\d{1,10}$/.test(searchInput ?? '')
   const avgjoerSoek = () => {
     if (gyldigInputFnr) {
@@ -39,17 +39,7 @@ export const Search = () => {
   useEffect(() => {
     reset()
     resetSakSoek()
-    if (searchInput.length === 0) {
-      setFeilInput(false)
-    } else if (searchInput.length && searchInput.length === 11 && !gyldigInputFnr) {
-      setFeilInput(true)
-    } else if (searchInput.length && searchInput.length < 11 && !gyldigInputSakId) {
-      setFeilInput(true)
-    } else if (searchInput.length && searchInput.length > 11 && /\D/g.test(searchInput ?? '')) {
-      setFeilInput(true)
-    } else {
-      setFeilInput(false)
-    }
+    setFeilInput(!!searchInput.length && !(gyldigInputFnr || gyldigInputSakId))
   }, [searchInput])
 
   useEffect(() => {
@@ -68,7 +58,7 @@ export const Search = () => {
         placeholder="Fødselsnummer eller sakid "
         label="Tast inn fødselsnummer eller sakid"
         hideLabel
-        onChange={setSearchInput}
+        onChange={(value) => setSearchInput(value.trim())}
         onKeyUp={onEnter}
         autoComplete="off"
       >

--- a/apps/etterlatte-saksbehandling-ui/client/src/utils/fnr.test.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/utils/fnr.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { fnrErGyldig } from './fnr'
+
+describe('Test date functions', () => {
+  it(`Sjekk diverse gyldige test fnr`, () => {
+    expect(fnrErGyldig('11057523044')).to.be.true
+    expect(fnrErGyldig('26117512737')).to.be.true
+    expect(fnrErGyldig('26104500284')).to.be.true
+    expect(fnrErGyldig('24116324268')).to.be.true
+    expect(fnrErGyldig('04096222195')).to.be.true
+    expect(fnrErGyldig('05126307952')).to.be.true
+  })
+
+  it(`Sjekk diverse syntetiske fnr`, () => {
+    expect(fnrErGyldig('07823847585')).to.be.true
+    expect(fnrErGyldig('24910198617')).to.be.true
+    expect(fnrErGyldig('06859597627')).to.be.true
+    expect(fnrErGyldig('21919898760')).to.be.true
+    expect(fnrErGyldig('12900799991')).to.be.true
+    expect(fnrErGyldig('20840699480')).to.be.true
+    expect(fnrErGyldig('27813648046')).to.be.true
+    expect(fnrErGyldig('07823847585')).to.be.true
+    expect(fnrErGyldig('24910198617')).to.be.true
+    expect(fnrErGyldig('06859597627')).to.be.true
+    expect(fnrErGyldig('21919898760')).to.be.true
+    expect(fnrErGyldig('06488309690')).to.be.true
+    expect(fnrErGyldig('30017215759')).to.be.true
+  })
+
+  it(`Sjekk diverse ugyldige numeriske verdier`, () => {
+    expect(fnrErGyldig('1234')).to.be.false
+
+    expect(fnrErGyldig('15048900000')).to.be.false
+    expect(fnrErGyldig('00000000000')).to.be.false
+    expect(fnrErGyldig('11111111111')).to.be.false
+    expect(fnrErGyldig('22222222222')).to.be.false
+    expect(fnrErGyldig('33333333333')).to.be.false
+    expect(fnrErGyldig('44444444444')).to.be.false
+    expect(fnrErGyldig('55555555555')).to.be.false
+    expect(fnrErGyldig('66666666666')).to.be.false
+    expect(fnrErGyldig('77777777777')).to.be.false
+    expect(fnrErGyldig('88888888888')).to.be.false
+    expect(fnrErGyldig('99999999999')).to.be.false
+
+    expect(fnrErGyldig('36117512737')).to.be.false
+    expect(fnrErGyldig('12345678901')).to.be.false
+    expect(fnrErGyldig('00000000001')).to.be.false
+    expect(fnrErGyldig('10000000000')).to.be.false
+  })
+
+  it(`Sjekk diverse ugyldige tekst verdier`, () => {
+    expect(fnrErGyldig(undefined)).to.be.false
+    expect(fnrErGyldig('')).to.be.false
+    expect(fnrErGyldig('     ')).to.be.false
+    expect(fnrErGyldig('hei')).to.be.false
+    expect(fnrErGyldig('gyldigfnrmedtekst11057523044')).to.be.false
+  })
+})

--- a/apps/etterlatte-saksbehandling-ui/client/src/utils/fnr.test.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/utils/fnr.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { fnrErGyldig } from './fnr'
+import { fnrErGyldig, fnrHarGyldigFormat } from './fnr'
 
-describe('Test date functions', () => {
-  it(`Sjekk diverse gyldige test fnr`, () => {
+describe('Test validering av fnr - med kontrollsiffer', () => {
+  it('Sjekk diverse gyldige test fnr', () => {
     expect(fnrErGyldig('11057523044')).to.be.true
     expect(fnrErGyldig('26117512737')).to.be.true
     expect(fnrErGyldig('26104500284')).to.be.true
@@ -11,7 +11,7 @@ describe('Test date functions', () => {
     expect(fnrErGyldig('05126307952')).to.be.true
   })
 
-  it(`Sjekk diverse syntetiske fnr`, () => {
+  it('Sjekk diverse syntetiske fnr', () => {
     expect(fnrErGyldig('07823847585')).to.be.true
     expect(fnrErGyldig('24910198617')).to.be.true
     expect(fnrErGyldig('06859597627')).to.be.true
@@ -27,7 +27,7 @@ describe('Test date functions', () => {
     expect(fnrErGyldig('30017215759')).to.be.true
   })
 
-  it(`Sjekk diverse ugyldige numeriske verdier`, () => {
+  it('Sjekk diverse ugyldige numeriske verdier', () => {
     expect(fnrErGyldig('1234')).to.be.false
 
     expect(fnrErGyldig('15048900000')).to.be.false
@@ -48,11 +48,48 @@ describe('Test date functions', () => {
     expect(fnrErGyldig('10000000000')).to.be.false
   })
 
-  it(`Sjekk diverse ugyldige tekst verdier`, () => {
+  it('Sjekk diverse ugyldige tekst verdier', () => {
     expect(fnrErGyldig(undefined)).to.be.false
     expect(fnrErGyldig('')).to.be.false
     expect(fnrErGyldig('     ')).to.be.false
     expect(fnrErGyldig('hei')).to.be.false
     expect(fnrErGyldig('gyldigfnrmedtekst11057523044')).to.be.false
+  })
+})
+
+describe('Test format på fnr', () => {
+  it('Sjekk diverse gyldige verdier', () => {
+    expect(fnrHarGyldigFormat('07823847585')).to.be.true
+    expect(fnrHarGyldigFormat('24910198617')).to.be.true
+    expect(fnrHarGyldigFormat('06859597627')).to.be.true
+    expect(fnrHarGyldigFormat('21919898760')).to.be.true
+    expect(fnrHarGyldigFormat('12900799991')).to.be.true
+    expect(fnrHarGyldigFormat('20840699480')).to.be.true
+    expect(fnrHarGyldigFormat('27813648046')).to.be.true
+    expect(fnrHarGyldigFormat('07823847585')).to.be.true
+    expect(fnrHarGyldigFormat('24910198617')).to.be.true
+    expect(fnrHarGyldigFormat('06859597627')).to.be.true
+    expect(fnrHarGyldigFormat('21919898760')).to.be.true
+    expect(fnrHarGyldigFormat('06488309690')).to.be.true
+    expect(fnrHarGyldigFormat('30017215759')).to.be.true
+  })
+
+  it('Sjekk diverse ugyldige verdier', () => {
+    expect(fnrHarGyldigFormat('1')).to.be.false
+    expect(fnrHarGyldigFormat('12')).to.be.false
+    expect(fnrHarGyldigFormat('123')).to.be.false
+    expect(fnrHarGyldigFormat('1234')).to.be.false
+    expect(fnrHarGyldigFormat('12345')).to.be.false
+    expect(fnrHarGyldigFormat('123456')).to.be.false
+    expect(fnrHarGyldigFormat('1234567')).to.be.false
+    expect(fnrHarGyldigFormat('12345678')).to.be.false
+    expect(fnrHarGyldigFormat('123456789')).to.be.false
+    expect(fnrHarGyldigFormat('1234567890')).to.be.false
+    expect(fnrHarGyldigFormat('123456789012')).to.be.false
+    expect(fnrHarGyldigFormat(undefined)).to.be.false
+    expect(fnrHarGyldigFormat('')).to.be.false
+    expect(fnrHarGyldigFormat('     ')).to.be.false
+    expect(fnrHarGyldigFormat('hei')).to.be.false
+    expect(fnrHarGyldigFormat('gyldigfnrmedtekst11057523044')).to.be.false
   })
 })

--- a/apps/etterlatte-saksbehandling-ui/client/src/utils/fnr.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/utils/fnr.ts
@@ -1,1 +1,36 @@
-export const GYLDIG_FNR = (input: string | undefined) => /^\d{11}$/.test(input ?? '')
+const controlDigits1 = [3, 7, 6, 1, 8, 9, 4, 5, 2]
+const controlDigits2 = [5, 4, 3, 2, 7, 6, 5, 4, 3, 2]
+
+const mod = (arr: number[], value: string): number => {
+  const sum = arr.map((v, i) => v * Number(value[i])).reduce((prevNum, currNum) => prevNum + currNum)
+
+  const result = 11 - (sum % 11)
+
+  if (result === 11) return 0
+  else return result
+}
+
+const validerKontrollsiffer = (value: string): boolean => {
+  const ks1 = Number(value[9])
+
+  const c1 = mod(controlDigits1, value)
+  if (c1 === 10 || c1 !== ks1) {
+    return false
+  }
+
+  const c2 = mod(controlDigits2, value)
+
+  return !(c2 === 10 || c2 !== Number(value[10]))
+}
+
+export const fnrErGyldig = (input: string | undefined): boolean => {
+  const value = input?.trim()
+
+  if (!/^\d{11}$/.test(value ?? ''))
+    // hvis fnr ikke består av 11 siffer
+    return false
+  else if (/^\d{6}0{5}$/.test(value!!))
+    // hvis siste 5 siffer i fnr er 00000
+    return false
+  else return validerKontrollsiffer(value!!)
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/utils/fnr.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/utils/fnr.ts
@@ -23,6 +23,10 @@ const validerKontrollsiffer = (value: string): boolean => {
   return !(c2 === 10 || c2 !== Number(value[10]))
 }
 
+/**
+ * Avansert validering for å se om fnr. er et ekte/gyldig.
+ * Bruker kontrollsiffer for å validere gyldigheten.
+ **/
 export const fnrErGyldig = (input: string | undefined): boolean => {
   const value = input?.trim()
 
@@ -33,4 +37,11 @@ export const fnrErGyldig = (input: string | undefined): boolean => {
     // hvis siste 5 siffer i fnr er 00000
     return false
   else return validerKontrollsiffer(value!!)
+}
+
+/**
+ * Forenklet validering som kun sjekker om fnr. har gyldig format (11 siffer, ikke tom, undefined, e.l.)
+ **/
+export const fnrHarGyldigFormat = (input: string | undefined): boolean => {
+  return !!input && /^\d{11}$/.test(input)
 }

--- a/libs/saksbehandling-common/src/main/kotlin/person/FolkeregisteridentifikatorValidator.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/person/FolkeregisteridentifikatorValidator.kt
@@ -13,7 +13,7 @@ class FolkeregisteridentifikatorValidator {
          * Control digits are valid.
          */
         fun isValid(value: String): Boolean {
-            return !Regex("[0]{11}").matches(value) &&
+            return !Regex("0{11}").matches(value) &&
                 value.length == 11 &&
                 value.toBigIntegerOrNull() != null &&
                 validateControlDigits(value)
@@ -31,11 +31,8 @@ class FolkeregisteridentifikatorValidator {
             }
 
             val c2 = mod(controlDigits2, value)
-            if (c2 == 10 || c2 != Character.getNumericValue(value[10])) {
-                return false
-            }
 
-            return true
+            return !(c2 == 10 || c2 != Character.getNumericValue(value[10]))
         }
 
         /**


### PR DESCRIPTION
- Sikrer skikkelig validering av fnr. med `fnrErGyldig` (tilsvarende sjekk i backend)
- Fnr. søk i oppgavelista trimmes
- Generelt søk etter sak/fnr. trimmes 


Har ved alt for mange anledninger/demoer sett at det kopieres og limes inn fnr. hvor det sniker seg inn et mellomrom. Mellomrom i teksten regnes som ugyldig i dagens løsning. Legger derfor til litt trimming slik at dette ignoreres og man får et litt "friere søk". 