### PR TITLE
Unngår bruk av kafka-avro-serializer-biblioteket der det ikkje trengs

### DIFF
--- a/apps/etterlatte-egne-ansatte-lytter/build.gradle.kts
+++ b/apps/etterlatte-egne-ansatte-lytter/build.gradle.kts
@@ -21,7 +21,6 @@ dependencies {
 
     implementation(libs.kafka.clients)
     implementation(libs.kafka.avro)
-    implementation(libs.kafka.avroserializer)
 
     testImplementation(libs.kafka.embeddedenv)
     testImplementation(libs.el.api)

--- a/apps/etterlatte-egne-ansatte-lytter/src/main/kotlin/no/nav/etterlatte/kafka/KafkaEnvironment.kt
+++ b/apps/etterlatte-egne-ansatte-lytter/src/main/kotlin/no/nav/etterlatte/kafka/KafkaEnvironment.kt
@@ -1,12 +1,10 @@
 package no.nav.etterlatte.kafka
 
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig
-import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
 import org.apache.kafka.common.serialization.StringDeserializer
 
 class KafkaEnvironment : Kafkakonfigurasjon<StringDeserializer>(
     groupId = "SKJERMING_GROUP_ID",
     deserializerClass = StringDeserializer::class.java,
-    userInfoConfigKey = SchemaRegistryClientConfig.USER_INFO_CONFIG,
-    schemaRegistryUrlConfigKey = AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+    userInfoConfigKey = Avrokonstanter.USER_INFO_CONFIG,
+    schemaRegistryUrlConfigKey = Avrokonstanter.SCHEMA_REGISTRY_URL_CONFIG,
 )

--- a/apps/etterlatte-egne-ansatte-lytter/src/test/kotlin/no/nav/etterlatte/kafka/SkjermingslesingTest.kt
+++ b/apps/etterlatte-egne-ansatte-lytter/src/test/kotlin/no/nav/etterlatte/kafka/SkjermingslesingTest.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.kafka
 
-import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -83,7 +82,7 @@ class SkjermingslesingTest {
                 ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to kafkaEnv.brokersURL,
                 ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java.canonicalName,
                 ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java.canonicalName,
-                KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG to kafkaEnv.schemaRegistry?.url,
+                Avrokonstanter.SCHEMA_REGISTRY_URL_CONFIG to kafkaEnv.schemaRegistry?.url,
                 ProducerConfig.ACKS_CONFIG to "all",
             ),
         )
@@ -97,7 +96,7 @@ class SkjermingslesingTest {
                     put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, kafkaEnv.brokersURL)
                     put(ConsumerConfig.GROUP_ID_CONFIG, env["SKJERMING_GROUP_ID"])
                     put(ConsumerConfig.CLIENT_ID_CONFIG, "etterlatte-egne-ansatte-lytter")
-                    put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, kafkaEnv.schemaRegistry?.url!!)
+                    put(Avrokonstanter.SCHEMA_REGISTRY_URL_CONFIG, kafkaEnv.schemaRegistry?.url!!)
                     put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java)
                     put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java)
                     put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")

--- a/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/config/KafkaEnvironment.kt
+++ b/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/config/KafkaEnvironment.kt
@@ -1,7 +1,7 @@
 package no.nav.etterlatte.joarkhendelser.config
 
 import io.confluent.kafka.serializers.KafkaAvroDeserializer
-import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
+import no.nav.etterlatte.kafka.Avrokonstanter
 import no.nav.etterlatte.kafka.Kafkakonfigurasjon
 import org.apache.kafka.common.IsolationLevel
 import java.util.Locale
@@ -9,8 +9,8 @@ import java.util.Locale
 class KafkaEnvironment : Kafkakonfigurasjon<KafkaAvroDeserializer>(
     groupId = "JOARK_HENDELSE_GROUP_ID",
     deserializerClass = KafkaAvroDeserializer::class.java,
-    userInfoConfigKey = KafkaAvroDeserializerConfig.USER_INFO_CONFIG,
-    schemaRegistryUrlConfigKey = KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG,
+    userInfoConfigKey = Avrokonstanter.USER_INFO_CONFIG,
+    schemaRegistryUrlConfigKey = Avrokonstanter.SCHEMA_REGISTRY_URL_CONFIG,
     isolationLevelConfig = IsolationLevel.READ_COMMITTED.toString().lowercase(Locale.getDefault()),
     specificAvroReaderConfig = true,
 )

