### PR TITLE
Fjerne backendlogging av "ResizeObserver loop completed with undelivered notifications"

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/utils/logger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/utils/logger.tsx
@@ -80,7 +80,9 @@ export const setupWindowOnError = () => {
     if (import.meta.env.MODE === 'development') {
       console.error(error.message, error.stack)
     } else {
-      logger.error({ lineno, columnno: colno, message, error: JSON.stringify(error) })
+      if (message !== 'ResizeObserver loop completed with undelivered notifications.') {
+        logger.error({ lineno, columnno: colno, message, error: JSON.stringify(error) })
+      }
 
       if (error.stack && error.stack?.indexOf('invokeGuardedCallbackDev') >= 0 && !error.alreadySeen) {
         error.alreadySeen = true

--- a/apps/etterlatte-saksbehandling-ui/client/src/utils/logger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/utils/logger.tsx
@@ -74,8 +74,9 @@ export const logger = {
 
 export const setupWindowOnError = () => {
   addEventListener('error', (event) => {
-    const { error, lineno, colno, message } = event
+    const { error: kanskjeError, lineno, colno, message } = event
 
+    const error = kanskjeError || {}
     if (import.meta.env.MODE === 'development') {
       console.error(error.message, error.stack)
     } else {


### PR DESCRIPTION
Gravde litt i ResizeObserver-feilen vi ser periodisk i loggene i prod, og fikk gjenskapt i alle fall et tilfelle der den inntreffer: Hvis man ser på en hendelse i saksoversikten og åpner modalen "Lukk hendelse" får vi en ResizeObserver-loop-feil. Dette er ikke forbundet med noe som faktisk ødelegger for brukeren, og vi ignorerer i praksis i dag denne feilmeldingen når den treffer loggene. Undersøkte litt mer for å se om jeg kunne hindre selve feilen, men kom ikke noe videre. Det er nok noe aksel-relatert.

Foreslått løsning er i denne PR'en: Ignorerer akkurat denne feilmeldingen i den generelle onError-listeneren vi har på window for sending til backend. Det er uansett ikke en feil som påvirker brukeren (så langt jeg kan se). Det logges fremdeles i lokal utvikling, så der kan man slå seg løs om man vil angripe problemet igjen.