### PR TITLE
Omregning - flytte asynkrone kall ut av databasetransaksjon

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
@@ -8,7 +8,7 @@ import no.nav.etterlatte.behandling.domain.toBehandlingOpprettet
 import no.nav.etterlatte.behandling.domain.toStatistikkBehandling
 import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.behandling.klienter.MigreringKlient
-import no.nav.etterlatte.behandling.revurdering.RevurderingService
+import no.nav.etterlatte.behandling.revurdering.AutomatiskRevurderingService
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseService
 import no.nav.etterlatte.inTransaction
@@ -40,7 +40,7 @@ import java.time.LocalDateTime
 class BehandlingFactory(
     private val oppgaveService: OppgaveService,
     private val grunnlagService: GrunnlagService,
-    private val revurderingService: RevurderingService,
+    private val revurderingService: AutomatiskRevurderingService,
     private val gyldighetsproevingService: GyldighetsproevingService,
     private val sakService: SakService,
     private val behandlingDao: BehandlingDao,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
@@ -156,7 +156,7 @@ class BehandlingFactory(
                 mottattDato = mottattDato,
                 kilde = kilde,
                 revurderingAarsak = Revurderingaarsak.NY_SOEKNAD,
-            )?.let { BehandlingOgOppgave(it, null) }
+            )?.oppdater()?.let { BehandlingOgOppgave(it, null) }
         } else {
             val harBehandlingUnderbehandling =
                 harBehandlingerForSak.filter { behandling ->

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
@@ -1,6 +1,8 @@
 package no.nav.etterlatte.behandling.domain
 
+import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.behandling.BehandlingSammendrag
+import no.nav.etterlatte.behandling.filterBehandlingerForEnheter
 import no.nav.etterlatte.behandling.revurdering.RevurderingInfoMedBegrunnelse
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
@@ -183,6 +185,13 @@ sealed class Behandling {
         message: String = "Behandlingen støtter ikke statusendringen til status $behandlingStatus",
     ) : Exception(message)
 }
+
+fun <T : Behandling> T?.sjekkEnhet() =
+    this?.let { behandling ->
+        listOf(behandling).filterBehandlingerForEnheter(
+            Kontekst.get().AppUser,
+        ).firstOrNull()
+    }
 
 internal fun Behandling.toStatistikkBehandling(
     persongalleri: Persongalleri,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningRoutes.kt
@@ -27,10 +27,15 @@ fun Route.omregningRoutes(omregningService: OmregningService) {
                             prosessType = request.prosesstype,
                             forrigeBehandling = forrigeBehandling,
                             persongalleri = persongalleri,
-                        ).oppdater()
+                        )
                     }
-                val behandlingId = revurderingOgOppfoelging.id
-                val sakType = revurderingOgOppfoelging.sak.sakType
+                revurderingOgOppfoelging.leggInnGrunnlag()
+                inTransaction {
+                    revurderingOgOppfoelging.opprettOgTildelOppgave()
+                }
+                revurderingOgOppfoelging.sendMeldingForHendelse()
+                val behandlingId = revurderingOgOppfoelging.behandlingId()
+                val sakType = revurderingOgOppfoelging.sakType()
                 call.respond(OpprettOmregningResponse(behandlingId, forrigeBehandling.id, sakType))
             }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningRoutes.kt
@@ -19,7 +19,7 @@ fun Route.omregningRoutes(omregningService: OmregningService) {
                 val request = call.receive<Omregningshendelse>()
                 val forrigeBehandling = inTransaction { omregningService.hentForrigeBehandling(request.sakId) }
                 val persongalleri = omregningService.hentPersongalleri(forrigeBehandling.id)
-                val (behandlingId, sakType) =
+                val revurderingOgOppfoelging =
                     inTransaction {
                         omregningService.opprettOmregning(
                             sakId = request.sakId,
@@ -27,8 +27,10 @@ fun Route.omregningRoutes(omregningService: OmregningService) {
                             prosessType = request.prosesstype,
                             forrigeBehandling = forrigeBehandling,
                             persongalleri = persongalleri,
-                        )
+                        ).oppdater()
                     }
+                val behandlingId = revurderingOgOppfoelging.id
+                val sakType = revurderingOgOppfoelging.sak.sakType
                 call.respond(OpprettOmregningResponse(behandlingId, forrigeBehandling.id, sakType))
             }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
