### PR TITLE
Gjør filter for hendelse mer lesbart

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/filtreringAvOppgaver/typer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/filtreringAvOppgaver/typer.ts
@@ -44,7 +44,7 @@ export const OPPGAVETYPEFILTER: Record<OppgavetypeFilterKeys, string> = {
   FOERSTEGANGSBEHANDLING: 'Førstegangsbehandling',
   REVURDERING: 'Revurdering',
   ATTESTERING: 'Attestering',
-  VURDER_KONSEKVENS: 'Vurder konsekvense for hendelse',
+  VURDER_KONSEKVENS: 'Hendelse',
   UNDERKJENT: 'Underkjent behandling',
   GOSYS: 'Gosys',
   KRAVPAKKE_UTLAND: 'Kravpakke utland',


### PR DESCRIPTION
Her burde vi på sikt vurdere om selve enum verdien til hendelse også bare burde hete `HENDELSE` og ikke `VURDER_KONSEKVENS`