### PR TITLE
Øke ressurser for utbetaling kraftig pga konsistensavstemming.

### DIFF
--- a/apps/etterlatte-utbetaling/.nais/prod.yaml
+++ b/apps/etterlatte-utbetaling/.nais/prod.yaml
@@ -48,10 +48,10 @@ spec:
     - secret: my-application-unleash-api-token
   resources:
     requests:
-      cpu: 25m
-      memory: 320Mi
+      cpu: 2000m
+      memory: 640Mi
   replicas:
-    cpuThresholdPercentage: 90
+    cpuThresholdPercentage: 95
     max: 1
     min: 1
   env:


### PR DESCRIPTION
Midlertidig tiltak mens vi ser på å fikse koden. CPU-bruken er altfor høy, ser i Grafana at den øker til 10 (med 24t vindu) og 15!! (med 48t vindu). Litt rart det, men det er uansett tullete tall.