### PR TITLE
EY-3277 Skriv tilganger i behandlingsappen

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/Contekst.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Contekst.kt
@@ -29,6 +29,10 @@ interface User {
     fun name(): String
 
     fun kanSetteKilde(): Boolean = false
+
+    fun harSkrivetilgang(): Boolean = false
+
+    fun harLesetilgang(): Boolean = false
 }
 
 abstract class ExternalUser(val identifiedBy: TokenValidationContext) : User
@@ -49,6 +53,10 @@ class SystemUser(identifiedBy: TokenValidationContext) : ExternalUser(identified
     override fun kanSetteKilde(): Boolean {
         return identifiedBy.hentTokenClaims(AZURE_ISSUER)!!.containsClaim("roles", "kan-sette-kilde")
     }
+
+    override fun harSkrivetilgang(): Boolean = true
+
+    override fun harLesetilgang(): Boolean = true
 }
 
 class SaksbehandlerMedEnheterOgRoller(
@@ -68,6 +76,18 @@ class SaksbehandlerMedEnheterOgRoller(
                 navAnsattKlient.hentEnhetForSaksbehandler(name()).map { it.id }
             }
         }
+
+    override fun harSkrivetilgang(): Boolean {
+        val enheter = enheter()
+        val skrivetilgangEnhetsnummere = Enheter.enheterMedSkrivetilgang()
+        return enheter.any { skrivetilgangEnhetsnummere.contains(it) }
+    }
+
+    override fun harLesetilgang(): Boolean {
+        val enheter = enheter()
+        val lesetilgangEnheter = Enheter.enheterMedLesetilgang()
+        return enheter.any { lesetilgangEnheter.contains(it) }
+    }
 }
 
 fun decideUser(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
 import no.nav.etterlatte.libs.common.sak.Saker
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.tilgangsstyring.kunAttestant
+import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
 import no.nav.etterlatte.vedtaksvurdering.VedtakHendelse
 
 internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingStatusService) {
@@ -30,9 +31,11 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         }
         post("/opprett") {
             // Kalles kun av vilkårsvurdering når total-vurdering slettes
-            haandterStatusEndring(call) {
-                inTransaction {
-                    behandlingsstatusService.settOpprettet(behandlingId, brukerTokenInfo, false)
+            kunSkrivetilgang {
+                haandterStatusEndring(call) {
+                    inTransaction {
+                        behandlingsstatusService.settOpprettet(behandlingId, brukerTokenInfo, false)
+                    }
                 }
             }
         }
@@ -45,9 +48,11 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
             }
         }
         post("/vilkaarsvurder") {
-            haandterStatusEndring(call) {
-                inTransaction {
-                    behandlingsstatusService.settVilkaarsvurdert(behandlingId, brukerTokenInfo, false)
+            kunSkrivetilgang {
+                haandterStatusEndring(call) {
+                    inTransaction {
+                        behandlingsstatusService.settVilkaarsvurdert(behandlingId, brukerTokenInfo, false)
+                    }
                 }
             }
         }
@@ -60,9 +65,11 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
             }
         }
         post("/oppdaterTrygdetid") {
-            haandterStatusEndring(call) {
-                inTransaction {
-                    behandlingsstatusService.settTrygdetidOppdatert(behandlingId, brukerTokenInfo, false)
+            kunSkrivetilgang {
+                haandterStatusEndring(call) {
+                    inTransaction {
+                        behandlingsstatusService.settTrygdetidOppdatert(behandlingId, brukerTokenInfo, false)
+                    }
                 }
             }
         }
@@ -76,9 +83,11 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         }
 
         post("/beregn") {
-            haandterStatusEndring(call) {
-                inTransaction {
-                    behandlingsstatusService.settBeregnet(behandlingId, brukerTokenInfo, false)
+            kunSkrivetilgang {
+                haandterStatusEndring(call) {
+                    inTransaction {
+                        behandlingsstatusService.settBeregnet(behandlingId, brukerTokenInfo, false)
+                    }
                 }
             }
         }
@@ -92,9 +101,11 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         }
 
         post("/avkort") {
-            haandterStatusEndring(call) {
-                inTransaction {
-                    behandlingsstatusService.settAvkortet(behandlingId, brukerTokenInfo, false)
+            kunSkrivetilgang {
+                haandterStatusEndring(call) {
+                    inTransaction {
+                        behandlingsstatusService.settAvkortet(behandlingId, brukerTokenInfo, false)
+                    }
                 }
             }
         }
@@ -125,28 +136,34 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         }
 
         post("/tilsamordning") {
-            val vedtakHendelse = call.receive<VedtakHendelse>()
-            haandterStatusEndring(call) {
-                inTransaction {
-                    behandlingsstatusService.settTilSamordnetVedtak(behandlingId, vedtakHendelse)
+            kunSkrivetilgang {
+                val vedtakHendelse = call.receive<VedtakHendelse>()
+                haandterStatusEndring(call) {
+                    inTransaction {
+                        behandlingsstatusService.settTilSamordnetVedtak(behandlingId, vedtakHendelse)
+                    }
                 }
             }
         }
 
         post("/samordnet") {
-            val vedtakHendelse = call.receive<VedtakHendelse>()
-            haandterStatusEndring(call) {
-                inTransaction {
-                    behandlingsstatusService.settSamordnetVedtak(behandlingId, vedtakHendelse)
+            kunSkrivetilgang {
+                val vedtakHendelse = call.receive<VedtakHendelse>()
+                haandterStatusEndring(call) {
+                    inTransaction {
+                        behandlingsstatusService.settSamordnetVedtak(behandlingId, vedtakHendelse)
+                    }
                 }
             }
         }
 
         post("/iverksett") {
-            val vedtakHendelse = call.receive<VedtakHendelse>()
-            haandterStatusEndring(call) {
-                inTransaction {
-                    behandlingsstatusService.settIverksattVedtak(behandlingId, vedtakHendelse)
+            kunSkrivetilgang {
+                val vedtakHendelse = call.receive<VedtakHendelse>()
+                haandterStatusEndring(call) {
+                    inTransaction {
+                        behandlingsstatusService.settIverksattVedtak(behandlingId, vedtakHendelse)
+                    }
                 }
             }
         }
@@ -154,10 +171,12 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
 
     route("/behandlinger") {
         post("/settTilbakeTilTrygdetidOppdatert") {
-            val saker = call.receive<Saker>()
-            val tilbakestilteBehandlinger =
-                behandlingsstatusService.migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning(saker)
-            call.respond(tilbakestilteBehandlinger)
+            kunSkrivetilgang {
+                val saker = call.receive<Saker>()
+                val tilbakestilteBehandlinger =
+                    behandlingsstatusService.migrerStatusPaaAlleBehandlingerSomTrengerNyBeregning(saker)
+                call.respond(tilbakestilteBehandlinger)
+            }
         }
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/SjekklisteRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/SjekklisteRoute.kt
@@ -14,7 +14,8 @@ import no.nav.etterlatte.behandling.sjekkliste.OppdatertSjekkliste
 import no.nav.etterlatte.behandling.sjekkliste.SjekklisteService
 import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.behandlingId
-import no.nav.etterlatte.libs.common.kunSaksbehandler
+import no.nav.etterlatte.tilgangsstyring.kunSaksbehandlerMedSkrivetilgang
+import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
 
 internal fun Route.sjekklisteRoute(sjekklisteService: SjekklisteService) {
     route("/api/sjekkliste/{$BEHANDLINGID_CALL_PARAMETER}") {
@@ -24,12 +25,14 @@ internal fun Route.sjekklisteRoute(sjekklisteService: SjekklisteService) {
         }
 
         post {
-            val result = sjekklisteService.opprettSjekkliste(behandlingId)
-            call.respond(result)
+            kunSkrivetilgang {
+                val result = sjekklisteService.opprettSjekkliste(behandlingId)
+                call.respond(result)
+            }
         }
 
         put {
-            kunSaksbehandler {
+            kunSaksbehandlerMedSkrivetilgang {
                 val oppdatering = call.receive<OppdatertSjekkliste>()
                 val result = sjekklisteService.oppdaterSjekkliste(behandlingId, oppdatering)
                 call.respond(result)
@@ -37,7 +40,7 @@ internal fun Route.sjekklisteRoute(sjekklisteService: SjekklisteService) {
         }
 
         post("/item/{sjekklisteItemId}") {
-            kunSaksbehandler {
+            kunSaksbehandlerMedSkrivetilgang {
                 val sjekklisteItemId = requireNotNull(call.parameters["sjekklisteItemId"]).toLong()
                 val oppdatering = call.receive<OppdaterSjekklisteItem>()
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoRoutes.kt
@@ -19,6 +19,7 @@ import no.nav.etterlatte.libs.common.behandlingId
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.medBody
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
+import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
 import no.nav.etterlatte.token.BrukerTokenInfo
 import java.util.UUID
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoRoutes.kt
@@ -28,25 +28,27 @@ internal fun Route.behandlingInfoRoutes(service: BehandlingInfoService) {
     route("/api/behandling/{$BEHANDLINGID_CALL_PARAMETER}/info") {
         route("/brevutfall") {
             post {
-                medBody<BrevutfallOgEtterbetalingDto> { dto ->
-                    val brevutfallOgEtterbetaling =
-                        inTransaction {
-                            logger.info("Lagrer brevutfall og etterbetaling for behandling $behandlingId")
-                            val (brevutfallLagret, etterbetalingLagret) =
-                                service.lagreBrevutfallOgEtterbetaling(
-                                    behandlingId,
-                                    brukerTokenInfo,
-                                    dto.toBrevutfall(behandlingId, brukerTokenInfo),
-                                    dto.toEtterbetaling(behandlingId, brukerTokenInfo),
-                                )
+                kunSkrivetilgang {
+                    medBody<BrevutfallOgEtterbetalingDto> { dto ->
+                        val brevutfallOgEtterbetaling =
+                            inTransaction {
+                                logger.info("Lagrer brevutfall og etterbetaling for behandling $behandlingId")
+                                val (brevutfallLagret, etterbetalingLagret) =
+                                    service.lagreBrevutfallOgEtterbetaling(
+                                        behandlingId,
+                                        brukerTokenInfo,
+                                        dto.toBrevutfall(behandlingId, brukerTokenInfo),
+                                        dto.toEtterbetaling(behandlingId, brukerTokenInfo),
+                                    )
 
-                            BrevutfallOgEtterbetalingDto(
-                                behandlingId,
-                                etterbetalingLagret?.toDto(),
-                                brevutfallLagret.toDto(),
-                            )
-                        }
-                    call.respond(brevutfallOgEtterbetaling)
+                                BrevutfallOgEtterbetalingDto(
+                                    behandlingId,
+                                    etterbetalingLagret?.toDto(),
+                                    brevutfallLagret.toDto(),
+                                )
+                            }
+                        call.respond(brevutfallOgEtterbetaling)
+                    }
                 }
             }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/bosattutland/BosattUtlandRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/bosattutland/BosattUtlandRoutes.kt
@@ -12,11 +12,12 @@ import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.behandlingId
 import no.nav.etterlatte.libs.common.kunSaksbehandler
+import no.nav.etterlatte.tilgangsstyring.kunSaksbehandlerMedSkrivetilgang
 
 internal fun Route.bosattUtlandRoutes(bosattUtlandService: BosattUtlandService) {
     route("api/bosattutland/{$BEHANDLINGID_CALL_PARAMETER}") {
         post {
-            kunSaksbehandler {
+            kunSaksbehandlerMedSkrivetilgang {
                 val request = call.receive<BosattUtland>()
                 val bosattUtland = inTransaction { bosattUtlandService.lagreBosattUtland(request) }
                 call.respond(bosattUtland)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/generellbehandling/GenerellBehandlingRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/generellbehandling/GenerellBehandlingRoute.kt
@@ -19,6 +19,7 @@ import no.nav.etterlatte.libs.common.kunSaksbehandler
 import no.nav.etterlatte.libs.common.sakId
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.sak.SakService
+import no.nav.etterlatte.tilgangsstyring.kunSaksbehandlerMedSkrivetilgang
 
 internal fun Route.generellbehandlingRoutes(
     generellBehandlingService: GenerellBehandlingService,
@@ -27,7 +28,7 @@ internal fun Route.generellbehandlingRoutes(
     val logger = application.log
 
     post("/api/generellbehandling/{$SAKID_CALL_PARAMETER}") {
-        kunSaksbehandler { saksbehandler ->
+        kunSaksbehandlerMedSkrivetilgang { saksbehandler ->
             val request = call.receive<OpprettGenerellBehandlingRequest>()
             val finnSak = inTransaction { sakService.finnSak(sakId) }
             if (finnSak == null) {
@@ -47,7 +48,7 @@ internal fun Route.generellbehandlingRoutes(
     }
 
     put("/api/generellbehandling/sendtilattestering/{$SAKID_CALL_PARAMETER}") {
-        kunSaksbehandler { saksbehandler ->
+        kunSaksbehandlerMedSkrivetilgang { saksbehandler ->
             val request = call.receive<GenerellBehandling>()
             inTransaction {
                 generellBehandlingService.sendTilAttestering(request, saksbehandler)
@@ -60,7 +61,7 @@ internal fun Route.generellbehandlingRoutes(
     }
 
     post("/api/generellbehandling/attester/{$SAKID_CALL_PARAMETER}/{$GENERELLBEHANDLINGID_CALL_PARAMETER}") {
-        kunSaksbehandler { saksbehandler ->
+        kunSaksbehandlerMedSkrivetilgang { saksbehandler ->
             inTransaction {
                 generellBehandlingService.attester(generellBehandlingId, saksbehandler)
             }
@@ -70,7 +71,7 @@ internal fun Route.generellbehandlingRoutes(
     }
 
     post("/api/generellbehandling/underkjenn/{$SAKID_CALL_PARAMETER}/{$GENERELLBEHANDLINGID_CALL_PARAMETER}") {
-        kunSaksbehandler { saksbehandler ->
+        kunSaksbehandlerMedSkrivetilgang { saksbehandler ->
             val kommentar = call.receive<Kommentar>()
             inTransaction {
                 generellBehandlingService.underkjenn(generellBehandlingId, saksbehandler, kommentar)
@@ -81,7 +82,7 @@ internal fun Route.generellbehandlingRoutes(
     }
 
     put("/api/generellbehandling/oppdater/{$SAKID_CALL_PARAMETER}") {
-        kunSaksbehandler {
+        kunSaksbehandlerMedSkrivetilgang {
             val request = call.receive<GenerellBehandling>()
             inTransaction {
                 generellBehandlingService.lagreNyeOpplysninger(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageRoutes.kt
@@ -19,10 +19,11 @@ import no.nav.etterlatte.libs.common.behandling.Kabalrespons
 import no.nav.etterlatte.libs.common.behandling.KlageUtfallUtenBrev
 import no.nav.etterlatte.libs.common.hvisEnabled
 import no.nav.etterlatte.libs.common.klageId
-import no.nav.etterlatte.libs.common.kunSaksbehandler
 import no.nav.etterlatte.libs.common.kunSystembruker
 import no.nav.etterlatte.libs.common.medBody
 import no.nav.etterlatte.libs.common.sakId
+import no.nav.etterlatte.tilgangsstyring.kunSaksbehandlerMedSkrivetilgang
+import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
 
 enum class KlageFeatureToggle(private val key: String) : FeatureToggle {
     KanBrukeKlageToggle("pensjon-etterlatte.kan-bruke-klage"),
@@ -37,13 +38,15 @@ internal fun Route.klageRoutes(
 ) {
     route("/api/klage") {
         post("opprett/{$SAKID_CALL_PARAMETER}") {
-            hvisEnabled(featureToggleService, KlageFeatureToggle.KanBrukeKlageToggle) {
-                val sakId = sakId
-                val klage =
-                    inTransaction {
-                        klageService.opprettKlage(sakId)
-                    }
-                call.respond(klage)
+            kunSkrivetilgang {
+                hvisEnabled(featureToggleService, KlageFeatureToggle.KanBrukeKlageToggle) {
+                    val sakId = sakId
+                    val klage =
+                        inTransaction {
+                            klageService.opprettKlage(sakId)
+                        }
+                    call.respond(klage)
+                }
             }
         }
 
@@ -63,7 +66,7 @@ internal fun Route.klageRoutes(
 
             put("formkrav") {
                 hvisEnabled(featureToggleService, KlageFeatureToggle.KanBrukeKlageToggle) {
-                    kunSaksbehandler { saksbehandler ->
+                    kunSaksbehandlerMedSkrivetilgang { saksbehandler ->
                         medBody<VurdereFormkravDto> { formkravDto ->
                             val oppdatertKlage =
                                 inTransaction {
@@ -77,7 +80,7 @@ internal fun Route.klageRoutes(
 
             put("utfall") {
                 hvisEnabled(featureToggleService, KlageFeatureToggle.KanBrukeKlageToggle) {
-                    kunSaksbehandler { saksbehandler ->
+                    kunSaksbehandlerMedSkrivetilgang { saksbehandler ->
                         medBody<VurdertUtfallDto> { utfall ->
                             val oppdatertKlage =
                                 inTransaction {
@@ -91,7 +94,7 @@ internal fun Route.klageRoutes(
 
             post("ferdigstill") {
                 hvisEnabled(featureToggleService, KlageFeatureToggle.KanBrukeKlageToggle) {
-                    kunSaksbehandler { saksbehandler ->
+                    kunSaksbehandlerMedSkrivetilgang { saksbehandler ->
                         val ferdigstiltKlage =
                             inTransaction {
                                 klageService.ferdigstillKlage(klageId, saksbehandler)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningRoutes.kt
@@ -9,21 +9,24 @@ import io.ktor.server.routing.route
 import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.behandling.Omregningshendelse
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
 import java.util.UUID
 
 fun Route.omregningRoutes(omregningService: OmregningService) {
     route("/omregning") {
         post {
-            val request = call.receive<Omregningshendelse>()
-            val (behandlingId, forrigeBehandlingId, sakType) =
-                inTransaction {
-                    omregningService.opprettOmregning(
-                        sakId = request.sakId,
-                        fraDato = request.fradato,
-                        prosessType = request.prosesstype,
-                    )
-                }
-            call.respond(OpprettOmregningResponse(behandlingId, forrigeBehandlingId, sakType))
+            kunSkrivetilgang {
+                val request = call.receive<Omregningshendelse>()
+                val (behandlingId, forrigeBehandlingId, sakType) =
+                    inTransaction {
+                        omregningService.opprettOmregning(
+                            sakId = request.sakId,
+                            fraDato = request.fradato,
+                            prosessType = request.prosesstype,
+                        )
+                    }
+                call.respond(OpprettOmregningResponse(behandlingId, forrigeBehandlingId, sakType))
+            }
         }
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilgang/TilgangRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilgang/TilgangRoutes.kt
@@ -22,10 +22,10 @@ import no.nav.etterlatte.token.BrukerTokenInfo
 import no.nav.etterlatte.token.Saksbehandler
 import no.nav.etterlatte.token.Systembruker
 
-const val SKRIVETILGANG_CALL_PARAMETER = "skrivetilgang"
+const val SKRIVETILGANG_CALL_QUERYPARAMETER = "skrivetilgang"
 inline val PipelineContext<*, ApplicationCall>.berOmSkrivetilgang: Boolean
     get() =
-        call.request.queryParameters[SKRIVETILGANG_CALL_PARAMETER]?.let { it.toBoolean() } ?: throw NullPointerException(
+        call.request.queryParameters[SKRIVETILGANG_CALL_QUERYPARAMETER]?.let { it.toBoolean() } ?: throw NullPointerException(
             "Skrivetilgangparameter er ikke i path params",
         )
 
@@ -48,7 +48,7 @@ internal fun Route.tilgangRoutes(tilgangService: TilgangService) {
             call.respond(harTilgang)
         }
 
-        get("/behandling/{$BEHANDLINGID_CALL_PARAMETER}/{$SKRIVETILGANG_CALL_PARAMETER}") {
+        get("/behandling/{$BEHANDLINGID_CALL_PARAMETER}") {
             val harTilgang =
                 harTilgangBrukertypeSjekk(brukerTokenInfo) { _ ->
                     tilgangService.harTilgangTilBehandling(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilgang/TilgangRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilgang/TilgangRoutes.kt
@@ -26,7 +26,7 @@ const val SKRIVETILGANG_CALL_PARAMETER = "skrivetilgang"
 inline val PipelineContext<*, ApplicationCall>.berOmSkrivetilgang: Boolean
     get() =
         call.parameters[SKRIVETILGANG_CALL_PARAMETER]?.let { it.toBoolean() } ?: throw NullPointerException(
-            "Skrivparameter er ikke i path params",
+            "Skrivetilgangparameter er ikke i path params",
         )
 
 internal fun Route.tilgangRoutes(tilgangService: TilgangService) {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilgang/TilgangRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilgang/TilgangRoutes.kt
@@ -25,7 +25,7 @@ import no.nav.etterlatte.token.Systembruker
 const val SKRIVETILGANG_CALL_PARAMETER = "skrivetilgang"
 inline val PipelineContext<*, ApplicationCall>.berOmSkrivetilgang: Boolean
     get() =
-        call.parameters[SKRIVETILGANG_CALL_PARAMETER]?.let { it.toBoolean() } ?: throw NullPointerException(
+        call.request.queryParameters[SKRIVETILGANG_CALL_PARAMETER]?.let { it.toBoolean() } ?: throw NullPointerException(
             "Skrivetilgangparameter er ikke i path params",
         )
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilgang/TilgangRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilgang/TilgangRoutes.kt
@@ -33,6 +33,9 @@ internal fun Route.tilgangRoutes(tilgangService: TilgangService) {
     route("/$TILGANG_ROUTE_PATH") {
         post("/person") {
             val fnr = call.receive<String>()
+            if (berOmSkrivetilgang && !Kontekst.get().AppUser.harSkrivetilgang()) {
+                call.respond(false)
+            }
             val harTilgang =
                 harTilgangBrukertypeSjekk(brukerTokenInfo) { _ ->
                     inTransaction {
@@ -42,13 +45,13 @@ internal fun Route.tilgangRoutes(tilgangService: TilgangService) {
                         )
                     }
                 }
-            if (berOmSkrivetilgang) {
-                call.respond(harTilgang && Kontekst.get().AppUser.harSkrivetilgang())
-            }
             call.respond(harTilgang)
         }
 
         get("/behandling/{$BEHANDLINGID_CALL_PARAMETER}") {
+            if (berOmSkrivetilgang && !Kontekst.get().AppUser.harSkrivetilgang()) {
+                call.respond(false)
+            }
             val harTilgang =
                 harTilgangBrukertypeSjekk(brukerTokenInfo) { _ ->
                     tilgangService.harTilgangTilBehandling(
@@ -56,13 +59,14 @@ internal fun Route.tilgangRoutes(tilgangService: TilgangService) {
                         Kontekst.get().appUserAsSaksbehandler().saksbehandlerMedRoller,
                     )
                 }
-            if (berOmSkrivetilgang) {
-                call.respond(harTilgang && Kontekst.get().AppUser.harSkrivetilgang())
-            }
+
             call.respond(harTilgang)
         }
 
         get("/sak/{$SAKID_CALL_PARAMETER}") {
+            if (berOmSkrivetilgang && !Kontekst.get().AppUser.harSkrivetilgang()) {
+                call.respond(false)
+            }
             val harTilgang =
                 harTilgangBrukertypeSjekk(brukerTokenInfo) { _ ->
                     tilgangService.harTilgangTilSak(
@@ -70,9 +74,6 @@ internal fun Route.tilgangRoutes(tilgangService: TilgangService) {
                         Kontekst.get().appUserAsSaksbehandler().saksbehandlerMedRoller,
                     )
                 }
-            if (berOmSkrivetilgang) {
-                call.respond(harTilgang && Kontekst.get().AppUser.harSkrivetilgang())
-            }
             call.respond(harTilgang)
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/egenansatt/EgenAnsattRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/egenansatt/EgenAnsattRoute.kt
@@ -14,6 +14,7 @@ import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.skjermet.EgenAnsattSkjermet
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
+import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
 
 internal fun Route.egenAnsattRoute(
     egenAnsattService: EgenAnsattService,
@@ -23,18 +24,20 @@ internal fun Route.egenAnsattRoute(
 
     route("/egenansatt") {
         post {
-            val skjermetHendelse = call.receive<EgenAnsattSkjermet>()
-            logger.info("Mottar en egen ansatt hendelse fra skjermingsløsningen")
-            inTransaction {
-                egenAnsattService.haandterSkjerming(skjermetHendelse)
-            }.also {
-                requestLogger.loggRequest(
-                    brukerTokenInfo,
-                    Folkeregisteridentifikator.of(skjermetHendelse.fnr),
-                    "egenansatt-skjermet",
-                )
+            kunSkrivetilgang {
+                val skjermetHendelse = call.receive<EgenAnsattSkjermet>()
+                logger.info("Mottar en egen ansatt hendelse fra skjermingsløsningen")
+                inTransaction {
+                    egenAnsattService.haandterSkjerming(skjermetHendelse)
+                }.also {
+                    requestLogger.loggRequest(
+                        brukerTokenInfo,
+                        Folkeregisteridentifikator.of(skjermetHendelse.fnr),
+                        "egenansatt-skjermet",
+                    )
+                }
+                call.respond(HttpStatusCode.OK)
             }
-            call.respond(HttpStatusCode.OK)
         }
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseRoute.kt
@@ -23,72 +23,91 @@ import no.nav.etterlatte.libs.common.pdlhendelse.SivilstandHendelse
 import no.nav.etterlatte.libs.common.pdlhendelse.UtflyttingsHendelse
 import no.nav.etterlatte.libs.common.pdlhendelse.VergeMaalEllerFremtidsfullmakt
 import no.nav.etterlatte.libs.common.sakId
+import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
 
 internal fun Route.grunnlagsendringshendelseRoute(grunnlagsendringshendelseService: GrunnlagsendringshendelseService) {
     val logger = application.log
 
     route("/grunnlagsendringshendelse") {
         post("/doedshendelse") {
-            val doedshendelse = call.receive<Doedshendelse>()
-            logger.info("Mottar en doedshendelse fra PDL")
-            grunnlagsendringshendelseService.opprettDoedshendelse(doedshendelse)
-            call.respond(HttpStatusCode.OK)
+            kunSkrivetilgang {
+                val doedshendelse = call.receive<Doedshendelse>()
+                logger.info("Mottar en doedshendelse fra PDL")
+                grunnlagsendringshendelseService.opprettDoedshendelse(doedshendelse)
+                call.respond(HttpStatusCode.OK)
+            }
         }
 
         post("/utflyttingshendelse") {
-            val utflyttingsHendelse = call.receive<UtflyttingsHendelse>()
-            logger.info("Mottar en utflyttingshendelse fra PDL")
-            grunnlagsendringshendelseService.opprettUtflyttingshendelse(utflyttingsHendelse)
-            call.respond(HttpStatusCode.OK)
+            kunSkrivetilgang {
+                val utflyttingsHendelse = call.receive<UtflyttingsHendelse>()
+                logger.info("Mottar en utflyttingshendelse fra PDL")
+                grunnlagsendringshendelseService.opprettUtflyttingshendelse(utflyttingsHendelse)
+                call.respond(HttpStatusCode.OK)
+            }
         }
 
         post("/forelderbarnrelasjonhendelse") {
-            val forelderBarnRelasjonHendelse = call.receive<ForelderBarnRelasjonHendelse>()
-            logger.info("Mottar en forelder-barn-relasjon-hendelse fra PDL")
-            grunnlagsendringshendelseService.opprettForelderBarnRelasjonHendelse(forelderBarnRelasjonHendelse)
-            call.respond(HttpStatusCode.OK)
+            kunSkrivetilgang {
+                val forelderBarnRelasjonHendelse = call.receive<ForelderBarnRelasjonHendelse>()
+                logger.info("Mottar en forelder-barn-relasjon-hendelse fra PDL")
+                grunnlagsendringshendelseService.opprettForelderBarnRelasjonHendelse(forelderBarnRelasjonHendelse)
+                call.respond(HttpStatusCode.OK)
+            }
         }
 
         post("/adressebeskyttelse") {
-            val adressebeskyttelse = call.receive<Adressebeskyttelse>()
-            logger.info("Mottar en adressebeskyttelse-hendelse fra PDL")
-            grunnlagsendringshendelseService.oppdaterAdressebeskyttelseHendelse(adressebeskyttelse)
-            call.respond(HttpStatusCode.OK)
+            kunSkrivetilgang {
+                val adressebeskyttelse = call.receive<Adressebeskyttelse>()
+                logger.info("Mottar en adressebeskyttelse-hendelse fra PDL")
+                grunnlagsendringshendelseService.oppdaterAdressebeskyttelseHendelse(adressebeskyttelse)
+                call.respond(HttpStatusCode.OK)
+            }
         }
 
         post("/bostedsadresse") {
-            val bostedsadresse = call.receive<Bostedsadresse>()
-            logger.info("Mottar en adresse-hendelse fra PDL")
-            grunnlagsendringshendelseService.oppdaterAdresseHendelse(bostedsadresse)
-            call.respond(HttpStatusCode.OK)
+            kunSkrivetilgang {
+                val bostedsadresse = call.receive<Bostedsadresse>()
+                logger.info("Mottar en adresse-hendelse fra PDL")
+                grunnlagsendringshendelseService.oppdaterAdresseHendelse(bostedsadresse)
+                call.respond(HttpStatusCode.OK)
+            }
         }
 
         post("/vergemaalellerfremtidsfullmakt") {
-            val vergeMaalEllerFremtidsfullmakt = call.receive<VergeMaalEllerFremtidsfullmakt>()
-            logger.info("Mottar en vergeMaalEllerFremtidsfullmakt-hendelse fra PDL")
-            grunnlagsendringshendelseService.opprettVergemaalEllerFremtidsfullmakt(vergeMaalEllerFremtidsfullmakt)
-            call.respond(HttpStatusCode.OK)
+            kunSkrivetilgang {
+                val vergeMaalEllerFremtidsfullmakt = call.receive<VergeMaalEllerFremtidsfullmakt>()
+                logger.info("Mottar en vergeMaalEllerFremtidsfullmakt-hendelse fra PDL")
+                grunnlagsendringshendelseService.opprettVergemaalEllerFremtidsfullmakt(vergeMaalEllerFremtidsfullmakt)
+                call.respond(HttpStatusCode.OK)
+            }
         }
 
         post("/sivilstandhendelse") {
-            val sivilstandHendelse = call.receive<SivilstandHendelse>()
-            logger.info("Mottar en sivilstand-hendelse fra PDL")
-            grunnlagsendringshendelseService.opprettSivilstandHendelse(sivilstandHendelse)
-            call.respond(HttpStatusCode.OK)
+            kunSkrivetilgang {
+                val sivilstandHendelse = call.receive<SivilstandHendelse>()
+                logger.info("Mottar en sivilstand-hendelse fra PDL")
+                grunnlagsendringshendelseService.opprettSivilstandHendelse(sivilstandHendelse)
+                call.respond(HttpStatusCode.OK)
+            }
         }
 
         post("/institusjonsopphold") {
-            val oppholdsHendelse = call.receive<InstitusjonsoppholdHendelseBeriket>()
-            logger.info("Mottar en institusjons-hendelse fra inst2")
-            grunnlagsendringshendelseService.opprettInstitusjonsOppholdhendelse(oppholdsHendelse)
-            call.respond(HttpStatusCode.OK)
+            kunSkrivetilgang {
+                val oppholdsHendelse = call.receive<InstitusjonsoppholdHendelseBeriket>()
+                logger.info("Mottar en institusjons-hendelse fra inst2")
+                grunnlagsendringshendelseService.opprettInstitusjonsOppholdhendelse(oppholdsHendelse)
+                call.respond(HttpStatusCode.OK)
+            }
         }
 
         post("/reguleringfeilet") {
-            val hendelse = call.receive<ReguleringFeiletHendelse>()
-            logger.info("Motter hendelse om at regulering har feilet i sak ${hendelse.sakId}")
-            grunnlagsendringshendelseService.opprettEndretGrunnbeloepHendelse(hendelse.sakId)
-            call.respond(HttpStatusCode.OK)
+            kunSkrivetilgang {
+                val hendelse = call.receive<ReguleringFeiletHendelse>()
+                logger.info("Motter hendelse om at regulering har feilet i sak ${hendelse.sakId}")
+                grunnlagsendringshendelseService.opprettEndretGrunnbeloepHendelse(hendelse.sakId)
+                call.respond(HttpStatusCode.OK)
+            }
         }
 
         route("/{$SAKID_CALL_PARAMETER}") {

--- a/apps/etterlatte-behandling/src/main/kotlin/institusjonsopphold/InstitusjonsoppholdRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/institusjonsopphold/InstitusjonsoppholdRoutes.kt
@@ -12,18 +12,21 @@ import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.hentNavidentFraToken
 import no.nav.etterlatte.libs.common.sakId
+import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
 
 internal fun Route.institusjonsoppholdRoute(institusjonsoppholdService: InstitusjonsoppholdService) {
     route("/api/institusjonsoppholdbegrunnelse/{$SAKID_CALL_PARAMETER}") {
         post {
-            hentNavidentFraToken { navIdent ->
-                val institusjonsoppholdBegrunnelse = call.receive<InstitusjonsoppholdBegrunnelseWrapper>()
-                institusjonsoppholdService.leggInnInstitusjonsoppholdBegrunnelse(
-                    sakId,
-                    Grunnlagsopplysning.Saksbehandler.create(navIdent),
-                    institusjonsoppholdBegrunnelse.institusjonsopphold,
-                )
-                call.respond(HttpStatusCode.OK)
+            kunSkrivetilgang {
+                hentNavidentFraToken { navIdent ->
+                    val institusjonsoppholdBegrunnelse = call.receive<InstitusjonsoppholdBegrunnelseWrapper>()
+                    institusjonsoppholdService.leggInnInstitusjonsoppholdBegrunnelse(
+                        sakId,
+                        Grunnlagsopplysning.Saksbehandler.create(navIdent),
+                        institusjonsoppholdBegrunnelse.institusjonsopphold,
+                    )
+                    call.respond(HttpStatusCode.OK)
+                }
             }
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -57,7 +57,7 @@ class OppgaveService(
             oppgaveDao.finnOppgaverForStrengtFortroligOgStrengtFortroligUtland(aktuelleOppgavetyperForRoller)
         } else {
             oppgaveDao.hentOppgaver(aktuelleOppgavetyperForRoller).sortedByDescending { it.opprettet }
-        }.filterForEnheter(Kontekst.get().AppUser)
+        }.filterForEnheter(Kontekst.get().appUserAsSaksbehandler())
     }
 
     private fun List<OppgaveIntern>.filterForEnheter(bruker: User) = this.filterOppgaverForEnheter(bruker)

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
@@ -25,7 +25,6 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.SisteIverksatteBehandling
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
-import no.nav.etterlatte.libs.common.hentNavidentFraToken
 import no.nav.etterlatte.libs.common.kunSaksbehandler
 import no.nav.etterlatte.libs.common.kunSystembruker
 import no.nav.etterlatte.libs.common.oppgave.OppgaveListe
@@ -35,6 +34,7 @@ import no.nav.etterlatte.libs.common.sak.Saker
 import no.nav.etterlatte.libs.common.sakId
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.oppgave.OppgaveService
+import no.nav.etterlatte.tilgangsstyring.kunSaksbehandlerMedSkrivetilgang
 import no.nav.etterlatte.tilgangsstyring.withFoedselsnummerAndGradering
 import no.nav.etterlatte.tilgangsstyring.withFoedselsnummerInternal
 import org.slf4j.LoggerFactory
@@ -157,7 +157,7 @@ internal fun Route.sakWebRoutes(
             }
 
             post("/endre_enhet") {
-                hentNavidentFraToken { navIdent ->
+                kunSaksbehandlerMedSkrivetilgang { navIdent ->
                     val enhetrequest = call.receive<EnhetRequest>()
                     try {
                         if (enhetrequest.enhet !in Enheter.entries.map { it.enhetNr }) {
@@ -191,7 +191,8 @@ internal fun Route.sakWebRoutes(
                         }
 
                         logger.info(
-                            "Saksbehandler $navIdent endret enhet på sak: $sakId og tilhørende oppgaver til enhet: ${sakMedEnhet.enhet}",
+                            "Saksbehandler ${navIdent.ident} endret enhet på sak: $sakId og " +
+                                "tilhørende oppgaver til enhet: ${sakMedEnhet.enhet}",
                         )
                         call.respond(HttpStatusCode.OK)
                     } catch (e: TilstandException.UgyldigTilstand) {

--- a/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
@@ -182,6 +182,28 @@ suspend inline fun PipelineContext<*, ApplicationCall>.withFoedselsnummerAndGrad
     }
 }
 
+suspend inline fun PipelineContext<*, ApplicationCall>.kunSkrivetilgang(onSuccess: () -> Unit) {
+    val harSkrivetilgang = Kontekst.get().AppUser.harSkrivetilgang()
+    when (harSkrivetilgang) {
+        true -> onSuccess()
+        false -> call.respond(HttpStatusCode.Forbidden)
+    }
+}
+
+suspend inline fun PipelineContext<*, ApplicationCall>.kunSaksbehandlerMedSkrivetilgang(onSuccess: (Saksbehandler) -> Unit) {
+    when (val token = brukerTokenInfo) {
+        is Saksbehandler -> {
+            val harSkrivetilgang = Kontekst.get().appUserAsSaksbehandler().harSkrivetilgang()
+            when (harSkrivetilgang) {
+                true -> onSuccess(token)
+                false -> call.respond(HttpStatusCode.Forbidden)
+            }
+        }
+
+        else -> call.respond(HttpStatusCode.Forbidden)
+    }
+}
+
 suspend inline fun PipelineContext<*, ApplicationCall>.kunAttestant(onSuccess: () -> Unit) {
     when (brukerTokenInfo) {
         is Saksbehandler -> {

--- a/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
@@ -96,11 +96,11 @@ fun withTestApplicationBuilder(
 
 private val user = mockk<SaksbehandlerMedEnheterOgRoller>()
 
-fun Route.attachMockContext() {
+fun Route.attachMockContext(saksbehandlerMedEnheterOgRoller: SaksbehandlerMedEnheterOgRoller? = null) {
     intercept(ApplicationCallPipeline.Call) {
         val context1 =
             Context(
-                user,
+                saksbehandlerMedEnheterOgRoller ?: user,
                 object : DatabaseKontekst {
                     override fun activeTx(): Connection {
                         throw IllegalArgumentException()

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
@@ -14,6 +14,7 @@ import io.ktor.http.contentType
 import io.ktor.serialization.jackson.jackson
 import io.ktor.server.testing.testApplication
 import no.nav.etterlatte.BehandlingIntegrationTest
+import no.nav.etterlatte.behandling.tilgang.SKRIVETILGANG_CALL_QUERYPARAMETER
 import no.nav.etterlatte.libs.common.FoedselsNummerMedGraderingDTO
 import no.nav.etterlatte.libs.common.FoedselsnummerDTO
 import no.nav.etterlatte.libs.common.behandling.BehandlingsBehov
@@ -262,7 +263,7 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
             }
 
             val harTilgang: Boolean =
-                client.get("/$TILGANG_ROUTE_PATH/behandling/$behandlingId/true") {
+                client.get("/$TILGANG_ROUTE_PATH/behandling/$behandlingId?$SKRIVETILGANG_CALL_QUERYPARAMETER=true") {
                     addAuthToken(tokenSaksbehandler)
                 }.let {
                     Assertions.assertEquals(HttpStatusCode.OK, it.status)
@@ -284,7 +285,7 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
             }
 
             val harIkkeTilgang: Boolean =
-                client.get("/$TILGANG_ROUTE_PATH/behandling/$behandlingId/true") {
+                client.get("/$TILGANG_ROUTE_PATH/behandling/$behandlingId?$SKRIVETILGANG_CALL_QUERYPARAMETER=true") {
                     addAuthToken(tokenSaksbehandler)
                 }.let {
                     Assertions.assertEquals(HttpStatusCode.OK, it.status)

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
@@ -39,7 +39,9 @@ import java.util.UUID
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AdressebeskyttelseTest : BehandlingIntegrationTest() {
     @BeforeAll
-    fun start() = startServer()
+    fun start() {
+        startServer()
+    }
 
     @AfterEach
     fun afterEach() {
@@ -260,7 +262,7 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
             }
 
             val harTilgang: Boolean =
-                client.get("/$TILGANG_ROUTE_PATH/behandling/$behandlingId") {
+                client.get("/$TILGANG_ROUTE_PATH/behandling/$behandlingId/true") {
                     addAuthToken(tokenSaksbehandler)
                 }.let {
                     Assertions.assertEquals(HttpStatusCode.OK, it.status)
@@ -282,7 +284,7 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
             }
 
             val harIkkeTilgang: Boolean =
-                client.get("/$TILGANG_ROUTE_PATH/behandling/$behandlingId") {
+                client.get("/$TILGANG_ROUTE_PATH/behandling/$behandlingId/true") {
                     addAuthToken(tokenSaksbehandler)
                 }.let {
                     Assertions.assertEquals(HttpStatusCode.OK, it.status)

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
@@ -15,6 +15,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
 import no.nav.etterlatte.attachMockContext
 import no.nav.etterlatte.behandling.BehandlingFactory
 import no.nav.etterlatte.behandling.BehandlingService
@@ -179,8 +180,10 @@ internal class BehandlingRoutesTest {
     }
 
     private fun withTestApplication(block: suspend (client: HttpClient) -> Unit) {
+        val user = mockk<SaksbehandlerMedEnheterOgRoller>()
+        every { user.harSkrivetilgang() } returns true
         withTestApplicationBuilder(block, hoconApplicationConfig) {
-            attachMockContext()
+            attachMockContext(user)
             behandlingRoutes(
                 behandlingService,
                 gyldighetsproevingService,

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoRoutesTest.kt
@@ -16,11 +16,14 @@ import io.ktor.serialization.jackson.JacksonConverter
 import io.ktor.server.config.HoconApplicationConfig
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.etterlatte.behandling.BehandlingService
 import no.nav.etterlatte.behandling.BehandlingStatusService
 import no.nav.etterlatte.behandling.domain.Behandling
+import no.nav.etterlatte.behandling.domain.SaksbehandlerEnhet
+import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.config.ApplicationContext
 import no.nav.etterlatte.libs.common.behandling.Aldersgruppe
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
@@ -71,6 +74,11 @@ internal class BehandlingInfoRoutesTest {
                 behandlingInfoDao,
                 behandlingService,
                 behandlingsstatusService,
+            )
+
+        coEvery { applicationContext.navAnsattKlient.hentEnhetForSaksbehandler(any()) } returns
+            listOf(
+                SaksbehandlerEnhet(Enheter.defaultEnhet.enhetNr, Enheter.defaultEnhet.navn),
             )
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingRoutesTest.kt
@@ -12,10 +12,13 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.jackson.JacksonConverter
 import io.ktor.server.config.HoconApplicationConfig
 import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.etterlatte.behandling.domain.SaksbehandlerEnhet
 import no.nav.etterlatte.behandling.revurdering.OpprettRevurderingRequest
 import no.nav.etterlatte.behandling.revurdering.RevurderingRoutesFeatureToggle
+import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.config.ApplicationContext
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -47,6 +50,10 @@ internal class RevurderingRoutesTest {
                 every { harTilgangTilBehandling(any(), any()) } returns true
                 every { harTilgangTilSak(any(), any()) } returns true
             }
+        coEvery { applicationContext.navAnsattKlient.hentEnhetForSaksbehandler(any()) } returns
+            listOf(
+                SaksbehandlerEnhet(Enheter.defaultEnhet.enhetNr, Enheter.defaultEnhet.name),
+            )
     }
 
     @BeforeEach

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakRoutesTest.kt
@@ -16,6 +16,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
 import no.nav.etterlatte.attachMockContext
 import no.nav.etterlatte.behandling.BehandlingRequestLogger
 import no.nav.etterlatte.behandling.BehandlingService
@@ -218,8 +219,10 @@ internal class SakRoutesTest {
     }
 
     private fun withTestApplication(block: suspend (client: HttpClient) -> Unit) {
+        val user = mockk<SaksbehandlerMedEnheterOgRoller>()
+        every { user.harSkrivetilgang() } returns true
         withTestApplicationBuilder(block, hoconApplicationConfig) {
-            attachMockContext()
+            attachMockContext(user)
             sakSystemRoutes(
                 tilgangService,
                 sakService,

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -57,7 +57,7 @@ fun Route.avkorting(
         }
 
         post("/med/{forrigeBehandlingId}") {
-            withBehandlingId(behandlingKlient) {
+            withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 logger.info("Regulere avkorting for behandlingId=$it")
                 val forrigeBehandlingId = call.uuid("forrigeBehandlingId")
                 val avkorting = avkortingService.kopierAvkorting(it, forrigeBehandlingId, brukerTokenInfo)

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -43,7 +43,7 @@ fun Route.avkorting(
         }
 
         post {
-            withBehandlingId(behandlingKlient) {
+            withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 logger.info("Lagre avkorting for behandlingId=$it")
                 val avkortingGrunnlag = call.receive<AvkortingGrunnlagDto>()
                 val avkorting =

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRoutes.kt
@@ -48,7 +48,7 @@ fun Route.beregning(
         }
 
         post("/{$BEHANDLINGID_CALL_PARAMETER}/overstyrt") {
-            withBehandlingId(behandlingKlient) {
+            withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 logger.info("Oppretter overstyrBeregning med behandlingId=$it")
 
                 val overstyrBeregning =
@@ -66,7 +66,7 @@ fun Route.beregning(
         }
 
         post("/{$BEHANDLINGID_CALL_PARAMETER}") {
-            withBehandlingId(behandlingKlient) {
+            withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 logger.info("Oppretter beregning for behandlingId=$it")
                 val beregning = beregningService.opprettBeregning(it, brukerTokenInfo)
                 call.respond(beregning.toDTO())
@@ -74,7 +74,7 @@ fun Route.beregning(
         }
 
         post("/opprettForOpphoer/{$BEHANDLINGID_CALL_PARAMETER}") {
-            withBehandlingId(behandlingKlient) {
+            withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 beregningService.opprettForOpphoer(it, brukerTokenInfo)
                 call.respond(HttpStatusCode.OK)
             }

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutes.kt
@@ -34,7 +34,7 @@ fun Route.beregningsGrunnlag(
         }
 
         post("/{$BEHANDLINGID_CALL_PARAMETER}/barnepensjon") {
-            withBehandlingId(behandlingKlient) { behandlingId ->
+            withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
                 val body = call.receive<BarnepensjonBeregningsGrunnlag>()
 
                 when {
@@ -50,7 +50,7 @@ fun Route.beregningsGrunnlag(
         }
 
         post("/{$BEHANDLINGID_CALL_PARAMETER}/omstillingstoenad") {
-            withBehandlingId(behandlingKlient) { behandlingId ->
+            withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
                 val body = call.receive<OmstillingstoenadBeregningsGrunnlag>()
 
                 when {
@@ -106,7 +106,7 @@ fun Route.beregningsGrunnlag(
         }
 
         post("/{$BEHANDLINGID_CALL_PARAMETER}/overstyr") {
-            withBehandlingId(behandlingKlient) { behandlingId ->
+            withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
                 logger.info("Henter overstyr grunnlag for behandling $behandlingId")
 
                 val body = call.receive<OverstyrBeregningGrunnlagDTO>()

--- a/apps/etterlatte-beregning/src/main/kotlin/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/klienter/BehandlingKlient.kt
@@ -166,6 +166,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
 
     override suspend fun harTilgangTilBehandling(
         behandlingId: UUID,
+        skrivetilgang: Boolean,
         bruker: Saksbehandler,
     ): Boolean {
         try {
@@ -174,7 +175,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/behandling/$behandlingId",
+                            url = "$resourceUrl/tilgang/behandling/$behandlingId/$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                 )

--- a/apps/etterlatte-beregning/src/main/kotlin/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/klienter/BehandlingKlient.kt
@@ -175,7 +175,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/behandling/$behandlingId/$skrivetilgang",
+                            url = "$resourceUrl/tilgang/behandling/$behandlingId?skrivetilgang=$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                 )

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
@@ -54,7 +54,7 @@ class AvkortingRoutesTest {
     @BeforeAll
     fun beforeAll() {
         server.start()
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
     }
 
     @AfterAll

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRoutesTest.kt
@@ -71,7 +71,7 @@ internal class BeregningRoutesTest {
 
         applicationConfig =
             buildTestApplicationConfigurationForOauth(server.config.httpServer.port(), AZURE_ISSUER, CLIENT_ID)
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
     }
 
     @AfterAll
@@ -102,7 +102,7 @@ internal class BeregningRoutesTest {
         val beregning = beregning()
         val behandling = mockk<DetaljertBehandling>()
 
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
         every { beregningRepository.hent(beregning.behandlingId) } returns beregning
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
         every { behandling.sak } returns 1L
@@ -129,7 +129,7 @@ internal class BeregningRoutesTest {
         val beregning = beregning()
 
         every { beregningRepository.hent(beregning.behandlingId) } returns beregning
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns false
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns false
 
         testApplication {
             environment { config = applicationConfig }
@@ -151,7 +151,7 @@ internal class BeregningRoutesTest {
 
         coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns mockBehandling()
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
         every { beregningRepository.hentOverstyrBeregning(1L) } returns null
         coEvery { beregnBarnepensjonService.beregn(any(), any()) } returns beregning
         every { beregningRepository.lagreEllerOppdaterBeregning(any()) } returnsArgument 0
@@ -182,7 +182,7 @@ internal class BeregningRoutesTest {
     fun `skal hente overstyrBeregning`() {
         val behandling = mockk<DetaljertBehandling>()
 
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
         every { behandling.sak } returns 1L
         every { beregningRepository.hentOverstyrBeregning(1L) } returns OverstyrBeregning(1L, "Test", Tidspunkt.now())
@@ -208,7 +208,7 @@ internal class BeregningRoutesTest {
     fun `skal ikke hente overstyrBeregning hvis den ikke finnes`() {
         val behandling = mockk<DetaljertBehandling>()
 
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
         every { behandling.sak } returns 1L
         every { beregningRepository.hentOverstyrBeregning(1L) } returns null

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
@@ -77,7 +77,7 @@ internal class BeregningsGrunnlagRoutesTest {
 
     @Test
     fun `skal returnere 204 naar beregnings ikke finnes`() {
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns
             DetaljertBehandling(
                 id = randomUUID(),
@@ -126,7 +126,7 @@ internal class BeregningsGrunnlagRoutesTest {
                     ),
                 begrunnelse = "",
             )
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
         coEvery { behandlingKlient.hentBehandling(idRevurdering, any()) } returns
             DetaljertBehandling(
                 id = randomUUID(),
@@ -182,7 +182,7 @@ internal class BeregningsGrunnlagRoutesTest {
 
     @Test
     fun `skal hente beregning`() {
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
 
         val id = randomUUID()
 
@@ -213,7 +213,7 @@ internal class BeregningsGrunnlagRoutesTest {
 
     @Test
     fun `skal returnere not found naar saksbehandler ikke har tilgang til behandling`() {
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns false
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns false
 
         testApplication {
             environment { config = applicationConfig }
@@ -230,7 +230,7 @@ internal class BeregningsGrunnlagRoutesTest {
 
     @Test
     fun `skal returnere not found naar saksbehandler ikke har tilgang til behandling ved opprettelse`() {
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns false
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns false
 
         testApplication {
             environment { config = applicationConfig }
@@ -260,7 +260,7 @@ internal class BeregningsGrunnlagRoutesTest {
 
     @Test
     fun `skal opprettere`() {
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
         coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
         every { repository.finnBarnepensjonGrunnlagForBehandling(any()) } returns null
         every { repository.lagre(any()) } returns true
@@ -320,7 +320,7 @@ internal class BeregningsGrunnlagRoutesTest {
 
     @Test
     fun `skal returnere conflict fra opprettelse `() {
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
         coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
         every { repository.finnBarnepensjonGrunnlagForBehandling(any()) } returns null
         every { repository.lagre(any()) } returns false
@@ -383,7 +383,7 @@ internal class BeregningsGrunnlagRoutesTest {
         val forrige = randomUUID()
         val nye = randomUUID()
 
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
         coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
         every { repository.finnBarnepensjonGrunnlagForBehandling(forrige) } returns
             BeregningsGrunnlag(
@@ -414,7 +414,7 @@ internal class BeregningsGrunnlagRoutesTest {
         val forrige = randomUUID()
         val nye = randomUUID()
 
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
         coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
         every { repository.finnBarnepensjonGrunnlagForBehandling(forrige) } returns
             BeregningsGrunnlag(
@@ -445,7 +445,7 @@ internal class BeregningsGrunnlagRoutesTest {
         val forrige = randomUUID()
         val nye = randomUUID()
 
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
         coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
         every { repository.finnBarnepensjonGrunnlagForBehandling(forrige) } returns null
         every { repository.lagre(any()) } returns true
@@ -468,7 +468,7 @@ internal class BeregningsGrunnlagRoutesTest {
         val forrige = randomUUID()
         val nye = randomUUID()
 
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
         coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
         every { repository.finnBarnepensjonGrunnlagForBehandling(forrige) } returns
             BeregningsGrunnlag(
@@ -505,7 +505,7 @@ internal class BeregningsGrunnlagRoutesTest {
     fun `skal hente overstyr beregning grunnlag`() {
         val behandlingId = randomUUID()
 
-        coEvery { behandlingKlient.harTilgangTilBehandling(behandlingId, any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(behandlingId, any(), any()) } returns true
 
         every { repository.finnOverstyrBeregningGrunnlagForBehandling(behandlingId) } returns
             listOf(
@@ -588,7 +588,7 @@ internal class BeregningsGrunnlagRoutesTest {
         val behandlingId = randomUUID()
         val slot = slot<List<OverstyrBeregningGrunnlagDao>>()
 
-        coEvery { behandlingKlient.harTilgangTilBehandling(behandlingId, any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(behandlingId, any(), any()) } returns true
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns
             DetaljertBehandling(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
@@ -61,7 +61,7 @@ fun Route.brevRoute(
         }
 
         post("mottaker") {
-            withSakId(tilgangssjekker) {
+            withSakId(tilgangssjekker, skrivetilgang = true) {
                 val body = call.receive<OppdaterMottakerRequest>()
 
                 val mottaker = service.oppdaterMottaker(brevId, body.mottaker)
@@ -71,7 +71,7 @@ fun Route.brevRoute(
         }
 
         post("tittel") {
-            withSakId(tilgangssjekker) {
+            withSakId(tilgangssjekker, skrivetilgang = true) {
                 val request = call.receive<OppdaterTittelRequest>()
 
                 service.oppdaterTittel(brevId, request.tittel)
@@ -88,7 +88,7 @@ fun Route.brevRoute(
             }
 
             post {
-                withSakId(tilgangssjekker) {
+                withSakId(tilgangssjekker, skrivetilgang = true) {
                     val brevId = brevId
                     val body = call.receive<OppdaterPayloadRequest>()
 
@@ -100,7 +100,7 @@ fun Route.brevRoute(
         }
 
         post("ferdigstill") {
-            withSakId(tilgangssjekker) {
+            withSakId(tilgangssjekker, skrivetilgang = true) {
                 service.ferdigstill(brevId, brukerTokenInfo)
 
                 call.respond(HttpStatusCode.OK)
@@ -108,7 +108,7 @@ fun Route.brevRoute(
         }
 
         post("journalfoer") {
-            withSakId(tilgangssjekker) {
+            withSakId(tilgangssjekker, skrivetilgang = true) {
                 val journalpostId = service.journalfoer(brevId, brukerTokenInfo)
 
                 call.respond(JournalpostIdDto(journalpostId))
@@ -116,7 +116,7 @@ fun Route.brevRoute(
         }
 
         post("distribuer") {
-            withSakId(tilgangssjekker) {
+            withSakId(tilgangssjekker, skrivetilgang = true) {
                 val bestillingsId = service.distribuer(brevId)
 
                 call.respond(BestillingsIdDto(bestillingsId))
@@ -139,7 +139,7 @@ fun Route.brevRoute(
         }
 
         post {
-            withSakId(tilgangssjekker) { sakId ->
+            withSakId(tilgangssjekker, skrivetilgang = true) { sakId ->
                 logger.info("Oppretter nytt brev på sak=$sakId)")
 
                 measureTimedValue {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevRoute.kt
@@ -42,7 +42,7 @@ fun Route.vedtaksbrevRoute(
         }
 
         post("vedtak") {
-            withBehandlingId(tilgangssjekker) { behandlingId ->
+            withBehandlingId(tilgangssjekker, skrivetilgang = true) { behandlingId ->
                 val sakId = sakId
 
                 logger.info("Oppretter vedtaksbrev for behandling (sakId=$sakId, behandlingId=$behandlingId)")
@@ -72,7 +72,7 @@ fun Route.vedtaksbrevRoute(
         }
 
         post("vedtak/ferdigstill") {
-            withBehandlingId(tilgangssjekker) { behandlingId ->
+            withBehandlingId(tilgangssjekker, skrivetilgang = true) { behandlingId ->
                 logger.info("Ferdigstiller vedtaksbrev for behandling (id=$behandlingId)")
 
                 measureTimedValue {
@@ -85,7 +85,7 @@ fun Route.vedtaksbrevRoute(
         }
 
         put("payload/tilbakestill") {
-            withBehandlingId(tilgangssjekker) {
+            withBehandlingId(tilgangssjekker, skrivetilgang = true) {
                 val body = call.receive<ResetPayloadRequest>()
                 val brevId = body.brevId
                 val sakId = body.sakId

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/DokumentRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/DokumentRoute.kt
@@ -25,7 +25,7 @@ fun Route.dokumentRoute(
 ) {
     route("dokumenter") {
         post {
-            withFoedselsnummer(tilgangssjekker) { foedselsnummer ->
+            withFoedselsnummer(tilgangssjekker, skrivetilgang = true) { foedselsnummer ->
                 val visTemaPen = call.request.queryParameters["visTemaPen"]?.toBoolean() ?: false
 
                 val result =

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/Tilgangssjekker.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/Tilgangssjekker.kt
@@ -37,7 +37,7 @@ class Tilgangssjekker(
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/behandling/$behandlingId/$skrivetilgang",
+                            url = "$resourceUrl/tilgang/behandling/$behandlingId?skrivetilgang=$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                 )
@@ -61,7 +61,7 @@ class Tilgangssjekker(
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/person/$skrivetilgang",
+                            url = "$resourceUrl/tilgang/person?skrivetilgang=$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                     postBody = foedselsnummer.value,
@@ -86,7 +86,7 @@ class Tilgangssjekker(
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/sak/$sakId/$skrivetilgang",
+                            url = "$resourceUrl/tilgang/sak/$sakId?skrivetilgang=$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                 )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/Tilgangssjekker.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/Tilgangssjekker.kt
@@ -28,6 +28,7 @@ class Tilgangssjekker(
 
     override suspend fun harTilgangTilBehandling(
         behandlingId: UUID,
+        skrivetilgang: Boolean,
         bruker: Saksbehandler,
     ): Boolean {
         try {
@@ -36,7 +37,7 @@ class Tilgangssjekker(
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/behandling/$behandlingId",
+                            url = "$resourceUrl/tilgang/behandling/$behandlingId/$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                 )
@@ -51,6 +52,7 @@ class Tilgangssjekker(
 
     override suspend fun harTilgangTilPerson(
         foedselsnummer: Folkeregisteridentifikator,
+        skrivetilgang: Boolean,
         bruker: Saksbehandler,
     ): Boolean {
         try {
@@ -59,7 +61,7 @@ class Tilgangssjekker(
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/person",
+                            url = "$resourceUrl/tilgang/person/$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                     postBody = foedselsnummer.value,
@@ -75,6 +77,7 @@ class Tilgangssjekker(
 
     override suspend fun harTilgangTilSak(
         sakId: Long,
+        skrivetilgang: Boolean,
         bruker: Saksbehandler,
     ): Boolean {
         try {
@@ -83,7 +86,7 @@ class Tilgangssjekker(
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/sak/$sakId",
+                            url = "$resourceUrl/tilgang/sak/$sakId/$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                 )

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
@@ -77,7 +77,7 @@ internal class BrevRouteTest {
         val brevId = Random.nextLong()
 
         coEvery { brevService.hentBrev(any()) } returns opprettBrev(brevId)
-        coEvery { tilgangssjekker.harTilgangTilSak(any(), any()) } returns true
+        coEvery { tilgangssjekker.harTilgangTilSak(any(), any(), any()) } returns true
 
         testApplication {
             val client = httpClient()
@@ -101,7 +101,7 @@ internal class BrevRouteTest {
         val pdf = Pdf("Hello world".toByteArray())
 
         coEvery { brevService.genererPdf(any(), any()) } returns pdf
-        coEvery { tilgangssjekker.harTilgangTilSak(any(), any()) } returns true
+        coEvery { tilgangssjekker.harTilgangTilSak(any(), any(), any()) } returns true
 
         testApplication {
             val client = httpClient()
@@ -119,7 +119,7 @@ internal class BrevRouteTest {
 
         coVerify(exactly = 1) {
             brevService.genererPdf(brevId, any())
-            tilgangssjekker.harTilgangTilSak(any(), any())
+            tilgangssjekker.harTilgangTilSak(any(), any(), any())
         }
     }
 
@@ -128,7 +128,7 @@ internal class BrevRouteTest {
         val brevId = Random.nextLong()
 
         coEvery { brevService.hentBrevPayload(any()) } returns BrevPayload(Slate(), null)
-        coEvery { tilgangssjekker.harTilgangTilSak(any(), any()) } returns true
+        coEvery { tilgangssjekker.harTilgangTilSak(any(), any(), any()) } returns true
 
         testApplication {
             val client = httpClient()
@@ -145,7 +145,7 @@ internal class BrevRouteTest {
 
         coVerify(exactly = 1) {
             brevService.hentBrevPayload(brevId)
-            tilgangssjekker.harTilgangTilSak(any(), any())
+            tilgangssjekker.harTilgangTilSak(any(), any(), any())
         }
     }
 
@@ -154,7 +154,7 @@ internal class BrevRouteTest {
         val brevId = Random.nextLong()
         coEvery { brevService.lagreBrevPayload(any(), any()) } returns 1
         coEvery { brevService.lagreBrevPayloadVedlegg(any(), any()) } returns 1
-        coEvery { tilgangssjekker.harTilgangTilSak(any(), any()) } returns true
+        coEvery { tilgangssjekker.harTilgangTilSak(any(), any(), any()) } returns true
 
         testApplication {
             val client = httpClient()
@@ -172,13 +172,13 @@ internal class BrevRouteTest {
 
         coVerify(exactly = 1) {
             brevService.lagreBrevPayload(brevId, any())
-            tilgangssjekker.harTilgangTilSak(any(), any())
+            tilgangssjekker.harTilgangTilSak(any(), any(), any())
         }
     }
 
     @Test
     fun `Endepunkt som ikke finnes`() {
-        coEvery { tilgangssjekker.harTilgangTilSak(any(), any()) } returns true
+        coEvery { tilgangssjekker.harTilgangTilSak(any(), any(), any()) } returns true
 
         testApplication {
             val client = httpClient()

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
@@ -74,7 +74,7 @@ internal class VedtaksbrevRouteTest {
     @Test
     fun `Endepunkt for henting av vedtaksbrev - brev finnes`() {
         coEvery { vedtaksbrevService.hentVedtaksbrev(any()) } returns opprettBrev()
-        coEvery { tilgangssjekker.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { tilgangssjekker.harTilgangTilBehandling(any(), any(), any()) } returns true
 
         testApplication {
             val client = httpClient()
@@ -94,7 +94,7 @@ internal class VedtaksbrevRouteTest {
     @Test
     fun `Endepunkt for henting av vedtaksbrev - brev finnes ikke`() {
         coEvery { vedtaksbrevService.hentVedtaksbrev(any()) } returns null
-        coEvery { tilgangssjekker.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { tilgangssjekker.harTilgangTilBehandling(any(), any(), any()) } returns true
 
         testApplication {
             val client = httpClient()
@@ -110,14 +110,14 @@ internal class VedtaksbrevRouteTest {
 
         coVerify {
             vedtaksbrevService.hentVedtaksbrev(BEHANDLING_ID)
-            tilgangssjekker.harTilgangTilBehandling(any(), any())
+            tilgangssjekker.harTilgangTilBehandling(any(), any(), any())
         }
     }
 
     @Test
     fun `Endepunkt for oppretting av vedtaksbrev`() {
         coEvery { vedtaksbrevService.opprettVedtaksbrev(any(), any(), any()) } returns opprettBrev()
-        coEvery { tilgangssjekker.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { tilgangssjekker.harTilgangTilBehandling(any(), any(), any()) } returns true
 
         testApplication {
             val client = httpClient()
@@ -134,7 +134,7 @@ internal class VedtaksbrevRouteTest {
 
         coVerify(exactly = 1) {
             vedtaksbrevService.opprettVedtaksbrev(SAK_ID, BEHANDLING_ID, any())
-            tilgangssjekker.harTilgangTilBehandling(any(), any())
+            tilgangssjekker.harTilgangTilBehandling(any(), any(), any())
         }
     }
 
@@ -144,7 +144,7 @@ internal class VedtaksbrevRouteTest {
         val pdf = Pdf("Hello world".toByteArray())
 
         coEvery { vedtaksbrevService.genererPdf(any(), any()) } returns pdf
-        coEvery { tilgangssjekker.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { tilgangssjekker.harTilgangTilBehandling(any(), any(), any()) } returns true
 
         testApplication {
             val client = httpClient()
@@ -162,14 +162,14 @@ internal class VedtaksbrevRouteTest {
 
         coVerify(exactly = 1) {
             vedtaksbrevService.genererPdf(brevId, any())
-            tilgangssjekker.harTilgangTilBehandling(any(), any())
+            tilgangssjekker.harTilgangTilBehandling(any(), any(), any())
         }
     }
 
     @Test
     fun `Endepunkt for ferdigstilling av vedtaksbrev`() {
         coEvery { vedtaksbrevService.ferdigstillVedtaksbrev(any(), any()) } just Runs
-        coEvery { tilgangssjekker.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { tilgangssjekker.harTilgangTilBehandling(any(), any(), any()) } returns true
 
         testApplication {
             val client = httpClient()
@@ -185,13 +185,13 @@ internal class VedtaksbrevRouteTest {
 
         coVerify(exactly = 1) {
             vedtaksbrevService.ferdigstillVedtaksbrev(BEHANDLING_ID, any())
-            tilgangssjekker.harTilgangTilBehandling(any(), any())
+            tilgangssjekker.harTilgangTilBehandling(any(), any(), any())
         }
     }
 
     @Test
     fun `Endepunkt som ikke finnes`() {
-        coEvery { tilgangssjekker.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { tilgangssjekker.harTilgangTilBehandling(any(), any(), any()) } returns true
 
         testApplication {
             val client = httpClient()

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokument/DokumentRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokument/DokumentRouteTest.kt
@@ -68,7 +68,7 @@ internal class DokumentRouteTest {
     @Test
     fun `Endepunkt for uthenting av alle dokumenter tilknyttet brukeren`() {
         coEvery { journalpostService.hentDokumenter(any(), any(), any(), any()) } returns HentDokumentoversiktBrukerResult()
-        coEvery { tilgangssjekker.harTilgangTilPerson(any(), any()) } returns true
+        coEvery { tilgangssjekker.harTilgangTilPerson(any(), any(), any()) } returns true
 
         val token = accessToken
         val fnr = SOEKER_FOEDSELSNUMMER.value

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingGrunnlagRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/BehandlingGrunnlagRoutes.kt
@@ -57,7 +57,7 @@ fun Route.behandlingGrunnlagRoute(
         }
 
         post("nye-opplysninger") {
-            withBehandlingId(behandlingKlient) { behandlingId ->
+            withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
                 val opplysningsbehov = call.receive<NyeSaksopplysninger>()
                 grunnlagService.lagreNyeSaksopplysninger(
                     opplysningsbehov.sakId,
@@ -70,7 +70,7 @@ fun Route.behandlingGrunnlagRoute(
 
         post("opprett-grunnlag") {
             kunSystembruker {
-                withBehandlingId(behandlingKlient) { behandlingId ->
+                withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
                     val opplysningsbehov = call.receive<Opplysningsbehov>()
                     grunnlagService.opprettGrunnlag(behandlingId, opplysningsbehov)
                     call.respond(HttpStatusCode.OK)
@@ -80,7 +80,7 @@ fun Route.behandlingGrunnlagRoute(
 
         post("oppdater-grunnlag") {
             kunSystembruker {
-                withBehandlingId(behandlingKlient) { behandlingId ->
+                withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
                     val request = call.receive<OppdaterGrunnlagRequest>()
                     grunnlagService.oppdaterGrunnlag(behandlingId, request.sakId, request.sakType)
                     call.respond(HttpStatusCode.OK)

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/PersonRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/PersonRoutes.kt
@@ -20,7 +20,7 @@ fun Route.personRoute(
 ) {
     route("person") {
         post("saker") {
-            withFoedselsnummer(behandlingKlient) { fnr ->
+            withFoedselsnummer(behandlingKlient, skrivetilgang = true) { fnr ->
                 val saksliste = grunnlagService.hentAlleSakerForFnr(fnr)
                 call.respond(saksliste)
             }
@@ -28,7 +28,7 @@ fun Route.personRoute(
 
         post("roller") {
             kunSystembruker {
-                withFoedselsnummer(behandlingKlient) { fnr ->
+                withFoedselsnummer(behandlingKlient, skrivetilgang = true) { fnr ->
                     val personMedSakOgRoller = grunnlagService.hentSakerOgRoller(fnr)
                     call.respond(personMedSakOgRoller)
                 }
@@ -38,7 +38,7 @@ fun Route.personRoute(
         post("navn") {
             hentNavidentFraToken { navIdent ->
                 try {
-                    withFoedselsnummer(behandlingKlient) { foedselsnummer ->
+                    withFoedselsnummer(behandlingKlient, skrivetilgang = true) { foedselsnummer ->
                         val opplysning =
                             grunnlagService.hentOpplysningstypeNavnFraFnr(
                                 foedselsnummer,

--- a/apps/etterlatte-grunnlag/src/main/kotlin/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/klienter/BehandlingKlient.kt
@@ -84,7 +84,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient, private val h
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/behandling/$behandlingId/$skrivetilgang",
+                            url = "$resourceUrl/tilgang/behandling/$behandlingId?skrivetilgang=$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                 )
@@ -108,7 +108,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient, private val h
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/sak/$sakId/$skrivetilgang",
+                            url = "$resourceUrl/tilgang/sak/$sakId?skrivetilgang=$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                 )
@@ -132,7 +132,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient, private val h
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/person/$skrivetilgang",
+                            url = "$resourceUrl/tilgang/person?skrivetilgang=$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                     postBody = foedselsnummer.value,

--- a/apps/etterlatte-grunnlag/src/main/kotlin/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/klienter/BehandlingKlient.kt
@@ -75,6 +75,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient, private val h
 
     override suspend fun harTilgangTilBehandling(
         behandlingId: UUID,
+        skrivetilgang: Boolean,
         bruker: Saksbehandler,
     ): Boolean {
         try {
@@ -83,7 +84,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient, private val h
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/behandling/$behandlingId",
+                            url = "$resourceUrl/tilgang/behandling/$behandlingId/$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                 )
@@ -98,6 +99,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient, private val h
 
     override suspend fun harTilgangTilSak(
         sakId: Long,
+        skrivetilgang: Boolean,
         bruker: Saksbehandler,
     ): Boolean {
         try {
@@ -106,7 +108,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient, private val h
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/sak/$sakId",
+                            url = "$resourceUrl/tilgang/sak/$sakId/$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                 )
@@ -121,6 +123,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient, private val h
 
     override suspend fun harTilgangTilPerson(
         foedselsnummer: Folkeregisteridentifikator,
+        skrivetilgang: Boolean,
         bruker: Saksbehandler,
     ): Boolean {
         try {
@@ -129,7 +132,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient, private val h
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/person",
+                            url = "$resourceUrl/tilgang/person/$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                     postBody = foedselsnummer.value,

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/BehandlingGrunnlagRoutesKtTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/BehandlingGrunnlagRoutesKtTest.kt
@@ -129,7 +129,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
         val behandlingId = UUID.randomUUID()
 
         every { grunnlagService.hentOpplysningsgrunnlag(any()) } returns null
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
 
         testApplication {
             environment {
@@ -155,7 +155,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
         }
 
         verify(exactly = 1) { grunnlagService.hentOpplysningsgrunnlag(any()) }
-        coVerify(exactly = 1) { behandlingKlient.harTilgangTilBehandling(any(), any()) }
+        coVerify(exactly = 1) { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) }
     }
 
     @Test
@@ -164,7 +164,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
         val testData = GrunnlagTestData().hentOpplysningsgrunnlag()
 
         every { grunnlagService.hentOpplysningsgrunnlag(any<UUID>()) } returns testData
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
 
         testApplication {
             val response =
@@ -180,7 +180,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
         }
 
         verify(exactly = 1) { grunnlagService.hentOpplysningsgrunnlag(any()) }
-        coVerify(exactly = 1) { behandlingKlient.harTilgangTilBehandling(any(), any()) }
+        coVerify(exactly = 1) { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) }
     }
 
     @ParameterizedTest
@@ -198,7 +198,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
             )
 
         every { grunnlagService.hentGrunnlagAvType(any<UUID>(), any<Opplysningstype>()) } returns opplysning
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
 
         testApplication {
             val response =
@@ -214,7 +214,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
         }
 
         verify(exactly = 1) { grunnlagService.hentGrunnlagAvType(behandlingId, type) }
-        coVerify(exactly = 1) { behandlingKlient.harTilgangTilBehandling(any(), any()) }
+        coVerify(exactly = 1) { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) }
     }
 
     @Test
@@ -231,7 +231,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
             )
 
         every { grunnlagService.hentHistoriskForeldreansvar(any<UUID>()) } returns opplysning
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
 
         testApplication {
             val response =
@@ -249,7 +249,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
         }
 
         verify(exactly = 1) { grunnlagService.hentHistoriskForeldreansvar(behandlingId) }
-        coVerify(exactly = 1) { behandlingKlient.harTilgangTilBehandling(any(), any()) }
+        coVerify(exactly = 1) { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) }
     }
 
     @Test
@@ -266,7 +266,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
             )
 
         every { grunnlagService.lagreNyeSaksopplysninger(any(), any(), any()) } just Runs
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
 
         testApplication {
             val actualResponse =
@@ -284,7 +284,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
         val opplysningerSlot = slot<List<Grunnlagsopplysning<JsonNode>>>()
 
         verify(exactly = 1) { grunnlagService.lagreNyeSaksopplysninger(sakId, behandlingId, capture(opplysningerSlot)) }
-        coVerify(exactly = 1) { behandlingKlient.harTilgangTilBehandling(behandlingId, any()) }
+        coVerify(exactly = 1) { behandlingKlient.harTilgangTilBehandling(behandlingId, any(), any()) }
 
         val faktiskOpplysning = opplysningerSlot.captured.single()
 

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/PersonRoutesTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/PersonRoutesTest.kt
@@ -178,7 +178,7 @@ internal class PersonRoutesTest {
     fun `Hent navn på person`() {
         val response = NavnOpplysningDTO(1, "Test", "Mellom", "Testesen", SOEKER_FOEDSELSNUMMER.value)
         every { grunnlagService.hentOpplysningstypeNavnFraFnr(any(), any()) } returns response
-        coEvery { behandlingKlient.harTilgangTilPerson(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilPerson(any(), any(), any()) } returns true
 
         testApplication {
             environment {
@@ -199,12 +199,12 @@ internal class PersonRoutesTest {
         }
 
         verify(exactly = 1) { grunnlagService.hentOpplysningstypeNavnFraFnr(SOEKER_FOEDSELSNUMMER, any()) }
-        coVerify { behandlingKlient.harTilgangTilPerson(SOEKER_FOEDSELSNUMMER, any()) }
+        coVerify { behandlingKlient.harTilgangTilPerson(SOEKER_FOEDSELSNUMMER, any(), any()) }
     }
 
     @Test
     fun `Hent navn på person - saksbehandler har ikke tilgang`() {
-        coEvery { behandlingKlient.harTilgangTilPerson(any(), any()) } returns false
+        coEvery { behandlingKlient.harTilgangTilPerson(any(), any(), any()) } returns false
 
         testApplication {
             environment {
@@ -223,7 +223,7 @@ internal class PersonRoutesTest {
             assertEquals(HttpStatusCode.NotFound, actualResponse.status)
         }
 
-        coVerify { behandlingKlient.harTilgangTilPerson(SOEKER_FOEDSELSNUMMER, any()) }
+        coVerify { behandlingKlient.harTilgangTilPerson(SOEKER_FOEDSELSNUMMER, any(), any()) }
     }
 
     private fun ApplicationTestBuilder.createHttpClient(): HttpClient {

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/SakGrunnlagRoutesKtTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/SakGrunnlagRoutesKtTest.kt
@@ -97,7 +97,7 @@ internal class SakGrunnlagRoutesKtTest {
         val sakId = Random.nextLong()
 
         every { grunnlagService.hentOpplysningsgrunnlagForSak(any()) } returns null
-        coEvery { behandlingKlient.harTilgangTilSak(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilSak(any(), any(), any()) } returns true
 
         testApplication {
             val response =
@@ -112,7 +112,7 @@ internal class SakGrunnlagRoutesKtTest {
         }
 
         verify(exactly = 1) { grunnlagService.hentOpplysningsgrunnlagForSak(any()) }
-        coVerify(exactly = 1) { behandlingKlient.harTilgangTilSak(any(), any()) }
+        coVerify(exactly = 1) { behandlingKlient.harTilgangTilSak(any(), any(), any()) }
     }
 
     @Test
@@ -121,7 +121,7 @@ internal class SakGrunnlagRoutesKtTest {
         val testData = GrunnlagTestData().hentOpplysningsgrunnlag()
 
         every { grunnlagService.hentOpplysningsgrunnlagForSak(any()) } returns testData
-        coEvery { behandlingKlient.harTilgangTilSak(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilSak(any(), any(), any()) } returns true
 
         testApplication {
             val response =
@@ -137,7 +137,7 @@ internal class SakGrunnlagRoutesKtTest {
         }
 
         verify(exactly = 1) { grunnlagService.hentOpplysningsgrunnlagForSak(sakId) }
-        coVerify(exactly = 1) { behandlingKlient.harTilgangTilSak(sakId, any()) }
+        coVerify(exactly = 1) { behandlingKlient.harTilgangTilSak(sakId, any(), any()) }
     }
 
     @Test
@@ -149,7 +149,7 @@ internal class SakGrunnlagRoutesKtTest {
             )
 
         every { grunnlagService.hentPersonerISak(any()) } returns testData
-        coEvery { behandlingKlient.harTilgangTilSak(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilSak(any(), any(), any()) } returns true
 
         testApplication {
             val response =
@@ -165,7 +165,7 @@ internal class SakGrunnlagRoutesKtTest {
         }
 
         verify(exactly = 1) { grunnlagService.hentPersonerISak(sakId) }
-        coVerify(exactly = 1) { behandlingKlient.harTilgangTilSak(sakId, any()) }
+        coVerify(exactly = 1) { behandlingKlient.harTilgangTilSak(sakId, any(), any()) }
     }
 
     private fun ApplicationTestBuilder.createHttpClient(): HttpClient {

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/NyTrygdetidRoutes.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/NyTrygdetidRoutes.kt
@@ -56,7 +56,7 @@ fun Route.trygdetidV2(
         }
 
         post {
-            withBehandlingId(behandlingKlient) {
+            withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 logger.info("Oppretter trygdetid(er) for behandling $behandlingId")
                 val trygdetid = trygdetidService.opprettTrygdetiderForBehandling(behandlingId, brukerTokenInfo)
                 call.respond(trygdetid.map { it.toDto() })
@@ -64,7 +64,7 @@ fun Route.trygdetidV2(
         }
 
         post("overstyr") {
-            withBehandlingId(behandlingKlient) {
+            withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 logger.info("Oppdater trygdetid (overstyring) for behandling $behandlingId")
                 val trygdetidOverstyringDto = call.receive<TrygdetidOverstyringDto>()
 
@@ -81,7 +81,7 @@ fun Route.trygdetidV2(
 
         route("{${TRYGDETIDID_CALL_PARAMETER}}") {
             post("grunnlag") {
-                withBehandlingId(behandlingKlient) {
+                withBehandlingId(behandlingKlient, skrivetilgang = true) {
                     logger.info("Legger til trygdetidsgrunnlag for behandling $behandlingId")
                     val trygdetidgrunnlagDto = call.receive<TrygdetidGrunnlagDto>()
 
@@ -95,7 +95,7 @@ fun Route.trygdetidV2(
             }
 
             post("/grunnlag/yrkesskade") {
-                withBehandlingId(behandlingKlient) {
+                withBehandlingId(behandlingKlient, skrivetilgang = true) {
                     logger.info("Legger til yrkesskade trygdetidsgrunnlag for behandling $behandlingId")
                     trygdetidService.lagreYrkesskadeTrygdetidGrunnlag(
                         behandlingId,
@@ -105,7 +105,7 @@ fun Route.trygdetidV2(
             }
 
             delete("/grunnlag/{trygdetidGrunnlagId}") {
-                withBehandlingId(behandlingKlient) {
+                withBehandlingId(behandlingKlient, skrivetilgang = true) {
                     withParam("trygdetidGrunnlagId") { trygdetidGrunnlagId ->
                         logger.info("Sletter trygdetidsgrunnlag for behandling $behandlingId")
                         val trygdetid =
@@ -122,7 +122,7 @@ fun Route.trygdetidV2(
         }
 
         post("/kopier/{forrigeBehandlingId}") {
-            withBehandlingId(behandlingKlient) {
+            withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 logger.info("Oppretter kopi av forrige trygdetider for behandling $behandlingId")
                 val forrigeBehandlingId = call.uuid("forrigeBehandlingId")
                 trygdetidService.kopierSisteTrygdetidberegninger(behandlingId, forrigeBehandlingId, brukerTokenInfo)
@@ -131,7 +131,7 @@ fun Route.trygdetidV2(
         }
 
         post("/migrering") {
-            withBehandlingId(behandlingKlient) {
+            withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 logger.info("Migrering overstyrer trygdetid for behandling $behandlingId")
 
                 val overstyringDto = call.receive<MigreringOverstyringDto>()

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
@@ -42,7 +42,7 @@ class BehandlingKlient(config: Config, httpClient: HttpClient) : BehandlingTilga
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/behandling/$behandlingId/$skrivetilgang",
+                            url = "$resourceUrl/tilgang/behandling/$behandlingId?skrivetilgang=$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                 )

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
@@ -31,6 +31,7 @@ class BehandlingKlient(config: Config, httpClient: HttpClient) : BehandlingTilga
 
     override suspend fun harTilgangTilBehandling(
         behandlingId: UUID,
+        skrivetilgang: Boolean,
         bruker: Saksbehandler,
     ): Boolean {
         try {
@@ -41,7 +42,7 @@ class BehandlingKlient(config: Config, httpClient: HttpClient) : BehandlingTilga
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/behandling/$behandlingId",
+                            url = "$resourceUrl/tilgang/behandling/$behandlingId/$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                 )

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidRoutesTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/TrygdetidRoutesTest.kt
@@ -36,7 +36,7 @@ internal class TrygdetidRoutesTest {
     @BeforeAll
     fun beforeAll() {
         server.start()
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
     }
 
     @AfterAll
@@ -59,7 +59,7 @@ internal class TrygdetidRoutesTest {
         }
 
         coVerify {
-            behandlingKlient.harTilgangTilBehandling(any(), any())
+            behandlingKlient.harTilgangTilBehandling(any(), any(), any())
             trygdetidService.hentTrygdetid(any(), any())
         }
     }
@@ -82,7 +82,7 @@ internal class TrygdetidRoutesTest {
         }
 
         coVerify {
-            behandlingKlient.harTilgangTilBehandling(any(), any())
+            behandlingKlient.harTilgangTilBehandling(any(), any(), any())
             trygdetidService.sjekkGyldighetOgOppdaterBehandlingStatus(any(), any())
         }
     }

--- a/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/avtale/AvtaleRoutesTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/trygdetid/avtale/AvtaleRoutesTest.kt
@@ -64,7 +64,7 @@ internal class AvtaleRoutesTest {
     @BeforeEach
     fun beforeEach() {
         clearAllMocks()
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
     }
 
     @AfterEach
@@ -144,7 +144,7 @@ internal class AvtaleRoutesTest {
 
             avtale.avtaleKode shouldBe "TEST"
 
-            coVerify(exactly = 1) { behandlingKlient.harTilgangTilBehandling(any(), any()) }
+            coVerify(exactly = 1) { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) }
             verify(exactly = 1) { repository.hentAvtale(any()) }
         }
     }
@@ -187,7 +187,7 @@ internal class AvtaleRoutesTest {
             avtale.behandlingId shouldBe behandlingId
             avtale.kilde.ident shouldBe "Saksbehandler01"
 
-            coVerify(exactly = 1) { behandlingKlient.harTilgangTilBehandling(any(), any()) }
+            coVerify(exactly = 1) { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) }
             verify(exactly = 1) { repository.opprettAvtale(any()) }
         }
     }
@@ -231,7 +231,7 @@ internal class AvtaleRoutesTest {
             avtale.behandlingId shouldBe behandlingId
             avtale.kilde.ident shouldBe "Saksbehandler01"
 
-            coVerify(exactly = 1) { behandlingKlient.harTilgangTilBehandling(any(), any()) }
+            coVerify(exactly = 1) { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) }
             verify(exactly = 1) { repository.lagreAvtale(any()) }
         }
     }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -264,28 +264,28 @@ fun Route.tilbakekrevingvedtakRoute(
 
     route("/tilbakekreving/{$BEHANDLINGID_CALL_PARAMETER}") {
         post("/lagre-vedtak") {
-            withBehandlingId(behandlingKlient) {
+            withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 val dto = call.receive<TilbakekrevingVedtakDto>()
                 logger.info("Oppretter vedtak for tilbakekreving=${dto.tilbakekrevingId}")
                 call.respond(service.opprettEllerOppdaterVedtak(dto))
             }
         }
         post("/fatt-vedtak") {
-            withBehandlingId(behandlingKlient) {
+            withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 val dto = call.receive<TilbakekrevingFattEllerAttesterVedtakDto>()
                 logger.info("Fatter vedtak for tilbakekreving=${dto.tilbakekrevingId}")
                 call.respond(service.fattVedtak(dto))
             }
         }
         post("/attester-vedtak") {
-            withBehandlingId(behandlingKlient) {
+            withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 val dto = call.receive<TilbakekrevingFattEllerAttesterVedtakDto>()
                 logger.info("Attesterer vedtak for tilbakekreving=${dto.tilbakekrevingId}")
                 call.respond(service.attesterVedtak(dto))
             }
         }
         post("/underkjenn-vedtak") {
-            withBehandlingId(behandlingKlient) {
+            withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 logger.info("Underkjenner vedtak for tilbakekreving=$behandlingId")
                 call.respond(service.underkjennVedtak(behandlingId))
             }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/klienter/BehandlingKlient.kt
@@ -377,7 +377,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/behandling/$behandlingId/$skrivetilgang",
+                            url = "$resourceUrl/tilgang/behandling/$behandlingId?skrivetilgang=$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                 )

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/klienter/BehandlingKlient.kt
@@ -368,6 +368,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
 
     override suspend fun harTilgangTilBehandling(
         behandlingId: UUID,
+        skrivetilgang: Boolean,
         bruker: Saksbehandler,
     ): Boolean {
         try {
@@ -376,7 +377,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/behandling/$behandlingId",
+                            url = "$resourceUrl/tilgang/behandling/$behandlingId/$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                 )
@@ -391,6 +392,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
 
     override suspend fun harTilgangTilSak(
         sakId: Long,
+        skrivetilgang: Boolean,
         bruker: Saksbehandler,
     ): Boolean {
         try {
@@ -399,7 +401,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/sak/$sakId",
+                            url = "$resourceUrl/tilgang/sak/$sakId/$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                 )

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingRouteTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtaksvurderingRouteTest.kt
@@ -86,7 +86,7 @@ internal class VedtaksvurderingRouteTest {
 
     @BeforeEach
     fun beforeEach() {
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
     }
 
     @AfterAll
@@ -145,7 +145,7 @@ internal class VedtaksvurderingRouteTest {
         }
 
         coVerify(exactly = 1) {
-            behandlingKlient.harTilgangTilBehandling(any(), any())
+            behandlingKlient.harTilgangTilBehandling(any(), any(), any())
             vedtaksvurderingService.hentVedtakMedBehandlingId(any<UUID>())
         }
     }
@@ -177,7 +177,7 @@ internal class VedtaksvurderingRouteTest {
         }
 
         coVerify(exactly = 1) {
-            behandlingKlient.harTilgangTilBehandling(any(), any())
+            behandlingKlient.harTilgangTilBehandling(any(), any(), any())
             vedtaksvurderingService.hentVedtakMedBehandlingId(any<UUID>())
         }
     }
@@ -231,7 +231,7 @@ internal class VedtaksvurderingRouteTest {
             }
 
             coVerify(exactly = 1) {
-                behandlingKlient.harTilgangTilBehandling(any(), any())
+                behandlingKlient.harTilgangTilBehandling(any(), any(), any())
                 vedtaksvurderingService.hentVedtakMedBehandlingId(any<UUID>())
             }
         }
@@ -288,7 +288,7 @@ internal class VedtaksvurderingRouteTest {
             }
 
             coVerify(exactly = 1) {
-                behandlingKlient.harTilgangTilBehandling(any(), any())
+                behandlingKlient.harTilgangTilBehandling(any(), any(), any())
                 vedtaksvurderingService.hentVedtakMedBehandlingId(any<UUID>())
             }
         }
@@ -336,7 +336,7 @@ internal class VedtaksvurderingRouteTest {
         }
 
         coVerify(exactly = 1) {
-            behandlingKlient.harTilgangTilBehandling(any(), any())
+            behandlingKlient.harTilgangTilBehandling(any(), any(), any())
             vedtaksvurderingService.hentVedtakMedBehandlingId(any<UUID>())
         }
     }
@@ -379,7 +379,7 @@ internal class VedtaksvurderingRouteTest {
             // vedtaksammendrag.datoAttestert shouldBe attestertVedtak.attestasjon?.tidspunkt?.toNorskTid()
 
             coVerify(exactly = 1) {
-                behandlingKlient.harTilgangTilBehandling(any(), any())
+                behandlingKlient.harTilgangTilBehandling(any(), any(), any())
                 vedtaksvurderingService.hentVedtakMedBehandlingId(any<UUID>())
             }
         }
@@ -391,7 +391,7 @@ internal class VedtaksvurderingRouteTest {
         val loependeYtelse = LoependeYtelse(erLoepende = true, LocalDate.now())
 
         every { vedtakBehandlingService.sjekkOmVedtakErLoependePaaDato(any(), any()) } returns loependeYtelse
-        coEvery { behandlingKlient.harTilgangTilSak(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilSak(any(), any(), any()) } returns true
 
         testApplication {
             environment { config = applicationConfig }
@@ -419,7 +419,7 @@ internal class VedtaksvurderingRouteTest {
             hentetLoependeYtelse.dato shouldBe loependeYtelse.dato
 
             coVerify(exactly = 1) {
-                behandlingKlient.harTilgangTilSak(any(), any())
+                behandlingKlient.harTilgangTilSak(any(), any(), any())
                 vedtakBehandlingService.sjekkOmVedtakErLoependePaaDato(any(), any())
             }
         }
@@ -474,7 +474,7 @@ internal class VedtaksvurderingRouteTest {
             }
 
             coVerify(exactly = 1) {
-                behandlingKlient.harTilgangTilBehandling(any(), any())
+                behandlingKlient.harTilgangTilBehandling(any(), any(), any())
                 vedtakBehandlingService.opprettEllerOppdaterVedtak(any(), match { it.ident() == SAKSBEHANDLER_1 })
             }
         }
@@ -534,7 +534,7 @@ internal class VedtaksvurderingRouteTest {
             }
 
             coVerify(exactly = 1) {
-                behandlingKlient.harTilgangTilBehandling(any(), any())
+                behandlingKlient.harTilgangTilBehandling(any(), any(), any())
                 vedtakBehandlingService.fattVedtak(any(), match { it.ident() == SAKSBEHANDLER_1 }, any())
                 rapidService.sendToRapid(any())
             }
@@ -601,7 +601,7 @@ internal class VedtaksvurderingRouteTest {
             }
 
             coVerify(exactly = 1) {
-                behandlingKlient.harTilgangTilBehandling(any(), any())
+                behandlingKlient.harTilgangTilBehandling(any(), any(), any())
                 vedtakBehandlingService.attesterVedtak(
                     any(),
                     match { it == attestertVedtakKommentar.kommentar },
@@ -669,7 +669,7 @@ internal class VedtaksvurderingRouteTest {
             }
 
             coVerify(exactly = 1) {
-                behandlingKlient.harTilgangTilBehandling(any(), any())
+                behandlingKlient.harTilgangTilBehandling(any(), any(), any())
                 vedtakBehandlingService.underkjennVedtak(
                     any(),
                     match { it.ident() == SAKSBEHANDLER_1 },
@@ -709,7 +709,7 @@ internal class VedtaksvurderingRouteTest {
             }
 
             coVerify(exactly = 1) {
-                behandlingKlient.harTilgangTilBehandling(any(), any())
+                behandlingKlient.harTilgangTilBehandling(any(), any(), any())
                 vedtakBehandlingService.tilbakestillIkkeIverksatteVedtak(any())
             }
         }

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/migrering/AutomatiskBehandlingRoutesKtTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/migrering/AutomatiskBehandlingRoutesKtTest.kt
@@ -73,7 +73,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
 
     @BeforeEach
     fun beforeEach() {
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
     }
 
     @AfterAll
@@ -154,7 +154,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
                 vedtakService.attesterVedtak(behandlingId, any(), any(), Fagsaksystem.EY.navn)
             }
             coVerify(atLeast = 1) {
-                behandlingKlient.harTilgangTilBehandling(any(), any())
+                behandlingKlient.harTilgangTilBehandling(any(), any(), any())
             }
         }
     }
@@ -237,7 +237,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
                     vedtakService.attesterVedtak(behandlingId, any(), any(), Fagsaksystem.EY.navn)
                 }
                 coVerify(atLeast = 1) {
-                    behandlingKlient.harTilgangTilBehandling(any(), any())
+                    behandlingKlient.harTilgangTilBehandling(any(), any(), any())
                 }
             }
         }
@@ -295,7 +295,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
                     behandlingKlient.tildelSaksbehandler(any(), any())
                 }
                 coVerify(atLeast = 1) {
-                    behandlingKlient.harTilgangTilBehandling(any(), any())
+                    behandlingKlient.harTilgangTilBehandling(any(), any(), any())
                 }
             }
         }
@@ -351,7 +351,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
                     vedtakService.attesterVedtak(behandlingId, any(), any(), Fagsaksystem.EY.navn)
                 }
                 coVerify(atLeast = 1) {
-                    behandlingKlient.harTilgangTilBehandling(any(), any())
+                    behandlingKlient.harTilgangTilBehandling(any(), any(), any())
                 }
             }
         }

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
@@ -45,7 +45,7 @@ fun Route.vilkaarsvurdering(
         }
 
         post("/{$BEHANDLINGID_CALL_PARAMETER}/opprett") {
-            withBehandlingId(behandlingKlient) { behandlingId ->
+            withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
                 try {
                     val kopierVedRevurdering =
                         call.request.queryParameters["kopierVedRevurdering"]?.let { it.toBoolean() }
@@ -108,7 +108,7 @@ fun Route.vilkaarsvurdering(
         }
 
         post("/{$BEHANDLINGID_CALL_PARAMETER}") {
-            withBehandlingId(behandlingKlient) { behandlingId ->
+            withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
                 val vurdertVilkaarDto = call.receive<VurdertVilkaarDto>()
                 val vurdertVilkaar = vurdertVilkaarDto.toVurdertVilkaar(brukerTokenInfo.ident())
 
@@ -138,7 +138,7 @@ fun Route.vilkaarsvurdering(
         }
 
         post("/{$BEHANDLINGID_CALL_PARAMETER}/oppdater-status") {
-            withBehandlingId(behandlingKlient) { behandlingId ->
+            withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
                 val statusOppdatert =
                     vilkaarsvurderingService.sjekkGyldighetOgOppdaterBehandlingStatus(behandlingId, brukerTokenInfo)
                 call.respond(HttpStatusCode.OK, StatusOppdatertDto(statusOppdatert))
@@ -146,7 +146,7 @@ fun Route.vilkaarsvurdering(
         }
 
         delete("/{$BEHANDLINGID_CALL_PARAMETER}/{vilkaarId}") {
-            withBehandlingId(behandlingKlient) { behandlingId ->
+            withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
                 withParam("vilkaarId") { vilkaarId ->
                     logger.info("Sletter vurdering på vilkår $vilkaarId for $behandlingId")
                     try {
@@ -171,7 +171,7 @@ fun Route.vilkaarsvurdering(
         }
 
         delete("/{$BEHANDLINGID_CALL_PARAMETER}") {
-            withBehandlingId(behandlingKlient) { behandlingId ->
+            withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
                 logger.info("Sletter vilkårsvurdering for $behandlingId")
 
                 try {
@@ -189,7 +189,7 @@ fun Route.vilkaarsvurdering(
 
         route("/resultat") {
             post("/{$BEHANDLINGID_CALL_PARAMETER}") {
-                withBehandlingId(behandlingKlient) { behandlingId ->
+                withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
                     val vurdertResultatDto = call.receive<VurdertVilkaarsvurderingResultatDto>()
                     val vurdertResultat =
                         vurdertResultatDto.toVilkaarsvurderingResultat(

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/klienter/BehandlingKlient.kt
@@ -187,6 +187,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
 
     override suspend fun harTilgangTilBehandling(
         behandlingId: UUID,
+        skrivetilgang: Boolean,
         bruker: Saksbehandler,
     ): Boolean {
         try {
@@ -195,7 +196,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/behandling/$behandlingId",
+                            url = "$resourceUrl/tilgang/behandling/$behandlingId/$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                 )

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/vilkaarsvurdering/klienter/BehandlingKlient.kt
@@ -196,7 +196,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/tilgang/behandling/$behandlingId/$skrivetilgang",
+                            url = "$resourceUrl/tilgang/behandling/$behandlingId?skrivetilgang=$skrivetilgang",
                         ),
                     brukerTokenInfo = bruker,
                 )

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
@@ -97,7 +97,7 @@ internal class VilkaarsvurderingRoutesTest {
             behandlingKlient.settBehandlingStatusVilkaarsvurdert(any(), any())
         } returns true
         coEvery { behandlingKlient.settBehandlingStatusOpprettet(any(), any(), any()) } returns true
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
         coEvery { grunnlagKlient.hentGrunnlag(any(), any(), any()) } returns GrunnlagTestData().hentOpplysningsgrunnlag()
     }
 
@@ -184,7 +184,7 @@ internal class VilkaarsvurderingRoutesTest {
     fun `skal returnere not found dersom saksbehandler ikke har tilgang til behandlingen`() {
         val behandlingKlient = mockk<BehandlingKlient>()
         val nyBehandlingId = UUID.randomUUID()
-        coEvery { behandlingKlient.harTilgangTilBehandling(nyBehandlingId, any()) } returns false
+        coEvery { behandlingKlient.harTilgangTilBehandling(nyBehandlingId, any(), any()) } returns false
 
         testApplication {
             environment {
@@ -200,7 +200,7 @@ internal class VilkaarsvurderingRoutesTest {
 
             assertEquals(response.status, HttpStatusCode.NotFound)
             coVerify(exactly = 1) {
-                behandlingKlient.harTilgangTilBehandling(nyBehandlingId, any())
+                behandlingKlient.harTilgangTilBehandling(nyBehandlingId, any(), any())
             }
         }
     }
@@ -622,7 +622,7 @@ internal class VilkaarsvurderingRoutesTest {
         val behandlingKlient = mockk<BehandlingKlient>()
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns detaljertBehandling()
         coEvery { behandlingKlient.kanSetteBehandlingStatusVilkaarsvurdert(any(), any()) } returns true
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
 
         val vilkaarsvurderingServiceImpl =
             VilkaarsvurderingService(
@@ -649,7 +649,7 @@ internal class VilkaarsvurderingRoutesTest {
         val behandlingKlient = mockk<BehandlingKlient>()
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns detaljertBehandling()
         coEvery { behandlingKlient.kanSetteBehandlingStatusVilkaarsvurdert(any(), any()) } returns false
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
 
         val vilkaarsvurderingServiceImpl =
             VilkaarsvurderingService(
@@ -679,7 +679,7 @@ internal class VilkaarsvurderingRoutesTest {
         val behandlingKlient = mockk<BehandlingKlient>()
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns detaljertBehandling()
         coEvery { behandlingKlient.settBehandlingStatusOpprettet(any(), any(), any()) } returns false
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
 
         val vilkaarsvurderingServiceImpl =
             VilkaarsvurderingService(
@@ -711,7 +711,7 @@ internal class VilkaarsvurderingRoutesTest {
                 true,
                 false,
             )
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
 
         val vilkaarsvurderingServiceImpl =
             VilkaarsvurderingService(

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/migrering/MigreringTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/vilkaarsvurdering/migrering/MigreringTest.kt
@@ -99,7 +99,7 @@ class MigreringTest {
             MigreringService(
                 vilkaarsvurderingRepository,
             )
-        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any()) } returns true
+        coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
         coEvery { behandlingKlient.kanSetteBehandlingStatusVilkaarsvurdert(any(), any()) } returns true
         coEvery { behandlingKlient.hentBehandling(behandlingId, any()) } returns detaljertBehandling()
         coEvery { behandlingKlient.settBehandlingStatusVilkaarsvurdert(behandlingId, any()) } returns true

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/Enheter.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/Enheter.kt
@@ -2,21 +2,34 @@ package no.nav.etterlatte.common
 
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 
-enum class Enheter(val enhetNr: String, val navn: String, val inkludertForNasjonalTilgang: Boolean) {
-    STRENGT_FORTROLIG("2103", "NAV Vikafossen", false),
-    STRENGT_FORTROLIG_UTLAND("2103", "NAV Vikafossen", false),
-    EGNE_ANSATTE("4883", "NAV Familie- og pensjonsytelser Egne ansatte", false),
-    UTLAND("0001", "NAV Familie- og pensjonsytelser Utland", false),
-    AALESUND("4815", "NAV Familie- og pensjonsytelser Ålesund", true),
-    AALESUND_UTLAND("4862", "NAV Familie- og pensjonsytelser Ålesund Utland", false),
-    STEINKJER("4817", "NAV Familie- og pensjonsytelser Steinkjer", true),
-    PORSGRUNN("4808", "NAV Familie- og pensjonsytelser Porsgrunn", true),
+enum class Enheter(
+    val enhetNr: String,
+    val navn: String,
+    val inkludertForNasjonalTilgang: Boolean,
+    val lesetilgang: Boolean,
+    val skrivetilgang: Boolean,
+) {
+    STRENGT_FORTROLIG("2103", "NAV Vikafossen", false, true, true),
+    STRENGT_FORTROLIG_UTLAND("2103", "NAV Vikafossen", false, true, true),
+    EGNE_ANSATTE("4883", "NAV Familie- og pensjonsytelser Egne ansatte", false, true, true),
+    UTLAND("0001", "NAV Familie- og pensjonsytelser Utland", false, true, true),
+    AALESUND("4815", "NAV Familie- og pensjonsytelser Ålesund", true, true, true),
+    AALESUND_UTLAND("4862", "NAV Familie- og pensjonsytelser Ålesund Utland", false, true, true),
+    STEINKJER("4817", "NAV Familie- og pensjonsytelser Steinkjer", true, true, true),
+    PORSGRUNN("4808", "NAV Familie- og pensjonsytelser Porsgrunn", true, true, true),
+    OEST_VIKEN("4101", "NAV Kontaktsenter Øst-Viken", false, true, false),
+    TROENDELAG("4116", "NAV Kontaktsenter Trøndelag", false, true, false),
+    NORDLAND_BODOE("4118", "NAV Kontaktsenter Nordland Bodø", false, true, false),
     ;
 
     companion object {
         val defaultEnhet = PORSGRUNN
 
         fun nasjonalTilgangEnheter() = entries.filter { it.inkludertForNasjonalTilgang }.map { it.enhetNr }
+
+        fun enheterMedSkrivetilgang() = entries.filter { it.skrivetilgang }.map { it.enhetNr }.toSet()
+
+        fun enheterMedLesetilgang() = entries.filter { it.lesetilgang }.map { it.enhetNr }.toSet()
     }
 }
 

--- a/libs/etterlatte-ktor/src/main/kotlin/RouteUtils.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/RouteUtils.kt
@@ -64,12 +64,13 @@ inline val PipelineContext<*, ApplicationCall>.klageId: UUID
 
 suspend inline fun PipelineContext<*, ApplicationCall>.withBehandlingId(
     behandlingTilgangsSjekk: BehandlingTilgangsSjekk,
+    skrivetilgang: Boolean = false,
     onSuccess: (id: UUID) -> Unit,
 ) = withParam(BEHANDLINGID_CALL_PARAMETER) { behandlingId ->
     when (brukerTokenInfo) {
         is Saksbehandler -> {
             val harTilgangTilBehandling =
-                behandlingTilgangsSjekk.harTilgangTilBehandling(behandlingId, brukerTokenInfo as Saksbehandler)
+                behandlingTilgangsSjekk.harTilgangTilBehandling(behandlingId, skrivetilgang, brukerTokenInfo as Saksbehandler)
             if (harTilgangTilBehandling) {
                 onSuccess(behandlingId)
             } else {
@@ -84,11 +85,12 @@ suspend inline fun PipelineContext<*, ApplicationCall>.withBehandlingId(
 
 suspend inline fun PipelineContext<*, ApplicationCall>.withSakId(
     sakTilgangsSjekk: SakTilgangsSjekk,
+    skrivetilgang: Boolean = false,
     onSuccess: (id: Long) -> Unit,
 ) = call.parameters[SAKID_CALL_PARAMETER]!!.toLong().let { sakId ->
     when (brukerTokenInfo) {
         is Saksbehandler -> {
-            val harTilgangTilSak = sakTilgangsSjekk.harTilgangTilSak(sakId, brukerTokenInfo as Saksbehandler)
+            val harTilgangTilSak = sakTilgangsSjekk.harTilgangTilSak(sakId, skrivetilgang, brukerTokenInfo as Saksbehandler)
             if (harTilgangTilSak) {
                 onSuccess(sakId)
             } else {
@@ -103,6 +105,7 @@ suspend inline fun PipelineContext<*, ApplicationCall>.withSakId(
 
 suspend inline fun PipelineContext<*, ApplicationCall>.withFoedselsnummer(
     personTilgangsSjekk: PersonTilgangsSjekk,
+    skrivetilgang: Boolean = false,
     onSuccess: (fnr: Folkeregisteridentifikator) -> Unit,
 ) {
     val foedselsnummerDTO = call.receive<FoedselsnummerDTO>()
@@ -113,6 +116,7 @@ suspend inline fun PipelineContext<*, ApplicationCall>.withFoedselsnummer(
             val harTilgangTilPerson =
                 personTilgangsSjekk.harTilgangTilPerson(
                     foedselsnummer,
+                    skrivetilgang,
                     brukerTokenInfo as Saksbehandler,
                 )
             if (harTilgangTilPerson) {
@@ -212,6 +216,7 @@ data class FoedselsNummerMedGraderingDTO(
 interface BehandlingTilgangsSjekk {
     suspend fun harTilgangTilBehandling(
         behandlingId: UUID,
+        skrivetilgang: Boolean = false,
         bruker: Saksbehandler,
     ): Boolean
 }
@@ -219,6 +224,7 @@ interface BehandlingTilgangsSjekk {
 interface SakTilgangsSjekk {
     suspend fun harTilgangTilSak(
         sakId: Long,
+        skrivetilgang: Boolean = false,
         bruker: Saksbehandler,
     ): Boolean
 }
@@ -226,6 +232,7 @@ interface SakTilgangsSjekk {
 interface PersonTilgangsSjekk {
     suspend fun harTilgangTilPerson(
         foedselsnummer: Folkeregisteridentifikator,
+        skrivetilgang: Boolean = false,
         bruker: Saksbehandler,
     ): Boolean
 }

--- a/libs/etterlatte-ktor/src/test/kotlin/RestModuleTest.kt
+++ b/libs/etterlatte-ktor/src/test/kotlin/RestModuleTest.kt
@@ -115,9 +115,9 @@ class RestModuleTest {
 
     @Test
     fun `skal kun svare ok dersom bruker har tilgang`() {
-        coEvery { behandlingTilgangsSjekkMock.harTilgangTilBehandling(any(), any()) } returns true
-        coEvery { sakTilgangsSjekkMock.harTilgangTilSak(any(), any()) } returns true
-        coEvery { personTilgangsSjekkMock.harTilgangTilPerson(any(), any()) } returns true
+        coEvery { behandlingTilgangsSjekkMock.harTilgangTilBehandling(any(), any(), any()) } returns true
+        coEvery { sakTilgangsSjekkMock.harTilgangTilSak(any(), any(), any()) } returns true
+        coEvery { personTilgangsSjekkMock.harTilgangTilPerson(any(), any(), any()) } returns true
 
         testApplication {
             environment {
@@ -137,9 +137,9 @@ class RestModuleTest {
                 setBody(FoedselsnummerDTO("27458328671").toJson())
             }.let { assertEquals(OK, it.status) }
 
-            coEvery { behandlingTilgangsSjekkMock.harTilgangTilBehandling(any(), any()) } returns false
-            coEvery { sakTilgangsSjekkMock.harTilgangTilSak(any(), any()) } returns false
-            coEvery { personTilgangsSjekkMock.harTilgangTilPerson(any(), any()) } returns false
+            coEvery { behandlingTilgangsSjekkMock.harTilgangTilBehandling(any(), any(), any()) } returns false
+            coEvery { sakTilgangsSjekkMock.harTilgangTilSak(any(), any(), any()) } returns false
+            coEvery { personTilgangsSjekkMock.harTilgangTilPerson(any(), any(), any()) } returns false
 
             client.get("/behandling/${UUID.randomUUID()}") {
                 header(HttpHeaders.Authorization, "Bearer $token")


### PR DESCRIPTION
Enhetsbasert les/skriv tilgang, for hver request der en skrive operasjon forespørres så slår vi opp enheter for saksbehandleren og sjekker om enheten har skrivetilgang. Se Enheter.kt.
Alle andre apper enn behandling må sendes med param skrivetilgang: Boolean for om de skal utføre en skriveoperasjon eller ei. Dette kontrolleres i Tilgangsstyringroutes.