### PR TITLE
Egen db-kolonne for å lagre om det er løpende ytelse på saken for enklere oppslag

### DIFF
--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/Hendelse.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/Hendelse.kt
@@ -26,6 +26,7 @@ data class Hendelse(
     val versjon: Int,
     val status: HendelseStatus,
     val steg: String,
+    val loependeYtelse: Boolean?,
     val info: Any?,
 )
 

--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/HendelseDao.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/HendelseDao.kt
@@ -179,6 +179,28 @@ class HendelseDao(private val datasource: DataSource) : Transactions<HendelseDao
         }
     }
 
+    fun settHarLoependeYtelse(
+        hendelseId: UUID,
+        loependeYtelse: Boolean,
+    ) {
+        datasource.transaction {
+            queryOf(
+                """
+                UPDATE hendelse 
+                SET loepende_ytelse = :loependeYtelse,
+                    endret = now(),
+                    versjon = versjon + 1
+                WHERE id = :id
+                """.trimIndent(),
+                mapOf(
+                    "id" to hendelseId,
+                    "loependeYtelse" to loependeYtelse,
+                ),
+            )
+                .let { query -> it.run(query.asUpdate) }
+        }
+    }
+
     fun pollHendelser(limit: Int = 5): List<Hendelse> {
         return datasource.transaction {
             queryOf(
@@ -204,6 +226,7 @@ class HendelseDao(private val datasource: DataSource) : Transactions<HendelseDao
             versjon = int("versjon"),
             status = HendelseStatus.valueOf(string("status")),
             steg = string("steg"),
+            loependeYtelse = boolean("loepende_ytelse"),
             info = anyOrNull("info"),
         )
 

--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/HendelseRiver.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/HendelseRiver.kt
@@ -58,6 +58,7 @@ class HendelseRiver(
             if (steg == "VURDERT_LOEPENDE_YTELSE") {
                 val loependeYtelse = packet[HENDELSE_DATA_KEY]["loependeYtelse"].asBoolean()
                 logger.info("Sak $sakId har løpende ytelse? $loependeYtelse")
+                hendelseDao.settHarLoependeYtelse(hendelseIdUUID, loependeYtelse)
             } else if (steg == "OPPGAVE_OPPRETTET") {
                 logger.info("Ferdigstiller hendelse")
                 hendelseDao.oppdaterHendelseStatus(hendelseIdUUID, HendelseStatus.FERDIG)

--- a/apps/etterlatte-tidshendelser/src/main/resources/db/migration/V3__loepende_ytelse.sql
+++ b/apps/etterlatte-tidshendelser/src/main/resources/db/migration/V3__loepende_ytelse.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hendelse ADD COLUMN loepende_ytelse BOOLEAN;

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/HendelseRiverTest.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/HendelseRiverTest.kt
@@ -48,6 +48,7 @@ class HendelseRiverTest(dataSource: DataSource) {
         with(hendelseDao.hentHendelserForJobb(jobb.id).first()) {
             this.steg shouldBe "VURDERT_LOEPENDE_YTELSE"
             this.info shouldNotBe null
+            this.loependeYtelse shouldBe true
         }
     }
 


### PR DESCRIPTION
I stedet for å sjekke logger eller kolonna med fulle meldinger i json.

Poenget er at antallet hendelser som produseres kan være langt høyere enn de som faktisk medfører noe, og det bør være lett å finne ut av dette.