### PR TITLE
Grunnlag gir ut personer basert på hva som ligger i persongalleriet

### DIFF
--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnBarnepensjonServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnBarnepensjonServiceTest.kt
@@ -248,7 +248,11 @@ internal class BeregnBarnepensjonServiceTest {
                 any(),
                 any(),
             )
-        } returns barnepensjonBeregningsGrunnlag(behandling.id, listOf(HELSOESKEN_FOEDSELSNUMMER, HELSOESKEN2_FOEDSELSNUMMER))
+        } returns
+            barnepensjonBeregningsGrunnlag(
+                behandling.id,
+                listOf(HELSOESKEN_FOEDSELSNUMMER, HELSOESKEN2_FOEDSELSNUMMER),
+            )
         coEvery { trygdetidKlient.hentTrygdetid(any(), any()) } returns mockTrygdetid(behandling.id)
 
         runBlocking {
@@ -619,22 +623,17 @@ internal class BeregnBarnepensjonServiceTest {
     }
 
     private fun grunnlagMedEkstraAvdoedForelder(doedsdato: LocalDate): Grunnlag {
-        val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
+        val grunnlagEnAvdoed = GrunnlagTestData().hentOpplysningsgrunnlag()
         val nyligAvdoedFoedselsnummer = AVDOED2_FOEDSELSNUMMER
-        val nyligAvdoed: List<Grunnlagsdata<JsonNode>> =
-            listOf(
-                mapOf(
-                    Opplysningstype.DOEDSDATO to konstantOpplysning(doedsdato),
-                    Opplysningstype.PERSONROLLE to konstantOpplysning(AVDOED),
-                    Opplysningstype.FOEDSELSNUMMER to konstantOpplysning(nyligAvdoedFoedselsnummer),
-                ),
+        val nyligAvdoed: Grunnlagsdata<JsonNode> =
+            mapOf(
+                Opplysningstype.DOEDSDATO to konstantOpplysning(doedsdato),
+                Opplysningstype.PERSONROLLE to konstantOpplysning(AVDOED),
+                Opplysningstype.FOEDSELSNUMMER to konstantOpplysning(nyligAvdoedFoedselsnummer),
             )
-        return Grunnlag(
-            grunnlag.soeker,
-            grunnlag.familie + nyligAvdoed,
-            grunnlag.sak,
-            grunnlag.metadata,
-        )
+        return GrunnlagTestData(
+            opplysningsmapAvdoedeOverrides = listOf(nyligAvdoed) + grunnlagEnAvdoed.hentAvdoede(),
+        ).hentOpplysningsgrunnlag()
     }
 
     private fun <T : Any> konstantOpplysning(a: T): Opplysning.Konstant<JsonNode> {

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
@@ -86,12 +86,8 @@ internal class BeregningsGrunnlagServiceTest {
                     Opplysningstype.FOEDSELSNUMMER to konstantOpplysning(nyligAvdoedFoedselsnummer),
                 ),
             )
-        return Grunnlag(
-            grunnlag.soeker,
-            grunnlag.familie + nyligAvdoed,
-            grunnlag.sak,
-            grunnlag.metadata,
-        )
+
+        return GrunnlagTestData(opplysningsmapAvdoedeOverrides = grunnlag.hentAvdoede() + nyligAvdoed).hentOpplysningsgrunnlag()
     }
 
     private fun <T : Any> konstantOpplysning(a: T): Opplysning.Konstant<JsonNode> {

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/BehandlingTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/BehandlingTest.kt
@@ -15,6 +15,7 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Navn
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.person.BrevMottaker
 import no.nav.etterlatte.libs.common.person.FamilieRelasjon
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.MottakerAdresse
 import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.person.PersonRolle
@@ -23,6 +24,7 @@ import no.nav.etterlatte.libs.common.person.VergemaalEllerFremtidsfullmakt
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED2_FOEDSELSNUMMER
+import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.GJENLEVENDE_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
@@ -225,7 +227,20 @@ internal class BehandlingTest {
                             Opplysningstype.FOEDSELSNUMMER to opprettOpplysning(GJENLEVENDE_FOEDSELSNUMMER.toJsonNode()),
                         ),
                     ),
-                sak = emptyMap(),
+                sak =
+                    mapOf(
+                        Opplysningstype.PERSONGALLERI_V1 to
+                            opprettOpplysning(
+                                Persongalleri(
+                                    soeker = SOEKER_FOEDSELSNUMMER.value,
+                                    innsender = GJENLEVENDE_FOEDSELSNUMMER.value,
+                                    soesken = listOf(),
+                                    avdoed = listOf(AVDOED_FOEDSELSNUMMER.value),
+                                    gjenlevende = listOf(GJENLEVENDE_FOEDSELSNUMMER.value),
+                                    personerUtenIdent = listOf(),
+                                ).toJsonNode(),
+                            ),
+                    ),
                 metadata = mockk(),
             )
 
