### PR TITLE
Viss vi prøver å opprette vedtaksbrev, forventar vi at vi har ein ved…

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapperVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapperVedtak.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.brev.model
 
 import no.nav.etterlatte.brev.brevbaker.Brevkoder
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 
 data class BrevkodeRequest(
@@ -30,7 +31,10 @@ class BrevKodeMapperVedtak {
                     VedtakType.OPPHOER -> Brevkoder.BP_OPPHOER
                     VedtakType.TILBAKEKREVING -> Brevkoder.TILBAKEKREVING
                     VedtakType.AVVIST_KLAGE -> Brevkoder.AVVIST_KLAGE
-                    null -> throw IllegalStateException("Skal ikke kunne komme hit med manglande vedtakstype, for request $request")
+                    null -> throw UgyldigForespoerselException(
+                        "MANGLENDE_VEDTAKSTYPE_VEDTAKSBREV",
+                        "Skal ikke kunne komme hit med manglande vedtakstype, for request $request",
+                    )
                 }
             }
 
@@ -42,7 +46,10 @@ class BrevKodeMapperVedtak {
                     VedtakType.OPPHOER -> Brevkoder.OMS_OPPHOER
                     VedtakType.TILBAKEKREVING -> Brevkoder.TILBAKEKREVING
                     VedtakType.AVVIST_KLAGE -> Brevkoder.AVVIST_KLAGE
-                    null -> throw IllegalStateException("Skal ikke kunne komme hit med manglande vedtakstype, for request $request")
+                    null -> throw UgyldigForespoerselException(
+                        "MANGLENDE_VEDTAKSTYPE_VEDTAKSBREV",
+                        "Skal ikke kunne komme hit med manglande vedtakstype, for request $request",
+                    )
                 }
             }
         }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapperVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapperVedtak.kt
@@ -24,12 +24,13 @@ class BrevKodeMapperVedtak {
                 when (request.vedtakType) {
                     VedtakType.INNVILGELSE ->
                         if (request.erForeldreloes) Brevkoder.BP_INNVILGELSE_FORELDRELOES else Brevkoder.BP_INNVILGELSE
+
                     VedtakType.AVSLAG -> Brevkoder.BP_AVSLAG
                     VedtakType.ENDRING -> Brevkoder.BP_REVURDERING
                     VedtakType.OPPHOER -> Brevkoder.BP_OPPHOER
                     VedtakType.TILBAKEKREVING -> Brevkoder.TILBAKEKREVING
                     VedtakType.AVVIST_KLAGE -> Brevkoder.AVVIST_KLAGE
-                    null -> TODO()
+                    null -> throw IllegalStateException("Skal ikke kunne komme hit med manglande vedtakstype, for request $request")
                 }
             }
 
@@ -41,7 +42,7 @@ class BrevKodeMapperVedtak {
                     VedtakType.OPPHOER -> Brevkoder.OMS_OPPHOER
                     VedtakType.TILBAKEKREVING -> Brevkoder.TILBAKEKREVING
                     VedtakType.AVVIST_KLAGE -> Brevkoder.AVVIST_KLAGE
-                    null -> TODO()
+                    null -> throw IllegalStateException("Skal ikke kunne komme hit med manglande vedtakstype, for request $request")
                 }
             }
         }


### PR DESCRIPTION
…takstype. Nokre gongar har vi visst ikkje det, og da er det nyttig å få heile requestobjektet som tok oss dit.

Denne gongen verkar det som det er det at vedtaket (og behandlinga) ikkje fins som er utløysande, men det vil vera lettare å spore når vi ser heile requestobjektet

Ref https://logs.adeo.no/app/discover#/doc/96e648c0-980a-11e9-830a-e17bbd64b4db/logstash-apps-prod-006928?id=gYzAwY0Bi6PkYLAlcDke