### PR TITLE
ny tjeneste på Sak for endring av enhet

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
@@ -132,7 +132,7 @@ internal fun Route.sakWebRoutes(
                 call.respond(sak ?: HttpStatusCode.NotFound)
             }
 
-            post("/endreEnhet") {
+            post("/endre_enhet") {
                 hentNavidentFraToken { navIdent ->
                     val enhet = call.receive<String>()
                     try {

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
@@ -274,9 +274,4 @@ data class UtenlandstilknytningRequest(
     val begrunnelse: String,
 )
 
-data class EndreEnhetRequest(
-    val enhet: String,
-    val begrunnelse: String,
-)
-
 data class FoersteVirkDto(val foersteIverksatteVirkISak: LocalDate, val sakId: Long)

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
@@ -145,6 +145,7 @@ internal fun Route.sakWebRoutes(
                             sakService.oppdaterEnhetForSaker(listOf(sakMedEnhet))
                             oppgaveService.oppdaterEnhetForRelaterteOppgaver(listOf(sakMedEnhet))
                         }
+                        logger.info("Endret enhet på sak: $sakId  og tilhørende oppgaver til enhet: ${sakMedEnhet.enhet}")
                         call.respond(sakMedEnhet)
                     } catch (e: TilstandException.UgyldigTilstand) {
                         call.respond(HttpStatusCode.BadRequest, "Kan ikke endre enhet på sak og oppgaver")

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
@@ -145,11 +145,7 @@ internal fun Route.sakWebRoutes(
                             sakService.oppdaterEnhetForSaker(listOf(sakMedEnhet))
                             oppgaveService.oppdaterEnhetForRelaterteOppgaver(listOf(sakMedEnhet))
                         }
-                        call.respondText(
-                            contentType = ContentType.Application.Json,
-                            status = HttpStatusCode.OK,
-                            text = sakMedEnhet.toJson(),
-                        )
+                        call.respond(sakMedEnhet)
                     } catch (e: TilstandException.UgyldigTilstand) {
                         call.respond(HttpStatusCode.BadRequest, "Kan ikke endre enhet på sak og oppgaver")
                     }


### PR DESCRIPTION
Frontend kommer i en separat PR. Det er noe rot i tjenester mellom grunnlagshendelser og sak/oppgave på endring av enhet. Tenker å rydde opp der i en separat sak senere