### PR TITLE
EY-3284: Håndterer at PDL kan ha vergemål uten vergens fødselsnummer.

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/Grunnlagmapper.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/Grunnlagmapper.kt
@@ -89,7 +89,11 @@ fun Grunnlag.mapVerge(
     brevutfallDto: BrevutfallDto?,
 ): Verge? =
     with(this) {
-        val relevantVerge = hentRelevantVerge(soeker.hentVergemaalellerfremtidsfullmakt()?.verdi)
+        val relevantVerge =
+            hentRelevantVerge(
+                soeker.hentVergemaalellerfremtidsfullmakt()?.verdi,
+                soeker.hentFoedselsnummer()?.verdi,
+            )
         if (relevantVerge != null) {
             return hentVergemaal(relevantVerge, behandlingId)
         }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/VergeService.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/VergeService.kt
@@ -34,7 +34,7 @@ class VergeService(private val persondataKlient: PersondataKlient) {
         if ((vergeListe?.size ?: 0) > 1) {
             sikkerLogg.warn("Flere verger for fødselsnummer " + pdlPerson.foedselsnummer)
         }
-        return hentRelevantVerge(vergeListe)
+        return hentRelevantVerge(vergeListe, pdlPerson.foedselsnummer)
     }
 
     private fun hentVergesAdresse(relevantVerge: VergemaalEllerFremtidsfullmakt): Grunnlagsopplysning<BrevMottaker>? {

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/VergeServiceTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/VergeServiceTest.kt
@@ -1,0 +1,83 @@
+package grunnlag
+
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.etterlatte.grunnlag.VergeService
+import no.nav.etterlatte.grunnlag.adresse.PersondataAdresse
+import no.nav.etterlatte.grunnlag.adresse.REGOPPSLAG_ADRESSE
+import no.nav.etterlatte.grunnlag.klienter.PersondataKlient
+import no.nav.etterlatte.libs.common.person.BrevMottaker
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.person.Person
+import no.nav.etterlatte.libs.common.person.VergeEllerFullmektig
+import no.nav.etterlatte.libs.common.person.VergemaalEllerFremtidsfullmakt
+import org.junit.jupiter.api.Test
+
+class VergeServiceTest {
+    private val mockPersondataKlient = mockk<PersondataKlient>()
+    private val mockPerson = mockk<Person>()
+    private val vergeService = VergeService(mockPersondataKlient)
+
+    @Test
+    fun `Hvis vergemaal ikke har vergens fnr kan ikke adressen hentes`() {
+        val vergemaalUtenFnr = vergemaalUtenFnr()
+
+        every { mockPerson.vergemaalEllerFremtidsfullmakt } returns
+            listOf(vergemaalUtenFnr)
+        every { mockPerson.foedselsnummer } returns Folkeregisteridentifikator.of("09498230323")
+
+        val vergesAdresse = vergeService.hentGrunnlagsopplysningVergesAdresse(mockPerson)
+        vergesAdresse shouldBe null
+    }
+
+    @Test
+    fun `Hvis vergemaal har vergens fnr skal adressen hentes`() {
+        val vergemaalMedFnr = vergemaalMedFnr()
+        val persondataAdresse = mockk<PersondataAdresse>()
+        val brevMottaker = brevMottaker()
+
+        every { persondataAdresse.tilFrittstaendeBrevMottaker(any()) } returns brevMottaker
+        every {
+            mockPersondataKlient.hentAdresseGittFnr(vergemaalMedFnr.vergeEllerFullmektig.motpartsPersonident!!.value)
+        } returns persondataAdresse
+
+        every { mockPerson.vergemaalEllerFremtidsfullmakt } returns
+            listOf(vergemaalMedFnr())
+        every { mockPerson.foedselsnummer } returns Folkeregisteridentifikator.of("09498230323")
+
+        val vergesAdresse = vergeService.hentGrunnlagsopplysningVergesAdresse(mockPerson)
+        vergesAdresse!!.opplysning shouldBeEqual brevMottaker
+    }
+
+    private fun brevMottaker() = BrevMottaker("Johnny Cash", mockk(), mockk(), REGOPPSLAG_ADRESSE)
+
+    private fun vergemaalUtenFnr() =
+        VergemaalEllerFremtidsfullmakt(
+            embete = "",
+            type = "",
+            vergeEllerFullmektig =
+                VergeEllerFullmektig(
+                    motpartsPersonident = null,
+                    navn = "John",
+                    tjenesteomraade = "",
+                    omfangetErInnenPersonligOmraade = true,
+                    omfang = "",
+                ),
+        )
+
+    private fun vergemaalMedFnr() =
+        VergemaalEllerFremtidsfullmakt(
+            embete = "",
+            type = "",
+            vergeEllerFullmektig =
+                VergeEllerFullmektig(
+                    motpartsPersonident = Folkeregisteridentifikator.of("10418305857"),
+                    navn = "John",
+                    tjenesteomraade = "",
+                    omfangetErInnenPersonligOmraade = true,
+                    omfang = "",
+                ),
+        )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/Verger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/gyldigFramsattSoeknad/Verger.tsx
@@ -47,7 +47,11 @@ export const Verger = ({ sakId, behandlingId }: Props) => {
             label="Verge"
             tekst={
               <>
-                <KopierbarVerdi value={it.vergeEllerFullmektig.motpartsPersonident!} />
+                {it.vergeEllerFullmektig.motpartsPersonident ? (
+                  <KopierbarVerdi value={it.vergeEllerFullmektig.motpartsPersonident!} />
+                ) : (
+                  'Fødselsnummer ikke registrert'
+                )}
                 <br />
                 {it.vergeEllerFullmektig.omfang &&
                   (omfangMap.get(it.vergeEllerFullmektig.omfang) ?? it.vergeEllerFullmektig.omfang)}

--- a/libs/saksbehandling-common/src/main/kotlin/person/Person.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/person/Person.kt
@@ -279,7 +279,7 @@ private fun harVergensFnr(
     if (manglerFnr) {
         sikkerlogger()
             .error(
-                "Vergemålet for person '$soekersFnr' i PDL mangler vergens fødselsnummer. " +
+                "Et vergemål for person '${soekersFnr?.value}' i PDL mangler vergens fødselsnummer. " +
                     "Vergens navn: ${vergemaal.vergeEllerFullmektig.navn}.",
             )
     }


### PR DESCRIPTION
Vergens adresse blir da null.