### PR TITLE
EY-3300 Kun hente utsendingsinfo på utgående journalposter

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/Model.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/Model.kt
@@ -5,15 +5,19 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import no.nav.etterlatte.brev.dokarkiv.BrukerIdType
 import no.nav.etterlatte.brev.dokarkiv.JournalpostSak
 
-data class HentDokumentoversiktBrukerResult(
-    val journalposter: List<Journalpost> = emptyList(),
-    val error: Error? = null,
-)
-
 data class HentJournalpostResult(
     val journalpost: Journalpost? = null,
     val error: Error? = null,
 )
+
+data class HentUtsendingsinfoResponse(
+    val data: ResponseData? = null,
+    val errors: List<Error>? = null,
+) {
+    data class ResponseData(
+        val journalpost: JournalpostUtsendingsinfo? = null,
+    )
+}
 
 data class JournalpostResponse(
     val data: ResponseData? = null,
@@ -100,6 +104,11 @@ data class Journalpost(
     val datoOpprettet: String,
 )
 
+data class JournalpostUtsendingsinfo(
+    val journalpostId: String,
+    val utsendingsinfo: Utsendingsinfo?,
+)
+
 data class DokumentInfo(
     val dokumentInfoId: String,
     val tittel: String?,
@@ -134,10 +143,10 @@ data class AvsenderMottaker(
 )
 
 // https://confluence.adeo.no/display/BOA/Type%3A+Utsendingsinfo
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class Utsendingsinfo(
     val fysiskpostSendt: FysiskpostSendt?,
     val digitalpostSendt: DigitalpostSendt?,
-    val varselSendt: VarselSendt?,
 ) {
     // Mappes hvis Journalpost.utsendingskanal er S (sentral utskrift)
     data class FysiskpostSendt(
@@ -147,13 +156,5 @@ data class Utsendingsinfo(
     // Mappes hvis Journalpost.utsendingskanal er SDP (sikker digital postkasse)
     data class DigitalpostSendt(
         val adresse: String?,
-    )
-
-    data class VarselSendt(
-        val type: String?,
-        val adresse: String?,
-        val tittel: String?,
-        val tekst: String?,
-        val tidspunkt: String?,
     )
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafService.kt
@@ -57,6 +57,21 @@ class SafService(
         }
     }
 
+    suspend fun hentUtsendingsinfo(
+        journalpostId: String,
+        bruker: BrukerTokenInfo,
+    ): JournalpostUtsendingsinfo? {
+        logger.info("Henter utsendingsinfo fra journalpost (id=$journalpostId)")
+
+        val response = safKlient.hentUtsendingsInfo(journalpostId, bruker)
+
+        return if (response.errors.isNullOrEmpty()) {
+            response.data?.journalpost
+        } else {
+            throw konverterTilForespoerselException(response.errors)
+        }
+    }
+
     private fun konverterTilForespoerselException(errors: List<Error>): ForespoerselException {
         errors.forEach {
             logger.error("${errors.size} feil oppsto ved kall mot saf: ${it.toJson()}")

--- a/apps/etterlatte-brev-api/src/main/resources/graphql/utsendingsinfo.graphql
+++ b/apps/etterlatte-brev-api/src/main/resources/graphql/utsendingsinfo.graphql
@@ -1,0 +1,15 @@
+query(
+   $journalpostId: String!,
+) {
+    journalpost(journalpostId: $journalpostId) {
+        journalpostId
+        utsendingsinfo {
+            fysiskpostSendt {
+                adressetekstKonvolutt
+            }
+            digitalpostSendt {
+                adresse
+            }
+        }
+    }
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/dokument.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/dokument.ts
@@ -1,5 +1,6 @@
 import {
   Journalpost,
+  JournalpostUtsendingsinfo,
   KnyttTilAnnenSakRequest,
   KnyttTilAnnenSakResponse,
   OppdaterJournalpostRequest,
@@ -41,6 +42,10 @@ export const oppdaterJournalpost = async (args: {
 
 export const hentJournalpost = async (journalpostId: string): Promise<ApiResponse<Journalpost>> =>
   apiClient.get(`/dokumenter/${journalpostId}`)
+
+export const hentUtsendingsinfo = async (args: {
+  journalpostId: string
+}): Promise<ApiResponse<JournalpostUtsendingsinfo>> => apiClient.get(`/dokumenter/${args.journalpostId}/utsendingsinfo`)
 
 export const hentDokumentPDF = async (args: {
   journalpostId: string

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Journalpost.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Journalpost.ts
@@ -13,6 +13,18 @@ export interface Journalpost {
   utsendingsinfo?: object
 }
 
+export interface JournalpostUtsendingsinfo {
+  journalpostId: string
+  utsendingsinfo?: {
+    fysiskpostSendt?: {
+      adressetekstKonvolutt?: string
+    }
+    digitalpostSendt?: {
+      adresse?: string
+    }
+  }
+}
+
 export interface OppdaterJournalpostRequest {
   journalpostId: string
   tittel?: string


### PR DESCRIPTION
### Liten infoknapp på utgående journalposter
<img width="658" alt="Screenshot 2024-02-16 at 15 25 40" src="https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/38053dcc-5908-42a8-a97b-0d8b7ab2e179">


### Åpner modal som viser utsendingsinfo
<img width="1015" alt="Screenshot 2024-02-16 at 15 22 54" src="https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/6bf3bdf3-c684-40d0-875b-5bdd1f9841ef">


### Hvis ingen utsendingsinfo finnes
<img width="1048" alt="Screenshot 2024-02-16 at 15 23 00" src="https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/1b278cd2-576e-456a-941a-2db46a5fa932">
