### PR TITLE
Sperrer for opprettelse av vedtaksbrev i feil behandlingsstatus

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
@@ -83,6 +83,12 @@ class VedtaksbrevService(
             "Vedtaksbrev finnes allerede på behandling (id=$behandlingId) og kan ikke opprettes på nytt"
         }
 
+        brevdataFacade.hentBehandling(behandlingId, brukerTokenInfo).status.let { status ->
+            require(status.kanEndres()) {
+                "Behandling (id=$behandlingId) har status $status og kan ikke opprette vedtaksbrev"
+            }
+        }
+
         val generellBrevData =
             retryOgPakkUt { brevdataFacade.hentGenerellBrevData(sakId, behandlingId, brukerTokenInfo) }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
@@ -275,6 +275,11 @@ class BrevdataFacade(
 
         return trygdetidService.finnTrygdetidsgrunnlag(behandlingId, beregning, brukerTokenInfo)
     }
+
+    suspend fun hentBehandling(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ) = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
 }
 
 fun hentBenyttetTrygdetidOgProratabroek(beregningsperiode: CommonBeregningsperiode): Pair<Int, IntBroek?> {


### PR DESCRIPTION
Vi har sett at det i mange tilfeller opprettes vedtaksbrev automatisk når saksbehandler går inn på et iverksatt vedtak, og det av en eller annen grunn ikke har blitt opprettet i den automatiske behandlingen.

Dersom det ikke ligger noen vedtaksbrev der fra før av (f. eks pga. feil under migrerte eller omregnede saker), så vil det opprettes et nytt dersom saksbehandler går til brevsiden i Gjenny. Det er uheldig at brevet kan opprettes på en behandling som er iverksatt, for det vil heller aldri bli sendt, og er misvisende.

Tanken er å kaste feil å lene seg på feilhåndteringen i frontend, da dette ikke er noe som normalt skal skje.