### PR TITLE
Revert "Disable deploy av hendelse-samordning til prod inntil videre (#2649)"

### DIFF
--- a/.github/workflows/app-etterlatte-hendelser-samordning.yaml
+++ b/.github/workflows/app-etterlatte-hendelser-samordning.yaml
@@ -44,25 +44,10 @@ jobs:
       contents: 'read'
       id-token: 'write'
 
-#  deploy:
-#    if: github.event_name != 'pull_request'
-#    needs: build
-#    uses: ./.github/workflows/.deploy.yaml
-#    with:
-#      image: ${{ needs.build.outputs.image }}
-#    secrets: inherit
-
-  deploy-to-dev-gcp:
-    name: dev-gcp
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+  deploy:
     if: github.event_name != 'pull_request'
     needs: build
-    steps:
-      - uses: actions/checkout@v4
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: apps/${{ github.workflow }}/.nais/dev.yaml
-          VAR: image=${{ needs.build.outputs.image }}
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/apps/etterlatte-hendelser-samordning/.nais/prod.yaml
+++ b/apps/etterlatte-hendelser-samordning/.nais/prod.yaml
@@ -1,7 +1,7 @@
 apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
-  name: etterlatte-hendelse-samordning
+  name: etterlatte-hendelser-samordning
   namespace: etterlatte
   labels:
     team: etterlatte


### PR DESCRIPTION
This reverts commit 7be6081fdb18357214ff07d4e64f49fdb2d865db.


Vært i møte med samhandlingsteamet, og alt deres er deployet til produksjon så på tide å sjekke integrasjonen/tilgangen her