### PR TITLE
Oppgraderer til nyaste versjon av kafka-avro-serializer, satsar på at…

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ jackson-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xm
 
 kafka-clients = { module = "org.apache.kafka:kafka-clients", version = "3.6.1" }
 kafka-avro = { module = "org.apache.avro:avro", version = "1.11.3" }
-kafka-avroserializer = { module = "io.confluent:kafka-avro-serializer", version = "7.5.1" }
+kafka-avroserializer = { module = "io.confluent:kafka-avro-serializer", version = "7.6.0" }
 kafka-embeddedenv = { module = "no.nav:kafka-embedded-env", version = "3.2.4" }
 el-api = { module = "javax.el:javax.el-api", version = "3.0.0"}
 el-impl = { module = "org.glassfish:jakarta.el", version = "3.0.4" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ jackson-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xm
 kafka-clients = { module = "org.apache.kafka:kafka-clients", version = "3.6.1" }
 kafka-avro = { module = "org.apache.avro:avro", version = "1.11.3" }
 kafka-avroserializer = { module = "io.confluent:kafka-avro-serializer", version = "7.6.0" }
-kafka-embeddedenv = { module = "no.nav:kafka-embedded-env", version = "3.2.4" }
+kafka-embeddedenv = { module = "no.nav:kafka-embedded-env", version = "3.2.5" }
 el-api = { module = "javax.el:javax.el-api", version = "3.0.0"}
 el-impl = { module = "org.glassfish:jakarta.el", version = "3.0.4" }
 


### PR DESCRIPTION
… dei har retta ein del sårbarheiter no.

Matchande PR i felles: https://github.com/navikt/pensjon-etterlatte-felles/pull/203

Da eg sjekka ståa i [EY-3454](https://jira.adeo.no/browse/EY-3454), var sårbarheitene i hendelser-pdl, hendelser-joark og  notifikasjoner pga transitive avhengnadar frå dette biblioteket. Vil vera fint å få det ut av verda.