### PR TITLE
Filtrer mot enheter direkte mot database for oppgaver og ikke etterpå

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/Contekst.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Contekst.kt
@@ -7,6 +7,7 @@ import no.nav.etterlatte.libs.ktor.AZURE_ISSUER
 import no.nav.etterlatte.libs.ktor.hentTokenClaims
 import no.nav.etterlatte.tilgangsstyring.AzureGroup
 import no.nav.etterlatte.tilgangsstyring.SaksbehandlerMedRoller
+import no.nav.etterlatte.tilgangsstyring.saksbehandlereMedTilgangTilAlleEnheter
 import no.nav.etterlatte.token.BrukerTokenInfo
 import no.nav.etterlatte.token.Saksbehandler
 import no.nav.etterlatte.token.Systembruker
@@ -67,6 +68,8 @@ class SaksbehandlerMedEnheterOgRoller(
     override fun name(): String {
         return identifiedBy.hentTokenClaims(AZURE_ISSUER)!!.getStringClaim("NAVident")
     }
+
+    fun erSuperbruker() = name() in (saksbehandlereMedTilgangTilAlleEnheter)
 
     fun enheter() =
         if (saksbehandlerMedRoller.harRolleNasjonalTilgang()) {

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDaoMedEndringssporing.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDaoMedEndringssporing.kt
@@ -107,8 +107,9 @@ class OppgaveDaoMedEndringssporingImpl(
     override fun hentOppgaver(
         oppgaveTypeTyper: List<OppgaveType>,
         enheter: List<String>,
+        erSuperBruker: Boolean,
     ): List<OppgaveIntern> {
-        return oppgaveDao.hentOppgaver(oppgaveTypeTyper, enheter)
+        return oppgaveDao.hentOppgaver(oppgaveTypeTyper, enheter, erSuperBruker)
     }
 
     override fun finnOppgaverForStrengtFortroligOgStrengtFortroligUtland(oppgaveTypeTyper: List<OppgaveType>): List<OppgaveIntern> {

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDaoMedEndringssporing.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDaoMedEndringssporing.kt
@@ -104,8 +104,11 @@ class OppgaveDaoMedEndringssporingImpl(
         return oppgaveDao.hentOppgaverForSak(sakId)
     }
 
-    override fun hentOppgaver(oppgaveTypeTyper: List<OppgaveType>): List<OppgaveIntern> {
-        return oppgaveDao.hentOppgaver(oppgaveTypeTyper)
+    override fun hentOppgaver(
+        oppgaveTypeTyper: List<OppgaveType>,
+        enheter: List<String>,
+    ): List<OppgaveIntern> {
+        return oppgaveDao.hentOppgaver(oppgaveTypeTyper, enheter)
     }
 
     override fun finnOppgaverForStrengtFortroligOgStrengtFortroligUtland(oppgaveTypeTyper: List<OppgaveType>): List<OppgaveIntern> {

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
@@ -55,7 +55,7 @@ internal fun Route.oppgaveRoutes(
                 call.respond(
                     inTransaction {
                         service.finnOppgaverForBruker(
-                            Kontekst.get().appUserAsSaksbehandler().saksbehandlerMedRoller,
+                            Kontekst.get().appUserAsSaksbehandler(),
                         )
                     },
                 )

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -7,7 +7,6 @@ import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
 import no.nav.etterlatte.Self
 import no.nav.etterlatte.SystemUser
-import no.nav.etterlatte.User
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseService
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
@@ -22,7 +21,6 @@ import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
 import no.nav.etterlatte.sak.SakDao
 import no.nav.etterlatte.tilgangsstyring.SaksbehandlerMedRoller
-import no.nav.etterlatte.tilgangsstyring.filterForEnheter
 import no.nav.etterlatte.token.BrukerTokenInfo
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -49,18 +47,17 @@ class OppgaveService(
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this.javaClass.name)
 
-    fun finnOppgaverForBruker(bruker: SaksbehandlerMedRoller): List<OppgaveIntern> {
-        val rollerSomBrukerHar = finnAktuelleRoller(bruker)
+    fun finnOppgaverForBruker(bruker: SaksbehandlerMedEnheterOgRoller): List<OppgaveIntern> {
+        val rollerSomBrukerHar = finnAktuelleRoller(bruker.saksbehandlerMedRoller)
         val aktuelleOppgavetyperForRoller = aktuelleOppgavetyperForRolleTilSaksbehandler(rollerSomBrukerHar)
 
-        return if (bruker.harRolleStrengtFortrolig()) {
+        return if (bruker.saksbehandlerMedRoller.harRolleStrengtFortrolig()) {
             oppgaveDao.finnOppgaverForStrengtFortroligOgStrengtFortroligUtland(aktuelleOppgavetyperForRoller)
         } else {
-            oppgaveDao.hentOppgaver(aktuelleOppgavetyperForRoller).sortedByDescending { it.opprettet }
-        }.filterForEnheter(Kontekst.get().appUserAsSaksbehandler())
+            val enheter = bruker.enheter()
+            oppgaveDao.hentOppgaver(aktuelleOppgavetyperForRoller, enheter).sortedByDescending { it.opprettet }
+        }
     }
-
-    private fun List<OppgaveIntern>.filterForEnheter(bruker: User) = this.filterOppgaverForEnheter(bruker)
 
     private fun aktuelleOppgavetyperForRolleTilSaksbehandler(roller: List<Rolle>) =
         roller.flatMap {
@@ -444,13 +441,6 @@ class OppgaveService(
 }
 
 class FantIkkeSakException(msg: String) : Exception(msg)
-
-fun List<OppgaveIntern>.filterOppgaverForEnheter(user: User) =
-    this.filterForEnheter(
-        user,
-    ) { item, enheter ->
-        enheter.contains(item.enhet)
-    }
 
 enum class Rolle {
     SAKSBEHANDLER,

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -54,8 +54,11 @@ class OppgaveService(
         return if (bruker.saksbehandlerMedRoller.harRolleStrengtFortrolig()) {
             oppgaveDao.finnOppgaverForStrengtFortroligOgStrengtFortroligUtland(aktuelleOppgavetyperForRoller)
         } else {
-            val enheter = bruker.enheter()
-            oppgaveDao.hentOppgaver(aktuelleOppgavetyperForRoller, enheter).sortedByDescending { it.opprettet }
+            oppgaveDao.hentOppgaver(
+                aktuelleOppgavetyperForRoller,
+                bruker.enheter(),
+                bruker.erSuperbruker(),
+            ).sortedByDescending { it.opprettet }
         }
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
@@ -220,7 +220,7 @@ suspend inline fun PipelineContext<*, ApplicationCall>.kunAttestant(onSuccess: (
     }
 }
 
-private val saksbehandlereMedTilgangTilAlleEnheter = listOf("S128848", "K105085", "O113803")
+val saksbehandlereMedTilgangTilAlleEnheter = listOf("S128848", "K105085", "O113803")
 
 fun <T> List<T>.filterForEnheter(
     user: User,

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
@@ -51,7 +51,7 @@ internal class OppgaveDaoTest {
         oppgaveDao.opprettOppgave(lagNyOppgave(sakAalesund))
         oppgaveDao.opprettOppgave(lagNyOppgave(sakAalesund))
 
-        val hentOppgaver = oppgaveDao.hentOppgaver(OppgaveType.entries, listOf(Enheter.AALESUND.enhetNr))
+        val hentOppgaver = oppgaveDao.hentOppgaver(OppgaveType.entries, listOf(Enheter.AALESUND.enhetNr), false)
         assertEquals(3, hentOppgaver.size)
     }
 
@@ -61,7 +61,7 @@ internal class OppgaveDaoTest {
         val oppgaveNy = lagNyOppgave(sakAalesund, OppgaveKilde.BEHANDLING, OppgaveType.ATTESTERING)
         oppgaveDao.opprettOppgave(oppgaveNy)
 
-        val hentOppgaver = oppgaveDao.hentOppgaver(OppgaveType.entries, listOf(Enheter.AALESUND.enhetNr))
+        val hentOppgaver = oppgaveDao.hentOppgaver(OppgaveType.entries, listOf(Enheter.AALESUND.enhetNr), false)
         assertEquals(1, hentOppgaver.size)
         assertEquals(OppgaveType.ATTESTERING, hentOppgaver[0].type)
     }
@@ -90,7 +90,7 @@ internal class OppgaveDaoTest {
         val oppgaveUtenbeskyttelse = lagNyOppgave(sakutenbeskyttelse)
         oppgaveDao.opprettOppgave(oppgaveUtenbeskyttelse)
 
-        val hentetOppgave = oppgaveDao.hentOppgaver(OppgaveType.entries, listOf(Enheter.AALESUND.enhetNr))
+        val hentetOppgave = oppgaveDao.hentOppgaver(OppgaveType.entries, listOf(Enheter.AALESUND.enhetNr), false)
         assertEquals(1, hentetOppgave.size)
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
@@ -51,7 +51,7 @@ internal class OppgaveDaoTest {
         oppgaveDao.opprettOppgave(lagNyOppgave(sakAalesund))
         oppgaveDao.opprettOppgave(lagNyOppgave(sakAalesund))
 
-        val hentOppgaver = oppgaveDao.hentOppgaver(OppgaveType.entries)
+        val hentOppgaver = oppgaveDao.hentOppgaver(OppgaveType.entries, listOf(Enheter.AALESUND.enhetNr))
         assertEquals(3, hentOppgaver.size)
     }
 
@@ -61,7 +61,7 @@ internal class OppgaveDaoTest {
         val oppgaveNy = lagNyOppgave(sakAalesund, OppgaveKilde.BEHANDLING, OppgaveType.ATTESTERING)
         oppgaveDao.opprettOppgave(oppgaveNy)
 
-        val hentOppgaver = oppgaveDao.hentOppgaver(OppgaveType.entries)
+        val hentOppgaver = oppgaveDao.hentOppgaver(OppgaveType.entries, listOf(Enheter.AALESUND.enhetNr))
         assertEquals(1, hentOppgaver.size)
         assertEquals(OppgaveType.ATTESTERING, hentOppgaver[0].type)
     }
@@ -90,7 +90,7 @@ internal class OppgaveDaoTest {
         val oppgaveUtenbeskyttelse = lagNyOppgave(sakutenbeskyttelse)
         oppgaveDao.opprettOppgave(oppgaveUtenbeskyttelse)
 
-        val hentetOppgave = oppgaveDao.hentOppgaver(OppgaveType.entries)
+        val hentetOppgave = oppgaveDao.hentOppgaver(OppgaveType.entries, listOf(Enheter.AALESUND.enhetNr))
         assertEquals(1, hentetOppgave.size)
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -719,8 +719,10 @@ internal class OppgaveServiceTest {
         sakDao.oppdaterAdresseBeskyttelse(adressebeskyttetSak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
 
         val saksbehandlerRoller = generateSaksbehandlerMedRoller(AzureGroup.SAKSBEHANDLER)
+        every { saksbehandler.enheter() } returns listOf(Enheter.AALESUND.enhetNr)
+        every { saksbehandler.saksbehandlerMedRoller } returns saksbehandlerRoller
 
-        val oppgaver = oppgaveService.finnOppgaverForBruker(saksbehandlerRoller)
+        val oppgaver = oppgaveService.finnOppgaverForBruker(saksbehandler)
         Assertions.assertEquals(1, oppgaver.size)
         val oppgaveUtenbeskyttelse = oppgaver[0]
         Assertions.assertEquals(nyOppgave.id, oppgaveUtenbeskyttelse.id)
@@ -739,14 +741,17 @@ internal class OppgaveServiceTest {
         )
 
         val saksbehandlerMedRoller = generateSaksbehandlerMedRoller(AzureGroup.SAKSBEHANDLER)
-        val oppgaverUtenEndring = oppgaveService.finnOppgaverForBruker(saksbehandlerMedRoller)
+        every { saksbehandler.enheter() } returns listOf(Enheter.AALESUND.enhetNr, Enheter.STEINKJER.enhetNr)
+        every { saksbehandler.saksbehandlerMedRoller } returns saksbehandlerMedRoller
+
+        val oppgaverUtenEndring = oppgaveService.finnOppgaverForBruker(saksbehandler)
         Assertions.assertEquals(1, oppgaverUtenEndring.size)
         Assertions.assertEquals(Enheter.AALESUND.enhetNr, oppgaverUtenEndring[0].enhet)
 
         oppgaveService.oppdaterEnhetForRelaterteOppgaver(
             listOf(GrunnlagsendringshendelseService.SakMedEnhet(oppgaverUtenEndring[0].sakId, Enheter.STEINKJER.enhetNr)),
         )
-        val oppgaverMedEndring = oppgaveService.finnOppgaverForBruker(saksbehandlerMedRoller)
+        val oppgaverMedEndring = oppgaveService.finnOppgaverForBruker(saksbehandler)
 
         Assertions.assertEquals(1, oppgaverMedEndring.size)
         Assertions.assertEquals(Enheter.STEINKJER.enhetNr, oppgaverMedEndring[0].enhet)
@@ -775,7 +780,10 @@ internal class OppgaveServiceTest {
 
         sakDao.oppdaterAdresseBeskyttelse(adressebeskyttetSak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
         val saksbehandlerMedRollerStrengtFortrolig = generateSaksbehandlerMedRoller(AzureGroup.STRENGT_FORTROLIG)
-        val oppgaver = oppgaveService.finnOppgaverForBruker(saksbehandlerMedRollerStrengtFortrolig)
+        every { saksbehandler.enheter() } returns listOf(Enheter.STRENGT_FORTROLIG.enhetNr)
+        every { saksbehandler.saksbehandlerMedRoller } returns saksbehandlerMedRollerStrengtFortrolig
+
+        val oppgaver = oppgaveService.finnOppgaverForBruker(saksbehandler)
         Assertions.assertEquals(1, oppgaver.size)
         val strengtFortroligOppgave = oppgaver[0]
         Assertions.assertEquals(adressebeskyttetOppgave.id, strengtFortroligOppgave.id)
@@ -804,7 +812,10 @@ internal class OppgaveServiceTest {
             )
 
         val saksbehandlerMedRollerAttestant = generateSaksbehandlerMedRoller(AzureGroup.ATTESTANT)
-        val oppgaver = oppgaveService.finnOppgaverForBruker(saksbehandlerMedRollerAttestant)
+        every { saksbehandler.enheter() } returns listOf(Enheter.AALESUND.enhetNr)
+        every { saksbehandler.saksbehandlerMedRoller } returns saksbehandlerMedRollerAttestant
+
+        val oppgaver = oppgaveService.finnOppgaverForBruker(saksbehandler)
         Assertions.assertEquals(1, oppgaver.size)
         val strengtFortroligOppgave = oppgaver[0]
         Assertions.assertEquals(attestantOppgave.id, strengtFortroligOppgave.id)
@@ -904,7 +915,6 @@ internal class OppgaveServiceTest {
 
     @Test
     fun `Skal filtrere bort oppgaver med annen enhet`() {
-        every { saksbehandler.enheter() } returns listOf(Enheter.AALESUND.enhetNr)
         Kontekst.set(
             Context(
                 saksbehandler,
@@ -947,7 +957,10 @@ internal class OppgaveServiceTest {
         oppgaveService.tildelSaksbehandler(oppgavesteinskjer.id, saksbehandlerid)
 
         val saksbehandlerMedRoller = generateSaksbehandlerMedRoller(AzureGroup.SAKSBEHANDLER)
-        val finnOppgaverForBruker = oppgaveService.finnOppgaverForBruker(saksbehandlerMedRoller)
+        every { saksbehandler.enheter() } returns listOf(Enheter.AALESUND.enhetNr)
+        every { saksbehandler.saksbehandlerMedRoller } returns saksbehandlerMedRoller
+
+        val finnOppgaverForBruker = oppgaveService.finnOppgaverForBruker(saksbehandler)
 
         Assertions.assertEquals(1, finnOppgaverForBruker.size)
         val aalesundfunnetOppgave = finnOppgaverForBruker[0]


### PR DESCRIPTION
Merk her mister superbrukerne sine tilganger for oppgavelisten.
Fikset i https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/3497/commits/31135afedfe97b72b3963d6dafd3d85f225d420d
Men avventer svar på om det kan fjernes.