### PR TITLE
Bedre feilmelding til saksbehandler ved manglende enhetstilgang

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
@@ -112,10 +112,16 @@ internal fun Route.sakSystemRoutes(
     }
 }
 
-class PersonManglerSak(message: String) :
+class PersonManglerSak() :
     UgyldigForespoerselException(
         code = "PERSON_MANGLER_SAK",
-        detail = message,
+        detail = "Personen har ingen saker i Gjenny",
+    )
+
+class ManglerTilgangTilEnhet(enheter: List<String>) :
+    UgyldigForespoerselException(
+        code = "MANGLER_TILGANG_TIL_ENHET",
+        detail = "Mangler tilgang til enhet $enheter",
     )
 
 class SakIkkeFunnetException(message: String) :

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
@@ -77,9 +77,12 @@ class SakServiceImpl(
     }
 
     override fun hentEnkeltSakForPerson(fnr: String): Sak {
-        return this.finnSaker(
-            fnr,
-        ).firstOrNull() ?: throw PersonManglerSak("Personen har ikke sak")
+        val saker = finnSakerForPerson(fnr)
+
+        if (saker.isEmpty()) throw PersonManglerSak()
+
+        return saker.filterForEnheter().firstOrNull()
+            ?: throw ManglerTilgangTilEnhet(saker.map { it.enhet })
     }
 
     override suspend fun finnNavkontorForPerson(fnr: String): Navkontor {


### PR DESCRIPTION
P.t. får saksbehandler bare beskjed om at "personen har ingen saker", når de enkelt kan se i eks. Pesys at dette ikke stemmer. Dette blir deretter rapportert som feil hos oss, noe det ikke er. 

Legger derfor på en ekstra sjekk og feilmelding for å gi de litt mer å gå på. 