### PR TITLE
Quote image template so that nais validate doesn't error out

### DIFF
--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   ingresses:
     - "https://etterlatte-behandling.intern.dev.nav.no"

--- a/apps/etterlatte-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-behandling/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   gcp:
     sqlInstances:

--- a/apps/etterlatte-beregning-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-beregning-kafka/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-beregning-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-beregning-kafka/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-beregning/.nais/dev.yaml
+++ b/apps/etterlatte-beregning/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   ingresses:
     - "https://etterlatte-beregning.intern.dev.nav.no"

--- a/apps/etterlatte-beregning/.nais/prod.yaml
+++ b/apps/etterlatte-beregning/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-brev-api/.nais/dev.yaml
+++ b/apps/etterlatte-brev-api/.nais/dev.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     reloader.stakater.com/match: "true"
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   ingresses:
     - "https://etterlatte-brev-api.intern.dev.nav.no"

--- a/apps/etterlatte-brev-api/.nais/prod.yaml
+++ b/apps/etterlatte-brev-api/.nais/prod.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     reloader.stakater.com/match: "true"
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-egne-ansatte-lytter/.nais/dev.yaml
+++ b/apps/etterlatte-egne-ansatte-lytter/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-egne-ansatte-lytter/.nais/prod.yaml
+++ b/apps/etterlatte-egne-ansatte-lytter/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-fordeler/.nais/dev.yaml
+++ b/apps/etterlatte-fordeler/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-fordeler/.nais/prod.yaml
+++ b/apps/etterlatte-fordeler/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-grunnlag/.nais/dev.yaml
+++ b/apps/etterlatte-grunnlag/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   ingresses:
     - https://etterlatte-grunnlag.intern.dev.nav.no

--- a/apps/etterlatte-grunnlag/.nais/prod.yaml
+++ b/apps/etterlatte-grunnlag/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   gcp:
     sqlInstances:

--- a/apps/etterlatte-gyldig-soeknad/.nais/dev.yaml
+++ b/apps/etterlatte-gyldig-soeknad/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   azure:
     application:

--- a/apps/etterlatte-gyldig-soeknad/.nais/prod.yaml
+++ b/apps/etterlatte-gyldig-soeknad/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   azure:
     application:

--- a/apps/etterlatte-hendelser-joark/.nais/dev.yaml
+++ b/apps/etterlatte-hendelser-joark/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-hendelser-joark/.nais/prod.yaml
+++ b/apps/etterlatte-hendelser-joark/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-hendelser-pdl/.nais/dev.yaml
+++ b/apps/etterlatte-hendelser-pdl/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-hendelser-pdl/.nais/prod.yaml
+++ b/apps/etterlatte-hendelser-pdl/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-hendelser-samordning/.nais/dev.yaml
+++ b/apps/etterlatte-hendelser-samordning/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-hendelser-samordning/.nais/prod.yaml
+++ b/apps/etterlatte-hendelser-samordning/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-institusjonsopphold/.nais/dev.yaml
+++ b/apps/etterlatte-institusjonsopphold/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-institusjonsopphold/.nais/prod.yaml
+++ b/apps/etterlatte-institusjonsopphold/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-klage/.nais/dev.yaml
+++ b/apps/etterlatte-klage/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-migrering/.nais/dev.yaml
+++ b/apps/etterlatte-migrering/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   ingresses:
     - "https://etterlatte-migrering.intern.dev.nav.no"

--- a/apps/etterlatte-migrering/.nais/prod.yaml
+++ b/apps/etterlatte-migrering/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-oppdater-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-oppdater-behandling/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-oppdater-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-oppdater-behandling/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-opplysninger-fra-soeknad/.nais/dev.yaml
+++ b/apps/etterlatte-opplysninger-fra-soeknad/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-opplysninger-fra-soeknad/.nais/prod.yaml
+++ b/apps/etterlatte-opplysninger-fra-soeknad/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-pdltjenester/.nais/dev.yaml
+++ b/apps/etterlatte-pdltjenester/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   ingresses:
     - https://etterlatte-pdltjenester.intern.dev.nav.no

--- a/apps/etterlatte-pdltjenester/.nais/prod.yaml
+++ b/apps/etterlatte-pdltjenester/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     path: "health/isalive"

