### PR TITLE
Få med stacktrace på forespørselexception - alltid

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/generellbehandling/GenerellBehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/generellbehandling/GenerellBehandlingService.kt
@@ -5,7 +5,6 @@ import no.nav.etterlatte.behandling.domain.Foerstegangsbehandling
 import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.behandling.klienter.GrunnlagKlient
 import no.nav.etterlatte.inTransaction
-import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.generellbehandling.Attestant
 import no.nav.etterlatte.libs.common.generellbehandling.Behandler
@@ -345,22 +344,19 @@ class GenerellBehandlingService(
 }
 
 class FantIkkeAvdoedException(msg: String) :
-    ForespoerselException(
-        status = 400,
+    UgyldigForespoerselException(
         code = "FANT_IKKE_AVDOED",
         detail = msg,
     )
 
 class FantIkkeFoerstegangsbehandlingForKravpakkeOgSak(msg: String) :
-    ForespoerselException(
-        status = 400,
+    UgyldigForespoerselException(
         code = "FANT_IKKE_FOERSTEGANGSBEHANDLING_FOR_KRAVPAKKE",
         detail = msg,
     )
 
 class FantIkkeKravpakkeForFoerstegangsbehandling(msg: String) :
-    ForespoerselException(
-        status = 400,
+    UgyldigForespoerselException(
         code = "FANT_IKKE_KRAVPAKKE_FOR_FOERSTEGANGSBEHANDLING",
         detail = msg,
     )

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnBarnepensjonService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnBarnepensjonService.kt
@@ -3,7 +3,6 @@ package no.nav.etterlatte.beregning
 import beregning.regler.finnAnvendtGrunnbeloep
 import beregning.regler.finnAnvendtTrygdetid
 import com.fasterxml.jackson.databind.JsonNode
-import io.ktor.http.HttpStatusCode
 import no.nav.etterlatte.beregning.BeregnBarnepensjonServiceFeatureToggle.BrukNyttRegelverkIBeregning
 import no.nav.etterlatte.beregning.grunnlag.BeregningsGrunnlag
 import no.nav.etterlatte.beregning.grunnlag.BeregningsGrunnlagService
@@ -28,7 +27,7 @@ import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.virkningstidspunkt
 import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
 import no.nav.etterlatte.libs.common.beregning.Beregningstype
-import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsdata
 import no.nav.etterlatte.libs.common.grunnlag.Metadata
@@ -309,8 +308,7 @@ class BeregnBarnepensjonService(
                         beskrivelse = "Trygdetid avdød forelder",
                     ),
                 )
-            } ?: throw ForespoerselException(
-                HttpStatusCode.BadRequest.value,
+            } ?: throw UgyldigForespoerselException(
                 code = "MÅ_FASTSETTE_TRYGDETID",
                 detail = "Mangler trygdetid, gå tilbake til trygdetidsiden for å opprette dette",
             ),

--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SelvbetjeningAuthorizationPlugin.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SelvbetjeningAuthorizationPlugin.kt
@@ -1,12 +1,11 @@
 package no.nav.etterlatte.samordning.vedtak
 
-import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.createRouteScopedPlugin
 import io.ktor.server.application.log
 import io.ktor.server.auth.AuthenticationChecked
 import io.ktor.server.auth.principal
-import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
+import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.common.logging.getCorrelationId
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -30,8 +29,7 @@ val SelvbetjeningAuthorizationPlugin =
 
                     if (!validator.invoke(call, Folkeregisteridentifikator.of(subject!!))) {
                         application.log.info("Request avslått pga mismatch mellom subject og etterspurt fnr")
-                        throw ForespoerselException(
-                            status = HttpStatusCode.Forbidden.value,
+                        throw IkkeTillattException(
                             code = "GE-VALIDATE-ACCESS-FNR",
                             detail = "Kan kun etterspørre egne data",
                             meta =
@@ -48,5 +46,5 @@ val SelvbetjeningAuthorizationPlugin =
 
 class PluginConfiguration {
     var issuer: String = "tokenx"
-    var validator: (ApplicationCall, Folkeregisteridentifikator) -> Boolean = { call, borgerIdent -> false }
+    var validator: (ApplicationCall, Folkeregisteridentifikator) -> Boolean = { _, _ -> false }
 }

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/NyTrygdetidRoutes.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/NyTrygdetidRoutes.kt
@@ -32,7 +32,10 @@ fun PipelineContext<*, ApplicationCall>.trygdetidId(): UUID {
     return try {
         this.call.parameters[TRYGDETIDID_CALL_PARAMETER]?.let { UUID.fromString(it) }!!
     } catch (e: Exception) {
-        throw UgyldigForespoerselException("MANGLER_TRYGDETID_ID", "Kunne ikke lese ut parameteret trygdetidId")
+        throw UgyldigForespoerselException(
+            "MANGLER_TRYGDETID_ID",
+            "Kunne ikke lese ut parameteret trygdetidId",
+        )
     }
 }
 

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/grunnlag/GrunnlagVersjonValidering.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/grunnlag/GrunnlagVersjonValidering.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.vedtaksvurdering.grunnlag
 
-import io.ktor.http.HttpStatusCode
-import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.trygdetid.TrygdetidDto
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingDto
 import no.nav.etterlatte.vedtaksvurdering.BeregningOgAvkorting
@@ -37,8 +36,7 @@ object GrunnlagVersjonValidering {
     }
 }
 
-class UlikVersjonGrunnlag(detail: String) : ForespoerselException(
+class UlikVersjonGrunnlag(detail: String) : UgyldigForespoerselException(
     code = "ULIK_VERSJON_GRUNNLAG",
-    status = HttpStatusCode.BadRequest.value,
     detail = detail,
 )

--- a/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
@@ -136,7 +136,7 @@ class StatusPagesKonfigurasjon(private val sikkerLogg: Logger) {
             )
         }
 
-        this.info("En forespørselsfeil oppstod i et endepunkt, detaljer: ${internfeil.detail}", internfeil)
+        this.info("En forespørselsfeil oppstod i et endepunkt, detaljer: ${internfeil.detail}", internfeil.cause ?: internfeil)
     }
 
     private suspend fun ApplicationCall.respond(feil: ForespoerselException) {

--- a/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
@@ -13,6 +13,7 @@ import no.nav.etterlatte.libs.common.feilhaandtering.GenerellIkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
+import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilLoggerException
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.ktor.erDeserialiseringsException
 import org.slf4j.Logger
@@ -95,7 +96,7 @@ class StatusPagesKonfigurasjon(private val sikkerLogg: Logger) {
 
         status(*statusCodes5xx) { call, code ->
             val feil =
-                ForespoerselException(
+                InternfeilLoggerException(
                     status = code.value,
                     detail = call.request.uri,
                     code = "5XX_FEIL",
@@ -135,8 +136,7 @@ class StatusPagesKonfigurasjon(private val sikkerLogg: Logger) {
             )
         }
 
-        // Logger ikke meta, siden det kan inneholde identiferende informasjon
-        this.info("En forespørselsfeil oppstod i et endepunkt, detaljer: ${internfeil.detail}", internfeil.cause ?: internfeil.noMeta())
+        this.info("En forespørselsfeil oppstod i et endepunkt, detaljer: ${internfeil.detail}", internfeil)
     }
 
     private suspend fun ApplicationCall.respond(feil: ForespoerselException) {

--- a/libs/saksbehandling-common/src/main/kotlin/feilhaandtering/ForespoerselException.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/feilhaandtering/ForespoerselException.kt
@@ -7,10 +7,6 @@ open class ForespoerselException(
     open val meta: Map<String, Any>? = null,
     override val cause: Throwable? = null,
 ) : Exception(detail, cause) {
-    fun noMeta(): ForespoerselException {
-        return ForespoerselException(status = status, code = code, detail = detail, cause = cause)
-    }
-
     fun somExceptionResponse(): ExceptionResponse {
         return ExceptionResponse(
             status = status,

--- a/libs/saksbehandling-common/src/main/kotlin/feilhaandtering/InternfeilException.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/feilhaandtering/InternfeilException.kt
@@ -1,5 +1,12 @@
 package no.nav.etterlatte.libs.common.feilhaandtering
 
+open class InternfeilLoggerException(
+    open val status: Int,
+    open val code: String,
+    open val detail: String,
+    override val cause: Throwable? = null,
+) : Exception(detail, cause)
+
 open class InternfeilException(
     open val detail: String,
     override val cause: Throwable? = null,


### PR DESCRIPTION
* Rydde litt hvor hvilke exceptions kastes

NB: Meta inneholder ikke sensitive data
Kun behandlingid og tidspunkt