### PR TITLE
Spesifikk tekst for 401 i StatusPages

### DIFF
--- a/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
@@ -65,6 +65,15 @@ class StatusPagesKonfigurasjon(private val sikkerLogg: Logger) {
                         ),
                     )
 
+                HttpStatusCode.Unauthorized ->
+                    call.respond(
+                        ForespoerselException(
+                            status = 401,
+                            code = "UNAUTHORIZED",
+                            detail = "Forespørselen er ikke autentisert",
+                        ),
+                    )
+
                 HttpStatusCode.Forbidden ->
                     call.respond(
                         IkkeTillattException(


### PR DESCRIPTION
For å unngå "ukjent" når man spør med utløpt token, og får
```
{
    "status": 401,
    "detail": "En ukjent feil oppstod",
    "code": "UNKNOWN_ERROR",
    "meta": null
}
```