--- a/apps/etterlatte-saksbehandling-ui/.nais/dev.yaml
+++ b/apps/etterlatte-saksbehandling-ui/.nais/dev.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     reloader.stakater.com/match: "true"
 spec:
-  image: {{ image }}
+  image: "{{image}}"
   port: 8080
   replicas:
     max: 2
@@ -89,7 +89,7 @@ spec:
     - name: RINA_URL
       value: https://rina-ss3-q.adeo.no
     - name: APP_VERSION
-      value: {{ image }}
+      value: "{{ image }}"
   envFrom:
     - secret: my-application-unleash-api-token
   accessPolicy:

--- a/apps/etterlatte-saksbehandling-ui/.nais/prod.yaml
+++ b/apps/etterlatte-saksbehandling-ui/.nais/prod.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     reloader.stakater.com/match: "true"
 spec:
-  image: {{ image }}
+  image: "{{image}}"
   port: 8080
   replicas:
     max: 4
@@ -89,7 +89,7 @@ spec:
     - name: RINA_URL
       value: http://rina-ss1.adeo.no
     - name: APP_VERSION
-      value: {{ image }}
+      value: "{{ image }}"
   envFrom:
     - secret: my-application-unleash-api-token
   accessPolicy:

--- a/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   ingresses:
     - "https://etterlatte-samordning-vedtak.ekstern.dev.nav.no"  # Skru av etterhvert, skal nås via etterlatte-gw

--- a/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   ingresses:
     - "https://etterlatte-samordning-vedtak.nav.no"   # Skru av etterhvert, skal nås via etterlatte-gw

--- a/apps/etterlatte-statistikk/.nais/dev.yaml
+++ b/apps/etterlatte-statistikk/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   gcp:
     sqlInstances:

--- a/apps/etterlatte-statistikk/.nais/prod.yaml
+++ b/apps/etterlatte-statistikk/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   gcp:
     sqlInstances:

--- a/apps/etterlatte-testdata/.nais/dev.yaml
+++ b/apps/etterlatte-testdata/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   ingresses:
     - https://etterlatte-testdata.intern.dev.nav.no

--- a/apps/etterlatte-tilbakekreving/.nais/dev.yaml
+++ b/apps/etterlatte-tilbakekreving/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-tilbakekreving/.nais/prod.yaml
+++ b/apps/etterlatte-tilbakekreving/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-trygdetid-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-trygdetid-kafka/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-trygdetid-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-trygdetid-kafka/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-trygdetid/.nais/dev.yaml
+++ b/apps/etterlatte-trygdetid/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   ingresses:
     - "https://etterlatte-trygdetid.intern.dev.nav.no"

--- a/apps/etterlatte-trygdetid/.nais/prod.yaml
+++ b/apps/etterlatte-trygdetid/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-utbetaling/.nais/dev.yaml
+++ b/apps/etterlatte-utbetaling/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-utbetaling/.nais/prod.yaml
+++ b/apps/etterlatte-utbetaling/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-vedtaksvurdering-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-vedtaksvurdering-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     reloader.stakater.com/match: "true"
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   ingresses:
     - "https://etterlatte-vedtaksvurdering.intern.dev.nav.no"

--- a/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     reloader.stakater.com/match: "true"
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   gcp:
     sqlInstances:

--- a/apps/etterlatte-vilkaarsvurdering-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-vilkaarsvurdering-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5

--- a/apps/etterlatte-vilkaarsvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vilkaarsvurdering/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   ingresses:
     - "https://etterlatte-vilkaarsvurdering.intern.dev.nav.no"

--- a/apps/etterlatte-vilkaarsvurdering/.nais/prod.yaml
+++ b/apps/etterlatte-vilkaarsvurdering/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: etterlatte
 spec:
-  image: {{image}}
+  image: "{{image}}"
   port: 8080
   liveness:
     initialDelay: 5


### PR DESCRIPTION
Ref [slack thread](https://nav-it.slack.com/archives/C01DE3M9YBV/p1702393019644039?thread_ts=1702391030.259339&cid=C01DE3M9YBV)

nais validate doesn't replace variables (in our case image tag) - so if you have just {{image}} you get an invalid yaml to json conversion.

Suggested fix from slack is to quote the variables.

Should not have any functional change - just allows nais validate to run.

Happily - our nais dev.yaml/prod.yaml files seem to be valid :)