### PR TITLE
Går til gammel fallback manglende søsken

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
@@ -16,11 +16,6 @@ import java.util.UUID
 
 val REFORM_TIDSPUNKT_BP = YearMonth.of(2024, 1)
 
-class VirkningstidspunktBPErFoerReformMenManglerSoeskenjustering : UgyldigForespoerselException(
-    code = "MANGLER_SØSKEN_FØR_REFORM_BP",
-    detail = "Man må ha søskenjustering før reform for barnepensjon",
-)
-
 class ManglerVirkningstidspunktBP : UgyldigForespoerselException(
     code = "MANGLER_VIRK_BP",
     detail = "Mangler virkningstidspunkt for barnepensjon.",
@@ -93,9 +88,18 @@ class BeregningsGrunnlagService(
                             null -> throw ManglerVirkningstidspunktBP()
                             else -> {
                                 if (virk.dato.isBefore(REFORM_TIDSPUNKT_BP)) {
-                                    throw VirkningstidspunktBPErFoerReformMenManglerSoeskenjustering()
+                                    // Her burde man egentlig ha en sjekk på om avdøde har noen barn.
+                                    // Hvis avdøde har barn og vi er før reformtidspunkt må disse barnene søskenjusteres
+                                    listOf(
+                                        GrunnlagMedPeriode(
+                                            data = emptyList(),
+                                            fom = virk.dato.atDay(1),
+                                            tom = null,
+                                        ),
+                                    )
+                                } else {
+                                    emptyList()
                                 }
-                                emptyList()
                             }
                         }
                     }

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
@@ -25,7 +25,6 @@ import no.nav.etterlatte.beregning.grunnlag.OverstyrBeregningGrunnlagDao
 import no.nav.etterlatte.beregning.grunnlag.OverstyrBeregningGrunnlagData
 import no.nav.etterlatte.beregning.grunnlag.REFORM_TIDSPUNKT_BP
 import no.nav.etterlatte.beregning.grunnlag.Reduksjon
-import no.nav.etterlatte.beregning.grunnlag.VirkningstidspunktBPErFoerReformMenManglerSoeskenjustering
 import no.nav.etterlatte.beregning.regler.toGrunnlag
 import no.nav.etterlatte.klienter.BehandlingKlientImpl
 import no.nav.etterlatte.klienter.GrunnlagKlient
@@ -495,7 +494,8 @@ internal class BeregningsGrunnlagServiceTest {
 
     @Test
     fun `skal lagre beregningsmetode BP før reform, må ha med søskenperioder`() {
-        val behandling = mockBehandling(SakType.BARNEPENSJON, randomUUID(), virkningstidspunktdato = YearMonth.of(2023, 11))
+        val behandling =
+            mockBehandling(SakType.BARNEPENSJON, randomUUID(), virkningstidspunktdato = YearMonth.of(2023, 11))
         val slot = slot<BeregningsGrunnlag>()
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
@@ -538,7 +538,8 @@ internal class BeregningsGrunnlagServiceTest {
 
     @Test
     fun `skal lagre beregningsmetode BP før reform uten søsken kaster feil VirkningstidsErFoerReformMenManglerSoeskenjustering`() {
-        val behandling = mockBehandling(SakType.BARNEPENSJON, randomUUID(), virkningstidspunktdato = YearMonth.of(2023, 11))
+        val behandling =
+            mockBehandling(SakType.BARNEPENSJON, randomUUID(), virkningstidspunktdato = YearMonth.of(2023, 11))
         val slot = slot<BeregningsGrunnlag>()
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
@@ -548,21 +549,23 @@ internal class BeregningsGrunnlagServiceTest {
         val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns hentOpplysningsgrunnlag
 
-        assertThrows<VirkningstidspunktBPErFoerReformMenManglerSoeskenjustering> {
-            runBlocking {
-                beregningsGrunnlagService.lagreBarnepensjonBeregningsGrunnlag(
-                    randomUUID(),
-                    BarnepensjonBeregningsGrunnlag(
-                        emptyList(),
-                        emptyList(),
-                        BeregningsMetodeBeregningsgrunnlag(BeregningsMetode.BEST),
-                    ),
-                    mockk {
-                        every { ident() } returns "Z123456"
-                    },
-                )
-            }
+        runBlocking {
+            beregningsGrunnlagService.lagreBarnepensjonBeregningsGrunnlag(
+                randomUUID(),
+                BarnepensjonBeregningsGrunnlag(
+                    emptyList(),
+                    emptyList(),
+                    BeregningsMetodeBeregningsgrunnlag(BeregningsMetode.BEST),
+                ),
+                mockk {
+                    every { ident() } returns "Z123456"
+                },
+            )
         }
+        assertEquals(
+            listOf(GrunnlagMedPeriode<List<SoeskenMedIBeregning>>(emptyList(), behandling.virkningstidspunkt?.dato?.atDay(1)!!, null)),
+            slot.captured.soeskenMedIBeregning,
+        )
     }
 
     @Test


### PR DESCRIPTION
Det er litt manglende validering, men nå settes søskenjusteringen slik den skal for behandlinger på gammelt regelverk. Vi kan vurdere om vi vil ha en ekstra sjekk på om avdøde har barn her, med tanke på at det gjelder kun gammelt regelverk og vi aldri har hatt en slik sjekk.