### PR TITLE
Tolker den parsede zonedDateTime sin instant som UTC i statistikk

### DIFF
--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/Utils.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/Utils.kt
@@ -8,7 +8,7 @@ import no.nav.helse.rapids_rivers.JsonMessage
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
-import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.ZonedDateTime
 
 private val defaultLog = LoggerFactory.getLogger("parseTekniskTid")
@@ -28,7 +28,7 @@ internal fun parseTekniskTid(
             return LocalDateTime.parse(pakkeTid)
         } catch (e: Exception) {
             try {
-                return LocalDateTime.ofInstant(ZonedDateTime.parse(pakkeTid).toInstant(), ZoneId.of("UTC"))
+                return LocalDateTime.ofInstant(ZonedDateTime.parse(pakkeTid).toInstant(), ZoneOffset.UTC)
             } catch (e2: Exception) {
                 e2.addSuppressed(e)
                 logger.warn("Kunne ikke parse teknisk tid på hendelse $eventName, på grunn av feil", e2)

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/Utils.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/Utils.kt
@@ -3,12 +3,12 @@ package no.nav.etterlatte.statistikk.river
 import no.nav.etterlatte.libs.common.rapidsandrivers.TEKNISK_TID_KEY
 import no.nav.etterlatte.libs.common.rapidsandrivers.eventName
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.common.tidspunkt.norskTidssone
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.helse.rapids_rivers.JsonMessage
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.ZonedDateTime
 
 private val defaultLog = LoggerFactory.getLogger("parseTekniskTid")
@@ -28,7 +28,7 @@ internal fun parseTekniskTid(
             return LocalDateTime.parse(pakkeTid)
         } catch (e: Exception) {
             try {
-                return LocalDateTime.ofInstant(ZonedDateTime.parse(pakkeTid).toInstant(), norskTidssone)
+                return LocalDateTime.ofInstant(ZonedDateTime.parse(pakkeTid).toInstant(), ZoneId.of("UTC"))
             } catch (e2: Exception) {
                 e2.addSuppressed(e)
                 logger.warn("Kunne ikke parse teknisk tid på hendelse $eventName, på grunn av feil", e2)

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/river/UtilsTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/river/UtilsTest.kt
@@ -10,7 +10,7 @@ class UtilsTest {
     fun `kan parse ZonedDateTime`() {
         val format = "2023-11-22T08:42:18.892199Z"
         val tid = parseTekniskTid(format, "event1")
-        Assertions.assertEquals(LocalDateTime.of(2023, Month.NOVEMBER, 22, 9, 42, 18, 892199000), tid)
+        Assertions.assertEquals(LocalDateTime.of(2023, Month.NOVEMBER, 22, 8, 42, 18, 892199000), tid)
     }
 
     @Test


### PR DESCRIPTION
Unngår ekstra shift av tidspunkt med 1 time ekstra