### PR TITLE
Cacher bibliotek i dockerfila

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 FROM gcr.io/distroless/java21
 ENV TZ="Europe/Oslo"
 WORKDIR /app
+COPY build/libs/*-*.jar ./
 COPY build/libs/*.jar ./
 EXPOSE 8080
 USER nonroot


### PR DESCRIPTION
Biblioteka våre oppdaterer seg mykje sjeldnare enn koden vår gjer. Dermed er det fint viss vi kan hente biblioteka frå Docker-cachen når vi kun har endra på vår kode. Biblioteka har typisk ein bindestrek i namnet, så kopierer inn dei først som eit eiget lag i dockerfila.

Skulle ideelt sett hatt regex eller noko som gjorde at vi kun kopierte dei med nummer etter bindestrek, for å hindre å få med våre eigne libs, men det var litt tricky å få med. Dette er uansett betre enn det var.