### PR TITLE
EY-3086 Endrer gyldig fra dato til 01.01.2024 for omstillingsstønad

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/AvkortetYtelse.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/AvkortetYtelse.kt
@@ -1,6 +1,6 @@
 package no.nav.etterlatte.avkorting.regler
 
-import no.nav.etterlatte.beregning.regler.omstillingstoenad.OMS_GYLDIG_FROM_TEST
+import no.nav.etterlatte.beregning.regler.omstillingstoenad.OMS_GYLDIG_FRA
 import no.nav.etterlatte.libs.regler.FaktumNode
 import no.nav.etterlatte.libs.regler.KonstantGrunnlag
 import no.nav.etterlatte.libs.regler.PeriodisertGrunnlag
@@ -41,7 +41,7 @@ data class AvkortetYtelseGrunnlag(
 
 val beregningsbeloep: Regel<AvkortetYtelseGrunnlag, Int> =
     finnFaktumIGrunnlag(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Finner beregnet ytelse før avkorting",
         finnFaktum = AvkortetYtelseGrunnlag::beregning,
         finnFelt = { it },
@@ -49,7 +49,7 @@ val beregningsbeloep: Regel<AvkortetYtelseGrunnlag, Int> =
 
 val avkortingsbeloep: Regel<AvkortetYtelseGrunnlag, Int> =
     finnFaktumIGrunnlag(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Finner avkortignsbeløp",
         finnFaktum = AvkortetYtelseGrunnlag::avkorting,
         finnFelt = { it },
@@ -57,7 +57,7 @@ val avkortingsbeloep: Regel<AvkortetYtelseGrunnlag, Int> =
 
 val fordeltRestanseGrunnlag: Regel<AvkortetYtelseGrunnlag, Int> =
     finnFaktumIGrunnlag(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Restanse fordelt over gjenværende måneder for gjeldende år",
         finnFaktum = AvkortetYtelseGrunnlag::fordeltRestanse,
         finnFelt = { it },
@@ -65,7 +65,7 @@ val fordeltRestanseGrunnlag: Regel<AvkortetYtelseGrunnlag, Int> =
 
 val avkorteYtelse =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Finner endelig ytelse ved å trekke avkortingsbeløp fra beregnet ytelse",
         regelReferanse = RegelReferanse(id = "REGEL-AVKORTET-YTELSE"),
     ) benytter beregningsbeloep og avkortingsbeloep med { beregningsbeloep, avkortingsbeloep ->
@@ -74,7 +74,7 @@ val avkorteYtelse =
 
 val avkortetYtelseMedRestanse =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Legger til restanse fra endret avkorting til tidligere måneder",
         regelReferanse = RegelReferanse(id = "REGEL-AVKORTET-YTELSE-MED-RESTANSE"),
     ) benytter avkorteYtelse og fordeltRestanseGrunnlag med { avkorteYtelse, fordeltRestanse ->

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/InntektAvkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/InntektAvkorting.kt
@@ -1,6 +1,6 @@
 package no.nav.etterlatte.avkorting.regler
 
-import no.nav.etterlatte.beregning.regler.omstillingstoenad.OMS_GYLDIG_FROM_TEST
+import no.nav.etterlatte.beregning.regler.omstillingstoenad.OMS_GYLDIG_FRA
 import no.nav.etterlatte.grunnbeloep.Grunnbeloep
 import no.nav.etterlatte.grunnbeloep.GrunnbeloepRepository
 import no.nav.etterlatte.libs.regler.FaktumNode
@@ -59,14 +59,14 @@ val historiskeGrunnbeloep =
 
 val grunnbeloep: Regel<InntektAvkortingGrunnlagWrapper, Grunnbeloep> =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Finner grunnbeløp",
         regelReferanse = RegelReferanse(id = "REGEL-GRUNNBELOEP"),
     ) velgNyesteGyldige historiskeGrunnbeloep
 
 val inntektavkortingsgrunnlag: Regel<InntektAvkortingGrunnlagWrapper, InntektAvkortingGrunnlag> =
     finnFaktumIGrunnlag(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Finner inntektsavkortingsgrunnlag",
         finnFaktum = InntektAvkortingGrunnlagWrapper::inntektAvkortingGrunnlag,
         finnFelt = { it },
@@ -74,7 +74,7 @@ val inntektavkortingsgrunnlag: Regel<InntektAvkortingGrunnlagWrapper, InntektAvk
 
 val maanedsinntekt =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Inntekt for relevant periode nedrundet til nærmeste tusen oppdelt i relevante måneder",
         regelReferanse = RegelReferanse(id = "REGEL-NEDRUNDET-MÅNEDSINNTEKT"),
     ) benytter inntektavkortingsgrunnlag med { inntektavkortingsgrunnlag ->
@@ -88,7 +88,7 @@ val maanedsinntekt =
 
 val overstegetInntektPerMaaned =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Finner månedlig oversteget inntekt",
         regelReferanse = RegelReferanse(id = "REGEL-MÅNEDSINNTEKT-OVERSTEGET-HALV-G"),
     ) benytter maanedsinntekt og grunnbeloep med { inntekt, grunnbeleop ->
@@ -100,7 +100,7 @@ val overstegetInntektPerMaaned =
 
 val avkortingFaktor =
     definerKonstant<InntektAvkortingGrunnlagWrapper, Beregningstall>(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Faktor for inntektsavkorting",
         regelReferanse = RegelReferanse("REGEL-FAKTOR-FOR-AVKORTING"),
         verdi = Beregningstall(0.45),
@@ -108,7 +108,7 @@ val avkortingFaktor =
 
 val inntektAvkorting =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Avkorter inntekt som har oversteget et halvt grunnbeløp med avkortingsfaktor",
         regelReferanse = RegelReferanse(id = "REGEL-INNTEKT-AVKORTING"),
     ) benytter overstegetInntektPerMaaned og avkortingFaktor med { overstegetInntekt, avkortingFaktor ->
@@ -117,7 +117,7 @@ val inntektAvkorting =
 
 val kroneavrundetInntektAvkorting =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Gjør en kroneavrunding av intektavkorting",
         regelReferanse = RegelReferanse(id = "REGEL-KRONEAVRUNDING"),
     ) benytter inntektAvkorting med { inntektAvkorting ->

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/Restanse.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/Restanse.kt
@@ -1,6 +1,6 @@
 package no.nav.etterlatte.avkorting.regler
 
-import no.nav.etterlatte.beregning.regler.omstillingstoenad.OMS_GYLDIG_FROM_TEST
+import no.nav.etterlatte.beregning.regler.omstillingstoenad.OMS_GYLDIG_FRA
 import no.nav.etterlatte.libs.regler.FaktumNode
 import no.nav.etterlatte.libs.regler.Regel
 import no.nav.etterlatte.libs.regler.RegelMeta
@@ -20,7 +20,7 @@ data class RestanseGrunnlag(
 
 val tidligereYtelse: Regel<RestanseGrunnlag, List<Int>> =
     finnFaktumIGrunnlag(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Finner tidligere ytelse etter avkorting",
         finnFaktum = RestanseGrunnlag::tidligereYtelseEtterAvkorting,
         finnFelt = { it },
@@ -28,14 +28,14 @@ val tidligereYtelse: Regel<RestanseGrunnlag, List<Int>> =
 
 val nyYtelse: Regel<RestanseGrunnlag, List<Int>> =
     finnFaktumIGrunnlag(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Finner ny forventet ytelse etter avkorting",
         finnFaktum = RestanseGrunnlag::nyForventetYtelseEtterAvkorting,
         finnFelt = { it },
     )
 val virkningstidspunkt: Regel<RestanseGrunnlag, YearMonth> =
     finnFaktumIGrunnlag(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Virkningstidspunkt til restanse skal gjelde fra",
         finnFaktum = RestanseGrunnlag::fraOgMedNyForventetInntekt,
         finnFelt = { it },
@@ -43,7 +43,7 @@ val virkningstidspunkt: Regel<RestanseGrunnlag, YearMonth> =
 
 val totalRestanse =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Beregner restanse etter endret ytelse etter avkorting på grunn av endret årsinntekt",
         regelReferanse = RegelReferanse("TOTAL-RESTANSE-INNTEKTSENDRING"),
     ) benytter tidligereYtelse og nyYtelse med { tidligereYtelse, nyYtelse ->
@@ -52,7 +52,7 @@ val totalRestanse =
 
 val gjenvaerendeMaaneder =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Beregner hvor mange måneder som gjenstår i gjeldende år fra nytt virkningstidspunkt",
         regelReferanse = RegelReferanse("GJENVAERENDE-MAANEDER-FOR-FORDELT-RESTANSE"),
     ) benytter virkningstidspunkt med { virkningstidspunkt ->
@@ -63,7 +63,7 @@ val gjenvaerendeMaaneder =
 
 val fordeltRestanse =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Fordeler oppsummert restanse over gjenværende måneder av gjeldende år",
         regelReferanse = RegelReferanse("FORDELT-RESTANSE-INNTEKTSENDRING"),
     ) benytter totalRestanse og gjenvaerendeMaaneder med { sumRestanse, gjenvaerendeMaaneder ->
@@ -72,7 +72,7 @@ val fordeltRestanse =
 
 val restanse =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Beregner restanse etter endret ytelse etter avkorting på grunn av endret årsinntekt",
         regelReferanse = RegelReferanse("RESTANSE-INNTEKTSENDRING"),
     ) benytter totalRestanse og fordeltRestanse med { totalRestanse, fordeltRestanse ->

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/omstillingstoenad/BeregnOmstillingstoenad.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/omstillingstoenad/BeregnOmstillingstoenad.kt
@@ -39,7 +39,7 @@ data class OmstillingstoenadGrunnlag(
 
 val beregnOmstillingstoenadRegel =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Reduserer ytelsen mot opptjening i folketrygden",
         regelReferanse = RegelReferanse(id = "OMS-BEREGNING-2024-REDUSER-MOT-TRYGDETID"),
     ) benytter omstillingstoenadSatsRegel og trygdetidsFaktor med { sats, trygdetidsfaktor ->
@@ -48,7 +48,7 @@ val beregnOmstillingstoenadRegel =
 
 val OmstillingstoenadSatsMedInstitusjonsopphold =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Sikrer at ytelsen ikke blir større med institusjonsoppholdberegning",
         regelReferanse = RegelReferanse(id = "OMS-BEREGNING-GUNSTIGHET-INSTITUSJON"),
     ) benytter omstillingstoenadSatsRegel og institusjonsoppholdSatsRegelOMS med { standardSats, institusjonsoppholdSats ->
@@ -57,7 +57,7 @@ val OmstillingstoenadSatsMedInstitusjonsopphold =
 
 val omstillingstoenadSats =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Bruker institusjonsoppholdberegning hvis bruker er i institusjon",
         regelReferanse = RegelReferanse("OMS-BEREGNING-KANSKJEANVENDINSTITUSJON"),
     ) benytter omstillingstoenadSatsRegel og OmstillingstoenadSatsMedInstitusjonsopphold og erBrukerIInstitusjonOMS med {
@@ -70,7 +70,7 @@ val omstillingstoenadSats =
 
 val kroneavrundetOmstillingstoenadRegel =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Gjør en kroneavrunding av beregningen",
         regelReferanse = RegelReferanse(id = "REGEL-KRONEAVRUNDING"),
     ) benytter beregnOmstillingstoenadRegel med { beregnetOmstillingstoenad ->
@@ -79,7 +79,7 @@ val kroneavrundetOmstillingstoenadRegel =
 
 val beregnOmstillingstoenadRegelMedInstitusjon =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Bruker institusjonsoppholdberegning hvis bruker er i institusjon",
         regelReferanse = RegelReferanse(id = "OMS-BEREGNING-2024-REDUSER-MOT-TRYGDETID"),
     ) benytter omstillingstoenadSats og trygdetidsFaktor med { sats, trygdetidsfaktor ->
@@ -88,7 +88,7 @@ val beregnOmstillingstoenadRegelMedInstitusjon =
 
 val kroneavrundetOmstillingstoenadRegelMedInstitusjon =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Gjør en kroneavrunding av omstillingstønad inkludert institusjonsopphold",
         regelReferanse = RegelReferanse(id = "REGEL-KRONEAVRUNDING-INSTITUSJON"),
     ) benytter beregnOmstillingstoenadRegelMedInstitusjon med { beregnetOmstillingstoenad ->

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/omstillingstoenad/InstitusjonsoppholdreglerOMS.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/omstillingstoenad/InstitusjonsoppholdreglerOMS.kt
@@ -14,14 +14,14 @@ import no.nav.etterlatte.regler.Beregningstall
 
 val institusjonsoppholdRegelOMS: Regel<OmstillingstoenadGrunnlag, Prosent> =
     finnFaktumIGrunnlag(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Finner % av G mottaker skal ha for denne institusjonsoppholdytelsen",
         finnFaktum = OmstillingstoenadGrunnlag::institusjonsopphold,
     ) { it?.prosentEtterReduksjon() ?: Prosent.hundre }
 
 val erBrukerIInstitusjonOMS: Regel<OmstillingstoenadGrunnlag, Boolean> =
     finnFaktumIGrunnlag(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Finner om bruker har et institusjonsopphold",
         finnFaktum = OmstillingstoenadGrunnlag::institusjonsopphold,
     ) {
@@ -30,7 +30,7 @@ val erBrukerIInstitusjonOMS: Regel<OmstillingstoenadGrunnlag, Boolean> =
 
 val institusjonsoppholdSatsRegelOMS =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Finner satsen for institusjonsoppholdberegning",
         regelReferanse = RegelReferanse(id = "Finner sats for bruker, gitt at de skal ha institusjonsoppholdsats"),
     ) benytter grunnbeloep og institusjonsoppholdRegelOMS og faktorKonstant med { grunnbeloep, prosent, faktor ->

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/omstillingstoenad/Konstanter.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/omstillingstoenad/Konstanter.kt
@@ -2,5 +2,4 @@ package no.nav.etterlatte.beregning.regler.omstillingstoenad
 
 import java.time.LocalDate
 
-// TODO settes tidligere enn reformtidspunkt for å kunne gjøre en beregning
-val OMS_GYLDIG_FROM_TEST: LocalDate = LocalDate.of(2023, 1, 1)
+val OMS_GYLDIG_FRA: LocalDate = LocalDate.of(2024, 1, 1)

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/omstillingstoenad/sats/OmstillingsstoenadSats.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/omstillingstoenad/sats/OmstillingsstoenadSats.kt
@@ -1,6 +1,6 @@
 package no.nav.etterlatte.beregning.regler.omstillingstoenad.sats
 
-import no.nav.etterlatte.beregning.regler.omstillingstoenad.OMS_GYLDIG_FROM_TEST
+import no.nav.etterlatte.beregning.regler.omstillingstoenad.OMS_GYLDIG_FRA
 import no.nav.etterlatte.beregning.regler.omstillingstoenad.OmstillingstoenadGrunnlag
 import no.nav.etterlatte.grunnbeloep.Grunnbeloep
 import no.nav.etterlatte.grunnbeloep.GrunnbeloepRepository
@@ -27,14 +27,14 @@ val historiskeGrunnbeloep =
 
 val grunnbeloep: Regel<OmstillingstoenadGrunnlag, Grunnbeloep> =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Finner grunnbeløp for periode i beregning",
         regelReferanse = RegelReferanse(id = "REGEL-GRUNNBELOEP"),
     ) velgNyesteGyldige historiskeGrunnbeloep
 
 val faktorKonstant =
     definerKonstant<OmstillingstoenadGrunnlag, Beregningstall>(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Faktor for omstillingsstønad",
         regelReferanse = RegelReferanse(id = "OMS-BEREGNING-2024-FAKTOR"),
         verdi = Beregningstall(2.25),
@@ -42,7 +42,7 @@ val faktorKonstant =
 
 val omstillingstoenadSatsRegel =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Beregn sats for omstillingsstønad",
         regelReferanse = RegelReferanse(id = "OMS-BEREGNING-2024-SATS"),
     ) benytter faktorKonstant og grunnbeloep med { faktor, grunnbeloep ->

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/omstillingstoenad/trygdetidsfaktor/Trygdetidsfaktor.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/omstillingstoenad/trygdetidsfaktor/Trygdetidsfaktor.kt
@@ -2,7 +2,7 @@ package no.nav.etterlatte.beregning.regler.omstillingstoenad.trygdetidsfaktor
 
 import no.nav.etterlatte.beregning.regler.AnvendtTrygdetid
 import no.nav.etterlatte.beregning.regler.omstillingstoenad.Avdoed
-import no.nav.etterlatte.beregning.regler.omstillingstoenad.OMS_GYLDIG_FROM_TEST
+import no.nav.etterlatte.beregning.regler.omstillingstoenad.OMS_GYLDIG_FRA
 import no.nav.etterlatte.beregning.regler.omstillingstoenad.OmstillingstoenadGrunnlag
 import no.nav.etterlatte.libs.common.beregning.BeregningsMetode
 import no.nav.etterlatte.libs.common.beregning.SamletTrygdetidMedBeregningsMetode
@@ -18,7 +18,7 @@ import no.nav.etterlatte.regler.Beregningstall
 
 val trygdetidRegel: Regel<OmstillingstoenadGrunnlag, SamletTrygdetidMedBeregningsMetode> =
     finnFaktumIGrunnlag(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Finner avdødes trygdetid",
         finnFaktum = OmstillingstoenadGrunnlag::avdoed,
         finnFelt = Avdoed::trygdetid,
@@ -26,7 +26,7 @@ val trygdetidRegel: Regel<OmstillingstoenadGrunnlag, SamletTrygdetidMedBeregning
 
 val nasjonalTrygdetidRegel =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Finn trygdetid basert på faktisk nasjonal",
         regelReferanse = RegelReferanse(id = "OMS-BEREGNING-2024-NASJONAL-TRYGDETID"),
     ) benytter trygdetidRegel med { trygdetid ->
@@ -35,7 +35,7 @@ val nasjonalTrygdetidRegel =
 
 val teoretiskTrygdetidRegel =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Finn trygdetid basert på faktisk teoretisk og broek",
         regelReferanse = RegelReferanse(id = "OMS-BEREGNING-2024-PRORATA-TRYGDETID"),
     ) benytter trygdetidRegel med { trygdetid ->
@@ -44,7 +44,7 @@ val teoretiskTrygdetidRegel =
 
 val trygdetidBruktRegel =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Finn trygdetid basert på faktisk, teoretisk og beregningsmetgode",
         regelReferanse = RegelReferanse(id = "OMS-BEREGNING-2024-VALGT-TRYGDETID"),
     ) benytter trygdetidRegel og nasjonalTrygdetidRegel og teoretiskTrygdetidRegel med {
@@ -66,7 +66,7 @@ val trygdetidBruktRegel =
 
 val maksTrygdetid =
     definerKonstant<OmstillingstoenadGrunnlag, Beregningstall>(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Full trygdetidsopptjening er 40 år",
         regelReferanse = RegelReferanse("OMS-BEREGNING-2024-MAKS-TRYGDETID"),
         verdi = Beregningstall(40),
@@ -74,7 +74,7 @@ val maksTrygdetid =
 
 val trygdetidsFaktor =
     RegelMeta(
-        gjelderFra = OMS_GYLDIG_FROM_TEST,
+        gjelderFra = OMS_GYLDIG_FRA,
         beskrivelse = "Finn trygdetidsfaktor",
         regelReferanse = RegelReferanse(id = "OMS-BEREGNING-2024-TRYGDETIDSFAKTOR"),
     ) benytter maksTrygdetid og trygdetidBruktRegel med {

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -166,7 +166,7 @@ fun aarsoppgjoer(
 
 fun ytelseFoerAvkorting(
     beregning: Int = 100,
-    periode: Periode = Periode(fom = YearMonth.of(2023, 1), tom = null),
+    periode: Periode = Periode(fom = YearMonth.of(2024, 1), tom = null),
     beregningsreferanse: UUID = UUID.randomUUID(),
 ) = YtelseFoerAvkorting(
     beregning = beregning,
@@ -284,7 +284,7 @@ fun behandling(
     sak: Long = 123,
     sakType: SakType = SakType.OMSTILLINGSSTOENAD,
     behandlingType: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-    virkningstidspunkt: Virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1)),
+    virkningstidspunkt: Virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, 1)),
     status: BehandlingStatus = BehandlingStatus.BEREGNET,
 ) = DetaljertBehandling(
     id = id,

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRegelkjoringTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRegelkjoringTest.kt
@@ -18,20 +18,20 @@ import java.util.UUID
 class AvkortingRegelkjoringTest {
     @Test
     fun `skal beregne avkorting for inntekt til en foerstegangsbehandling`() {
-        val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 6))
+        val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, 6))
         val avkortingGrunnlag =
             listOf(
                 avkortinggrunnlag(
                     aarsinntekt = 300000,
                     fratrekkInnAar = 50000,
                     relevanteMaanederInnAar = 10,
-                    periode = Periode(fom = YearMonth.of(2023, 6), tom = YearMonth.of(2023, 8)),
+                    periode = Periode(fom = YearMonth.of(2024, 6), tom = YearMonth.of(2024, 8)),
                 ),
                 avkortinggrunnlag(
                     aarsinntekt = 600000,
                     fratrekkInnAar = 100000,
                     relevanteMaanederInnAar = 10,
-                    periode = Periode(fom = YearMonth.of(2023, 9), tom = null),
+                    periode = Periode(fom = YearMonth.of(2024, 9), tom = null),
                 ),
             )
 
@@ -44,14 +44,14 @@ class AvkortingRegelkjoringTest {
         with(avkortingsperioder[0]) {
             regelResultat shouldNotBe null
             tidspunkt shouldNotBe null
-            periode.fom shouldBe YearMonth.of(2023, 6)
-            periode.tom shouldBe YearMonth.of(2023, 8)
+            periode.fom shouldBe YearMonth.of(2024, 6)
+            periode.tom shouldBe YearMonth.of(2024, 8)
             avkorting shouldBe 9026
         }
         with(avkortingsperioder[1]) {
             regelResultat shouldNotBe null
             tidspunkt shouldNotBe null
-            periode.fom shouldBe YearMonth.of(2023, 9)
+            periode.fom shouldBe YearMonth.of(2024, 9)
             periode.tom shouldBe null
             avkorting shouldBe 20276
         }
@@ -59,16 +59,16 @@ class AvkortingRegelkjoringTest {
 
     @Test
     fun `skal ikke tillate aa beregne avkorting for inntekt med feil perioder`() {
-        val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1))
+        val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, 1))
         val avkortingGrunnlag =
             listOf(
                 avkortinggrunnlag(
                     aarsinntekt = 300000,
-                    periode = Periode(fom = YearMonth.of(2023, 1), tom = null),
+                    periode = Periode(fom = YearMonth.of(2024, 1), tom = null),
                 ),
                 avkortinggrunnlag(
                     aarsinntekt = 500000,
-                    periode = Periode(fom = YearMonth.of(2023, 4), tom = null),
+                    periode = Periode(fom = YearMonth.of(2024, 4), tom = null),
                 ),
             )
 
@@ -82,22 +82,22 @@ class AvkortingRegelkjoringTest {
 
     @Test
     fun `skal beregne endelig avkortet ytelse`() {
-        val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1))
+        val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, 1))
         val beregningsId = UUID.randomUUID()
         val beregninger =
             listOf(
                 YtelseFoerAvkorting(
                     beregning = 5000,
                     Periode(
-                        fom = YearMonth.of(2023, 1),
-                        tom = YearMonth.of(2023, 3),
+                        fom = YearMonth.of(2024, 1),
+                        tom = YearMonth.of(2024, 3),
                     ),
                     beregningsreferanse = beregningsId,
                 ),
                 YtelseFoerAvkorting(
                     beregning = 10000,
                     Periode(
-                        fom = YearMonth.of(2023, 4),
+                        fom = YearMonth.of(2024, 4),
                         tom = null,
                     ),
                     beregningsreferanse = beregningsId,
@@ -107,17 +107,17 @@ class AvkortingRegelkjoringTest {
             listOf(
                 avkortingsperiode(
                     avkorting = 1000,
-                    fom = YearMonth.of(2023, 1),
-                    tom = YearMonth.of(2023, 1),
+                    fom = YearMonth.of(2024, 1),
+                    tom = YearMonth.of(2024, 1),
                 ),
                 avkortingsperiode(
                     avkorting = 2000,
-                    fom = YearMonth.of(2023, 2),
-                    tom = YearMonth.of(2023, 2),
+                    fom = YearMonth.of(2024, 2),
+                    tom = YearMonth.of(2024, 2),
                 ),
                 avkortingsperiode(
                     avkorting = 3000,
-                    fom = YearMonth.of(2023, 3),
+                    fom = YearMonth.of(2024, 3),
                 ),
             )
 
@@ -133,28 +133,28 @@ class AvkortingRegelkjoringTest {
         with(avkortetYtelse[0]) {
             regelResultat shouldNotBe null
             tidspunkt shouldNotBe null
-            periode.fom shouldBe YearMonth.of(2023, 1)
-            periode.tom shouldBe YearMonth.of(2023, 1)
+            periode.fom shouldBe YearMonth.of(2024, 1)
+            periode.tom shouldBe YearMonth.of(2024, 1)
             ytelseEtterAvkorting shouldBe 4000
             avkortingsbeloep shouldBe 1000
             ytelseFoerAvkorting shouldBe 5000
         }
         with(avkortetYtelse[1]) {
-            periode.fom shouldBe YearMonth.of(2023, 2)
-            periode.tom shouldBe YearMonth.of(2023, 2)
+            periode.fom shouldBe YearMonth.of(2024, 2)
+            periode.tom shouldBe YearMonth.of(2024, 2)
             ytelseEtterAvkorting shouldBe 3000
             avkortingsbeloep shouldBe 2000
             ytelseFoerAvkorting shouldBe 5000
         }
         with(avkortetYtelse[2]) {
-            periode.fom shouldBe YearMonth.of(2023, 3)
-            periode.tom shouldBe YearMonth.of(2023, 3)
+            periode.fom shouldBe YearMonth.of(2024, 3)
+            periode.tom shouldBe YearMonth.of(2024, 3)
             ytelseEtterAvkorting shouldBe 2000
             avkortingsbeloep shouldBe 3000
             ytelseFoerAvkorting shouldBe 5000
         }
         with(avkortetYtelse[3]) {
-            periode.fom shouldBe YearMonth.of(2023, 4)
+            periode.fom shouldBe YearMonth.of(2024, 4)
             periode.tom shouldBe null
             ytelseEtterAvkorting shouldBe 7000
             avkortingsbeloep shouldBe 3000

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -90,7 +90,7 @@ internal class AvkortingServiceTest {
 
             coEvery { behandlingKlient.hentBehandling(behandlingId, bruker) } returns behandling
             every { avkortingRepository.hentAvkorting(behandlingId) } returns avkorting
-            every { avkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2023, 1)) } returns avkorting
+            every { avkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 1)) } returns avkorting
 
             runBlocking {
                 service.hentAvkorting(behandlingId, bruker) shouldBe avkorting
@@ -98,7 +98,7 @@ internal class AvkortingServiceTest {
             coVerify {
                 behandlingKlient.hentBehandling(behandlingId, bruker)
                 avkortingRepository.hentAvkorting(behandlingId)
-                avkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2023, 1))
+                avkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 1))
             }
         }
 
@@ -134,7 +134,7 @@ internal class AvkortingServiceTest {
                 eksisterendeAvkorting.beregnAvkortingRevurdering(beregning)
                 avkortingRepository.lagreAvkorting(behandlingId, reberegnetAvkorting)
                 behandlingKlient.avkort(behandlingId, bruker, true)
-                lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2023, 1))
+                lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 1))
             }
             coVerify(exactly = 2) {
                 avkortingRepository.hentAvkorting(behandlingId)
@@ -151,7 +151,7 @@ internal class AvkortingServiceTest {
                     status = behandlingStatusEtterBeregnet,
                     behandlingType = BehandlingType.REVURDERING,
                     sak = 123L,
-                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1)),
+                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, 1)),
                 )
             val forrigeBehandlingId = UUID.randomUUID()
             val eksisterendeAvkorting = mockk<Avkorting>()
