### PR TITLE
Reduserer antall detaljer pr avstemmingsmelding

### DIFF
--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingJob.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingJob.kt
@@ -2,9 +2,9 @@ package no.nav.etterlatte.utbetaling.avstemming
 
 import no.nav.etterlatte.jobs.LoggerInfo
 import no.nav.etterlatte.jobs.fixedRateCancellableTimer
-import no.nav.etterlatte.libs.common.tidspunkt.norskKlokke
 import no.nav.etterlatte.libs.jobs.LeaderElection
 import no.nav.etterlatte.sikkerLogg
+import no.nav.etterlatte.utbetaling.common.januar
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
 import org.slf4j.LoggerFactory
 import java.time.Clock
@@ -55,7 +55,11 @@ class KonsistensavstemmingJob(
         private val log = LoggerFactory.getLogger(this::class.java)
 
         fun run() {
-            val idag = LocalDate.now(clock.norskKlokke())
+            // val idag = LocalDate.now(clock.norskKlokke())
+            val idag =
+                4.januar(
+                    2024,
+                ) // TODO quick-fiks for å sende feilet avstemming bakover i tid - krever at forrige avstemming er slettet
             kjoereplan.find { dato -> dato == idag }?.let {
                 if (leaderElection.isLeader()) {
                     log.info("Starter $jobbNavn")

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingJob.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/avstemming/KonsistensavstemmingJob.kt
@@ -2,9 +2,9 @@ package no.nav.etterlatte.utbetaling.avstemming
 
 import no.nav.etterlatte.jobs.LoggerInfo
 import no.nav.etterlatte.jobs.fixedRateCancellableTimer
+import no.nav.etterlatte.libs.common.tidspunkt.norskKlokke
 import no.nav.etterlatte.libs.jobs.LeaderElection
 import no.nav.etterlatte.sikkerLogg
-import no.nav.etterlatte.utbetaling.common.januar
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
 import org.slf4j.LoggerFactory
 import java.time.Clock
@@ -55,11 +55,7 @@ class KonsistensavstemmingJob(
         private val log = LoggerFactory.getLogger(this::class.java)
 
         fun run() {
-            // val idag = LocalDate.now(clock.norskKlokke())
-            val idag =
-                4.januar(
-                    2024,
-                ) // TODO quick-fiks for å sende feilet avstemming bakover i tid - krever at forrige avstemming er slettet
+            val idag = LocalDate.now(clock.norskKlokke())
             kjoereplan.find { dato -> dato == idag }?.let {
                 if (leaderElection.isLeader()) {
                     log.info("Starter $jobbNavn")

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/common/Utils.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/common/Utils.kt
@@ -65,7 +65,7 @@ fun UUID.toUUID30() = this.toString().replace("-", "").substring(0, 30).let { UU
 
 data class UUID30(val value: String)
 
-const val ANTALL_DETALJER_PER_AVSTEMMINGMELDING_OPPDRAG = 70
+const val ANTALL_DETALJER_PER_AVSTEMMINGMELDING_OPPDRAG = 30
 
 val tidsstempelDatoOppdrag = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 val tidsstempelTimeOppdrag = DateTimeFormatter.ofPattern("yyyyMMddHH")

--- a/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/config/ApplicationContext.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/utbetaling/config/ApplicationContext.kt
@@ -37,8 +37,11 @@ import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.UtbetalingService
 import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helse.rapids_rivers.RapidsConnection
 import rapidsandrivers.getRapidEnv
+import java.time.Clock
 import java.time.Duration
+import java.time.Instant
 import java.time.LocalTime
+import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 
 class ApplicationContext(
@@ -137,7 +140,8 @@ class ApplicationContext(
             leaderElection,
             initialDelay = Duration.of(2, ChronoUnit.MINUTES).toMillis(),
             periode = Duration.of(4, ChronoUnit.HOURS),
-            clock = clock,
+            // clock = clock,
+            clock = Clock.fixed(Instant.parse("2024-01-04T03:00:00.00Z"), ZoneOffset.UTC), // TODO fjern denne når ny avstemming er utført
             saktype = Saktype.BARNEPENSJON,
         )
 

--- a/apps/etterlatte-utbetaling/src/main/resources/db/migration/V16__sletter_konsistensavstemming_som_feilet.sql
+++ b/apps/etterlatte-utbetaling/src/main/resources/db/migration/V16__sletter_konsistensavstemming_som_feilet.sql
@@ -1,0 +1,2 @@
+-- Sletter avstemming som feilet pga størrelse på meldingene som sendes over
+DELETE FROM avstemming WHERE id = 'C7NWTARVQbe7iX0mJ6T8uw';


### PR DESCRIPTION
- Justerer ned antall detaljer pr avstemmingsmelding for å komme under 50k pr melding
- Fjerner eksisterende konsistensavstemming som oppdrag ikke kunne lese inn pga størrelse på meldingene. 
- Hardkoder dato for når avstemmingen skal kjøres. Ikke så pent, men bør fungere 😛 

En oppfølging på denne er å sette tilbake til riktig dato for avstemmingen.