### PR TITLE
Ny status til behandling - AVSLAG

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
@@ -9,10 +9,12 @@ import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseService
 import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.generellbehandling.GenerellBehandling
+import no.nav.etterlatte.libs.common.oppgave.VedtakEndringDTO
 import no.nav.etterlatte.libs.common.sak.SakIDListe
 import no.nav.etterlatte.libs.common.sak.Saker
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
+import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.token.BrukerTokenInfo
 import no.nav.etterlatte.vedtaksvurdering.VedtakHendelse
 import org.slf4j.LoggerFactory
@@ -61,7 +63,7 @@ interface BehandlingStatusService {
 
     fun settAttestertVedtak(
         behandling: Behandling,
-        vedtakHendelse: VedtakHendelse,
+        vedtak: VedtakEndringDTO,
     )
 
     fun sjekkOmKanReturnereVedtak(behandlingId: UUID)
@@ -176,10 +178,14 @@ class BehandlingStatusServiceImpl(
 
     override fun settAttestertVedtak(
         behandling: Behandling,
-        vedtakHendelse: VedtakHendelse,
+        vedtak: VedtakEndringDTO,
     ) {
-        lagreNyBehandlingStatus(behandling.tilAttestert())
-        registrerVedtakHendelse(behandling.id, vedtakHendelse, HendelseType.ATTESTERT)
+        if (vedtak.vedtakType == VedtakType.AVSLAG) {
+            lagreNyBehandlingStatus(behandling.tilAvslag())
+        } else {
+            lagreNyBehandlingStatus(behandling.tilAttestert())
+        }
+        registrerVedtakHendelse(behandling.id, vedtak.vedtakHendelse, HendelseType.ATTESTERT)
     }
 
     override fun sjekkOmKanReturnereVedtak(behandlingId: UUID) {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingVedtakRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingVedtakRoute.kt
@@ -137,7 +137,7 @@ internal fun Route.behandlingVedtakRoute(
                     call.respond(HttpStatusCode.NotFound, "Fant ingen behandling")
                 } else {
                     inTransaction {
-                        behandlingsstatusService.settAttestertVedtak(behandling, attesterVedtakOppgave.vedtakHendelse)
+                        behandlingsstatusService.settAttestertVedtak(behandling, attesterVedtakOppgave)
                         try {
                             oppgaveService.ferdigStillOppgaveUnderBehandling(
                                 referanse = attesterVedtakOppgave.sakIdOgReferanse.referanse,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/AutomatiskRevurdering.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/AutomatiskRevurdering.kt
@@ -63,6 +63,8 @@ data class AutomatiskRevurdering(
 
     override fun tilAttestert() = endreTilStatus(BehandlingStatus.ATTESTERT)
 
+    override fun tilAvslag() = endreTilStatus(BehandlingStatus.AVSLAG)
+
     override fun tilReturnert() = endreTilStatus(BehandlingStatus.RETURNERT)
 
     override fun tilTilSamordning() = endreTilStatus(BehandlingStatus.TIL_SAMORDNING)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
@@ -8,6 +8,7 @@ import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus.ATTESTERT
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus.AVKORTET
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus.AVSLAG
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus.BEREGNET
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus.FATTET_VEDTAK
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus.OPPRETTET
@@ -162,6 +163,10 @@ sealed class Behandling {
 
     open fun tilAttestert(): Behandling {
         throw BehandlingStoetterIkkeStatusEndringException(ATTESTERT)
+    }
+
+    open fun tilAvslag(): Behandling {
+        throw BehandlingStoetterIkkeStatusEndringException(AVSLAG)
     }
 
     open fun tilReturnert(): Behandling {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Foerstegangsbehandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Foerstegangsbehandling.kt
@@ -127,6 +127,11 @@ data class Foerstegangsbehandling(
             endreTilStatus(BehandlingStatus.ATTESTERT)
         }
 
+    override fun tilAvslag() =
+        hvisTilstandEr(BehandlingStatus.FATTET_VEDTAK) {
+            endreTilStatus(BehandlingStatus.AVSLAG)
+        }
+
     override fun tilReturnert() =
         hvisTilstandEr(BehandlingStatus.FATTET_VEDTAK) {
             endreTilStatus(BehandlingStatus.RETURNERT)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ManuellRevurdering.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ManuellRevurdering.kt
@@ -160,6 +160,11 @@ data class ManuellRevurdering(
             endreTilStatus(BehandlingStatus.ATTESTERT)
         }
 
+    override fun tilAvslag() =
+        hvisTilstandEr(BehandlingStatus.FATTET_VEDTAK) {
+            endreTilStatus(BehandlingStatus.AVSLAG)
+        }
+
     override fun tilReturnert() =
         hvisTilstandEr(BehandlingStatus.FATTET_VEDTAK) {
             endreTilStatus(BehandlingStatus.RETURNERT)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ManueltOpphoer.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ManueltOpphoer.kt
@@ -76,6 +76,11 @@ data class ManueltOpphoer(
             endreTilStatus(BehandlingStatus.ATTESTERT)
         }
 
+    override fun tilAvslag() =
+        hvisTilstandEr(BehandlingStatus.FATTET_VEDTAK) {
+            endreTilStatus(BehandlingStatus.AVSLAG)
+        }
+
     override fun tilReturnert() =
         hvisTilstandEr(BehandlingStatus.FATTET_VEDTAK) {
             endreTilStatus(BehandlingStatus.RETURNERT)

--- a/apps/etterlatte-behandling/src/test/kotlin/VerdikjedeTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/VerdikjedeTest.kt
@@ -318,6 +318,7 @@ class VerdikjedeTest : BehandlingIntegrationTest() {
                                 referanse = behandlingId.toString(),
                             ),
                         vedtakHendelse = VedtakHendelse(123L, Tidspunkt.now(), "Saksbehandler01", null),
+                        vedtakType = VedtakType.INNVILGELSE,
                     ),
                 )
             }.also {
@@ -361,6 +362,7 @@ class VerdikjedeTest : BehandlingIntegrationTest() {
                                 referanse = behandlingId.toString(),
                             ),
                         vedtakHendelse = VedtakHendelse(123L, Tidspunkt.now(), saksbehandler02, null, null),
+                        vedtakType = VedtakType.INNVILGELSE,
                     ),
                 )
             }.also {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/oppsummering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/oppsummering.tsx
@@ -15,6 +15,7 @@ export const Behandlingsoppsummering = ({ behandlingsInfo, beslutning }: Props) 
     behandlingsInfo.status === IBehandlingStatus.ATTESTERT ||
     behandlingsInfo.status === IBehandlingStatus.TIL_SAMORDNING ||
     behandlingsInfo.status === IBehandlingStatus.SAMORDNET ||
+    behandlingsInfo.status === IBehandlingStatus.AVSLAG ||
     beslutning === IBeslutning.godkjenn
   ) {
     return <Innvilget behandlingsInfo={behandlingsInfo} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/oversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/oversikt.tsx
@@ -47,6 +47,8 @@ export const Oversikt = ({ behandlingsInfo }: { behandlingsInfo: IBehandlingInfo
         return 'Samordnet'
       case IBehandlingStatus.IVERKSATT:
         return 'Iverksatt'
+      case IBehandlingStatus.AVSLAG:
+        return 'Avslag'
       case IBehandlingStatus.AVBRUTT:
         return 'Avbrutt'
       case IBehandlingStatus.OPPRETTET:

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.ts
@@ -63,11 +63,13 @@ export const erFerdigBehandlet = (status: IBehandlingStatus): boolean => {
     status === IBehandlingStatus.TIL_SAMORDNING ||
     status === IBehandlingStatus.SAMORDNET ||
     status === IBehandlingStatus.IVERKSATT ||
+    status === IBehandlingStatus.AVSLAG ||
     status === IBehandlingStatus.AVBRUTT
   )
 }
 export const behandlingErIverksattEllerSamordnet = (behandlingStatus: IBehandlingStatus): boolean =>
   behandlingStatus === IBehandlingStatus.IVERKSATT ||
+  behandlingStatus === IBehandlingStatus.AVSLAG ||
   behandlingStatus === IBehandlingStatus.SAMORDNET ||
   behandlingStatus === IBehandlingStatus.TIL_SAMORDNING
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/behandlingsslistemappere.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/behandlingsslistemappere.ts
@@ -54,6 +54,8 @@ export function behandlingStatusTilLesbartnavn(status: IBehandlingStatus) {
       return 'Til samordning'
     case IBehandlingStatus.SAMORDNET:
       return 'Samordnet'
+    case IBehandlingStatus.AVSLAG:
+      return 'Avslag'
     case IBehandlingStatus.IVERKSATT:
       return 'Iverksatt'
     default:

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IDetaljertBehandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IDetaljertBehandling.ts
@@ -57,6 +57,7 @@ export enum IBehandlingStatus {
   SAMORDNET = 'SAMORDNET',
   IVERKSATT = 'IVERKSATT',
   AVBRUTT = 'AVBRUTT',
+  AVSLAG = 'AVSLAG',
 }
 
 export enum UtlandstilknytningType {

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
@@ -127,6 +127,7 @@ class VedtakBehandlingService(
                                             inntruffet = fattetVedtak.vedtakFattet?.tidspunkt!!,
                                             saksbehandler = fattetVedtak.vedtakFattet.ansvarligSaksbehandler,
                                         ),
+                                    vedtakType = fattetVedtak.type,
                                 ),
                         )
                     }
@@ -198,6 +199,7 @@ class VedtakBehandlingService(
                                         saksbehandler = attestertVedtak.attestasjon.attestant,
                                         kommentar = kommentar,
                                     ),
+                                vedtakType = attestertVedtak.type,
                             ),
                     )
                 }
@@ -255,6 +257,7 @@ class VedtakBehandlingService(
                                     kommentar = begrunnelse.kommentar,
                                     valgtBegrunnelse = begrunnelse.valgtBegrunnelse,
                                 ),
+                            vedtakType = underkjentVedtak.type,
                         ),
                     )
                 }

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/BehandlingStatus.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/BehandlingStatus.kt
@@ -8,6 +8,7 @@ enum class BehandlingStatus {
     AVKORTET,
     FATTET_VEDTAK,
     ATTESTERT,
+    AVSLAG,
     RETURNERT,
     TIL_SAMORDNING,
     SAMORDNET,
@@ -39,6 +40,7 @@ enum class BehandlingStatus {
                 SAMORDNET,
                 TIL_SAMORDNING,
                 ATTESTERT,
+                AVSLAG,
             )
 
         fun kanEndres() = underBehandling() - FATTET_VEDTAK
@@ -55,6 +57,7 @@ enum class BehandlingStatus {
                 OPPRETTET,
                 VILKAARSVURDERT,
                 TRYGDETID_OPPDATERT,
+                AVSLAG,
             )
     }
 }

--- a/libs/etterlatte-oppgave-model/src/main/kotlin/Oppgave/OppgaveIntern.kt
+++ b/libs/etterlatte-oppgave-model/src/main/kotlin/Oppgave/OppgaveIntern.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.libs.common.oppgave
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.vedtaksvurdering.VedtakHendelse
 import java.util.UUID
 
@@ -148,6 +149,7 @@ data class SakIdOgReferanse(
 data class VedtakEndringDTO(
     val sakIdOgReferanse: SakIdOgReferanse,
     val vedtakHendelse: VedtakHendelse,
+    val vedtakType: VedtakType,
 )
 
 data class NyOppgaveDto(


### PR DESCRIPTION
Behandlinger som avvises blir værende med status ATTESTERT. Vi har da ingen enkel måte å skille behandlinger som avventer iverksettelse fra Oppdrag og de som er ferdig behandlet med avslag.
Legger derfor til ny status AVSLAG til behandling.

Hvis endringene blir godkjent skal jeg også lage flyway som setter status på eksisterende behandlinger som er vedtatt med avslag til AVSLAG (i en ny PR).