### PR TITLE
Fikser 1 time mismatch i teknisk tid for iverksatte vedtak

### DIFF
--- a/apps/etterlatte-statistikk/src/main/resources/db/migration/V31__fiks_mismatch_automatisk_iverksatte_vedtak.sql
+++ b/apps/etterlatte-statistikk/src/main/resources/db/migration/V31__fiks_mismatch_automatisk_iverksatte_vedtak.sql
@@ -1,0 +1,7 @@
+update sak s
+set teknisk_tid = s.teknisk_tid + interval '1 hour'
+where s.behandling_status = 'IVERKSATT'
+  and s.saksbehandler = 'EY'
+  and s.teknisk_tid < (select s2.teknisk_tid
+                       from sak s2
+                       where s2.behandling_status = 'ATTESTERT' and s.behandling_id = s2.behandling_id);


### PR DESCRIPTION
Jeg ser ikke helt hvorfor dette skjer kun med den automatiske vedtaksriveren, men det blir feil kontra vedtakene som er sendt ut derifra (men ikke i vanlig behandlingsflyt). Tar gjerne imot innspill 😅 