### PR TITLE
Fikser 1 time mismatch i teknisk tid for iverksatte vedtak

### DIFF
--- a/apps/etterlatte-statistikk/src/main/resources/db/migration/V31__fiks_mismatch_automatisk_iverksatte_vedtak.sql
+++ b/apps/etterlatte-statistikk/src/main/resources/db/migration/V31__fiks_mismatch_automatisk_iverksatte_vedtak.sql
@@ -1,7 +1,15 @@
+create temporary view saker_med_offset_teknisk_tid as
+(
+select s_iverksatt.behandling_id, s_iverksatt.teknisk_tid
+from sak s_iverksatt
+         left join sak b_attestert on s_iverksatt.behandling_id = b_attestert.behandling_id
+where s_iverksatt.behandling_status = 'IVERKSATT'
+  and b_attestert.behandling_status = 'ATTESTERT'
+  and s_iverksatt.teknisk_tid < b_attestert.teknisk_tid
+    );
+
 update sak s
 set teknisk_tid = s.teknisk_tid + interval '1 hour'
-where s.behandling_status = 'IVERKSATT'
-  and s.saksbehandler = 'EY'
-  and s.teknisk_tid < (select s2.teknisk_tid
-                       from sak s2
-                       where s2.behandling_status = 'ATTESTERT' and s.behandling_id = s2.behandling_id);
+from saker_med_offset_teknisk_tid saker_med_feil
+where s.behandling_id = saker_med_feil.behandling_id
+  and s.behandling_status = 'IVERKSATT';

--- a/apps/etterlatte-statistikk/src/main/resources/db/migration/V31__fiks_mismatch_automatisk_iverksatte_vedtak.sql
+++ b/apps/etterlatte-statistikk/src/main/resources/db/migration/V31__fiks_mismatch_automatisk_iverksatte_vedtak.sql
@@ -1,11 +1,11 @@
 create temporary view saker_med_offset_teknisk_tid as
 (
-select s_iverksatt.behandling_id, s_iverksatt.teknisk_tid
-from sak s_iverksatt
-         left join sak b_attestert on s_iverksatt.behandling_id = b_attestert.behandling_id
-where s_iverksatt.behandling_status = 'IVERKSATT'
+select b_iverksatt.behandling_id, b_iverksatt.teknisk_tid
+from sak b_iverksatt
+         left join sak b_attestert on b_iverksatt.behandling_id = b_attestert.behandling_id
+where b_iverksatt.behandling_status = 'IVERKSATT'
   and b_attestert.behandling_status = 'ATTESTERT'
-  and s_iverksatt.teknisk_tid < b_attestert.teknisk_tid
+  and b_iverksatt.teknisk_tid < b_attestert.teknisk_tid
     );
 
 update sak s

--- a/apps/etterlatte-statistikk/src/main/resources/db/migration/V31__fiks_mismatch_automatisk_iverksatte_vedtak.sql
+++ b/apps/etterlatte-statistikk/src/main/resources/db/migration/V31__fiks_mismatch_automatisk_iverksatte_vedtak.sql
@@ -12,4 +12,5 @@ update sak s
 set teknisk_tid = s.teknisk_tid + interval '1 hour'
 from saker_med_offset_teknisk_tid saker_med_feil
 where s.behandling_id = saker_med_feil.behandling_id
+  and s.saksbehandler = 'EY'
   and s.behandling_status = 'IVERKSATT';


### PR DESCRIPTION
Bruker et midlertidig view for kilde til hva tiden skal settes som, siden subselect timet ut i prod