@@ -175,7 +175,7 @@ internal class AvkortingServiceTest {
                 avkortingRepository.hentAvkorting(behandlingId)
                 behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, bruker)
                 avkortingRepository.hentAvkorting(forrigeBehandlingId)
-                eksisterendeAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2023, 1), forrigeAvkorting)
+                eksisterendeAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 1), forrigeAvkorting)
             }
         }
 
@@ -189,7 +189,7 @@ internal class AvkortingServiceTest {
                     status = behandlingStatusEtterBeregnet,
                     behandlingType = BehandlingType.REVURDERING,
                     sak = 123L,
-                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1)),
+                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, 1)),
                 )
             val forrigeBehandlingId = UUID.randomUUID()
             val eksisterendeAvkorting = mockk<Avkorting>()
@@ -213,7 +213,7 @@ internal class AvkortingServiceTest {
                 avkortingRepository.hentAvkorting(behandlingId)
                 behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, bruker)
                 avkortingRepository.hentAvkorting(forrigeBehandlingId)
-                eksisterendeAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2023, 1), null)
+                eksisterendeAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 1), null)
             }
         }
 
@@ -225,7 +225,7 @@ internal class AvkortingServiceTest {
                     id = behandlingId,
                     behandlingType = BehandlingType.REVURDERING,
                     sak = 123L,
-                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1)),
+                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, 1)),
                 )
             val forrigeBehandlingId = UUID.randomUUID()
             val forrigeAvkorting = mockk<Avkorting>()
