### PR TITLE
EY-3538: Distroless node

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/Dockerfile
+++ b/apps/etterlatte-saksbehandling-ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs20-debian12
+FROM node:20-bookworm-slim as base
 
 WORKDIR /app
 COPY ./client/dist ./client
@@ -9,6 +9,13 @@ ENV NODE_ENV="production"
 
 RUN cd ./server && yarn install --frozen-lockfile
 
+
+FROM gcr.io/distroless/nodejs20-debian12 as prod
+COPY --from=base /app /app
+
+USER nonroot
+
+WORKDIR /app
 EXPOSE 4000
 
-CMD ["node", "./server/index.js"]
+CMD ["./server/index.js"]

--- a/apps/etterlatte-saksbehandling-ui/Dockerfile
+++ b/apps/etterlatte-saksbehandling-ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bookworm-slim
+FROM gcr.io/distroless/nodejs20-debian12
 
 WORKDIR /app
 COPY ./client/dist ./client

--- a/apps/etterlatte-saksbehandling-ui/Dockerfile
+++ b/apps/etterlatte-saksbehandling-ui/Dockerfile
@@ -14,6 +14,7 @@ FROM gcr.io/distroless/nodejs20-debian12 as prod
 COPY --from=base /app /app
 
 USER nonroot
+ENV NODE_ENV="production"
 
 WORKDIR /app
 EXPOSE 4000

--- a/apps/etterlatte-saksbehandling-ui/server/Dockerfile.dev
+++ b/apps/etterlatte-saksbehandling-ui/server/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs20-debian12
+FROM node:20-bookworm-slim
 
 WORKDIR /home/node/app
 COPY package.json .

--- a/apps/etterlatte-saksbehandling-ui/server/Dockerfile.dev
+++ b/apps/etterlatte-saksbehandling-ui/server/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:20-bookworm-slim
+FROM gcr.io/distroless/nodejs20-debian12
 
 WORKDIR /home/node/app
 COPY package.json .


### PR DESCRIPTION
[Testa i dev](https://github.com/navikt/pensjon-etterlatte-saksbehandling/actions/runs/7971569969), fungerer fint.

Har skildra formålet i jirameldinga, men legg like godt inn her også:

> Vi bruker distroless baseimages for backend-applikasjonane våre, det kan vi med fordel gjera også for node-applikasjonane.
> 
> Trudde slim-versjonane av det offisielle node-baseimaget skulle vera slim, men desse inneheld ein god del andre bibliotek i tillegg. [Distroless-node](https://github.com/GoogleContainerTools/distroless/blob/main/nodejs/README.md) verkar meir eigna, der får vi kun med akkurat det vi treng.
> 
> Oppdaga gjennom sårbarheita i node-ip, som no gjer at [slsa-analysen ](https://console.nav.cloud.nais.io/team/etterlatte/vulnerabilities)viser at alle frontendapplikasjonane våre er sårbare, utan at det sårbare er i vår kode.
> 
> Bør bytte i Gjenny-frontend, søknadsdialogane og i slackbot, fordel at desse er like.


Prøvde på noko tilsvarande i Dockerfile.dev, som vi bruker lokalt, men det ga feil som
```
11:05:00 AM [vite] http proxy error at /api/logg:
Error: connect ECONNREFUSED 0.0.0.0:8080
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16) (x4)
```

Kan (og potensielt bør) nok løysast.