### PR TITLE
EY-3526 Legg ved år i merknad på oppgave for aldersovergang

### DIFF
--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/TidshendelseRiver.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/TidshendelseRiver.kt
@@ -73,7 +73,7 @@ class TidshendelseRiver(
                         behandlingService.opprettOppgave(
                             sakId,
                             OppgaveType.MANUELT_OPPHOER,
-                            merknad = "Aldersovergang",
+                            merknad = generateMerknad(type),
                             frist = frist,
                         )
                     hendelseData["opprettetOppgaveId"] = oppgaveId
@@ -88,5 +88,17 @@ class TidshendelseRiver(
             packet[HENDELSE_DATA_KEY] = hendelseData
             context.publish(packet.toJson())
         }
+    }
+
+    private fun generateMerknad(type: String): String {
+        val argument =
+            when (type) {
+                "AO_BP20" -> "20"
+                "AO_BP21" -> "21"
+                "AO_OMS67" -> "67"
+                else -> throw IllegalArgumentException("Ikke-støttet type: $type")
+            }
+
+        return "Aldersovergang v/$argument år"
     }
 }

--- a/apps/etterlatte-oppdater-behandling/src/test/kotlin/TidshendelseRiverTest.kt
+++ b/apps/etterlatte-oppdater-behandling/src/test/kotlin/TidshendelseRiverTest.kt
@@ -38,7 +38,15 @@ class TidshendelseRiverTest {
 
         val melding = lagMeldingForVurdertLoependeYtelse(hendelseId, sakId, behandlingsmaaned, dryRun = false)
 
-        every { behandlingService.opprettOppgave(sakId, OppgaveType.MANUELT_OPPHOER, any(), "Aldersovergang", frist) } returns nyOppgaveID
+        every {
+            behandlingService.opprettOppgave(
+                sakId,
+                OppgaveType.MANUELT_OPPHOER,
+                any(),
+                "Aldersovergang v/20 år",
+                frist,
+            )
+        } returns nyOppgaveID
 
         with(inspector.apply { sendTestMessage(melding.toJson()) }.inspektør) {
             size shouldBe 1
@@ -51,7 +59,7 @@ class TidshendelseRiverTest {
             field(0, HENDELSE_DATA_KEY)["opprettetOppgaveId"].asText() shouldBe nyOppgaveID.toString()
         }
 
-        verify { behandlingService.opprettOppgave(sakId, OppgaveType.MANUELT_OPPHOER, any(), "Aldersovergang", frist) }
+        verify { behandlingService.opprettOppgave(sakId, OppgaveType.MANUELT_OPPHOER, any(), "Aldersovergang v/20 år", frist) }
     }
 
     @Test


### PR DESCRIPTION
En løsning for å gi litt mer input til saksbehandler inntil oppgave(-lista) har gjennomgått endringer, som diskutert 19. feb, mtp å kunne ha noe mer egnede felter for slikt.