@@ -31,20 +31,18 @@ class OmregningService(
         forrigeBehandling: Behandling,
         persongalleri: Persongalleri,
     ): Pair<UUID, SakType> {
+        if (prosessType == Prosesstype.MANUELL) {
+            throw Exception("Støtter ikke prosesstype MANUELL")
+        }
         val behandling =
-            when (prosessType) {
-                Prosesstype.AUTOMATISK ->
-                    revurderingService.opprettAutomatiskRevurdering(
-                        sakId = sakId,
-                        forrigeBehandling = forrigeBehandling,
-                        revurderingAarsak = Revurderingaarsak.REGULERING,
-                        virkningstidspunkt = fraDato,
-                        kilde = Vedtaksloesning.GJENNY,
-                        persongalleri = persongalleri,
-                    )?.oppdater()
-
-                Prosesstype.MANUELL -> throw Exception("Støtter ikke prosesstype MANUELL")
-            } ?: throw Exception("Opprettelse av revurdering feilet for $sakId")
+            revurderingService.opprettAutomatiskRevurdering(
+                sakId = sakId,
+                forrigeBehandling = forrigeBehandling,
+                revurderingAarsak = Revurderingaarsak.REGULERING,
+                virkningstidspunkt = fraDato,
+                kilde = Vedtaksloesning.GJENNY,
+                persongalleri = persongalleri,
+            )?.oppdater() ?: throw Exception("Opprettelse av revurdering feilet for $sakId")
         return Pair(behandling.id, behandling.sak.sakType)
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
@@ -44,9 +44,7 @@ class OmregningService(
                 kilde = Vedtaksloesning.GJENNY,
                 persongalleri = persongalleri,
             ),
-        ) {
-            throw Exception("Opprettelse av revurdering feilet for $sakId")
-        }
+        ) { "Opprettelse av revurdering feilet for $sakId" }
     }
 }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
@@ -10,6 +10,7 @@ import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import java.time.LocalDate
 import java.util.UUID
 
