### PR TITLE
Bumped lib etterlatte-common

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,7 +70,7 @@ ktor2-mustache = { module = "io.ktor:ktor-server-mustache", version.ref = "ktor2
 ktor2-clientmock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor2-version" }
 ktor2-servertests = { module = "io.ktor:ktor-server-tests", version.ref = "ktor2-version" }
 
-etterlatte-common = { module = "pensjon-etterlatte-libs:common", version = "2024.01.05-09.38.6f5ada710f9f"}
+etterlatte-common = { module = "pensjon-etterlatte-libs:common", version = "2024.01.17-13.26.695db1c36957"}
 teamdokumenthandtering-avroschemas = { module = "no.nav.teamdokumenthandtering:teamdokumenthandtering-avro-schemas", version = "08c0b2d2" }
 
 logging-slf4japi = { module = "org.slf4j:slf4j-api", version = "2.0.10" }


### PR DESCRIPTION
endringen der er at `nav-token-support` er bumpet til v4, som allerede er gjort i dette repoet