### PR TITLE
EY-3481 Innhaldet i varselbrevet

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -39,6 +39,7 @@ import no.nav.etterlatte.brev.hentinformasjon.TrygdetidKlient
 import no.nav.etterlatte.brev.hentinformasjon.TrygdetidService
 import no.nav.etterlatte.brev.hentinformasjon.VedtaksvurderingKlient
 import no.nav.etterlatte.brev.hentinformasjon.VedtaksvurderingService
+import no.nav.etterlatte.brev.hentinformasjon.beregning.BeregningService
 import no.nav.etterlatte.brev.model.BrevDataMapperFerdigstillingVedtak
 import no.nav.etterlatte.brev.model.BrevDataMapperRedigerbartUtfallVedtak
 import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
@@ -181,7 +182,8 @@ class ApplicationBuilder {
             brevDataMapperFerdigstilling,
         )
 
-    private val brevDataMapperVarsel = BrevDataMapperVarsel(brevdataFacade)
+    private val beregningService = BeregningService(beregningKlient)
+    private val brevDataMapperVarsel = BrevDataMapperVarsel(brevdataFacade, beregningService)
 
     private val varselbrevService =
         VarselbrevService(db, brevoppretter, behandlingKlient, pdfGenerator, brevDataMapperVarsel)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -183,7 +183,7 @@ class ApplicationBuilder {
         )
 
     private val beregningService = BeregningService(beregningKlient)
-    private val brevDataMapperVarsel = BrevDataMapperVarsel(brevdataFacade, beregningService, trygdetidService)
+    private val brevDataMapperVarsel = BrevDataMapperVarsel(beregningService, trygdetidService)
 
     private val varselbrevService =
         VarselbrevService(db, brevoppretter, behandlingKlient, pdfGenerator, brevDataMapperVarsel)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -42,6 +42,7 @@ import no.nav.etterlatte.brev.hentinformasjon.VedtaksvurderingService
 import no.nav.etterlatte.brev.model.BrevDataMapperFerdigstillingVedtak
 import no.nav.etterlatte.brev.model.BrevDataMapperRedigerbartUtfallVedtak
 import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
+import no.nav.etterlatte.brev.varselbrev.BrevDataMapperVarsel
 import no.nav.etterlatte.brev.varselbrev.VarselbrevService
 import no.nav.etterlatte.brev.varselbrev.varselbrevRoute
 import no.nav.etterlatte.brev.vedtaksbrevRoute
@@ -180,7 +181,10 @@ class ApplicationBuilder {
             brevDataMapperFerdigstilling,
         )
 
