### PR TITLE
Skrive les tilgang frontend

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
@@ -18,6 +18,7 @@ import { usePersonopplysninger, usePersonopplysningerOmsAvdoede } from '~compone
 
 import { isPending } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
+import { useAppSelector } from '~store/Store'
 
 export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => {
   const { behandling } = props
@@ -26,7 +27,9 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
   const soeker = usePersonopplysninger()?.soeker?.opplysning
   const avdoede = usePersonopplysningerOmsAvdoede()
   const avdoedesDoedsdato = avdoede?.opplysning?.doedsdato
-  const redigerbar = behandlingErRedigerbar(behandling.status)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+
+  const redigerbar = behandlingErRedigerbar(behandling.status) && innloggetSaksbehandler.skriveTilgang
   const configContext = useContext(ConfigContext)
 
   const [beskrivelse, setBeskrivelse] = useState<string>('')

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
@@ -8,7 +8,7 @@ import Spinner from '~shared/Spinner'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { YtelseEtterAvkorting } from '~components/behandling/avkorting/YtelseEtterAvkorting'
 import { IBehandlingReducer, oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'
-import { useAppDispatch } from '~store/Store'
+import { useAppDispatch, useAppSelector } from '~store/Store'
 import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
 import { behandlingErRedigerbar } from '~components/behandling/felles/utils'
 
@@ -19,7 +19,9 @@ export const Avkorting = (props: { behandling: IBehandlingReducer }) => {
   const dispatch = useAppDispatch()
   const [avkortingStatus, hentAvkortingRequest] = useApiCall(hentAvkorting)
   const [avkorting, setAvkorting] = useState<IAvkorting>()
-  const redigerbar = behandlingErRedigerbar(behandling.status)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+
+  const redigerbar = behandlingErRedigerbar(behandling.status) && innloggetSaksbehandler.skriveTilgang
 
   useEffect(() => {
     if (!avkorting) {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -26,6 +26,7 @@ import { OmstillingsstoenadToolTip } from '~components/behandling/beregne/Omstil
 
 import { isPending } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
+import { useAppSelector } from '~store/Store'
 
 export const AvkortingInntekt = (props: {
   behandling: IBehandlingReducer
@@ -33,8 +34,9 @@ export const AvkortingInntekt = (props: {
   redigerbar: boolean
   setAvkorting: (avkorting: IAvkorting) => void
 }) => {
-  const behandling = props.behandling
-  const redigerbar = props.redigerbar
+  const { behandling } = props
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+  const redigerbar = props.redigerbar && innloggetSaksbehandler.skriveTilgang
   const avkortingGrunnlag = [...props.avkortingGrunnlag]
   avkortingGrunnlag?.sort((a, b) => new Date(b.fom!).getTime() - new Date(a.fom!).getTime())
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
@@ -3,7 +3,7 @@ import { Border, HeadingWrapper } from '../soeknadsoversikt/styled'
 import { behandlingErRedigerbar, behandlingSkalSendeBrev } from '../felles/utils'
 import { formaterStringDato } from '~utils/formattering'
 import { useVedtaksResultat } from '../useVedtaksResultat'
-import { useAppDispatch } from '~store/Store'
+import { useAppDispatch, useAppSelector } from '~store/Store'
 import { useBehandlingRoutes } from '../BehandlingRoutes'
 import React, { useEffect, useState } from 'react'
 import { hentBeregning } from '~shared/api/beregning'
@@ -42,7 +42,9 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
   const virkningstidspunkt = behandling.virkningstidspunkt?.dato
     ? formaterStringDato(behandling.virkningstidspunkt.dato)
     : undefined
-  const redigerbar = behandlingErRedigerbar(behandling.status)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+
+  const redigerbar = behandlingErRedigerbar(behandling.status) && innloggetSaksbehandler.skriveTilgang
   const erOpphoer = behandling.vilkårsprøving?.resultat?.utfall == VilkaarsvurderingResultat.IKKE_OPPFYLT
   const vedtaksresultat =
     behandling.behandlingType !== IBehandlingsType.MANUELT_OPPHOER ? useVedtaksResultat() : 'opphoer'

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
@@ -3,7 +3,7 @@ import { BehandlingHandlingKnapper } from '../handlinger/BehandlingHandlingKnapp
 import { useBehandlingRoutes } from '../BehandlingRoutes'
 import { behandlingErRedigerbar } from '../felles/utils'
 import { NesteOgTilbake } from '../handlinger/NesteOgTilbake'
-import { useAppDispatch } from '~store/Store'
+import { useAppDispatch, useAppSelector } from '~store/Store'
 import { hentBeregningsGrunnlag, lagreBeregningsGrunnlag, opprettEllerEndreBeregning } from '~shared/api/beregning'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import {
@@ -43,7 +43,9 @@ const BeregningsgrunnlagBarnepensjon = (props: { behandling: IBehandlingReducer 
   const { next } = useBehandlingRoutes()
   const personopplysninger = usePersonopplysninger()
   const avdoede = personopplysninger?.avdoede.find((po) => po)
-  const redigerbar = behandlingErRedigerbar(behandling.status)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+
+  const redigerbar = behandlingErRedigerbar(behandling.status) && innloggetSaksbehandler.skriveTilgang
   const dispatch = useAppDispatch()
   const [lagreBeregningsgrunnlag, postBeregningsgrunnlag] = useApiCall(lagreBeregningsGrunnlag)
   const [beregningsgrunnlag, fetchBeregningsgrunnlag] = useApiCall(hentBeregningsGrunnlag)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
@@ -3,7 +3,7 @@ import { BehandlingHandlingKnapper } from '../handlinger/BehandlingHandlingKnapp
 import { useBehandlingRoutes } from '../BehandlingRoutes'
 import { behandlingErRedigerbar } from '../felles/utils'
 import { NesteOgTilbake } from '../handlinger/NesteOgTilbake'
-import { useAppDispatch } from '~store/Store'
+import { useAppDispatch, useAppSelector } from '~store/Store'
 import {
   hentBeregningsGrunnlagOMS,
   lagreBeregningsGrunnlagOMS,
@@ -39,7 +39,9 @@ const BeregningsgrunnlagOmstillingsstoenad = (props: { behandling: IBehandlingRe
   const { behandling } = props
   const { next } = useBehandlingRoutes()
   const dispatch = useAppDispatch()
-  const redigerbar = behandlingErRedigerbar(behandling.status)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+
+  const redigerbar = behandlingErRedigerbar(behandling.status) && innloggetSaksbehandler.skriveTilgang
   const [beregningsgrunnlag, fetchBeregningsgrunnlag] = useApiCall(hentBeregningsGrunnlagOMS)
   const [lagreBeregningsgrunnlagOMS, postBeregningsgrunnlag] = useApiCall(lagreBeregningsGrunnlagOMS)
   const [endreBeregning, postOpprettEllerEndreBeregning] = useApiCall(opprettEllerEndreBeregning)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
@@ -26,7 +26,7 @@ import { SjekklisteValideringErrorSummary } from '~components/behandling/sjekkli
 import { IHendelse } from '~shared/types/IHendelse'
 import { oppdaterBehandling, resetBehandling } from '~store/reducers/BehandlingReducer'
 import { hentBehandling } from '~shared/api/behandling'
-import { useAppDispatch } from '~store/Store'
+import { useAppDispatch, useAppSelector } from '~store/Store'
 import { getVergeadresseFraGrunnlag } from '~shared/api/grunnlag'
 import { VergeFeilhaandtering } from '~components/person/VergeFeilhaandtering'
 import { isPending, isPendingOrInitial } from '~shared/api/apiUtils'
@@ -40,7 +40,9 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
   const { behandlingId } = useParams()
   const dispatch = useAppDispatch()
   const { sakId, soeknadMottattDato } = props.behandling
-  const redigerbar = behandlingErRedigerbar(props.behandling.status)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+
+  const redigerbar = behandlingErRedigerbar(props.behandling.status) && innloggetSaksbehandler.skriveTilgang
 
   const [vedtaksbrev, setVedtaksbrev] = useState<IBrev | undefined>(undefined)
   const [visAdvarselBehandlingEndret, setVisAdvarselBehandlingEndret] = useState(false)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/Brevutfall.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/Brevutfall.tsx
@@ -10,6 +10,7 @@ import { BrevutfallVisning } from '~components/behandling/brevutfall/BrevutfallV
 import Spinner from '~shared/Spinner'
 import { MapApiResult } from '~shared/components/MapApiResult'
 import { SakType } from '~shared/types/sak'
+import { useAppSelector } from '~store/Store'
 
 export interface BrevutfallOgEtterbetaling {
   etterbetaling?: Etterbetaling | null
@@ -48,7 +49,9 @@ const initialBrevutfallOgEtterbetaling = (saktype: SakType) => {
 
 export const Brevutfall = (props: { behandling: IDetaljertBehandling }) => {
   const behandling = props.behandling
-  const redigerbar = behandlingErRedigerbar(behandling.status)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+
+  const redigerbar = behandlingErRedigerbar(behandling.status) && innloggetSaksbehandler.skriveTilgang
   const [brevutfallOgEtterbetaling, setBrevutfallOgEtterbetaling] = useState<BrevutfallOgEtterbetaling>(
     initialBrevutfallOgEtterbetaling(behandling.sakType)
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/AdoptertAv.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/AdoptertAv.tsx
@@ -13,6 +13,7 @@ import { Revurderingsbegrunnelse } from '~components/behandling/revurderingsover
 
 import { isPending, isSuccess } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
+import { useAppSelector } from '~store/Store'
 
 function formaterNavn(navn: Navn) {
   return [navn.fornavn, navn.mellomnavn, navn.etternavn].join(' ')
@@ -26,7 +27,9 @@ export const AdoptertAv = (props: { behandling: IDetaljertBehandling }) => {
   const [feilmelding, setFeilmelding] = useState<string | undefined>(undefined)
   const [begrunnelse, setBegrunnelse] = useState(behandling.revurderinginfo?.begrunnelse ?? '')
   const [lagrestatus, lagre] = useApiCall(lagreRevurderingInfo)
-  const redigerbar = behandlingErRedigerbar(behandling.status)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+  const redigerbar = behandlingErRedigerbar(behandling.status) && innloggetSaksbehandler.skriveTilgang
+
   const handlesubmit = (e: FormEvent) => {
     e.stopPropagation()
     e.preventDefault()

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/GrunnForSoeskenjustering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/GrunnForSoeskenjustering.tsx
@@ -19,6 +19,7 @@ import { Revurderingsbegrunnelse } from '~components/behandling/revurderingsover
 
 import { isPending, isSuccess } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
+import { useAppSelector } from '~store/Store'
 
 export const GrunnForSoeskenjustering = (props: { behandling: IDetaljertBehandling }) => {
   const { behandling } = props
@@ -29,7 +30,8 @@ export const GrunnForSoeskenjustering = (props: { behandling: IDetaljertBehandli
   const [feilmelding, setFeilmelding] = useState<string | undefined>(undefined)
   const [begrunnelse, setBegrunnelse] = useState(behandling.revurderinginfo?.begrunnelse ?? '')
   const [lagrestatus, lagre] = useApiCall(lagreRevurderingInfo)
-  const redigerbar = behandlingErRedigerbar(behandling.status)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+  const redigerbar = behandlingErRedigerbar(behandling.status) && innloggetSaksbehandler.skriveTilgang
   const harEndretInfo =
     soeskenjusteringInfo?.grunnForSoeskenjustering !== null &&
     valgtSoeskenjustering !== soeskenjusteringInfo?.grunnForSoeskenjustering

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/OmgjoeringAvFarskap.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/OmgjoeringAvFarskap.tsx
@@ -18,6 +18,7 @@ import { Revurderingsbegrunnelse } from '~components/behandling/revurderingsover
 
 import { isPending, isSuccess } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
+import { useAppSelector } from '~store/Store'
 
 export const OmgjoeringAvFarskap = (props: { behandling: IDetaljertBehandling }) => {
   const { behandling } = props
@@ -30,7 +31,8 @@ export const OmgjoeringAvFarskap = (props: { behandling: IDetaljertBehandling })
   const [feilmelding, setFeilmelding] = useState<string | undefined>(undefined)
   const [begrunnelse, setBegrunnelse] = useState(behandling.revurderinginfo?.begrunnelse ?? '')
   const [lagrestatus, lagre] = useApiCall(lagreRevurderingInfo)
-  const redigerbar = behandlingErRedigerbar(behandling.status)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+  const redigerbar = behandlingErRedigerbar(behandling.status) && innloggetSaksbehandler.skriveTilgang
   const handlesubmit = (e: FormEvent) => {
     e.stopPropagation()
     e.preventDefault()

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/RevurderingAnnen.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/RevurderingAnnen.tsx
@@ -12,6 +12,7 @@ import { Revurderingsbegrunnelse } from '~components/behandling/revurderingsover
 
 import { isPending, isSuccess } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
+import { useAppSelector } from '~store/Store'
 
 export const RevurderingAnnen = (props: { behandling: IDetaljertBehandling }) => {
   const { behandling } = props
@@ -20,7 +21,8 @@ export const RevurderingAnnen = (props: { behandling: IDetaljertBehandling }) =>
   const [begrunnelse, setBegrunnelse] = useState(behandling.revurderinginfo?.begrunnelse ?? '')
   const [feilmelding, setFeilmelding] = useState<string | null>(null)
   const [lagrestatus, lagre] = useApiCall(lagreRevurderingInfo)
-  const redigerbar = behandlingErRedigerbar(behandling.status)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+  const redigerbar = behandlingErRedigerbar(behandling.status) && innloggetSaksbehandler.skriveTilgang
 
   const handlesubmit = (e: FormEvent) => {
     e.stopPropagation()

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/Revurderingsoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/Revurderingsoversikt.tsx
@@ -40,6 +40,7 @@ import { SluttbehandlingUtlandInfo } from '~shared/types/RevurderingInfo'
 import OppdaterGrunnlagModal from '~components/behandling/handlinger/OppdaterGrunnlagModal'
 import { Utlandstilknytning } from '~components/behandling/soeknadsoversikt/utlandstilknytning/Utlandstilknytning'
 import { format } from 'date-fns'
+import { useAppSelector } from '~store/Store'
 
 const revurderingsaarsakTilTekst = (revurderingsaarsak: Revurderingaarsak): string =>
   tekstRevurderingsaarsak[revurderingsaarsak]
@@ -88,7 +89,8 @@ const hjemlerOgBeskrivelseBarnepensjon = (revurderingsaarsak: Revurderingaarsak)
 
 export const Revurderingsoversikt = (props: { behandling: IDetaljertBehandling }) => {
   const { behandling } = props
-  const redigerbar = behandlingErRedigerbar(behandling.status)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+  const redigerbar = behandlingErRedigerbar(behandling.status) && innloggetSaksbehandler.skriveTilgang
   const revurderingsaarsak = requireNotNull(
     behandling.revurderingsaarsak,
     'Kan ikke starte en revurdering uten en revurderingsårsak'

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/Soeknadoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/Soeknadoversikt.tsx
@@ -31,10 +31,12 @@ import { Info } from '~components/behandling/soeknadsoversikt/Info'
 import { formaterStringDato } from '~utils/formattering'
 import { formaterGrunnlagKilde } from '~components/behandling/soeknadsoversikt/utils'
 import { usePersonopplysninger } from '~components/person/usePersonopplysninger'
+import { useAppSelector } from '~store/Store'
 
 export const Soeknadsoversikt = (props: { behandling: IDetaljertBehandling }) => {
   const { behandling } = props
-  const redigerbar = behandlingErRedigerbar(behandling.status)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+  const redigerbar = behandlingErRedigerbar(behandling.status) && innloggetSaksbehandler.skriveTilgang
   const erGyldigFremsatt = behandling.gyldighetsprøving?.resultat === VurderingsResultat.OPPFYLT
   const personopplysninger = usePersonopplysninger()
   const avdoede = personopplysninger?.avdoede?.find((po) => po)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/GyldigFramsattBarnepensjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/barnepensjon/GyldigFramsattBarnepensjon.tsx
@@ -20,6 +20,7 @@ import { getPersongalleriFraSoeknad } from '~shared/api/grunnlag'
 import { Familieforhold } from '~shared/types/Person'
 
 import { isSuccess } from '~shared/api/apiUtils'
+import { useAppSelector } from '~store/Store'
 
 export const GyldigFramsattBarnepensjon = ({
   behandling,
@@ -35,8 +36,8 @@ export const GyldigFramsattBarnepensjon = ({
   if (gyldigFramsatt == null) {
     return <div style={{ color: 'red' }}>Kunne ikke hente ut data om søknaden er gyldig framsatt</div>
   }
-
-  const redigerbar = behandlingErRedigerbar(behandling.status)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+  const redigerbar = behandlingErRedigerbar(behandling.status) && innloggetSaksbehandler.skriveTilgang
   const [personGalleriSoeknad, getPersonGalleriSoeknad] = useApiCall(getPersongalleriFraSoeknad)
   useEffect(() => {
     getPersonGalleriSoeknad({ sakId: behandling.sakId, behandlingId: behandling.id })

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/omstillingsstoenad/GyldigFramsattOmstillingsstoenad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/omstillingsstoenad/GyldigFramsattOmstillingsstoenad.tsx
@@ -13,6 +13,7 @@ import { behandlingErRedigerbar } from '~components/behandling/felles/utils'
 import { StatusIconProps } from '~shared/icons/statusIcon'
 import { Personopplysning } from '~shared/types/grunnlag'
 import { Verger } from '~components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/Verger'
+import { useAppSelector } from '~store/Store'
 
 export const GyldigFramsattOmstillingsstoenad = ({
   behandling,
@@ -23,7 +24,8 @@ export const GyldigFramsattOmstillingsstoenad = ({
   behandling: IDetaljertBehandling
   innsender?: Personopplysning
 }) => {
-  const redigerbar = behandlingErRedigerbar(behandling.status)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+  const redigerbar = behandlingErRedigerbar(behandling.status) && innloggetSaksbehandler.skriveTilgang
   const navn = innsender ? `${innsender.opplysning.fornavn} ${innsender.opplysning.etternavn}` : 'Ukjent'
   const undertekst = formaterGrunnlagKilde(innsender?.kilde)
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidVisning.tsx
@@ -16,7 +16,7 @@ import YrkesskadeTrygdetid from '~components/behandling/trygdetid/YrkesskadeTryg
 import { Trygdetid } from '~components/behandling/trygdetid/Trygdetid'
 import { oppdaterStatus } from '~shared/api/trygdetid'
 import { oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'
-import { useAppDispatch } from '~store/Store'
+import { useAppDispatch, useAppSelector } from '~store/Store'
 import { handlinger } from '~components/behandling/handlinger/typer'
 import { Vilkaarsresultat } from '~components/behandling/felles/Vilkaarsresultat'
 
@@ -26,7 +26,9 @@ import { isFailureHandler } from '~shared/api/IsFailureHandler'
 const TrygdetidVisning = (props: { behandling: IDetaljertBehandling }) => {
   const { behandling } = props
   const dispatch = useAppDispatch()
-  const redigerbar = behandlingErRedigerbar(behandling.status)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+
+  const redigerbar = behandlingErRedigerbar(behandling.status) && innloggetSaksbehandler.skriveTilgang
   const { next } = useBehandlingRoutes()
   const [vilkaarsvurdering, getVilkaarsvurdering] = useApiCall(hentVilkaarsvurdering)
   const [yrkesskadeTrygdetid, setYrkesskadeTrygdetid] = useState<boolean>(false)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
@@ -10,7 +10,7 @@ import {
   oppdaterBehandlingsstatus,
   updateVilkaarsvurdering,
 } from '~store/reducers/BehandlingReducer'
-import { useAppDispatch } from '~store/Store'
+import { useAppDispatch, useAppSelector } from '~store/Store'
 import { Alert, BodyLong, Button, Heading } from '@navikt/ds-react'
 import { Border, HeadingWrapper } from '../soeknadsoversikt/styled'
 import { behandlingErRedigerbar } from '~components/behandling/felles/utils'
@@ -33,7 +33,8 @@ export const Vilkaarsvurdering = (props: { behandling: IBehandlingReducer }) => 
   const { behandlingId } = useParams()
   const dispatch = useAppDispatch()
   const vilkaarsvurdering = behandling.vilkårsprøving
-  const redigerbar = behandlingErRedigerbar(behandling.status)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+  const redigerbar = behandlingErRedigerbar(behandling.status) && innloggetSaksbehandler.skriveTilgang
   const [vilkaarsvurderingStatus, fetchVilkaarsvurdering] = useApiCall(hentVilkaarsvurdering)
   const [slettVilkaarsvurderingStatus, slettGammelVilkaarsvurdering] = useApiCall(slettVilkaarsvurdering)
   const [opprettNyVilkaarsvurderingStatus, opprettNyVilkaarsvurdering] = useApiCall(opprettVilkaarsvurdering)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/generellbehandling/KravpakkeUtland.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/generellbehandling/KravpakkeUtland.tsx
@@ -45,6 +45,7 @@ import { GenerellbehandlingSidemeny } from '~components/generellbehandling/Gener
 
 import { isPending, isPendingOrInitial, isSuccess, mapApiResult } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
+import { useAppSelector } from '~store/Store'
 
 const TextFieldBegrunnelse = styled(Textarea).attrs({ size: 'medium' })`
   max-width: 40rem;
@@ -79,6 +80,7 @@ const KravpakkeUtland = (props: { utlandsBehandling: Generellbehandling & { innh
   const [putOppdaterGenerellBehandlingStatus, putOppdaterGenerellBehandling] = useApiCall(oppdaterGenerellBehandling)
   const [avdoedeStatus, avdoedeFetch] = useApiCall(getGrunnlagsAvOpplysningstype)
   const [avdoed, setAvdoed] = useState<Grunnlagsopplysning<IPdlPerson, KildePdl> | null>(null)
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
 
   const [hentAlleLandRequest, fetchAlleLand] = useApiCall(hentAlleLand)
 
@@ -143,7 +145,8 @@ const KravpakkeUtland = (props: { utlandsBehandling: Generellbehandling & { innh
     }
   }
 
-  const redigerbar = generellbehandlingErRedigerbar(utlandsBehandling.status)
+  const redigerbar = generellbehandlingErRedigerbar(utlandsBehandling.status) && innloggetSaksbehandler.skriveTilgang
+
   return (
     <GridContainer>
       <MainContent style={{ whiteSpace: 'pre-wrap' }}>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/Klagebehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/Klagebehandling.tsx
@@ -1,7 +1,7 @@
 import { useKlage } from '~components/klage/useKlage'
 import { Navigate, Route, Routes, useMatch } from 'react-router-dom'
 import React, { useEffect } from 'react'
-import { useAppDispatch } from '~store/Store'
+import { useAppDispatch, useAppSelector } from '~store/Store'
 import { addKlage, resetKlage } from '~store/reducers/KlageReducer'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { getPerson } from '~shared/api/grunnlag'
@@ -29,6 +29,8 @@ export function Klagebehandling() {
   const klageIdFraUrl = match?.params.klageId
   const viHarLastetRiktigKlage = klageIdFraUrl === klage?.id
 
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+  const kanRedigere = innloggetSaksbehandler.skriveTilgang
   useEffect(() => {
     if (!klageIdFraUrl) return
 
@@ -60,7 +62,7 @@ export function Klagebehandling() {
         <GridContainer>
           <MainContent>
             <Routes>
-              <Route path="formkrav" element={<KlageFormkrav />} />
+              <Route path="formkrav" element={<KlageFormkrav kanRedigere={kanRedigere} />} />
               <Route path="vurdering" element={<KlageVurdering />} />
               <Route path="brev" element={<KlageBrev />} />
               <Route path="oppsummering" element={<KlageOppsummering />} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/formkrav/KlageFormkrav.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/formkrav/KlageFormkrav.tsx
@@ -73,7 +73,7 @@ function mapFormkrav(krav: FilledFormDataFormkrav, vedtakIKlagen: Array<Vedtaket
   return { ...krav, vedtaketKlagenGjelder: null }
 }
 
-export function KlageFormkrav() {
+export function KlageFormkrav({ kanRedigere }: { kanRedigere: boolean }) {
   const klage = useKlage()
   const [lagreFormkravStatus, lagreFormkrav] = useApiCall(oppdaterFormkravIKlage)
   const dispatch = useAppDispatch()
@@ -99,6 +99,9 @@ export function KlageFormkrav() {
   const kjenteVedtak = mapSuccess(iverksatteVedtak, (vedtak) => vedtak) ?? []
 
   function sendInnFormkrav(krav: FormDataFormkrav) {
+    if (!kanRedigere) {
+      return
+    }
     if (!klage) {
       return
     }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Tilgangsmelding.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Tilgangsmelding.tsx
@@ -1,17 +1,23 @@
 import { useAppSelector } from '~store/Store'
 import { Alert, GuidePanel } from '@navikt/ds-react'
+import { Container } from '~shared/styled'
 
 export const Tilgangsmelding = () => {
   const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
 
   if (innloggetSaksbehandler.leseTilgang) {
     return (
-      <GuidePanel>
-        Vi ser at du har lesetilgang til systemet. For å søke opp personer eller saker vennligst benytt søkefelt i
-        hjørnet.
-      </GuidePanel>
+      <Container>
+        <GuidePanel>
+          Du har lesetilgang til systemet. For å søke opp personer eller saker vennligst benytt søkefelt i hjørnet.
+        </GuidePanel>
+      </Container>
     )
   } else {
-    return <Alert variant="error">Det er ikke registrert lese eller skrivetilgang på deg.</Alert>
+    return (
+      <Container>
+        <Alert variant="error">Det er ikke registrert lese eller skrivetilgang på deg.</Alert>
+      </Container>
+    )
   }
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Tilgangsmelding.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/Tilgangsmelding.tsx
@@ -1,0 +1,17 @@
+import { useAppSelector } from '~store/Store'
+import { Alert, GuidePanel } from '@navikt/ds-react'
+
+export const Tilgangsmelding = () => {
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+
+  if (innloggetSaksbehandler.leseTilgang) {
+    return (
+      <GuidePanel>
+        Vi ser at du har lesetilgang til systemet. For å søke opp personer eller saker vennligst benytt søkefelt i
+        hjørnet.
+      </GuidePanel>
+    )
+  } else {
+    return <Alert variant="error">Det er ikke registrert lese eller skrivetilgang på deg.</Alert>
+  }
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/ToggleMinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/ToggleMinOppgaveliste.tsx
@@ -24,7 +24,9 @@ const TabsWidth = styled(Tabs)`
 
 export const ToggleMinOppgaveliste = () => {
   const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
-
+  if (!innloggetSaksbehandler.skriveTilgang) {
+    return null
+  }
   const [filter, setFilter] = useState<Filter>(initialFilter())
   const [oppgaveListeValg, setOppgaveListeValg] = useState<OppgavelisteToggle>('Oppgavelista')
   const [oppgaver, hentOppgaverFetch] = useApiCall(hentOppgaver)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/ToggleMinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/ToggleMinOppgaveliste.tsx
@@ -14,6 +14,7 @@ import { Container } from '~shared/styled'
 
 import { isPending, isSuccess } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
+import { Tilgangsmelding } from '~components/nyoppgavebenk/Tilgangsmelding'
 
 type OppgavelisteToggle = 'Oppgavelista' | 'MinOppgaveliste'
 
@@ -25,7 +26,7 @@ const TabsWidth = styled(Tabs)`
 export const ToggleMinOppgaveliste = () => {
   const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
   if (!innloggetSaksbehandler.skriveTilgang) {
-    return null
+    return <Tilgangsmelding />
   }
   const [filter, setFilter] = useState<Filter>(initialFilter())
   const [oppgaveListeValg, setOppgaveListeValg] = useState<OppgavelisteToggle>('Oppgavelista')

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/brev/TilbakekrevingBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/brev/TilbakekrevingBrev.tsx
@@ -18,6 +18,7 @@ import { VergeFeilhaandtering } from '~components/person/VergeFeilhaandtering'
 
 import { isPending, isPendingOrInitial } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
+import { useAppSelector } from '~store/Store'
 
 export function TilbakekrevingBrev({ tilbakekreving }: { tilbakekreving: TilbakekrevingBehandling }) {
   const kanAttesteres = [
@@ -29,7 +30,8 @@ export function TilbakekrevingBrev({ tilbakekreving }: { tilbakekreving: Tilbake
   const [vedtaksbrev, setVedtaksbrev] = useState<IBrev | undefined>(undefined)
   const [hentBrevStatus, hentBrevRequest] = useApiCall(hentVedtaksbrev)
   const [opprettBrevStatus, opprettNyttVedtaksbrev] = useApiCall(opprettVedtaksbrev)
-
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+  const redigerbar = innloggetSaksbehandler.skriveTilgang
   const [vergeadresse, getVergeadresse] = useApiCall(getVergeadresseFraGrunnlag)
 
   const hentBrev = () => {
@@ -79,14 +81,14 @@ export function TilbakekrevingBrev({ tilbakekreving }: { tilbakekreving: Tilbake
               <MottakerPanel
                 vedtaksbrev={vedtaksbrev}
                 oppdater={(val) => setVedtaksbrev({ ...vedtaksbrev, mottaker: val })}
-                redigerbar={true}
+                redigerbar={redigerbar}
                 vergeadresse={getData(vergeadresse)}
               />
             )}
           </ContentHeader>
         </Sidebar>
 
-        {vedtaksbrev && <RedigerbartBrev brev={vedtaksbrev} kanRedigeres={true} />}
+        {vedtaksbrev && <RedigerbartBrev brev={vedtaksbrev} kanRedigeres={redigerbar} />}
         {isFailureHandler({
           apiResult: hentBrevStatus,
           errorMessage: 'Feil ved henting av brev',

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/saksbehandler.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/saksbehandler.ts
@@ -5,6 +5,8 @@ export interface ISaksbehandler {
   etternavn: string
   enheter: IEnhet[]
   kanAttestere: boolean
+  leseTilgang: boolean
+  skriveTilgang: boolean
 }
 
 interface IEnhet {

--- a/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/InnloggetSaksbehandlerReducer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/store/reducers/InnloggetSaksbehandlerReducer.ts
@@ -9,6 +9,8 @@ export const initialState: InnloggetSaksbehandlerReducer = {
     etternavn: '',
     enheter: [],
     kanAttestere: false,
+    skriveTilgang: false,
+    leseTilgang: false,
   },
 }
 

--- a/apps/etterlatte-saksbehandling-ui/server/src/routers/innloggetBrukerRouter.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/routers/innloggetBrukerRouter.ts
@@ -31,25 +31,28 @@ const kanAttestere = (groups: string[]): boolean => {
   }
 }
 
-const NKSEnheter = ['4101', '4116', '4118'] //Les
-const stoettedeEnheter = ['2103', '4883', '0001', '4815', '4862', '4817', '4808'] //Skriv
-const devEnhet = ['2970']
+const NKSEnheterKunLes = ['4101', '4116', '4118'] //Les
+const skriveOgLesEnheter = ['2103', '4883', '0001', '4815', '4862', '4817', '4808'] //Skriv
+const devenhetZBruker = ['2970']
 
 const harSkrivetilgang = (enheter: IEnhet[]) => {
   if (!process.env.NAIS_CLUSTER_NAME || process.env.NAIS_CLUSTER_NAME === 'dev-gcp') {
-    return enheter.some((e) => stoettedeEnheter.includes(e.enhetId) || devEnhet.includes(e.enhetId))
+    return enheter.some((e) => skriveOgLesEnheter.includes(e.enhetId) || devenhetZBruker.includes(e.enhetId))
   }
-  return enheter.some((e) => stoettedeEnheter.includes(e.enhetId))
+  return enheter.some((e) => skriveOgLesEnheter.includes(e.enhetId))
 }
 
 const harLesetilgang = (enheter: IEnhet[]) => {
   if (!process.env.NAIS_CLUSTER_NAME || process.env.NAIS_CLUSTER_NAME === 'dev-gcp') {
     return enheter.some(
-      (e) => NKSEnheter.includes(e.enhetId) || stoettedeEnheter.includes(e.enhetId) || devEnhet.includes(e.enhetId)
+      (e) =>
+        NKSEnheterKunLes.includes(e.enhetId) ||
+        skriveOgLesEnheter.includes(e.enhetId) ||
+        devenhetZBruker.includes(e.enhetId)
     )
   }
 
-  return enheter.some((e) => NKSEnheter.includes(e.enhetId) || stoettedeEnheter.includes(e.enhetId))
+  return enheter.some((e) => NKSEnheterKunLes.includes(e.enhetId) || skriveOgLesEnheter.includes(e.enhetId))
 }
 
 const getSaksbehandler = async (req: Request): Promise<ISaksbehandler | null> => {

--- a/apps/etterlatte-saksbehandling-ui/server/src/routers/innloggetBrukerRouter.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/routers/innloggetBrukerRouter.ts
@@ -19,6 +19,8 @@ export interface ISaksbehandler {
   etternavn: string
   enheter: IEnhet[]
   kanAttestere: boolean
+  leseTilgang: boolean
+  skriveTilgang: boolean
 }
 
 const kanAttestere = (groups: string[]): boolean => {
@@ -27,6 +29,27 @@ const kanAttestere = (groups: string[]): boolean => {
   } else {
     return groups.includes('11053fd7-e674-4552-9a88-f9fcedfa70b3') // 0000-GA-PENSJON_ATTESTERING (PROD)
   }
+}
+
+const NKSEnheter = ['4101', '4116', '4118'] //Les
+const stoettedeEnheter = ['2103', '4883', '0001', '4815', '4862', '4817', '4808'] //Skriv
+const devEnhet = ['2970']
+
+const harSkrivetilgang = (enheter: IEnhet[]) => {
+  if (!process.env.NAIS_CLUSTER_NAME || process.env.NAIS_CLUSTER_NAME === 'dev-gcp') {
+    return enheter.some((e) => stoettedeEnheter.includes(e.enhetId) || devEnhet.includes(e.enhetId))
+  }
+  return enheter.some((e) => stoettedeEnheter.includes(e.enhetId))
+}
+
+const harLesetilgang = (enheter: IEnhet[]) => {
+  if (!process.env.NAIS_CLUSTER_NAME || process.env.NAIS_CLUSTER_NAME === 'dev-gcp') {
+    return enheter.some(
+      (e) => NKSEnheter.includes(e.enhetId) || stoettedeEnheter.includes(e.enhetId) || devEnhet.includes(e.enhetId)
+    )
+  }
+
+  return enheter.some((e) => NKSEnheter.includes(e.enhetId) || stoettedeEnheter.includes(e.enhetId))
 }
 
 const getSaksbehandler = async (req: Request): Promise<ISaksbehandler | null> => {
@@ -38,13 +61,16 @@ const getSaksbehandler = async (req: Request): Promise<ISaksbehandler | null> =>
   const bearerToken = auth.split(' ')[1]
   const parsedToken = parseJwt(bearerToken)
 
+  const enheter = await hentEnheter(req, bearerToken)
   return {
     ident: parsedToken.NAVident,
     navn: parsedToken.name,
     fornavn: parsedToken.name.split(', ')[1],
     etternavn: parsedToken.name.split(', ')[0],
-    enheter: await hentEnheter(req, bearerToken),
+    enheter: enheter,
     kanAttestere: kanAttestere(parsedToken.groups),
+    leseTilgang: harLesetilgang(enheter),
+    skriveTilgang: harSkrivetilgang(enheter),
   }
 }
 


### PR DESCRIPTION
Tar backend i egen pr

Siden NKS har samme ad-rolle som våre saksbehandlere må vi basere oss på enheter, og NKS har tre enheter som kun er NKS så da kan vi bruke det.

De vil kun ha søkefelt da de kommer i j9, det får de nå. 
+ Sperre på redigerbar en del steder. Kanskje flere steder jeg burde lagt det på men kommer ikke på alle nå.