### PR TITLE
Redusert cpu for lytter-apps

### DIFF
--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -51,6 +51,9 @@ spec:
           - NAVident
   kafka:
     pool: nav-dev
+  resources:
+    requests:
+      cpu: 100m
   replicas:
     cpuThresholdPercentage: 90
     max: 2

--- a/apps/etterlatte-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-behandling/.nais/prod.yaml
@@ -56,6 +56,9 @@ spec:
           - NAVident
   kafka:
     pool: nav-prod
+  resources:
+    requests:
+      cpu: 100m
   replicas:
     cpuThresholdPercentage: 90
     max: 4

--- a/apps/etterlatte-beregning-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-beregning-kafka/.nais/dev.yaml
@@ -22,6 +22,9 @@ spec:
   azure:
     application:
       enabled: true
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-beregning-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-beregning-kafka/.nais/prod.yaml
@@ -22,6 +22,9 @@ spec:
   azure:
     application:
       enabled: true
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-egne-ansatte-lytter/.nais/dev.yaml
+++ b/apps/etterlatte-egne-ansatte-lytter/.nais/dev.yaml
@@ -21,6 +21,9 @@ spec:
   azure:
     application:
       enabled: true
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-egne-ansatte-lytter/.nais/prod.yaml
+++ b/apps/etterlatte-egne-ansatte-lytter/.nais/prod.yaml
@@ -21,6 +21,9 @@ spec:
   azure:
     application:
       enabled: true
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-gyldig-soeknad/.nais/dev.yaml
+++ b/apps/etterlatte-gyldig-soeknad/.nais/dev.yaml
@@ -21,6 +21,9 @@ spec:
   prometheus:
     enabled: true
     path: /metrics
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-gyldig-soeknad/.nais/prod.yaml
+++ b/apps/etterlatte-gyldig-soeknad/.nais/prod.yaml
@@ -21,6 +21,9 @@ spec:
   prometheus:
     enabled: true
     path: /metrics
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-hendelser-joark/.nais/dev.yaml
+++ b/apps/etterlatte-hendelser-joark/.nais/dev.yaml
@@ -23,6 +23,9 @@ spec:
       enabled: true
   secureLogs:
     enabled: true
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-hendelser-joark/.nais/prod.yaml
+++ b/apps/etterlatte-hendelser-joark/.nais/prod.yaml
@@ -23,6 +23,9 @@ spec:
       enabled: true
   secureLogs:
     enabled: true
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-institusjonsopphold/.nais/dev.yaml
+++ b/apps/etterlatte-institusjonsopphold/.nais/dev.yaml
@@ -21,6 +21,9 @@ spec:
   azure:
     application:
       enabled: true
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-institusjonsopphold/.nais/prod.yaml
+++ b/apps/etterlatte-institusjonsopphold/.nais/prod.yaml
@@ -21,6 +21,9 @@ spec:
   azure:
     application:
       enabled: true
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-opplysninger-fra-soeknad/.nais/dev.yaml
+++ b/apps/etterlatte-opplysninger-fra-soeknad/.nais/dev.yaml
@@ -19,6 +19,9 @@ spec:
     path: /metrics
   kafka:
     pool: nav-dev
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-opplysninger-fra-soeknad/.nais/prod.yaml
+++ b/apps/etterlatte-opplysninger-fra-soeknad/.nais/prod.yaml
@@ -19,6 +19,9 @@ spec:
     path: /metrics
   kafka:
     pool: nav-prod
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-trygdetid-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-trygdetid-kafka/.nais/dev.yaml
@@ -22,6 +22,9 @@ spec:
   azure:
     application:
       enabled: true
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-trygdetid-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-trygdetid-kafka/.nais/prod.yaml
@@ -22,6 +22,9 @@ spec:
   azure:
     application:
       enabled: true
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-vedtaksvurdering-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/.nais/dev.yaml
@@ -22,6 +22,9 @@ spec:
   azure:
     application:
       enabled: true
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-vedtaksvurdering-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/.nais/prod.yaml
@@ -22,6 +22,9 @@ spec:
   azure:
     application:
       enabled: true
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-vilkaarsvurdering-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/.nais/dev.yaml
@@ -22,6 +22,9 @@ spec:
   azure:
     application:
       enabled: true
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-vilkaarsvurdering-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/.nais/prod.yaml
@@ -22,6 +22,9 @@ spec:
   azure:
     application:
       enabled: true
+  resources:
+    requests:
+      cpu: 25m
   replicas:
     cpuThresholdPercentage: 90
     max: 1


### PR DESCRIPTION
Så, fra default `200m` til `25m`. Ser ikke ut til at lytter-applikasjonene bruker veldig mye cpu, og selv med såpass stort kutt bør det være greit nok med cpu til å kjøre appen stabilt. Er jo ikke satt limit, så de spike'ne som kommer en gang iblant bør håndteres fint.

https://console.nav.cloud.nais.io/team/etterlatte/utilization?from=2023-12-12&to=2023-12-19