### PR TITLE
EY-3431: Forenkle brevkode ved å rydde bort moglegheit til å lage brev med prosesstypane manuell og automatisk

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -159,7 +159,7 @@ class ApplicationBuilder {
     private val brevoppretter = Brevoppretter(adresseService, db, brevdataFacade, brevbakerService, redigerbartVedleggHenter)
 
     private val pdfGenerator =
-        PDFGenerator(db, brevdataFacade, brevDataMapperFerdigstilling, adresseService, brevbakerService, migreringBrevDataService)
+        PDFGenerator(db, brevdataFacade, brevDataMapperFerdigstilling, adresseService, brevbakerService)
 
     private val vedtaksbrevService =
         VedtaksbrevService(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -144,7 +144,7 @@ class ApplicationBuilder {
 
     private val brevDataMapper = BrevDataMapper(brevdataFacade, migreringBrevDataService)
 
-    private val brevDataMapperFerdigstilling = BrevDataMapperFerdigstilling(brevdataFacade, migreringBrevDataService, brevDataMapper)
+    private val brevDataMapperFerdigstilling = BrevDataMapperFerdigstilling(brevdataFacade, brevDataMapper)
 
     private val brevKodeMapper = BrevKodeMapper()
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -107,7 +107,7 @@ class BrevService(
             bruker,
             null,
             avsenderRequest = { b, g -> g.avsenderRequest(b) },
-            brevKode = { _, _ -> Brevkoder(TOM_DELMAL, TOM_MAL_INFORMASJONSBREV) },
+            brevKode = { _ -> Brevkoder(TOM_DELMAL, TOM_MAL_INFORMASJONSBREV) },
         )
 
     suspend fun ferdigstill(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -185,9 +185,9 @@ class Brevoppretter(
         val payload =
             when (redigerbarTekstRequest.prosessType) {
                 BrevProsessType.REDIGERBAR -> brevbaker.hentRedigerbarTekstFraBrevbakeren(redigerbarTekstRequest)
-                BrevProsessType.AUTOMATISK -> throw IllegalStateException("Skal ikke lenger opprette brev med prosesstype automatisk")
-                BrevProsessType.MANUELL -> throw IllegalStateException("Brevdata ikke relevant for ${BrevProsessType.MANUELL}")
-                BrevProsessType.OPPLASTET_PDF -> throw IllegalStateException("Payload ikke relevant for ${BrevProsessType.OPPLASTET_PDF}")
+                else -> throw IllegalStateException(
+                    "Vi skal kun opprette innhold for brev med prosesstype redigerbar, ikke ${redigerbarTekstRequest.prosessType}",
+                )
             }
 
         return BrevInnhold(tittel, redigerbarTekstRequest.generellBrevData.spraak, payload)
@@ -200,11 +200,7 @@ class Brevoppretter(
     ): List<BrevInnholdVedlegg>? =
         when (prosessType) {
             BrevProsessType.REDIGERBAR -> redigerbartVedleggHenter.hentInitiellPayloadVedlegg(bruker, generellBrevData)
-            BrevProsessType.AUTOMATISK -> throw IllegalStateException("Skal ikke lenger opprette brev med prosesstype automatisk")
-            BrevProsessType.MANUELL -> throw IllegalStateException("Skal ikke lenger opprette brev med prosesstype manuell")
-            BrevProsessType.OPPLASTET_PDF -> throw IllegalStateException(
-                "Vedlegg payload ikke relevant for ${BrevProsessType.OPPLASTET_PDF}",
-            )
+            else -> throw IllegalStateException("Vi skal kun opprette innhold for brev med prosesstype redigerbar, ikke $prosessType")
         }
 }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -19,7 +19,6 @@ import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.OpprettNyttBrev
-import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.Vergemaal
 import no.nav.etterlatte.libs.common.retryOgPakkUt
@@ -163,7 +162,7 @@ class Brevoppretter(
 
                 else -> {
                     val mottakerFnr =
-                        innsender?.fnr?.value?.takeUnless { it == Vedtaksloesning.PESYS.name }
+                        innsender?.fnr?.value?.takeIf { Folkeregisteridentifikator.isValid(it) }
                             ?: soeker.fnr.value
                     adresseService.hentMottakerAdresse(mottakerFnr)
                 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -185,7 +185,7 @@ class Brevoppretter(
         val payload =
             when (redigerbarTekstRequest.prosessType) {
                 BrevProsessType.REDIGERBAR -> brevbaker.hentRedigerbarTekstFraBrevbakeren(redigerbarTekstRequest)
-                BrevProsessType.AUTOMATISK -> null
+                BrevProsessType.AUTOMATISK -> throw IllegalStateException("Skal ikke lenger opprette brev med prosesstype automatisk")
                 BrevProsessType.MANUELL -> throw IllegalStateException("Brevdata ikke relevant for ${BrevProsessType.MANUELL}")
                 BrevProsessType.OPPLASTET_PDF -> throw IllegalStateException("Payload ikke relevant for ${BrevProsessType.OPPLASTET_PDF}")
             }
@@ -200,7 +200,7 @@ class Brevoppretter(
     ): List<BrevInnholdVedlegg>? =
         when (prosessType) {
             BrevProsessType.REDIGERBAR -> redigerbartVedleggHenter.hentInitiellPayloadVedlegg(bruker, generellBrevData)
-            BrevProsessType.AUTOMATISK -> null
+            BrevProsessType.AUTOMATISK -> throw IllegalStateException("Skal ikke lenger opprette brev med prosesstype automatisk")
             BrevProsessType.MANUELL -> null
             BrevProsessType.OPPLASTET_PDF -> throw IllegalStateException(
                 "Vedlegg payload ikke relevant for ${BrevProsessType.OPPLASTET_PDF}",

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -201,7 +201,7 @@ class Brevoppretter(
         when (prosessType) {
             BrevProsessType.REDIGERBAR -> redigerbartVedleggHenter.hentInitiellPayloadVedlegg(bruker, generellBrevData)
             BrevProsessType.AUTOMATISK -> throw IllegalStateException("Skal ikke lenger opprette brev med prosesstype automatisk")
-            BrevProsessType.MANUELL -> null
+            BrevProsessType.MANUELL -> throw IllegalStateException("Skal ikke lenger opprette brev med prosesstype manuell")
             BrevProsessType.OPPLASTET_PDF -> throw IllegalStateException(
                 "Vedlegg payload ikke relevant for ${BrevProsessType.OPPLASTET_PDF}",
             )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -131,7 +131,7 @@ class Brevoppretter(
                 { _, _ -> brevKode }
             } else {
                 { mapper, data ->
-                    mapper.brevKode(data, BrevProsessType.REDIGERBAR).redigering
+                    mapper.brevKode(data).redigering
                 }
             }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
@@ -26,7 +26,6 @@ class PDFGenerator(
     private val brevDataMapper: BrevDataMapperFerdigstilling,
     private val adresseService: AdresseService,
     private val brevbakerService: BrevbakerService,
-    private val migreringBrevDataService: MigreringBrevDataService,
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
@@ -111,7 +111,7 @@ class PDFGenerator(
                     brev.tittel,
                 )
 
-            BrevProsessType.AUTOMATISK -> brevDataMapper.brevData(generellBrevData, brukerTokenInfo)
+            BrevProsessType.AUTOMATISK -> throw IllegalStateException("Skal ikke lenger opprette brev med prosesstype automatisk")
             BrevProsessType.MANUELL -> ManueltBrevData(hentLagretInnhold(brev))
             BrevProsessType.OPPLASTET_PDF -> throw IllegalStateException("Brevdata ikke relevant for ${BrevProsessType.OPPLASTET_PDF}")
         }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
@@ -35,7 +35,7 @@ class PDFGenerator(
         bruker: BrukerTokenInfo,
         automatiskMigreringRequest: MigreringBrevRequest?,
         avsenderRequest: (BrukerTokenInfo, GenerellBrevData) -> AvsenderRequest,
-        brevKode: (GenerellBrevData, Brev) -> Brevkoder,
+        brevKode: (GenerellBrevData) -> Brevkoder,
         lagrePdfHvisVedtakFattet: (GenerellBrevData, Brev, Pdf) -> Unit = { _, _, _ -> run {} },
     ): Pdf {
         sjekkOmBrevKanEndres(id)
@@ -50,7 +50,7 @@ class PDFGenerator(
         bruker: BrukerTokenInfo,
         automatiskMigreringRequest: MigreringBrevRequest?,
         avsenderRequest: (BrukerTokenInfo, GenerellBrevData) -> AvsenderRequest,
-        brevKode: (GenerellBrevData, Brev) -> Brevkoder,
+        brevKode: (GenerellBrevData) -> Brevkoder,
         lagrePdfHvisVedtakFattet: (GenerellBrevData, Brev, Pdf) -> Unit = { _, _, _ -> run {} },
     ): Pdf {
         val brev = db.hentBrev(id)
@@ -67,7 +67,7 @@ class PDFGenerator(
             retryOgPakkUt { brevDataFacade.hentGenerellBrevData(brev.sakId, brev.behandlingId, bruker) }
         val avsender = adresseService.hentAvsender(avsenderRequest(bruker, generellBrevData))
 
-        val brevkodePar = brevKode(generellBrevData, brev)
+        val brevkodePar = brevKode(generellBrevData)
 
         val sak = generellBrevData.sak
         val letterData =

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/RedigerbartVedleggHenter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/RedigerbartVedleggHenter.kt
@@ -5,7 +5,6 @@ import no.nav.etterlatte.brev.brevbaker.BrevbakerService
 import no.nav.etterlatte.brev.brevbaker.EtterlatteBrevKode
 import no.nav.etterlatte.brev.brevbaker.RedigerbarTekstRequest
 import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
-import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.BrevVedleggKey
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
@@ -88,7 +87,6 @@ class RedigerbartVedleggHenter(private val brevbakerService: BrevbakerService) {
                     RedigerbarTekstRequest(
                         generellBrevData = generellBrevData,
                         brukerTokenInfo = bruker,
-                        prosessType = BrevProsessType.REDIGERBAR,
                         brevkode = { _, _ -> kode },
                     ),
                 ),

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
@@ -63,12 +63,7 @@ class VedtaksbrevService(
             bruker = bruker,
             automatiskMigreringRequest = automatiskMigreringRequest,
             avsenderRequest = { brukerToken, generellBrevData -> generellBrevData.avsenderRequest(brukerToken) },
-            brevKode = { generellBrevData, brev ->
-                brevKodeMapper.brevKode(
-                    generellBrevData,
-                    brev.prosessType,
-                )
-            },
+            brevKode = { brevKodeMapper.brevKode(it) },
         ) { generellBrevData, brev, pdf ->
             lagrePdfHvisVedtakFattet(
                 brev.id,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
@@ -44,14 +44,13 @@ class VedtaksbrevService(
         brukerTokenInfo: BrukerTokenInfo,
         automatiskMigreringRequest: MigreringBrevRequest? = null,
         // TODO EY-3232 - Fjerne migreringstilpasning
-    ): Brev {
-        return brevoppretter.opprettVedtaksbrev(
+    ): Brev =
+        brevoppretter.opprettVedtaksbrev(
             sakId = sakId,
             behandlingId = behandlingId,
             brukerTokenInfo = brukerTokenInfo,
             automatiskMigreringRequest = automatiskMigreringRequest,
         )
-    }
 
     suspend fun genererPdf(
         id: BrevID,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/Behandling.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/Behandling.kt
@@ -41,6 +41,8 @@ data class GenerellBrevData(
         } ?: AvsenderRequest(saksbehandlerIdent = bruker.ident(), sakenhet = sak.enhet)
 
     fun erMigrering() = systemkilde == Vedtaksloesning.PESYS && behandlingId != null && revurderingsaarsak == null
+
+    fun vedtakstype() = forenkletVedtak?.type?.name?.lowercase()
 }
 
 data class Trygdetid(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerService.kt
@@ -6,7 +6,6 @@ import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.model.BrevDataMapper
 import no.nav.etterlatte.brev.model.BrevID
 import no.nav.etterlatte.brev.model.BrevKodeMapper
-import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.token.BrukerTokenInfo
@@ -55,7 +54,6 @@ class BrevbakerService(
 data class RedigerbarTekstRequest(
     val generellBrevData: GenerellBrevData,
     val brukerTokenInfo: BrukerTokenInfo,
-    val prosessType: BrevProsessType,
     val brevkode: (mapper: BrevKodeMapper, g: GenerellBrevData) -> EtterlatteBrevKode,
     val migrering: MigreringBrevRequest? = null,
 ) {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerService.kt
@@ -56,6 +56,4 @@ data class RedigerbarTekstRequest(
     val brukerTokenInfo: BrukerTokenInfo,
     val brevkode: (mapper: BrevKodeMapper, g: GenerellBrevData) -> EtterlatteBrevKode,
     val migrering: MigreringBrevRequest? = null,
-) {
-    fun vedtakstype() = generellBrevData.forenkletVedtak?.type?.name?.lowercase()
-}
+)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstilling.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstilling.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.brev.model
 
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import no.nav.etterlatte.brev.MigreringBrevDataService
 import no.nav.etterlatte.brev.MigreringBrevRequest
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.brevbaker.Brevkoder
@@ -31,8 +30,8 @@ import no.nav.etterlatte.token.BrukerTokenInfo
 
 class BrevDataMapperFerdigstilling(
     private val brevdataFacade: BrevdataFacade,
-    private val migreringBrevDataService: MigreringBrevDataService,
-    private val brevDataMapper: BrevDataMapper, // TODO: Håper vi kan få bort denne koplinga snart
+    private val brevDataMapper: BrevDataMapper,
+    // TODO: Håper vi kan få bort denne koplinga snart
 ) {
     suspend fun brevDataFerdigstilling(
         generellBrevData: GenerellBrevData,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapper.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapper.kt
@@ -2,23 +2,11 @@ package no.nav.etterlatte.brev.model
 
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.brevbaker.Brevkoder
-import no.nav.etterlatte.brev.brevbaker.EtterlatteBrevKode.OMSTILLINGSSTOENAD_REVURDERING_OPPHOER_MANUELL
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 
 class BrevKodeMapper {
     fun brevKode(
-        generellBrevData: GenerellBrevData,
-        brevProsessType: BrevProsessType,
-        erOmregningNyRegel: Boolean = false,
-    ) = when (brevProsessType) {
-        BrevProsessType.AUTOMATISK -> throw IllegalStateException("Skal ikke lenger opprette brev med prosesstype automatisk")
-        BrevProsessType.REDIGERBAR -> brevKodeAutomatisk(generellBrevData, erOmregningNyRegel)
-        BrevProsessType.MANUELL -> Brevkoder(OMSTILLINGSSTOENAD_REVURDERING_OPPHOER_MANUELL)
-        BrevProsessType.OPPLASTET_PDF -> throw IllegalStateException("Brevkode ikke relevant for ${BrevProsessType.OPPLASTET_PDF}")
-    }
-
-    private fun brevKodeAutomatisk(
         generellBrevData: GenerellBrevData,
         erOmregningNyRegel: Boolean = false,
     ): Brevkoder {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapper.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapper.kt
@@ -12,7 +12,7 @@ class BrevKodeMapper {
         brevProsessType: BrevProsessType,
         erOmregningNyRegel: Boolean = false,
     ) = when (brevProsessType) {
-        BrevProsessType.AUTOMATISK -> brevKodeAutomatisk(generellBrevData, erOmregningNyRegel)
+        BrevProsessType.AUTOMATISK -> throw IllegalStateException("Skal ikke lenger opprette brev med prosesstype automatisk")
         BrevProsessType.REDIGERBAR -> brevKodeAutomatisk(generellBrevData, erOmregningNyRegel)
         BrevProsessType.MANUELL -> Brevkoder(OMSTILLINGSSTOENAD_REVURDERING_OPPHOER_MANUELL)
         BrevProsessType.OPPLASTET_PDF -> throw IllegalStateException("Brevkode ikke relevant for ${BrevProsessType.OPPLASTET_PDF}")

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
@@ -76,12 +76,7 @@ class OpprettJournalfoerOgDistribuerRiver(
                         attestantIdent = Fagsaksystem.EY.navn,
                     )
                 },
-                brevKode = { _, _ ->
-                    Brevkoder(
-                        brevKode,
-                        EtterlatteBrevKode.TOM_MAL_INFORMASJONSBREV,
-                    )
-                },
+                brevKode = { _ -> Brevkoder(brevKode, EtterlatteBrevKode.TOM_MAL_INFORMASJONSBREV) },
             )
         }
         logger.info("Journalfører $brevKode-brev i sak $sakId")

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -87,7 +87,7 @@ internal class VedtaksbrevServiceTest {
     private val brevKodeMapper = BrevKodeMapper()
     private val brevbakerService = mockk<BrevbakerService>()
     private val pdfGenerator =
-        PDFGenerator(db, brevdataFacade, brevDataMapperFerdigstilling, adresseService, brevbakerService, migreringBrevDataService)
+        PDFGenerator(db, brevdataFacade, brevDataMapperFerdigstilling, adresseService, brevbakerService)
     private val redigerbartVedleggHenter = RedigerbartVedleggHenter(brevbakerService)
     private val brevoppretter = Brevoppretter(adresseService, db, brevdataFacade, brevbakerService, redigerbartVedleggHenter)
 

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -83,7 +83,7 @@ internal class VedtaksbrevServiceTest {
     private val dokarkivService = mockk<DokarkivServiceImpl>()
     private val migreringBrevDataService = MigreringBrevDataService(brevdataFacade)
     private val brevDataMapper = BrevDataMapper(brevdataFacade, migreringBrevDataService)
-    private val brevDataMapperFerdigstilling = BrevDataMapperFerdigstilling(brevdataFacade, migreringBrevDataService, brevDataMapper)
+    private val brevDataMapperFerdigstilling = BrevDataMapperFerdigstilling(brevdataFacade, brevDataMapper)
     private val brevKodeMapper = BrevKodeMapper()
     private val brevbakerService = mockk<BrevbakerService>()
     private val pdfGenerator =


### PR DESCRIPTION
For nye brev no bruker vi kun prosesstypen redigerbar, og det har vi gjort ei god stund.

For dei med manuell opnar vi framleis for å generere PDF, sia det fins nokre brev i prod-databasen som ikkje er ferdigstilt, inklusive eit par frå midten av januar. Usikker på korvidt desse framleis er relevante eller ikkje, men tenkjer å følgje opp den delen seinare.