--- a/apps/etterlatte-hendelser-pdl/src/main/kotlin/hendelserpdl/config/KafkaEnvironment.kt
+++ b/apps/etterlatte-hendelser-pdl/src/main/kotlin/hendelserpdl/config/KafkaEnvironment.kt
@@ -1,7 +1,7 @@
 package no.nav.etterlatte.hendelserpdl.config
 
 import io.confluent.kafka.serializers.KafkaAvroDeserializer
-import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
+import no.nav.etterlatte.kafka.Avrokonstanter
 import no.nav.etterlatte.kafka.Kafkakonfigurasjon
 import org.apache.kafka.common.IsolationLevel
 import java.util.Locale
@@ -9,8 +9,8 @@ import java.util.Locale
 class KafkaEnvironment : Kafkakonfigurasjon<KafkaAvroDeserializer>(
     groupId = "LEESAH_KAFKA_GROUP_ID",
     deserializerClass = KafkaAvroDeserializer::class.java,
-    userInfoConfigKey = KafkaAvroDeserializerConfig.USER_INFO_CONFIG,
-    schemaRegistryUrlConfigKey = KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG,
+    userInfoConfigKey = Avrokonstanter.USER_INFO_CONFIG,
+    schemaRegistryUrlConfigKey = Avrokonstanter.SCHEMA_REGISTRY_URL_CONFIG,
     isolationLevelConfig = IsolationLevel.READ_COMMITTED.toString().lowercase(Locale.getDefault()),
     specificAvroReaderConfig = true,
 )

--- a/apps/etterlatte-hendelser-pdl/src/test/kotlin/hendelserpdl/IntegrationTest.kt
+++ b/apps/etterlatte-hendelser-pdl/src/test/kotlin/hendelserpdl/IntegrationTest.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.hendelserpdl
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.confluent.kafka.serializers.KafkaAvroDeserializer
-import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
 import io.confluent.kafka.serializers.KafkaAvroSerializer
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -17,6 +16,7 @@ import io.mockk.verify
 import no.nav.common.KafkaEnvironment
 import no.nav.etterlatte.hendelserpdl.common.PersonhendelseKonsument
 import no.nav.etterlatte.hendelserpdl.pdl.PdlTjenesterKlient
+import no.nav.etterlatte.kafka.Avrokonstanter
 import no.nav.etterlatte.kafka.KafkaConsumerConfiguration
 import no.nav.etterlatte.kafka.LocalKafkaConfig
 import no.nav.etterlatte.kafka.rapidsAndRiversProducer
@@ -127,14 +127,14 @@ class IntegrationTest {
                     put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, kafkaEnv.brokersURL)
                     put(ConsumerConfig.GROUP_ID_CONFIG, env["LEESAH_KAFKA_GROUP_ID"])
                     put(ConsumerConfig.CLIENT_ID_CONFIG, "etterlatte-pdl-hendelser")
-                    put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, kafkaEnv.schemaRegistry?.url!!)
+                    put(Avrokonstanter.SCHEMA_REGISTRY_URL_CONFIG, kafkaEnv.schemaRegistry?.url!!)
                     put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java)
                     put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer::class.java)
                     put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
                     put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 100)
                     put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false)
                     put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, trettiSekunder)
-                    put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, true)
+                    put(Avrokonstanter.SPECIFIC_AVRO_READER_CONFIG, true)
                 }
             return properties
         }
@@ -146,7 +146,7 @@ class IntegrationTest {
                 ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to kafkaEnv.brokersURL,
                 ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to KafkaAvroSerializer::class.java.canonicalName,
                 ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to KafkaAvroSerializer::class.java.canonicalName,
-                KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG to kafkaEnv.schemaRegistry?.url,
+                Avrokonstanter.SCHEMA_REGISTRY_URL_CONFIG to kafkaEnv.schemaRegistry?.url,
                 ProducerConfig.ACKS_CONFIG to "all",
             ),
         )

