### PR TITLE
Oppdatere versjon på gosys-oppgave i sesjon ved til-/fradeling

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/ToggleMinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/ToggleMinOppgaveliste.tsx
@@ -63,6 +63,10 @@ export const ToggleMinOppgaveliste = () => {
       const index = oppdatertOppgaveState.findIndex((o) => o.id === id)
       oppdatertOppgaveState[index].saksbehandler = saksbehandler
       oppdatertOppgaveState[index].status = 'UNDER_BEHANDLING'
+      let gjeldendeVersjon = oppdatertOppgaveState[index].versjon
+      if (gjeldendeVersjon) {
+        oppdatertOppgaveState[index].versjon = ++gjeldendeVersjon
+      }
       setHentedeOppgaver(oppdatertOppgaveState)
     }, 2000)
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/FristHandlinger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/minoppgaveliste/FristHandlinger.tsx
@@ -19,7 +19,7 @@ const FristWrapper = styled.span<{ fristHarPassert: boolean; utenKnapp?: boolean
 export const FristHandlinger = (props: {
   orginalFrist: string
   oppgaveId: string
-  oppgaveVersjon: string | null
+  oppgaveVersjon: number | null
   type: Oppgavetype
   hentOppgaver: () => void
   erRedigerbar: boolean

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/tildeling/RedigerSaksbehandler.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/tildeling/RedigerSaksbehandler.tsx
@@ -11,7 +11,7 @@ export interface RedigerSaksbehandlerProps {
   sakId: number
   oppdaterTildeling: (id: string, saksbehandler: string | null) => void
   erRedigerbar: boolean
-  versjon: string | null
+  versjon: number | null
   type: Oppgavetype
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/tildeling/TildelSaksbehandler.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/nyoppgavebenk/tildeling/TildelSaksbehandler.tsx
@@ -10,7 +10,7 @@ export const TildelSaksbehandler = (props: {
   oppgaveId: string
   oppdaterTildeling: (id: string, saksbehandler: string) => void
   erRedigerbar: boolean
-  versjon: string | null
+  versjon: number | null
   type: Oppgavetype
 }) => {
   const { oppgaveId, oppdaterTildeling, erRedigerbar, versjon, type } = props

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaver.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaver.ts
@@ -19,7 +19,7 @@ export interface OppgaveDTO {
   // GOSYS-spesifikt
   beskrivelse: string | null
   gjelder: string | null
-  versjon: string | null
+  versjon: number | null
 }
 
 export interface NyOppgaveDto {
@@ -61,7 +61,7 @@ export const ferdigstillOppgave = async (id: string): Promise<ApiResponse<any>> 
 
 export interface SaksbehandlerEndringDto {
   saksbehandler: string
-  versjon: string | null
+  versjon: number | null
 }
 
 export const tildelSaksbehandlerApi = async (args: {
@@ -92,7 +92,7 @@ export const fjernSaksbehandlerApi = async (args: {
   oppgaveId: string
   sakId: number
   type: string
-  versjon: string | null
+  versjon: number | null
 }): Promise<ApiResponse<void>> => {
   if (args.type == 'GOSYS') {
     return apiClient.post(`/oppgaver/gosys/${args.oppgaveId}/tildel-saksbehandler`, {
@@ -106,7 +106,7 @@ export const fjernSaksbehandlerApi = async (args: {
 
 export interface RedigerFristRequest {
   frist: Date
-  versjon: string | null
+  versjon: number | null
 }
 export const redigerFristApi = async (args: {
   oppgaveId: string


### PR DESCRIPTION
For å unngå feilsituasjoner knyttet til optimistisk låsing der kun én saksbehandler er involvert, f.eks. tildele seg og så fradele uten å ha brukt hent/refresh i mellomtiden. Gosys enforcer dette på alt av updates.

Kommer slike feil i backend når dette skjer: https://logs.adeo.no/app/r?l=DISCOVER_SINGLE_DOC_LOCATOR&v=8.11.3&lz=N4IglgdgJgpgHiAXCAnANhmgLADgMYAMAtCjgQIZECMVMKROAzBUTFQOwBGnU2nWUTiAA0IAE4B7AO4BJaPCQgANhIDmAZwAu5dQAsi5AA6H1RQ5KhECBNDgBMKEeOkyoigKKcAWkSIBNKQAhFAB9ACsCKQBlAHVGPwA1ADcARycxGAAzGDEMsUUAeiNDAqgwdTwJJJyAYgKAfhDVAF4ACk0wAFsYRFbMyU7ECGkiOyxdAFI7ADFdYU0JIekASmWAMhDyNsqlAFdOiHVEAEJWpRhqpWFu9XVyVRhhGAgkvCUddWFipTA8cg6JBBhIYJFBlsJILA4IgAOToTC4QgkMiUGh0BjMShsLg8PgCTgw4QpXY5ACevXeEFUu3uPT2eGej2JZNhcBClVyMHeAIgITAUEQjBgnAIeHQlDQKA4RFwKEYBiwjDsRAArFg8FB2FRNWMVQTViAAL5AA%3D%3D

Denne PRen fjerner ikke muligheten for at det kan oppstå altså - om det er race condition mellom 2+ saksbehandlere.