### PR TITLE
Inbound krakend trengs ikke å spesifiseres i nais.yaml

### DIFF
--- a/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
@@ -96,7 +96,6 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: etterlatte-krakend
         - application: pensjon-pen-q0
           namespace: pensjon-q0
           cluster: dev-fss

--- a/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
@@ -94,7 +94,6 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: etterlatte-krakend
         - application: pensjon-pen
           namespace: pensjondeployer
           cluster: prod-fss


### PR DESCRIPTION
> Jeg har fått gjennom kall via GW til faktisk app med bruk av appens ingress i apiendpoints-oppsettet, men ikke ved bruk av http://<app-name>. Har åpnet opp i appen for innkommende fra etterlatte-krakend. Er det noe mangel på å åpne opp på krakend-siden for utgående til appen?


Tommy Trøen:

> _det skal settes opp automatisk netpol basert på appName  i apiendpoints specen, dvs der må du ha det samme navnet som appen du spesifiserer i http//app-name. mulig vi kan lage noe logikk som gjør at vi kan fjerne appName fra specen også hvis det ikke er så tydelig_

https://nav-it.slack.com/archives/C02C9GJP17D/p1698225646227899?thread_ts=1697806246.535379&cid=C02C9GJP17D