### PR TITLE
EY-3621 Filtrere fnr og sakid samme felt (exact match)

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/ToggleMinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/ToggleMinOppgaveliste.tsx
@@ -133,7 +133,7 @@ export const ToggleMinOppgaveliste = () => {
   }, [location.pathname])
 
   useEffect(() => {
-    leggFilterILocalStorage({ ...oppgavelistaFilter, fnrFilter: '', sakidFilter: '' })
+    leggFilterILocalStorage({ ...oppgavelistaFilter, sakEllerFnrFilter: '' })
   }, [oppgavelistaFilter])
 
   useEffect(() => {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/filtreringAvOppgaver/FilterRad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/filtreringAvOppgaver/FilterRad.tsx
@@ -33,34 +33,26 @@ export const FilterRad = ({
   setFilter,
   saksbehandlereIEnhet,
 }: Props): ReactNode => {
-  const [sakId, setSakId] = useState<string>(filter.sakidFilter)
-  const [fnr, setFnr] = useState<string>(filter.fnrFilter)
+  const [sakEllerFnr, setSakEllerFnr] = useState<string>(filter.sakEllerFnrFilter)
 
   const kanBrukeKlage = useFeatureEnabledMedDefault(FEATURE_TOGGLE_KAN_BRUKE_KLAGE, false)
 
   useEffect(() => {
-    const delay = setTimeout(() => setFilter({ ...filter, sakidFilter: sakId || '', fnrFilter: fnr || '' }), 500)
+    const delay = setTimeout(() => setFilter({ ...filter, sakEllerFnrFilter: sakEllerFnr }), 500)
     return () => clearTimeout(delay)
-  }, [sakId, fnr])
+  }, [sakEllerFnr])
 
   return (
     <>
       <FlexRow $spacing align="start">
         <TextField
-          label="Sak ID"
+          label="Sakid / Fnr."
           width="1rem"
-          value={sakId}
-          onChange={(e) => setSakId(e.target.value?.replace(/[^0-9+]/, ''))}
+          value={sakEllerFnr}
+          onChange={(e) => setSakEllerFnr(e.target.value?.replace(/[^0-9+]/, ''))}
           type="tel"
           min={0}
           placeholder="Søk"
-        />
-        <TextField
-          label="Fødselsnummer"
-          value={fnr}
-          onChange={(e) => setFnr(e.target.value?.replace(/[^0-9+]/, ''))}
-          placeholder="Søk"
-          autoComplete="off"
         />
         <Select
           label="Frist"

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/filtreringAvOppgaver/filtrerOppgaver.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/filtreringAvOppgaver/filtrerOppgaver.ts
@@ -87,17 +87,13 @@ export function filtrerOppgaveType(oppgavetypeFilter: Array<string>, oppgaver: O
   }
 }
 
-function finnFnrIOppgaver(fnr: string, oppgaver: OppgaveDTO[]): OppgaveDTO[] {
-  if (fnr && fnr.length > 0) {
-    return oppgaver.filter((o) => o.fnr?.includes(fnr.trim()))
-  } else {
-    return oppgaver
-  }
-}
-
-function finnSakidIOppgaver(sakid: string, oppgaver: OppgaveDTO[]): OppgaveDTO[] {
-  if (sakid && sakid.length > 0) {
-    return oppgaver.filter((o) => o.sakId?.toString() === sakid)
+function finnSakEllerFnrIOppgaver(sakEllerFnr: string, oppgaver: OppgaveDTO[]): OppgaveDTO[] {
+  if (sakEllerFnr && sakEllerFnr.length > 0) {
+    if (sakEllerFnr.length === 11) {
+      return oppgaver.filter(({ fnr }) => fnr === sakEllerFnr.trim())
+    } else {
+      return oppgaver.filter(({ sakId }) => sakId?.toString() === sakEllerFnr.trim())
+    }
   } else {
     return oppgaver
   }
@@ -117,49 +113,45 @@ export function filtrerFrist(fristFilterKeys: FristFilterKeys, oppgaver: Oppgave
 }
 
 export function filtrerOppgaver(
-  sakidFilter: string,
+  sakEllerFnrFilter: string,
   enhetsFilter: EnhetFilterKeys,
   fristFilter: FristFilterKeys,
   saksbehandlerFilter: string,
   ytelseFilter: YtelseFilterKeys,
   oppgavestatusFilter: Array<string>,
   oppgavetypeFilter: Array<string>,
-  oppgaver: OppgaveDTO[],
-  fnr: string
+  oppgaver: OppgaveDTO[]
 ): OppgaveDTO[] {
-  const sakidFiltrert = finnSakidIOppgaver(sakidFilter, oppgaver)
-  const enhetFiltrert = filtrerEnhet(enhetsFilter, sakidFiltrert)
+  const enhetFiltrert = filtrerEnhet(enhetsFilter, oppgaver)
   const saksbehandlerFiltrert = filtrerSaksbehandler(saksbehandlerFilter, enhetFiltrert)
   const ytelseFiltrert = filtrerYtelse(ytelseFilter, saksbehandlerFiltrert)
   const oppgaveFiltrert = filtrerOppgaveStatus(oppgavestatusFilter, ytelseFiltrert)
   const oppgaveTypeFiltrert = filtrerOppgaveType(oppgavetypeFilter, oppgaveFiltrert)
   const fristFiltrert = filtrerFrist(fristFilter, oppgaveTypeFiltrert)
 
-  return finnFnrIOppgaver(fnr, fristFiltrert)
+  return finnSakEllerFnrIOppgaver(sakEllerFnrFilter, fristFiltrert)
 }
 
 export const initialFilter = (): Filter => {
   return {
-    sakidFilter: '',
+    sakEllerFnrFilter: '',
     enhetsFilter: 'visAlle',
     fristFilter: 'visAlle',
     saksbehandlerFilter: SAKSBEHANDLERFILTER.visAlle,
     ytelseFilter: 'visAlle',
     oppgavestatusFilter: [OPPGAVESTATUSFILTER.NY, OPPGAVESTATUSFILTER.UNDER_BEHANDLING],
     oppgavetypeFilter: [OPPGAVETYPEFILTER.visAlle],
-    fnrFilter: '',
   }
 }
 
 export const minOppgavelisteFiltre = (): Filter => {
   return {
-    sakidFilter: '',
+    sakEllerFnrFilter: '',
     enhetsFilter: 'visAlle',
     fristFilter: 'visAlle',
     saksbehandlerFilter: 'visAlle',
     ytelseFilter: 'visAlle',
     oppgavestatusFilter: [OPPGAVESTATUSFILTER.UNDER_BEHANDLING],
     oppgavetypeFilter: [OPPGAVETYPEFILTER.visAlle],
-    fnrFilter: '',
   }
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/filtreringAvOppgaver/typer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/filtreringAvOppgaver/typer.ts
@@ -63,12 +63,11 @@ export const FRISTFILTER = {
 export type FristFilterKeys = keyof typeof FRISTFILTER
 
 export interface Filter {
-  sakidFilter: string
+  sakEllerFnrFilter: string
   enhetsFilter: EnhetFilterKeys
   fristFilter: FristFilterKeys
   saksbehandlerFilter: string
   ytelseFilter: YtelseFilterKeys
   oppgavestatusFilter: Array<string>
   oppgavetypeFilter: Array<string>
-  fnrFilter: string
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaver/Oppgaver.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaver/Oppgaver.tsx
@@ -35,15 +35,14 @@ export const Oppgaver = ({
   const [sortering, setSortering] = useState<OppgaveSortering>(hentSorteringFraLocalStorage())
   const filtrerteOppgaver = filter
     ? filtrerOppgaver(
-        filter.sakidFilter,
+        filter.sakEllerFnrFilter,
         filter.enhetsFilter,
         filter.fristFilter,
         filter.saksbehandlerFilter,
         filter.ytelseFilter,
         filter.oppgavestatusFilter,
         filter.oppgavetypeFilter,
-        [...oppgaver],
-        filter.fnrFilter
+        [...oppgaver]
       )
     : oppgaver
 


### PR DESCRIPTION
Etter ønske fra saksbehandlere. Var også ønske om å låse til eksakt match på fnr eller sakid for å ikke få så mye "støy" i resultatet. 


![Screenshot 2024-03-05 at 10 23 09](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/bb9c42f8-2d72-493c-ab14-a45df06c82b4)
