### PR TITLE
Verdier i skjema for trydetid ble ikke lagret riktig

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlag.tsx
@@ -56,7 +56,7 @@ export const TrygdetidGrunnlag = ({
       {
         behandlingId: behandlingId,
         // Flippe verdi av prorata for å matche PESYS
-        trygdetidgrunnlag: { ...data, prorata: !data.prorata },
+        trygdetidgrunnlag: { ...data, prorata: !!data.prorata },
       },
       (respons) => {
         setTrygdetid(respons)
@@ -117,16 +117,16 @@ export const TrygdetidGrunnlag = ({
               {trygdetidGrunnlagType === ITrygdetidGrunnlagType.FAKTISK && (
                 <>
                   <PoengAar legend="Poeng i inn/ut år">
-                    <Checkbox {...register('poengInnAar')} value={getValues().poengInnAar}>
+                    <Checkbox {...register('poengInnAar')} value="">
                       Poeng i inn år
                     </Checkbox>
-                    <Checkbox {...register('poengUtAar')} value={getValues().poengUtAar}>
+                    <Checkbox {...register('poengUtAar')} value="">
                       Poeng i ut år
                     </Checkbox>
                   </PoengAar>
 
                   <Prorata legend="Prorata">
-                    <Checkbox {...register('prorata')} value={getValues().prorata}>
+                    <Checkbox {...register('prorata')} value="">
                       Ikke med i prorata
                     </Checkbox>
                   </Prorata>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlag.tsx
@@ -117,6 +117,8 @@ export const TrygdetidGrunnlag = ({
               {trygdetidGrunnlagType === ITrygdetidGrunnlagType.FAKTISK && (
                 <>
                   <PoengAar legend="Poeng i inn/ut år">
+                    {/* Stoppe aksel å klage på at checkbox ikke har value, mens RHF styrer den */}
+                    {/* Hvis man setter verdien fra RHF i Aksel Checkbox vil den overridet til string */}
                     <Checkbox {...register('poengInnAar')} value="">
                       Poeng i inn år
                     </Checkbox>


### PR DESCRIPTION
[FAGSYSTEM-314343 Barnepensjon - feil i beregning av trygdetid til avdøde](https://jira.adeo.no/browse/FAGSYSTEM-314343)