### PR TITLE
EY-3636 Støtte flytting av journalpost som ikke ikke er ferdigstilt

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/HaandterAvvikModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/HaandterAvvikModal.tsx
@@ -4,11 +4,13 @@ import { useState } from 'react'
 import { Journalpost, Journalstatus } from '~shared/types/Journalpost'
 import { FeilregistrerJournalpost } from '~components/person/dokumenter/avvik/FeilregistrerJournalpost'
 import { OpphevFeilregistreringJournalpost } from '~components/person/dokumenter/avvik/OpphevFeilregistreringJournalpost'
-import { FlyttJournalpost } from '~components/person/dokumenter/avvik/FlyttJournalpost'
+import { KnyttTilAnnenSak } from '~components/person/dokumenter/avvik/KnyttTilAnnenSak'
 import { Result } from '~shared/api/apiUtils'
 import { SakMedBehandlinger } from '~components/person/typer'
 import { InfoWrapper } from '~components/behandling/soeknadsoversikt/styled'
 import { Info } from '~components/behandling/soeknadsoversikt/Info'
+import { kanEndreJournalpost } from '~components/person/journalfoeringsoppgave/journalpost/validering'
+import { KnyttTilAnnentBruker } from './KnyttTilAnnenBruker'
 
 enum Aarsak {
   UTGAAR = 'UTGAAR',
@@ -90,9 +92,16 @@ export const HaandterAvvikModal = ({
               <FeilregistrerJournalpost journalpost={journalpost} />
             ))}
 
-          {aarsak === Aarsak.OVERFOER && (
-            <FlyttJournalpost journalpost={journalpost} sakStatus={sakStatus} lukkModal={() => setIsOpen(false)} />
-          )}
+          {aarsak === Aarsak.OVERFOER &&
+            (kanEndreJournalpost(journalpost) ? (
+              <KnyttTilAnnentBruker
+                journalpost={journalpost}
+                sakStatus={sakStatus}
+                lukkModal={() => setIsOpen(false)}
+              />
+            ) : (
+              <KnyttTilAnnenSak journalpost={journalpost} sakStatus={sakStatus} lukkModal={() => setIsOpen(false)} />
+            ))}
         </Modal.Body>
       </Modal>
     </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/KnyttTilAnnenBruker.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/KnyttTilAnnenBruker.tsx
