### PR TITLE
EY-3530 API i grunnlag for å hente saker med dødsdato i angitt måned

### DIFF
--- a/apps/etterlatte-grunnlag/build.gradle.kts
+++ b/apps/etterlatte-grunnlag/build.gradle.kts
@@ -42,5 +42,6 @@ dependencies {
     testImplementation(libs.ktor2.servertests)
     testImplementation(project(":libs:testdata"))
     testImplementation(libs.test.kotest.assertionscore)
-    testImplementation(testFixtures((project(":libs:etterlatte-ktor"))))
+    testImplementation(testFixtures(project(":libs:etterlatte-database")))
+    testImplementation(testFixtures(project(":libs:etterlatte-ktor")))
 }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangRoutes.kt
@@ -14,4 +14,11 @@ fun Route.aldersovergangRoutes(aldersovergangService: AldersovergangService) {
             call.respond(aldersovergangService.hentSoekereFoedtIEnGittMaaned(yearMonth))
         }
     }
+
+    route("/doedsdato") {
+        get("{yearMonth}") {
+            val behandlingsmaaned = call.parameters["yearMonth"].toString().let { YearMonth.parse(it) }
+            call.respond(aldersovergangService.hentSakerHvorDoedsfallForekomIGittMaaned(behandlingsmaaned))
+        }
+    }
 }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangService.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangService.kt
@@ -4,4 +4,7 @@ import java.time.YearMonth
 
 class AldersovergangService(private val dao: AldersovergangDao) {
     fun hentSoekereFoedtIEnGittMaaned(maaned: YearMonth) = dao.hentSoekereFoedtIEnGittMaaned(maaned)
+
+    fun hentSakerHvorDoedsfallForekomIGittMaaned(behandlingsmaaned: YearMonth) =
+        dao.hentSakerHvorDoedsfallForekomIGittMaaned(behandlingsmaaned)
 }

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagDbExtension.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagDbExtension.kt
@@ -1,0 +1,17 @@
+package no.nav.etterlatte.grunnlag
+
+import no.nav.etterlatte.GenerellDatabaseExtension
+import no.nav.etterlatte.ResetDatabaseStatement
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+@ResetDatabaseStatement(
+    """
+TRUNCATE grunnlagshendelse
+""",
+)
+class GrunnlagDbExtension : GenerellDatabaseExtension(), AfterEachCallback {
+    override fun afterEach(context: ExtensionContext?) {
+        resetDb()
+    }
+}

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/aldersovergang/AldersovergangTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/aldersovergang/AldersovergangTest.kt
@@ -11,6 +11,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import io.mockk.mockk
+import no.nav.etterlatte.grunnlag.GrunnlagDbExtension
 import no.nav.etterlatte.grunnlag.OpplysningDao
 import no.nav.etterlatte.ktor.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.runServer
@@ -20,9 +21,6 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.serialize
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.database.DataSourceBuilder
-import no.nav.etterlatte.libs.database.POSTGRES_VERSION
-import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED2_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.HELSOESKEN_FOEDSELSNUMMER
@@ -33,31 +31,17 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
+import org.junit.jupiter.api.extension.ExtendWith
 import java.util.UUID
 import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class AldersovergangTest {
-    @Container
-    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:$POSTGRES_VERSION")
-    private lateinit var dataSource: DataSource
+@ExtendWith(GrunnlagDbExtension::class)
+class AldersovergangTest(private val dataSource: DataSource) {
     private val server = MockOAuth2Server()
 
     @BeforeAll
     fun beforeAll() {
-        postgreSQLContainer.start()
-        postgreSQLContainer.withUrlParam("user", postgreSQLContainer.username)
-        postgreSQLContainer.withUrlParam("password", postgreSQLContainer.password)
-
-        dataSource =
-            DataSourceBuilder.createDataSource(
-                jdbcUrl = postgreSQLContainer.jdbcUrl,
-                username = postgreSQLContainer.username,
-                password = postgreSQLContainer.password,
-            ).also { it.migrate() }
-
         server.start()
     }
 

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/itest/GrunnlagDaoIntegrationTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/itest/GrunnlagDaoIntegrationTest.kt
@@ -7,6 +7,7 @@ import io.mockk.spyk
 import io.mockk.verify
 import lagGrunnlagsopplysning
 import no.nav.etterlatte.grunnlag.BehandlingGrunnlagVersjon
+import no.nav.etterlatte.grunnlag.GrunnlagDbExtension
 import no.nav.etterlatte.grunnlag.OpplysningDao
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -26,9 +27,6 @@ import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.Person
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.toJsonNode
-import no.nav.etterlatte.libs.database.DataSourceBuilder
-import no.nav.etterlatte.libs.database.POSTGRES_VERSION
-import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.database.toList
 import no.nav.etterlatte.libs.testdata.grunnlag.ADRESSE_DEFAULT
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED2_FOEDSELSNUMMER
@@ -41,7 +39,6 @@ import no.nav.etterlatte.libs.testdata.grunnlag.INNSENDER_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER2_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.kilde
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -51,8 +48,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
+import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDate
 import java.time.Month
 import java.time.YearMonth
@@ -61,41 +57,18 @@ import javax.sql.DataSource
 import kotlin.random.Random
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-internal class GrunnlagDaoIntegrationTest {
-    @Container
-    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:$POSTGRES_VERSION")
-
+@ExtendWith(GrunnlagDbExtension::class)
+internal class GrunnlagDaoIntegrationTest(private val dataSource: DataSource) {
     private lateinit var opplysningRepo: OpplysningDao
-    private lateinit var dataSource: DataSource
 
     @BeforeAll
     fun beforeAll() {
-        postgreSQLContainer.start()
-        postgreSQLContainer.withUrlParam("user", postgreSQLContainer.username)
-        postgreSQLContainer.withUrlParam("password", postgreSQLContainer.password)
-
-        dataSource =
-            DataSourceBuilder.createDataSource(
-                jdbcUrl = postgreSQLContainer.jdbcUrl,
-                username = postgreSQLContainer.username,
-                password = postgreSQLContainer.password,
-            )
-        dataSource.migrate()
-
         opplysningRepo = spyk(OpplysningDao(dataSource))
-    }
-
-    @AfterAll
-    fun afterAll() {
-        postgreSQLContainer.stop()
     }
 
     @AfterEach
     fun afterEach() {
         clearAllMocks()
-        dataSource.connection.use {
-            it.prepareStatement("TRUNCATE grunnlagshendelse").execute()
-        }
     }
 
     @Test


### PR DESCRIPTION
For å understøtte hendelser for OMS:

- Opphør tre år etter dødsfall
- Opphør etter ytterligere to år innvilget
- Sende infobrev om aktivitetsplikt fire mnd etter dødsfall
- Sende infobrev om aktivitetsplikt 10 mnd etter dødsfall

