### PR TITLE
Egen toggle for ferdigstilling av klage

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageRoutes.kt
@@ -28,6 +28,7 @@ import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
 
 enum class KlageFeatureToggle(private val key: String) : FeatureToggle {
     KanBrukeKlageToggle("pensjon-etterlatte.kan-bruke-klage"),
+    KanFerdigstilleKlageToggle("pensjons-etterlatte.kan-ferdigstille-klage"),
     ;
 
     override fun key(): String = key
@@ -96,7 +97,7 @@ internal fun Route.klageRoutes(
             }
 
             post("ferdigstill") {
-                hvisEnabled(featureToggleService, KlageFeatureToggle.KanBrukeKlageToggle) {
+                hvisEnabled(featureToggleService, KlageFeatureToggle.KanFerdigstilleKlageToggle) {
                     kunSaksbehandlerMedSkrivetilgang { saksbehandler ->
                         val ferdigstiltKlage =
                             inTransaction {


### PR DESCRIPTION
Lar oss styre om man kan ferdigstille en klagebehandling, for å kunne teste behandling underveis i produksjon uten å evt. brekke noe som krever masse opprydding