### PR TITLE
EY-3672 Støtte henting av navn med aktørid

### DIFF
--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/ParallelleSannheterKlient.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/ParallelleSannheterKlient.kt
@@ -45,6 +45,9 @@ class ParallelleSannheterKlient(
                 ),
         )
 
+    suspend fun avklarFolkeregisteridentifikator(folkeregisteridentifikator: List<PdlFolkeregisteridentifikator>) =
+        avklar(folkeregisteridentifikator, Avklaring.FOLKEREGISTERIDENTIFIKATOR)
+
     suspend fun avklarAdressebeskyttelse(adressebeskyttelse: List<PdlAdressebeskyttelse>) =
         avklarNullable(adressebeskyttelse, Avklaring.ADRESSEBESKYTTELSE)
 
@@ -113,6 +116,7 @@ class ParallelleSannheterKlient(
     }
 
     private enum class Avklaring(val feltnavn: String) {
+        FOLKEREGISTERIDENTIFIKATOR("folkeregisteridentifikator"),
         NAVN("navn"),
         ADRESSEBESKYTTELSE("adressebeskyttelse"),
         STATSBORGERSKAP("statsborgerskap"),

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
@@ -69,6 +69,11 @@ data class PdlPersonResponse(
     val errors: List<PdlResponseError>? = null,
 )
 
+data class PdlPersonNavnResponse(
+    val data: PdlPersonNavnResponseData? = null,
+    val errors: List<PdlResponseError>? = null,
+)
+
 data class PdlPersonResponseBolk(
     val data: PdlPersonResponseBulkData? = null,
     val errors: List<PdlResponseError>? = null,
@@ -130,6 +135,10 @@ data class PdlPersonResponseData(
     val hentPerson: PdlHentPerson? = null,
 )
 
+data class PdlPersonNavnResponseData(
+    val hentPerson: PdlHentPersonNavn? = null,
+)
+
 data class PdlPersonResponseBulkData(
     val hentPersonBolk: List<PdlHentPersonBolkResult>? = null,
 )
@@ -142,6 +151,11 @@ data class PdlHentPersonBolkResult(
 
 data class PdlHentPersonAdressebeskyttelse(
     val adressebeskyttelse: List<PdlAdressebeskyttelse>,
+)
+
+data class PdlHentPersonNavn(
+    val folkeregisteridentifikator: List<PdlFolkeregisteridentifikator>,
+    val navn: List<PdlNavn>,
 )
 
 data class PdlHentPerson(
@@ -174,6 +188,14 @@ enum class PdlGradering {
     FORTROLIG,
     UGRADERT,
 }
+
+data class PdlFolkeregisteridentifikator(
+    val identifikasjonsnummer: String,
+    val status: String,
+    val type: String,
+    val folkeregistermetadata: PdlFolkeregistermetadata? = null,
+    val metadata: PdlMetadata,
+)
 
 data class PdlNavn(
     val fornavn: String,

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlOboKlient.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlOboKlient.kt
@@ -30,14 +30,14 @@ class PdlOboKlient(private val httpClient: HttpClient, private val config: Confi
     suspend fun hentPersonNavn(
         ident: String,
         bruker: BrukerTokenInfo,
-    ): PdlPersonResponse {
+    ): PdlPersonNavnResponse {
         val request =
             PdlGraphqlRequest(
-                query = getQuery("/pdl/hentPerson.graphql"),
+                query = getQuery("/pdl/hentPersonNavn.graphql"),
                 variables = PdlVariables(ident),
             )
 
-        return retry<PdlPersonResponse>(times = 3) {
+        return retry<PdlPersonNavnResponse>(times = 3) {
             httpClient.post(apiUrl) {
                 bearerAuth(getOboToken(bruker))
                 behandlingsnummer(Behandlingsnummer.BARNEPENSJON, Behandlingsnummer.OMSTILLINGSSTOENAD)

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/PersonMapper.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/PersonMapper.kt
@@ -13,6 +13,7 @@ import no.nav.etterlatte.libs.common.person.Sivilstatus
 import no.nav.etterlatte.libs.common.person.Statsborgerskap
 import no.nav.etterlatte.pdl.ParallelleSannheterKlient
 import no.nav.etterlatte.pdl.PdlHentPerson
+import no.nav.etterlatte.pdl.PdlHentPersonNavn
 import no.nav.etterlatte.pdl.PdlKlient
 import no.nav.etterlatte.pdl.PdlStatsborgerskap
 import org.slf4j.LoggerFactory
@@ -96,17 +97,25 @@ object PersonMapper {
 
     fun mapPersonNavn(
         ppsKlient: ParallelleSannheterKlient,
-        fnr: Folkeregisteridentifikator,
-        hentPerson: PdlHentPerson,
+        ident: String,
+        hentPerson: PdlHentPersonNavn,
     ): PersonNavn =
         runBlocking {
             val navn = ppsKlient.avklarNavn(hentPerson.navn)
+
+            val fnr =
+                if (Folkeregisteridentifikator.isValid(ident)) {
+                    ident
+                } else {
+                    ppsKlient.avklarFolkeregisteridentifikator(hentPerson.folkeregisteridentifikator)
+                        .identifikasjonsnummer
+                }
 
             PersonNavn(
                 fornavn = navn.fornavn,
                 mellomnavn = navn.mellomnavn,
                 etternavn = navn.etternavn,
-                foedselsnummer = fnr,
+                foedselsnummer = Folkeregisteridentifikator.of(fnr),
             )
         }
 

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/personweb/PersonWebRoute.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/personweb/PersonWebRoute.kt
@@ -8,7 +8,6 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.libs.common.kunSaksbehandler
-import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 
 fun Route.personWebRoute(
@@ -20,9 +19,9 @@ fun Route.personWebRoute(
             kunSaksbehandler {
                 val request = call.receive<HentPersonNavnRequest>()
 
-                val person = service.hentPersonNavn(request.foedselsnummer, brukerTokenInfo)
+                val person = service.hentPersonNavn(request.ident, brukerTokenInfo)
 
-                sporing.logg(brukerTokenInfo, request.foedselsnummer, call.request.path(), "Hentet navn på person")
+                sporing.logg(brukerTokenInfo, person.foedselsnummer, call.request.path(), "Hentet navn på person")
 
                 call.respond(person)
             }
@@ -31,5 +30,5 @@ fun Route.personWebRoute(
 }
 
 private data class HentPersonNavnRequest(
-    val foedselsnummer: Folkeregisteridentifikator,
+    val ident: String,
 )

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/personweb/PersonWebService.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/personweb/PersonWebService.kt
@@ -2,7 +2,7 @@ package no.nav.etterlatte.personweb
 
 import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
 import no.nav.etterlatte.libs.common.pdl.FantIkkePersonException
-import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.person.maskerFnr
 import no.nav.etterlatte.pdl.ParallelleSannheterKlient
 import no.nav.etterlatte.pdl.PdlOboKlient
 import no.nav.etterlatte.pdl.PdlResponseError
@@ -24,26 +24,26 @@ class PersonWebService(
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     suspend fun hentPersonNavn(
-        foedselsnummer: Folkeregisteridentifikator,
+        ident: String,
         bruker: BrukerTokenInfo,
     ): PersonNavn {
-        logger.info("Henter navn for fnr=$foedselsnummer fra PDL")
+        logger.info("Henter navn for ident=${ident.maskerFnr()} fra PDL")
 
-        return pdlOboKlient.hentPersonNavn(foedselsnummer.value, bruker).let {
+        return pdlOboKlient.hentPersonNavn(ident, bruker).let {
             if (it.data?.hentPerson == null) {
                 val pdlFeil = it.errors?.joinToString()
 
                 if (it.errors?.personIkkeFunnet() == true) {
-                    throw FantIkkePersonException("Fant ikke personen $foedselsnummer")
+                    throw FantIkkePersonException("Fant ikke person i PDL")
                 } else {
                     throw PdlForesporselFeilet(
-                        "Kunne ikke hente person med fnr=$foedselsnummer fra PDL: $pdlFeil",
+                        "Kunne ikke hente person med ident=${ident.maskerFnr()} fra PDL: $pdlFeil",
                     )
                 }
             } else {
                 PersonMapper.mapPersonNavn(
                     ppsKlient = ppsKlient,
-                    fnr = foedselsnummer,
+                    ident = ident,
                     hentPerson = it.data.hentPerson,
                 )
             }

--- a/apps/etterlatte-pdltjenester/src/main/resources/pdl/hentPersonNavn.graphql
+++ b/apps/etterlatte-pdltjenester/src/main/resources/pdl/hentPersonNavn.graphql
@@ -1,3 +1,12 @@
+fragment folkeregistermetadata on Folkeregistermetadata {
+    ajourholdstidspunkt
+    gyldighetstidspunkt
+    opphoerstidspunkt
+    kilde
+    aarsak
+    sekvens
+}
+
 fragment metadata on Metadata {
     master
     historisk
@@ -15,6 +24,17 @@ query(
     $ident: ID!,
 ) {
     hentPerson(ident: $ident) {
+        folkeregisteridentifikator(historikk: false) {
+            identifikasjonsnummer
+            status
+            type
+            folkeregistermetadata {
+                ...folkeregistermetadata
+            }
+            metadata {
+                ...metadata
+            }
+        }
         navn {
             fornavn
             mellomnavn

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/pdltjenester.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/pdltjenester.ts
@@ -1,5 +1,12 @@
 import { apiClient, ApiResponse } from '~shared/api/apiClient'
 import { IPdlPersonNavn } from '~shared/types/Person'
 
-export const hentPersonNavn = async (foedselsnummer: string): Promise<ApiResponse<IPdlPersonNavn>> =>
-  apiClient.post(`/pdltjenester/person/navn`, { foedselsnummer })
+/**
+ * Hent navn til person med ident.
+ * Identen kan være:
+ * - Fødselsnummer
+ * - AktørID
+ * - NPID
+ **/
+export const hentPersonNavn = async (ident: string): Promise<ApiResponse<IPdlPersonNavn>> =>
+  apiClient.post(`/pdltjenester/person/navn`, { ident })


### PR DESCRIPTION
Vi får ofte aktørid i bruker-objektet på journalposter. Som en følge av det er det vanskelig for saksbehandler å se at det er koblet til riktig person ved behandling av journalføringsoppgaver. 

Legger derfor til støtte for henting av navn på aktørid slik at vi kan vise navnet til personen ved siden av bruker-identen fra dokarkiv. 