### PR TITLE
Hendelse-samordning, takle meldinger bedre

### DIFF
--- a/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/samordning/SamordningHendelseHandler.kt
+++ b/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/samordning/SamordningHendelseHandler.kt
@@ -14,10 +14,7 @@ class SamordningHendelseHandler(
     /**
      * Skal kun dytte info videre for Omstillingsstønad-hendelser slik at R&R lytter kan faktisk håndtere det
      */
-    fun handleSamordningHendelse(
-        hendelse: SamordningVedtakHendelse,
-        hendelseKey: String,
-    ) {
+    fun handleSamordningHendelse(hendelse: SamordningVedtakHendelse) {
         if (hendelse.fagomrade != FAGOMRADE_OMS) {
             return
         }
@@ -40,7 +37,7 @@ class SamordningHendelseHandler(
             }
         } else {
             logger.warn(
-                "Mottatt hendelse $hendelseKey med fagområde EYO, men ikke ytelse OMS [vedtakId=${hendelse.vedtakId}",
+                "Mottatt hendelse med fagområde EYO, men ikke ytelse OMS [vedtakId=${hendelse.vedtakId}",
             )
         }
     }

--- a/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/samordning/SamordningHendelseHandler.kt
+++ b/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/samordning/SamordningHendelseHandler.kt
@@ -25,17 +25,19 @@ class SamordningHendelseHandler(
         if (hendelse.artTypeKode == SAKSTYPE_OMS) {
             logger.info("Behandler samordning-hendelse [vedtakId=${hendelse.vedtakId}")
 
-            kafkaProduser.publiser(
-                noekkel = UUID.randomUUID().toString(),
-                verdi =
-                    JsonMessage.newMessage(
-                        eventName = "VEDTAK:SAMORDNING_MOTTATT",
-                        map =
-                            mapOf(
-                                "vedtakId" to hendelse.vedtakId,
-                            ),
-                    ),
-            )
+            hendelse.vedtakId?.let {
+                kafkaProduser.publiser(
+                    noekkel = UUID.randomUUID().toString(),
+                    verdi =
+                        JsonMessage.newMessage(
+                            eventName = "VEDTAK:SAMORDNING_MOTTATT",
+                            map =
+                                mapOf(
+                                    "vedtakId" to it,
+                                ),
+                        ),
+                )
+            }
         } else {
             logger.warn(
                 "Mottatt hendelse $hendelseKey med fagområde EYO, men ikke ytelse OMS [vedtakId=${hendelse.vedtakId}",

--- a/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/samordning/SamordningHendelseKonsument.kt
+++ b/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/samordning/SamordningHendelseKonsument.kt
@@ -21,7 +21,7 @@ class SamordningHendelseKonsument(
         stream { meldinger ->
             meldinger
                 .forEach {
-                    logger.info("Behandler $it")
+                    logger.info("Behandler melding [key=${it.key()}]")
 
                     withLogContext {
                         handler.handleSamordningHendelse(

--- a/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/samordning/SamordningHendelseKonsument.kt
+++ b/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/samordning/SamordningHendelseKonsument.kt
@@ -26,7 +26,6 @@ class SamordningHendelseKonsument(
                     withLogContext {
                         handler.handleSamordningHendelse(
                             hendelse = it.value(),
-                            hendelseKey = it.key(),
                         )
                     }
                 }

--- a/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/samordning/SamordningHendelseKonsument.kt
+++ b/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/samordning/SamordningHendelseKonsument.kt
@@ -21,6 +21,8 @@ class SamordningHendelseKonsument(
         stream { meldinger ->
             meldinger
                 .forEach {
+                    logger.info("Behandler $it")
+
                     withLogContext {
                         handler.handleSamordningHendelse(
                             hendelse = it.value(),

--- a/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/samordning/SamordningVedtakHendelse.kt
+++ b/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/samordning/SamordningVedtakHendelse.kt
@@ -3,11 +3,15 @@ package no.nav.etterlatte.samordning
 /**
  * Definisjon ekstern hendelse (fra SAM)
  */
-data class SamordningVedtakHendelse(
-    val fagomrade: String,
-    val artTypeKode: String,
-    val vedtakId: Long,
-)
+class SamordningVedtakHendelse {
+    var fagomrade: String? = null
+    var artTypeKode: String? = null
+    var vedtakId: Long? = null
+
+    override fun toString(): String {
+        return "SamordningVedtakHendelse[fagomrade=$fagomrade, artTypeKode=$artTypeKode, vedtakId=$vedtakId]"
+    }
+}
 
 const val FAGOMRADE_OMS = "EYO"
 const val SAKSTYPE_OMS = "OMS"

--- a/apps/etterlatte-hendelser-samordning/src/test/kotlin/no/nav/etterlatte/samordning/SamordningHendelseIntegrationTest.kt
+++ b/apps/etterlatte-hendelser-samordning/src/test/kotlin/no/nav/etterlatte/samordning/SamordningHendelseIntegrationTest.kt
@@ -59,11 +59,11 @@ class SamordningHendelseIntegrationTest {
                 SAMORDNINGVEDTAK_HENDELSE_TOPIC,
                 1,
                 UUID.randomUUID().toString(),
-                SamordningVedtakHendelse(
-                    fagomrade = "PENSJON",
-                    artTypeKode = "AP2025",
-                    vedtakId = 100200300L,
-                ),
+                SamordningVedtakHendelse().apply {
+                    fagomrade = "PENSJON"
+                    artTypeKode = "AP2025"
+                    vedtakId = 100200300L
+                },
             ),
         )
         producerForSamordningVedtakHendelse.send(
@@ -71,11 +71,11 @@ class SamordningHendelseIntegrationTest {
                 SAMORDNINGVEDTAK_HENDELSE_TOPIC,
                 1,
                 UUID.randomUUID().toString(),
-                SamordningVedtakHendelse(
-                    fagomrade = "EYO",
-                    artTypeKode = "OMS",
-                    vedtakId = 99900022201L,
-                ),
+                SamordningVedtakHendelse().apply {
+                    fagomrade = "EYO"
+                    artTypeKode = "OMS"
+                    vedtakId = 99900022201L
+                },
             ),
         )
 


### PR DESCRIPTION
Så det i dev, og det er også i prod - masse "tomme" meldinger som gjør at constructor og key ikke er bare-bare å benytte.

https://nav-it.slack.com/archives/C063E3VAP24/p1701341203910689?thread_ts=1701332241.471129&cid=C063E3VAP24