### PR TITLE
Legg på eksplisitt feilhandtering av at dødsdato manglar

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
@@ -89,9 +89,15 @@ data class BarnepensjonInnvilgelseRedigerbartUtfall(
 
             return BarnepensjonInnvilgelseRedigerbartUtfall(
                 virkningsdato = utbetalingsinfo.virkningsdato,
-                avdoed = generellBrevData.personerISak.avdoede.minBy { it.doedsdato },
-                sisteBeregningsperiodeDatoFom = beregningsperioder.maxBy { it.datoFOM }.datoFOM,
-                sisteBeregningsperiodeBeloep = beregningsperioder.maxBy { it.datoFOM }.utbetaltBeloep,
+                avdoed =
+                    generellBrevData.personerISak.avdoede.minByOrNull { it.doedsdato }
+                        ?: throw IllegalStateException("Ingen avdød med dødsdato"),
+                sisteBeregningsperiodeDatoFom =
+                    beregningsperioder.maxByOrNull { it.datoFOM }?.datoFOM
+                        ?: throw IllegalStateException("Ingen beregningsperiode med dato FOM"),
+                sisteBeregningsperiodeBeloep =
+                    beregningsperioder.maxByOrNull { it.datoFOM }?.utbetaltBeloep
+                        ?: throw IllegalStateException("Intet utbetalt beløp i siste beregningsperiode"),
                 erEtterbetaling = etterbetaling != null,
                 harFlereUtbetalingsperioder = utbetalingsinfo.beregningsperioder.size > 1,
             )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
@@ -19,6 +19,7 @@ import no.nav.etterlatte.grunnbeloep.Grunnbeloep
 import no.nav.etterlatte.libs.common.behandling.Aldersgruppe
 import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.pensjon.brevbaker.api.model.Kroner
 import java.time.LocalDate
 
@@ -91,13 +92,22 @@ data class BarnepensjonInnvilgelseRedigerbartUtfall(
                 virkningsdato = utbetalingsinfo.virkningsdato,
                 avdoed =
                     generellBrevData.personerISak.avdoede.minByOrNull { it.doedsdato }
-                        ?: throw IllegalStateException("Ingen avdød med dødsdato"),
+                        ?: throw UgyldigForespoerselException(
+                            code = "AVDOED_MED_DOEDSDATO_MANGLER",
+                            detail = "Ingen avdød med dødsdato",
+                        ),
                 sisteBeregningsperiodeDatoFom =
                     beregningsperioder.maxByOrNull { it.datoFOM }?.datoFOM
-                        ?: throw IllegalStateException("Ingen beregningsperiode med dato FOM"),
+                        ?: throw UgyldigForespoerselException(
+                            code = "INGEN_BEREGNINGSPERIODE_MED_FOM",
+                            detail = "Ingen beregningsperiode med dato FOM",
+                        ),
                 sisteBeregningsperiodeBeloep =
                     beregningsperioder.maxByOrNull { it.datoFOM }?.utbetaltBeloep
-                        ?: throw IllegalStateException("Intet utbetalt beløp i siste beregningsperiode"),
+                        ?: throw UgyldigForespoerselException(
+                            code = "INTET_UTBETALT_BELOEP",
+                            detail = "Intet utbetalt beløp i siste beregningsperiode",
+                        ),
                 erEtterbetaling = etterbetaling != null,
                 harFlereUtbetalingsperioder = utbetalingsinfo.beregningsperioder.size > 1,
             )


### PR DESCRIPTION
Per no får vi ein `NoSuchElementException`, som ikkje er openbar før du har sett litt på koden (og resonnert deg fram til kva for eitt av dei moglege høva som slår til): https://logs.adeo.no/app/discover#/doc/96e648c0-980a-11e9-830a-e17bbd64b4db/logstash-apps-test-003041?id=qPxksY0BDLTuiVdR0qdm