### PR TITLE
EY-3478 Naviger til sak for oppgaver opprettet via aldersovergang-hendelse

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/components/HandlingerForOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/components/HandlingerForOppgave.tsx
@@ -93,9 +93,14 @@ export const HandlingerForOppgave = ({ oppgave }: { oppgave: OppgaveDTO }) => {
     case 'MANUELT_OPPHOER':
       return (
         <>
-          {erInnloggetSaksbehandlerOppgave && (
+          {erInnloggetSaksbehandlerOppgave && referanse && (
             <Button size="small" href={`/behandling/${referanse}`} as="a">
               Gå til opphør
+            </Button>
+          )}
+          {erInnloggetSaksbehandlerOppgave && !referanse && (
+            <Button size="small" href={`/person/${fnr}`} as="a">
+              Gå til sak
             </Button>
           )}
         </>


### PR DESCRIPTION
Disse  har ikke referanse til behandling, ettersom sistnevnte ikke automatisk opprettes. For å unngå lenke som ikke gjør noe.

Kan sees på som en noe midlertidig løsning, det er en del spørsmål som har kommet opp etterhvert - f.eks. om det bør være en egen oppgavetype for aldersovergang.

