### PR TITLE
Endre på ordlyd etter ønske fra flere saksbehandlere

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/OppdaterJournalpost.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/OppdaterJournalpost.tsx
@@ -14,7 +14,7 @@ import { EndreBruker } from '~components/person/journalfoeringsoppgave/journalpo
 import { EndreAvsenderMottaker } from '~components/person/journalfoeringsoppgave/journalpost/EndreAvsenderMottaker'
 import { EndreSak } from '~components/person/journalfoeringsoppgave/journalpost/EndreSak'
 import { EndreDokumenter } from '~components/person/journalfoeringsoppgave/journalpost/EndreDokumenter'
-import FerdigstillJournalpostModal from '~components/person/journalfoeringsoppgave/journalpost/modal/FerdigstillJournalpostModal'
+import JournalfoerJournalpostModal from '~components/person/journalfoeringsoppgave/journalpost/modal/JournalfoerJournalpostModal'
 import LagreJournalpostModal from '~components/person/journalfoeringsoppgave/journalpost/modal/LagreJournalpostModal'
 import { EndreTittelJournalpost } from '~components/person/journalfoeringsoppgave/journalpost/EndreTittelJournalpost'
 
@@ -85,7 +85,7 @@ export const OppdaterJournalpost = ({ initialJournalpost, oppgaveId, sak }: Prop
           <FlexRow justify="center" $spacing>
             <LagreJournalpostModal journalpost={journalpost} oppgaveId={oppgaveId} />
 
-            <FerdigstillJournalpostModal journalpost={journalpost} sak={sak} />
+            <JournalfoerJournalpostModal journalpost={journalpost} sak={sak} />
           </FlexRow>
           <FlexRow justify="center">
             <AvbrytBehandleJournalfoeringOppgave />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/modal/JournalfoerJournalpostModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/modal/JournalfoerJournalpostModal.tsx
@@ -18,7 +18,7 @@ interface ModalProps {
   sak: ISak
 }
 
-export default function FerdigstillJournalpostModal({ journalpost, sak }: ModalProps) {
+export default function JournalfoerJournalpostModal({ journalpost, sak }: ModalProps) {
   const [open, setOpen] = useState(false)
 
   const [oppdaterStatus, apiOppdaterJournalpost] = useApiCall(oppdaterJournalpost)
@@ -37,23 +37,23 @@ export default function FerdigstillJournalpostModal({ journalpost, sak }: ModalP
         onClick={() => setOpen(true)}
         disabled={!sak?.id || !sak?.sakType || !temaTilhoererGjenny(journalpost)}
       >
-        Ferdigstill
+        Journalfør
       </Button>
 
       <Modal open={open} aria-labelledby="modal-heading" onClose={() => setOpen(false)}>
         <Modal.Body>
           <Heading size="medium" id="modal-heading" spacing>
-            Ferdigstill journalpost
+            Journalfør
           </Heading>
 
           {kanFerdigstilles ? (
             <BodyLong spacing>
-              Du ferdigstiller nå journalposten. Denne handlingen kan ikke angres. <br />
-              Er du sikker på at du vil ferdigstille?
+              Du journalfører nå journalposten. Denne handlingen kan ikke angres. <br />
+              Er du sikker på at du vil fortsette?
             </BodyLong>
           ) : (
             <Alert variant="error">
-              <strong>Kan ikke ferdigstille journalpost</strong>
+              <strong>Kan ikke journalføre før følgende er fikset: </strong>
               <ul>
                 {feilmeldinger.map((e, i) => (
                   <li key={`feilmelding-${i}`}>{e}</li>
@@ -65,7 +65,7 @@ export default function FerdigstillJournalpostModal({ journalpost, sak }: ModalP
           <br />
 
           {isSuccess(oppdaterStatus) ? (
-            <Alert variant="success">Journalpost ferdigstilt. Laster siden på nytt...</Alert>
+            <Alert variant="success">Journalpost journalført ok! Laster siden på nytt...</Alert>
           ) : (
             <FlexRow justify="center">
               <Button variant="secondary" onClick={() => setOpen(false)} disabled={isPending(oppdaterStatus)}>
@@ -77,14 +77,14 @@ export default function FerdigstillJournalpostModal({ journalpost, sak }: ModalP
                 loading={isPending(oppdaterStatus)}
                 disabled={!kanFerdigstilles}
               >
-                Ja, ferdigstill
+                Ja, journalfør
               </Button>
             </FlexRow>
           )}
 
           {mapFailure(oppdaterStatus, (error) => (
             <Modal.Footer>
-              <ApiErrorAlert>{error.detail || 'Det oppsto en feil ved ferdigstilling av journalposten'}</ApiErrorAlert>
+              <ApiErrorAlert>{error.detail || 'Det oppsto en feil ved journalføring av journalposten'}</ApiErrorAlert>
             </Modal.Footer>
           ))}
         </Modal.Body>


### PR DESCRIPTION
Fått tilbakemelding fra flere at "ferdigstill" er litt forvirrende, siden det også brukes om oppgave (ferdigstill oppgave). 

Endrer derfor til "journalfør" slik at det blir likt som i Gosys. 