@@ -32,7 +33,7 @@ class OmregningService(
         persongalleri: Persongalleri,
     ): RevurderingOgOppfoelging {
         if (prosessType == Prosesstype.MANUELL) {
-            throw Exception("Støtter ikke prosesstype MANUELL")
+            throw StoetterIkkeProsesstypeManuell()
         }
         return requireNotNull(
             revurderingService.opprettAutomatiskRevurdering(
@@ -48,3 +49,8 @@ class OmregningService(
         }
     }
 }
+
+class StoetterIkkeProsesstypeManuell : UgyldigForespoerselException(
+    code = "StoetterIkkeProsesstypeManuell",
+    detail = "Støtter ikke omregning for manuell behandling",
+)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
@@ -5,11 +5,11 @@ import no.nav.etterlatte.behandling.BehandlingService
 import no.nav.etterlatte.behandling.GrunnlagService
 import no.nav.etterlatte.behandling.domain.Behandling
 import no.nav.etterlatte.behandling.revurdering.AutomatiskRevurderingService
+import no.nav.etterlatte.behandling.revurdering.RevurderingOgOppfoelging
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
-import no.nav.etterlatte.libs.common.behandling.SakType
 import java.time.LocalDate
 import java.util.UUID
 
@@ -30,11 +30,11 @@ class OmregningService(
         prosessType: Prosesstype,
         forrigeBehandling: Behandling,
         persongalleri: Persongalleri,
-    ): Pair<UUID, SakType> {
+    ): RevurderingOgOppfoelging {
         if (prosessType == Prosesstype.MANUELL) {
             throw Exception("Støtter ikke prosesstype MANUELL")
         }
-        val behandling =
+        return requireNotNull(
             revurderingService.opprettAutomatiskRevurdering(
                 sakId = sakId,
                 forrigeBehandling = forrigeBehandling,
@@ -42,7 +42,9 @@ class OmregningService(
                 virkningstidspunkt = fraDato,
                 kilde = Vedtaksloesning.GJENNY,
                 persongalleri = persongalleri,
-            )?.oppdater() ?: throw Exception("Opprettelse av revurdering feilet for $sakId")
-        return Pair(behandling.id, behandling.sak.sakType)
+            ),
+        ) {
+            throw Exception("Opprettelse av revurdering feilet for $sakId")
+        }
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.BehandlingService
 import no.nav.etterlatte.behandling.GrunnlagService
 import no.nav.etterlatte.behandling.domain.Behandling
-import no.nav.etterlatte.behandling.revurdering.RevurderingService
+import no.nav.etterlatte.behandling.revurdering.AutomatiskRevurderingService
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
@@ -16,7 +16,7 @@ import java.util.UUID
 class OmregningService(
     private val behandlingService: BehandlingService,
     private val grunnlagService: GrunnlagService,
-    private val revurderingService: RevurderingService,
+    private val revurderingService: AutomatiskRevurderingService,
 ) {
     fun hentForrigeBehandling(sakId: Long) =
         behandlingService.hentSisteIverksatte(sakId)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
@@ -41,7 +41,7 @@ class OmregningService(
                         virkningstidspunkt = fraDato,
                         kilde = Vedtaksloesning.GJENNY,
                         persongalleri = persongalleri,
-                    )
+                    )?.oppdater()
 
                 Prosesstype.MANUELL -> throw Exception("Støtter ikke prosesstype MANUELL")
             } ?: throw Exception("Opprettelse av revurdering feilet for $sakId")

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -34,6 +34,6 @@ class AutomatiskRevurderingService(private val revurderingService: RevurderingSe
             boddEllerArbeidetUtlandet = forrigeBehandling.boddEllerArbeidetUtlandet,
             begrunnelse = begrunnelse ?: "Automatisk revurdering - ${revurderingAarsak.name.lowercase()}",
             saksbehandlerIdent = Fagsaksystem.EY.navn,
-        )
+        ).oppdater()
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -1,9 +1,13 @@
 package no.nav.etterlatte.behandling.revurdering
 
 import no.nav.etterlatte.behandling.domain.Behandling
