### PR TITLE
Oppgraderer til nyaste commons-compress

### DIFF
--- a/apps/etterlatte-egne-ansatte-lytter/build.gradle.kts
+++ b/apps/etterlatte-egne-ansatte-lytter/build.gradle.kts
@@ -20,7 +20,10 @@ dependencies {
     implementation(libs.jackson.datatypejsr310)
 
     implementation(libs.kafka.clients)
-    implementation(libs.kafka.avro)
+    implementation(libs.kafka.avro) {
+        exclude("org.apache.commons", "commons-compress")
+    }
+    implementation(libs.commons.compress)
 
     testImplementation(libs.kafka.embeddedenv)
     testImplementation(libs.el.api)

--- a/apps/etterlatte-hendelser-joark/build.gradle.kts
+++ b/apps/etterlatte-hendelser-joark/build.gradle.kts
@@ -29,7 +29,11 @@ dependencies {
     implementation(libs.jackson.datatypejsr310)
 
     implementation(libs.kafka.clients)
-    implementation(libs.kafka.avro)
+    implementation(libs.kafka.avro) {
+        exclude("org.apache.commons", "commons-compress")
+    }
+    implementation(libs.commons.compress)
+
     implementation(libs.kafka.avroserializer)
 
     implementation(libs.teamdokumenthandtering.avroschemas)

--- a/apps/etterlatte-hendelser-pdl/build.gradle.kts
+++ b/apps/etterlatte-hendelser-pdl/build.gradle.kts
@@ -25,7 +25,10 @@ dependencies {
     implementation(libs.jackson.datatypejsr310)
 
     implementation(libs.kafka.clients)
-    implementation(libs.kafka.avro)
+    implementation(libs.kafka.avro) {
+        exclude("org.apache.commons", "commons-compress")
+    }
+    implementation(libs.commons.compress)
     implementation(libs.kafka.avroserializer)
 
     testImplementation(libs.kafka.embeddedenv)

--- a/apps/etterlatte-hendelser-samordning/build.gradle.kts
+++ b/apps/etterlatte-hendelser-samordning/build.gradle.kts
@@ -19,7 +19,10 @@ dependencies {
     implementation(libs.jackson.datatypejsr310)
 
     implementation(libs.kafka.clients)
-    implementation(libs.kafka.avro)
+    implementation(libs.kafka.avro) {
+        exclude("org.apache.commons", "commons-compress")
+    }
+    implementation(libs.commons.compress)
 
     testImplementation(libs.kafka.embeddedenv)
     testImplementation(libs.el.api)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -99,6 +99,7 @@ test-testcontainer-jupiter = { module = "org.testcontainers:junit-jupiter", vers
 test-testcontainer-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainer-version" }
 test-wiremock = { module = "org.wiremock:wiremock", version = "3.3.1" }
 
+commons-compress = { module = "org.apache.commons:commons-compress", version = "1.26.0"}
 unleash-client = { module = "io.getunleash:unleash-client-java", version = "9.2.0" }
 
 [bundles]


### PR DESCRIPTION
Det er sårbarheiter i commons-compress, inkludert ein kategorisert som high. Tar derfor i bruk nyaste patch-versjon, der sårbarheitene er retta. Den gamle versjonen kjem inn transitivt via Apache Avro, som oppdaterast (altfor, spør du meg) sjeldan, så det er ikkje godt å seie kor fort neste versjon der kjem.

Har gått nøye gjennom [release notes](https://commons.apache.org/proper/commons-compress/changes-report.html#a1.23.0) for Commons Compress mellom 1.22.0, som vi køyrer på i dag og som kom allereie i november 22, og 1.26.0, og det ser ut til å vera utelukkande små feilrettingar, kan ikkje sjå noko risikabelt der