### PR TITLE
Fjerne utsendingsinfo fra journalpost

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/Model.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/Model.kt
@@ -98,7 +98,6 @@ data class Journalpost(
     val bruker: Bruker?,
     val sak: JournalpostSak?,
     val datoOpprettet: String,
-    val utsendingsinfo: Utsendingsinfo?,
 )
 
 data class Dokumenter(

--- a/apps/etterlatte-brev-api/src/main/resources/graphql/dokumentoversiktBruker.graphql
+++ b/apps/etterlatte-brev-api/src/main/resources/graphql/dokumentoversiktBruker.graphql
@@ -34,21 +34,6 @@ query(
             }
             kanal
             datoOpprettet
-            utsendingsinfo {
-                fysiskpostSendt {
-                    adressetekstKonvolutt
-                }
-                digitalpostSendt {
-                    adresse
-                }
-                varselSendt {
-                    type
-                    adresse
-                    tittel
-                    tekst
-                    tidspunkt
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Må fjernes midlertidig pga. måten SAF er satt opp. Må etterspørre utsendingsinfo separat siden det å etterspørre i journalposten medfører tom liste i respons.