### PR TITLE
Migrering - overstyr alltid ved flyktningerfordel.

### DIFF
--- a/apps/etterlatte-trygdetid-kafka/src/main/kotlin/MigreringHendelserRiver.kt
+++ b/apps/etterlatte-trygdetid-kafka/src/main/kotlin/MigreringHendelserRiver.kt
@@ -56,6 +56,9 @@ internal class MigreringHendelserRiver(
             if (request.dodAvYrkesskade) {
                 logger.info("Avdød hadde yrkesskade i Pesys, oppretter yrkesskadegrunnlag for behandling $behandlingId")
                 trygdetidService.opprettGrunnlagVedYrkesskade(behandlingId)
+            } else if (request.anvendtFlyktningerfordel()) {
+                logger.info("Avdød hadde flyktningerfordel i Pesys, overstyrer med samme trygdetid $behandlingId")
+                overstyrBeregnetTrygdetid(request, behandlingId)
             } else if (request.trygdetid.perioder.isNotEmpty()) {
                 logger.info("Mottok trygdetidsperioder for behandling $behandlingId")
                 leggTilPerioder(request, behandlingId)

--- a/libs/etterlatte-migrering-model/src/main/kotlin/no/nav/etterlatte/rapidsandrivers/migrering/MigreringRequest.kt
+++ b/libs/etterlatte-migrering-model/src/main/kotlin/no/nav/etterlatte/rapidsandrivers/migrering/MigreringRequest.kt
@@ -50,6 +50,12 @@ data class MigreringRequest(
     fun harMindreEnn40AarsTrygdetid(): Boolean {
         return beregning.anvendtTrygdetid < 40
     }
+
+    fun anvendtFlyktningerfordel(): Boolean {
+        return flyktningStatus &&
+            foersteVirkningstidspunkt < YearMonth.of(2021, 1) &&
+            beregning.anvendtTrygdetid == 40
+    }
 }
 
 data class AvdoedForelder(


### PR DESCRIPTION
Grunnlaget (flyktningstatus og første virk) blir allerede lagret ned på saken, slik at vi kan hente dette og vise frem senere i frontend.

EY-3126