### PR TITLE
Refaktorering DatabaseExtension mtp gjenbruk og konfig

### DIFF
--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/AldersovergangerIntegrationTest.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/AldersovergangerIntegrationTest.kt
@@ -16,10 +16,9 @@ import java.time.Month
 import java.time.YearMonth
 import javax.sql.DataSource
 
-@ExtendWith(DatabaseExtension::class)
+@ExtendWith(TidshendelserDatabaseExtension::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class AldersovergangerIntegrationTest {
-    private val dataSource: DataSource = DatabaseExtension.dataSource
+class AldersovergangerIntegrationTest(dataSource: DataSource) {
     private val grunnlagKlient: GrunnlagKlient = mockk<GrunnlagKlient>()
     private val hendelseDao = HendelseDao(dataSource)
     private val jobbTestdata = JobbTestdata(dataSource, hendelseDao)

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/DatabaseExtension.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/DatabaseExtension.kt
@@ -113,8 +113,7 @@ open class DatabaseExtension : AfterAllCallback, ExtensionContext.Store.Closeabl
         parameterContext: ParameterContext,
         extensionContext: ExtensionContext,
     ): Boolean {
-        return parameterContext.parameter?.type == DataSource::class.java ||
-            parameterContext.parameter?.type == ResetDb::class.java
+        return parameterContext.parameter?.type == DataSource::class.java
     }
 
     override fun resolveParameter(
@@ -123,21 +122,9 @@ open class DatabaseExtension : AfterAllCallback, ExtensionContext.Store.Closeabl
     ): Any {
         if (parameterContext.parameter?.type == DataSource::class.java) {
             return dataSource
-        } else if (parameterContext.parameter?.type == ResetDb::class.java) {
-            return ResetDbImpl(this)
         } else {
             throw IllegalArgumentException("Kan ikke resolve parameter av type ${parameterContext.parameter?.type}")
         }
-    }
-}
-
-interface ResetDb {
-    fun invoke()
-}
-
-private class ResetDbImpl(private val extension: DatabaseExtension) : ResetDb {
-    override fun invoke() {
-        extension.resetDb()
     }
 }
 

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/HendelsePollerIntegrationTest.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/HendelsePollerIntegrationTest.kt
@@ -11,12 +11,11 @@ import java.time.Month
 import java.time.YearMonth
 import javax.sql.DataSource
 
-@ExtendWith(DatabaseExtension::class)
+@ExtendWith(TidshendelserDatabaseExtension::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class HendelsePollerIntegrationTest {
+class HendelsePollerIntegrationTest(dataSource: DataSource) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    private val dataSource: DataSource = DatabaseExtension.dataSource
     private val hendelseDao = HendelseDao(dataSource)
     private val jobbTestdata = JobbTestdata(dataSource, hendelseDao)
     private val hendelsePoller =

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/HendelseRiverTest.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/HendelseRiverTest.kt
@@ -16,10 +16,9 @@ import java.time.YearMonth
 import javax.sql.DataSource
 import kotlin.random.Random
 
-@ExtendWith(DatabaseExtension::class)
+@ExtendWith(TidshendelserDatabaseExtension::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class HendelseRiverTest {
-    private val dataSource: DataSource = DatabaseExtension.dataSource
+class HendelseRiverTest(dataSource: DataSource) {
     private val hendelseDao = HendelseDao(dataSource)
     private val jobbTestdata = JobbTestdata(dataSource, hendelseDao)
 

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/JobbPollerIntegrationTest.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/JobbPollerIntegrationTest.kt
@@ -17,7 +17,8 @@ import javax.sql.DataSource
 class JobbPollerIntegrationTest(dataSource: DataSource) {
     companion object {
         @RegisterExtension
-        private val tidshendelserDatabaseExtension = TidshendelserDatabaseExtension()
+        @Suppress("unused")
+        private val tidshendelserDatabaseExtension = TidshendelserDatabaseExtension(resetAfterEach = true)
     }
 
     private val aldersovergangerService = mockk<AldersovergangerService>()
@@ -28,7 +29,6 @@ class JobbPollerIntegrationTest(dataSource: DataSource) {
     @AfterEach
     fun afterEach() {
         clearAllMocks()
-        tidshendelserDatabaseExtension.resetDb()
     }
 
     @Test

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/JobbPollerIntegrationTest.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/JobbPollerIntegrationTest.kt
@@ -7,15 +7,19 @@ import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.time.LocalDate
 import java.time.Month
 import java.time.YearMonth
 import javax.sql.DataSource
 
-@ExtendWith(TidshendelserDatabaseExtension::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class JobbPollerIntegrationTest(dataSource: DataSource, private val resetDb: ResetDb) {
+class JobbPollerIntegrationTest(dataSource: DataSource) {
+    companion object {
+        @RegisterExtension
+        private val tidshendelserDatabaseExtension = TidshendelserDatabaseExtension()
+    }
+
     private val aldersovergangerService = mockk<AldersovergangerService>()
     private val hendelseDao = HendelseDao(dataSource)
     private val jobbTestdata = JobbTestdata(dataSource, hendelseDao)
@@ -24,7 +28,7 @@ class JobbPollerIntegrationTest(dataSource: DataSource, private val resetDb: Res
     @AfterEach
     fun afterEach() {
         clearAllMocks()
-        resetDb.invoke()
+        tidshendelserDatabaseExtension.resetDb()
     }
 
     @Test

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/JobbPollerIntegrationTest.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/JobbPollerIntegrationTest.kt
@@ -13,10 +13,9 @@ import java.time.Month
 import java.time.YearMonth
 import javax.sql.DataSource
 
-@ExtendWith(DatabaseExtension::class)
+@ExtendWith(TidshendelserDatabaseExtension::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class JobbPollerIntegrationTest {
-    private val dataSource: DataSource = DatabaseExtension.dataSource
+class JobbPollerIntegrationTest(dataSource: DataSource, private val resetDb: ResetDb) {
     private val aldersovergangerService = mockk<AldersovergangerService>()
     private val hendelseDao = HendelseDao(dataSource)
     private val jobbTestdata = JobbTestdata(dataSource, hendelseDao)
@@ -25,7 +24,7 @@ class JobbPollerIntegrationTest {
     @AfterEach
     fun afterEach() {
         clearAllMocks()
-        DatabaseExtension.resetDb()
+        resetDb.invoke()
     }
 
     @Test

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/TidshendelserDatabaseExtension.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/TidshendelserDatabaseExtension.kt
@@ -1,0 +1,10 @@
+package no.nav.etterlatte.tidshendelser
+
+@ResetDatabaseStatement(
+    """
+    TRUNCATE hendelse CASCADE;
+    TRUNCATE jobb CASCADE;
+    ALTER SEQUENCE jobb_id_seq RESTART WITH 1;
+""",
+)
+class TidshendelserDatabaseExtension : DatabaseExtension()

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/TidshendelserDatabaseExtension.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/TidshendelserDatabaseExtension.kt
@@ -7,4 +7,5 @@ package no.nav.etterlatte.tidshendelser
     ALTER SEQUENCE jobb_id_seq RESTART WITH 1;
 """,
 )
-class TidshendelserDatabaseExtension : DatabaseExtension()
+class TidshendelserDatabaseExtension(resetAfterEach: Boolean = false) :
+    DatabaseExtension(resetAfterEach = resetAfterEach)


### PR DESCRIPTION
- ikke lengre singleton
- kan injecte datasource inn i testene (constructor)
- konfigurerbart reset-statements

Hvilket da gjør at denne kan legges inn i database-fixtures for gjenbruk