### PR TITLE
Utvider personmodellen med pdlStatsborgerskap

### DIFF
--- a/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
@@ -360,6 +360,7 @@ fun personOpplysning(doedsdato: LocalDate? = null) =
         avdoedesBarn = null,
         avdoedesBarnUtenIdent = null,
         vergemaalEllerFremtidsfullmakt = null,
+        pdlStatsborgerskap = null,
     )
 
 fun kommerBarnetTilgode(
@@ -416,6 +417,7 @@ fun mockPerson(
     familieRelasjon = familieRelasjon?.let { OpplysningDTO(it, UUID.randomUUID().toString()) },
     avdoedesBarn = null,
     vergemaalEllerFremtidsfullmakt = vergemaal?.map { OpplysningDTO(it, UUID.randomUUID().toString()) },
+    pdlStatsborgerskap = null,
 )
 
 fun kommerBarnetTilGodeVurdering(behandlingId: UUID) =

--- a/apps/etterlatte-fordeler/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-fordeler/src/test/kotlin/TestHelper.kt
@@ -58,6 +58,7 @@ fun mockPerson(
     avdoedesBarn = null,
     avdoedesBarnUtenIdent = null,
     vergemaalEllerFremtidsfullmakt = vergemaalEllerFremtidsfullmakt,
+    pdlStatsborgerskap = null,
 )
 
 fun mockNorskAdresse(

--- a/apps/etterlatte-grunnlag/src/test/kotlin/Utils.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/Utils.kt
@@ -103,4 +103,5 @@ fun mockPerson() =
         familieRelasjon = null,
         avdoedesBarn = null,
         vergemaalEllerFremtidsfullmakt = null,
+        pdlStatsborgerskap = null,
     )

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/itest/GrunnlagDaoIntegrationTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/itest/GrunnlagDaoIntegrationTest.kt
@@ -484,6 +484,6 @@ internal class GrunnlagDaoIntegrationTest {
     private fun opprettMockPerson(fnr: Folkeregisteridentifikator): Person =
         Person(
             UUID.randomUUID().toString(), null, UUID.randomUUID().toString(), fnr, null, 1234, null, null, null, null,
-            null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null, null,
         )
 }

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/PersonMapper.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/PersonMapper.kt
@@ -10,11 +10,16 @@ import no.nav.etterlatte.libs.common.person.HentPersonRequest
 import no.nav.etterlatte.libs.common.person.Person
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.person.Sivilstatus
+import no.nav.etterlatte.libs.common.person.Statsborgerskap
 import no.nav.etterlatte.pdl.ParallelleSannheterKlient
 import no.nav.etterlatte.pdl.PdlHentPerson
 import no.nav.etterlatte.pdl.PdlKlient
+import no.nav.etterlatte.pdl.PdlStatsborgerskap
+import org.slf4j.LoggerFactory
 
 object PersonMapper {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
     fun mapPerson(
         ppsKlient: ParallelleSannheterKlient,
         pdlKlient: PdlKlient,
@@ -27,7 +32,11 @@ object PersonMapper {
         runBlocking {
             val navn = ppsKlient.avklarNavn(hentPerson.navn)
             val adressebeskyttelse = ppsKlient.avklarAdressebeskyttelse(hentPerson.adressebeskyttelse)
-            val statsborgerskap = hentPerson.statsborgerskap?.let { ppsKlient.avklarStatsborgerskap(it) }
+            val (statsborgerskap, pdlStatsborgerskap) =
+                kanskjeAvklarStatsborgerskap(
+                    ppsKlient,
+                    hentPerson.statsborgerskap,
+                )
             val ppsSivilstand = hentPerson.sivilstand?.let { ppsKlient.avklarSivilstand(it) }
             val foedsel = ppsKlient.avklarFoedsel(hentPerson.foedsel)
             val doedsfall = ppsKlient.avklarDoedsfall(hentPerson.doedsfall)
@@ -66,13 +75,24 @@ object PersonMapper {
                     },
                 kontaktadresse = hentPerson.kontaktadresse?.let { AdresseMapper.mapKontaktadresse(ppsKlient, it) },
                 statsborgerskap = statsborgerskap?.land,
+                pdlStatsborgerskap = pdlStatsborgerskap,
                 sivilstatus = ppsSivilstand?.let { Sivilstatus.valueOf(it.type.name) } ?: Sivilstatus.UOPPGITT,
                 sivilstand = hentPerson.sivilstand?.let { SivilstandMapper.mapSivilstand(it) },
                 utland = UtlandMapper.mapUtland(hentPerson),
-                familieRelasjon = FamilieRelasjonMapper.mapFamilieRelasjon(hentPerson, personRolle, aksepterPersonerUtenIdent),
+                familieRelasjon =
+                    FamilieRelasjonMapper.mapFamilieRelasjon(
+                        hentPerson,
+                        personRolle,
+                        aksepterPersonerUtenIdent,
+                    ),
                 avdoedesBarn = barnekull?.barn,
                 avdoedesBarnUtenIdent = barnekull?.barnUtenIdent,
-                vergemaalEllerFremtidsfullmakt = hentPerson.vergemaalEllerFremtidsfullmakt?.let { VergeMapper.mapVerge(it) },
+                vergemaalEllerFremtidsfullmakt =
+                    hentPerson.vergemaalEllerFremtidsfullmakt?.let {
+                        VergeMapper.mapVerge(
+                            it,
+                        )
+                    },
             )
         }
 
@@ -86,7 +106,11 @@ object PersonMapper {
         runBlocking {
             val navn = ppsKlient.avklarNavn(hentPerson.navn)
             val adressebeskyttelse = ppsKlient.avklarAdressebeskyttelse(hentPerson.adressebeskyttelse)
-            val statsborgerskap = hentPerson.statsborgerskap?.let { ppsKlient.avklarStatsborgerskap(it) }
+            val (statsborgerskap, statsborgerskapPdl) =
+                kanskjeAvklarStatsborgerskap(
+                    ppsKlient,
+                    hentPerson.statsborgerskap,
+                )
             val ppsSivilstand = hentPerson.sivilstand?.let { ppsKlient.avklarSivilstand(it) }
             val foedsel = ppsKlient.avklarFoedsel(hentPerson.foedsel)
             val doedsfall = ppsKlient.avklarDoedsfall(hentPerson.doedsfall)
@@ -114,7 +138,10 @@ object PersonMapper {
                 foedeland = foedsel.foedeland?.let { OpplysningDTO(it, foedsel.metadata.opplysningsId) },
                 adressebeskyttelse =
                     adressebeskyttelse?.let {
-                        OpplysningDTO(AdressebeskyttelseGradering.valueOf(it.gradering.toString()), it.metadata.opplysningsId)
+                        OpplysningDTO(
+                            AdressebeskyttelseGradering.valueOf(it.gradering.toString()),
+                            it.metadata.opplysningsId,
+                        )
                     } ?: OpplysningDTO(AdressebeskyttelseGradering.UGRADERT, null),
                 bostedsadresse =
                     hentPerson.bostedsadresse?.let { AdresseMapper.mapBostedsadresse(ppsKlient, it) }
@@ -130,6 +157,7 @@ object PersonMapper {
                     hentPerson.kontaktadresse?.let { AdresseMapper.mapKontaktadresse(ppsKlient, it) }
                         ?.map { OpplysningDTO(it, null) },
                 statsborgerskap = statsborgerskap?.let { OpplysningDTO(it.land, it.metadata.opplysningsId) },
+                pdlStatsborgerskap = statsborgerskapPdl?.let { OpplysningDTO(it, null) },
                 sivilstatus =
                     ppsSivilstand?.let {
                         OpplysningDTO(
@@ -152,4 +180,27 @@ object PersonMapper {
                         ?.map { OpplysningDTO(it, null) },
             )
         }
+
+    private suspend fun kanskjeAvklarStatsborgerskap(
+        ppsKlient: ParallelleSannheterKlient,
+        statsborgerskap: List<PdlStatsborgerskap>?,
+    ): Pair<PdlStatsborgerskap?, List<Statsborgerskap>?> {
+        if (statsborgerskap == null) {
+            return null to null
+        }
+        try {
+            return ppsKlient.avklarStatsborgerskap(statsborgerskap) to null
+        } catch (e: Exception) {
+            logger.warn("PPS feilet i avklaring av statsborgerskap, sender tilbake fullt grunnlag fra PDL")
+            return null to statsborgerskap.map { it.tilStatsborgerskap() }
+        }
+    }
+}
+
+fun PdlStatsborgerskap.tilStatsborgerskap(): Statsborgerskap {
+    return Statsborgerskap(
+        land = this.land,
+        gyldigFraOgMed = this.gyldigFraOgMed,
+        gyldigTilOgMed = this.gyldigTilOgMed,
+    )
 }

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/TestHelper.kt
@@ -73,6 +73,7 @@ fun mockPerson(
     familieRelasjon = familieRelasjon?.let { OpplysningDTO(it, UUID.randomUUID().toString()) },
     avdoedesBarn = null,
     vergemaalEllerFremtidsfullmakt = vergemaal?.map { OpplysningDTO(it, UUID.randomUUID().toString()) },
+    pdlStatsborgerskap = null,
 )
 
 fun mockFolkeregisterident(fnr: String) = PdlIdentifikator.FolkeregisterIdent(Folkeregisteridentifikator.of(fnr))

--- a/libs/etterlatte-pdl-model/src/main/kotlin/pdl/PersonDTO.kt
+++ b/libs/etterlatte-pdl-model/src/main/kotlin/pdl/PersonDTO.kt
@@ -7,6 +7,7 @@ import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.Person
 import no.nav.etterlatte.libs.common.person.Sivilstand
 import no.nav.etterlatte.libs.common.person.Sivilstatus
+import no.nav.etterlatte.libs.common.person.Statsborgerskap
 import no.nav.etterlatte.libs.common.person.Utland
 import no.nav.etterlatte.libs.common.person.VergemaalEllerFremtidsfullmakt
 import java.time.LocalDate
@@ -28,6 +29,7 @@ data class PersonDTO(
     val sivilstatus: OpplysningDTO<Sivilstatus>?,
     val sivilstand: List<OpplysningDTO<Sivilstand>>?,
     val statsborgerskap: OpplysningDTO<String>?,
+    val pdlStatsborgerskap: OpplysningDTO<List<Statsborgerskap>>?,
     var utland: OpplysningDTO<Utland>?,
     var familieRelasjon: OpplysningDTO<FamilieRelasjon>?,
     var avdoedesBarn: List<Person>?,

--- a/libs/saksbehandling-common/src/main/kotlin/person/Person.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/person/Person.kt
@@ -34,11 +34,18 @@ data class Person(
     val sivilstatus: Sivilstatus?,
     val sivilstand: List<Sivilstand>?,
     val statsborgerskap: String?,
+    val pdlStatsborgerskap: List<Statsborgerskap>?,
     var utland: Utland?,
     var familieRelasjon: FamilieRelasjon?,
     var avdoedesBarn: List<Person>?,
     var avdoedesBarnUtenIdent: List<PersonUtenIdent>?,
     var vergemaalEllerFremtidsfullmakt: List<VergemaalEllerFremtidsfullmakt>?,
+)
+
+data class Statsborgerskap(
+    val land: String,
+    val gyldigFraOgMed: LocalDate?,
+    val gyldigTilOgMed: LocalDate?,
 )
 
 enum class AdresseType {

--- a/libs/testdata/src/main/kotlin/pdl/PersonTestData.kt
+++ b/libs/testdata/src/main/kotlin/pdl/PersonTestData.kt
@@ -44,5 +44,6 @@ fun personTestData(opplysningsmap: Map<Opplysningstype, Opplysning<JsonNode>>): 
         familieRelasjon = opplysningsmap.hentFamilierelasjon()?.verdi,
         avdoedesBarn = opplysningsmap.hentAvdoedesbarn()?.verdi?.avdoedesBarn,
         vergemaalEllerFremtidsfullmakt = opplysningsmap.hentVergemaalellerfremtidsfullmakt()?.verdi,
+        pdlStatsborgerskap = null,
         avdoedesBarnUtenIdent = null,
     )


### PR DESCRIPTION
Dette inneholder kilden hvis pps feiler / kan ikke avklare statsborgerskapet unikt.
Der vi viser / bryr oss om Statsborgerskap må vi ta med denne også hvis den er satt.