### PR TITLE
justerer type og status for klage-statistikk-hendelser

### DIFF
--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/service/StatistikkService.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/service/StatistikkService.kt
@@ -271,8 +271,8 @@ class StatistikkService(
         sakId = statistikkKlage.klage.sak.id,
         mottattTidspunkt = statistikkKlage.klage.opprettet,
         registrertTidspunkt = statistikkKlage.tidspunkt,
-        type = hendelse.name,
-        status = statistikkKlage.klage.status.name,
+        type = "KLAGE",
+        status = hendelse.name,
         resultat =
             when (statistikkKlage.klage.utfall) {
                 is KlageUtfall.Omgjoering -> "OMGJOERING"


### PR DESCRIPTION
Type er alltid "KLAGE", og statusen er basert på klagehendelsetypen