### PR TITLE
EY-3433 Støtte flere dokumenter på journalpost

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/DokumentRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/DokumentRoute.kt
@@ -79,7 +79,7 @@ fun Route.dokumentRoute(
             get("/{dokumentInfoId}") {
                 val journalpostId = call.parameters["journalpostId"]!!
                 val dokumentInfoId = call.parameters["dokumentInfoId"]!!
-                val innhold = safService.hentDokumentPDF(journalpostId, dokumentInfoId, brukerTokenInfo.accessToken())
+                val innhold = safService.hentDokumentPDF(journalpostId, dokumentInfoId, brukerTokenInfo)
 
                 call.respond(innhold)
             }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafKlient.kt
@@ -7,22 +7,20 @@ import com.typesafe.config.ConfigFactory
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.ResponseException
-import io.ktor.client.request.accept
+import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
-import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.content.TextContent
+import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import no.nav.etterlatte.brev.dokarkiv.BrukerIdType
 import no.nav.etterlatte.libs.common.RetryResult
 import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
 import no.nav.etterlatte.libs.common.retry
-import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.ktorobo.AzureAdClient
 import no.nav.etterlatte.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
@@ -44,12 +42,12 @@ class SafKlient(
     suspend fun hentDokumentPDF(
         journalpostId: String,
         dokumentInfoId: String,
-        accessToken: String,
+        bruker: BrukerTokenInfo,
     ): ByteArray =
         try {
             httpClient.get("$baseUrl/rest/hentdokument/$journalpostId/$dokumentInfoId/ARKIV") {
-                header("Authorization", "Bearer ${getToken(accessToken)}")
-                header("Content-Type", "application/json")
+                bearerAuth(getOboToken(bruker))
+                contentType(ContentType.Application.Json)
             }.body()
         } catch (re: ResponseException) {
             logger.error("Feil i kall mot Saf: ${re.response.bodyAsText()}")
@@ -80,7 +78,7 @@ class SafKlient(
         fnr: String,
         visTemaPen: Boolean,
         idType: BrukerIdType,
-        brukerTokenInfo: BrukerTokenInfo,
+        bruker: BrukerTokenInfo,
     ): DokumentoversiktBrukerResponse {
         logger.info("VisTemaPen=$visTemaPen")
 
@@ -103,9 +101,9 @@ class SafKlient(
         return retry {
             val res =
                 httpClient.post("$baseUrl/graphql") {
-                    header("Authorization", "Bearer ${getToken(brukerTokenInfo.accessToken())}")
-                    accept(ContentType.Application.Json)
-                    setBody(TextContent(request.toJson(), ContentType.Application.Json))
+                    bearerAuth(getOboToken(bruker))
+                    contentType(ContentType.Application.Json)
+                    setBody(request)
                 }
 
             if (res.status.isSuccess()) {
@@ -123,7 +121,7 @@ class SafKlient(
 
     suspend fun hentJournalpost(
         journalpostId: String,
-        brukerTokenInfo: BrukerTokenInfo,
+        bruker: BrukerTokenInfo,
     ): JournalpostResponse {
         val request =
             GraphqlRequest(
@@ -134,9 +132,9 @@ class SafKlient(
         return retry {
             val res =
                 httpClient.post("$baseUrl/graphql") {
-                    header("Authorization", "Bearer ${getToken(brukerTokenInfo.accessToken())}")
-                    accept(ContentType.Application.Json)
-                    setBody(TextContent(request.toJson(), ContentType.Application.Json))
+                    bearerAuth(getOboToken(bruker))
+                    contentType(ContentType.Application.Json)
+                    setBody(request)
                 }
 
             if (res.status.isSuccess()) {
@@ -158,11 +156,11 @@ class SafKlient(
             .replace(Regex("[\n\t]"), "")
     }
 
-    private suspend fun getToken(accessToken: String): String {
+    private suspend fun getOboToken(bruker: BrukerTokenInfo): String {
         val token =
             azureAdClient.getOnBehalfOfAccessTokenForResource(
                 listOf(safScope),
-                accessToken,
+                bruker.accessToken(),
             )
         return token.get()?.accessToken ?: ""
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafService.kt
@@ -18,22 +18,22 @@ class SafService(
     suspend fun hentDokumentPDF(
         journalpostId: String,
         dokumentInfoId: String,
-        accessToken: String,
+        bruker: BrukerTokenInfo,
     ): ByteArray {
         logger.info("Henter dokument (journalpostId=$journalpostId, dokumentInfoId=$dokumentInfoId)")
 
-        return safKlient.hentDokumentPDF(journalpostId, dokumentInfoId, accessToken)
+        return safKlient.hentDokumentPDF(journalpostId, dokumentInfoId, bruker)
     }
 
     suspend fun hentDokumenter(
         ident: String,
         visTemaPen: Boolean,
         idType: BrukerIdType,
-        brukerTokenInfo: BrukerTokenInfo,
+        bruker: BrukerTokenInfo,
     ): List<Journalpost> {
         logger.info("Henter alle journalposter for ident=${ident.maskerFnr()} (visTemaPen=$visTemaPen)")
 
-        val response = safKlient.hentDokumenter(ident, visTemaPen, idType, brukerTokenInfo)
+        val response = safKlient.hentDokumenter(ident, visTemaPen, idType, bruker)
 
         return if (response.errors.isNullOrEmpty()) {
             response.data?.dokumentoversiktBruker?.journalposter ?: emptyList()
@@ -44,11 +44,11 @@ class SafService(
 
     suspend fun hentJournalpost(
         journalpostId: String,
-        brukerTokenInfo: BrukerTokenInfo,
+        bruker: BrukerTokenInfo,
     ): Journalpost? {
         logger.info("Henter journalpost (id=$journalpostId)")
 
-        val response = safKlient.hentJournalpost(journalpostId, brukerTokenInfo)
+        val response = safKlient.hentJournalpost(journalpostId, bruker)
 
         return if (response.errors.isNullOrEmpty()) {
             response.data?.journalpost

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/dokumentModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/dokumentModal.tsx
@@ -1,25 +1,21 @@
-import { Button, Heading, Modal } from '@navikt/ds-react'
+import { Button, Dropdown, Heading, Modal } from '@navikt/ds-react'
 import { useState } from 'react'
 import { hentDokumentPDF } from '~shared/api/dokument'
 import Spinner from '~shared/Spinner'
 import { PdfVisning } from '~shared/brev/pdf-visning'
 import { FlexRow } from '~shared/styled'
+import { Journalpost } from '~shared/types/Journalpost'
+import styled from 'styled-components'
 
-export default function DokumentModal({
-  tittel,
-  journalpostId,
-  dokumentInfoId,
-}: {
-  tittel: string
-  journalpostId: string
-  dokumentInfoId: string
-}) {
+export default function DokumentModal({ journalpost }: { journalpost: Journalpost }) {
+  const { tittel, journalpostId, dokumenter } = journalpost
+
   const [error, setError] = useState<string>()
   const [fileURL, setFileURL] = useState<string>('')
   const [isOpen, setIsOpen] = useState<boolean>(false)
   const [hasLoaded, setHasLoaded] = useState<boolean>(false)
 
-  const open = async (journalpostId: string, dokumentInfoId: string) => {
+  const open = async (dokumentInfoId: string) => {
     setIsOpen(true)
 
     hentDokumentPDF({ journalpostId, dokumentInfoId })
@@ -42,9 +38,28 @@ export default function DokumentModal({
 
   return (
     <>
-      <Button variant="secondary" size="small" onClick={() => open(journalpostId, dokumentInfoId)}>
-        Åpne dokument
-      </Button>
+      {dokumenter.length > 1 ? (
+        <Dropdown>
+          <Button variant="secondary" size="small" as={Dropdown.Toggle}>
+            Åpne
+          </Button>
+          <DropdownMenu>
+            <Dropdown.Menu.GroupedList>
+              <Dropdown.Menu.GroupedList.Heading>Velg dokument</Dropdown.Menu.GroupedList.Heading>
+              <Dropdown.Menu.Divider />
+              {dokumenter.map((dok) => (
+                <Dropdown.Menu.GroupedList.Item key={dok.dokumentInfoId} onClick={() => open(dok.dokumentInfoId)}>
+                  {dok.tittel}
+                </Dropdown.Menu.GroupedList.Item>
+              ))}
+            </Dropdown.Menu.GroupedList>
+          </DropdownMenu>
+        </Dropdown>
+      ) : dokumenter.length === 1 ? (
+        <Button variant="secondary" size="small" onClick={() => open(dokumenter[0].dokumentInfoId)}>
+          Åpne
+        </Button>
+      ) : null}
 
       <Modal open={isOpen} onClose={() => setIsOpen(false)}>
         <Modal.Header>
@@ -67,3 +82,7 @@ export default function DokumentModal({
     </>
   )
 }
+
+const DropdownMenu = styled(Dropdown.Menu)`
+  width: 50ch;
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/dokumentliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/dokumentliste.tsx
@@ -66,11 +66,7 @@ export const Dokumentliste = ({ dokumenter }: { dokumenter: Result<Journalpost[]
                       <FlexRow justify="right">
                         <UtsendingsinfoModal journalpost={dokument} />
 
-                        <DokumentModal
-                          tittel={dokument.tittel}
-                          journalpostId={dokument.journalpostId}
-                          dokumentInfoId={dokument.dokumenter[0].dokumentInfoId}
-                        />
+                        <DokumentModal journalpost={dokument} />
                       </FlexRow>
                     </Table.DataCell>
                   </Table.Row>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/dokumentlisteLiten.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/dokumentlisteLiten.tsx
@@ -16,16 +16,16 @@ export const DokumentlisteLiten = ({ dokumenter }: { dokumenter: Result<Journalp
     {isPending(dokumenter) && <Spinner label="Henter dokumenter" visible />}
 
     {isSuccess(dokumenter) &&
-      (dokumenter.data.length ? (
-        dokumenter.data.map((dokument) => (
-          <div key={`${dokument.journalpostId}/${dokument.dokumenter[0].dokumentInfoId}`}>
-            <BodyShort as="div" size="small" spacing>
+      (dokumenter.data?.map((dokument) => (
+        <div key={dokument.journalpostId}>
+          {dokument.dokumenter.map((dokumentInfo) => (
+            <BodyShort key={dokumentInfo.dokumentInfoId} as="div" size="small" spacing>
               <Link
-                href={`/api/dokumenter/${dokument.journalpostId}/${dokument.dokumenter[0].dokumentInfoId}`}
+                href={`/api/dokumenter/${dokument.journalpostId}/${dokumentInfo.dokumentInfoId}`}
                 target="_blank"
                 rel="noreferrer noopener"
               >
-                {dokument.tittel}
+                {dokumentInfo.tittel}
                 <ExternalLinkIcon title={dokument.tittel} />
               </Link>
               <Detail>
@@ -33,9 +33,9 @@ export const DokumentlisteLiten = ({ dokumenter }: { dokumenter: Result<Journalp
                 {dokument.avsenderMottaker.navn || 'Ukjent'} ({formaterStringDato(dokument.datoOpprettet)})
               </Detail>
             </BodyShort>
-          </div>
-        ))
-      ) : (
+          ))}
+        </div>
+      )) || (
         <Detail style={{ textAlign: 'center' }}>
           <i>Ingen dokumenter ble funnet</i>
         </Detail>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/VelgJournalpost.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/VelgJournalpost.tsx
@@ -119,11 +119,7 @@ export default function VelgJournalpost({ journalpostId }: { journalpostId: stri
                     <Table.DataCell>{formaterJournalpostType(journalpost.journalposttype)}</Table.DataCell>
                     <Table.DataCell>
                       <FlexRow>
-                        <DokumentModal
-                          tittel={journalpost.tittel}
-                          journalpostId={journalpost.journalpostId}
-                          dokumentInfoId={journalpost.dokumenter[0].dokumentInfoId}
-                        />
+                        <DokumentModal journalpost={journalpost} />
 
                         <Button variant="primary" size="small" onClick={() => velgJournalpost(journalpost)}>
                           Velg


### PR DESCRIPTION
Det er vanlig at det finnes vedlegg på en journalpost. P.t. er det ikke mulig for saksbehandler å se disse i Gjenny, ettersom dagens løsning bare tar `[0]` i dokument-arrayen. Denne endringen vil gjøre det mulig for sb å se resterende dokumenter. 

### Dersom det finnes flere dokumenter på en journalpost vil det nå bli vist på denne måten: 
<img width="901" alt="Screenshot 2024-02-15 at 14 55 42" src="https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/3a6bb4ac-ff8a-4017-ad74-c81ebf85ede0">

### Sidebar i behandling er samme som før, men viser nå _alt_:
<img width="654" alt="Screenshot 2024-02-15 at 15 50 18" src="https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/6049aa37-af76-4660-9107-fa29d0906e52">
