### PR TITLE
Gjenoppretting - Fjerner overstyr enhet og legger til gradering

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringService.kt
@@ -181,8 +181,7 @@ class MigreringService(
         sakService.finnEllerOpprettSak(
             request.soeker.value,
             SakType.BARNEPENSJON,
-            request.enhet.nr,
-            sjekkEnhetMotNorg = false,
+            gradering = request.gradering,
         )
 
     fun avbrytBehandling(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringService.kt
@@ -6,6 +6,7 @@ import no.nav.etterlatte.behandling.BehandlingService
 import no.nav.etterlatte.behandling.GyldighetsproevingService
 import no.nav.etterlatte.behandling.domain.toStatistikkBehandling
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeService
+import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingHendelseType
@@ -182,6 +183,11 @@ class MigreringService(
             request.soeker.value,
             SakType.BARNEPENSJON,
             gradering = request.gradering,
+            overstyrendeEnhet =
+                when (request.gradering?.erStrengtFortrolig()) {
+                    true -> Enheter.STRENGT_FORTROLIG.navn
+                    else -> null
+                },
         )
 
     fun avbrytBehandling(

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
@@ -51,10 +51,6 @@ internal class Verifiserer(
         feilSomAvbryter.addAll(finnesIPdlFeil)
 
         if (soeker != null) {
-            if (soeker.adressebeskyttelse?.verdi?.erStrengtFortrolig() == true) {
-                // Vi kjører strengt fortrolig til sist. Hvis saker har blitt strengt fortrolig etter opphør avbryter vi.
-                feilSomAvbryter.add(StrengtFortroligPDL)
-            }
             feilSomMedfoererManuell.addAll(sjekkAtSoekerHarRelevantVerge(patchedRequest, soeker))
             if (!patchedRequest.erUnder18) {
                 feilSomMedfoererManuell.addAll(sjekkOmSoekerHaddeFlyktningerfordel(patchedRequest))

--- a/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/migrering/verifisering/Verifiserer.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.migrering.verifisering
 
 import kotlinx.coroutines.runBlocking
-import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.grunnlag.VurdertBostedsland
 import no.nav.etterlatte.libs.common.logging.samleExceptions
@@ -44,36 +43,32 @@ internal class Verifiserer(
         patchedRequestResult.onFailure { feilen ->
             feilSomMedfoererManuell.add(PDLException(feilen).also { it.addSuppressed(feilen) })
         }
-        patchedRequestResult.onSuccess { patchedRequest ->
-            if (patchedRequest.enhet.nr == Enheter.STRENGT_FORTROLIG.enhetNr) {
-                // Vi kjører strengt fortrolig til sist.
-                feilSomAvbryter.add(StrengtFortroligPesys)
-            }
-            val finnesIPdlFeil = pesonerFinnesIPdlEllerSoekerErDoed(patchedRequest)
-            feilSomAvbryter.addAll(finnesIPdlFeil)
 
-            val soeker = personHenter.hentPerson(PersonRolle.BARN, patchedRequest.soeker).getOrNull()
+        val patchedRequest = patchedRequestResult.getOrThrow()
 
-            if (soeker != null) {
-                if (soeker.adressebeskyttelse?.verdi?.erStrengtFortrolig() == true) {
-                    // Vi kjører strengt fortrolig til sist. Hvis saker har blitt strengt fortrolig etter opphør avbryter vi.
-                    feilSomAvbryter.add(StrengtFortroligPDL)
-                }
-                feilSomMedfoererManuell.addAll(sjekkAtSoekerHarRelevantVerge(patchedRequest, soeker))
-                if (!patchedRequest.erUnder18) {
-                    feilSomMedfoererManuell.addAll(sjekkOmSoekerHaddeFlyktningerfordel(patchedRequest))
-                    feilSomMedfoererManuell.addAll(sjekkAdresseOgUtlandsopphold(patchedRequest.pesysId.id, soeker, patchedRequest))
-                    feilSomMedfoererManuell.addAll(sjekkOmSoekerHarFlereAvoedeForeldre(patchedRequest, soeker))
-                    feilSomMedfoererManuell.addAll(sjekkOmForandringIForeldreforhold(patchedRequest, soeker))
-                    // Trolig unødvendig da ukjente foreldre alltid er utlandsaker
-                    feilSomMedfoererManuell.addAll(sjekkOmUkjentForelder(patchedRequest))
-                }
+        val soeker = personHenter.hentPerson(PersonRolle.BARN, patchedRequest.soeker).getOrNull()
+        val finnesIPdlFeil = pesonerFinnesIPdlEllerSoekerErDoed(patchedRequest)
+        feilSomAvbryter.addAll(finnesIPdlFeil)
+
+        if (soeker != null) {
+            if (soeker.adressebeskyttelse?.verdi?.erStrengtFortrolig() == true) {
+                // Vi kjører strengt fortrolig til sist. Hvis saker har blitt strengt fortrolig etter opphør avbryter vi.
+                feilSomAvbryter.add(StrengtFortroligPDL)
             }
-            if (patchedRequest.beregning.meta?.beregningsMetodeType != "FOLKETRYGD") {
-                feilSomMedfoererManuell.add(BeregningsmetodeIkkeNasjonal)
+            feilSomMedfoererManuell.addAll(sjekkAtSoekerHarRelevantVerge(patchedRequest, soeker))
+            if (!patchedRequest.erUnder18) {
+                feilSomMedfoererManuell.addAll(sjekkOmSoekerHaddeFlyktningerfordel(patchedRequest))
+                feilSomMedfoererManuell.addAll(sjekkAdresseOgUtlandsopphold(patchedRequest.pesysId.id, soeker, patchedRequest))
+                feilSomMedfoererManuell.addAll(sjekkOmSoekerHarFlereAvoedeForeldre(patchedRequest, soeker))
+                feilSomMedfoererManuell.addAll(sjekkOmForandringIForeldreforhold(patchedRequest, soeker))
+                // Trolig unødvendig da ukjente foreldre alltid er utlandsaker
+                feilSomMedfoererManuell.addAll(sjekkOmUkjentForelder(patchedRequest))
             }
-            feilSomMedfoererManuell.addAll(verifiserUfoere(patchedRequest))
         }
+        if (patchedRequest.beregning.meta?.beregningsMetodeType != "FOLKETRYGD") {
+            feilSomMedfoererManuell.add(BeregningsmetodeIkkeNasjonal)
+        }
+        feilSomMedfoererManuell.addAll(verifiserUfoere(patchedRequest))
 
         val alleFeil = feilSomAvbryter + feilSomMedfoererManuell
         if (alleFeil.isNotEmpty()) {
@@ -82,7 +77,7 @@ internal class Verifiserer(
                     "Kan ikke migrere. Se sikkerlogg for detaljer",
             )
             repository.lagreFeilkjoering(
-                patchedRequestResult.getOrNull()?.toJson() ?: request.toJson(),
+                patchedRequest.toJson(),
                 feilendeSteg = Migreringshendelser.VERIFISER.lagEventnameForType(),
                 feil = alleFeil.map { it.message }.toJson(),
                 pesysId = request.pesysId,
@@ -92,9 +87,10 @@ internal class Verifiserer(
                 throw samleExceptions(feilSomAvbryter)
             }
         }
-        return patchedRequestResult.getOrThrow().copy(
+        return patchedRequest.copy(
             utlandstilknytningType = utenlandstilknytningsjekker.finnUtenlandstilknytning(request),
             kanAutomatiskGjenopprettes = feilSomMedfoererManuell.isEmpty(),
+            gradering = soeker?.adressebeskyttelse?.verdi,
         )
     }
 

--- a/libs/etterlatte-migrering-model/src/main/kotlin/no/nav/etterlatte/rapidsandrivers/migrering/MigreringRequest.kt
+++ b/libs/etterlatte-migrering-model/src/main/kotlin/no/nav/etterlatte/rapidsandrivers/migrering/MigreringRequest.kt
@@ -5,6 +5,7 @@ import no.nav.etterlatte.libs.common.IntBroek
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
+import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.time.YearMonth
@@ -30,6 +31,7 @@ data class MigreringRequest(
     val utlandstilknytningType: UtlandstilknytningType? = null,
     val erUnder18: Boolean = true,
     val kanAutomatiskGjenopprettes: Boolean = false,
+    val gradering: AdressebeskyttelseGradering? = null,
 ) {
     fun opprettPersongalleri() =
         Persongalleri(


### PR DESCRIPTION
- Enhet til tidligere pesys sak skal ikke videreføres med utledes i Gjenny
- Gradering fra pdl sendes med videre til opprettelse av sak