### PR TITLE
Benytter logstash markers i stedet for logg-ctx ved polling

### DIFF
--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/HendelsePoller.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/HendelsePoller.kt
@@ -1,9 +1,8 @@
 package no.nav.etterlatte.tidshendelser
 
+import net.logstash.logback.marker.Markers
 import no.nav.etterlatte.jobs.LoggerInfo
 import no.nav.etterlatte.jobs.fixedRateCancellableTimer
-import no.nav.etterlatte.libs.common.logging.getCorrelationId
-import no.nav.etterlatte.libs.common.logging.withLogContext
 import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.util.Timer
@@ -48,21 +47,21 @@ class HendelsePoller(
                     .associateBy { it.id }
 
             hendelser.forEach {
-                withLogContext(
-                    correlationId = getCorrelationId(),
-                    mapOf(
-                        "jobbId" to it.jobbId.toString(),
-                        "hendelseId" to it.id.toString(),
-                        "sakId" to it.sakId.toString(),
-                        "type" to jobsById[it.jobbId]!!.type.toString(),
-                    ),
-                ) {
-                    logger.info("Behandler hendelse: [id=${it.id}, sakId=${it.sakId}]")
+                val markers =
+                    Markers.appendEntries(
+                        mapOf(
+                            "jobbId" to it.jobbId.toString(),
+                            "hendelseId" to it.id.toString(),
+                            "sakId" to it.sakId.toString(),
+                            "type" to jobsById[it.jobbId]!!.type.toString(),
+                        ),
+                    )
 
-                    hendelsePublisher.publish(hendelse = it, jobb = jobsById[it.jobbId]!!)
+                logger.info(markers, "Behandler hendelse: [id=${it.id}, sakId=${it.sakId}]")
 
-                    hendelseDao.oppdaterHendelseStatus(it.id, HendelseStatus.SENDT)
-                }
+                hendelsePublisher.publish(hendelse = it, jobb = jobsById[it.jobbId]!!)
+
+                hendelseDao.oppdaterHendelseStatus(it.id, HendelseStatus.SENDT)
             }
         }
     }


### PR DESCRIPTION
Kjørt noen jobber i prod i dag for aldersoverganger, og la litt tilfeldig merke til at hendelsepollertasken logger med en del metadata som ikke tilhører den, men til håndteringen av enkelthendelser - og som burde bli fjernet når man går ut av scopet der? 
https://logs.adeo.no/app/r/s/R7qsN

Byttet om til markers-interfacet så tråd-type problematikk unngås i sin helhet.