### PR TITLE
EY-3637 Endre visning ved attestering og attestert for tilbakekreving

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/Tilbakekrevingsbehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/Tilbakekrevingsbehandling.tsx
@@ -50,12 +50,12 @@ export function Tilbakekrevingsbehandling() {
   return (
     <>
       <StatusBar result={personStatus} />
+      <TilbakekrevingStegmeny />
       <Spinner visible={isPending(fetchTilbakekrevingStatus)} label="Henter tilbakekrevingsbehandling" />
 
       {!!tilbakekreving && viHarLastetRiktigTilbakekreving && (
         <GridContainer>
           <MainContent>
-            <TilbakekrevingStegmeny behandling={tilbakekreving} />
             <Routes>
               <Route
                 path="vurdering"
@@ -68,6 +68,7 @@ export function Tilbakekrevingsbehandling() {
           <TilbakekrevingSidemeny />
         </GridContainer>
       )}
+
       {isFailureHandler({
         apiResult: fetchTilbakekrevingStatus,
         errorMessage: 'Kunne ikke hente tilbakekrevingsbehandling',

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/brev/TilbakekrevingBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/brev/TilbakekrevingBrev.tsx
@@ -1,6 +1,6 @@
 import { Alert, Heading } from '@navikt/ds-react'
 import { Content, ContentHeader, FlexRow } from '~shared/styled'
-import { HeadingWrapper } from '~components/behandling/soeknadsoversikt/styled'
+import { Border, HeadingWrapper } from '~components/behandling/soeknadsoversikt/styled'
 import { SendTilAttesteringModal } from '~components/behandling/handlinger/SendTilAttesteringModal'
 import { erUnderBehandling, TilbakekrevingBehandling } from '~shared/types/Tilbakekreving'
 import { fattVedtak, opprettVedtak } from '~shared/api/tilbakekreving'
@@ -89,6 +89,7 @@ export function TilbakekrevingBrev({
           errorMessage: 'Kunne ikke opprette brev',
         })}
       </BrevContent>
+      <Border />
       <FlexRow justify="center">
         {kanAttesteres && (
           <SendTilAttesteringModal

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/sidemeny/TilbakekrevingSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/sidemeny/TilbakekrevingSidemeny.tsx
@@ -1,11 +1,11 @@
 import { CollapsibleSidebar, SidebarContent, SidebarTools } from '~shared/styled'
 import React, { useEffect, useState } from 'react'
-import { BodyShort, Button } from '@navikt/ds-react'
+import { Alert, Button, Heading, Tag } from '@navikt/ds-react'
 import { ChevronLeftDoubleIcon, ChevronRightDoubleIcon } from '@navikt/aksel-icons'
 import { useTilbakekreving } from '~components/tilbakekreving/useTilbakekreving'
 import { SidebarPanel } from '~shared/components/Sidebar'
 import { useAppDispatch, useAppSelector } from '~store/Store'
-import { TilbakekrevingStatus } from '~shared/types/Tilbakekreving'
+import { teksterTilbakekrevingStatus, TilbakekrevingStatus } from '~shared/types/Tilbakekreving'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import Spinner from '~shared/Spinner'
@@ -14,8 +14,14 @@ import { IBeslutning } from '~components/behandling/attestering/types'
 import { hentVedtakSammendrag } from '~shared/api/vedtaksvurdering'
 import { updateVedtakSammendrag } from '~store/reducers/VedtakReducer'
 
-import { mapApiResult } from '~shared/api/apiUtils'
+import { mapApiResult, mapSuccess } from '~shared/api/apiUtils'
 import { DokumentlisteLiten } from '~components/person/dokumenter/DokumentlisteLiten'
+import { tagColors, TagList } from '~shared/Tags'
+import { formaterSakstype } from '~utils/formattering'
+import { Info, Tekst } from '~components/behandling/attestering/styled'
+import { hentOppgaveForBehandlingUnderBehandlingIkkeattestertOppgave } from '~shared/api/oppgaver'
+import { KopierbarVerdi } from '~shared/statusbar/kopierbarVerdi'
+import { SettPaaVent } from '~components/behandling/sidemeny/SettPaaVent'
 
 export function TilbakekrevingSidemeny() {
   const tilbakekreving = useTilbakekreving()
@@ -25,6 +31,20 @@ export function TilbakekrevingSidemeny() {
 
   const [fetchVedtakStatus, fetchVedtakSammendrag] = useApiCall(hentVedtakSammendrag)
   const [beslutning, setBeslutning] = useState<IBeslutning>()
+
+  const [oppgaveForBehandlingenStatus, requesthentOppgaveForBehandling] = useApiCall(
+    hentOppgaveForBehandlingUnderBehandlingIkkeattestertOppgave
+  )
+
+  const hentOppgaveForBehandling = () => {
+    if (tilbakekreving) {
+      requesthentOppgaveForBehandling({ referanse: tilbakekreving.id, sakId: tilbakekreving.sak.id })
+    }
+  }
+
+  useEffect(() => {
+    hentOppgaveForBehandling()
+  }, [])
 
   const kanAttestere =
     !!tilbakekreving &&
@@ -48,8 +68,53 @@ export function TilbakekrevingSidemeny() {
         </Button>
       </SidebarTools>
       <SidebarContent collapsed={collapsed}>
-        <SidebarPanel>
-          <BodyShort>Her kan vi vise info om tilbakekrevingen, som sakid: {tilbakekreving?.sak?.id}</BodyShort>
+        <SidebarPanel border>
+          <Heading size="small">Tilbakekreving</Heading>
+          <Heading size="xsmall" spacing>
+            {teksterTilbakekrevingStatus[tilbakekreving!!.status]}
+          </Heading>
+          <TagList>
+            <li>
+              <Tag variant={tagColors[tilbakekreving!!.sak.sakType]}>
+                {formaterSakstype(tilbakekreving!!.sak.sakType)}
+              </Tag>
+            </li>
+          </TagList>
+          <div className="info">
+            <Info>Saksbehandler</Info>
+            {mapApiResult(
+              oppgaveForBehandlingenStatus,
+              <Spinner visible={true} label="Henter oppgave" />,
+              () => (
+                <ApiErrorAlert>Kunne ikke hente saksbehandler fra oppgave</ApiErrorAlert>
+              ),
+              (oppgave) =>
+                !!oppgave?.saksbehandler ? (
+                  <Tekst>{oppgave.saksbehandler?.navn || oppgave.saksbehandler?.ident}</Tekst>
+                ) : (
+                  <Alert size="small" variant="warning">
+                    Ingen saksbehandler har tatt denne oppgaven
+                  </Alert>
+                )
+            )}
+          </div>
+          <div>
+            <Info>Sakid:</Info>
+            <KopierbarVerdi value={tilbakekreving!!.sak.id.toString()} />
+          </div>
+          {mapSuccess(oppgaveForBehandlingenStatus, (oppgave) => {
+            if (
+              [
+                TilbakekrevingStatus.OPPRETTET,
+                TilbakekrevingStatus.UNDER_ARBEID,
+                TilbakekrevingStatus.UNDERKJENT,
+                TilbakekrevingStatus.FATTET_VEDTAK,
+              ].includes(tilbakekreving!!.status)
+            ) {
+              return <SettPaaVent oppgave={oppgave} refreshOppgave={hentOppgaveForBehandling} />
+            }
+            return null
+          })}
         </SidebarPanel>
       </SidebarContent>
       {kanAttestere && (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/stegmeny/TilbakekrevingStegmeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/stegmeny/TilbakekrevingStegmeny.tsx
@@ -1,18 +1,25 @@
 import { StegMenyWrapper } from '~components/behandling/StegMeny/stegmeny'
 import React from 'react'
 import { TilbakekrevingNavLenke } from '~components/tilbakekreving/stegmeny/TilbakekrevingNavLenke'
+import { useTilbakekreving } from '~components/tilbakekreving/useTilbakekreving'
 import { TilbakekrevingBehandling } from '~shared/types/Tilbakekreving'
 
-export function TilbakekrevingStegmeny({ behandling }: { behandling: TilbakekrevingBehandling }) {
+export function TilbakekrevingStegmeny() {
+  const tilbakekrevingBehandling = useTilbakekreving()
+
   return (
     <StegMenyWrapper>
       <TilbakekrevingNavLenke path="vurdering" description="Vurdering" enabled separator />
       <TilbakekrevingNavLenke
         path="brev"
         description="Brev"
-        enabled={!!behandling.tilbakekreving.vurdering.konklusjon}
+        enabled={kanSeBrev(tilbakekrevingBehandling)}
         separator={false}
       />
     </StegMenyWrapper>
   )
+}
+
+function kanSeBrev(tilbakekrevingBehandling: TilbakekrevingBehandling | null): boolean {
+  return !!tilbakekrevingBehandling?.tilbakekreving?.vurdering.konklusjon
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurdering.tsx
@@ -1,12 +1,14 @@
 import { Button, Heading } from '@navikt/ds-react'
 import { Content, ContentHeader, FlexRow } from '~shared/styled'
-import { HeadingWrapper } from '~components/behandling/soeknadsoversikt/styled'
+import { Border, HeadingWrapper } from '~components/behandling/soeknadsoversikt/styled'
 import { useNavigate } from 'react-router-dom'
 import React from 'react'
 import { TilbakekrevingBehandling } from '~shared/types/Tilbakekreving'
 import { TilbakekrevingVurderingOverordnet } from '~components/tilbakekreving/vurdering/TilbakekrevingVurderingOverordnet'
 import { TilbakekrevingVurderingPerioder } from '~components/tilbakekreving/vurdering/TilbakekrevingVurderingPerioder'
 import { TilbakekrevingVurderingOppsummering } from '~components/tilbakekreving/vurdering/TilbakekrevingVurderingOppsummering'
+import { TilbakekrevingVurderingPerioderVisning } from '~components/tilbakekreving/vurdering/TilbakekrevingVurderingPerioderVisning'
+import { TilbakekrevingVurderingOverordnetVisning } from '~components/tilbakekreving/vurdering/TilbakekrevingVurderingOverordnetVisning'
 
 export function TilbakekrevingVurdering({
   behandling,
@@ -25,12 +27,22 @@ export function TilbakekrevingVurdering({
           </Heading>
         </HeadingWrapper>
       </ContentHeader>
-      <TilbakekrevingVurderingOverordnet behandling={behandling} redigerbar={redigerbar} />
-      <TilbakekrevingVurderingPerioder behandling={behandling} redigerbar={redigerbar} />
+      {redigerbar ? (
+        <>
+          <TilbakekrevingVurderingOverordnet behandling={behandling} redigerbar={redigerbar} />
+          <TilbakekrevingVurderingPerioder behandling={behandling} redigerbar={redigerbar} />
+        </>
+      ) : (
+        <>
+          <TilbakekrevingVurderingOverordnetVisning behandling={behandling} />
+          <TilbakekrevingVurderingPerioderVisning behandling={behandling} />
+        </>
+      )}
       <TilbakekrevingVurderingOppsummering behandling={behandling} />
+      <Border />
       <FlexRow $spacing={true} justify="center">
         <Button variant="primary" onClick={() => navigate(`/tilbakekreving/${behandling?.id}/brev`)}>
-          {redigerbar ? 'Lagre vedtak' : 'Gå til vedtak'}
+          {redigerbar ? 'Opprett vedtak' : 'Gå til vedtak'}
         </Button>
       </FlexRow>
     </Content>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingOppsummering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingOppsummering.tsx
@@ -1,74 +1,69 @@
 import { TilbakekrevingBehandling } from '~shared/types/Tilbakekreving'
-import { InnholdPadding } from '~components/behandling/soeknadsoversikt/styled'
 import React from 'react'
 import { Heading, Table } from '@navikt/ds-react'
-import styled from 'styled-components'
 import { NOK } from '~utils/formattering'
+import { InnholdPadding } from '~components/behandling/soeknadsoversikt/styled'
 
 export function TilbakekrevingVurderingOppsummering({ behandling }: { behandling: TilbakekrevingBehandling }) {
   function sum(beloeper: (number | null)[]) {
     if (beloeper.length === 0) return 0
     return beloeper.map((beloep) => (beloep ? beloep : 0)).reduce((sum, current) => sum + current)
   }
+
   const tilbakekreving = behandling.tilbakekreving
   const sumFeilutbetaling = sum(tilbakekreving.perioder.map((it) => it.ytelse.beregnetFeilutbetaling))
   const sumTilbakekreving = sum(tilbakekreving.perioder.map((it) => it.ytelse.bruttoTilbakekreving))
   const sumRenter = sum(tilbakekreving.perioder.map((it) => it.ytelse.rentetillegg))
   const sumSkatt = sum(tilbakekreving.perioder.map((it) => it.ytelse.skatt))
   const oppsummertInnkreving = sumTilbakekreving + sumRenter - sumSkatt
+
   return (
     <InnholdPadding>
       <Heading level="3" size="medium">
         Oppsummering
       </Heading>
-      <TableWrapper>
-        <Table className="table" zebraStripes>
-          <Table.Header>
-            <Table.Row>
-              <Table.HeaderCell></Table.HeaderCell>
-              <Table.HeaderCell>Beregnet feilutbetaling</Table.HeaderCell>
-              <Table.HeaderCell></Table.HeaderCell>
-              <Table.HeaderCell>Tilbakekreving</Table.HeaderCell>
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            <Table.Row key="Beloep">
-              <Table.HeaderCell>Beløp</Table.HeaderCell>
-              <Table.DataCell>{NOK(sumFeilutbetaling)}</Table.DataCell>
-              <Table.DataCell></Table.DataCell>
-              <Table.DataCell></Table.DataCell>
-            </Table.Row>
-            <Table.Row key="tilbakekreving">
-              <Table.HeaderCell>Brutto tilbakekreving</Table.HeaderCell>
-              <Table.DataCell></Table.DataCell>
-              <Table.DataCell></Table.DataCell>
-              <Table.DataCell>{NOK(sumTilbakekreving)}</Table.DataCell>
-            </Table.Row>
-            <Table.Row key="Renter">
-              <Table.HeaderCell>Renter</Table.HeaderCell>
-              <Table.DataCell></Table.DataCell>
-              <Table.DataCell>+</Table.DataCell>
-              <Table.DataCell>{NOK(sumRenter)}</Table.DataCell>
-            </Table.Row>
-            <Table.Row key="Skatt">
-              <Table.HeaderCell>Skatt</Table.HeaderCell>
-              <Table.DataCell></Table.DataCell>
-              <Table.DataCell>-</Table.DataCell>
-              <Table.DataCell>{NOK(sumSkatt)}</Table.DataCell>
-            </Table.Row>
-            <Table.Row key="SumInnkreving">
-              <Table.HeaderCell>Sum til innkreving</Table.HeaderCell>
-              <Table.HeaderCell></Table.HeaderCell>
-              <Table.HeaderCell>=</Table.HeaderCell>
-              <Table.HeaderCell>{NOK(oppsummertInnkreving)}</Table.HeaderCell>
-            </Table.Row>
-          </Table.Body>
-        </Table>
-      </TableWrapper>
+      <Table className="table" zebraStripes style={{ width: '40%' }}>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell></Table.HeaderCell>
+            <Table.HeaderCell>Beregnet feilutbetaling</Table.HeaderCell>
+            <Table.HeaderCell></Table.HeaderCell>
+            <Table.HeaderCell>Tilbakekreving</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row key="Beloep">
+            <Table.HeaderCell>Beløp</Table.HeaderCell>
+            <Table.DataCell>{NOK(sumFeilutbetaling)}</Table.DataCell>
+            <Table.DataCell></Table.DataCell>
+            <Table.DataCell></Table.DataCell>
+          </Table.Row>
+          <Table.Row key="tilbakekreving">
+            <Table.HeaderCell>Brutto tilbakekreving</Table.HeaderCell>
+            <Table.DataCell></Table.DataCell>
+            <Table.DataCell></Table.DataCell>
+            <Table.DataCell>{NOK(sumTilbakekreving)}</Table.DataCell>
+          </Table.Row>
+          <Table.Row key="Renter">
+            <Table.HeaderCell>Renter</Table.HeaderCell>
+            <Table.DataCell></Table.DataCell>
+            <Table.DataCell>+</Table.DataCell>
+            <Table.DataCell>{NOK(sumRenter)}</Table.DataCell>
+          </Table.Row>
+          <Table.Row key="Skatt">
+            <Table.HeaderCell>Skatt</Table.HeaderCell>
+            <Table.DataCell></Table.DataCell>
+            <Table.DataCell>-</Table.DataCell>
+            <Table.DataCell>{NOK(sumSkatt)}</Table.DataCell>
+          </Table.Row>
+          <Table.Row key="SumInnkreving">
+            <Table.HeaderCell>Sum til innkreving</Table.HeaderCell>
+            <Table.HeaderCell></Table.HeaderCell>
+            <Table.HeaderCell>=</Table.HeaderCell>
+            <Table.HeaderCell>{NOK(oppsummertInnkreving)}</Table.HeaderCell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
     </InnholdPadding>
   )
 }
-
-const TableWrapper = styled.div`
-  width: 35%;
-`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingOverordnet.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingOverordnet.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Radio, RadioGroup, Select, Textarea, VStack } from '@navikt/ds-react'
+import { Button, Radio, RadioGroup, Select, Textarea, VStack } from '@navikt/ds-react'
 import {
   teksterTilbakekrevingAarsak,
   teksterTilbakekrevingAktsomhet,
@@ -10,13 +10,14 @@ import {
   TilbakekrevingVurdering,
 } from '~shared/types/Tilbakekreving'
 import { useApiCall } from '~shared/hooks/useApiCall'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { lagreTilbakekrevingsvurdering } from '~shared/api/tilbakekreving'
 import { addTilbakekreving } from '~store/reducers/TilbakekrevingReducer'
 import { useAppDispatch } from '~store/Store'
 
-import { isPending } from '~shared/api/apiUtils'
+import { isPending, isSuccess } from '~shared/api/apiUtils'
 import { InnholdPadding } from '~components/behandling/soeknadsoversikt/styled'
+import { Toast } from '~shared/alerts/Toast'
 
 export function TilbakekrevingVurderingOverordnet({
   behandling,
@@ -27,24 +28,14 @@ export function TilbakekrevingVurderingOverordnet({
 }) {
   const dispatch = useAppDispatch()
   const [lagreVurderingStatus, lagreVurderingRequest] = useApiCall(lagreTilbakekrevingsvurdering)
-  const [visLagret, setVisLagret] = useState(false)
   const [vurdering, setVurdering] = useState<TilbakekrevingVurdering>(behandling.tilbakekreving.vurdering)
 
   const lagreVurdering = () => {
     // TODO validering?
     lagreVurderingRequest({ behandlingsId: behandling.id, vurdering }, (lagretTilbakekreving) => {
       dispatch(addTilbakekreving(lagretTilbakekreving))
-      setVisLagret(true)
     })
   }
-
-  useEffect(() => {
-    if (visLagret) {
-      setTimeout(() => {
-        setVisLagret(false)
-      }, 5000)
-    }
-  }, [visLagret])
 
   return (
     <InnholdPadding>
@@ -195,11 +186,7 @@ export function TilbakekrevingVurderingOverordnet({
             >
               Lagre vurdering
             </Button>
-            {visLagret && (
-              <Alert size="small" variant="success" style={{ maxWidth: 'fit-content' }}>
-                Vurdering lagret.
-              </Alert>
-            )}
+            {isSuccess(lagreVurderingStatus) && <Toast melding="Vurdering lagret" />}
           </VStack>
         )}
       </VStack>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingOverordnet.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingOverordnet.tsx
@@ -1,19 +1,22 @@
-import { BodyShort, Button, Label, Radio, RadioGroup, Select } from '@navikt/ds-react'
+import { Alert, Button, Radio, RadioGroup, Select, Textarea, VStack } from '@navikt/ds-react'
 import {
-  TilbakekrevingBehandling,
+  teksterTilbakekrevingAarsak,
+  teksterTilbakekrevingAktsomhet,
+  teksterTilbakekrevingHjemmel,
   TilbakekrevingAarsak,
   TilbakekrevingAktsomhet,
+  TilbakekrevingBehandling,
   TilbakekrevingHjemmel,
   TilbakekrevingVurdering,
 } from '~shared/types/Tilbakekreving'
 import { useApiCall } from '~shared/hooks/useApiCall'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { lagreTilbakekrevingsvurdering } from '~shared/api/tilbakekreving'
 import { addTilbakekreving } from '~store/reducers/TilbakekrevingReducer'
-import styled from 'styled-components'
 import { useAppDispatch } from '~store/Store'
 
 import { isPending } from '~shared/api/apiUtils'
+import { InnholdPadding } from '~components/behandling/soeknadsoversikt/styled'
 
 export function TilbakekrevingVurderingOverordnet({
   behandling,
@@ -24,24 +27,31 @@ export function TilbakekrevingVurderingOverordnet({
 }) {
   const dispatch = useAppDispatch()
   const [lagreVurderingStatus, lagreVurderingRequest] = useApiCall(lagreTilbakekrevingsvurdering)
+  const [visLagret, setVisLagret] = useState(false)
   const [vurdering, setVurdering] = useState<TilbakekrevingVurdering>(behandling.tilbakekreving.vurdering)
 
   const lagreVurdering = () => {
     // TODO validering?
     lagreVurderingRequest({ behandlingsId: behandling.id, vurdering }, (lagretTilbakekreving) => {
       dispatch(addTilbakekreving(lagretTilbakekreving))
+      setVisLagret(true)
     })
   }
 
+  useEffect(() => {
+    if (visLagret) {
+      setTimeout(() => {
+        setVisLagret(false)
+      }, 5000)
+    }
+  }, [visLagret])
+
   return (
-    <InnholdForm>
-      <>
-        <Label>Årsak</Label>
+    <InnholdPadding>
+      <VStack gap="8" style={{ width: '30em' }}>
         <Select
-          label="Aarsak"
-          hideLabel={true}
+          label="Årsak"
           value={vurdering.aarsak ?? ''}
-          readOnly={!redigerbar}
           onChange={(e) => {
             if (e.target.value == '') return
             setVurdering({
@@ -51,27 +61,17 @@ export function TilbakekrevingVurderingOverordnet({
           }}
         >
           <option value="">Velg..</option>
-          <option value={TilbakekrevingAarsak.ANNET}>Annet</option>
-          <option value={TilbakekrevingAarsak.ARBHOYINNT}>Inntekt</option>
-          <option value={TilbakekrevingAarsak.BEREGNFEIL}>Beregningsfeil</option>
-          <option value={TilbakekrevingAarsak.DODSFALL}>Dødsfall</option>
-          <option value={TilbakekrevingAarsak.EKTESKAP}>Eksteskap/Samboer med felles barn</option>
-          <option value={TilbakekrevingAarsak.FEILREGEL}>Feil regelbruk</option>
-          <option value={TilbakekrevingAarsak.FLYTTUTLAND}>Flyttet utland</option>
-          <option value={TilbakekrevingAarsak.IKKESJEKKYTELSE}>Ikke sjekket mot andre ytelse</option>
-          <option value={TilbakekrevingAarsak.OVERSETTMLD}>Oversett melding fra bruker</option>
-          <option value={TilbakekrevingAarsak.SAMLIV}>Samliv</option>
-          <option value={TilbakekrevingAarsak.UTBFEILMOT}>Utbetaling til feil mottaker</option>
+          {Object.values(TilbakekrevingAarsak).map((aarsak) => (
+            <option key={aarsak} value={aarsak}>
+              {teksterTilbakekrevingAarsak[aarsak]}
+            </option>
+          ))}
         </Select>
-      </>
-      <TextAreaWrapper>
-        <>
-          <Label>Beskriv feilutbetalingen</Label>
-          <Beskrivelse>Gi en kort beskrivelse av bakgrunnen for feilutbetalingen og når ble den oppdaget.</Beskrivelse>
-        </>
-        <textarea
+
+        <Textarea
+          label="Beskriv feilutbetalingen"
+          description="Gi en kort beskrivelse av bakgrunnen for feilutbetalingen og når ble den oppdaget."
           value={vurdering.beskrivelse ?? ''}
-          readOnly={!redigerbar}
           onChange={(e) =>
             setVurdering({
               ...vurdering,
@@ -79,15 +79,12 @@ export function TilbakekrevingVurderingOverordnet({
             })
           }
         />
-      </TextAreaWrapper>
-      <>
-        <Label>Vurder uaktsomhet</Label>
+
         <RadioGroup
-          legend=""
+          legend={<div style={{ fontSize: 'large' }}>Vurder uaktsomhet</div>}
           size="small"
           className="radioGroup"
           value={vurdering.aktsomhet.aktsomhet ?? ''}
-          readOnly={!redigerbar}
           onChange={(e) =>
             setVurdering({
               ...vurdering,
@@ -98,18 +95,18 @@ export function TilbakekrevingVurderingOverordnet({
           }
         >
           <div className="flex">
-            <Radio value={TilbakekrevingAktsomhet.GOD_TRO}>God tro</Radio>
-            <Radio value={TilbakekrevingAktsomhet.SIMPEL_UAKTSOMHET}>Simpel uaktsomhet</Radio>
-            <Radio value={TilbakekrevingAktsomhet.GROV_UAKTSOMHET}>Grov uaktsomhet</Radio>
+            {Object.values(TilbakekrevingAktsomhet).map((aktsomhet) => (
+              <Radio key={aktsomhet} value={aktsomhet}>
+                {teksterTilbakekrevingAktsomhet[aktsomhet]}
+              </Radio>
+            ))}
           </div>
         </RadioGroup>
-      </>
-      {vurdering.aktsomhet.aktsomhet === TilbakekrevingAktsomhet.GROV_UAKTSOMHET && (
-        <TextAreaWrapper>
-          <Label>Gjør en strafferettslig vurdering (Valgfri)</Label>
-          <textarea
+
+        {vurdering.aktsomhet.aktsomhet === TilbakekrevingAktsomhet.GROV_UAKTSOMHET && (
+          <Textarea
+            label="Gjør en strafferettslig vurdering (Valgfri)"
             value={vurdering.aktsomhet.strafferettsligVurdering ?? ''}
-            readOnly={!redigerbar}
             onChange={(e) =>
               setVurdering({
                 ...vurdering,
@@ -120,19 +117,17 @@ export function TilbakekrevingVurderingOverordnet({
               })
             }
           />
-        </TextAreaWrapper>
-      )}
-      {vurdering.aktsomhet.aktsomhet &&
-        [TilbakekrevingAktsomhet.SIMPEL_UAKTSOMHET, TilbakekrevingAktsomhet.GROV_UAKTSOMHET].includes(
-          vurdering.aktsomhet.aktsomhet
-        ) && (
-          <>
-            <TextAreaWrapper>
-              <Label>Redusering av kravet</Label>
-              <BodyShort>Finnes det grunner til å redusere kravet?</BodyShort>
-              <textarea
+        )}
+
+        {vurdering.aktsomhet.aktsomhet &&
+          [TilbakekrevingAktsomhet.SIMPEL_UAKTSOMHET, TilbakekrevingAktsomhet.GROV_UAKTSOMHET].includes(
+            vurdering.aktsomhet.aktsomhet
+          ) && (
+            <>
+              <Textarea
+                label="Redusering av kravet"
+                description="Finnes det grunner til å redusere kravet?"
                 value={vurdering.aktsomhet.reduseringAvKravet ?? ''}
-                readOnly={!redigerbar}
                 onChange={(e) =>
                   setVurdering({
                     ...vurdering,
@@ -143,12 +138,9 @@ export function TilbakekrevingVurderingOverordnet({
                   })
                 }
               />
-            </TextAreaWrapper>
-            <TextAreaWrapper>
-              <Label>Rentevurdering</Label>
-              <textarea
+              <Textarea
+                label="Rentevurdering"
                 value={vurdering.aktsomhet.rentevurdering ?? ''}
-                readOnly={!redigerbar}
                 onChange={(e) =>
                   setVurdering({
                     ...vurdering,
@@ -159,14 +151,12 @@ export function TilbakekrevingVurderingOverordnet({
                   })
                 }
               />
-            </TextAreaWrapper>
-          </>
-        )}
-      <TextAreaWrapper>
-        <Label>Konklusjon</Label>
-        <textarea
+            </>
+          )}
+
+        <Textarea
+          label="Konklusjon"
           value={vurdering.konklusjon ?? ''}
-          readOnly={!redigerbar}
           onChange={(e) =>
             setVurdering({
               ...vurdering,
@@ -174,14 +164,10 @@ export function TilbakekrevingVurderingOverordnet({
             })
           }
         />
-      </TextAreaWrapper>
-      <DropdownWrapper>
-        <Label>Rettslig grunnlag</Label>
+
         <Select
           label="Hjemmel"
-          hideLabel={true}
           value={vurdering.hjemmel ?? ''}
-          readOnly={!redigerbar}
           onChange={(e) => {
             if (e.target.value == '') return
             setVurdering({
@@ -191,53 +177,32 @@ export function TilbakekrevingVurderingOverordnet({
           }}
         >
           <option value="">Velg hjemmel</option>
-          <option value={TilbakekrevingHjemmel.ULOVFESTET}>Lovfestet</option>
-          <option value={TilbakekrevingHjemmel.TJUETO_FEMTEN_EN_LEDD_EN}>& 22-15 1. ledd, 1. punktum</option>
-          <option value={TilbakekrevingHjemmel.TJUETO_FEMTEN_EN_LEDD_TO_FORSETT}>
-            & 22-15 1. ledd, 2. punktum (forsett)
-          </option>
-          <option value={TilbakekrevingHjemmel.TJUETO_FEMTEN_EN_LEDD_TO_UAKTSOMT}>
-            & 22-15 1. ledd, 2. punktum (uaktsomt)
-          </option>
-          <option value={TilbakekrevingHjemmel.TJUETO_FEMTEN_FEM}>& 22-15 5. ledd</option>
-          <option value={TilbakekrevingHjemmel.TJUETO_FEMTEN_SEKS}>& 22-15 6. ledd</option>
-          <option value={TilbakekrevingHjemmel.TJUETO_SEKSTEN}>& 22-16</option>
+          {Object.values(TilbakekrevingHjemmel).map((hjemmel) => (
+            <option key={hjemmel} value={hjemmel}>
+              {teksterTilbakekrevingHjemmel[hjemmel]}
+            </option>
+          ))}
         </Select>
-      </DropdownWrapper>
 
-      {redigerbar && (
-        <Button variant="primary" onClick={lagreVurdering} loading={isPending(lagreVurderingStatus)}>
-          Lagre vurdering
-        </Button>
-      )}
-    </InnholdForm>
+        {redigerbar && (
+          <VStack gap="5">
+            <Button
+              variant="primary"
+              size="small"
+              onClick={lagreVurdering}
+              loading={isPending(lagreVurderingStatus)}
+              style={{ maxWidth: '7.5em' }}
+            >
+              Lagre vurdering
+            </Button>
+            {visLagret && (
+              <Alert size="small" variant="success" style={{ maxWidth: 'fit-content' }}>
+                Vurdering lagret.
+              </Alert>
+            )}
+          </VStack>
+        )}
+      </VStack>
+    </InnholdPadding>
   )
 }
-
-const InnholdForm = styled.div`
-  padding: 2em 2em 2em 4em;
-  width: 25em;
-`
-const TextAreaWrapper = styled.div`
-  display: grid;
-  align-items: flex-end;
-  margin-top: 1em;
-  margin-bottom: 1em;
-
-  textArea {
-    margin-top: 1em;
-    border-width: 1px;
-    border-radius: 4px 4px 0 4px;
-    height: 98px;
-    text-indent: 4px;
-    resize: none;
-  }
-`
-const DropdownWrapper = styled.div`
-  margin-top: 2em;
-  margin-bottom: 2em;
-`
-
-const Beskrivelse = styled.div`
-  margin: 10px 0;
-`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingOverordnetVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingOverordnetVisning.tsx
@@ -1,0 +1,55 @@
+import { BodyShort, Label, VStack } from '@navikt/ds-react'
+import {
+  teksterTilbakekrevingAarsak,
+  teksterTilbakekrevingAktsomhet,
+  teksterTilbakekrevingHjemmel,
+  TilbakekrevingAktsomhet,
+  TilbakekrevingBehandling,
+  TilbakekrevingVurdering,
+} from '~shared/types/Tilbakekreving'
+import React, { useState } from 'react'
+import { InnholdPadding } from '~components/behandling/soeknadsoversikt/styled'
+
+export function TilbakekrevingVurderingOverordnetVisning({ behandling }: { behandling: TilbakekrevingBehandling }) {
+  const [vurdering] = useState<TilbakekrevingVurdering>(behandling.tilbakekreving.vurdering)
+
+  return (
+    <InnholdPadding>
+      <VStack gap="8" style={{ width: '30em' }}>
+        <Tekstfelt label="Årsak" value={teksterTilbakekrevingAarsak[vurdering.aarsak!!]} />
+        <Tekstfelt label="Beskriv feilutbetalingen" value={vurdering.beskrivelse} />
+        <Tekstfelt
+          label="Vurder uaktsomhet"
+          value={teksterTilbakekrevingAktsomhet[vurdering.aktsomhet.aktsomhet!!]}
+        />
+
+        {vurdering.aktsomhet.aktsomhet === TilbakekrevingAktsomhet.GROV_UAKTSOMHET && (
+          <Tekstfelt
+            label="Gjør en strafferettslig vurdering (Valgfri)"
+            value={vurdering.aktsomhet.strafferettsligVurdering}
+          />
+        )}
+        {vurdering.aktsomhet.aktsomhet &&
+          [TilbakekrevingAktsomhet.SIMPEL_UAKTSOMHET, TilbakekrevingAktsomhet.GROV_UAKTSOMHET].includes(
+            vurdering.aktsomhet.aktsomhet
+          ) && (
+            <>
+              <Tekstfelt label="Redusering av kravet" value={vurdering.aktsomhet.reduseringAvKravet} />
+              <Tekstfelt label="Rentevurdering" value={vurdering.aktsomhet.rentevurdering} />
+            </>
+          )}
+        <Tekstfelt label="Konklusjon" value={vurdering.konklusjon} />
+        <Tekstfelt label="Hjemmel" value={teksterTilbakekrevingHjemmel[vurdering.hjemmel!!]} />
+      </VStack>
+    </InnholdPadding>
+  )
+}
+
+function Tekstfelt({ label, value }: { label: String; value?: String | null }) {
+  return (
+    <VStack gap="2">
+      <Label>{label}</Label>
+      <BodyShort>{value ?? ''}</BodyShort>
+    </VStack>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingPerioder.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingPerioder.tsx
@@ -9,13 +9,14 @@ import {
 } from '~shared/types/Tilbakekreving'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { lagreTilbakekrevingsperioder } from '~shared/api/tilbakekreving'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { addTilbakekreving } from '~store/reducers/TilbakekrevingReducer'
 import { useAppDispatch } from '~store/Store'
 import { HeadingWrapper, InnholdPadding } from '~components/behandling/soeknadsoversikt/styled'
-import { Alert, Button, Heading, Select, Table, TextField, VStack } from '@navikt/ds-react'
+import { Button, Heading, Select, Table, TextField, VStack } from '@navikt/ds-react'
 
-import { isPending } from '~shared/api/apiUtils'
+import { isPending, isSuccess } from '~shared/api/apiUtils'
+import { Toast } from '~shared/alerts/Toast'
 
 export function TilbakekrevingVurderingPerioder({
   behandling,
@@ -26,7 +27,6 @@ export function TilbakekrevingVurderingPerioder({
 }) {
   const dispatch = useAppDispatch()
   const [lagrePerioderStatus, lagrePerioderRequest] = useApiCall(lagreTilbakekrevingsperioder)
-  const [visLagret, setVisLagret] = useState(false)
   const [perioder, setPerioder] = useState<TilbakekrevingPeriode[]>(behandling.tilbakekreving.perioder)
 
   const updateBeloeper = (index: number, oppdatertBeloep: TilbakekrevingBeloep) => {
@@ -38,17 +38,8 @@ export function TilbakekrevingVurderingPerioder({
     // TODO validering?
     lagrePerioderRequest({ behandlingsId: behandling.id, perioder }, (lagretTilbakekreving) => {
       dispatch(addTilbakekreving(lagretTilbakekreving))
-      setVisLagret(true)
     })
   }
-
-  useEffect(() => {
-    if (visLagret) {
-      setTimeout(() => {
-        setVisLagret(false)
-      }, 5000)
-    }
-  }, [visLagret])
 
   return (
     <InnholdPadding>
@@ -240,11 +231,7 @@ export function TilbakekrevingVurderingPerioder({
           >
             Lagre perioder
           </Button>
-          {visLagret && (
-            <Alert size="small" variant="success" style={{ maxWidth: 'fit-content' }}>
-              Perioder lagret.
-            </Alert>
-          )}
+          {isSuccess(lagrePerioderStatus) && <Toast melding="Perioder lagret" />}
         </VStack>
       )}
     </InnholdPadding>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingPerioder.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingPerioder.tsx
@@ -1,4 +1,6 @@
 import {
+  teksterTilbakekrevingResultat,
+  teksterTilbakekrevingSkyld,
   TilbakekrevingBehandling,
   TilbakekrevingBeloep,
   TilbakekrevingPeriode,
@@ -7,12 +9,11 @@ import {
 } from '~shared/types/Tilbakekreving'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { lagreTilbakekrevingsperioder } from '~shared/api/tilbakekreving'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { addTilbakekreving } from '~store/reducers/TilbakekrevingReducer'
 import { useAppDispatch } from '~store/Store'
 import { HeadingWrapper, InnholdPadding } from '~components/behandling/soeknadsoversikt/styled'
-import { Button, Heading, Select, Table, TextField } from '@navikt/ds-react'
-import styled from 'styled-components'
+import { Alert, Button, Heading, Select, Table, TextField, VStack } from '@navikt/ds-react'
 
 import { isPending } from '~shared/api/apiUtils'
 
@@ -25,6 +26,7 @@ export function TilbakekrevingVurderingPerioder({
 }) {
   const dispatch = useAppDispatch()
   const [lagrePerioderStatus, lagrePerioderRequest] = useApiCall(lagreTilbakekrevingsperioder)
+  const [visLagret, setVisLagret] = useState(false)
   const [perioder, setPerioder] = useState<TilbakekrevingPeriode[]>(behandling.tilbakekreving.perioder)
 
   const updateBeloeper = (index: number, oppdatertBeloep: TilbakekrevingBeloep) => {
@@ -36,8 +38,17 @@ export function TilbakekrevingVurderingPerioder({
     // TODO validering?
     lagrePerioderRequest({ behandlingsId: behandling.id, perioder }, (lagretTilbakekreving) => {
       dispatch(addTilbakekreving(lagretTilbakekreving))
+      setVisLagret(true)
     })
   }
+
+  useEffect(() => {
+    if (visLagret) {
+      setTimeout(() => {
+        setVisLagret(false)
+      }, 5000)
+    }
+  }, [visLagret])
 
   return (
     <InnholdPadding>
@@ -49,7 +60,7 @@ export function TilbakekrevingVurderingPerioder({
       <Table className="table" zebraStripes>
         <Table.Header>
           <Table.Row>
-            <Table.HeaderCell>Måned</Table.HeaderCell>
+            <Table.HeaderCell style={{ width: '5em' }}>Måned</Table.HeaderCell>
             <Table.HeaderCell>Brutto utbetaling</Table.HeaderCell>
             <Table.HeaderCell>Ny brutto utbetaling</Table.HeaderCell>
             <Table.HeaderCell>Beregnet feilutbetaling</Table.HeaderCell>
@@ -67,18 +78,17 @@ export function TilbakekrevingVurderingPerioder({
           {perioder.map((periode, index) => {
             const beloeper = periode.ytelse
             return (
-              <Table.Row key={'beloeperRad' + index}>
+              <Table.Row key={'beloeperRad' + index} style={{ alignItems: 'start' }}>
                 <Table.DataCell key="maaned">{periode.maaned.toString()}</Table.DataCell>
-                <Table.DataCell key="bruttoUtbetaling">{beloeper.bruttoUtbetaling}</Table.DataCell>
-                <Table.DataCell key="nyBruttoUtbetaling">{beloeper.nyBruttoUtbetaling}</Table.DataCell>
+                <Table.DataCell key="bruttoUtbetaling">{beloeper.bruttoUtbetaling} kr</Table.DataCell>
+                <Table.DataCell key="nyBruttoUtbetaling">{beloeper.nyBruttoUtbetaling} kr</Table.DataCell>
                 <Table.DataCell key="beregnetFeilutbetaling">
                   <TextField
                     label=""
-                    placeholder="Beregnet feilutbetaling"
+                    hideLabel={true}
                     value={beloeper.beregnetFeilutbetaling ?? ''}
                     pattern="[0-9]{11}"
                     maxLength={10}
-                    readOnly={!redigerbar}
                     onChange={(e) =>
                       onChangeNumber(e, (value) => {
                         updateBeloeper(index, {
@@ -89,14 +99,13 @@ export function TilbakekrevingVurderingPerioder({
                     }
                   />
                 </Table.DataCell>
-                <Table.DataCell key="skatteprosent">{beloeper.skatteprosent}</Table.DataCell>
+                <Table.DataCell key="skatteprosent">{beloeper.skatteprosent} %</Table.DataCell>
                 <Table.DataCell key="bruttoTilbakekreving">
                   <TextField
                     label=""
-                    placeholder="Brutto tilbakekreving"
+                    hideLabel={true}
                     value={beloeper.bruttoTilbakekreving ?? ''}
                     pattern="[0-9]"
-                    readOnly={!redigerbar}
                     onChange={(e) =>
                       onChangeNumber(e, (value) => {
                         updateBeloeper(index, {
@@ -110,7 +119,7 @@ export function TilbakekrevingVurderingPerioder({
                 <Table.DataCell key="nettoTilbakekreving">
                   <TextField
                     label=""
-                    placeholder="Netto tilbakekreving"
+                    hideLabel={true}
                     value={beloeper.nettoTilbakekreving ?? ''}
                     pattern="[0-9]"
                     readOnly={!redigerbar}
@@ -127,10 +136,9 @@ export function TilbakekrevingVurderingPerioder({
                 <Table.DataCell key="skatt">
                   <TextField
                     label=""
-                    placeholder="Skatt"
+                    hideLabel={true}
                     value={beloeper.skatt ?? ''}
                     pattern="[0-9]"
-                    readOnly={!redigerbar}
                     onChange={(e) =>
                       onChangeNumber(e, (value) => {
                         updateBeloeper(index, {
@@ -146,7 +154,6 @@ export function TilbakekrevingVurderingPerioder({
                     label="Skyld"
                     hideLabel={true}
                     value={beloeper.skyld ?? ''}
-                    readOnly={!redigerbar}
                     onChange={(e) => {
                       if (e.target.value === '') return
                       updateBeloeper(index, {
@@ -156,10 +163,11 @@ export function TilbakekrevingVurderingPerioder({
                     }}
                   >
                     <option value="">Velg..</option>
-                    <option value={TilbakekrevingSkyld.IKKE_FORDELT}>Ikke fordelt</option>
-                    <option value={TilbakekrevingSkyld.BRUKER}>Bruker</option>
-                    <option value={TilbakekrevingSkyld.NAV}>Nav</option>
-                    <option value={TilbakekrevingSkyld.SKYLDDELING}>Skylddeling</option>
+                    {Object.values(TilbakekrevingSkyld).map((skyld) => (
+                      <option key={skyld} value={skyld}>
+                        {teksterTilbakekrevingSkyld[skyld]}
+                      </option>
+                    ))}
                   </Select>
                 </Table.DataCell>
                 <Table.DataCell key="resultat">
@@ -167,7 +175,6 @@ export function TilbakekrevingVurderingPerioder({
                     label="Resultat"
                     hideLabel={true}
                     value={beloeper.resultat ?? ''}
-                    readOnly={!redigerbar}
                     onChange={(e) => {
                       if (e.target.value === '') return
                       updateBeloeper(index, {
@@ -177,20 +184,20 @@ export function TilbakekrevingVurderingPerioder({
                     }}
                   >
                     <option value="">Velg..</option>
-                    <option value={TilbakekrevingResultat.FORELDET}>Foreldet</option>
-                    <option value={TilbakekrevingResultat.INGEN_TILBAKEKREV}>Ingen tilbakekreving</option>
-                    <option value={TilbakekrevingResultat.DELVIS_TILBAKEKREV}>Delvis tilbakekreving</option>
-                    <option value={TilbakekrevingResultat.FULL_TILBAKEKREV}>Full tilbakekreving</option>
+                    {Object.values(TilbakekrevingResultat).map((resultat) => (
+                      <option key={resultat} value={resultat}>
+                        {teksterTilbakekrevingResultat[resultat]}
+                      </option>
+                    ))}
                   </Select>
                 </Table.DataCell>
                 <Table.DataCell key="tilbakekrevingsprosent">
                   <TextField
                     label=""
-                    placeholder="Tilbakekrevingsprosent"
+                    hideLabel={true}
                     value={beloeper.tilbakekrevingsprosent ?? ''}
                     pattern="[0-9]"
                     maxLength={3}
-                    readOnly={!redigerbar}
                     onChange={(e) =>
                       onChangeNumber(e, (value) => {
                         updateBeloeper(index, {
@@ -204,10 +211,9 @@ export function TilbakekrevingVurderingPerioder({
                 <Table.DataCell key="rentetillegg">
                   <TextField
                     label=""
-                    placeholder="Rentetillegg"
+                    hideLabel={true}
                     value={beloeper.rentetillegg ?? ''}
                     pattern="[0-9]"
-                    readOnly={!redigerbar}
                     onChange={(e) =>
                       onChangeNumber(e, (value) => {
                         updateBeloeper(index, {
@@ -224,11 +230,22 @@ export function TilbakekrevingVurderingPerioder({
         </Table.Body>
       </Table>
       {redigerbar && (
-        <ButtonWrapper>
-          <Button variant="primary" onClick={lagrePerioder} loading={isPending(lagrePerioderStatus)}>
-            Lagre
+        <VStack gap="5">
+          <Button
+            style={{ marginTop: '1em', maxWidth: '8em' }}
+            variant="primary"
+            size="small"
+            onClick={lagrePerioder}
+            loading={isPending(lagrePerioderStatus)}
+          >
+            Lagre perioder
           </Button>
-        </ButtonWrapper>
+          {visLagret && (
+            <Alert size="small" variant="success" style={{ maxWidth: 'fit-content' }}>
+              Perioder lagret.
+            </Alert>
+          )}
+        </VStack>
       )}
     </InnholdPadding>
   )
@@ -237,7 +254,3 @@ export function TilbakekrevingVurderingPerioder({
 const onChangeNumber = (e: React.ChangeEvent<HTMLInputElement>, onChange: (value: number | null) => void) => {
   onChange(isNaN(parseInt(e.target.value)) ? null : parseInt(e.target.value))
 }
-
-const ButtonWrapper = styled.div`
-  margin-top: 1em;
-`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingPerioderVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingPerioderVisning.tsx
@@ -1,0 +1,62 @@
+import {
+  teksterTilbakekrevingResultat,
+  teksterTilbakekrevingSkyld,
+  TilbakekrevingBehandling,
+  TilbakekrevingPeriode,
+} from '~shared/types/Tilbakekreving'
+import React, { useState } from 'react'
+import { HeadingWrapper, InnholdPadding } from '~components/behandling/soeknadsoversikt/styled'
+import { Heading, Table } from '@navikt/ds-react'
+
+export function TilbakekrevingVurderingPerioderVisning({ behandling }: { behandling: TilbakekrevingBehandling }) {
+  const [perioder] = useState<TilbakekrevingPeriode[]>(behandling.tilbakekreving.perioder)
+
+  return (
+    <InnholdPadding>
+      <HeadingWrapper>
+        <Heading level="2" size="medium" spacing>
+          Utbetalinger
+        </Heading>
+      </HeadingWrapper>
+      <Table className="table" zebraStripes>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Måned</Table.HeaderCell>
+            <Table.HeaderCell>Brutto utbetaling</Table.HeaderCell>
+            <Table.HeaderCell>Ny brutto utbetaling</Table.HeaderCell>
+            <Table.HeaderCell>Beregnet feilutbetaling</Table.HeaderCell>
+            <Table.HeaderCell>Skatteprosent</Table.HeaderCell>
+            <Table.HeaderCell>Brutto tilbakekreving</Table.HeaderCell>
+            <Table.HeaderCell>Netto tilbakekreving</Table.HeaderCell>
+            <Table.HeaderCell>Skatt</Table.HeaderCell>
+            <Table.HeaderCell>Skyld</Table.HeaderCell>
+            <Table.HeaderCell>Resultat</Table.HeaderCell>
+            <Table.HeaderCell>Tilbakekrevingsprosent</Table.HeaderCell>
+            <Table.HeaderCell>Rentetillegg</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {perioder.map((periode, index) => {
+            const beloeper = periode.ytelse
+            return (
+              <Table.Row key={'beloeperRad' + index}>
+                <Table.DataCell key="maaned">{periode.maaned.toString()}</Table.DataCell>
+                <Table.DataCell key="bruttoUtbetaling">{beloeper.bruttoUtbetaling} kr</Table.DataCell>
+                <Table.DataCell key="nyBruttoUtbetaling">{beloeper.nyBruttoUtbetaling} kr</Table.DataCell>
+                <Table.DataCell key="beregnetFeilutbetaling">{beloeper.beregnetFeilutbetaling} kr</Table.DataCell>
+                <Table.DataCell key="skatteprosent">{beloeper.skatteprosent} %</Table.DataCell>
+                <Table.DataCell key="bruttoTilbakekreving">{beloeper.bruttoTilbakekreving} kr</Table.DataCell>
+                <Table.DataCell key="nettoTilbakekreving">{beloeper.nettoTilbakekreving} kr</Table.DataCell>
+                <Table.DataCell key="skatt">{beloeper.skatt} kr</Table.DataCell>
+                <Table.DataCell key="skyld">{teksterTilbakekrevingSkyld[beloeper.skyld!!]}</Table.DataCell>
+                <Table.DataCell key="resultat">{teksterTilbakekrevingResultat[beloeper.resultat!!]}</Table.DataCell>
+                <Table.DataCell key="tilbakekrevingsprosent">{beloeper.tilbakekrevingsprosent} %</Table.DataCell>
+                <Table.DataCell key="rentetillegg">{beloeper.rentetillegg} kr</Table.DataCell>
+              </Table.Row>
+            )
+          })}
+        </Table.Body>
+      </Table>
+    </InnholdPadding>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/alerts/Toast.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/alerts/Toast.tsx
@@ -31,7 +31,7 @@ export const Toast = ({ melding, ...rest }: ToastProps) => {
 }
 
 const ToastAlert = styled(Alert)`
-  position: absolute;
+  position: fixed;
   right: 3rem;
   top: 3rem;
   box-shadow: -0.3rem 0.3rem 0.6rem 0 rgba(150, 150, 150, 0.5);

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/alerts/Toast.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/alerts/Toast.tsx
@@ -34,5 +34,6 @@ const ToastAlert = styled(Alert)`
   position: fixed;
   right: 3rem;
   top: 3rem;
+  z-index: 1;
   box-shadow: -0.3rem 0.3rem 0.6rem 0 rgba(150, 150, 150, 0.5);
 `

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Tilbakekreving.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Tilbakekreving.ts
@@ -54,7 +54,6 @@ export enum TilbakekrevingAarsak {
   DODSFALL = 'DODSFALL',
   EKTESKAP = 'EKTESKAP',
   FEILREGEL = 'FEILREGEL',
-  FEILUFOREG = 'FEILUFOREG',
   FLYTTUTLAND = 'FLYTTUTLAND',
   IKKESJEKKYTELSE = 'IKKESJEKKYTELSE',
   OVERSETTMLD = 'OVERSETTMLD',
@@ -62,10 +61,30 @@ export enum TilbakekrevingAarsak {
   UTBFEILMOT = 'UTBFEILMOT',
 }
 
+export const teksterTilbakekrevingAarsak: Record<TilbakekrevingAarsak, string> = {
+  ANNET: 'Annet',
+  ARBHOYINNT: 'Inntekt',
+  BEREGNFEIL: 'Beregningsfeil',
+  DODSFALL: 'Dødsfall',
+  EKTESKAP: 'Eksteskap/Samboer med felles barn',
+  FEILREGEL: 'Feil regelbruk',
+  FLYTTUTLAND: 'Flyttet utland',
+  IKKESJEKKYTELSE: 'Ikke sjekket mot andre ytelse',
+  OVERSETTMLD: 'Oversett melding fra bruker',
+  SAMLIV: 'Samliv',
+  UTBFEILMOT: 'Utbetaling til feil mottaker',
+} as const
+
 export enum TilbakekrevingAktsomhet {
   GOD_TRO = 'GOD_TRO',
   SIMPEL_UAKTSOMHET = 'SIMPEL_UAKTSOMHET',
   GROV_UAKTSOMHET = 'GROV_UAKTSOMHET',
+}
+
+export const teksterTilbakekrevingAktsomhet: Record<TilbakekrevingAktsomhet, string> = {
+  GOD_TRO: 'God tro',
+  SIMPEL_UAKTSOMHET: 'Simpel uaktsomhet',
+  GROV_UAKTSOMHET: 'Grov uaktsomhet',
 }
 
 export enum TilbakekrevingStatus {
@@ -95,12 +114,27 @@ export enum TilbakekrevingSkyld {
   SKYLDDELING = 'SKYLDDELING',
 }
 
+export const teksterTilbakekrevingSkyld: Record<TilbakekrevingSkyld, string> = {
+  BRUKER: 'Bruker',
+  IKKE_FORDELT: 'Ikke fordelt',
+  NAV: 'Nav',
+  SKYLDDELING: 'Skylddeling',
+}
+
 export enum TilbakekrevingResultat {
   DELVIS_TILBAKEKREV = 'DELVIS_TILBAKEKREV',
   FEILREGISTRERT = 'FEILREGISTRERT',
   FORELDET = 'FORELDET',
   FULL_TILBAKEKREV = 'FULL_TILBAKEKREV',
   INGEN_TILBAKEKREV = 'INGEN_TILBAKEKREV',
+}
+
+export const teksterTilbakekrevingResultat: Record<TilbakekrevingResultat, string> = {
+  INGEN_TILBAKEKREV: 'Full tilbakekreving',
+  DELVIS_TILBAKEKREV: 'Delvis tilbakekreving',
+  FULL_TILBAKEKREV: 'Ingen tilbakekreving',
+  FEILREGISTRERT: 'Feilregistrert',
+  FORELDET: 'Foreldet',
 }
 
 export enum TilbakekrevingHjemmel {
@@ -112,3 +146,13 @@ export enum TilbakekrevingHjemmel {
   TJUETO_FEMTEN_SEKS = 'TJUETO_FEMTEN_SEKS',
   TJUETO_SEKSTEN = 'TJUETO_SEKSTEN',
 }
+
+export const teksterTilbakekrevingHjemmel: Record<TilbakekrevingHjemmel, string> = {
+  ULOVFESTET: 'Lovfestet',
+  TJUETO_FEMTEN_EN_LEDD_EN: '§ 22-15 1. ledd, 1. punktum',
+  TJUETO_FEMTEN_EN_LEDD_TO_FORSETT: '§ 22-15 1. ledd, 2. punktum (forsett)',
+  TJUETO_FEMTEN_EN_LEDD_TO_UAKTSOMT: '§ 22-15 1. ledd, 2. punktum (uaktsomt)',
+  TJUETO_FEMTEN_FEM: '§ 22-15 5. ledd',
+  TJUETO_FEMTEN_SEKS: '§ 22-15 6. ledd',
+  TJUETO_SEKSTEN: '§ 22-16',
+} as const


### PR DESCRIPTION
- Endrer måten vedtak som er til attestering, samt ferdige behandlinger vises på, slik at det blir tilsvarende de andre behandlingene vi har. Dette i stedet for bruk av readonly-felter. 
- Legger inn felter i sidemenyen (sakId, ytelse, status og sett til vent)
- Legger inn manglende streker over knappene i bunn av skjermbildet
- Forenkler dropdown-lister ved å mappe over en liste som også kan brukes ved visning
- Legger inn en success-alert når lagring av vurdering eller lagring av perioder er utført. Dette for å tydeliggjøre at det faktisk ble lagret.