### PR TITLE
EY-3545: Setter riktig type i vilkår for aktivitetsplikt

### DIFF
--- a/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V20__fikser_vilkaar_aktivitetsplikt.sql
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V20__fikser_vilkaar_aktivitetsplikt.sql
@@ -1,0 +1,1 @@
+UPDATE delvilkaar SET vilkaar_type = 'OMS_AKTIVITET_ETTER_6_MND' WHERE vilkaar_type = 'OMS_RETT_UTEN_TIDSBEGRENSNING' AND tittel = 'Krav til aktivitet etter 6 måneder';


### PR DESCRIPTION
Fikser vilkårsvurderingene som har blitt opprettet for omstillingsstønad med feil type på aktivitetsplikts-vilkåret.