### PR TITLE
EY-3355 Korrigert uthenting av saker hvor bruker har gitt alder

### DIFF
--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangDao.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangDao.kt
@@ -21,9 +21,12 @@ class AldersovergangDao(private val datasource: DataSource) : Transactions<Alder
             """
             select g.sak_id as sak_id from grunnlagshendelse g
                      inner join grunnlagshendelse g2 on g.sak_id = g2.sak_id and g.fnr = g2.fnr and g.hendelsenummer != g2.hendelsenummer
-                     and g.hendelsenummer = (select hendelsenummer from grunnlagshendelse where sak_id = g.sak_id
-                     and opplysning_type = 'FOEDSELSDATO' 
-                      order by hendelsenummer desc limit 1 )
+                     and g.hendelsenummer = (
+                        select max(hendelsenummer) from grunnlagshendelse 
+                        where sak_id = g.sak_id
+                        and opplysning_type = 'FOEDSELSDATO' 
+                        and fnr = g.fnr
+                     )
             where g.opplysning_type = 'FOEDSELSDATO'
             and g2.opplysning_type = 'SOEKER_PDL_V1'
             and TO_DATE(g.opplysning, '\"YYYY-MM-DD\"') BETWEEN :start AND :slutt

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/aldersovergang/AldersovergangTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/aldersovergang/AldersovergangTest.kt
@@ -22,6 +22,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.database.POSTGRES_VERSION
 import no.nav.etterlatte.libs.database.migrate
+import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.HELSOESKEN_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import no.nav.security.mock.oauth2.MockOAuth2Server
@@ -71,6 +72,7 @@ class AldersovergangTest {
         opplysningDao.leggTilOpplysning(sakId, Opplysningstype.FOEDSELSDATO, TextNode("2018-01-01"), fnrInnenfor)
         opplysningDao.leggTilOpplysning(sakId, Opplysningstype.FOEDSELSDATO, TextNode("2020-01-01"), fnrInnenfor)
         opplysningDao.leggTilOpplysning(sakId, Opplysningstype.SOEKER_PDL_V1, TextNode("hei, hallo"), fnrInnenfor)
+        opplysningDao.leggTilOpplysning(sakId, Opplysningstype.FOEDSELSDATO, TextNode("1987-04-20"), AVDOED_FOEDSELSNUMMER)
 
         val sakIdUtenfor = 2000L
         val fnrUtenfor = HELSOESKEN_FOEDSELSNUMMER


### PR DESCRIPTION
Dette er pga av dataene i nyopprettet case i dev, enkel familie. Barnet født i mars 2004. Dersom sql'en kjøres med start/slutt 2004-03-01 til 2004-03-31, så returneres ingenting. Det er pga at det finnes 3 hendelser av type FOEDSELSDATO, men barnets/søker er den med lavest ID... så original spørring finner opplysningen for avdøde forelder. Bugfixen er dermed å sjekke at hendelsen som hentes ut tilhører _søker_. 
