### PR TITLE
Justert opp memory på en del apps

### DIFF
--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -54,7 +54,7 @@ spec:
   resources:
     requests:
       cpu: 50m
-      memory: 384Mi
+      memory: 448Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 2

--- a/apps/etterlatte-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-behandling/.nais/prod.yaml
@@ -59,7 +59,7 @@ spec:
   resources:
     requests:
       cpu: 50m
-      memory: 384Mi
+      memory: 448Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 4

--- a/apps/etterlatte-beregning/.nais/dev.yaml
+++ b/apps/etterlatte-beregning/.nais/dev.yaml
@@ -24,7 +24,7 @@ spec:
   resources:
     requests:
       cpu: 25m
-      memory: 320Mi
+      memory: 384Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 2

--- a/apps/etterlatte-beregning/.nais/prod.yaml
+++ b/apps/etterlatte-beregning/.nais/prod.yaml
@@ -22,7 +22,7 @@ spec:
   resources:
     requests:
       cpu: 25m
-      memory: 320Mi
+      memory: 384Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 4

--- a/apps/etterlatte-brev-api/.nais/dev.yaml
+++ b/apps/etterlatte-brev-api/.nais/dev.yaml
@@ -49,7 +49,7 @@ spec:
       memory: 640Mi
     requests:
       cpu: 20m
-      memory: 320Mi
+      memory: 384Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-brev-api/.nais/prod.yaml
+++ b/apps/etterlatte-brev-api/.nais/prod.yaml
@@ -59,7 +59,7 @@ spec:
       memory: 640Mi
     requests:
       cpu: 20m
-      memory: 320Mi
+      memory: 384Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-grunnlag/.nais/dev.yaml
+++ b/apps/etterlatte-grunnlag/.nais/dev.yaml
@@ -53,7 +53,7 @@ spec:
   resources:
     requests:
       cpu: 50m
-      memory: 320Mi
+      memory: 384Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 2

--- a/apps/etterlatte-grunnlag/.nais/prod.yaml
+++ b/apps/etterlatte-grunnlag/.nais/prod.yaml
@@ -68,7 +68,7 @@ spec:
   resources:
     requests:
       cpu: 50m
-      memory: 320Mi
+      memory: 384Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 4

--- a/apps/etterlatte-hendelser-pdl/.nais/dev.yaml
+++ b/apps/etterlatte-hendelser-pdl/.nais/dev.yaml
@@ -26,6 +26,7 @@ spec:
   resources:
     requests:
       cpu: 20m
+      memory: 384Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-hendelser-pdl/.nais/prod.yaml
+++ b/apps/etterlatte-hendelser-pdl/.nais/prod.yaml
@@ -26,6 +26,7 @@ spec:
   resources:
     requests:
       cpu: 20m
+      memory: 384Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -8,8 +8,6 @@ import io.ktor.server.engine.applicationEngineEnvironment
 import io.ktor.server.engine.connector
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.routing.routing
-import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics
-import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
 import no.nav.etterlatte.kafka.startLytting
 import no.nav.etterlatte.libs.ktor.healthApi
 import no.nav.etterlatte.libs.ktor.metricsModule
@@ -32,13 +30,7 @@ class Server(private val context: ApplicationContext) {
                         routing {
                             healthApi()
                         }
-                        metricsModule(
-                            additionalMetrics =
-                                listOf(
-                                    JvmGcMetrics(),
-                                    JvmThreadMetrics(),
-                                ),
-                        )
+                        metricsModule()
                     }
                     connector { port = context.httpPort }
                 },

--- a/apps/etterlatte-pdltjenester/.nais/dev.yaml
+++ b/apps/etterlatte-pdltjenester/.nais/dev.yaml
@@ -28,7 +28,7 @@ spec:
   resources:
     requests:
       cpu: 25m
-      memory: 320Mi
+      memory: 384Mi
   replicas:
     min: 1
     max: 1

--- a/apps/etterlatte-pdltjenester/.nais/prod.yaml
+++ b/apps/etterlatte-pdltjenester/.nais/prod.yaml
@@ -26,7 +26,7 @@ spec:
   resources:
     requests:
       cpu: 25m
-      memory: 320Mi
+      memory: 384Mi
   replicas:
     min: 1
     max: 1

--- a/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
@@ -28,10 +28,10 @@ spec:
     enabled: true
   resources:
     limits:
-      memory: 256Mi
+      memory: 640Mi
     requests:
       cpu: 10m
-      memory: 192Mi
+      memory: 320Mi
   replicas:
     min: 1
     max: 2

--- a/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
@@ -28,10 +28,10 @@ spec:
     enabled: true
   resources:
     limits:
-      memory: 256Mi
+      memory: 640Mi
     requests:
       cpu: 10m
-      memory: 192Mi
+      memory: 320Mi
   replicas:
     min: 1
     max: 2

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -6,8 +6,6 @@ import io.ktor.server.config.HoconApplicationConfig
 import io.ktor.server.engine.applicationEngineEnvironment
 import io.ktor.server.engine.connector
 import io.ktor.server.engine.embeddedServer
