### PR TITLE
Slette ubrukt brevdata wiring og skilje skarpare mellom brevdata for redigering og for ferdigstilling

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDTO.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDTO.kt
@@ -1,5 +1,0 @@
-package no.nav.etterlatte.brev.model
-
-interface BrevDTO {
-    val innhold: List<Slate.Element>
-}

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevData.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevData.kt
@@ -6,6 +6,10 @@ interface BrevdataMedInnhold : BrevData {
     val innhold: List<Slate.Element>
 }
 
+interface BrevDataFerdigstilling : BrevdataMedInnhold
+
+interface BrevDataRedigerbar : BrevData
+
 data class ManueltBrevData(override val innhold: List<Slate.Element> = emptyList()) : BrevdataMedInnhold
 
 data class ManueltBrevMedTittelData(override val innhold: List<Slate.Element>, val tittel: String? = null) :

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevData.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevData.kt
@@ -1,7 +1,12 @@
 package no.nav.etterlatte.brev.model
 
-abstract class BrevData
+interface BrevData
 
-data class ManueltBrevData(val innhold: List<Slate.Element> = emptyList()) : BrevData()
+interface BrevdataMedInnhold : BrevData {
+    val innhold: List<Slate.Element>
+}
 
-data class ManueltBrevMedTittelData(val innhold: List<Slate.Element>, val tittel: String? = null) : BrevData()
+data class ManueltBrevData(override val innhold: List<Slate.Element> = emptyList()) : BrevdataMedInnhold
+
+data class ManueltBrevMedTittelData(override val innhold: List<Slate.Element>, val tittel: String? = null) :
+    BrevdataMedInnhold

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevData.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevData.kt
@@ -1,45 +1,7 @@
 package no.nav.etterlatte.brev.model
 
-import no.nav.etterlatte.libs.common.behandling.RevurderingInfo
-import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
+abstract class BrevData
 
-abstract class BrevData {
-    inline fun <reified T : RevurderingInfo> valider(
-        revurderingsaarsakVedtak: Revurderingaarsak?,
-        revurderingInfo: RevurderingInfo?,
-        revurderingAarsak: Revurderingaarsak,
-    ): T = BrevDataValidator.valider(revurderingsaarsakVedtak, revurderingInfo, revurderingAarsak)
-}
-
-object BrevDataValidator {
-    inline fun <reified T : RevurderingInfo> valider(
-        revurderingsaarsakVedtak: Revurderingaarsak?,
-        revurderingInfo: RevurderingInfo?,
-        revurderingAarsak: Revurderingaarsak,
-    ): T {
-        val lesbartnavn = revurderingAarsak.name.lowercase()
-        if (revurderingsaarsakVedtak != revurderingAarsak) {
-            throw IllegalArgumentException(
-                "Kan ikke opprette et revurderingsbrev for $lesbartnavn når " +
-                    "revurderingsårsak er $revurderingsaarsakVedtak",
-            )
-        }
-        if (revurderingInfo !is T) {
-            throw IllegalArgumentException(
-                "Kan ikke opprette et revurderingsbrev for $lesbartnavn når " +
-                    "revurderingsinfo ikke er $lesbartnavn",
-            )
-        }
-        return revurderingInfo
-    }
-}
-
-abstract class EndringBrevData : BrevData()
-
-data class ManueltBrevData(val innhold: List<Slate.Element> = emptyList()) : BrevData() {
-    companion object {
-        fun fra(innhold: List<Slate.Element> = emptyList()) = ManueltBrevData(innhold)
-    }
-}
+data class ManueltBrevData(val innhold: List<Slate.Element> = emptyList()) : BrevData()
 
 data class ManueltBrevMedTittelData(val innhold: List<Slate.Element>, val tittel: String? = null) : BrevData()

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevData.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevData.kt
@@ -10,7 +10,7 @@ interface BrevDataFerdigstilling : BrevdataMedInnhold
 
 interface BrevDataRedigerbar : BrevData
 
