### PR TITLE
Samkøyre logikken for korleis vi gjer distribuering for alle typar brev

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -6,6 +6,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.server.config.HoconApplicationConfig
 import no.nav.etterlatte.brev.BrevService
+import no.nav.etterlatte.brev.Brevdistribuerer
 import no.nav.etterlatte.brev.MigreringBrevDataService
 import no.nav.etterlatte.brev.VedtaksbrevService
 import no.nav.etterlatte.brev.adresse.AdresseService
@@ -163,10 +164,11 @@ class ApplicationBuilder {
             soekerService,
             adresseService,
             dokarkivService,
-            distribusjonService,
             brevbakerService,
             brevdataFacade,
         )
+
+    private val brevdistribuerer = Brevdistribuerer(db, distribusjonService)
 
     private val vedtaksbrevService =
         VedtaksbrevService(
@@ -190,7 +192,7 @@ class ApplicationBuilder {
         RapidApplication.Builder(RapidApplication.RapidApplicationConfig.fromEnv(env))
             .withKtorModule {
                 restModule(sikkerLogg, routePrefix = "api", config = HoconApplicationConfig(config)) {
-                    brevRoute(brevService, tilgangssjekker)
+                    brevRoute(brevService, brevdistribuerer, tilgangssjekker)
                     vedtaksbrevRoute(vedtaksbrevService, tilgangssjekker)
                     dokumentRoute(journalpostService, dokarkivService, tilgangssjekker)
                 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -214,7 +214,7 @@ class ApplicationBuilder {
 
                 JournalfoerVedtaksbrevRiver(this, vedtaksbrevService)
                 VedtaksbrevUnderkjentRiver(this, vedtaksbrevService)
-                DistribuerBrevRiver(this, vedtaksbrevService, distribusjonService)
+                DistribuerBrevRiver(this, distribusjonService)
             }
 
     private fun fiksEnkeltbrev() {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -6,7 +6,6 @@ import io.ktor.client.HttpClient
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.server.config.HoconApplicationConfig
 import no.nav.etterlatte.brev.BrevService
-import no.nav.etterlatte.brev.Brevdistribuerer
 import no.nav.etterlatte.brev.MigreringBrevDataService
 import no.nav.etterlatte.brev.VedtaksbrevService
 import no.nav.etterlatte.brev.adresse.AdresseService
@@ -20,6 +19,7 @@ import no.nav.etterlatte.brev.brevbaker.BrevbakerJSONParagraphMixIn
 import no.nav.etterlatte.brev.brevbaker.BrevbakerKlient
 import no.nav.etterlatte.brev.brevbaker.BrevbakerService
 import no.nav.etterlatte.brev.db.BrevRepository
+import no.nav.etterlatte.brev.distribusjon.Brevdistribuerer
 import no.nav.etterlatte.brev.distribusjon.DistribusjonKlient
 import no.nav.etterlatte.brev.distribusjon.DistribusjonServiceImpl
 import no.nav.etterlatte.brev.dokarkiv.DokarkivKlient
@@ -214,7 +214,7 @@ class ApplicationBuilder {
 
                 JournalfoerVedtaksbrevRiver(this, vedtaksbrevService)
                 VedtaksbrevUnderkjentRiver(this, vedtaksbrevService)
-                DistribuerBrevRiver(this, distribusjonService)
+                DistribuerBrevRiver(this, brevdistribuerer)
             }
 
     private fun fiksEnkeltbrev() {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
@@ -10,6 +10,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.util.pipeline.PipelineContext
+import no.nav.etterlatte.brev.distribusjon.Brevdistribuerer
 import no.nav.etterlatte.brev.hentinformasjon.Tilgangssjekker
 import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
 import no.nav.etterlatte.brev.model.Mottaker

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
@@ -34,6 +34,7 @@ inline val PipelineContext<*, ApplicationCall>.brevId: Long
 @OptIn(ExperimentalTime::class)
 fun Route.brevRoute(
     service: BrevService,
+    distribuerer: Brevdistribuerer,
     tilgangssjekker: Tilgangssjekker,
 ) {
     val logger = LoggerFactory.getLogger("no.nav.etterlatte.brev.BrevRoute")
@@ -117,7 +118,7 @@ fun Route.brevRoute(
 
         post("distribuer") {
             withSakId(tilgangssjekker, skrivetilgang = true) {
-                val bestillingsId = service.distribuer(brevId)
+                val bestillingsId = distribuerer.distribuer(brevId)
 
                 call.respond(BestillingsIdDto(bestillingsId))
             }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -7,9 +7,6 @@ import no.nav.etterlatte.brev.brevbaker.BrevbakerService
 import no.nav.etterlatte.brev.brevbaker.EtterlatteBrevKode
 import no.nav.etterlatte.brev.brevbaker.LanguageCode
 import no.nav.etterlatte.brev.db.BrevRepository
-import no.nav.etterlatte.brev.distribusjon.DistribusjonService
-import no.nav.etterlatte.brev.distribusjon.DistribusjonsTidspunktType
-import no.nav.etterlatte.brev.distribusjon.DistribusjonsType
 import no.nav.etterlatte.brev.dokarkiv.DokarkivService
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.hentinformasjon.SakService
@@ -38,7 +35,6 @@ class BrevService(
     private val soekerService: SoekerService,
     private val adresseService: AdresseService,
     private val dokarkivService: DokarkivService,
-    private val distribusjonService: DistribusjonService,
     private val brevbakerService: BrevbakerService,
     private val brevDataFacade: BrevdataFacade,
 ) {
@@ -191,34 +187,6 @@ class BrevService(
         logger.info("Brev med id=${brev.id} markert som journalført")
 
         return response.journalpostId
-    }
-
-    fun distribuer(id: BrevID): String {
-        val brev = hentBrev(id)
-
-        if (brev.status != Status.JOURNALFOERT) {
-            throw IllegalStateException(
-                "Forventet status ${Status.JOURNALFOERT} på brev (id=${brev.id}), men fikk ${brev.status}",
-            )
-        }
-
-        val journalpostId =
-            requireNotNull(db.hentJournalpostId(id)) {
-                "JournalpostID mangler på brev (id=${brev.id}, status=${brev.status})"
-            }
-
-        val mottaker =
-            requireNotNull(brev.mottaker) {
-                "Mottaker må være satt for å kunne distribuere brevet (id: $id)"
-            }
-
-        return distribusjonService.distribuerJournalpost(
-            brevId = brev.id,
-            journalpostId = journalpostId,
-            type = DistribusjonsType.ANNET,
-            tidspunkt = DistribusjonsTidspunktType.KJERNETID,
-            adresse = mottaker.adresse,
-        )
     }
 
     private fun sjekkOmBrevKanEndres(brevID: BrevID) {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevdistribuerer.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevdistribuerer.kt
@@ -1,0 +1,41 @@
+package no.nav.etterlatte.brev
+
+import no.nav.etterlatte.brev.db.BrevRepository
+import no.nav.etterlatte.brev.distribusjon.DistribusjonService
+import no.nav.etterlatte.brev.distribusjon.DistribusjonsTidspunktType
+import no.nav.etterlatte.brev.distribusjon.DistribusjonsType
+import no.nav.etterlatte.brev.model.BrevID
+import no.nav.etterlatte.brev.model.Status
+
+class Brevdistribuerer(
+    private val db: BrevRepository,
+    private val distribusjonService: DistribusjonService,
+) {
+    fun distribuer(id: BrevID): String {
+        val brev = db.hentBrev(id)
+
+        if (brev.status != Status.JOURNALFOERT) {
+            throw IllegalStateException(
+                "Forventet status ${Status.JOURNALFOERT} på brev (id=${brev.id}), men fikk ${brev.status}",
+            )
+        }
+
+        val journalpostId =
+            requireNotNull(db.hentJournalpostId(id)) {
+                "JournalpostID mangler på brev (id=${brev.id}, status=${brev.status})"
+            }
+
+        val mottaker =
+            requireNotNull(brev.mottaker) {
+                "Mottaker må være satt for å kunne distribuere brevet (id: $id)"
+            }
+
+        return distribusjonService.distribuerJournalpost(
+            brevId = brev.id,
+            journalpostId = journalpostId,
+            type = DistribusjonsType.ANNET,
+            tidspunkt = DistribusjonsTidspunktType.KJERNETID,
+            adresse = mottaker.adresse,
+        )
+    }
+}

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevdistribuerer.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevdistribuerer.kt
@@ -1,16 +1,20 @@
 package no.nav.etterlatte.brev
 
 import no.nav.etterlatte.brev.db.BrevRepository
+import no.nav.etterlatte.brev.distribusjon.BestillingsID
 import no.nav.etterlatte.brev.distribusjon.DistribusjonService
 import no.nav.etterlatte.brev.distribusjon.DistribusjonsTidspunktType
 import no.nav.etterlatte.brev.distribusjon.DistribusjonsType
 import no.nav.etterlatte.brev.model.BrevID
 import no.nav.etterlatte.brev.model.Status
+import org.slf4j.LoggerFactory
 
 class Brevdistribuerer(
     private val db: BrevRepository,
     private val distribusjonService: DistribusjonService,
 ) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
     fun distribuer(id: BrevID): String {
         val brev = db.hentBrev(id)
 
@@ -37,5 +41,30 @@ class Brevdistribuerer(
             tidspunkt = DistribusjonsTidspunktType.KJERNETID,
             adresse = mottaker.adresse,
         )
+    }
+
+    fun distribuerVedtaksbrev(
+        brevId: Long,
+        distribusjonType: DistribusjonsType,
+        journalpostId: String,
+    ): BestillingsID {
+        logger.info("Starter distribuering av brev.")
+
+        val brev = db.hentBrev(brevId)
+
+        val mottaker =
+            requireNotNull(brev.mottaker) {
+                "Kan ikke distribuere brev når mottaker er 'null' i brev med id=${brev.id}"
+            }
+
+        val bestillingsId =
+            distribusjonService.distribuerJournalpost(
+                brevId = brev.id,
+                journalpostId = journalpostId,
+                type = distribusjonType,
+                tidspunkt = DistribusjonsTidspunktType.KJERNETID,
+                adresse = mottaker.adresse,
+            )
+        return bestillingsId
     }
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/distribusjon/Brevdistribuerer.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/distribusjon/Brevdistribuerer.kt
@@ -1,10 +1,6 @@
-package no.nav.etterlatte.brev
+package no.nav.etterlatte.brev.distribusjon
 
 import no.nav.etterlatte.brev.db.BrevRepository
-import no.nav.etterlatte.brev.distribusjon.BestillingsID
-import no.nav.etterlatte.brev.distribusjon.DistribusjonService
-import no.nav.etterlatte.brev.distribusjon.DistribusjonsTidspunktType
-import no.nav.etterlatte.brev.distribusjon.DistribusjonsType
 import no.nav.etterlatte.brev.model.BrevID
 import no.nav.etterlatte.brev.model.Status
 import org.slf4j.LoggerFactory

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/distribusjon/DistribusjonService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/distribusjon/DistribusjonService.kt
@@ -15,7 +15,7 @@ interface DistribusjonService {
     ): BestillingsID
 }
 
-class DistribusjonServiceImpl(
+internal class DistribusjonServiceImpl(
     private val klient: DistribusjonKlient,
     private val db: BrevRepository,
 ) : DistribusjonService {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/DistribuerBrevRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/DistribuerBrevRiver.kt
@@ -28,10 +28,10 @@ internal class DistribuerBrevRiver(
         context: MessageContext,
     ) {
         val bestillingsId =
-            brevdistribuerer.distribuerVedtaksbrev(
-                packet["brevId"].asLong(),
-                packet.distribusjonType(),
-                packet["journalpostId"].asText(),
+            brevdistribuerer.distribuer(
+                id = packet["brevId"].asLong(),
+                distribusjonsType = packet.distribusjonType(),
+                journalpostIdInn = packet["journalpostId"].asText(),
             )
         rapidsConnection.svarSuksess(packet, bestillingsId)
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/DistribuerBrevRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/DistribuerBrevRiver.kt
@@ -1,7 +1,7 @@
 package no.nav.etterlatte.rivers
 
-import no.nav.etterlatte.brev.Brevdistribuerer
 import no.nav.etterlatte.brev.distribusjon.BestillingsID
+import no.nav.etterlatte.brev.distribusjon.Brevdistribuerer
 import no.nav.etterlatte.brev.distribusjon.DistribusjonsType
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
 import no.nav.helse.rapids_rivers.JsonMessage

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/DistribuerBrevRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/DistribuerBrevRiver.kt
@@ -1,9 +1,7 @@
 package no.nav.etterlatte.rivers
 
-import no.nav.etterlatte.brev.VedtaksbrevService
+import no.nav.etterlatte.brev.Brevdistribuerer
 import no.nav.etterlatte.brev.distribusjon.BestillingsID
-import no.nav.etterlatte.brev.distribusjon.DistribusjonService
-import no.nav.etterlatte.brev.distribusjon.DistribusjonsTidspunktType
 import no.nav.etterlatte.brev.distribusjon.DistribusjonsType
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
 import no.nav.helse.rapids_rivers.JsonMessage
@@ -14,8 +12,7 @@ import rapidsandrivers.migrering.ListenerMedLogging
 
 internal class DistribuerBrevRiver(
     private val rapidsConnection: RapidsConnection,
-    private val vedtaksbrevService: VedtaksbrevService,
-    private val distribusjonService: DistribusjonService,
+    private val brevdistribuerer: Brevdistribuerer,
 ) : ListenerMedLogging() {
     private val logger = LoggerFactory.getLogger(DistribuerBrevRiver::class.java)
 
@@ -30,24 +27,12 @@ internal class DistribuerBrevRiver(
         packet: JsonMessage,
         context: MessageContext,
     ) {
-        logger.info("Starter distribuering av brev.")
-
-        val brev = vedtaksbrevService.hentBrev(packet["brevId"].asLong())
-
-        val mottaker =
-            requireNotNull(brev.mottaker) {
-                "Kan ikke distribuere brev når mottaker er 'null' i brev med id=${brev.id}"
-            }
-
         val bestillingsId =
-            distribusjonService.distribuerJournalpost(
-                brevId = brev.id,
-                journalpostId = packet["journalpostId"].asText(),
-                type = packet.distribusjonType(),
-                tidspunkt = DistribusjonsTidspunktType.KJERNETID,
-                adresse = mottaker.adresse,
+            brevdistribuerer.distribuerVedtaksbrev(
+                packet["brevId"].asLong(),
+                packet.distribusjonType(),
+                packet["journalpostId"].asText(),
             )
-
         rapidsConnection.svarSuksess(packet, bestillingsId)
     }
 

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
@@ -24,6 +24,7 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.etterlatte.brev.BrevService.BrevPayload
+import no.nav.etterlatte.brev.distribusjon.Brevdistribuerer
 import no.nav.etterlatte.brev.hentinformasjon.Tilgangssjekker
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
@@ -53,6 +53,7 @@ internal class BrevRouteTest {
     private val mockOAuth2Server = MockOAuth2Server()
     private lateinit var hoconApplicationConfig: HoconApplicationConfig
     private val brevService = mockk<BrevService>()
+    private val brevdistribuerer = mockk<Brevdistribuerer>()
     private val tilgangssjekker = mockk<Tilgangssjekker>()
 
     @BeforeAll
@@ -253,6 +254,7 @@ internal class BrevRouteTest {
             restModule(this.log, routePrefix = "api") {
                 brevRoute(
                     brevService,
+                    brevdistribuerer,
                     tilgangssjekker,
                 )
             }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevdistribuererTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevdistribuererTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.etterlatte.brev.db.BrevRepository
+import no.nav.etterlatte.brev.distribusjon.Brevdistribuerer
 import no.nav.etterlatte.brev.distribusjon.DistribusjonServiceImpl
 import no.nav.etterlatte.brev.distribusjon.DistribusjonsTidspunktType
 import no.nav.etterlatte.brev.distribusjon.DistribusjonsType

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevdistribuererTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevdistribuererTest.kt
@@ -1,0 +1,123 @@
+package no.nav.etterlatte.brev
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.etterlatte.brev.db.BrevRepository
+import no.nav.etterlatte.brev.distribusjon.DistribusjonServiceImpl
+import no.nav.etterlatte.brev.distribusjon.DistribusjonsTidspunktType
+import no.nav.etterlatte.brev.distribusjon.DistribusjonsType
+import no.nav.etterlatte.brev.model.Adresse
+import no.nav.etterlatte.brev.model.Brev
+import no.nav.etterlatte.brev.model.BrevProsessType
+import no.nav.etterlatte.brev.model.Mottaker
+import no.nav.etterlatte.brev.model.Status
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import kotlin.random.Random
+
+class BrevdistribuererTest {
+    private val db = mockk<BrevRepository>(relaxed = true)
+    private val distribusjonService = mockk<DistribusjonServiceImpl>()
+
+    private val brevdistribuerer = Brevdistribuerer(db, distribusjonService)
+
+    @Test
+    fun `Distribusjon fungerer som forventet`() {
+        val brev = opprettBrev(Status.JOURNALFOERT, BrevProsessType.MANUELL)
+        val journalpostId = "1"
+
+        every { db.hentBrev(any()) } returns brev
+        every { db.hentJournalpostId(any()) } returns journalpostId
+        every { distribusjonService.distribuerJournalpost(any(), any(), any(), any(), any()) } returns "123"
+
+        val bestillingsID = brevdistribuerer.distribuer(brev.id)
+        bestillingsID shouldBe "123"
+
+        verify {
+            db.hentBrev(brev.id)
+            db.hentJournalpostId(brev.id)
+            distribusjonService.distribuerJournalpost(
+                brev.id,
+                journalpostId,
+                DistribusjonsType.ANNET,
+                DistribusjonsTidspunktType.KJERNETID,
+                brev.mottaker!!.adresse,
+            )
+        }
+    }
+
+    @Test
+    fun `Distribusjon avbrytes hvis journalpostId mangler`() {
+        val brev = opprettBrev(Status.JOURNALFOERT, BrevProsessType.MANUELL)
+
+        every { db.hentBrev(any()) } returns brev
+        every { db.hentJournalpostId(any()) } returns null
+
+        assertThrows<IllegalArgumentException> {
+            brevdistribuerer.distribuer(brev.id)
+        }
+
+        verify {
+            db.hentBrev(brev.id)
+            db.hentJournalpostId(brev.id)
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        Status::class,
+        mode = EnumSource.Mode.EXCLUDE,
+        names = ["JOURNALFOERT"],
+    )
+    fun `Distribusjon avbrytes ved feil status`(status: Status) {
+        val brev = opprettBrev(status, BrevProsessType.MANUELL)
+
+        every { db.hentBrev(any()) } returns brev
+
+        assertThrows<IllegalStateException> {
+            brevdistribuerer.distribuer(brev.id)
+        }
+
+        verify {
+            db.hentBrev(brev.id)
+        }
+    }
+
+    private fun opprettBrev(
+        status: Status,
+        prosessType: BrevProsessType,
+    ) = Brev(
+        id = Random.nextLong(10000),
+        sakId = Random.nextLong(10000),
+        behandlingId = null,
+        tittel = null,
+        prosessType = prosessType,
+        soekerFnr = "fnr",
+        status = status,
+        statusEndret = Tidspunkt.now(),
+        opprettet = Tidspunkt.now(),
+        mottaker = opprettMottaker(),
+    )
+
+    private fun opprettMottaker() =
+        Mottaker(
+            "Stor Snerk",
+            foedselsnummer = Foedselsnummer("1234567890"),
+            orgnummer = null,
+            adresse =
+                Adresse(
+                    adresseType = "NORSKPOSTADRESSE",
+                    adresselinje1 = "Testgaten 13",
+                    postnummer = "1234",
+                    poststed = "OSLO",
+                    land = "Norge",
+                    landkode = "NOR",
+                ),
+        )
+}

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/DistribuerBrevRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/DistribuerBrevRiverTest.kt
@@ -6,8 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.etterlatte.brev.VedtaksbrevService
-import no.nav.etterlatte.brev.distribusjon.DistribusjonServiceImpl
-import no.nav.etterlatte.brev.distribusjon.DistribusjonsTidspunktType
+import no.nav.etterlatte.brev.distribusjon.Brevdistribuerer
 import no.nav.etterlatte.brev.distribusjon.DistribusjonsType
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Mottaker
@@ -22,9 +21,9 @@ import java.util.UUID
 
 internal class DistribuerBrevRiverTest {
     private val brevService = mockk<VedtaksbrevService>()
-    private val distribusjonService = mockk<DistribusjonServiceImpl>(relaxed = true)
+    private val brevdistribuerer = mockk<Brevdistribuerer>(relaxed = true)
 
-    private val inspector = TestRapid().apply { DistribuerBrevRiver(this, distribusjonService) }
+    private val inspector = TestRapid().apply { DistribuerBrevRiver(this, brevdistribuerer) }
 
     private val brevId = 100L
     private val journalpostId = "11111"
@@ -42,7 +41,7 @@ internal class DistribuerBrevRiverTest {
     fun before() = clearAllMocks()
 
     @AfterEach
-    fun after() = confirmVerified(distribusjonService, brevService)
+    fun after() = confirmVerified(brevdistribuerer, brevService)
 
     @Test
     fun `Gyldig melding skal sende journalpost til distribusjon`() {
@@ -67,15 +66,7 @@ internal class DistribuerBrevRiverTest {
         inspector.apply { sendTestMessage(melding.toJson()) }.inspektør
 
         verify(exactly = 1) {
-            brevService.hentBrev(brevId)
-
-            distribusjonService.distribuerJournalpost(
-                brevId,
-                journalpostId,
-                DistribusjonsType.VEDTAK,
-                DistribusjonsTidspunktType.KJERNETID,
-                adresse,
-            )
+            brevdistribuerer.distribuer(brevId, DistribusjonsType.VEDTAK, journalpostId)
         }
     }
 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/DistribuerBrevRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/DistribuerBrevRiverTest.kt
@@ -24,7 +24,7 @@ internal class DistribuerBrevRiverTest {
     private val brevService = mockk<VedtaksbrevService>()
     private val distribusjonService = mockk<DistribusjonServiceImpl>(relaxed = true)
 
-    private val inspector = TestRapid().apply { DistribuerBrevRiver(this, brevService, distribusjonService) }
+    private val inspector = TestRapid().apply { DistribuerBrevRiver(this, distribusjonService) }
 
     private val brevId = 100L
     private val journalpostId = "11111"

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
@@ -5,7 +5,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import no.nav.etterlatte.brev.VedtaksbrevService
-import no.nav.etterlatte.brev.distribusjon.DistribusjonService
+import no.nav.etterlatte.brev.distribusjon.Brevdistribuerer
 import no.nav.etterlatte.brev.dokarkiv.OpprettJournalpostResponse
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
@@ -54,8 +54,8 @@ internal class OpprettJournalfoerOgDistribuer {
                 coEvery { it.hentBrev(any()) } returns brev
             }
         val distribusjonService =
-            mockk<DistribusjonService>().also {
-                coEvery { it.distribuerJournalpost(brev.id, any(), any(), any(), any()) } returns ""
+            mockk<Brevdistribuerer>().also {
+                coEvery { it.distribuer(brev.id, any(), any()) } returns ""
             }
         val testRapid =
             TestRapid().apply {
@@ -100,8 +100,8 @@ internal class OpprettJournalfoerOgDistribuer {
                 coEvery { it.ferdigstillVedtaksbrev(behandlingId, any(), true) } just runs
             }
         val distribusjonService =
-            mockk<DistribusjonService>().also {
-                coEvery { it.distribuerJournalpost(brev.id, any(), any(), any(), any()) } returns ""
+            mockk<Brevdistribuerer>().also {
+                coEvery { it.distribuer(brev.id, any(), any()) } returns ""
             }
         val testRapid =
             TestRapid().apply {

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
@@ -60,7 +60,7 @@ internal class OpprettJournalfoerOgDistribuer {
         val testRapid =
             TestRapid().apply {
                 JournalfoerVedtaksbrevRiver(this, vedtaksbrevService)
-                DistribuerBrevRiver(this, vedtaksbrevService, distribusjonService)
+                DistribuerBrevRiver(this, distribusjonService)
             }
 
         testRapid.sendTestMessage(
@@ -106,7 +106,7 @@ internal class OpprettJournalfoerOgDistribuer {
         val testRapid =
             TestRapid().apply {
                 JournalfoerVedtaksbrevRiver(this, vedtaksbrevService)
-                DistribuerBrevRiver(this, vedtaksbrevService, distribusjonService)
+                DistribuerBrevRiver(this, distribusjonService)
             }
 
         testRapid.sendTestMessage(


### PR DESCRIPTION
Ser ingen grunn til at distribuering skal vera forskjellig avhengig av type brev, så samkøyrer det.

Har også på blokka å gjera liknande for journalføring og knaskje også andre steg i brevproduksjonen, men ein ting av gongen.