### PR TITLE
Behandlingsnummer på regoppslag

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -21,6 +21,7 @@ import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.OpprettNyttBrev
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
+import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.Vergemaal
@@ -96,7 +97,7 @@ class Brevoppretter(
                     behandlingId = behandlingId,
                     prosessType = BrevProsessType.REDIGERBAR,
                     soekerFnr = generellBrevData.personerISak.soeker.fnr.value,
-                    mottaker = finnMottaker(generellBrevData.personerISak),
+                    mottaker = finnMottaker(generellBrevData.sak.sakType, generellBrevData.personerISak),
                     opprettet = Tidspunkt.now(),
                     innhold = innhold,
                     innholdVedlegg = innholdVedlegg,
@@ -178,7 +179,10 @@ class Brevoppretter(
         }
     }
 
-    private suspend fun finnMottaker(personerISak: PersonerISak): Mottaker =
+    private suspend fun finnMottaker(
+        sakType: SakType,
+        personerISak: PersonerISak,
+    ): Mottaker =
         with(personerISak) {
             when (verge) {
                 is Vergemaal -> verge.toMottaker()
@@ -187,7 +191,7 @@ class Brevoppretter(
                     val mottakerFnr =
                         innsender?.fnr?.value?.takeIf { Folkeregisteridentifikator.isValid(it) }
                             ?: soeker.fnr.value
-                    adresseService.hentMottakerAdresse(mottakerFnr)
+                    adresseService.hentMottakerAdresse(sakType, mottakerFnr)
                 }
             }
         }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/AdresseService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/AdresseService.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import no.nav.etterlatte.brev.adresse.navansatt.NavansattKlient
 import no.nav.etterlatte.brev.model.Mottaker
+import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.token.Fagsaksystem
 import no.nav.pensjon.brevbaker.api.model.Telefonnummer
