### PR TITLE
utbetaling - øke memory limits pga request

### DIFF
--- a/apps/etterlatte-utbetaling/.nais/prod.yaml
+++ b/apps/etterlatte-utbetaling/.nais/prod.yaml
@@ -47,6 +47,8 @@ spec:
     - secret: etterlatte-secrets
     - secret: my-application-unleash-api-token
   resources:
+    limits:
+      memory: 4096Mi
     requests:
       cpu: 2000m
       memory: 640Mi


### PR DESCRIPTION
Status: failure: Application/etterlatte-utbetaling (FailedSynchronization): persisting Deployment to Kubernetes: Invalid: Deployment.apps "etterlatte-utbetaling" is invalid: spec.template.spec.containers[0].resources.requests: Invalid value: "640Mi": must be less than or equal to memory limit of 512Mi (total of 1 errors)

https://github.com/navikt/pensjon-etterlatte-saksbehandling/actions/runs/7407820642