### PR TITLE
Ny tjeneste for å hente ut berørte personer ved dødsfall.

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/BeroertePersonerVedDoedsfallService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/BeroertePersonerVedDoedsfallService.kt
@@ -13,7 +13,7 @@ class BeroertePersonerVedDoedsfallService(private val pdlTjenesterKlient: PdlTje
     fun hentBeroertePersoner(fnr: String): List<Person> {
         val avdoed = pdlTjenesterKlient.hentPdlModell(fnr, PersonRolle.AVDOED, SakType.BARNEPENSJON)
 
-        assert(avdoed.doedsdato != null) { "Personen er ikke død" }
+        checkNotNull(avdoed.doedsdato) { "Personen er ikke død" }
 
         return finnBeroerteBarn(avdoed)
     }
@@ -28,7 +28,7 @@ class BeroertePersonerVedDoedsfallService(private val pdlTjenesterKlient: PdlTje
     }
 }
 
-fun Person.under20PaaDato(dato: LocalDate): Boolean =
+private fun Person.under20PaaDato(dato: LocalDate): Boolean =
     if (foedselsdato != null) {
         ChronoUnit.YEARS.between(foedselsdato, dato) < 20
     } else {

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/BeroertePersonerVedDoedsfallService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/BeroertePersonerVedDoedsfallService.kt
@@ -1,0 +1,36 @@
+package no.nav.etterlatte.grunnlagsendring
+
+import no.nav.etterlatte.common.klienter.PdlTjenesterKlient
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.pdl.PersonDTO
+import no.nav.etterlatte.libs.common.person.Person
+import no.nav.etterlatte.libs.common.person.PersonRolle
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+class BeroertePersonerVedDoedsfallService(private val pdlTjenesterKlient: PdlTjenesterKlient) {
+    // Finner beroerte personer basert på regler beskrevet i https://confluence.adeo.no/display/TE/Funksjonelle+krav
+    fun hentBeroertePersoner(fnr: String): List<Person> {
+        val avdoed = pdlTjenesterKlient.hentPdlModell(fnr, PersonRolle.AVDOED, SakType.BARNEPENSJON)
+
+        assert(avdoed.doedsdato != null) { "Personen er ikke død" }
+
+        return finnBeroerteBarn(avdoed)
+    }
+
+    private fun finnBeroerteBarn(avdoed: PersonDTO): List<Person> {
+        val maanedenEtterDoedsfall = avdoed.doedsdato!!.verdi.plusMonths(1).withDayOfMonth(1)
+
+        return with(avdoed.avdoedesBarn ?: emptyList()) {
+            this.filter { barn -> barn.doedsdato == null }
+                .filter { barn -> barn.under20PaaDato(maanedenEtterDoedsfall) }
+        }
+    }
+}
+
+fun Person.under20PaaDato(dato: LocalDate): Boolean =
+    if (foedselsdato != null) {
+        ChronoUnit.YEARS.between(foedselsdato, dato) < 20
+    } else {
+        foedselsnummer.getAgeAtDate(dato) < 20
+    }

--- a/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
@@ -276,30 +276,32 @@ fun grunnlagsOpplysningMedPersonopplysning(personopplysning: Person) =
         periode = null,
     )
 
