### PR TITLE
Logge errormelding ved rejection

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/apiClient.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/apiClient.ts
@@ -116,7 +116,7 @@ async function apiFetcher<T>(props: Options): Promise<ApiResponse<T>> {
   } catch (e) {
     console.error('Rejection i fetch / utlesing av data', e)
     if (shouldLogError) {
-      logger.generalError({ msg: 'Fikk Rejection i kall mot backend', errorInfo: { url, method } })
+      logger.generalError({ msg: `Fikk Rejection i kall mot backend: ${e}`, errorInfo: { url, method } })
     }
     return {
       ok: false,


### PR DESCRIPTION
Vi får denne feilmeldingen ganske ofte. Logger derfor `e` til backend for å se hva som _faktisk_ feiler. 