### PR TITLE
FAGSYSTEM-317799 Korrigere pattern på postnummer + tag på utland

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottaker.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottaker.tsx
@@ -1,5 +1,5 @@
-import { IBrev } from '~shared/types/Brev'
-import { Alert, Heading, Panel } from '@navikt/ds-react'
+import { AdresseType, IBrev } from '~shared/types/Brev'
+import { Alert, Heading, Panel, Tag } from '@navikt/ds-react'
 import React, { useEffect, useState } from 'react'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { getVergeadresseForPerson } from '~shared/api/grunnlag'
@@ -31,7 +31,12 @@ export function BrevMottaker({ brev, kanRedigeres }: { brev: IBrev; kanRedigeres
       )}
       <FlexRow justify="space-between">
         <Heading spacing level="2" size="medium">
-          Mottaker
+          Mottaker{' '}
+          {mottaker.adresse.adresseType === AdresseType.UTENLANDSKPOSTADRESSE && (
+            <Tag variant="alt1" size="small">
+              Utenlandsk adresse
+            </Tag>
+          )}
         </Heading>
         <div>
           {kanRedigeres && <BrevMottakerModal brev={brevState} setBrev={setBrevState} vergeadresse={vergeadresse} />}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottakerModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottakerModal.tsx
@@ -180,12 +180,14 @@ export function BrevMottakerModal({ brev, setBrev, vergeadresse }: Props) {
                 {...register('adresse.postnummer', {
                   required: {
                     value: erNorskAdresse,
-                    message: 'Postnummer må være satt på norske adresser',
+                    message: 'Postnummer må være satt på norsk adresse',
                   },
-                  pattern: {
-                    value: /\d{4}/,
-                    message: 'Postnummer skal være fire siffer',
-                  },
+                  pattern: erNorskAdresse
+                    ? {
+                        value: /\d{4}/,
+                        message: 'Norsk postnummer må være fire siffer',
+                      }
+                    : undefined,
                 })}
                 label="Postnummer"
                 error={errors?.adresse?.postnummer?.message}
@@ -194,7 +196,7 @@ export function BrevMottakerModal({ brev, setBrev, vergeadresse }: Props) {
                 {...register('adresse.poststed', {
                   required: {
                     value: erNorskAdresse,
-                    message: 'Poststed må være satt',
+                    message: 'Poststed må være satt norsk adresse',
                   },
                 })}
                 label="Poststed"

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottakerModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottakerModal.tsx
@@ -196,7 +196,7 @@ export function BrevMottakerModal({ brev, setBrev, vergeadresse }: Props) {
                 {...register('adresse.poststed', {
                   required: {
                     value: erNorskAdresse,
-                    message: 'Poststed må være satt norsk adresse',
+                    message: 'Poststed må være satt på norsk adresse',
                   },
                 })}
                 label="Poststed"


### PR DESCRIPTION
Kun låse til 4 siffer hvis norsk adresse. 


<img width="841" alt="Screenshot 2024-02-13 at 12 03 11" src="https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/0b08c838-4b21-4204-a186-808279b90bc3">
