### PR TITLE
EY-3166 Opprette manuell jfr-oppgave ved manglende bruker

### DIFF
--- a/apps/etterlatte-hendelser-joark/.nais/dev.yaml
+++ b/apps/etterlatte-hendelser-joark/.nais/dev.yaml
@@ -49,6 +49,10 @@ spec:
       value: api://dev-gcp.etterlatte.etterlatte-pdltjenester/.default
     - name: ETTERLATTE_PDLTJENESTER_URL
       value: http://etterlatte-pdltjenester
+    - name: OPPGAVE_SCOPE
+      value: api://dev-fss.oppgavehandtering.oppgave/.default
+    - name: OPPGAVE_BASE_URL
+      value: https://oppgave.dev-fss-pub.nais.io
   accessPolicy:
     outbound:
       rules:
@@ -56,3 +60,4 @@ spec:
         - application: etterlatte-pdltjenester
       external:
         - host: saf-q2.dev-fss-pub.nais.io
+        - host: oppgave.dev-fss-pub.nais.io

--- a/apps/etterlatte-hendelser-joark/.nais/prod.yaml
+++ b/apps/etterlatte-hendelser-joark/.nais/prod.yaml
@@ -49,6 +49,10 @@ spec:
       value: api://prod-gcp.etterlatte.etterlatte-pdltjenester/.default
     - name: ETTERLATTE_PDLTJENESTER_URL
       value: http://etterlatte-pdltjenester
+    - name: OPPGAVE_SCOPE
+      value: api://prod-fss.oppgavehandtering.oppgave/.default
+    - name: OPPGAVE_BASE_URL
+      value: https://oppgave.prod-fss-pub.nais.io
   accessPolicy:
     outbound:
       rules:
@@ -56,3 +60,4 @@ spec:
         - application: etterlatte-pdltjenester
       external:
         - host: saf.prod-fss-pub.nais.io
+        - host: oppgave.prod-fss-pub.nais.io

--- a/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/config/ApplicationContext.kt
+++ b/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/config/ApplicationContext.kt
@@ -8,6 +8,7 @@ import joarkhendelser.pdl.PdlTjenesterKlient
 import no.nav.etterlatte.joarkhendelser.JoarkHendelseHandler
 import no.nav.etterlatte.joarkhendelser.behandling.BehandlingService
 import no.nav.etterlatte.joarkhendelser.common.JoarkhendelseKonsument
+import no.nav.etterlatte.joarkhendelser.oppgave.OppgaveKlient
 import no.nav.etterlatte.libs.common.requireEnvValue
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 
@@ -32,10 +33,17 @@ class ApplicationContext(env: Map<String, String> = System.getenv()) {
             config.getString("pdl.base.url"),
         )
 
+    private val oppgaveKlient =
+        OppgaveKlient(
+            httpClientCredentials(config.getString("oppgave.base.url")),
+            config.getString("oppgave.azure.scope"),
+        )
+
     private val joarkHendelseHandler =
         JoarkHendelseHandler(
             BehandlingService(behandlingKlient, pdlTjenesterKlient),
             safKlient,
+            oppgaveKlient,
             pdlTjenesterKlient,
         )
 

--- a/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/config/ApplicationContext.kt
+++ b/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/config/ApplicationContext.kt
@@ -35,8 +35,8 @@ class ApplicationContext(env: Map<String, String> = System.getenv()) {
 
     private val oppgaveKlient =
         OppgaveKlient(
-            httpClientCredentials(config.getString("oppgave.base.url")),
-            config.getString("oppgave.azure.scope"),
+            httpClientCredentials(config.getString("oppgave.azure.scope")),
+            config.getString("oppgave.base.url"),
         )
 
     private val joarkHendelseHandler =

--- a/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/oppgave/OppgaveKlient.kt
+++ b/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/oppgave/OppgaveKlient.kt
@@ -1,0 +1,46 @@
+package no.nav.etterlatte.joarkhendelser.oppgave
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import no.nav.etterlatte.libs.common.logging.sikkerlogger
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+
+class OppgaveKlient(
+    private val httpClient: HttpClient,
+    private val url: String,
+) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    suspend fun opprettOppgave(
+        journalpostId: Long,
+        tema: String,
+    ) {
+        logger.info("Oppretter manuell journalføringsoppgave")
+
+        val response =
+            httpClient.post("$url/pdlident") {
+                contentType(ContentType.Application.Json)
+                setBody(OpprettOppgaveRequest(journalpostId.toString(), tema))
+            }.body<JsonNode>()
+
+        logger.info("Opprettet oppgave (id=${response["id"]}, status=${response["status"]}, tema=${response["tema"]})")
+        sikkerlogger().info("Opprettet oppgave med respons: \n$response")
+    }
+}
+
+@Suppress("unused")
+data class OpprettOppgaveRequest(
+    val journalpostId: String,
+    val tema: String,
+) {
+    val aktoerId: String? = null
+    val oppgavetype = "JFR" // JFR = Journalføring
+    val prioritet = "NORM"
+    val aktivDato = LocalDate.now().toString()
+}

--- a/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/oppgave/OppgaveKlient.kt
+++ b/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/oppgave/OppgaveKlient.kt
@@ -24,7 +24,7 @@ class OppgaveKlient(
         logger.info("Oppretter manuell journalføringsoppgave")
 
         val response =
-            httpClient.post("$url/pdlident") {
+            httpClient.post("$url/api/v1/oppgaver") {
                 contentType(ContentType.Application.Json)
                 setBody(OpprettOppgaveRequest(journalpostId.toString(), tema))
             }.body<JsonNode>()

--- a/apps/etterlatte-hendelser-joark/src/main/resources/application.conf
+++ b/apps/etterlatte-hendelser-joark/src/main/resources/application.conf
@@ -11,3 +11,6 @@ saf.azure.scope = ${?SAF_SCOPE}
 
 pdl.base.url = ${ETTERLATTE_PDLTJENESTER_URL}
 pdl.azure.scope = ${?PDLTJENESTER_AZURE_SCOPE}
+
+oppgave.base.url = ${OPPGAVE_BASE_URL}
+oppgave.azure.scope = ${?OPPGAVE_SCOPE}


### PR DESCRIPTION
Dersom journalposten mangler bruker vil vi opprette en manuell journalføringsoppgave i Gosys. 
Dette fordi OppgaveAPI-et støtter manglende bruker, i motsetning til vårt eget oppgavesystem. 