### PR TITLE
Det var for tidleg å rydde bort spesialhandtering for migrering, vi treng dei jo for 1.1.24-sakene

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -7,6 +7,7 @@ import io.ktor.server.config.HoconApplicationConfig
 import no.nav.etterlatte.brev.BrevService
 import no.nav.etterlatte.brev.Brevoppretter
 import no.nav.etterlatte.brev.JournalfoerBrevService
+import no.nav.etterlatte.brev.MigreringBrevDataService
 import no.nav.etterlatte.brev.PDFGenerator
 import no.nav.etterlatte.brev.PDFService
 import no.nav.etterlatte.brev.RedigerbartVedleggHenter
@@ -141,7 +142,9 @@ class ApplicationBuilder {
 
     private val distribusjonService = DistribusjonServiceImpl(distribusjonKlient, db)
 
-    private val brevDataMapperRedigerbartUtfall = BrevDataMapperRedigerbartUtfall(brevdataFacade)
+    private val migreringBrevDataService = MigreringBrevDataService(brevdataFacade)
+
+    private val brevDataMapperRedigerbartUtfall = BrevDataMapperRedigerbartUtfall(brevdataFacade, migreringBrevDataService)
 
     private val brevDataMapperFerdigstilling = BrevDataMapperFerdigstilling(brevdataFacade)
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -38,6 +38,7 @@ class BrevService(
             sakId = sakId,
             behandlingId = null,
             bruker = bruker,
+            automatiskMigreringRequest = null,
             brevKode = brevkoder.redigering,
             brevtype = brevkoder.redigering.brevtype,
         ).first
@@ -102,6 +103,7 @@ class BrevService(
         pdfGenerator.genererPdf(
             id,
             bruker,
+            null,
             avsenderRequest = { b, g -> g.avsenderRequest(b) },
             brevKode = { _ -> Brevkoder.TOMT_INFORMASJONSBREV },
         )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/MigreringBrevDataService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/MigreringBrevDataService.kt
@@ -1,0 +1,36 @@
+package no.nav.etterlatte.brev
+
+import kotlinx.coroutines.coroutineScope
+import no.nav.etterlatte.brev.behandling.GenerellBrevData
+import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
+import no.nav.etterlatte.brev.model.bp.BarnepensjonOmregnetNyttRegelverkRedigerbartUtfall
+import no.nav.etterlatte.libs.common.Vedtaksloesning
+import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
+import no.nav.etterlatte.token.BrukerTokenInfo
+
+class MigreringBrevDataService(private val brevdataFacade: BrevdataFacade) {
+    suspend fun opprettMigreringBrevdata(
+        generellBrevData: GenerellBrevData,
+        migrering: MigreringBrevRequest?,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): BarnepensjonOmregnetNyttRegelverkRedigerbartUtfall {
+        if (generellBrevData.systemkilde != Vedtaksloesning.PESYS) {
+            throw InternfeilException("Kan ikke opprette et migreringsbrev fra pesys hvis kilde ikke er pesys")
+        }
+        return coroutineScope {
+            val virkningstidspunkt =
+                requireNotNull(generellBrevData.forenkletVedtak!!.virkningstidspunkt) {
+                    "Migreringsvedtaket må ha et virkningstidspunkt"
+                }
+
+            val utbetalingsinfo =
+                brevdataFacade.finnUtbetalingsinfo(
+                    generellBrevData.behandlingId!!,
+                    virkningstidspunkt,
+                    brukerTokenInfo,
+                    generellBrevData.sak.sakType,
+                )
+            BarnepensjonOmregnetNyttRegelverkRedigerbartUtfall.fra(generellBrevData, utbetalingsinfo, migrering)
+        }
+    }
+}

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
@@ -10,6 +10,7 @@ import no.nav.etterlatte.brev.model.BrevKodeMapper
 import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Status
+import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.token.BrukerTokenInfo
@@ -41,20 +42,25 @@ class VedtaksbrevService(
         sakId: Long,
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
+        automatiskMigreringRequest: MigreringBrevRequest? = null,
+        // TODO EY-3232 - Fjerne migreringstilpasning
     ): Brev =
         brevoppretter.opprettVedtaksbrev(
             sakId = sakId,
             behandlingId = behandlingId,
             brukerTokenInfo = brukerTokenInfo,
+            automatiskMigreringRequest = automatiskMigreringRequest,
         )
 
     suspend fun genererPdf(
         id: BrevID,
         bruker: BrukerTokenInfo,
+        automatiskMigreringRequest: MigreringBrevRequest? = null,
     ): Pdf =
         pdfGenerator.genererPdf(
             id = id,
             bruker = bruker,
+            automatiskMigreringRequest = automatiskMigreringRequest,
             avsenderRequest = { brukerToken, generellBrevData -> generellBrevData.avsenderRequest(brukerToken) },
             brevKode = { brevKodeMapper.brevKode(it) },
         ) { generellBrevData, brev, pdf ->
@@ -63,12 +69,14 @@ class VedtaksbrevService(
                 generellBrevData.forenkletVedtak!!,
                 pdf,
                 bruker,
+                automatiskMigreringRequest != null,
             )
         }
 
     suspend fun ferdigstillVedtaksbrev(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
+        migrering: Boolean = false,
     ) {
         val brev =
             requireNotNull(hentVedtaksbrev(behandlingId)) {
@@ -90,7 +98,7 @@ class VedtaksbrevService(
                 brukerTokenInfo,
             )
 
-        if (vedtakStatus != VedtakStatus.FATTET_VEDTAK) {
+        if (vedtakStatus != VedtakStatus.FATTET_VEDTAK && !migrering) {
             throw IllegalStateException(
                 "Vedtak status er $vedtakStatus. Avventer ferdigstilling av brev (id=${brev.id})",
             )
@@ -124,8 +132,9 @@ class VedtaksbrevService(
         vedtak: ForenkletVedtak,
         pdf: Pdf,
         brukerTokenInfo: BrukerTokenInfo,
+        migrering: Boolean = false,
     ) {
-        if (vedtak.status != VedtakStatus.FATTET_VEDTAK) {
+        if (vedtak.status != VedtakStatus.FATTET_VEDTAK && !migrering) {
             logger.info("Vedtak status er ${vedtak.status}. Avventer ferdigstilling av brev (id=$brevId)")
             return
         }
@@ -151,6 +160,13 @@ class VedtaksbrevService(
         return db.fjernFerdigstiltStatusUnderkjentVedtak(id, vedtak)
     }
 }
+
+// TODO EY-3232 - Fjerne
+data class MigreringBrevRequest(
+    val brutto: Int,
+    val yrkesskade: Boolean,
+    val utlandstilknytningType: UtlandstilknytningType?,
+)
 
 class UgyldigStatusKanIkkeFerdigstilles(id: BrevID, status: Status) : UgyldigForespoerselException(
     code = "UGYLDIG_STATUS_BREV",

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/Behandling.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/Behandling.kt
@@ -40,6 +40,8 @@ data class GenerellBrevData(
             )
         } ?: AvsenderRequest(saksbehandlerIdent = bruker.ident(), sakenhet = sak.enhet)
 
+    fun erMigrering() = systemkilde == Vedtaksloesning.PESYS && behandlingId != null && revurderingsaarsak == null
+
     fun vedtakstype() = forenkletVedtak?.type?.name?.lowercase()
 }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerService.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.brev.brevbaker
 
+import no.nav.etterlatte.brev.MigreringBrevRequest
 import no.nav.etterlatte.brev.adresse.AdresseService
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.model.BrevDataMapperRedigerbartUtfall
@@ -54,4 +55,5 @@ data class RedigerbarTekstRequest(
     val generellBrevData: GenerellBrevData,
     val brukerTokenInfo: BrukerTokenInfo,
     val brevkode: (mapper: BrevKodeMapper, g: GenerellBrevData) -> EtterlatteBrevKode,
+    val migrering: MigreringBrevRequest? = null,
 )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstilling.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstilling.kt
@@ -2,8 +2,9 @@ package no.nav.etterlatte.brev.model
 
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import no.nav.etterlatte.brev.MigreringBrevRequest
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
-import no.nav.etterlatte.brev.brevbaker.EtterlatteBrevKode
+import no.nav.etterlatte.brev.brevbaker.Brevkoder
 import no.nav.etterlatte.brev.brevbaker.EtterlatteBrevKode.BARNEPENSJON_AVSLAG
 import no.nav.etterlatte.brev.brevbaker.EtterlatteBrevKode.BARNEPENSJON_INNVILGELSE
 import no.nav.etterlatte.brev.brevbaker.EtterlatteBrevKode.BARNEPENSJON_OPPHOER
@@ -19,6 +20,7 @@ import no.nav.etterlatte.brev.brevbaker.EtterlatteBrevKode.TOM_MAL_INFORMASJONSB
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.model.bp.BarnepensjonAvslag
 import no.nav.etterlatte.brev.model.bp.BarnepensjonInnvilgelse
+import no.nav.etterlatte.brev.model.bp.BarnepensjonOmregnetNyttRegelverk
 import no.nav.etterlatte.brev.model.bp.BarnepensjonOpphoer
 import no.nav.etterlatte.brev.model.bp.BarnepensjonRevurdering
 import no.nav.etterlatte.brev.model.oms.OmstillingsstoenadAvslag
@@ -33,10 +35,32 @@ class BrevDataMapperFerdigstilling(private val brevdataFacade: BrevdataFacade) {
         generellBrevData: GenerellBrevData,
         bruker: BrukerTokenInfo,
         innholdMedVedlegg: InnholdMedVedlegg,
+        kode: Brevkoder,
+        automatiskMigreringRequest: MigreringBrevRequest?,
         tittel: String? = null,
-        brevkode: EtterlatteBrevKode,
-    ): BrevData =
-        when (brevkode) {
+    ): BrevData {
+        if (generellBrevData.erMigrering()) {
+            return coroutineScope {
+                val fetcher = BrevDatafetcher(brevdataFacade, bruker, generellBrevData)
+                val utbetalingsinfo = async { fetcher.hentUtbetaling() }
+                val trygdetid = async { fetcher.hentTrygdetid() }
+                val grunnbeloep = async { fetcher.hentGrunnbeloep() }
+                val etterbetaling = async { fetcher.hentEtterbetaling() }
+
+                BarnepensjonOmregnetNyttRegelverk.fra(
+                    innhold = innholdMedVedlegg,
+                    erUnder18Aar = generellBrevData.personerISak.soeker.under18,
+                    utbetalingsinfo = utbetalingsinfo.await(),
+                    etterbetaling = etterbetaling.await(),
+                    trygdetid = requireNotNull(trygdetid.await()),
+                    grunnbeloep = grunnbeloep.await(),
+                    migreringRequest = automatiskMigreringRequest,
+                    utlandstilknytning = generellBrevData.utlandstilknytning?.type,
+                )
+            }
+        }
+
+        return when (kode.ferdigstilling) {
             TOM_MAL_INFORMASJONSBREV -> ManueltBrevMedTittelData(innholdMedVedlegg.innhold(), tittel)
             BARNEPENSJON_REVURDERING -> barnepensjonRevurdering(bruker, generellBrevData, innholdMedVedlegg)
             BARNEPENSJON_INNVILGELSE -> barnepensjonInnvilgelse(bruker, generellBrevData, innholdMedVedlegg)
@@ -52,8 +76,9 @@ class BrevDataMapperFerdigstilling(private val brevdataFacade: BrevdataFacade) {
             OMSTILLINGSSTOENAD_VARSEL -> ManueltBrevData()
 
             TILBAKEKREVING_FERDIG -> TilbakekrevingFerdigData.fra(generellBrevData, innholdMedVedlegg)
-            else -> throw IllegalStateException("Klarte ikke å finne brevdata for brevkode $brevkode for ferdigstilling.")
+            else -> throw IllegalStateException("Klarte ikke å finne brevdata for brevkode $kode for ferdigstilling.")
         }
+    }
 
     private suspend fun barnepensjonRevurdering(
         brukerTokenInfo: BrukerTokenInfo,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfall.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfall.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.brev.model
 
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import no.nav.etterlatte.brev.MigreringBrevDataService
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.brevbaker.RedigerbarTekstRequest
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
@@ -15,35 +16,43 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.token.BrukerTokenInfo
 
-class BrevDataMapperRedigerbartUtfall(private val brevdataFacade: BrevdataFacade) {
+class BrevDataMapperRedigerbartUtfall(
+    private val brevdataFacade: BrevdataFacade,
+    private val migreringBrevDataService: MigreringBrevDataService,
+) {
     suspend fun brevData(redigerbarTekstRequest: RedigerbarTekstRequest) =
         with(redigerbarTekstRequest) {
-            when (generellBrevData.sak.sakType) {
-                SakType.BARNEPENSJON -> {
-                    when (generellBrevData.forenkletVedtak?.type) {
-                        VedtakType.INNVILGELSE -> barnepensjonInnvilgelse(brukerTokenInfo, generellBrevData)
-                        VedtakType.ENDRING -> barnepensjonEndring(brukerTokenInfo, generellBrevData)
-                        VedtakType.AVSLAG -> ManueltBrevData()
-                        VedtakType.OPPHOER -> ManueltBrevData()
-                        VedtakType.TILBAKEKREVING -> TilbakekrevingInnholdBrevData.fra(generellBrevData)
-                        null -> ManueltBrevData()
-                    }
+            if (generellBrevData.erMigrering()) {
+                migreringBrevDataService.opprettMigreringBrevdata(generellBrevData, migrering, brukerTokenInfo)
+            } else {
+                brevData(generellBrevData, brukerTokenInfo)
+            }
+        }
+
+    private suspend fun brevData(
+        generellBrevData: GenerellBrevData,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): BrevData =
+        when (generellBrevData.sak.sakType) {
+            SakType.BARNEPENSJON -> {
+                when (generellBrevData.forenkletVedtak?.type) {
+                    VedtakType.INNVILGELSE -> barnepensjonInnvilgelse(brukerTokenInfo, generellBrevData)
+                    VedtakType.ENDRING -> barnepensjonEndring(brukerTokenInfo, generellBrevData)
+                    VedtakType.AVSLAG -> ManueltBrevData()
+                    VedtakType.OPPHOER -> ManueltBrevData()
+                    VedtakType.TILBAKEKREVING -> TilbakekrevingInnholdBrevData.fra(generellBrevData)
+                    null -> ManueltBrevData()
                 }
+            }
 
-                SakType.OMSTILLINGSSTOENAD -> {
-                    when (generellBrevData.forenkletVedtak?.type) {
-                        VedtakType.INNVILGELSE -> omstillingsstoenadInnvilgelse(brukerTokenInfo, generellBrevData)
-                        VedtakType.ENDRING -> ManueltBrevData()
-                        VedtakType.AVSLAG -> OmstillingsstoenadAvslag.fra(generellBrevData, emptyList())
-                        VedtakType.OPPHOER ->
-                            OmstillingsstoenadOpphoerRedigerbartUtfall.fra(
-                                generellBrevData,
-                                emptyList(),
-                            )
-
-                        VedtakType.TILBAKEKREVING -> TilbakekrevingInnholdBrevData.fra(generellBrevData)
-                        null -> ManueltBrevData()
-                    }
+            SakType.OMSTILLINGSSTOENAD -> {
+                when (generellBrevData.forenkletVedtak?.type) {
+                    VedtakType.INNVILGELSE -> omstillingsstoenadInnvilgelse(brukerTokenInfo, generellBrevData)
+                    VedtakType.ENDRING -> ManueltBrevData()
+                    VedtakType.AVSLAG -> OmstillingsstoenadAvslag.fra(generellBrevData, emptyList())
+                    VedtakType.OPPHOER -> OmstillingsstoenadOpphoerRedigerbartUtfall.fra(generellBrevData, emptyList())
+                    VedtakType.TILBAKEKREVING -> TilbakekrevingInnholdBrevData.fra(generellBrevData)
+                    null -> ManueltBrevData()
                 }
             }
         }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapper.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapper.kt
@@ -6,8 +6,13 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 
 class BrevKodeMapper {
-    fun brevKode(generellBrevData: GenerellBrevData): Brevkoder =
-        when (generellBrevData.sak.sakType) {
+    fun brevKode(generellBrevData: GenerellBrevData): Brevkoder {
+        if (generellBrevData.erMigrering()) {
+            assert(listOf(VedtakType.INNVILGELSE, VedtakType.ENDRING).contains(generellBrevData.forenkletVedtak?.type))
+            return Brevkoder.OMREGNING
+        }
+
+        return when (generellBrevData.sak.sakType) {
             SakType.BARNEPENSJON -> {
                 when (generellBrevData.forenkletVedtak?.type) {
                     VedtakType.INNVILGELSE -> Brevkoder.BP_INNVILGELSE
@@ -30,4 +35,5 @@ class BrevKodeMapper {
                 }
             }
         }
+    }
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOmregnetNyttRegelverk.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOmregnetNyttRegelverk.kt
@@ -1,0 +1,110 @@
+package no.nav.etterlatte.brev.model.bp
+
+import no.nav.etterlatte.brev.MigreringBrevRequest
+import no.nav.etterlatte.brev.behandling.GenerellBrevData
+import no.nav.etterlatte.brev.behandling.Trygdetid
+import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
+import no.nav.etterlatte.brev.model.BarnepensjonBeregning
+import no.nav.etterlatte.brev.model.BarnepensjonEtterbetaling
+import no.nav.etterlatte.brev.model.BrevData
+import no.nav.etterlatte.brev.model.Etterbetaling
+import no.nav.etterlatte.brev.model.EtterbetalingDTO
+import no.nav.etterlatte.brev.model.InnholdMedVedlegg
+import no.nav.etterlatte.brev.model.Slate
+import no.nav.etterlatte.grunnbeloep.Grunnbeloep
+import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
+import no.nav.etterlatte.libs.common.person.ForelderVerge
+import no.nav.etterlatte.token.Fagsaksystem
+import no.nav.pensjon.brevbaker.api.model.Kroner
+
+data class BarnepensjonOmregnetNyttRegelverkRedigerbartUtfall(
+    val utbetaltFoerReform: Kroner,
+    val utbetaltEtterReform: Kroner,
+    val erForeldreloes: Boolean,
+    val erBosattUtlandet: Boolean,
+) : BrevData() {
+    companion object {
+        fun fra(
+            generellBrevData: GenerellBrevData,
+            utbetalingsinfo: Utbetalingsinfo,
+            migreringRequest: MigreringBrevRequest?,
+        ): BarnepensjonOmregnetNyttRegelverkRedigerbartUtfall {
+            val defaultBrevdataOmregning =
+                BarnepensjonOmregnetNyttRegelverkRedigerbartUtfall(
+                    utbetaltFoerReform = Kroner(0),
+                    utbetaltEtterReform = Kroner(utbetalingsinfo.beloep.value),
+                    erBosattUtlandet = false,
+                    erForeldreloes =
+                        generellBrevData.personerISak.soeker.foreldreloes ||
+                            (
+                                generellBrevData.personerISak.avdoede.size > 1 &&
+                                    generellBrevData.personerISak.verge !is ForelderVerge
+                            ),
+                )
+            if (generellBrevData.erMigrering()) {
+                val pesysUtbetaltFoerReform = migreringRequest?.brutto ?: 0
+                val pesysUtenlandstilknytning =
+                    migreringRequest?.utlandstilknytningType ?: requireNotNull(generellBrevData.utlandstilknytning) {
+                        "Mangler utlandstilknytning for behandling=${generellBrevData.behandlingId}"
+                    }.type
+
+                if (generellBrevData.forenkletVedtak?.saksbehandlerIdent == Fagsaksystem.EY.navn &&
+                    defaultBrevdataOmregning.erForeldreloes
+                ) {
+                    throw IllegalStateException(
+                        "Vi har en automatisk migrering som setter foreldreløs. " +
+                            "Dette skal ikke skje, siden dette brevet må redigeres av saksbehandler",
+                    )
+                }
+                return defaultBrevdataOmregning.copy(
+                    utbetaltFoerReform = Kroner(pesysUtbetaltFoerReform),
+                    erBosattUtlandet = pesysUtenlandstilknytning == UtlandstilknytningType.BOSATT_UTLAND,
+                )
+            }
+
+            return defaultBrevdataOmregning
+        }
+    }
+}
+
+data class BarnepensjonOmregnetNyttRegelverk(
+    val innhold: List<Slate.Element>,
+    val beregning: BarnepensjonBeregning,
+    val etterbetaling: BarnepensjonEtterbetaling?,
+    val erUnder18Aar: Boolean,
+    val erBosattUtlandet: Boolean,
+) : BrevData() {
+    companion object {
+        fun fra(
+            innhold: InnholdMedVedlegg,
+            erUnder18Aar: Boolean?,
+            utbetalingsinfo: Utbetalingsinfo,
+            trygdetid: Trygdetid,
+            grunnbeloep: Grunnbeloep,
+            etterbetaling: EtterbetalingDTO?,
+            migreringRequest: MigreringBrevRequest?,
+            utlandstilknytning: UtlandstilknytningType?,
+        ): BarnepensjonOmregnetNyttRegelverk {
+            val erUnder18AarNonNull =
+                requireNotNull(erUnder18Aar) {
+                    "Klarte ikke å bestemme om alder på søker er under eller over 18 år. Kan dermed ikke velge riktig brev"
+                }
+
+            val beregningsperioder = barnepensjonBeregningsperioder(utbetalingsinfo)
+
+            return BarnepensjonOmregnetNyttRegelverk(
+                innhold = innhold.innhold(),
+                erUnder18Aar = erUnder18AarNonNull,
+                beregning = barnepensjonBeregning(innhold, utbetalingsinfo, grunnbeloep, beregningsperioder, trygdetid),
+                etterbetaling =
+                    etterbetaling
+                        ?.let { dto -> Etterbetaling.fraBarnepensjonBeregningsperioder(dto, beregningsperioder) },
+                erBosattUtlandet =
+                    (
+                        migreringRequest?.utlandstilknytningType
+                            ?: requireNotNull(utlandstilknytning)
+                    ) == UtlandstilknytningType.BOSATT_UTLAND,
+            )
+        }
+    }
+}

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
@@ -67,6 +67,7 @@ class OpprettJournalfoerOgDistribuerRiver(
             pdfGenerator.ferdigstillOgGenererPDF(
                 id = brevId,
                 bruker = brukerTokenInfo,
+                automatiskMigreringRequest = null,
                 avsenderRequest = { _, _ ->
                     AvsenderRequest(
                         saksbehandlerIdent = Fagsaksystem.EY.navn,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/migrering/OpprettVedtaksbrevForMigreringRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/migrering/OpprettVedtaksbrevForMigreringRiver.kt
@@ -1,11 +1,13 @@
 package no.nav.etterlatte.rivers.migrering
 
 import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.brev.MigreringBrevRequest
 import no.nav.etterlatte.brev.VedtaksbrevService
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseHendelseType
 import no.nav.etterlatte.rapidsandrivers.migrering.KILDE_KEY
+import no.nav.etterlatte.rapidsandrivers.migrering.hendelseData
 import no.nav.etterlatte.token.Systembruker
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
@@ -40,14 +42,35 @@ internal class OpprettVedtaksbrevForMigreringRiver(
         val behandlingId = UUID.fromString(packet["vedtak.behandlingId"].asText())
         val brukerTokenInfo = Systembruker.migrering
         runBlocking {
+            val hendelseData = packet.hendelseData
+            val migreringBrevRequest =
+                with(hendelseData) {
+                    MigreringBrevRequest(
+                        brutto = beregning.brutto,
+                        utlandstilknytningType = utlandstilknytningType,
+                        yrkesskade = dodAvYrkesskade,
+                    )
+                }
+            if (migreringBrevRequest.utlandstilknytningType == null) {
+                logger.warn(
+                    "Fikk null i utenlandstilknytningstype for migreringrequest med " +
+                        "pesysId=${hendelseData.pesysId}.",
+                )
+            } else {
+                logger.info(
+                    "Fikk utlandstilknytningstype=${migreringBrevRequest.utlandstilknytningType} for " +
+                        "migreringrequesten med pesysId=${hendelseData.pesysId}",
+                )
+            }
             val vedtaksbrev: Brev =
                 service.opprettVedtaksbrev(
                     sakId,
                     behandlingId,
                     brukerTokenInfo,
+                    migreringBrevRequest,
                 )
-            service.genererPdf(vedtaksbrev.id, brukerTokenInfo)
-            service.ferdigstillVedtaksbrev(behandlingId, brukerTokenInfo)
+            service.genererPdf(vedtaksbrev.id, brukerTokenInfo, migreringBrevRequest)
+            service.ferdigstillVedtaksbrev(behandlingId, brukerTokenInfo, true)
         }
         logger.info("Har oppretta vedtaksbrev i sak $sakId")
         packet[PDF_GENERERT] = true

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -32,6 +32,7 @@ import no.nav.etterlatte.brev.hentinformasjon.VedtaksvurderingService
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevDataMapperFerdigstilling
+import no.nav.etterlatte.brev.model.BrevDataMapperRedigerbartUtfall
 import no.nav.etterlatte.brev.model.BrevKodeMapper
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Brevtype
@@ -80,6 +81,8 @@ internal class VedtaksbrevServiceTest {
     private val vedtaksvurderingService = mockk<VedtaksvurderingService>()
     private val adresseService = mockk<AdresseService>()
     private val dokarkivService = mockk<DokarkivServiceImpl>()
+    private val migreringBrevDataService = MigreringBrevDataService(brevdataFacade)
+    private val brevDataMapperRedigerbartUtfall = BrevDataMapperRedigerbartUtfall(brevdataFacade, migreringBrevDataService)
     private val brevDataMapperFerdigstilling = BrevDataMapperFerdigstilling(brevdataFacade)
     private val brevKodeMapper = BrevKodeMapper()
     private val brevbakerService = mockk<BrevbakerService>()

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/InformasjonsbrevTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/InformasjonsbrevTest.kt
@@ -94,6 +94,7 @@ class InformasjonsbrevTest {
                         any(),
                         any(),
                         any(),
+                        any(),
                     )
                 } returns Pair(mockk<Brev>().also { every { it.id } returns brevId }, mockk())
             }
@@ -102,6 +103,7 @@ class InformasjonsbrevTest {
                 coEvery {
                     it.ferdigstillOgGenererPDF(
                         brevId,
+                        any(),
                         any(),
                         any(),
                         any(),

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettVedtaksbrevForMigreringRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettVedtaksbrevForMigreringRiverTest.kt
@@ -68,15 +68,15 @@ internal class OpprettVedtaksbrevForMigreringRiverTest {
         val melding = opprettMelding(vedtak, migreringRequest, VedtakKafkaHendelseHendelseType.FATTET)
         val brev = opprettBrev()
 
-        coEvery { vedtaksbrevService.opprettVedtaksbrev(any(), behandlingId, any()) } returns brev
-        coEvery { vedtaksbrevService.genererPdf(brev.id, any()) } returns mockk<Pdf>()
-        coEvery { vedtaksbrevService.ferdigstillVedtaksbrev(brev.behandlingId!!, any()) } just runs
+        coEvery { vedtaksbrevService.opprettVedtaksbrev(any(), behandlingId, any(), any()) } returns brev
+        coEvery { vedtaksbrevService.genererPdf(brev.id, any(), any()) } returns mockk<Pdf>()
+        coEvery { vedtaksbrevService.ferdigstillVedtaksbrev(brev.behandlingId!!, any(), true) } just runs
 
         val inspektoer = opprettBrevRapid.apply { sendTestMessage(melding.toJson()) }.inspektør
 
-        coVerify(exactly = 1) { vedtaksbrevService.opprettVedtaksbrev(any(), behandlingId, any()) }
-        coVerify(exactly = 1) { vedtaksbrevService.genererPdf(brev.id, any()) }
-        coVerify(exactly = 1) { vedtaksbrevService.ferdigstillVedtaksbrev(brev.behandlingId!!, any()) }
+        coVerify(exactly = 1) { vedtaksbrevService.opprettVedtaksbrev(any(), behandlingId, any(), any()) }
+        coVerify(exactly = 1) { vedtaksbrevService.genererPdf(brev.id, any(), any()) }
+        coVerify(exactly = 1) { vedtaksbrevService.ferdigstillVedtaksbrev(brev.behandlingId!!, any(), true) }
 
         val meldingSendt = inspektoer.message(0)
         assertEquals(VedtakKafkaHendelseHendelseType.FATTET.lagEventnameForType(), meldingSendt.get(EVENT_NAME_KEY).asText())


### PR DESCRIPTION
Revert "EY-3438: Rydde bort spesialhandtering som ikkje trengs lenger for migrering/omregning frå brev-api (#3667)"

This reverts commit 9474bbaeae5b2393c8fff1e77c33ea8f938ba3c1.