### PR TITLE
Skriv om så vi har éin og berre éin måte å hente tokens på

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafKlient.kt
@@ -173,9 +173,9 @@ class SafKlient(
 
     private suspend fun getOboToken(bruker: BrukerTokenInfo): String {
         val token =
-            azureAdClient.getOnBehalfOfAccessTokenForResource(
+            azureAdClient.hentTokenFraAD(
+                bruker,
                 listOf(safScope),
-                bruker.accessToken(),
             )
         return token.get()?.accessToken ?: ""
     }

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlOboKlient.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlOboKlient.kt
@@ -67,9 +67,9 @@ class PdlOboKlient(private val httpClient: HttpClient, private val config: Confi
 
     private suspend fun getOboToken(bruker: BrukerTokenInfo): String {
         val token =
-            azureAdClient.getOnBehalfOfAccessTokenForResource(
+            azureAdClient.hentTokenFraAD(
+                bruker,
                 listOf(pdlScope),
-                bruker.accessToken(),
             )
 
         return requireNotNull(token.get()?.accessToken) {

--- a/apps/etterlatte-testdata/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/Application.kt
@@ -56,6 +56,7 @@ import no.nav.etterlatte.testdata.features.index.IndexFeature
 import no.nav.etterlatte.testdata.features.samordning.SamordningMottattFeature
 import no.nav.etterlatte.testdata.features.soeknad.OpprettSoeknadFeature
 import no.nav.etterlatte.testdata.features.standardmelding.StandardMeldingFeature
+import no.nav.etterlatte.token.Systembruker
 import no.nav.security.token.support.v2.tokenValidationSupport
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -173,12 +174,17 @@ fun PipelineContext<Unit, ApplicationCall>.brukerIdFraToken() = call.firstValidT
 
 fun getDollyAccessToken(): String =
     runBlocking {
-        azureAdClient.getAccessTokenForResource(listOf("api://${config.getString("dolly.client.id")}/.default"))
+        azureAdClient.hentTokenFraAD(
+            Systembruker.testdata,
+            listOf("api://${config.getString("dolly.client.id")}/.default"),
+        )
             .get()!!.accessToken
     }
 
 fun getTestnavAccessToken(): String =
     runBlocking {
-        azureAdClient.getAccessTokenForResource(listOf("api://${config.getString("testnav.client.id")}/.default"))
-            .get()!!.accessToken
+        azureAdClient.hentTokenFraAD(
+            Systembruker.testdata,
+            listOf("api://${config.getString("testnav.client.id")}/.default"),
+        ).get()!!.accessToken
     }

--- a/libs/etterlatte-ktor/src/main/kotlin/no/nav/etterlatte/libs/ktorobo/AzureAdClient.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/no/nav/etterlatte/libs/ktorobo/AzureAdClient.kt
@@ -27,6 +27,8 @@ import kotlinx.coroutines.future.future
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.ktor.client.ClientCallLogging
 import no.nav.etterlatte.libs.common.retryOgPakkUt
+import no.nav.etterlatte.token.BrukerTokenInfo
+import no.nav.etterlatte.token.Systembruker
 import java.util.concurrent.TimeUnit
 
 internal val defaultHttpClient =
@@ -89,6 +91,15 @@ class AzureAdClient(
                 ex,
             )
         }
+
+    suspend fun hentTokenFraAD(
+        bruker: BrukerTokenInfo,
+        scopes: List<String>,
+    ) = if (bruker is Systembruker) {
+        getAccessTokenForResource(scopes)
+    } else {
+        getOnBehalfOfAccessTokenForResource(scopes, bruker.accessToken())
+    }
 
     // Service-to-service access token request (client credentials grant)
     suspend fun getAccessTokenForResource(scopes: List<String>): Result<AccessToken, ThrowableErrorMessage> {

--- a/libs/etterlatte-ktor/src/main/kotlin/no/nav/etterlatte/libs/ktorobo/AzureAdClient.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/no/nav/etterlatte/libs/ktorobo/AzureAdClient.kt
@@ -102,7 +102,7 @@ class AzureAdClient(
     }
 
     // Service-to-service access token request (client credentials grant)
-    suspend fun getAccessTokenForResource(scopes: List<String>): Result<AccessToken, ThrowableErrorMessage> {
+    internal suspend fun getAccessTokenForResource(scopes: List<String>): Result<AccessToken, ThrowableErrorMessage> {
         val params = { _: ClientCredentialsTokenRequest ->
             Parameters.build {
                 append("client_id", config.getString("azure.app.client.id"))
@@ -141,7 +141,7 @@ class AzureAdClient(
     }
 
     // Service-to-service access token request (on-behalf-of flow)
-    suspend fun getOnBehalfOfAccessTokenForResource(
+    internal suspend fun getOnBehalfOfAccessTokenForResource(
         scopes: List<String>,
         accessToken: String,
     ): Result<AccessToken, ThrowableErrorMessage> {

--- a/libs/etterlatte-ktor/src/main/kotlin/no/nav/etterlatte/libs/ktorobo/DownstreamResourceClass.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/no/nav/etterlatte/libs/ktorobo/DownstreamResourceClass.kt
@@ -20,7 +20,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import no.nav.etterlatte.token.BrukerTokenInfo
-import no.nav.etterlatte.token.Systembruker
 import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger(DownstreamResourceClient::class.java)
@@ -34,7 +33,7 @@ class DownstreamResourceClient(
         brukerTokenInfo: BrukerTokenInfo,
     ): Result<Resource, Throwable> {
         val scopes = listOf("api://${resource.clientId}/.default")
-        return hentTokenFraAD(brukerTokenInfo, scopes)
+        return azureAdClient.hentTokenFraAD(brukerTokenInfo, scopes)
             .andThen { oboAccessToken ->
                 fetchFromDownstreamApi(resource, oboAccessToken)
             }
@@ -46,24 +45,13 @@ class DownstreamResourceClient(
             }
     }
 
-    private suspend fun hentTokenFraAD(
-        brukerTokenInfo: BrukerTokenInfo,
-        scopes: List<String>,
-    ): Result<AccessToken, ThrowableErrorMessage> =
-        if (brukerTokenInfo is Systembruker) {
-            azureAdClient.getAccessTokenForResource(scopes)
-        } else {
-            azureAdClient
-                .getOnBehalfOfAccessTokenForResource(scopes, brukerTokenInfo.accessToken())
-        }
-
     suspend fun post(
         resource: Resource,
         brukerTokenInfo: BrukerTokenInfo,
         postBody: Any,
     ): Result<Resource, Throwable> {
         val scopes = listOf("api://${resource.clientId}/.default")
-        return hentTokenFraAD(brukerTokenInfo, scopes)
+        return azureAdClient.hentTokenFraAD(brukerTokenInfo, scopes)
             .andThen { token ->
                 postToDownstreamApi(resource, token, postBody)
             }
@@ -78,7 +66,7 @@ class DownstreamResourceClient(
         putBody: Any,
     ): Result<Resource, Throwable> {
         val scopes = listOf("api://${resource.clientId}/.default")
-        return hentTokenFraAD(brukerTokenInfo, scopes)
+        return azureAdClient.hentTokenFraAD(brukerTokenInfo, scopes)
             .andThen { token ->
                 putToDownstreamApi(resource, token, putBody)
             }
@@ -93,7 +81,7 @@ class DownstreamResourceClient(
         postBody: String,
     ): Result<Resource, Throwable> {
         val scopes = listOf("api://${resource.clientId}/.default")
-        return hentTokenFraAD(brukerTokenInfo, scopes)
+        return azureAdClient.hentTokenFraAD(brukerTokenInfo, scopes)
             .andThen { oboAccessToken ->
                 deleteToDownstreamApi(resource, oboAccessToken, postBody)
             }
@@ -108,7 +96,7 @@ class DownstreamResourceClient(
         patchBody: String,
     ): Result<Resource, Throwable> {
         val scopes = listOf("api://${resource.clientId}/.default")
-        return hentTokenFraAD(brukerTokenInfo, scopes)
+        return azureAdClient.hentTokenFraAD(brukerTokenInfo, scopes)
             .andThen { oboAccessToken ->
                 patchToDownstreamApi(resource, oboAccessToken, patchBody)
             }

--- a/libs/etterlatte-ktor/src/main/kotlin/no/nav/etterlatte/token/BrukerTokenInfo.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/no/nav/etterlatte/token/BrukerTokenInfo.kt
@@ -66,6 +66,7 @@ data class Systembruker(
         val migrering = Systembruker(Systembrukere.MIGRERING)
         val brev = Systembruker(Systembrukere.BREV)
         val doedshendelse = Systembruker(Systembrukere.DOEDSHENDELSE)
+        val testdata = Systembruker(Systembrukere.TESTDATA)
     }
 }
 
@@ -102,4 +103,5 @@ enum class Systembrukere(val oid: String) {
     BREV("brev"),
     MIGRERING("migrering"),
     DOEDSHENDELSE("doedshendelse"),
+    TESTDATA("testdata"),
 }

--- a/libs/etterlatte-ktor/src/test/kotlin/no/nav/etterlatte/libs/ktorobo/DownstreamResourceClientTest.kt
+++ b/libs/etterlatte-ktor/src/test/kotlin/no/nav/etterlatte/libs/ktorobo/DownstreamResourceClientTest.kt
@@ -1,12 +1,7 @@
 package no.nav.etterlatte.libs.ktorobo
 
-import com.github.michaelbull.result.Ok
 import io.ktor.http.ContentType
-import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
-import kotlinx.coroutines.runBlocking
-import no.nav.etterlatte.token.BrukerTokenInfo
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -24,35 +19,5 @@ internal class DownstreamResourceClientTest {
 
         assertTrue(contentTypeErLik(contenttypeMedCharset, ContentType.Application.Json))
         assertTrue(contentTypeErLik(ContentType.Application.Json, contenttypeMedCharset))
-    }
-
-    @Test
-    fun `bruker client credentials viss JWT-claims sub og oid er like`() {
-        every { runBlocking { azureAdClient.getAccessTokenForResource(any()) } } returns Ok(mockk())
-
-        runBlocking {
-            client.get(
-                resource,
-                BrukerTokenInfo.of(accessToken = "a", oid = "b", sub = "b", saksbehandler = null, claims = null),
-            )
-        }
-        verify { runBlocking { azureAdClient.getAccessTokenForResource(any()) } }
-        verify(exactly = 0) {
-            runBlocking { azureAdClient.getOnBehalfOfAccessTokenForResource(any(), any()) }
-        }
-    }
-
-    @Test
-    fun `bruker OBO viss JWT-claims sub og oid er ulike`() {
-        every { runBlocking { azureAdClient.getOnBehalfOfAccessTokenForResource(any(), any()) } } returns Ok(mockk())
-
-        runBlocking {
-            client.get(
-                resource,
-                BrukerTokenInfo.of(accessToken = "a", oid = "b", sub = "c", saksbehandler = "s1", claims = null),
-            )
-        }
-        verify { runBlocking { azureAdClient.getOnBehalfOfAccessTokenForResource(any(), "a") } }
-        verify(exactly = 0) { runBlocking { azureAdClient.getAccessTokenForResource(any()) } }
     }
 }


### PR DESCRIPTION
Som det er no har vi eit par-tre forskjellige inngangsvegar til å hente tokens, korav ikkje alle støttar systembrukar-kall.

Dels kjens det som unødvendig kompleksitet, men mest av alt kjens det som noko som på eit tidspunkt vil gjera at vi introduserer feil, og at regulering eller andre automatiske jobbar plutseleg sluttar å funke fordi vi endra ein plass utan å tenkje på dét.

Løyser det derfor ved at AzureAdClient kun eksponerer ut éin metode offentleg, og den tar høgde for at det kan vera systembrukar eller saksbehandlar.