--- a/apps/etterlatte-hendelser-samordning/build.gradle.kts
+++ b/apps/etterlatte-hendelser-samordning/build.gradle.kts
@@ -20,7 +20,6 @@ dependencies {
 
     implementation(libs.kafka.clients)
     implementation(libs.kafka.avro)
-    implementation(libs.kafka.avroserializer)
 
     testImplementation(libs.kafka.embeddedenv)
     testImplementation(libs.el.api)

--- a/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/samordning/KafkaEnvironment.kt
+++ b/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/samordning/KafkaEnvironment.kt
@@ -2,15 +2,14 @@ package no.nav.etterlatte.samordning
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig
-import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
+import no.nav.etterlatte.kafka.Avrokonstanter
 import no.nav.etterlatte.kafka.Kafkakonfigurasjon
 
 class KafkaEnvironment : Kafkakonfigurasjon<KafkaEnvironment.JsonDeserializer>(
     groupId = "SAMORDNINGVEDTAK_HENDELSE_GROUP_ID",
     deserializerClass = JsonDeserializer::class.java,
-    userInfoConfigKey = SchemaRegistryClientConfig.USER_INFO_CONFIG,
-    schemaRegistryUrlConfigKey = AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+    userInfoConfigKey = Avrokonstanter.USER_INFO_CONFIG,
+    schemaRegistryUrlConfigKey = Avrokonstanter.SCHEMA_REGISTRY_URL_CONFIG,
 ) {
     class JsonDeserializer : org.apache.kafka.common.serialization.Deserializer<SamordningVedtakHendelse> {
         override fun deserialize(

--- a/apps/etterlatte-hendelser-samordning/src/test/kotlin/no/nav/etterlatte/samordning/SamordningHendelseIntegrationTest.kt
+++ b/apps/etterlatte-hendelser-samordning/src/test/kotlin/no/nav/etterlatte/samordning/SamordningHendelseIntegrationTest.kt
@@ -1,11 +1,11 @@
 package no.nav.etterlatte.samordning
 
 import com.fasterxml.jackson.core.JsonProcessingException
-import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
 import io.ktor.server.application.Application
 import io.mockk.spyk
 import io.mockk.verify
 import no.nav.common.KafkaEnvironment
+import no.nav.etterlatte.kafka.Avrokonstanter
 import no.nav.etterlatte.kafka.KafkaConsumerConfiguration
 import no.nav.etterlatte.kafka.LocalKafkaConfig
 import no.nav.etterlatte.kafka.rapidsAndRiversProducer
@@ -98,7 +98,7 @@ class SamordningHendelseIntegrationTest {
                 ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to kafkaEnv.brokersURL,
                 ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java.canonicalName,
                 ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to SamJsonSerializer::class.java.canonicalName,
-                KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG to kafkaEnv.schemaRegistry?.url,
+                Avrokonstanter.SCHEMA_REGISTRY_URL_CONFIG to kafkaEnv.schemaRegistry?.url,
                 ProducerConfig.ACKS_CONFIG to "all",
             ),
         )
@@ -112,13 +112,13 @@ class SamordningHendelseIntegrationTest {
                     put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, kafkaEnv.brokersURL)
                     put(ConsumerConfig.GROUP_ID_CONFIG, env["KAFKA_GROUP_ID"])
                     put(ConsumerConfig.CLIENT_ID_CONFIG, "etterlatte-test-v1")
-                    put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, kafkaEnv.schemaRegistry?.url!!)
+                    put(Avrokonstanter.SCHEMA_REGISTRY_URL_CONFIG, kafkaEnv.schemaRegistry?.url!!)
                     put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java)
                     put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer::class.java)
                     put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
                     put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 100)
                     put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, tiSekunder)
-                    put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, true)
+                    put(Avrokonstanter.SPECIFIC_AVRO_READER_CONFIG, true)
                 }
             return properties
         }

--- a/apps/etterlatte-institusjonsopphold/build.gradle.kts
+++ b/apps/etterlatte-institusjonsopphold/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
     implementation(libs.ktor2.clientcontentnegotiation)
     implementation(libs.ktor2.clientjackson)
     implementation(libs.kafka.clients)
-    implementation(libs.kafka.avroserializer)
 
     testImplementation(libs.ktor2.clientmock)
     testImplementation(libs.kotlinx.coroutinescore)

