### PR TITLE
Bruker riktige beløper for å beregne om revurdering medfører endring i utbretaling for omstillingsstønad

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
@@ -252,6 +252,22 @@ class BrevdataFacade(
         )
     }
 
+    suspend fun finnForrigeAvkortingsinfo(
+        sakId: Long,
+        sakType: SakType,
+        virkningstidspunkt: YearMonth,
+        vedtakType: VedtakType,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Avkortingsinfo? {
+        return finnAvkortingsinfo(
+            behandlingKlient.hentSisteIverksatteBehandling(sakId, brukerTokenInfo).id,
+            sakType,
+            virkningstidspunkt,
+            vedtakType,
+            brukerTokenInfo,
+        )
+    }
+
     suspend fun finnTrygdetid(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
@@ -227,8 +227,8 @@ class BrevDataMapperFerdigstillingVedtak(private val brevdataFacade: BrevdataFac
     ) = coroutineScope {
         val fetcher = BrevDatafetcherVedtak(brevdataFacade, brukerTokenInfo, generellBrevData)
         val utbetalingsinfo = async { fetcher.hentUtbetaling() }
-        val forrigeUtbetalingsinfo = async { fetcher.hentForrigeUtbetaling() }
         val avkortingsinfo = async { fetcher.hentAvkortinginfo() }
+        val forrigeAvkortingsinfo = async { fetcher.hentForrigeAvkortinginfo() }
         val trygdetid = async { fetcher.hentTrygdetid() }
         val etterbetaling = async { fetcher.hentEtterbetaling() }
         val brevutfall = async { fetcher.hentBrevutfall() }
@@ -237,7 +237,7 @@ class BrevDataMapperFerdigstillingVedtak(private val brevdataFacade: BrevdataFac
             innholdMedVedlegg,
             requireNotNull(avkortingsinfo.await()),
             utbetalingsinfo.await(),
-            forrigeUtbetalingsinfo.await(),
+            forrigeAvkortingsinfo.await(),
             etterbetaling.await(),
             requireNotNull(trygdetid.await()),
             requireNotNull(brevutfall.await()),

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDatafetcherVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDatafetcherVedtak.kt
@@ -67,5 +67,14 @@ internal class BrevDatafetcherVedtak(
             )
         }
 
+    suspend fun hentForrigeAvkortinginfo() =
+        brevdataFacade.finnForrigeAvkortingsinfo(
+            sak.id,
+            sak.sakType,
+            vedtakVirkningstidspunkt,
+            type!!,
+            brukerTokenInfo,
+        )
+
     suspend fun hentTrygdetid() = behandlingId?.let { brevdataFacade.finnTrygdetid(it, brukerTokenInfo) }
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadRevurdering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadRevurdering.kt
@@ -40,7 +40,7 @@ data class OmstillingsstoenadRevurdering(
             innholdMedVedlegg: InnholdMedVedlegg,
             avkortingsinfo: Avkortingsinfo,
             utbetalingsinfo: Utbetalingsinfo,
-            forrigeUtbetalingsinfo: Utbetalingsinfo?,
+            forrigeAvkortingsinfo: Avkortingsinfo?,
             etterbetalingDTO: EtterbetalingDTO?,
             trygdetid: Trygdetid,
             brevutfall: BrevutfallDto,
@@ -68,7 +68,7 @@ data class OmstillingsstoenadRevurdering(
                         innholdMedVedlegg,
                         BrevVedleggKey.OMS_FORHAANDSVARSEL_FEILUTBETALING,
                     ),
-                erEndret = forrigeUtbetalingsinfo == null || forrigeUtbetalingsinfo.beloep != utbetalingsinfo.beloep,
+                erEndret = erEndret(forrigeAvkortingsinfo, avkortingsinfo),
                 erOmgjoering = revurderingaarsak == Revurderingaarsak.OMGJOERING_ETTER_KLAGE,
                 // TODO klage kobler seg på her
                 datoVedtakOmgjoering = null,
@@ -103,6 +103,17 @@ data class OmstillingsstoenadRevurdering(
                 lavEllerIngenInntekt = brevutfall.lavEllerIngenInntekt == LavEllerIngenInntekt.JA,
                 feilutbetaling = feilutbetaling,
             )
+        }
+
+        private fun erEndret(
+            forrigeAvkortingsinfo: Avkortingsinfo?,
+            avkortingsinfo: Avkortingsinfo,
+        ): Boolean {
+            // Sjekker siste periode på forrige iverksatte og gjeldende behandling - mulig dette ikke holder
+            // med litt mer komplekse behandlinger?
+            val beloepForrigeBehandling = forrigeAvkortingsinfo?.beregningsperioder?.maxBy { it.datoFOM }?.utbetaltBeloep
+            val beloepGjeldendeBehandling = avkortingsinfo.beregningsperioder.maxBy { it.datoFOM }.utbetaltBeloep
+            return beloepForrigeBehandling == null || beloepForrigeBehandling != beloepGjeldendeBehandling
         }
     }
 }


### PR DESCRIPTION
Endrer fra å se på utbetalingsinfo, til å se på avkortingsinfo for å finne ut om vi har endring på utbetaling ift forrige iverksatte behandling. Ikke veldig fan av hvordan utbetalingsinfo og avkortingsinfo er strukturert pr nå, men tror det får duge inntil vi har fått på plass revurderingsbrevet i første utgave. 