### PR TITLE
Korrigert dto og gjort statusoppdatering blocking

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakBehandlingService.kt
@@ -302,7 +302,7 @@ class VedtakBehandlingService(
         return VedtakOgRapid(tilSamordningVedtakLocal.toDto(), tilSamordning)
     }
 
-    suspend fun samordnetVedtak(
+    fun samordnetVedtak(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         vedtakTilSamordning: Vedtak? = null,

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -145,7 +145,7 @@ fun Route.vedtaksvurderingRoute(
                 logger.info("Vedtak er til samordning for behandling $behandlingId")
                 val vedtak = vedtakBehandlingService.tilSamordningVedtak(behandlingId, brukerTokenInfo)
                 rapidService.sendToRapid(vedtak)
-                call.respond(HttpStatusCode.OK, vedtak.vedtak)
+                call.respond(HttpStatusCode.OK, vedtak.rapidInfo1.vedtak)
             }
         }
 
@@ -154,7 +154,7 @@ fun Route.vedtaksvurderingRoute(
                 logger.info("Vedtak ferdig samordning for behandling $behandlingId")
                 val vedtak = vedtakBehandlingService.samordnetVedtak(behandlingId, brukerTokenInfo)
                 rapidService.sendToRapid(vedtak)
-                call.respond(HttpStatusCode.OK, vedtak.vedtak)
+                call.respond(HttpStatusCode.OK, vedtak.rapidInfo1.vedtak)
             }
         }
 
@@ -219,7 +219,7 @@ fun Route.vedtaksvurderingRoute(
 
                 val samordnetVedtak = vedtakBehandlingService.samordnetVedtak(vedtak!!.behandlingId, brukerTokenInfo)
                 rapidService.sendToRapid(samordnetVedtak)
-                call.respond(HttpStatusCode.OK, samordnetVedtak.vedtak)
+                call.respond(HttpStatusCode.OK, samordnetVedtak.rapidInfo1.vedtak)
             }
         }
     }

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtakBehandlingServiceTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtakBehandlingServiceTest.kt
@@ -1129,15 +1129,13 @@ internal class VedtakBehandlingServiceTest {
     fun `skal ikke sette vedtak til samordnet pga ugyldig vedtaksstatus for oppdatering`() {
         val behandlingId = randomUUID()
 
-        runBlocking {
-            repository.opprettVedtak(opprettVedtak(behandlingId = behandlingId, status = VedtakStatus.ATTESTERT))
+        repository.opprettVedtak(opprettVedtak(behandlingId = behandlingId, status = VedtakStatus.ATTESTERT))
 
-            assertThrows<VedtakTilstandException> {
-                service.samordnetVedtak(behandlingId, attestant)
-            }
-
-            coVerify { behandlingKlientMock wasNot called }
+        assertThrows<VedtakTilstandException> {
+            service.samordnetVedtak(behandlingId, attestant)
         }
+
+        coVerify { behandlingKlientMock wasNot called }
     }
 
     private fun underkjennVedtakBegrunnelse() = UnderkjennVedtakDto("Vedtaket er ugyldig", "Annet")


### PR DESCRIPTION
DTO i usynk med `vedtaksvurdering-kafka`

Hadde noe problemer med at kall feilet med at status var SAMORDNET i stedet for TIL_SAMORDNING, når den oppdateringen gjøres innenfor samme route. Ser ut til at å droppe suspend fjernet den feilen.