### PR TITLE
EY-3269 Legger til revurderingsårsak for opphør uten brev

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -116,7 +116,7 @@ internal fun Application.module(context: ApplicationContext) {
                 generellBehandlingService = generellBehandlingService,
                 sakService = sakService,
             )
-            revurderingRoutes(revurderingService = revurderingService)
+            revurderingRoutes(revurderingService = revurderingService, featureToggleService = featureToggleService)
             omregningRoutes(omregningService = omregningService)
             migreringRoutes(migreringService = migreringService)
             bosattUtlandRoutes(bosattUtlandService = bosattUtlandService)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
@@ -23,7 +23,7 @@ import no.nav.etterlatte.libs.common.kunSaksbehandler
 import no.nav.etterlatte.libs.common.medBody
 import no.nav.etterlatte.libs.common.sakId
 
-enum class BehandlingStatusServiceFeatureToggle(private val key: String) : FeatureToggle {
+enum class RevurderingRoutesFeatureToggle(private val key: String) : FeatureToggle {
     VisRevurderingsaarsakOpphoerUtenBrev("pensjon-etterlatte.vis-opphoer-uten-brev"),
     ;
 
@@ -103,7 +103,7 @@ internal fun Route.revurderingRoutes(
                     .filter {
                         if (it == Revurderingaarsak.OPPHOER_UTEN_BREV) {
                             featureToggleService.isEnabled(
-                                BehandlingStatusServiceFeatureToggle.VisRevurderingsaarsakOpphoerUtenBrev,
+                                RevurderingRoutesFeatureToggle.VisRevurderingsaarsakOpphoerUtenBrev,
                                 false,
                             )
                         } else {

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingRoutesTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import testsupport.buildTestApplicationConfigurationForOauth
@@ -46,10 +47,13 @@ internal class RevurderingRoutesTest {
                 every { harTilgangTilBehandling(any(), any()) } returns true
                 every { harTilgangTilSak(any(), any()) } returns true
             }
+    }
 
+    @BeforeEach
+    fun beforeEach() {
         every {
             applicationContext.featureToggleService.isEnabled(RevurderingRoutesFeatureToggle.VisRevurderingsaarsakOpphoerUtenBrev, any())
-        } returns false
+        } returns true
     }
 
     @AfterAll
@@ -191,7 +195,6 @@ internal class RevurderingRoutesTest {
                 }
 
             val revurderingAarsak: List<Revurderingaarsak> = response.body()
-            println(revurderingAarsak)
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(
                 revurderingAarsak.containsAll(

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingRoutesTest.kt
@@ -15,6 +15,7 @@ import io.ktor.server.testing.testApplication
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.etterlatte.behandling.revurdering.OpprettRevurderingRequest
+import no.nav.etterlatte.behandling.revurdering.RevurderingRoutesFeatureToggle
 import no.nav.etterlatte.config.ApplicationContext
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -46,7 +47,9 @@ internal class RevurderingRoutesTest {
                 every { harTilgangTilSak(any(), any()) } returns true
             }
 
-        every { applicationContext.featureToggleService.isEnabled(any(), any()) } returns true
+        every {
+            applicationContext.featureToggleService.isEnabled(RevurderingRoutesFeatureToggle.VisRevurderingsaarsakOpphoerUtenBrev, any())
+        } returns false
     }
 
     @AfterAll
@@ -167,7 +170,9 @@ internal class RevurderingRoutesTest {
 
     @Test
     fun `returnerer ikke revurderingsaarsak opphoer uten brev dersom feature toggle er av`() {
-        every { applicationContext.featureToggleService.isEnabled(any(), any()) } returns false
+        every {
+            applicationContext.featureToggleService.isEnabled(RevurderingRoutesFeatureToggle.VisRevurderingsaarsakOpphoerUtenBrev, any())
+        } returns false
 
         testApplication {
             environment { config = hoconApplicationConfig }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.ts
@@ -94,7 +94,10 @@ export const behandlingSkalSendeBrev = (
     case IBehandlingsType.REVURDERING:
       return !(
         //revurderingsaarsak === Revurderingaarsak.REGULERING || TODO EY-3232 Fjern utkommentering
-        (revurderingsaarsak === Revurderingaarsak.DOEDSFALL)
+        (
+          revurderingsaarsak === Revurderingaarsak.DOEDSFALL ||
+          revurderingsaarsak === Revurderingaarsak.OPPHOER_UTEN_BREV
+        )
       )
   }
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Revurderingaarsak.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Revurderingaarsak.ts
@@ -20,6 +20,7 @@ export enum Revurderingaarsak {
   INSTITUSJONSOPPHOLD = 'INSTITUSJONSOPPHOLD',
   OMGJOERING_ETTER_KLAGE = 'OMGJOERING_ETTER_KLAGE',
   SLUTTBEHANDLING_UTLAND = 'SLUTTBEHANDLING_UTLAND',
+  OPPHOER_UTEN_BREV = 'OPPHOER_UTEN_BREV',
 }
 
 export const tekstRevurderingsaarsak: Record<Revurderingaarsak, string> = {
@@ -42,6 +43,7 @@ export const tekstRevurderingsaarsak: Record<Revurderingaarsak, string> = {
   INSTITUSJONSOPPHOLD: 'Institusjonsopphold',
   OMGJOERING_ETTER_KLAGE: 'Omgjøring etter klage',
   SLUTTBEHANDLING_UTLAND: 'Sluttbehandling utland',
+  OPPHOER_UTEN_BREV: 'Opphør uten å sende brev',
 } as const
 
 export const erOpphoer = (revurderingsaarsak: Revurderingaarsak) =>
@@ -50,4 +52,5 @@ export const erOpphoer = (revurderingsaarsak: Revurderingaarsak) =>
     Revurderingaarsak.ADOPSJON,
     Revurderingaarsak.OMGJOERING_AV_FARSKAP,
     Revurderingaarsak.SIVILSTAND,
+    Revurderingaarsak.OPPHOER_UTEN_BREV,
   ].includes(revurderingsaarsak)

--- a/libs/saksbehandling-common/src/main/kotlin/behandling/Revurderingaarsak.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/behandling/Revurderingaarsak.kt
@@ -84,6 +84,7 @@ enum class Revurderingaarsak(
     YRKESSKADE(SAKTYPE_BP_OMS, KunIDev, IkkeOpphoerSkalSendeBrev, redigerbartBrev = true),
     OMGJOERING_ETTER_KLAGE(SAKTYPE_BP_OMS, KunIDev, IkkeOpphoerSkalSendeBrev, redigerbartBrev = true),
     SLUTTBEHANDLING_UTLAND(SAKTYPE_BP_OMS, KunIDev, IkkeOpphoerSkalSendeBrev, redigerbartBrev = true),
+    OPPHOER_UTEN_BREV(SAKTYPE_BP_OMS, KunIDev, OpphoerUtenBrev),
     ;
 
     fun kanBrukesIMiljo(): Boolean =


### PR DESCRIPTION
Denne skal brukes for å opphøre sak(er) fra som har blitt migrert fra pesys, men har etterpå blitt opphørt i pesys og dermed aldri skulle vært i Gjenny.

Dette er kun backend. Kommer en frontend-endring som kun viser denne revurderingsårsaken dersom saksbehandler er intern.