-    private val varselbrevService = VarselbrevService(db, brevoppretter, behandlingKlient, pdfGenerator)
+    private val brevDataMapperVarsel = BrevDataMapperVarsel(brevdataFacade)
+
+    private val varselbrevService =
+        VarselbrevService(db, brevoppretter, behandlingKlient, pdfGenerator, brevDataMapperVarsel)
 
     private val journalfoerBrevService = JournalfoerBrevService(db, sakService, dokarkivService, vedtaksbrevService)
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -118,7 +118,7 @@ class ApplicationBuilder {
     private val beregningKlient = BeregningKlient(config, httpClient())
     private val behandlingKlient = BehandlingKlient(config, httpClient())
     private val trygdetidKlient = TrygdetidKlient(config, httpClient())
-    private val trygdetidService = TrygdetidService(trygdetidKlient)
+    private val trygdetidService = TrygdetidService(trygdetidKlient, beregningKlient)
 
     private val sakService = SakService(behandlingKlient)
 
@@ -183,7 +183,7 @@ class ApplicationBuilder {
         )
 
     private val beregningService = BeregningService(beregningKlient)
-    private val brevDataMapperVarsel = BrevDataMapperVarsel(brevdataFacade, beregningService)
+    private val brevDataMapperVarsel = BrevDataMapperVarsel(brevdataFacade, beregningService, trygdetidService)
 
     private val varselbrevService =
         VarselbrevService(db, brevoppretter, behandlingKlient, pdfGenerator, brevDataMapperVarsel)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -122,25 +122,27 @@ class ApplicationBuilder {
 
     private val sakService = SakService(behandlingKlient)
 
+    private val beregningService = BeregningService(beregningKlient)
     private val brevdataFacade =
         BrevdataFacade(
             vedtakKlient,
             grunnlagKlient,
-            beregningKlient,
+            beregningService,
             behandlingKlient,
             sakService,
             trygdetidService,
         )
     private val norg2Klient = Norg2Klient(env.requireEnvValue("NORG2_URL"), httpClient())
     private val datasource = DataSourceBuilder.createDataSource(env)
+
     private val db = BrevRepository(datasource)
 
     private val brevgenereringRepository = StartBrevgenereringRepository(datasource)
 
     private val adresseService = AdresseService(norg2Klient, navansattKlient, regoppslagKlient)
-
     private val dokarkivKlient =
         DokarkivKlient(httpClient("DOKARKIV_SCOPE", false), env.requireEnvValue("DOKARKIV_URL"))
+
     private val dokarkivService = DokarkivServiceImpl(dokarkivKlient, db)
 
     private val distribusjonKlient =
@@ -181,8 +183,6 @@ class ApplicationBuilder {
             brevDataMapperRedigerbartUtfallVedtak,
             brevDataMapperFerdigstilling,
         )
-
-    private val beregningService = BeregningService(beregningKlient)
     private val brevDataMapperVarsel = BrevDataMapperVarsel(beregningService, trygdetidService)
 
     private val varselbrevService =

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/RedigerbartVedleggHenter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/RedigerbartVedleggHenter.kt
@@ -7,7 +7,7 @@ import no.nav.etterlatte.brev.brevbaker.BrevbakerService
 import no.nav.etterlatte.brev.brevbaker.EtterlatteBrevKode
 import no.nav.etterlatte.brev.brevbaker.RedigerbarTekstRequest
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
-import no.nav.etterlatte.brev.model.BrevDatafetcher
+import no.nav.etterlatte.brev.model.BrevDatafetcherVedtak
 import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
 import no.nav.etterlatte.brev.model.BrevVedleggKey
 import no.nav.etterlatte.brev.model.ManueltBrevData
@@ -151,7 +151,7 @@ class RedigerbartVedleggHenter(private val brevbakerService: BrevbakerService, p
         generellBrevData: GenerellBrevData,
     ): Boolean =
         coroutineScope {
-            val fetcher = BrevDatafetcher(brevdataFacade, bruker, generellBrevData)
+            val fetcher = BrevDatafetcherVedtak(brevdataFacade, bruker, generellBrevData)
             val brevutfall = async { fetcher.hentBrevutfall() }
             val brevutfallHentet = requireNotNull(brevutfall.await())
             brevutfallHentet.feilutbetaling?.valg == FeilutbetalingValg.JA_VARSEL

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
@@ -9,7 +9,6 @@ import no.nav.etterlatte.brev.behandling.Beregningsperiode
 import no.nav.etterlatte.brev.behandling.ForenkletVedtak
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.behandling.PersonerISak
-import no.nav.etterlatte.brev.behandling.Trygdetid
 import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
 import no.nav.etterlatte.brev.behandling.hentUtbetaltBeloep
 import no.nav.etterlatte.brev.behandling.mapAvdoede
@@ -303,11 +302,7 @@ class BrevdataFacade(
     suspend fun finnTrygdetid(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
-    ): Trygdetid? {
-        val beregning = beregningKlient.hentBeregning(behandlingId, brukerTokenInfo)!!
-
-        return trygdetidService.finnTrygdetidsgrunnlag(behandlingId, beregning, brukerTokenInfo)
-    }
+    ) = trygdetidService.finnTrygdetid(behandlingId, brukerTokenInfo)
 
     suspend fun hentBehandling(
         behandlingId: UUID,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
@@ -212,12 +212,9 @@ class BrevdataFacade(
     suspend fun finnUtbetalingsinfo(
         behandlingId: UUID,
         virkningstidspunkt: YearMonth,
-        brukerTokenInfo: BrukerTokenInfo,
+        bruker: BrukerTokenInfo,
         sakType: SakType,
-    ): Utbetalingsinfo =
-        requireNotNull(beregningService.finnUtbetalingsinfoNullable(behandlingId, virkningstidspunkt, brukerTokenInfo, sakType)) {
-            "Utbetalingsinfo er nødvendig, men mangler"
-        }
+    ): Utbetalingsinfo = beregningService.finnUtbetalingsinfo(behandlingId, virkningstidspunkt, bruker, sakType)
 
     suspend fun hentGrunnbeloep(brukerTokenInfo: BrukerTokenInfo) = beregningService.hentGrunnbeloep(brukerTokenInfo)
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
@@ -17,6 +17,7 @@ import no.nav.etterlatte.brev.behandling.mapSoeker
 import no.nav.etterlatte.brev.behandling.mapSpraak
 import no.nav.etterlatte.brev.behandling.mapVerge
 import no.nav.etterlatte.brev.behandlingklient.BehandlingKlient
+import no.nav.etterlatte.brev.hentinformasjon.beregning.BeregningService
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.IntBroek
@@ -38,7 +39,7 @@ import no.nav.etterlatte.libs.common.beregning.Beregningsperiode as CommonBeregn
 class BrevdataFacade(
     private val vedtaksvurderingKlient: VedtaksvurderingKlient,
     private val grunnlagKlient: GrunnlagKlient,
-    private val beregningKlient: BeregningKlient,
+    private val beregningService: BeregningService,
     private val behandlingKlient: BehandlingKlient,
     private val sakService: SakService,
     private val trygdetidService: TrygdetidService,
@@ -226,8 +227,8 @@ class BrevdataFacade(
         brukerTokenInfo: BrukerTokenInfo,
         sakType: SakType,
     ): Utbetalingsinfo? {
-        val beregning = beregningKlient.hentBeregning(behandlingId, brukerTokenInfo) ?: return null
-        val beregningsGrunnlag = beregningKlient.hentBeregningsGrunnlag(behandlingId, sakType, brukerTokenInfo)
+        val beregning = beregningService.hentBeregning(behandlingId, brukerTokenInfo) ?: return null
+        val beregningsGrunnlag = beregningService.hentBeregningsGrunnlag(behandlingId, sakType, brukerTokenInfo)
 
         val beregningsperioder =
             beregning.beregningsperioder.map {
@@ -263,7 +264,7 @@ class BrevdataFacade(
         )
     }
 
-    suspend fun hentGrunnbeloep(brukerTokenInfo: BrukerTokenInfo) = beregningKlient.hentGrunnbeloep(brukerTokenInfo)
+    suspend fun hentGrunnbeloep(brukerTokenInfo: BrukerTokenInfo) = beregningService.hentGrunnbeloep(brukerTokenInfo)
 
     suspend fun finnAvkortingsinfo(
         behandlingId: UUID,
@@ -274,7 +275,7 @@ class BrevdataFacade(
     ): Avkortingsinfo? {
         if (sakType == SakType.BARNEPENSJON || vedtakType == VedtakType.OPPHOER) return null
 
-        val ytelseMedGrunnlag = beregningKlient.hentYtelseMedGrunnlag(behandlingId, brukerTokenInfo)
+        val ytelseMedGrunnlag = beregningService.hentYtelseMedGrunnlag(behandlingId, brukerTokenInfo)
 
         val beregningsperioder =
             ytelseMedGrunnlag.perioder.map {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/TrygdetidService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/TrygdetidService.kt
@@ -11,8 +11,17 @@ import no.nav.etterlatte.trygdetid.TrygdetidType
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
-class TrygdetidService(private val trygdetidKlient: TrygdetidKlient) {
+class TrygdetidService(private val trygdetidKlient: TrygdetidKlient, private val beregningKlient: BeregningKlient) {
     private val logger = LoggerFactory.getLogger(this::class.java)
+
+    suspend fun finnTrygdetid(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid? {
+        val beregning = beregningKlient.hentBeregning(behandlingId, brukerTokenInfo)!!
+
+        return finnTrygdetidsgrunnlag(behandlingId, beregning, brukerTokenInfo)
+    }
 
     suspend fun finnTrygdetidsgrunnlag(
         behandlingId: UUID,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningService.kt
@@ -1,8 +1,14 @@
 package no.nav.etterlatte.brev.hentinformasjon.beregning
 
+import no.nav.etterlatte.brev.behandling.Beregningsperiode
+import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
+import no.nav.etterlatte.brev.behandling.hentUtbetaltBeloep
 import no.nav.etterlatte.brev.hentinformasjon.BeregningKlient
+import no.nav.etterlatte.brev.hentinformasjon.hentBenyttetTrygdetidOgProratabroek
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.token.BrukerTokenInfo
+import no.nav.pensjon.brevbaker.api.model.Kroner
+import java.time.YearMonth
 import java.util.UUID
 
 class BeregningService(private val beregningKlient: BeregningKlient) {
@@ -23,4 +29,47 @@ class BeregningService(private val beregningKlient: BeregningKlient) {
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ) = beregningKlient.hentYtelseMedGrunnlag(behandlingId, brukerTokenInfo)
+
+    suspend fun finnUtbetalingsinfoNullable(
+        behandlingId: UUID,
+        virkningstidspunkt: YearMonth,
+        brukerTokenInfo: BrukerTokenInfo,
+        sakType: SakType,
+    ): Utbetalingsinfo? {
+        val beregning = hentBeregning(behandlingId, brukerTokenInfo) ?: return null
+        val beregningsGrunnlag = hentBeregningsGrunnlag(behandlingId, sakType, brukerTokenInfo)
+
+        val beregningsperioder =
+            beregning.beregningsperioder.map {
+                val (benyttetTrygdetid, prorataBroek) = hentBenyttetTrygdetidOgProratabroek(it)
+
+                Beregningsperiode(
+                    datoFOM = it.datoFOM.atDay(1),
+                    datoTOM = it.datoTOM?.atEndOfMonth(),
+                    grunnbeloep = Kroner(it.grunnbelop),
+                    antallBarn = (it.soeskenFlokk?.size ?: 0) + 1,
+                    // Legger til 1 pga at beregning fjerner soeker
+                    utbetaltBeloep = Kroner(it.utbetaltBeloep),
+                    trygdetid = benyttetTrygdetid,
+                    prorataBroek = prorataBroek,
+                    institusjon = it.institusjonsopphold != null,
+                    beregningsMetodeAnvendt = requireNotNull(it.beregningsMetode),
+                    beregningsMetodeFraGrunnlag =
+                        beregningsGrunnlag?.beregningsMetode?.beregningsMetode
+                            ?: requireNotNull(it.beregningsMetode),
+                    // ved manuelt overstyrt beregning har vi ikke grunnlag
+                )
+            }
+
+        val soeskenjustering = beregning.beregningsperioder.any { !it.soeskenFlokk.isNullOrEmpty() }
+        val antallBarn = if (soeskenjustering) beregningsperioder.last().antallBarn else 1
+
+        return Utbetalingsinfo(
+            antallBarn,
+            Kroner(beregningsperioder.hentUtbetaltBeloep()),
+            virkningstidspunkt.atDay(1),
+            soeskenjustering,
+            beregningsperioder,
+        )
+    }
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningService.kt
@@ -1,8 +1,26 @@
 package no.nav.etterlatte.brev.hentinformasjon.beregning
 
 import no.nav.etterlatte.brev.hentinformasjon.BeregningKlient
+import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.token.BrukerTokenInfo
+import java.util.UUID
 
 class BeregningService(private val beregningKlient: BeregningKlient) {
     suspend fun hentGrunnbeloep(bruker: BrukerTokenInfo) = beregningKlient.hentGrunnbeloep(bruker)
+
+    suspend fun hentBeregning(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ) = beregningKlient.hentBeregning(behandlingId, brukerTokenInfo)
+
+    suspend fun hentBeregningsGrunnlag(
+        behandlingId: UUID,
+        sakType: SakType,
+        brukerTokenInfo: BrukerTokenInfo,
+    ) = beregningKlient.hentBeregningsGrunnlag(behandlingId, sakType, brukerTokenInfo)
+
+    suspend fun hentYtelseMedGrunnlag(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ) = beregningKlient.hentYtelseMedGrunnlag(behandlingId, brukerTokenInfo)
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningService.kt
@@ -30,6 +30,16 @@ class BeregningService(private val beregningKlient: BeregningKlient) {
         brukerTokenInfo: BrukerTokenInfo,
     ) = beregningKlient.hentYtelseMedGrunnlag(behandlingId, brukerTokenInfo)
 
+    suspend fun finnUtbetalingsinfo(
+        behandlingId: UUID,
+        virkningstidspunkt: YearMonth,
+        brukerTokenInfo: BrukerTokenInfo,
+        sakType: SakType,
+    ): Utbetalingsinfo =
+        requireNotNull(finnUtbetalingsinfoNullable(behandlingId, virkningstidspunkt, brukerTokenInfo, sakType)) {
+            "Utbetalingsinfo er nødvendig, men mangler"
+        }
+
     suspend fun finnUtbetalingsinfoNullable(
         behandlingId: UUID,
         virkningstidspunkt: YearMonth,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningService.kt
@@ -1,0 +1,8 @@
+package no.nav.etterlatte.brev.hentinformasjon.beregning
+
+import no.nav.etterlatte.brev.hentinformasjon.BeregningKlient
+import no.nav.etterlatte.token.BrukerTokenInfo
+
+class BeregningService(private val beregningKlient: BeregningKlient) {
+    suspend fun hentGrunnbeloep(bruker: BrukerTokenInfo) = beregningKlient.hentGrunnbeloep(bruker)
+}

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
@@ -86,7 +86,7 @@ class BrevDataMapperFerdigstillingVedtak(private val brevdataFacade: BrevdataFac
         innholdMedVedlegg: InnholdMedVedlegg,
         automatiskMigreringRequest: MigreringBrevRequest?,
     ) = coroutineScope {
-        val fetcher = BrevDatafetcher(brevdataFacade, bruker, generellBrevData)
+        val fetcher = BrevDatafetcherVedtak(brevdataFacade, bruker, generellBrevData)
         val utbetalingsinfo = async { fetcher.hentUtbetaling() }
         val trygdetid = async { fetcher.hentTrygdetid() }
         val grunnbeloep = async { fetcher.hentGrunnbeloep() }
@@ -113,7 +113,7 @@ class BrevDataMapperFerdigstillingVedtak(private val brevdataFacade: BrevdataFac
         generellBrevData: GenerellBrevData,
         innholdMedVedlegg: InnholdMedVedlegg,
     ) = coroutineScope {
-        val fetcher = BrevDatafetcher(brevdataFacade, brukerTokenInfo, generellBrevData)
+        val fetcher = BrevDatafetcherVedtak(brevdataFacade, brukerTokenInfo, generellBrevData)
         val utbetalingsinfo = async { fetcher.hentUtbetaling() }
         val forrigeUtbetalingsinfo = async { fetcher.hentForrigeUtbetaling() }
         val trygdetid = async { fetcher.hentTrygdetid() }
@@ -138,7 +138,7 @@ class BrevDataMapperFerdigstillingVedtak(private val brevdataFacade: BrevdataFac
         generellBrevData: GenerellBrevData,
         innholdMedVedlegg: InnholdMedVedlegg,
     ) = coroutineScope {
-        val fetcher = BrevDatafetcher(brevdataFacade, brukerTokenInfo, generellBrevData)
+        val fetcher = BrevDatafetcherVedtak(brevdataFacade, brukerTokenInfo, generellBrevData)
         val utbetalingsinfo = async { fetcher.hentUtbetaling() }
         val trygdetid = async { fetcher.hentTrygdetid() }
         val grunnbeloep = async { fetcher.hentGrunnbeloep() }
@@ -186,7 +186,7 @@ class BrevDataMapperFerdigstillingVedtak(private val brevdataFacade: BrevdataFac
         innholdMedVedlegg: InnholdMedVedlegg,
         generellBrevData: GenerellBrevData,
     ) = coroutineScope {
-        val fetcher = BrevDatafetcher(brevdataFacade, brukerTokenInfo, generellBrevData)
+        val fetcher = BrevDatafetcherVedtak(brevdataFacade, brukerTokenInfo, generellBrevData)
         val brevutfall = async { fetcher.hentBrevutfall() }
 
         BarnepensjonOpphoer.fra(
@@ -201,7 +201,7 @@ class BrevDataMapperFerdigstillingVedtak(private val brevdataFacade: BrevdataFac
         generellBrevData: GenerellBrevData,
         innholdMedVedlegg: InnholdMedVedlegg,
     ) = coroutineScope {
-        val fetcher = BrevDatafetcher(brevdataFacade, brukerTokenInfo, generellBrevData)
+        val fetcher = BrevDatafetcherVedtak(brevdataFacade, brukerTokenInfo, generellBrevData)
         val utbetalingsinfo = async { fetcher.hentUtbetaling() }
         val avkortingsinfo = async { fetcher.hentAvkortinginfo() }
         val trygdetid = async { fetcher.hentTrygdetid() }
@@ -224,7 +224,7 @@ class BrevDataMapperFerdigstillingVedtak(private val brevdataFacade: BrevdataFac
         generellBrevData: GenerellBrevData,
         innholdMedVedlegg: InnholdMedVedlegg,
     ) = coroutineScope {
-        val fetcher = BrevDatafetcher(brevdataFacade, brukerTokenInfo, generellBrevData)
+        val fetcher = BrevDatafetcherVedtak(brevdataFacade, brukerTokenInfo, generellBrevData)
         val utbetalingsinfo = async { fetcher.hentUtbetaling() }
         val forrigeUtbetalingsinfo = async { fetcher.hentForrigeUtbetaling() }
         val avkortingsinfo = async { fetcher.hentAvkortinginfo() }
@@ -249,7 +249,7 @@ class BrevDataMapperFerdigstillingVedtak(private val brevdataFacade: BrevdataFac
         generellBrevData: GenerellBrevData,
         innholdMedVedlegg: InnholdMedVedlegg,
     ) = coroutineScope {
-        val fetcher = BrevDatafetcher(brevdataFacade, brukerTokenInfo, generellBrevData)
+        val fetcher = BrevDatafetcherVedtak(brevdataFacade, brukerTokenInfo, generellBrevData)
         val brevutfall = async { fetcher.hentBrevutfall() }
 
         OmstillingsstoenadOpphoer.fra(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
@@ -79,7 +79,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
         brukerTokenInfo: BrukerTokenInfo,
         generellBrevData: GenerellBrevData,
     ) = coroutineScope {
-        val fetcher = BrevDatafetcher(brevdataFacade, brukerTokenInfo, generellBrevData)
+        val fetcher = BrevDatafetcherVedtak(brevdataFacade, brukerTokenInfo, generellBrevData)
         val utbetalingsinfo = async { fetcher.hentUtbetaling() }
         val etterbetaling = async { fetcher.hentEtterbetaling() }
 
@@ -101,7 +101,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
         brukerTokenInfo: BrukerTokenInfo,
         generellBrevData: GenerellBrevData,
     ) = coroutineScope {
-        val fetcher = BrevDatafetcher(brevdataFacade, brukerTokenInfo, generellBrevData)
+        val fetcher = BrevDatafetcherVedtak(brevdataFacade, brukerTokenInfo, generellBrevData)
         val brevutfall = async { fetcher.hentBrevutfall() }
 
         BarnepensjonOpphoerRedigerbarUtfall.fra(
@@ -113,7 +113,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
         brukerTokenInfo: BrukerTokenInfo,
         generellBrevData: GenerellBrevData,
     ) = coroutineScope {
-        val fetcher = BrevDatafetcher(brevdataFacade, brukerTokenInfo, generellBrevData)
+        val fetcher = BrevDatafetcherVedtak(brevdataFacade, brukerTokenInfo, generellBrevData)
         val etterbetaling = async { fetcher.hentEtterbetaling() }
 
         BarnepensjonRevurderingRedigerbartUtfall.fra(etterbetaling.await())
@@ -123,7 +123,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
         bruker: BrukerTokenInfo,
         generellBrevData: GenerellBrevData,
     ) = coroutineScope {
-        val fetcher = BrevDatafetcher(brevdataFacade, bruker, generellBrevData)
+        val fetcher = BrevDatafetcherVedtak(brevdataFacade, bruker, generellBrevData)
         val utbetalingsinfo = async { fetcher.hentUtbetaling() }
         val avkortingsinfo = async { fetcher.hentAvkortinginfo() }
         val etterbetaling = async { fetcher.hentEtterbetaling() }
@@ -140,7 +140,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
         bruker: BrukerTokenInfo,
         generellBrevData: GenerellBrevData,
     ) = coroutineScope {
-        val fetcher = BrevDatafetcher(brevdataFacade, bruker, generellBrevData)
+        val fetcher = BrevDatafetcherVedtak(brevdataFacade, bruker, generellBrevData)
         val avkortingsinfo = async { fetcher.hentAvkortinginfo() }
         val etterbetaling = async { fetcher.hentEtterbetaling() }
         val brevutfall = async { fetcher.hentBrevutfall() }
@@ -156,7 +156,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
         bruker: BrukerTokenInfo,
         generellBrevData: GenerellBrevData,
     ) = coroutineScope {
-        val fetcher = BrevDatafetcher(brevdataFacade, bruker, generellBrevData)
+        val fetcher = BrevDatafetcherVedtak(brevdataFacade, bruker, generellBrevData)
         val brevutfall = async { fetcher.hentBrevutfall() }
 
         OmstillingsstoenadOpphoerRedigerbartUtfall.fra(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDatafetcherVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDatafetcherVedtak.kt
@@ -8,7 +8,7 @@ import no.nav.etterlatte.token.BrukerTokenInfo
 import java.time.YearMonth
 import java.util.UUID
 
-internal class BrevDatafetcher(
+internal class BrevDatafetcherVedtak(
     private val brevdataFacade: BrevdataFacade,
     private val brukerTokenInfo: BrukerTokenInfo,
     private val behandlingId: UUID?,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonVarsel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonVarsel.kt
@@ -1,0 +1,19 @@
+package no.nav.etterlatte.brev.model.bp
+
+import no.nav.etterlatte.brev.model.BarnepensjonBeregning
+import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
+import no.nav.etterlatte.brev.model.BrevDataRedigerbar
+import no.nav.etterlatte.brev.model.Slate
+
+data class BarnepensjonVarsel(
+    override val innhold: List<Slate.Element>,
+    val beregning: BarnepensjonBeregning,
+    val erUnder18Aar: Boolean,
+    val erBosattUtlandet: Boolean,
+) : BrevDataFerdigstilling
+
+data class BarnepensjonVarselRedigerbartUtfall(
+    val beregning: BarnepensjonBeregning,
+    val automatiskBehandla: Boolean,
+    val erBosattUtlandet: Boolean,
+) : BrevDataRedigerbar

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonVarsel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonVarsel.kt
@@ -13,7 +13,6 @@ data class BarnepensjonVarsel(
 ) : BrevDataFerdigstilling
 
 data class BarnepensjonVarselRedigerbartUtfall(
-    val beregning: BarnepensjonBeregning,
     val automatiskBehandla: Boolean,
     val erBosattUtlandet: Boolean,
 ) : BrevDataRedigerbar

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/BrevDataMapperVarsel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/BrevDataMapperVarsel.kt
@@ -3,7 +3,6 @@ package no.nav.etterlatte.brev.varselbrev
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
-import no.nav.etterlatte.brev.model.BrevData
 import no.nav.etterlatte.brev.model.BrevDataFerdigstillingRequest
 import no.nav.etterlatte.brev.model.BrevDatafetcher
 import no.nav.etterlatte.brev.model.ManueltBrevData
@@ -11,7 +10,6 @@ import no.nav.etterlatte.brev.model.bp.BarnepensjonVarsel
 import no.nav.etterlatte.brev.model.bp.barnepensjonBeregning
 import no.nav.etterlatte.brev.model.bp.barnepensjonBeregningsperioder
 import no.nav.etterlatte.libs.common.behandling.SakType
-import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
 
 class BrevDataMapperVarsel(private val brevdataFacade: BrevdataFacade) {
     suspend fun hentBrevDataFerdigstilling(request: BrevDataFerdigstillingRequest) =
@@ -22,7 +20,7 @@ class BrevDataMapperVarsel(private val brevdataFacade: BrevdataFacade) {
             }
         }
 
-    private suspend fun hentBrevDataFerdigstillingBarnepensjon(it: BrevDataFerdigstillingRequest): BrevData =
+    private suspend fun hentBrevDataFerdigstillingBarnepensjon(it: BrevDataFerdigstillingRequest) =
         coroutineScope {
             val fetcher = BrevDatafetcher(brevdataFacade, it.bruker, it.generellBrevData)
             val grunnbeloep = async { fetcher.hentGrunnbeloep() }
@@ -39,7 +37,7 @@ class BrevDataMapperVarsel(private val brevdataFacade: BrevdataFacade) {
                         trygdetid = requireNotNull(trygdetid.await()),
                     ),
                 erUnder18Aar = it.generellBrevData.personerISak.soeker.under18 ?: true,
-                erBosattUtlandet = it.generellBrevData.utlandstilknytning?.type == UtlandstilknytningType.BOSATT_UTLAND,
+                erBosattUtlandet = it.generellBrevData.utlandstilknytning?.erBosattUtland() ?: false,
             )
         }
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/BrevDataMapperVarsel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/BrevDataMapperVarsel.kt
@@ -1,0 +1,45 @@
+package no.nav.etterlatte.brev.varselbrev
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
+import no.nav.etterlatte.brev.model.BrevData
+import no.nav.etterlatte.brev.model.BrevDataFerdigstillingRequest
+import no.nav.etterlatte.brev.model.BrevDatafetcher
+import no.nav.etterlatte.brev.model.ManueltBrevData
+import no.nav.etterlatte.brev.model.bp.BarnepensjonVarsel
+import no.nav.etterlatte.brev.model.bp.barnepensjonBeregning
+import no.nav.etterlatte.brev.model.bp.barnepensjonBeregningsperioder
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
+
+class BrevDataMapperVarsel(private val brevdataFacade: BrevdataFacade) {
+    suspend fun hentBrevDataFerdigstilling(request: BrevDataFerdigstillingRequest) =
+        coroutineScope {
+            when (request.generellBrevData.sak.sakType) {
+                SakType.BARNEPENSJON -> hentBrevDataFerdigstillingBarnepensjon(request)
+                SakType.OMSTILLINGSSTOENAD -> ManueltBrevData(request.innholdMedVedlegg.innhold())
+            }
+        }
+
+    private suspend fun hentBrevDataFerdigstillingBarnepensjon(it: BrevDataFerdigstillingRequest): BrevData =
+        coroutineScope {
+            val fetcher = BrevDatafetcher(brevdataFacade, it.bruker, it.generellBrevData)
+            val grunnbeloep = async { fetcher.hentGrunnbeloep() }
+            val trygdetid = async { fetcher.hentTrygdetid() }
+            val utbetalingsinfo = async { fetcher.hentUtbetaling() }
+            BarnepensjonVarsel(
+                innhold = it.innholdMedVedlegg.innhold(),
+                beregning =
+                    barnepensjonBeregning(
+                        innhold = it.innholdMedVedlegg,
+                        utbetalingsinfo = utbetalingsinfo.await(),
+                        grunnbeloep = grunnbeloep.await(),
+                        beregningsperioder = barnepensjonBeregningsperioder(utbetalingsinfo.await()),
+                        trygdetid = requireNotNull(trygdetid.await()),
+                    ),
+                erUnder18Aar = it.generellBrevData.personerISak.soeker.under18 ?: true,
+                erBosattUtlandet = it.generellBrevData.utlandstilknytning?.type == UtlandstilknytningType.BOSATT_UTLAND,
+            )
+        }
+}

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/BrevDataMapperVarsel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/BrevDataMapperVarsel.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.brev.varselbrev
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
+import no.nav.etterlatte.brev.hentinformasjon.beregning.BeregningService
 import no.nav.etterlatte.brev.model.BrevDataFerdigstillingRequest
 import no.nav.etterlatte.brev.model.BrevDatafetcherVedtak
 import no.nav.etterlatte.brev.model.ManueltBrevData
@@ -11,7 +12,7 @@ import no.nav.etterlatte.brev.model.bp.barnepensjonBeregning
 import no.nav.etterlatte.brev.model.bp.barnepensjonBeregningsperioder
 import no.nav.etterlatte.libs.common.behandling.SakType
 
-class BrevDataMapperVarsel(private val brevdataFacade: BrevdataFacade) {
+class BrevDataMapperVarsel(private val brevdataFacade: BrevdataFacade, private val beregningService: BeregningService) {
     suspend fun hentBrevDataFerdigstilling(request: BrevDataFerdigstillingRequest) =
         coroutineScope {
             when (request.generellBrevData.sak.sakType) {
@@ -23,7 +24,7 @@ class BrevDataMapperVarsel(private val brevdataFacade: BrevdataFacade) {
     private suspend fun hentBrevDataFerdigstillingBarnepensjon(it: BrevDataFerdigstillingRequest) =
         coroutineScope {
             val fetcher = BrevDatafetcherVedtak(brevdataFacade, it.bruker, it.generellBrevData)
-            val grunnbeloep = async { fetcher.hentGrunnbeloep() }
+            val grunnbeloep = async { beregningService.hentGrunnbeloep(it.bruker) }
             val trygdetid = async { fetcher.hentTrygdetid() }
             val utbetalingsinfo = async { fetcher.hentUtbetaling() }
             BarnepensjonVarsel(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/BrevDataMapperVarsel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/BrevDataMapperVarsel.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.model.BrevDataFerdigstillingRequest
-import no.nav.etterlatte.brev.model.BrevDatafetcher
+import no.nav.etterlatte.brev.model.BrevDatafetcherVedtak
 import no.nav.etterlatte.brev.model.ManueltBrevData
 import no.nav.etterlatte.brev.model.bp.BarnepensjonVarsel
 import no.nav.etterlatte.brev.model.bp.barnepensjonBeregning
@@ -22,7 +22,7 @@ class BrevDataMapperVarsel(private val brevdataFacade: BrevdataFacade) {
 
     private suspend fun hentBrevDataFerdigstillingBarnepensjon(it: BrevDataFerdigstillingRequest) =
         coroutineScope {
-            val fetcher = BrevDatafetcher(brevdataFacade, it.bruker, it.generellBrevData)
+            val fetcher = BrevDatafetcherVedtak(brevdataFacade, it.bruker, it.generellBrevData)
             val grunnbeloep = async { fetcher.hentGrunnbeloep() }
             val trygdetid = async { fetcher.hentTrygdetid() }
             val utbetalingsinfo = async { fetcher.hentUtbetaling() }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
@@ -18,6 +18,7 @@ internal class VarselbrevService(
     private val brevoppretter: Brevoppretter,
     private val behandlingKlient: BehandlingKlient,
     private val pdfGenerator: PDFGenerator,
+    private val brevDataMapperVarsel: BrevDataMapperVarsel,
 ) {
     fun hentVarselbrev(behandlingId: UUID) = db.hentBrevForBehandling(behandlingId, Brevtype.VARSEL)
 
@@ -60,7 +61,7 @@ internal class VarselbrevService(
         automatiskMigreringRequest = null,
         avsenderRequest = { brukerToken, generellBrevData -> generellBrevData.avsenderRequest(brukerToken) },
         brevKode = { hentBrevkode(it.sakType) },
-        brevData = { ManueltBrevData(it.innholdMedVedlegg.innhold()) },
+        brevData = { brevDataMapperVarsel.hentBrevDataFerdigstilling(it) },
     )
 }
 

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/hentinformasjon/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/hentinformasjon/TrygdetidServiceTest.kt
@@ -25,10 +25,11 @@ import java.util.UUID
 
 internal class TrygdetidServiceTest {
     private val trygdetidKlient = mockk<TrygdetidKlient>()
+    private val beregningKlient = mockk<BeregningKlient>()
 
     @Test
     fun `henter trygdetid nasjonal beregning`() {
-        val service = TrygdetidService(trygdetidKlient)
+        val service = TrygdetidService(trygdetidKlient, beregningKlient)
         val behandlingId = UUID.randomUUID()
         coEvery { trygdetidKlient.hentTrygdetid(any(), any()) } returns listOf(trygdetidDto(behandlingId))
 
@@ -51,7 +52,7 @@ internal class TrygdetidServiceTest {
 
     @Test
     fun `henter ut prorata riktig`() {
-        val service = TrygdetidService(trygdetidKlient)
+        val service = TrygdetidService(trygdetidKlient, beregningKlient)
         val behandlingId = UUID.randomUUID()
         coEvery { trygdetidKlient.hentTrygdetid(any(), any()) } returns listOf(trygdetidDto(behandlingId))
 

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningServiceTest.kt
@@ -1,0 +1,138 @@
+package no.nav.etterlatte.brev.hentinformasjon.beregning
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.brev.hentinformasjon.BeregningKlient
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.beregning.BeregningDTO
+import no.nav.etterlatte.libs.common.beregning.BeregningsGrunnlagFellesDto
+import no.nav.etterlatte.libs.common.beregning.BeregningsMetode
+import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
+import no.nav.etterlatte.token.BrukerTokenInfo
+import no.nav.pensjon.brevbaker.api.model.Kroner
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+import java.util.UUID
+
+class BeregningServiceTest {
+    private val beregningKlient = mockk<BeregningKlient>()
+
+    private val service = BeregningService(beregningKlient = beregningKlient)
+
+    @Test
+    fun `FinnUtbetalingsinfo returnerer korrekt informasjon`() {
+        coEvery { beregningKlient.hentBeregning(any(), any()) } returns opprettBeregning()
+        coEvery { beregningKlient.hentBeregningsGrunnlag(any(), any(), any()) } returns opprettBeregningsgrunnlag()
+
+        val utbetalingsinfo =
+            runBlocking {
+                service.finnUtbetalingsinfo(BEHANDLING_ID, YearMonth.now(), BRUKERTokenInfo, SakType.BARNEPENSJON)
+            }
+
+        Assertions.assertEquals(Kroner(3063), utbetalingsinfo.beloep)
+        Assertions.assertEquals(YearMonth.now().atDay(1), utbetalingsinfo.virkningsdato)
+        Assertions.assertEquals(false, utbetalingsinfo.soeskenjustering)
+        Assertions.assertEquals(
+            listOf(BREV_BEREGNINGSPERIODE),
+            utbetalingsinfo.beregningsperioder,
+        )
+
+        coVerify(exactly = 1) {
+            service.hentBeregning(BEHANDLING_ID, any())
+            service.hentBeregningsGrunnlag(BEHANDLING_ID, any(), any())
+        }
+    }
+
+    @Test
+    fun `FinnUtbetalingsinfo returnerer korrekt antall barn ved soeskenjustering`() {
+        coEvery { beregningKlient.hentBeregning(any(), any()) } returns opprettBeregningSoeskenjustering()
+        coEvery { beregningKlient.hentBeregningsGrunnlag(any(), any(), any()) } returns opprettBeregningsgrunnlag()
+
+        val utbetalingsinfo =
+            runBlocking {
+                service.finnUtbetalingsinfo(BEHANDLING_ID, YearMonth.now(), BRUKERTokenInfo, SakType.BARNEPENSJON)
+            }
+
+        Assertions.assertEquals(2, utbetalingsinfo.antallBarn)
+        Assertions.assertTrue(utbetalingsinfo.soeskenjustering)
+
+        coVerify(exactly = 1) {
+            service.hentBeregning(any(), any())
+            service.hentBeregningsGrunnlag(any(), any(), any())
+        }
+    }
+
+    private fun opprettBeregning() =
+        mockk<BeregningDTO> {
+            every { beregningsperioder } returns
+                listOf(
+                    opprettBeregningsperiode(
+                        YearMonth.now(),
+                        beloep = 3063,
+                    ),
+                )
+        }
+
+    private fun opprettBeregningsperiode(
+        fom: YearMonth,
+        tom: YearMonth? = null,
+        beloep: Int,
+        soeskenFlokk: List<String>? = null,
+    ) = Beregningsperiode(
+        fom,
+        tom,
+        beloep,
+        soeskenFlokk,
+        null,
+        1000,
+        10000,
+        10,
+        beregningsMetode = BeregningsMetode.NASJONAL,
+        samletNorskTrygdetid = 10,
+        samletTeoretiskTrygdetid = 20,
+        broek = null,
+    )
+
+    private fun opprettBeregningSoeskenjustering() =
+        mockk<BeregningDTO> {
+            every { beregningsperioder } returns
+                listOf(
+                    opprettBeregningsperiode(
+                        YearMonth.now(),
+                        beloep = 3063,
+                        soeskenFlokk = listOf("barn2"),
+                    ),
+                )
+        }
+
+    private fun opprettBeregningsgrunnlag() =
+        mockk<BeregningsGrunnlagFellesDto> {
+            every { beregningsMetode } returns
+                mockk {
+                    every { beregningsMetode } returns BeregningsMetode.BEST
+                }
+        }
+
+    private companion object {
+        private val BEHANDLING_ID = UUID.randomUUID()
+        private const val SAKSBEHANDLER_IDENT = "Z1235"
+        private val BRUKERTokenInfo = BrukerTokenInfo.of("321", SAKSBEHANDLER_IDENT, null, null, null)
+        private val BREV_BEREGNINGSPERIODE =
+            no.nav.etterlatte.brev.behandling.Beregningsperiode(
+                YearMonth.now().atDay(1),
+                null,
+                Kroner(10000),
+                1,
+                Kroner(3063),
+                10,
+                null,
+                false,
+                BeregningsMetode.NASJONAL,
+                BeregningsMetode.BEST,
+            )
+    }
+}

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
@@ -100,7 +100,7 @@ class VarselbrevTest {
             )
         val behandlingKlient = mockk<BehandlingKlient>().also { coEvery { it.hentSak(sak.id, any()) } returns sak }
         val pdfGenerator = mockk<PDFGenerator>()
-        service = VarselbrevService(brevRepository, brevoppretter, behandlingKlient, pdfGenerator)
+        service = VarselbrevService(brevRepository, brevoppretter, behandlingKlient, pdfGenerator, mockk())
     }
 
     @AfterEach

--- a/libs/saksbehandling-common/src/main/kotlin/behandling/Utlandstilknytning.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/behandling/Utlandstilknytning.kt
@@ -6,7 +6,9 @@ data class Utlandstilknytning(
     val type: UtlandstilknytningType,
     val kilde: Grunnlagsopplysning.Kilde,
     val begrunnelse: String,
-)
+) {
+    fun erBosattUtland() = this.type == UtlandstilknytningType.BOSATT_UTLAND
+}
 
 enum class UtlandstilknytningType {
     NASJONAL,


### PR DESCRIPTION
Vart litt uventa refaktorisering for å komme i mål. Viste seg nemleg at Brevdatafetcher baserer seg på at det fins virkningstidspunkt på _vedtaket_, og her har vi jo ikkje eit vedtak. Kunne nok ha tweaka litt for å få det til, men det kjens ryddigare å heller gå rett mot services.

Trur det generelt er lurt å gå mot ein liknande struktur i brev-api som vi har i resten av applikasjonen, med tynne klientlag, logikk i services og at vi spør om det vi treng.

Heng saman med https://github.com/navikt/pensjonsbrev/pull/538