### PR TITLE
Fjerner ekstra kall for å hente utbetalingsinfo for omstillingsstønad-brev

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/Behandling.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/Behandling.kt
@@ -102,6 +102,8 @@ data class AvkortetBeregningsperiode(
     val ytelseFoerAvkorting: Kroner,
     val trygdetid: Int,
     val utbetaltBeloep: Kroner,
+    val beregningsMetodeAnvendt: BeregningsMetode,
+    val beregningsMetodeFraGrunnlag: BeregningsMetode,
 )
 
 data class Beregningsperiode(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/BrevdataFacade.kt
@@ -3,7 +3,6 @@ package no.nav.etterlatte.brev.hentinformasjon
 import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import no.nav.etterlatte.brev.behandling.AvkortetBeregningsperiode
 import no.nav.etterlatte.brev.behandling.Avkortingsinfo
 import no.nav.etterlatte.brev.behandling.ForenkletVedtak
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
@@ -29,7 +28,6 @@ import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.vedtak.VedtakInnholdDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.token.BrukerTokenInfo
-import no.nav.pensjon.brevbaker.api.model.Kroner
 import java.time.YearMonth
 import java.util.UUID
 import no.nav.etterlatte.libs.common.beregning.Beregningsperiode as CommonBeregningsperiode
@@ -228,31 +226,13 @@ class BrevdataFacade(
         virkningstidspunkt: YearMonth,
         vedtakType: VedtakType,
         brukerTokenInfo: BrukerTokenInfo,
-    ): Avkortingsinfo? {
-        if (sakType == SakType.BARNEPENSJON || vedtakType == VedtakType.OPPHOER) return null
-
-        val ytelseMedGrunnlag = beregningService.hentYtelseMedGrunnlag(behandlingId, brukerTokenInfo)
-
-        val beregningsperioder =
-            ytelseMedGrunnlag.perioder.map {
-                AvkortetBeregningsperiode(
-                    datoFOM = it.periode.fom.atDay(1),
-                    datoTOM = it.periode.tom?.atEndOfMonth(),
-                    inntekt = Kroner(it.aarsinntekt - it.fratrekkInnAar),
-                    ytelseFoerAvkorting = Kroner(it.ytelseFoerAvkorting),
-                    utbetaltBeloep = Kroner(it.ytelseEtterAvkorting),
-                    trygdetid = it.trygdetid,
-                )
-            }
-
-        val aarsInntekt = ytelseMedGrunnlag.perioder.first().aarsinntekt
-        val grunnbeloep = ytelseMedGrunnlag.perioder.first().grunnbelop
-
-        return Avkortingsinfo(
-            grunnbeloep = Kroner(grunnbeloep),
-            inntekt = Kroner(aarsInntekt),
-            virkningsdato = virkningstidspunkt.atDay(1),
-            beregningsperioder,
+    ): Avkortingsinfo {
+        return beregningService.finnAvkortingsinfo(
+            behandlingId,
+            sakType,
+            virkningstidspunkt,
+            vedtakType,
+            brukerTokenInfo,
         )
     }
 
@@ -263,8 +243,9 @@ class BrevdataFacade(
         vedtakType: VedtakType,
         brukerTokenInfo: BrukerTokenInfo,
     ): Avkortingsinfo? {
-        return finnAvkortingsinfo(
-            behandlingKlient.hentSisteIverksatteBehandling(sakId, brukerTokenInfo).id,
+        val forrigeIverksatteBehandlingId = behandlingKlient.hentSisteIverksatteBehandling(sakId, brukerTokenInfo).id
+        return beregningService.finnAvkortingsinfoNullable(
+            forrigeIverksatteBehandlingId,
             sakType,
             virkningstidspunkt,
             vedtakType,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningService.kt
@@ -1,11 +1,14 @@
 package no.nav.etterlatte.brev.hentinformasjon.beregning
 
+import no.nav.etterlatte.brev.behandling.AvkortetBeregningsperiode
+import no.nav.etterlatte.brev.behandling.Avkortingsinfo
 import no.nav.etterlatte.brev.behandling.Beregningsperiode
 import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
 import no.nav.etterlatte.brev.behandling.hentUtbetaltBeloep
 import no.nav.etterlatte.brev.hentinformasjon.BeregningKlient
 import no.nav.etterlatte.brev.hentinformasjon.hentBenyttetTrygdetidOgProratabroek
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.token.BrukerTokenInfo
 import no.nav.pensjon.brevbaker.api.model.Kroner
 import java.time.YearMonth
@@ -24,11 +27,6 @@ class BeregningService(private val beregningKlient: BeregningKlient) {
         sakType: SakType,
         brukerTokenInfo: BrukerTokenInfo,
     ) = beregningKlient.hentBeregningsGrunnlag(behandlingId, sakType, brukerTokenInfo)
-
-    suspend fun hentYtelseMedGrunnlag(
-        behandlingId: UUID,
-        brukerTokenInfo: BrukerTokenInfo,
-    ) = beregningKlient.hentYtelseMedGrunnlag(behandlingId, brukerTokenInfo)
 
     suspend fun finnUtbetalingsinfo(
         behandlingId: UUID,
@@ -80,6 +78,57 @@ class BeregningService(private val beregningKlient: BeregningKlient) {
             virkningstidspunkt.atDay(1),
             soeskenjustering,
             beregningsperioder,
+        )
+    }
+
+    suspend fun finnAvkortingsinfo(
+        behandlingId: UUID,
+        sakType: SakType,
+        virkningstidspunkt: YearMonth,
+        vedtakType: VedtakType,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Avkortingsinfo =
+        requireNotNull(finnAvkortingsinfoNullable(behandlingId, sakType, virkningstidspunkt, vedtakType, brukerTokenInfo)) {
+            "Avkortingsinfo er nødvendig, men mangler"
+        }
+
+    suspend fun finnAvkortingsinfoNullable(
+        behandlingId: UUID,
+        sakType: SakType,
+        virkningstidspunkt: YearMonth,
+        vedtakType: VedtakType,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Avkortingsinfo? {
+        if (sakType == SakType.BARNEPENSJON || vedtakType == VedtakType.OPPHOER) return null
+
+        val ytelseMedGrunnlag = beregningKlient.hentYtelseMedGrunnlag(behandlingId, brukerTokenInfo)
+        val beregningsGrunnlag = hentBeregningsGrunnlag(behandlingId, sakType, brukerTokenInfo)
+
+        val beregningsperioder =
+            ytelseMedGrunnlag.perioder.map {
+                AvkortetBeregningsperiode(
+                    datoFOM = it.periode.fom.atDay(1),
+                    datoTOM = it.periode.tom?.atEndOfMonth(),
+                    inntekt = Kroner(it.aarsinntekt - it.fratrekkInnAar),
+                    ytelseFoerAvkorting = Kroner(it.ytelseFoerAvkorting),
+                    utbetaltBeloep = Kroner(it.ytelseEtterAvkorting),
+                    trygdetid = it.trygdetid,
+                    beregningsMetodeAnvendt = requireNotNull(it.beregningsMetode),
+                    beregningsMetodeFraGrunnlag =
+                        beregningsGrunnlag?.beregningsMetode?.beregningsMetode
+                            ?: requireNotNull(it.beregningsMetode),
+                    // ved manuelt overstyrt beregning har vi ikke grunnlag
+                )
+            }
+
+        val aarsInntekt = ytelseMedGrunnlag.perioder.first().aarsinntekt
+        val grunnbeloep = ytelseMedGrunnlag.perioder.first().grunnbelop
+
+        return Avkortingsinfo(
+            grunnbeloep = Kroner(grunnbeloep),
+            inntekt = Kroner(aarsInntekt),
+            virkningsdato = virkningstidspunkt.atDay(1),
+            beregningsperioder = beregningsperioder,
         )
     }
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningService.kt
@@ -88,7 +88,7 @@ class BeregningService(private val beregningKlient: BeregningKlient) {
         vedtakType: VedtakType,
         brukerTokenInfo: BrukerTokenInfo,
     ): Avkortingsinfo =
-        requireNotNull(finnAvkortingsinfoNullable(behandlingId, sakType, virkningstidspunkt, vedtakType, brukerTokenInfo)) {
+        checkNotNull(finnAvkortingsinfoNullable(behandlingId, sakType, virkningstidspunkt, vedtakType, brukerTokenInfo)) {
             "Avkortingsinfo er nødvendig, men mangler"
         }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
@@ -204,7 +204,6 @@ class BrevDataMapperFerdigstillingVedtak(private val brevdataFacade: BrevdataFac
         innholdMedVedlegg: InnholdMedVedlegg,
     ) = coroutineScope {
         val fetcher = BrevDatafetcherVedtak(brevdataFacade, brukerTokenInfo, generellBrevData)
-        val utbetalingsinfo = async { fetcher.hentUtbetaling() }
         val avkortingsinfo = async { fetcher.hentAvkortinginfo() }
         val trygdetid = async { fetcher.hentTrygdetid() }
         val etterbetaling = async { fetcher.hentEtterbetaling() }
@@ -213,8 +212,7 @@ class BrevDataMapperFerdigstillingVedtak(private val brevdataFacade: BrevdataFac
         OmstillingsstoenadInnvilgelse.fra(
             innholdMedVedlegg,
             generellBrevData,
-            utbetalingsinfo.await(),
-            requireNotNull(avkortingsinfo.await()),
+            avkortingsinfo.await(),
             etterbetaling.await(),
             requireNotNull(trygdetid.await()),
             requireNotNull(brevutfall.await()),
@@ -227,7 +225,6 @@ class BrevDataMapperFerdigstillingVedtak(private val brevdataFacade: BrevdataFac
         innholdMedVedlegg: InnholdMedVedlegg,
     ) = coroutineScope {
         val fetcher = BrevDatafetcherVedtak(brevdataFacade, brukerTokenInfo, generellBrevData)
-        val utbetalingsinfo = async { fetcher.hentUtbetaling() }
         val avkortingsinfo = async { fetcher.hentAvkortinginfo() }
         val forrigeAvkortingsinfo = async { fetcher.hentForrigeAvkortinginfo() }
         val trygdetid = async { fetcher.hentTrygdetid() }
@@ -236,8 +233,7 @@ class BrevDataMapperFerdigstillingVedtak(private val brevdataFacade: BrevdataFac
 
         OmstillingsstoenadRevurdering.fra(
             innholdMedVedlegg,
-            requireNotNull(avkortingsinfo.await()),
-            utbetalingsinfo.await(),
+            avkortingsinfo.await(),
             forrigeAvkortingsinfo.await(),
             etterbetaling.await(),
             requireNotNull(trygdetid.await()),

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDatafetcherVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDatafetcherVedtak.kt
@@ -57,15 +57,13 @@ internal class BrevDatafetcherVedtak(
         }
 
     suspend fun hentAvkortinginfo() =
-        behandlingId?.let {
-            brevdataFacade.finnAvkortingsinfo(
-                it,
-                sak.sakType,
-                vedtakVirkningstidspunkt,
-                type!!,
-                brukerTokenInfo,
-            )
-        }
+        brevdataFacade.finnAvkortingsinfo(
+            behandlingId!!,
+            sak.sakType,
+            vedtakVirkningstidspunkt,
+            type!!,
+            brukerTokenInfo,
+        )
 
     suspend fun hentForrigeAvkortinginfo() =
         brevdataFacade.finnForrigeAvkortingsinfo(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelse.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelse.kt
@@ -33,7 +33,6 @@ data class OmstillingsstoenadInnvilgelse(
         fun fra(
             innholdMedVedlegg: InnholdMedVedlegg,
             generellBrevData: GenerellBrevData,
-            utbetalingsinfo: Utbetalingsinfo,
             avkortingsinfo: Avkortingsinfo,
             etterbetaling: EtterbetalingDTO?,
             trygdetid: Trygdetid,
@@ -71,8 +70,8 @@ data class OmstillingsstoenadInnvilgelse(
                                 beregnetTrygdetidMaaneder = trygdetid.maanederTrygdetid,
                                 prorataBroek = trygdetid.prorataBroek,
                                 mindreEnnFireFemtedelerAvOpptjeningstiden = trygdetid.mindreEnnFireFemtedelerAvOpptjeningstiden,
-                                beregningsMetodeFraGrunnlag = utbetalingsinfo.beregningsperioder.first().beregningsMetodeFraGrunnlag,
-                                beregningsMetodeAnvendt = utbetalingsinfo.beregningsperioder.first().beregningsMetodeAnvendt,
+                                beregningsMetodeFraGrunnlag = avkortingsinfo.beregningsperioder.first().beregningsMetodeFraGrunnlag,
+                                beregningsMetodeAnvendt = avkortingsinfo.beregningsperioder.first().beregningsMetodeAnvendt,
                             ),
                     ),
                 innvilgetMindreEnnFireMndEtterDoedsfall =

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadRevurdering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadRevurdering.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.brev.model.oms
 
 import no.nav.etterlatte.brev.behandling.Avkortingsinfo
 import no.nav.etterlatte.brev.behandling.Trygdetid
-import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
 import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
 import no.nav.etterlatte.brev.model.BrevDataRedigerbar
 import no.nav.etterlatte.brev.model.BrevVedleggKey
@@ -39,7 +38,6 @@ data class OmstillingsstoenadRevurdering(
         fun fra(
             innholdMedVedlegg: InnholdMedVedlegg,
             avkortingsinfo: Avkortingsinfo,
-            utbetalingsinfo: Utbetalingsinfo,
             forrigeAvkortingsinfo: Avkortingsinfo?,
             etterbetalingDTO: EtterbetalingDTO?,
             trygdetid: Trygdetid,
@@ -87,8 +85,8 @@ data class OmstillingsstoenadRevurdering(
                                 beregnetTrygdetidMaaneder = trygdetid.maanederTrygdetid,
                                 prorataBroek = trygdetid.prorataBroek,
                                 mindreEnnFireFemtedelerAvOpptjeningstiden = trygdetid.mindreEnnFireFemtedelerAvOpptjeningstiden,
-                                beregningsMetodeFraGrunnlag = utbetalingsinfo.beregningsperioder.first().beregningsMetodeFraGrunnlag,
-                                beregningsMetodeAnvendt = utbetalingsinfo.beregningsperioder.first().beregningsMetodeAnvendt,
+                                beregningsMetodeFraGrunnlag = avkortingsinfo.beregningsperioder.first().beregningsMetodeFraGrunnlag,
+                                beregningsMetodeAnvendt = avkortingsinfo.beregningsperioder.first().beregningsMetodeAnvendt,
                             ),
                     ),
                 etterbetaling =


### PR DESCRIPTION
Inntil nå har man hentet ut både beregning og beregning med avkorting for omstillingsstønad. Dette er unødvendig da alt (også beregningsmetode) returneres fra sistnevnte etter en liten endring i beregning. 