### PR TITLE
EY-3185 Samordning - vedtak og etterbetaling

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakBehandlingService.kt
@@ -302,7 +302,7 @@ class VedtakBehandlingService(
                 behandlingId = behandlingId,
             )
 
-        val isEtterbetaling = behandlingKlient.harEtterbetaling(behandlingId, brukerTokenInfo)
+        val isEtterbetaling = erVedtakMedEtterbetaling(tilSamordningVedtakLocal, repository)
 
         if (!samKlient.samordneVedtak(tilSamordningVedtakLocal, isEtterbetaling, brukerTokenInfo)) {
             logger.info("Svar fra samordning: ikke nødvendig å vente for vedtak=${vedtak.id} [behandlingId=$behandlingId]")

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakEtterbetaling.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakEtterbetaling.kt
@@ -1,0 +1,53 @@
+package no.nav.etterlatte.vedtaksvurdering
+
+import no.nav.etterlatte.libs.common.tidspunkt.norskKlokke
+import no.nav.etterlatte.libs.common.vedtak.Periode
+import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
+import java.time.Clock
+import java.time.Month
+import java.time.YearMonth
+
+val WAY_INTO_THE_FUTURE: YearMonth = YearMonth.of(2999, Month.DECEMBER)
+
+internal fun erVedtakMedEtterbetaling(
+    vedtakSomBehandles: Vedtak,
+    vedtaksvurderingRepository: VedtaksvurderingRepository,
+    clock: Clock = norskKlokke(),
+): Boolean {
+    when (val innhold = vedtakSomBehandles.innhold) {
+        is VedtakBehandlingInnhold -> {
+            val now = YearMonth.now(clock)
+
+            if (innhold.virkningstidspunkt < now) {
+                val ferdigstilteVedtak = vedtaksvurderingRepository.hentFerdigstilteVedtak(vedtakSomBehandles.soeker)
+                val tidligereVedtakTidslinje = Vedtakstidslinje(ferdigstilteVedtak).sammenstill(YearMonth.of(2024, Month.JANUARY))
+                val tidligereUtbetalingsperioder =
+                    tidligereVedtakTidslinje
+                        .filter { it.innhold is VedtakBehandlingInnhold }
+                        .flatMap { (it.innhold as VedtakBehandlingInnhold).utbetalingsperioder }
+                        .filter { it.periode.fom < now }
+
+                // Finn tidligere utbetalingsperiode som matcher ny(e)
+                // og sjekk om det er endring i beløp, hvis ny er høyere så er det etterbetaling
+                return innhold.utbetalingsperioder
+                    .filter { it.periode.fom < now }
+                    .associateWith { tidligereUtbetalingsperioder.find { up -> up.overlapper(it) } }
+                    .any { entry -> entry.value?.beloep?.compareTo(entry.key.beloep) == -1 }
+            }
+            return false
+        }
+        is VedtakTilbakekrevingInnhold -> throw IllegalArgumentException("Ikke aktuelt for tilbakekreving")
+    }
+}
+
+internal fun Utbetalingsperiode.overlapper(other: Utbetalingsperiode): Boolean {
+    return periode.overlapper(other.periode)
+}
+
+internal fun Periode.overlapper(other: Periode): Boolean {
+    val thisTomSafe = this.tom ?: WAY_INTO_THE_FUTURE
+    val thatTomSafe = other.tom ?: WAY_INTO_THE_FUTURE
+    return this.fom == other.fom ||
+        this.tom == other.tom ||
+        other.fom.isBefore(thisTomSafe) && thatTomSafe.isAfter(this.fom)
+}

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakEtterbetaling.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakEtterbetaling.kt
@@ -9,6 +9,8 @@ import java.time.YearMonth
 
 val WAY_INTO_THE_FUTURE: YearMonth = YearMonth.of(2999, Month.DECEMBER)
 
+val OMS_START_YTELSE: YearMonth = YearMonth.of(2024, Month.JANUARY)
+
 internal fun erVedtakMedEtterbetaling(
     vedtakSomBehandles: Vedtak,
     vedtaksvurderingRepository: VedtaksvurderingRepository,
@@ -20,7 +22,7 @@ internal fun erVedtakMedEtterbetaling(
 
             if (innhold.virkningstidspunkt < now) {
                 val ferdigstilteVedtak = vedtaksvurderingRepository.hentFerdigstilteVedtak(vedtakSomBehandles.soeker)
-                val tidligereVedtakTidslinje = Vedtakstidslinje(ferdigstilteVedtak).sammenstill(YearMonth.of(2024, Month.JANUARY))
+                val tidligereVedtakTidslinje = Vedtakstidslinje(ferdigstilteVedtak).sammenstill(OMS_START_YTELSE)
                 val tidligereUtbetalingsperioder =
                     tidligereVedtakTidslinje
                         .filter { it.innhold is VedtakBehandlingInnhold }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakEtterbetaling.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/VedtakEtterbetaling.kt
@@ -32,13 +32,15 @@ internal fun erVedtakMedEtterbetaling(
                 return innhold.utbetalingsperioder
                     .filter { it.periode.fom < now }
                     .associateWith { tidligereUtbetalingsperioder.find { up -> up.overlapper(it) } }
-                    .any { entry -> entry.value?.beloep?.compareTo(entry.key.beloep) == -1 }
+                    .any { entry -> entry.value?.beloepErMindreEnn(entry.key) ?: true }
             }
             return false
         }
         is VedtakTilbakekrevingInnhold -> throw IllegalArgumentException("Ikke aktuelt for tilbakekreving")
     }
 }
+
+internal fun Utbetalingsperiode.beloepErMindreEnn(that: Utbetalingsperiode) = this.beloep?.compareTo(that.beloep) == -1
 
 internal fun Utbetalingsperiode.overlapper(other: Utbetalingsperiode): Boolean {
     return periode.overlapper(other.periode)

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/vedtaksvurdering/klienter/BehandlingKlient.kt
@@ -98,11 +98,6 @@ interface BehandlingKlient : BehandlingTilgangsSjekk, SakTilgangsSjekk {
         oppgaveTilAttestering: OppgaveIntern,
         brukerTokenInfo: BrukerTokenInfo,
     ): Boolean
-
-    suspend fun harEtterbetaling(
-        behandlingId: UUID,
-        brukerTokenInfo: BrukerTokenInfo,
-    ): Boolean
 }
 
 class BehandlingKlientException(override val message: String, override val cause: Throwable? = null) :
@@ -445,25 +440,4 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
             BehandlingStatus.RETURNERT -> "returner"
             else -> throw BehandlingKlientException("Ugyldig status ${status.name}")
         }
