### PR TITLE
Legger til tilgangssjekk for behandlinger med klageId

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakTilgangDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakTilgangDao.kt
@@ -48,6 +48,7 @@ class SakTilgangDao(private val datasource: DataSource) {
                 )
             statement.setString(1, behandlingId)
             statement.setString(2, behandlingId)
+            statement.setString(3, behandlingId)
             return statement.executeQuery().singleOrNull {
                 SakMedGraderingOgSkjermet(
                     id = getLong(1),

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakTilgangDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakTilgangDao.kt
@@ -43,7 +43,8 @@ class SakTilgangDao(private val datasource: DataSource) {
                 connection.prepareStatement(
                     "select id, adressebeskyttelse, erSkjermet from sak where id =" +
                         " (select sak_id from behandling where id = ?::uuid" +
-                        " union select sak_id from tilbakekreving where id = ?::uuid)",
+                        " union select sak_id from tilbakekreving where id = ?::uuid" +
+                        " union select sak_id from klage where id = ?::uuid)",
                 )
             statement.setString(1, behandlingId)
             statement.setString(2, behandlingId)

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
@@ -17,7 +17,6 @@ import no.nav.etterlatte.libs.common.behandling.Klage
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
-import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import no.nav.etterlatte.opprettBehandling
 import no.nav.etterlatte.sak.SakDao
 import no.nav.etterlatte.sak.SakService
@@ -53,18 +52,19 @@ internal class TilgangServiceTest(val dataSource: DataSource) {
 
     @BeforeAll
     fun beforeAll() {
+        val connection = dataSource.connection
         tilgangService = TilgangServiceImpl(SakTilgangDao(dataSource))
-        sakRepo = SakDao { dataSource.connection }
+        sakRepo = SakDao { connection }
 
         sakService = SakServiceImpl(sakRepo, skjermingKlient, brukerService)
         behandlingRepo =
             BehandlingDao(
                 KommerBarnetTilGodeDao {
-                    dataSource.connection
+                    connection
                 },
-                RevurderingDao { dataSource.connection },
-            ) { dataSource.connection }
-        klageDao = KlageDaoImpl { dataSource.connection }
+                RevurderingDao { connection },
+            ) { connection }
+        klageDao = KlageDaoImpl { connection }
     }
 
     @Test
@@ -95,7 +95,7 @@ internal class TilgangServiceTest(val dataSource: DataSource) {
 
     @Test
     fun `Skal sjekke tilganger til klager med klageId for behandlingId`() {
-        val fnr = SOEKER_FOEDSELSNUMMER.value
+        val fnr = AVDOED_FOEDSELSNUMMER.value
         val sak = sakRepo.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr)
         val jwtclaims = JWTClaimsSet.Builder().claim("groups", strengtfortroligDev).build()
 

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
@@ -5,14 +5,19 @@ import io.mockk.mockk
 import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.behandling.BehandlingDao
 import no.nav.etterlatte.behandling.BrukerService
+import no.nav.etterlatte.behandling.klage.KlageDao
+import no.nav.etterlatte.behandling.klage.KlageDaoImpl
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeDao
 import no.nav.etterlatte.behandling.revurdering.RevurderingDao
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.common.klienter.SkjermingKlient
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.InnkommendeKlage
+import no.nav.etterlatte.libs.common.behandling.Klage
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
+import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import no.nav.etterlatte.opprettBehandling
 import no.nav.etterlatte.sak.SakDao
 import no.nav.etterlatte.sak.SakService
@@ -29,6 +34,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDate
 import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -38,6 +44,7 @@ internal class TilgangServiceTest(val dataSource: DataSource) {
     private lateinit var sakService: SakService
     private lateinit var sakRepo: SakDao
     private lateinit var behandlingRepo: BehandlingDao
+    private lateinit var klageDao: KlageDao
     private val strengtfortroligDev = "5ef775f2-61f8-4283-bf3d-8d03f428aa14"
     private val fortroligDev = "ea930b6b-9397-44d9-b9e6-f4cf527a632a"
     private val egenAnsattDev = "dbe4ad45-320b-4e9a-aaa1-73cca4ee124d"
@@ -57,6 +64,7 @@ internal class TilgangServiceTest(val dataSource: DataSource) {
                 },
                 RevurderingDao { dataSource.connection },
             ) { dataSource.connection }
+        klageDao = KlageDaoImpl { dataSource.connection }
     }
 
     @Test
@@ -83,6 +91,55 @@ internal class TilgangServiceTest(val dataSource: DataSource) {
             )
 
         Assertions.assertEquals(false, harTilgangTilBehandling)
+    }
+
+    @Test
+    fun `Skal sjekke tilganger til klager med klageId for behandlingId`() {
+        val fnr = SOEKER_FOEDSELSNUMMER.value
+        val sak = sakRepo.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr)
+        val jwtclaims = JWTClaimsSet.Builder().claim("groups", strengtfortroligDev).build()
+
+        val saksbehandlerMedStrengtfortrolig =
+            SaksbehandlerMedRoller(
+                Saksbehandler("", "ident", JwtTokenClaims(jwtclaims)),
+                mapOf(AzureGroup.STRENGT_FORTROLIG to strengtfortroligDev),
+            )
+        sakService.oppdaterAdressebeskyttelse(sak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
+        val klage =
+            Klage.ny(
+                sak,
+                InnkommendeKlage(
+                    mottattDato = LocalDate.of(2024, 2, 1),
+                    journalpostId = "123",
+                    innsender = null,
+                ),
+            )
+        klageDao.lagreKlage(klage)
+
+        val saksbehandlerUtenStrengtFortrolig =
+            SaksbehandlerMedRoller(
+                Saksbehandler("", "annenIdent", JwtTokenClaims(jwtclaims)),
+                mapOf(),
+            )
+        val harTilgangStrengtFortroligBehandling =
+            tilgangService.harTilgangTilBehandling(
+                klage.id.toString(),
+                saksbehandlerMedStrengtfortrolig,
+            )
+        val harTilgangStrengtFortroligKlage = tilgangService.harTilgangTilKlage(klage.id.toString(), saksbehandlerMedStrengtfortrolig)
+
+        Assertions.assertTrue(harTilgangStrengtFortroligKlage)
+        Assertions.assertTrue(harTilgangStrengtFortroligBehandling)
+
+        val harTilgangIkkeFortroligBehandling =
+            tilgangService.harTilgangTilBehandling(
+                klage.id.toString(),
+                saksbehandlerUtenStrengtFortrolig,
+            )
+        val harTilgangIkkeFortroligKlage = tilgangService.harTilgangTilKlage(klage.id.toString(), saksbehandlerUtenStrengtFortrolig)
+
+        Assertions.assertFalse(harTilgangIkkeFortroligBehandling)
+        Assertions.assertFalse(harTilgangIkkeFortroligKlage)
     }
 
     @Test


### PR DESCRIPTION
For å støtte at vi i andre apper kan sjekke om vi har tilgang til behandlingen med klageId, som dukker opp som en problemstilling i f.eks. vedtaksvurdering / brev-api