### PR TITLE
Mer fleksibel / lettleselig mappermetode for ApiResult

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/apiUtils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/apiUtils.ts
@@ -25,21 +25,23 @@ export type Mappers<T, R> = {
   error?: (_: ApiError) => R
 }
 
-export const mapResult = <T, R>(result: Result<T>, mappers: Mappers<T, R>): R | null => {
+export const mapResultFallback = <T, R, F>(result: Result<T>, mappers: Mappers<T, R>, fallback: F): R | F => {
   if (isInitial(result)) {
-    return mappers.initial ?? null
+    return mappers.initial !== undefined ? mappers.initial : fallback
   }
   if (isPending(result)) {
-    return mappers.pending ?? null
+    return mappers.pending !== undefined ? mappers.pending : fallback
   }
   if (isFailure(result)) {
-    return mappers.error?.(result.error) ?? null
+    return mappers.error !== undefined ? mappers.error(result.error) : fallback
   }
   if (isSuccess(result)) {
-    return mappers.success?.(result.data) ?? null
+    return mappers.success !== undefined ? mappers.success(result.data) : fallback
   }
   throw new Error(`Ukjent status på result: ${JSON.stringify(result)}`)
 }
+
+export const mapResult = <T, R>(result: Result<T>, mappers: Mappers<T, R>) => mapResultFallback(result, mappers, null)
 
 export const mapApiResult = <T>(
   result: Result<T>,

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/apiUtils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/apiUtils.ts
@@ -50,7 +50,7 @@ export const mapApiResult = <T>(
   return mapResult(result, {
     pending: mapInitialOrPending,
     initial: mapInitialOrPending,
-    error: mapError,
+    error: (error) => (error.status === 502 ? null : mapError(error)),
     success: mapSuccess,
   })
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/apiUtils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/apiUtils.ts
@@ -22,7 +22,7 @@ export type Mappers<T, R> = {
   success?: (_: T) => R
   initial?: R
   pending?: R
-  error?: (_: ApiError) => R
+  error?: ((_: ApiError) => R) | R
 }
 
 export const mapResultFallback = <T, R, F>(result: Result<T>, mappers: Mappers<T, R>, fallback: F): R | F => {
@@ -33,7 +33,14 @@ export const mapResultFallback = <T, R, F>(result: Result<T>, mappers: Mappers<T
     return mappers.pending !== undefined ? mappers.pending : fallback
   }
   if (isFailure(result)) {
-    return mappers.error !== undefined ? mappers.error(result.error) : fallback
+    if (mappers.error === undefined) {
+      return fallback
+    }
+    if (typeof mappers.error === 'function') {
+      return (mappers.error as Function)(result.error)
+    } else {
+      return mappers.error
+    }
   }
   if (isSuccess(result)) {
     return mappers.success !== undefined ? mappers.success(result.data) : fallback


### PR DESCRIPTION
Eksempel med `mapApiResult`:

```tsx
mapApiResult(
  klager,
  <Spinner visible label="Henter klager i saken" />,
  () => <ApiErrorAlert>Kunne ikke hente klager</ApiErrorAlert>,
  (klageliste) => <KlageTabell klager={klageliste} />
)
```

Samme eksempel med `mapResult` (ja, kun pending er satt her -- men spinneren gir uansett kun mening når den er pending):

```tsx
mapResult(klager, {
  success: (klageliste) => <KlageTabell klager={klageliste} />,
  pending: <Spinner visible label="Henter klager i saken" />,
  error: () => <ApiErrorAlert>Kunne ikke hente klager</ApiErrorAlert>,
})
```