### PR TITLE
EY-3426: Ved kopiering av vilkårsvurdering legges nye vilkår til og utdaterte fjernes

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
@@ -72,6 +72,12 @@ export const Vilkaarsvurdering = (props: { behandling: IBehandlingReducer }) => 
     !vilkaarsvurderingErPaaNyttRegelverk(vilkaarsvurdering) &&
     behandlingGjelderBarnepensjonPaaNyttRegelverk(behandling)
 
+  const visOppdaterteVilkaar = () =>
+    vilkaarsvurdering &&
+    redigerbar &&
+    behandling.behandlingType == IBehandlingsType.REVURDERING &&
+    vilkaarsvurdering?.resultat == undefined
+
   const resetVilkaarsvurdering = () => {
     if (!behandlingId) throw new Error('Mangler behandlingsid')
     slettGammelVilkaarsvurdering(behandlingId, () => {
@@ -108,6 +114,17 @@ export const Vilkaarsvurdering = (props: { behandling: IBehandlingReducer }) => 
                 apiResult: slettVilkaarsvurderingStatus,
                 errorMessage: 'Klarte ikke slette vilkårsvurderingen',
               })}
+            </AlertWrapper>
+          )}
+
+          {visOppdaterteVilkaar() && (
+            <AlertWrapper>
+              <Alert variant="info">
+                <BodyLong>
+                  Denne behandlingen har automatisk kopiert vilkårsvurderingen fra forrige iverksatte behandling. Et
+                  eller flere vilkår er lagt til eller fjernet og utfall må derfor vurderes på nytt.
+                </BodyLong>
+              </Alert>
             </AlertWrapper>
           )}
 

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
@@ -7,6 +7,7 @@ import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
+import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.behandling.erPaaNyttRegelverk
@@ -144,6 +145,18 @@ class VilkaarsvurderingService(
             val virkningstidspunkt =
                 behandling.virkningstidspunkt ?: throw VirkningstidspunktIkkeSattException(behandlingId)
 
+            val kopierteVilkaar =
+                when {
+                    behandling.revurderingsaarsak == Revurderingaarsak.REGULERING ->
+                        tidligereVilkaarsvurdering.vilkaar.kopier()
+                    else ->
+                        oppdaterVilkaar(
+                            kopierteVilkaar = tidligereVilkaarsvurdering.vilkaar.kopier(),
+                            behandling = behandling,
+                            virkningstidspunkt = virkningstidspunkt,
+                        )
+                }
+
             val nyVilkaarsvurdering =
                 vilkaarsvurderingRepository.kopierVilkaarsvurdering(
                     nyVilkaarsvurdering =
@@ -151,12 +164,7 @@ class VilkaarsvurderingService(
                             behandlingId = behandlingId,
                             grunnlagVersjon = grunnlag.metadata.versjon,
                             virkningstidspunkt = virkningstidspunkt.dato,
-                            vilkaar =
-                                oppdaterVilkaar(
-                                    kopierteVilkaar = tidligereVilkaarsvurdering.vilkaar.kopier(),
-                                    behandling = behandling,
-                                    virkningstidspunkt = virkningstidspunkt,
-                                ),
+                            vilkaar = kopierteVilkaar,
                             resultat = tidligereVilkaarsvurdering.resultat,
                         ),
                     kopiertFraId = tidligereVilkaarsvurdering.id,

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
@@ -160,7 +160,12 @@ class VilkaarsvurderingService(
                     ),
                 kopiertFraId = tidligereVilkaarsvurdering.id,
             ).also {
-                runBlocking { behandlingKlient.settBehandlingStatusVilkaarsvurdert(behandlingId, brukerTokenInfo) }
+                if (it.vilkaar.any { vilkaar -> vilkaar.vurdering == null }) {
+                    // Hvis noen av vilkårene mangler vurdering - slett vilkårsvurderingresultat
+                    vilkaarsvurderingRepository.slettVilkaarsvurderingResultat(it.behandlingId)
+                } else {
+                    runBlocking { behandlingKlient.settBehandlingStatusVilkaarsvurdert(behandlingId, brukerTokenInfo) }
+                }
             }
         }
     }

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
@@ -550,7 +550,7 @@ internal class VilkaarsvurderingRoutesTest {
             val vilkaarsvurdering = objectMapper.readValue(response.bodyAsText(), VilkaarsvurderingDto::class.java)
             assertEquals(HttpStatusCode.OK, response.status)
             assertEquals(revurderingBehandlingId, vilkaarsvurdering.behandlingId)
-            assertTrue(vilkaarsvurdering.resultat == null) // siden vilkår ikke har vurdering her
+            assertNull(vilkaarsvurdering.resultat) // siden vilkår ikke har vurdering her
         }
     }
 

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
@@ -550,7 +550,7 @@ internal class VilkaarsvurderingRoutesTest {
             val vilkaarsvurdering = objectMapper.readValue(response.bodyAsText(), VilkaarsvurderingDto::class.java)
             assertEquals(HttpStatusCode.OK, response.status)
             assertEquals(revurderingBehandlingId, vilkaarsvurdering.behandlingId)
-            assertTrue(vilkaarsvurdering.resultat != null)
+            assertTrue(vilkaarsvurdering.resultat == null) // siden vilkår ikke har vurdering her
         }
     }
 


### PR DESCRIPTION
Sjekker opp gjeldende vilkår mot vilkår i den kopierte vurderingen
- Vilkår som ikke lenger finnes i listen over gjeldende vilkår fjernes
- Vilkår som er nye i listen over gjeldende vilkår legges til

Dersom nye vilkår er lagt til, vil disse mangle vurdering. Vi fjerner derfor totaltvurdering på vilkårsvuderingen.

Dersom vilkårene er uforandre, beholdes totaltvurderingen.