### PR TITLE
EY-3250: Setter hverken orgnummer eller fnr på verges samhandleradresse

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
@@ -126,8 +126,8 @@ class BrevRepository(private val ds: DataSource) {
                 OPPDATER_MOTTAKER_QUERY,
                 mapOf(
                     "brev_id" to id,
-                    "foedselsnummer" to mottaker.foedselsnummer?.value,
-                    "orgnummer" to mottaker.orgnummer,
+                    "foedselsnummer" to mottaker.foedselsnummer?.value?.let { it.ifBlank { null } },
+                    "orgnummer" to mottaker.orgnummer?.let { it.ifBlank { null } },
                     "navn" to mottaker.navn,
                     "adressetype" to mottaker.adresse.adresseType,
                     "adresselinje1" to mottaker.adresse.adresselinje1,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -46,9 +46,6 @@ data class Mottaker(
     val adresse: Adresse,
 ) {
     init {
-        require(foedselsnummer != null || orgnummer != null) {
-            "Fødselsnummer eller orgnummer må være spesifisert"
-        }
         require(navn.isNotBlank()) {
             "Navn på mottaker må være satt"
         }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/VergeService.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/VergeService.kt
@@ -7,7 +7,6 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.BrevMottaker
-import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.person.Person
 import no.nav.etterlatte.libs.common.person.VergemaalEllerFremtidsfullmakt
 import no.nav.etterlatte.libs.common.person.hentRelevantVerge
@@ -65,10 +64,7 @@ class VergeService(
         relevantVerge: VergemaalEllerFremtidsfullmakt,
     ): BrevMottaker {
         val pdlVergeFoedselsnummer = relevantVerge.vergeEllerFullmektig.motpartsPersonident!!.value
-        return vergesAdresseInfo.tilFrittstaendeBrevMottaker()
-            .copy(
-                foedselsnummer = MottakerFoedselsnummer(pdlVergeFoedselsnummer),
-            )
+        return vergesAdresseInfo.tilFrittstaendeBrevMottaker(pdlVergeFoedselsnummer)
     }
 
     private fun BrevMottaker.tilGrunnlagsopplysning(registersReferanse: String?): Grunnlagsopplysning<BrevMottaker> =

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/adresse/PersondataAdresse.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/adresse/PersondataAdresse.kt
@@ -24,7 +24,7 @@ sealed class PersondataAdresse(
 ) {
     /**
      * Med frittstående menes at adressen skal kunne brukes til å adressere bare denne personen, uten c/o. */
-    abstract fun tilFrittstaendeBrevMottaker(): BrevMottaker
+    abstract fun tilFrittstaendeBrevMottaker(foedselsnummer: String): BrevMottaker
 }
 
 data class VergeSamhandlerFormat(
@@ -41,11 +41,11 @@ data class VergeSamhandlerFormat(
 ) : PersondataAdresse("VERGE_SAMHANDLER_POSTADRESSE", adresselinjer, adresseString) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    override fun tilFrittstaendeBrevMottaker(): BrevMottaker {
+    override fun tilFrittstaendeBrevMottaker(foedselsnummer: String): BrevMottaker {
         logger.debug("Tolker ${this::class.simpleName}, med landkode: ${landkode.quoted}, land: ${land.quoted}")
         return BrevMottaker(
             navn = navn ?: "Ukjent",
-            foedselsnummer = null,
+            foedselsnummer = null, // Brevmottaker skal hverken ha fnr eller orgnummer
             adresse =
                 MottakerAdresse(
                     adresseType = adressetypeFromLand(landkode, land),
@@ -69,10 +69,10 @@ data class VergePersonFormat(
     val vergePid: String,
     val navn: String?,
 ) : PersondataAdresse("VERGE_PERSON_POSTADRESSE", adresselinjer, adresseString) {
-    override fun tilFrittstaendeBrevMottaker(): BrevMottaker {
+    override fun tilFrittstaendeBrevMottaker(foedselsnummer: String): BrevMottaker {
         return BrevMottaker(
             navn = navn ?: "Ukjent",
-            foedselsnummer = MottakerFoedselsnummer(vergePid),
+            foedselsnummer = MottakerFoedselsnummer(foedselsnummer),
             adresse =
                 MottakerAdresse(
                     adresseType = adressetypeFromLand(adresse.landkode, adresse.land),
@@ -96,10 +96,10 @@ data class RegoppslagFormat(
     val navn: String?,
 ) :
     PersondataAdresse("REGOPPSLAG_ADRESSE", adresselinjer, adresseString) {
-    override fun tilFrittstaendeBrevMottaker(): BrevMottaker {
+    override fun tilFrittstaendeBrevMottaker(foedselsnummer: String): BrevMottaker {
         return BrevMottaker(
             navn = navn ?: "Ukjent",
-            foedselsnummer = null,
+            foedselsnummer = MottakerFoedselsnummer(foedselsnummer),
             adresse =
                 MottakerAdresse(
                     adresseType = adressetypeFromLand(adresse.landkode, adresse.land),

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagHenterTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagHenterTest.kt
@@ -83,7 +83,7 @@ class GrunnlagHenterTest {
         } returns grunnlagTestData.hentPersonGalleri()
 
         val persondataAdresseVerge = mockk<PersondataAdresse>()
-        every { persondataAdresseVerge.tilFrittstaendeBrevMottaker() } returns sampleVergeAdresse()
+        every { persondataAdresseVerge.tilFrittstaendeBrevMottaker(any()) } returns sampleVergeAdresse()
         every {
             vergeService.hentGrunnlagsopplysningVergesAdresse(grunnlagTestData.soeker)
         } returns grunnlagsopplysningVergesAdresse()

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/detaljer/MottakerPanel.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/detaljer/MottakerPanel.tsx
@@ -54,12 +54,14 @@ export default function MottakerPanel({
           label="Adresse"
           tekst={
             <>
-              {[adresse?.adresselinje1, adresse?.adresselinje2, adresse?.adresselinje3].map((linje) => (
-                <>
-                  {linje}
-                  <br />
-                </>
-              ))}
+              {[adresse?.adresselinje1, adresse?.adresselinje2, adresse?.adresselinje3]
+                .filter((linje) => linje != null)
+                .map((linje) => (
+                  <>
+                    {linje}
+                    <br />
+                  </>
+                ))}
               <br />
               {adresse?.postnummer} {adresse?.poststed}
               <br />


### PR DESCRIPTION
Sletter krav om at enten orgnr eller fnr må finnes i en BrevMottaker. Kan gjeninnføres hvis/når vi får orgnummer på samhandlere.

Fikser også adressevisning i mottaker-panel.