### PR TITLE
EY-3355 Sjekke løpende ytelse for måneden etter behandlingsmåned

### DIFF
--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/rivers/AldersovergangRiver.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/rivers/AldersovergangRiver.kt
@@ -61,10 +61,13 @@ class AldersovergangRiver(
                 val hendelseData = mutableMapOf<String, Any>()
 
                 val behandlingsdato = packet.dato
+                // Sjekker løpende ytelse for måneden _etter_ behandlingsdato (dvs når bruker fyller år, dødsdato osv.)
+                // Ytelsen skal løpe ut behandlingsmåneden. Unngå videre behandling der ytelsen kanskje allerede er opphørt.
+                val maanedEtterBehandlingsdato = behandlingsdato.plusMonths(1)
                 logger.info("Sjekker løpende ytelse for sak $sakId, behandlingsmåned=$behandlingsdato, dryrun=$dryrun")
 
-                val loependeYtelse = vedtakService.harLoependeYtelserFra(sakId, behandlingsdato)
-                logger.info("Sak $sakId, behandlingsmåned=$behandlingsdato har løpende ytelse: ${loependeYtelse.erLoepende}")
+                val loependeYtelse = vedtakService.harLoependeYtelserFra(sakId, maanedEtterBehandlingsdato)
+                logger.info("Sak $sakId har løpende ytelse per $maanedEtterBehandlingsdato? ${loependeYtelse.erLoepende}")
                 hendelseData["loependeYtelse"] = loependeYtelse.erLoepende
 
                 if (loependeYtelse.erLoepende && type == "AO_BP20") {

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/rivers/AldersovergangRiverTest.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/rivers/AldersovergangRiverTest.kt
@@ -36,7 +36,8 @@ class AldersovergangRiverTest {
 
     @Test
     fun `skal lese melding og sjekke loepende ytelse`() {
-        every { vedtakService.harLoependeYtelserFra(sakId, datoFom) } returns LoependeYtelseDTO(true, datoFom, behandlingId)
+        every { vedtakService.harLoependeYtelserFra(sakId, datoFom.plusMonths(1)) } returns
+            LoependeYtelseDTO(true, datoFom, behandlingId)
         every {
             vedtakService.harLoependeYtelserFra(
                 sakId,
@@ -68,13 +69,14 @@ class AldersovergangRiverTest {
             field(0, DRYRUN).asBoolean() shouldBe false
         }
 
-        verify { vedtakService.harLoependeYtelserFra(sakId, datoFom) }
+        verify { vedtakService.harLoependeYtelserFra(sakId, datoFom.plusMonths(1)) }
         verify { vedtakService.harLoependeYtelserFra(sakId, datoFomJanuar2024) }
     }
 
     @Test
     fun `skal lese melding og returnere negativt svar for loepende ytelse`() {
-        every { vedtakService.harLoependeYtelserFra(sakId, datoFom) } returns LoependeYtelseDTO(false, datoFom)
+        every { vedtakService.harLoependeYtelserFra(sakId, datoFom.plusMonths(1)) } returns
+            LoependeYtelseDTO(false, datoFom)
 
         val melding =
             JsonMessage.newMessage(
@@ -99,6 +101,6 @@ class AldersovergangRiverTest {
             field(0, DRYRUN).asBoolean() shouldBe true
         }
 
-        verify { vedtakService.harLoependeYtelserFra(sakId, datoFom) }
+        verify { vedtakService.harLoependeYtelserFra(sakId, datoFom.plusMonths(1)) }
     }
 }


### PR DESCRIPTION
Behandlingsmåneden er effektivt måneden som ytelsen skal løpe _ut_, og det gir derfor mening å sjekke om det finnes ytelse måneden _etter_. 

Uten denne endringen vil det kunne identifiseres løpende ytelse for aldersovergangen selv om den allerede er opphørt.