### PR TITLE
krakend-operator spec endret: scope -> scopes

### DIFF
--- a/apps/etterlatte-samordning-vedtak/.nais/apiendpoints.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/apiendpoints.yaml
@@ -11,7 +11,7 @@ spec:
     name: maskinporten
     cache: true
     debug: true
-    scope:
+    scopes:
       - "nav:etterlatteytelser:vedtaksinformasjon.read"
   endpoints:
     - path: /samordning/vedtak


### PR DESCRIPTION
deploy feilet: https://github.com/navikt/pensjon-etterlatte-saksbehandling/actions/runs/8264180480/job/22607504532

Endring i krakend-operator: https://github.com/nais/krakend/commit/2f11949c571cae49f97663faeb74327ad55c1ac3

Krakend er jo litt i beta ennå, har ikke funnet noe annonsering av dette men ser at et par andre har også fått samme feil.

Jeg har annonsert mot tp-leverandørene at krakend likevel _ikke_ blir tingen å bruke hos oss, endepunktet får leve frem til sommeren-ish.