### PR TITLE
EY-3458 Avbryte oppgaver hvor journalpost har utgått

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
@@ -227,13 +227,15 @@ internal fun Route.oppgaveRoutes(
         }
 
         put("/avbryt/referanse/{referanse}") {
-            val referanse = call.parameters["referanse"]!!
+            kunSystembruker {
+                val referanse = call.parameters["referanse"]!!
 
-            inTransaction {
-                service.avbrytAapneOppgaverMedReferanse(referanse)
+                inTransaction {
+                    service.avbrytAapneOppgaverMedReferanse(referanse)
+                }
+
+                call.respond(HttpStatusCode.OK)
             }
-
-            call.respond(HttpStatusCode.OK)
         }
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
@@ -1,12 +1,12 @@
 package no.nav.etterlatte.oppgave
 
-import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.put
@@ -146,12 +146,10 @@ internal fun Route.oppgaveRoutes(
                     call.respond(HttpStatusCode.OK)
                 }
             }
-            route("saksbehandler", HttpMethod.Delete) {
-                handle {
-                    kunSaksbehandlerMedSkrivetilgang {
-                        inTransaction { service.fjernSaksbehandler(oppgaveId) }
-                        call.respond(HttpStatusCode.OK)
-                    }
+            delete("saksbehandler") {
+                kunSaksbehandlerMedSkrivetilgang {
+                    inTransaction { service.fjernSaksbehandler(oppgaveId) }
+                    call.respond(HttpStatusCode.OK)
                 }
             }
             put("frist") {
@@ -210,8 +208,8 @@ internal fun Route.oppgaveRoutes(
         }
     }
 
-    route("/oppgaver/sak/{$SAKID_CALL_PARAMETER}/opprett") {
-        post {
+    route("/oppgaver") {
+        post("/sak/{$SAKID_CALL_PARAMETER}/opprett") {
             kunSystembruker {
                 val nyOppgaveDto = call.receive<NyOppgaveDto>()
                 call.respond(
@@ -226,6 +224,16 @@ internal fun Route.oppgaveRoutes(
                     },
                 )
             }
+        }
+
+        put("/avbryt/referanse/{referanse}") {
+            val referanse = call.parameters["referanse"]!!
+
+            inTransaction {
+                service.avbrytAapneOppgaverMedReferanse(referanse)
+            }
+
+            call.respond(HttpStatusCode.OK)
         }
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -436,6 +436,14 @@ class OppgaveService(
             }
     }
 
+    fun avbrytAapneOppgaverMedReferanse(referanse: String) {
+        logger.info("Avbryter åpne oppgaver med referanse=$referanse")
+
+        oppgaveDao.hentOppgaverForReferanse(referanse)
+            .filterNot { Status.erAvsluttet(it.status) }
+            .forEach { oppgaveDao.endreStatusPaaOppgave(it.id, Status.AVBRUTT) }
+    }
+
     fun hentSakOgOppgaverForSak(sakId: Long): OppgaveListe {
         val sak = sakDao.hentSak(sakId)
         if (sak != null) {

--- a/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/JoarkHendelseHandler.kt
+++ b/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/JoarkHendelseHandler.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.joarkhendelser
 import joarkhendelser.joark.SafKlient
 import joarkhendelser.pdl.PdlTjenesterKlient
 import no.nav.etterlatte.joarkhendelser.behandling.BehandlingService
+import no.nav.etterlatte.joarkhendelser.joark.Bruker
 import no.nav.etterlatte.joarkhendelser.joark.BrukerIdType
 import no.nav.etterlatte.joarkhendelser.joark.HendelseType
 import no.nav.etterlatte.joarkhendelser.joark.Journalpost
@@ -49,9 +50,7 @@ class JoarkHendelseHandler(
 
         logger.info("Starter behandling av hendelse (id=${hendelse.hendelsesId}) med tema ${hendelse.temaNytt}")
 
-        val sakType = hendelse.temaTilSakType()
         val journalpostId = hendelse.journalpostId
-
         val journalpost = safKlient.hentJournalpost(journalpostId).journalpost
 
         if (journalpost == null) {
@@ -66,27 +65,13 @@ class JoarkHendelseHandler(
         try {
             if (journalpost.bruker == null) {
                 logger.warn("Bruker mangler på journalpost id=$journalpost")
-
-                oppgaveKlient.opprettOppgave(journalpostId, hendelse.temaNytt)
-
+                oppgaveKlient.opprettManuellJournalfoeringsoppgave(journalpostId, hendelse.temaNytt)
                 return
-            } else if (journalpost.bruker.type == BrukerIdType.ORGNR) {
-                // TODO:
-                //  Må vi lage støtte for ORGNR...?
-                throw IllegalStateException("Journalpost med id=$journalpostId har brukerId av typen ${BrukerIdType.ORGNR}")
             }
 
-            val ident =
-                when (val pdlIdentifikator = pdlTjenesterKlient.hentPdlIdentifikator(journalpost.bruker.id)) {
-                    is PdlIdentifikator.FolkeregisterIdent -> pdlIdentifikator.folkeregisterident.value
-                    is PdlIdentifikator.Npid -> {
-                        throw IllegalStateException("Bruker tilknyttet journalpost=$journalpostId har kun NPID!")
-                    }
+            val ident = hentFolkeregisterIdent(journalpostId, journalpost.bruker)
 
-                    null -> throw IllegalStateException(
-                        "Ident tilknyttet journalpost=$journalpostId er null i PDL – avbryter behandling",
-                    )
-                }
+            val sakType = hendelse.temaTilSakType()
 
             when (val type = hendelse.hendelsesType) {
                 HendelseType.JOURNALPOST_MOTTATT -> {
@@ -112,13 +97,11 @@ class JoarkHendelseHandler(
 
                 // TODO: Må avklare om dette er noe vi faktisk trenger å behandle
                 HendelseType.JOURNALPOST_UTGAATT -> {
-                    behandlingService.opprettOppgave(
-                        ident,
-                        sakType,
-                        "Journalpost har utgått",
-                        hendelse.journalpostId.toString(),
-                    )
+                    logger.info("Journalpost $journalpostId har status=${journalpost.journalstatus}")
+
+                    behandlingService.avbrytOppgaverTilknyttetJournalpost(journalpostId)
                 }
+
                 else -> throw IllegalArgumentException("Journalpost=$journalpostId har ukjent hendelsesType=$type")
             }
         } catch (e: Exception) {
@@ -158,6 +141,28 @@ class JoarkHendelseHandler(
             return
         } else {
             logger.info("Uhåndtert tilstand av journalpost=${journalpost.journalpostId}")
+        }
+    }
+
+    private suspend fun hentFolkeregisterIdent(
+        journalpostId: Long,
+        bruker: Bruker,
+    ): String {
+        if (bruker.type == BrukerIdType.ORGNR) {
+            // TODO:
+            //  Må vi lage støtte for ORGNR...?
+            throw IllegalStateException("Journalpost med id=$journalpostId har brukerId av typen ${BrukerIdType.ORGNR}")
+        }
+
+        return when (val pdlIdentifikator = pdlTjenesterKlient.hentPdlIdentifikator(bruker.id)) {
+            is PdlIdentifikator.FolkeregisterIdent -> pdlIdentifikator.folkeregisterident.value
+            is PdlIdentifikator.Npid -> {
+                throw IllegalStateException("Bruker tilknyttet journalpost=$journalpostId har kun NPID!")
+            }
+
+            null -> throw IllegalStateException(
+                "Ident tilknyttet journalpost=$journalpostId er null i PDL – avbryter behandling",
+            )
         }
     }
 }

--- a/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/behandling/BehandlingKlient.kt
+++ b/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/behandling/BehandlingKlient.kt
@@ -5,7 +5,9 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.post
+import io.ktor.client.request.put
 import io.ktor.client.request.setBody
+import io.ktor.client.utils.EmptyContent.contentType
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
@@ -68,5 +70,9 @@ class BehandlingKlient(
         }.body<ObjectNode>().let {
             UUID.fromString(it["id"].textValue())
         }
+    }
+
+    suspend fun avbrytOppgaver(referanse: String) {
+        httpClient.put("$url/oppgaver/avbryt/referanse/$referanse")
     }
 }

--- a/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/behandling/BehandlingService.kt
+++ b/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/behandling/BehandlingService.kt
@@ -37,6 +37,12 @@ class BehandlingService(
             }
     }
 
+    suspend fun avbrytOppgaverTilknyttetJournalpost(journalpostId: Long) {
+        logger.info("Avbryter oppgaver tilknyttet journalpostId=$journalpostId")
+
+        behandlingKlient.avbrytOppgaver(journalpostId.toString())
+    }
+
     private suspend fun hentEllerOpprettSak(
         ident: String,
         sakType: SakType,

--- a/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/oppgave/OppgaveKlient.kt
+++ b/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/oppgave/OppgaveKlient.kt
@@ -17,7 +17,7 @@ class OppgaveKlient(
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    suspend fun opprettOppgave(
+    suspend fun opprettManuellJournalfoeringsoppgave(
         journalpostId: Long,
         tema: String,
     ) {

--- a/apps/etterlatte-hendelser-joark/src/test/kotlin/joarkhendelser/JoarkHendelseHandlerTest.kt
+++ b/apps/etterlatte-hendelser-joark/src/test/kotlin/joarkhendelser/JoarkHendelseHandlerTest.kt
@@ -178,6 +178,33 @@ internal class JoarkHendelseHandlerTest {
                 behandlingKlientMock.opprettOppgave(any(), any(), journalpostId.toString())
             }
         }
+
+        @ParameterizedTest
+        @EnumSource(SakType::class)
+        fun `Journalpost med JOURNALPOST_UTGAATT skal avbryte tilhørende oppgaver`(sakType: SakType) {
+            val journalpostId = Random.nextLong()
+            val ident = "09498230323"
+            val journalpost =
+                opprettJournalpost(journalpostId, sakType = sakType, bruker = Bruker(ident, BrukerIdType.FNR))
+
+            coEvery { safKlientMock.hentJournalpost(any()) } returns HentJournalpostResult(journalpost)
+            coEvery { pdlTjenesterKlientMock.hentPdlIdentifikator(any()) } returns
+                PdlIdentifikator.FolkeregisterIdent(
+                    Folkeregisteridentifikator.of(ident),
+                )
+
+            val hendelse = opprettHendelse(journalpostId, sakType.tema, HendelseType.JOURNALPOST_UTGAATT)
+
+            runBlocking {
+                sut.haandterHendelse(hendelse)
+            }
+
+            coVerify(exactly = 1) {
+                safKlientMock.hentJournalpost(journalpostId)
+                pdlTjenesterKlientMock.hentPdlIdentifikator(ident)
+                behandlingKlientMock.avbrytOppgaver(journalpostId.toString())
+            }
+        }
     }
 
     @Nested
@@ -236,7 +263,7 @@ internal class JoarkHendelseHandlerTest {
                     opprettJournalpost(journalpostId, status = Journalstatus.MOTTATT, bruker = null),
                     null,
                 )
-            coEvery { oppgaveKlient.opprettOppgave(any(), any()) } just Runs
+            coEvery { oppgaveKlient.opprettManuellJournalfoeringsoppgave(any(), any()) } just Runs
 
             val hendelse = opprettHendelse(journalpostId, SakType.OMSTILLINGSSTOENAD.tema)
 
@@ -246,7 +273,7 @@ internal class JoarkHendelseHandlerTest {
 
             coVerify(exactly = 1) {
                 safKlientMock.hentJournalpost(journalpostId)
-                oppgaveKlient.opprettOppgave(journalpostId, "EYO")
+                oppgaveKlient.opprettManuellJournalfoeringsoppgave(journalpostId, "EYO")
             }
             coVerify {
                 behandlingKlientMock wasNot Called


### PR DESCRIPTION
Setter oppgaver som ikke er avsluttet til status avbrutt dersom journalposten de tilhører har utgått. 
Ingen av våre saksbehandlere har (så vidt jeg er kjent) rettigheter til å se utgåtte journalposter og det er heller ikke noe behov for behandling av en utgått journalpost. 