### PR TITLE
Enkel visning av utsendingsinfo på journalpost

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/Model.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/Model.kt
@@ -98,6 +98,7 @@ data class Journalpost(
     val bruker: Bruker?,
     val sak: JournalpostSak?,
     val datoOpprettet: String,
+    val utsendingsinfo: Utsendingsinfo?,
 )
 
 data class Dokumenter(
@@ -122,3 +123,32 @@ data class AvsenderMottaker(
     val land: String?,
     val erLikBruker: Boolean?,
 )
+
+data class Utsendingsinfo(
+    val adresselinje1: String,
+    val adresselinje2: String,
+    val adresselinje3: String,
+    val postnummer: String,
+    val poststed: String,
+    val landkode: String,
+    val digitalpostkasseAdresse: String,
+    val fysiskpostSendt: FysiskpostSendt,
+    val digitalpostSendt: DigitalpostSendt,
+    val varselSendt: VarselSendt,
+) {
+    data class FysiskpostSendt(
+        val adressetekstKonvolutt: String,
+    )
+
+    data class DigitalpostSendt(
+        val adresse: String,
+    )
+
+    data class VarselSendt(
+        val type: String,
+        val adresse: String,
+        val tittel: String,
+        val tekst: String,
+        val tidspunkt: String,
+    )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/dokumentliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/dokumentliste.tsx
@@ -1,4 +1,4 @@
-import { Detail, Heading, Table } from '@navikt/ds-react'
+import { Button, Detail, Heading, Modal, Table } from '@navikt/ds-react'
 import { formaterStringDato } from '~utils/formattering'
 import DokumentModal from './dokumentModal'
 import Spinner from '~shared/Spinner'
@@ -6,6 +6,9 @@ import { Journalpost } from '~shared/types/Journalpost'
 import { ApiErrorAlert } from '~ErrorBoundary'
 
 import { mapApiResult, Result } from '~shared/api/apiUtils'
+import { InformationSquareIcon } from '@navikt/aksel-icons'
+import { FlexRow } from '~shared/styled'
+import { useState } from 'react'
 
 const colonner = ['ID', 'Tittel', 'Avsender/Mottaker', 'Dato', 'Sak', 'Status', 'Type', '']
 
@@ -60,11 +63,15 @@ export const Dokumentliste = ({ dokumenter }: { dokumenter: Result<Journalpost[]
                     <Table.DataCell>{dokument.journalstatus}</Table.DataCell>
                     <Table.DataCell>{dokument.journalposttype === 'I' ? 'Inngående' : 'Utgående'}</Table.DataCell>
                     <Table.DataCell>
-                      <DokumentModal
-                        tittel={dokument.tittel}
-                        journalpostId={dokument.journalpostId}
-                        dokumentInfoId={dokument.dokumenter[0].dokumentInfoId}
-                      />
+                      <FlexRow justify="right">
+                        <UtsendingsinfoModal journalpost={dokument} />
+
+                        <DokumentModal
+                          tittel={dokument.tittel}
+                          journalpostId={dokument.journalpostId}
+                          dokumentInfoId={dokument.dokumenter[0].dokumentInfoId}
+                        />
+                      </FlexRow>
                     </Table.DataCell>
                   </Table.Row>
                 ))}
@@ -75,3 +82,31 @@ export const Dokumentliste = ({ dokumenter }: { dokumenter: Result<Journalpost[]
     </Table>
   </>
 )
+
+const UtsendingsinfoModal = ({ journalpost }: { journalpost: Journalpost }) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  if (journalpost.journalposttype !== 'U' || !journalpost.utsendingsinfo) return null
+
+  return (
+    <>
+      <Button
+        variant="tertiary"
+        title="Utsendingsinfo"
+        size="small"
+        icon={<InformationSquareIcon />}
+        onClick={() => setIsOpen(true)}
+      />
+
+      <Modal open={isOpen} onClose={() => setIsOpen(false)}>
+        <Modal.Header>
+          <Heading size="medium">Utsendingsinfo</Heading>
+        </Modal.Header>
+
+        <Modal.Body>
+          <pre>{JSON.stringify(journalpost.utsendingsinfo, null, 2)}</pre>
+        </Modal.Body>
+      </Modal>
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/dokumentoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/dokumentoversikt.tsx
@@ -1,10 +1,10 @@
 import { Dokumentliste } from './dokumentliste'
-import styled from 'styled-components'
 import { useEffect } from 'react'
 import { hentDokumenter } from '~shared/api/dokument'
 import { SidebarPanel } from '~shared/components/Sidebar'
 import { DokumentlisteLiten } from './dokumentlisteLiten'
 import { useApiCall } from '~shared/hooks/useApiCall'
+import { Container } from '~shared/styled'
 
 export const Dokumentoversikt = (props: { fnr: string; liten?: boolean }) => {
   const [dokumenter, hentDokumenterForBruker] = useApiCall(hentDokumenter)
@@ -16,19 +16,8 @@ export const Dokumentoversikt = (props: { fnr: string; liten?: boolean }) => {
       <DokumentlisteLiten dokumenter={dokumenter} />
     </SidebarPanel>
   ) : (
-    <OversiktWrapper>
+    <Container>
       <Dokumentliste dokumenter={dokumenter} />
-    </OversiktWrapper>
+    </Container>
   )
 }
-
-export const OversiktWrapper = styled.div`
-  min-width: 40em;
-  max-width: 70%;
-
-  margin: 3em 1em;
-
-  .behandlinger {
-    margin-top: 5em;
-  }
-`

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Journalpost.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Journalpost.ts
@@ -10,6 +10,7 @@ export interface Journalpost {
   kanal: string
   sak?: JournalpostSak
   datoOpprettet: string
+  utsendingsinfo?: object
 }
 
 export interface OppdaterJournalpostRequest {


### PR DESCRIPTION
Vise utsendingsinfo i json-format til saksbehandler. Minimumsløsning enn så lenge. 
Får ikke testet på en god måte verken lokalt eller i dev siden utsendingsinfo aldri blir satt i dev. 

Vil se omtrent slik ut: 
<img width="1426" alt="Skjermbilde 2024-01-25 kl  08 22 51" src="https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/7dfff36a-fcfa-49b8-ad7f-7d0d56953dc9">
