### PR TITLE
Migrering skal sette rett prosesstype + oppdater behandlinger som er feil

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringService.kt
@@ -15,6 +15,7 @@ import no.nav.etterlatte.libs.common.behandling.Flyktning
 import no.nav.etterlatte.libs.common.behandling.JaNei
 import no.nav.etterlatte.libs.common.behandling.JaNeiMedBegrunnelse
 import no.nav.etterlatte.libs.common.behandling.KommerBarnetTilgode
+import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Utlandstilknytning
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -137,10 +138,11 @@ class MigreringService(
         request: MigreringRequest,
         sak: Sak,
     ) = behandlingFactory.opprettBehandling(
-        sak.id,
-        request.opprettPersongalleri(),
-        null,
-        Vedtaksloesning.PESYS,
+        sakId = sak.id,
+        persongalleri = request.opprettPersongalleri(),
+        mottattDato = null,
+        kilde = Vedtaksloesning.PESYS,
+        prosessType = Prosesstype.AUTOMATISK,
     )
 
     private fun finnEllerOpprettSak(request: MigreringRequest) =

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/v81__sett_riktig_prosesstype_migrerte_saker.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/v81__sett_riktig_prosesstype_migrerte_saker.sql
@@ -1,0 +1,8 @@
+UPDATE behandling
+SET prosesstype = 'AUTOMATISK'
+WHERE kilde = 'PESYS'
+  AND behandlingstype = 'FØRSTEGANGSBEHANDLING'
+  AND virkningstidspunkt::JSONB -> 'kilde' ->> 'ident' = 'PESYS'
+  AND virkningstidspunkt::JSONB ->> 'begrunnelse' = 'Automatisk importert fra Pesys'
+  AND virkningstidspunkt::JSONB ->>'dato' = '2024-01'
+  AND prosesstype = 'MANUELL';

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/migrering/MigreringRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/migrering/MigreringRoutesTest.kt
@@ -14,6 +14,7 @@ import io.ktor.server.testing.testApplication
 import no.nav.etterlatte.BehandlingIntegrationTest
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
+import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.sak.BehandlingOgSak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
@@ -93,6 +94,7 @@ class MigreringRoutesTest : BehandlingIntegrationTest() {
                 }.body<DetaljertBehandling>()
 
             Assertions.assertEquals(YearMonth.of(2024, 1), behandling.virkningstidspunkt!!.dato)
+            Assertions.assertEquals(Prosesstype.AUTOMATISK, behandling.prosesstype)
 
             client.get("/saker/${behandling.sak}") {
                 addAuthToken(tokenSaksbehandler)


### PR DESCRIPTION
Vi har p.t over 10.000 saker som ligger med prosesstype `MANUELL` som burde vært tagget som `AUTOMATISK`.