### PR TITLE
Fjerne sjekken på skrivetilgang mot Gosys-apiet

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveRoute.kt
@@ -15,7 +15,6 @@ import no.nav.etterlatte.libs.common.oppgave.RedigerFristGosysRequest
 import no.nav.etterlatte.libs.common.oppgave.SaksbehandlerEndringGosysDto
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.oppgave.GosysOppgaveversjon
-import no.nav.etterlatte.tilgangsstyring.kunSaksbehandlerMedSkrivetilgang
 
 internal fun Route.gosysOppgaveRoute(gosysService: GosysOppgaveService) {
     route("/api/oppgaver/gosys") {
@@ -35,7 +34,7 @@ internal fun Route.gosysOppgaveRoute(gosysService: GosysOppgaveService) {
             }
 
             post("tildel-saksbehandler") {
-                kunSaksbehandlerMedSkrivetilgang {
+                kunSaksbehandler {
                     val saksbehandlerEndringDto = call.receive<SaksbehandlerEndringGosysDto>()
                     val oppdatertVersjon =
                         gosysService.tildelOppgaveTilSaksbehandler(
@@ -49,7 +48,7 @@ internal fun Route.gosysOppgaveRoute(gosysService: GosysOppgaveService) {
             }
 
             post("endre-frist") {
-                kunSaksbehandlerMedSkrivetilgang {
+                kunSaksbehandler {
                     val redigerFristRequest = call.receive<RedigerFristGosysRequest>()
                     val oppdatertVersjon =
                         gosysService.endreFrist(
@@ -63,7 +62,7 @@ internal fun Route.gosysOppgaveRoute(gosysService: GosysOppgaveService) {
             }
 
             post("ferdigstill") {
-                kunSaksbehandlerMedSkrivetilgang {
+                kunSaksbehandler {
                     val versjon = call.request.queryParameters["versjon"]!!.toLong()
 
                     call.respond(gosysService.ferdigstill(gosysOppgaveId, versjon, brukerTokenInfo))
@@ -71,7 +70,7 @@ internal fun Route.gosysOppgaveRoute(gosysService: GosysOppgaveService) {
             }
 
             post("feilregistrer") {
-                kunSaksbehandlerMedSkrivetilgang {
+                kunSaksbehandler {
                     val request = call.receive<FeilregistrerOppgaveRequest>()
 
                     call.respond(gosysService.feilregistrer(gosysOppgaveId, request, brukerTokenInfo))


### PR DESCRIPTION
Vi har ingen støtte for sjekk av enhet mot Gosys. Fjerner derfor denne inntil videre slik at saksbehandlere får gjort jobben sin. 

Må undersøke om Gosys har sjekk av dette på sin side. Hvis så kan vi mest sannsynlig bare la det være. 