### PR TITLE
Konsistensavstemming - benytte custom serializers ved skriving av sluttresultat

### DIFF
--- a/apps/etterlatte-utbetaling/build.gradle.kts
+++ b/apps/etterlatte-utbetaling/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
 
     testImplementation(libs.ktor2.clientmock)
     testImplementation(libs.kotlinx.coroutinescore)
+    testImplementation(libs.test.kotest.assertionscore)
     testImplementation(libs.test.wiremock)
     testImplementation(project(":libs:testdata"))
     testImplementation(testFixtures(project(":libs:etterlatte-mq")))

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/KonsistensavstemmingTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/KonsistensavstemmingTest.kt
@@ -1,0 +1,82 @@
+package no.nav.etterlatte.utbetaling.avstemming
+
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.shouldNotBe
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.toJson
+import no.nav.etterlatte.utbetaling.grensesnittavstemming.UUIDBase64
+import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
+import no.nav.etterlatte.utbetaling.oppdragForKonsistensavstemming
+import no.nav.etterlatte.utbetaling.oppdragslinjeForKonsistensavstemming
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import kotlin.reflect.full.memberProperties
+
+class KonsistensavstemmingTest {
+    @Nested
+    inner class Serializers {
+        @Test
+        fun `verifiser at serialiser (custom) og deserialiser (med standard Jackson) gir samme resultat`() {
+            val testdata = opprettKonsistensavstemmingAlleFelterUtfylt()
+
+            for (prop in Konsistensavstemming::class.memberProperties) {
+                prop.get(testdata) shouldNotBe null
+            }
+
+            testdata.loependeUtbetalinger.forEach { oppdrag ->
+                for (prop in OppdragForKonsistensavstemming::class.memberProperties) {
+                    prop.get(oppdrag) shouldNotBe null
+                }
+
+                oppdrag.utbetalingslinjer.forEach { osLinje ->
+                    for (prop in OppdragslinjeForKonsistensavstemming::class.memberProperties) {
+                        prop.get(osLinje) shouldNotBe null
+                    }
+                }
+            }
+
+            // Custom serializer
+            val serialized = testdata.toJson()
+
+            // Standard (reflection-based) deserializer
+            val deSerialized = objectMapper.readValue(serialized, Konsistensavstemming::class.java)
+
+            // Kun data classes, så equality kan benyttes uten videre
+            deSerialized shouldBeEqual testdata
+        }
+    }
+
+    private fun opprettKonsistensavstemmingAlleFelterUtfylt(opprettetTilOgMed: Tidspunkt = Tidspunkt.now()): Konsistensavstemming {
+        val oppdragslinjer =
+            listOf(
+                oppdragslinjeForKonsistensavstemming(
+                    id = 125L,
+                    beloep = BigDecimal(11000),
+                    fraOgMed = LocalDate.of(2023, 10, 7),
+                    tilOgMed = LocalDate.of(2023, 11, 14),
+                    forrigeUtbetalingslinjeId = 123L,
+                ),
+                oppdragslinjeForKonsistensavstemming(
+                    id = 126L,
+                    beloep = BigDecimal(12000),
+                    fraOgMed = LocalDate.of(2023, 12, 1),
+                    tilOgMed = LocalDate.of(2023, 12, 31),
+                    forrigeUtbetalingslinjeId = 125L,
+                ),
+            )
+        val oppdrag = oppdragForKonsistensavstemming(oppdragslinjeForKonsistensavstemming = oppdragslinjer)
+
+        return Konsistensavstemming(
+            id = UUIDBase64(),
+            sakType = Saktype.BARNEPENSJON,
+            opprettet = Tidspunkt.now(),
+            avstemmingsdata = "noe slags data her",
+            loependeFraOgMed = Tidspunkt.now(),
+            opprettetTilOgMed = opprettetTilOgMed,
+            loependeUtbetalinger = listOf(oppdrag),
+        )
+    }
+}


### PR DESCRIPTION
Et annet, noe mindre, tiltak for å redusere cpu-bruk. Her ved at man unngår standard-serializerens bruk av kotlin reflection. Til og med bruken av litt enkle "verdi"-typer som wrapper, for eks `SakId`, `UtbetalingslinjeId` påvirker dette ganske kraftig. Har derfor laget en test som er ment til å avdekke om man legger til nye felt men glemmer å oppdatere serializeren.

Reduserer cpu-bruken for denne delen av koden relativt med ca 75%, basert på gjentatte lokale kjøringer med ca 5000 innslag i utbetalingstabellen (resetter "sist kjørt"-data mellom hver gang, og stopper app/jvm).

- Før endring:
![image](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/8087437/5b6a7df1-9415-4602-8549-7f7562fe75fe)

- Etter endring:
![image](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/8087437/ef04a1d6-3806-4316-ada2-c21c994e151b)
