### PR TITLE
Forbedre requestLoggerMiddleware

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/server/src/index.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/index.ts
@@ -3,7 +3,6 @@ import path from 'path'
 import { ApiConfig, appConf, ClientConfig } from './config/config'
 import { authenticateUser } from './middleware/auth'
 import { logger } from './monitoring/logger'
-import { requestLogger } from './middleware/logging'
 import { tokenMiddleware } from './middleware/getOboToken'
 import { proxy } from './middleware/proxy'
 import { loggerRouter } from './routers/loggerRouter'
@@ -11,16 +10,16 @@ import prometheus from './monitoring/prometheus'
 import { innloggetBrukerRouter } from './routers/innloggetBrukerRouter'
 import { norg2Router } from './routers/norg2Router'
 import { unleashRouter } from './routers/unleashRouter'
+import { requestLoggerMiddleware } from './middleware/logging'
 
 logger.info(`environment: ${process.env.NODE_ENV}`)
 
 const clientPath = path.resolve(__dirname, '..', 'client')
-const isDev = process.env.NODE_ENV !== 'production'
 
 const app = express()
 app.set('trust proxy', 1)
 app.use('/', express.static(clientPath))
-app.use(requestLogger(isDev))
+app.use(requestLoggerMiddleware)
 
 app.use(['/health/isAlive', '/health/isReady'], (_: Request, res: Response) => {
   res.send('OK')

--- a/apps/etterlatte-saksbehandling-ui/server/src/middleware/logging.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/middleware/logging.ts
@@ -1,19 +1,13 @@
 import { NextFunction, Request, Response } from 'express'
 import { logger } from '../monitoring/logger'
+import { sanitizeUrl } from '../utils/sanitize'
 
-const requestLoggerIncludeHeaders = (req: Request, res: Response, next: NextFunction) => {
-  if (!req.url.includes('health')) {
-    logger.info('Request', { ...req.headers, url: req.url })
+const kanLoggeRequest = (input: string | undefined) => !/(health|metrics)/.test(input ?? '')
+
+export const requestLoggerMiddleware = (req: Request, _: Response, next: NextFunction) => {
+  if (kanLoggeRequest(req.url)) {
+    logger.info(`${req.method} ${sanitizeUrl(req.url)}`)
   }
+
   next()
 }
-
-const requestLoggerExcludeHeaders = (req: Request, res: Response, next: NextFunction) => {
-  if (!req.url.includes('health')) {
-    logger.info('Request', { url: req.url })
-  }
-  next()
-}
-
-export const requestLogger = (includeHeaders: boolean) =>
-  includeHeaders ? requestLoggerIncludeHeaders : requestLoggerExcludeHeaders

--- a/apps/etterlatte-saksbehandling-ui/server/src/tests/sanitize.test.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/tests/sanitize.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai'
+import { sanitizeUrl } from '../utils/sanitize'
+
+describe('Sanitize', () => {
+  it('Sanitize url virker som forventet', () => {
+    const skalIkkeEndres = [
+      'localhost:8080/behandling/7af41e2d-632a-4ae2-b9ce-41c7e24fa134',
+      'localhost:8080/sak/12345',
+      'localhost:8080/behandling/7af41e2d-632a-4ae2-b9ce-41c7e24fa134/vilkaarsvurdering/123',
+      'localhost:8080/sak/1235/brev/102/',
+    ]
+
+    skalIkkeEndres.forEach((url) => {
+      expect(sanitizeUrl(url)).to.equal(url)
+    })
+
+    expect(sanitizeUrl('localhost:8080/person/25418933200')).to.equal('localhost:8080/person/254189*****')
+  })
+})

--- a/apps/etterlatte-saksbehandling-ui/server/src/utils/sanitize.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/utils/sanitize.ts
@@ -1,4 +1,4 @@
-export function sanitize(value: String | undefined | null) {
+export function sanitize(value?: string) {
   if (value === undefined) {
     return undefined
   }


### PR DESCRIPTION
Fjernet `isDev` sjekk som logget headers siden den så og si aldri er i bruk mtp. dagens oppsett av lokal kjøring. 

Logg output tilsvarer nå backend. Så loggmelding vil da eksempelvis være: 
`POST /api/beregning/<id>/overstyrt` 

... i stedet for dagens...
`Request` ...hvor man må åpne meldingen i Kibana for å se endepunkt og metode.