### PR TITLE
Paralleliser appers tester unntatt behandling

### DIFF
--- a/apps/etterlatte-behandling/build.gradle.kts
+++ b/apps/etterlatte-behandling/build.gradle.kts
@@ -48,4 +48,11 @@ dependencies {
     testImplementation(libs.test.kotest.assertionscore)
     testImplementation(project(":libs:testdata"))
     testImplementation(project(":libs:etterlatte-funksjonsbrytere"))
+
+    tasks {
+        withType<Test> {
+            useJUnitPlatform()
+            maxParallelForks = 1
+        }
+    }
 }

--- a/apps/etterlatte-beregning/build.gradle.kts
+++ b/apps/etterlatte-beregning/build.gradle.kts
@@ -39,4 +39,11 @@ dependencies {
         exclude("org.slf4j", "slf4j-api")
     }
     testImplementation(project(":libs:testdata"))
+
+    tasks {
+        withType<Test> {
+            useJUnitPlatform()
+            maxParallelForks = Runtime.getRuntime().availableProcessors()
+        }
+    }
 }

--- a/apps/etterlatte-brev-api/build.gradle.kts
+++ b/apps/etterlatte-brev-api/build.gradle.kts
@@ -50,4 +50,11 @@ dependencies {
     testImplementation(libs.kotlinx.coroutinescore)
     testImplementation(libs.navfelles.mockoauth2server)
     testImplementation(project(":libs:testdata"))
+
+    tasks {
+        withType<Test> {
+            useJUnitPlatform()
+            maxParallelForks = Runtime.getRuntime().availableProcessors()
+        }
+    }
 }

--- a/apps/etterlatte-grunnlag/build.gradle.kts
+++ b/apps/etterlatte-grunnlag/build.gradle.kts
@@ -40,4 +40,11 @@ dependencies {
     testImplementation(libs.ktor2.servertests)
     testImplementation(project(":libs:testdata"))
     testImplementation(libs.test.kotest.assertionscore)
+
+    tasks {
+        withType<Test> {
+            useJUnitPlatform()
+            maxParallelForks = Runtime.getRuntime().availableProcessors()
+        }
+    }
 }

--- a/apps/etterlatte-klage/build.gradle.kts
+++ b/apps/etterlatte-klage/build.gradle.kts
@@ -16,4 +16,11 @@ dependencies {
     implementation(libs.ktor2.okhttp)
 
     testImplementation(libs.test.jupiter.api)
+
+    tasks {
+        withType<Test> {
+            useJUnitPlatform()
+            maxParallelForks = Runtime.getRuntime().availableProcessors()
+        }
+    }
 }

--- a/apps/etterlatte-migrering/build.gradle.kts
+++ b/apps/etterlatte-migrering/build.gradle.kts
@@ -23,4 +23,11 @@ dependencies {
     implementation(libs.database.kotliquery)
     testImplementation(libs.ktor2.servertests)
     testImplementation(testFixtures((project(":libs:etterlatte-database"))))
+
+    tasks {
+        withType<Test> {
+            useJUnitPlatform()
+            maxParallelForks = Runtime.getRuntime().availableProcessors()
+        }
+    }
 }

--- a/apps/etterlatte-pdltjenester/build.gradle.kts
+++ b/apps/etterlatte-pdltjenester/build.gradle.kts
@@ -40,4 +40,11 @@ dependencies {
     testImplementation(libs.navfelles.mockoauth2server)
     testImplementation(libs.test.kotest.assertionscore)
     testImplementation(project(":libs:testdata"))
+
+    tasks {
+        withType<Test> {
+            useJUnitPlatform()
+            maxParallelForks = Runtime.getRuntime().availableProcessors()
+        }
+    }
 }

--- a/apps/etterlatte-statistikk/build.gradle.kts
+++ b/apps/etterlatte-statistikk/build.gradle.kts
@@ -20,4 +20,11 @@ dependencies {
 
     testImplementation(libs.test.kotest.assertionscore)
     testImplementation(libs.kotlinx.coroutinescore)
+
+    tasks {
+        withType<Test> {
+            useJUnitPlatform()
+            maxParallelForks = Runtime.getRuntime().availableProcessors()
+        }
+    }
 }

--- a/apps/etterlatte-tilbakekreving/build.gradle.kts
+++ b/apps/etterlatte-tilbakekreving/build.gradle.kts
@@ -49,4 +49,11 @@ dependencies {
     testImplementation(libs.test.kotest.assertionscore)
     testImplementation(project(":libs:testdata"))
     testImplementation(testFixtures(project(":libs:etterlatte-mq")))
+
+    tasks {
+        withType<Test> {
+            useJUnitPlatform()
+            maxParallelForks = Runtime.getRuntime().availableProcessors()
+        }
+    }
 }

--- a/apps/etterlatte-trygdetid/build.gradle.kts
+++ b/apps/etterlatte-trygdetid/build.gradle.kts
@@ -28,4 +28,11 @@ dependencies {
     testImplementation(project(":libs:testdata"))
     testImplementation(libs.ktor2.jackson)
     testImplementation(libs.ktor2.clientcontentnegotiation)
+
+    tasks {
+        withType<Test> {
+            useJUnitPlatform()
+            maxParallelForks = Runtime.getRuntime().availableProcessors()
+        }
+    }
 }

--- a/apps/etterlatte-utbetaling/build.gradle.kts
+++ b/apps/etterlatte-utbetaling/build.gradle.kts
@@ -35,4 +35,11 @@ dependencies {
     testImplementation(libs.test.wiremock)
     testImplementation(project(":libs:testdata"))
     testImplementation(testFixtures(project(":libs:etterlatte-mq")))
+
+    tasks {
+        withType<Test> {
+            useJUnitPlatform()
+            maxParallelForks = Runtime.getRuntime().availableProcessors()
+        }
+    }
 }

--- a/apps/etterlatte-vedtaksvurdering/build.gradle.kts
+++ b/apps/etterlatte-vedtaksvurdering/build.gradle.kts
@@ -41,4 +41,11 @@ dependencies {
         exclude("org.slf4j", "slf4j-api")
     }
     testImplementation(project(":libs:testdata"))
+
+    tasks {
+        withType<Test> {
+            useJUnitPlatform()
+            maxParallelForks = Runtime.getRuntime().availableProcessors()
+        }
+    }
 }

--- a/apps/etterlatte-vilkaarsvurdering/build.gradle.kts
+++ b/apps/etterlatte-vilkaarsvurdering/build.gradle.kts
@@ -39,4 +39,11 @@ dependencies {
         exclude("org.slf4j", "slf4j-api")
     }
     testImplementation(project(":libs:testdata"))
+
+    tasks {
+        withType<Test> {
+            useJUnitPlatform()
+            maxParallelForks = Runtime.getRuntime().availableProcessors()
+        }
+    }
 }


### PR DESCRIPTION
En del apper som beregning og vilkårsvurder m.m. halverer test-kjøretiden med disse endringene.