### PR TITLE
Konsistensavstemming - egen type av Utbetaling for denne jobben

### DIFF
--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/utbetaling/Utbetaling.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/iverksetting/utbetaling/Utbetaling.kt
@@ -81,6 +81,28 @@ data class Utbetalingslinje(
     val kjoereplan: Kjoereplan,
 )
 
+/**
+ * Samme som [Utbetaling], men noen felt er ekskludert da de ikke benyttes
+ * av konsistensavstemmingen og krever mye prosessering for å lastes.
+ */
+data class UtbetalingForKonsistensavstemming(
+    val id: UUID,
+    val sakId: SakId,
+    val sakType: Saktype,
+    val behandlingId: BehandlingId,
+    val vedtakId: VedtakId,
+    val opprettet: Tidspunkt,
+    val endret: Tidspunkt,
+    val avstemmingsnoekkel: Tidspunkt,
+    val stoenadsmottaker: Foedselsnummer,
+    val saksbehandler: NavIdent,
+    val saksbehandlerEnhet: String? = null,
+    val attestant: NavIdent,
+    val attestantEnhet: String? = null,
+    val utbetalingslinjer: List<Utbetalingslinje>,
+    val utbetalingshendelser: List<Utbetalingshendelse>,
+)
+
 enum class Kjoereplan(private val oppdragVerdi: String) {
     // ref. https://confluence.adeo.no/display/OKSY/Inputdata+fra+fagrutinen+til+Oppdragssystemet:
     // "Bruk-kjoreplan gjør det mulig å velge om delytelsen skal beregnes/utbetales i henhold til kjøreplanen eller om

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/TestHelper.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/TestHelper.kt
@@ -23,6 +23,7 @@ import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Sak
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.SakId
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Utbetaling
+import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.UtbetalingForKonsistensavstemming
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.UtbetalingStatus
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Utbetalingshendelse
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Utbetalingslinje
@@ -126,6 +127,53 @@ fun oppdragMedFeiletKvittering(
             beskrMelding = "Beskrivelse"
         }
 }