@@ -261,7 +261,7 @@ internal class AvkortingServiceTest {
                 forrigeAvkorting.kopierAvkorting()
                 kopiertAvkorting.beregnAvkortingRevurdering(beregning)
                 avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
-                lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2023, 1), forrigeAvkorting)
+                lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 1), forrigeAvkorting)
                 behandlingKlient.avkort(behandlingId, bruker, true)
             }
             coVerify(exactly = 2) {
@@ -279,7 +279,7 @@ internal class AvkortingServiceTest {
                     status = behandlingBeregnetStatus,
                     behandlingType = BehandlingType.REVURDERING,
                     sak = 123L,
-                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1)),
+                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, 1)),
                 )
             val forrigeBehandlingId = UUID.randomUUID()
             val eksisterendeAvkorting = mockk<Avkorting>()
@@ -314,7 +314,7 @@ internal class AvkortingServiceTest {
                 eksisterendeAvkorting.beregnAvkortingRevurdering(beregning)
                 avkortingRepository.lagreAvkorting(behandlingId, reberegnetAvkorting)
                 behandlingKlient.avkort(behandlingId, bruker, true)
-                lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2023, 1), forrigeAvkorting)
+                lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 1), forrigeAvkorting)
             }
             coVerify(exactly = 2) {
                 avkortingRepository.hentAvkorting(behandlingId)
@@ -338,7 +338,7 @@ internal class AvkortingServiceTest {
                 behandling(
                     id = behandlingId,
                     behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 1)),
+                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, 1)),
                 )
 
             every { avkortingRepository.hentAvkorting(any()) } returns eksisterendeAvkorting andThen lagretAvkorting
