### PR TITLE
Fjernet OMS-sjekklistepunkt om løst samordning

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/sjekkliste/Sjekkliste.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/sjekkliste/Sjekkliste.kt
@@ -57,7 +57,6 @@ internal val defaultSjekklisteItemsOMS =
         "Opprettet oppgave i Gosys for videre oppfølging av aktivitetsplikt",
         "Ikke registrert/feil kontonummer i saken - opprettet oppgave til NØP",
         "Refusjonskrav (annen NAV-ytelse) i etterbetaling av OMS - opprettet oppgave til NØP",
-        "Samordning - løst opp pga ingen refusjon, se eget notat",
         "Bosatt Norge: Innhenter EØS og bank-opplysninger",
         "Bosatt Norge: Sendt brev til bruker om krav til avtaleland",
         "Bosatt Norge: Opprettet oppfølgingsoppgave på sluttbehandling i Gosys",


### PR DESCRIPTION
fra Mari

> Kunne du fjernet sjekkpunktet på OMS om samordning (Samordning - løst opp pga ingen refusjon, se eget notat) når du får tid? Dette er nok kommet med ved en feil. Ser det er vist til Pesys også, så sikkert tenkt å ha det der i tilfelle det skulle komme noe mer..