### PR TITLE
Erstatter 'Enum.values()' med 'Enum.entries' etter bumping av Kotlin

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
@@ -98,7 +98,7 @@ internal fun Route.revurderingRoutes(
                     ?: return@get call.respond(HttpStatusCode.BadRequest, "Ugyldig saktype")
 
             val stoettedeRevurderinger =
-                Revurderingaarsak.values()
+                Revurderingaarsak.entries
                     .filter { it.erStoettaRevurdering(sakType) }
                     .filter {
                         if (it == Revurderingaarsak.OPPHOER_UTEN_BREV) {

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -183,7 +183,7 @@ internal class ApplicationContext(
     val migreringHttpClient: HttpClient = migreringHttpClient(config),
 ) {
     val httpPort = env.getOrDefault("HTTP_PORT", "8080").toInt()
-    val saksbehandlerGroupIdsByKey = AzureGroup.values().associateWith { env.requireEnvValue(it.envKey) }
+    val saksbehandlerGroupIdsByKey = AzureGroup.entries.associateWith { env.requireEnvValue(it.envKey) }
     val sporingslogg = Sporingslogg()
     val behandlingRequestLogger = BehandlingRequestLogger(sporingslogg)
     val dataSource = DataSourceBuilder.createDataSource(env.props)

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -65,9 +65,9 @@ class OppgaveService(
     private fun aktuelleOppgavetyperForRolleTilSaksbehandler(roller: List<Rolle>) =
         roller.flatMap {
             when (it) {
-                Rolle.SAKSBEHANDLER -> OppgaveType.values().toList() - OppgaveType.ATTESTERING
+                Rolle.SAKSBEHANDLER -> OppgaveType.entries - OppgaveType.ATTESTERING
                 Rolle.ATTESTANT -> listOf(OppgaveType.ATTESTERING)
-                Rolle.STRENGT_FORTROLIG -> OppgaveType.values().toList()
+                Rolle.STRENGT_FORTROLIG -> OppgaveType.entries
             }.distinct()
         }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
@@ -150,7 +150,7 @@ internal fun Route.sakWebRoutes(
                 hentNavidentFraToken { navIdent ->
                     val enhetrequest = call.receive<EnhetRequest>()
                     try {
-                        if (enhetrequest.enhet !in Enheter.values().map { it.enhetNr }) {
+                        if (enhetrequest.enhet !in Enheter.entries.map { it.enhetNr }) {
                             throw UgyldigForespoerselException(
                                 code = "ENHET IKKE GYLDIG",
                                 detail = "enhet ${enhetrequest.enhet} er ikke i listen over gyldige enheter",

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoReguleringTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoReguleringTest.kt
@@ -67,7 +67,7 @@ internal class BehandlingDaoReguleringTest {
         postgreSQLContainer.stop()
     }
 
-    private fun hentMigrerbareStatuses() = BehandlingStatus.values().toList() - BehandlingStatus.skalIkkeOmregnesVedGRegulering().toSet()
+    private fun hentMigrerbareStatuses() = BehandlingStatus.entries - BehandlingStatus.skalIkkeOmregnesVedGRegulering().toSet()
 
     @ParameterizedTest(
         name = "behandling med status {0} skal endres til aa vaere VILKAARSVURDERT",

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingRoutesTest.kt
@@ -132,7 +132,7 @@ internal class RevurderingRoutesTest {
             val revurderingAarsak: List<Revurderingaarsak> = response.body()
             assertEquals(HttpStatusCode.OK, response.status)
             val revurderingsaarsakerForBarnepensjon =
-                Revurderingaarsak.values().filter { it.erStoettaRevurdering(SakType.BARNEPENSJON) }
+                Revurderingaarsak.entries.filter { it.erStoettaRevurdering(SakType.BARNEPENSJON) }
             assertEquals(revurderingsaarsakerForBarnepensjon.size, revurderingAarsak.size)
             assertTrue(
                 revurderingAarsak.containsAll<Any>(
@@ -164,7 +164,7 @@ internal class RevurderingRoutesTest {
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(
                 revurderingAarsak.containsAll(
-                    Revurderingaarsak.values()
+                    Revurderingaarsak.entries
                         .filter { it.gyldigForSakType(SakType.OMSTILLINGSSTOENAD) }
                         .filter { it.name !== Revurderingaarsak.NY_SOEKNAD.toString() },
                 ),
@@ -198,7 +198,7 @@ internal class RevurderingRoutesTest {
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(
                 revurderingAarsak.containsAll(
-                    Revurderingaarsak.values()
+                    Revurderingaarsak.entries
                         .filterNot { it == Revurderingaarsak.OPPHOER_UTEN_BREV }
                         .filter { it.gyldigForSakType(SakType.OMSTILLINGSSTOENAD) }
                         .filter { it.name !== Revurderingaarsak.NY_SOEKNAD.toString() },

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseDaoTest.kt
@@ -305,7 +305,7 @@ internal class GrunnlagsendringshendelseDaoTest {
         val alleHendelser =
             grunnlagsendringshendelsesRepo.hentGrunnlagsendringshendelserMedStatuserISak(
                 sakid,
-                GrunnlagsendringStatus.values().toList(),
+                GrunnlagsendringStatus.entries,
             )
         assertEquals(alleHendelser.size, 4)
         assertEquals(

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
@@ -68,7 +68,7 @@ internal class OppgaveDaoTest {
         oppgaveDao.opprettOppgave(lagNyOppgave(sakAalesund))
         oppgaveDao.opprettOppgave(lagNyOppgave(sakAalesund))
 
-        val hentOppgaver = oppgaveDao.hentOppgaver(OppgaveType.values().toList())
+        val hentOppgaver = oppgaveDao.hentOppgaver(OppgaveType.entries)
         assertEquals(3, hentOppgaver.size)
     }
 
@@ -78,7 +78,7 @@ internal class OppgaveDaoTest {
         val oppgaveNy = lagNyOppgave(sakAalesund, OppgaveKilde.BEHANDLING, OppgaveType.ATTESTERING)
         oppgaveDao.opprettOppgave(oppgaveNy)
 
-        val hentOppgaver = oppgaveDao.hentOppgaver(OppgaveType.values().toList())
+        val hentOppgaver = oppgaveDao.hentOppgaver(OppgaveType.entries)
         assertEquals(1, hentOppgaver.size)
         assertEquals(OppgaveType.ATTESTERING, hentOppgaver[0].type)
     }
@@ -107,7 +107,7 @@ internal class OppgaveDaoTest {
         val oppgaveUtenbeskyttelse = lagNyOppgave(sakutenbeskyttelse)
         oppgaveDao.opprettOppgave(oppgaveUtenbeskyttelse)
 
-        val hentetOppgave = oppgaveDao.hentOppgaver(OppgaveType.values().toList())
+        val hentetOppgave = oppgaveDao.hentOppgaver(OppgaveType.entries)
         assertEquals(1, hentetOppgave.size)
     }
 
@@ -120,7 +120,7 @@ internal class OppgaveDaoTest {
 
         val hentetOppgave =
             oppgaveDao
-                .finnOppgaverForStrengtFortroligOgStrengtFortroligUtland(OppgaveType.values().toList())
+                .finnOppgaverForStrengtFortroligOgStrengtFortroligUtland(OppgaveType.entries)
         assertEquals(1, hentetOppgave.size)
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakServiceTest.kt
@@ -79,7 +79,7 @@ internal class SakServiceTest {
 
         every { tokenValidationContext.getJwtToken(any()) } returns token
 
-        val groups = AzureGroup.values().associateWith { it.name }
+        val groups = AzureGroup.entries.associateWith { it.name }
 
         Kontekst.set(
             Context(

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagHendelserRiver.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/GrunnlagHendelserRiver.kt
@@ -76,6 +76,6 @@ class GrunnlagHendelserRiver(
     }
 
     companion object {
-        private val OPPLYSNING_TYPER = Opplysningstype.values().map { it.name }
+        private val OPPLYSNING_TYPER = Opplysningstype.entries.map { it.name }
     }
 }

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/itest/GrunnlagDaoIntegrationTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/itest/GrunnlagDaoIntegrationTest.kt
@@ -157,7 +157,7 @@ internal class GrunnlagDaoIntegrationTest {
     fun `Hente nyeste grunnlag av type`() {
         val sakId = Random.nextLong()
         val behandlingId = UUID.randomUUID()
-        val type = Opplysningstype.SOEKER_PDL_V1
+        val type = SOEKER_PDL_V1
 
         lagGrunnlagsopplysning(type, verdi = opprettMockPerson(SOEKER_FOEDSELSNUMMER).toJsonNode())
             .also { opplysningRepo.leggOpplysningTilGrunnlag(sakId, it) }
@@ -203,9 +203,9 @@ internal class GrunnlagDaoIntegrationTest {
         lagGrunnlagsopplysning(AVDOED_PDL_V1).also { opplysningRepo.leggOpplysningTilGrunnlag(33, it) }
         lagGrunnlagsopplysning(AVDOED_PDL_V1, uuid = uuid).also { opplysningRepo.leggOpplysningTilGrunnlag(33, it) }
 
-        assertEquals(uuid, opplysningRepo.finnNyesteGrunnlagForSak(33, Opplysningstype.AVDOED_PDL_V1)?.opplysning?.id)
+        assertEquals(uuid, opplysningRepo.finnNyesteGrunnlagForSak(33, AVDOED_PDL_V1)?.opplysning?.id)
         // Skal håndtere at opplysning ikke finnes
-        assertEquals(null, opplysningRepo.finnNyesteGrunnlagForSak(0L, Opplysningstype.AVDOED_PDL_V1))
+        assertEquals(null, opplysningRepo.finnNyesteGrunnlagForSak(0L, AVDOED_PDL_V1))
     }
 
     @Test
@@ -223,12 +223,12 @@ internal class GrunnlagDaoIntegrationTest {
 
         assertEquals(
             behandlingId,
-            opplysningRepo.finnNyesteGrunnlagForBehandling(behandlingId, Opplysningstype.AVDOED_PDL_V1)?.opplysning?.id,
+            opplysningRepo.finnNyesteGrunnlagForBehandling(behandlingId, AVDOED_PDL_V1)?.opplysning?.id,
         )
         // Skal håndtere at opplysning ikke finnes
         assertEquals(
             null,
-            opplysningRepo.finnNyesteGrunnlagForBehandling(UUID.randomUUID(), Opplysningstype.AVDOED_PDL_V1),
+            opplysningRepo.finnNyesteGrunnlagForBehandling(UUID.randomUUID(), AVDOED_PDL_V1),
         )
     }
 
@@ -436,7 +436,7 @@ internal class GrunnlagDaoIntegrationTest {
         repeat(10) {
             val annenBehandlingId = UUID.randomUUID()
             val tempHendelsenummer =
-                Opplysningstype.values().maxOf { opplysningstype ->
+                Opplysningstype.entries.toTypedArray().maxOf { opplysningstype ->
                     opplysningRepo.leggOpplysningTilGrunnlag(sakId, lagGrunnlagsopplysning(opplysningstype))
                 }
             opplysningRepo.oppdaterVersjonForBehandling(annenBehandlingId, sakId, tempHendelsenummer)

--- a/apps/etterlatte-hendelser-pdl/src/main/kotlin/hendelserpdl/PersonHendelseFordeler.kt
+++ b/apps/etterlatte-hendelser-pdl/src/main/kotlin/hendelserpdl/PersonHendelseFordeler.kt
@@ -227,7 +227,7 @@ class PersonHendelseFordeler(
         )
     }
 
-    private fun opplysningstyperSomHaandteres() = LeesahOpplysningstype.values().map { it.toString() }
+    private fun opplysningstyperSomHaandteres() = LeesahOpplysningstype.entries.map { it.toString() }
 
     private fun publiserPaaRapid(
         opplysningstype: LeesahOpplysningstype,

--- a/apps/etterlatte-klage/src/test/kotlin/KabalOversendelseTest.kt
+++ b/apps/etterlatte-klage/src/test/kotlin/KabalOversendelseTest.kt
@@ -8,7 +8,7 @@ class KabalOversendelseTest {
     @Test
     fun `kan mappe alle KabalHjemmel til Hjemmel i klagekodeverk`() {
         Assertions.assertDoesNotThrow {
-            KabalHjemmel.values().forEach {
+            KabalHjemmel.entries.forEach {
                 it.tilHjemmel()
             }
         }

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/LandNormalisert.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/LandNormalisert.kt
@@ -278,7 +278,7 @@ enum class LandNormalisert(val isoCode: String, val beskrivelse: String) {
         private val mapAvLandkodeOgBeskrivelse = HashMap<String, String>()
 
         init {
-            LandNormalisert.values().forEach {
+            entries.forEach {
                 mapAvLandkodeOgBeskrivelse[it.isoCode] = it.beskrivelse
             }
         }

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/Enheter.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/Enheter.kt
@@ -16,7 +16,7 @@ enum class Enheter(val enhetNr: String, val navn: String, val inkludertForNasjon
     companion object {
         val defaultEnhet = PORSGRUNN
 
-        fun nasjonalTilgangEnheter() = Enheter.values().filter { it.inkludertForNasjonalTilgang }.map { it.enhetNr }
+        fun nasjonalTilgangEnheter() = entries.filter { it.inkludertForNasjonalTilgang }.map { it.enhetNr }
     }
 }
 


### PR DESCRIPTION
'Enum.values()' is recommended to be replaced by 'Enum.entries' since 1.9

https://kotlinlang.org/docs/whatsnew19.html#stable-replacement-of-the-enum-class-values-function