### PR TITLE
Fix justere tilgang med hardkodede brukeridenter

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
@@ -200,7 +200,7 @@ suspend inline fun PipelineContext<*, ApplicationCall>.kunAttestant(onSuccess: (
     }
 }
 
-private val saksbehandlereMedTilgangTilAlleEnheter = listOf("Z994945")
+private val saksbehandlereMedTilgangTilAlleEnheter = listOf("S128848", "K105085", "O113803")
 
 fun <T> List<T>.filterForEnheter(
     featureToggleService: FeatureToggleService,

--- a/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
@@ -200,12 +200,16 @@ suspend inline fun PipelineContext<*, ApplicationCall>.kunAttestant(onSuccess: (
     }
 }
 
+private val saksbehandlereMedTilgangTilAlleEnheter = listOf("Z994945")
+
 fun <T> List<T>.filterForEnheter(
     featureToggleService: FeatureToggleService,
     toggle: FeatureToggle,
     user: User,
     filter: (item: T, enheter: List<String>) -> Boolean,
-) = if (featureToggleService.isEnabled(toggle, false)) {
+) = if (featureToggleService.isEnabled(toggle, false) &&
+    user.name() !in(saksbehandlereMedTilgangTilAlleEnheter)
+) {
     when (user) {
         is SaksbehandlerMedEnheterOgRoller -> {
             val enheter = user.enheter()

--- a/apps/etterlatte-behandling/src/test/kotlin/BehandlingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/BehandlingIntegrationTest.kt
@@ -436,6 +436,7 @@ abstract class BehandlingIntegrationTest {
             mapOf(
                 "sub" to mittsystem,
                 "oid" to mittsystem,
+                "azp_name" to mittsystem,
             ),
         )
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
@@ -55,7 +55,7 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 class BehandlingServiceImplTest {
-    private val user = mockk<SaksbehandlerMedEnheterOgRoller>()
+    private val user = mockk<SaksbehandlerMedEnheterOgRoller> { every { name() } returns "ident" }
 
     @BeforeEach
     fun before() {

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/GyldighetsproevingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/GyldighetsproevingServiceImplTest.kt
@@ -45,7 +45,7 @@ import java.time.YearMonth
 import java.util.UUID
 
 internal class GyldighetsproevingServiceImplTest {
-    private val user = mockk<SaksbehandlerMedEnheterOgRoller>()
+    private val user = mockk<SaksbehandlerMedEnheterOgRoller> { every { name() } returns "ident" }
     private val sakDaoMock = mockk<SakDao>()
     private val behandlingDaoMock = mockk<BehandlingDao>()
     private val hendelseDaoMock = mockk<HendelseDao>()

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/RealManueltOpphoerServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/RealManueltOpphoerServiceTest.kt
@@ -44,7 +44,7 @@ import java.time.YearMonth
 import java.util.UUID
 
 internal class RealManueltOpphoerServiceTest {
-    private val user = mockk<SaksbehandlerMedEnheterOgRoller>()
+    private val user = mockk<SaksbehandlerMedEnheterOgRoller> { every { name() } returns "ident" }
     private val oppgaveService = mockk<OppgaveService>()
     private val grunnlagServiceMock = mockk<GrunnlagService>(relaxed = true)
 

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -134,6 +134,7 @@ internal class OppgaveServiceTest {
     fun beforeEach() {
         val saksbehandlerRoller = generateSaksbehandlerMedRoller(AzureGroup.SAKSBEHANDLER)
         every { saksbehandler.enheter() } returns Enheter.nasjonalTilgangEnheter()
+        every { saksbehandler.name() } returns "ident"
 
         setNewKontekstWithMockUser(saksbehandler)
 
@@ -172,7 +173,7 @@ internal class OppgaveServiceTest {
 
     @Test
     fun `skal tildele attesteringsoppgave hvis systembruker og fatte`() {
-        val systemBruker = mockk<SystemUser>()
+        val systemBruker = mockk<SystemUser> { every { name() } returns "name" }
         setNewKontekstWithMockUser(systemBruker)
 
         val opprettetSak = sakDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
@@ -227,7 +228,7 @@ internal class OppgaveServiceTest {
                 vanligSaksbehandler,
             )
 
-        val attestantSaksbehandler = mockk<SaksbehandlerMedEnheterOgRoller>()
+        val attestantSaksbehandler = mockk<SaksbehandlerMedEnheterOgRoller> { every { name() } returns "ident" }
         setNewKontekstWithMockUser(attestantSaksbehandler)
         val attestantmedRoller = generateSaksbehandlerMedRoller(AzureGroup.ATTESTANT)
         mockForSaksbehandlerMedRoller(attestantSaksbehandler, attestantmedRoller)
@@ -261,7 +262,7 @@ internal class OppgaveServiceTest {
                 vanligSaksbehandler,
             )
 
-        val saksbehandlerto = mockk<SaksbehandlerMedEnheterOgRoller>()
+        val saksbehandlerto = mockk<SaksbehandlerMedEnheterOgRoller> { every { name() } returns "ident" }
         setNewKontekstWithMockUser(saksbehandlerto)
         val saksbehandlerMedRoller = generateSaksbehandlerMedRoller(AzureGroup.SAKSBEHANDLER)
         mockForSaksbehandlerMedRoller(saksbehandlerto, saksbehandlerMedRoller)
@@ -386,7 +387,7 @@ internal class OppgaveServiceTest {
                 merknad = null,
             )
 
-        val attestantmock = mockk<SaksbehandlerMedEnheterOgRoller>()
+        val attestantmock = mockk<SaksbehandlerMedEnheterOgRoller> { every { name() } returns "ident" }
         setNewKontekstWithMockUser(attestantmock)
         mockForSaksbehandlerMedRoller(attestantmock, generateSaksbehandlerMedRoller(AzureGroup.ATTESTANT))
         oppgaveService.tildelSaksbehandler(oppgaveUnderBehandlingAnnenBehandling.id, saksbehandler.ident)
@@ -1049,7 +1050,7 @@ internal class OppgaveServiceTest {
                 null,
             )
 
-        val attestantmock = mockk<SaksbehandlerMedEnheterOgRoller>()
+        val attestantmock = mockk<SaksbehandlerMedEnheterOgRoller> { every { name() } returns "ident" }
         setNewKontekstWithMockUser(attestantmock)
         mockForSaksbehandlerMedRoller(attestantmock, generateSaksbehandlerMedRoller(AzureGroup.ATTESTANT))
         oppgaveService.tildelSaksbehandler(attestertBehandlingsoppgave.id, "attestant")


### PR DESCRIPTION
Gir tilgang til behandlinger, oppgaver og saker for alle enheter for våre fagressurser, samtidig som vi slår det av for resten av saksbehandlerene.

Tanken var å gjøre dette som en del av feature-togglen, halvparten av testene i behandling feilet, så går for den enkle varianten inntil jeg får på plass det 😛 