### PR TITLE
Tilpasser avslagsbrev for barnepensjon iht oppdatert mal

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/Grunnlagmapper.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/Grunnlagmapper.kt
@@ -171,6 +171,7 @@ private fun Grunnlag.erOver18(brevutfallDto: BrevutfallDto?): Boolean {
         return true
     }
     // TODO henting fra PDL skal fjernes når migrering er unnagjort. Da kan vi alltid bruke brevutfall
+    // TODO denne brukes nå også midlertidig av avslagsbrev siden vi ikke har noe brevutfall der enda
     val dato18Aar =
         requireNotNull(this.soeker.hentFoedselsdato()) {
             "Barnet har ikke fødselsdato i grunnlag. Dette skal ikke skje, vi " +

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
@@ -102,7 +102,7 @@ class BrevdataFacade(
                 vedtak.vedtakFattet?.let { vedtak.attestasjon?.attestant ?: innloggetSaksbehandlerIdent }
 
             val behandling =
-                if (vedtak.type == VedtakType.INNVILGELSE) {
+                if (vedtak.type in listOf(VedtakType.INNVILGELSE, VedtakType.AVSLAG)) {
                     behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
                 } else {
                     null

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapper.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapper.kt
@@ -31,6 +31,7 @@ import no.nav.etterlatte.brev.brevbaker.EtterlatteBrevKode.TOM_MAL
 import no.nav.etterlatte.brev.brevbaker.RedigerbarTekstRequest
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.model.bp.AdopsjonRevurderingBrevdata
+import no.nav.etterlatte.brev.model.bp.AvslagBrevData
 import no.nav.etterlatte.brev.model.bp.EndringHovedmalBrevData
 import no.nav.etterlatte.brev.model.bp.InnvilgetBrevData
 import no.nav.etterlatte.brev.model.bp.InnvilgetBrevDataEnkel
@@ -426,7 +427,16 @@ class BrevDataMapper(
                 }
             }
 
-            BARNEPENSJON_AVSLAG -> ManueltBrevData.fra(innholdMedVedlegg.innhold())
+            BARNEPENSJON_AVSLAG -> {
+                coroutineScope {
+                    AvslagBrevData.fra(
+                        innhold = innholdMedVedlegg,
+                        // TODO må kunne sette brevutfall ved avslag. Det er pr nå ikke mulig da dette ligger i beregningssteget.
+                        brukerUnder18Aar = generellBrevData.personerISak.soeker.under18 ?: true,
+                        utlandstilknytning = generellBrevData.utlandstilknytning?.type,
+                    )
+                }
+            }
 
             OMS_FOERSTEGANGSVEDTAK_INNVILGELSE -> {
                 coroutineScope {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapper.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapper.kt
@@ -428,14 +428,12 @@ class BrevDataMapper(
             }
 
             BARNEPENSJON_AVSLAG -> {
-                coroutineScope {
-                    AvslagBrevData.fra(
-                        innhold = innholdMedVedlegg,
-                        // TODO må kunne sette brevutfall ved avslag. Det er pr nå ikke mulig da dette ligger i beregningssteget.
-                        brukerUnder18Aar = generellBrevData.personerISak.soeker.under18 ?: true,
-                        utlandstilknytning = generellBrevData.utlandstilknytning?.type,
-                    )
-                }
+                AvslagBrevData.fra(
+                    innhold = innholdMedVedlegg,
+                    // TODO må kunne sette brevutfall ved avslag. Det er pr nå ikke mulig da dette ligger i beregningssteget.
+                    brukerUnder18Aar = generellBrevData.personerISak.soeker.under18 ?: true,
+                    utlandstilknytning = generellBrevData.utlandstilknytning?.type,
+                )
             }
 
             OMS_FOERSTEGANGSVEDTAK_INNVILGELSE -> {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/AvslagBrevData.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/AvslagBrevData.kt
@@ -1,0 +1,25 @@
+package no.nav.etterlatte.brev.model.bp
+
+import no.nav.etterlatte.brev.model.BrevData
+import no.nav.etterlatte.brev.model.InnholdMedVedlegg
+import no.nav.etterlatte.brev.model.Slate
+import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
+
+data class AvslagBrevData(
+    val innhold: List<Slate.Element>,
+    val brukerUnder18Aar: Boolean,
+    val bosattUtland: Boolean,
+) : BrevData() {
+    companion object {
+        fun fra(
+            innhold: InnholdMedVedlegg,
+            brukerUnder18Aar: Boolean,
+            utlandstilknytning: UtlandstilknytningType?,
+        ): AvslagBrevData =
+            AvslagBrevData(
+                innhold = innhold.innhold(),
+                brukerUnder18Aar = brukerUnder18Aar,
+                bosattUtland = utlandstilknytning == UtlandstilknytningType.BOSATT_UTLAND,
+            )
+    }
+}


### PR DESCRIPTION
Gjør noen endrer slik at avslagsbrevet kan ta høyde for over/under 18 + bosatt utland.

Inntil videre så hentes over/under 18 ut på samme måte som i migrering, ved bruk av fødselsdato fra pdl. Tanken er å endre dette til å bruke brevutfall, men det krever litt større endringer.