@@ -1,0 +1,143 @@
+import React, { useState } from 'react'
+import { Alert, Button, TextField } from '@navikt/ds-react'
+import { isPending, isSuccess, mapResult, mapSuccess, Result } from '~shared/api/apiUtils'
+import { BrukerIdType, Journalpost, Sakstype } from '~shared/types/Journalpost'
+import { ISak } from '~shared/types/sak'
+import { hentSak } from '~shared/api/sak'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { SakMedBehandlinger } from '~components/person/typer'
+import { FlexRow } from '~shared/styled'
+import { temaFraSakstype } from '~components/person/journalfoeringsoppgave/journalpost/EndreSak'
+import { oppdaterJournalpost } from '~shared/api/dokument'
+import { MagnifyingGlassIcon } from '@navikt/aksel-icons'
+import Spinner from '~shared/Spinner'
+import { useNavigate } from 'react-router-dom'
+import { Oppgavetype, opprettOppgave, tildelSaksbehandlerApi } from '~shared/api/oppgaver'
+import { useAppSelector } from '~store/Store'
+import { SakOverfoeringDetailjer } from 'src/components/person/dokumenter/avvik/common/SakOverfoeringDetailjer'
+
+export const KnyttTilAnnentBruker = ({
+  journalpost,
+  sakStatus,
+  lukkModal,
+}: {
+  journalpost: Journalpost
+  sakStatus: Result<SakMedBehandlinger>
+  lukkModal: () => void
+}) => {
+  const navigate = useNavigate()
+  const innloggetSaksbehandler = useAppSelector((state) => state.saksbehandlerReducer.innloggetSaksbehandler)
+
+  const [sakid, setSakid] = useState<string>()
+
+  const [annenSakStatus, hentAnnenSak] = useApiCall(hentSak)
+  const [oppdaterResult, apiOppdaterJournalpost] = useApiCall(oppdaterJournalpost)
+  const [opprettOppgaveStatus, apiOpprettOppgave] = useApiCall(opprettOppgave)
+  const [tildelSaksbehandlerStatus, tildelSaksbehandler] = useApiCall(tildelSaksbehandlerApi)
+
+  const flyttJournalpost = (sak: ISak) => {
+    apiOppdaterJournalpost(
+      {
+        journalpost: {
+          ...journalpost,
+          bruker: {
+            id: sak.ident,
+            type: BrukerIdType.FNR,
+          },
+          sak: {
+            fagsakId: sak.id.toString(),
+            fagsaksystem: 'EY',
+            sakstype: Sakstype.FAGSAK,
+          },
+          tema: temaFraSakstype(sak.sakType),
+        },
+      },
+      ({ journalpostId }) => {
+        const oppgaveType: Oppgavetype = 'JOURNALFOERING'
+
+        apiOpprettOppgave(
+          {
+            sakId: sak.id,
+            request: {
+              oppgaveType,
+              referanse: journalpostId,
+              merknad: `Journalpost flyttet fra bruker ${journalpost.bruker?.id}`,
+              oppgaveKilde: 'SAKSBEHANDLER',
+            },
+          },
+          (oppgave) => {
+            tildelSaksbehandler({
+              oppgaveId: oppgave.id,
+              type: oppgaveType,
+              nysaksbehandler: { saksbehandler: innloggetSaksbehandler.ident, versjon: null },
+            })
+          }
+        )
+      }
+    )
+  }
+
+  if (isSuccess(oppdaterResult) && isSuccess(opprettOppgaveStatus) && isSuccess(tildelSaksbehandlerStatus)) {
+    return (
+      <>
+        <Alert variant="success">Journalposten ble flyttet til sak {sakid} og journalføringsoppgave opprettet.</Alert>
+
+        <br />
+
+        <FlexRow justify="right">
+          <Button variant="tertiary" onClick={() => window.location.reload()}>
+            Avslutt
+          </Button>
+          {mapSuccess(opprettOppgaveStatus, (oppgave) => (
+            <Button onClick={() => navigate(`/oppgave/${oppgave.id}`)}>Gå til oppgaven</Button>
+          ))}
+        </FlexRow>
+      </>
+    )
+  }
+
+  const isLoading = isPending(oppdaterResult) || isPending(opprettOppgaveStatus) || isPending(tildelSaksbehandlerStatus)
+
+  return mapResult(annenSakStatus, {
+    initial: (
+      <FlexRow align="end" $spacing>
+        <TextField
+          label="Hvilken sakid skal journalposten flyttes til?"
+          value={sakid || ''}
+          type="tel"
+          onChange={(e) => setSakid(e.target.value?.replace(/[^0-9+]/, ''))}
+        />
+        <Button
+          onClick={() => hentAnnenSak(Number(sakid))}
+          loading={isPending(annenSakStatus)}
+          disabled={!sakid}
+          icon={<MagnifyingGlassIcon />}
+        >
+          Søk
+        </Button>
+      </FlexRow>
+    ),
+    pending: <Spinner visible label="Henter sak..." />,
+    success: (annenSak) => (
+      <>
+        {isSuccess(sakStatus) && <SakOverfoeringDetailjer fra={sakStatus.data.sak} til={annenSak} />}
+        <br />
+
+        <FlexRow justify="right">
+          <Button variant="secondary" onClick={lukkModal} disabled={isLoading}>
+            Nei, avbryt
+          </Button>
+          <Button onClick={() => flyttJournalpost(annenSak)} loading={isLoading}>
+            Flytt journalpost til sak {annenSak.id}
+          </Button>
+        </FlexRow>
+      </>
+    ),
+    error: (error) =>
+      error.status === 404 ? (
+        <Alert variant="warning">Fant ikke sak {sakid}</Alert>
+      ) : (
+        <Alert variant="error">Ukjent feil ved henting av sak {sakid}</Alert>
+      ),
+  })
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/KnyttTilAnnenSak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/KnyttTilAnnenSak.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Alert, Box, Button, Heading, Table, TextField } from '@navikt/ds-react'
+import { Alert, Button, TextField } from '@navikt/ds-react'
 import { isPending, isSuccess, mapFailure, mapResult, mapSuccess, Result } from '~shared/api/apiUtils'
 import { Journalpost, Journalstatus, Sakstype } from '~shared/types/Journalpost'
 import { ISak } from '~shared/types/sak'
@@ -11,8 +11,8 @@ import { temaFraSakstype } from '~components/person/journalfoeringsoppgave/journ
 import { feilregistrerSakstilknytning, knyttTilAnnenSak } from '~shared/api/dokument'
 import { MagnifyingGlassIcon } from '@navikt/aksel-icons'
 import Spinner from '~shared/Spinner'