--- a/apps/etterlatte-institusjonsopphold/src/main/kotlin/kafka/KafkaEnvironment.kt
+++ b/apps/etterlatte-institusjonsopphold/src/main/kotlin/kafka/KafkaEnvironment.kt
@@ -2,16 +2,14 @@ package no.nav.etterlatte.kafka
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig
-import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
 import org.apache.kafka.common.IsolationLevel
 import java.util.Locale
 
 class KafkaEnvironment : Kafkakonfigurasjon<KafkaEnvironment.JsonDeserializer>(
     groupId = "INSTITUSJONSOPPHOLD_GROUP_ID",
     deserializerClass = JsonDeserializer::class.java,
-    userInfoConfigKey = SchemaRegistryClientConfig.USER_INFO_CONFIG,
-    schemaRegistryUrlConfigKey = AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+    userInfoConfigKey = Avrokonstanter.USER_INFO_CONFIG,
+    schemaRegistryUrlConfigKey = Avrokonstanter.SCHEMA_REGISTRY_URL_CONFIG,
     isolationLevelConfig = IsolationLevel.READ_COMMITTED.toString().lowercase(Locale.getDefault()),
 ) {
     class JsonDeserializer : org.apache.kafka.common.serialization.Deserializer<KafkaOppholdHendelse> {

--- a/apps/etterlatte-klage/build.gradle.kts
+++ b/apps/etterlatte-klage/build.gradle.kts
@@ -11,7 +11,6 @@ dependencies {
     implementation(project(":libs:saksbehandling-common"))
 
     implementation(libs.kafka.clients)
-    implementation(libs.kafka.avroserializer)
     implementation(libs.klage.kodeverk)
     implementation(libs.ktor2.okhttp)
 

--- a/apps/etterlatte-klage/src/main/kotlin/no/nav/etterlatte/klage/KlageKafkakonsument.kt
+++ b/apps/etterlatte-klage/src/main/kotlin/no/nav/etterlatte/klage/KlageKafkakonsument.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.klage
 
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig
-import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
+import no.nav.etterlatte.kafka.Avrokonstanter
 import no.nav.etterlatte.kafka.Kafkakonfigurasjon
 import no.nav.etterlatte.kafka.Kafkakonsument
 import org.apache.kafka.clients.consumer.KafkaConsumer
@@ -27,6 +26,6 @@ class KlageKafkakonsument(
 internal class KafkaEnvironment : Kafkakonfigurasjon<StringDeserializer>(
     groupId = "KLAGE_GROUP_ID",
     deserializerClass = StringDeserializer::class.java,
-    userInfoConfigKey = SchemaRegistryClientConfig.USER_INFO_CONFIG,
-    schemaRegistryUrlConfigKey = AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+    userInfoConfigKey = Avrokonstanter.USER_INFO_CONFIG,
+    schemaRegistryUrlConfigKey = Avrokonstanter.SCHEMA_REGISTRY_URL_CONFIG,
 )

--- a/libs/etterlatte-kafka/src/main/kotlin/kafka/Avrokonstanter.kt
+++ b/libs/etterlatte-kafka/src/main/kotlin/kafka/Avrokonstanter.kt
@@ -3,8 +3,11 @@ package no.nav.etterlatte.kafka
 object Avrokonstanter {
     const val SPECIFIC_AVRO_READER_CONFIG = "specific.avro.reader"
     const val BASIC_AUTH_CREDENTIALS_SOURCE = SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE
+    const val USER_INFO_CONFIG = SchemaRegistryClientConfig.USER_INFO_CONFIG
+    const val SCHEMA_REGISTRY_URL_CONFIG = "schema.registry.url"
 
     private object SchemaRegistryClientConfig {
         const val BASIC_AUTH_CREDENTIALS_SOURCE = "basic.auth.credentials.source"
+        const val USER_INFO_CONFIG = "basic.auth.user.info"
     }
 }

--- a/libs/etterlatte-kafka/src/test/kotlin/AvrokonstanterTest.kt
+++ b/libs/etterlatte-kafka/src/test/kotlin/AvrokonstanterTest.kt
@@ -1,19 +1,29 @@
 package no.nav.etterlatte.kafka
 
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
-import org.junit.jupiter.api.Assertions
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class AvrokonstanterTest {
     @Test
     fun `vaare hardkodede konstanter i libs matcher med dem i Avro-biblioteket`() {
-        Assertions.assertEquals(
+        assertEquals(
             AbstractKafkaSchemaSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE,
             Avrokonstanter.BASIC_AUTH_CREDENTIALS_SOURCE,
         )
-        Assertions.assertEquals(
-            io.confluent.kafka.serializers.KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG,
+        assertEquals(
+            KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG,
             Avrokonstanter.SPECIFIC_AVRO_READER_CONFIG,
+        )
+        assertEquals(
+            SchemaRegistryClientConfig.USER_INFO_CONFIG,
+            Avrokonstanter.USER_INFO_CONFIG,
+        )
+        assertEquals(
+            AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+            Avrokonstanter.SCHEMA_REGISTRY_URL_CONFIG,
         )
     }
 }


### PR DESCRIPTION
Dette biblioteket trekkjer med seg ein eldre versjon av snappy-java, som dukkar opp i fleng på https://console.nav.cloud.nais.io/team/etterlatte/vulnerabilities , og også ein confluent-spesifikk versjon av kafka-clients som eg ikkje har funne koden til.

Unngår dermed å bruke dette biblioteket der det ikkje trengs, trade-offen er eit par ekstra konstantar i kafka-repoet si Avrokonstanter-fil, og det tenkjer eg er vel verdt det.