### PR TITLE
EY-3355 Spesifisere når jobber kan starte ("åpningstid")

### DIFF
--- a/apps/etterlatte-tidshendelser/.nais/dev.yaml
+++ b/apps/etterlatte-tidshendelser/.nais/dev.yaml
@@ -45,7 +45,9 @@ spec:
     - name: JOBB_POLLER_INITIAL_DELAY
       value: "60"
     - name: JOBB_POLLER_INTERVAL
-      value: "PT10S"
+      value: "PT30S"
+    - name: JOBB_POLLER_OPENING_HOURS
+      value: "06-23"
     - name: HENDELSE_POLLER_INITIAL_DELAY
       value: "60"
     - name: HENDELSE_POLLER_INTERVAL

--- a/apps/etterlatte-tidshendelser/.nais/prod.yaml
+++ b/apps/etterlatte-tidshendelser/.nais/prod.yaml
@@ -60,7 +60,9 @@ spec:
     - name: JOBB_POLLER_INITIAL_DELAY
       value: "60"
     - name: JOBB_POLLER_INTERVAL
-      value: "PT10S"
+      value: "PT30S"
+    - name: JOBB_POLLER_OPENING_HOURS
+      value: "09-15"
     - name: HENDELSE_POLLER_INITIAL_DELAY
       value: "60"
     - name: HENDELSE_POLLER_INTERVAL

--- a/apps/etterlatte-tidshendelser/.run/etterlatte-tidshendelser.dev-gcp.run.xml
+++ b/apps/etterlatte-tidshendelser/.run/etterlatte-tidshendelser.dev-gcp.run.xml
@@ -3,6 +3,7 @@
     <envs>
       <env name="JOBB_POLLER_INITIAL_DELAY" value="5" />
       <env name="JOBB_POLLER_INTERVAL" value="PT10S" />
+      <env name="JOBB_POLLER_OPENING_HOURS" value="00-23" />
       <env name="HENDELSE_POLLER_INITIAL_DELAY" value="10" />
       <env name="HENDELSE_POLLER_INTERVAL" value="PT10S" />
       <env name="HENDELSE_POLLER_MAX_ANTALL" value="5" />

--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/AppContext.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/AppContext.kt
@@ -4,6 +4,7 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import io.ktor.client.HttpClient
 import no.nav.etterlatte.libs.common.Miljoevariabler
+import no.nav.etterlatte.libs.common.tidspunkt.norskKlokke
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 import no.nav.etterlatte.tidshendelser.klient.GrunnlagKlient
@@ -45,6 +46,8 @@ class AppContext(
         JobbPollerTask(
             initialDelaySeconds = env.requireEnvValue("JOBB_POLLER_INITIAL_DELAY").toLong(),
             periode = env.requireEnvValue("JOBB_POLLER_INTERVAL").let { Duration.parse(it) } ?: Duration.ofMinutes(5),
+            openingHours = env.requireEnvValue("JOBB_POLLER_OPENING_HOURS").let { OpeningHours.of(it) },
+            klokke = norskKlokke(),
             jobbPoller = JobbPoller(hendelseDao, aldersovergangerService),
         )
 

--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/JobbPoller.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/JobbPoller.kt
@@ -3,12 +3,15 @@ package no.nav.etterlatte.tidshendelser
 import no.nav.etterlatte.jobs.LoggerInfo
 import no.nav.etterlatte.jobs.fixedRateCancellableTimer
 import org.slf4j.LoggerFactory
+import java.time.Clock
 import java.time.Duration
 import java.util.Timer
 
 class JobbPollerTask(
     private val initialDelaySeconds: Long,
     private val periode: Duration,
+    private val klokke: Clock,
+    private val openingHours: OpeningHours,
     private val jobbPoller: JobbPoller,
 ) {
     private val logger = LoggerFactory.getLogger(JobbPollerTask::class.java)
@@ -22,7 +25,9 @@ class JobbPollerTask(
             period = periode.toMillis(),
             loggerInfo = LoggerInfo(logger = logger),
         ) {
-            jobbPoller.poll()
+            if (openingHours.isOpen(klokke)) {
+                jobbPoller.poll()
+            }
         }
     }
 }
@@ -45,5 +50,20 @@ class JobbPoller(
                 JobbType.AO_BP21 -> aldersovergangerService.execute(it)
             }
         }
+    }
+}
+
+data class OpeningHours(val start: Int, val slutt: Int) {
+    companion object {
+        fun of(openingHours: String): OpeningHours {
+            openingHours.split("-").toList()
+                .also { require(it.size == 2) }
+                .let { return OpeningHours(it[0].toInt(), it[1].toInt()) }
+        }
+    }
+
+    fun isOpen(klokke: Clock): Boolean {
+        val time = klokke.instant().atZone(klokke.zone).hour
+        return time in start until slutt
     }
 }

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/JobbPollerTest.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/JobbPollerTest.kt
@@ -1,0 +1,33 @@
+package no.nav.etterlatte.tidshendelser
+
+import io.kotest.matchers.shouldBe
+import no.nav.etterlatte.libs.common.tidspunkt.norskTidssone
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.ZonedDateTime
+
+class JobbPollerTest {
+    @Nested
+    inner class OpeningHoursTest {
+        private val openingHours08to16 = OpeningHours.of("08-16")
+
+        @Test
+        fun `kl 8 er i aapningstida 8-16`() {
+            val noon = ZonedDateTime.now().withHour(12).toInstant()
+            openingHours08to16.isOpen(Clock.fixed(noon, norskTidssone)) shouldBe true
+        }
+
+        @Test
+        fun `kl bittelitt over 16 er utenfor aapningstida 8-16`() {
+            val sekstenish = ZonedDateTime.now().withHour(16).withMinute(0).withSecond(1).toInstant()
+            openingHours08to16.isOpen(Clock.fixed(sekstenish, norskTidssone)) shouldBe false
+        }
+
+        @Test
+        fun `midnatt er utenfor aapningstida 8-16`() {
+            val midnatt = ZonedDateTime.now().withHour(0).withMinute(0).withSecond(1).toInstant()
+            openingHours08to16.isOpen(Clock.fixed(midnatt, norskTidssone)) shouldBe false
+        }
+    }
+}


### PR DESCRIPTION
Et alternativ kan være å angi dette i selve jobbtabellen.

Uansett så er poenget å ha litt mer kontroll, og at jobber helst starter på et tidspunkt hvor folk er våkne og kan eventuelt ta tak i problemer som måtte oppstå.