-
-    override suspend fun harEtterbetaling(
-        behandlingId: UUID,
-        brukerTokenInfo: BrukerTokenInfo,
-    ): Boolean {
-        logger.info("Henter eventuell etterbetaling for behandlingId=$behandlingId")
-
-        val resource = Resource(clientId = clientId, url = "$resourceUrl/api/behandling/$behandlingId/info/etterbetaling")
-        val response = downstreamResourceClient.get(resource = resource, brukerTokenInfo = brukerTokenInfo)
-
-        return response.mapBoth(
-            success = { res -> res.response != null },
-            failure = {
-                logger.info(
-                    "Feil ved henting av etterbetaling, behandlingId=$behandlingId",
-                    it.cause,
-                )
-                false
-            },
-        )
-    }
 }

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/SamordningsvedtakRouteTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/SamordningsvedtakRouteTest.kt
@@ -12,7 +12,6 @@ import io.ktor.server.testing.testApplication
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.confirmVerified
 import io.mockk.mockk
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -56,7 +55,6 @@ class SamordningsvedtakRouteTest {
 
     @AfterEach
     fun afterEach() {
-        confirmVerified()
         clearAllMocks()
     }
 

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtakBehandlingServiceTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtakBehandlingServiceTest.kt
@@ -30,6 +30,7 @@ import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
 import no.nav.etterlatte.libs.common.beregning.Beregningstype
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.oppgave.VedtakEndringDTO
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.rapidsandrivers.SKAL_SENDE_BREV
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -1128,11 +1129,17 @@ internal class VedtakBehandlingServiceTest {
         val behandlingId = randomUUID()
 
         coEvery { behandlingKlientMock.tilSamordning(behandlingId, attestant, any()) } returns true
-        coEvery { behandlingKlientMock.harEtterbetaling(behandlingId, attestant) } returns false
         coEvery { samKlientMock.samordneVedtak(any(), false, attestant) } returns true
 
         runBlocking {
-            repository.opprettVedtak(opprettVedtak(behandlingId = behandlingId, status = VedtakStatus.ATTESTERT))
+            repository.opprettVedtak(
+                opprettVedtak(
+                    behandlingId = behandlingId,
+                    status = VedtakStatus.ATTESTERT,
+                    soeker = Folkeregisteridentifikator.of("08815997000"),
+                ),
+            )
+
             val oppdatertVedtak = service.tilSamordningVedtak(behandlingId, attestant)
 
             oppdatertVedtak.vedtak.status shouldBe VedtakStatus.TIL_SAMORDNING
@@ -1146,7 +1153,6 @@ internal class VedtakBehandlingServiceTest {
         val behandlingId = randomUUID()
 
         coEvery { behandlingKlientMock.tilSamordning(behandlingId, attestant, any()) } returns true
-        coEvery { behandlingKlientMock.harEtterbetaling(behandlingId, attestant) } returns false
         coEvery { samKlientMock.samordneVedtak(any(), false, attestant) } returns false
         coEvery { behandlingKlientMock.samordnet(any(), any(), any()) } returns true
         coEvery { trygdetidKlientMock.hentTrygdetid(any(), any()) } returns trygdetidDtoUtenDiff()

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtakEtterbetalingKtTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/vedtaksvurdering/VedtakEtterbetalingKtTest.kt
@@ -1,0 +1,194 @@
+package no.nav.etterlatte.vedtaksvurdering
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.norskTidssone
+import no.nav.etterlatte.libs.common.vedtak.Periode
+import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
+import no.nav.etterlatte.libs.common.vedtak.UtbetalingsperiodeType
+import no.nav.etterlatte.libs.common.vedtak.VedtakFattet
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import vedtaksvurdering.vedtak
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.Month
+import java.time.YearMonth
+import kotlin.random.Random
+
+class VedtakEtterbetalingKtTest {
+    private val januar2024 = YearMonth.of(2024, Month.JANUARY)
+    private val februar2024 = YearMonth.of(2024, Month.FEBRUARY)
+    private val mars2024 = YearMonth.of(2024, Month.MARCH)
+
+    private val klokkeMars2023: Clock = Clock.fixed(Instant.parse("2024-03-06T10:00:00Z"), norskTidssone)
+
+    private val repository = mockk<VedtaksvurderingRepository>()
+
+    @Test
+    fun `ikke etterbetaling, ingen tidligere periode`() {
+        val vedtak = vedtak(virkningstidspunkt = februar2024)
+
+        every { repository.hentFerdigstilteVedtak(vedtak.soeker) } returns emptyList()
+
+        val resultat = erVedtakMedEtterbetaling(vedtak, repository, klokkeMars2023)
+
+        verify { repository.hentFerdigstilteVedtak(vedtak.soeker) }
+
+        resultat shouldBe false
+    }
+
+    @Test
+    fun `ikke etterbetaling, tidligere periode men samme beloep`() {
+        val nyttVedtak =
+            aVedtakMedUtbetalingsperiode(
+                virkningstidspunkt = februar2024,
+                beloep = 2500,
+                fattetTidspunkt = "2024-01-29T14:05:00Z",
+            )
+
+        every { repository.hentFerdigstilteVedtak(nyttVedtak.soeker) } returns
+            listOf(
+                aVedtakMedUtbetalingsperiode(
+                    virkningstidspunkt = januar2024,
+                    beloep = 2500,
+                    fattetTidspunkt = "2024-01-26T11:25:00Z",
+                ),
+            )
+
+        val resultat = erVedtakMedEtterbetaling(nyttVedtak, repository, klokkeMars2023)
+
+        resultat shouldBe false
+    }
+
+    @Test
+    fun `etterbetaling - ny periode har hoeyere beloep`() {
+        val nyttVedtak =
+            aVedtakMedUtbetalingsperiode(
+                virkningstidspunkt = februar2024,
+                beloep = 3500,
+                fattetTidspunkt = "2024-01-26T11:25:00Z",
+            )
+
+        every { repository.hentFerdigstilteVedtak(nyttVedtak.soeker) } returns
+            listOf(
+                aVedtakMedUtbetalingsperiode(
+                    virkningstidspunkt = januar2024,
+                    beloep = 2500,
+                    fattetTidspunkt = "2023-12-16T13:30:00Z",
+                ),
+            )
+
+        val resultat = erVedtakMedEtterbetaling(nyttVedtak, repository, klokkeMars2023)
+
+        resultat shouldBe true
+    }
+
+    @Test
+    fun `etterbetaling - flere tidligere perioder, ny periode har hoeyere beloep`() {
+        val nyttVedtak =
+            aVedtakMedUtbetalingsperiode(
+                virkningstidspunkt = februar2024,
+                beloep = 3500,
+                fattetTidspunkt = "2024-03-06T13:30:00Z",
+            )
+
+        every { repository.hentFerdigstilteVedtak(nyttVedtak.soeker) } returns
+            listOf(
+                aVedtakMedUtbetalingsperiode(
+                    virkningstidspunkt = januar2024,
+                    beloep = 2000,
+                    fattetTidspunkt = "2024-01-07T13:30:00Z",
+                ),
+                aVedtakMedUtbetalingsperiode(
+                    virkningstidspunkt = februar2024,
+                    beloep = 2500,
+                    fattetTidspunkt = "2024-01-26T14:00:00Z",
+                ),
+                aVedtakMedUtbetalingsperiode(
+                    virkningstidspunkt = mars2024,
+                    beloep = 3000,
+                    fattetTidspunkt = "2024-03-05T10:00:00Z",
+                ),
+            )
+
+        val resultat = erVedtakMedEtterbetaling(nyttVedtak, repository, klokkeMars2023)
+
+        resultat shouldBe true
+    }
+
+    private fun aVedtakMedUtbetalingsperiode(
+        virkningstidspunkt: YearMonth,
+        beloep: Long,
+        fattetTidspunkt: String,
+    ) = vedtak(
+        virkningstidspunkt = virkningstidspunkt,
+        vedtakFattet =
+            VedtakFattet(
+                "Z01",
+                "1234",
+                Tidspunkt.parse(fattetTidspunkt),
+            ),
+        utbetalingsperioder =
+            listOf(
+                Utbetalingsperiode(
+                    id = Random.nextLong(),
+                    periode = Periode(virkningstidspunkt, null),
+                    beloep = BigDecimal.valueOf(beloep),
+                    type = UtbetalingsperiodeType.UTBETALING,
+                ),
+            ),
+    )
+
+    @Nested
+    internal inner class PeriodeOverlapp {
+        @Test
+        fun `ingen overlapp - lukkede perioder`() {
+            val periodeA = Periode(YearMonth.of(2024, Month.JANUARY), YearMonth.of(2024, Month.FEBRUARY))
+            val periodeB = Periode(YearMonth.of(2024, Month.MARCH), YearMonth.of(2024, Month.APRIL))
+
+            periodeA.overlapper(periodeB) shouldBe false
+            periodeB.overlapper(periodeA) shouldBe false
+        }
+
+        @Test
+        fun `ingen overlapp - siste periode er aapen`() {
+            val periodeA = Periode(YearMonth.of(2024, Month.JANUARY), YearMonth.of(2024, Month.FEBRUARY))
+            val periodeB = Periode(YearMonth.of(2024, Month.MARCH), null)
+
+            periodeA.overlapper(periodeB) shouldBe false
+            periodeB.overlapper(periodeA) shouldBe false
+        }
+
+        @Test
+        fun `overlapp - foerste periode er aapen`() {
+            val periodeB = Periode(YearMonth.of(2024, Month.JANUARY), null)
+            val periodeA = Periode(YearMonth.of(2024, Month.FEBRUARY), YearMonth.of(2024, Month.APRIL))
+
+            periodeA.overlapper(periodeB) shouldBe true
+            periodeB.overlapper(periodeA) shouldBe true
+        }
+
+        @Test
+        fun `overlapp - start og slutt samme maaned, foerste periode er aapen`() {
+            val periodeB = Periode(YearMonth.of(2024, Month.JANUARY), null)
+            val periodeA = Periode(YearMonth.of(2024, Month.JANUARY), YearMonth.of(2024, Month.JANUARY))
+
+            periodeA.overlapper(periodeB) shouldBe true
+            periodeB.overlapper(periodeA) shouldBe true
+        }
+
+        @Test
+        fun `overlapp - begge perioder er aapne`() {
+            val periodeB = Periode(YearMonth.of(2024, Month.JANUARY), null)
+            val periodeA = Periode(YearMonth.of(2024, Month.FEBRUARY), null)
+
+            periodeA.overlapper(periodeB) shouldBe true
+            periodeB.overlapper(periodeA) shouldBe true
+        }
+    }
+}


### PR DESCRIPTION
Endrer fra å bare sjekke avhukningen av etterbetalingen av saksbehandler, til å sjekke opp mot beløp i eventuelle tidligere vedtak. Hvis høyere beløp i vedtak som skal iverksettes enn i tidligere vedtak, så etterbetaling - men kun hvis vedtaket gjelder tilbake i tid og beløpet gjelder periode tilbake i tid.