-import { formaterSakstype } from '~utils/formattering'
 import { useNavigate } from 'react-router-dom'
+import { SakOverfoeringDetailjer } from 'src/components/person/dokumenter/avvik/common/SakOverfoeringDetailjer'
 
 const erSammeSak = (sak: ISak, journalpost: Journalpost): boolean => {
   const { sak: journalpostSak, tema } = journalpost
@@ -26,7 +26,12 @@ const erSammeSak = (sak: ISak, journalpost: Journalpost): boolean => {
   )
 }
 
-export const FlyttJournalpost = ({
+/**
+ * Knytt til annen sak brukes i tilfeller hvor journalposten er JOURNALFOERT / FERDIGSTILT.
+ * Når en journalpost er i denne tilstanden kan den ikke redigeres på vanlig vis og må dermed
+ * feilregistreres og flyttes til ny sak (dokarkiv lager bare kopi av den gamle).
+ **/
+export const KnyttTilAnnenSak = ({
   journalpost,
   sakStatus,
   lukkModal,
@@ -139,7 +144,7 @@ export const FlyttJournalpost = ({
         pending: <Spinner visible label="Henter sak..." />,
         success: (annenSak) => (
           <>
-            {isSuccess(sakStatus) && <FlyttTilSakDetaljer fra={sakStatus.data.sak} til={annenSak} />}
+            {isSuccess(sakStatus) && <SakOverfoeringDetailjer fra={sakStatus.data.sak} til={annenSak} />}
             <br />
 
             <Alert variant="warning" inline>
@@ -182,39 +187,3 @@ export const FlyttJournalpost = ({
     </>
   )
 }
-
-const FlyttTilSakDetaljer = ({ fra, til }: { fra: ISak; til: ISak }) => (
-  <Box borderWidth="1" padding="4" borderRadius="medium" borderColor="border-subtle" background="bg-subtle">
-    <Heading size="xsmall" spacing>
-      Flyttedetaljer
-    </Heading>
-
-    <Table size="small">
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell />
-          <Table.HeaderCell>Fra</Table.HeaderCell>
-          <Table.HeaderCell>Til</Table.HeaderCell>
-        </Table.Row>
-      </Table.Header>
-
-      <Table.Body>
-        <Table.Row>
-          <Table.HeaderCell>Sakid</Table.HeaderCell>
-          <Table.DataCell>{fra.id}</Table.DataCell>
-          <Table.DataCell>{til.id}</Table.DataCell>
-        </Table.Row>
-        <Table.Row>
-          <Table.HeaderCell>Ident</Table.HeaderCell>
-          <Table.DataCell>{fra.ident}</Table.DataCell>
-          <Table.DataCell>{til.ident}</Table.DataCell>
-        </Table.Row>
-        <Table.Row>
-          <Table.HeaderCell>Sakstype</Table.HeaderCell>
-          <Table.DataCell>{formaterSakstype(fra.sakType)}</Table.DataCell>
-          <Table.DataCell>{formaterSakstype(til.sakType)}</Table.DataCell>
-        </Table.Row>
-      </Table.Body>
-    </Table>
-  </Box>
-)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/common/SakOverfoeringDetailjer.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/common/SakOverfoeringDetailjer.tsx
@@ -1,0 +1,40 @@
+import { ISak } from '~shared/types/sak'
+import { Box, Heading, Table } from '@navikt/ds-react'
+import { formaterSakstype } from '~utils/formattering'
+import React from 'react'
+
+export const SakOverfoeringDetailjer = ({ fra, til }: { fra: ISak; til: ISak }) => (
+  <Box borderWidth="1" padding="4" borderRadius="medium" borderColor="border-subtle" background="bg-subtle">
+    <Heading size="xsmall" spacing>
+      Flyttedetaljer
+    </Heading>
+
+    <Table size="small">
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell />
+          <Table.HeaderCell>Fra</Table.HeaderCell>
+          <Table.HeaderCell>Til</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+
+      <Table.Body>
+        <Table.Row>
+          <Table.HeaderCell>Sakid</Table.HeaderCell>
+          <Table.DataCell>{fra.id}</Table.DataCell>
+          <Table.DataCell>{til.id}</Table.DataCell>
+        </Table.Row>
+        <Table.Row>
+          <Table.HeaderCell>Ident</Table.HeaderCell>
+          <Table.DataCell>{fra.ident}</Table.DataCell>
+          <Table.DataCell>{til.ident}</Table.DataCell>
+        </Table.Row>
+        <Table.Row>
+          <Table.HeaderCell>Sakstype</Table.HeaderCell>
+          <Table.DataCell>{formaterSakstype(fra.sakType)}</Table.DataCell>
+          <Table.DataCell>{formaterSakstype(til.sakType)}</Table.DataCell>
+        </Table.Row>
+      </Table.Body>
+    </Table>
+  </Box>
+)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/BehandleJournalfoeringOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/BehandleJournalfoeringOppgave.tsx
@@ -33,6 +33,8 @@ import { FEATURE_TOGGLE_KAN_BRUKE_KLAGE } from '~components/person/KlageListe'
 import { Sidebar, SidebarPanel } from '~shared/components/Sidebar'
 import { hentJournalpost } from '~shared/api/dokument'
 import { JournalpostInnhold } from './journalpost/JournalpostInnhold'
+import { hentPersonNavn } from '~shared/api/pdltjenester'
+import { StatusBar } from '~shared/statusbar/Statusbar'
 
 export default function BehandleJournalfoeringOppgave() {
   const { nyBehandlingRequest, oppgave, sakMedBehandlinger } = useJournalfoeringOppgave()
@@ -41,6 +43,7 @@ export default function BehandleJournalfoeringOppgave() {
   const [oppgaveStatus, apiHentOppgave] = useApiCall(hentOppgave)
   const [sakStatus, apiHentSak] = useApiCall(hentSakMedBehandlnger)
   const [journalpostStatus, apiHentJournalpost] = useApiCall(hentJournalpost)
+  const [personResult, hentPerson] = useApiCall(hentPersonNavn)
 
   const kanBrukeKlage = useFeatureEnabledMedDefault(FEATURE_TOGGLE_KAN_BRUKE_KLAGE, false)
 
@@ -68,6 +71,10 @@ export default function BehandleJournalfoeringOppgave() {
         } else {
           throw Error(`Oppgave id=${oppgaveId} mangler referanse til journalposten`)
         }
+
+        if (oppgave.fnr) {
+          hentPerson(oppgave.fnr)
+        }
       })
     }
   }, [oppgaveId])
@@ -80,6 +87,7 @@ export default function BehandleJournalfoeringOppgave() {
 
   return (
     <>
+      <StatusBar result={personResult} />
       <NavigerTilbakeMeny label="Tilbake til oppgavebenken" path="/" />
 
       <GridContainer>
@@ -121,19 +129,19 @@ export default function BehandleJournalfoeringOppgave() {
           <VelgJournalpost journalpostStatus={journalpostStatus} />
         </Column>
 
-        {mapSuccess(
-          journalpostStatus,
-          (journalpost) =>
-            !kanEndreJournalpost(journalpost) && (
-              <Sidebar>
-                {oppgave && <OppgaveDetaljer oppgave={oppgave} />}
+        <Sidebar>
+          {oppgave && <OppgaveDetaljer oppgave={oppgave} />}
 
+          {mapSuccess(
+            journalpostStatus,
+            (journalpost) =>
+              !kanEndreJournalpost(journalpost) && (
                 <SidebarPanel border>
                   <JournalpostInnhold journalpost={journalpost} />
                 </SidebarPanel>
-              </Sidebar>
-            )
-        )}
+              )
+          )}
+        </Sidebar>
       </GridContainer>
     </>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/dokument.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/dokument.ts
@@ -38,7 +38,7 @@ export const oppdaterJournalpost = async (args: {
   journalpost: OppdaterJournalpostRequest
   forsoekFerdigstill?: boolean
   journalfoerendeEnhet?: string
-}): Promise<ApiResponse<any>> => {
+}): Promise<ApiResponse<{ journalpostId: string }>> => {
   const queryParams = args.forsoekFerdigstill
     ? `journalfoerendeEnhet=${args.journalfoerendeEnhet}&forsoekFerdigstill=${args.forsoekFerdigstill}`
     : ''


### PR DESCRIPTION
Endre litt på måten man flytter en journalpost til annen sak/bruker i tilfeller hvor journalposten ikke er ferdigstilt/journalført. 

Endepunktet `/knyttTilAnnenSak` i dokarkiv fungerer kun dersom journalposten allerede har en sakstilknytning, noe den ikke nødvendigvis har. 