### PR TITLE
Lagt til index på fremmednøkkel utbetalingshendelse.utbetaling_id

### DIFF
--- a/apps/etterlatte-utbetaling/src/main/resources/db/migration/V17__utbetalingshendelse_index.sql
+++ b/apps/etterlatte-utbetaling/src/main/resources/db/migration/V17__utbetalingshendelse_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX ON utbetalingshendelse (utbetaling_id);


### PR DESCRIPTION
Denne spørringen har kjørt hundretusenvis av ganger nå, de siste 7 dagene. Litt mer enn normalt antageligvis pga problemene med konsistensavstemmingen og rekjøring.
```
SELECT
  id,
  utbetaling_id,
  tidspunkt,
  status
FROM
  utbetalingshendelse
WHERE
  utbetaling_id = $1
```

https://console.cloud.google.com/sql/instances/etterlatte-utbetaling/insights;database=utbetaling;duration=P7D;trace=470e83cc06da0cba84ad27849fb4c143;span=7f358f4c109267ef;query_hash=5094536347900720165;sort_by=TOTAL_EXEC_TIME?authuser=0&project=etterlatte-prod-207c

Avg execution time: 3.99 ms
Times called: 409,184
Avg rows returned: 2.999

I og for seg så er det jo grei ytelse her, men volumet gjør at det blir litt. 

I lokal database med 2000 rader (dev-kopi, + litt) så gir gjentatte kjøringer av `explain analyze` følgende:

- **UTEN INDEKS**
Seq Scan on utbetalingshendelse  (cost=0.00..45.16 rows=3 width=47) (actual time=0.250..0.251 rows=0 loops=1)
  Filter: (utbetaling_id = 'c58d8c10-0210-4d08-8e26-b843d076fe7a'::uuid)
  Rows Removed by Filter: 2013
Planning Time: 0.048 ms
Execution Time: 0.301 ms

- **MED NY INDEKS**
Bitmap Heap Scan on utbetalingshendelse  (cost=4.30..12.85 rows=3 width=47) (actual time=0.013..0.013 rows=0 loops=1)
  Recheck Cond: (utbetaling_id = 'c58d8c10-0210-4d08-8e26-b843d076fe7a'::uuid)
  ->  Bitmap Index Scan on utbetalingshendelse_utbetaling_id_idx  (cost=0.00..4.30 rows=3 width=0) (actual time=0.011..0.012 rows=0 loops=1)
        Index Cond: (utbetaling_id = 'c58d8c10-0210-4d08-8e26-b843d076fe7a'::uuid)
Planning Time: 0.060 ms
Execution Time: 0.030 ms