### PR TITLE
EY-3335 - fiks setting av utland enhetnr

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BrukerService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BrukerService.kt
@@ -91,7 +91,7 @@ class BrukerServiceImpl(
                 } else {
                     ArbeidsFordelingEnhet(
                         Enheter.UTLAND.navn,
-                        Enheter.UTLAND.navn,
+                        Enheter.UTLAND.enhetNr,
                     )
                 }
             }

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V87__fiks_enhet_i_sak.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V87__fiks_enhet_i_sak.sql
@@ -1,0 +1,1 @@
+UPDATE sak SET enhet='0001' WHERE enhet='NAV Familie- og pensjonsytelser Utland'


### PR DESCRIPTION
VI har 9 saker i prod med enhet navn i sak: `NAV Familie- og pensjonsytelser Utland` - burde vært enhetnr