### PR TITLE
Videre refaktorering av db-extension

### DIFF
--- a/apps/etterlatte-behandling/src/test/kotlin/BehandlingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/BehandlingIntegrationTest.kt
@@ -58,13 +58,17 @@ import no.nav.etterlatte.oppgaveGosys.GosysOppgaveKlient
 import no.nav.etterlatte.oppgaveGosys.GosysOppgaver
 import no.nav.etterlatte.token.BrukerTokenInfo
 import no.nav.security.mock.oauth2.MockOAuth2Server
-import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.time.LocalDate
 import java.util.UUID
 
-@ExtendWith(DatabaseExtension::class)
 abstract class BehandlingIntegrationTest {
-    private val postgreSQLContainer = DatabaseExtension.postgreSQLContainer
+    companion object {
+        @RegisterExtension
+        private val dbExtension = DatabaseExtension()
+    }
+
+    private val postgreSQLContainer = GenerellDatabaseExtension.postgreSQLContainer
     protected val server: MockOAuth2Server = MockOAuth2Server()
     internal lateinit var applicationContext: ApplicationContext
 
@@ -300,7 +304,7 @@ abstract class BehandlingIntegrationTest {
         }
 
     fun resetDatabase() {
-        DatabaseExtension.resetDb()
+        dbExtension.resetDb()
     }
 
     protected fun afterAll() {

--- a/apps/etterlatte-behandling/src/test/kotlin/DatabaseExtension.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/DatabaseExtension.kt
@@ -1,40 +1,15 @@
 package no.nav.etterlatte
 
-import org.junit.jupiter.api.extension.AfterAllCallback
-import org.junit.jupiter.api.extension.BeforeAllCallback
-import org.junit.jupiter.api.extension.ExtensionContext
-
-/**
- * Det tar veldig mye tid å kjøre opp stadig nye Postgres-containere og kjøre Flyway migreringer.
- * Denne extensionen kjører opp èn instans, som så gjenbrukes av de som måtte ønske det.
- */
-object DatabaseExtension : BeforeAllCallback, AfterAllCallback, ExtensionContext.Store.CloseableResource {
-    override fun beforeAll(context: ExtensionContext) {
-        GenerellDatabaseExtension.beforeAll(context)
-    }
-
-    override fun afterAll(context: ExtensionContext) {
-        GenerellDatabaseExtension.afterAll(RESET_DATABASE)
-    }
-
-    override fun close() {
-        GenerellDatabaseExtension.close()
-    }
-
-    val dataSource = GenerellDatabaseExtension.dataSource
-
-    val postgreSQLContainer = GenerellDatabaseExtension.postgreSQLContainer
-
-    private const val RESET_DATABASE = """
-                        TRUNCATE behandling CASCADE;
-                        TRUNCATE behandlinghendelse CASCADE;
-                        TRUNCATE grunnlagsendringshendelse CASCADE;
-                        TRUNCATE sak CASCADE;
-                        TRUNCATE oppgave CASCADE;
-                        
-                        ALTER SEQUENCE behandlinghendelse_id_seq RESTART WITH 1;
-                        ALTER SEQUENCE sak_id_seq RESTART WITH 1;
-                        """
-
-    fun resetDb() = GenerellDatabaseExtension.resetDb(RESET_DATABASE)
-}
+@ResetDatabaseStatement(
+    """
+    TRUNCATE behandling CASCADE;
+    TRUNCATE behandlinghendelse CASCADE;
+    TRUNCATE grunnlagsendringshendelse CASCADE;
+    TRUNCATE sak CASCADE;
+    TRUNCATE oppgave CASCADE;
+    
+    ALTER SEQUENCE behandlinghendelse_id_seq RESTART WITH 1;
+    ALTER SEQUENCE sak_id_seq RESTART WITH 1;
+""",
+)
+class DatabaseExtension : GenerellDatabaseExtension()

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
@@ -29,11 +29,11 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
+import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-internal class TilgangServiceTest {
-    private val dataSource = DatabaseExtension.dataSource
+internal class TilgangServiceTest(val dataSource: DataSource) {
     private lateinit var tilgangService: TilgangService
     private lateinit var sakService: SakService
     private lateinit var sakRepo: SakDao

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoReguleringTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoReguleringTest.kt
@@ -18,15 +18,18 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@ExtendWith(DatabaseExtension::class)
-internal class BehandlingDaoReguleringTest {
-    private val dataSource: DataSource = DatabaseExtension.dataSource
+internal class BehandlingDaoReguleringTest(val dataSource: DataSource) {
+    companion object {
+        @RegisterExtension
+        private val dbExtension = DatabaseExtension()
+    }
+
     private lateinit var sakRepo: SakDao
     private lateinit var behandlingRepo: BehandlingDao
 
@@ -40,7 +43,7 @@ internal class BehandlingDaoReguleringTest {
 
     @AfterEach
     fun afterEach() {
-        DatabaseExtension.resetDb()
+        dbExtension.resetDb()
     }
 
     private fun hentMigrerbareStatuses() = BehandlingStatus.entries - BehandlingStatus.skalIkkeOmregnesVedGRegulering().toSet()

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingDaoTest.kt
@@ -39,11 +39,11 @@ import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDate
 import java.time.YearMonth
+import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-internal class BehandlingDaoTest {
-    private val dataSource = DatabaseExtension.dataSource
+internal class BehandlingDaoTest(val dataSource: DataSource) {
     private lateinit var sakRepo: SakDao
     private lateinit var behandlingRepo: BehandlingDao
     private lateinit var kommerBarnetTilGodeDao: KommerBarnetTilGodeDao

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoDaoTest.kt
@@ -31,8 +31,7 @@ import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-internal class BehandlingInfoDaoTest {
-    private val dataSource: DataSource = DatabaseExtension.dataSource
+internal class BehandlingInfoDaoTest(val dataSource: DataSource) {
     private lateinit var behandlingDao: BehandlingDao
     private lateinit var sakDao: SakDao
     private lateinit var dao: BehandlingInfoDao

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/bosattutland/BosattUtlandDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/bosattutland/BosattUtlandDaoTest.kt
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDate
 import java.util.UUID
+import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-internal class BosattUtlandDaoTest {
-    private val dataSource = DatabaseExtension.dataSource
+internal class BosattUtlandDaoTest(val dataSource: DataSource) {
     private lateinit var bosattUtlandDao: BosattUtlandDao
 
     @BeforeAll

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingDaoTest.kt
@@ -18,8 +18,7 @@ import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-internal class GenerellBehandlingDaoTest {
-    private val dataSource: DataSource = DatabaseExtension.dataSource
+internal class GenerellBehandlingDaoTest(val dataSource: DataSource) {
     private lateinit var dao: GenerellBehandlingDao
 
     @BeforeAll

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingServiceTest.kt
@@ -57,11 +57,11 @@ import java.sql.Connection
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import java.util.UUID.randomUUID
+import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-class GenerellBehandlingServiceTest {
-    private val dataSource = DatabaseExtension.dataSource
+class GenerellBehandlingServiceTest(val dataSource: DataSource) {
     private lateinit var dao: GenerellBehandlingDao
     private lateinit var oppgaveDao: OppgaveDao
     private lateinit var hendelseDao: HendelseDao

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/klage/KlageDaoImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/klage/KlageDaoImplTest.kt
@@ -25,11 +25,11 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
+import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-internal class KlageDaoImplTest {
-    private val dataSource = DatabaseExtension.dataSource
+internal class KlageDaoImplTest(val dataSource: DataSource) {
     private lateinit var sakRepo: SakDao
     private lateinit var klageDao: KlageDaoImpl
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/klage/KlageRoutesIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/klage/KlageRoutesIntegrationTest.kt
@@ -13,7 +13,6 @@ import io.ktor.server.testing.testApplication
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.etterlatte.BehandlingIntegrationTest
-import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.ktor.runServerWithModule
 import no.nav.etterlatte.libs.common.FoedselsnummerDTO
@@ -52,7 +51,7 @@ class KlageRoutesIntegrationTest : BehandlingIntegrationTest() {
                     every { isEnabled(KlageFeatureToggle.KanBrukeKlageToggle, any()) } returns true
                 },
         ).also {
-            DatabaseExtension.resetDb()
+            resetDatabase()
         }
 
     @AfterEach
@@ -61,7 +60,7 @@ class KlageRoutesIntegrationTest : BehandlingIntegrationTest() {
     }
 
     @Test
-    fun `opprettelse av klage går bra og henting gir 404 etter at saken blir skjermet`() {
+    fun `opprettelse av klage gaar bra og henting gir 404 etter at saken blir skjermet`() {
         withTestApplication { client ->
             val sak: Sak = opprettSak(client)
 
@@ -99,7 +98,7 @@ class KlageRoutesIntegrationTest : BehandlingIntegrationTest() {
     }
 
     @Test
-    fun `opprettelse av klage går bra og henting gjør tilgangskontroll når saken får adressebeskyttelse`() {
+    fun `opprettelse av klage gaar bra og henting gjoer tilgangskontroll naar saken faar adressebeskyttelse`() {
         withTestApplication { client ->
             val sak: Sak = opprettSak(client)
             val klage: Klage =
@@ -144,7 +143,7 @@ class KlageRoutesIntegrationTest : BehandlingIntegrationTest() {
     }
 
     @Test
-    fun `avbrytelse av klage går bra`() {
+    fun `avbrytelse av klage gaar bra`() {
         withTestApplication { client ->
             val sak: Sak = opprettSak(client)
 
@@ -183,7 +182,7 @@ class KlageRoutesIntegrationTest : BehandlingIntegrationTest() {
     }
 
     @Test
-    fun `oppdatering av kabalstatus går bra`() {
+    fun `oppdatering av kabalstatus gaar bra`() {
         withTestApplication { client ->
             val sak: Sak = opprettSak(client)
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/sjekkliste/SjekklisteIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/sjekkliste/SjekklisteIntegrationTest.kt
@@ -21,10 +21,11 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.extension.ExtendWith
 import java.sql.Connection
+import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-class SjekklisteIntegrationTest {
+class SjekklisteIntegrationTest(val dataSource: DataSource) {
     private val user =
         mockk<SaksbehandlerMedEnheterOgRoller>().apply {
             every { this@apply.name() } returns "Z123456"
@@ -32,7 +33,6 @@ class SjekklisteIntegrationTest {
 
     private val behandlingService = mockk<BehandlingService>()
     private val oppgaveService = mockk<OppgaveService>()
-    private val dataSource = DatabaseExtension.dataSource
     private lateinit var sjekklisteDao: SjekklisteDao
     private lateinit var sjekklisteService: SjekklisteService
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingDaoTest.kt
@@ -36,8 +36,7 @@ import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-class TilbakekrevingDaoTest {
-    private val dataSource: DataSource = DatabaseExtension.dataSource
+class TilbakekrevingDaoTest(val dataSource: DataSource) {
     private lateinit var sakDao: SakDao
     private lateinit var tilbakekrevingDao: TilbakekrevingDao
 

--- a/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattServiceTest.kt
@@ -38,13 +38,13 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import org.slf4j.Logger
 import java.sql.Connection
+import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-internal class EgenAnsattServiceTest {
-    val sikkerLogg: Logger = sikkerlogger()
+internal class EgenAnsattServiceTest(val dataSource: DataSource) {
+    private val sikkerLogg: Logger = sikkerlogger()
 
-    private val dataSource = DatabaseExtension.dataSource
     private lateinit var sakRepo: SakDao
     private lateinit var oppgaveRepo: OppgaveDaoImpl
     private lateinit var oppgaveRepoMedSporing: OppgaveDaoMedEndringssporingImpl

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseDaoTest.kt
@@ -37,11 +37,11 @@ import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDate
 import java.util.UUID
+import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-internal class GrunnlagsendringshendelseDaoTest {
-    private val dataSource = DatabaseExtension.dataSource
+internal class GrunnlagsendringshendelseDaoTest(val dataSource: DataSource) {
     private lateinit var sakRepo: SakDao
     private lateinit var grunnlagsendringshendelsesRepo: GrunnlagsendringshendelseDao
     private lateinit var behandlingRepo: BehandlingDao

--- a/apps/etterlatte-behandling/src/test/kotlin/institusjonsopphold/institusjonsopphold/InstitusjonsoppholdDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/institusjonsopphold/institusjonsopphold/InstitusjonsoppholdDaoTest.kt
@@ -12,11 +12,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import java.util.UUID
+import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-internal class InstitusjonsoppholdDaoTest {
-    private val dataSource = DatabaseExtension.dataSource
+internal class InstitusjonsoppholdDaoTest(val dataSource: DataSource) {
     private lateinit var institusjonsoppholdDao: InstitusjonsoppholdDao
 
     @BeforeAll

--- a/apps/etterlatte-behandling/src/test/kotlin/metrics/BehandlingMetricsOppgaveTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/metrics/BehandlingMetricsOppgaveTest.kt
@@ -20,12 +20,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import java.util.UUID
+import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-internal class BehandlingMetricsOppgaveTest {
-    private val ds = DatabaseExtension.dataSource
-
+internal class BehandlingMetricsOppgaveTest(private val ds: DataSource) {
     private lateinit var oppgaveDao: OppgaveDaoImpl
     private lateinit var sakDao: SakDao
 

--- a/apps/etterlatte-behandling/src/test/kotlin/metrics/BehandlingMetricsTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/metrics/BehandlingMetricsTest.kt
@@ -22,11 +22,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.YearMonth
+import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-internal class BehandlingMetricsTest {
-    private val ds = DatabaseExtension.dataSource
+internal class BehandlingMetricsTest(private val ds: DataSource) {
     private lateinit var behandlingMetrikkerDao: BehandlingMetrikkerDao
     private lateinit var oppgaveDao: OppgaveMetrikkerDao
     private lateinit var behandlingRepo: BehandlingDao

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
@@ -19,11 +19,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import java.util.UUID
+import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-internal class OppgaveDaoTest {
-    private val dataSource = DatabaseExtension.dataSource
+internal class OppgaveDaoTest(val dataSource: DataSource) {
     private lateinit var oppgaveDao: OppgaveDao
     private lateinit var sakDao: SakDao
     private lateinit var saktilgangDao: SakTilgangDao

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -43,11 +43,11 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import java.sql.Connection
 import java.util.UUID
+import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-internal class OppgaveServiceTest {
-    private val dataSource = DatabaseExtension.dataSource
+internal class OppgaveServiceTest(val dataSource: DataSource) {
     private lateinit var sakDao: SakDao
     private lateinit var oppgaveDao: OppgaveDao
     private lateinit var oppgaveService: OppgaveService

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakDaoTest.kt
@@ -12,11 +12,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDate
+import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-internal class SakDaoTest {
-    private val dataSource = DatabaseExtension.dataSource
+internal class SakDaoTest(val dataSource: DataSource) {
     private lateinit var sakRepo: SakDao
     private lateinit var tilgangService: TilgangService
 

--- a/apps/etterlatte-behandling/src/test/kotlin/saksbehandler/SaksbehandlerInfoDaoTransTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/saksbehandler/SaksbehandlerInfoDaoTransTest.kt
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
+import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DatabaseExtension::class)
-internal class SaksbehandlerInfoDaoTransTest {
-    private val dataSource = DatabaseExtension.dataSource
+internal class SaksbehandlerInfoDaoTransTest(val dataSource: DataSource) {
     private lateinit var saksbehandlerInfoDaoTrans: SaksbehandlerInfoDaoTrans
     private lateinit var saksbehandlerInfoDao: SaksbehandlerInfoDao
 

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/AldersovergangerIntegrationTest.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/AldersovergangerIntegrationTest.kt
@@ -18,8 +18,7 @@ import javax.sql.DataSource
 
 @ExtendWith(DatabaseExtension::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class AldersovergangerIntegrationTest {
-    private val dataSource: DataSource = DatabaseExtension.dataSource
+class AldersovergangerIntegrationTest(dataSource: DataSource) {
     private val grunnlagKlient: GrunnlagKlient = mockk<GrunnlagKlient>()
     private val hendelseDao = HendelseDao(dataSource)
     private val jobbTestdata = JobbTestdata(dataSource, hendelseDao)

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/DatabaseExtension.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/DatabaseExtension.kt
@@ -1,34 +1,13 @@
 package no.nav.etterlatte.tidshendelser
 
 import no.nav.etterlatte.GenerellDatabaseExtension
-import org.junit.jupiter.api.extension.AfterAllCallback
-import org.junit.jupiter.api.extension.BeforeAllCallback
-import org.junit.jupiter.api.extension.ExtensionContext
+import no.nav.etterlatte.ResetDatabaseStatement
 
-/**
- * Det tar veldig mye tid å kjøre opp stadig nye Postgres-containere og kjøre Flyway migreringer.
- * Denne extensionen kjører opp èn instans, som så gjenbrukes av de som måtte ønske det.
- */
-object DatabaseExtension : BeforeAllCallback, AfterAllCallback, ExtensionContext.Store.CloseableResource {
-    override fun beforeAll(context: ExtensionContext) {
-        GenerellDatabaseExtension.beforeAll(context)
-    }
-
-    override fun afterAll(context: ExtensionContext) {
-        GenerellDatabaseExtension.afterAll(RESET_DATABASE)
-    }
-
-    override fun close() {
-        GenerellDatabaseExtension.close()
-    }
-
-    val dataSource = GenerellDatabaseExtension.dataSource
-
-    private const val RESET_DATABASE = """
-                    TRUNCATE hendelse CASCADE;
-                    TRUNCATE jobb CASCADE;
-                    ALTER SEQUENCE jobb_id_seq RESTART WITH 1;
-                    """
-
-    fun resetDb() = GenerellDatabaseExtension.resetDb(RESET_DATABASE.trimIndent())
-}
+@ResetDatabaseStatement(
+    """
+    TRUNCATE hendelse CASCADE;
+    TRUNCATE jobb CASCADE;
+    ALTER SEQUENCE jobb_id_seq RESTART WITH 1;
+""",
+)
+class DatabaseExtension : GenerellDatabaseExtension()

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/HendelsePollerIntegrationTest.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/HendelsePollerIntegrationTest.kt
@@ -13,10 +13,9 @@ import javax.sql.DataSource
 
 @ExtendWith(DatabaseExtension::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class HendelsePollerIntegrationTest {
+class HendelsePollerIntegrationTest(dataSource: DataSource) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    private val dataSource: DataSource = DatabaseExtension.dataSource
     private val hendelseDao = HendelseDao(dataSource)
     private val jobbTestdata = JobbTestdata(dataSource, hendelseDao)
     private val hendelsePoller =

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/HendelseRiverTest.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/HendelseRiverTest.kt
@@ -18,8 +18,7 @@ import kotlin.random.Random
 
 @ExtendWith(DatabaseExtension::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class HendelseRiverTest {
-    private val dataSource: DataSource = DatabaseExtension.dataSource
+class HendelseRiverTest(dataSource: DataSource) {
     private val hendelseDao = HendelseDao(dataSource)
     private val jobbTestdata = JobbTestdata(dataSource, hendelseDao)
 

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/JobbPollerIntegrationTest.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/JobbPollerIntegrationTest.kt
@@ -7,16 +7,19 @@ import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.time.LocalDate
 import java.time.Month
 import java.time.YearMonth
 import javax.sql.DataSource
 
-@ExtendWith(DatabaseExtension::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class JobbPollerIntegrationTest {
-    private val dataSource: DataSource = DatabaseExtension.dataSource
+class JobbPollerIntegrationTest(dataSource: DataSource) {
+    companion object {
+        @RegisterExtension
+        private val dbExtension = DatabaseExtension()
+    }
+
     private val aldersovergangerService = mockk<AldersovergangerService>()
     private val hendelseDao = HendelseDao(dataSource)
     private val jobbTestdata = JobbTestdata(dataSource, hendelseDao)
@@ -25,7 +28,7 @@ class JobbPollerIntegrationTest {
     @AfterEach
     fun afterEach() {
         clearAllMocks()
-        DatabaseExtension.resetDb()
+        dbExtension.resetDb()
     }
 
     @Test

--- a/libs/etterlatte-database/src/testFixtures/kotlin/no/nav/etterlatte/GenerellDatabaseExtension.kt
+++ b/libs/etterlatte-database/src/testFixtures/kotlin/no/nav/etterlatte/GenerellDatabaseExtension.kt
@@ -4,8 +4,10 @@ import com.zaxxer.hikari.HikariDataSource
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.database.POSTGRES_VERSION
 import no.nav.etterlatte.libs.database.migrate
+import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.ExtensionContext
-import org.junit.jupiter.api.extension.ExtensionContext.Namespace.GLOBAL
+import org.junit.jupiter.api.extension.ParameterContext
+import org.junit.jupiter.api.extension.ParameterResolver
 import org.slf4j.LoggerFactory
 import org.testcontainers.containers.PostgreSQLContainer
 import java.io.PrintWriter
@@ -13,32 +15,35 @@ import java.sql.Connection
 import java.util.logging.Logger
 import javax.sql.DataSource
 
-object GenerellDatabaseExtension {
-    private val logger: org.slf4j.Logger = LoggerFactory.getLogger(this::class.java)
+/**
+ * Det tar veldig mye tid å kjøre opp stadig nye Postgres-containere og kjøre Flyway migreringer.
+ * Denne extensionen kjører opp èn instans, som så gjenbrukes av de som måtte ønske det.
+ * <p>
+ * Benytt @ResetDatabaseStatement i en subklasse for å angi SQL for å tømme databasen.
+ */
+open class GenerellDatabaseExtension : AfterAllCallback, ExtensionContext.Store.CloseableResource, ParameterResolver {
+    companion object {
+        val logger: org.slf4j.Logger = LoggerFactory.getLogger(this::class.java)
+        val postgreSQLContainer =
+            PostgreSQLContainer<Nothing>("postgres:$POSTGRES_VERSION")
+                .also { logger.info("Starting shared Postgres testcontainer") }
+                .also { it.start() }
 
-    val postgreSQLContainer =
-        PostgreSQLContainer<Nothing>("postgres:$POSTGRES_VERSION")
-            .also { logger.info("Starting shared Postgres testcontainer") }
-            .also { it.start() }
-
-    private val ds: DataSource =
-        DataSourceBuilder.createDataSource(
-            jdbcUrl = postgreSQLContainer.jdbcUrl,
-            username = postgreSQLContainer.username,
-            password = postgreSQLContainer.password,
-        ).apply { migrate() }
+        val ds: DataSource =
+            DataSourceBuilder.createDataSource(
+                jdbcUrl = postgreSQLContainer.jdbcUrl,
+                username = postgreSQLContainer.username,
+                password = postgreSQLContainer.password,
+            ).apply { migrate() }
+    }
 
     private val connections = mutableListOf<Connection>()
-
-    fun beforeAll(context: ExtensionContext) {
-        context.root.getStore(GLOBAL).put("postgres-testdb", this)
-    }
 
     /**
      * Ikke gå tom for tilkoblinger, så kast ut alle som er ferdige med jobben sin
      */
-    fun afterAll(resetDatabase: String) {
-        resetDb(resetDatabase)
+    override fun afterAll(context: ExtensionContext) {
+        resetDb()
 
         connections.forEach {
             (ds as HikariDataSource).evictConnection(it)
@@ -46,25 +51,34 @@ object GenerellDatabaseExtension {
         connections.clear()
     }
 
-    val dataSource: DataSource
+    private val dataSource: DataSource
         get() = DataSourceWrapper(ds, connections::add)
 
     /**
      * Trigges av rammeverket når siste testinstans er kjørt.
      */
-    fun close() {
+    override fun close() {
         logger.info("Stopping shared Postgres testcontainer")
         postgreSQLContainer.stop()
     }
 
     /**
-     * Sikre at hver testklasse starter med en fresh database, i det minste for sentrale tabeller
+     * Sikre at hver testklasse starter med en fresh database
      */
-    fun resetDb(sql: String) {
-        logger.info("Resetting database...")
-        dataSource.connection.use {
-            it.prepareStatement(sql.trimIndent()).execute()
-        }
+    fun resetDb() {
+        (
+            this::class.java.annotations
+                .find { it.annotationClass == ResetDatabaseStatement::class } as? ResetDatabaseStatement
+        )
+            ?.let { annotation ->
+                ds.connection.use {
+                    logger.info("Resetting database...")
+                    it.createStatement().execute(annotation.statement)
+                }
+            }
+            ?: {
+                logger.info("Skipper reset av database, @ResetDatabaseStatement ikke funnet.")
+            }
     }
 
     /**
@@ -96,4 +110,26 @@ object GenerellDatabaseExtension {
             password: String?,
         ): Connection = datasource.getConnection(username, password).also { collector.invoke(it) }
     }
+
+    override fun supportsParameter(
+        parameterContext: ParameterContext,
+        extensionContext: ExtensionContext,
+    ): Boolean {
+        return parameterContext.parameter?.type == DataSource::class.java
+    }
+
+    override fun resolveParameter(
+        parameterContext: ParameterContext,
+        extensionContext: ExtensionContext,
+    ): Any {
+        return if (parameterContext.parameter?.type == DataSource::class.java) {
+            dataSource
+        } else {
+            throw IllegalArgumentException("Kan ikke resolve parameter av type ${parameterContext.parameter?.type}")
+        }
+    }
 }
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+annotation class ResetDatabaseStatement(val statement: String)


### PR DESCRIPTION
- unngå å ha selve extensionen som object/singleton
- konfigurering av reset sql via annotasjon
  - ikke veldig mye jobb å gjøre dette som annotasjon på selve testklassen, men da må man jo selvfølgelig angi det pr testklasse  
- injisering av database som constructor param i testklassene

Erstatter #3734