@@ -13,8 +14,11 @@ class AdresseService(
     private val navansattKlient: NavansattKlient,
     private val regoppslagKlient: RegoppslagKlient,
 ) {
-    suspend fun hentMottakerAdresse(ident: String): Mottaker {
-        val regoppslag = regoppslagKlient.hentMottakerAdresse(ident)
+    suspend fun hentMottakerAdresse(
+        sakType: SakType,
+        ident: String,
+    ): Mottaker {
+        val regoppslag = regoppslagKlient.hentMottakerAdresse(sakType, ident)
 
         val fnr = Folkeregisteridentifikator.of(ident)
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/RegoppslagKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/RegoppslagKlient.kt
@@ -5,11 +5,15 @@ import com.github.benmanes.caffeine.cache.Caffeine
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.ResponseException
+import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.innsendtsoeknad.common.Behandlingsnummer
+import no.nav.etterlatte.libs.common.pdl.AdressebeskyttelseKlient.Companion.HEADER_BEHANDLINGSNUMMER
 import no.nav.etterlatte.sikkerLogg
 import org.slf4j.LoggerFactory
 import java.time.Duration
@@ -25,7 +29,10 @@ class RegoppslagKlient(
             .expireAfterWrite(Duration.ofMinutes(15))
             .build<String, RegoppslagResponseDTO>()
 
-    suspend fun hentMottakerAdresse(ident: String): RegoppslagResponseDTO? =
+    suspend fun hentMottakerAdresse(
+        sakType: SakType,
+        ident: String,
+    ): RegoppslagResponseDTO? =
         try {
             val regoppslagCache = cache.getIfPresent(ident)
 
@@ -36,6 +43,7 @@ class RegoppslagKlient(
                 logger.info("Ingen cachet mottakeradresse funnet. Henter fra regoppslag")
 
                 client.post("$url/rest/postadresse") {
+                    header(HEADER_BEHANDLINGSNUMMER, Behandlingsnummer.BARNEPENSJON.behandlingsnummer)
                     contentType(ContentType.Application.Json)
                     setBody(RegoppslagRequest(ident))
                 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -211,7 +211,7 @@ internal class VedtaksbrevServiceTest {
             every { db.hentBrevForBehandling(behandling.behandlingId!!, Brevtype.VEDTAK) } returns emptyList()
             coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any()) } returns behandling
             coEvery { adresseService.hentAvsender(any()) } returns opprettAvsender()
-            coEvery { adresseService.hentMottakerAdresse(any()) } returns mottaker
+            coEvery { adresseService.hentMottakerAdresse(any(), any()) } returns mottaker
             coEvery { brevbakerService.hentRedigerbarTekstFraBrevbakeren(any()) } returns Slate(emptyList())
             coEvery { brevdataFacade.hentBehandling(any(), any()) } returns
                 mockk<DetaljertBehandling>().apply {
@@ -232,7 +232,7 @@ internal class VedtaksbrevServiceTest {
             coVerify {
                 db.hentBrevForBehandling(BEHANDLING_ID, Brevtype.VEDTAK)
                 brevdataFacade.hentGenerellBrevData(sakId, BEHANDLING_ID, any())
-                adresseService.hentMottakerAdresse(behandling.personerISak.innsender!!.fnr.value)
+                adresseService.hentMottakerAdresse(sakType, behandling.personerISak.innsender!!.fnr.value)
             }
 
             verify {
@@ -270,7 +270,7 @@ internal class VedtaksbrevServiceTest {
             coEvery { brevbakerService.hentRedigerbarTekstFraBrevbakeren(any()) } returns opprettRenderedJsonLetter()
             every { db.hentBrevForBehandling(behandling.behandlingId!!, Brevtype.VEDTAK) } returns emptyList()
             coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any()) } returns behandling
-            coEvery { adresseService.hentMottakerAdresse(any()) } returns mottaker
+            coEvery { adresseService.hentMottakerAdresse(sakType, any()) } returns mottaker
             coEvery { brevdataFacade.finnUtbetalingsinfo(any(), any(), any(), any()) } returns utbetalingsinfo
             coEvery { brevdataFacade.hentEtterbetaling(any(), any()) } returns null
             coEvery { brevdataFacade.hentBehandling(any(), any()) } returns
@@ -291,7 +291,7 @@ internal class VedtaksbrevServiceTest {
             coVerify {
                 db.hentBrevForBehandling(BEHANDLING_ID, Brevtype.VEDTAK)
                 brevdataFacade.hentGenerellBrevData(sakId, BEHANDLING_ID, any())
-                adresseService.hentMottakerAdresse(behandling.personerISak.innsender!!.fnr.value)
+                adresseService.hentMottakerAdresse(sakType, behandling.personerISak.innsender!!.fnr.value)
                 brevbakerService.hentRedigerbarTekstFraBrevbakeren(any())
             }
 
@@ -350,7 +350,7 @@ internal class VedtaksbrevServiceTest {
 
             every { db.hentBrevForBehandling(behandling.behandlingId!!, Brevtype.VEDTAK) } returns listOf()
             coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any()) } returns behandling
-            coEvery { adresseService.hentMottakerAdresse(any()) } returns mottaker
+            coEvery { adresseService.hentMottakerAdresse(any(), any()) } returns mottaker
 
             coEvery { brevdataFacade.hentBehandling(any(), any()) } returns
                 mockk<DetaljertBehandling>().apply {

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
@@ -51,7 +51,7 @@ class VarselbrevTest {
         val brevRepository = BrevRepository(datasource)
         val adresseService =
             mockk<AdresseService>().also {
-                coEvery { it.hentMottakerAdresse(any()) } returns Mottaker.tom(SOEKER_FOEDSELSNUMMER)
+                coEvery { it.hentMottakerAdresse(any(), any()) } returns Mottaker.tom(SOEKER_FOEDSELSNUMMER)
             }
         val brevdataFacade =
             mockk<BrevdataFacade>().also {

--- a/apps/etterlatte-pdltjenester/build.gradle.kts
+++ b/apps/etterlatte-pdltjenester/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     implementation(libs.ktor2.auth)
 
     implementation(libs.bundles.jackson)
+    implementation(libs.etterlatte.common)
 
     implementation(libs.navfelles.tokenclientcore)
     implementation(libs.navfelles.tokenvalidationktor2)

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlKlient.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlKlient.kt
@@ -10,7 +10,7 @@ import io.ktor.http.ContentType.Application.Json
 import io.ktor.http.contentType
 import no.nav.etterlatte.libs.common.RetryResult
 import no.nav.etterlatte.libs.common.behandling.SakType
-import no.nav.etterlatte.libs.common.person.Behandlingsnummer
+import no.nav.etterlatte.libs.common.innsendtsoeknad.common.Behandlingsnummer
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.HentAdressebeskyttelseRequest
 import no.nav.etterlatte.libs.common.person.HentFolkeregisterIdenterForAktoerIdBolkRequest

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/person/Behandlingsnummer.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/person/Behandlingsnummer.kt
@@ -1,7 +1,0 @@
-package no.nav.etterlatte.libs.common.person
-
-// behandlingsnummere: https://behandlingskatalog.nais.adeo.no/team/cf8730ca-3aa7-4a94-97ec-75bcc620b63f
-enum class Behandlingsnummer(val behandlingsnummer: String) {
-    BARNEPENSJON("B359"),
-    OMSTILLINGSSTOENAD("B373"),
-}


### PR DESCRIPTION
Fekk feil lokalt på at behandlingsnummer mangla som header på regoppslag.

Er nok forbigåande, og kjem nok pga https://nav-it.slack.com/archives/CLZ9RS7H8/p1707305337667359 , som vi har tatt høgde for ein del plassar, men altså ikkje akkurat her. Uansett fint å få på plass heller før enn seinare.