### PR TITLE
EY-3636 Håndtere avvik på journalpost

### DIFF
--- a/apps/etterlatte-brev-api/src/main/resources/graphql/dokumentoversiktBruker.graphql
+++ b/apps/etterlatte-brev-api/src/main/resources/graphql/dokumentoversiktBruker.graphql
@@ -31,6 +31,10 @@ query(
                     saksbehandlerHarTilgang
                 }
             }
+            bruker {
+                id
+                type
+            }
             avsenderMottaker {
                 id
                 navn

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentRad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentRad.tsx
@@ -10,6 +10,7 @@ import { FlexRow } from '~shared/styled'
 import { UtsendingsinfoModal } from '~components/person/dokumenter/UtsendingsinfoModal'
 import { OppgaveFraJournalpostModal } from '~components/person/dokumenter/OppgaveFraJournalpostModal'
 import DokumentModal from '~components/person/dokumenter/DokumentModal'
+import { HaandterAvvikModal } from './avvik/HaandterAvvikModal'
 
 export const DokumentRad = ({
   dokument,
@@ -58,6 +59,8 @@ export const DokumentRad = ({
               sakStatus={sakStatus}
             />
           )}
+
+          <HaandterAvvikModal journalpost={dokument} sakStatus={sakStatus} />
 
           <DokumentModal journalpost={dokument} />
         </FlexRow>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/FeilregistrerJournalpost.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/FeilregistrerJournalpost.tsx
@@ -1,0 +1,48 @@
+import { Alert, Button, Loader } from '@navikt/ds-react'
+import { FlexRow } from '~shared/styled'
+import { isPending, isSuccess } from '~shared/api/apiUtils'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { feilregistrerSakstilknytning } from '~shared/api/dokument'
+import { Journalpost } from '~shared/types/Journalpost'
+
+export const FeilregistrerJournalpost = ({ journalpost }: { journalpost: Journalpost }) => {
+  const [feilSakstilknytningStatus, apiFeilregistrerSakstilknytning] = useApiCall(feilregistrerSakstilknytning)
+
+  const feilregistrer = () =>
+    apiFeilregistrerSakstilknytning(journalpost.journalpostId, () => {
+      setTimeout(() => window.location.reload(), 2000)
+    })
+
+  if (isSuccess(feilSakstilknytningStatus)) {
+    return (
+      <Alert variant="success">
+        Journalposten ble feilregistrert. Laster siden på nytt <Loader />
+      </Alert>
+    )
+  }
+
+  return (
+    <>
+      {journalpost.sak ? (
+        <Alert variant="info">Du markerer nå journalposten som feilregistrert</Alert>
+      ) : (
+        <Alert variant="warning">
+          Kan ikke feilregistrere sakstilknytning når journalposten ikke er tilknyttet en sak
+        </Alert>
+      )}
+      <br />
+
+      <br />
+      <FlexRow justify="right">
+        <Button
+          variant="danger"
+          onClick={feilregistrer}
+          loading={isPending(feilSakstilknytningStatus)}
+          disabled={!journalpost.sak || isSuccess(feilSakstilknytningStatus)}
+        >
+          Feilregistrer sakstilknytning
+        </Button>
+      </FlexRow>
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/FlyttJournalpost.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/FlyttJournalpost.tsx
@@ -1,0 +1,220 @@
+import React, { useState } from 'react'
+import { Alert, Box, Button, Heading, Table, TextField } from '@navikt/ds-react'
+import { isPending, isSuccess, mapFailure, mapResult, mapSuccess, Result } from '~shared/api/apiUtils'
+import { Journalpost, Journalstatus, Sakstype } from '~shared/types/Journalpost'
+import { ISak } from '~shared/types/sak'
+import { hentSak } from '~shared/api/sak'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { SakMedBehandlinger } from '~components/person/typer'
+import { FlexRow } from '~shared/styled'
+import { temaFraSakstype } from '~components/person/journalfoeringsoppgave/journalpost/EndreSak'
+import { feilregistrerSakstilknytning, knyttTilAnnenSak } from '~shared/api/dokument'
+import { MagnifyingGlassIcon } from '@navikt/aksel-icons'
+import Spinner from '~shared/Spinner'
+import { formaterSakstype } from '~utils/formattering'
+import { useNavigate } from 'react-router-dom'
+
+const erSammeSak = (sak: ISak, journalpost: Journalpost): boolean => {
+  const { sak: journalpostSak, tema } = journalpost
+
+  return (
+    !!journalpostSak &&
+    journalpostSak.fagsakId === sak.id.toString() &&
+    journalpostSak.sakstype === Sakstype.FAGSAK &&
+    journalpostSak.fagsaksystem === 'EY' &&
+    tema === temaFraSakstype(sak.sakType)
+  )
+}
+
+export const FlyttJournalpost = ({
+  journalpost,
+  sakStatus,
+  lukkModal,
+}: {
+  journalpost: Journalpost
+  sakStatus: Result<SakMedBehandlinger>
+  lukkModal: () => void
+}) => {
+  const navigate = useNavigate()
+
+  const [sakid, setSakid] = useState<string>()
+
+  const [annenSakStatus, hentAnnenSak] = useApiCall(hentSak)
+  const [knyttTilAnnenSakStatus, apiKnyttTilAnnenSak] = useApiCall(knyttTilAnnenSak)
+  const [feilregSakstilknytningStatus, apiFeilregistrerSakstilknytning] = useApiCall(feilregistrerSakstilknytning)
+
+  const flyttJournalpost = (sak: ISak) => {
+    apiKnyttTilAnnenSak({
+      journalpostId: journalpost.journalpostId,
+      request: {
+        bruker: {
+          id: sak.ident,
+          idType: 'FNR',
+        },
+        fagsakId: sak.id.toString(),
+        fagsaksystem: 'EY',
+        journalfoerendeEnhet: sak.enhet,
+        sakstype: 'FAGSAK',
+        tema: temaFraSakstype(sak.sakType),
+      },
+    })
+  }
+
+  const flyttOgFeilregistrerJournalpost = (sak: ISak) => {
+    if (journalpost.journalstatus === Journalstatus.FEILREGISTRERT) {
+      flyttJournalpost(sak)
+    } else {
+      apiFeilregistrerSakstilknytning(journalpost.journalpostId, () => {
+        flyttJournalpost(sak)
+      })
+    }
+  }
+
+  if (isSuccess(knyttTilAnnenSakStatus) && isSuccess(feilregSakstilknytningStatus)) {
+    return (
+      <>
+        <Alert variant="success">
+          Journalposten ble feilregistrert og flyttet til annen sak{' '}
+          {mapSuccess(annenSakStatus, (sak) => `(sakid=${sak.id}, fnr=${sak.ident}, saktype=${sak.sakType})`)}
+        </Alert>
+
+        <br />
+
+        <FlexRow justify="right">
+          <Button variant="tertiary" onClick={() => window.location.reload()}>
+            Avslutt
+          </Button>
+          {mapSuccess(annenSakStatus, (sak) => (
+            <Button onClick={() => navigate(`/person/${sak.ident}`)}>Gå til sak {sak.id}</Button>
+          ))}
+        </FlexRow>
+      </>
+    )
+  }
+
+  return (
+    <>
+      {mapResult(sakStatus, {
+        success: ({ sak }) =>
+          erSammeSak(sak, journalpost) ? (
+            <Alert variant="info" inline>
+              Journalposten er allerede tilknyttet brukerens sak i Gjenny. <br />
+              Ønsker du å flytte journalposten til en annen bruker sin sak?
+            </Alert>
+          ) : (
+            <Alert variant="warning">Journalposten er ikke tilknyttet denne brukeren sin sak.</Alert>
+          ),
+        error: (error) => (
+          <>
+            {error.status === 404 ? (
+              <Alert variant="warning">Brukeren har ingen sak i Gjenny</Alert>
+            ) : (
+              <Alert variant="error">Ukjent feil ved henting av brukerens sak</Alert>
+            )}
+          </>
+        ),
+      })}
+
+      <br />
+
+      {mapResult(annenSakStatus, {
+        initial: (
+          <FlexRow align="end" $spacing>
+            <TextField
+              label="Hvilken sakid skal journalposten flyttes til?"
+              value={sakid || ''}
+              type="tel"
+              onChange={(e) => setSakid(e.target.value?.replace(/[^0-9+]/, ''))}
+            />
+            <Button
+              onClick={() => hentAnnenSak(Number(sakid))}
+              loading={isPending(annenSakStatus)}
+              disabled={!sakid}
+              icon={<MagnifyingGlassIcon />}
+            >
+              Søk
+            </Button>
+          </FlexRow>
+        ),
+        pending: <Spinner visible label="Henter sak..." />,
+        success: (annenSak) => (
+          <>
+            {isSuccess(sakStatus) && <FlyttTilSakDetaljer fra={sakStatus.data.sak} til={annenSak} />}
+            <br />
+
+            <Alert variant="warning" inline>
+              OBS! Journalposten du flytter vil automatisk bli markert som feilregistrert, slik at kun den nye blir
+              gjeldende.
+            </Alert>
+            <br />
+
+            {mapFailure(knyttTilAnnenSakStatus, (error) => (
+              <Alert variant="error">{error.detail || 'Ukjent feil oppsto ved flytting av journalpost'}</Alert>
+            ))}
+
+            {mapFailure(feilregSakstilknytningStatus, (error) => (
+              <Alert variant="error">{error.detail || 'Ukjent feil oppsto ved feilregistrering av journalpost'}</Alert>
+            ))}
+
+            <FlexRow justify="right">
+              <Button variant="secondary" onClick={lukkModal}>
+                Nei, avbryt
+              </Button>
+              <Button
+                onClick={() => flyttOgFeilregistrerJournalpost(annenSak)}
+                loading={isPending(feilregSakstilknytningStatus) || isPending(knyttTilAnnenSakStatus)}
+              >
+                Flytt journalpost til sak {annenSak.id}
+              </Button>
+            </FlexRow>
+          </>
+        ),
+        error: (error) => (
+          <>
+            {error.status === 404 ? (
+              <Alert variant="warning">Fant ikke sak {sakid}</Alert>
+            ) : (
+              <Alert variant="error">Ukjent feil ved henting av sak {sakid}</Alert>
+            )}
+          </>
+        ),
+      })}
+    </>
+  )
+}
+
+const FlyttTilSakDetaljer = ({ fra, til }: { fra: ISak; til: ISak }) => (
+  <Box borderWidth="1" padding="4" borderRadius="medium" borderColor="border-subtle" background="bg-subtle">
+    <Heading size="xsmall" spacing>
+      Flyttedetaljer
+    </Heading>
+
+    <Table size="small">
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell />
+          <Table.HeaderCell>Fra</Table.HeaderCell>
+          <Table.HeaderCell>Til</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+
+      <Table.Body>
+        <Table.Row>
+          <Table.HeaderCell>Sakid</Table.HeaderCell>
+          <Table.DataCell>{fra.id}</Table.DataCell>
+          <Table.DataCell>{til.id}</Table.DataCell>
+        </Table.Row>
+        <Table.Row>
+          <Table.HeaderCell>Ident</Table.HeaderCell>
+          <Table.DataCell>{fra.ident}</Table.DataCell>
+          <Table.DataCell>{til.ident}</Table.DataCell>
+        </Table.Row>
+        <Table.Row>
+          <Table.HeaderCell>Sakstype</Table.HeaderCell>
+          <Table.DataCell>{formaterSakstype(fra.sakType)}</Table.DataCell>
+          <Table.DataCell>{formaterSakstype(til.sakType)}</Table.DataCell>
+        </Table.Row>
+      </Table.Body>
+    </Table>
+  </Box>
+)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/HaandterAvvikModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/HaandterAvvikModal.tsx
@@ -1,0 +1,100 @@
+import { CogRotationIcon } from '@navikt/aksel-icons'
+import { BodyShort, Box, Button, Heading, Modal, Radio, RadioGroup } from '@navikt/ds-react'
+import { useState } from 'react'
+import { Journalpost, Journalstatus } from '~shared/types/Journalpost'
+import { FeilregistrerJournalpost } from '~components/person/dokumenter/avvik/FeilregistrerJournalpost'
+import { OpphevFeilregistreringJournalpost } from '~components/person/dokumenter/avvik/OpphevFeilregistreringJournalpost'
+import { FlyttJournalpost } from '~components/person/dokumenter/avvik/FlyttJournalpost'
+import { Result } from '~shared/api/apiUtils'
+import { SakMedBehandlinger } from '~components/person/typer'
+import { InfoWrapper } from '~components/behandling/soeknadsoversikt/styled'
+import { Info } from '~components/behandling/soeknadsoversikt/Info'
+
+enum Aarsak {
+  UTGAAR = 'UTGAAR',
+  OVERFOER = 'OVERFOER',
+  FEILREGISTRER = 'FEILREGISTRER',
+}
+
+export const HaandterAvvikModal = ({
+  journalpost,
+  sakStatus,
+}: {
+  journalpost: Journalpost
+  sakStatus: Result<SakMedBehandlinger>
+}) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [aarsak, setAarsak] = useState<Aarsak>()
+
+  return (
+    <>
+      <Button
+        variant="secondary"
+        size="small"
+        icon={<CogRotationIcon />}
+        title="Håndter avvik"
+        onClick={() => setIsOpen(true)}
+      />
+
+      <Modal open={isOpen} onClose={() => setIsOpen(false)} aria-labelledby="modal-heading" width="medium">
+        <Modal.Header>
+          <Heading size="medium">Håndter avvik på journalpost</Heading>
+        </Modal.Header>
+
+        <Modal.Body>
+          <Box borderWidth="1" padding="4" borderRadius="medium" borderColor="border-subtle" background="bg-subtle">
+            <Heading size="xsmall" spacing>
+              Journalpostdetailjer
+            </Heading>
+
+            <InfoWrapper>
+              <Info label="Journalpost ID" tekst={journalpost.journalpostId} />
+              <Info label="Bruker" tekst={`${journalpost.bruker?.id || '-'} (${journalpost.bruker?.type})`} />
+              <Info label="Sakstype" tekst={journalpost.sak?.sakstype || '-'} />
+              <Info label="FagsakId" tekst={journalpost.sak?.fagsakId || '-'} />
+              <Info label="Fagsaksystem" tekst={journalpost.sak?.fagsaksystem || '-'} />
+              <Info label="Tema" tekst={journalpost.tema || '-'} />
+
+              <Info
+                label="Dokumenter"
+                tekst={
+                  <>
+                    {journalpost.dokumenter.map((dok) => (
+                      <BodyShort key={dok.dokumentInfoId}>{dok.tittel}</BodyShort>
+                    ))}
+                  </>
+                }
+              />
+            </InfoWrapper>
+          </Box>
+          <br />
+
+          <RadioGroup legend="Velg handling" value={aarsak || ''} onChange={(checked) => setAarsak(checked as Aarsak)}>
+            <Radio value={Aarsak.OVERFOER}>Overfør til annen sak</Radio>
+            <Radio value={Aarsak.FEILREGISTRER}>
+              {journalpost.journalstatus === Journalstatus.FEILREGISTRERT ? 'Opphev feilregistrering' : 'Feilregistrer'}
+            </Radio>
+
+            {/* TODO: Skal lage støtte for den fortløpende, men prioriterer overføring til annen sak */}
+            {/*<option value={Aarsak.UTGAAR}>Sett til utgår</option>*/}
+          </RadioGroup>
+
+          <br />
+
+          {aarsak === Aarsak.UTGAAR && <>{/*TODO*/}</>}
+
+          {aarsak === Aarsak.FEILREGISTRER &&
+            (journalpost.journalstatus === Journalstatus.FEILREGISTRERT ? (
+              <OpphevFeilregistreringJournalpost journalpost={journalpost} />
+            ) : (
+              <FeilregistrerJournalpost journalpost={journalpost} />
+            ))}
+
+          {aarsak === Aarsak.OVERFOER && (
+            <FlyttJournalpost journalpost={journalpost} sakStatus={sakStatus} lukkModal={() => setIsOpen(false)} />
+          )}
+        </Modal.Body>
+      </Modal>
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/OpphevFeilregistreringJournalpost.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/OpphevFeilregistreringJournalpost.tsx
@@ -1,0 +1,48 @@
+import { Alert, Box, Button, Loader } from '@navikt/ds-react'
+import { FlexRow } from '~shared/styled'
+import { isPending, isSuccess } from '~shared/api/apiUtils'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { opphevFeilregistrertSakstilknytning } from '~shared/api/dokument'
+import { Journalpost } from '~shared/types/Journalpost'
+import { InfoWrapper } from '~components/behandling/soeknadsoversikt/styled'
+import { Info } from '~components/behandling/soeknadsoversikt/Info'
+
+export const OpphevFeilregistreringJournalpost = ({ journalpost }: { journalpost: Journalpost }) => {
+  const [opphevFeilregistreringStatus, apiOpphevFeilregistrering] = useApiCall(opphevFeilregistrertSakstilknytning)
+
+  const opphevFeilregistrering = () =>
+    apiOpphevFeilregistrering(journalpost.journalpostId, () => {
+      setTimeout(() => window.location.reload(), 2000)
+    })
+
+  if (isSuccess(opphevFeilregistreringStatus)) {
+    return (
+      <Alert variant="success">
+        Feilregistrering av journalpost ble opphevet. Laster siden på nytt <Loader />
+      </Alert>
+    )
+  }
+
+  return (
+    <>
+      <Alert variant="info">Du opphever nå status feilregistrert på journalposten</Alert>
+      <br />
+
+      <Box borderWidth="1" padding="4" borderRadius="medium" borderColor="border-subtle">
+        <InfoWrapper>
+          <Info label="Sakstype" tekst={journalpost.sak?.sakstype || '-'} />
+          <Info label="FagsakId" tekst={journalpost.sak?.fagsakId || '-'} />
+          <Info label="Fagsaksystem" tekst={journalpost.sak?.fagsaksystem || '-'} />
+          <Info label="Tema" tekst={journalpost.sak?.tema || '-'} />
+        </InfoWrapper>
+      </Box>
+
+      <br />
+      <FlexRow justify="right">
+        <Button onClick={opphevFeilregistrering} loading={isPending(opphevFeilregistreringStatus)}>
+          Opphev feilregistrering
+        </Button>
+      </FlexRow>
+    </>
+  )
+}


### PR DESCRIPTION
- Støtte feilregistrering og flytting av journalpost
- Ved flytting blir journalposten automatisk feilregistrert

TODO: 
- Litt grumsete kode i `FlyttJournalpost.tsx`, men prioriterer å få ut fiksen. Har som plan å opprette oppgave på saksbehandler når de vil endre på journalpost for å øke sporbarheten. 
- Må støtte flere avvik. Journalpost utgår, avbrutt, m.m.


![Screenshot 2024-03-08 at 15 01 12](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/f2415392-e0d1-409a-943d-2ac6b5e62678)


![Screenshot 2024-03-08 at 15 01 21](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/fde73276-6dc1-4e73-9806-c1204e77acb4)


![Screenshot 2024-03-08 at 15 01 34](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/a37e1adf-8e36-4ce2-aad7-f151b60c8823)


![Screenshot 2024-03-08 at 15 01 42](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/91fa3ae0-a9cf-4d7e-8ff1-bdd29b26a72c)
