### PR TITLE
Det verkar som vi no uforvarande kan starte regulering ved å, uavheng…

### DIFF
--- a/.github/workflows/.build-job.yaml
+++ b/.github/workflows/.build-job.yaml
@@ -1,0 +1,48 @@
+name: .build-job.yaml
+
+on:
+  workflow_call:
+    outputs:
+      image:
+        description: "Docker image url"
+        value: ${{ jobs.build-and-publish.outputs.image }}
+
+jobs:
+  build-and-publish:
+    name: Build & publish
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 10
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    outputs:
+      image: ${{ steps.docker-build-push.outputs.image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Java v17.x
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17.x
+          cache: gradle
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+      - name: Gradle test and build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew :jobs:${{ github.workflow }}:build
+
+      - name: Build and publish docker image
+        uses: nais/docker-build-push@v0
+        id: docker-build-push
+        with:
+          team: etterlatte
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+          dockerfile: docker/Dockerfile
+          docker_context: jobs/${{ github.workflow }}/
+          image_suffix: ${{ github.workflow }}
+          tag: ${{ env.GITHUB_REF_SLUG }}
+      - name: Print docker tag
+        run: echo 'Docker-tag er ${{ steps.docker-build-push.outputs.image }} ' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/.deploy-job.yaml
+++ b/.github/workflows/.deploy-job.yaml
@@ -1,0 +1,43 @@
+name: .deploy-job.yaml
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: 'Lenke til docker image'
+        required: true
+        type: string
+
+jobs:
+  deploy-to-dev-gcp:
+    name: dev-gcp
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: jobs/${{ github.workflow }}/.nais/dev.yaml
+          VAR: image=${{ inputs.image }}
+
+  deploy-to-prod-gcp:
+    name: prod-gcp
+    if: ${{ github.ref == 'refs/heads/main' || github.event.inputs.deploy-prod == 'true' }}
+    needs: deploy-to-dev-gcp
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: andstor/file-existence-action@v2
+        id: check_files
+        with:
+          files: "jobs/${{ github.workflow }}/.nais/prod.yaml"
+      - uses: nais/deploy/actions/deploy@v1
+        if: steps.check_files.outputs.files_exists == 'true'
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: jobs/${{ github.workflow }}/.nais/prod.yaml
+          VAR: image=${{ inputs.image }}

--- a/.github/workflows/.test-job.yaml
+++ b/.github/workflows/.test-job.yaml
@@ -1,0 +1,23 @@
+name: .test-job.yaml
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    name: Verify pull request
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Java v17.x
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17.x
+          cache: gradle
+      - name: Gradle test and build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew :jobs:${{ github.workflow }}:test --stacktrace

--- a/.github/workflows/job-start-regulering.yaml
+++ b/.github/workflows/job-start-regulering.yaml
@@ -25,12 +25,12 @@ on:
 jobs:
   test:
     if: github.event_name == 'pull_request'
-    uses: ./.github/workflows/.test.yaml
+    uses: ./.github/workflows/.test-job.yaml
     secrets: inherit
 
   build:
     if: github.event_name != 'pull_request'
-    uses: ./.github/workflows/.build.yaml
+    uses: ./.github/workflows/.build-job.yaml
     secrets: inherit
     permissions:
       contents: 'read'
@@ -39,7 +39,7 @@ jobs:
   deploy:
     if: github.event_name != 'pull_request'
     needs: build
-    uses: ./.github/workflows/.deploy.yaml
+    uses: ./.github/workflows/.deploy-job.yaml
     with:
       image: ${{ needs.build.outputs.image }}
     secrets: inherit

--- a/.github/workflows/job-start-regulering.yaml
+++ b/.github/workflows/job-start-regulering.yaml
@@ -14,9 +14,11 @@ on:
   push:
     branches:
       - main
-      - release/*
-      - feature/*
-      - fix/*
+    paths:
+      - jobs/start-regulering/**
+  pull_request:
+    branches:
+      - main
     paths:
       - jobs/start-regulering/**
 

--- a/.github/workflows/job-start-regulering.yaml
+++ b/.github/workflows/job-start-regulering.yaml
@@ -1,9 +1,5 @@
 name: start-regulering
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}/${{ github.workflow }}:${{ github.sha }}
-  JOB_NAME: ${{ github.workflow }}
-
 on:
   workflow_dispatch: # Allow manually triggered workflow run
     inputs:
@@ -25,30 +21,23 @@ on:
       - jobs/start-regulering/**
 
 jobs:
-  build-and-publish:
-    name: Build, test, and publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Setup Java v17.x
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17.x
-          cache: gradle
-      - name: Gradle test and build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :jobs:${JOB_NAME}:test :jobs:${JOB_NAME}:build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and publish docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
-          docker build --tag ${IMAGE} jobs/${JOB_NAME}
-          docker push ${IMAGE}
-      - name: Print docker tag
-        run: echo 'Docker-tag er ${{ env.image }} ' >> $GITHUB_STEP_SUMMARY
+  test:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/.test.yaml
+    secrets: inherit
+
+  build:
+    if: github.event_name != 'pull_request'
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/apps/etterlatte-oppdater-behandling/build.gradle.kts
+++ b/apps/etterlatte-oppdater-behandling/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     implementation(project(":libs:ktor2client-auth-clientcredentials"))
     implementation(project(":libs:saksbehandling-common"))
     implementation(project(":libs:etterlatte-behandling-model"))
+    implementation(project(":libs:etterlatte-funksjonsbrytere"))
     implementation(project(":libs:etterlatte-ktor"))
     implementation(project(":libs:etterlatte-pdl-model"))
     implementation(project(":libs:etterlatte-migrering-model"))

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/AppBuilder.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/AppBuilder.kt
@@ -1,7 +1,11 @@
 package no.nav.etterlatte
 
 import com.fasterxml.jackson.databind.SerializationFeature
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
 import io.ktor.client.HttpClient
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggleProperties
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.libs.common.Miljoevariabler
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 
@@ -21,4 +25,13 @@ class AppBuilder(props: Miljoevariabler) {
             ekstraJacksoninnstillinger = { it.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS) },
         )
     }
+
+    val featureToggleService = FeatureToggleService.initialiser(featureToggleProperties(ConfigFactory.load()))
 }
+
+private fun featureToggleProperties(config: Config) =
+    FeatureToggleProperties(
+        applicationName = config.getString("funksjonsbrytere.unleash.applicationName"),
+        host = config.getString("funksjonsbrytere.unleash.host"),
+        apiKey = config.getString("funksjonsbrytere.unleash.token"),
+    )

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/Application.kt
@@ -11,11 +11,12 @@ import rapidsandrivers.getRapidEnv
 
 fun main() {
     val rapidEnv = getRapidEnv()
+    val appBuilder = AppBuilder(Miljoevariabler(rapidEnv))
     RapidApplication.create(rapidEnv).also { rapidsConnection ->
-        val behandlingservice = AppBuilder(Miljoevariabler(rapidEnv)).createBehandlingService()
+        val behandlingservice = appBuilder.createBehandlingService()
         PdlHendelserRiver(rapidsConnection, behandlingservice)
         OmregningsHendelserRiver(rapidsConnection, behandlingservice)
-        ReguleringsforespoerselRiver(rapidsConnection, behandlingservice)
+        ReguleringsforespoerselRiver(rapidsConnection, behandlingservice, appBuilder.featureToggleService)
         MigrerEnEnkeltSakRiver(rapidsConnection, behandlingservice)
         ReguleringFeiletRiver(rapidsConnection, behandlingservice)
         AvbrytBehandlingHvisMigreringFeilaRiver(rapidsConnection, behandlingservice)

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/ReguleringsforespoerselRiver.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/ReguleringsforespoerselRiver.kt
@@ -56,9 +56,9 @@ internal class ReguleringsforespoerselRiver(
     }
 }
 
-enum class ReguleringFeatureToggle : FeatureToggle {
-    START_REGULERING,
+enum class ReguleringFeatureToggle(private val key: String) : FeatureToggle {
+    START_REGULERING("start-regulering"),
     ;
 
-    override fun key() = name
+    override fun key() = key
 }

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/ReguleringsforespoerselRiver.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/ReguleringsforespoerselRiver.kt
@@ -1,6 +1,8 @@
 package no.nav.etterlatte.regulering
 
 import no.nav.etterlatte.BehandlingService
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggle
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.rapidsandrivers.ReguleringEvents
 import no.nav.etterlatte.rapidsandrivers.ReguleringEvents.FINN_LOEPENDE_YTELSER
@@ -17,6 +19,7 @@ import rapidsandrivers.tilbakestilteBehandlinger
 internal class ReguleringsforespoerselRiver(
     rapidsConnection: RapidsConnection,
     private val behandlingService: BehandlingService,
+    private val featureToggleService: FeatureToggleService,
 ) : ListenerMedLoggingOgFeilhaandtering(ReguleringEvents.START_REGULERING) {
     private val logger = LoggerFactory.getLogger(ReguleringsforespoerselRiver::class.java)
 
@@ -32,6 +35,11 @@ internal class ReguleringsforespoerselRiver(
     ) {
         logger.info("Leser reguleringsfoerespoersel for dato ${packet.dato}")
 
+        if (!featureToggleService.isEnabled(ReguleringFeatureToggle.START_REGULERING, false)) {
+            logger.info("Regulering er deaktivert ved funksjonsbryter. Avbryter reguleringsforespørsel.")
+            return
+        }
+
         val tilbakemigrerte =
             behandlingService.migrerAlleTempBehandlingerTilbakeTilVilkaarsvurdert().also { sakIdListe ->
                 logger.info(
@@ -46,4 +54,11 @@ internal class ReguleringsforespoerselRiver(
             context.publish(packet.toJson())
         }
     }
+}
+
+enum class ReguleringFeatureToggle : FeatureToggle {
+    START_REGULERING,
+    ;
+
+    override fun key() = name
 }

--- a/apps/etterlatte-oppdater-behandling/src/main/resources/application.conf
+++ b/apps/etterlatte-oppdater-behandling/src/main/resources/application.conf
@@ -1,0 +1,3 @@
+funksjonsbrytere.unleash.applicationName = ${?NAIS_APP_NAME}
+funksjonsbrytere.unleash.host = ${?UNLEASH_SERVER_API_URL}
+funksjonsbrytere.unleash.token = ${?UNLEASH_SERVER_API_TOKEN}

--- a/apps/etterlatte-oppdater-behandling/src/test/kotlin/regulering/ReguleringsforespoerselRiverTest.kt
+++ b/apps/etterlatte-oppdater-behandling/src/test/kotlin/regulering/ReguleringsforespoerselRiverTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.etterlatte.BehandlingService
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
 import no.nav.etterlatte.libs.common.rapidsandrivers.FEILENDE_STEG
@@ -40,7 +41,8 @@ internal class ReguleringsforespoerselRiverTest {
     fun `kan ta imot reguleringsmelding og kalle på behandling`() {
         val melding = genererReguleringMelding(foersteMai2023)
         val vedtakServiceMock = mockk<BehandlingService>(relaxed = true)
-        val inspector = TestRapid().apply { ReguleringsforespoerselRiver(this, vedtakServiceMock) }
+        val featureToggleService = mockk<FeatureToggleService>().also { every { it.isEnabled(any(), any()) } returns true }
+        val inspector = TestRapid().apply { ReguleringsforespoerselRiver(this, vedtakServiceMock, featureToggleService) }
 
         inspector.sendTestMessage(melding.toJson())
         verify(exactly = 1) {
@@ -61,7 +63,8 @@ internal class ReguleringsforespoerselRiverTest {
                     Sak("saksbehandler1", SakType.BARNEPENSJON, 3L, "4808"),
                 ),
             )
-        val inspector = TestRapid().apply { ReguleringsforespoerselRiver(this, vedtakServiceMock) }
+        val featureToggleService = mockk<FeatureToggleService>().also { every { it.isEnabled(any(), any()) } returns true }
+        val inspector = TestRapid().apply { ReguleringsforespoerselRiver(this, vedtakServiceMock, featureToggleService) }
 
         inspector.sendTestMessage(melding.toJson())
         val sendteMeldinger = inspector.inspektør.size
@@ -85,7 +88,8 @@ internal class ReguleringsforespoerselRiverTest {
                     Sak("saksbehandler1", SakType.BARNEPENSJON, 1003L, "4808"),
                 ),
             )
-        val inspector = TestRapid().apply { ReguleringsforespoerselRiver(this, behandlingServiceMock) }
+        val featureToggleService = mockk<FeatureToggleService>().also { every { it.isEnabled(any(), any()) } returns true }
+        val inspector = TestRapid().apply { ReguleringsforespoerselRiver(this, behandlingServiceMock, featureToggleService) }
         inspector.sendTestMessage(melding.toJson())
 
         val melding1 = inspector.inspektør.message(0)
@@ -114,7 +118,8 @@ internal class ReguleringsforespoerselRiverTest {
             SakIDListe(
                 listOf(BehandlingOgSak(behandlingId1, sakId), BehandlingOgSak(behandlingId2, sakId)),
             )
-        val inspector = TestRapid().apply { ReguleringsforespoerselRiver(this, behandlingServiceMock) }
+        val featureToggleService = mockk<FeatureToggleService>().also { every { it.isEnabled(any(), any()) } returns true }
+        val inspector = TestRapid().apply { ReguleringsforespoerselRiver(this, behandlingServiceMock, featureToggleService) }
         inspector.sendTestMessage(melding.toJson())
 
         val melding1 = inspector.inspektør.message(0)
@@ -130,7 +135,8 @@ internal class ReguleringsforespoerselRiverTest {
             behandlingServiceMock.migrerAlleTempBehandlingerTilbakeTilVilkaarsvurdert()
         } throws RuntimeException("feil")
 
-        val inspector = TestRapid().apply { ReguleringsforespoerselRiver(this, behandlingServiceMock) }
+        val featureToggleService = mockk<FeatureToggleService>().also { every { it.isEnabled(any(), any()) } returns true }
+        val inspector = TestRapid().apply { ReguleringsforespoerselRiver(this, behandlingServiceMock, featureToggleService) }
 
         inspector.sendTestMessage(melding.toJson())
 

--- a/jobs/start-regulering/Dockerfile
+++ b/jobs/start-regulering/Dockerfile
@@ -1,4 +1,7 @@
-FROM ghcr.io/navikt/baseimages/temurin:17
-
+FROM gcr.io/distroless/java17
+ENV TZ="Europe/Oslo"
+WORKDIR /app
 COPY build/libs/*.jar ./
-
+EXPOSE 8080
+USER nonroot
+CMD ["app.jar"]

--- a/jobs/start-regulering/src/main/kotlin/Application.kt
+++ b/jobs/start-regulering/src/main/kotlin/Application.kt
@@ -35,5 +35,5 @@ fun main() {
 
 internal fun createRecord(dato: LocalDate) =
     JsonMessage.newMessage(
-        mapOf("@event_name" to ReguleringEvents.EVENT_NAME, ReguleringEvents.DATO to dato.toString()),
+        mapOf("@event_name" to ReguleringEvents.START_REGULERING, ReguleringEvents.DATO to dato.toString()),
     ).toJson()


### PR DESCRIPTION
…ig av korfor eller kva, endre noko i reguleringsjobben, som gjer at den blir deploya på nytt. Det kjens veldig  utrygt.

Legg derfor inn ein funksjonsbrytar vi kan skru eksplisitt på når vi skal køyre regulering. Da er det ikkje lenger farleg å deploye ein app, og vi kan enkelt styre det av og på.

Oppdaterer med det samme Dockerfila, og trur vi kan bruke samme byggejobboppsett her som vi gjer på appane våre