### PR TITLE
FAGSYSTEM-313675 Tillater virkningstidspunkt 3 år bakover i tid inkludert søknadsmåned

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
@@ -298,16 +298,16 @@ internal class BehandlingServiceImpl(
             makstidspunktFoerSoeknad = YearMonth.from(kravdato.minusYears(3))
         }
 
-        val etterMaksTidspunktEllersMinstManedEtterDoedsfall =
+        val paaEllerEtterMaksTidspunktEllersMinstManedEtterDoedsfall =
             if (doedsdato == null) {
                 true // Mangler døsfall når avdød er ukjent
             } else if (doedsdato.isBefore(makstidspunktFoerSoeknad)) {
-                virkningstidspunkt.isAfter(makstidspunktFoerSoeknad)
+                virkningstidspunkt.isAfter(makstidspunktFoerSoeknad) || virkningstidspunkt == makstidspunktFoerSoeknad
             } else {
                 virkningstidspunkt.isAfter(doedsdato)
             }
 
-        return harGyldigFormat && etterMaksTidspunktEllersMinstManedEtterDoedsfall
+        return harGyldigFormat && paaEllerEtterMaksTidspunktEllersMinstManedEtterDoedsfall
     }
 
     override fun hentFoersteVirk(sakId: Long): YearMonth? {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.behandling
 
-import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.User
@@ -12,7 +11,6 @@ import no.nav.etterlatte.behandling.hendelse.HendelseType
 import no.nav.etterlatte.behandling.hendelse.LagretHendelse
 import no.nav.etterlatte.behandling.hendelse.registrerVedtakHendelseFelles
 import no.nav.etterlatte.behandling.klienter.GrunnlagKlient
-import no.nav.etterlatte.behandling.klienter.GrunnlagKlientException
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeDao
 import no.nav.etterlatte.common.tidligsteIverksatteVirkningstidspunkt
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseDao
@@ -39,7 +37,6 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.toJsonNode
-import no.nav.etterlatte.libs.ktorobo.ThrowableErrorMessage
 import no.nav.etterlatte.oppgave.OppgaveService
 import no.nav.etterlatte.tilgangsstyring.filterForEnheter
 import no.nav.etterlatte.token.BrukerTokenInfo
@@ -258,32 +255,14 @@ internal class BehandlingServiceImpl(
         request: VirkningstidspunktRequest,
     ): Boolean {
         val virkningstidspunkt = request.dato
-        val begrunnelse = request.begrunnelse
-        val harGyldigFormat = virkningstidspunkt.year in (0..9999) && begrunnelse != null
+        val harGyldigFormat = virkningstidspunkt.year in (0..9999) && request.begrunnelse != null
 
         val behandling =
             requireNotNull(inTransaction { hentBehandling(behandlingId) }) { "Fant ikke behandling $behandlingId" }
-        val personopplysning =
-            try {
-                grunnlagKlient.finnPersonOpplysning(behandlingId, Opplysningstype.AVDOED_PDL_V1, brukerTokenInfo)
-            } catch (e: GrunnlagKlientException) {
-                when (e.cause) {
-                    is ThrowableErrorMessage -> {
-                        if (e.cause.response?.status == HttpStatusCode.NotFound) {
-                            null
-                        } else {
-                            throw e
-                        }
-                    }
+        val doedsdato = hentDoedsdato(behandlingId, brukerTokenInfo).let { YearMonth.from(it) }
+        val soeknadMottatt = behandling.mottattDato().let { YearMonth.from(it) }
 
-                    else -> throw e
-                }
-            }.also {
-                it?.fnr?.let { behandlingRequestLogger.loggRequest(brukerTokenInfo, it, "behandling") }
-            }
-
-        val doedsdato = personopplysning?.opplysning?.doedsdato?.let { YearMonth.from(it) }
-        val soeknadMottatt = YearMonth.from(behandling.mottattDato())
+        // For BP er makstidspunkt 3 år - dette gjelder også unntaksvis for OMS
         var makstidspunktFoerSoeknad = soeknadMottatt.minusYears(3)
 
         if (behandling.utlandstilknytning == null) {
@@ -298,16 +277,32 @@ internal class BehandlingServiceImpl(
             makstidspunktFoerSoeknad = YearMonth.from(kravdato.minusYears(3))
         }
 
-        val paaEllerEtterMaksTidspunktEllersMinstManedEtterDoedsfall =
-            if (doedsdato == null) {
-                true // Mangler døsfall når avdød er ukjent
-            } else if (doedsdato.isBefore(makstidspunktFoerSoeknad)) {
-                virkningstidspunkt.isAfter(makstidspunktFoerSoeknad) || virkningstidspunkt == makstidspunktFoerSoeknad
-            } else {
-                virkningstidspunkt.isAfter(doedsdato)
+        val datoForVirkningstidspunktErGydligInnenforMaksBegrensninger =
+            when {
+                doedsdato == null -> true // Mangler dødsfall når avdød er ukjent
+                doedsdato.isBefore(makstidspunktFoerSoeknad) -> {
+                    when (behandling.sak.sakType) {
+                        SakType.OMSTILLINGSSTOENAD ->
+                            // For omstillingsstønad vil virkningstidspunktet tidligst være mnd etter makstidspunkt
+                            virkningstidspunkt.isAfter(makstidspunktFoerSoeknad)
+                        SakType.BARNEPENSJON ->
+                            // For barnepensjon vil virkningstidspunktet tidligst være samme mnd som makstidspunkt
+                            virkningstidspunkt.isAfter(makstidspunktFoerSoeknad) || virkningstidspunkt == makstidspunktFoerSoeknad
+                    }
+                }
+                else -> virkningstidspunkt.isAfter(doedsdato)
             }
 
-        return harGyldigFormat && paaEllerEtterMaksTidspunktEllersMinstManedEtterDoedsfall
+        return harGyldigFormat && datoForVirkningstidspunktErGydligInnenforMaksBegrensninger
+    }
+
+    private suspend fun hentDoedsdato(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): LocalDate? {
+        return grunnlagKlient.finnPersonOpplysning(behandlingId, Opplysningstype.AVDOED_PDL_V1, brukerTokenInfo)
+            .also { it?.fnr?.let { fnr -> behandlingRequestLogger.loggRequest(brukerTokenInfo, fnr, "behandling") } }
+            ?.let { it.opplysning.doedsdato }
     }
 
     override fun hentFoersteVirk(sakId: Long): YearMonth? {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/GrunnlagKlient.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.github.michaelbull.result.mapBoth
 import com.typesafe.config.Config
 import io.ktor.client.HttpClient
+import io.ktor.http.HttpStatusCode
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
@@ -59,7 +60,13 @@ class GrunnlagKlientObo(config: Config, httpClient: HttpClient) : GrunnlagKlient
                 )
                 .mapBoth(
                     success = { resource -> resource.response?.let { objectMapper.readValue(it.toString()) } },
-                    failure = { errorResponse -> throw errorResponse },
+                    failure = { errorResponse ->
+                        if (errorResponse.response?.status == HttpStatusCode.NotFound) {
+                            null
+                        } else {
+                            throw errorResponse
+                        }
+                    },
                 )
         } catch (e: Exception) {
             throw GrunnlagKlientException(

--- a/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
@@ -116,6 +116,7 @@ fun opprettBehandling(
 fun foerstegangsbehandling(
     id: UUID = UUID.randomUUID(),
     sakId: Long,
+    sakType: SakType = SakType.BARNEPENSJON,
     behandlingOpprettet: LocalDateTime = Tidspunkt.now().toLocalDatetimeUTC(),
     sistEndret: LocalDateTime = Tidspunkt.now().toLocalDatetimeUTC(),
     status: BehandlingStatus = BehandlingStatus.OPPRETTET,
@@ -133,7 +134,7 @@ fun foerstegangsbehandling(
     sak =
         Sak(
             ident = persongalleri.soeker,
-            sakType = SakType.BARNEPENSJON,
+            sakType = sakType,
             id = sakId,
             enhet = enhet,
         ),

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
@@ -533,13 +533,42 @@ class BehandlingServiceImplTest {
     }
 
     @Test
-    fun `erGyldigVirkningstidspunkt hvis tidspunkt er tre aar foer mottatt soeknad`() {
+    fun `erGyldigVirkningstidspunkt er true hvis tidspunkt er akkurat tre aar foer mottatt soeknad`() {
         val bodyVirkningstidspunkt = Tidspunkt.parse("2017-01-01T00:00:00Z")
         val bodyBegrunnelse = "begrunnelse"
         val request = VirkningstidspunktRequest(bodyVirkningstidspunkt.toString(), bodyBegrunnelse)
 
-        val soeknadMottatt = LocalDateTime.parse("2020-01-01T00:00:00.000000000")
+        val soeknadMottatt = LocalDateTime.parse("2020-01-15T00:00:00.000000000")
         val doedsdato = LocalDate.parse("2016-12-30")
+
+        val service =
+            behandlingServiceMedMocks(
+                doedsdato = doedsdato,
+                soeknadMottatt = soeknadMottatt,
+                utlandstilknytning =
+                    Utlandstilknytning(
+                        UtlandstilknytningType.NASJONAL,
+                        Grunnlagsopplysning.Saksbehandler.create("ident"),
+                        "begrunnelse",
+                    ),
+            )
+
+        val gyldigVirkningstidspunkt =
+            runBlocking {
+                service.erGyldigVirkningstidspunkt(BEHANDLINGS_ID, TOKEN, request)
+            }
+
+        assertTrue(gyldigVirkningstidspunkt)
+    }
+
+    @Test
+    fun `erGyldigVirkningstidspunkt er false hvis tidspunkt er over tre aar foer mottatt soeknad`() {
+        val bodyVirkningstidspunkt = Tidspunkt.parse("2016-12-01T00:00:00Z")
+        val bodyBegrunnelse = "begrunnelse"
+        val request = VirkningstidspunktRequest(bodyVirkningstidspunkt.toString(), bodyBegrunnelse)
+
+        val soeknadMottatt = LocalDateTime.parse("2020-01-15T00:00:00.000000000")
+        val doedsdato = LocalDate.parse("2016-11-30")
 
         val service =
             behandlingServiceMedMocks(

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.behandling
 
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
@@ -27,6 +28,7 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingHendelseType
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BoddEllerArbeidetUtlandet
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
+import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
 import no.nav.etterlatte.libs.common.behandling.Utlandstilknytning
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
@@ -47,6 +49,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import java.sql.Connection
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -400,194 +404,160 @@ class BehandlingServiceImplTest {
         assertEquals(Saksrolle.UKJENT, resUkjentRolle)
     }
 
-    @Test
-    fun `Virkningstidspunkt krever fastsetting av utlandstilknytning`() {
-        val bodyVirkningstidspunkt = Tidspunkt.parse("2017-02-01T00:00:00Z")
-        val bodyBegrunnelse = "begrunnelse"
-        val request = VirkningstidspunktRequest(bodyVirkningstidspunkt.toString(), bodyBegrunnelse)
-
-        val soeknadMottatt = LocalDateTime.parse("2020-01-01T00:00:00.000000000")
-        val doedsdato = LocalDate.parse("2016-12-30")
-
-        val service = behandlingServiceMedMocks(doedsdato, soeknadMottatt)
+    @ParameterizedTest
+    @EnumSource(SakType::class, names = ["OMSTILLINGSSTOENAD", "BARNEPENSJON"], mode = EnumSource.Mode.INCLUDE)
+    fun `skal feile dersom virkningstidspunkt ikke har satt utlandstilknytning`(sakType: SakType) {
         assertThrows<VirkningstidspunktMaaHaUtenlandstilknytning> {
-            runBlocking {
-                service.erGyldigVirkningstidspunkt(BEHANDLINGS_ID, TOKEN, request)
-            }
+            sjekkOmVirkningstidspunktErGyldig(
+                sakType = sakType,
+                utlandstilknytningType = null,
+                virkningstidspunkt = Tidspunkt.parse("2015-02-01T00:00:00Z"),
+                soeknadMottatt = LocalDateTime.parse("2020-01-01T00:00:00"),
+                doedsdato = LocalDate.parse("2014-01-01"),
+            )
         }
     }
 
-    @Test
-    fun `Ved utlandstilknytning bosatt utland må kravdato være med`() {
-        val bodyVirkningstidspunkt = Tidspunkt.parse("2017-02-01T00:00:00Z")
-        val bodyBegrunnelse = "begrunnelse"
-        val request = VirkningstidspunktRequest(bodyVirkningstidspunkt.toString(), bodyBegrunnelse)
-
-        val soeknadMottatt = LocalDateTime.parse("2020-01-01T00:00:00.000000000")
-        val doedsdato = LocalDate.parse("2016-12-30")
-
-        val service =
-            behandlingServiceMedMocks(
-                doedsdato = doedsdato,
-                soeknadMottatt = soeknadMottatt,
-                utlandstilknytning =
-                    Utlandstilknytning(
-                        UtlandstilknytningType.BOSATT_UTLAND,
-                        Grunnlagsopplysning.Saksbehandler.create("ident"),
-                        "begrunnelse",
-                    ),
-            )
-
+    @ParameterizedTest
+    @EnumSource(SakType::class, names = ["OMSTILLINGSSTOENAD", "BARNEPENSJON"], mode = EnumSource.Mode.INCLUDE)
+    fun `skal feile dersom kravdato ikke er med ved bosatt utland`(sakType: SakType) {
         assertThrows<KravdatoMaaFinnesHvisBosattutland> {
-            runBlocking {
-                service.erGyldigVirkningstidspunkt(BEHANDLINGS_ID, TOKEN, request)
-            }
+            sjekkOmVirkningstidspunktErGyldig(
+                sakType = sakType,
+                utlandstilknytningType = UtlandstilknytningType.BOSATT_UTLAND,
+                virkningstidspunkt = Tidspunkt.parse("2015-02-01T00:00:00Z"),
+                soeknadMottatt = LocalDateTime.parse("2020-01-01T00:00:00"),
+                doedsdato = LocalDate.parse("2014-01-01"),
+            )
         }
     }
 
-    @Test
-    fun `Ved utlandstilknytning bosatt utland med kravdato skal kravdato brukes ikke soeknadmottatt`() {
-        val bodyVirkningstidspunkt = Tidspunkt.parse("2017-02-01T00:00:00Z")
-        val bodyBegrunnelse = "begrunnelse"
-        val bodyKravdato = Tidspunkt.parse("2019-02-01T00:00:00Z")
-        val request = VirkningstidspunktRequest(bodyVirkningstidspunkt.toString(), bodyBegrunnelse, bodyKravdato.toLocalDate())
-        val doedsdato = LocalDate.parse("2014-01-01")
-
-        val soeknadMottatt = LocalDateTime.parse("2009-01-01T00:00:00.000000000")
-
-        val service =
-            behandlingServiceMedMocks(
-                doedsdato = doedsdato,
-                soeknadMottatt = soeknadMottatt,
-                utlandstilknytning =
-                    Utlandstilknytning(
-                        UtlandstilknytningType.BOSATT_UTLAND,
-                        Grunnlagsopplysning.Saksbehandler.create("ident"),
-                        "begrunnelse",
-                    ),
+    @ParameterizedTest
+    @EnumSource(SakType::class, names = ["OMSTILLINGSSTOENAD", "BARNEPENSJON"], mode = EnumSource.Mode.INCLUDE)
+    fun `skal legge til grunn kravdato i stedet for soeknadMottattDato ved bosatt utland`(sakType: SakType) {
+        val gyldigVirkningstidspunkt =
+            sjekkOmVirkningstidspunktErGyldig(
+                sakType = sakType,
+                utlandstilknytningType = UtlandstilknytningType.BOSATT_UTLAND,
+                virkningstidspunkt = Tidspunkt.parse("2015-02-01T00:00:00Z"),
+                kravdato = Tidspunkt.parse("2017-02-01T00:00:00Z"),
+                // brukes denne vil ikke virk være innenfor 3 år
+                soeknadMottatt = LocalDateTime.parse("2020-01-01T00:00:00"),
+                doedsdato = LocalDate.parse("2014-01-01"),
             )
 
-        val svar =
-            runBlocking {
-                service.erGyldigVirkningstidspunkt(BEHANDLINGS_ID, TOKEN, request)
-            }
-        assertTrue(svar)
+        gyldigVirkningstidspunkt shouldBe true
+    }
+
+    @ParameterizedTest
+    @EnumSource(SakType::class, names = ["OMSTILLINGSSTOENAD", "BARNEPENSJON"], mode = EnumSource.Mode.INCLUDE)
+    fun `skal gi gyldig virkningstidspunkt hvis tidspunkt er en maaned etter doedsfall`(sakType: SakType) {
+        val gyldigVirkningstidspunkt =
+            sjekkOmVirkningstidspunktErGyldig(
+                sakType = sakType,
+                virkningstidspunkt = Tidspunkt.parse("2020-02-01T00:00:00Z"),
+                soeknadMottatt = LocalDateTime.parse("2020-02-01T00:00:00"),
+                doedsdato = LocalDate.parse("2020-01-01"),
+            )
+
+        gyldigVirkningstidspunkt shouldBe true
+    }
+
+    @ParameterizedTest
+    @EnumSource(SakType::class, names = ["OMSTILLINGSSTOENAD", "BARNEPENSJON"], mode = EnumSource.Mode.INCLUDE)
+    fun `skal gi ugyldig virkningstidspunkt hvis tidspunkt er foer en maaned etter doedsfall`(sakType: SakType) {
+        val gyldigVirkningstidspunkt =
+            sjekkOmVirkningstidspunktErGyldig(
+                sakType = sakType,
+                virkningstidspunkt = Tidspunkt.parse("2020-01-01T00:00:00Z"),
+                soeknadMottatt = LocalDateTime.parse("2020-02-01T00:00:00"),
+                doedsdato = LocalDate.parse("2020-01-01"),
+            )
+
+        gyldigVirkningstidspunkt shouldBe false
     }
 
     @Test
-    fun `erGyldigVirkningstidspunkt hvis tidspunkt er maaned etter doedsfall og maks tre aar foer mottatt soeknad`() {
-        val bodyVirkningstidspunkt = Tidspunkt.parse("2017-02-01T00:00:00Z")
-        val bodyBegrunnelse = "begrunnelse"
-        val request = VirkningstidspunktRequest(bodyVirkningstidspunkt.toString(), bodyBegrunnelse)
-
-        val soeknadMottatt = LocalDateTime.parse("2020-01-01T00:00:00.000000000")
-        val doedsdato = LocalDate.parse("2016-12-30")
-
-        val service =
-            behandlingServiceMedMocks(
-                doedsdato = doedsdato,
-                soeknadMottatt = soeknadMottatt,
-                utlandstilknytning =
-                    Utlandstilknytning(
-                        UtlandstilknytningType.NASJONAL,
-                        Grunnlagsopplysning.Saksbehandler.create("ident"),
-                        "begrunnelse",
-                    ),
+    fun `skal gi gyldig virkningstidspunkt hvis tidspunkt er inntil tre aar foer mottatt soeknad for barnepensjon`() {
+        val gyldigVirkningstidspunkt =
+            sjekkOmVirkningstidspunktErGyldig(
+                sakType = SakType.BARNEPENSJON,
+                virkningstidspunkt = Tidspunkt.parse("2017-01-01T00:00:00Z"),
+                soeknadMottatt = LocalDateTime.parse("2020-01-15T00:00:00"),
+                doedsdato = LocalDate.parse("2016-11-30"),
             )
 
-        val gyldigVirkningstidspunkt =
-            runBlocking {
-                service.erGyldigVirkningstidspunkt(BEHANDLINGS_ID, TOKEN, request)
-            }
-
-        assertTrue(gyldigVirkningstidspunkt)
+        gyldigVirkningstidspunkt shouldBe true
     }
 
     @Test
-    fun `erGyldigVirkningstidspunkt er false hvis tidspunkt er foer en maaned etter doedsfall`() {
-        val bodyVirkningstidspunkt = Tidspunkt.parse("2020-01-01T00:00:00Z")
-        val bodyBegrunnelse = "begrunnelse"
-        val request = VirkningstidspunktRequest(bodyVirkningstidspunkt.toString(), bodyBegrunnelse)
-
-        val soeknadMottatt = LocalDateTime.parse("2020-02-01T00:00:00.000000000")
-        val doedsdato = LocalDate.parse("2020-01-01")
-
-        val service =
-            behandlingServiceMedMocks(
-                doedsdato = doedsdato,
-                soeknadMottatt = soeknadMottatt,
-                utlandstilknytning =
-                    Utlandstilknytning(
-                        UtlandstilknytningType.NASJONAL,
-                        Grunnlagsopplysning.Saksbehandler.create("ident"),
-                        "begrunnelse",
-                    ),
+    fun `skal gi gyldig virkningstidspunkt hvis tidspunkt er under tre aar foer mottatt soeknad for omstillingsstoenad`() {
+        val gyldigVirkningstidspunkt =
+            sjekkOmVirkningstidspunktErGyldig(
+                sakType = SakType.OMSTILLINGSSTOENAD,
+                virkningstidspunkt = Tidspunkt.parse("2017-02-01T00:00:00Z"),
+                soeknadMottatt = LocalDateTime.parse("2020-01-15T00:00:00"),
+                doedsdato = LocalDate.parse("2016-11-30"),
             )
 
-        val gyldigVirkningstidspunkt =
-            runBlocking {
-                service.erGyldigVirkningstidspunkt(BEHANDLINGS_ID, TOKEN, request)
-            }
-
-        assertFalse(gyldigVirkningstidspunkt)
+        gyldigVirkningstidspunkt shouldBe true
     }
 
     @Test
-    fun `erGyldigVirkningstidspunkt er true hvis tidspunkt er akkurat tre aar foer mottatt soeknad`() {
-        val bodyVirkningstidspunkt = Tidspunkt.parse("2017-01-01T00:00:00Z")
-        val bodyBegrunnelse = "begrunnelse"
-        val request = VirkningstidspunktRequest(bodyVirkningstidspunkt.toString(), bodyBegrunnelse)
-
-        val soeknadMottatt = LocalDateTime.parse("2020-01-15T00:00:00.000000000")
-        val doedsdato = LocalDate.parse("2016-12-30")
-
-        val service =
-            behandlingServiceMedMocks(
-                doedsdato = doedsdato,
-                soeknadMottatt = soeknadMottatt,
-                utlandstilknytning =
-                    Utlandstilknytning(
-                        UtlandstilknytningType.NASJONAL,
-                        Grunnlagsopplysning.Saksbehandler.create("ident"),
-                        "begrunnelse",
-                    ),
+    fun `skal gi ugyldig virkningstidspunkt hvis tidspunkt er over tre aar foer mottatt soeknad for barnepensjon`() {
+        val gyldigVirkningstidspunkt =
+            sjekkOmVirkningstidspunktErGyldig(
+                sakType = SakType.BARNEPENSJON,
+                virkningstidspunkt = Tidspunkt.parse("2016-12-01T00:00:00Z"),
+                soeknadMottatt = LocalDateTime.parse("2020-01-15T00:00:00"),
+                doedsdato = LocalDate.parse("2016-11-30"),
             )
 
-        val gyldigVirkningstidspunkt =
-            runBlocking {
-                service.erGyldigVirkningstidspunkt(BEHANDLINGS_ID, TOKEN, request)
-            }
-
-        assertTrue(gyldigVirkningstidspunkt)
+        gyldigVirkningstidspunkt shouldBe false
     }
 
     @Test
-    fun `erGyldigVirkningstidspunkt er false hvis tidspunkt er over tre aar foer mottatt soeknad`() {
-        val bodyVirkningstidspunkt = Tidspunkt.parse("2016-12-01T00:00:00Z")
-        val bodyBegrunnelse = "begrunnelse"
-        val request = VirkningstidspunktRequest(bodyVirkningstidspunkt.toString(), bodyBegrunnelse)
+    fun `skal gi ugyldig virkningstidspunkt hvis tidspunkt er tre aar foer mottatt soeknad for omstillingsstoenad`() {
+        val gyldigVirkningstidspunkt =
+            sjekkOmVirkningstidspunktErGyldig(
+                sakType = SakType.OMSTILLINGSSTOENAD,
+                virkningstidspunkt = Tidspunkt.parse("2016-01-01T00:00:00Z"),
+                soeknadMottatt = LocalDateTime.parse("2020-01-15T00:00:00"),
+                doedsdato = LocalDate.parse("2016-11-30"),
+            )
 
-        val soeknadMottatt = LocalDateTime.parse("2020-01-15T00:00:00.000000000")
-        val doedsdato = LocalDate.parse("2016-11-30")
+        gyldigVirkningstidspunkt shouldBe false
+    }
 
+    private fun sjekkOmVirkningstidspunktErGyldig(
+        sakType: SakType,
+        utlandstilknytningType: UtlandstilknytningType? = UtlandstilknytningType.NASJONAL,
+        virkningstidspunkt: Tidspunkt = Tidspunkt.parse("2016-01-01T00:00:00Z"),
+        begrunnelse: String = "en begrunnelse",
+        soeknadMottatt: LocalDateTime = LocalDateTime.parse("2020-01-15T00:00:00"),
+        doedsdato: LocalDate = LocalDate.parse("2016-11-30"),
+        kravdato: Tidspunkt? = null,
+    ): Boolean {
         val service =
             behandlingServiceMedMocks(
+                sakType = sakType,
                 doedsdato = doedsdato,
                 soeknadMottatt = soeknadMottatt,
                 utlandstilknytning =
-                    Utlandstilknytning(
-                        UtlandstilknytningType.NASJONAL,
-                        Grunnlagsopplysning.Saksbehandler.create("ident"),
-                        "begrunnelse",
-                    ),
+                    utlandstilknytningType?.let {
+                        Utlandstilknytning(
+                            utlandstilknytningType,
+                            Grunnlagsopplysning.Saksbehandler.create("ident"),
+                            "begrunnelse",
+                        )
+                    },
             )
 
-        val gyldigVirkningstidspunkt =
-            runBlocking {
-                service.erGyldigVirkningstidspunkt(BEHANDLINGS_ID, TOKEN, request)
-            }
+        val request = VirkningstidspunktRequest(virkningstidspunkt.toString(), begrunnelse, kravdato?.toLocalDate())
 
-        assertFalse(gyldigVirkningstidspunkt)
+        return runBlocking {
+            service.erGyldigVirkningstidspunkt(BEHANDLINGS_ID, TOKEN, request)
+        }
     }
 
     @Test
@@ -749,6 +719,7 @@ class BehandlingServiceImplTest {
     }
 
     private fun behandlingServiceMedMocks(
+        sakType: SakType = SakType.BARNEPENSJON,
         doedsdato: LocalDate?,
         soeknadMottatt: LocalDateTime,
         utlandstilknytning: Utlandstilknytning? = null,
@@ -757,6 +728,7 @@ class BehandlingServiceImplTest {
             foerstegangsbehandling(
                 id = BEHANDLINGS_ID,
                 sakId = SAK_ID,
+                sakType = sakType,
                 soeknadMottattDato = soeknadMottatt,
                 utlandstilknytning = utlandstilknytning,
             )


### PR DESCRIPTION
I den aktuelle saken var søknad mottatt i desember 2023 og virkningstidspunkt satt til 01.12.2020. Dødstidspunkt var i midten av 2020. Saksbehandler fikk ikke satt virkningstidspunkt fra desember 2023 i dette tilfellet. Denne PR'en åpner for dette for Barnepensjon.

For omstillingsstønad gjelder reglene slik de var. Tidligste virkningstidspunkt der ville basert på § 22-13 vært januar 2023.