### PR TITLE
Reduserer requested CPU for samordning-vedtak

### DIFF
--- a/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
@@ -26,6 +26,12 @@ spec:
     path: /metrics
   secureLogs:
     enabled: true
+  resources:
+    limits:
+      memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
   replicas:
     min: 1
     max: 2

--- a/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
@@ -26,6 +26,12 @@ spec:
     path: /metrics
   secureLogs:
     enabled: true
+  resources:
+    limits:
+      memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
   replicas:
     min: 1
     max: 2


### PR DESCRIPTION
Dette er jo ikke akkurat den mest belastede tjenesten vi har, så har lyst til å se hvordan dette arter seg.

https://console.nav.cloud.nais.io/team/etterlatte/dev-gcp/app/etterlatte-samordning-vedtak/utilization?from=2023-11-01&to=2023-12-01