### PR TITLE
EY-3442: Førehandsvisning av varselbrev, pluss konseptet brevtype i frontend

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -169,7 +169,7 @@ class ApplicationBuilder {
             pdfGenerator,
         )
 
-    private val varselbrevService = VarselbrevService(db, brevoppretter, behandlingKlient)
+    private val varselbrevService = VarselbrevService(db, brevoppretter, behandlingKlient, pdfGenerator)
 
     private val journalfoerBrevService = JournalfoerBrevService(db, sakService, dokarkivService, vedtaksbrevService)
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
@@ -377,6 +377,7 @@ class BrevRepository(private val ds: DataSource) {
                 ),
             journalpostId = row.stringOrNull("journalpost_id"),
             bestillingsID = row.stringOrNull("bestilling_id"),
+            brevtype = row.string("brevtype").let { Brevtype.valueOf(it) },
         )
     }
 
@@ -404,7 +405,7 @@ class BrevRepository(private val ds: DataSource) {
         const val HENT_BREV_QUERY = """
             SELECT 
                 b.id, b.sak_id, b.behandling_id, b.prosess_type, b.soeker_fnr, b.opprettet, h.status_id, 
-                h.opprettet as hendelse_opprettet, m.*, i.tittel, b.journalpost_id, b.bestilling_id
+                h.opprettet as hendelse_opprettet, m.*, i.tittel, b.journalpost_id, b.bestilling_id, b.brevtype
             FROM brev b
             INNER JOIN mottaker m on b.id = m.brev_id
             INNER JOIN hendelse h on b.id = h.brev_id
@@ -420,7 +421,7 @@ class BrevRepository(private val ds: DataSource) {
         const val HENT_BREV_FOR_BEHANDLING_QUERY = """
             SELECT 
                 b.id, b.sak_id, b.behandling_id, b.prosess_type, b.soeker_fnr, h.status_id, b.opprettet, 
-                h.opprettet as hendelse_opprettet, m.*, i.tittel, b.journalpost_id, b.bestilling_id
+                h.opprettet as hendelse_opprettet, m.*, i.tittel, b.journalpost_id, b.bestilling_id, b.brevtype
             FROM brev b
             INNER JOIN mottaker m on b.id = m.brev_id
             INNER JOIN hendelse h on b.id = h.brev_id
@@ -438,7 +439,7 @@ class BrevRepository(private val ds: DataSource) {
         const val HENT_BREV_FOR_SAK_QUERY = """
             SELECT 
                 b.id, b.sak_id, b.behandling_id, b.prosess_type, b.soeker_fnr, h.status_id, b.opprettet, 
-                h.opprettet as hendelse_opprettet, m.*, i.tittel, b.journalpost_id, b.bestilling_id
+                h.opprettet as hendelse_opprettet, m.*, i.tittel, b.journalpost_id, b.bestilling_id, b.brevtype
             FROM brev b
             INNER JOIN mottaker m on b.id = m.brev_id
             INNER JOIN hendelse h on b.id = h.brev_id

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstilling.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstilling.kt
@@ -42,14 +42,14 @@ class BrevDataMapperFerdigstilling(private val brevdataFacade: BrevdataFacade) {
             BARNEPENSJON_INNVILGELSE -> barnepensjonInnvilgelse(bruker, generellBrevData, innholdMedVedlegg)
             BARNEPENSJON_AVSLAG -> barnepensjonAvslag(innholdMedVedlegg, generellBrevData)
             BARNEPENSJON_OPPHOER -> barnepensjonOpphoer(innholdMedVedlegg, generellBrevData)
-            BARNEPENSJON_VARSEL -> ManueltBrevData()
+            BARNEPENSJON_VARSEL -> ManueltBrevData(innholdMedVedlegg.innhold())
 
             OMSTILLINGSSTOENAD_INNVILGELSE -> omstillingsstoenadInnvilgelse(bruker, generellBrevData, innholdMedVedlegg)
             OMSTILLINGSSTOENAD_REVURDERING -> omstillingsstoenadRevurdering(bruker, generellBrevData, innholdMedVedlegg)
             OMSTILLINGSSTOENAD_AVSLAG -> OmstillingsstoenadAvslag.fra(generellBrevData, innholdMedVedlegg.innhold())
             OMSTILLINGSSTOENAD_OPPHOER ->
                 OmstillingsstoenadOpphoer.fra(generellBrevData.utlandstilknytning, innholdMedVedlegg.innhold())
-            OMSTILLINGSSTOENAD_VARSEL -> ManueltBrevData()
+            OMSTILLINGSSTOENAD_VARSEL -> ManueltBrevData(innholdMedVedlegg.innhold())
 
             TILBAKEKREVING_FERDIG -> TilbakekrevingFerdigData.fra(generellBrevData, innholdMedVedlegg)
             else -> throw IllegalStateException("Klarte ikke å finne brevdata for brevkode $brevkode for ferdigstilling.")

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -105,6 +105,7 @@ data class Brev(
     val mottaker: Mottaker,
     val journalpostId: String? = null,
     val bestillingsID: BestillingsID? = null,
+    val brevtype: Brevtype,
 ) {
     fun kanEndres() = status in listOf(Status.OPPRETTET, Status.OPPDATERT)
 
@@ -123,6 +124,7 @@ data class Brev(
             statusEndret = opprettNyttBrev.opprettet,
             mottaker = opprettNyttBrev.mottaker,
             opprettet = opprettNyttBrev.opprettet,
+            brevtype = opprettNyttBrev.brevtype,
         )
     }
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevRoute.kt
@@ -53,5 +53,20 @@ internal fun Route.varselbrevRoute(
                 }
             }
         }
+
+        get("/pdf") {
+            withBehandlingId(tilgangssjekker) {
+                val brevId = requireNotNull(call.parameters["brevId"]).toLong()
+
+                logger.info("Genererer PDF for varselbrev (id=$brevId)")
+
+                measureTimedValue {
+                    service.genererPdf(brevId, brukerTokenInfo).bytes
+                }.let { (pdf, varighet) ->
+                    logger.info("Generering av pdf tok ${varighet.toString(DurationUnit.SECONDS, 2)}")
+                    call.respond(pdf)
+                }
+            }
+        }
     }
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.brev.varselbrev
 
 import no.nav.etterlatte.brev.Brevoppretter
+import no.nav.etterlatte.brev.PDFGenerator
 import no.nav.etterlatte.brev.behandlingklient.BehandlingKlient
 import no.nav.etterlatte.brev.brevbaker.Brevkoder
 import no.nav.etterlatte.brev.db.BrevRepository
@@ -14,6 +15,7 @@ internal class VarselbrevService(
     private val db: BrevRepository,
     private val brevoppretter: Brevoppretter,
     private val behandlingKlient: BehandlingKlient,
+    private val pdfGenerator: PDFGenerator,
 ) {
     fun hentVarselbrev(behandlingId: UUID) = db.hentBrevForBehandling(behandlingId, Brevtype.VARSEL)
 
@@ -37,4 +39,14 @@ internal class VarselbrevService(
             brevtype = Brevtype.VARSEL,
         ).first
     }
+
+    suspend fun genererPdf(
+        brevId: Long,
+        bruker: BrukerTokenInfo,
+    ) = pdfGenerator.genererPdf(
+        id = brevId,
+        bruker = bruker,
+        avsenderRequest = { brukerToken, generellBrevData -> generellBrevData.avsenderRequest(brukerToken) },
+        brevKode = { _ -> Brevkoder.BP_VARSEL },
+    )
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
@@ -48,5 +48,7 @@ internal class VarselbrevService(
         bruker = bruker,
         avsenderRequest = { brukerToken, generellBrevData -> generellBrevData.avsenderRequest(brukerToken) },
         brevKode = { _ -> Brevkoder.BP_VARSEL },
+        // TODO: Brevkode her kan også vera OMS_VARSEL i OMS-saker. Generelt kjens brevkodemappinga ut som noko som
+        // fortener litt opprydding snart.
     )
 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
@@ -26,6 +26,7 @@ import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevID
 import no.nav.etterlatte.brev.model.BrevProsessType
+import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Slate
@@ -235,6 +236,7 @@ internal class BrevRouteTest {
                         landkode = "NOR",
                     ),
                 ),
+            brevtype = Brevtype.INFORMASJON,
         )
 
     private fun ApplicationTestBuilder.httpClient(): HttpClient =

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
@@ -18,6 +18,7 @@ import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
+import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.brev.model.Status
@@ -249,6 +250,7 @@ internal class BrevServiceTest {
         statusEndret = Tidspunkt.now(),
         opprettet = Tidspunkt.now(),
         mottaker = opprettMottaker(),
+        brevtype = Brevtype.INFORMASJON,
     )
 
     private fun opprettMottaker() =

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevdistribuererTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevdistribuererTest.kt
@@ -13,6 +13,7 @@ import no.nav.etterlatte.brev.distribusjon.FeilStatusForDistribusjon
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
+import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -105,6 +106,7 @@ class BrevdistribuererTest {
         statusEndret = Tidspunkt.now(),
         opprettet = Tidspunkt.now(),
         mottaker = opprettMottaker(),
+        brevtype = Brevtype.MANUELT,
     )
 
     private fun opprettMottaker() =

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.brev.hentinformasjon.SakService
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
+import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.common.Enheter
@@ -131,6 +132,7 @@ class JournalfoerBrevServiceTest {
                 Tidspunkt.now(),
                 Tidspunkt.now(),
                 mottaker = mockk(),
+                brevtype = Brevtype.MANUELT,
             )
 
         every { vedtaksbrevService.hentVedtaksbrev(any()) } returns brev
@@ -173,6 +175,7 @@ class JournalfoerBrevServiceTest {
                             landkode = "NOR",
                         ),
                     ),
+                brevtype = Brevtype.INFORMASJON,
             )
 
         coEvery { vedtaksbrevService.hentVedtaksbrev(any()) } returns forventetBrev
@@ -241,6 +244,7 @@ class JournalfoerBrevServiceTest {
                             landkode = "NOR",
                         ),
                     ),
+                brevtype = Brevtype.MANUELT,
             )
 
         every { db.hentBrev(any()) } returns forventetBrev
@@ -291,6 +295,7 @@ class JournalfoerBrevServiceTest {
         statusEndret = Tidspunkt.now(),
         opprettet = Tidspunkt.now(),
         mottaker = opprettMottaker(),
+        brevtype = Brevtype.INFORMASJON,
     )
 
     private fun opprettMottaker() =

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
@@ -24,6 +24,7 @@ import no.nav.etterlatte.brev.hentinformasjon.Tilgangssjekker
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
+import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Status
@@ -242,6 +243,7 @@ internal class VedtaksbrevRouteTest {
                 null,
                 Adresse(adresseType = "NORSKPOSTADRESSE", "Testgaten 13", "1234", "OSLO", land = "Norge", landkode = "NOR"),
             ),
+            brevtype = Brevtype.INFORMASJON,
         )
 
     private fun ApplicationTestBuilder.httpClient(): HttpClient =

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -615,6 +615,7 @@ internal class VedtaksbrevServiceTest {
         Tidspunkt.now(),
         Tidspunkt.now(),
         mottaker = opprettMottaker(),
+        brevtype = Brevtype.VEDTAK,
     )
 
     private fun opprettGenerellBrevdata(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivServiceTest.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevInnhold
 import no.nav.etterlatte.brev.model.BrevProsessType
+import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Spraak
@@ -77,6 +78,7 @@ internal class DokarkivServiceTest {
                         null,
                         Adresse(adresseType = "NORSKPOSTADRESSE", "Testgaten 13", "1234", "OSLO", land = "Norge", landkode = "NOR"),
                     ),
+                brevtype = Brevtype.MANUELT,
             )
         val forventetResponse = OpprettJournalpostResponse("12345", journalpostferdigstilt = true)
 

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.brev.Brevoppretter
+import no.nav.etterlatte.brev.PDFGenerator
 import no.nav.etterlatte.brev.RedigerbartVedleggHenter
 import no.nav.etterlatte.brev.adresse.AdresseService
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
@@ -98,7 +99,8 @@ class VarselbrevTest {
                 redigerbartVedleggHenter,
             )
         val behandlingKlient = mockk<BehandlingKlient>().also { coEvery { it.hentSak(sak.id, any()) } returns sak }
-        service = VarselbrevService(brevRepository, brevoppretter, behandlingKlient)
+        val pdfGenerator = mockk<PDFGenerator>()
+        service = VarselbrevService(brevRepository, brevoppretter, behandlingKlient, pdfGenerator)
     }
 
     @AfterEach

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiverTest.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.brev.distribusjon.DistribusjonsType
 import no.nav.etterlatte.brev.dokarkiv.OpprettJournalpostResponse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
+import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -68,6 +69,7 @@ internal class JournalfoerVedtaksbrevRiverTest {
                 Tidspunkt.now(),
                 Tidspunkt.now(),
                 mottaker = mockk(),
+                brevtype = Brevtype.VEDTAK,
             )
         val response = OpprettJournalpostResponse("1234", true, emptyList())
 

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.brev.dokarkiv.OpprettJournalpostResponse
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
+import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.Vedtaksloesning
@@ -146,6 +147,7 @@ internal class OpprettJournalfoerOgDistribuer {
                     null,
                     Adresse(adresseType = "privat", landkode = "NO", land = "Norge"),
                 ),
+            brevtype = Brevtype.INFORMASJON,
         )
 
     private fun lagVedtakDto(behandlingId: UUID) =

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettVedtaksbrevForMigreringRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettVedtaksbrevForMigreringRiverTest.kt
@@ -10,6 +10,7 @@ import io.mockk.runs
 import no.nav.etterlatte.brev.VedtaksbrevService
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
+import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
@@ -105,6 +106,7 @@ internal class OpprettVedtaksbrevForMigreringRiverTest {
             Tidspunkt.now(),
             Tidspunkt.now(),
             mottaker = mockk(),
+            brevtype = Brevtype.VEDTAK,
         )
 
     private fun opprettMelding(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/VedtaksbrevUnderkjentRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/VedtaksbrevUnderkjentRiverTest.kt
@@ -9,6 +9,7 @@ import io.mockk.verify
 import no.nav.etterlatte.brev.VedtaksbrevService
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
+import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -130,5 +131,6 @@ internal class VedtaksbrevUnderkjentRiverTest {
             Tidspunkt.now(),
             Tidspunkt.now(),
             mottaker = mockk(),
+            brevtype = Brevtype.VEDTAK,
         )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/ForhaandsvisningBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/ForhaandsvisningBrev.tsx
@@ -20,11 +20,14 @@ export default function ForhaandsvisningBrev({ brev }: { brev: IBrev }) {
   }, [fileURL])
 
   useEffect(() => {
-    genererBrevPdf({ brevId: brev.id, behandlingId: brev.behandlingId, sakId: brev.sakId }, (bytes) => {
-      const blob = new Blob([bytes], { type: 'application/pdf' })
+    genererBrevPdf(
+      { brevId: brev.id, behandlingId: brev.behandlingId, sakId: brev.sakId, brevtype: brev.brevtype },
+      (bytes) => {
+        const blob = new Blob([bytes], { type: 'application/pdf' })
 
-      setFileURL(URL.createObjectURL(blob))
-    })
+        setFileURL(URL.createObjectURL(blob))
+      }
+    )
   }, [brev.id, brev.behandlingId])
 
   return (

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
@@ -48,8 +48,10 @@ export const genererPdf = async (props: {
   behandlingId?: string
   brevtype: Brevtype
 }): Promise<ApiResponse<ArrayBuffer>> => {
-  if (props.behandlingId) {
+  if (props.brevtype === Brevtype.VEDTAK) {
     return apiClient.get(`/brev/behandling/${props.behandlingId}/vedtak/pdf?brevId=${props.brevId}`)
+  } else if (props.brevtype === Brevtype.VARSEL) {
+    return apiClient.get(`/brev/behandling/${props.behandlingId}/varsel/pdf?brevId=${props.brevId}`)
   } else if (props.sakId && !props.behandlingId) {
     return apiClient.get(`/brev/${props.brevId}/pdf?sakId=${props.sakId}`)
   } else {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
@@ -1,5 +1,5 @@
 import { apiClient, ApiResponse } from './apiClient'
-import { IBrev, Mottaker } from '~shared/types/Brev'
+import { Brevtype, IBrev, Mottaker } from '~shared/types/Brev'
 
 export const hentBrev = async (props: { brevId: number; sakId: number }): Promise<ApiResponse<IBrev>> =>
   apiClient.get(`/brev/${props.brevId}?sakId=${props.sakId}`)
@@ -46,6 +46,7 @@ export const genererPdf = async (props: {
   brevId: number
   sakId?: number
   behandlingId?: string
+  brevtype: Brevtype
 }): Promise<ApiResponse<ArrayBuffer>> => {
   if (props.behandlingId) {
     return apiClient.get(`/brev/behandling/${props.behandlingId}/vedtak/pdf?brevId=${props.brevId}`)

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Brev.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Brev.ts
@@ -9,6 +9,7 @@ export interface IBrev {
   statusEndret: string
   mottaker: Mottaker
   opprettet: string
+  brevtype: Brevtype
 }
 
 export interface Mottaker {
@@ -60,4 +61,13 @@ export enum Spraak {
   NB = 'nb',
   NN = 'nn',
   EN = 'en',
+}
+
+export enum Brevtype {
+  VEDTAK = 'VEDTAK',
+  VARSEL = 'VARSEL',
+  INFORMASJON = 'INFORMASJON',
+  OPPLASTET_PDF = 'OPPLASTET_PDF',
+  MANUELT = 'MANUELT',
+  VEDLEGG = 'VEDLEGG',
 }


### PR DESCRIPTION
Tar med konseptet _brevtype_ også over i frontend. Liker betre å bruke det til å skilje på forskjellige typar brev enn meir tangerande eigenskapar som behandling-id, sak-id osv.