-data class ManueltBrevData(override val innhold: List<Slate.Element> = emptyList()) : BrevdataMedInnhold
+data class ManueltBrevData(override val innhold: List<Slate.Element> = emptyList()) : BrevdataMedInnhold, BrevDataRedigerbar
 
 data class ManueltBrevMedTittelData(override val innhold: List<Slate.Element>, val tittel: String? = null) :
     BrevdataMedInnhold

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
@@ -39,7 +39,7 @@ data class BrevDataFerdigstillingRequest(
 )
 
 class BrevDataMapperFerdigstillingVedtak(private val brevdataFacade: BrevdataFacade) {
-    suspend fun brevDataFerdigstilling(request: BrevDataFerdigstillingRequest): BrevData {
+    suspend fun brevDataFerdigstilling(request: BrevDataFerdigstillingRequest): BrevDataFerdigstilling {
         with(request) {
             if (generellBrevData.erMigrering()) {
                 return coroutineScope {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/EtterlatteBrev.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/EtterlatteBrev.kt
@@ -26,7 +26,7 @@ data class BarnepensjonBeregning(
     val beregningsperioder: List<BarnepensjonBeregningsperiode>,
     val sisteBeregningsperiode: BarnepensjonBeregningsperiode,
     val trygdetid: TrygdetidMedBeregningsmetode,
-) : BrevDTO
+) : BrevdataMedInnhold
 
 data class BarnepensjonBeregningsperiode(
     val datoFOM: LocalDate,
@@ -44,7 +44,7 @@ data class OmstillingsstoenadBeregning(
     val beregningsperioder: List<OmstillingsstoenadBeregningsperiode>,
     val sisteBeregningsperiode: OmstillingsstoenadBeregningsperiode,
     val trygdetid: TrygdetidMedBeregningsmetode,
-) : BrevDTO
+) : BrevdataMedInnhold
 
 data class OmstillingsstoenadBeregningsperiode(
     val datoFOM: LocalDate,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonAvslag.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonAvslag.kt
@@ -1,15 +1,15 @@
 package no.nav.etterlatte.brev.model.bp
 
-import no.nav.etterlatte.brev.model.BrevData
+import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
 
 data class BarnepensjonAvslag(
-    val innhold: List<Slate.Element>,
+    override val innhold: List<Slate.Element>,
     val brukerUnder18Aar: Boolean,
     val bosattUtland: Boolean,
-) : BrevData {
+) : BrevDataFerdigstilling {
     companion object {
         fun fra(
             innhold: InnholdMedVedlegg,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonAvslag.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonAvslag.kt
@@ -9,7 +9,7 @@ data class BarnepensjonAvslag(
     val innhold: List<Slate.Element>,
     val brukerUnder18Aar: Boolean,
     val bosattUtland: Boolean,
-) : BrevData() {
+) : BrevData {
     companion object {
         fun fra(
             innhold: InnholdMedVedlegg,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
@@ -28,7 +28,7 @@ data class BarnepensjonInnvilgelse(
     val brukerUnder18Aar: Boolean,
     val bosattUtland: Boolean,
     val kunNyttRegelverk: Boolean,
-) : BrevData() {
+) : BrevData {
     companion object {
         val tidspunktNyttRegelverk: LocalDate = LocalDate.of(2024, 1, 1)
 
@@ -68,7 +68,7 @@ data class BarnepensjonInnvilgelseRedigerbartUtfall(
     val sisteBeregningsperiodeBeloep: Kroner,
     val erEtterbetaling: Boolean,
     val harFlereUtbetalingsperioder: Boolean,
-) : BrevData() {
+) : BrevData {
     companion object {
         fun fra(
             generellBrevData: GenerellBrevData,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
@@ -7,7 +7,8 @@ import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
 import no.nav.etterlatte.brev.model.BarnepensjonBeregning
 import no.nav.etterlatte.brev.model.BarnepensjonBeregningsperiode
 import no.nav.etterlatte.brev.model.BarnepensjonEtterbetaling
-import no.nav.etterlatte.brev.model.BrevData
+import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
+import no.nav.etterlatte.brev.model.BrevDataRedigerbar
 import no.nav.etterlatte.brev.model.BrevVedleggKey
 import no.nav.etterlatte.brev.model.Etterbetaling
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
@@ -22,13 +23,13 @@ import no.nav.pensjon.brevbaker.api.model.Kroner
 import java.time.LocalDate
 
 data class BarnepensjonInnvilgelse(
-    val innhold: List<Slate.Element>,
+    override val innhold: List<Slate.Element>,
     val beregning: BarnepensjonBeregning,
     val etterbetaling: BarnepensjonEtterbetaling?,
     val brukerUnder18Aar: Boolean,
     val bosattUtland: Boolean,
     val kunNyttRegelverk: Boolean,
-) : BrevData {
+) : BrevDataFerdigstilling {
     companion object {
         val tidspunktNyttRegelverk: LocalDate = LocalDate.of(2024, 1, 1)
 
@@ -68,7 +69,7 @@ data class BarnepensjonInnvilgelseRedigerbartUtfall(
     val sisteBeregningsperiodeBeloep: Kroner,
     val erEtterbetaling: Boolean,
     val harFlereUtbetalingsperioder: Boolean,
-) : BrevData {
+) : BrevDataRedigerbar {
     companion object {
         fun fra(
             generellBrevData: GenerellBrevData,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOmregnetNyttRegelverk.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOmregnetNyttRegelverk.kt
@@ -22,7 +22,7 @@ data class BarnepensjonOmregnetNyttRegelverkRedigerbartUtfall(
     val utbetaltEtterReform: Kroner,
     val erForeldreloes: Boolean,
     val erBosattUtlandet: Boolean,
-) : BrevData() {
+) : BrevData {
     companion object {
         fun fra(
             generellBrevData: GenerellBrevData,
@@ -73,7 +73,7 @@ data class BarnepensjonOmregnetNyttRegelverk(
     val etterbetaling: BarnepensjonEtterbetaling?,
     val erUnder18Aar: Boolean,
     val erBosattUtlandet: Boolean,
-) : BrevData() {
+) : BrevData {
     companion object {
         fun fra(
             innhold: InnholdMedVedlegg,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOmregnetNyttRegelverk.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOmregnetNyttRegelverk.kt
@@ -6,7 +6,8 @@ import no.nav.etterlatte.brev.behandling.Trygdetid
 import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
 import no.nav.etterlatte.brev.model.BarnepensjonBeregning
 import no.nav.etterlatte.brev.model.BarnepensjonEtterbetaling
-import no.nav.etterlatte.brev.model.BrevData
+import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
+import no.nav.etterlatte.brev.model.BrevDataRedigerbar
 import no.nav.etterlatte.brev.model.Etterbetaling
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
@@ -22,7 +23,7 @@ data class BarnepensjonOmregnetNyttRegelverkRedigerbartUtfall(
     val utbetaltEtterReform: Kroner,
     val erForeldreloes: Boolean,
     val erBosattUtlandet: Boolean,
-) : BrevData {
+) : BrevDataRedigerbar {
     companion object {
         fun fra(
             generellBrevData: GenerellBrevData,
@@ -68,12 +69,12 @@ data class BarnepensjonOmregnetNyttRegelverkRedigerbartUtfall(
 }
 
 data class BarnepensjonOmregnetNyttRegelverk(
-    val innhold: List<Slate.Element>,
+    override val innhold: List<Slate.Element>,
     val beregning: BarnepensjonBeregning,
     val etterbetaling: BarnepensjonEtterbetaling?,
     val erUnder18Aar: Boolean,
     val erBosattUtlandet: Boolean,
-) : BrevData {
+) : BrevDataFerdigstilling {
     companion object {
         fun fra(
             innhold: InnholdMedVedlegg,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOpphoer.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOpphoer.kt
@@ -1,15 +1,15 @@
 package no.nav.etterlatte.brev.model.bp
 
-import no.nav.etterlatte.brev.model.BrevData
+import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
 
 data class BarnepensjonOpphoer(
-    val innhold: List<Slate.Element>,
+    override val innhold: List<Slate.Element>,
     val brukerUnder18Aar: Boolean,
     val bosattUtland: Boolean,
-) : BrevData {
+) : BrevDataFerdigstilling {
     companion object {
         fun fra(
             innhold: InnholdMedVedlegg,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOpphoer.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOpphoer.kt
@@ -9,7 +9,7 @@ data class BarnepensjonOpphoer(
     val innhold: List<Slate.Element>,
     val brukerUnder18Aar: Boolean,
     val bosattUtland: Boolean,
-) : BrevData() {
+) : BrevData {
     companion object {
         fun fra(
             innhold: InnholdMedVedlegg,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
@@ -5,7 +5,6 @@ import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
 import no.nav.etterlatte.brev.model.BarnepensjonBeregning
 import no.nav.etterlatte.brev.model.BarnepensjonEtterbetaling
 import no.nav.etterlatte.brev.model.BrevData
-import no.nav.etterlatte.brev.model.EndringBrevData
 import no.nav.etterlatte.brev.model.Etterbetaling
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
@@ -24,7 +23,7 @@ data class BarnepensjonRevurdering(
     val bosattUtland: Boolean,
     val kunNyttRegelverk: Boolean,
     val harFlereUtbetalingsperioder: Boolean,
-) : EndringBrevData() {
+) : BrevData() {
     companion object {
         fun fra(
             innhold: InnholdMedVedlegg,
@@ -62,7 +61,7 @@ data class BarnepensjonRevurdering(
 
 data class BarnepensjonRevurderingRedigerbartUtfall(
     val erEtterbetaling: Boolean,
-) : EndringBrevData() {
+) : BrevData() {
     companion object {
         fun fra(etterbetaling: EtterbetalingDTO?): BrevData {
             return BarnepensjonRevurderingRedigerbartUtfall(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
@@ -23,7 +23,7 @@ data class BarnepensjonRevurdering(
     val bosattUtland: Boolean,
     val kunNyttRegelverk: Boolean,
     val harFlereUtbetalingsperioder: Boolean,
-) : BrevData() {
+) : BrevData {
     companion object {
         fun fra(
             innhold: InnholdMedVedlegg,
@@ -61,7 +61,7 @@ data class BarnepensjonRevurdering(
 
 data class BarnepensjonRevurderingRedigerbartUtfall(
     val erEtterbetaling: Boolean,
-) : BrevData() {
+) : BrevData {
     companion object {
         fun fra(etterbetaling: EtterbetalingDTO?): BrevData {
             return BarnepensjonRevurderingRedigerbartUtfall(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
@@ -4,7 +4,8 @@ import no.nav.etterlatte.brev.behandling.Trygdetid
 import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
 import no.nav.etterlatte.brev.model.BarnepensjonBeregning
 import no.nav.etterlatte.brev.model.BarnepensjonEtterbetaling
-import no.nav.etterlatte.brev.model.BrevData
+import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
+import no.nav.etterlatte.brev.model.BrevDataRedigerbar
 import no.nav.etterlatte.brev.model.Etterbetaling
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
@@ -15,7 +16,7 @@ import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
 
 data class BarnepensjonRevurdering(
-    val innhold: List<Slate.Element>,
+    override val innhold: List<Slate.Element>,
     val erEndret: Boolean,
     val beregning: BarnepensjonBeregning,
     val etterbetaling: BarnepensjonEtterbetaling?,
@@ -23,7 +24,7 @@ data class BarnepensjonRevurdering(
     val bosattUtland: Boolean,
     val kunNyttRegelverk: Boolean,
     val harFlereUtbetalingsperioder: Boolean,
-) : BrevData {
+) : BrevDataFerdigstilling {
     companion object {
         fun fra(
             innhold: InnholdMedVedlegg,
@@ -34,7 +35,7 @@ data class BarnepensjonRevurdering(
             grunnbeloep: Grunnbeloep,
             utlandstilknytning: UtlandstilknytningType?,
             brevutfall: BrevutfallDto,
-        ): BrevData {
+        ): BarnepensjonRevurdering {
             val beregningsperioder = barnepensjonBeregningsperioder(utbetalingsinfo)
 
             return BarnepensjonRevurdering(
@@ -61,9 +62,9 @@ data class BarnepensjonRevurdering(
 
 data class BarnepensjonRevurderingRedigerbartUtfall(
     val erEtterbetaling: Boolean,
-) : BrevData {
+) : BrevDataRedigerbar {
     companion object {
-        fun fra(etterbetaling: EtterbetalingDTO?): BrevData {
+        fun fra(etterbetaling: EtterbetalingDTO?): BarnepensjonRevurderingRedigerbartUtfall {
             return BarnepensjonRevurderingRedigerbartUtfall(
                 erEtterbetaling = etterbetaling != null,
             )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/klage/AvvistKlageFerdigData.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/klage/AvvistKlageFerdigData.kt
@@ -6,7 +6,7 @@ import no.nav.etterlatte.brev.model.InnholdMedVedlegg
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.libs.common.behandling.SakType
 
-data class AvvistKlageFerdigData(val innhold: List<Slate.Element>, val data: AvvistKlageInnholdBrevData) : BrevData() {
+data class AvvistKlageFerdigData(val innhold: List<Slate.Element>, val data: AvvistKlageInnholdBrevData) : BrevData {
     companion object {
         fun fra(
             generellBrevData: GenerellBrevData,
@@ -23,7 +23,7 @@ data class AvvistKlageFerdigData(val innhold: List<Slate.Element>, val data: Avv
 // TODO: Mer innhold inn i greia
 data class AvvistKlageInnholdBrevData(
     val sakType: SakType,
-) : BrevData() {
+) : BrevData {
     companion object {
         fun fra(generellBrevData: GenerellBrevData): AvvistKlageInnholdBrevData {
             val klage = generellBrevData.forenkletVedtak?.klage ?: throw IllegalArgumentException("Vedtak mangler klage")

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/klage/AvvistKlageFerdigData.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/klage/AvvistKlageFerdigData.kt
@@ -1,12 +1,14 @@
 package no.nav.etterlatte.brev.model.klage
 
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
-import no.nav.etterlatte.brev.model.BrevData
+import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
+import no.nav.etterlatte.brev.model.BrevDataRedigerbar
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.libs.common.behandling.SakType
 
-data class AvvistKlageFerdigData(val innhold: List<Slate.Element>, val data: AvvistKlageInnholdBrevData) : BrevData {
+data class AvvistKlageFerdigData(override val innhold: List<Slate.Element>, val data: AvvistKlageInnholdBrevData) :
+    BrevDataFerdigstilling {
     companion object {
         fun fra(
             generellBrevData: GenerellBrevData,
@@ -23,7 +25,7 @@ data class AvvistKlageFerdigData(val innhold: List<Slate.Element>, val data: Avv
 // TODO: Mer innhold inn i greia
 data class AvvistKlageInnholdBrevData(
     val sakType: SakType,
-) : BrevData {
+) : BrevDataRedigerbar {
     companion object {
         fun fra(generellBrevData: GenerellBrevData): AvvistKlageInnholdBrevData {
             val klage = generellBrevData.forenkletVedtak?.klage ?: throw IllegalArgumentException("Vedtak mangler klage")

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadAvslag.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadAvslag.kt
@@ -1,15 +1,15 @@
 package no.nav.etterlatte.brev.model.oms
 
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
-import no.nav.etterlatte.brev.model.BrevData
+import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
 
 data class OmstillingsstoenadAvslag(
-    val innhold: List<Slate.Element>,
+    override val innhold: List<Slate.Element>,
     val avdoedNavn: String,
     val bosattUtland: Boolean,
-) : BrevData {
+) : BrevDataFerdigstilling {
     companion object {
         fun fra(
             generellBrevData: GenerellBrevData,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadAvslag.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadAvslag.kt
@@ -9,7 +9,7 @@ data class OmstillingsstoenadAvslag(
     val innhold: List<Slate.Element>,
     val avdoedNavn: String,
     val bosattUtland: Boolean,
-) : BrevData() {
+) : BrevData {
     companion object {
         fun fra(
             generellBrevData: GenerellBrevData,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelse.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelse.kt
@@ -27,7 +27,7 @@ data class OmstillingsstoenadInnvilgelse(
     val innvilgetMindreEnnFireMndEtterDoedsfall: Boolean,
     val lavEllerIngenInntekt: Boolean,
     val etterbetaling: OmstillingsstoenadEtterbetaling?,
-) : BrevData() {
+) : BrevData {
     companion object {
         fun fra(
             innholdMedVedlegg: InnholdMedVedlegg,
@@ -92,7 +92,7 @@ data class OmstillingsstoenadInnvilgelseRedigerbartUtfall(
     val avdoed: Avdoed,
     val utbetalingsbeloep: Kroner,
     val etterbetaling: Boolean,
-) : BrevData() {
+) : BrevData {
     companion object {
         fun fra(
             generellBrevData: GenerellBrevData,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelse.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelse.kt
@@ -5,7 +5,8 @@ import no.nav.etterlatte.brev.behandling.Avkortingsinfo
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.behandling.Trygdetid
 import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
-import no.nav.etterlatte.brev.model.BrevData
+import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
+import no.nav.etterlatte.brev.model.BrevDataRedigerbar
 import no.nav.etterlatte.brev.model.BrevVedleggKey
 import no.nav.etterlatte.brev.model.Etterbetaling
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
@@ -21,13 +22,13 @@ import no.nav.pensjon.brevbaker.api.model.Kroner
 import java.time.LocalDate
 
 data class OmstillingsstoenadInnvilgelse(
-    val innhold: List<Slate.Element>,
+    override val innhold: List<Slate.Element>,
     val avdoed: Avdoed,
     val beregning: OmstillingsstoenadBeregning,
     val innvilgetMindreEnnFireMndEtterDoedsfall: Boolean,
     val lavEllerIngenInntekt: Boolean,
     val etterbetaling: OmstillingsstoenadEtterbetaling?,
-) : BrevData {
+) : BrevDataFerdigstilling {
     companion object {
         fun fra(
             innholdMedVedlegg: InnholdMedVedlegg,
@@ -92,7 +93,7 @@ data class OmstillingsstoenadInnvilgelseRedigerbartUtfall(
     val avdoed: Avdoed,
     val utbetalingsbeloep: Kroner,
     val etterbetaling: Boolean,
-) : BrevData {
+) : BrevDataRedigerbar {
     companion object {
         fun fra(
             generellBrevData: GenerellBrevData,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadOpphoer.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadOpphoer.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 data class OmstillingsstoenadOpphoer(
     val innhold: List<Slate.Element>,
     val bosattUtland: Boolean,
-) : BrevData() {
+) : BrevData {
     companion object {
         fun fra(
             utlandstilknytning: Utlandstilknytning?,
@@ -26,7 +26,7 @@ data class OmstillingsstoenadOpphoer(
 data class OmstillingsstoenadOpphoerRedigerbartUtfall(
     val innhold: List<Slate.Element>,
     val virkningsdato: LocalDate,
-) : BrevData() {
+) : BrevData {
     companion object {
         fun fra(
             generellBrevData: GenerellBrevData,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadOpphoer.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadOpphoer.kt
@@ -1,16 +1,17 @@
 package no.nav.etterlatte.brev.model.oms
 
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
-import no.nav.etterlatte.brev.model.BrevData
+import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
+import no.nav.etterlatte.brev.model.BrevDataRedigerbar
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.libs.common.behandling.Utlandstilknytning
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
 import java.time.LocalDate
 
 data class OmstillingsstoenadOpphoer(
-    val innhold: List<Slate.Element>,
+    override val innhold: List<Slate.Element>,
     val bosattUtland: Boolean,
-) : BrevData {
+) : BrevDataFerdigstilling {
     companion object {
         fun fra(
             utlandstilknytning: Utlandstilknytning?,
@@ -26,7 +27,7 @@ data class OmstillingsstoenadOpphoer(
 data class OmstillingsstoenadOpphoerRedigerbartUtfall(
     val innhold: List<Slate.Element>,
     val virkningsdato: LocalDate,
-) : BrevData {
+) : BrevDataRedigerbar {
     companion object {
         fun fra(
             generellBrevData: GenerellBrevData,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadRevurdering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadRevurdering.kt
@@ -32,7 +32,7 @@ data class OmstillingsstoenadRevurdering(
     val harUtbetaling: Boolean,
     val lavEllerIngenInntekt: Boolean,
     val feilutbetaling: FeilutbetalingType,
-) : BrevData() {
+) : BrevData {
     companion object {
         fun fra(
             innholdMedVedlegg: InnholdMedVedlegg,
@@ -104,7 +104,7 @@ data class OmstillingsstoenadRevurderingRedigerbartUtfall(
     val feilutbetaling: FeilutbetalingType,
     val harUtbetaling: Boolean,
     val harEtterbetaling: Boolean,
-) : BrevData() {
+) : BrevData {
     companion object {
         fun fra(
             avkortingsinfo: Avkortingsinfo,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadRevurdering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadRevurdering.kt
@@ -3,7 +3,8 @@ package no.nav.etterlatte.brev.model.oms
 import no.nav.etterlatte.brev.behandling.Avkortingsinfo
 import no.nav.etterlatte.brev.behandling.Trygdetid
 import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
-import no.nav.etterlatte.brev.model.BrevData
+import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
+import no.nav.etterlatte.brev.model.BrevDataRedigerbar
 import no.nav.etterlatte.brev.model.BrevVedleggKey
 import no.nav.etterlatte.brev.model.Etterbetaling
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
@@ -21,7 +22,7 @@ import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import java.time.LocalDate
 
 data class OmstillingsstoenadRevurdering(
-    val innhold: List<Slate.Element>,
+    override val innhold: List<Slate.Element>,
     val innholdForhaandsvarsel: List<Slate.Element>,
     val erEndret: Boolean,
     val erOmgjoering: Boolean,
@@ -32,7 +33,7 @@ data class OmstillingsstoenadRevurdering(
     val harUtbetaling: Boolean,
     val lavEllerIngenInntekt: Boolean,
     val feilutbetaling: FeilutbetalingType,
-) : BrevData {
+) : BrevDataFerdigstilling {
     companion object {
         fun fra(
             innholdMedVedlegg: InnholdMedVedlegg,
@@ -104,7 +105,7 @@ data class OmstillingsstoenadRevurderingRedigerbartUtfall(
     val feilutbetaling: FeilutbetalingType,
     val harUtbetaling: Boolean,
     val harEtterbetaling: Boolean,
-) : BrevData {
+) : BrevDataRedigerbar {
     companion object {
         fun fra(
             avkortingsinfo: Avkortingsinfo,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/tilbakekreving/TilbakekrevingBrevData.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/tilbakekreving/TilbakekrevingBrevData.kt
@@ -14,7 +14,7 @@ import java.time.LocalDate
 data class TilbakekrevingFerdigData(
     val innhold: List<Slate.Element>,
     val data: TilbakekrevingInnholdBrevData,
-) : BrevData() {
+) : BrevData {
     companion object {
         fun fra(
             generellBrevData: GenerellBrevData,
@@ -33,7 +33,7 @@ data class TilbakekrevingInnholdBrevData(
     val harForeldelse: Boolean,
     val perioder: List<TilbakekrevingPeriodeData>,
     val summer: TilbakekrevingBeloeperData,
-) : BrevData() {
+) : BrevData {
     companion object {
         fun fra(generellBrevData: GenerellBrevData): TilbakekrevingInnholdBrevData {
             val tilbakekreving =

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/tilbakekreving/TilbakekrevingBrevData.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/tilbakekreving/TilbakekrevingBrevData.kt
@@ -1,7 +1,8 @@
 package no.nav.etterlatte.brev.model.tilbakekreving
 
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
-import no.nav.etterlatte.brev.model.BrevData
+import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
+import no.nav.etterlatte.brev.model.BrevDataRedigerbar
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -12,9 +13,9 @@ import no.nav.pensjon.brevbaker.api.model.Kroner
 import java.time.LocalDate
 
 data class TilbakekrevingFerdigData(
-    val innhold: List<Slate.Element>,
+    override val innhold: List<Slate.Element>,
     val data: TilbakekrevingInnholdBrevData,
-) : BrevData {
+) : BrevDataFerdigstilling {
     companion object {
         fun fra(
             generellBrevData: GenerellBrevData,
@@ -33,7 +34,7 @@ data class TilbakekrevingInnholdBrevData(
     val harForeldelse: Boolean,
     val perioder: List<TilbakekrevingPeriodeData>,
     val summer: TilbakekrevingBeloeperData,
-) : BrevData {
+) : BrevDataRedigerbar {
     companion object {
         fun fra(generellBrevData: GenerellBrevData): TilbakekrevingInnholdBrevData {
             val tilbakekreving =

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -32,12 +32,12 @@ import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.hentinformasjon.VedtaksvurderingService
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
+import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
 import no.nav.etterlatte.brev.model.BrevDataMapperFerdigstillingVedtak
 import no.nav.etterlatte.brev.model.BrevDataMapperRedigerbartUtfallVedtak
 import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Brevtype
-import no.nav.etterlatte.brev.model.ManueltBrevData
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.OpprettNyttBrev
 import no.nav.etterlatte.brev.model.Pdf
@@ -484,7 +484,7 @@ internal class VedtaksbrevServiceTest {
             coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any()) } returns behandling
             coEvery { adresseService.hentAvsender(any()) } returns opprettAvsender()
             coEvery { brevbakerService.genererPdf(any(), any()) } returns opprettBrevbakerResponse()
-            coEvery { brevDataMapperFerdigstilling.brevDataFerdigstilling(any()) } returns ManueltBrevData()
+            coEvery { brevDataMapperFerdigstilling.brevDataFerdigstilling(any()) } returns ManueltBrevDataTest()
 
             runBlocking {
                 vedtaksbrevService.genererPdf(brev.id, bruker = SAKSBEHANDLER)
@@ -511,7 +511,7 @@ internal class VedtaksbrevServiceTest {
             coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any()) } returns behandling
             coEvery { adresseService.hentAvsender(any()) } returns opprettAvsender()
             coEvery { brevbakerService.genererPdf(any(), any()) } returns opprettBrevbakerResponse()
-            coEvery { brevDataMapperFerdigstilling.brevDataFerdigstilling(any()) } returns ManueltBrevData()
+            coEvery { brevDataMapperFerdigstilling.brevDataFerdigstilling(any()) } returns ManueltBrevDataTest()
 
             runBlocking {
                 vedtaksbrevService.genererPdf(brev.id, bruker = ATTESTANT)
@@ -539,7 +539,7 @@ internal class VedtaksbrevServiceTest {
             coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any()) } returns behandling
             coEvery { adresseService.hentAvsender(any()) } returns opprettAvsender()
             coEvery { brevbakerService.genererPdf(any(), any()) } returns opprettBrevbakerResponse()
-            coEvery { brevDataMapperFerdigstilling.brevDataFerdigstilling(any()) } returns ManueltBrevData()
+            coEvery { brevDataMapperFerdigstilling.brevDataFerdigstilling(any()) } returns ManueltBrevDataTest()
 
             runBlocking {
                 vedtaksbrevService.genererPdf(brev.id, bruker = SAKSBEHANDLER)
@@ -747,3 +747,5 @@ internal class VedtaksbrevServiceTest {
             ),
         )
 }
+
+data class ManueltBrevDataTest(override val innhold: List<Slate.Element> = emptyList()) : BrevDataFerdigstilling


### PR DESCRIPTION
Trur vi gjer livet enklare for oss sjølve med eit skarpare skilje og også meir eksplisittt typa kode.

Tilsvarande avgrensing som i `BrevDataMapperFerdigstillingVedtak` bør forresten på plass i `BrevDataMapperRedigerbartUtfallVedtak`, men der må det litt oppsplitting i eit par brevdatatypar på plass først, så det kan vente littegrann.