+import no.nav.etterlatte.behandling.domain.sjekkEnhet
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
+import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
+import no.nav.etterlatte.libs.common.behandling.tilVirkningstidspunkt
+import no.nav.etterlatte.token.Fagsaksystem
 import java.time.LocalDate
 
 class AutomatiskRevurderingService(private val revurderingService: RevurderingService) {
@@ -16,14 +20,20 @@ class AutomatiskRevurderingService(private val revurderingService: RevurderingSe
         persongalleri: Persongalleri,
         mottattDato: String? = null,
         begrunnelse: String? = null,
-    ) = revurderingService.opprettAutomatiskRevurdering(
-        sakId,
-        forrigeBehandling,
-        revurderingAarsak,
-        virkningstidspunkt,
-        kilde,
-        persongalleri,
-        mottattDato,
-        begrunnelse,
-    )
+    ) = forrigeBehandling.sjekkEnhet()?.let {
+        revurderingService.opprettRevurdering(
+            sakId = sakId,
+            persongalleri = persongalleri,
+            forrigeBehandling = forrigeBehandling.id,
+            mottattDato = mottattDato,
+            prosessType = Prosesstype.AUTOMATISK,
+            kilde = kilde,
+            revurderingAarsak = revurderingAarsak,
+            virkningstidspunkt = virkningstidspunkt?.tilVirkningstidspunkt("Opprettet automatisk"),
+            utlandstilknytning = forrigeBehandling.utlandstilknytning,
+            boddEllerArbeidetUtlandet = forrigeBehandling.boddEllerArbeidetUtlandet,
+            begrunnelse = begrunnelse ?: "Automatisk revurdering - ${revurderingAarsak.name.lowercase()}",
+            saksbehandlerIdent = Fagsaksystem.EY.navn,
+        )
+    }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -34,6 +34,6 @@ class AutomatiskRevurderingService(private val revurderingService: RevurderingSe
             boddEllerArbeidetUtlandet = forrigeBehandling.boddEllerArbeidetUtlandet,
             begrunnelse = begrunnelse ?: "Automatisk revurdering - ${revurderingAarsak.name.lowercase()}",
             saksbehandlerIdent = Fagsaksystem.EY.navn,
-        ).oppdater()
+        )
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -1,0 +1,29 @@
+package no.nav.etterlatte.behandling.revurdering
+
+import no.nav.etterlatte.behandling.domain.Behandling
+import no.nav.etterlatte.libs.common.Vedtaksloesning
+import no.nav.etterlatte.libs.common.behandling.Persongalleri
+import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
+import java.time.LocalDate
+
+class AutomatiskRevurderingService(private val revurderingService: RevurderingService) {
+    fun opprettAutomatiskRevurdering(
+        sakId: Long,
+        forrigeBehandling: Behandling,
+        revurderingAarsak: Revurderingaarsak,
+        virkningstidspunkt: LocalDate? = null,
+        kilde: Vedtaksloesning,
+        persongalleri: Persongalleri,
+        mottattDato: String? = null,
+        begrunnelse: String? = null,
+    ) = revurderingService.opprettAutomatiskRevurdering(
+        sakId,
+        forrigeBehandling,
+        revurderingAarsak,
+        virkningstidspunkt,
+        kilde,
+        persongalleri,
+        mottattDato,
+        begrunnelse,
+    )
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -308,22 +308,38 @@ class RevurderingService(
 
             behandlingDao.hentBehandling(opprettBehandling.id)!! as Revurdering
         }.also { revurdering ->
-            grunnlagService.leggInnNyttGrunnlag(revurdering, persongalleri)
-
-            val oppgave =
-                oppgaveService.opprettNyOppgaveMedSakOgReferanse(
-                    referanse = revurdering.id.toString(),
-                    sakId = sakId,
-                    oppgaveKilde = OppgaveKilde.BEHANDLING,
-                    oppgaveType = OppgaveType.REVURDERING,
-                    merknad = begrunnelse,
-                )
-            oppgaveService.tildelSaksbehandler(oppgave.id, saksbehandlerIdent)
-            behandlingHendelser.sendMeldingForHendelseMedDetaljertBehandling(
-                revurdering.toStatistikkBehandling(persongalleri),
-                BehandlingHendelseType.OPPRETTET,
+            leggInnGrunnlagOpprettOppgaveTildelSaksbehandlerSendMelding(
+                revurdering,
+                persongalleri,
+                sakId,
+                begrunnelse,
+                saksbehandlerIdent,
             )
         }
+
+    private fun leggInnGrunnlagOpprettOppgaveTildelSaksbehandlerSendMelding(
+        revurdering: Revurdering,
+        persongalleri: Persongalleri,
+        sakId: Long,
+        begrunnelse: String?,
+        saksbehandlerIdent: String,
+    ) {
+        grunnlagService.leggInnNyttGrunnlag(revurdering, persongalleri)
+
+        val oppgave =
+            oppgaveService.opprettNyOppgaveMedSakOgReferanse(
+                referanse = revurdering.id.toString(),
+                sakId = sakId,
+                oppgaveKilde = OppgaveKilde.BEHANDLING,
+                oppgaveType = OppgaveType.REVURDERING,
+                merknad = begrunnelse,
+            )
+        oppgaveService.tildelSaksbehandler(oppgave.id, saksbehandlerIdent)
+        behandlingHendelser.sendMeldingForHendelseMedDetaljertBehandling(
+            revurdering.toStatistikkBehandling(persongalleri),
+            BehandlingHendelseType.OPPRETTET,
+        )
+    }
 
     private fun lagreRevurderingsaarsakFritekst(
         fritekstAarsak: String,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -29,7 +29,6 @@ import no.nav.etterlatte.libs.common.behandling.RevurderingInfo
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.Utlandstilknytning
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
-import no.nav.etterlatte.libs.common.behandling.tilVirkningstidspunkt
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
@@ -38,10 +37,8 @@ import no.nav.etterlatte.libs.common.oppgave.Status
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.oppgave.OppgaveService
-import no.nav.etterlatte.token.Fagsaksystem
 import no.nav.etterlatte.token.Saksbehandler
 import org.slf4j.LoggerFactory
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -243,32 +240,6 @@ class RevurderingService(
             }
         }
 
-    fun opprettAutomatiskRevurdering(
-        sakId: Long,
-        forrigeBehandling: Behandling,
-        revurderingAarsak: Revurderingaarsak,
-        virkningstidspunkt: LocalDate? = null,
-        kilde: Vedtaksloesning,
-        persongalleri: Persongalleri,
-        mottattDato: String? = null,
-        begrunnelse: String? = null,
-    ) = forrigeBehandling.sjekkEnhet()?.let {
-        opprettRevurdering(
-            sakId = sakId,
-            persongalleri = persongalleri,
-            forrigeBehandling = forrigeBehandling.id,
-            mottattDato = mottattDato,
-            prosessType = Prosesstype.AUTOMATISK,
-            kilde = kilde,
-            revurderingAarsak = revurderingAarsak,
-            virkningstidspunkt = virkningstidspunkt?.tilVirkningstidspunkt("Opprettet automatisk"),
-            utlandstilknytning = forrigeBehandling.utlandstilknytning,
-            boddEllerArbeidetUtlandet = forrigeBehandling.boddEllerArbeidetUtlandet,
-            begrunnelse = begrunnelse ?: "Automatisk revurdering - ${revurderingAarsak.name.lowercase()}",
-            saksbehandlerIdent = Fagsaksystem.EY.navn,
-        )
-    }
-
     private fun behandlingErAvTypenRevurderingOgKanEndres(behandlingId: UUID) {
         val behandling = hentBehandling(behandlingId)
         if (behandling?.type != BehandlingType.REVURDERING) {
@@ -289,7 +260,9 @@ class RevurderingService(
         revurderingDao.lagreRevurderingInfo(behandlingId, revurderingInfoMedBegrunnelse, kilde)
     }
 
-    private fun opprettRevurdering(
+    // Denne burde nok ha vore private eller noko, men for å ikkje få ei altfor stor omskriving
+    // gjer eg han til internal for no
+    internal fun opprettRevurdering(
         sakId: Long,
         persongalleri: Persongalleri,
         forrigeBehandling: UUID?,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.behandling.revurdering
 
 import io.ktor.server.plugins.BadRequestException
 import kotlinx.coroutines.runBlocking
-import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.behandling.BehandlingDao
 import no.nav.etterlatte.behandling.BehandlingHendelseType
 import no.nav.etterlatte.behandling.BehandlingHendelserKafkaProducer
@@ -12,9 +11,9 @@ import no.nav.etterlatte.behandling.domain.Behandling
 import no.nav.etterlatte.behandling.domain.Foerstegangsbehandling
 import no.nav.etterlatte.behandling.domain.OpprettBehandling
 import no.nav.etterlatte.behandling.domain.Revurdering
+import no.nav.etterlatte.behandling.domain.sjekkEnhet
 import no.nav.etterlatte.behandling.domain.toBehandlingOpprettet
 import no.nav.etterlatte.behandling.domain.toStatistikkBehandling
-import no.nav.etterlatte.behandling.filterBehandlingerForEnheter
 import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeService
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggle
@@ -361,11 +360,4 @@ class RevurderingService(
         val revurderingInfo = RevurderingInfo.RevurderingAarsakAnnen(fritekstAarsak)
         lagreRevurderingInfo(behandlingId, RevurderingInfoMedBegrunnelse(revurderingInfo, null), saksbehandlerIdent)
     }
-
-    private fun <T : Behandling> T?.sjekkEnhet() =
-        this?.let { behandling ->
-            listOf(behandling).filterBehandlingerForEnheter(
-                Kontekst.get().AppUser,
-            ).firstOrNull()
-        }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -321,10 +321,10 @@ class RevurderingService(
                         BehandlingHendelseType.OPPRETTET,
                     )
                 },
-                oppfoelging = { revurdering ->
+                opprettOgTildelOppgave = {
                     val oppgave =
                         oppgaveService.opprettNyOppgaveMedSakOgReferanse(
-                            referanse = revurdering.id.toString(),
+                            referanse = it.id.toString(),
                             sakId = sakId,
                             oppgaveKilde = OppgaveKilde.BEHANDLING,
                             oppgaveType = OppgaveType.REVURDERING,
@@ -348,12 +348,12 @@ class RevurderingService(
 data class RevurderingOgOppfoelging(
     val revurdering: Revurdering,
     val leggInnGrunnlag: () -> Unit,
-    private val oppfoelging: (Revurdering) -> Unit,
+    val opprettOgTildelOppgave: () -> Unit,
     val sendMeldingForHendelse: () -> Unit,
 ) {
     fun oppdater(): Revurdering {
         leggInnGrunnlag()
-        oppfoelging(revurdering)
+        opprettOgTildelOppgave()
         sendMeldingForHendelse()
         return revurdering
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -313,39 +313,23 @@ class RevurderingService(
             behandlingDao.hentBehandling(opprettBehandling.id)!! as Revurdering
         }.let {
             RevurderingOgOppfoelging(it) { revurdering ->
-                leggInnGrunnlagOpprettOppgaveTildelSaksbehandlerSendMelding(
-                    revurdering,
-                    persongalleri,
-                    sakId,
-                    begrunnelse,
-                    saksbehandlerIdent,
+                grunnlagService.leggInnNyttGrunnlag(revurdering, persongalleri)
+
+                val oppgave =
+                    oppgaveService.opprettNyOppgaveMedSakOgReferanse(
+                        referanse = revurdering.id.toString(),
+                        sakId = sakId,
+                        oppgaveKilde = OppgaveKilde.BEHANDLING,
+                        oppgaveType = OppgaveType.REVURDERING,
+                        merknad = begrunnelse,
+                    )
+                oppgaveService.tildelSaksbehandler(oppgave.id, saksbehandlerIdent)
+                behandlingHendelser.sendMeldingForHendelseMedDetaljertBehandling(
+                    revurdering.toStatistikkBehandling(persongalleri),
+                    BehandlingHendelseType.OPPRETTET,
                 )
             }
         }
-
-    private fun leggInnGrunnlagOpprettOppgaveTildelSaksbehandlerSendMelding(
-        revurdering: Revurdering,
-        persongalleri: Persongalleri,
-        sakId: Long,
-        begrunnelse: String?,
-        saksbehandlerIdent: String,
-    ) {
-        grunnlagService.leggInnNyttGrunnlag(revurdering, persongalleri)
-
-        val oppgave =
-            oppgaveService.opprettNyOppgaveMedSakOgReferanse(
-                referanse = revurdering.id.toString(),
-                sakId = sakId,
-                oppgaveKilde = OppgaveKilde.BEHANDLING,
-                oppgaveType = OppgaveType.REVURDERING,
-                merknad = begrunnelse,
-            )
-        oppgaveService.tildelSaksbehandler(oppgave.id, saksbehandlerIdent)
-        behandlingHendelser.sendMeldingForHendelseMedDetaljertBehandling(
-            revurdering.toStatistikkBehandling(persongalleri),
-            BehandlingHendelseType.OPPRETTET,
-        )
-    }
 
     private fun lagreRevurderingsaarsakFritekst(
         fritekstAarsak: String,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -357,4 +357,8 @@ data class RevurderingOgOppfoelging(
         sendMeldingForHendelse()
         return revurdering
     }
+
+    fun behandlingId() = revurdering.id
+
+    fun sakType() = revurdering.sak.sakType
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -312,9 +312,7 @@ class RevurderingService(
 
             behandlingDao.hentBehandling(opprettBehandling.id)!! as Revurdering
         }.let {
-            RevurderingOgOppfoelging(it) { revurdering ->
-                grunnlagService.leggInnNyttGrunnlag(revurdering, persongalleri)
-
+            RevurderingOgOppfoelging(it, { grunnlagService.leggInnNyttGrunnlag(it, persongalleri) }) { revurdering ->
                 val oppgave =
                     oppgaveService.opprettNyOppgaveMedSakOgReferanse(
                         referanse = revurdering.id.toString(),
@@ -341,8 +339,13 @@ class RevurderingService(
     }
 }
 
-data class RevurderingOgOppfoelging(val revurdering: Revurdering, private val oppfoelging: (Revurdering) -> Unit) {
+data class RevurderingOgOppfoelging(
+    val revurdering: Revurdering,
+    val leggInnGrunnlag: () -> Unit,
+    private val oppfoelging: (Revurdering) -> Unit,
+) {
     fun oppdater(): Revurdering {
+        leggInnGrunnlag()
         oppfoelging(revurdering)
         return revurdering
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -41,6 +41,7 @@ import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeDao
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeService
 import no.nav.etterlatte.behandling.omregning.MigreringService
 import no.nav.etterlatte.behandling.omregning.OmregningService
+import no.nav.etterlatte.behandling.revurdering.AutomatiskRevurderingService
 import no.nav.etterlatte.behandling.revurdering.RevurderingDao
 import no.nav.etterlatte.behandling.revurdering.RevurderingService
 import no.nav.etterlatte.behandling.sjekkliste.SjekklisteDao
@@ -261,6 +262,7 @@ internal class ApplicationContext(
             revurderingDao = revurderingDao,
             behandlingService = behandlingService,
         )
+    val automatiskRevurderingService = AutomatiskRevurderingService(revurderingService)
 
     val gyldighetsproevingService =
         GyldighetsproevingServiceImpl(
@@ -271,7 +273,7 @@ internal class ApplicationContext(
         OmregningService(
             behandlingService = behandlingService,
             grunnlagService = grunnlagsService,
-            revurderingService = revurderingService,
+            revurderingService = automatiskRevurderingService,
         )
 
     val tilgangService = TilgangServiceImpl(SakTilgangDao(dataSource))
@@ -308,7 +310,7 @@ internal class ApplicationContext(
         BehandlingFactory(
             oppgaveService = oppgaveService,
             grunnlagService = grunnlagsService,
-            revurderingService = revurderingService,
+            revurderingService = automatiskRevurderingService,
             gyldighetsproevingService = gyldighetsproevingService,
             sakService = sakService,
             behandlingDao = behandlingDao,

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
@@ -26,6 +26,7 @@ import no.nav.etterlatte.behandling.domain.OpprettBehandling
 import no.nav.etterlatte.behandling.domain.Revurdering
 import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeService
+import no.nav.etterlatte.behandling.revurdering.AutomatiskRevurderingService
 import no.nav.etterlatte.behandling.revurdering.RevurderingDao
 import no.nav.etterlatte.behandling.revurdering.RevurderingService
 import no.nav.etterlatte.common.Enheter
@@ -85,17 +86,19 @@ class BehandlingFactoryTest {
         }
     private val revurderingDao = mockk<RevurderingDao>()
     private val revurderingService =
-        RevurderingService(
-            oppgaveService,
-            grunnlagService,
-            behandlingHendelserKafkaProducerMock,
-            featureToggleService,
-            behandlingDaoMock,
-            hendelseDaoMock,
-            grunnlagsendringshendelseDao,
-            kommerBarnetTilGodeService,
-            revurderingDao,
-            behandlingService,
+        AutomatiskRevurderingService(
+            RevurderingService(
+                oppgaveService,
+                grunnlagService,
+                behandlingHendelserKafkaProducerMock,
+                featureToggleService,
+                behandlingDaoMock,
+                hendelseDaoMock,
+                grunnlagsendringshendelseDao,
+                kommerBarnetTilGodeService,
+                revurderingDao,
+                behandlingService,
+            ),
         )
     private val behandlingFactory =
         BehandlingFactory(

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingServiceIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingServiceIntegrationTest.kt
@@ -378,7 +378,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
             BehandlingFactory(
                 oppgaveService = oppgaveService,
                 grunnlagService = grunnlagService,
-                revurderingService = revurderingService,
+                revurderingService = AutomatiskRevurderingService(revurderingService),
                 gyldighetsproevingService = applicationContext.gyldighetsproevingService,
                 sakService = applicationContext.sakService,
                 behandlingDao = applicationContext.behandlingDao,
@@ -651,7 +651,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
             BehandlingFactory(
                 oppgaveService = applicationContext.oppgaveService,
                 grunnlagService = applicationContext.grunnlagsService,
-                revurderingService = applicationContext.revurderingService,
+                revurderingService = applicationContext.automatiskRevurderingService,
                 gyldighetsproevingService = applicationContext.gyldighetsproevingService,
                 sakService = applicationContext.sakService,
                 behandlingDao = applicationContext.behandlingDao,
@@ -778,7 +778,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
             BehandlingFactory(
                 oppgaveService = applicationContext.oppgaveService,
                 grunnlagService = applicationContext.grunnlagsService,
-                revurderingService = applicationContext.revurderingService,
+                revurderingService = applicationContext.automatiskRevurderingService,
                 gyldighetsproevingService = applicationContext.gyldighetsproevingService,
                 sakService = applicationContext.sakService,
                 behandlingDao = applicationContext.behandlingDao,
@@ -823,7 +823,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
             BehandlingFactory(
                 oppgaveService = applicationContext.oppgaveService,
                 grunnlagService = applicationContext.grunnlagsService,
-                revurderingService = applicationContext.revurderingService,
+                revurderingService = applicationContext.automatiskRevurderingService,
                 gyldighetsproevingService = applicationContext.gyldighetsproevingService,
                 sakService = applicationContext.sakService,
                 behandlingDao = applicationContext.behandlingDao,
@@ -866,7 +866,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
             BehandlingFactory(
                 oppgaveService = applicationContext.oppgaveService,
                 grunnlagService = applicationContext.grunnlagsService,
-                revurderingService = applicationContext.revurderingService,
+                revurderingService = applicationContext.automatiskRevurderingService,
                 gyldighetsproevingService = applicationContext.gyldighetsproevingService,
                 sakService = applicationContext.sakService,
                 behandlingDao = applicationContext.behandlingDao,
@@ -911,7 +911,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
             BehandlingFactory(
                 oppgaveService = applicationContext.oppgaveService,
                 grunnlagService = applicationContext.grunnlagsService,
-                revurderingService = applicationContext.revurderingService,
+                revurderingService = applicationContext.automatiskRevurderingService,
                 gyldighetsproevingService = applicationContext.gyldighetsproevingService,
                 sakService = applicationContext.sakService,
                 behandlingDao = applicationContext.behandlingDao,
@@ -958,7 +958,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
             BehandlingFactory(
                 oppgaveService = applicationContext.oppgaveService,
                 grunnlagService = applicationContext.grunnlagsService,
-                revurderingService = applicationContext.revurderingService,
+                revurderingService = applicationContext.automatiskRevurderingService,
                 gyldighetsproevingService = applicationContext.gyldighetsproevingService,
                 sakService = applicationContext.sakService,
                 behandlingDao = applicationContext.behandlingDao,


### PR DESCRIPTION
Trur det kan vera lurt å sjå på denne commit for commit, for å følgje tankerekka mi, men målet er iallfall det vi ser i `OmregningRoutes` - at `omregningService.opprettOmregning` er synkront og i ein transaksjon, og at grunnlag-kall m.m. som skjer etterpå ikkje skjer i den transaksjonen.