### PR TITLE
Endrer reguleringsflyten til kun å tilbakestille behandlinger vi ønsker å regulere.

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
@@ -14,6 +14,7 @@ import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.generellbehandling.GenerellBehandling
 import no.nav.etterlatte.libs.common.sak.SakIDListe
+import no.nav.etterlatte.libs.common.sak.Saker
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.token.BrukerTokenInfo
@@ -96,7 +97,7 @@ interface BehandlingStatusService {
         vedtakHendelse: VedtakHendelse,
     )
 
-    fun migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning(): SakIDListe
+    fun migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning(saker: Saker): SakIDListe
 }
 
 class BehandlingStatusServiceImpl(
@@ -272,12 +273,12 @@ class BehandlingStatusServiceImpl(
         }
     }
 
-    override fun migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning() =
+    override fun migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning(saker: Saker) =
         inTransaction {
-            behandlingDao.migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning()
+            behandlingDao.migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning(saker)
         }
 
-    fun registrerVedtakHendelse(
+    private fun registrerVedtakHendelse(
         behandlingId: UUID,
         vedtakHendelse: VedtakHendelse,
         hendelseType: HendelseType,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
@@ -13,6 +13,7 @@ import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.behandlingId
 import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
+import no.nav.etterlatte.libs.common.sak.Saker
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.tilgangsstyring.kunAttestant
 import no.nav.etterlatte.vedtaksvurdering.VedtakHendelse
@@ -153,8 +154,9 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
 
     route("/behandlinger") {
         post("/settTilbakeTilTrygdetidOppdatert") {
+            val saker = call.receive<Saker>()
             val tilbakestilteBehandlinger =
-                behandlingsstatusService.migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning()
+                behandlingsstatusService.migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning(saker)
             call.respond(tilbakestilteBehandlinger)
         }
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoReguleringTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoReguleringTest.kt
@@ -1,12 +1,15 @@
 package no.nav.etterlatte.behandling
 
+import io.kotest.matchers.collections.shouldContainExactly
 import no.nav.etterlatte.behandling.domain.Foerstegangsbehandling
+import no.nav.etterlatte.behandling.domain.OpprettBehandling
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeDao
 import no.nav.etterlatte.behandling.revurdering.RevurderingDao
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.sak.Saker
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.database.POSTGRES_VERSION
 import no.nav.etterlatte.libs.database.migrate
@@ -16,6 +19,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -70,13 +74,13 @@ internal class BehandlingDaoReguleringTest {
     )
     @MethodSource("hentMigrerbareStatuses")
     fun `behandlinger som er beregnet maa beregnes paa nytt`(status: BehandlingStatus) {
-        val sak = sakRepo.opprettSak("123", SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr).id
+        val sak = sakRepo.opprettSak("123", SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr)
         val opprettBehandling =
-            opprettBehandling(type = BehandlingType.FØRSTEGANGSBEHANDLING, sakId = sak, status = status)
-
+            opprettBehandling(type = BehandlingType.FØRSTEGANGSBEHANDLING, sakId = sak.id, status = status)
         behandlingRepo.opprettBehandling(opprettBehandling)
+
         val trengerNyBeregning =
-            behandlingRepo.migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning()
+            behandlingRepo.migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning(Saker(listOf(sak)))
 
         with(behandlingRepo.hentBehandling(opprettBehandling.id)) {
             val expected = BehandlingStatus.TRYGDETID_OPPDATERT
@@ -84,7 +88,41 @@ internal class BehandlingDaoReguleringTest {
 
             assertEquals(expected, actual)
         }
-        assertEquals(listOf(opprettBehandling.id), trengerNyBeregning.behandlingerForSak(sak))
+        assertEquals(listOf(opprettBehandling.id), trengerNyBeregning.behandlingerForSak(sak.id))
+    }
+
+    @Test
+    fun `Kun behandlinger som er sendt inn skal tilbakestilles`() {
+        val relevantSak = sakRepo.opprettSak("123", SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr)
+        val ikkeRelevantSak = sakRepo.opprettSak("321", SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr)
+        val sakOgBehandling: List<OpprettBehandling> =
+            listOf(relevantSak, ikkeRelevantSak).map {
+                val opprettBehandling =
+                    opprettBehandling(
+                        type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                        sakId = it.id,
+                        status = BehandlingStatus.BEREGNET,
+                    )
+
+                return behandlingRepo.opprettBehandling(opprettBehandling)
+            }
+
+        val trengerNyBeregning =
+            behandlingRepo.migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning(Saker(listOf(relevantSak)))
+
+        trengerNyBeregning.ider.map { it.sakId } shouldContainExactly listOf(relevantSak.id)
+        with(behandlingRepo.hentBehandling(sakOgBehandling.find { it.sakId == relevantSak.id }!!.id)) {
+            val expected = BehandlingStatus.TRYGDETID_OPPDATERT
+            val actual = (this as Foerstegangsbehandling).status
+
+            assertEquals(expected, actual)
+        }
+        with(behandlingRepo.hentBehandling(sakOgBehandling.find { it.sakId == ikkeRelevantSak.id }!!.id)) {
+            val expected = BehandlingStatus.BEREGNET
+            val actual = (this as Foerstegangsbehandling).status
+
+            assertEquals(expected, actual)
+        }
     }
 
     private fun hentStatuser() = BehandlingStatus.skalIkkeOmregnesVedGRegulering()
@@ -92,12 +130,12 @@ internal class BehandlingDaoReguleringTest {
     @ParameterizedTest(name = "behandling med status {0} skal fortsette aa ha samme status ved migrering")
     @MethodSource("hentStatuser")
     fun `irrelevante behandlinger skal ikke endre status ved migrering`(status: BehandlingStatus) {
-        val sak = sakRepo.opprettSak("123", SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr).id
+        val sak = sakRepo.opprettSak("123", SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr)
         val opprettBehandling =
-            opprettBehandling(type = BehandlingType.FØRSTEGANGSBEHANDLING, sakId = sak, status = status)
-
+            opprettBehandling(type = BehandlingType.FØRSTEGANGSBEHANDLING, sakId = sak.id, status = status)
         behandlingRepo.opprettBehandling(opprettBehandling)
-        behandlingRepo.migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning()
+
+        behandlingRepo.migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning(Saker(listOf(sak)))
 
         with(behandlingRepo.hentBehandling(opprettBehandling.id)) {
             val expected = status

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/BehandlingService.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/BehandlingService.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte
 
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
@@ -46,7 +45,7 @@ interface BehandlingService {
 
     fun opprettOmregning(omregningshendelse: Omregningshendelse): OpprettOmregningResponse
 
-    fun migrerAlleTempBehandlingerTilbakeTilTrygdetidOppdatert(): SakIDListe
+    fun migrerAlleTempBehandlingerTilbakeTilTrygdetidOppdatert(saker: Saker): SakIDListe
 
     fun migrer(hendelse: MigreringRequest): BehandlingOgSak
 
@@ -140,10 +139,11 @@ class BehandlingServiceImpl(
         }
     }
 
-    override fun migrerAlleTempBehandlingerTilbakeTilTrygdetidOppdatert(): SakIDListe {
+    override fun migrerAlleTempBehandlingerTilbakeTilTrygdetidOppdatert(saker: Saker): SakIDListe {
         return runBlocking {
             behandlingKlient.post("$url/behandlinger/settTilbakeTilTrygdetidOppdatert") {
                 contentType(ContentType.Application.Json)
+                setBody(saker)
             }.body()
         }
     }
@@ -157,9 +157,12 @@ class BehandlingServiceImpl(
         }
 
     override fun hentAlleSaker(): Saker =
-        runBlocking {
-            behandlingKlient.get("$url/saker").body()
-        }
+        // For å regne om ytelsene til nytt regelverk ønsker vi kun å omregne saker som ikke kommer fra migrering
+        // Kommenterer ut kall til behandling midlertidig for å håndtere dette manuelt.
+//        runBlocking {
+//            behandlingKlient.get("$url/saker").body()
+//        }
+        Saker(emptyList())
 
     override fun avbryt(behandlingId: UUID) =
         runBlocking {

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/ReguleringsforespoerselRiver.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/ReguleringsforespoerselRiver.kt
@@ -40,14 +40,18 @@ internal class ReguleringsforespoerselRiver(
             return
         }
 
+        val sakerTilOmregning = behandlingService.hentAlleSaker()
+
         val tilbakemigrerte =
-            behandlingService.migrerAlleTempBehandlingerTilbakeTilTrygdetidOppdatert().also { sakIdListe ->
-                logger.info(
-                    "Tilbakemigrert ${sakIdListe.ider.size} behandlinger:\n" +
-                        sakIdListe.ider.joinToString("\n") { "Sak ${it.sakId} - ${it.behandlingId}" },
-                )
-            }
-        behandlingService.hentAlleSaker().saker.forEach {
+            behandlingService.migrerAlleTempBehandlingerTilbakeTilTrygdetidOppdatert(sakerTilOmregning)
+                .also { sakIdListe ->
+                    logger.info(
+                        "Tilbakemigrert ${sakIdListe.ider.size} behandlinger:\n" +
+                            sakIdListe.ider.joinToString("\n") { "Sak ${it.sakId} - ${it.behandlingId}" },
+                    )
+                }
+
+        sakerTilOmregning.saker.forEach {
             packet.eventName = FINN_LOEPENDE_YTELSER
             packet.tilbakestilteBehandlinger = tilbakemigrerte.behandlingerForSak(it.id)
             packet.sakId = it.id

--- a/apps/etterlatte-oppdater-behandling/src/test/kotlin/regulering/ReguleringsforespoerselRiverTest.kt
+++ b/apps/etterlatte-oppdater-behandling/src/test/kotlin/regulering/ReguleringsforespoerselRiverTest.kt
@@ -38,7 +38,7 @@ internal class ReguleringsforespoerselRiverTest {
         )
 
     @Test
-    fun `kan ta imot reguleringsmelding og kalle på behandling`() {
+    fun `kan ta imot reguleringsmelding og kalle paa behandling`() {
         val melding = genererReguleringMelding(foersteMai2023)
         val vedtakServiceMock = mockk<BehandlingService>(relaxed = true)
         val featureToggleService = mockk<FeatureToggleService>().also { every { it.isEnabled(any(), any()) } returns true }
@@ -46,7 +46,7 @@ internal class ReguleringsforespoerselRiverTest {
 
         inspector.sendTestMessage(melding.toJson())
         verify(exactly = 1) {
-            vedtakServiceMock.migrerAlleTempBehandlingerTilbakeTilTrygdetidOppdatert()
+            vedtakServiceMock.migrerAlleTempBehandlingerTilbakeTilTrygdetidOppdatert(any())
             vedtakServiceMock.hentAlleSaker()
         }
     }
@@ -114,7 +114,7 @@ internal class ReguleringsforespoerselRiverTest {
             )
         val behandlingId1 = UUID.randomUUID()
         val behandlingId2 = UUID.randomUUID()
-        every { behandlingServiceMock.migrerAlleTempBehandlingerTilbakeTilTrygdetidOppdatert() } returns
+        every { behandlingServiceMock.migrerAlleTempBehandlingerTilbakeTilTrygdetidOppdatert(any()) } returns
             SakIDListe(
                 listOf(BehandlingOgSak(behandlingId1, sakId), BehandlingOgSak(behandlingId2, sakId)),
             )
@@ -132,7 +132,7 @@ internal class ReguleringsforespoerselRiverTest {
         val melding = genererReguleringMelding(foersteMai2023)
         val behandlingServiceMock = mockk<BehandlingService>(relaxed = true)
         coEvery {
-            behandlingServiceMock.migrerAlleTempBehandlingerTilbakeTilTrygdetidOppdatert()
+            behandlingServiceMock.migrerAlleTempBehandlingerTilbakeTilTrygdetidOppdatert(any())
         } throws RuntimeException("feil")
 
         val featureToggleService = mockk<FeatureToggleService>().also { every { it.isEnabled(any(), any()) } returns true }

--- a/jobs/start-regulering/src/main/kotlin/Application.kt
+++ b/jobs/start-regulering/src/main/kotlin/Application.kt
@@ -11,7 +11,8 @@ import java.util.UUID
 import kotlin.system.exitProcess
 
 /** 1e mai 2023 */
-val GRUNNBELOEP_REGULERING_DATO: LocalDate = LocalDate.of(2023, 5, 1)
+val REGELVERK_OMREGNING_2024: LocalDate = LocalDate.of(2024, 1, 1)
+// val GRUNNBELOEP_REGULERING_DATO: LocalDate = LocalDate.of(2023, 5, 1)
 
 val logger: Logger = LoggerFactory.getLogger("StartReguleringJob")
 
@@ -25,7 +26,7 @@ fun main() {
 
     producer.publiser(
         noekkel = "StartReguleringJob-${UUID.randomUUID()}",
-        verdi = createRecord(GRUNNBELOEP_REGULERING_DATO),
+        verdi = createRecord(REGELVERK_OMREGNING_2024),
     )
     producer.close()
 


### PR DESCRIPTION
Legger også opp til en manuell liste av sakIder istedet for å hente alt fra behandling.