### PR TITLE
Ikke benytte feilhåndtering-lytter for tidshendelser-rivers

### DIFF
--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/TidshendelseRiver.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/TidshendelseRiver.kt
@@ -11,7 +11,7 @@ import no.nav.etterlatte.rapidsandrivers.DATO_KEY
 import no.nav.etterlatte.rapidsandrivers.DRYRUN
 import no.nav.etterlatte.rapidsandrivers.EventNames
 import no.nav.etterlatte.rapidsandrivers.HENDELSE_DATA_KEY
-import no.nav.etterlatte.rapidsandrivers.ListenerMedLoggingOgFeilhaandtering
+import no.nav.etterlatte.rapidsandrivers.ListenerMedLogging
 import no.nav.etterlatte.rapidsandrivers.SAK_ID_KEY
 import no.nav.etterlatte.rapidsandrivers.dato
 import no.nav.etterlatte.rapidsandrivers.sakId
@@ -25,7 +25,7 @@ import java.time.YearMonth
 class TidshendelseRiver(
     rapidsConnection: RapidsConnection,
     private val behandlingService: BehandlingService,
-) : ListenerMedLoggingOgFeilhaandtering() {
+) : ListenerMedLogging() {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {

--- a/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/TidshendelseRiver.kt
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/TidshendelseRiver.kt
@@ -9,7 +9,7 @@ import no.nav.etterlatte.rapidsandrivers.DATO_KEY
 import no.nav.etterlatte.rapidsandrivers.DRYRUN
 import no.nav.etterlatte.rapidsandrivers.EventNames
 import no.nav.etterlatte.rapidsandrivers.HENDELSE_DATA_KEY
-import no.nav.etterlatte.rapidsandrivers.ListenerMedLoggingOgFeilhaandtering
+import no.nav.etterlatte.rapidsandrivers.ListenerMedLogging
 import no.nav.etterlatte.rapidsandrivers.SAK_ID_KEY
 import no.nav.etterlatte.rapidsandrivers.sakId
 import no.nav.etterlatte.vilkaarsvurdering.services.VilkaarsvurderingService
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory
 class TidshendelseRiver(
     rapidsConnection: RapidsConnection,
     private val vilkaarsvurderingService: VilkaarsvurderingService,
-) : ListenerMedLoggingOgFeilhaandtering() {
+) : ListenerMedLogging() {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {


### PR DESCRIPTION
Har ikke kontroll på hele mekanismen her, og det er ikke implementert noe spesifikt for `tidshendelser` for å håndtere det så inntil videre tenker jeg det er best å bare feile