### PR TITLE
Fikser visning i redigerbare vedlegg på brev

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/ForhaandsvisningBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/ForhaandsvisningBrev.tsx
@@ -51,6 +51,6 @@ const PdfViewer = styled.embed`
 
 const Container = styled.div`
   margin: auto;
-  height: 100%;
+  height: 75vh;
   width: 100%;
 `

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
@@ -93,7 +93,7 @@ export default function RedigerbartBrev({ brev, kanRedigeres, lukkAdvarselBehand
   }
 
   return (
-    <Container forhaandsvisning={fane === ManueltBrevFane.FORHAANDSVIS}>
+    <Container>
       <Tabs value={fane} onChange={setFane}>
         <Tabs.List>
           <Tabs.Tab
@@ -120,7 +120,7 @@ export default function RedigerbartBrev({ brev, kanRedigeres, lukkAdvarselBehand
             <Spinner visible label="Henter brevinnhold ..." />
           )}
           {isSuccess(hentManuellPayloadStatus) && isSuccessOrInitial(tilbakestillManuellPayloadStatus) && (
-            <PanelWrapper>
+            <>
               <SlateEditor value={content} onChange={onChange} readonly={!kanRedigeres} />
 
               {kanRedigeres && (
@@ -133,7 +133,7 @@ export default function RedigerbartBrev({ brev, kanRedigeres, lukkAdvarselBehand
                   tilbakestillSynlig={!!brev.behandlingId}
                 />
               )}
-            </PanelWrapper>
+            </>
           )}
           {isFailureHandler({
             apiResult: tilbakestillManuellPayloadStatus,
@@ -146,35 +146,33 @@ export default function RedigerbartBrev({ brev, kanRedigeres, lukkAdvarselBehand
             (isPending(tilbakestillManuellPayloadStatus) && <Spinner visible label="Henter brevinnhold ..." />)}
           {isSuccess(hentManuellPayloadStatus) && isSuccessOrInitial(tilbakestillManuellPayloadStatus) && (
             <>
-              <PanelWrapper>
-                <Accordion>
-                  {vedlegg &&
-                    vedlegg.map((brevVedlegg) => (
-                      <Accordion.Item key={brevVedlegg.key}>
-                        <Accordion.Header>{brevVedlegg.tittel}</Accordion.Header>
-                        <Accordion.Content>
-                          <SlateEditor
-                            value={brevVedlegg.payload}
-                            onChange={onChangeVedlegg}
-                            readonly={!kanRedigeres}
-                            editKey={brevVedlegg.key}
-                          />
-                        </Accordion.Content>
-                      </Accordion.Item>
-                    ))}
-                </Accordion>
+              <Accordion indent={false}>
+                {vedlegg &&
+                  vedlegg.map((brevVedlegg) => (
+                    <Accordion.Item key={brevVedlegg.key}>
+                      <Accordion.Header>{brevVedlegg.tittel}</Accordion.Header>
+                      <Accordion.Content>
+                        <SlateEditor
+                          value={brevVedlegg.payload}
+                          onChange={onChangeVedlegg}
+                          readonly={!kanRedigeres}
+                          editKey={brevVedlegg.key}
+                        />
+                      </Accordion.Content>
+                    </Accordion.Item>
+                  ))}
+              </Accordion>
 
-                {kanRedigeres && (
-                  <TilbakestillOgLagreRad
-                    lagretStatus={lagretStatus}
-                    lagre={lagre}
-                    tilbakestill={tilbakestill}
-                    tilbakestillManuellPayloadStatus={isPending(tilbakestillManuellPayloadStatus)}
-                    lagreManuellPayloadStatus={isPending(lagreManuellPayloadStatus)}
-                    tilbakestillSynlig={!!brev.behandlingId}
-                  />
-                )}
-              </PanelWrapper>
+              {kanRedigeres && (
+                <TilbakestillOgLagreRad
+                  lagretStatus={lagretStatus}
+                  lagre={lagre}
+                  tilbakestill={tilbakestill}
+                  tilbakestillManuellPayloadStatus={isPending(tilbakestillManuellPayloadStatus)}
+                  lagreManuellPayloadStatus={isPending(lagreManuellPayloadStatus)}
+                  tilbakestillSynlig={!!brev.behandlingId}
+                />
+              )}
             </>
           )}
           {isFailureHandler({
@@ -184,34 +182,13 @@ export default function RedigerbartBrev({ brev, kanRedigeres, lukkAdvarselBehand
         </Tabs.Panel>
 
         <Tabs.Panel value={ManueltBrevFane.FORHAANDSVIS}>
-          <PanelWrapper forhaandsvisning>
-            <ForhaandsvisningBrev brev={brev} />
-          </PanelWrapper>
+          <ForhaandsvisningBrev brev={brev} />
         </Tabs.Panel>
       </Tabs>
     </Container>
   )
 }
 
-interface StyledProps {
-  forhaandsvisning?: boolean
-}
-
-const Container = styled.div<StyledProps>`
-  margin: auto;
-  height: 100%;
+const Container = styled.div`
   width: 100%;
-  position: relative;
-  .navds-tabs,
-  .navds-tabs__tabpanel {
-    height: inherit;
-    width: inherit;
-    max-height: ${(p) => (p.forhaandsvisning ? '75vh' : 'calc(75vh - 8rem)')};
-  }
-`
-
-const PanelWrapper = styled.div<StyledProps>`
-  height: 100%;
-  width: 100%;
-  max-height: ${(p) => (p.forhaandsvisning ? 'calc(75vh - 3rem)' : 'calc(75vh - 5rem)')};
 `

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/TilbakestillOgLagreRad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/TilbakestillOgLagreRad.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { Button, Detail } from '@navikt/ds-react'
 import { FileResetIcon, FloppydiskIcon } from '@navikt/aksel-icons'
 import { GeneriskModal } from '~shared/modal/modal'
