### PR TITLE
Håndtere 204-respons fra SAM

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/Samordning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/Samordning.tsx
@@ -3,7 +3,7 @@ import { BodyShort, Heading, Label, Link, Modal, Table } from '@navikt/ds-react'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { hentSamordningsdata } from '~shared/api/vedtaksvurdering'
 import { Samordningsvedtak } from '~components/vedtak/typer'
-import { isPending } from '~shared/api/apiUtils'
+import { isPending, isSuccess } from '~shared/api/apiUtils'
 import Spinner from '~shared/Spinner'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import styled from 'styled-components'
@@ -114,7 +114,7 @@ export const SamordningModal = ({ behandlingId }: { behandlingId: string }) => {
               </div>
             ))}
 
-          {!isPending(hentet) && samordningsdata?.length === 0 && <BodyShort>Ingen data.</BodyShort>}
+          {isSuccess(hentet) && samordningsdata?.length === 0 && <BodyShort>Ingen data.</BodyShort>}
         </Modal.Body>
       </Modal>
     </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/Samordning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/Samordning.tsx
@@ -113,6 +113,8 @@ export const SamordningModal = ({ behandlingId }: { behandlingId: string }) => {
                 </Table>
               </div>
             ))}
+
+          {!isPending(hentet) && samordningsdata?.length === 0 && <BodyShort>Ingen data.</BodyShort>}
         </Modal.Body>
       </Modal>
     </>

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/klienter/SamKlient.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/klienter/SamKlient.kt
@@ -12,6 +12,7 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.request.url
 import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
@@ -78,10 +79,10 @@ class SamKlientImpl(
                     parameter("vedtakId", "${vedtak.id}")
                 }
 
-            if (response.status.isSuccess()) {
-                return response.body<List<Samordningsvedtak>>()
-            } else {
-                throw ResponseException(response, "Kunne ikke hente samordningsdata")
+            return when (response.status) {
+                HttpStatusCode.OK -> response.body<List<Samordningsvedtak>>()
+                HttpStatusCode.NoContent -> emptyList()
+                else -> throw ResponseException(response, "Kunne ikke hente samordningsdata")
             }
         } catch (e: Exception) {
             throw SamordneVedtakGenerellException("Kunne ikke hente samordningsdata", e)


### PR DESCRIPTION
Kræsjer slik det er nå, men UIet er jo ikke supertilgjengelig da ettersom eller ingenting lite står og venter på samordning. 

Til info så jobbes det på en større endring på UIet her, ref EY-3314. 