### PR TITLE
EY-3542 Bruke OppgaveSaksbehandler-objekt i stedet for to string-felter

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingVedtakRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingVedtakRoute.kt
@@ -103,10 +103,10 @@ internal fun Route.behandlingVedtakRoute(
                                     merknad = merknadFraAttestant,
                                     saksbehandler = brukerTokenInfo,
                                 )
-                            if (sisteSaksbehandlerIkkeAttestering.ident != null) {
+                            if (sisteSaksbehandlerIkkeAttestering?.ident != null) {
                                 oppgaveService.tildelSaksbehandler(
                                     ferdigstillOppgaveUnderbehandlingOgLagNyMedType.id,
-                                    sisteSaksbehandlerIkkeAttestering.ident!!,
+                                    sisteSaksbehandlerIkkeAttestering.ident,
                                 )
                             } else {
                                 logger.warn(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/generellbehandling/GenerellBehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/generellbehandling/GenerellBehandlingService.kt
@@ -104,9 +104,9 @@ class GenerellBehandlingService(
                     behandlingId = generellBehandling.tilknyttetBehandling!!,
                 )
             if (kanskjeOppgaveMedSaksbehandler != null) {
-                val saksbehandler = kanskjeOppgaveMedSaksbehandler.saksbehandlerIdent
+                val saksbehandler = kanskjeOppgaveMedSaksbehandler.saksbehandler
                 if (saksbehandler != null) {
-                    oppgaveService.tildelSaksbehandler(oppgave.id, saksbehandler)
+                    oppgaveService.tildelSaksbehandler(oppgave.id, saksbehandler.ident)
                     logger.info(
                         "Opprettet generell behandling for utland for sak: ${generellBehandling.sakId} " +
                             "og behandling: ${generellBehandling.tilknyttetBehandling}. Gjelder oppgave: ${oppgave.id}",

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -355,7 +355,7 @@ class RevurderingService(
         if (omgjoeringsoppgave.sakId != sakId) {
             throw FeilIOmgjoering.OppgaveOgSakErForskjellig(sakId, omgjoeringsoppgave)
         }
-        if (omgjoeringsoppgave.saksbehandlerIdent != saksbehandler.ident) {
+        if (omgjoeringsoppgave.saksbehandler?.ident != saksbehandler.ident) {
             throw FeilIOmgjoering.SaksbehandlerHarIkkeOppgaven(saksbehandler, omgjoeringsoppgave)
         }
 
@@ -435,7 +435,7 @@ sealed class FeilIOmgjoering {
         UgyldigForespoerselException(
             "SAKSBEHANDLER_HAR_IKKE_OPPGAVEN",
             "Saksbehandler med ident=${saksbehandler.ident} er ikke saksbehandler i oppgaven med " +
-                "id=$omgjoeringsoppgave (saksbehandler i oppgaven er ${omgjoeringsoppgave.saksbehandlerIdent}).",
+                "id=$omgjoeringsoppgave (saksbehandler i oppgaven er ${omgjoeringsoppgave.saksbehandler?.ident}).",
         )
 
     class ManglerBehandlingForOmgjoering(klage: Klage) : InternfeilException(

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDao.kt
@@ -4,6 +4,7 @@ import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
 import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
+import no.nav.etterlatte.libs.common.oppgave.OppgaveSaksbehandler
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.oppgave.Status
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
@@ -83,7 +84,7 @@ class OppgaveDaoImpl(private val connectionAutoclosing: ConnectionAutoclosing) :
                 statement.setString(3, oppgaveIntern.enhet)
                 statement.setLong(4, oppgaveIntern.sakId)
                 statement.setString(5, oppgaveIntern.type.name)
-                statement.setString(6, oppgaveIntern.saksbehandlerIdent)
+                statement.setString(6, oppgaveIntern.saksbehandler?.ident)
                 statement.setString(7, oppgaveIntern.referanse)
                 statement.setString(8, oppgaveIntern.merknad)
                 statement.setTidspunkt(9, oppgaveIntern.opprettet)
@@ -378,8 +379,10 @@ class OppgaveDaoImpl(private val connectionAutoclosing: ConnectionAutoclosing) :
             sakType = SakType.valueOf(getString("saktype")),
             fnr = getString("fnr"),
             frist = getTidspunktOrNull("frist"),
-            saksbehandlerIdent = getString("saksbehandler"),
-            saksbehandlerNavn = getString("navn"),
+            saksbehandler =
+                getString("saksbehandler")?.let {
+                    OppgaveSaksbehandler(getString("saksbehandler"), getString("navn"))
+                },
         )
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
@@ -124,8 +124,11 @@ internal fun Route.oppgaveRoutes(
 
             get("/ikkeattestert/{referanse}") {
                 kunSaksbehandler {
-                    val saksbehandler = inTransaction { service.hentSisteSaksbehandlerIkkeAttestertOppgave(referanse) }
-                    call.respond(saksbehandler)
+                    val saksbehandler =
+                        inTransaction {
+                            service.hentSisteSaksbehandlerIkkeAttestertOppgave(referanse)
+                        }
+                    call.respond(saksbehandler ?: HttpStatusCode.NoContent)
                 }
             }
             get("/ikkeattestertOppgave/{referanse}") {

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveService.kt
@@ -7,6 +7,7 @@ import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.common.klienter.PdlTjenesterKlient
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.oppgave.GosysOppgave
+import no.nav.etterlatte.libs.common.oppgave.OppgaveSaksbehandler
 import no.nav.etterlatte.libs.common.oppgave.Status
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.tilgangsstyring.filterForEnheter
@@ -130,7 +131,7 @@ class GosysOppgaveServiceImpl(
                 fnr = fnrByAktoerId[this.aktoerId],
                 gjelder = temaTilSakType[this.tema]!!.name,
                 enhet = this.tildeltEnhetsnr,
-                saksbehandlerIdent = this.tilordnetRessurs,
+                saksbehandler = this.tilordnetRessurs?.let { OppgaveSaksbehandler(it) },
                 beskrivelse = this.beskrivelse,
                 sakType = temaTilSakType[this.tema]!!,
             )

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
@@ -186,7 +186,7 @@ internal fun Route.sakWebRoutes(
                             sakService.oppdaterEnhetForSaker(listOf(sakMedEnhet))
                             oppgaveService.oppdaterEnhetForRelaterteOppgaver(listOf(sakMedEnhet))
                             for (oppgaveIntern in oppgaveService.hentOppgaverForSak(sakId)) {
-                                if (oppgaveIntern.saksbehandlerIdent != null &&
+                                if (oppgaveIntern.saksbehandler != null &&
                                     oppgaveIntern.status == Status.UNDER_BEHANDLING
                                 ) {
                                     oppgaveService.fjernSaksbehandler(

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingServiceTest.kt
@@ -213,7 +213,7 @@ class GenerellBehandlingServiceTest(val dataSource: DataSource) {
         Assertions.assertEquals(OppgaveKilde.GENERELL_BEHANDLING, manuellBehandlingOppgave.kilde)
         Assertions.assertEquals(OppgaveType.KRAVPAKKE_UTLAND, manuellBehandlingOppgave.type)
         Assertions.assertEquals(sak.id, manuellBehandlingOppgave.sakId)
-        Assertions.assertNull(manuellBehandlingOppgave.saksbehandlerIdent)
+        Assertions.assertNull(manuellBehandlingOppgave.saksbehandler)
     }
 
     @Test
@@ -248,7 +248,7 @@ class GenerellBehandlingServiceTest(val dataSource: DataSource) {
         Assertions.assertEquals(OppgaveKilde.GENERELL_BEHANDLING, manuellBehandlingOppgave.kilde)
         Assertions.assertEquals(OppgaveType.KRAVPAKKE_UTLAND, manuellBehandlingOppgave.type)
         Assertions.assertEquals(sak.id, manuellBehandlingOppgave.sakId)
-        Assertions.assertNull(manuellBehandlingOppgave.saksbehandlerIdent)
+        Assertions.assertNull(manuellBehandlingOppgave.saksbehandler)
 
         verify {
             hendelseDao.generellBehandlingHendelse(

--- a/apps/etterlatte-behandling/src/test/kotlin/metrics/BehandlingMetricsOppgaveTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/metrics/BehandlingMetricsOppgaveTest.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
 import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
+import no.nav.etterlatte.libs.common.oppgave.OppgaveSaksbehandler
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.oppgave.Status
 import no.nav.etterlatte.libs.common.sak.Sak
@@ -121,11 +122,11 @@ internal class BehandlingMetricsOppgaveTest(private val ds: DataSource) {
     fun lagNyOppgave(
         sak: Sak,
         status: Status,
-        saksbehandler: String,
+        ident: String,
     ) = OppgaveIntern(
         id = UUID.randomUUID(),
         status = status,
-        saksbehandlerIdent = saksbehandler,
+        saksbehandler = OppgaveSaksbehandler(ident),
         enhet = sak.enhet,
         sakId = sak.id,
         kilde = OppgaveKilde.BEHANDLING,

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
@@ -94,7 +94,7 @@ internal class OppgaveDaoTest(val dataSource: DataSource) {
                 saksbehandlerIdent,
             )
         assertEquals(1, oppgaverKunForSaksbehandler.size)
-        assertEquals(saksbehandlerIdent, oppgaverKunForSaksbehandler[0].saksbehandlerIdent)
+        assertEquals(saksbehandlerIdent, oppgaverKunForSaksbehandler[0].saksbehandler?.ident)
         assertEquals(oppgaveForIdentFiltrering.id, oppgaverKunForSaksbehandler[0].id)
 
         val alleOppgaver =
@@ -219,7 +219,7 @@ internal class OppgaveDaoTest(val dataSource: DataSource) {
         val nySaksbehandler = "nysaksbehandler"
         oppgaveDao.settNySaksbehandler(oppgaveNy.id, nySaksbehandler)
         val hentetOppgave = oppgaveDao.hentOppgave(oppgaveNy.id)
-        assertEquals(nySaksbehandler, hentetOppgave?.saksbehandlerIdent)
+        assertEquals(nySaksbehandler, hentetOppgave?.saksbehandler?.ident)
         assertEquals(Status.UNDER_BEHANDLING, hentetOppgave?.status)
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -135,7 +135,7 @@ internal class OppgaveServiceTest(val dataSource: DataSource) {
         oppgaveService.tildelSaksbehandler(nyOppgave.id, nysaksbehandler)
 
         val oppgaveMedNySaksbehandler = oppgaveService.hentOppgave(nyOppgave.id)
-        assertEquals(nysaksbehandler, oppgaveMedNySaksbehandler?.saksbehandlerIdent)
+        assertEquals(nysaksbehandler, oppgaveMedNySaksbehandler?.saksbehandler?.ident)
     }
 
     @Test
@@ -168,7 +168,7 @@ internal class OppgaveServiceTest(val dataSource: DataSource) {
 
         oppgaveService.tildelSaksbehandler(sakIdOgReferanse.id, systembruker)
         val systembrukerOppgave = oppgaveService.hentOppgave(sakIdOgReferanse.id)
-        assertEquals(systembruker, systembrukerOppgave?.saksbehandlerIdent!!)
+        assertEquals(systembruker, systembrukerOppgave?.saksbehandler!!.ident)
     }
 
     @Test
@@ -202,7 +202,7 @@ internal class OppgaveServiceTest(val dataSource: DataSource) {
 
         oppgaveService.tildelSaksbehandler(sakIdOgReferanse.id, attestantmedRoller.saksbehandler.ident)
         val attestantTildeltOppgave = oppgaveService.hentOppgave(sakIdOgReferanse.id)
-        assertEquals(attestantmedRoller.saksbehandler.ident, attestantTildeltOppgave?.saksbehandlerIdent!!)
+        assertEquals(attestantmedRoller.saksbehandler.ident, attestantTildeltOppgave?.saksbehandler!!.ident)
     }
 
     @Test
@@ -379,7 +379,7 @@ internal class OppgaveServiceTest(val dataSource: DataSource) {
         oppgaveService.byttSaksbehandler(nyOppgave.id, nysaksbehandler)
 
         val oppgaveMedNySaksbehandler = oppgaveService.hentOppgave(nyOppgave.id)
-        assertEquals(nysaksbehandler, oppgaveMedNySaksbehandler?.saksbehandlerIdent)
+        assertEquals(nysaksbehandler, oppgaveMedNySaksbehandler?.saksbehandler?.ident)
     }
 
     @Test
@@ -399,7 +399,7 @@ internal class OppgaveServiceTest(val dataSource: DataSource) {
             oppgaveService.byttSaksbehandler(nyOppgave.id, nysaksbehandler)
         }
         val oppgaveMedNySaksbehandler = oppgaveService.hentOppgave(nyOppgave.id)
-        assertEquals(nyOppgave.saksbehandlerIdent, oppgaveMedNySaksbehandler?.saksbehandlerIdent)
+        assertEquals(nyOppgave.saksbehandler, oppgaveMedNySaksbehandler?.saksbehandler?.ident)
     }
 
     @Test
@@ -428,7 +428,7 @@ internal class OppgaveServiceTest(val dataSource: DataSource) {
         oppgaveService.fjernSaksbehandler(nyOppgave.id)
         val oppgaveUtenSaksbehandler = oppgaveService.hentOppgave(nyOppgave.id)
         Assertions.assertNotNull(oppgaveUtenSaksbehandler?.id)
-        Assertions.assertNull(oppgaveUtenSaksbehandler?.saksbehandlerIdent)
+        Assertions.assertNull(oppgaveUtenSaksbehandler?.saksbehandler)
         assertEquals(Status.NY, oppgaveUtenSaksbehandler?.status)
     }
 
@@ -468,7 +468,7 @@ internal class OppgaveServiceTest(val dataSource: DataSource) {
         }
         val lagretOppgave = oppgaveService.hentOppgave(nyOppgave.id)
 
-        assertEquals(lagretOppgave?.saksbehandlerIdent, saksbehandler)
+        assertEquals(lagretOppgave?.saksbehandler?.ident, saksbehandler)
     }
 
     @Test
@@ -879,13 +879,13 @@ internal class OppgaveServiceTest(val dataSource: DataSource) {
         oppgaveService.tildelSaksbehandler(nyOppgave.id, nysaksbehandler)
 
         val oppgaveMedNySaksbehandler = oppgaveService.hentOppgave(nyOppgave.id)
-        assertEquals(nysaksbehandler, oppgaveMedNySaksbehandler?.saksbehandlerIdent)
+        assertEquals(nysaksbehandler, oppgaveMedNySaksbehandler?.saksbehandler?.ident)
 
         val hentEndringerForOppgave = oppgaveDaoMedEndringssporing.hentEndringerForOppgave(nyOppgave.id)
         assertEquals(1, hentEndringerForOppgave.size)
         val endringPaaOppgave = hentEndringerForOppgave[0]
-        Assertions.assertNull(endringPaaOppgave.oppgaveFoer.saksbehandlerIdent)
-        assertEquals("nysaksbehandler", endringPaaOppgave.oppgaveEtter.saksbehandlerIdent)
+        Assertions.assertNull(endringPaaOppgave.oppgaveFoer.saksbehandler)
+        assertEquals("nysaksbehandler", endringPaaOppgave.oppgaveEtter.saksbehandler?.ident)
         assertEquals(Status.NY, endringPaaOppgave.oppgaveFoer.status)
         assertEquals(Status.UNDER_BEHANDLING, endringPaaOppgave.oppgaveEtter.status)
     }
@@ -1020,7 +1020,7 @@ internal class OppgaveServiceTest(val dataSource: DataSource) {
         val saksbehandlerHentet =
             oppgaveService.hentSisteSaksbehandlerIkkeAttestertOppgave(behandlingId)
 
-        assertEquals(saksbehandlerIdent, saksbehandlerHentet.ident)
+        assertEquals(saksbehandlerIdent, saksbehandlerHentet!!.ident)
     }
 
     @Test
@@ -1062,7 +1062,7 @@ internal class OppgaveServiceTest(val dataSource: DataSource) {
         val saksbehandlerHentet =
             oppgaveService.hentSisteSaksbehandlerIkkeAttestertOppgave(revurderingId)
 
-        assertEquals(saksbehandlerIdent, saksbehandlerHentet.ident)
+        assertEquals(saksbehandlerIdent, saksbehandlerHentet!!.ident)
     }
 
     @Test
@@ -1098,7 +1098,7 @@ internal class OppgaveServiceTest(val dataSource: DataSource) {
         val saksbehandlerHentet =
             oppgaveService.hentSisteSaksbehandlerIkkeAttestertOppgave(behandlingId)
 
-        assertEquals(saksbehandler.ident, saksbehandlerHentet.ident)
+        assertEquals(saksbehandler.ident, saksbehandlerHentet!!.ident)
     }
 
     @Test
@@ -1115,6 +1115,6 @@ internal class OppgaveServiceTest(val dataSource: DataSource) {
         val saksbehandlerHentet =
             oppgaveService.hentSisteSaksbehandlerIkkeAttestertOppgave(behandlingId)
 
-        Assertions.assertNull(saksbehandlerHentet.ident)
+        Assertions.assertNull(saksbehandlerHentet?.ident)
     }
 }

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakRoutesTest.kt
@@ -25,6 +25,7 @@ import no.nav.etterlatte.ktor.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.runServer
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
+import no.nav.etterlatte.libs.common.oppgave.OppgaveSaksbehandler
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.oppgave.Status
 import no.nav.etterlatte.libs.common.sak.Sak
@@ -86,7 +87,7 @@ internal class SakRoutesTest {
                     sakId = 1,
                     kilde = null,
                     type = OppgaveType.ATTESTERING,
-                    saksbehandlerIdent = "Bjarne",
+                    saksbehandler = OppgaveSaksbehandler("Rask Spaghetti"),
                     referanse = "hmm",
                     merknad = null,
                     opprettet = Tidspunkt.now(),
@@ -101,7 +102,7 @@ internal class SakRoutesTest {
                     sakId = 1,
                     kilde = null,
                     type = OppgaveType.KLAGE,
-                    saksbehandlerIdent = null,
+                    saksbehandler = null,
                     referanse = "hmm",
                     merknad = null,
                     opprettet = Tidspunkt.now(),
@@ -116,7 +117,7 @@ internal class SakRoutesTest {
                     sakId = 1,
                     kilde = null,
                     type = OppgaveType.KLAGE,
-                    saksbehandlerIdent = "Bjarne",
+                    saksbehandler = OppgaveSaksbehandler("Rask Spaghetti"),
                     referanse = "hmm",
                     merknad = null,
                     opprettet = Tidspunkt.now(),

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/oversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/oversikt.tsx
@@ -134,7 +134,9 @@ export const Oversikt = ({ behandlingsInfo }: { behandlingsInfo: IBehandlingInfo
           ),
           () =>
             oppgavenTilBehandlingen ? (
-              <Tekst>{oppgavenTilBehandlingen.saksbehandlerNavn || oppgavenTilBehandlingen.saksbehandlerIdent}</Tekst>
+              <Tekst>
+                {oppgavenTilBehandlingen.saksbehandler?.navn || oppgavenTilBehandlingen.saksbehandler?.ident}
+              </Tekst>
             ) : (
               <Alert size="small" variant="warning">
                 Ingen saksbehandler har tatt denne oppgaven

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/ToggleMinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/ToggleMinOppgaveliste.tsx
@@ -12,7 +12,13 @@ import {
   leggFilterILocalStorage,
 } from '~components/oppgavebenk/oppgaveFiltrering/filterLocalStorage'
 import { useApiCall } from '~shared/hooks/useApiCall'
-import { hentGosysOppgaver, hentOppgaverMedStatus, OppgaveDTO, saksbehandlereIEnhetApi } from '~shared/api/oppgaver'
+import {
+  hentGosysOppgaver,
+  hentOppgaverMedStatus,
+  OppgaveDTO,
+  OppgaveSaksbehandler,
+  saksbehandlereIEnhetApi,
+} from '~shared/api/oppgaver'
 import { isSuccess } from '~shared/api/apiUtils'
 import {
   finnOgOppdaterSaksbehandlerTildeling,
@@ -85,19 +91,19 @@ export const ToggleMinOppgaveliste = () => {
   }
 
   const filtrerKunInnloggetBrukerOppgaver = (oppgaver: Array<OppgaveDTO>) => {
-    return oppgaver.filter((o) => o.saksbehandlerIdent === innloggetSaksbehandler.ident)
+    return oppgaver.filter((o) => o.saksbehandler?.ident === innloggetSaksbehandler.ident)
   }
 
   const oppdaterSaksbehandlerTildeling = (
     oppgave: OppgaveDTO,
-    saksbehandler: string | null,
+    saksbehandler: OppgaveSaksbehandler | null,
     versjon: number | null
   ) => {
     setTimeout(() => {
       setOppgavelistaOppgaver(
         finnOgOppdaterSaksbehandlerTildeling(oppgavelistaOppgaver, oppgave.id, saksbehandler, versjon)
       )
-      if (innloggetSaksbehandler.ident === saksbehandler) {
+      if (innloggetSaksbehandler.ident === saksbehandler?.ident) {
         setMinOppgavelisteOppgaver(leggTilOppgavenIMinliste(minOppgavelisteOppgaver, oppgave, saksbehandler, versjon))
       } else {
         setMinOppgavelisteOppgaver(
@@ -214,6 +220,7 @@ export const ToggleMinOppgaveliste = () => {
             filter={oppgavelistaFilter}
             setFilter={setOppgavelistaFilter}
             alleOppgaver={oppgavelistaOppgaver}
+            saksbehandlereIEnhet={saksbehandlereIEnheter}
           />
 
           <OppgaveFeilWrapper oppgaver={minOppgavelisteOppgaverResult} gosysOppgaver={gosysOppgaverResult}>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/components/HandlingerForOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/components/HandlingerForOppgave.tsx
@@ -8,10 +8,9 @@ import { OmgjoerVedtakModal } from '~components/oppgavebenk/oppgaveModal/Omgjoer
 export const HandlingerForOppgave = ({ oppgave }: { oppgave: OppgaveDTO }) => {
   const innloggetsaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
 
-  const { id, type, kilde, fnr, saksbehandlerIdent, referanse } = oppgave
-  const erInnloggetSaksbehandlerOppgave = saksbehandlerIdent
-    ? saksbehandlerIdent === innloggetsaksbehandler.ident
-    : false
+  const { id, type, kilde, fnr, saksbehandler, referanse } = oppgave
+  const erInnloggetSaksbehandlerOppgave = saksbehandler?.ident === innloggetsaksbehandler.ident
+
   if (kilde === 'GENERELL_BEHANDLING') {
     switch (type) {
       case 'UNDERKJENT':

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveFiltrering/FilterRad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveFiltrering/FilterRad.tsx
@@ -17,16 +17,18 @@ import {
 } from '~components/oppgavebenk/oppgaveFiltrering/oppgavelistafiltre'
 import { useFeatureEnabledMedDefault } from '~shared/hooks/useFeatureToggle'
 import { FlexRow } from '~shared/styled'
-import { OppgaveDTO } from '~shared/api/oppgaver'
 import { FEATURE_TOGGLE_KAN_BRUKE_KLAGE } from '~components/person/KlageListe'
 import { VelgOppgavestatuser } from '~components/oppgavebenk/oppgaveFiltrering/VelgOppgavestatuser'
+import { Saksbehandler } from '~shared/types/saksbehandler'
+import { OppgaveDTO } from '~shared/api/oppgaver'
 
 interface Props {
   hentAlleOppgaver: () => void
   hentOppgaverStatus: (oppgavestatusFilter: Array<string>) => void
   filter: Filter
   setFilter: (filter: Filter) => void
-  alleOppgaver: OppgaveDTO[]
+  alleOppgaver: Array<OppgaveDTO>
+  saksbehandlereIEnhet: Array<Saksbehandler>
 }
 
 export const FilterRad = ({
@@ -36,8 +38,8 @@ export const FilterRad = ({
   setFilter,
   alleOppgaver,
 }: Props): ReactNode => {
-  const saksbehandlere = new Set(
-    alleOppgaver.map((oppgave) => oppgave.saksbehandlerIdent).filter((s): s is Exclude<typeof s, null> => s !== null)
+  const saksbehandlere: Set<string> = new Set(
+    alleOppgaver.map((oppgave) => oppgave.saksbehandler?.ident || '').filter((ident) => !!ident)
   )
   const [saksbehandlerFilterLokal, setSaksbehandlerFilterLokal] = useState<string>(filter.saksbehandlerFilter)
   const kanBrukeKlage = useFeatureEnabledMedDefault(FEATURE_TOGGLE_KAN_BRUKE_KLAGE, false)
@@ -70,6 +72,8 @@ export const FilterRad = ({
               </option>
             ))}
         </Select>
+
+        {/* TODO: Burde være en liste over navn, ikke identer. Burde også KUN vise de som tilhører enhet */}
         <UNSAFE_Combobox
           label="Saksbehandler"
           value={saksbehandlerFilterLokal}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveFiltrering/oppgavelistafiltre.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveFiltrering/oppgavelistafiltre.ts
@@ -51,11 +51,11 @@ function filtrerSaksbehandler(saksbehandlerFilter: string, oppgaver: OppgaveDTO[
   } else {
     return oppgaver.filter((o) => {
       if (saksbehandlerFilter === SAKSBEHANDLERFILTER.Tildelt) {
-        return o.saksbehandlerIdent !== null
+        return !!o.saksbehandler?.ident
       } else if (saksbehandlerFilter === SAKSBEHANDLERFILTER.IkkeTildelt) {
-        return o.saksbehandlerIdent === null
+        return !o.saksbehandler?.ident
       } else if (saksbehandlerFilter && saksbehandlerFilter !== '') {
-        return o.saksbehandlerIdent === saksbehandlerFilter
+        return o.saksbehandler?.ident === saksbehandlerFilter
       } else {
         return true
       }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/GosysOppgaveModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/GosysOppgaveModal.tsx
@@ -24,7 +24,7 @@ const InfoGrid = styled.div`
 
 export const GosysOppgaveModal = ({ oppgave }: { oppgave: OppgaveDTO }) => {
   const [open, setOpen] = useState(false)
-  const { opprettet, frist, status, fnr, gjelder, enhet, saksbehandlerIdent, beskrivelse, sakType } = oppgave
+  const { opprettet, frist, status, fnr, gjelder, enhet, saksbehandler, beskrivelse, sakType } = oppgave
 
   const configContext = useContext(ConfigContext)
 
@@ -71,7 +71,7 @@ export const GosysOppgaveModal = ({ oppgave }: { oppgave: OppgaveDTO }) => {
             </div>
             <div>
               <Label>Saksbehandler</Label>
-              <BodyShort>{hyphenIfNull(saksbehandlerIdent)}</BodyShort>
+              <BodyShort>{saksbehandler?.ident || '-'}</BodyShort>
             </div>
           </InfoGrid>
           <div>
@@ -99,5 +99,3 @@ export const GosysOppgaveModal = ({ oppgave }: { oppgave: OppgaveDTO }) => {
     </>
   )
 }
-
-const hyphenIfNull = (inputString: string | null) => (inputString ? inputString : '-')

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaver/Oppgaver.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaver/Oppgaver.tsx
@@ -1,5 +1,5 @@
 import { Alert } from '@navikt/ds-react'
-import { OppgaveDTO } from '~shared/api/oppgaver'
+import { OppgaveDTO, OppgaveSaksbehandler } from '~shared/api/oppgaver'
 import React, { ReactNode, useEffect, useState } from 'react'
 import { OppgaverTable } from '~components/oppgavebenk/oppgaverTable/OppgaverTable'
 import { PagineringsKontroller } from '~components/oppgavebenk/oppgaver/PagineringsKontroller'
@@ -15,7 +15,7 @@ import { Filter, filtrerOppgaver } from '~components/oppgavebenk/oppgaveFiltreri
 
 export interface OppgavelisteProps {
   oppgaver: OppgaveDTO[]
-  oppdaterTildeling: (oppgave: OppgaveDTO, saksbehandler: string | null, versjon: number | null) => void
+  oppdaterTildeling: (oppgave: OppgaveDTO, saksbehandler: OppgaveSaksbehandler | null, versjon: number | null) => void
   saksbehandlereIEnhet: Array<Saksbehandler>
   oppdaterFrist?: (id: string, nyfrist: string, versjon: number | null) => void
   filter?: Filter

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaverTable/OppgaverTable.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaverTable/OppgaverTable.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useState } from 'react'
 import { SortState, Table } from '@navikt/ds-react'
 import { OppgaverTableHeader } from '~components/oppgavebenk/oppgaverTable/OppgaverTableHeader'
-import { OppgaveDTO } from '~shared/api/oppgaver'
+import { OppgaveDTO, OppgaveSaksbehandler } from '~shared/api/oppgaver'
 import { OppgaverTableRow } from '~components/oppgavebenk/oppgaverTable/OppgaverTableRow'
 import { leggTilSorteringILocalStorage, OppgaveSortering } from '~components/oppgavebenk/oppgaverTable/oppgavesortering'
 import { Saksbehandler } from '~shared/types/saksbehandler'
@@ -17,7 +17,7 @@ interface SorteringsState extends Omit<SortState, 'direction'> {
 
 interface Props {
   oppgaver: ReadonlyArray<OppgaveDTO>
-  oppdaterTildeling: (oppgave: OppgaveDTO, saksbehandler: string | null, versjon: number | null) => void
+  oppdaterTildeling: (oppgave: OppgaveDTO, saksbehandler: OppgaveSaksbehandler | null, versjon: number | null) => void
   oppdaterFrist?: (id: string, nyfrist: string, versjon: number | null) => void
   saksbehandlereIEnhet: Array<Saksbehandler>
   setSortering: (nySortering: OppgaveSortering) => void

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaverTable/OppgaverTableRow.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaverTable/OppgaverTableRow.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react'
 import { Table } from '@navikt/ds-react'
-import { erOppgaveRedigerbar, OppgaveDTO } from '~shared/api/oppgaver'
+import { erOppgaveRedigerbar, OppgaveDTO, OppgaveSaksbehandler } from '~shared/api/oppgaver'
 import { formaterStringDato } from '~utils/formattering'
 import { FristWrapper } from '~components/oppgavebenk/frist/FristWrapper'
 import SaksoversiktLenke from '~components/oppgavebenk/components/SaksoversiktLenke'
@@ -14,7 +14,7 @@ import { Saksbehandler } from '~shared/types/saksbehandler'
 interface Props {
   oppgave: OppgaveDTO
   saksbehandlereIEnhet: Array<Saksbehandler>
-  oppdaterTildeling: (oppgave: OppgaveDTO, saksbehandler: string | null, versjon: number | null) => void
+  oppdaterTildeling: (oppgave: OppgaveDTO, saksbehandler: OppgaveSaksbehandler | null, versjon: number | null) => void
   oppdaterFrist?: (id: string, nyfrist: string, versjon: number | null) => void
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/tildeling/VelgSaksbehandler.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/tildeling/VelgSaksbehandler.tsx
@@ -8,6 +8,7 @@ import {
   erOppgaveRedigerbar,
   fjernSaksbehandlerApi,
   OppgaveDTO,
+  OppgaveSaksbehandler,
   tildelSaksbehandlerApi,
 } from '~shared/api/oppgaver'
 import { useApiCall } from '~shared/hooks/useApiCall'
@@ -15,15 +16,15 @@ import { Saksbehandler } from '~shared/types/saksbehandler'
 
 interface Props {
   saksbehandlereIEnhet: Array<Saksbehandler>
-  oppdaterTildeling: (oppgave: OppgaveDTO, saksbehandler: string | null, versjon: number | null) => void
+  oppdaterTildeling: (oppgave: OppgaveDTO, saksbehandler: OppgaveSaksbehandler | null, versjon: number | null) => void
   oppgave: OppgaveDTO
 }
 
 const mapSaksbehandler = (oppgave: OppgaveDTO): Saksbehandler | undefined =>
-  oppgave.saksbehandlerIdent
+  oppgave.saksbehandler
     ? {
-        ident: oppgave.saksbehandlerIdent,
-        navn: oppgave.saksbehandlerNavn || oppgave.saksbehandlerIdent,
+        ident: oppgave.saksbehandler.ident,
+        navn: oppgave.saksbehandler.navn || oppgave.saksbehandler.ident,
       }
     : undefined
 
@@ -52,7 +53,7 @@ export const VelgSaksbehandler = ({ saksbehandlereIEnhet, oppdaterTildeling, opp
         byttSaksbehandler(
           { oppgaveId, type, nysaksbehandler: { saksbehandler: selectedSaksbehandler.ident!, versjon } },
           (result) => {
-            oppdaterTildeling(oppgave, selectedSaksbehandler.ident, result.versjon)
+            oppdaterTildeling(oppgave, selectedSaksbehandler, result.versjon)
             setValgtSaksbehandler(saksbehandler)
             setOpenDropdown(false)
           },
@@ -66,7 +67,7 @@ export const VelgSaksbehandler = ({ saksbehandlereIEnhet, oppdaterTildeling, opp
     tildelSaksbehandler(
       { oppgaveId, type, nysaksbehandler: { saksbehandler: innloggetSaksbehandler.ident, versjon } },
       (result) => {
-        oppdaterTildeling(oppgave, innloggetSaksbehandler.ident, result.versjon)
+        oppdaterTildeling(oppgave, innloggetSaksbehandler, result.versjon)
         setValgtSaksbehandler({
           ident: innloggetSaksbehandler.ident,
           navn: innloggetSaksbehandler.navn,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/utils/oppgaveutils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/utils/oppgaveutils.ts
@@ -1,16 +1,16 @@
-import { OppgaveDTO } from '~shared/api/oppgaver'
+import { OppgaveDTO, OppgaveSaksbehandler } from '~shared/api/oppgaver'
 import { logger } from '~utils/logger'
 
 export const finnOgOppdaterSaksbehandlerTildeling = (
   oppgaver: OppgaveDTO[],
   oppgaveId: string,
-  saksbehandler: string | null,
+  saksbehandler: OppgaveSaksbehandler | null,
   versjon: number | null
 ) => {
   const index = oppgaver.findIndex((o) => o.id === oppgaveId)
   if (index > -1) {
     const oppdatertOppgaveState = [...oppgaver]
-    oppdatertOppgaveState[index].saksbehandlerIdent = saksbehandler
+    oppdatertOppgaveState[index].saksbehandler = saksbehandler
     oppdatertOppgaveState[index].status = 'UNDER_BEHANDLING'
     oppdatertOppgaveState[index].versjon = versjon
     return oppdatertOppgaveState
@@ -22,10 +22,10 @@ export const finnOgOppdaterSaksbehandlerTildeling = (
 export const leggTilOppgavenIMinliste = (
   oppgaver: OppgaveDTO[],
   oppgave: OppgaveDTO,
-  saksbehandler: string | null,
+  saksbehandler: OppgaveSaksbehandler | null,
   versjon: number | null
 ): OppgaveDTO[] => {
-  return [...oppgaver, { ...oppgave, saksbehandlerIdent: saksbehandler, status: 'UNDER_BEHANDLING', versjon: versjon }]
+  return [...oppgaver, { ...oppgave, saksbehandler: saksbehandler, status: 'UNDER_BEHANDLING', versjon: versjon }]
 }
 
 export const oppdaterFrist = (

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaver.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaver.ts
@@ -16,15 +16,17 @@ export interface OppgaveDTO {
   sakType: SakType
   fnr: string | null
   frist: string
-  saksbehandlerIdent: string | null
-
-  //Oppgaveliste spesifikt
-  saksbehandlerNavn: string | null
+  saksbehandler?: OppgaveSaksbehandler
 
   // GOSYS-spesifikt
   beskrivelse: string | null
   gjelder: string | null
   versjon: number | null
+}
+
+export interface OppgaveSaksbehandler {
+  ident: string
+  navn?: string
 }
 
 export interface NyOppgaveDto {

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/migrering/AutomatiskBehandlingRoutesKtTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/migrering/AutomatiskBehandlingRoutesKtTest.kt
@@ -354,7 +354,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
             sakId = 1,
             kilde = null,
             type = OppgaveType.ATTESTERING,
-            saksbehandlerIdent = null,
+            saksbehandler = null,
             referanse = referanse.toString(),
             merknad = null,
             sakType = SakType.BARNEPENSJON,

--- a/libs/etterlatte-oppgave-model/src/main/kotlin/Oppgave/OppgaveIntern.kt
+++ b/libs/etterlatte-oppgave-model/src/main/kotlin/Oppgave/OppgaveIntern.kt
@@ -11,7 +11,7 @@ abstract class Oppgave {
     abstract val status: Status
     abstract val type: OppgaveType
     abstract val enhet: String
-    abstract val saksbehandlerIdent: String?
+    abstract val saksbehandler: OppgaveSaksbehandler?
     abstract val opprettet: Tidspunkt
     abstract val sakType: SakType
     abstract val fnr: String?
@@ -19,7 +19,7 @@ abstract class Oppgave {
 }
 
 data class OppgaveSaksbehandler(
-    val ident: String? = null,
+    val ident: String,
     val navn: String? = null,
 )
 
@@ -30,8 +30,7 @@ data class OppgaveIntern(
     val sakId: Long,
     val kilde: OppgaveKilde? = null,
     override val type: OppgaveType,
-    override val saksbehandlerIdent: String? = null,
-    val saksbehandlerNavn: String? = null,
+    override val saksbehandler: OppgaveSaksbehandler? = null,
     val referanse: String,
     val merknad: String? = null,
     override val opprettet: Tidspunkt,
@@ -39,10 +38,10 @@ data class OppgaveIntern(
     override val fnr: String? = null,
     override val frist: Tidspunkt?,
 ) : Oppgave() {
-    fun toSaksbehandler() = OppgaveSaksbehandler(saksbehandlerIdent, saksbehandlerNavn)
+//    fun toSaksbehandler() = OppgaveSaksbehandler(saksbehandlerIdent, saksbehandlerNavn)
 
     fun manglerSaksbehandler(): Boolean {
-        return saksbehandlerIdent == null
+        return saksbehandler == null
     }
 
     fun erAvsluttet(): Boolean = status.erAvsluttet()
@@ -60,7 +59,7 @@ data class GosysOppgave(
     val id: Long,
     val versjon: Long,
     override val status: Status,
-    override val saksbehandlerIdent: String?,
+    override val saksbehandler: OppgaveSaksbehandler?,
     override val enhet: String,
     override val opprettet: Tidspunkt,
     override val frist: Tidspunkt?,
@@ -179,7 +178,7 @@ fun opprettNyOppgaveMedReferanseOgSak(
         enhet = sak.enhet,
         sakId = sak.id,
         kilde = oppgaveKilde,
-        saksbehandlerIdent = null,
+        saksbehandler = null,
         referanse = referanse,
         merknad = merknad,
         opprettet = Tidspunkt.now(),


### PR DESCRIPTION
Bruke `OppgaveSaksbehandler` konsekvent, i stedet for oppgave med `saksbehandlerIdent` og `saksbehandlerNavn`. 