### PR TITLE
EY-3304 Endre språk/målform i brev

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
@@ -20,6 +20,7 @@ import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
 import no.nav.etterlatte.brev.model.ManueltBrevData
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Slate
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.common.brev.BestillingsIdDto
 import no.nav.etterlatte.libs.common.brev.JournalpostIdDto
@@ -81,6 +82,16 @@ fun Route.brevRoute(
                 val request = call.receive<OppdaterTittelRequest>()
 
                 service.oppdaterTittel(brevId, request.tittel)
+
+                call.respond(HttpStatusCode.OK)
+            }
+        }
+
+        post("spraak") {
+            withSakId(tilgangssjekker, skrivetilgang = true) {
+                val request = call.receive<OppdaterSpraakRequest>()
+
+                service.oppdaterSpraak(brevId, request.spraak)
 
                 call.respond(HttpStatusCode.OK)
             }
@@ -197,4 +208,8 @@ data class OppdaterMottakerRequest(
 
 data class OppdaterTittelRequest(
     val tittel: String,
+)
+
+data class OppdaterSpraakRequest(
+    val spraak: Spraak,
 )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -12,6 +12,7 @@ import no.nav.etterlatte.brev.model.ManueltBrevMedTittelData
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Slate
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
@@ -99,6 +100,16 @@ class BrevService(
         sjekkOmBrevKanEndres(id)
         return db.oppdaterTittel(id, tittel)
             .also { logger.info("Tittel på brev (id=$id) oppdatert") }
+    }
+
+    suspend fun oppdaterSpraak(
+        id: BrevID,
+        spraak: Spraak,
+    ) {
+        sjekkOmBrevKanEndres(id)
+
+        db.oppdaterSpraak(id, spraak)
+            .also { logger.info("Språk i brev (id=$id) endret til $spraak") }
     }
 
     suspend fun genererPdf(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -20,6 +20,7 @@ import no.nav.etterlatte.brev.model.BrevkodeRequest
 import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.OpprettNyttBrev
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
@@ -115,6 +116,8 @@ class Brevoppretter(
         automatiskMigreringRequest: MigreringBrevRequest? = null,
         brevDataMapping: suspend (RedigerbarTekstRequest) -> BrevData,
     ): BrevService.BrevPayload {
+        val spraak = db.hentBrevInnhold(brevId)?.spraak
+
         with(
             hentInnData(
                 sakId,
@@ -123,6 +126,7 @@ class Brevoppretter(
                 brevKode,
                 automatiskMigreringRequest,
                 brevDataMapping,
+                spraak,
             ),
         ) {
             if (innhold.payload != null) {
@@ -147,9 +151,10 @@ class Brevoppretter(
         brevKode: (b: BrevkodeRequest) -> EtterlatteBrevKode,
         automatiskMigreringRequest: MigreringBrevRequest? = null,
         brevDataMapping: suspend (RedigerbarTekstRequest) -> BrevData,
+        overstyrSpraak: Spraak? = null,
     ): OpprettBrevRequest {
         val generellBrevData =
-            retryOgPakkUt { brevdataFacade.hentGenerellBrevData(sakId, behandlingId, bruker) }
+            retryOgPakkUt { brevdataFacade.hentGenerellBrevData(sakId, behandlingId, overstyrSpraak, bruker) }
 
         val brevkodeRequest =
             BrevkodeRequest(
@@ -178,7 +183,7 @@ class Brevoppretter(
             val innholdVedlegg = async { redigerbartVedleggHenter.hentInitiellPayloadVedlegg(bruker, generellBrevData) }
             OpprettBrevRequest(
                 generellBrevData,
-                BrevInnhold(tittel, generellBrevData.spraak, innhold.await()),
+                BrevInnhold(tittel, overstyrSpraak ?: generellBrevData.spraak, innhold.await()),
                 innholdVedlegg.await(),
             )
         }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -181,9 +181,10 @@ class Brevoppretter(
                 }
 
             val innholdVedlegg = async { redigerbartVedleggHenter.hentInitiellPayloadVedlegg(bruker, generellBrevData) }
+
             OpprettBrevRequest(
                 generellBrevData,
-                BrevInnhold(tittel, overstyrSpraak ?: generellBrevData.spraak, innhold.await()),
+                BrevInnhold(tittel, generellBrevData.spraak, innhold.await()),
                 innholdVedlegg.await(),
             )
         }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
@@ -72,7 +72,7 @@ class PDFGenerator(
         }
 
         val generellBrevData =
-            retryOgPakkUt { brevDataFacade.hentGenerellBrevData(brev.sakId, brev.behandlingId, bruker) }
+            retryOgPakkUt { brevDataFacade.hentGenerellBrevData(brev.sakId, brev.behandlingId, brev.spraak, bruker) }
         val avsender = adresseService.hentAvsender(avsenderRequest(bruker, generellBrevData))
 
         val brevkodePar =

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
@@ -61,7 +61,7 @@ class BrevdataFacade(
     suspend fun hentGenerellBrevData(
         sakId: Long,
         behandlingId: UUID?,
-        spraak: Spraak? = null,
+        overstyrSpraak: Spraak? = null,
         brukerTokenInfo: BrukerTokenInfo,
     ): GenerellBrevData {
         return coroutineScope {
@@ -106,6 +106,7 @@ class BrevdataFacade(
                     null
                 }
             val systemkilde = behandling?.kilde ?: Vedtaksloesning.GJENNY // Dette kan være en pesys-sak
+            val spraak = overstyrSpraak ?: grunnlag.mapSpraak()
 
             when (vedtak?.type) {
                 VedtakType.INNVILGELSE,
@@ -130,7 +131,7 @@ class BrevdataFacade(
                                     virkningstidspunkt = vedtakInnhold.virkningstidspunkt,
                                     revurderingInfo = vedtakInnhold.behandling.revurderingInfo,
                                 ),
-                            spraak = spraak ?: grunnlag.mapSpraak(),
+                            spraak = spraak,
                             revurderingsaarsak = vedtakInnhold.behandling.revurderingsaarsak,
                             systemkilde = systemkilde,
                             utlandstilknytning = behandling?.utlandstilknytning,
@@ -156,7 +157,7 @@ class BrevdataFacade(
                                         (vedtak.innhold as VedtakInnholdDto.VedtakTilbakekrevingDto).tilbakekreving.toJson(),
                                     ),
                             ),
-                        spraak = grunnlag.mapSpraak(),
+                        spraak = spraak,
                         systemkilde = systemkilde,
                     )
 
@@ -179,7 +180,7 @@ class BrevdataFacade(
                                         (vedtak.innhold as VedtakInnholdDto.Klage).klage.toJson(),
                                     ),
                             ),
-                        spraak = grunnlag.mapSpraak(),
+                        spraak = spraak,
                         systemkilde = systemkilde,
                     )
 
@@ -189,7 +190,7 @@ class BrevdataFacade(
                         personerISak = personerISak,
                         behandlingId = behandlingId,
                         forenkletVedtak = null,
-                        spraak = grunnlag.mapSpraak(),
+                        spraak = spraak,
                         systemkilde = systemkilde,
                         utlandstilknytning = behandling?.utlandstilknytning,
                     )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
@@ -19,6 +19,7 @@ import no.nav.etterlatte.brev.behandling.mapSpraak
 import no.nav.etterlatte.brev.behandling.mapVerge
 import no.nav.etterlatte.brev.behandlingklient.BehandlingKlient
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.IntBroek
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
@@ -60,6 +61,7 @@ class BrevdataFacade(
     suspend fun hentGenerellBrevData(
         sakId: Long,
         behandlingId: UUID?,
+        spraak: Spraak? = null,
         brukerTokenInfo: BrukerTokenInfo,
     ): GenerellBrevData {
         return coroutineScope {
@@ -128,7 +130,7 @@ class BrevdataFacade(
                                     virkningstidspunkt = vedtakInnhold.virkningstidspunkt,
                                     revurderingInfo = vedtakInnhold.behandling.revurderingInfo,
                                 ),
-                            spraak = grunnlag.mapSpraak(),
+                            spraak = spraak ?: grunnlag.mapSpraak(),
                             revurderingsaarsak = vedtakInnhold.behandling.revurderingsaarsak,
                             systemkilde = systemkilde,
                             utlandstilknytning = behandling?.utlandstilknytning,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.brev.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import no.nav.etterlatte.brev.adresse.RegoppslagResponseDTO
-import no.nav.etterlatte.brev.distribusjon.BestillingsID
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
@@ -94,14 +93,13 @@ data class Brev(
     val sakId: Long,
     val behandlingId: UUID?,
     val tittel: String?,
+    val spraak: Spraak,
     val prosessType: BrevProsessType,
     val soekerFnr: String,
     val status: Status,
     val statusEndret: Tidspunkt,
     val opprettet: Tidspunkt,
     val mottaker: Mottaker,
-    val journalpostId: String? = null,
-    val bestillingsID: BestillingsID? = null,
     val brevtype: Brevtype,
 ) {
     fun kanEndres() = status in listOf(Status.OPPRETTET, Status.OPPDATERT)
@@ -115,6 +113,7 @@ data class Brev(
             sakId = opprettNyttBrev.sakId,
             behandlingId = opprettNyttBrev.behandlingId,
             tittel = opprettNyttBrev.innhold.tittel,
+            spraak = opprettNyttBrev.innhold.spraak,
             prosessType = opprettNyttBrev.prosessType,
             soekerFnr = opprettNyttBrev.soekerFnr,
             status = opprettNyttBrev.status,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
@@ -30,6 +30,7 @@ import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Slate
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.ktor.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.runServer
@@ -217,6 +218,7 @@ internal class BrevRouteTest {
             sakId = 41,
             behandlingId = null,
             tittel = null,
+            spraak = Spraak.NB,
             prosessType = BrevProsessType.AUTOMATISK,
             soekerFnr = "soeker_fnr",
             status = Status.OPPRETTET,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
@@ -21,6 +21,7 @@ import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Slate
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.token.BrukerTokenInfo
@@ -245,6 +246,7 @@ internal class BrevServiceTest {
         sakId = Random.nextLong(10000),
         behandlingId = behandlingId,
         tittel = null,
+        spraak = Spraak.NB,
         prosessType = prosessType,
         soekerFnr = "fnr",
         status = status,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevdistribuererTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevdistribuererTest.kt
@@ -15,6 +15,7 @@ import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
@@ -50,7 +51,7 @@ class BrevdistribuererTest {
                 journalpostId,
                 DistribusjonsType.ANNET,
                 DistribusjonsTidspunktType.KJERNETID,
-                brev.mottaker!!.adresse,
+                brev.mottaker.adresse,
             )
         }
     }
@@ -100,6 +101,7 @@ class BrevdistribuererTest {
         sakId = Random.nextLong(10000),
         behandlingId = null,
         tittel = null,
+        spraak = Spraak.NB,
         prosessType = prosessType,
         soekerFnr = "fnr",
         status = status,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
@@ -18,6 +18,7 @@ import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -126,6 +127,7 @@ class JournalfoerBrevServiceTest {
                 41,
                 BEHANDLING_ID,
                 "tittel",
+                spraak = Spraak.NB,
                 BrevProsessType.AUTOMATISK,
                 "fnr",
                 Status.JOURNALFOERT,
@@ -156,6 +158,7 @@ class JournalfoerBrevServiceTest {
                 sakId = 41,
                 behandlingId = null,
                 tittel = null,
+                spraak = Spraak.NB,
                 prosessType = BrevProsessType.AUTOMATISK,
                 soekerFnr = "soeker_fnr",
                 status = Status.FERDIGSTILT,
@@ -225,6 +228,7 @@ class JournalfoerBrevServiceTest {
                 sakId = 41,
                 behandlingId = null,
                 tittel = null,
+                spraak = Spraak.NB,
                 prosessType = BrevProsessType.AUTOMATISK,
                 soekerFnr = "soeker_fnr1",
                 status = Status.FERDIGSTILT,
@@ -289,6 +293,7 @@ class JournalfoerBrevServiceTest {
         sakId = Random.nextLong(10000),
         behandlingId = null,
         tittel = null,
+        spraak = Spraak.NB,
         prosessType = prosessType,
         soekerFnr = "fnr",
         status = status,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
@@ -27,6 +27,7 @@ import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Pdf
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.ktor.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.runServer
@@ -232,6 +233,7 @@ internal class VedtaksbrevRouteTest {
             41,
             BEHANDLING_ID,
             "tittel",
+            Spraak.NB,
             BrevProsessType.AUTOMATISK,
             "soeker_fnr",
             Status.OPPRETTET,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -35,6 +35,7 @@ import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
 import no.nav.etterlatte.brev.model.BrevDataMapperFerdigstillingVedtak
 import no.nav.etterlatte.brev.model.BrevDataMapperRedigerbartUtfallVedtak
+import no.nav.etterlatte.brev.model.BrevInnhold
 import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
 import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
 import no.nav.etterlatte.brev.model.BrevProsessType
@@ -213,7 +214,7 @@ internal class VedtaksbrevServiceTest {
             val mottaker = opprettMottaker()
 
             every { db.hentBrevForBehandling(behandling.behandlingId!!, Brevtype.VEDTAK) } returns emptyList()
-            coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any()) } returns behandling
+            coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any(), any()) } returns behandling
             coEvery { adresseService.hentAvsender(any()) } returns opprettAvsender()
             coEvery { adresseService.hentMottakerAdresse(any(), any()) } returns mottaker
             coEvery { brevbakerService.hentRedigerbarTekstFraBrevbakeren(any()) } returns Slate(emptyList())
@@ -239,7 +240,7 @@ internal class VedtaksbrevServiceTest {
 
             coVerify {
                 db.hentBrevForBehandling(BEHANDLING_ID, Brevtype.VEDTAK)
-                brevdataFacade.hentGenerellBrevData(sakId, BEHANDLING_ID, any())
+                brevdataFacade.hentGenerellBrevData(sakId, BEHANDLING_ID, null, any())
                 adresseService.hentMottakerAdresse(sakType, behandling.personerISak.innsender!!.fnr.value)
             }
 
@@ -277,7 +278,7 @@ internal class VedtaksbrevServiceTest {
 
             coEvery { brevbakerService.hentRedigerbarTekstFraBrevbakeren(any()) } returns opprettRenderedJsonLetter()
             every { db.hentBrevForBehandling(behandling.behandlingId!!, Brevtype.VEDTAK) } returns emptyList()
-            coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any()) } returns behandling
+            coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any(), any()) } returns behandling
             coEvery { adresseService.hentMottakerAdresse(sakType, any()) } returns mottaker
             coEvery { brevdataFacade.finnUtbetalingsinfo(any(), any(), any(), any()) } returns utbetalingsinfo
             coEvery { brevdataFacade.hentEtterbetaling(any(), any()) } returns null
@@ -298,7 +299,7 @@ internal class VedtaksbrevServiceTest {
 
             coVerify {
                 db.hentBrevForBehandling(BEHANDLING_ID, Brevtype.VEDTAK)
-                brevdataFacade.hentGenerellBrevData(sakId, BEHANDLING_ID, any())
+                brevdataFacade.hentGenerellBrevData(sakId, BEHANDLING_ID, null, any())
                 adresseService.hentMottakerAdresse(sakType, behandling.personerISak.innsender!!.fnr.value)
                 brevbakerService.hentRedigerbarTekstFraBrevbakeren(any())
             }
@@ -357,7 +358,7 @@ internal class VedtaksbrevServiceTest {
             val mottaker = opprettMottaker()
 
             every { db.hentBrevForBehandling(behandling.behandlingId!!, Brevtype.VEDTAK) } returns listOf()
-            coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any()) } returns behandling
+            coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any(), any()) } returns behandling
             coEvery { adresseService.hentMottakerAdresse(any(), any()) } returns mottaker
 
             coEvery { brevdataFacade.hentBehandling(any(), any()) } returns
@@ -489,7 +490,7 @@ internal class VedtaksbrevServiceTest {
 
             val brev = opprettBrev(Status.OPPRETTET, BrevProsessType.REDIGERBAR)
             every { db.hentBrev(any()) } returns brev
-            coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any()) } returns behandling
+            coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any(), any()) } returns behandling
             coEvery { adresseService.hentAvsender(any()) } returns opprettAvsender()
             coEvery { brevbakerService.genererPdf(any(), any()) } returns opprettBrevbakerResponse()
             coEvery { brevDataMapperFerdigstilling.brevDataFerdigstilling(any()) } returns ManueltBrevDataTest()
@@ -503,7 +504,7 @@ internal class VedtaksbrevServiceTest {
             }
 
             coVerify {
-                brevdataFacade.hentGenerellBrevData(brev.sakId, brev.behandlingId!!, SAKSBEHANDLER)
+                brevdataFacade.hentGenerellBrevData(brev.sakId, brev.behandlingId!!, brev.spraak, SAKSBEHANDLER)
                 adresseService.hentAvsender(any())
                 brevbakerService.genererPdf(any(), any())
             }
@@ -516,7 +517,7 @@ internal class VedtaksbrevServiceTest {
 
             val brev = opprettBrev(Status.OPPRETTET, BrevProsessType.REDIGERBAR)
             every { db.hentBrev(any()) } returns brev
-            coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any()) } returns behandling
+            coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any(), any()) } returns behandling
             coEvery { adresseService.hentAvsender(any()) } returns opprettAvsender()
             coEvery { brevbakerService.genererPdf(any(), any()) } returns opprettBrevbakerResponse()
             coEvery { brevDataMapperFerdigstilling.brevDataFerdigstilling(any()) } returns ManueltBrevDataTest()
@@ -531,7 +532,7 @@ internal class VedtaksbrevServiceTest {
             }
 
             coVerify {
-                brevdataFacade.hentGenerellBrevData(brev.sakId, brev.behandlingId!!, ATTESTANT)
+                brevdataFacade.hentGenerellBrevData(brev.sakId, brev.behandlingId!!, brev.spraak, ATTESTANT)
                 adresseService.hentAvsender(any())
                 brevbakerService.genererPdf(any(), any())
             }
@@ -544,7 +545,7 @@ internal class VedtaksbrevServiceTest {
 
             val brev = opprettBrev(Status.OPPRETTET, BrevProsessType.REDIGERBAR)
             every { db.hentBrev(any()) } returns brev
-            coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any()) } returns behandling
+            coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any(), any()) } returns behandling
             coEvery { adresseService.hentAvsender(any()) } returns opprettAvsender()
             coEvery { brevbakerService.genererPdf(any(), any()) } returns opprettBrevbakerResponse()
             coEvery { brevDataMapperFerdigstilling.brevDataFerdigstilling(any()) } returns ManueltBrevDataTest()
@@ -558,7 +559,7 @@ internal class VedtaksbrevServiceTest {
             }
 
             coVerify {
-                brevdataFacade.hentGenerellBrevData(brev.sakId, brev.behandlingId!!, SAKSBEHANDLER)
+                brevdataFacade.hentGenerellBrevData(brev.sakId, brev.behandlingId!!, behandling.spraak, SAKSBEHANDLER)
                 adresseService.hentAvsender(any())
                 brevbakerService.genererPdf(any(), any())
             }
@@ -575,14 +576,16 @@ internal class VedtaksbrevServiceTest {
             val tomPayload = Slate(listOf(Slate.Element(Slate.ElementType.PARAGRAPH)))
 
             every { db.hentBrev(any()) } returns brev
-            coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any()) } returns behandling
+            every { db.hentBrevInnhold(any()) } returns BrevInnhold("Tittel", Spraak.NB, Slate(emptyList()))
+            coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any(), any()) } returns behandling
             coEvery { brevdataFacade.hentBrevutfall(any(), any()) } returns
                 mockk<BrevutfallDto> {
                     every { feilutbetaling?.valg } returns FeilutbetalingValg.JA_VARSEL
                 }
             coEvery { brevbakerService.hentRedigerbarTekstFraBrevbakeren(any()) } returnsMany
                 listOf(
-                    opprettOpphoerPayload(), opprettVedleggPayload(),
+                    opprettOpphoerPayload(),
+                    opprettVedleggPayload(),
                 )
 
             runBlocking {
@@ -604,6 +607,7 @@ internal class VedtaksbrevServiceTest {
                 )
 
             verify {
+                db.hentBrevInnhold(brev.id)
                 db.oppdaterPayload(brev.id, opphoerPayload)
                 db.oppdaterPayload(brev.id, tomPayload)
                 db.oppdaterPayloadVedlegg(brev.id, listOf(vedleggPayload(opprettVedleggPayload())))
@@ -611,7 +615,7 @@ internal class VedtaksbrevServiceTest {
             }
 
             coVerify {
-                brevdataFacade.hentGenerellBrevData(brev.sakId, brev.behandlingId!!, SAKSBEHANDLER)
+                brevdataFacade.hentGenerellBrevData(brev.sakId, brev.behandlingId!!, behandling.spraak, SAKSBEHANDLER)
                 brevbakerService.hentRedigerbarTekstFraBrevbakeren(any())
             }
         }
@@ -653,6 +657,7 @@ internal class VedtaksbrevServiceTest {
         sakId = Random.nextLong(10000),
         behandlingId = BEHANDLING_ID,
         tittel = "tittel",
+        spraak = Spraak.NB,
         prosessType = prosessType,
         soekerFnr = "fnr",
         status = status,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivServiceTest.kt
@@ -66,6 +66,7 @@ internal class DokarkivServiceTest {
                 sakId = sakId,
                 behandlingId = null,
                 tittel = null,
+                spraak = Spraak.NB,
                 prosessType = BrevProsessType.AUTOMATISK,
                 soekerFnr = "soeker_fnr",
                 status = Status.OPPRETTET,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
@@ -56,11 +56,7 @@ class VarselbrevTest {
         val brevdataFacade =
             mockk<BrevdataFacade>().also {
                 coEvery {
-                    it.hentGenerellBrevData(
-                        sak.id,
-                        any(),
-                        any(),
-                    )
+                    it.hentGenerellBrevData(sak.id, any(), any(), any())
                 } returns
                     mockk<GenerellBrevData>().also {
                         every { it.vedtakstype() } returns ""

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiverTest.kt
@@ -17,6 +17,7 @@ import no.nav.etterlatte.brev.dokarkiv.OpprettJournalpostResponse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Brevtype
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -63,6 +64,7 @@ internal class JournalfoerVedtaksbrevRiverTest {
                 41,
                 BEHANDLING_ID,
                 "tittel",
+                Spraak.NB,
                 BrevProsessType.AUTOMATISK,
                 "fnr",
                 Status.FERDIGSTILT,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
@@ -11,6 +11,7 @@ import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Brevtype
 import no.nav.etterlatte.brev.model.Mottaker
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
@@ -135,6 +136,7 @@ internal class OpprettJournalfoerOgDistribuer {
             sakId = 1L,
             behandlingId = behandlingId,
             tittel = "tittel",
+            spraak = Spraak.NB,
             prosessType = BrevProsessType.AUTOMATISK,
             soekerFnr = "123",
             status = Status.FERDIGSTILT,
@@ -142,7 +144,7 @@ internal class OpprettJournalfoerOgDistribuer {
             Tidspunkt.now(),
             mottaker =
                 Mottaker(
-                    "Marte Kirkerud",
+                    "Langsom Hest",
                     mockk(),
                     null,
                     Adresse(adresseType = "privat", landkode = "NO", land = "Norge"),

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettVarselbrevForGjenopprettaRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettVarselbrevForGjenopprettaRiverTest.kt
@@ -11,6 +11,7 @@ import no.nav.etterlatte.brev.brevbaker.Brevkoder
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Brevtype
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.brev.varselbrev.VarselbrevResponse
 import no.nav.etterlatte.brev.varselbrev.VarselbrevService
@@ -80,6 +81,7 @@ internal class OpprettVarselbrevForGjenopprettaRiverTest {
             saksnr,
             behandlingId,
             "tittel",
+            Spraak.NB,
             BrevProsessType.AUTOMATISK,
             "fnr",
             Status.FERDIGSTILT,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettVedtaksbrevForMigreringRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettVedtaksbrevForMigreringRiverTest.kt
@@ -100,6 +100,7 @@ internal class OpprettVedtaksbrevForMigreringRiverTest {
             41,
             behandlingId,
             "tittel",
+            Spraak.NB,
             BrevProsessType.AUTOMATISK,
             "fnr",
             Status.FERDIGSTILT,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/VedtaksbrevUnderkjentRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/VedtaksbrevUnderkjentRiverTest.kt
@@ -10,6 +10,7 @@ import no.nav.etterlatte.brev.VedtaksbrevService
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Brevtype
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -125,6 +126,7 @@ internal class VedtaksbrevUnderkjentRiverTest {
             41,
             UUID.randomUUID(),
             "tittel",
+            Spraak.NB,
             BrevProsessType.AUTOMATISK,
             "fnr",
             Status.JOURNALFOERT,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
@@ -34,6 +34,7 @@ import { addValideringsfeil, Valideringsfeilkoder } from '~store/reducers/Sjekkl
 import { visSjekkliste } from '~store/reducers/BehandlingSidemenyReducer'
 import { BrevMottaker } from '~components/person/brev/mottaker/BrevMottaker'
 import BrevTittel from '~components/person/brev/tittel/BrevTittel'
+import BrevSpraak from '~components/person/brev/spraak/BrevSpraak'
 
 export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
   const { behandlingId } = useParams()
@@ -154,6 +155,8 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
                   tittel={vedtaksbrev.tittel}
                   kanRedigeres={redigerbar}
                 />
+                <br />
+                <BrevSpraak brev={vedtaksbrev} kanRedigeres={redigerbar} />
                 <br />
                 <BrevMottaker brev={vedtaksbrev} kanRedigeres={redigerbar} />
               </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrev.tsx
@@ -19,6 +19,7 @@ import BrevTittel from '~components/person/brev/tittel/BrevTittel'
 import { mapApiResult } from '~shared/api/apiUtils'
 import { BrevMottaker } from '~components/person/brev/mottaker/BrevMottaker'
 import { Heading, Panel } from '@navikt/ds-react'
+import BrevSpraak from '~components/person/brev/spraak/BrevSpraak'
 
 export default function NyttBrev() {
   const { brevId, sakId, fnr } = useParams()
@@ -57,6 +58,9 @@ export default function NyttBrev() {
             <Column>
               <div style={{ margin: '1rem' }}>
                 <BrevTittel brevId={brev.id} sakId={brev.sakId} tittel={brev.tittel} kanRedigeres={kanRedigeres} />
+              </div>
+              <div style={{ margin: '1rem' }}>
+                <BrevSpraak brev={brev} kanRedigeres={kanRedigeres} />
               </div>
               <div style={{ margin: '1rem' }}>
                 <BrevMottaker brev={brev} kanRedigeres={kanRedigeres} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/spraak/BrevSpraak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/spraak/BrevSpraak.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react'
+import { Alert, BodyShort, Heading, Panel } from '@navikt/ds-react'
+import { FlexRow } from '~shared/styled'
+import { IBrev } from '~shared/types/Brev'
+import { BrevSpraakModal } from '~components/person/brev/spraak/BrevSpraakModal'
+import { formaterSpraak } from '~utils/formattering'
+
+interface Props {
+  brev: IBrev
+  kanRedigeres: boolean
+}
+
+export default function BrevSpraak({ brev, kanRedigeres }: Props) {
+  const [nyttSpraak, setNyttSpraak] = useState(brev.spraak)
+
+  return (
+    <Panel border>
+      <FlexRow justify="space-between">
+        <Heading spacing level="2" size="medium">
+          Språk / målform
+        </Heading>
+        {kanRedigeres && (
+          <BrevSpraakModal
+            nyttSpraak={nyttSpraak}
+            settNyttSpraak={setNyttSpraak}
+            brevId={brev.id}
+            sakId={brev.sakId}
+            behandlingId={brev.behandlingId}
+          />
+        )}
+      </FlexRow>
+
+      {nyttSpraak ? (
+        <>
+          <BodyShort spacing>{formaterSpraak(nyttSpraak)}</BodyShort>
+          {brev.spraak !== nyttSpraak && (
+            <Alert variant="success" size="small">
+              Språk oppdatert!
+            </Alert>
+          )}
+        </>
+      ) : (
+        <Alert variant="warning" size="small">
+          Språk mangler
+        </Alert>
+      )}
+    </Panel>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/spraak/BrevSpraakModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/spraak/BrevSpraakModal.tsx
@@ -1,0 +1,133 @@
+import React, { Dispatch, ReactNode, SetStateAction, useState } from 'react'
+import { Alert, BodyShort, Button, Heading, Modal, Select } from '@navikt/ds-react'
+import { isFailureHandler } from '~shared/api/IsFailureHandler'
+import { FlexRow } from '~shared/styled'
+import { isPending } from '~shared/api/apiUtils'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { oppdaterSpraak, tilbakestillManuellPayload } from '~shared/api/brev'
+import { useForm } from 'react-hook-form'
+import { DocPencilIcon } from '@navikt/aksel-icons'
+import { Spraak } from '~shared/types/Brev'
+import { formaterSpraak } from '~utils/formattering'
+
+interface Props {
+  nyttSpraak: Spraak
+  settNyttSpraak: Dispatch<SetStateAction<Spraak>>
+  brevId: number
+  sakId: number
+  behandlingId?: string
+}
+
+export const BrevSpraakModal = ({ nyttSpraak, settNyttSpraak, brevId, sakId, behandlingId }: Props): ReactNode => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [oppdaterSpraakStatus, apiOppdaterSpraak] = useApiCall(oppdaterSpraak)
+  const [tilbakestillBrevStatus, apiTilbakestillBrev] = useApiCall(tilbakestillManuellPayload)
+
+  const {
+    register,
+    formState: { isDirty, errors },
+    handleSubmit,
+    reset,
+  } = useForm({ defaultValues: { spraak: nyttSpraak } })
+
+  const lagre = ({ spraak }: { spraak: Spraak }) => {
+    if (!isDirty) {
+      setIsOpen(false) // Ikke gjør noe hvis spraak er uendret
+      return
+    }
+
+    if (spraak) {
+      apiOppdaterSpraak({ brevId, sakId, spraak }, () => {
+        if (!!behandlingId) {
+          apiTilbakestillBrev({ brevId, sakId, behandlingId }, () => {
+            window.location.reload()
+          })
+        } else {
+          setIsOpen(false)
+          settNyttSpraak(spraak)
+        }
+      })
+    }
+  }
+
+  const avbryt = () => {
+    reset({ spraak: nyttSpraak })
+    setIsOpen(false)
+  }
+
+  return (
+    <div>
+      <Button variant="secondary" onClick={() => setIsOpen(true)} icon={<DocPencilIcon aria-hidden />} size="small" />
+
+      <Modal open={isOpen} onClose={avbryt} width="medium">
+        <form onSubmit={handleSubmit(lagre)}>
+          <Modal.Body>
+            <Heading size="large" spacing>
+              Endre tittel
+            </Heading>
+
+            <Select
+              {...register('spraak', {
+                required: {
+                  value: true,
+                  message: 'Du må velge ',
+                },
+              })}
+              label="Endre språk/målform"
+              error={errors.spraak?.message}
+              defaultValue={nyttSpraak}
+            >
+              {Object.values(Spraak).map((spraak) => (
+                <option key={spraak} value={spraak}>
+                  {formaterSpraak(spraak)}
+                </option>
+              ))}
+            </Select>
+
+            <br />
+
+            {!!behandlingId && (
+              <BodyShort as="div" spacing>
+                <Alert variant="warning" inline>
+                  Endring av språk på vedtaksbrev vil medføre at brevet tilbakestilles og informasjon hentes på nytt.
+                  Dette vil slette tidligere endringer, så husk å kopiere tekst du vil beholde før du fortsetter.
+                </Alert>
+              </BodyShort>
+            )}
+
+            {isFailureHandler({
+              apiResult: oppdaterSpraakStatus,
+              errorMessage: 'Kunne ikke oppdatere tittel',
+            })}
+            {isFailureHandler({
+              apiResult: tilbakestillBrevStatus,
+              errorMessage:
+                'Kunne ikke tilbakestille brev med nytt språk automatisk. Forsøk å tilbakestille brevet manuelt',
+            })}
+          </Modal.Body>
+
+          <Modal.Footer>
+            <FlexRow justify="right">
+              <Button
+                variant="secondary"
+                type="button"
+                disabled={isPending(oppdaterSpraakStatus) || isPending(tilbakestillBrevStatus)}
+                onClick={avbryt}
+              >
+                Avbryt
+              </Button>
+              <Button
+                variant="primary"
+                type="submit"
+                loading={isPending(oppdaterSpraakStatus) || isPending(tilbakestillBrevStatus)}
+                disabled={!isDirty}
+              >
+                Lagre
+              </Button>
+            </FlexRow>
+          </Modal.Footer>
+        </form>
+      </Modal>
+    </div>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
@@ -1,5 +1,5 @@
 import { apiClient, ApiResponse } from './apiClient'
-import { Brevtype, IBrev, Mottaker } from '~shared/types/Brev'
+import { Brevtype, IBrev, Mottaker, Spraak } from '~shared/types/Brev'
 
 export const hentBrev = async (props: { brevId: number; sakId: number }): Promise<ApiResponse<IBrev>> =>
   apiClient.get(`/brev/${props.brevId}?sakId=${props.sakId}`)
@@ -38,6 +38,13 @@ export const oppdaterTittel = async (args: {
   tittel: string
 }): Promise<ApiResponse<IBrev>> =>
   apiClient.post(`/brev/${args.brevId}/tittel?sakId=${args.sakId}`, { tittel: args.tittel })
+
+export const oppdaterSpraak = async (args: {
+  brevId: number
+  sakId: number
+  spraak: Spraak
+}): Promise<ApiResponse<IBrev>> =>
+  apiClient.post(`/brev/${args.brevId}/spraak?sakId=${args.sakId}`, { spraak: args.spraak })
 
 export const slettBrev = async (args: { brevId: number; sakId: number }): Promise<ApiResponse<IBrev>> =>
   apiClient.delete(`/brev/${args.brevId}?sakId=${args.sakId}`)

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Brev.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Brev.ts
@@ -2,6 +2,7 @@ export interface IBrev {
   id: number
   sakId: number
   tittel: string
+  spraak: Spraak
   behandlingId: string
   prosessType: BrevProsessType
   soekerFnr: string


### PR DESCRIPTION
Støtter endring av målform/språk i brev. 
Må nok på sikt gjøres noen endringer på "andre brev" når vi får maler der også, men enn så lenge løser dette hvert fall det meste av språkproblematikken. 

<img width="1285" alt="Screenshot 2024-02-12 at 16 01 57" src="https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/533aa083-e208-4cd5-91d0-974d2f6d342f">
