### PR TITLE
EY-3274 Støtte flyttTilAnnenSak på feilregistrert journalpost

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
@@ -67,6 +67,25 @@ internal fun Route.oppgaveRoutes(
                 }
             }
 
+            post("/opprett") {
+                kunSaksbehandler {
+                    val nyOppgaveDto = call.receive<NyOppgaveDto>()
+
+                    val nyOppgave =
+                        inTransaction {
+                            service.opprettNyOppgaveMedSakOgReferanse(
+                                nyOppgaveDto.referanse ?: "",
+                                sakId,
+                                nyOppgaveDto.oppgaveKilde,
+                                nyOppgaveDto.oppgaveType,
+                                nyOppgaveDto.merknad,
+                            )
+                        }
+
+                    call.respond(nyOppgave)
+                }
+            }
+
             get("/ferdigstiltogattestert/{referanse}") {
                 kunSaksbehandler {
                     val saksbehandler =

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivKlient.kt
@@ -71,6 +71,25 @@ class DokarkivKlient(private val client: HttpClient, private val url: String) {
             contentType(ContentType.Application.Json)
             setBody(OppdaterJournalpostTemaRequest(nyttTema))
         }.body()
+
+    internal suspend fun feilregistrerSakstilknytning(journalpostId: String): String =
+        client.patch("$url/$journalpostId/feilregistrer/feilregistrerSakstilknytning") {
+            contentType(ContentType.Application.Json)
+        }.body()
+
+    internal suspend fun opphevFeilregistrertSakstilknytning(journalpostId: String): String =
+        client.patch("$url/$journalpostId/feilregistrer/opphevFeilregistrertSakstilknytning") {
+            contentType(ContentType.Application.Json)
+        }.body()
+
+    internal suspend fun knyttTilAnnenSak(
+        journalpostId: String,
+        request: KnyttTilAnnenSakRequest,
+    ): KnyttTilAnnenSakResponse =
+        client.put("$url/$journalpostId/knyttTilAnnenSak") {
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }.body()
 }
 
 data class OppdaterJournalpostTemaRequest(val tema: String)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivService.kt
@@ -37,6 +37,15 @@ interface DokarkivService {
         journalpostId: String,
         nyttTema: String,
     )
+
+    suspend fun feilregistrerSakstilknytning(journalpostId: String)
+
+    suspend fun opphevFeilregistrertSakstilknytning(journalpostId: String)
+
+    suspend fun knyttTilAnnenSak(
+        journalpostId: String,
+        request: KnyttTilAnnenSakRequest,
+    ): KnyttTilAnnenSakResponse
 }
 
 class DokarkivServiceImpl(
@@ -127,6 +136,23 @@ class DokarkivServiceImpl(
         client.endreTema(journalpostId, nyttTema)
     }
 
+    override suspend fun feilregistrerSakstilknytning(journalpostId: String) {
+        client.feilregistrerSakstilknytning(journalpostId)
+    }
+
+    override suspend fun opphevFeilregistrertSakstilknytning(journalpostId: String) {
+        client.opphevFeilregistrertSakstilknytning(journalpostId)
+    }
+
+    override suspend fun knyttTilAnnenSak(
+        journalpostId: String,
+        request: KnyttTilAnnenSakRequest,
+    ): KnyttTilAnnenSakResponse {
+        return client.knyttTilAnnenSak(journalpostId, request).also {
+            logger.info("Journalpost knyttet til annen sak (nyJournalpostId=${it.nyJournalpostId})\n$request")
+        }
+    }
+
     private fun mapTilJournalpostRequest(
         brevId: BrevID,
         vedtak: VedtakTilJournalfoering,
@@ -143,8 +169,8 @@ class DokarkivServiceImpl(
             eksternReferanseId = "${vedtak.behandlingId}.$brevId",
             sak = JournalpostSak(Sakstype.FAGSAK, vedtak.sak.id.toString()),
             dokumenter = listOf(pdf.tilJournalpostDokument(innhold.tittel)),
-            tema = vedtak.sak.sakType.tema, // https://confluence.adeo.no/display/BOA/Tema
-            kanal = "S", // https://confluence.adeo.no/display/BOA/Utsendingskanal
+            tema = vedtak.sak.sakType.tema,
+            kanal = "S",
             journalfoerendeEnhet = vedtak.ansvarligEnhet,
         )
     }
@@ -164,8 +190,8 @@ class DokarkivServiceImpl(
             eksternReferanseId = "${brev.sakId}.${brev.id}",
             sak = JournalpostSak(Sakstype.FAGSAK, brev.sakId.toString()),
             dokumenter = listOf(pdf.tilJournalpostDokument(innhold.tittel)),
-            tema = sak.sakType.tema, // https://confluence.adeo.no/display/BOA/Tema
-            kanal = "S", // https://confluence.adeo.no/display/BOA/Utsendingskanal
+            tema = sak.sakType.tema,
+            kanal = "S",
             journalfoerendeEnhet = sak.enhet,
         )
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/Journalpost.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/Journalpost.kt
@@ -7,6 +7,11 @@ import java.time.LocalDateTime
 
 /**
  * Requestobjekt for å opprette ny Journalpost
+ *
+ * Tema:
+ *  https://confluence.adeo.no/display/BOA/Tema
+ * Kanal:
+ *  https://confluence.adeo.no/display/BOA/Utsendingskanal
  **/
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 data class OpprettJournalpostRequest(
@@ -40,6 +45,19 @@ data class OpprettJournalpostResponse(
 
 data class OppdaterJournalpostResponse(
     val journalpostId: String,
+)
+
+data class KnyttTilAnnenSakRequest(
+    val bruker: Bruker,
+    val fagsakId: String,
+    val fagsaksystem: String,
+    val journalfoerendeEnhet: String,
+    val tema: String,
+    val sakstype: Sakstype,
+)
+
+data class KnyttTilAnnenSakResponse(
+    val nyJournalpostId: String,
 )
 
 data class AvsenderMottaker(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/Model.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/Model.kt
@@ -71,6 +71,7 @@ data class GraphqlRequest(
 
 data class DokumentOversiktBrukerVariables(
     val brukerId: BrukerId,
+    val tema: List<String>,
     val foerste: Int,
 ) : GraphqlVariables
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafClient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafClient.kt
@@ -52,11 +52,15 @@ class SafClient(
             throw JournalpostException("Feil ved kall til hentdokument", ex)
         }
 
+    // TODO: Fjerne param [visTemaPen] når gjenlevendepensjon er borte
     override suspend fun hentDokumenter(
         fnr: String,
+        visTemaPen: Boolean,
         idType: BrukerIdType,
         brukerTokenInfo: BrukerTokenInfo,
     ): HentDokumentoversiktBrukerResult {
+        logger.info("VisTemaPen=$visTemaPen")
+
         val request =
             GraphqlRequest(
                 query = getQuery("/graphql/dokumentoversiktBruker.graphql"),
@@ -67,7 +71,9 @@ class SafClient(
                                 id = fnr,
                                 type = idType,
                             ),
-                        10, // TODO: Finn en grense eller fiks paginering
+                        tema = if (visTemaPen) listOf("EYO", "EYB", "PEN") else listOf("EYO", "EYB"),
+                        // TODO: Finn en grense eller fiks paginering
+                        foerste = 10,
                     ),
             )
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafService.kt
@@ -6,6 +6,7 @@ import no.nav.etterlatte.token.BrukerTokenInfo
 interface SafService {
     suspend fun hentDokumenter(
         fnr: String,
+        visTemaPen: Boolean,
         idType: BrukerIdType,
         brukerTokenInfo: BrukerTokenInfo,
     ): HentDokumentoversiktBrukerResult

--- a/apps/etterlatte-brev-api/src/main/resources/graphql/dokumentoversiktBruker.graphql
+++ b/apps/etterlatte-brev-api/src/main/resources/graphql/dokumentoversiktBruker.graphql
@@ -1,11 +1,12 @@
 query(
-   $brukerId: BrukerIdInput!,
-   $foerste: Int!,
+    $brukerId: BrukerIdInput!,
+    $tema: [Tema!]!,
+    $foerste: Int!,
 ) {
     dokumentoversiktBruker(
         brukerId: $brukerId,
         foerste: $foerste,
-        tema: [EYO, EYB],
+        tema: $tema,
         journalposttyper: [I, U],
         journalstatuser:[]
     ) {

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokument/DokumentRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokument/DokumentRouteTest.kt
@@ -67,7 +67,7 @@ internal class DokumentRouteTest {
 
     @Test
     fun `Endepunkt for uthenting av alle dokumenter tilknyttet brukeren`() {
-        coEvery { journalpostService.hentDokumenter(any(), any(), any()) } returns HentDokumentoversiktBrukerResult()
+        coEvery { journalpostService.hentDokumenter(any(), any(), any(), any()) } returns HentDokumentoversiktBrukerResult()
         coEvery { tilgangssjekker.harTilgangTilPerson(any(), any()) } returns true
 
         val token = accessToken
@@ -102,7 +102,7 @@ internal class DokumentRouteTest {
             assertEquals(HttpStatusCode.OK, response.status)
         }
 
-        coVerify(exactly = 1) { journalpostService.hentDokumenter(fnr, BrukerIdType.FNR, any()) }
+        coVerify(exactly = 1) { journalpostService.hentDokumenter(fnr, false, BrukerIdType.FNR, any()) }
     }
 
     @Test

--- a/apps/etterlatte-saksbehandling-ui/client/src/App.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/App.tsx
@@ -26,6 +26,7 @@ import BehandleJournalfoeringOppgave from '~components/person/journalfoeringsopp
 
 import { isSuccess } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
+import { FlyttJournalpost } from '~components/person/flyttjournalpost/FlyttJournalpost'
 
 function App() {
   const innloggetbrukerHentet = useInnloggetSaksbehandler()
@@ -54,6 +55,7 @@ function App() {
                 <Routes>
                   <Route path="/" element={<ToggleMinOppgaveliste />} />
                   <Route path="/oppgavebenken" element={<ToggleMinOppgaveliste />} />
+                  <Route path="/flyttjournalpost" element={<FlyttJournalpost />} />
                   <Route path="/person/:fnr" element={<Person />} />
                   <Route path="/oppgave/:id/*" element={<BehandleJournalfoeringOppgave />} />
                   <Route path="/person/:fnr/sak/:sakId/brev/:brevId" element={<NyttBrev />} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/flyttjournalpost/FeilregistrerJournalpost.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/flyttjournalpost/FeilregistrerJournalpost.tsx
@@ -1,0 +1,83 @@
+import { Alert, BodyShort, Button, List, Panel } from '@navikt/ds-react'
+import { FlexRow } from '~shared/styled'
+import { isPending } from '~shared/api/apiUtils'
+import React from 'react'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { feilregistrerSakstilknytning, opphevFeilregistrertSakstilknytning } from '~shared/api/dokument'
+import { Journalpost } from '~shared/types/Journalpost'
+
+export const FeilregistrerJournalpost = ({
+  valgtJournalpost,
+  oppdaterJournalposter,
+}: {
+  valgtJournalpost: Journalpost
+  oppdaterJournalposter: () => void
+}) => {
+  const [feilSakstilknytningStatus, apiFeilregistrerSakstilknytning] = useApiCall(feilregistrerSakstilknytning)
+  const [opphevFeilregisrteringStatus, apiOpphevFeilregistrering] = useApiCall(opphevFeilregistrertSakstilknytning)
+
+  const opphevFeilregistrering = () => {
+    if (!valgtJournalpost) return
+
+    apiOpphevFeilregistrering(valgtJournalpost.journalpostId, () => {
+      oppdaterJournalposter()
+    })
+  }
+
+  const feilregistrer = () => {
+    if (!valgtJournalpost) return
+
+    apiFeilregistrerSakstilknytning(valgtJournalpost.journalpostId, () => {
+      oppdaterJournalposter()
+    })
+  }
+
+  return (
+    <Panel>
+      <BodyShort spacing>
+        Du har valgt journalpost med ID {valgtJournalpost.journalpostId}.
+        <br />
+        Med dokument(er):
+      </BodyShort>
+      <List>
+        {valgtJournalpost.dokumenter.map((dok) => (
+          <List.Item key={dok.dokumentInfoId}>{dok.tittel}</List.Item>
+        ))}
+      </List>
+
+      {valgtJournalpost?.journalstatus === 'FEILREGISTRERT' ? (
+        <Alert variant="info">
+          Journalposten er markert som feilregistrert
+          <br />
+          (sakid {valgtJournalpost.sak?.fagsakId ? `er ${valgtJournalpost.sak?.fagsakId}` : 'mangler'} og tilhører
+          fagsystem {valgtJournalpost.sak?.fagsaksystem})
+        </Alert>
+      ) : (
+        <Alert variant="warning">
+          Journalposten tilhører ikke Gjenny (EY)!
+          <br />
+          Sakid {valgtJournalpost.sak?.fagsakId ? `er ${valgtJournalpost.sak?.fagsakId}` : 'mangler'} og tilhører
+          fagsystem {valgtJournalpost.sak?.fagsaksystem}
+        </Alert>
+      )}
+
+      <br />
+
+      <FlexRow justify="right">
+        {valgtJournalpost?.journalstatus === 'FEILREGISTRERT' ? (
+          <Button
+            variant="secondary"
+            onClick={opphevFeilregistrering}
+            loading={isPending(opphevFeilregisrteringStatus)}
+          >
+            Opphev feilregistrering
+          </Button>
+        ) : (
+          <Button variant="danger" onClick={feilregistrer} loading={isPending(feilSakstilknytningStatus)}>
+            Feilregistrer sakstilknytning
+          </Button>
+        )}
+      </FlexRow>
+    </Panel>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/flyttjournalpost/FlyttJournalpost.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/flyttjournalpost/FlyttJournalpost.tsx
@@ -1,0 +1,134 @@
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { hentAlleDokumenterInklPensjon, hentDokumentPDF } from '~shared/api/dokument'
+import React, { useEffect, useState } from 'react'
+import { Button, Detail, Heading, TextField } from '@navikt/ds-react'
+import { fnrErGyldig } from '~utils/fnr'
+import { ApiErrorAlert } from '~ErrorBoundary'
+import { mapApiResult } from '~shared/api/apiUtils'
+import Spinner from '~shared/Spinner'
+import { Column, Container, FlexRow, GridContainer } from '~shared/styled'
+import { Journalpost } from '~shared/types/Journalpost'
+import styled from 'styled-components'
+import { VelgJournalpost } from '~components/person/flyttjournalpost/VelgJournalpost'
+import { Sakstilknytning } from '~components/person/flyttjournalpost/Sakstilknytning'
+
+/**
+ * Midlertidig løsning inntil Gjenlevendepensjon er helt ute av systemet.
+ * Dette sikrer at vi kan overføre eventuelle feilsendte søknader (gjenlevendepensjon som skulle vært OMS) til Gjenny.
+ **/
+export const FlyttJournalpost = ({}: {}) => {
+  const [fileURL, setFileURL] = useState<string>()
+  const [bruker, setBruker] = useState<string>('')
+  const [valgtJournalpost, setValgtJournalpost] = useState<Journalpost>()
+
+  const [journalposterStatus, hentAlleJournalposter] = useApiCall(hentAlleDokumenterInklPensjon)
+
+  const [dokument, hentDokument, resetHentDokument] = useApiCall(hentDokumentPDF)
+
+  useEffect(() => {
+    if (!!valgtJournalpost) {
+      hentDokument(
+        {
+          journalpostId: valgtJournalpost.journalpostId,
+          dokumentInfoId: valgtJournalpost.dokumenter[0].dokumentInfoId,
+        },
+        (bytes) => {
+          const blob = new Blob([bytes], { type: 'application/pdf' })
+
+          setFileURL(URL.createObjectURL(blob))
+        }
+      )
+    }
+  }, [valgtJournalpost])
+
+  useEffect(() => {
+    if (!!fileURL)
+      setTimeout(() => {
+        URL.revokeObjectURL(fileURL)
+      }, 1000)
+  }, [fileURL])
+
+  const hentDataForBruker = () => {
+    hentAlleJournalposter(bruker, () => {
+      resetHentDokument()
+      setValgtJournalpost(undefined)
+    })
+  }
+
+  const oppdaterJournalposter = () => {
+    hentAlleJournalposter(bruker, (journalposter) => {
+      const oppdatertJournalpost = journalposter.find(
+        (journalpost) => journalpost.journalpostId === valgtJournalpost!!.journalpostId
+      )
+      setValgtJournalpost(oppdatertJournalpost)
+    })
+  }
+
+  return (
+    <GridContainer>
+      <Column style={{ minWidth: '50%' }}>
+        <Container>
+          <Heading size="large" spacing>
+            Flytt journalpost
+          </Heading>
+
+          <FlexRow align="end" $spacing>
+            <TextField
+              label="Brukers fødselsnummer"
+              description="Må være et gyldig fødselsnummer"
+              value={bruker}
+              onChange={(e) => setBruker(e.target.value)}
+            />
+
+            <Button onClick={hentDataForBruker} disabled={!fnrErGyldig(bruker)}>
+              Hent journalposter
+            </Button>
+          </FlexRow>
+
+          <VelgJournalpost
+            valgtJournalpost={valgtJournalpost}
+            setValgtJournalpost={setValgtJournalpost}
+            journalposterStatus={journalposterStatus}
+          />
+
+          <br />
+          <br />
+
+          {!!valgtJournalpost && (
+            <Sakstilknytning
+              bruker={bruker}
+              valgtJournalpost={valgtJournalpost}
+              oppdaterJournalposter={oppdaterJournalposter}
+            />
+          )}
+        </Container>
+      </Column>
+
+      <Column>
+        {!!valgtJournalpost && (
+          <>
+            <Heading size="medium" spacing>
+              Journalpost ({valgtJournalpost.journalpostId})<Detail>{valgtJournalpost.tittel}</Detail>
+            </Heading>
+
+            {mapApiResult(
+              dokument,
+              <Spinner label="Klargjør forhåndsvisning av PDF" visible />,
+              () => (
+                <ApiErrorAlert>Feil ved henting av PDF</ApiErrorAlert>
+              ),
+              () => (!!fileURL ? <PdfViewer src={fileURL} /> : <></>)
+            )}
+          </>
+        )}
+      </Column>
+    </GridContainer>
+  )
+}
+
+const PdfViewer = styled.embed`
+  min-width: 680px;
+  width: 100%;
+  min-height: 600px;
+  height: 100%;
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/flyttjournalpost/Sakstilknytning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/flyttjournalpost/Sakstilknytning.tsx
@@ -1,0 +1,292 @@
+import { Alert, BodyShort, Button, Heading, List, Modal, Panel, Select } from '@navikt/ds-react'
+import { FlexRow } from '~shared/styled'
+import { isPending, isSuccess, mapApiResult } from '~shared/api/apiUtils'
+import Spinner from '~shared/Spinner'
+import { ApiError } from '~shared/api/apiClient'
+import { ApiErrorAlert } from '~ErrorBoundary'
+import { InfoWrapper } from '~components/behandling/soeknadsoversikt/styled'
+import { Info } from '~components/behandling/soeknadsoversikt/Info'
+import React, { useEffect, useState } from 'react'
+import { Journalpost, KnyttTilAnnenSakResponse } from '~shared/types/Journalpost'
+import { temaFraSakstype } from '~components/person/journalfoeringsoppgave/journalpost/EndreSak'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import {
+  feilregistrerSakstilknytning,
+  knyttTilAnnenSak,
+  opphevFeilregistrertSakstilknytning,
+} from '~shared/api/dokument'
+import { hentSakForPerson, hentSakMedBehandlnger } from '~shared/api/sak'
+import { fnrErGyldig } from '~utils/fnr'
+import { SakType } from '~shared/types/sak'
+import { formaterSakstype } from '~utils/formattering'
+import { opprettOppgave } from '~shared/api/oppgaver'
+import { useNavigate } from 'react-router-dom'
+
+interface Props {
+  bruker: string
+  valgtJournalpost: Journalpost
+  oppdaterJournalposter: () => void
+}
+
+export const Sakstilknytning = ({ bruker, valgtJournalpost, oppdaterJournalposter }: Props) => {
+  const navigate = useNavigate()
+
+  const [sakType, setSakType] = useState<SakType>()
+
+  const [sakMedBehandlingerStatus, apiHentSakMedBehandlinger] = useApiCall(hentSakMedBehandlnger)
+  const [hentEllerOpprettSakStatus, apiHentEllerOpprettSak] = useApiCall(hentSakForPerson)
+  const [nyOppgaveStatus, apiOpprettNyOppgave] = useApiCall(opprettOppgave)
+
+  const [knyttTilAnnenSakStatus, apiKnyttTilAnnenSak] = useApiCall(knyttTilAnnenSak)
+  const [feilSakstilknytningStatus, apiFeilregistrerSakstilknytning] = useApiCall(feilregistrerSakstilknytning)
+  const [opphevFeilregisrteringStatus, apiOpphevFeilregistrertSakstilknytning] = useApiCall(
+    opphevFeilregistrertSakstilknytning
+  )
+
+  useEffect(() => {
+    if (!fnrErGyldig(bruker)) return
+
+    apiHentSakMedBehandlinger(bruker)
+  }, [])
+
+  useEffect(() => {
+    if (isSuccess(hentEllerOpprettSakStatus)) {
+      apiHentSakMedBehandlinger(bruker)
+    }
+  }, [hentEllerOpprettSakStatus])
+
+  const opphevFeilregistrering = () => {
+    if (!valgtJournalpost) return
+
+    apiOpphevFeilregistrertSakstilknytning(valgtJournalpost.journalpostId, () => {
+      oppdaterJournalposter()
+    })
+  }
+
+  const feilregistrer = () => {
+    if (!valgtJournalpost) return
+
+    apiFeilregistrerSakstilknytning(valgtJournalpost.journalpostId, () => {
+      oppdaterJournalposter()
+    })
+  }
+
+  const opprettSak = () => {
+    if (!sakType) return
+
+    apiHentEllerOpprettSak({
+      fnr: bruker,
+      type: sakType,
+      opprettHvisIkkeFinnes: true,
+    })
+  }
+
+  const opprettNyOppgave = (sakId: number, journalpostId: string) => {
+    apiOpprettNyOppgave(
+      {
+        sakId,
+        request: {
+          oppgaveType: 'JOURNALFOERING',
+          referanse: journalpostId!!,
+          merknad: 'Flyttet fra annen sak',
+        },
+      },
+      () => setTimeout(() => navigate('/'), 5000)
+    )
+  }
+
+  const knyttJournalpostTilGjennySak = () => {
+    if (!valgtJournalpost || !isSuccess(sakMedBehandlingerStatus)) return
+
+    const sak = sakMedBehandlingerStatus.data.sak
+
+    apiKnyttTilAnnenSak(
+      {
+        journalpostId: valgtJournalpost.journalpostId,
+        request: {
+          bruker: {
+            id: sak.ident,
+            idType: 'FNR',
+          },
+          fagsakId: sak.id.toString(),
+          fagsaksystem: 'EY',
+          journalfoerendeEnhet: sak.enhet,
+          sakstype: 'FAGSAK',
+          tema: temaFraSakstype(sak.sakType),
+        },
+      },
+      (response: KnyttTilAnnenSakResponse) => {
+        opprettNyOppgave(sak.id, response.nyJournalpostId)
+      }
+    )
+  }
+
+  if (valgtJournalpost.sak?.fagsaksystem === 'EY') {
+    return (
+      <>
+        <Alert variant="info">
+          Journalposten er allerede tilkoblet en sak i Gjenny (saksid {valgtJournalpost.sak.fagsakId})
+        </Alert>
+
+        {isSuccess(sakMedBehandlingerStatus) && !sakMedBehandlingerStatus.data.behandlinger.length && (
+          <>
+            <br />
+            <Alert variant="warning">
+              Det finnes ingen behandlinger på sak {sakMedBehandlingerStatus.data.sak.id}. Ønsker du å opprette en
+              behandlingsoppgave?
+            </Alert>
+            <br />
+
+            <FlexRow justify="right">
+              <Button
+                onClick={() => opprettNyOppgave(sakMedBehandlingerStatus.data.sak.id, valgtJournalpost.journalpostId)}
+                loading={isPending(nyOppgaveStatus)}
+              >
+                Opprett oppgave
+              </Button>
+            </FlexRow>
+          </>
+        )}
+
+        {isSuccess(nyOppgaveStatus) && (
+          <Modal open={true}>
+            <Alert variant="success">Ny oppgave er klar for behandling. Du sendes straks til oppgavebenken.</Alert>
+          </Modal>
+        )}
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Heading size="small">Valgt journalpost</Heading>
+
+      {valgtJournalpost.sak?.fagsaksystem !== 'EY' && (
+        <Panel>
+          <BodyShort spacing>
+            Du har valgt journalpost med ID {valgtJournalpost.journalpostId}.
+            <br />
+            Med dokument(er):
+          </BodyShort>
+          <List>
+            {valgtJournalpost.dokumenter.map((dok) => (
+              <List.Item key={dok.dokumentInfoId}>{dok.tittel}</List.Item>
+            ))}
+          </List>
+
+          {valgtJournalpost?.journalstatus === 'FEILREGISTRERT' ? (
+            <Alert variant="info">
+              Journalposten er markert som feilregistrert
+              <br />
+              (sakid {valgtJournalpost.sak?.fagsakId ? `er ${valgtJournalpost.sak?.fagsakId}` : 'mangler'} og tilhører
+              fagsystem {valgtJournalpost.sak?.fagsaksystem})
+            </Alert>
+          ) : (
+            <Alert variant="warning">
+              Journalposten tilhører ikke Gjenny (EY)!
+              <br />
+              Sakid {valgtJournalpost.sak?.fagsakId ? `er ${valgtJournalpost.sak?.fagsakId}` : 'mangler'} og tilhører
+              fagsystem {valgtJournalpost.sak?.fagsaksystem}
+            </Alert>
+          )}
+
+          <br />
+
+          <FlexRow justify="right">
+            {valgtJournalpost?.journalstatus === 'FEILREGISTRERT' ? (
+              <Button
+                variant="secondary"
+                onClick={opphevFeilregistrering}
+                loading={isPending(opphevFeilregisrteringStatus)}
+              >
+                Opphev feilregistrering
+              </Button>
+            ) : (
+              <Button variant="danger" onClick={feilregistrer} loading={isPending(feilSakstilknytningStatus)}>
+                Feilregistrer sakstilknytning
+              </Button>
+            )}
+          </FlexRow>
+        </Panel>
+      )}
+
+      <hr />
+      <br />
+
+      {mapApiResult(
+        sakMedBehandlingerStatus,
+        <Spinner label="Sjekker om bruker har sak og behandling" visible />,
+        (error: ApiError) => {
+          if (error.code === 'PERSON_MANGLER_SAK') {
+            return (
+              <Panel>
+                <Alert variant="warning">
+                  Personen ({bruker}) har ingen sak i Gjenny
+                  <br />
+                  For å flytte en journalpost til Gjenny må brukeren ha en sak. Velg saktype og opprett sak.
+                </Alert>
+                <br />
+
+                <FlexRow justify="right" align="end">
+                  <Select
+                    label="Sakstype"
+                    value={sakType || ''}
+                    onChange={(e) => setSakType(e.target.value as SakType)}
+                  >
+                    <option value={undefined}>Velg saktype ...</option>
+                    <option value={SakType.BARNEPENSJON}>{formaterSakstype(SakType.BARNEPENSJON)}</option>
+                    <option value={SakType.OMSTILLINGSSTOENAD}>{formaterSakstype(SakType.OMSTILLINGSSTOENAD)}</option>
+                  </Select>
+                  <Button onClick={opprettSak} disabled={!sakType} loading={isPending(hentEllerOpprettSakStatus)}>
+                    Opprett {sakType ? formaterSakstype(sakType) : 'sak'}
+                  </Button>
+                </FlexRow>
+              </Panel>
+            )
+          } else return <ApiErrorAlert>{error.detail}</ApiErrorAlert>
+        },
+        (sak) => (
+          <Panel>
+            <Heading size="small">Brukers sak i Gjenny</Heading>
+            <InfoWrapper>
+              <Info label="SakID" tekst={sak.sak.id} />
+              <Info label="Sakstype" tekst={formaterSakstype(sak.sak.sakType)} />
+              <Info label="Enhet" tekst={sak.sak.enhet} />
+            </InfoWrapper>
+
+            <br />
+
+            <Alert variant="info">
+              Journalposten er tilknyttet en annen sak, men kan knyttes til Gjenny-saken. Når du knytter en journalpost
+              til en annen sak vil det bli laget en kopi av journalposten som knyttes til saken. Den gamle (med feil
+              sakstilknytning) må være feilregistrert. Det vil også bli opprettet en oppgave i oppgavelisten for
+              behandling av den nye journalposten.
+              <br /> <br />
+              <strong>OBS!</strong> Det er ingen begrensning på antall ganger du kan opprette kopi-journalposter
+              tilknyttet saken, så pass på at det ikke allerede finnes en ny versjon av journalposten som er tilknyttet
+              saken.
+            </Alert>
+
+            <br />
+
+            <FlexRow justify="right">
+              <Button
+                onClick={knyttJournalpostTilGjennySak}
+                loading={isPending(knyttTilAnnenSakStatus) || isPending(nyOppgaveStatus)}
+                disabled={isSuccess(nyOppgaveStatus)}
+              >
+                Knytt til sak {sak.sak.id}
+              </Button>
+            </FlexRow>
+          </Panel>
+        )
+      )}
+
+      {isSuccess(nyOppgaveStatus) && (
+        <Modal open={true}>
+          <Alert variant="success">Ny oppgave er klar for behandling. Du sendes straks til oppgavebenken.</Alert>
+        </Modal>
+      )}
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/flyttjournalpost/VelgJournalpost.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/flyttjournalpost/VelgJournalpost.tsx
@@ -1,0 +1,105 @@
+import { mapAllApiResult, Result } from '~shared/api/apiUtils'
+import Spinner from '~shared/Spinner'
+import { ApiErrorAlert } from '~ErrorBoundary'
+import { Alert, Button, Heading, Table } from '@navikt/ds-react'
+import { formaterStringDato } from '~utils/formattering'
+import React from 'react'
+import { Journalpost } from '~shared/types/Journalpost'
+import { Info } from '~components/behandling/soeknadsoversikt/Info'
+import { InfoWrapper } from '~components/behandling/soeknadsoversikt/styled'
+import styled from 'styled-components'
+
+interface Props {
+  valgtJournalpost?: Journalpost
+  setValgtJournalpost: (journalpost: Journalpost) => void
+  journalposterStatus: Result<Journalpost[]>
+}
+
+const JournalpostDetaljer = ({ journalpost }: { journalpost: Journalpost }) => (
+  <>
+    <InfoPanel>
+      <Heading size="small">Sak</Heading>
+
+      <InfoWrapper>
+        <Info label="SakID" tekst={journalpost.sak?.fagsakId || '-'} />
+        <Info label="Sakstype" tekst={journalpost.sak?.sakstype || '-'} />
+        <Info label="Fagsystem" tekst={journalpost.sak?.fagsaksystem || '-'} />
+        <Info label="Tema" tekst={journalpost.sak?.tema || '-'} />
+      </InfoWrapper>
+    </InfoPanel>
+
+    <InfoPanel>
+      <Heading size="small">Dokumenter</Heading>
+
+      {journalpost.dokumenter.map((dok, i) => (
+        <Info label={`Dokument (${dok.dokumentInfoId})`} tekst={dok.tittel} key={i} />
+      ))}
+    </InfoPanel>
+  </>
+)
+
+export const VelgJournalpost = ({ valgtJournalpost, setValgtJournalpost, journalposterStatus }: Props) => {
+  return mapAllApiResult(
+    journalposterStatus,
+    <Spinner visible label="Henter journalposter for bruker" />,
+    null,
+    () => <ApiErrorAlert>Feil oppsto ved henting av journalposter</ApiErrorAlert>,
+    (journalposter) => (
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>{/* expand */}</Table.HeaderCell>
+            <Table.HeaderCell>ID</Table.HeaderCell>
+            <Table.HeaderCell>Opprettet</Table.HeaderCell>
+            <Table.HeaderCell>Tema</Table.HeaderCell>
+            <Table.HeaderCell>Status</Table.HeaderCell>
+            <Table.HeaderCell>{/* knapper */}</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {journalposter.length ? (
+            journalposter.map((journalpost) => (
+              <Table.ExpandableRow
+                key={journalpost.journalpostId}
+                content={<JournalpostDetaljer journalpost={journalpost} />}
+              >
+                <Table.DataCell>{journalpost.journalpostId}</Table.DataCell>
+                <Table.DataCell>
+                  {journalpost.datoOpprettet ? formaterStringDato(journalpost.datoOpprettet) : '-'}
+                </Table.DataCell>
+                <Table.DataCell>{journalpost.tema}</Table.DataCell>
+                <Table.DataCell>{journalpost.journalstatus}</Table.DataCell>
+                <Table.DataCell>
+                  {journalpost.journalpostId === valgtJournalpost?.journalpostId ? (
+                    <Alert size="small" variant="success" style={{ width: 'fit-content' }}>
+                      Valgt
+                    </Alert>
+                  ) : (
+                    <Button size="small" onClick={() => setValgtJournalpost(journalpost)}>
+                      Velg
+                    </Button>
+                  )}
+                </Table.DataCell>
+              </Table.ExpandableRow>
+            ))
+          ) : (
+            <Table.Row>
+              <Table.DataCell colSpan={100}>Ingen journalposter funnet på bruker</Table.DataCell>
+            </Table.Row>
+          )}
+        </Table.Body>
+      </Table>
+    )
+  )
+}
+
+const InfoPanel = styled.div`
+  padding: 0.5rem;
+  border: 1px solid lightgray;
+  border-radius: 0.2rem;
+  background: #fafafa;
+
+  :not(:last-child) {
+    margin-bottom: 1rem;
+  }
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/EndreSak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/EndreSak.tsx
@@ -4,7 +4,7 @@ import { Button, Heading, Table } from '@navikt/ds-react'
 import React from 'react'
 import { TabsAddIcon, XMarkIcon } from '@navikt/aksel-icons'
 
-const temaFraSakstype = (sakstype: SakType): string => {
+export const temaFraSakstype = (sakstype: SakType): string => {
   switch (sakstype) {
     case SakType.BARNEPENSJON:
       return 'EYB'

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/dokument.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/dokument.ts
@@ -1,9 +1,18 @@
-import { Journalpost, OppdaterJournalpostRequest } from '~shared/types/Journalpost'
+import {
+  Journalpost,
+  KnyttTilAnnenSakRequest,
+  KnyttTilAnnenSakResponse,
+  OppdaterJournalpostRequest,
+} from '~shared/types/Journalpost'
 import { apiClient, ApiResponse } from './apiClient'
 import { ISak } from '~shared/types/sak'
 
 export const hentDokumenter = async (fnr: string): Promise<ApiResponse<Journalpost[]>> =>
   apiClient.post(`/dokumenter`, { foedselsnummer: fnr })
+
+// Midlertidig for å støtte uthenting av gjenlevendepensjon
+export const hentAlleDokumenterInklPensjon = async (fnr: string): Promise<ApiResponse<Journalpost[]>> =>
+  apiClient.post(`/dokumenter?visTemaPen=true`, { foedselsnummer: fnr })
 
 export const ferdigstillJournalpost = async (args: { journalpostId: string; sak: ISak }): Promise<ApiResponse<Blob>> =>
   apiClient.post(`/dokumenter/${args.journalpostId}/ferdigstill`, { ...args.sak })
@@ -12,6 +21,18 @@ export const endreTemaJournalpost = async (args: {
   journalpostId: string
   nyttTema: string
 }): Promise<ApiResponse<any>> => apiClient.put(`/dokumenter/${args.journalpostId}/tema/${args.nyttTema}`, {})
+
+export const feilregistrerSakstilknytning = async (journalpostId: string): Promise<ApiResponse<any>> =>
+  apiClient.put(`/dokumenter/${journalpostId}/feilregistrerSakstilknytning`, {})
+
+export const opphevFeilregistrertSakstilknytning = async (journalpostId: string): Promise<ApiResponse<any>> =>
+  apiClient.put(`/dokumenter/${journalpostId}/opphevFeilregistrertSakstilknytning`, {})
+
+export const knyttTilAnnenSak = async (args: {
+  journalpostId: string
+  request: KnyttTilAnnenSakRequest
+}): Promise<ApiResponse<KnyttTilAnnenSakResponse>> =>
+  apiClient.put(`/dokumenter/${args.journalpostId}/knyttTilAnnenSak`, { ...args.request })
 
 export const oppdaterJournalpost = async (args: {
   journalpost: OppdaterJournalpostRequest

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaver.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaver.ts
@@ -22,6 +22,13 @@ export interface OppgaveDTO {
   versjon: string | null
 }
 
+export interface NyOppgaveDto {
+  oppgaveKilde?: OppgaveKilde
+  oppgaveType: Oppgavetype
+  merknad?: string
+  referanse?: string
+}
+
 export type Oppgavestatus = 'NY' | 'UNDER_BEHANDLING' | 'FERDIGSTILT' | 'FEILREGISTRERT' | 'AVBRUTT'
 export type OppgaveKilde = 'HENDELSE' | 'BEHANDLING' | 'EKSTERN' | 'GENERELL_BEHANDLING' | 'TILBAKEKREVING'
 export type Oppgavetype =
@@ -43,6 +50,11 @@ export const erOppgaveRedigerbar = (status: Oppgavestatus): boolean => ['NY', 'U
 export const hentOppgaver = async (): Promise<ApiResponse<OppgaveDTO[]>> => apiClient.get('/oppgaver')
 export const hentOppgave = async (id: string): Promise<ApiResponse<OppgaveDTO>> => apiClient.get(`/oppgaver/${id}`)
 export const hentGosysOppgaver = async (): Promise<ApiResponse<OppgaveDTO[]>> => apiClient.get('/oppgaver/gosys')
+
+export const opprettOppgave = async (args: {
+  sakId: number
+  request: NyOppgaveDto
+}): Promise<ApiResponse<OppgaveDTO>> => apiClient.post(`/oppgaver/sak/${args.sakId}/opprett`, { ...args.request })
 
 export const ferdigstillOppgave = async (id: string): Promise<ApiResponse<any>> =>
   apiClient.put(`/oppgaver/${id}/ferdigstill`, {})

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/sak.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/sak.ts
@@ -27,8 +27,18 @@ export const hentFlyktningStatusForSak = async (sakId: number): Promise<ApiRespo
   return apiClient.get(`sak/${sakId}/flyktning`)
 }
 
-export const hentSakForPerson = async (args: { fnr: string; type: SakType }): Promise<ApiResponse<ISak>> =>
-  apiClient.post(`/personer/sak/${args.type}`, { foedselsnummer: args.fnr })
+export const hentSakForPerson = async (args: {
+  fnr: string
+  type: SakType
+  opprettHvisIkkeFinnes?: boolean
+}): Promise<ApiResponse<ISak>> => {
+  if (args.opprettHvisIkkeFinnes) {
+    // TODO: Fjerne når søknad gjenlevendepensjon ikke lenger må behandles
+    return apiClient.post(`/personer/sak/${args.type}?opprettHvisIkkeFinnes=true`, { foedselsnummer: args.fnr })
+  } else {
+    return apiClient.post(`/personer/sak/${args.type}`, { foedselsnummer: args.fnr })
+  }
+}
 
 export const byttEnhetPaaSak = async (args: { sakId: number; enhet: String }): Promise<ApiResponse<void>> => {
   return apiClient.post(`sak/${args.sakId}/endre_enhet`, { enhet: args.enhet })

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/styled.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/styled.tsx
@@ -71,7 +71,7 @@ export const FlexRow = styled.div<{
 }>`
   display: flex;
   justify-content: ${(props) => props.justify ?? 'left'};
-  align-items: ${(props) => props.justify ?? 'normal'};
+  align-items: ${(props) => props.align ?? 'normal'};
   gap: 1rem;
   ${(props) =>
     props.$spacing &&

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Journalpost.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Journalpost.ts
@@ -22,6 +22,22 @@ export interface OppdaterJournalpostRequest {
   sak?: JournalpostSak
 }
 
+export interface KnyttTilAnnenSakRequest {
+  bruker: {
+    id: string
+    idType: string
+  }
+  fagsakId: string
+  fagsaksystem: string
+  journalfoerendeEnhet: string
+  sakstype: string
+  tema: string
+}
+
+export interface KnyttTilAnnenSakResponse {
+  nyJournalpostId: string
+}
+
 export interface DokumentInfo {
   dokumentInfoId: string
   tittel: string

--- a/apps/etterlatte-saksbehandling-ui/docker-compose.yml
+++ b/apps/etterlatte-saksbehandling-ui/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       APP_VERSION: 1
       # Lokale URL-er skal kommenteres ut når de ikke er i bruk
 #      BREV_API_URL: http://host.docker.internal:8084
+#      BEHANDLING_API_URL: http://host.docker.internal:8090
     env_file:
       - .env.dev-gcp # Opprettes med script get-secret.sh. Les README
 


### PR DESCRIPTION
Nå som gjenlevendepensjon og omstillingsstønad kjører parallelt kan vi potensielt motta mange feilsendte journalposter. 

Gjenlevendepensjon som havner i Gjenny er enkelt – bytt tema til `PEN` og den plukkes opp av Pesys/Gosys.

Omstillingsstønad som havner i Pesys er verre: journalposten blir ferdigstilt og vi har ingen støtte for å hente den ut. Denne endringen gjør det mulig å feilregistrere journalposten og knytte den til sak i Gjenny. 

Dette er en _**midlertidig fiks**_, derav litt rotete grensesnitt og kode. 

### Flyt blir da som følger: 
1. Pesys får "Søknad om gjenlevendepensjon"
2. Saksbehandler ser den skulle vært omstillingsstønad pga. dato for dødsfallet. 
3. Åpner Gjenny og `/flyttjournalpost` (skjult som adminverktøy enn så lenge)
4. ...forts under:

### 5. Søker opp bruker
![Skjermbilde 2023-12-21 kl  10 04 14](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/26b404b9-6b07-4887-b693-27679b66697b)

### 6. Velger journalpost
![Skjermbilde 2023-12-21 kl  10 05 32](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/1b4fdac9-f280-4ccf-9442-6efc300b5774)

### 7. Markerer med feilregistrert sakstilknytning
![Skjermbilde 2023-12-21 kl  10 06 10](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/4987805c-e8a0-46d0-a1aa-823cee956d7d)

### 8. Oppretter sak for bruker hvis ikke finnes
![Skjermbilde 2023-12-21 kl  10 06 38](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/a8e8c8e8-5849-4d42-a5f7-c25b8a5eb836)

### 9. Knytter til den nye saken i Gjenny.
Når dette er gjort blir det opprettet en journalføringsoppgave hvor saksbehandler kan opprette ny behandling basert på journalpostens innhold. 