@@ -365,7 +365,7 @@ internal class AvkortingServiceTest {
                     beregning,
                 )
                 avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
-                lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2023, 1))
+                lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 1))
                 behandlingKlient.avkort(behandlingId, bruker, true)
             }
             coVerify(exactly = 2) {
@@ -382,7 +382,7 @@ internal class AvkortingServiceTest {
                     id = revurderingId,
                     behandlingType = BehandlingType.REVURDERING,
                     sak = sakId,
-                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2023, 3)),
+                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, 3)),
                 )
             val forrigeBehandling = UUID.randomUUID()
             val forrigeAvkorting = mockk<Avkorting>()
@@ -418,7 +418,7 @@ internal class AvkortingServiceTest {
                 avkortingRepository.lagreAvkorting(revurderingId, beregnetAvkorting)
                 behandlingKlient.hentSisteIverksatteBehandling(sakId, bruker)
                 avkortingRepository.hentAvkorting(forrigeBehandling)
-                lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2023, 3), forrigeAvkorting)
+                lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 3), forrigeAvkorting)
                 behandlingKlient.avkort(revurderingId, bruker, true)
             }
             coVerify(exactly = 2) {

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -36,13 +36,13 @@ internal class AvkortingTest {
                         avkortetYtelseAar =
                             listOf(
                                 avkortetYtelse(
-                                    periode = Periode(fom = YearMonth.of(2023, 3), tom = YearMonth.of(2023, 4)),
+                                    periode = Periode(fom = YearMonth.of(2024, 3), tom = YearMonth.of(2024, 4)),
                                 ),
                                 avkortetYtelse(
-                                    periode = Periode(fom = YearMonth.of(2023, 5), tom = YearMonth.of(2023, 7)),
+                                    periode = Periode(fom = YearMonth.of(2024, 5), tom = YearMonth.of(2024, 7)),
                                 ),
                                 avkortetYtelse(
-                                    periode = Periode(fom = YearMonth.of(2023, 8), tom = null),
+                                    periode = Periode(fom = YearMonth.of(2024, 8), tom = null),
                                 ),
                             ),
                     ),
@@ -50,7 +50,7 @@ internal class AvkortingTest {
 
         @Test
         fun `fyller ut avkortet ytelse foer virkningstidspunkt ved aa kutte aarsoppgjoer fra virkningstidspunkt`() {
-            avkorting.medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2023, 5)).asClue {
+            avkorting.medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2024, 5)).asClue {
                 it.avkortetYtelseFraVirkningstidspunkt.size shouldBe 2
                 it.avkortetYtelseFraVirkningstidspunkt[0] shouldBe avkorting.aarsoppgjoer.avkortetYtelseAar[1]
                 it.avkortetYtelseFraVirkningstidspunkt[1] shouldBe avkorting.aarsoppgjoer.avkortetYtelseAar[2]
@@ -59,30 +59,30 @@ internal class AvkortingTest {
 
         @Test
         fun `kutter periode fra aarsoppgjoer hvis virkningstidspunkt begynner midt i periode `() {
-            avkorting.medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2023, 4)).asClue {
+            avkorting.medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2024, 4)).asClue {
                 it.avkortetYtelseFraVirkningstidspunkt.size shouldBe 3
                 with(it.avkortetYtelseFraVirkningstidspunkt[0]) {
                     shouldBeEqualToIgnoringFields(avkorting.aarsoppgjoer.avkortetYtelseAar[0], AvkortetYtelse::periode)
-                    periode shouldBe Periode(fom = YearMonth.of(2023, 4), tom = YearMonth.of(2023, 4))
+                    periode shouldBe Periode(fom = YearMonth.of(2024, 4), tom = YearMonth.of(2024, 4))
                 }
                 it.avkortetYtelseFraVirkningstidspunkt[1] shouldBe avkorting.aarsoppgjoer.avkortetYtelseAar[1]
                 it.avkortetYtelseFraVirkningstidspunkt[2] shouldBe avkorting.aarsoppgjoer.avkortetYtelseAar[2]
             }
 
-            avkorting.medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2023, 6)).asClue {
+            avkorting.medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2024, 6)).asClue {
                 it.avkortetYtelseFraVirkningstidspunkt.size shouldBe 2
                 with(it.avkortetYtelseFraVirkningstidspunkt[0]) {
                     shouldBeEqualToIgnoringFields(avkorting.aarsoppgjoer.avkortetYtelseAar[1], AvkortetYtelse::periode)
-                    periode shouldBe Periode(fom = YearMonth.of(2023, 6), tom = YearMonth.of(2023, 7))
+                    periode shouldBe Periode(fom = YearMonth.of(2024, 6), tom = YearMonth.of(2024, 7))
                 }
                 it.avkortetYtelseFraVirkningstidspunkt[1] shouldBe avkorting.aarsoppgjoer.avkortetYtelseAar[2]
             }
 
-            avkorting.medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2023, 9)).asClue {
+            avkorting.medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2024, 9)).asClue {
                 it.avkortetYtelseFraVirkningstidspunkt.size shouldBe 1
                 with(it.avkortetYtelseFraVirkningstidspunkt[0]) {
                     shouldBeEqualToIgnoringFields(avkorting.aarsoppgjoer.avkortetYtelseAar[2], AvkortetYtelse::periode)
-                    periode shouldBe Periode(fom = YearMonth.of(2023, 9), tom = null)
+                    periode shouldBe Periode(fom = YearMonth.of(2024, 9), tom = null)
                 }
             }
         }
@@ -90,7 +90,7 @@ internal class AvkortingTest {
 
     @Nested
     inner class KopierAvkorting {
-        private val virkningstidspunkt = YearMonth.of(2023, 7)
+        private val virkningstidspunkt = YearMonth.of(2024, 7)
         private val beregningId = UUID.randomUUID()
 
         private val eksisterendeAvkorting =
@@ -144,12 +144,12 @@ internal class AvkortingTest {
     inner class OppdaterMedInntektsgrunnlag {
         private val foersteGrunnlag =
             avkortinggrunnlag(
-                periode = Periode(fom = YearMonth.of(2023, 1), tom = YearMonth.of(2023, 3)),
+                periode = Periode(fom = YearMonth.of(2024, 1), tom = YearMonth.of(2024, 3)),
             )
         private val andreGrunnlag =
             avkortinggrunnlag(
                 aarsinntekt = 1000000,
-                periode = Periode(fom = YearMonth.of(2023, 4), tom = null),
+                periode = Periode(fom = YearMonth.of(2024, 4), tom = null),
             )
         private val avkorting =
             avkorting(
@@ -180,7 +180,7 @@ internal class AvkortingTest {
 
         @Test
         fun `Eksisterer ikke grunnlag skal det legges til og til og med paa periode til siste grunnlag skal settes`() {
-            val nyttGrunnlag = avkortinggrunnlag(periode = Periode(fom = YearMonth.of(2023, 8), tom = null))
+            val nyttGrunnlag = avkortinggrunnlag(periode = Periode(fom = YearMonth.of(2024, 8), tom = null))
 
             val oppdatertAvkorting = avkorting.oppdaterMedInntektsgrunnlag(nyttGrunnlag)
 
@@ -193,7 +193,7 @@ internal class AvkortingTest {
                 size shouldBe 3
                 get(0).grunnlag shouldBe foersteGrunnlag
                 get(1).grunnlag.shouldBeEqualToIgnoringFields(andreGrunnlag, AvkortingGrunnlag::periode)
-                get(1).grunnlag.periode shouldBe Periode(fom = YearMonth.of(2023, 4), tom = YearMonth.of(2023, 7))
+                get(1).grunnlag.periode shouldBe Periode(fom = YearMonth.of(2024, 4), tom = YearMonth.of(2024, 7))
                 get(2).grunnlag shouldBe nyttGrunnlag
             }
         }
@@ -208,11 +208,11 @@ internal class AvkortingTest {
                 size shouldBe 2
                 get(0).shouldBeEqualToIgnoringFields(
                     avkortetYtelse(
-                        periode = Periode(fom = YearMonth.of(2023, 3), tom = YearMonth.of(2023, 4)),
-                        ytelseEtterAvkorting = 6516,
-                        ytelseEtterAvkortingFoerRestanse = 6516,
+                        periode = Periode(fom = YearMonth.of(2024, 3), tom = YearMonth.of(2024, 4)),
+                        ytelseEtterAvkorting = 6650,
+                        ytelseEtterAvkortingFoerRestanse = 6650,
                         restanse = null,
-                        avkortingsbeloep = 9160,
+                        avkortingsbeloep = 9026,
                         ytelseFoerAvkorting = 15676,
                         type = AvkortetYtelseType.AARSOPPGJOER,
                         inntektsgrunnlag = null,
@@ -224,7 +224,7 @@ internal class AvkortingTest {
                 )
                 get(1).shouldBeEqualToIgnoringFields(
                     avkortetYtelse(
-                        periode = Periode(fom = YearMonth.of(2023, 5), tom = null),
+                        periode = Periode(fom = YearMonth.of(2024, 5), tom = null),
                         ytelseEtterAvkorting = 7656,
                         ytelseEtterAvkortingFoerRestanse = 7656,
                         restanse = null,
@@ -250,10 +250,10 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 3), tom = YearMonth.of(2023, 4)),
-                            ytelseEtterAvkorting = 6516,
-                            ytelseEtterAvkortingFoerRestanse = 6516,
-                            avkortingsbeloep = 9160,
+                            periode = Periode(fom = YearMonth.of(2024, 3), tom = YearMonth.of(2024, 4)),
+                            ytelseEtterAvkorting = 6650,
+                            ytelseEtterAvkortingFoerRestanse = 6650,
+                            avkortingsbeloep = 9026,
                             ytelseFoerAvkorting = 15676,
                             inntektsgrunnlag = null,
                         ),
@@ -269,7 +269,7 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 5), tom = YearMonth.of(2023, 6)),
+                            periode = Periode(fom = YearMonth.of(2024, 5), tom = YearMonth.of(2024, 6)),
                             ytelseEtterAvkorting = 7656,
                             ytelseEtterAvkortingFoerRestanse = 7656,
                             avkortingsbeloep = 9026,
@@ -288,7 +288,7 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 7), tom = null),
+                            periode = Periode(fom = YearMonth.of(2024, 7), tom = null),
                             ytelseEtterAvkorting = 156,
                             ytelseEtterAvkortingFoerRestanse = 3156,
                             avkortingsbeloep = 13526,
@@ -324,10 +324,10 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 3), tom = YearMonth.of(2023, 4)),
-                            ytelseEtterAvkorting = 6516,
-                            ytelseEtterAvkortingFoerRestanse = 6516,
-                            avkortingsbeloep = 9160,
+                            periode = Periode(fom = YearMonth.of(2024, 3), tom = YearMonth.of(2024, 4)),
+                            ytelseEtterAvkorting = 6650,
+                            ytelseEtterAvkortingFoerRestanse = 6650,
+                            avkortingsbeloep = 9026,
                             ytelseFoerAvkorting = 15676,
                             inntektsgrunnlag = null,
                         ),
@@ -343,7 +343,7 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 5), tom = YearMonth.of(2023, 6)),
+                            periode = Periode(fom = YearMonth.of(2024, 5), tom = YearMonth.of(2024, 6)),
                             ytelseEtterAvkorting = 7656,
                             ytelseEtterAvkortingFoerRestanse = 7656,
                             avkortingsbeloep = 9026,
