### PR TITLE
behandling - gjenbruk av Postgres testcontainer på tvers

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.config
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
+import com.zaxxer.hikari.HikariDataSource
 import io.ktor.client.HttpClient
 import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.behandling.BehandlingDao
@@ -369,5 +370,9 @@ internal class ApplicationContext(
             Duration.of(10, ChronoUnit.MINUTES).toMillis(),
             periode = Duration.of(5, ChronoUnit.MINUTES),
         )
+    }
+
+    fun close() {
+        (dataSource as HikariDataSource).close()
     }
 }

--- a/apps/etterlatte-behandling/src/test/kotlin/DatabaseExtension.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/DatabaseExtension.kt
@@ -1,0 +1,115 @@
+package no.nav.etterlatte
+
+import com.zaxxer.hikari.HikariDataSource
+import no.nav.etterlatte.libs.database.DataSourceBuilder
+import no.nav.etterlatte.libs.database.POSTGRES_VERSION
+import no.nav.etterlatte.libs.database.migrate
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace.GLOBAL
+import org.slf4j.LoggerFactory
+import org.testcontainers.containers.PostgreSQLContainer
+import java.io.PrintWriter
+import java.sql.Connection
+import java.util.logging.Logger
+import javax.sql.DataSource
+
+/**
+ * Det tar veldig mye tid å kjøre opp stadig nye Postgres-containere og kjøre Flyway migreringer.
+ * Denne extensionen kjører opp èn instans, som så gjenbrukes av de som måtte ønske det.
+ */
+object DatabaseExtension : BeforeAllCallback, AfterAllCallback, ExtensionContext.Store.CloseableResource {
+    private val logger: org.slf4j.Logger = LoggerFactory.getLogger(DatabaseExtension::class.java)
+
+    val postgreSQLContainer =
+        PostgreSQLContainer<Nothing>("postgres:$POSTGRES_VERSION")
+            .also { logger.info("Starting shared Postgres testcontainer") }
+            .also { it.start() }
+
+    private val dataSource: DataSource =
+        DataSourceBuilder.createDataSource(
+            jdbcUrl = postgreSQLContainer.jdbcUrl,
+            username = postgreSQLContainer.username,
+            password = postgreSQLContainer.password,
+        ).apply { migrate() }
+
+    private val connections = mutableListOf<Connection>()
+
+    override fun beforeAll(context: ExtensionContext) {
+        context.root.getStore(GLOBAL).put("postgres-testdb", this)
+    }
+
+    /**
+     * Ikke gå tom for tilkoblinger, så kast ut alle som er ferdige med jobben sin
+     */
+    override fun afterAll(context: ExtensionContext) {
+        resetDb()
+
+        connections.forEach {
+            (dataSource as HikariDataSource).evictConnection(it)
+        }
+        connections.clear()
+    }
+
+    fun dataSource(): DataSource = DataSourceWrapper(dataSource, connections::add)
+
+    /**
+     * Trigges av rammeverket når siste testinstans er kjørt.
+     */
+    override fun close() {
+        logger.info("Stopping shared Postgres testcontainer")
+        postgreSQLContainer.stop()
+    }
+
+    /**
+     * Sikre at hver testklasse starter med en fresh database, i det minste for sentrale tabeller
+     */
+    fun resetDb() {
+        logger.info("Resetting database...")
+        dataSource().connection.use {
+            it.prepareStatement(
+                """
+                TRUNCATE behandling CASCADE;
+                TRUNCATE behandlinghendelse CASCADE;
+                TRUNCATE grunnlagsendringshendelse CASCADE;
+                TRUNCATE sak CASCADE;
+                TRUNCATE oppgave CASCADE;
+                
+                ALTER SEQUENCE behandlinghendelse_id_seq RESTART WITH 1;
+                ALTER SEQUENCE sak_id_seq RESTART WITH 1;
+                """.trimIndent(),
+            ).execute()
+        }
+    }
+
+    /**
+     * Wrappe slik at når konsument ber om ny connection så kan den tas vare på mtp eviction
+     */
+    private class DataSourceWrapper(val datasource: DataSource, val collector: (Connection) -> Unit) : DataSource {
+        override fun getLogWriter(): PrintWriter = datasource.logWriter
+
+        override fun setLogWriter(out: PrintWriter?) {
+            datasource.logWriter = out
+        }
+
+        override fun setLoginTimeout(seconds: Int) {
+            datasource.loginTimeout = seconds
+        }
+
+        override fun getLoginTimeout(): Int = datasource.loginTimeout
+
+        override fun getParentLogger(): Logger = datasource.parentLogger
+
+        override fun <T : Any?> unwrap(iface: Class<T>?): T = datasource.unwrap(iface)
+
+        override fun isWrapperFor(iface: Class<*>?): Boolean = datasource.isWrapperFor(iface)
+
+        override fun getConnection(): Connection = datasource.connection.also { collector.invoke(it) }
+
+        override fun getConnection(
+            username: String?,
+            password: String?,
+        ): Connection = datasource.getConnection(username, password).also { collector.invoke(it) }
+    }
+}

