### PR TITLE
EY-3209 Midlertidig bruke fordelt=true på OMS for å korrigere journalføring

### DIFF
--- a/apps/etterlatte-gyldig-soeknad/src/main/kotlin/gyldigsoeknad/omstillingsstoenad/InnsendtSoeknadRiver.kt
+++ b/apps/etterlatte-gyldig-soeknad/src/main/kotlin/gyldigsoeknad/omstillingsstoenad/InnsendtSoeknadRiver.kt
@@ -70,6 +70,7 @@ internal class InnsendtSoeknadRiver(
 
             context.publish(
                 packet.apply {
+                    set(FordelerFordelt.soeknadFordeltKey, true)
                     set(GyldigSoeknadVurdert.sakIdKey, sak.id)
                     set(GyldigSoeknadVurdert.behandlingIdKey, behandlingId)
                 }.toJson(),


### PR DESCRIPTION
Hører sammen med: 
https://github.com/navikt/pensjon-etterlatte/pull/949