+
+fun utbetalingKonsistensavstemming(
+    id: UUID = UUID.randomUUID(),
+    sakId: SakId = SakId(1),
+    sakType: Saktype? = Saktype.BARNEPENSJON,
+    vedtakId: Long = 1,
+    avstemmingsnoekkel: Tidspunkt = Tidspunkt.now(),
+    opprettet: Tidspunkt = Tidspunkt.now(),
+    utbetalingslinjeId: Long = 1L,
+    periodeFra: LocalDate = LocalDate.parse("2022-01-01"),
+    periodeTil: LocalDate? = null,
+    utbetalingslinjer: List<Utbetalingslinje> =
+        listOf(
+            utbetalingslinje(
+                id,
+                sakId,
+                utbetalingslinjeId,
+                periodeFra = periodeFra,
+                periodeTil = periodeTil,
+                opprettet = opprettet,
+            ),
+        ),
+    utbetalingshendelser: List<Utbetalingshendelse> =
+        listOf(
+            utbetalingshendelse(
+                utbetalingId = id,
+                tidspunkt = opprettet,
+            ),
+        ),
+    behandlingId: UUID = UUID.randomUUID(),
+) = UtbetalingForKonsistensavstemming(
+    id = id,
+    vedtakId = VedtakId(vedtakId),
+    behandlingId = BehandlingId(behandlingId, behandlingId.toUUID30()),
+    sakType = sakType ?: Saktype.BARNEPENSJON,
+    sakId = sakId,
+    opprettet = opprettet,
+    endret = Tidspunkt.now(),
+    avstemmingsnoekkel = avstemmingsnoekkel,
+    stoenadsmottaker = Foedselsnummer("12345678903"),
+    saksbehandler = NavIdent("12345678"),
+    saksbehandlerEnhet = "4819",
+    attestant = NavIdent("87654321"),
+    attestantEnhet = "4819",
+    utbetalingslinjer = utbetalingslinjer,
+    utbetalingshendelser = utbetalingshendelser,
+)
 
 fun utbetaling(
     id: UUID = UUID.randomUUID(),

--- a/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/KonsistensavstemmingServiceKtTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/utbetaling/avstemming/KonsistensavstemmingServiceKtTest.kt
@@ -12,7 +12,7 @@ import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.UtbetalingDao
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.UtbetalingslinjeId
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Utbetalingslinjetype
-import no.nav.etterlatte.utbetaling.utbetaling
+import no.nav.etterlatte.utbetaling.utbetalingKonsistensavstemming
 import no.nav.etterlatte.utbetaling.utbetalingslinje
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -30,7 +30,7 @@ internal class KonsistensavstemmingServiceKtTest {
 
     @Test
     fun `skal starte konsistensavstemming for Barnepensjon`() {
-        val utbetaling = utbetaling()
+        val utbetaling = utbetalingKonsistensavstemming()
         every {
             utbetalingDao.hentUtbetalingerForKonsistensavstemming(
                 any(),
@@ -151,11 +151,11 @@ internal class KonsistensavstemmingServiceKtTest {
             )
         } returns
             listOf(
-                utbetaling(
+                utbetalingKonsistensavstemming(
                     periodeFra = idag.minusDays(200),
                     periodeTil = idag.minusDays(50),
                 ),
-                utbetaling(
+                utbetalingKonsistensavstemming(
                     utbetalingslinjer =
                         listOf(
                             utbetalingslinje(periodeFra = idag.minusDays(300)),
@@ -206,9 +206,9 @@ internal class KonsistensavstemmingServiceKtTest {
 
         val opprettet = LocalDateTime.of(1997, 12, 1, 0, 0).toNorskTidspunkt()
 
-        val utbetaling1 = utbetaling(opprettet = opprettet, utbetalingslinjer = listOf(linje1))
-        val utbetaling2 = utbetaling(opprettet = opprettet, utbetalingslinjer = listOf(linje2))
-        val utbetaling3 = utbetaling(opprettet = opprettet, utbetalingslinjer = listOf(linje3))
+        val utbetaling1 = utbetalingKonsistensavstemming(opprettet = opprettet, utbetalingslinjer = listOf(linje1))
+        val utbetaling2 = utbetalingKonsistensavstemming(opprettet = opprettet, utbetalingslinjer = listOf(linje2))
+        val utbetaling3 = utbetalingKonsistensavstemming(opprettet = opprettet, utbetalingslinjer = listOf(linje3))
         val utbetalingsliste = listOf(utbetaling1, utbetaling2, utbetaling3)
 
         every { utbetalingDao.hentUtbetalingerForKonsistensavstemming(any(), any(), any()) } returns utbetalingsliste
@@ -285,9 +285,9 @@ internal class KonsistensavstemmingServiceKtTest {
 
         val opprettet = LocalDateTime.of(1997, 12, 1, 0, 0).toNorskTidspunkt()
 
-        val utbetaling1 = utbetaling(opprettet = opprettet, utbetalingslinjer = listOf(linje1))
-        val utbetaling2 = utbetaling(opprettet = opprettet, utbetalingslinjer = listOf(linje2))
-        val utbetaling3 = utbetaling(opprettet = opprettet, utbetalingslinjer = listOf(linje3))
+        val utbetaling1 = utbetalingKonsistensavstemming(opprettet = opprettet, utbetalingslinjer = listOf(linje1))
+        val utbetaling2 = utbetalingKonsistensavstemming(opprettet = opprettet, utbetalingslinjer = listOf(linje2))
+        val utbetaling3 = utbetalingKonsistensavstemming(opprettet = opprettet, utbetalingslinjer = listOf(linje3))
         val utbetalingsliste = listOf(utbetaling1, utbetaling2, utbetaling3)
 
         every { utbetalingDao.hentUtbetalingerForKonsistensavstemming(any(), any(), any()) } returns utbetalingsliste
@@ -367,10 +367,10 @@ internal class KonsistensavstemmingServiceKtTest {
                 type = Utbetalingslinjetype.OPPHOER,
             )
 
-        val utbetaling1 = utbetaling(opprettet = opprettet1, utbetalingslinjer = listOf(linje1))
-        val utbetaling2 = utbetaling(opprettet = opprettet2, utbetalingslinjer = listOf(linje2))
-        val utbetaling3 = utbetaling(opprettet = opprettet3, utbetalingslinjer = listOf(linje3))
-        val utbetaling4 = utbetaling(opprettet = opprettet4, utbetalingslinjer = listOf(linje4))
+        val utbetaling1 = utbetalingKonsistensavstemming(opprettet = opprettet1, utbetalingslinjer = listOf(linje1))
+        val utbetaling2 = utbetalingKonsistensavstemming(opprettet = opprettet2, utbetalingslinjer = listOf(linje2))
+        val utbetaling3 = utbetalingKonsistensavstemming(opprettet = opprettet3, utbetalingslinjer = listOf(linje3))
+        val utbetaling4 = utbetalingKonsistensavstemming(opprettet = opprettet4, utbetalingslinjer = listOf(linje4))
         val utbetalingsliste = listOf(utbetaling1, utbetaling2, utbetaling3, utbetaling4)
 
         every { utbetalingDao.hentUtbetalingerForKonsistensavstemming(any(), any(), any()) } returns utbetalingsliste
@@ -459,10 +459,10 @@ internal class KonsistensavstemmingServiceKtTest {
                 type = Utbetalingslinjetype.OPPHOER,
             )
 
-        val utbetaling1 = utbetaling(opprettet = opprettet, utbetalingslinjer = listOf(linje1))
-        val utbetaling2 = utbetaling(opprettet = opprettet, utbetalingslinjer = listOf(linje2))
-        val utbetaling3 = utbetaling(opprettet = opprettet, utbetalingslinjer = listOf(linje3))
-        val utbetaling4 = utbetaling(opprettet = opprettet, utbetalingslinjer = listOf(linje4))
+        val utbetaling1 = utbetalingKonsistensavstemming(opprettet = opprettet, utbetalingslinjer = listOf(linje1))
+        val utbetaling2 = utbetalingKonsistensavstemming(opprettet = opprettet, utbetalingslinjer = listOf(linje2))
+        val utbetaling3 = utbetalingKonsistensavstemming(opprettet = opprettet, utbetalingslinjer = listOf(linje3))
+        val utbetaling4 = utbetalingKonsistensavstemming(opprettet = opprettet, utbetalingslinjer = listOf(linje4))
         val utbetalingsliste = listOf(utbetaling1, utbetaling2, utbetaling3, utbetaling4)
 
         every { utbetalingDao.hentUtbetalingerForKonsistensavstemming(any(), any(), any()) } returns utbetalingsliste
@@ -531,8 +531,8 @@ internal class KonsistensavstemmingServiceKtTest {
                 type = Utbetalingslinjetype.OPPHOER,
             )
 
-        val utbetaling1 = utbetaling(opprettet = opprettet, utbetalingslinjer = listOf(linje1))
-        val utbetaling2 = utbetaling(opprettet = opprettet, utbetalingslinjer = listOf(linje2))
+        val utbetaling1 = utbetalingKonsistensavstemming(opprettet = opprettet, utbetalingslinjer = listOf(linje1))
+        val utbetaling2 = utbetalingKonsistensavstemming(opprettet = opprettet, utbetalingslinjer = listOf(linje2))
         val utbetalingsliste = listOf(utbetaling1, utbetaling2)
 
         every { utbetalingDao.hentUtbetalingerForKonsistensavstemming(any(), any(), any()) } returns utbetalingsliste
@@ -606,13 +606,13 @@ internal class KonsistensavstemmingServiceKtTest {
         val sak1 = SakId(1L)
         val sak2 = SakId(2L)
         val utbetaling1 =
-            utbetaling(sakId = sak1, opprettet = opprettet1, utbetalingslinjer = listOf(linje1Sak1))
+            utbetalingKonsistensavstemming(sakId = sak1, opprettet = opprettet1, utbetalingslinjer = listOf(linje1Sak1))
         val utbetaling2 =
-            utbetaling(sakId = sak1, opprettet = opprettet2, utbetalingslinjer = listOf(linje2Sak1))
+            utbetalingKonsistensavstemming(sakId = sak1, opprettet = opprettet2, utbetalingslinjer = listOf(linje2Sak1))
         val utbetaling3 =
-            utbetaling(sakId = sak2, opprettet = opprettet3, utbetalingslinjer = listOf(linje1Sak2))
+            utbetalingKonsistensavstemming(sakId = sak2, opprettet = opprettet3, utbetalingslinjer = listOf(linje1Sak2))
         val utbetaling4 =
-            utbetaling(sakId = sak2, opprettet = opprettet2, utbetalingslinjer = listOf(linje2Sak2))
+            utbetalingKonsistensavstemming(sakId = sak2, opprettet = opprettet2, utbetalingslinjer = listOf(linje2Sak2))
         val utbetalingsliste = listOf(utbetaling1, utbetaling2, utbetaling3, utbetaling4)
 
         every { utbetalingDao.hentUtbetalingerForKonsistensavstemming(any(), any(), any()) } returns utbetalingsliste


### PR DESCRIPTION
For en **_massiv_** ytelsegevinst, ved at man 
1) unngår å hente felter som ikke jobben ikke benytter fra databasen (vedtak/oppdrag/kvittering)
2) og dermed slipper kostbar deserialisering

Har bare kopiert eksisterende med alt det det medfører i stedet og fjernet det som ikke trengs. Jeg har sett litt på å unngå duplisering, men ser ikke helt noen løsning som ikke medfører noe annet enn mer kompleksitet uten noen særlig annen gevinst. Typ kotlin lazy, hierarkier og annet, men det krever en del endringer så jeg mener det er feil vei å gå. 
**Edit**: Om folk synes at de ekskluderte verdiene kan gjøres `nullable` i den opprinnelige typen, så er det forsåvidt en grei løsning tenker jeg, selv om man fremdeles bør ha en egen spørring slik at DB/nett slipper å hente dataene.

Lokale kjøringer med db i docker, ca 5000 rader i utbetalingstabellen.

- Før endring
![image](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/8087437/0b074a5b-7ba7-40f1-8aac-836c47ec998f)

- Etter endring
![image](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/8087437/65b0732b-1adf-4622-a28b-d4bfb88ed415)
