### PR TITLE
Videresende ResponseException fra DownstreamResourceClient

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/GrunnlagKlient.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.github.michaelbull.result.mapBoth
 import com.typesafe.config.Config
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.ResponseException
 import io.ktor.http.HttpStatusCode
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -60,18 +61,16 @@ class GrunnlagKlientObo(config: Config, httpClient: HttpClient) : GrunnlagKlient
                 )
                 .mapBoth(
                     success = { resource -> resource.response?.let { objectMapper.readValue(it.toString()) } },
-                    failure = { errorResponse ->
-                        if (errorResponse.response?.status == HttpStatusCode.NotFound) {
-                            null
-                        } else {
-                            throw errorResponse
-                        }
-                    },
+                    failure = { errorResponse -> throw errorResponse },
                 )
-        } catch (e: Exception) {
+        } catch (re: ResponseException) {
+            if (re.response.status == HttpStatusCode.NotFound) {
+                return null
+            }
+
             throw GrunnlagKlientException(
                 "Henting av opplysning ($opplysningsType) fra grunnlag for behandling med id=$behandlingId feilet",
-                e,
+                re,
             )
         }
     }

--- a/libs/etterlatte-ktor/src/main/kotlin/no/nav/etterlatte/libs/ktorobo/DownstreamResourceClass.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/no/nav/etterlatte/libs/ktorobo/DownstreamResourceClass.kt
@@ -31,7 +31,7 @@ class DownstreamResourceClient(
     suspend fun get(
         resource: Resource,
         brukerTokenInfo: BrukerTokenInfo,
-    ): Result<Resource, ThrowableErrorMessage> {
+    ): Result<Resource, Throwable> {
         val scopes = listOf("api://${resource.clientId}/.default")
         return hentTokenFraAD(brukerTokenInfo, scopes)
             .andThen { oboAccessToken ->
@@ -60,7 +60,7 @@ class DownstreamResourceClient(
         resource: Resource,
         brukerTokenInfo: BrukerTokenInfo,
         postBody: Any,
-    ): Result<Resource, ThrowableErrorMessage> {
+    ): Result<Resource, Throwable> {
         val scopes = listOf("api://${resource.clientId}/.default")
         return hentTokenFraAD(brukerTokenInfo, scopes)
             .andThen { token ->
@@ -75,7 +75,7 @@ class DownstreamResourceClient(
         resource: Resource,
         brukerTokenInfo: BrukerTokenInfo,
         postBody: String,
-    ): Result<Resource, ThrowableErrorMessage> {
+    ): Result<Resource, Throwable> {
         val scopes = listOf("api://${resource.clientId}/.default")
         return hentTokenFraAD(brukerTokenInfo, scopes)
             .andThen { oboAccessToken ->
@@ -90,7 +90,7 @@ class DownstreamResourceClient(
         resource: Resource,
         brukerTokenInfo: BrukerTokenInfo,
         patchBody: String,
-    ): Result<Resource, ThrowableErrorMessage> {
+    ): Result<Resource, Throwable> {
         val scopes = listOf("api://${resource.clientId}/.default")
         return hentTokenFraAD(brukerTokenInfo, scopes)
             .andThen { oboAccessToken ->
@@ -104,7 +104,7 @@ class DownstreamResourceClient(
     private suspend fun fetchFromDownstreamApi(
         resource: Resource,
         oboAccessToken: AccessToken,
-    ): Result<JsonNode?, ThrowableErrorMessage> =
+    ): Result<JsonNode?, Throwable> =
 
         runCatching {
             httpClient.get(resource.url) {
@@ -117,7 +117,7 @@ class DownstreamResourceClient(
                     when {
                         response.status == HttpStatusCode.NoContent -> Ok(null)
                         response.status.isSuccess() -> Ok(response.body())
-                        else -> response.toErr()
+                        else -> response.toResponseException()
                     }
                 },
                 onFailure = { error ->
@@ -129,7 +129,7 @@ class DownstreamResourceClient(
         resource: Resource,
         oboAccessToken: AccessToken,
         postBody: Any,
-    ): Result<Any, ThrowableErrorMessage> =
+    ): Result<Any, Throwable> =
 
         runCatching {
             httpClient.post(resource.url) {
@@ -149,7 +149,7 @@ class DownstreamResourceClient(
                                 Ok(response.status)
                             }
                         }
-                        else -> response.toErr()
+                        else -> response.toResponseException()
                     }
                 },
                 onFailure = { error ->
@@ -161,7 +161,7 @@ class DownstreamResourceClient(
         resource: Resource,
         oboAccessToken: AccessToken,
         postBody: String,
-    ): Result<JsonNode, ThrowableErrorMessage> =
+    ): Result<JsonNode, Throwable> =
 
         runCatching {
             httpClient.delete(resource.url) {
@@ -174,7 +174,7 @@ class DownstreamResourceClient(
                 onSuccess = { response ->
                     when {
                         response.status.isSuccess() -> Ok(response.body())
-                        else -> response.toErr()
+                        else -> response.toResponseException()
                     }
                 },
                 onFailure = { error ->
@@ -186,7 +186,7 @@ class DownstreamResourceClient(
         resource: Resource,
         oboAccessToken: AccessToken,
         patchBody: String,
-    ): Result<JsonNode, ThrowableErrorMessage> =
+    ): Result<JsonNode, Throwable> =
         runCatching {
             httpClient.patch(resource.url) {
                 header(HttpHeaders.Authorization, "Bearer ${oboAccessToken.accessToken}")
@@ -198,7 +198,7 @@ class DownstreamResourceClient(
                 onSuccess = { response ->
                     when {
                         response.status.isSuccess() -> Ok(response.body())
-                        else -> response.toErr()
+                        else -> response.toResponseException()
                     }
                 },
                 onFailure = { error ->


### PR DESCRIPTION
Forslag til oppdatering på `DownstreamResourceClient`. Gjør at den ikke lenger spiser http-responskoder, m.m.

Nå vil den returnere `ResponseException` i alle tilfeller det er mulig, og `ThrowableErrorMessage` i de resterende.