### PR TITLE
Samkøyre logikken for korleis vi gjer journalføring for alle typar brev

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -166,7 +166,6 @@ class ApplicationBuilder {
             brevdataFacade,
             vedtaksvurderingService,
             adresseService,
-            dokarkivService,
             brevbakerService,
             brevDataMapper,
             brevProsessTypeFactory,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -6,6 +6,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.server.config.HoconApplicationConfig
 import no.nav.etterlatte.brev.BrevService
+import no.nav.etterlatte.brev.JournalfoerBrevService
 import no.nav.etterlatte.brev.MigreringBrevDataService
 import no.nav.etterlatte.brev.VedtaksbrevService
 import no.nav.etterlatte.brev.adresse.AdresseService
@@ -141,8 +142,8 @@ class ApplicationBuilder {
 
     private val distribusjonKlient =
         DistribusjonKlient(httpClient("DOKDIST_SCOPE", false), env.requireEnvValue("DOKDIST_URL"))
-    private val distribusjonService = DistribusjonServiceImpl(distribusjonKlient, db)
 
+    private val distribusjonService = DistribusjonServiceImpl(distribusjonKlient, db)
     private val featureToggleService = FeatureToggleService.initialiser(featureToggleProperties(config))
 
     private val migreringBrevDataService = MigreringBrevDataService(brevdataFacade)
@@ -157,17 +158,6 @@ class ApplicationBuilder {
 
     private val vedtaksvurderingService = VedtaksvurderingService(vedtakKlient)
 
-    private val brevService =
-        BrevService(
-            db,
-            sakService,
-            soekerService,
-            adresseService,
-            dokarkivService,
-            brevbakerService,
-            brevdataFacade,
-        )
-
     private val brevdistribuerer = Brevdistribuerer(db, distribusjonService)
 
     private val vedtaksbrevService =
@@ -181,6 +171,19 @@ class ApplicationBuilder {
             brevDataMapper,
             brevProsessTypeFactory,
             migreringBrevDataService,
+        )
+
+    private val journalfoerBrevService = JournalfoerBrevService(db, sakService, dokarkivService, vedtaksbrevService)
+
+    private val brevService =
+        BrevService(
+            db,
+            sakService,
+            soekerService,
+            adresseService,
+            brevbakerService,
+            brevdataFacade,
+            journalfoerBrevService,
         )
 
     private val journalpostService =
@@ -212,7 +215,7 @@ class ApplicationBuilder {
 
                 OpprettVedtaksbrevForOmregningNyRegelRiver(this, vedtaksbrevService)
 
-                JournalfoerVedtaksbrevRiver(this, vedtaksbrevService)
+                JournalfoerVedtaksbrevRiver(this, vedtaksbrevService, db, dokarkivService)
                 VedtaksbrevUnderkjentRiver(this, vedtaksbrevService)
                 DistribuerBrevRiver(this, brevdistribuerer)
             }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -215,7 +215,7 @@ class ApplicationBuilder {
 
                 OpprettVedtaksbrevForOmregningNyRegelRiver(this, vedtaksbrevService)
 
-                JournalfoerVedtaksbrevRiver(this, vedtaksbrevService, db, dokarkivService)
+                JournalfoerVedtaksbrevRiver(this, journalfoerBrevService)
                 VedtaksbrevUnderkjentRiver(this, vedtaksbrevService)
                 DistribuerBrevRiver(this, brevdistribuerer)
             }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/JournalfoerBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/JournalfoerBrevService.kt
@@ -2,9 +2,13 @@ package no.nav.etterlatte.brev
 
 import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.dokarkiv.DokarkivService
+import no.nav.etterlatte.brev.dokarkiv.JournalfoeringsMappingRequest
+import no.nav.etterlatte.brev.dokarkiv.OpprettJournalpostResponse
 import no.nav.etterlatte.brev.hentinformasjon.SakService
+import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevID
 import no.nav.etterlatte.brev.model.Status
+import no.nav.etterlatte.rivers.VedtakTilJournalfoering
 import no.nav.etterlatte.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
 
@@ -12,6 +16,7 @@ class JournalfoerBrevService(
     private val db: BrevRepository,
     private val sakService: SakService,
     private val dokarkivService: DokarkivService,
+    private val service: VedtaksbrevService,
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -20,18 +25,63 @@ class JournalfoerBrevService(
         bruker: BrukerTokenInfo,
     ): String {
         val brev = db.hentBrev(id)
+        val sak = sakService.hentSak(brev.sakId, bruker)
 
+        return journalfoer(
+            brev,
+            JournalfoeringsMappingRequest(
+                brevId = brev.id,
+                brev = brev,
+                brukerident = brev.soekerFnr,
+                eksternReferansePrefiks = brev.sakId,
+                sakId = brev.sakId,
+                sakType = sak.sakType,
+                journalfoerendeEnhet = sak.enhet,
+            ),
+        ).journalpostId
+    }
+
+    suspend fun journalfoerVedtaksbrev(vedtak: VedtakTilJournalfoering): OpprettJournalpostResponse? {
+        logger.info("Nytt vedtak med id ${vedtak.vedtakId} er attestert. Ferdigstiller vedtaksbrev.")
+        val behandlingId = vedtak.behandlingId
+
+        val brev =
+            service.hentVedtaksbrev(behandlingId)
+                ?: throw NoSuchElementException("Ingen vedtaksbrev funnet på behandlingId=$behandlingId")
+
+        // TODO: Forbedre denne "fiksen". Gjøres nå for å lappe sammen
+        if (brev.status in listOf(Status.JOURNALFOERT, Status.DISTRIBUERT, Status.SLETTET)) {
+            logger.warn("Vedtaksbrev (id=${brev.id}) er allerede ${brev.status}.")
+            return null
+        }
+
+        val mappingRequest =
+            JournalfoeringsMappingRequest(
+                brevId = brev.id,
+                brev = requireNotNull(db.hentBrev(brev.id)),
+                brukerident = vedtak.sak.ident,
+                eksternReferansePrefiks = vedtak.behandlingId,
+                sakId = vedtak.sak.id,
+                sakType = vedtak.sak.sakType,
+                journalfoerendeEnhet = vedtak.ansvarligEnhet,
+            )
+
+        return journalfoer(brev, mappingRequest)
+            .also { logger.info("Vedtaksbrev for vedtak med id ${vedtak.vedtakId} er journalfoert OK") }
+    }
+
+    private suspend fun journalfoer(
+        brev: Brev,
+        mappingRequest: JournalfoeringsMappingRequest,
+    ): OpprettJournalpostResponse {
         if (brev.status != Status.FERDIGSTILT) {
             throw IllegalStateException("Ugyldig status ${brev.status} på brev (id=${brev.id})")
         }
 
-        val sak = sakService.hentSak(brev.sakId, bruker)
-
-        val response = dokarkivService.journalfoer(brev, sak)
+        val response = dokarkivService.journalfoer(mappingRequest)
 
         db.settBrevJournalfoert(brev.id, response)
         logger.info("Brev med id=${brev.id} markert som journalført")
-
-        return response.journalpostId
+        return response
     }
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/JournalfoerBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/JournalfoerBrevService.kt
@@ -75,6 +75,7 @@ class JournalfoerBrevService(
         brev: Brev,
         mappingRequest: JournalfoeringsMappingRequest,
     ): OpprettJournalpostResponse {
+        logger.info("Skal journalføre brev ${brev.id}")
         if (brev.status != Status.FERDIGSTILT) {
             throw IllegalStateException("Ugyldig status ${brev.status} på brev (id=${brev.id})")
         }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/JournalfoerBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/JournalfoerBrevService.kt
@@ -41,7 +41,7 @@ class JournalfoerBrevService(
         ).journalpostId
     }
 
-    suspend fun journalfoerVedtaksbrev(vedtak: VedtakTilJournalfoering): OpprettJournalpostResponse? {
+    suspend fun journalfoerVedtaksbrev(vedtak: VedtakTilJournalfoering): Pair<OpprettJournalpostResponse, BrevID>? {
         logger.info("Nytt vedtak med id ${vedtak.vedtakId} er attestert. Ferdigstiller vedtaksbrev.")
         val behandlingId = vedtak.behandlingId
 
@@ -68,6 +68,7 @@ class JournalfoerBrevService(
 
         return journalfoer(brev, mappingRequest)
             .also { logger.info("Vedtaksbrev for vedtak med id ${vedtak.vedtakId} er journalfoert OK") }
+            .let { Pair(it, brev.id) }
     }
 
     private suspend fun journalfoer(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/JournalfoerBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/JournalfoerBrevService.kt
@@ -1,0 +1,37 @@
+package no.nav.etterlatte.brev
+
+import no.nav.etterlatte.brev.db.BrevRepository
+import no.nav.etterlatte.brev.dokarkiv.DokarkivService
+import no.nav.etterlatte.brev.hentinformasjon.SakService
+import no.nav.etterlatte.brev.model.BrevID
+import no.nav.etterlatte.brev.model.Status
+import no.nav.etterlatte.token.BrukerTokenInfo
+import org.slf4j.LoggerFactory
+
+class JournalfoerBrevService(
+    private val db: BrevRepository,
+    private val sakService: SakService,
+    private val dokarkivService: DokarkivService,
+) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    suspend fun journalfoer(
+        id: BrevID,
+        bruker: BrukerTokenInfo,
+    ): String {
+        val brev = db.hentBrev(id)
+
+        if (brev.status != Status.FERDIGSTILT) {
+            throw IllegalStateException("Ugyldig status ${brev.status} på brev (id=${brev.id})")
+        }
+
+        val sak = sakService.hentSak(brev.sakId, bruker)
+
+        val response = dokarkivService.journalfoer(brev, sak)
+
+        db.settBrevJournalfoert(brev.id, response)
+        logger.info("Brev med id=${brev.id} markert som journalført")
+
+        return response.journalpostId
+    }
+}

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.brev
 
 import com.fasterxml.jackson.databind.JsonNode
-import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.brev.adresse.AdresseService
 import no.nav.etterlatte.brev.behandling.ForenkletVedtak
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
@@ -10,8 +9,6 @@ import no.nav.etterlatte.brev.brevbaker.BrevbakerService
 import no.nav.etterlatte.brev.brevbaker.EtterlatteBrevKode
 import no.nav.etterlatte.brev.brevbaker.RedigerbarTekstRequest
 import no.nav.etterlatte.brev.db.BrevRepository
-import no.nav.etterlatte.brev.dokarkiv.DokarkivServiceImpl
-import no.nav.etterlatte.brev.dokarkiv.OpprettJournalpostResponse
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.hentinformasjon.VedtaksvurderingService
 import no.nav.etterlatte.brev.model.Adresse
@@ -41,7 +38,6 @@ import no.nav.etterlatte.libs.common.person.Vergemaal
 import no.nav.etterlatte.libs.common.retryOgPakkUt
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
-import no.nav.etterlatte.rivers.VedtakTilJournalfoering
 import no.nav.etterlatte.token.BrukerTokenInfo
 import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import org.slf4j.LoggerFactory
@@ -52,7 +48,6 @@ class VedtaksbrevService(
     private val brevdataFacade: BrevdataFacade,
     private val vedtaksvurderingService: VedtaksvurderingService,
     private val adresseService: AdresseService,
-    private val dokarkivService: DokarkivServiceImpl,
     private val brevbaker: BrevbakerService,
     private val brevDataMapper: BrevDataMapper,
     private val brevProsessTypeFactory: BrevProsessTypeFactory,
@@ -348,21 +343,6 @@ class VedtaksbrevService(
                     " og attestant (${brukerTokenInfo.ident()}) er samme person.",
             )
         }
-    }
-
-    fun journalfoerVedtaksbrev(
-        vedtaksbrev: Brev,
-        vedtak: VedtakTilJournalfoering,
-    ): OpprettJournalpostResponse {
-        if (vedtaksbrev.status != Status.FERDIGSTILT) {
-            throw IllegalArgumentException("Ugyldig status ${vedtaksbrev.status} på vedtaksbrev (id=${vedtaksbrev.id})")
-        }
-
-        val journalfoeringResponse = runBlocking { dokarkivService.journalfoer(vedtaksbrev.id, vedtak) }
-
-        db.settBrevJournalfoert(vedtaksbrev.id, journalfoeringResponse)
-        logger.info("Brev med id=${vedtaksbrev.id} markert som journalført")
-        return journalfoeringResponse
     }
 
     fun fjernFerdigstiltStatusUnderkjentVedtak(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivService.kt
@@ -148,46 +148,30 @@ class DokarkivServiceImpl(
     private fun mapTilJournalpostRequest(
         brevId: BrevID,
         vedtak: VedtakTilJournalfoering,
-    ): OpprettJournalpostRequest {
-        val brukerident = vedtak.sak.ident
-        val eksternReferansePrefiks: Any = vedtak.behandlingId
-        val sakId = vedtak.sak.id
-        val journalfoerendeEnhet = vedtak.ansvarligEnhet
-        val brev = requireNotNull(db.hentBrev(brevId))
-        val sakType = vedtak.sak.sakType
-
-        return mapTilJournalpostRequest(
-            brevId,
-            brev,
-            brukerident,
-            eksternReferansePrefiks,
-            sakId,
-            sakType,
-            journalfoerendeEnhet,
+    ): OpprettJournalpostRequest =
+        mapTilJournalpostRequest(
+            brevId = brevId,
+            brev = requireNotNull(db.hentBrev(brevId)),
+            brukerident = vedtak.sak.ident,
+            eksternReferansePrefiks = vedtak.behandlingId,
+            sakId = vedtak.sak.id,
+            sakType = vedtak.sak.sakType,
+            journalfoerendeEnhet = vedtak.ansvarligEnhet,
         )
-    }
 
     private fun mapTilJournalpostRequest(
         brev: Brev,
         sak: Sak,
-    ): OpprettJournalpostRequest {
-        val brukerident = brev.soekerFnr
-        val eksternReferansePrefiks: Any = brev.sakId
-        val sakId = brev.sakId
-        val journalfoerendeEnhet = sak.enhet
-        val brevId = brev.id
-        val sakType = sak.sakType
-
-        return mapTilJournalpostRequest(
-            brevId,
-            brev,
-            brukerident,
-            eksternReferansePrefiks,
-            sakId,
-            sakType,
-            journalfoerendeEnhet,
+    ): OpprettJournalpostRequest =
+        mapTilJournalpostRequest(
+            brevId = brev.id,
+            brev = brev,
+            brukerident = brev.soekerFnr,
+            eksternReferansePrefiks = brev.sakId,
+            sakId = brev.sakId,
+            sakType = sak.sakType,
+            journalfoerendeEnhet = sak.enhet,
         )
-    }
 
     private fun mapTilJournalpostRequest(
         brevId: BrevID,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivService.kt
@@ -148,21 +148,26 @@ class DokarkivServiceImpl(
         brevId: BrevID,
         vedtak: VedtakTilJournalfoering,
     ): OpprettJournalpostRequest {
-        val innhold = requireNotNull(db.hentBrevInnhold(brevId))
-        val pdf = requireNotNull(db.hentPdf(brevId))
+        val brukerident = vedtak.sak.ident
+        val eksternReferansePrefiks = vedtak.behandlingId
+        val sakId = vedtak.sak.id
+        val sak = vedtak.sak
+        val journalfoerendeEnhet = vedtak.ansvarligEnhet
         val brev = requireNotNull(db.hentBrev(brevId))
 
+        val innhold = requireNotNull(db.hentBrevInnhold(brevId))
+        val pdf = requireNotNull(db.hentPdf(brevId))
         return OpprettJournalpostRequest(
             tittel = innhold.tittel,
             journalposttype = JournalPostType.UTGAAENDE,
             avsenderMottaker = brev.avsenderMottaker(),
-            bruker = Bruker(vedtak.sak.ident),
-            eksternReferanseId = "${vedtak.behandlingId}.$brevId",
-            sak = JournalpostSak(Sakstype.FAGSAK, vedtak.sak.id.toString()),
+            bruker = Bruker(brukerident),
+            eksternReferanseId = "$eksternReferansePrefiks.$brevId",
+            sak = JournalpostSak(Sakstype.FAGSAK, sakId.toString()),
             dokumenter = listOf(pdf.tilJournalpostDokument(innhold.tittel)),
-            tema = vedtak.sak.sakType.tema,
+            tema = sak.sakType.tema,
             kanal = "S",
-            journalfoerendeEnhet = vedtak.ansvarligEnhet,
+            journalfoerendeEnhet = journalfoerendeEnhet,
         )
     }
 
@@ -170,20 +175,25 @@ class DokarkivServiceImpl(
         brev: Brev,
         sak: Sak,
     ): OpprettJournalpostRequest {
-        val innhold = requireNotNull(db.hentBrevInnhold(brev.id))
-        val pdf = requireNotNull(db.hentPdf(brev.id))
+        val brukerident = brev.soekerFnr
+        val eksternReferansePrefiks = brev.sakId
+        val sakId = brev.sakId
+        val journalfoerendeEnhet = sak.enhet
+        val brevId = brev.id
 
+        val innhold = requireNotNull(db.hentBrevInnhold(brevId))
+        val pdf = requireNotNull(db.hentPdf(brevId))
         return OpprettJournalpostRequest(
             tittel = innhold.tittel,
             journalposttype = JournalPostType.UTGAAENDE,
             avsenderMottaker = brev.avsenderMottaker(),
-            bruker = Bruker(brev.soekerFnr),
-            eksternReferanseId = "${brev.sakId}.${brev.id}",
-            sak = JournalpostSak(Sakstype.FAGSAK, brev.sakId.toString()),
+            bruker = Bruker(brukerident),
+            eksternReferanseId = "$eksternReferansePrefiks.$brevId",
+            sak = JournalpostSak(Sakstype.FAGSAK, sakId.toString()),
             dokumenter = listOf(pdf.tilJournalpostDokument(innhold.tittel)),
             tema = sak.sakType.tema,
             kanal = "S",
-            journalfoerendeEnhet = sak.enhet,
+            journalfoerendeEnhet = journalfoerendeEnhet,
         )
     }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivService.kt
@@ -61,7 +61,7 @@ class DokarkivServiceImpl(
         return journalfoer(request.brevId) { mapTilJournalpostRequest(request) }
     }
 
-    suspend fun journalfoer(
+    private suspend fun journalfoer(
         brevId: BrevID,
         request: () -> OpprettJournalpostRequest,
     ): OpprettJournalpostResponse {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivService.kt
@@ -57,32 +57,23 @@ class DokarkivServiceImpl(
     override suspend fun journalfoer(
         brevId: BrevID,
         vedtak: VedtakTilJournalfoering,
-    ): OpprettJournalpostResponse {
-        logger.info("Oppretter journalpost for brev med id=$brevId")
-
-        val request = mapTilJournalpostRequest(brevId, vedtak)
-
-        return client.opprettJournalpost(request, true).also {
-            logger.info(
-                "Journalpost opprettet (journalpostId=${it.journalpostId}, ferdigstilt=${it.journalpostferdigstilt})",
-            )
-        }
-    }
+    ): OpprettJournalpostResponse = journalfoer(brevId) { mapTilJournalpostRequest(brevId, vedtak) }
 
     override suspend fun journalfoer(
         brev: Brev,
         sak: Sak,
+    ): OpprettJournalpostResponse = journalfoer(brev.id) { mapTilJournalpostRequest(brev, sak) }
+
+    private suspend fun journalfoer(
+        brevId: BrevID,
+        request: () -> OpprettJournalpostRequest,
     ): OpprettJournalpostResponse {
-        logger.info("Oppretter journalpost for brev med id=${brev.id}")
-
-        val request = mapTilJournalpostRequest(brev, sak)
-
-        return client.opprettJournalpost(request, true)
-            .also {
-                logger.info(
-                    "Journalpost opprettet (journalpostId=${it.journalpostId}, ferdigstilt=${it.journalpostferdigstilt})",
-                )
-            }
+        logger.info("Oppretter journalpost for brev med id=$brevId")
+        return client.opprettJournalpost(request(), true).also {
+            logger.info(
+                "Journalpost opprettet (journalpostId=${it.journalpostId}, ferdigstilt=${it.journalpostferdigstilt})",
+            )
+        }
     }
 
     override suspend fun oppdater(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiver.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.brev.VedtaksbrevService
 import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.distribusjon.DistribusjonsType
-import no.nav.etterlatte.brev.dokarkiv.DokarkivServiceImpl
+import no.nav.etterlatte.brev.dokarkiv.DokarkivService
 import no.nav.etterlatte.brev.model.BrevID
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
@@ -26,7 +26,7 @@ internal class JournalfoerVedtaksbrevRiver(
     private val rapidsConnection: RapidsConnection,
     private val service: VedtaksbrevService,
     private val db: BrevRepository,
-    private val dokarkivService: DokarkivServiceImpl,
+    private val dokarkivService: DokarkivService,
 ) : ListenerMedLogging() {
     private val logger = LoggerFactory.getLogger(JournalfoerVedtaksbrevRiver::class.java)
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiver.kt
@@ -56,7 +56,6 @@ internal class JournalfoerVedtaksbrevRiver(
                     ansvarligEnhet = packet["vedtak.vedtakFattet.ansvarligEnhet"].asText(),
                 )
 
-            logger.info("Nytt vedtak med id ${vedtak.vedtakId} er attestert. Ferdigstiller vedtaksbrev.")
             val response = runBlocking { journalfoerBrevService.journalfoerVedtaksbrev(vedtak) } ?: return
             rapidsConnection.svarSuksess(
                 packet,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiver.kt
@@ -63,7 +63,7 @@ internal class JournalfoerVedtaksbrevRiver(
                 response.first.journalpostId,
             )
         } catch (e: Exception) {
-            logger.error("Feil ved ferdigstilling av vedtaksbrev: ", e)
+            logger.error("Feil ved journalføring av vedtaksbrev: ", e)
             throw e
         }
     }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
@@ -3,8 +3,6 @@ package no.nav.etterlatte.brev
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.clearAllMocks
-import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
@@ -16,8 +14,6 @@ import no.nav.etterlatte.brev.brevbaker.BrevbakerKlient
 import no.nav.etterlatte.brev.brevbaker.BrevbakerService
 import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.distribusjon.DistribusjonServiceImpl
-import no.nav.etterlatte.brev.dokarkiv.DokarkivServiceImpl
-import no.nav.etterlatte.brev.dokarkiv.OpprettJournalpostResponse
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.hentinformasjon.SakService
 import no.nav.etterlatte.brev.hentinformasjon.SoekerService
@@ -28,8 +24,6 @@ import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.brev.model.Status
-import no.nav.etterlatte.libs.common.behandling.SakType
-import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.token.BrukerTokenInfo
 import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
@@ -50,7 +44,7 @@ internal class BrevServiceTest {
     private val sakService = mockk<SakService>()
     private val soekerService = mockk<SoekerService>()
     private val adresseService = mockk<AdresseService>()
-    private val dokarkivService = mockk<DokarkivServiceImpl>()
+    private val journalfoerBrevService = mockk<JournalfoerBrevService>()
     private val distribusjonService = mockk<DistribusjonServiceImpl>()
     private val brevDataMapper = mockk<BrevDataMapper>()
     private val brevDataFacade = mockk<BrevdataFacade>()
@@ -61,9 +55,9 @@ internal class BrevServiceTest {
             sakService,
             soekerService,
             adresseService,
-            dokarkivService,
             BrevbakerService(brevbaker, adresseService, brevDataMapper),
             brevDataFacade,
+            journalfoerBrevService,
         )
 
     private val bruker = BrukerTokenInfo.of(UUID.randomUUID().toString(), "Z123456", null, null, null)
@@ -75,7 +69,7 @@ internal class BrevServiceTest {
 
     @AfterEach
     fun after() {
-        confirmVerified(db, sakOgBehandlingService, adresseService, dokarkivService, distribusjonService, brevbaker)
+        confirmVerified(db, sakOgBehandlingService, adresseService, journalfoerBrevService, distribusjonService, brevbaker)
     }
 
     @Nested
@@ -152,58 +146,6 @@ internal class BrevServiceTest {
             verify {
                 db.hentBrevPayload(brev.id)
                 db.hentBrevPayloadVedlegg(brev.id)
-            }
-        }
-    }
-
-    @Nested
-    inner class JournalfoeringAvBrev {
-        @Test
-        fun `Journalfoering fungerer som forventet`() {
-            val brev = opprettBrev(Status.FERDIGSTILT, BrevProsessType.MANUELL)
-            val sak = Sak("ident", SakType.BARNEPENSJON, brev.sakId, "1234")
-            val journalpostResponse = OpprettJournalpostResponse("444", journalpostferdigstilt = true)
-
-            coEvery { sakService.hentSak(any(), any()) } returns sak
-            coEvery { dokarkivService.journalfoer(any<Brev>(), any()) } returns journalpostResponse
-            every { db.hentBrev(any()) } returns brev
-            every { db.settBrevJournalfoert(any(), any()) } returns true
-
-            val faktiskJournalpostId =
-                runBlocking {
-                    brevService.journalfoer(brev.id, bruker)
-                }
-
-            faktiskJournalpostId shouldBe journalpostResponse.journalpostId
-
-            verify {
-                db.hentBrev(brev.id)
-                db.settBrevJournalfoert(brev.id, journalpostResponse)
-            }
-            coVerify {
-                sakService.hentSak(sak.id, bruker)
-                dokarkivService.journalfoer(brev, sak)
-            }
-        }
-
-        @ParameterizedTest
-        @EnumSource(
-            Status::class,
-            mode = EnumSource.Mode.EXCLUDE,
-            names = ["FERDIGSTILT"],
-        )
-        fun `Journalfoering feiler hvis status er feil`(status: Status) {
-            val brev = opprettBrev(status, BrevProsessType.MANUELL)
-            every { db.hentBrev(any()) } returns brev
-
-            runBlocking {
-                assertThrows<IllegalStateException> {
-                    brevService.journalfoer(brev.id, bruker)
-                }
-            }
-
-            verify {
-                db.hentBrev(brev.id)
             }
         }
     }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
@@ -141,6 +141,7 @@ class JournalfoerBrevServiceTest {
         runBlocking { service.journalfoerVedtaksbrev(vedtak) }
 
         verify(exactly = 1) { vedtaksbrevService.hentVedtaksbrev(vedtak.behandlingId) }
+        coVerify(exactly = 0) { dokarkivService.journalfoer(any()) }
     }
 
     @ParameterizedTest

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
@@ -1,0 +1,133 @@
+package no.nav.etterlatte.brev
+
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.brev.db.BrevRepository
+import no.nav.etterlatte.brev.dokarkiv.DokarkivService
+import no.nav.etterlatte.brev.dokarkiv.OpprettJournalpostResponse
+import no.nav.etterlatte.brev.hentinformasjon.SakService
+import no.nav.etterlatte.brev.model.Adresse
+import no.nav.etterlatte.brev.model.Brev
+import no.nav.etterlatte.brev.model.BrevProsessType
+import no.nav.etterlatte.brev.model.Mottaker
+import no.nav.etterlatte.brev.model.Status
+import no.nav.etterlatte.common.Enheter
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.sak.Sak
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.token.BrukerTokenInfo
+import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.util.UUID
+import kotlin.random.Random
+
+class JournalfoerBrevServiceTest {
+    private val db = mockk<BrevRepository>(relaxed = true)
+    private val sakService = mockk<SakService>()
+    private val dokarkivService = mockk<DokarkivService>()
+    private val vedtaksbrevService = mockk<VedtaksbrevService>()
+
+    private val bruker = BrukerTokenInfo.of(UUID.randomUUID().toString(), "Z123456", null, null, null)
+
+    @Test
+    fun `Journalfoering fungerer som forventet`() {
+        val brev = opprettBrev(Status.FERDIGSTILT, BrevProsessType.MANUELL)
+        val sak = Sak("ident", SakType.BARNEPENSJON, brev.sakId, "1234")
+        val journalpostResponse = OpprettJournalpostResponse("444", journalpostferdigstilt = true)
+
+        val service = JournalfoerBrevService(db, sakService, dokarkivService, vedtaksbrevService)
+
+        coEvery { sakService.hentSak(any(), any()) } returns sak
+        coEvery { dokarkivService.journalfoer(any()) } returns journalpostResponse
+        every { db.hentBrev(any()) } returns brev
+        every { db.settBrevJournalfoert(any(), any()) } returns true
+
+        val faktiskJournalpostId =
+            runBlocking {
+                service.journalfoer(brev.id, bruker)
+            }
+
+        faktiskJournalpostId shouldBe journalpostResponse.journalpostId
+
+        verify {
+            db.hentBrev(brev.id)
+            db.settBrevJournalfoert(brev.id, journalpostResponse)
+        }
+        coVerify {
+            sakService.hentSak(sak.id, bruker)
+            dokarkivService.journalfoer(any())
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        Status::class,
+        mode = EnumSource.Mode.EXCLUDE,
+        names = ["FERDIGSTILT"],
+    )
+    fun `Journalfoering feiler hvis status er feil`(status: Status) {
+        val brev = opprettBrev(status, BrevProsessType.MANUELL)
+        every { db.hentBrev(any()) } returns brev
+        coEvery {
+            sakService.hentSak(
+                any(),
+                any(),
+            )
+        } returns
+            mockk<Sak>().also {
+                every { it.sakType } returns SakType.BARNEPENSJON
+                every { it.enhet } returns Enheter.UTLAND.enhetNr
+            }
+        val service = JournalfoerBrevService(db, sakService, dokarkivService, vedtaksbrevService)
+
+        runBlocking {
+            assertThrows<IllegalStateException> {
+                service.journalfoer(brev.id, bruker)
+            }
+        }
+
+        verify {
+            db.hentBrev(brev.id)
+        }
+    }
+
+    private fun opprettBrev(
+        status: Status,
+        prosessType: BrevProsessType,
+    ) = Brev(
+        id = Random.nextLong(10000),
+        sakId = Random.nextLong(10000),
+        behandlingId = null,
+        tittel = null,
+        prosessType = prosessType,
+        soekerFnr = "fnr",
+        status = status,
+        statusEndret = Tidspunkt.now(),
+        opprettet = Tidspunkt.now(),
+        mottaker = opprettMottaker(),
+    )
+
+    private fun opprettMottaker() =
+        Mottaker(
+            "Stor Snerk",
+            foedselsnummer = Foedselsnummer("1234567890"),
+            orgnummer = null,
+            adresse =
+                Adresse(
+                    adresseType = "NORSKPOSTADRESSE",
+                    adresselinje1 = "Testgaten 13",
+                    postnummer = "1234",
+                    poststed = "OSLO",
+                    land = "Norge",
+                    landkode = "NOR",
+                ),
+        )
+}

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -709,7 +709,7 @@ internal class VedtaksbrevServiceTest {
             val forventetBrev = opprettBrev(Status.FERDIGSTILT, mockk())
 
             val forventetResponse = OpprettJournalpostResponse("1", true)
-            coEvery { dokarkivService.journalfoer(any<BrevID>(), any()) } returns forventetResponse
+            coEvery { dokarkivService.journalfoer(any<BrevID>(), any<VedtakTilJournalfoering>()) } returns forventetResponse
 
             val vedtak = opprettVedtak()
 

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiverTest.kt
@@ -2,15 +2,16 @@ package no.nav.etterlatte.rivers
 
 import io.mockk.Called
 import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import no.nav.etterlatte.brev.JournalfoerBrevService
 import no.nav.etterlatte.brev.VedtaksbrevService
-import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.distribusjon.DistribusjonsType
-import no.nav.etterlatte.brev.dokarkiv.DokarkivService
 import no.nav.etterlatte.brev.dokarkiv.OpprettJournalpostResponse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
@@ -36,16 +37,14 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import java.time.YearMonth
 import java.util.UUID
 
 internal class JournalfoerVedtaksbrevRiverTest {
-    private val db = mockk<BrevRepository>()
     private val vedtaksbrevService = mockk<VedtaksbrevService>()
-    private val dokarkivService = mockk<DokarkivService>()
+    private val journalfoerBrevService = mockk<JournalfoerBrevService>()
 
-    private val testRapid = TestRapid().apply { JournalfoerVedtaksbrevRiver(this, vedtaksbrevService, db, dokarkivService) }
+    private val testRapid = TestRapid().apply { JournalfoerVedtaksbrevRiver(this, journalfoerBrevService) }
 
     @BeforeEach
     fun before() = clearMocks(vedtaksbrevService)
@@ -71,7 +70,7 @@ internal class JournalfoerVedtaksbrevRiverTest {
         val response = OpprettJournalpostResponse("1234", true, emptyList())
 
         every { vedtaksbrevService.hentVedtaksbrev(any()) } returns brev
-        every { vedtaksbrevService.journalfoerVedtaksbrev(any(), any()) } returns response
+        coEvery { journalfoerBrevService.journalfoerVedtaksbrev(any()) } returns Pair(response, 1)
 
         val vedtak = opprettVedtak()
         val melding = opprettMelding(vedtak)
@@ -79,9 +78,8 @@ internal class JournalfoerVedtaksbrevRiverTest {
         val inspektoer = testRapid.apply { sendTestMessage(melding.toJson()) }.inspektør
 
         val vedtakCapture = slot<VedtakTilJournalfoering>()
-        verify(exactly = 1) {
-            vedtaksbrevService.hentVedtaksbrev(vedtak.behandlingId)
-            vedtaksbrevService.journalfoerVedtaksbrev(any(), capture(vedtakCapture))
+        coVerify(exactly = 1) {
+            journalfoerBrevService.journalfoerVedtaksbrev(capture(vedtakCapture))
         }
 
         val vedtakActual = vedtakCapture.captured
@@ -95,34 +93,6 @@ internal class JournalfoerVedtaksbrevRiverTest {
         assertEquals(brev.id, actualMessage.get("brevId").asLong())
         assertEquals(response.journalpostId, actualMessage.get("journalpostId").asText())
         assertEquals(DistribusjonsType.VEDTAK.toString(), actualMessage.get("distribusjonType").asText())
-    }
-
-    @Test
-    fun `Brev er allerede journalfoert`() {
-        val brev =
-            Brev(
-                1,
-                41,
-                BEHANDLING_ID,
-                "tittel",
-                BrevProsessType.AUTOMATISK,
-                "fnr",
-                Status.JOURNALFOERT,
-                Tidspunkt.now(),
-                Tidspunkt.now(),
-                mottaker = mockk(),
-            )
-
-        every { vedtaksbrevService.hentVedtaksbrev(any()) } returns brev
-
-        val vedtak = opprettVedtak()
-        val melding = opprettMelding(vedtak)
-
-        val inspektoer = testRapid.apply { sendTestMessage(melding.toJson()) }.inspektør
-
-        assertEquals(0, inspektoer.size)
-
-        verify(exactly = 1) { vedtaksbrevService.hentVedtaksbrev(vedtak.behandlingId) }
     }
 
     @Test
@@ -158,20 +128,6 @@ internal class JournalfoerVedtaksbrevRiverTest {
         testRapid.apply { sendTestMessage(melding.toJson()) }.inspektør
 
         verify { vedtaksbrevService wasNot Called }
-    }
-
-    @Test
-    fun `Brev finnes ikke for behandling`() {
-        every { vedtaksbrevService.hentVedtaksbrev(any()) } returns null
-
-        val vedtak = opprettVedtak()
-        val melding = opprettMelding(vedtak)
-
-        assertThrows<NoSuchElementException> {
-            testRapid.apply { sendTestMessage(melding.toJson()) }
-        }
-
-        verify { vedtaksbrevService.hentVedtaksbrev(vedtak.behandlingId) }
     }
 
     private fun opprettMelding(vedtak: VedtakNyDto): JsonMessage {

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiverTest.kt
@@ -8,7 +8,9 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import no.nav.etterlatte.brev.VedtaksbrevService
+import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.distribusjon.DistribusjonsType
+import no.nav.etterlatte.brev.dokarkiv.DokarkivService
 import no.nav.etterlatte.brev.dokarkiv.OpprettJournalpostResponse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
@@ -39,9 +41,11 @@ import java.time.YearMonth
 import java.util.UUID
 
 internal class JournalfoerVedtaksbrevRiverTest {
+    private val db = mockk<BrevRepository>()
     private val vedtaksbrevService = mockk<VedtaksbrevService>()
+    private val dokarkivService = mockk<DokarkivService>()
 
-    private val testRapid = TestRapid().apply { JournalfoerVedtaksbrevRiver(this, vedtaksbrevService) }
+    private val testRapid = TestRapid().apply { JournalfoerVedtaksbrevRiver(this, vedtaksbrevService, db, dokarkivService) }
 
     @BeforeEach
     fun before() = clearMocks(vedtaksbrevService)

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
@@ -5,7 +5,9 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import no.nav.etterlatte.brev.VedtaksbrevService
+import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.distribusjon.Brevdistribuerer
+import no.nav.etterlatte.brev.dokarkiv.DokarkivService
 import no.nav.etterlatte.brev.dokarkiv.OpprettJournalpostResponse
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
@@ -53,13 +55,15 @@ internal class OpprettJournalfoerOgDistribuer {
                     )
                 coEvery { it.hentBrev(any()) } returns brev
             }
+        val db = mockk<BrevRepository>()
+        val dokarkivService = mockk<DokarkivService>()
         val distribusjonService =
             mockk<Brevdistribuerer>().also {
                 coEvery { it.distribuer(brev.id, any(), any()) } returns ""
             }
         val testRapid =
             TestRapid().apply {
-                JournalfoerVedtaksbrevRiver(this, vedtaksbrevService)
+                JournalfoerVedtaksbrevRiver(this, vedtaksbrevService, db, dokarkivService)
                 DistribuerBrevRiver(this, distribusjonService)
             }
 
@@ -103,9 +107,11 @@ internal class OpprettJournalfoerOgDistribuer {
             mockk<Brevdistribuerer>().also {
                 coEvery { it.distribuer(brev.id, any(), any()) } returns ""
             }
+        val db = mockk<BrevRepository>()
+        val dokarkivService = mockk<DokarkivService>()
         val testRapid =
             TestRapid().apply {
-                JournalfoerVedtaksbrevRiver(this, vedtaksbrevService)
+                JournalfoerVedtaksbrevRiver(this, vedtaksbrevService, db, dokarkivService)
                 DistribuerBrevRiver(this, distribusjonService)
             }
 


### PR DESCRIPTION
Tilsvarande som for distribusjon i https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/3302


Sikrar at vi journalfører likt uavhengig av om det er vedtaksbrev eller anna brev. Flytta med det samme logikk frå river til service, så river no kun hentar ut data frå pakka, kallar service og publiserer vidare.

Kan vera nyttig å sjå på denne commit for commit for å følgje tankerekka.