### PR TITLE
Tar bort avhengnad vi knapt bruker frå kafka-lib.

### DIFF
--- a/apps/etterlatte-egne-ansatte-lytter/src/test/kotlin/AvrokonstanterTest.kt
+++ b/apps/etterlatte-egne-ansatte-lytter/src/test/kotlin/AvrokonstanterTest.kt
@@ -1,0 +1,18 @@
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
+import no.nav.etterlatte.kafka.Avrokonstanter
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class AvrokonstanterTest {
+    @Test
+    fun `vaare hardkodede konstanter i libs matcher med dem i Avro-biblioteket`() {
+        Assertions.assertEquals(
+            AbstractKafkaSchemaSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE,
+            Avrokonstanter.BASIC_AUTH_CREDENTIALS_SOURCE,
+        )
+        Assertions.assertEquals(
+            io.confluent.kafka.serializers.KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG,
+            Avrokonstanter.SPECIFIC_AVRO_READER_CONFIG,
+        )
+    }
+}

--- a/libs/etterlatte-kafka/build.gradle.kts
+++ b/libs/etterlatte-kafka/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     testImplementation(libs.test.kotest.assertionscore)
     implementation(libs.kafka.clients)
     testImplementation(libs.kafka.embeddedenv)
+    testImplementation(libs.kafka.avroserializer)
 }
 
 tasks {

--- a/libs/etterlatte-kafka/build.gradle.kts
+++ b/libs/etterlatte-kafka/build.gradle.kts
@@ -21,7 +21,6 @@ dependencies {
     testRuntimeOnly(libs.test.jupiter.engine)
     testImplementation(libs.test.kotest.assertionscore)
     implementation(libs.kafka.clients)
-    implementation(libs.kafka.avroserializer)
     testImplementation(libs.kafka.embeddedenv)
 }
 

--- a/libs/etterlatte-kafka/src/main/kotlin/kafka/Avrokonstanter.kt
+++ b/libs/etterlatte-kafka/src/main/kotlin/kafka/Avrokonstanter.kt
@@ -1,0 +1,10 @@
+package no.nav.etterlatte.kafka
+
+object Avrokonstanter {
+    const val SPECIFIC_AVRO_READER_CONFIG = "specific.avro.reader"
+    const val BASIC_AUTH_CREDENTIALS_SOURCE = SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE
+
+    private object SchemaRegistryClientConfig {
+        const val BASIC_AUTH_CREDENTIALS_SOURCE = "basic.auth.credentials.source"
+    }
+}

--- a/libs/etterlatte-kafka/src/main/kotlin/kafka/Kafkakonfigurasjon.kt
+++ b/libs/etterlatte-kafka/src/main/kotlin/kafka/Kafkakonfigurasjon.kt
@@ -1,7 +1,5 @@
 package no.nav.etterlatte.kafka
 
-import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
-import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.config.SslConfigs
@@ -47,7 +45,7 @@ abstract class Kafkakonfigurasjon<T>(
             put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java)
             put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializerClass)
 
-            put(AbstractKafkaSchemaSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO")
+            put(Avrokonstanter.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO")
 
             put(
                 userInfoConfigKey,
@@ -60,6 +58,6 @@ abstract class Kafkakonfigurasjon<T>(
             )
 
             isolationLevelConfig?.let { this.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, it) }
-            specificAvroReaderConfig?.let { this.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, it) }
+            specificAvroReaderConfig?.let { this.put(Avrokonstanter.SPECIFIC_AVRO_READER_CONFIG, it) }
         }
 }

--- a/libs/etterlatte-kafka/src/test/kotlin/AvrokonstanterTest.kt
+++ b/libs/etterlatte-kafka/src/test/kotlin/AvrokonstanterTest.kt
@@ -1,5 +1,6 @@
+package no.nav.etterlatte.kafka
+
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
-import no.nav.etterlatte.kafka.Avrokonstanter
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 


### PR DESCRIPTION
I kafka-biblioteket trekkjer vi inn avroserializer-avhengnaden, som har mykje greier og er ganske omfattande. Vi bruker berre denne for å finne verdiane for eit par konstantar. Det er dyrt definerte konstantar.

Endrar derfor til at vi sjølv definerer desse konstantane i vår kode.

Er ikkje veldig uroleg for at desse konstantane endrar seg, men skulle dei gjera det, vil den nye testen avdekke det. Denne testen er i ein app som faktisk bruker avroserializer-avhengnaden, så det kostar ingenting å ha han der.

Avroserializer-biblioteket er brukt i seks applikasjonar (egne-ansatte-lytter, hendelser-joark, hendelser-pdl, hendelser-samordning, institusjonsopphold, klage), medan etterlatte-kafka er i bruk i 11 (desse seks pluss behandling, testdata, utbetaling, start-grunnlagsversjonering og start-regulering). Dermed vil denne endringa sørge for at dette biblioteket ikkje lenger lekk inn i behandling og utbetaling.