### PR TITLE
EY-3191 Legger til utlandstilknytning i behandling (kun db migrering)

### DIFF
--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V78__legger_til_utlandstilknytning_behandling.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V78__legger_til_utlandstilknytning_behandling.sql
@@ -1,0 +1,8 @@
+ALTER TABLE behandling ADD COLUMN utlandstilknytning JSONB;
+
+-- Oppdaterer utlandstilknytning på alle behandlinger basert på verdi i sak
+UPDATE behandling
+SET utlandstilknytning = sakUtlandstilknytning.utenlandstilknytning::jsonb
+FROM (SELECT utenlandstilknytning, id FROM sak WHERE utenlandstilknytning IS NOT NULL) AS sakUtlandstilknytning
+WHERE sakUtlandstilknytning.id = sak_id
+AND behandling.status != 'AVBRUTT';


### PR DESCRIPTION
Tar ut database-endringene fra https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/2899. Gjør det enklere om vi evnt må gjøre rollback.

Oppretter nytt felt i behandling, og oppdaterer utlandstilknytning basert på verdien i sakene. Lar verdiene også ligge i sak inntil endringene er verifisert.