### PR TITLE
Ny revurderingsårsak for opphør pga aldersovergang

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.ts
@@ -96,7 +96,8 @@ export const behandlingSkalSendeBrev = (
         //revurderingsaarsak === Revurderingaarsak.REGULERING || TODO EY-3232 Fjern utkommentering
         (
           revurderingsaarsak === Revurderingaarsak.DOEDSFALL ||
-          revurderingsaarsak === Revurderingaarsak.OPPHOER_UTEN_BREV
+          revurderingsaarsak === Revurderingaarsak.OPPHOER_UTEN_BREV ||
+          revurderingsaarsak === Revurderingaarsak.ALDERSOVERGANG
         )
       )
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Revurderingaarsak.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Revurderingaarsak.ts
@@ -21,6 +21,7 @@ export enum Revurderingaarsak {
   OMGJOERING_ETTER_KLAGE = 'OMGJOERING_ETTER_KLAGE',
   SLUTTBEHANDLING_UTLAND = 'SLUTTBEHANDLING_UTLAND',
   OPPHOER_UTEN_BREV = 'OPPHOER_UTEN_BREV',
+  ALDERSOVERGANG = 'ALDERSOVERGANG',
 }
 
 export const tekstRevurderingsaarsak: Record<Revurderingaarsak, string> = {
@@ -44,6 +45,7 @@ export const tekstRevurderingsaarsak: Record<Revurderingaarsak, string> = {
   OMGJOERING_ETTER_KLAGE: 'Omgjøring etter klage',
   SLUTTBEHANDLING_UTLAND: 'Sluttbehandling utland',
   OPPHOER_UTEN_BREV: 'Opphør uten å sende brev',
+  ALDERSOVERGANG: 'Aldersovergang',
 } as const
 
 export const erOpphoer = (revurderingsaarsak: Revurderingaarsak) =>
@@ -53,4 +55,5 @@ export const erOpphoer = (revurderingsaarsak: Revurderingaarsak) =>
     Revurderingaarsak.OMGJOERING_AV_FARSKAP,
     Revurderingaarsak.SIVILSTAND,
     Revurderingaarsak.OPPHOER_UTEN_BREV,
+    Revurderingaarsak.ALDERSOVERGANG,
   ].includes(revurderingsaarsak)

--- a/libs/saksbehandling-common/src/main/kotlin/behandling/Revurderingaarsak.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/behandling/Revurderingaarsak.kt
@@ -85,6 +85,7 @@ enum class Revurderingaarsak(
     OMGJOERING_ETTER_KLAGE(SAKTYPE_BP_OMS, KunIDev, IkkeOpphoerSkalSendeBrev, redigerbartBrev = true),
     SLUTTBEHANDLING_UTLAND(SAKTYPE_BP_OMS, KunIDev, IkkeOpphoerSkalSendeBrev, redigerbartBrev = true),
     OPPHOER_UTEN_BREV(SAKTYPE_BP_OMS, DevOgProd, OpphoerUtenBrev),
+    ALDERSOVERGANG(SAKTYPE_BP, KunIDev, OpphoerUtenBrev),
     ;
 
     fun kanBrukesIMiljo(): Boolean =


### PR DESCRIPTION
Legger til ny revurderingsårsak for aldersovergang i Barnepensjon. Kunne brukt "Opphør uten brev", men da mister vi litt informasjon ift statistikk etc. 