### PR TITLE
Justert ned cpu for vilkårsvurdering

### DIFF
--- a/apps/etterlatte-vilkaarsvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vilkaarsvurdering/.nais/dev.yaml
@@ -44,7 +44,10 @@ spec:
           - id: dbe4ad45-320b-4e9a-aaa1-73cca4ee124d # 0000-GA-Egne_ansatte
         extra:
           - NAVident
-
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 4

--- a/apps/etterlatte-vilkaarsvurdering/.nais/prod.yaml
+++ b/apps/etterlatte-vilkaarsvurdering/.nais/prod.yaml
@@ -54,7 +54,10 @@ spec:
           - id: e750ceb5-b70b-4d94-b4fa-9d22467b786b # 0000-GA-Egne_ansatte
         extra:
           - NAVident
-
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 4


### PR DESCRIPTION
Bør være _veldig_ trygt iht nais console. Default er `200m`, https://docs.nais.io/nais-application/application/#resourcesrequestscpu.