### PR TITLE
Forenkle brevkodemapping

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -41,7 +41,7 @@ import no.nav.etterlatte.brev.hentinformasjon.VedtaksvurderingKlient
 import no.nav.etterlatte.brev.hentinformasjon.VedtaksvurderingService
 import no.nav.etterlatte.brev.model.BrevDataMapperFerdigstilling
 import no.nav.etterlatte.brev.model.BrevDataMapperRedigerbartUtfall
-import no.nav.etterlatte.brev.model.BrevKodeMapper
+import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
 import no.nav.etterlatte.brev.varselbrev.VarselbrevService
 import no.nav.etterlatte.brev.varselbrev.varselbrevRoute
 import no.nav.etterlatte.brev.vedtaksbrevRoute
@@ -148,9 +148,9 @@ class ApplicationBuilder {
 
     private val brevDataMapperFerdigstilling = BrevDataMapperFerdigstilling(brevdataFacade)
 
-    private val brevKodeMapper = BrevKodeMapper()
+    private val brevKodeMapperVedtak = BrevKodeMapperVedtak()
 
-    private val brevbakerService = BrevbakerService(brevbaker, adresseService, brevDataMapperRedigerbartUtfall, brevKodeMapper)
+    private val brevbakerService = BrevbakerService(brevbaker, adresseService, brevDataMapperRedigerbartUtfall, brevKodeMapperVedtak)
 
     private val vedtaksvurderingService = VedtaksvurderingService(vedtakKlient)
 
@@ -167,7 +167,7 @@ class ApplicationBuilder {
         VedtaksbrevService(
             db,
             vedtaksvurderingService,
-            brevKodeMapper,
+            brevKodeMapperVedtak,
             brevoppretter,
             pdfGenerator,
         )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -159,7 +159,7 @@ class ApplicationBuilder {
     private val redigerbartVedleggHenter = RedigerbartVedleggHenter(brevbakerService)
 
     private val brevoppretter =
-        Brevoppretter(adresseService, db, brevdataFacade, brevbakerService, redigerbartVedleggHenter, brevKodeMapperVedtak)
+        Brevoppretter(adresseService, db, brevdataFacade, brevbakerService, redigerbartVedleggHenter)
 
     private val pdfGenerator =
         PDFGenerator(db, brevdataFacade, brevDataMapperFerdigstilling, adresseService, brevbakerService)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -158,7 +158,8 @@ class ApplicationBuilder {
 
     private val redigerbartVedleggHenter = RedigerbartVedleggHenter(brevbakerService)
 
-    private val brevoppretter = Brevoppretter(adresseService, db, brevdataFacade, brevbakerService, redigerbartVedleggHenter)
+    private val brevoppretter =
+        Brevoppretter(adresseService, db, brevdataFacade, brevbakerService, redigerbartVedleggHenter, brevKodeMapperVedtak)
 
     private val pdfGenerator =
         PDFGenerator(db, brevdataFacade, brevDataMapperFerdigstilling, adresseService, brevbakerService)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -150,7 +150,7 @@ class ApplicationBuilder {
 
     private val brevKodeMapperVedtak = BrevKodeMapperVedtak()
 
-    private val brevbakerService = BrevbakerService(brevbaker, adresseService, brevDataMapperRedigerbartUtfall, brevKodeMapperVedtak)
+    private val brevbakerService = BrevbakerService(brevbaker, adresseService, brevDataMapperRedigerbartUtfall)
 
     private val vedtaksvurderingService = VedtaksvurderingService(vedtakKlient)
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -105,7 +105,7 @@ class BrevService(
             bruker,
             null,
             avsenderRequest = { b, g -> g.avsenderRequest(b) },
-            brevKode = { _ -> Brevkoder.TOMT_INFORMASJONSBREV },
+            brevKode = { Brevkoder.TOMT_INFORMASJONSBREV },
         )
 
     suspend fun ferdigstill(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -39,7 +39,7 @@ class BrevService(
             behandlingId = null,
             bruker = bruker,
             automatiskMigreringRequest = null,
-            brevKode = brevkoder.redigering,
+            brevKode = { brevkoder.redigering },
             brevtype = brevkoder.redigering.brevtype,
         ).first
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -123,13 +123,13 @@ class Brevoppretter(
         val generellBrevData =
             retryOgPakkUt { brevdataFacade.hentGenerellBrevData(sakId, behandlingId, bruker) }
 
-        val brevkode: (mapper: BrevKodeMapperVedtak, g: GenerellBrevData) -> EtterlatteBrevKode =
+        val brevkodeRequest =
+            BrevkodeRequest(generellBrevData.erMigrering(), generellBrevData.sak.sakType, generellBrevData.forenkletVedtak?.type)
+        val brevkode: (mapper: BrevKodeMapperVedtak) -> EtterlatteBrevKode =
             if (brevKode != null) {
-                { _, _ -> brevKode }
+                { _ -> brevKode }
             } else {
-                { mapper, data ->
-                    mapper.brevKode(BrevkodeRequest(data.erMigrering(), data.sak.sakType, data.forenkletVedtak?.type)).redigering
-                }
+                { it.brevKode(brevkodeRequest).redigering }
             }
 
         val tittel =

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.brev.model.BrevInnhold
 import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
 import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
 import no.nav.etterlatte.brev.model.BrevProsessType
+import no.nav.etterlatte.brev.model.BrevkodeRequest
 import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.OpprettNyttBrev
@@ -127,7 +128,7 @@ class Brevoppretter(
                 { _, _ -> brevKode }
             } else {
                 { mapper, data ->
-                    mapper.brevKode(data).redigering
+                    mapper.brevKode(BrevkodeRequest(data.erMigrering(), data.sak.sakType, data.forenkletVedtak?.type)).redigering
                 }
             }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -14,7 +14,6 @@ import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevInnhold
 import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
-import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.BrevkodeRequest
 import no.nav.etterlatte.brev.model.Brevtype
@@ -35,7 +34,6 @@ class Brevoppretter(
     private val brevdataFacade: BrevdataFacade,
     private val brevbaker: BrevbakerService,
     private val redigerbartVedleggHenter: RedigerbartVedleggHenter,
-    private val brevKodeMapperVedtak: BrevKodeMapperVedtak,
 ) {
     suspend fun opprettVedtaksbrev(
         sakId: Long,
@@ -43,6 +41,7 @@ class Brevoppretter(
         brukerTokenInfo: BrukerTokenInfo,
         automatiskMigreringRequest: MigreringBrevRequest? = null,
         // TODO EY-3232 - Fjerne migreringstilpasning
+        brevKode: ((b: BrevkodeRequest) -> EtterlatteBrevKode),
     ): Brev {
         require(db.hentBrevForBehandling(behandlingId, Brevtype.VEDTAK).firstOrNull() == null) {
             "Vedtaksbrev finnes allerede på behandling (id=$behandlingId) og kan ikke opprettes på nytt"
@@ -61,7 +60,7 @@ class Brevoppretter(
             behandlingId = behandlingId,
             bruker = brukerTokenInfo,
             automatiskMigreringRequest = automatiskMigreringRequest,
-            brevKode = { brevKodeMapperVedtak.brevKode(it).redigering },
+            brevKode = brevKode,
             brevtype = Brevtype.VEDTAK,
         ).first
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -35,6 +35,7 @@ class Brevoppretter(
     private val brevdataFacade: BrevdataFacade,
     private val brevbaker: BrevbakerService,
     private val redigerbartVedleggHenter: RedigerbartVedleggHenter,
+    private val brevKodeMapperVedtak: BrevKodeMapperVedtak,
 ) {
     suspend fun opprettVedtaksbrev(
         sakId: Long,
@@ -125,12 +126,6 @@ class Brevoppretter(
 
         val brevkodeRequest =
             BrevkodeRequest(generellBrevData.erMigrering(), generellBrevData.sak.sakType, generellBrevData.forenkletVedtak?.type)
-        val brevkode: (mapper: BrevKodeMapperVedtak) -> EtterlatteBrevKode =
-            if (brevKode != null) {
-                { _ -> brevKode }
-            } else {
-                { it.brevKode(brevkodeRequest).redigering }
-            }
 
         val tittel =
             brevKode?.tittel ?: (generellBrevData.vedtakstype()?.let { "Vedtak om $it" } ?: "Tittel mangler")
@@ -141,7 +136,7 @@ class Brevoppretter(
                         RedigerbarTekstRequest(
                             generellBrevData,
                             bruker,
-                            brevkode,
+                            brevKode ?: brevKodeMapperVedtak.brevKode(brevkodeRequest).redigering,
                             automatiskMigreringRequest,
                         ),
                     )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -14,7 +14,7 @@ import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevInnhold
 import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
-import no.nav.etterlatte.brev.model.BrevKodeMapper
+import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
@@ -122,7 +122,7 @@ class Brevoppretter(
         val generellBrevData =
             retryOgPakkUt { brevdataFacade.hentGenerellBrevData(sakId, behandlingId, bruker) }
 
-        val brevkode: (mapper: BrevKodeMapper, g: GenerellBrevData) -> EtterlatteBrevKode =
+        val brevkode: (mapper: BrevKodeMapperVedtak, g: GenerellBrevData) -> EtterlatteBrevKode =
             if (brevKode != null) {
                 { _, _ -> brevKode }
             } else {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
@@ -13,6 +13,7 @@ import no.nav.etterlatte.brev.model.BrevData
 import no.nav.etterlatte.brev.model.BrevDataMapperFerdigstilling
 import no.nav.etterlatte.brev.model.BrevID
 import no.nav.etterlatte.brev.model.BrevProsessType
+import no.nav.etterlatte.brev.model.BrevkodeRequest
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
 import no.nav.etterlatte.brev.model.ManueltBrevData
 import no.nav.etterlatte.brev.model.Pdf
@@ -34,7 +35,7 @@ class PDFGenerator(
         bruker: BrukerTokenInfo,
         automatiskMigreringRequest: MigreringBrevRequest?,
         avsenderRequest: (BrukerTokenInfo, GenerellBrevData) -> AvsenderRequest,
-        brevKode: (GenerellBrevData) -> Brevkoder,
+        brevKode: (BrevkodeRequest) -> Brevkoder,
         lagrePdfHvisVedtakFattet: (GenerellBrevData, Brev, Pdf) -> Unit = { _, _, _ -> run {} },
     ): Pdf {
         sjekkOmBrevKanEndres(id)
@@ -49,7 +50,7 @@ class PDFGenerator(
         bruker: BrukerTokenInfo,
         automatiskMigreringRequest: MigreringBrevRequest?,
         avsenderRequest: (BrukerTokenInfo, GenerellBrevData) -> AvsenderRequest,
-        brevKode: (GenerellBrevData) -> Brevkoder,
+        brevKode: (BrevkodeRequest) -> Brevkoder,
         lagrePdfHvisVedtakFattet: (GenerellBrevData, Brev, Pdf) -> Unit = { _, _, _ -> run {} },
     ): Pdf {
         val brev = db.hentBrev(id)
@@ -66,7 +67,8 @@ class PDFGenerator(
             retryOgPakkUt { brevDataFacade.hentGenerellBrevData(brev.sakId, brev.behandlingId, bruker) }
         val avsender = adresseService.hentAvsender(avsenderRequest(bruker, generellBrevData))
 
-        val brevkodePar = brevKode(generellBrevData)
+        val brevkodePar =
+            brevKode(BrevkodeRequest(generellBrevData.erMigrering(), generellBrevData.sak.sakType, generellBrevData.forenkletVedtak?.type))
 
         val sak = generellBrevData.sak
         val letterData =

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/RedigerbartVedleggHenter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/RedigerbartVedleggHenter.kt
@@ -87,7 +87,7 @@ class RedigerbartVedleggHenter(private val brevbakerService: BrevbakerService) {
                     RedigerbarTekstRequest(
                         generellBrevData = generellBrevData,
                         brukerTokenInfo = bruker,
-                        brevkode = { _, _ -> kode },
+                        brevkode = { _ -> kode },
                     ),
                 ),
         )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/RedigerbartVedleggHenter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/RedigerbartVedleggHenter.kt
@@ -87,7 +87,7 @@ class RedigerbartVedleggHenter(private val brevbakerService: BrevbakerService) {
                     RedigerbarTekstRequest(
                         generellBrevData = generellBrevData,
                         brukerTokenInfo = bruker,
-                        brevkode = { _ -> kode },
+                        brevkode = kode,
                     ),
                 ),
         )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
@@ -7,7 +7,6 @@ import no.nav.etterlatte.brev.hentinformasjon.VedtaksvurderingService
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevID
 import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
-import no.nav.etterlatte.brev.model.BrevkodeRequest
 import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Status
@@ -63,15 +62,7 @@ class VedtaksbrevService(
             bruker = bruker,
             automatiskMigreringRequest = automatiskMigreringRequest,
             avsenderRequest = { brukerToken, generellBrevData -> generellBrevData.avsenderRequest(brukerToken) },
-            brevKode = {
-                brevKodeMapperVedtak.brevKode(
-                    BrevkodeRequest(
-                        it.erMigrering(),
-                        it.sak.sakType,
-                        it.forenkletVedtak!!.type,
-                    ),
-                )
-            },
+            brevKode = { brevKodeMapperVedtak.brevKode(it) },
         ) { generellBrevData, brev, pdf ->
             lagrePdfHvisVedtakFattet(
                 brev.id,
@@ -134,7 +125,10 @@ class VedtaksbrevService(
         brevId: Long,
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
-    ): BrevService.BrevPayload = brevoppretter.hentNyttInnhold(sakId, brevId, behandlingId, brukerTokenInfo)
+    ): BrevService.BrevPayload =
+        brevoppretter.hentNyttInnhold(sakId, brevId, behandlingId, brukerTokenInfo, {
+            brevKodeMapperVedtak.brevKode(it).redigering
+        })
 
     private fun lagrePdfHvisVedtakFattet(
         brevId: BrevID,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
@@ -6,7 +6,7 @@ import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.hentinformasjon.VedtaksvurderingService
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevID
-import no.nav.etterlatte.brev.model.BrevKodeMapper
+import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
 import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Status
@@ -20,7 +20,7 @@ import java.util.UUID
 class VedtaksbrevService(
     private val db: BrevRepository,
     private val vedtaksvurderingService: VedtaksvurderingService,
-    private val brevKodeMapper: BrevKodeMapper,
+    private val brevKodeMapperVedtak: BrevKodeMapperVedtak,
     private val brevoppretter: Brevoppretter,
     private val pdfGenerator: PDFGenerator,
 ) {
@@ -62,7 +62,7 @@ class VedtaksbrevService(
             bruker = bruker,
             automatiskMigreringRequest = automatiskMigreringRequest,
             avsenderRequest = { brukerToken, generellBrevData -> generellBrevData.avsenderRequest(brukerToken) },
-            brevKode = { brevKodeMapper.brevKode(it) },
+            brevKode = { brevKodeMapperVedtak.brevKode(it) },
         ) { generellBrevData, brev, pdf ->
             lagrePdfHvisVedtakFattet(
                 brev.id,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
@@ -7,6 +7,7 @@ import no.nav.etterlatte.brev.hentinformasjon.VedtaksvurderingService
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevID
 import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
+import no.nav.etterlatte.brev.model.BrevkodeRequest
 import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Status
@@ -62,7 +63,15 @@ class VedtaksbrevService(
             bruker = bruker,
             automatiskMigreringRequest = automatiskMigreringRequest,
             avsenderRequest = { brukerToken, generellBrevData -> generellBrevData.avsenderRequest(brukerToken) },
-            brevKode = { brevKodeMapperVedtak.brevKode(it) },
+            brevKode = {
+                brevKodeMapperVedtak.brevKode(
+                    BrevkodeRequest(
+                        it.erMigrering(),
+                        it.sak.sakType,
+                        it.forenkletVedtak!!.type,
+                    ),
+                )
+            },
         ) { generellBrevData, brev, pdf ->
             lagrePdfHvisVedtakFattet(
                 brev.id,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
@@ -50,6 +50,7 @@ class VedtaksbrevService(
             behandlingId = behandlingId,
             brukerTokenInfo = brukerTokenInfo,
             automatiskMigreringRequest = automatiskMigreringRequest,
+            brevKode = { brevKodeMapperVedtak.brevKode(it).redigering },
         )
 
     suspend fun genererPdf(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerService.kt
@@ -35,7 +35,7 @@ class BrevbakerService(
         val request =
             with(redigerbarTekstRequest) {
                 BrevbakerRequest.fra(
-                    brevkode(brevKodeMapperVedtak, generellBrevData),
+                    brevkode(brevKodeMapperVedtak),
                     brevDataMapperRedigerbartUtfall.brevData(this),
                     adresseService.hentAvsender(
                         generellBrevData.avsenderRequest(brukerTokenInfo),
@@ -54,6 +54,6 @@ class BrevbakerService(
 data class RedigerbarTekstRequest(
     val generellBrevData: GenerellBrevData,
     val brukerTokenInfo: BrukerTokenInfo,
-    val brevkode: (mapper: BrevKodeMapperVedtak, g: GenerellBrevData) -> EtterlatteBrevKode,
+    val brevkode: (mapper: BrevKodeMapperVedtak) -> EtterlatteBrevKode,
     val migrering: MigreringBrevRequest? = null,
 )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerService.kt
@@ -5,7 +5,6 @@ import no.nav.etterlatte.brev.adresse.AdresseService
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.model.BrevDataMapperRedigerbartUtfall
 import no.nav.etterlatte.brev.model.BrevID
-import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
 import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.token.BrukerTokenInfo
@@ -16,7 +15,6 @@ class BrevbakerService(
     private val brevbakerKlient: BrevbakerKlient,
     private val adresseService: AdresseService,
     private val brevDataMapperRedigerbartUtfall: BrevDataMapperRedigerbartUtfall,
-    private val brevKodeMapperVedtak: BrevKodeMapperVedtak,
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -35,7 +33,7 @@ class BrevbakerService(
         val request =
             with(redigerbarTekstRequest) {
                 BrevbakerRequest.fra(
-                    brevkode(brevKodeMapperVedtak),
+                    brevkode,
                     brevDataMapperRedigerbartUtfall.brevData(this),
                     adresseService.hentAvsender(
                         generellBrevData.avsenderRequest(brukerTokenInfo),
@@ -54,6 +52,6 @@ class BrevbakerService(
 data class RedigerbarTekstRequest(
     val generellBrevData: GenerellBrevData,
     val brukerTokenInfo: BrukerTokenInfo,
-    val brevkode: (mapper: BrevKodeMapperVedtak) -> EtterlatteBrevKode,
+    val brevkode: EtterlatteBrevKode,
     val migrering: MigreringBrevRequest? = null,
 )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerService.kt
@@ -5,7 +5,7 @@ import no.nav.etterlatte.brev.adresse.AdresseService
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.model.BrevDataMapperRedigerbartUtfall
 import no.nav.etterlatte.brev.model.BrevID
-import no.nav.etterlatte.brev.model.BrevKodeMapper
+import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
 import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.token.BrukerTokenInfo
@@ -16,7 +16,7 @@ class BrevbakerService(
     private val brevbakerKlient: BrevbakerKlient,
     private val adresseService: AdresseService,
     private val brevDataMapperRedigerbartUtfall: BrevDataMapperRedigerbartUtfall,
-    private val brevKodeMapper: BrevKodeMapper,
+    private val brevKodeMapperVedtak: BrevKodeMapperVedtak,
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -35,7 +35,7 @@ class BrevbakerService(
         val request =
             with(redigerbarTekstRequest) {
                 BrevbakerRequest.fra(
-                    brevkode(brevKodeMapper, generellBrevData),
+                    brevkode(brevKodeMapperVedtak, generellBrevData),
                     brevDataMapperRedigerbartUtfall.brevData(this),
                     adresseService.hentAvsender(
                         generellBrevData.avsenderRequest(brukerTokenInfo),
@@ -54,6 +54,6 @@ class BrevbakerService(
 data class RedigerbarTekstRequest(
     val generellBrevData: GenerellBrevData,
     val brukerTokenInfo: BrukerTokenInfo,
-    val brevkode: (mapper: BrevKodeMapper, g: GenerellBrevData) -> EtterlatteBrevKode,
+    val brevkode: (mapper: BrevKodeMapperVedtak, g: GenerellBrevData) -> EtterlatteBrevKode,
     val migrering: MigreringBrevRequest? = null,
 )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapperVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapperVedtak.kt
@@ -5,7 +5,7 @@ import no.nav.etterlatte.brev.brevbaker.Brevkoder
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 
-class BrevKodeMapper {
+class BrevKodeMapperVedtak {
     fun brevKode(generellBrevData: GenerellBrevData): Brevkoder {
         if (generellBrevData.erMigrering()) {
             assert(listOf(VedtakType.INNVILGELSE, VedtakType.ENDRING).contains(generellBrevData.forenkletVedtak?.type))

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapperVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapperVedtak.kt
@@ -7,15 +7,15 @@ import no.nav.etterlatte.libs.common.vedtak.VedtakType
 data class BrevkodeRequest(val erMigrering: Boolean, val sakType: SakType, val vedtakType: VedtakType?)
 
 class BrevKodeMapperVedtak {
-    fun brevKode(generellBrevData: BrevkodeRequest): Brevkoder {
-        if (generellBrevData.erMigrering) {
-            assert(listOf(VedtakType.INNVILGELSE, VedtakType.ENDRING).contains(generellBrevData.vedtakType))
+    fun brevKode(request: BrevkodeRequest): Brevkoder {
+        if (request.erMigrering) {
+            assert(listOf(VedtakType.INNVILGELSE, VedtakType.ENDRING).contains(request.vedtakType))
             return Brevkoder.OMREGNING
         }
 
-        return when (generellBrevData.sakType) {
+        return when (request.sakType) {
             SakType.BARNEPENSJON -> {
-                when (generellBrevData.vedtakType) {
+                when (request.vedtakType) {
                     VedtakType.INNVILGELSE -> Brevkoder.BP_INNVILGELSE
                     VedtakType.AVSLAG -> Brevkoder.BP_AVSLAG
                     VedtakType.ENDRING -> Brevkoder.BP_REVURDERING
@@ -26,7 +26,7 @@ class BrevKodeMapperVedtak {
             }
 
             SakType.OMSTILLINGSSTOENAD -> {
-                when (generellBrevData.vedtakType) {
+                when (request.vedtakType) {
                     VedtakType.INNVILGELSE -> Brevkoder.OMS_INNVILGELSE
                     VedtakType.AVSLAG -> Brevkoder.OMS_AVSLAG
                     VedtakType.ENDRING -> Brevkoder.OMS_REVURDERING

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapperVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapperVedtak.kt
@@ -1,37 +1,38 @@
 package no.nav.etterlatte.brev.model
 
-import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.brevbaker.Brevkoder
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 
+data class BrevkodeRequest(val erMigrering: Boolean, val sakType: SakType, val vedtakType: VedtakType?)
+
 class BrevKodeMapperVedtak {
-    fun brevKode(generellBrevData: GenerellBrevData): Brevkoder {
-        if (generellBrevData.erMigrering()) {
-            assert(listOf(VedtakType.INNVILGELSE, VedtakType.ENDRING).contains(generellBrevData.forenkletVedtak?.type))
+    fun brevKode(generellBrevData: BrevkodeRequest): Brevkoder {
+        if (generellBrevData.erMigrering) {
+            assert(listOf(VedtakType.INNVILGELSE, VedtakType.ENDRING).contains(generellBrevData.vedtakType))
             return Brevkoder.OMREGNING
         }
 
-        return when (generellBrevData.sak.sakType) {
+        return when (generellBrevData.sakType) {
             SakType.BARNEPENSJON -> {
-                when (generellBrevData.forenkletVedtak?.type) {
+                when (generellBrevData.vedtakType) {
                     VedtakType.INNVILGELSE -> Brevkoder.BP_INNVILGELSE
                     VedtakType.AVSLAG -> Brevkoder.BP_AVSLAG
                     VedtakType.ENDRING -> Brevkoder.BP_REVURDERING
                     VedtakType.OPPHOER -> Brevkoder.BP_OPPHOER
                     VedtakType.TILBAKEKREVING -> Brevkoder.TILBAKEKREVING
-                    null -> Brevkoder.TOMT_INFORMASJONSBREV
+                    null -> TODO()
                 }
             }
 
             SakType.OMSTILLINGSSTOENAD -> {
-                when (generellBrevData.forenkletVedtak?.type) {
+                when (generellBrevData.vedtakType) {
                     VedtakType.INNVILGELSE -> Brevkoder.OMS_INNVILGELSE
                     VedtakType.AVSLAG -> Brevkoder.OMS_AVSLAG
                     VedtakType.ENDRING -> Brevkoder.OMS_REVURDERING
                     VedtakType.OPPHOER -> Brevkoder.OMS_OPPHOER
                     VedtakType.TILBAKEKREVING -> Brevkoder.TILBAKEKREVING
-                    null -> Brevkoder.TOMT_INFORMASJONSBREV
+                    null -> TODO()
                 }
             }
         }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
@@ -33,7 +33,7 @@ internal class VarselbrevService(
             sakId = sakId,
             behandlingId = behandlingId,
             bruker = brukerTokenInfo,
-            brevKode = brevkode.redigering,
+            brevKode = { brevkode.redigering },
             brevtype = Brevtype.VARSEL,
         ).first
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
@@ -75,7 +75,7 @@ class OpprettJournalfoerOgDistribuerRiver(
                         attestantIdent = Fagsaksystem.EY.navn,
                     )
                 },
-                brevKode = { _ -> brevKode },
+                brevKode = { brevKode },
             )
         }
         logger.info("Journalfører $brevKode-brev i sak $sakId")

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
@@ -57,7 +57,7 @@ class OpprettJournalfoerOgDistribuerRiver(
                     sakId = sakId,
                     behandlingId = null,
                     bruker = brukerTokenInfo,
-                    brevKode = brevKode.redigering,
+                    brevKode = { brevKode.redigering },
                     brevtype = brevKode.redigering.brevtype,
                 )
             }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
@@ -17,6 +17,7 @@ import no.nav.etterlatte.brev.distribusjon.DistribusjonServiceImpl
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
+import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Slate
@@ -45,7 +46,8 @@ internal class BrevServiceTest {
     private val pdfGenerator = mockk<PDFGenerator>()
     private val brevbakerService = mockk<BrevbakerService>()
     private val redigerbartVedleggHenter = RedigerbartVedleggHenter(brevbakerService)
-    private val brevoppretter = Brevoppretter(adresseService, db, brevDataFacade, brevbakerService, redigerbartVedleggHenter)
+    private val brevoppretter =
+        Brevoppretter(adresseService, db, brevDataFacade, brevbakerService, redigerbartVedleggHenter, BrevKodeMapperVedtak())
 
     private val brevService =
         BrevService(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
@@ -17,7 +17,6 @@ import no.nav.etterlatte.brev.distribusjon.DistribusjonServiceImpl
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
-import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Slate
@@ -47,7 +46,7 @@ internal class BrevServiceTest {
     private val brevbakerService = mockk<BrevbakerService>()
     private val redigerbartVedleggHenter = RedigerbartVedleggHenter(brevbakerService)
     private val brevoppretter =
-        Brevoppretter(adresseService, db, brevDataFacade, brevbakerService, redigerbartVedleggHenter, BrevKodeMapperVedtak())
+        Brevoppretter(adresseService, db, brevDataFacade, brevbakerService, redigerbartVedleggHenter)
 
     private val brevService =
         BrevService(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -87,7 +87,8 @@ internal class VedtaksbrevServiceTest {
     private val pdfGenerator =
         PDFGenerator(db, brevdataFacade, brevDataMapperFerdigstilling, adresseService, brevbakerService)
     private val redigerbartVedleggHenter = RedigerbartVedleggHenter(brevbakerService)
-    private val brevoppretter = Brevoppretter(adresseService, db, brevdataFacade, brevbakerService, redigerbartVedleggHenter)
+    private val brevoppretter =
+        Brevoppretter(adresseService, db, brevdataFacade, brevbakerService, redigerbartVedleggHenter, brevKodeMapperVedtak)
 
     private val vedtaksbrevService =
         VedtaksbrevService(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -33,7 +33,7 @@ import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevDataMapperFerdigstilling
 import no.nav.etterlatte.brev.model.BrevDataMapperRedigerbartUtfall
-import no.nav.etterlatte.brev.model.BrevKodeMapper
+import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
@@ -84,7 +84,7 @@ internal class VedtaksbrevServiceTest {
     private val migreringBrevDataService = MigreringBrevDataService(brevdataFacade)
     private val brevDataMapperRedigerbartUtfall = BrevDataMapperRedigerbartUtfall(brevdataFacade, migreringBrevDataService)
     private val brevDataMapperFerdigstilling = BrevDataMapperFerdigstilling(brevdataFacade)
-    private val brevKodeMapper = BrevKodeMapper()
+    private val brevKodeMapperVedtak = BrevKodeMapperVedtak()
     private val brevbakerService = mockk<BrevbakerService>()
     private val pdfGenerator =
         PDFGenerator(db, brevdataFacade, brevDataMapperFerdigstilling, adresseService, brevbakerService)
@@ -95,7 +95,7 @@ internal class VedtaksbrevServiceTest {
         VedtaksbrevService(
             db,
             vedtaksvurderingService,
-            brevKodeMapper,
+            brevKodeMapperVedtak,
             brevoppretter,
             pdfGenerator,
         )

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -88,7 +88,7 @@ internal class VedtaksbrevServiceTest {
         PDFGenerator(db, brevdataFacade, brevDataMapperFerdigstilling, adresseService, brevbakerService)
     private val redigerbartVedleggHenter = RedigerbartVedleggHenter(brevbakerService)
     private val brevoppretter =
-        Brevoppretter(adresseService, db, brevdataFacade, brevbakerService, redigerbartVedleggHenter, brevKodeMapperVedtak)
+        Brevoppretter(adresseService, db, brevdataFacade, brevbakerService, redigerbartVedleggHenter)
 
     private val vedtaksbrevService =
         VedtaksbrevService(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -32,7 +32,6 @@ import no.nav.etterlatte.brev.hentinformasjon.VedtaksvurderingService
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevDataMapperFerdigstilling
-import no.nav.etterlatte.brev.model.BrevDataMapperRedigerbartUtfall
 import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Brevtype
@@ -82,7 +81,6 @@ internal class VedtaksbrevServiceTest {
     private val adresseService = mockk<AdresseService>()
     private val dokarkivService = mockk<DokarkivServiceImpl>()
     private val migreringBrevDataService = MigreringBrevDataService(brevdataFacade)
-    private val brevDataMapperRedigerbartUtfall = BrevDataMapperRedigerbartUtfall(brevdataFacade, migreringBrevDataService)
     private val brevDataMapperFerdigstilling = BrevDataMapperFerdigstilling(brevdataFacade)
     private val brevKodeMapperVedtak = BrevKodeMapperVedtak()
     private val brevbakerService = mockk<BrevbakerService>()

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
@@ -15,6 +15,7 @@ import no.nav.etterlatte.brev.brevbaker.BrevbakerService
 import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.model.Brev
+import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.brev.model.Spraak
@@ -64,6 +65,9 @@ class VarselbrevTest {
                     mockk<GenerellBrevData>().also {
                         every { it.vedtakstype() } returns ""
                         every { it.spraak } returns Spraak.NN
+                        every { it.erMigrering() } returns false
+                        every { it.sak } returns Sak("", SakType.BARNEPENSJON, 1L, "")
+                        every { it.forenkletVedtak } returns null
                         every { it.personerISak } returns
                             PersonerISak(
                                 null,
@@ -96,6 +100,7 @@ class VarselbrevTest {
                 brevdataFacade,
                 brevbaker,
                 redigerbartVedleggHenter,
+                BrevKodeMapperVedtak(),
             )
         val behandlingKlient = mockk<BehandlingKlient>().also { coEvery { it.hentSak(sak.id, any()) } returns sak }
         service = VarselbrevService(brevRepository, brevoppretter, behandlingKlient)

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
@@ -15,7 +15,6 @@ import no.nav.etterlatte.brev.brevbaker.BrevbakerService
 import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.model.Brev
-import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.brev.model.Spraak
@@ -100,7 +99,6 @@ class VarselbrevTest {
                 brevdataFacade,
                 brevbaker,
                 redigerbartVedleggHenter,
-                BrevKodeMapperVedtak(),
             )
         val behandlingKlient = mockk<BehandlingKlient>().also { coEvery { it.hentSak(sak.id, any()) } returns sak }
         service = VarselbrevService(brevRepository, brevoppretter, behandlingKlient)


### PR DESCRIPTION
BrevKodeMapper-klassa hadde eit veldig generisk namn, til trass for at ho kun gjer mapping for vedtak. For alle andre brev sender vi med brevkoden frå lengre ut.

Døper dermed om til å gjenspegle denne røynda. Gjer, vel så viktig, litt omstruktureringar så vi lenger innover i kodebasen ikkje treng å bry oss om denne i det heile tatt, men kun sjå på brevkoden direkte.