-import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics
-import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
 import no.nav.etterlatte.libs.common.Miljoevariabler
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.ktor.restModule
@@ -40,11 +38,6 @@ class Server(applicationContext: ApplicationContext) {
                         restModule(
                             sikkerLogg,
                             withMetrics = true,
-                            additionalMetrics =
-                                listOf(
-                                    JvmGcMetrics(),
-                                    JvmThreadMetrics(),
-                                ),
                         ) {
                             samordningVedtakRoute(
                                 samordningVedtakService = applicationContext.samordningVedtakService,

--- a/apps/etterlatte-statistikk/.nais/dev.yaml
+++ b/apps/etterlatte-statistikk/.nais/dev.yaml
@@ -30,6 +30,7 @@ spec:
   resources:
     requests:
       cpu: 25m
+      memory: 384Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-statistikk/.nais/prod.yaml
+++ b/apps/etterlatte-statistikk/.nais/prod.yaml
@@ -45,6 +45,7 @@ spec:
   resources:
     requests:
       cpu: 25m
+      memory: 384Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-trygdetid/.nais/dev.yaml
+++ b/apps/etterlatte-trygdetid/.nais/dev.yaml
@@ -47,7 +47,7 @@ spec:
   resources:
     requests:
       cpu: 25m
-      memory: 320Mi
+      memory: 384Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 4

--- a/apps/etterlatte-trygdetid/.nais/prod.yaml
+++ b/apps/etterlatte-trygdetid/.nais/prod.yaml
@@ -57,7 +57,7 @@ spec:
   resources:
     requests:
       cpu: 25m
-      memory: 320Mi
+      memory: 384Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 4

--- a/apps/etterlatte-trygdetid/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/Application.kt
@@ -5,6 +5,8 @@ import io.ktor.server.config.HoconApplicationConfig
 import io.ktor.server.engine.applicationEngineEnvironment
 import io.ktor.server.engine.connector
 import io.ktor.server.engine.embeddedServer
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
 import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.database.migrate
@@ -36,7 +38,15 @@ class Server(private val context: ApplicationContext) {
                     applicationEngineEnvironment {
                         config = HoconApplicationConfig(context.config)
                         module {
-                            restModule(sikkerLogg, withMetrics = true) {
+                            restModule(
+                                sikkerLogg,
+                                withMetrics = true,
+                                additionalMetrics =
+                                    listOf(
+                                        JvmGcMetrics(),
+                                        JvmThreadMetrics(),
+                                    ),
+                            ) {
                                 trygdetid(trygdetidService, behandlingKlient)
                                 trygdetidV2(trygdetidService, behandlingKlient)
                                 avtale(avtaleService, behandlingKlient)

--- a/apps/etterlatte-trygdetid/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/Application.kt
@@ -5,8 +5,6 @@ import io.ktor.server.config.HoconApplicationConfig
 import io.ktor.server.engine.applicationEngineEnvironment
 import io.ktor.server.engine.connector
 import io.ktor.server.engine.embeddedServer
-import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics
-import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
 import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.database.migrate
@@ -41,11 +39,6 @@ class Server(private val context: ApplicationContext) {
                             restModule(
                                 sikkerLogg,
                                 withMetrics = true,
-                                additionalMetrics =
-                                    listOf(
-                                        JvmGcMetrics(),
-                                        JvmThreadMetrics(),
-                                    ),
                             ) {
                                 trygdetid(trygdetidService, behandlingKlient)
                                 trygdetidV2(trygdetidService, behandlingKlient)

--- a/apps/etterlatte-utbetaling/.nais/dev.yaml
+++ b/apps/etterlatte-utbetaling/.nais/dev.yaml
@@ -38,7 +38,7 @@ spec:
   resources:
     requests:
       cpu: 40m
-      memory: 320Mi
+      memory: 384Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-utbetaling/.nais/prod.yaml
+++ b/apps/etterlatte-utbetaling/.nais/prod.yaml
@@ -49,7 +49,7 @@ spec:
   resources:
     requests:
       cpu: 40m
-      memory: 320Mi
+      memory: 384Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
@@ -50,7 +50,7 @@ spec:
       memory: 640Mi
     requests:
       cpu: 20m
-      memory: 320Mi
+      memory: 384Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
@@ -60,7 +60,7 @@ spec:
       memory: 640Mi
     requests:
       cpu: 20m
-      memory: 320Mi
+      memory: 384Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 1

--- a/apps/etterlatte-vilkaarsvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vilkaarsvurdering/.nais/dev.yaml
@@ -47,9 +47,9 @@ spec:
   resources:
     requests:
       cpu: 25m
-      memory: 256Mi
+      memory: 320Mi
     limits:
-      memory: 512Mi
+      memory: 640Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 4

--- a/apps/etterlatte-vilkaarsvurdering/.nais/prod.yaml
+++ b/apps/etterlatte-vilkaarsvurdering/.nais/prod.yaml
@@ -57,9 +57,9 @@ spec:
   resources:
     requests:
       cpu: 25m
-      memory: 256Mi
+      memory: 320Mi
     limits:
-      memory: 512Mi
+      memory: 640Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 4

--- a/libs/etterlatte-ktor/src/main/kotlin/MetricsModule.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/MetricsModule.kt
@@ -9,7 +9,9 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.micrometer.core.instrument.Clock
 import io.micrometer.core.instrument.binder.MeterBinder
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics
 import io.micrometer.core.instrument.binder.system.UptimeMetrics
@@ -22,7 +24,9 @@ fun Application.metricsModule(additionalMetrics: List<MeterBinder> = emptyList()
         registry = Metrikker.registrySaksbehandling
         meterBinders = listOf(
             LogbackMetrics(),
+            JvmGcMetrics(),
             JvmMemoryMetrics(),
+            JvmThreadMetrics(),
             ProcessorMetrics(),
             UptimeMetrics(),
         ) + additionalMetrics


### PR DESCRIPTION
Ser ut som disse i større grad nå trenger litt mer. Om det skyldes mer bruk, andre forhold (konsekvenser av oppdatering til Java 21?) eller annet er ikke jeg sikker på. Har også lagt til et par metrikker til som default, da noe av bakgrunnen for PRen er hendelsen med konsistensavstemming i `utbetaling`. Der var nok en del av problemet GC som aldri tok slutt pga masse data i minnet fordi for lite minne, cpu. Men ikke alle appene gir ut disse metrikkene p.t.