@@ -412,10 +427,6 @@ internal class BehandlingTest {
         opplysningsmapSakOverrides =
             mapOf(
                 Opplysningstype.SPRAAK to opprettOpplysning(Spraak.NB.toJsonNode()),
-                Opplysningstype.PERSONGALLERI_V1 to
-                    opprettOpplysning(
-                        Persongalleri("", innsender = "11057523044").toJsonNode(),
-                    ),
             ),
         opplysningsmapSoekerOverrides =
             mapOf(
@@ -424,6 +435,13 @@ internal class BehandlingTest {
         opplysningsmapAvdoedOverrides =
             mapOf(
                 Opplysningstype.NAVN to opprettOpplysning(avdoedNavn.toJsonNode()),
+            ),
+        opplysningsmapGjenlevendeOverrides =
+            mapOf(
+                Opplysningstype.FOEDSELSNUMMER to
+                    opprettOpplysning(
+                        Folkeregisteridentifikator.of("11057523044").toJsonNode(),
+                    ),
             ),
     ).hentOpplysningsgrunnlag()
 

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagHenterTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagHenterTest.kt
@@ -60,8 +60,7 @@ class GrunnlagHenterTest {
             listOf(
                 grunnlagTestData.soeker,
                 grunnlagTestData.gjenlevende,
-                grunnlagTestData.avdoed,
-            )
+            ) + grunnlagTestData.avdoede
         listOf.forEach { person ->
             every { pdltjenesterKlient.hentOpplysningsperson(person.foedselsnummer.value, any(), sakType) } returns
                 mockPerson().copy(foedselsnummer = OpplysningDTO(person.foedselsnummer, null))
@@ -98,7 +97,7 @@ class GrunnlagHenterTest {
                             soekerFnr.value,
                             grunnlagTestData.gjenlevende.foedselsnummer.value,
                             emptyList(),
-                            listOf(grunnlagTestData.avdoed.foedselsnummer.value),
+                            grunnlagTestData.avdoede.map { it.foedselsnummer.value },
                             listOf(grunnlagTestData.gjenlevende.foedselsnummer.value),
                         ),
                     ),

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TestHelper.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TestHelper.kt
@@ -48,7 +48,7 @@ fun behandling(
 fun trygdetid(
     behandlingId: UUID = randomUUID(),
     sakId: Long = 1,
-    ident: String = GrunnlagTestData().avdoed.foedselsnummer.value,
+    ident: String = GrunnlagTestData().avdoede.first().foedselsnummer.value,
     beregnetTrygdetid: DetaljertBeregnetTrygdetid? = null,
     trygdetidGrunnlag: List<TrygdetidGrunnlag> = emptyList(),
     opplysninger: List<Opplysningsgrunnlag> = standardOpplysningsgrunnlag(),

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceImplIntegrationTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceImplIntegrationTest.kt
@@ -85,7 +85,7 @@ internal class TrygdetidServiceImplIntegrationTest {
         val behandlingId = UUID.randomUUID()
         val grunnlagTestData = GrunnlagTestData()
 
-        val nyDoedsdato = grunnlagTestData.avdoed.doedsdato!!.plusDays(6)
+        val nyDoedsdato = grunnlagTestData.avdoede.first().doedsdato!!.plusDays(6)
         coEvery {
             grunnlagKlient.hentGrunnlag(any(), any())
         } returns grunnlagMedNyDoedsdato(nyDoedsdato)
@@ -106,10 +106,10 @@ internal class TrygdetidServiceImplIntegrationTest {
         with(trygdetid?.opplysningerDifferanse!!) {
             differanse shouldBe true
             with(oppdaterteGrunnlagsopplysninger) {
-                toLocalDate(avdoedFoedselsdato) shouldBe grunnlagTestData.avdoed.foedselsdato
+                toLocalDate(avdoedFoedselsdato) shouldBe grunnlagTestData.avdoede.first().foedselsdato
                 toLocalDate(avdoedDoedsdato) shouldBe nyDoedsdato
-                toLocalDate(avdoedFylteSeksten) shouldBe grunnlagTestData.avdoed.foedselsdato!!.plusYears(16)
-                toLocalDate(avdoedFyllerSeksti) shouldBe grunnlagTestData.avdoed.foedselsdato!!.plusYears(66)
+                toLocalDate(avdoedFylteSeksten) shouldBe grunnlagTestData.avdoede.first().foedselsdato!!.plusYears(16)
+                toLocalDate(avdoedFyllerSeksti) shouldBe grunnlagTestData.avdoede.first().foedselsdato!!.plusYears(66)
             }
         }
     }
@@ -139,10 +139,10 @@ internal class TrygdetidServiceImplIntegrationTest {
         with(trygdetid?.opplysningerDifferanse!!) {
             differanse shouldBe false
             with(oppdaterteGrunnlagsopplysninger) {
-                toLocalDate(avdoedFoedselsdato) shouldBe grunnlagTestData.avdoed.foedselsdato
-                toLocalDate(avdoedDoedsdato) shouldBe grunnlagTestData.avdoed.doedsdato
-                toLocalDate(avdoedFylteSeksten) shouldBe grunnlagTestData.avdoed.foedselsdato!!.plusYears(16)
-                toLocalDate(avdoedFyllerSeksti) shouldBe grunnlagTestData.avdoed.foedselsdato!!.plusYears(66)
+                toLocalDate(avdoedFoedselsdato) shouldBe grunnlagTestData.avdoede.first().foedselsdato
+                toLocalDate(avdoedDoedsdato) shouldBe grunnlagTestData.avdoede.first().doedsdato
+                toLocalDate(avdoedFylteSeksten) shouldBe grunnlagTestData.avdoede.first().foedselsdato!!.plusYears(16)
+                toLocalDate(avdoedFyllerSeksti) shouldBe grunnlagTestData.avdoede.first().foedselsdato!!.plusYears(66)
             }
         }
     }
@@ -185,10 +185,10 @@ internal class TrygdetidServiceImplIntegrationTest {
     }
 
     private fun opplysningsgrunnlag(grunnlagTestData: GrunnlagTestData): List<Opplysningsgrunnlag> {
-        val foedselsdato = grunnlagTestData.avdoed.foedselsdato!!
-        val doedsdato = grunnlagTestData.avdoed.doedsdato!!
-        val seksten = grunnlagTestData.avdoed.foedselsdato!!.plusYears(16)
-        val sekstiseks = grunnlagTestData.avdoed.foedselsdato!!.plusYears(66)
+        val foedselsdato = grunnlagTestData.avdoede.first().foedselsdato!!
+        val doedsdato = grunnlagTestData.avdoede.first().doedsdato!!
+        val seksten = grunnlagTestData.avdoede.first().foedselsdato!!.plusYears(16)
+        val sekstiseks = grunnlagTestData.avdoede.first().foedselsdato!!.plusYears(66)
         return listOf(
             Opplysningsgrunnlag.ny(TrygdetidOpplysningType.FOEDSELSDATO, pdlKilde, foedselsdato),
             Opplysningsgrunnlag.ny(TrygdetidOpplysningType.DOEDSDATO, pdlKilde, doedsdato),

--- a/libs/saksbehandling-common/src/main/kotlin/grunnlag/Grunnlag.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/grunnlag/Grunnlag.kt
@@ -1,6 +1,8 @@
 package no.nav.etterlatte.libs.common.grunnlag
 
 import com.fasterxml.jackson.databind.JsonNode
+import no.nav.etterlatte.libs.common.behandling.Persongalleri
+import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.person.PersonRolle
 
 class Grunnlag(
@@ -27,17 +29,43 @@ class Grunnlag(
 
     fun hentAvdoede(): List<Grunnlagsdata<JsonNode>> = hentFamiliemedlemmer(PersonRolle.AVDOED)
 
+    @Deprecated(
+        "Denne er ikke safe med tanke på endringer i persongalleri / feil i gammelt grunnlag",
+        replaceWith =
+            ReplaceWith("hentAvdoede().flatMap { it.barn }"),
+    )
     fun hentSoesken() = familie.filter { it.hentPersonrolle()?.verdi in listOf(PersonRolle.BARN, PersonRolle.TILKNYTTET_BARN) }
 
-    private fun hentFamiliemedlemNullable(personRolle: PersonRolle) = familie.find { it.hentPersonrolle()?.verdi == personRolle }
+    private fun hentFamiliemedlemNullable(personRolle: PersonRolle): Grunnlagsdata<JsonNode>? {
+        val aktuellePersoner = folkMedRolle(personRolle)
+        return familie
+            .filter { it.hentFoedselsnummer()?.verdi?.value in aktuellePersoner }
+            .find { it.hentPersonrolle()?.verdi == personRolle }
+    }
 
     private fun hentFamiliemedlem(personRolle: PersonRolle) =
         hentFamiliemedlemNullable(personRolle)
             ?: throw IllegalStateException("Fant ikke familiemedlem med rolle $personRolle")
 
-    private fun hentFamiliemedlemmer(personRolle: PersonRolle) = familie.filter { it.hentPersonrolle()?.verdi == personRolle }
+    private fun hentFamiliemedlemmer(personRolle: PersonRolle): List<Grunnlagsdata<JsonNode>> {
+        val aktuellePersoner = folkMedRolle(personRolle)
+
+        return familie.filter { it.hentFoedselsnummer()?.verdi?.value in aktuellePersoner }
+            .filter { it.hentPersonrolle()?.verdi == personRolle }
+    }
 
     fun hentVersjon() = metadata.versjon
+}
+
+fun Grunnlag.folkMedRolle(rolle: PersonRolle): List<String> {
+    val persongalleri = this.sak.hentKonstantOpplysning<Persongalleri>(Opplysningstype.PERSONGALLERI_V1)?.verdi
+    return when (rolle) {
+        PersonRolle.INNSENDER -> listOfNotNull(persongalleri?.innsender)
+        PersonRolle.BARN -> throw IllegalArgumentException("Grunnlag vet ikke hvem som er barn")
+        PersonRolle.AVDOED -> persongalleri?.avdoed ?: emptyList()
+        PersonRolle.GJENLEVENDE -> persongalleri?.gjenlevende ?: emptyList()
+        PersonRolle.TILKNYTTET_BARN -> throw IllegalArgumentException("Grunnlag vet ikke hvem som er barn")
+    }
 }
 
 data class Metadata(val sakId: Long, val versjon: Long)

--- a/libs/testdata/src/main/kotlin/grunnlag/GrunnlagTestData.kt
+++ b/libs/testdata/src/main/kotlin/grunnlag/GrunnlagTestData.kt
@@ -20,6 +20,7 @@ data class GrunnlagTestData(
     val opplysningsmapSoekerOverrides: Map<Opplysningstype, Opplysning<JsonNode>> = emptyMap(),
     val opplysningsmapSoeskenOverrides: Map<Opplysningstype, Opplysning<JsonNode>> = emptyMap(),
     val opplysningsmapAvdoedOverrides: Map<Opplysningstype, Opplysning<JsonNode>> = emptyMap(),
+    val opplysningsmapAvdoedeOverrides: List<Map<Opplysningstype, Opplysning<JsonNode>>> = emptyList(),
     val opplysningsmapGjenlevendeOverrides: Map<Opplysningstype, Opplysning<JsonNode>> = emptyMap(),
     val opplysningsmapHalvsoeskenOverrides: Map<Opplysningstype, Opplysning<JsonNode>> = emptyMap(),
     val opplysningsmapSakOverrides: Map<Opplysningstype, Opplysning<JsonNode>> = emptyMap(),
@@ -87,19 +88,24 @@ data class GrunnlagTestData(
                     ),
             )
 
-    val avdoed
-        get() = personTestData(avdoedTestopplysningerMap + avdoedesBarnOverrides + opplysningsmapAvdoedOverrides)
+    val avdoede
+        get() =
+            when (opplysningsmapAvdoedeOverrides.isEmpty()) {
+                true -> listOf(personTestData(avdoedTestopplysningerMap + avdoedesBarnOverrides + opplysningsmapAvdoedOverrides))
+                false -> opplysningsmapAvdoedeOverrides.map { personTestData(it) }
+            }
 
     fun hentOpplysningsgrunnlag(): Grunnlag =
         Grunnlag(
             soeker = soekerTestopplysningerMap + opplysningsmapSoekerOverrides,
             familie =
-                listOf(
+                listOfNotNull(
                     soeskenTestopplysningerMap + opplysningsmapSoeskenOverrides,
-                    avdoedTestopplysningerMap + avdoedesBarnOverrides + opplysningsmapAvdoedOverrides,
+                    (avdoedTestopplysningerMap + avdoedesBarnOverrides + opplysningsmapAvdoedOverrides)
+                        .takeIf { opplysningsmapAvdoedeOverrides.isEmpty() },
                     gjenlevendeTestopplysningerMap + opplysningsmapGjenlevendeOverrides,
                     halvsoeskenTestopplysningerMap + opplysningsmapHalvsoeskenOverrides,
-                ),
+                ) + opplysningsmapAvdoedeOverrides,
             sak = sak,
             metadata = Metadata(1, 15),
         )
@@ -108,12 +114,13 @@ data class GrunnlagTestData(
         Grunnlag(
             soeker = soekerTestopplysningerMap + opplysningsmapSoekerOverrides,
             familie =
-                listOf(
+                listOfNotNull(
                     soeskenTestopplysningerMap + opplysningsmapSoeskenOverrides,
-                    avdoedTestopplysningerMap + avdoedesBarnMedEnDoed + opplysningsmapAvdoedOverrides,
+                    (avdoedTestopplysningerMap + avdoedesBarnMedEnDoed + opplysningsmapAvdoedOverrides)
+                        .takeIf { opplysningsmapAvdoedeOverrides.isEmpty() },
                     gjenlevendeTestopplysningerMap + opplysningsmapGjenlevendeOverrides,
                     halvsoeskenTestopplysningerMap + opplysningsmapHalvsoeskenOverrides,
-                ),
+                ) + opplysningsmapAvdoedeOverrides,
             sak = sak,
             metadata = Metadata(1, 15),
         )
@@ -123,7 +130,7 @@ data class GrunnlagTestData(
             soeker = soeker.foedselsnummer.value,
             innsender = gjenlevende.foedselsnummer.value,
             soesken = listOf(soesken.foedselsnummer.value, halvsoesken.foedselsnummer.value),
-            avdoed = listOf(avdoed.foedselsnummer.value),
+            avdoed = avdoede.map { it.foedselsnummer.value },
             gjenlevende = listOf(gjenlevende.foedselsnummer.value),
         )
 

--- a/libs/testdata/src/main/kotlin/grunnlag/GrunnlagTestData.kt
+++ b/libs/testdata/src/main/kotlin/grunnlag/GrunnlagTestData.kt
@@ -3,10 +3,13 @@ package no.nav.etterlatte.libs.testdata.grunnlag
 import com.fasterxml.jackson.databind.JsonNode
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.Metadata
 import no.nav.etterlatte.libs.common.grunnlag.Opplysning
+import no.nav.etterlatte.libs.common.grunnlag.lagOpplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.AVDOEDESBARN
+import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.PERSONGALLERI_V1
 import no.nav.etterlatte.libs.common.person.AvdoedesBarn
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.testdata.pdl.personTestData
@@ -29,6 +32,20 @@ data class GrunnlagTestData(
         get() = personTestData(halvsoeskenTestopplysningerMap + opplysningsmapHalvsoeskenOverrides)
     val gjenlevende
         get() = personTestData(gjenlevendeTestopplysningerMap + opplysningsmapGjenlevendeOverrides)
+
+    val sak: Map<Opplysningstype, Opplysning<JsonNode>> =
+        opplysningsmapSakOverrides +
+            mapOf(
+                PERSONGALLERI_V1 to
+                    Opplysning.Konstant.create(
+                        lagOpplysning(
+                            opplysningsType = PERSONGALLERI_V1,
+                            kilde = Grunnlagsopplysning.automatiskSaksbehandler,
+                            opplysning = hentPersonGalleri().toJsonNode(),
+                            periode = null,
+                        ),
+                    ),
+            )
 
     private val avdoedesBarnOverrides
         get() =
@@ -83,7 +100,7 @@ data class GrunnlagTestData(
                     gjenlevendeTestopplysningerMap + opplysningsmapGjenlevendeOverrides,
                     halvsoeskenTestopplysningerMap + opplysningsmapHalvsoeskenOverrides,
                 ),
-            sak = opplysningsmapSakOverrides,
+            sak = sak,
             metadata = Metadata(1, 15),
         )
 
@@ -97,7 +114,7 @@ data class GrunnlagTestData(
                     gjenlevendeTestopplysningerMap + opplysningsmapGjenlevendeOverrides,
                     halvsoeskenTestopplysningerMap + opplysningsmapHalvsoeskenOverrides,
                 ),
-            sak = opplysningsmapSakOverrides,
+            sak = sak,
             metadata = Metadata(1, 15),
         )
 
@@ -117,7 +134,7 @@ data class GrunnlagTestData(
                 listOf(
                     gjenlevendeTestopplysningerMap + opplysningsmapGjenlevendeOverrides,
                 ),
-            sak = opplysningsmapSakOverrides,
+            sak = sak,
             metadata = Metadata(1, 1),
         )
 }

--- a/libs/testdata/src/main/kotlin/pdl/PersonTestData.kt
+++ b/libs/testdata/src/main/kotlin/pdl/PersonTestData.kt
@@ -25,11 +25,14 @@ import no.nav.etterlatte.libs.common.person.Person
 
 fun personTestData(opplysningsmap: Map<Opplysningstype, Opplysning<JsonNode>>): Person =
     Person(
-        fornavn = opplysningsmap.hentNavn()!!.verdi.fornavn,
-        etternavn = opplysningsmap.hentNavn()!!.verdi.etternavn,
-        foedselsnummer = opplysningsmap.hentFoedselsnummer()!!.verdi,
-        foedselsdato = opplysningsmap.hentFoedselsdato()!!.verdi,
-        foedselsaar = opplysningsmap.hentFoedselsaar()!!.verdi,
+        fornavn = opplysningsmap.hentNavn()?.verdi?.fornavn ?: "TEST",
+        etternavn = opplysningsmap.hentNavn()?.verdi?.etternavn ?: "PERSON",
+        foedselsnummer =
+            requireNotNull(opplysningsmap.hentFoedselsnummer()) {
+                "Mangler opplysning fødselsnummer for en testperson"
+            }.verdi,
+        foedselsdato = opplysningsmap.hentFoedselsdato()?.verdi,
+        foedselsaar = opplysningsmap.hentFoedselsaar()?.verdi ?: opplysningsmap.hentFoedselsdato()?.verdi?.year ?: 1970,
         foedeland = opplysningsmap.hentFoedeland()?.verdi,
         doedsdato = opplysningsmap.hentDoedsdato()?.verdi,
         adressebeskyttelse = opplysningsmap.hentAdressebeskyttelse()?.verdi,


### PR DESCRIPTION
Fikser problemer hvis det er utdatert / feil grunnlag på en sak. Den faktiske endringen er kun i `libs/saksbehandling-common/src/main/kotlin/grunnlag/Grunnlag.kt`, og alle andre endringer er i tester / mocks av grunnlag der det ikke var satt opp personer med fødselsnummer eller samsvarende persongalleri i grunnlaget. 