+import { FlexRow } from '~shared/styled'
 
 interface TilbakestillOgLagreRadProps {
   lagretStatus: LagretStatus
@@ -38,12 +39,8 @@ export const TilbakestillOgLagreRad = ({
             Tilbakestill brev
           </Button>
         )}
-        <LagreEndringer>
-          {lagretStatus.beskrivelse && (
-            <Detail as="span" style={{ marginRight: '5px' }}>
-              {lagretStatus.beskrivelse}
-            </Detail>
-          )}
+        <FlexRow align="end">
+          {lagretStatus.beskrivelse && <Detail as="span">{lagretStatus.beskrivelse}</Detail>}
           <Button
             icon={<FloppydiskIcon aria-hidden />}
             variant="primary"
@@ -53,7 +50,7 @@ export const TilbakestillOgLagreRad = ({
           >
             Lagre endringer
           </Button>
-        </LagreEndringer>
+        </FlexRow>
       </ButtonRow>
       <GeneriskModal
         tittel="Tilbakestill brevet"
@@ -67,11 +64,6 @@ export const TilbakestillOgLagreRad = ({
     </>
   )
 }
-
-const LagreEndringer = styled.div`
-  display: flex;
-  align-items: end;
-`
 
 const ButtonRow = styled.div`
   display: flex;

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/TilbakestillOgLagreRad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/TilbakestillOgLagreRad.tsx
@@ -38,8 +38,12 @@ export const TilbakestillOgLagreRad = ({
             Tilbakestill brev
           </Button>
         )}
-        <div>
-          {lagretStatus.beskrivelse && <Detail as="span">{lagretStatus.beskrivelse}</Detail>}
+        <LagreEndringer>
+          {lagretStatus.beskrivelse && (
+            <Detail as="span" style={{ marginRight: '5px' }}>
+              {lagretStatus.beskrivelse}
+            </Detail>
+          )}
           <Button
             icon={<FloppydiskIcon aria-hidden />}
             variant="primary"
@@ -49,7 +53,7 @@ export const TilbakestillOgLagreRad = ({
           >
             Lagre endringer
           </Button>
-        </div>
+        </LagreEndringer>
       </ButtonRow>
       <GeneriskModal
         tittel="Tilbakestill brevet"
@@ -63,6 +67,11 @@ export const TilbakestillOgLagreRad = ({
     </>
   )
 }
+
+const LagreEndringer = styled.div`
+  display: flex;
+  align-items: end;
+`
 
 const ButtonRow = styled.div`
   display: flex;

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
@@ -199,8 +199,6 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
 
 const BrevContent = styled.div`
   display: flex;
-  height: 75vh;
-  max-height: 75vh;
 `
 
 const Sidebar = styled.div`


### PR DESCRIPTION
Endrer slik at knappene i bunn følger etter dersom man åpner et vedlegg. Tidligere ville knappene bli liggende over hverandre.