@@ -362,7 +362,7 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 7), tom = YearMonth.of(2023, 8)),
+                            periode = Periode(fom = YearMonth.of(2024, 7), tom = YearMonth.of(2024, 8)),
                             ytelseEtterAvkorting = 156,
                             ytelseEtterAvkortingFoerRestanse = 3156,
                             avkortingsbeloep = 13526,
@@ -390,7 +390,7 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 9), tom = null),
+                            periode = Periode(fom = YearMonth.of(2024, 9), tom = null),
                             ytelseEtterAvkorting = 0,
                             ytelseEtterAvkortingFoerRestanse = 906,
                             avkortingsbeloep = 15776,
@@ -405,8 +405,8 @@ internal class AvkortingTest {
                     )
                     it.restanse!!.shouldBeEqualToIgnoringFields(
                         restanse(
-                            totalRestanse = 25032,
-                            fordeltRestanse = 6258,
+                            totalRestanse = 25300,
+                            fordeltRestanse = 6325,
                         ),
                         Restanse::id,
                         AvkortetYtelse::tidspunkt,
@@ -426,11 +426,11 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 3), tom = YearMonth.of(2023, 4)),
-                            ytelseEtterAvkorting = 11742,
-                            ytelseEtterAvkortingFoerRestanse = 11742,
-                            avkortingsbeloep = 9160,
-                            ytelseFoerAvkorting = 20902,
+                            periode = Periode(fom = YearMonth.of(2024, 3), tom = YearMonth.of(2024, 4)),
+                            ytelseEtterAvkorting = 13215,
+                            ytelseEtterAvkortingFoerRestanse = 13215,
+                            avkortingsbeloep = 9026,
+                            ytelseFoerAvkorting = 22241,
                             inntektsgrunnlag = null,
                         ),
                         AvkortetYtelse::id,
@@ -445,7 +445,7 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 5), tom = YearMonth.of(2023, 6)),
+                            periode = Periode(fom = YearMonth.of(2024, 5), tom = YearMonth.of(2024, 6)),
                             ytelseEtterAvkorting = 13215,
                             ytelseEtterAvkortingFoerRestanse = 13215,
                             avkortingsbeloep = 9026,
@@ -464,7 +464,7 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 7), tom = YearMonth.of(2023, 8)),
+                            periode = Periode(fom = YearMonth.of(2024, 7), tom = YearMonth.of(2024, 8)),
                             ytelseEtterAvkorting = 5715,
                             ytelseEtterAvkortingFoerRestanse = 8715,
                             avkortingsbeloep = 13526,
@@ -492,7 +492,7 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 9), tom = null),
+                            periode = Periode(fom = YearMonth.of(2024, 9), tom = null),
                             ytelseEtterAvkorting = 90,
                             ytelseEtterAvkortingFoerRestanse = 6465,
                             avkortingsbeloep = 15776,
@@ -528,11 +528,11 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 3), tom = YearMonth.of(2023, 4)),
-                            ytelseEtterAvkorting = 11742,
-                            ytelseEtterAvkortingFoerRestanse = 11742,
-                            avkortingsbeloep = 9160,
-                            ytelseFoerAvkorting = 20902,
+                            periode = Periode(fom = YearMonth.of(2024, 3), tom = YearMonth.of(2024, 4)),
+                            ytelseEtterAvkorting = 13215,
+                            ytelseEtterAvkortingFoerRestanse = 13215,
+                            avkortingsbeloep = 9026,
+                            ytelseFoerAvkorting = 22241,
                             inntektsgrunnlag = null,
                         ),
                         AvkortetYtelse::id,
@@ -547,7 +547,7 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 5), tom = YearMonth.of(2023, 6)),
+                            periode = Periode(fom = YearMonth.of(2024, 5), tom = YearMonth.of(2024, 6)),
                             ytelseEtterAvkorting = 13215,
                             ytelseEtterAvkortingFoerRestanse = 13215,
                             avkortingsbeloep = 9026,
@@ -566,7 +566,7 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 7), tom = YearMonth.of(2023, 8)),
+                            periode = Periode(fom = YearMonth.of(2024, 7), tom = YearMonth.of(2024, 8)),
                             ytelseEtterAvkorting = 5715,
                             ytelseEtterAvkortingFoerRestanse = 8715,
                             avkortingsbeloep = 13526,
@@ -594,7 +594,7 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 9), tom = null),
+                            periode = Periode(fom = YearMonth.of(2024, 9), tom = null),
                             ytelseEtterAvkorting = 2903,
                             ytelseEtterAvkortingFoerRestanse = 7590,
                             avkortingsbeloep = 14651,
@@ -630,11 +630,11 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 3), tom = YearMonth.of(2023, 3)),
-                            ytelseEtterAvkorting = 11742,
-                            ytelseEtterAvkortingFoerRestanse = 11742,
-                            avkortingsbeloep = 9160,
-                            ytelseFoerAvkorting = 20902,
+                            periode = Periode(fom = YearMonth.of(2024, 3), tom = YearMonth.of(2024, 3)),
+                            ytelseEtterAvkorting = 13215,
+                            ytelseEtterAvkortingFoerRestanse = 13215,
+                            avkortingsbeloep = 9026,
+                            ytelseFoerAvkorting = 22241,
                             inntektsgrunnlag = null,
                         ),
                         AvkortetYtelse::id,
@@ -649,11 +649,11 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 4), tom = YearMonth.of(2023, 4)),
-                            ytelseEtterAvkorting = 11742,
-                            ytelseEtterAvkortingFoerRestanse = 11742,
-                            avkortingsbeloep = 9160,
-                            ytelseFoerAvkorting = 20902,
+                            periode = Periode(fom = YearMonth.of(2024, 4), tom = YearMonth.of(2024, 4)),
+                            ytelseEtterAvkorting = 13215,
+                            ytelseEtterAvkortingFoerRestanse = 13215,
+                            avkortingsbeloep = 9026,
+                            ytelseFoerAvkorting = 22241,
                             inntektsgrunnlag = null,
                         ),
                         AvkortetYtelse::id,
@@ -668,7 +668,7 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 5), tom = YearMonth.of(2023, 6)),
+                            periode = Periode(fom = YearMonth.of(2024, 5), tom = YearMonth.of(2024, 6)),
                             ytelseEtterAvkorting = 13215,
                             ytelseEtterAvkortingFoerRestanse = 13215,
                             avkortingsbeloep = 9026,
@@ -687,7 +687,7 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 7), tom = YearMonth.of(2023, 8)),
+                            periode = Periode(fom = YearMonth.of(2024, 7), tom = YearMonth.of(2024, 8)),
                             ytelseEtterAvkorting = 5715,
                             ytelseEtterAvkortingFoerRestanse = 8715,
                             avkortingsbeloep = 13526,
