### PR TITLE
Migrerer key fra BEREGNING_INNHOLD til OMS_BEREGNING for brev-vedlegg

### DIFF
--- a/apps/etterlatte-brev-api/src/main/resources/db/migration/V14__oppdater_vedlegg_key.sql
+++ b/apps/etterlatte-brev-api/src/main/resources/db/migration/V14__oppdater_vedlegg_key.sql
@@ -1,0 +1,9 @@
+with vedlegg_key as (
+    select ('{'||index-1||',key}')::text[] as path, vedlegg, brev_id
+    from innhold, jsonb_array_elements(innhold.payload_vedlegg::jsonb) with ordinality arr(vedlegg, index)
+    where upper(vedlegg->>'key') = 'BEREGNING_INNHOLD'
+)
+update innhold
+set payload_vedlegg = jsonb_set(payload_vedlegg::jsonb, vedlegg_key.path, '"OMS_BEREGNING"', false)::text
+from vedlegg_key
+where innhold.brev_id = vedlegg_key.brev_id


### PR DESCRIPTION
Oppdaterer alle vedlegg hvor key er `BEREGNING_INNHOLD` til `OMS_BEREGNING` slik at vi kan fjerne quickfix'en som tillater begge varianter. 