### PR TITLE
Slår på grensesnitts- og konsistensavstemming for OMS i prod

### DIFF
--- a/apps/etterlatte-utbetaling/.nais/prod.yaml
+++ b/apps/etterlatte-utbetaling/.nais/prod.yaml
@@ -74,9 +74,9 @@ spec:
     - name: KONSISTENSAVSTEMMING_ENABLED
       value: "true"
     - name: GRENSESNITTAVSTEMMING_OMS_ENABLED
-      value: "false"
+      value: "true"
     - name: KONSISTENSAVSTEMMING_OMS_ENABLED
-      value: "false"
+      value: "true"
   accessPolicy:
     outbound:
       external:


### PR DESCRIPTION
Må ha på plass grensesnittsavstemming før vi gjør første vedtak for OMS.

Konsistensavstemming blir ikke kjørt før 4. januar, men skrur på denne også.