### PR TITLE
Tilpasser oppstart av migrering for gjenoppretting av tidligere saker

### DIFF
--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/PesysRepository.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/PesysRepository.kt
@@ -54,12 +54,12 @@ internal class PesysRepository(private val dataSource: DataSource) : Transaction
         )
     }
 
-    fun oppdaterKanGjennopprettesAutomatisk(
+    fun oppdaterKanGjenopprettesAutomatisk(
         migreringRequest: MigreringRequest,
         tx: TransactionalSession? = null,
     ) = tx.session {
         oppdater(
-            "UPDATE pesyssak SET gjennopprettes_automatisk = :automatisk " +
+            "UPDATE pesyssak SET gjenopprettes_automatisk = :automatisk " +
                 "WHERE id = :pesyssak",
             mapOf("id" to migreringRequest.pesysId, "automatisk" to migreringRequest.kanAutomatiskGjenopprettes),
             "Oppdaterer pesyssak med kan gjenopprettes automatisk",

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/PesysRepository.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/PesysRepository.kt
@@ -54,6 +54,18 @@ internal class PesysRepository(private val dataSource: DataSource) : Transaction
         )
     }
 
+    fun oppdaterKanGjennopprettesAutomatisk(
+        migreringRequest: MigreringRequest,
+        tx: TransactionalSession? = null,
+    ) = tx.session {
+        oppdater(
+            "UPDATE pesyssak SET gjennopprettes_automatisk = :automatisk " +
+                "WHERE id = :pesyssak",
+            mapOf("id" to migreringRequest.pesysId, "automatisk" to migreringRequest.kanAutomatiskGjenopprettes),
+            "Oppdaterer pesyssak med kan gjenopprettes automatisk",
+        )
+    }
+
     fun oppdaterStatus(
         id: PesysId,
         nyStatus: Migreringsstatus,

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/start/MigrerSpesifikkSakRiver.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/start/MigrerSpesifikkSakRiver.kt
@@ -107,6 +107,7 @@ internal class MigrerSpesifikkSakRiver(
             sendSakTilMigrering(packet, verifisertRequest, context, pesyssak)
         } else {
             logger.info("Migrering er skrudd av. Sender ikke pesys-sak ${pesyssak.id} videre.")
+            pesysRepository.lagreGyldigDryRun(verifisertRequest)
         }
     }
 

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/start/MigrerSpesifikkSakRiver.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/start/MigrerSpesifikkSakRiver.kt
@@ -99,7 +99,7 @@ internal class MigrerSpesifikkSakRiver(
 
         val verifisertRequest =
             verifiserer.verifiserRequest(pesyssak.tilMigreringsrequest()).also {
-                pesysRepository.oppdaterKanGjennopprettesAutomatisk(it)
+                pesysRepository.oppdaterKanGjenopprettesAutomatisk(it)
             }
         packet.hendelseData = verifisertRequest
 

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.migrering.verifisering
 
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
-import no.nav.etterlatte.libs.common.logging.samleExceptions
 import no.nav.etterlatte.libs.common.pdl.PersonDTO
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.PersonRolle
@@ -59,6 +58,7 @@ internal class Verifiserer(
         }
         return patchedRequest.getOrThrow().copy(
             utlandstilknytningType = utenlandstilknytningsjekker.finnUtenlandstilknytning(request),
+            kanAutomatiskGjenopprettes = feil.isEmpty(),
         )
     }
 
@@ -83,7 +83,6 @@ internal class Verifiserer(
             pesysId = request.pesysId,
         )
         repository.oppdaterStatus(request.pesysId, Migreringsstatus.VERIFISERING_FEILA)
-        throw samleExceptions(feil)
     }
 
     private fun sjekkAtPersonerFinsIPDL(request: MigreringRequest): List<Verifiseringsfeil> {

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.migrering.verifisering
 
 import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.libs.common.logging.samleExceptions
 import no.nav.etterlatte.libs.common.pdl.PersonDTO
@@ -37,14 +38,14 @@ internal class Verifiserer(
             feilSomMedfoererManuell.add(PDLException(feilen).also { it.addSuppressed(feilen) })
         }
         patchedRequest.onSuccess {
-            if (request.enhet.nr == "2103") {
+            if (request.enhet.nr == Enheter.STRENGT_FORTROLIG.enhetNr) {
                 feilSomMedfoererManuell.add(StrengtFortroligPesys) // TODO Strengt fortrolig
             }
-            val finnesfinnesIPdlFeil = sjekkAtPersonerFinsIPDL(it)
-            if (finnesfinnesIPdlFeil.any { finnes -> finnes is SoekerErDoed }) {
-                feilSomMedfoererMistetRett.addAll(finnesfinnesIPdlFeil)
+            val finnesIPdlFeil = sjekkAtPersonerFinsIPDL(it)
+            if (finnesIPdlFeil.any { finnes -> finnes is SoekerErDoed }) {
+                feilSomMedfoererMistetRett.addAll(finnesIPdlFeil)
             } else {
-                feilSomMedfoererManuell.addAll(finnesfinnesIPdlFeil)
+                feilSomMedfoererManuell.addAll(finnesIPdlFeil)
             }
             val soeker = personHenter.hentPerson(PersonRolle.BARN, request.soeker).getOrNull()
 

--- a/apps/etterlatte-migrering/src/main/resources/db/migration/V13__legge_til_gjenopprettes_automatisk.sql
+++ b/apps/etterlatte-migrering/src/main/resources/db/migration/V13__legge_til_gjenopprettes_automatisk.sql
@@ -1,0 +1,1 @@
+alter table pesyssak add column gjenopprettes_automatisk boolean;

--- a/apps/etterlatte-migrering/src/test/kotlin/migrering/PesysRepositoryTest.kt
+++ b/apps/etterlatte-migrering/src/test/kotlin/migrering/PesysRepositoryTest.kt
@@ -96,6 +96,18 @@ class PesysRepositoryTest {
     }
 
     @Test
+    fun `skal oppdatere pesyssak med gjenopprettes_automatisk`() {
+        val psak = pesysSak(123L)
+        repository.lagrePesyssak(psak)
+
+        val request =
+            psak.tilMigreringsrequest().copy(
+                kanAutomatiskGjenopprettes = true,
+            )
+        repository.oppdaterKanGjenopprettesAutomatisk(request)
+    }
+
+    @Test
     fun `lagre manuell migrering`() {
         val pesysId = 123L
 

--- a/libs/etterlatte-migrering-model/src/main/kotlin/no/nav/etterlatte/rapidsandrivers/migrering/MigreringRequest.kt
+++ b/libs/etterlatte-migrering-model/src/main/kotlin/no/nav/etterlatte/rapidsandrivers/migrering/MigreringRequest.kt
@@ -29,13 +29,14 @@ data class MigreringRequest(
     val spraak: Spraak,
     val utlandstilknytningType: UtlandstilknytningType? = null,
     val erUnder18: Boolean = true,
+    val kanAutomatiskGjenopprettes: Boolean = false,
 ) {
     fun opprettPersongalleri() =
         Persongalleri(
             soeker = this.soeker.value,
             avdoed = this.avdoedForelder.map { it.ident.value },
             gjenlevende = listOfNotNull(this.gjenlevendeForelder?.value),
-            innsender = Vedtaksloesning.PESYS.name,
+            innsender = Vedtaksloesning.PESYS.name, // TODO Endre?
         )
 
     fun erFolketrygdberegnet(): Boolean {


### PR DESCRIPTION
- Legge til felt kanBehandlesAutomatisk
- Verifisering skiller mellom "feil som fører til mistet rett på ytelse" og "gjenopprettes manuelt". Førstnevnte kaster feil og sistnevnte setter kanBehandlesAutomatisk=false
- Av verifiseringsfeil som finnes i koden per nå er samtlige "gjenopprettes manuelt" med unntak av søker er død.