@@ -715,7 +715,7 @@ internal class AvkortingTest {
                     it.shouldBeEqualToIgnoringFields(
                         avkortetYtelse(
                             type = AvkortetYtelseType.AARSOPPGJOER,
-                            periode = Periode(fom = YearMonth.of(2023, 9), tom = null),
+                            periode = Periode(fom = YearMonth.of(2024, 9), tom = null),
                             ytelseEtterAvkorting = 2903,
                             ytelseEtterAvkortingFoerRestanse = 7590,
                             avkortingsbeloep = 14651,
@@ -747,7 +747,7 @@ internal class AvkortingTest {
                 .beregnAvkortingMedNyttGrunnlag(
                     nyttGrunnlag =
                         avkortinggrunnlag(
-                            periode = Periode(fom = YearMonth.of(2023, 3), tom = null),
+                            periode = Periode(fom = YearMonth.of(2024, 3), tom = null),
                             aarsinntekt = 300000,
                             fratrekkInnAar = 50000,
                             relevanteMaanederInnAar = 10,
@@ -758,12 +758,12 @@ internal class AvkortingTest {
                             beregninger =
                                 listOf(
                                     beregningsperiode(
-                                        datoFOM = YearMonth.of(2023, 3),
-                                        datoTOM = YearMonth.of(2023, 4),
+                                        datoFOM = YearMonth.of(2024, 3),
+                                        datoTOM = YearMonth.of(2024, 4),
                                         utbetaltBeloep = 15676,
                                     ),
                                     beregningsperiode(
-                                        datoFOM = YearMonth.of(2023, 5),
+                                        datoFOM = YearMonth.of(2024, 5),
                                         utbetaltBeloep = 16682,
                                     ),
                                 ),
@@ -777,7 +777,7 @@ internal class AvkortingTest {
                     nyttGrunnlag =
                         avkortinggrunnlag(
                             id = UUID.randomUUID(),
-                            periode = Periode(fom = YearMonth.of(2023, 7), tom = null),
+                            periode = Periode(fom = YearMonth.of(2024, 7), tom = null),
                             aarsinntekt = 400000,
                             fratrekkInnAar = 50000,
                             relevanteMaanederInnAar = 10,
@@ -788,7 +788,7 @@ internal class AvkortingTest {
                             beregninger =
                                 listOf(
                                     beregningsperiode(
-                                        datoFOM = YearMonth.of(2023, 7),
+                                        datoFOM = YearMonth.of(2024, 7),
                                         utbetaltBeloep = 16682,
                                     ),
                                 ),
@@ -802,7 +802,7 @@ internal class AvkortingTest {
                     nyttGrunnlag =
                         avkortinggrunnlag(
                             id = UUID.randomUUID(),
-                            periode = Periode(fom = YearMonth.of(2023, 9), tom = null),
+                            periode = Periode(fom = YearMonth.of(2024, 9), tom = null),
                             aarsinntekt = 450000,
                             fratrekkInnAar = 50000,
                             relevanteMaanederInnAar = 10,
@@ -813,7 +813,7 @@ internal class AvkortingTest {
                             beregninger =
                                 listOf(
                                     beregningsperiode(
-                                        datoFOM = YearMonth.of(2023, 9),
+                                        datoFOM = YearMonth.of(2024, 9),
                                         utbetaltBeloep = 16682,
                                     ),
                                 ),
@@ -828,12 +828,12 @@ internal class AvkortingTest {
                         beregninger =
                             listOf(
                                 beregningsperiode(
-                                    datoFOM = YearMonth.of(2023, 3),
-                                    datoTOM = YearMonth.of(2023, 4),
-                                    utbetaltBeloep = 20902,
+                                    datoFOM = YearMonth.of(2024, 3),
+                                    datoTOM = YearMonth.of(2024, 4),
+                                    utbetaltBeloep = 22241,
                                 ),
                                 beregningsperiode(
-                                    datoFOM = YearMonth.of(2023, 5),
+                                    datoFOM = YearMonth.of(2024, 5),
                                     utbetaltBeloep = 22241,
                                 ),
                             ),
@@ -847,7 +847,7 @@ internal class AvkortingTest {
                         nyttGrunnlag =
                             avkortinggrunnlag(
                                 id = it.aarsoppgjoer.inntektsavkorting.last().grunnlag.id,
-                                periode = Periode(fom = YearMonth.of(2023, 9), tom = null),
+                                periode = Periode(fom = YearMonth.of(2024, 9), tom = null),
                                 aarsinntekt = 425000,
                                 fratrekkInnAar = 50000,
                                 relevanteMaanederInnAar = 10,
@@ -857,7 +857,7 @@ internal class AvkortingTest {
                             beregninger =
                                 listOf(
                                     beregningsperiode(
-                                        datoFOM = YearMonth.of(2023, 9),
+                                        datoFOM = YearMonth.of(2024, 9),
                                         utbetaltBeloep = 22241,
                                     ),
                                 ),
@@ -873,12 +873,12 @@ internal class AvkortingTest {
                         beregninger =
                             listOf(
                                 beregningsperiode(
-                                    datoFOM = YearMonth.of(2023, 4),
-                                    datoTOM = YearMonth.of(2023, 4),
-                                    utbetaltBeloep = 20902,
+                                    datoFOM = YearMonth.of(2024, 4),
+                                    datoTOM = YearMonth.of(2024, 4),
+                                    utbetaltBeloep = 22241,
                                 ),
                                 beregningsperiode(
-                                    datoFOM = YearMonth.of(2023, 5),
+                                    datoFOM = YearMonth.of(2024, 5),
                                     utbetaltBeloep = 22241,
                                 ),
                             ),

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/regler/AvkortetYtelseTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/regler/AvkortetYtelseTest.kt
@@ -13,7 +13,7 @@ class AvkortetYtelseTest {
         val avkortetYtelse =
             avkortetYtelseMedRestanse.anvend(
                 avkortetYtelseGrunnlag(beregning = 100000, avkorting = 50000),
-                RegelPeriode(LocalDate.of(2023, 1, 1)),
+                RegelPeriode(LocalDate.of(2024, 1, 1)),
             )
         avkortetYtelse.verdi shouldBe 50000
     }
@@ -23,7 +23,7 @@ class AvkortetYtelseTest {
         val avkortetYtelse =
             avkortetYtelseMedRestanse.anvend(
                 avkortetYtelseGrunnlag(beregning = 50000, avkorting = 100000),
-                RegelPeriode(LocalDate.of(2023, 1, 1)),
+                RegelPeriode(LocalDate.of(2024, 1, 1)),
             )
         avkortetYtelse.verdi shouldBe 0
     }

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/regler/InntektAvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/regler/InntektAvkortingTest.kt
@@ -14,7 +14,7 @@ import java.time.LocalDate
 class InntektAvkortingTest {
     @Test
     fun `avkortingsfaktor er 45 prosent`() {
-        val faktor = avkortingFaktor.anvend(inntektAvkortingGrunnlag(), RegelPeriode(LocalDate.now()))
+        val faktor = avkortingFaktor.anvend(inntektAvkortingGrunnlag(), RegelPeriode(LocalDate.of(2024, 1, 1)))
         faktor.verdi shouldBe Beregningstall(0.45)
     }
 
@@ -28,7 +28,7 @@ class InntektAvkortingTest {
                     inntektUtland = 100000,
                     relevanteMaaneder = 10,
                 ),
-                RegelPeriode(LocalDate.now()),
+                RegelPeriode(LocalDate.of(2024, 1, 1)),
             )
         inntekt.verdi.toInteger() shouldBe 45000
     }
@@ -38,9 +38,9 @@ class InntektAvkortingTest {
         val overstegetInntekt =
             overstegetInntektPerMaaned.anvend(
                 inntektAvkortingGrunnlag(inntekt = 120000),
-                RegelPeriode(LocalDate.of(2023, 1, 1)),
+                RegelPeriode(LocalDate.of(2024, 1, 1)),
             )
-        overstegetInntekt.verdi.toInteger() shouldBe 5355
+        overstegetInntekt.verdi.toInteger() shouldBe 5057
     }
 
     @Test
@@ -48,7 +48,7 @@ class InntektAvkortingTest {
         val overstegetInntekt =
             overstegetInntektPerMaaned.anvend(
                 inntektAvkortingGrunnlag(inntekt = 25000),
-                RegelPeriode(LocalDate.of(2023, 1, 1)),
+                RegelPeriode(LocalDate.of(2024, 1, 1)),
             )
         overstegetInntekt.verdi.toInteger() shouldBe 0
     }
@@ -58,8 +58,8 @@ class InntektAvkortingTest {
         val avkortingsbeloep =
             kroneavrundetInntektAvkorting.anvend(
                 inntektAvkortingGrunnlag(inntekt = 500000, fratrekkInnAar = 0, relevanteMaaneder = 12),
-                RegelPeriode(LocalDate.of(2023, 1, 1)),
+                RegelPeriode(LocalDate.of(2024, 1, 1)),
             )
-        avkortingsbeloep.verdi shouldBe 16660
+        avkortingsbeloep.verdi shouldBe 16526
     }
 }

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnBarnepensjonServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnBarnepensjonServiceTest.kt
@@ -730,14 +730,14 @@ internal class BeregnBarnepensjonServiceTest {
                     behandling,
                     Systembruker("migrering", "migrering"),
                 )
-            Assertions.assertEquals(2, beregning.beregningsperioder.size)
+            beregning.beregningsperioder.size shouldBeGreaterThanOrEqual 3
             with(beregning.beregningsperioder[0]) {
                 datoFOM shouldBe YearMonth.of(2023, Month.DECEMBER)
                 datoTOM shouldBe YearMonth.of(2023, Month.DECEMBER)
             }
             with(beregning.beregningsperioder[1]) {
                 datoFOM shouldBe YearMonth.of(2024, Month.JANUARY)
-                datoTOM shouldBe null
+                datoTOM shouldBe YearMonth.of(2024, Month.APRIL)
             }
         }
     }
@@ -770,7 +770,7 @@ internal class BeregnBarnepensjonServiceTest {
             }
             with(beregning.beregningsperioder[2]) {
                 datoFOM shouldBe YearMonth.of(2024, 1)
-                datoTOM shouldBe null
+                datoTOM shouldBe YearMonth.of(2024, 4)
                 utbetaltBeloep shouldBe BP_BELOEP_NYTT_REGELVERK_TO_DOEDE_FORELDRE
             }
         }

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnOmstillingsstoenadServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnOmstillingsstoenadServiceTest.kt
@@ -81,10 +81,10 @@ internal class BeregnOmstillingsstoenadServiceTest {
                 grunnlagMetadata shouldBe grunnlag.metadata
                 beregningsperioder.size shouldBeGreaterThanOrEqual 2
                 with(beregningsperioder.first()) {
-                    utbetaltBeloep shouldBe OMS_BELOEP_JAN_23
+                    utbetaltBeloep shouldBe OMS_BELOEP_JAN_24
                     datoFOM shouldBe behandling.virkningstidspunkt?.dato
-                    datoTOM shouldBe YearMonth.of(2023, Month.APRIL)
-                    grunnbelopMnd shouldBe GRUNNBELOEP_JAN_23
+                    datoTOM shouldBe YearMonth.of(2024, Month.APRIL)
+                    grunnbelopMnd shouldBe GRUNNBELOEP_JAN_24
                     soeskenFlokk shouldBe null
                     this.trygdetid shouldBe TRYGDETID_40_AAR
                     regelResultat shouldNotBe null
@@ -120,10 +120,10 @@ internal class BeregnOmstillingsstoenadServiceTest {
                 grunnlagMetadata shouldBe grunnlag.metadata
                 beregningsperioder.size shouldBeGreaterThanOrEqual 2
                 with(beregningsperioder.first()) {
-                    utbetaltBeloep shouldBe OMS_BELOEP_JAN_23_PRORATA
+                    utbetaltBeloep shouldBe OMS_BELOEP_JAN_24_PRORATA
                     datoFOM shouldBe behandling.virkningstidspunkt?.dato
-                    datoTOM shouldBe YearMonth.of(2023, Month.APRIL)
-                    grunnbelopMnd shouldBe GRUNNBELOEP_JAN_23
+                    datoTOM shouldBe YearMonth.of(2024, Month.APRIL)
+                    grunnbelopMnd shouldBe GRUNNBELOEP_JAN_24
                     soeskenFlokk shouldBe null
                     this.trygdetid shouldBe PRORATA_TRYGDETID_30_AAR / 2
                     regelResultat shouldNotBe null
@@ -159,10 +159,10 @@ internal class BeregnOmstillingsstoenadServiceTest {
                 grunnlagMetadata shouldBe grunnlag.metadata
                 beregningsperioder.size shouldBeGreaterThanOrEqual 2
                 with(beregningsperioder.first()) {
-                    utbetaltBeloep shouldBe OMS_BELOEP_JAN_23
+                    utbetaltBeloep shouldBe OMS_BELOEP_JAN_24
                     datoFOM shouldBe behandling.virkningstidspunkt?.dato
-                    datoTOM shouldBe YearMonth.of(2023, Month.APRIL)
-                    grunnbelopMnd shouldBe GRUNNBELOEP_JAN_23
+                    datoTOM shouldBe YearMonth.of(2024, Month.APRIL)
+                    grunnbelopMnd shouldBe GRUNNBELOEP_JAN_24
                     soeskenFlokk shouldBe null
                     this.trygdetid shouldBe TRYGDETID_40_AAR
                     regelResultat shouldNotBe null
@@ -203,10 +203,10 @@ internal class BeregnOmstillingsstoenadServiceTest {
                 grunnlagMetadata shouldBe grunnlag.metadata
                 beregningsperioder.size shouldBeGreaterThanOrEqual 2
                 with(beregningsperioder.first()) {
-                    utbetaltBeloep shouldBe OMS_BELOEP_JAN_23
+                    utbetaltBeloep shouldBe OMS_BELOEP_JAN_24
                     datoFOM shouldBe behandling.virkningstidspunkt?.dato
-                    datoTOM shouldBe YearMonth.of(2023, Month.APRIL)
-                    grunnbelopMnd shouldBe GRUNNBELOEP_JAN_23
+                    datoTOM shouldBe YearMonth.of(2024, Month.APRIL)
+                    grunnbelopMnd shouldBe GRUNNBELOEP_JAN_24
                     this.trygdetid shouldBe TRYGDETID_40_AAR
                 }
             }
@@ -246,7 +246,7 @@ internal class BeregnOmstillingsstoenadServiceTest {
                     utbetaltBeloep shouldBe 0
                     datoFOM shouldBe behandling.virkningstidspunkt?.dato
                     datoTOM shouldBe null
-                    grunnbelopMnd shouldBe GRUNNBELOEP_JAN_23
+                    grunnbelopMnd shouldBe GRUNNBELOEP_JAN_24
                     this.trygdetid shouldBe 0
                 }
             }
@@ -282,7 +282,7 @@ internal class BeregnOmstillingsstoenadServiceTest {
                     utbetaltBeloep shouldBe 0
                     datoFOM shouldBe behandling.virkningstidspunkt?.dato
                     datoTOM shouldBe null
-                    grunnbelopMnd shouldBe GRUNNBELOEP_JAN_23
+                    grunnbelopMnd shouldBe GRUNNBELOEP_JAN_24
                     soeskenFlokk shouldBe null
                     this.trygdetid shouldBe 0
                 }
@@ -335,7 +335,7 @@ internal class BeregnOmstillingsstoenadServiceTest {
 
     private fun mockBehandling(
         type: BehandlingType,
-        virk: YearMonth = VIRKNINGSTIDSPUNKT_JAN_23,
+        virk: YearMonth = VIRKNINGSTIDSPUNKT_JAN_24,
     ): DetaljertBehandling =
         mockk<DetaljertBehandling>().apply {
             every { id } returns randomUUID()
@@ -369,13 +369,13 @@ internal class BeregnOmstillingsstoenadServiceTest {
         }
 
     companion object {
-        val VIRKNINGSTIDSPUNKT_JAN_23: YearMonth = YearMonth.of(2023, 1)
+        val VIRKNINGSTIDSPUNKT_JAN_24: YearMonth = YearMonth.of(2024, 1)
         const val TRYGDETID_40_AAR: Int = 40
         const val PRORATA_TRYGDETID_30_AAR: Int = 30
         val PRORATA_BROEK: IntBroek = IntBroek(1, 2)
-        const val GRUNNBELOEP_JAN_23: Int = 9290
-        const val OMS_BELOEP_JAN_23: Int = 20902
-        const val OMS_BELOEP_JAN_23_PRORATA: Int = 7838
+        const val GRUNNBELOEP_JAN_24: Int = 9885
+        const val OMS_BELOEP_JAN_24: Int = 22241
+        const val OMS_BELOEP_JAN_24_PRORATA: Int = 8340
     }
 
     private fun omstillingstoenadBeregningsGrunnlag(

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/regler/sats/BarnepensjonSatsTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/regler/sats/BarnepensjonSatsTest.kt
@@ -28,7 +28,7 @@ import java.time.YearMonth
 internal class BarnepensjonSatsTest {
     @Test
     fun `historiskeGrunnbeloep skal hente alle historiske grunnbeloep`() {
-        historiskeGrunnbeloep.size shouldBeExactly 70
+        historiskeGrunnbeloep.size shouldBeExactly 71
     }
 
     @Test

--- a/apps/etterlatte-beregning/src/test/kotlin/grunnbeloep/GrunnbeloepRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/grunnbeloep/GrunnbeloepRepositoryTest.kt
@@ -9,7 +9,7 @@ import java.time.YearMonth
 internal class GrunnbeloepRepositoryTest {
     @Test
     fun `skal hente alle historiske grunnbeloep`() {
-        GrunnbeloepRepository.historiskeGrunnbeloep shouldHaveSize 70
+        GrunnbeloepRepository.historiskeGrunnbeloep shouldHaveSize 71
     }
 
     @Test

--- a/apps/etterlatte-beregning/src/test/resources/grunnbelop.json
+++ b/apps/etterlatte-beregning/src/test/resources/grunnbelop.json
@@ -1,0 +1,430 @@
+{
+  "grunnbeløp": [
+    {
+      "dato": "2024-05",
+      "grunnbeløp": 118620,
+      "grunnbeløpPerMåned": 9885,
+      "omregningsfaktor": 1.064076
+    },
+    {
+      "dato": "2023-05",
+      "grunnbeløp": 118620,
+      "grunnbeløpPerMåned": 9885,
+      "omregningsfaktor": 1.064076
+    },
+    {
+      "dato": "2022-05",
+      "grunnbeløp": 111477,
+      "grunnbeløpPerMåned": 9290,
+      "omregningsfaktor": 1.047726
+    },
+    {
+      "dato": "2021-05",
+      "grunnbeløp": 106399,
+      "grunnbeløpPerMåned": 8867,
+      "omregningsfaktor": 1.049807
+    },
+    {
+      "dato": "2020-05",
+      "grunnbeløp": 101351,
+      "grunnbeløpPerMåned": 8446,
+      "omregningsfaktor": 1.014951
+    },
+    {
+      "dato": "2019-05",
+      "grunnbeløp": 99858,
+      "grunnbeløpPerMåned": 8322,
+      "omregningsfaktor": 1.030707
+    },
+    {
+      "dato": "2018-05",
+      "grunnbeløp": 96883,
+      "grunnbeløpPerMåned": 8074,
+      "omregningsfaktor": 1.034699
+    },
+    {
+      "dato": "2017-05",
+      "grunnbeløp": 93634,
+      "grunnbeløpPerMåned": 7803,
+
+      "omregningsfaktor": 1.011428
+    },
+    {
+      "dato": "2016-05",
+      "grunnbeløp": 92576,
+      "grunnbeløpPerMåned": 7715,
+      "omregningsfaktor": 1.027846
+    },
+    {
+      "dato": "2015-05",
+      "grunnbeløp": 90068,
+      "grunnbeløpPerMåned": 7506,
+      "omregningsfaktor": 1.019214
+    },
+    {
+      "dato": "2014-05",
+      "grunnbeløp": 88370,
+      "grunnbeløpPerMåned": 7364,
+      "omregningsfaktor": 1.036659
+    },
+    {
+      "dato": "2013-05",
+      "grunnbeløp": 85245,
+      "grunnbeløpPerMåned": 7104,
+      "omregningsfaktor": 1.038029
+    },
+    {
+      "dato": "2012-05",
+      "grunnbeløp": 82122,
+      "grunnbeløpPerMåned": 6844,
+      "omregningsfaktor": 1.036685
+    },
+    {
+      "dato": "2011-05",
+      "grunnbeløp": 79216,
+      "grunnbeløpPerMåned": 6601,
+      "omregningsfaktor": 1.047263
+    },
+    {
+      "dato": "2010-05",
+      "grunnbeløp": 75641,
+      "grunnbeløpPerMåned": 6303,
+      "omregningsfaktor": 1.03787
+    },
+    {
+      "dato": "2009-05",
+      "grunnbeløp": 72881,
+      "grunnbeløpPerMåned": 6073,
+      "omregningsfaktor": 1.037363
+    },
+    {
+      "dato": "2008-05",
+      "grunnbeløp": 70256,
+      "grunnbeløpPerMåned": 5855,
+      "omregningsfaktor": 1.051548
+    },
+    {
+      "dato": "2007-05",
+      "grunnbeløp": 66812,
+      "grunnbeløpPerMåned": 5568,
+      "omregningsfaktor": 1.062329
+    },
+    {
+      "dato": "2006-05",
+      "grunnbeløp": 62892,
+      "grunnbeløpPerMåned": 5241,
+      "omregningsfaktor": 1.036129
+    },
+    {
+      "dato": "2005-05",
+      "grunnbeløp": 60699,
+      "grunnbeløpPerMåned": 5058,
+      "omregningsfaktor": 1.032682
+    },
+    {
+      "dato": "2004-05",
+      "grunnbeløp": 58778,
+      "grunnbeløpPerMåned": 4898,
+      "omregningsfaktor": 1.033714
+    },
+    {
+      "dato": "2003-05",
+      "grunnbeløp": 56861,
+      "grunnbeløpPerMåned": 4738,
+      "omregningsfaktor": 1.049677
+    },
+    {
+      "dato": "2002-05",
+      "grunnbeløp": 54170,
+      "grunnbeløpPerMåned": 4514,
+      "omregningsfaktor": 1.054712
+    },
+    {
+      "dato": "2001-05",
+      "grunnbeløp": 51360,
+      "grunnbeløpPerMåned": 4280,
+      "omregningsfaktor": 1.046242
+    },
+    {
+      "dato": "2000-05",
+      "grunnbeløp": 49090,
+      "grunnbeløpPerMåned": 4091,
+      "omregningsfaktor": 1.04558
+    },
+    {
+      "dato": "1999-05",
+      "grunnbeløp": 46950,
+      "grunnbeløpPerMåned": 3913,
+      "omregningsfaktor": 1.034825
+    },
+    {
+      "dato": "1998-05",
+      "grunnbeløp": 45370,
+      "grunnbeløpPerMåned": 3781,
+      "omregningsfaktor": 1.067529
+    },
+    {
+      "dato": "1997-05",
+      "grunnbeløp": 42500,
+      "grunnbeløpPerMåned": 3542,
+      "omregningsfaktor": 1.036585
+    },
+    {
+      "dato": "1996-05",
+      "grunnbeløp": 41000,
+      "grunnbeløpPerMåned": 3417,
+      "omregningsfaktor": 1.045119
+    },
+    {
+      "dato": "1995-05",
+      "grunnbeløp": 39230,
+      "grunnbeløpPerMåned": 3269,
+      "omregningsfaktor": 1.0302
+    },
+    {
+      "dato": "1994-05",
+      "grunnbeløp": 38080,
+      "grunnbeløpPerMåned": 3173,
+      "omregningsfaktor": 1.020912
+    },
+    {
+      "dato": "1993-05",
+      "grunnbeløp": 37300,
+      "grunnbeløpPerMåned": 3108,
+      "omregningsfaktor": 1.021918
+    },
+    {
+      "dato": "1992-05",
+      "grunnbeløp": 36500,
+      "grunnbeløpPerMåned": 3042,
+      "omregningsfaktor": 1.028169
+    },
+    {
+      "dato": "1991-05",
+      "grunnbeløp": 35500,
+      "grunnbeløpPerMåned": 2958,
+      "omregningsfaktor": 1.041056
+    },
+    {
+      "dato": "1990-12",
+      "grunnbeløp": 34100,
+      "grunnbeløpPerMåned": 2842,
+      "omregningsfaktor": 1.002941
+    },
+    {
+      "dato": "1990-05",
+      "grunnbeløp": 34000,
+      "grunnbeløpPerMåned": 2833,
+      "omregningsfaktor": 1.039755
+    },
+    {
+      "dato": "1989-04",
+      "grunnbeløp": 32700,
+      "grunnbeløpPerMåned": 2725,
+      "omregningsfaktor": 1.054839
+    },
+    {
+      "dato": "1988-04",
+      "grunnbeløp": 31000,
+      "grunnbeløpPerMåned": 2583,
+      "omregningsfaktor": 1.019737
+    },
+    {
+      "dato": "1988-01",
+      "grunnbeløp": 30400,
+      "grunnbeløpPerMåned": 2533,
+      "omregningsfaktor": 1.016722
+    },
+    {
+      "dato": "1987-05",
+      "grunnbeløp": 29900,
+      "grunnbeløpPerMåned": 2492,
+      "omregningsfaktor": 1.067857
+    },
+    {
+      "dato": "1986-05",
+      "grunnbeløp": 28000,
+      "grunnbeløpPerMåned": 2333,
+      "omregningsfaktor": 1.064639
+    },
+    {
+      "dato": "1986-01",
+      "grunnbeløp": 26300,
+      "grunnbeløpPerMåned": 2192,
+      "omregningsfaktor": 1.015444
+    },
+    {
+      "dato": "1985-05",
+      "grunnbeløp": 25900,
+      "grunnbeløpPerMåned": 2158,
+      "omregningsfaktor": 1.070248
+    },
+    {
+      "dato": "1984-05",
+      "grunnbeløp": 24200,
+      "grunnbeløpPerMåned": 2017,
+      "omregningsfaktor": 1.070796
+    },
+    {
+      "dato": "1983-05",
+      "grunnbeløp": 22600,
+      "grunnbeløpPerMåned": 1883,
+      "omregningsfaktor": 1.036697
+    },
+    {
+      "dato": "1983-01",
+      "grunnbeløp": 21800,
+      "grunnbeløpPerMåned": 1817,
+      "omregningsfaktor": 1.028302
+    },
+    {
+      "dato": "1982-05",
+      "grunnbeløp": 21200,
+      "grunnbeløpPerMåned": 1767,
+      "omregningsfaktor": 1.081633
+    },
+    {
+      "dato": "1981-10",
+      "grunnbeløp": 19600,
+      "grunnbeløpPerMåned": 1633,
+      "omregningsfaktor": 1.026178
+    },
+    {
+      "dato": "1981-05",
+      "grunnbeløp": 19100,
+      "grunnbeløpPerMåned": 1592,
+      "omregningsfaktor": 1.097701
+    },
+    {
+      "dato": "1981-01",
+      "grunnbeløp": 17400,
+      "grunnbeløpPerMåned": 1450,
+      "omregningsfaktor": 1.029586
+    },
+    {
+      "dato": "1980-05",
+      "grunnbeløp": 16900,
+      "grunnbeløpPerMåned": 1408,
+      "omregningsfaktor": 1.049689
+    },
+    {
+      "dato": "1980-01",
+      "grunnbeløp": 16100,
+      "grunnbeløpPerMåned": 1342,
+      "omregningsfaktor": 1.059211
+    },
+    {
+      "dato": "1979-01",
+      "grunnbeløp": 15200,
+      "grunnbeløpPerMåned": 1267,
+      "omregningsfaktor": 1.034014
+    },
+    {
+      "dato": "1978-07",
+      "grunnbeløp": 14700,
+      "grunnbeløpPerMåned": 1225,
+      "omregningsfaktor": 1.020833
+    },
+    {
+      "dato": "1977-12",
+      "grunnbeløp": 14400,
+      "grunnbeløpPerMåned": 1200,
+      "omregningsfaktor": 1.074627
+    },
+    {
+      "dato": "1977-05",
+      "grunnbeløp": 13400,
+      "grunnbeløpPerMåned": 1117,
+      "omregningsfaktor": 1.022901
+    },
+    {
+      "dato": "1977-01",
+      "grunnbeløp": 13100,
+      "grunnbeløpPerMåned": 1092,
+      "omregningsfaktor": 1.082645
+    },
+    {
+      "dato": "1976-05",
+      "grunnbeløp": 12100,
+      "grunnbeløpPerMåned": 1008,
+      "omregningsfaktor": 1.025424
+    },
+    {
+      "dato": "1976-01",
+      "grunnbeløp": 11800,
+      "grunnbeløpPerMåned": 983,
+      "omregningsfaktor": 1.072727
+    },
+    {
+      "dato": "1975-05",
+      "grunnbeløp": 11000,
+      "grunnbeløpPerMåned": 917,
+      "omregningsfaktor": 1.057692
+    },
+    {
+      "dato": "1975-01",
+      "grunnbeløp": 10400,
+      "grunnbeløpPerMåned": 867,
+      "omregningsfaktor": 1.072165
+    },
+    {
+      "dato": "1974-05",
+      "grunnbeløp": 9700,
+      "grunnbeløpPerMåned": 808,
+      "omregningsfaktor": 1.054348
+    },
+    {
+      "dato": "1974-01",
+      "grunnbeløp": 9200,
+      "grunnbeløpPerMåned": 767,
+      "omregningsfaktor": 1.082353
+    },
+    {
+      "dato": "1973-01",
+      "grunnbeløp": 8500,
+      "grunnbeløpPerMåned": 708,
+      "omregningsfaktor": 1.075949
+    },
+    {
+      "dato": "1972-01",
+      "grunnbeløp": 7900,
+      "grunnbeløpPerMåned": 658,
+      "omregningsfaktor": 1.053333
+    },
+    {
+      "dato": "1971-05",
+      "grunnbeløp": 7500,
+      "grunnbeløpPerMåned": 625,
+      "omregningsfaktor": 1.041667
+    },
+    {
+      "dato": "1971-01",
+      "grunnbeløp": 7200,
+      "grunnbeløpPerMåned": 600,
+      "omregningsfaktor": 1.058824
+    },
+    {
+      "dato": "1970-01",
+      "grunnbeløp": 6800,
+      "grunnbeløpPerMåned": 567,
+      "omregningsfaktor": 1.0625
+    },
+    {
+      "dato": "1969-01",
+      "grunnbeløp": 6400,
+      "grunnbeløpPerMåned": 533,
+      "omregningsfaktor": 1.084746
+    },
+    {
+      "dato": "1968-01",
+      "grunnbeløp": 5900,
+      "grunnbeløpPerMåned": 492,
+      "omregningsfaktor": 1.092593
+    },
+    {
+      "dato": "1967-01",
+      "grunnbeløp": 5400,
+      "grunnbeløpPerMåned": 450
+    }
+  ]
+}


### PR DESCRIPTION
For å unngå for store omskrivinger, er det lagt til en ny json-fil for grunnbeløp som brukes i tester. Her legges det til et tenkt grunnbeløp frem i tid (mai 2024). Dette er gjort for å unngå å måtte gjøre alle beregninger som inkluderer komplekse utregninger av avkortinger + restanser for omstillingsstønad på nytt da disse tok utgangspunkt i 2023. Det ville vært en veldig omfattende jobb å beregne beløp i alle disse testene på nytt nå. 

Dette er ikke en optimal løsning da testene bør bruke samme fil for grunnbeløp som selve beregningene i produksjon.