-fun personOpplysning(doedsdato: LocalDate? = null) =
-    Person(
-        fornavn = "Test",
-        etternavn = "Testulfsen",
-        foedselsnummer = SOEKER_FOEDSELSNUMMER,
-        foedselsdato = LocalDate.parse("2020-06-10"),
-        foedselsaar = 1985,
-        foedeland = null,
-        doedsdato = doedsdato,
-        adressebeskyttelse = AdressebeskyttelseGradering.UGRADERT,
-        bostedsadresse = null,
-        deltBostedsadresse = null,
-        kontaktadresse = null,
-        oppholdsadresse = null,
-        sivilstatus = null,
-        sivilstand = null,
-        statsborgerskap = null,
-        utland = null,
-        familieRelasjon = FamilieRelasjon(null, null, null),
-        avdoedesBarn = null,
-        avdoedesBarnUtenIdent = null,
-        vergemaalEllerFremtidsfullmakt = null,
-        pdlStatsborgerskap = null,
-    )
+fun personOpplysning(
+    doedsdato: LocalDate? = null,
+    foedselsdato: LocalDate? = LocalDate.parse("2020-06-10"),
+) = Person(
+    fornavn = "Test",
+    etternavn = "Testulfsen",
+    foedselsnummer = SOEKER_FOEDSELSNUMMER,
+    foedselsdato = foedselsdato,
+    foedselsaar = 1985,
+    foedeland = null,
+    doedsdato = doedsdato,
+    adressebeskyttelse = AdressebeskyttelseGradering.UGRADERT,
+    bostedsadresse = null,
+    deltBostedsadresse = null,
+    kontaktadresse = null,
+    oppholdsadresse = null,
+    sivilstatus = null,
+    sivilstand = null,
+    statsborgerskap = null,
+    utland = null,
+    familieRelasjon = FamilieRelasjon(null, null, null),
+    avdoedesBarn = null,
+    avdoedesBarnUtenIdent = null,
+    vergemaalEllerFremtidsfullmakt = null,
+    pdlStatsborgerskap = null,
+)
 
 fun kommerBarnetTilgode(
     behandlingId: UUID,

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/BeroertePersonerVedDoedsfallServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/BeroertePersonerVedDoedsfallServiceTest.kt
@@ -44,7 +44,7 @@ internal class BeroertePersonerVedDoedsfallServiceTest {
         val avdoed = mockPerson()
         every { pdlTjenesterKlient.hentPdlModell(avdoed.foedselsnummer.verdi.value, any(), any()) } returns avdoed
 
-        shouldThrow<AssertionError> {
+        shouldThrow<IllegalStateException> {
             service.hentBeroertePersoner(avdoed.foedselsnummer.verdi.value)
         }
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/BeroertePersonerVedDoedsfallServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/BeroertePersonerVedDoedsfallServiceTest.kt
@@ -1,0 +1,51 @@
+package grunnlagsendring
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.etterlatte.common.klienter.PdlTjenesterKlient
+import no.nav.etterlatte.grunnlagsendring.BeroertePersonerVedDoedsfallService
+import no.nav.etterlatte.libs.common.pdl.OpplysningDTO
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.mockPerson
+import no.nav.etterlatte.personOpplysning
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+internal class BeroertePersonerVedDoedsfallServiceTest {
+    private val pdlTjenesterKlient = mockk<PdlTjenesterKlient>()
+    private val service = BeroertePersonerVedDoedsfallService(pdlTjenesterKlient = pdlTjenesterKlient)
+
+    @Test
+    fun `Skal returnere barna som kan ha rett paa barnepensjon ved doedsfall`() {
+        val avdoed =
+            mockPerson().copy(
+                doedsdato = OpplysningDTO(LocalDate.of(2022, 8, 17), null),
+                avdoedesBarn =
+                    listOf(
+                        personOpplysning(foedselsdato = LocalDate.of(2000, 1, 1)),
+                        personOpplysning(foedselsdato = LocalDate.of(2002, 8, 30)),
+                        personOpplysning(foedselsdato = LocalDate.of(2002, 9, 15)),
+                        personOpplysning(foedselsdato = LocalDate.of(2005, 9, 15), doedsdato = LocalDate.of(2020, 8, 17)),
+                        personOpplysning(foedselsdato = null).copy(foedselsnummer = Folkeregisteridentifikator.of("26061363474")),
+                        personOpplysning(foedselsdato = LocalDate.of(2020, 9, 15)),
+                    ),
+            )
+        every { pdlTjenesterKlient.hentPdlModell(avdoed.foedselsnummer.verdi.value, any(), any()) } returns avdoed
+
+        val beroerteBarn = service.hentBeroertePersoner(avdoed.foedselsnummer.verdi.value)
+
+        beroerteBarn.size shouldBe 3
+    }
+
+    @Test
+    fun `Skal kaste feil hvis personen ikke er doed`() {
+        val avdoed = mockPerson()
+        every { pdlTjenesterKlient.hentPdlModell(avdoed.foedselsnummer.verdi.value, any(), any()) } returns avdoed
+
+        shouldThrow<AssertionError> {
+            service.hentBeroertePersoner(avdoed.foedselsnummer.verdi.value)
+        }
+    }
+}

--- a/libs/saksbehandling-common/src/main/kotlin/person/Folkeregisteridentifikator.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/person/Folkeregisteridentifikator.kt
@@ -90,6 +90,10 @@ class Folkeregisteridentifikator private constructor(
         return ChronoUnit.YEARS.between(getBirthDate(), LocalDate.now()).toInt()
     }
 
+    fun getAgeAtDate(date: LocalDate): Int {
+        return ChronoUnit.YEARS.between(getBirthDate(), date).toInt()
+    }
+
     /**
      * Sjekker om fødselsnummeret er av typen "Hjelpenummer".
      *


### PR DESCRIPTION
I første versjon er det kun barn av avdøde som er støttet (EPS og tidligere EPS kommer etterhvert), og det sjekkes på alder og at barnet er i livet. Bruk av denne tjenesten kommer i en senere PR.

EY-3384