--- a/apps/etterlatte-behandling/src/test/kotlin/OmregningIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/OmregningIntegrationTest.kt
@@ -28,7 +28,6 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.sak.Sak
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
@@ -53,11 +52,6 @@ class OmregningIntegrationTest : BehandlingIntegrationTest() {
 
     @AfterAll
     fun shutdown() = afterAll()
-
-    @AfterEach
-    fun afterEach() {
-        resetDatabase()
-    }
 
     @Nested
     inner class KanOmregne {
@@ -112,11 +106,6 @@ class OmregningIntegrationTest : BehandlingIntegrationTest() {
                     .tilIverksatt()
 
             inTransaction { applicationContext.behandlingDao.lagreStatus(iverksattBehandling) }
-        }
-
-        @AfterEach
-        fun afterEach() {
-            resetDatabase()
         }
 
         @Test

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.adressebeskyttelse
 
 import com.nimbusds.jwt.JWTClaimsSet
 import io.mockk.mockk
+import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.behandling.BehandlingDao
 import no.nav.etterlatte.behandling.BrukerService
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeDao
@@ -11,9 +12,6 @@ import no.nav.etterlatte.common.klienter.SkjermingKlient
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
-import no.nav.etterlatte.libs.database.DataSourceBuilder
-import no.nav.etterlatte.libs.database.POSTGRES_VERSION
-import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.opprettBehandling
 import no.nav.etterlatte.sak.SakDao
@@ -26,21 +24,16 @@ import no.nav.etterlatte.tilgangsstyring.AzureGroup
 import no.nav.etterlatte.tilgangsstyring.SaksbehandlerMedRoller
 import no.nav.etterlatte.token.Saksbehandler
 import no.nav.security.token.support.core.jwt.JwtTokenClaims
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
-import javax.sql.DataSource
+import org.junit.jupiter.api.extension.ExtendWith
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseExtension::class)
 internal class TilgangServiceTest {
-    @Container
-    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:$POSTGRES_VERSION")
-
-    private lateinit var dataSource: DataSource
+    private val dataSource = DatabaseExtension.dataSource()
     private lateinit var tilgangService: TilgangService
     private lateinit var sakService: SakService
     private lateinit var sakRepo: SakDao
@@ -53,17 +46,6 @@ internal class TilgangServiceTest {
 
     @BeforeAll
     fun beforeAll() {
-        postgreSQLContainer.start()
-        postgreSQLContainer.withUrlParam("user", postgreSQLContainer.username)
-        postgreSQLContainer.withUrlParam("password", postgreSQLContainer.password)
-
-        dataSource =
-            DataSourceBuilder.createDataSource(
-                jdbcUrl = postgreSQLContainer.jdbcUrl,
-                username = postgreSQLContainer.username,
-                password = postgreSQLContainer.password,
-            ).apply { migrate() }
-
         tilgangService = TilgangServiceImpl(SakTilgangDao(dataSource))
         sakRepo = SakDao { dataSource.connection }
 
@@ -75,11 +57,6 @@ internal class TilgangServiceTest {
                 },
                 RevurderingDao { dataSource.connection },
             ) { dataSource.connection }
-    }
-
-    @AfterAll
-    fun afterAll() {
-        postgreSQLContainer.stop()
     }
 
     @Test

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
 internal class TilgangServiceTest {
-    private val dataSource = DatabaseExtension.dataSource()
+    private val dataSource = DatabaseExtension.dataSource
     private lateinit var tilgangService: TilgangService
     private lateinit var sakService: SakService
     private lateinit var sakRepo: SakDao

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoReguleringTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoReguleringTest.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.behandling
 
 import io.kotest.matchers.collections.shouldContainExactly
+import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.behandling.domain.Foerstegangsbehandling
 import no.nav.etterlatte.behandling.domain.OpprettBehandling
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeDao
@@ -10,45 +11,27 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.sak.Saker
-import no.nav.etterlatte.libs.database.DataSourceBuilder
-import no.nav.etterlatte.libs.database.POSTGRES_VERSION
-import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.opprettBehandling
 import no.nav.etterlatte.sak.SakDao
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
 import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseExtension::class)
 internal class BehandlingDaoReguleringTest {
-    @Container
-    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:$POSTGRES_VERSION")
-
-    private lateinit var dataSource: DataSource
+    private val dataSource: DataSource = DatabaseExtension.dataSource()
     private lateinit var sakRepo: SakDao
     private lateinit var behandlingRepo: BehandlingDao
 
     @BeforeAll
     fun beforeAll() {
-        postgreSQLContainer.start()
-        postgreSQLContainer.withUrlParam("user", postgreSQLContainer.username)
-        postgreSQLContainer.withUrlParam("password", postgreSQLContainer.password)
-
-        dataSource =
-            DataSourceBuilder.createDataSource(
-                jdbcUrl = postgreSQLContainer.jdbcUrl,
-                username = postgreSQLContainer.username,
-                password = postgreSQLContainer.password,
-            ).apply { migrate() }
-
         val connection = dataSource.connection
         sakRepo = SakDao { connection }
         behandlingRepo =
@@ -57,14 +40,7 @@ internal class BehandlingDaoReguleringTest {
 
     @AfterEach
     fun afterEach() {
-        dataSource.connection.use {
-            it.prepareStatement("TRUNCATE behandling CASCADE;").execute()
-        }
-    }
-
-    @AfterAll
-    fun afterAll() {
-        postgreSQLContainer.stop()
+        DatabaseExtension.resetDb()
     }
 
     private fun hentMigrerbareStatuses() = BehandlingStatus.entries - BehandlingStatus.skalIkkeOmregnesVedGRegulering().toSet()

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoReguleringTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoReguleringTest.kt
@@ -26,7 +26,7 @@ import javax.sql.DataSource
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
 internal class BehandlingDaoReguleringTest {
-    private val dataSource: DataSource = DatabaseExtension.dataSource()
+    private val dataSource: DataSource = DatabaseExtension.dataSource
     private lateinit var sakRepo: SakDao
     private lateinit var behandlingRepo: BehandlingDao
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoTest.kt
@@ -43,7 +43,7 @@ import java.time.YearMonth
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
 internal class BehandlingDaoTest {
-    private val dataSource = DatabaseExtension.dataSource()
+    private val dataSource = DatabaseExtension.dataSource
     private lateinit var sakRepo: SakDao
     private lateinit var behandlingRepo: BehandlingDao
     private lateinit var kommerBarnetTilGodeDao: KommerBarnetTilGodeDao

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoTest.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.behandling
 
 import io.kotest.inspectors.forExactly
 import io.kotest.matchers.shouldBe
+import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.behandling.domain.Foerstegangsbehandling
 import no.nav.etterlatte.behandling.domain.ManueltOpphoer
 import no.nav.etterlatte.behandling.domain.Revurdering
@@ -25,12 +26,8 @@ import no.nav.etterlatte.libs.common.gyldigSoeknad.VurdertGyldighet
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
-import no.nav.etterlatte.libs.database.DataSourceBuilder
-import no.nav.etterlatte.libs.database.POSTGRES_VERSION
-import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.opprettBehandling
 import no.nav.etterlatte.sak.SakDao
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -39,36 +36,22 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertAll
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
+import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDate
 import java.time.YearMonth
-import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseExtension::class)
 internal class BehandlingDaoTest {
-    @Container
-    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:$POSTGRES_VERSION")
-
-    private lateinit var dataSource: DataSource
+    private val dataSource = DatabaseExtension.dataSource()
     private lateinit var sakRepo: SakDao
     private lateinit var behandlingRepo: BehandlingDao
     private lateinit var kommerBarnetTilGodeDao: KommerBarnetTilGodeDao
 
     @BeforeAll
     fun beforeAll() {
-        postgreSQLContainer.start()
-        postgreSQLContainer.withUrlParam("user", postgreSQLContainer.username)
-        postgreSQLContainer.withUrlParam("password", postgreSQLContainer.password)
-
-        dataSource =
-            DataSourceBuilder.createDataSource(
-                jdbcUrl = postgreSQLContainer.jdbcUrl,
-                username = postgreSQLContainer.username,
-                password = postgreSQLContainer.password,
-            ).apply { migrate() }
-
         val connection = dataSource.connection
+
         sakRepo = SakDao { connection }
         kommerBarnetTilGodeDao = KommerBarnetTilGodeDao { connection }
         behandlingRepo =
@@ -86,11 +69,6 @@ internal class BehandlingDaoTest {
         dataSource.connection.use {
             it.prepareStatement("TRUNCATE behandling CASCADE;").execute()
         }
-    }
-
-    @AfterAll
-    fun afterAll() {
-        postgreSQLContainer.stop()
     }
 
     @Test

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingsstatusRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingsstatusRoutesTest.kt
@@ -64,6 +64,7 @@ internal class BehandlingsstatusRoutesTest {
 
     @AfterAll
     fun after() {
+        applicationContext.close()
         server.shutdown()
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoDaoTest.kt
@@ -30,7 +30,7 @@ import javax.sql.DataSource
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
 internal class BehandlingInfoDaoTest {
-    private val dataSource: DataSource = DatabaseExtension.dataSource()
+    private val dataSource: DataSource = DatabaseExtension.dataSource
     private lateinit var behandlingDao: BehandlingDao
     private lateinit var sakDao: SakDao
     private lateinit var dao: BehandlingInfoDao

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoDaoTest.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.behandling.behandlinginfo
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.behandling.BehandlingDao
 import no.nav.etterlatte.behandling.domain.OpprettBehandling
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeDao
@@ -16,46 +17,28 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.database.DataSourceBuilder
-import no.nav.etterlatte.libs.database.POSTGRES_VERSION
-import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.sak.SakDao
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
+import org.junit.jupiter.api.extension.ExtendWith
 import java.time.YearMonth
 import java.util.UUID
 import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseExtension::class)
 internal class BehandlingInfoDaoTest {
-    private lateinit var dataSource: DataSource
+    private val dataSource: DataSource = DatabaseExtension.dataSource()
     private lateinit var behandlingDao: BehandlingDao
     private lateinit var sakDao: SakDao
     private lateinit var dao: BehandlingInfoDao
 
     private lateinit var behandlingId: UUID
 
-    @Container
-    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:$POSTGRES_VERSION")
-
     @BeforeAll
     fun setup() {
-        postgreSQLContainer.start()
-        postgreSQLContainer.withUrlParam("user", postgreSQLContainer.username)
-        postgreSQLContainer.withUrlParam("password", postgreSQLContainer.password)
-
-        dataSource =
-            DataSourceBuilder.createDataSource(
-                jdbcUrl = postgreSQLContainer.jdbcUrl,
-                username = postgreSQLContainer.username,
-                password = postgreSQLContainer.password,
-            ).apply { migrate() }
-
         val connection = dataSource.connection
         sakDao = SakDao { connection }
         behandlingDao =
@@ -76,11 +59,6 @@ internal class BehandlingInfoDaoTest {
             behandlingDao.opprettBehandling(it)
             behandlingId = it.id
         }
-    }
-
-    @AfterAll
-    fun afterAll() {
-        postgreSQLContainer.stop()
     }
 
     @Test

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoRoutesTest.kt
@@ -85,6 +85,7 @@ internal class BehandlingInfoRoutesTest {
 
     @AfterAll
     fun after() {
+        applicationContext.close()
         server.shutdown()
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/bosattutland/BosattUtlandDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/bosattutland/BosattUtlandDaoTest.kt
@@ -3,45 +3,24 @@ package no.nav.etterlatte.behandling.bosattutland
 import behandling.utland.LandMedDokumenter
 import behandling.utland.MottattDokument
 import io.kotest.matchers.shouldBe
-import no.nav.etterlatte.libs.database.DataSourceBuilder
-import no.nav.etterlatte.libs.database.POSTGRES_VERSION
-import no.nav.etterlatte.libs.database.migrate
-import org.junit.jupiter.api.AfterAll
+import no.nav.etterlatte.DatabaseExtension
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
+import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDate
 import java.util.UUID
-import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseExtension::class)
 internal class BosattUtlandDaoTest {
-    @Container
-    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:$POSTGRES_VERSION")
-    private lateinit var dataSource: DataSource
+    private val dataSource = DatabaseExtension.dataSource()
     private lateinit var bosattUtlandDao: BosattUtlandDao
 
     @BeforeAll
     fun beforeAll() {
-        postgreSQLContainer.start()
-        postgreSQLContainer.withUrlParam("user", postgreSQLContainer.username)
-        postgreSQLContainer.withUrlParam("password", postgreSQLContainer.password)
-
-        dataSource =
-            DataSourceBuilder.createDataSource(
-                jdbcUrl = postgreSQLContainer.jdbcUrl,
-                username = postgreSQLContainer.username,
-                password = postgreSQLContainer.password,
-            ).apply { migrate() }
         val connection = dataSource.connection
         bosattUtlandDao = BosattUtlandDao { connection }
-    }
-
-    @AfterAll
-    fun afterAll() {
-        postgreSQLContainer.stop()
     }
 
     @Test

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/bosattutland/BosattUtlandDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/bosattutland/BosattUtlandDaoTest.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
 internal class BosattUtlandDaoTest {
-    private val dataSource = DatabaseExtension.dataSource()
+    private val dataSource = DatabaseExtension.dataSource
     private lateinit var bosattUtlandDao: BosattUtlandDao
 
     @BeforeAll

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingDaoTest.kt
@@ -19,7 +19,7 @@ import javax.sql.DataSource
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
 internal class GenerellBehandlingDaoTest {
-    private val dataSource: DataSource = DatabaseExtension.dataSource()
+    private val dataSource: DataSource = DatabaseExtension.dataSource
     private lateinit var dao: GenerellBehandlingDao
 
     @BeforeAll

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingDaoTest.kt
@@ -1,46 +1,29 @@
 package no.nav.etterlatte.behandling.generellbehandling
 
+import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.libs.common.generellbehandling.DokumentMedSendtDato
 import no.nav.etterlatte.libs.common.generellbehandling.GenerellBehandling
 import no.nav.etterlatte.libs.common.generellbehandling.Innhold
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.database.DataSourceBuilder
-import no.nav.etterlatte.libs.database.POSTGRES_VERSION
-import no.nav.etterlatte.libs.database.migrate
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
+import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDate
 import java.util.UUID
 import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseExtension::class)
 internal class GenerellBehandlingDaoTest {
-    @Container
-    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:$POSTGRES_VERSION")
-
-    private lateinit var dataSource: DataSource
+    private val dataSource: DataSource = DatabaseExtension.dataSource()
     private lateinit var dao: GenerellBehandlingDao
 
     @BeforeAll
     fun beforeAll() {
-        postgreSQLContainer.start()
-        postgreSQLContainer.withUrlParam("user", postgreSQLContainer.username)
-        postgreSQLContainer.withUrlParam("password", postgreSQLContainer.password)
-
-        dataSource =
-            DataSourceBuilder.createDataSource(
-                jdbcUrl = postgreSQLContainer.jdbcUrl,
-                username = postgreSQLContainer.username,
-                password = postgreSQLContainer.password,
-            ).apply { migrate() }
-
         val connection = dataSource.connection
         dao = GenerellBehandlingDao { connection }
     }
@@ -50,11 +33,6 @@ internal class GenerellBehandlingDaoTest {
         dataSource.connection.use {
             it.prepareStatement("TRUNCATE generellbehandling CASCADE;").execute()
         }
-    }
-
-    @AfterAll
-    fun afterAll() {
-        postgreSQLContainer.stop()
     }
 
     @Test

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingServiceTest.kt
@@ -61,7 +61,7 @@ import java.util.UUID.randomUUID
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
 class GenerellBehandlingServiceTest {
-    private val dataSource = DatabaseExtension.dataSource()
+    private val dataSource = DatabaseExtension.dataSource
     private lateinit var dao: GenerellBehandlingDao
     private lateinit var oppgaveDao: OppgaveDao
     private lateinit var hendelseDao: HendelseDao

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/klage/KlageDaoImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/klage/KlageDaoImplTest.kt
@@ -22,7 +22,7 @@ import java.time.temporal.ChronoUnit
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
 internal class KlageDaoImplTest {
-    private val dataSource = DatabaseExtension.dataSource()
+    private val dataSource = DatabaseExtension.dataSource
     private lateinit var sakRepo: SakDao
     private lateinit var klageDao: KlageDaoImpl
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/klage/KlageRoutesIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/klage/KlageRoutesIntegrationTest.kt
@@ -14,6 +14,7 @@ import io.ktor.server.testing.testApplication
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.etterlatte.BehandlingIntegrationTest
+import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.behandling.objectMapper
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.libs.common.FoedselsnummerDTO
@@ -42,7 +43,9 @@ class KlageRoutesIntegrationTest : BehandlingIntegrationTest() {
                 mockk {
                     every { isEnabled(KlageFeatureToggle.KanBrukeKlageToggle, any()) } returns true
                 },
-        )
+        ).also {
+            DatabaseExtension.resetDb()
+        }
 
     @AfterEach
     fun afterEach() {

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingRoutesTest.kt
@@ -65,6 +65,7 @@ internal class RevurderingRoutesTest {
 
     @AfterAll
     fun after() {
+        applicationContext.close()
         server.shutdown()
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingServiceIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingServiceIntegrationTest.kt
@@ -46,7 +46,6 @@ import no.nav.etterlatte.persongalleri
 import no.nav.etterlatte.token.BrukerTokenInfo
 import no.nav.etterlatte.token.Saksbehandler
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -69,11 +68,6 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
 
         startServer()
         Kontekst.set(Context(user, DatabaseContext(applicationContext.dataSource)))
-    }
-
-    @AfterEach
-    fun afterEach() {
-        resetDatabase()
     }
 
     @AfterAll

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/sjekkliste/SjekklisteIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/sjekkliste/SjekklisteIntegrationTest.kt
@@ -35,7 +35,7 @@ class SjekklisteIntegrationTest {
 
     private val behandlingService = mockk<BehandlingService>()
     private val oppgaveService = mockk<OppgaveService>()
-    private val dataSource = DatabaseExtension.dataSource()
+    private val dataSource = DatabaseExtension.dataSource
     private lateinit var sjekklisteDao: SjekklisteDao
     private lateinit var sjekklisteService: SjekklisteService
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/sjekkliste/SjekklisteIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/sjekkliste/SjekklisteIntegrationTest.kt
@@ -6,6 +6,7 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.etterlatte.Context
+import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.DatabaseKontekst
 import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
@@ -15,21 +16,17 @@ import no.nav.etterlatte.behandling.sjekkliste.OppdatertSjekkliste
 import no.nav.etterlatte.behandling.sjekkliste.SjekklisteDao
 import no.nav.etterlatte.behandling.sjekkliste.SjekklisteService
 import no.nav.etterlatte.foerstegangsbehandling
-import no.nav.etterlatte.libs.database.DataSourceBuilder
-import no.nav.etterlatte.libs.database.POSTGRES_VERSION
-import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.oppgave.OppgaveService
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertAll
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
+import org.junit.jupiter.api.extension.ExtendWith
 import java.sql.Connection
-import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseExtension::class)
 class SjekklisteIntegrationTest {
     private val user =
         mockk<SaksbehandlerMedEnheterOgRoller>().apply {
@@ -38,26 +35,12 @@ class SjekklisteIntegrationTest {
 
     private val behandlingService = mockk<BehandlingService>()
     private val oppgaveService = mockk<OppgaveService>()
-    private lateinit var dataSource: DataSource
+    private val dataSource = DatabaseExtension.dataSource()
     private lateinit var sjekklisteDao: SjekklisteDao
     private lateinit var sjekklisteService: SjekklisteService
 
-    @Container
-    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:$POSTGRES_VERSION")
-
     @BeforeAll
     fun setup() {
-        postgreSQLContainer.start()
-        postgreSQLContainer.withUrlParam("user", postgreSQLContainer.username)
-        postgreSQLContainer.withUrlParam("password", postgreSQLContainer.password)
-
-        dataSource =
-            DataSourceBuilder.createDataSource(
-                jdbcUrl = postgreSQLContainer.jdbcUrl,
-                username = postgreSQLContainer.username,
-                password = postgreSQLContainer.password,
-            ).apply { migrate() }
-
         val connection = dataSource.connection
         sjekklisteDao = SjekklisteDao { connection }
         sjekklisteService = SjekklisteService(sjekklisteDao, behandlingService, oppgaveService)
@@ -70,7 +53,6 @@ class SjekklisteIntegrationTest {
 
     @AfterAll
     fun afterAll() {
-        postgreSQLContainer.stop()
         clearAllMocks()
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingDaoTest.kt
@@ -35,7 +35,7 @@ import javax.sql.DataSource
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
 class TilbakekrevingDaoTest {
-    private val dataSource: DataSource = DatabaseExtension.dataSource()
+    private val dataSource: DataSource = DatabaseExtension.dataSource
     private lateinit var sakDao: SakDao
     private lateinit var tilbakekrevingDao: TilbakekrevingDao
 

--- a/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattRouteTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattRouteTest.kt
@@ -44,7 +44,9 @@ class EgenAnsattRouteTest : BehandlingIntegrationTest() {
     private val norg2Klient = mockk<Norg2Klient>()
 
     @BeforeEach
-    fun start() = startServer(norg2Klient = norg2Klient)
+    fun start() =
+        startServer(norg2Klient = norg2Klient)
+            .also { resetDatabase() }
 
     @AfterEach
     fun afterEach() {

--- a/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattServiceTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import no.nav.etterlatte.Context
+import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.DatabaseKontekst
 import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
@@ -21,9 +22,6 @@ import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.common.person.GeografiskTilknytning
 import no.nav.etterlatte.libs.common.skjermet.EgenAnsattSkjermet
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.database.DataSourceBuilder
-import no.nav.etterlatte.libs.database.POSTGRES_VERSION
-import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED2_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.oppgave.OppgaveDaoImpl
@@ -32,26 +30,21 @@ import no.nav.etterlatte.oppgave.OppgaveService
 import no.nav.etterlatte.sak.SakDao
 import no.nav.etterlatte.sak.SakService
 import no.nav.etterlatte.sak.SakServiceImpl
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
 import org.slf4j.Logger
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
 import java.sql.Connection
-import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseExtension::class)
 internal class EgenAnsattServiceTest {
     val sikkerLogg: Logger = sikkerlogger()
 
-    @Container
-    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:$POSTGRES_VERSION")
-
-    private lateinit var dataSource: DataSource
+    private val dataSource = DatabaseExtension.dataSource()
     private lateinit var sakRepo: SakDao
     private lateinit var oppgaveRepo: OppgaveDaoImpl
     private lateinit var oppgaveRepoMedSporing: OppgaveDaoMedEndringssporingImpl
@@ -62,17 +55,6 @@ internal class EgenAnsattServiceTest {
 
     @BeforeAll
     fun beforeAll() {
-        postgreSQLContainer.start()
-        postgreSQLContainer.withUrlParam("user", postgreSQLContainer.username)
-        postgreSQLContainer.withUrlParam("password", postgreSQLContainer.password)
-
-        dataSource =
-            DataSourceBuilder.createDataSource(
-                jdbcUrl = postgreSQLContainer.jdbcUrl,
-                username = postgreSQLContainer.username,
-                password = postgreSQLContainer.password,
-            ).apply { migrate() }
-
         val pdltjenesterKlient = mockk<PdlTjenesterKlient>()
         val norg2Klient = mockk<Norg2Klient>()
         val featureToggleService = mockk<FeatureToggleService>()
@@ -121,11 +103,6 @@ internal class EgenAnsattServiceTest {
                 },
             ),
         )
-    }
-
-    @AfterAll
-    fun afterAll() {
-        postgreSQLContainer.stop()
     }
 
     @Test

--- a/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattServiceTest.kt
@@ -44,7 +44,7 @@ import java.sql.Connection
 internal class EgenAnsattServiceTest {
     val sikkerLogg: Logger = sikkerlogger()
 
-    private val dataSource = DatabaseExtension.dataSource()
+    private val dataSource = DatabaseExtension.dataSource
     private lateinit var sakRepo: SakDao
     private lateinit var oppgaveRepo: OppgaveDaoImpl
     private lateinit var oppgaveRepoMedSporing: OppgaveDaoMedEndringssporingImpl

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseDaoTest.kt
@@ -41,7 +41,7 @@ import java.util.UUID
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
 internal class GrunnlagsendringshendelseDaoTest {
-    private val dataSource = DatabaseExtension.dataSource()
+    private val dataSource = DatabaseExtension.dataSource
     private lateinit var sakRepo: SakDao
     private lateinit var grunnlagsendringshendelsesRepo: GrunnlagsendringshendelseDao
     private lateinit var behandlingRepo: BehandlingDao

--- a/apps/etterlatte-behandling/src/test/kotlin/institusjonsopphold/institusjonsopphold/InstitusjonsoppholdDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/institusjonsopphold/institusjonsopphold/InstitusjonsoppholdDaoTest.kt
@@ -16,7 +16,7 @@ import java.util.UUID
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
 internal class InstitusjonsoppholdDaoTest {
-    private val dataSource = DatabaseExtension.dataSource()
+    private val dataSource = DatabaseExtension.dataSource
     private lateinit var institusjonsoppholdDao: InstitusjonsoppholdDao
 
     @BeforeAll

--- a/apps/etterlatte-behandling/src/test/kotlin/institusjonsopphold/institusjonsopphold/InstitusjonsoppholdDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/institusjonsopphold/institusjonsopphold/InstitusjonsoppholdDaoTest.kt
@@ -1,49 +1,28 @@
 package institusjonsopphold.institusjonsopphold
 
+import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.institusjonsopphold.InstitusjonsoppholdBegrunnelse
 import no.nav.etterlatte.institusjonsopphold.InstitusjonsoppholdDao
 import no.nav.etterlatte.libs.common.behandling.JaNei
 import no.nav.etterlatte.libs.common.behandling.JaNeiMedBegrunnelse
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
-import no.nav.etterlatte.libs.database.DataSourceBuilder
-import no.nav.etterlatte.libs.database.POSTGRES_VERSION
-import no.nav.etterlatte.libs.database.migrate
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
+import org.junit.jupiter.api.extension.ExtendWith
 import java.util.UUID
-import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseExtension::class)
 internal class InstitusjonsoppholdDaoTest {
-    @Container
-    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:$POSTGRES_VERSION")
-    private lateinit var dataSource: DataSource
+    private val dataSource = DatabaseExtension.dataSource()
     private lateinit var institusjonsoppholdDao: InstitusjonsoppholdDao
 
     @BeforeAll
     fun beforeAll() {
-        postgreSQLContainer.start()
-        postgreSQLContainer.withUrlParam("user", postgreSQLContainer.username)
-        postgreSQLContainer.withUrlParam("password", postgreSQLContainer.password)
-
-        dataSource =
-            DataSourceBuilder.createDataSource(
-                jdbcUrl = postgreSQLContainer.jdbcUrl,
-                username = postgreSQLContainer.username,
-                password = postgreSQLContainer.password,
-            ).apply { migrate() }
         val connection = dataSource.connection
         institusjonsoppholdDao = InstitusjonsoppholdDao { connection }
-    }
-
-    @AfterAll
-    fun afterAll() {
-        postgreSQLContainer.stop()
     }
 
     @Test

--- a/apps/etterlatte-behandling/src/test/kotlin/metrics/BehandlingMetricsOppgaveTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/metrics/BehandlingMetricsOppgaveTest.kt
@@ -24,7 +24,7 @@ import java.util.UUID
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
 internal class BehandlingMetricsOppgaveTest {
-    private val ds = DatabaseExtension.dataSource()
+    private val ds = DatabaseExtension.dataSource
 
     private lateinit var oppgaveDao: OppgaveDaoImpl
     private lateinit var sakDao: SakDao

--- a/apps/etterlatte-behandling/src/test/kotlin/metrics/BehandlingMetricsTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/metrics/BehandlingMetricsTest.kt
@@ -26,7 +26,7 @@ import java.time.YearMonth
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
 internal class BehandlingMetricsTest {
-    private val ds = DatabaseExtension.dataSource()
+    private val ds = DatabaseExtension.dataSource
     private lateinit var behandlingMetrikkerDao: BehandlingMetrikkerDao
     private lateinit var oppgaveDao: OppgaveMetrikkerDao
     private lateinit var behandlingRepo: BehandlingDao

--- a/apps/etterlatte-behandling/src/test/kotlin/metrics/BehandlingMetricsTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/metrics/BehandlingMetricsTest.kt
@@ -4,6 +4,7 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
 import io.prometheus.client.CollectorRegistry
+import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.behandling.BehandlingDao
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.libs.common.Vedtaksloesning
@@ -14,23 +15,18 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.database.DataSourceBuilder
-import no.nav.etterlatte.libs.database.POSTGRES_VERSION
-import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.opprettBehandling
 import no.nav.etterlatte.sak.SakDao
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
+import org.junit.jupiter.api.extension.ExtendWith
 import java.time.YearMonth
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseExtension::class)
 internal class BehandlingMetricsTest {
-    @Container
-    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:$POSTGRES_VERSION")
+    private val ds = DatabaseExtension.dataSource()
     private lateinit var behandlingMetrikkerDao: BehandlingMetrikkerDao
     private lateinit var oppgaveDao: OppgaveMetrikkerDao
     private lateinit var behandlingRepo: BehandlingDao
@@ -41,14 +37,6 @@ internal class BehandlingMetricsTest {
 
     @BeforeAll
     fun beforeAll() {
-        postgreSQLContainer.start()
-
-        val ds =
-            DataSourceBuilder.createDataSource(
-                postgreSQLContainer.jdbcUrl,
-                postgreSQLContainer.username,
-                postgreSQLContainer.password,
-            ).also { it.migrate() }
         val connection = ds.connection
 
         sakRepo = SakDao { connection }
@@ -66,11 +54,6 @@ internal class BehandlingMetricsTest {
         behandlingMetrics = BehandlingMetrics(oppgaveDao, behandlingMetrikkerDao, testreg)
 
         behandlingMetrics.run()
-    }
-
-    @AfterAll
-    fun afterAll() {
-        postgreSQLContainer.stop()
     }
 
     @Test

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.oppgave
 
+import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
@@ -9,9 +10,6 @@ import no.nav.etterlatte.libs.common.oppgave.Status
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.database.DataSourceBuilder
-import no.nav.etterlatte.libs.database.POSTGRES_VERSION
-import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.sak.SakDao
 import no.nav.etterlatte.sak.SakTilgangDao
 import org.junit.jupiter.api.AfterEach
@@ -19,34 +17,19 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
+import org.junit.jupiter.api.extension.ExtendWith
 import java.util.UUID
-import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseExtension::class)
 internal class OppgaveDaoTest {
-    private lateinit var dataSource: DataSource
+    private val dataSource = DatabaseExtension.dataSource()
     private lateinit var oppgaveDao: OppgaveDao
     private lateinit var sakDao: SakDao
     private lateinit var saktilgangDao: SakTilgangDao
 
-    @Container
-    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:$POSTGRES_VERSION")
-
     @BeforeAll
     fun beforeAll() {
-        postgreSQLContainer.start()
-        postgreSQLContainer.withUrlParam("user", postgreSQLContainer.username)
-        postgreSQLContainer.withUrlParam("password", postgreSQLContainer.password)
-
-        dataSource =
-            DataSourceBuilder.createDataSource(
-                jdbcUrl = postgreSQLContainer.jdbcUrl,
-                username = postgreSQLContainer.username,
-                password = postgreSQLContainer.password,
-            ).apply { migrate() }
-
         val connection = dataSource.connection
         oppgaveDao = OppgaveDaoImpl { connection }
         sakDao = SakDao { connection }

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
@@ -23,7 +23,7 @@ import java.util.UUID
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
 internal class OppgaveDaoTest {
-    private val dataSource = DatabaseExtension.dataSource()
+    private val dataSource = DatabaseExtension.dataSource
     private lateinit var oppgaveDao: OppgaveDao
     private lateinit var sakDao: SakDao
     private lateinit var saktilgangDao: SakTilgangDao

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -46,7 +46,7 @@ import java.util.UUID
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
 internal class OppgaveServiceTest {
-    private val dataSource = DatabaseExtension.dataSource()
+    private val dataSource = DatabaseExtension.dataSource
     private lateinit var sakDao: SakDao
     private lateinit var oppgaveDao: OppgaveDao
     private lateinit var oppgaveService: OppgaveService

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakDaoTest.kt
@@ -16,7 +16,7 @@ import java.time.LocalDate
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
 internal class SakDaoTest {
-    private val dataSource = DatabaseExtension.dataSource()
+    private val dataSource = DatabaseExtension.dataSource
     private lateinit var sakRepo: SakDao
     private lateinit var tilgangService: TilgangService
 

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakDaoTest.kt
@@ -1,52 +1,30 @@
 package no.nav.etterlatte.sak
 
+import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseService
 import no.nav.etterlatte.libs.common.behandling.Flyktning
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
-import no.nav.etterlatte.libs.database.DataSourceBuilder
-import no.nav.etterlatte.libs.database.POSTGRES_VERSION
-import no.nav.etterlatte.libs.database.migrate
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
+import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDate
-import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseExtension::class)
 internal class SakDaoTest {
-    @Container
-    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:$POSTGRES_VERSION")
-
-    private lateinit var dataSource: DataSource
+    private val dataSource = DatabaseExtension.dataSource()
     private lateinit var sakRepo: SakDao
     private lateinit var tilgangService: TilgangService
 
     @BeforeAll
     fun beforeAll() {
-        postgreSQLContainer.start()
-        postgreSQLContainer.withUrlParam("user", postgreSQLContainer.username)
-        postgreSQLContainer.withUrlParam("password", postgreSQLContainer.password)
-
-        dataSource =
-            DataSourceBuilder.createDataSource(
-                jdbcUrl = postgreSQLContainer.jdbcUrl,
-                username = postgreSQLContainer.username,
-                password = postgreSQLContainer.password,
-            ).apply { migrate() }
         val connection = dataSource.connection
         sakRepo = SakDao { connection }
         tilgangService = TilgangServiceImpl(SakTilgangDao(dataSource))
-    }
-
-    @AfterAll
-    fun afterAll() {
-        postgreSQLContainer.stop()
     }
 
     @Test


### PR DESCRIPTION
av alle tester for raskere bygg.

Brorpartene av endringene forårsakes av problemer med tester som 

- ikke rydder opp
- baserer seg på databasen skal være fullstendig tom
- gjenbruk av fnr/testdata, og dermed forventning om helt tom starttilstand

For de 2 siste så bør man ikke ha slike forventninger med mindre det er et funksjonelt case på det. Legg inn _dine_ data, og sjekk _dine_ data.