### PR TITLE
Fikser validering av etterbetaling og gjør det mulig å velge datoer over årsskifte

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/MaanedVelger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/MaanedVelger.tsx
@@ -3,15 +3,19 @@ import { MonthPicker, useMonthpicker } from '@navikt/ds-react'
 import { UseMonthPickerOptions } from '@navikt/ds-react/esm/date/hooks/useMonthPicker'
 
 type MaanedVelgerProps = {
+  fromDate?: Date
+  toDate?: Date
   onChange: (date: Date | null) => void
   value?: Date
   label: string
 }
 
 const MaanedVelger = (props: MaanedVelgerProps) => {
-  const { value, onChange, label } = props
+  const { fromDate, toDate, value, onChange, label } = props
 
   const { monthpickerProps, inputProps } = useMonthpicker({
+    fromDate: fromDate ?? undefined,
+    toDate: toDate ?? undefined,
     onMonthChange: (date: Date) => {
       date?.setHours(12)
       onChange(date)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/Brevutfall.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/Brevutfall.tsx
@@ -99,6 +99,7 @@ export const Brevutfall = (props: { behandling: IDetaljertBehandling; resetBrevu
               brevutfallOgEtterbetaling={brevutfallOgEtterbetaling}
               setBrevutfallOgEtterbetaling={setBrevutfallOgEtterbetaling}
               setVisSkjema={setVisSkjema}
+              onAvbryt={hentBrevutfall}
             />
           ) : (
             <BrevutfallVisning

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/BrevutfallSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/BrevutfallSkjema.tsx
@@ -8,7 +8,7 @@ import { lagreBrevutfallApi } from '~shared/api/behandling'
 import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 import { isFailure, isPending } from '~shared/api/apiUtils'
 import { Aldersgruppe, BrevutfallOgEtterbetaling } from '~components/behandling/brevutfall/Brevutfall'
-import { add, lastDayOfMonth, startOfDay } from 'date-fns'
+import { add, formatISO, lastDayOfMonth, startOfDay, startOfMonth } from 'date-fns'
 import { updateBrevutfallOgEtterbetaling } from '~store/reducers/BehandlingReducer'
 import { useAppDispatch } from '~store/Store'
 
@@ -24,6 +24,7 @@ export const BrevutfallSkjema = (props: {
   setBrevutfallOgEtterbetaling: (brevutfall: BrevutfallOgEtterbetaling) => void
   setVisSkjema: (visSkjema: boolean) => void
   resetBrevutfallvalidering: () => void
+  onAvbryt: () => void
 }) => {
   const {
     behandling,
@@ -31,6 +32,7 @@ export const BrevutfallSkjema = (props: {
     setBrevutfallOgEtterbetaling,
     setVisSkjema,
     resetBrevutfallvalidering,
+    onAvbryt,
   } = props
   const [harEtterbetaling, setHarEtterbetaling] = useState<HarEtterbetaling>(
     brevutfallOgEtterbetaling.etterbetaling === undefined
@@ -77,6 +79,7 @@ export const BrevutfallSkjema = (props: {
 
       const fra = startOfDay(new Date(fom))
       const til = startOfDay(new Date(tom))
+
       if (fra > til) {
         feilmeldinger.push('Fra-måned kan ikke være etter til-måned.')
         return feilmeldinger
@@ -150,7 +153,7 @@ export const BrevutfallSkjema = (props: {
                   ...brevutfallOgEtterbetaling,
                   etterbetaling: {
                     ...brevutfallOgEtterbetaling.etterbetaling,
-                    datoFom: date ? date.toISOString() : undefined,
+                    datoFom: date ? formatISO(startOfMonth(date), { representation: 'date' }) : undefined,
                   },
                 })
               }
@@ -169,7 +172,7 @@ export const BrevutfallSkjema = (props: {
                   ...brevutfallOgEtterbetaling,
                   etterbetaling: {
                     ...brevutfallOgEtterbetaling.etterbetaling,
-                    datoTom: date ? lastDayOfMonth(date).toISOString() : undefined,
+                    datoTom: date ? formatISO(lastDayOfMonth(date), { representation: 'date' }) : undefined,
                   },
                 })
               }
@@ -223,6 +226,7 @@ export const BrevutfallSkjema = (props: {
           variant="secondary"
           size="small"
           onClick={() => {
+            onAvbryt()
             setVisSkjema(false)
           }}
         >


### PR DESCRIPTION
- Det oppstår en del problemer pga datoer med og uten tidspunkter og sammenligning av disse. Har først å sette datoene med tidspunkter som er starten av dagen ved valideringen siden tidspunkter i denne sammenhengen er irrelevant. 
- Setter opp fra-dato fra virkningstidspunkt og til-dato til og med inneværende måned + 1 (noe usikker på den siste der)