### PR TITLE
Sikre at vi har vedtak for automatisk gjenoppretta saker

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
@@ -12,7 +12,7 @@ import Spinner from '~shared/Spinner'
 import { BehandlingHandlingKnapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
 import { Alert, Button, Heading } from '@navikt/ds-react'
 import { useApiCall } from '~shared/hooks/useApiCall'
-import { IBehandlingStatus, IBehandlingsType } from '~shared/types/IDetaljertBehandling'
+import { IBehandlingStatus, IBehandlingsType, Vedtaksloesning } from '~shared/types/IDetaljertBehandling'
 import styled from 'styled-components'
 import { NesteOgTilbake } from '../handlinger/NesteOgTilbake'
 import { SendTilAttesteringModal } from '~components/behandling/handlinger/sendTilAttesteringModal'
@@ -67,15 +67,23 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
     }
     setManglerbrevutfall(false)
 
-    oppdaterVedtakRequest(behandling.id, () => {
-      const nyStatus = erBarnepensjon ? IBehandlingStatus.BEREGNET : IBehandlingStatus.AVKORTET
-      dispatch(oppdaterBehandlingsstatus(nyStatus))
-      if (skalSendeBrev) {
-        next()
-      } else {
-        setVisAttesteringsmodal(true)
-      }
-    })
+    if (behandling.kilde === Vedtaksloesning.GJENOPPRETTA) {
+      oppdaterStatus(erBarnepensjon, skalSendeBrev)
+    } else {
+      oppdaterVedtakRequest(behandling.id, () => {
+        oppdaterStatus(erBarnepensjon, skalSendeBrev)
+      })
+    }
+  }
+
+  const oppdaterStatus = (erBarnepensjon: boolean, skalSendeBrev: boolean) => {
+    const nyStatus = erBarnepensjon ? IBehandlingStatus.BEREGNET : IBehandlingStatus.AVKORTET
+    dispatch(oppdaterBehandlingsstatus(nyStatus))
+    if (skalSendeBrev) {
+      next()
+    } else {
+      setVisAttesteringsmodal(true)
+    }
   }
 
   return (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
@@ -116,13 +116,11 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
 
   useEffect(() => {
     if (behandlingId) {
-      fetchBehandling(behandlingId, (behandling) => {
-        if (behandling.kilde === Vedtaksloesning.GJENOPPRETTA) {
-          oppdaterVedtakRequest(behandling.id, () => {
-            hentBrevPaaNytt()
-          })
-        }
-      })
+      if (props.behandling.kilde === Vedtaksloesning.GJENOPPRETTA) {
+        oppdaterVedtakRequest(props.behandling.id, () => {
+          hentBrevPaaNytt()
+        })
+      }
     }
   }, [behandlingId])
 


### PR DESCRIPTION
Her går vi jo ikkje innom beregna-steget i frontend, men systemet behandlar til og med varselbrev.

Etter varselbrevet er sendt ut kan saksbehandlar gå inn på behanldinga, og da trynar det per no, fordi vedtaket ikkje enno er oppretta.


Ser diffen her på github vart litt rar, men sjå commit for commit eller lokalt ved behov.