### PR TITLE
Hotfix: Øke antall journalposter som hentes

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafKlient.kt
@@ -95,8 +95,8 @@ class SafKlient(
                                 type = idType,
                             ),
                         tema = if (visTemaPen) listOf("EYO", "EYB", "PEN") else listOf("EYO", "EYB"),
-                        // TODO: Finn en grense eller fiks paginering
-                        foerste = 20,
+                        // TODO: EY-3521
+                        foerste = 50,
                     ),
             )
 


### PR DESCRIPTION
Kjapp fiks for å sikre at saksbehandler får sett flere enn 20. Løser problemet midlertidig. 
Vil bli kraftig forbedret i [EY-3521](https://jira.adeo.no/browse/EY-3521). 