### PR TITLE
EY-3631 Automatisk opphør ved hendelse for barnepensjon 20 år

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningRoutes.kt
@@ -10,7 +10,9 @@ import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.behandling.Omregningshendelse
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.retryOgPakkUt
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
+import java.time.LocalTime
 import java.util.UUID
 
 fun Route.omregningRoutes(omregningService: OmregningService) {
@@ -25,9 +27,11 @@ fun Route.omregningRoutes(omregningService: OmregningService) {
                         omregningService.opprettOmregning(
                             sakId = request.sakId,
                             fraDato = request.fradato,
+                            revurderingAarsak = request.revurderingaarsak,
                             prosessType = request.prosesstype,
                             forrigeBehandling = forrigeBehandling,
                             persongalleri = persongalleri,
+                            oppgavefrist = request.oppgavefrist?.let { Tidspunkt.ofNorskTidssone(it, LocalTime.NOON) },
                         )
                     }
                 retryOgPakkUt { revurderingOgOppfoelging.leggInnGrunnlag() }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
@@ -11,6 +11,7 @@ import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.time.LocalDate
 import java.util.UUID
 
@@ -28,9 +29,11 @@ class OmregningService(
     fun opprettOmregning(
         sakId: Long,
         fraDato: LocalDate,
+        revurderingAarsak: Revurderingaarsak,
         prosessType: Prosesstype,
         forrigeBehandling: Behandling,
         persongalleri: Persongalleri,
+        oppgavefrist: Tidspunkt?,
     ): RevurderingOgOppfoelging {
         if (prosessType == Prosesstype.MANUELL) {
             throw StoetterIkkeProsesstypeManuell()
@@ -39,10 +42,11 @@ class OmregningService(
             revurderingService.opprettAutomatiskRevurdering(
                 sakId = sakId,
                 forrigeBehandling = forrigeBehandling,
-                revurderingAarsak = Revurderingaarsak.REGULERING,
+                revurderingAarsak = revurderingAarsak,
                 virkningstidspunkt = fraDato,
                 kilde = Vedtaksloesning.GJENNY,
                 persongalleri = persongalleri,
+                frist = oppgavefrist,
             ),
         ) { "Opprettelse av revurdering feilet for $sakId" }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
@@ -38,6 +38,9 @@ class OmregningService(
         if (prosessType == Prosesstype.MANUELL) {
             throw StoetterIkkeProsesstypeManuell()
         }
+
+        revurderingService.validerSakensTilstand(sakId, revurderingAarsak)
+
         return requireNotNull(
             revurderingService.opprettAutomatiskRevurdering(
                 sakId = sakId,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -38,4 +38,13 @@ class AutomatiskRevurderingService(private val revurderingService: RevurderingSe
             frist = frist,
         )
     }
+
+    fun validerSakensTilstand(
+        sakId: Long,
+        revurderingAarsak: Revurderingaarsak,
+    ) {
+        if (revurderingAarsak == Revurderingaarsak.ALDERSOVERGANG) {
+            revurderingService.maksEnOppgaveUnderbehandlingForKildeBehandling(sakId)
+        }
+    }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -6,6 +6,7 @@ import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.tilVirkningstidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
 import java.time.LocalDate
 
@@ -19,6 +20,7 @@ class AutomatiskRevurderingService(private val revurderingService: RevurderingSe
         persongalleri: Persongalleri,
         mottattDato: String? = null,
         begrunnelse: String? = null,
+        frist: Tidspunkt? = null,
     ) = forrigeBehandling.let {
         revurderingService.opprettRevurdering(
             sakId = sakId,
@@ -33,6 +35,7 @@ class AutomatiskRevurderingService(private val revurderingService: RevurderingSe
             boddEllerArbeidetUtlandet = forrigeBehandling.boddEllerArbeidetUtlandet,
             begrunnelse = begrunnelse ?: "Automatisk revurdering - ${revurderingAarsak.name.lowercase()}",
             saksbehandlerIdent = Fagsaksystem.EY.navn,
+            frist = frist,
         )
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -113,7 +113,7 @@ class RevurderingService(
             }
     }
 
-    private fun maksEnOppgaveUnderbehandlingForKildeBehandling(sakId: Long) {
+    fun maksEnOppgaveUnderbehandlingForKildeBehandling(sakId: Long) {
         val oppgaverForSak = oppgaveService.hentOppgaverForSak(sakId)
         val ingenBehandlingerUnderarbeid =
             oppgaverForSak.filter {

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/TidshendelseRiver.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/TidshendelseRiver.kt
@@ -10,6 +10,8 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.rapidsandrivers.ALDERSOVERGANG_ID_KEY
 import no.nav.etterlatte.rapidsandrivers.ALDERSOVERGANG_STEG_KEY
 import no.nav.etterlatte.rapidsandrivers.ALDERSOVERGANG_TYPE_KEY
+import no.nav.etterlatte.rapidsandrivers.BEHANDLING_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.BEHANDLING_VI_OMREGNER_FRA_KEY
 import no.nav.etterlatte.rapidsandrivers.DATO_KEY
 import no.nav.etterlatte.rapidsandrivers.DRYRUN
 import no.nav.etterlatte.rapidsandrivers.EventNames
@@ -89,8 +91,8 @@ class TidshendelseRiver(
                         ).let {
                             logger.info("Opprettet omregning ${it.behandlingId} [sak=$sakId]")
                             packet[ALDERSOVERGANG_STEG_KEY] = "BEHANDLING_OPPRETTET"
-                            hendelseData["opprettetBehandlingId"] = it.behandlingId
-                            hendelseData["forrigeBehandlingId"] = it.forrigeBehandlingId
+                            packet[BEHANDLING_ID_KEY] = it.behandlingId
+                            packet[BEHANDLING_VI_OMREGNER_FRA_KEY] = it.forrigeBehandlingId
                         }
                     } catch (e: Exception) {
                         logger.error("Kunne ikke opprette omregning [sak=$sakId]", e)

--- a/apps/etterlatte-oppdater-behandling/src/test/kotlin/TidshendelseRiverTest.kt
+++ b/apps/etterlatte-oppdater-behandling/src/test/kotlin/TidshendelseRiverTest.kt
@@ -16,11 +16,14 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.rapidsandrivers.ALDERSOVERGANG_ID_KEY
 import no.nav.etterlatte.rapidsandrivers.ALDERSOVERGANG_STEG_KEY
 import no.nav.etterlatte.rapidsandrivers.ALDERSOVERGANG_TYPE_KEY
+import no.nav.etterlatte.rapidsandrivers.BEHANDLING_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.BEHANDLING_VI_OMREGNER_FRA_KEY
 import no.nav.etterlatte.rapidsandrivers.DATO_KEY
 import no.nav.etterlatte.rapidsandrivers.DRYRUN
 import no.nav.etterlatte.rapidsandrivers.EventNames
 import no.nav.etterlatte.rapidsandrivers.HENDELSE_DATA_KEY
 import no.nav.etterlatte.rapidsandrivers.SAK_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.asUUID
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import org.junit.jupiter.api.Test
@@ -62,10 +65,10 @@ class TidshendelseRiverTest {
             field(0, EVENT_NAME_KEY).asText() shouldBe EventNames.ALDERSOVERGANG.name
             field(0, ALDERSOVERGANG_STEG_KEY).asText() shouldBe "OPPGAVE_OPPRETTET"
             field(0, ALDERSOVERGANG_TYPE_KEY).asText() shouldBe "AO_BP20"
-            field(0, ALDERSOVERGANG_ID_KEY).asText() shouldBe hendelseId.toString()
+            field(0, ALDERSOVERGANG_ID_KEY).asUUID() shouldBe hendelseId
             field(0, DRYRUN).asBoolean() shouldBe false
             field(0, HENDELSE_DATA_KEY) shouldHaveSize 1
-            field(0, HENDELSE_DATA_KEY)["opprettetOppgaveId"].asText() shouldBe nyOppgaveID.toString()
+            field(0, HENDELSE_DATA_KEY)["opprettetOppgaveId"].asUUID() shouldBe nyOppgaveID
         }
 
         verify { behandlingService.opprettOmregning(any()) }
@@ -106,11 +109,11 @@ class TidshendelseRiverTest {
             field(0, EVENT_NAME_KEY).asText() shouldBe EventNames.ALDERSOVERGANG.name
             field(0, ALDERSOVERGANG_STEG_KEY).asText() shouldBe "BEHANDLING_OPPRETTET"
             field(0, ALDERSOVERGANG_TYPE_KEY).asText() shouldBe "AO_BP20"
-            field(0, ALDERSOVERGANG_ID_KEY).asText() shouldBe hendelseId.toString()
+            field(0, ALDERSOVERGANG_ID_KEY).asUUID() shouldBe hendelseId
             field(0, DRYRUN).asBoolean() shouldBe false
-            field(0, HENDELSE_DATA_KEY) shouldHaveSize 2
-            field(0, HENDELSE_DATA_KEY)["opprettetBehandlingId"].asText() shouldBe nyBehandlingID.toString()
-            field(0, HENDELSE_DATA_KEY)["forrigeBehandlingId"].asText() shouldBe forrigeBehandlingID.toString()
+            field(0, HENDELSE_DATA_KEY) shouldHaveSize 0
+            field(0, BEHANDLING_ID_KEY).asUUID() shouldBe nyBehandlingID
+            field(0, BEHANDLING_VI_OMREGNER_FRA_KEY).asUUID() shouldBe forrigeBehandlingID
         }
 
         verify { behandlingService.opprettOmregning(omregningshendelse) }
@@ -129,7 +132,7 @@ class TidshendelseRiverTest {
             field(0, EVENT_NAME_KEY).asText() shouldBe EventNames.ALDERSOVERGANG.name
             field(0, ALDERSOVERGANG_STEG_KEY).asText() shouldBe "OPPGAVE_OPPRETTET"
             field(0, ALDERSOVERGANG_TYPE_KEY).asText() shouldBe "AO_BP20"
-            field(0, ALDERSOVERGANG_ID_KEY).asText() shouldBe hendelseId.toString()
+            field(0, ALDERSOVERGANG_ID_KEY).asUUID() shouldBe hendelseId
             field(0, DRYRUN).asBoolean() shouldBe true
             field(0, HENDELSE_DATA_KEY) shouldHaveSize 0
         }
@@ -151,7 +154,7 @@ class TidshendelseRiverTest {
             field(0, EVENT_NAME_KEY).asText() shouldBe EventNames.ALDERSOVERGANG.name
             field(0, ALDERSOVERGANG_STEG_KEY).asText() shouldBe "OPPGAVE_OPPRETTET"
             field(0, ALDERSOVERGANG_TYPE_KEY).asText() shouldBe "AO_BP20"
-            field(0, ALDERSOVERGANG_ID_KEY).asText() shouldBe hendelseId.toString()
+            field(0, ALDERSOVERGANG_ID_KEY).asUUID() shouldBe hendelseId
             field(0, DRYRUN).asBoolean() shouldBe false
             field(0, HENDELSE_DATA_KEY) shouldHaveSize 0
         }
@@ -174,7 +177,7 @@ class TidshendelseRiverTest {
             field(0, EVENT_NAME_KEY).asText() shouldBe EventNames.ALDERSOVERGANG.name
             field(0, ALDERSOVERGANG_STEG_KEY).asText() shouldBe "OPPGAVE_OPPRETTET"
             field(0, ALDERSOVERGANG_TYPE_KEY).asText() shouldBe "OMS_DOED_3AAR"
-            field(0, ALDERSOVERGANG_ID_KEY).asText() shouldBe hendelseId.toString()
+            field(0, ALDERSOVERGANG_ID_KEY).asUUID() shouldBe hendelseId
             field(0, DRYRUN).asBoolean() shouldBe false
             field(0, HENDELSE_DATA_KEY) shouldHaveSize 0
         }

--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/HendelseRiver.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/HendelseRiver.kt
@@ -59,7 +59,7 @@ class HendelseRiver(
                 val loependeYtelse = packet[HENDELSE_DATA_KEY]["loependeYtelse"].asBoolean()
                 logger.info("Sak $sakId har løpende ytelse? $loependeYtelse")
                 hendelseDao.settHarLoependeYtelse(hendelseIdUUID, loependeYtelse)
-            } else if (steg == "OPPGAVE_OPPRETTET") {
+            } else if (steg in listOf("VEDTAK_ATTESTERT", "OPPGAVE_OPPRETTET")) {
                 logger.info("Ferdigstiller hendelse")
                 hendelseDao.oppdaterHendelseStatus(hendelseIdUUID, HendelseStatus.FERDIG)
             }

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/rivers/AldersovergangRiver.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/rivers/AldersovergangRiver.kt
@@ -3,18 +3,24 @@ package no.nav.etterlatte.vedtaksvurdering.rivers
 import no.nav.etterlatte.VedtakService
 import no.nav.etterlatte.libs.common.logging.getCorrelationId
 import no.nav.etterlatte.libs.common.logging.withLogContext
-import no.nav.etterlatte.libs.common.vedtak.VedtakAldersovergangStepEvents
+import no.nav.etterlatte.libs.common.vedtak.VedtakAldersovergangStepEvents.IDENTIFISERT_SAK
+import no.nav.etterlatte.libs.common.vedtak.VedtakAldersovergangStepEvents.VEDTAK_ATTESTERT
+import no.nav.etterlatte.libs.common.vedtak.VedtakAldersovergangStepEvents.VILKAARSVURDERT
+import no.nav.etterlatte.libs.common.vedtak.VedtakAldersovergangStepEvents.VURDERT_LOEPENDE_YTELSE
 import no.nav.etterlatte.rapidsandrivers.ALDERSOVERGANG_ID_KEY
 import no.nav.etterlatte.rapidsandrivers.ALDERSOVERGANG_STEG_KEY
 import no.nav.etterlatte.rapidsandrivers.ALDERSOVERGANG_TYPE_KEY
+import no.nav.etterlatte.rapidsandrivers.BEHANDLING_ID_KEY
 import no.nav.etterlatte.rapidsandrivers.DATO_KEY
 import no.nav.etterlatte.rapidsandrivers.DRYRUN
 import no.nav.etterlatte.rapidsandrivers.EventNames
 import no.nav.etterlatte.rapidsandrivers.HENDELSE_DATA_KEY
 import no.nav.etterlatte.rapidsandrivers.ListenerMedLogging
 import no.nav.etterlatte.rapidsandrivers.SAK_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.behandlingId
 import no.nav.etterlatte.rapidsandrivers.dato
 import no.nav.etterlatte.rapidsandrivers.sakId
+import no.nav.etterlatte.vedtaksvurdering.RapidUtsender
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
@@ -30,12 +36,18 @@ class AldersovergangRiver(
 
     init {
         initialiserRiver(rapidsConnection, EventNames.ALDERSOVERGANG) {
-            validate { it.requireKey(ALDERSOVERGANG_STEG_KEY) }
+            validate {
+                it.requireAny(
+                    ALDERSOVERGANG_STEG_KEY,
+                    listOf(IDENTIFISERT_SAK.name, VILKAARSVURDERT.name),
+                )
+            }
             validate { it.requireKey(ALDERSOVERGANG_TYPE_KEY) }
             validate { it.requireKey(ALDERSOVERGANG_ID_KEY) }
             validate { it.requireKey(SAK_ID_KEY) }
             validate { it.requireKey(DATO_KEY) }
             validate { it.requireKey(DRYRUN) }
+            validate { it.interestedIn(BEHANDLING_ID_KEY) }
         }
     }
 
@@ -57,35 +69,87 @@ class AldersovergangRiver(
                 "type" to type,
             ),
         ) {
-            if (step == VedtakAldersovergangStepEvents.IDENTIFISERT_SAK.name) {
-                val hendelseData = mutableMapOf<String, Any>()
+            val behandlet =
+                when (step) {
+                    IDENTIFISERT_SAK.name ->
+                        handleIdentifisertSak(
+                            packet = packet,
+                            type = type,
+                            sakId = sakId,
+                            dryrun = dryrun,
+                        )
 
-                val behandlingsdato = packet.dato
-                // Sjekker løpende ytelse for måneden _etter_ behandlingsdato (dvs når bruker fyller år, dødsdato osv.)
-                // Ytelsen skal løpe ut behandlingsmåneden. Unngå videre behandling der ytelsen kanskje allerede er opphørt.
-                val maanedEtterBehandlingsdato = behandlingsdato.plusMonths(1)
-                logger.info("Sjekker løpende ytelse for sak $sakId, behandlingsmåned=$behandlingsdato, dryrun=$dryrun")
-
-                val loependeYtelse = vedtakService.harLoependeYtelserFra(sakId, maanedEtterBehandlingsdato)
-                logger.info("Sak $sakId har løpende ytelse per $maanedEtterBehandlingsdato? ${loependeYtelse.erLoepende}")
-                hendelseData["loependeYtelse"] = loependeYtelse.erLoepende
-                loependeYtelse.behandlingId?.let {
-                    hendelseData["loependeYtelse_behandlingId"] = it.toString()
+                    VILKAARSVURDERT.name ->
+                        handleVilkarsvurdertOgSkalFatteVedtak(
+                            packet = packet,
+                            sakId = sakId,
+                            dryrun = dryrun,
+                            context = context,
+                        )
+                    else -> false
                 }
 
-                if (loependeYtelse.erLoepende && type == "AO_BP20") {
-                    val loependeYtelsePerJanuar2024 = vedtakService.harLoependeYtelserFra(sakId, ikrafttredenEtterlattereformen)
-                    hendelseData["loependeYtelse_januar2024"] = loependeYtelsePerJanuar2024.erLoepende
-                    loependeYtelsePerJanuar2024.behandlingId?.let {
-                        hendelseData["loependeYtelse_januar2024_behandlingId"] = it.toString()
-                    }
-                }
-
-                packet[ALDERSOVERGANG_STEG_KEY] = VedtakAldersovergangStepEvents.VURDERT_LOEPENDE_YTELSE.name
-                packet[HENDELSE_DATA_KEY] = hendelseData
+            if (behandlet) {
+                // Reply med oppdatert melding
                 context.publish(packet.toJson())
             }
         }
+    }
+
+    private fun handleIdentifisertSak(
+        packet: JsonMessage,
+        type: String,
+        sakId: Long,
+        dryrun: Boolean,
+    ): Boolean {
+        val hendelseData = mutableMapOf<String, Any>()
+
+        val behandlingsdato = packet.dato
+        // Sjekker løpende ytelse for måneden _etter_ behandlingsdato (dvs når bruker fyller år, dødsdato osv.)
+        // Ytelsen skal løpe ut behandlingsmåneden. Unngå videre behandling der ytelsen kanskje allerede er opphørt.
+        val maanedEtterBehandlingsdato = behandlingsdato.plusMonths(1)
+        logger.info("Sjekker løpende ytelse for sak $sakId, behandlingsmåned=$behandlingsdato, dryrun=$dryrun")
+
+        val loependeYtelse = vedtakService.harLoependeYtelserFra(sakId, maanedEtterBehandlingsdato)
+        logger.info("Sak $sakId har løpende ytelse per $maanedEtterBehandlingsdato? ${loependeYtelse.erLoepende}")
+        hendelseData["loependeYtelse"] = loependeYtelse.erLoepende
+        loependeYtelse.behandlingId?.let {
+            hendelseData["loependeYtelse_behandlingId"] = it.toString()
+        }
+
+        if (loependeYtelse.erLoepende && type == "AO_BP20") {
+            val loependeYtelsePerJanuar2024 = vedtakService.harLoependeYtelserFra(sakId, ikrafttredenEtterlattereformen)
+            hendelseData["loependeYtelse_januar2024"] = loependeYtelsePerJanuar2024.erLoepende
+            loependeYtelsePerJanuar2024.behandlingId?.let {
+                hendelseData["loependeYtelse_januar2024_behandlingId"] = it.toString()
+            }
+        }
+
+        packet[ALDERSOVERGANG_STEG_KEY] = VURDERT_LOEPENDE_YTELSE.name
+        packet[HENDELSE_DATA_KEY] = hendelseData
+        return true
+    }
+
+    private fun handleVilkarsvurdertOgSkalFatteVedtak(
+        packet: JsonMessage,
+        sakId: Long,
+        dryrun: Boolean,
+        context: MessageContext,
+    ): Boolean {
+        val behandlingIdForOpphoer = packet.behandlingId
+
+        if (dryrun) {
+            logger.info("Dryrun: Fatter ikke vedtak for behandling=$behandlingIdForOpphoer")
+        } else {
+            logger.info("Fatter opphørsvedtak for behandling=$behandlingIdForOpphoer")
+            vedtakService.opprettVedtakFattOgAttester(sakId, behandlingIdForOpphoer)
+                .let {
+                    RapidUtsender.sendUt(it, JsonMessage.newMessage(emptyMap()), context)
+                }
+        }
+
+        packet[ALDERSOVERGANG_STEG_KEY] = VEDTAK_ATTESTERT.name
+        return true
     }
 
     companion object {

--- a/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/TidshendelseRiver.kt
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/TidshendelseRiver.kt
@@ -5,12 +5,16 @@ import no.nav.etterlatte.libs.common.logging.withLogContext
 import no.nav.etterlatte.rapidsandrivers.ALDERSOVERGANG_ID_KEY
 import no.nav.etterlatte.rapidsandrivers.ALDERSOVERGANG_STEG_KEY
 import no.nav.etterlatte.rapidsandrivers.ALDERSOVERGANG_TYPE_KEY
+import no.nav.etterlatte.rapidsandrivers.BEHANDLING_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.BEHANDLING_VI_OMREGNER_FRA_KEY
 import no.nav.etterlatte.rapidsandrivers.DATO_KEY
 import no.nav.etterlatte.rapidsandrivers.DRYRUN
 import no.nav.etterlatte.rapidsandrivers.EventNames
 import no.nav.etterlatte.rapidsandrivers.HENDELSE_DATA_KEY
 import no.nav.etterlatte.rapidsandrivers.ListenerMedLogging
 import no.nav.etterlatte.rapidsandrivers.SAK_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.asUUID
+import no.nav.etterlatte.rapidsandrivers.behandlingId
 import no.nav.etterlatte.rapidsandrivers.sakId
 import no.nav.etterlatte.vilkaarsvurdering.services.VilkaarsvurderingService
 import no.nav.helse.rapids_rivers.JsonMessage
@@ -26,13 +30,20 @@ class TidshendelseRiver(
 
     init {
         initialiserRiver(rapidsConnection, EventNames.ALDERSOVERGANG) {
-            validate { it.requireValue(ALDERSOVERGANG_STEG_KEY, "VURDERT_LOEPENDE_YTELSE") }
+            validate {
+                it.requireAny(
+                    ALDERSOVERGANG_STEG_KEY,
+                    listOf("VURDERT_LOEPENDE_YTELSE", "BEHANDLING_OPPRETTET"),
+                )
+            }
             validate { it.requireKey(ALDERSOVERGANG_TYPE_KEY) }
             validate { it.requireKey(ALDERSOVERGANG_ID_KEY) }
             validate { it.requireKey(SAK_ID_KEY) }
             validate { it.requireKey(DATO_KEY) }
             validate { it.requireKey(DRYRUN) }
             validate { it.requireKey(HENDELSE_DATA_KEY) }
+            validate { it.interestedIn(BEHANDLING_ID_KEY) }
+            validate { it.interestedIn(BEHANDLING_VI_OMREGNER_FRA_KEY) }
         }
     }
 
@@ -40,6 +51,7 @@ class TidshendelseRiver(
         packet: JsonMessage,
         context: MessageContext,
     ) {
+        val steg = packet[ALDERSOVERGANG_STEG_KEY].asText()
         val type = packet[ALDERSOVERGANG_TYPE_KEY].asText()
         val hendelseId = packet[ALDERSOVERGANG_ID_KEY].asText()
         val dryrun = packet[DRYRUN].asBoolean()
@@ -54,24 +66,50 @@ class TidshendelseRiver(
                 "dryRun" to dryrun.toString(),
             ),
         ) {
-            val hendelseData = packet[HENDELSE_DATA_KEY]
+            val behandlet =
+                when (steg) {
+                    "VURDERT_LOEPENDE_YTELSE" -> sjekkUnntaksregler(packet, type)
+                    "BEHANDLING_OPPRETTET" -> vilkaarsvurder(packet)
+                    else -> false
+                }
 
-            hendelseData["loependeYtelse_januar2024_behandlingId"]?.let {
-                val behandlingId = it.asText()
-                val result = vilkaarsvurderingService.harMigrertYrkesskadefordel(behandlingId)
-                logger.info("Løpende ytelse: sjekk av yrkesskadefordel før 2024-01-01: $result")
-                packet["yrkesskadefordel_pre_20240101"] = result
+            if (behandlet) {
+                // Reply med oppdatert melding
+                context.publish(packet.toJson())
             }
-
-            if (type in arrayOf("OMS_DOED_3AAR", "OMS_DOED_5AAR") && hendelseData["loependeYtelse"]?.asBoolean() == true) {
-                val loependeBehandlingId = hendelseData["loependeYtelse_behandlingId"].asText()
-                val result = vilkaarsvurderingService.harRettUtenTidsbegrensning(loependeBehandlingId)
-                logger.info("OMS: sjekk av rett uten tidsbegrensning: $result")
-                packet["oms_rett_uten_tidsbegrensning"] = result
-            }
-
-            packet[ALDERSOVERGANG_STEG_KEY] = "VURDERT_LOEPENDE_YTELSE_OG_VILKAAR"
-            context.publish(packet.toJson())
         }
+    }
+
+    private fun sjekkUnntaksregler(
+        packet: JsonMessage,
+        type: String,
+    ): Boolean {
+        val hendelseData = packet[HENDELSE_DATA_KEY]
+
+        hendelseData["loependeYtelse_januar2024_behandlingId"]?.let {
+            val behandlingId = it.asText()
+            val result = vilkaarsvurderingService.harMigrertYrkesskadefordel(behandlingId)
+            logger.info("Løpende ytelse: sjekk av yrkesskadefordel før 2024-01-01: $result")
+            packet["yrkesskadefordel_pre_20240101"] = result
+        }
+
+        if (type in arrayOf("OMS_DOED_3AAR", "OMS_DOED_5AAR") && hendelseData["loependeYtelse"]?.asBoolean() == true) {
+            val loependeBehandlingId = hendelseData["loependeYtelse_behandlingId"].asText()
+            val result = vilkaarsvurderingService.harRettUtenTidsbegrensning(loependeBehandlingId)
+            logger.info("OMS: sjekk av rett uten tidsbegrensning: $result")
+            packet["oms_rett_uten_tidsbegrensning"] = result
+        }
+
+        packet[ALDERSOVERGANG_STEG_KEY] = "VURDERT_LOEPENDE_YTELSE_OG_VILKAAR"
+        return true
+    }
+
+    private fun vilkaarsvurder(packet: JsonMessage): Boolean {
+        val behandlingId = packet.behandlingId
+        val forrigeBehandlingId = packet[BEHANDLING_VI_OMREGNER_FRA_KEY].asUUID()
+        vilkaarsvurderingService.opphoerAldersovergang(behandlingId, forrigeBehandlingId)
+
+        packet[ALDERSOVERGANG_STEG_KEY] = "VILKAARSVURDERT"
+        return true
     }
 }

--- a/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/TidshendelseRiver.kt
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/TidshendelseRiver.kt
@@ -69,7 +69,7 @@ class TidshendelseRiver(
             val behandlet =
                 when (steg) {
                     "VURDERT_LOEPENDE_YTELSE" -> sjekkUnntaksregler(packet, type)
-                    "BEHANDLING_OPPRETTET" -> vilkaarsvurder(packet)
+                    "BEHANDLING_OPPRETTET" -> vilkaarsvurder(packet, dryrun)
                     else -> false
                 }
 
@@ -104,10 +104,18 @@ class TidshendelseRiver(
         return true
     }
 
-    private fun vilkaarsvurder(packet: JsonMessage): Boolean {
+    private fun vilkaarsvurder(
+        packet: JsonMessage,
+        dryrun: Boolean,
+    ): Boolean {
         val behandlingId = packet.behandlingId
         val forrigeBehandlingId = packet[BEHANDLING_VI_OMREGNER_FRA_KEY].asUUID()
-        vilkaarsvurderingService.opphoerAldersovergang(behandlingId, forrigeBehandlingId)
+
+        if (dryrun) {
+            logger.info("Dryrun: skipper å behandle vilkårsvurdering for behandlingId=$behandlingId")
+        } else {
+            vilkaarsvurderingService.opphoerAldersovergang(behandlingId, forrigeBehandlingId)
+        }
 
         packet[ALDERSOVERGANG_STEG_KEY] = "VILKAARSVURDERT"
         return true

--- a/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/services/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/services/VilkaarsvurderingService.kt
@@ -26,6 +26,11 @@ interface VilkaarsvurderingService {
         yrkesskadeFordel: Boolean,
     ): HttpResponse
 
+    fun opphoerAldersovergang(
+        behandlingId: UUID,
+        behandlingKopiereFraId: UUID,
+    ): HttpResponse
+
     fun harMigrertYrkesskadefordel(behandlingId: String): Boolean
 
     fun harRettUtenTidsbegrensning(behandlingId: String): Boolean
@@ -57,6 +62,15 @@ class VilkaarsvurderingServiceImpl(private val vilkaarsvurderingKlient: HttpClie
         vilkaarsvurderingKlient.post("$url/api/vilkaarsvurdering/migrering/$behandlingId") {
             contentType(ContentType.Application.Json)
             setBody(VilkaarsvurderingMigreringRequest(yrkesskadeFordel))
+        }
+    }
+
+    override fun opphoerAldersovergang(
+        behandlingId: UUID,
+        behandlingKopiereFraId: UUID,
+    ) = runBlocking {
+        vilkaarsvurderingKlient.post("$url/api/vilkaarsvurdering/aldersovergang/$behandlingId?fra=$behandlingKopiereFraId") {
+            contentType(ContentType.Application.Json)
         }
     }
 

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/Application.kt
@@ -4,6 +4,7 @@ import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.initialisering.initEmbeddedServer
 import no.nav.etterlatte.libs.ktor.setReady
+import no.nav.etterlatte.vilkaarsvurdering.aldersovergang
 import no.nav.etterlatte.vilkaarsvurdering.config.ApplicationContext
 import no.nav.etterlatte.vilkaarsvurdering.migrering.migrering
 import no.nav.etterlatte.vilkaarsvurdering.vilkaarsvurdering
@@ -24,6 +25,7 @@ class Server(private val context: ApplicationContext) {
                 applicationConfig = context.config,
             ) {
                 vilkaarsvurdering(vilkaarsvurderingService, behandlingKlient)
+                aldersovergang(behandlingKlient, aldersovergangService)
                 migrering(migreringService, behandlingKlient, vilkaarsvurderingService)
             }
         }

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangRoutes.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangRoutes.kt
@@ -1,0 +1,43 @@
+package no.nav.etterlatte.vilkaarsvurdering
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.application.log
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.application
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import no.nav.etterlatte.libs.ktor.brukerTokenInfo
+import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.ktor.route.withBehandlingId
+import no.nav.etterlatte.vilkaarsvurdering.klienter.BehandlingKlient
+import java.util.UUID
+
+fun Route.aldersovergang(
+    behandlingKlient: BehandlingKlient,
+    aldersovergangService: AldersovergangService,
+) {
+    route("/api/vilkaarsvurdering/aldersovergang") {
+        val logger = application.log
+
+        post("/{$BEHANDLINGID_CALL_PARAMETER}") {
+            withBehandlingId(behandlingKlient) { behandlingId ->
+
+                val loependeBehandlingId =
+                    call.request.queryParameters["fra"]?.let { UUID.fromString(it) }
+                        ?: throw IllegalArgumentException("Mangler query parameter 'fra'")
+
+                logger.info("Behandler aldersovergang [behandlingId=$behandlingId, løpende behandlingId=$loependeBehandlingId]")
+                val vilkaarsvurdering =
+                    aldersovergangService.behandleOpphoerAldersovergang(
+                        behandlingId = behandlingId,
+                        loependeBehandlingId = loependeBehandlingId,
+                        brukerTokenInfo = call.brukerTokenInfo,
+                    )
+
+                call.respond(HttpStatusCode.OK, mapOf("vilkaarsvurderingid" to vilkaarsvurdering.id))
+            }
+        }
+    }
+}

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangService.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangService.kt
@@ -1,0 +1,68 @@
+package no.nav.etterlatte.vilkaarsvurdering
+
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.Utfall
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarType
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarVurderingData
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
+import java.time.LocalDateTime
+import java.util.UUID
+
+class AldersovergangService(
+    private val vilkaarsvurderingService: VilkaarsvurderingService,
+) {
+    suspend fun behandleOpphoerAldersovergang(
+        behandlingId: UUID,
+        loependeBehandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+        tidspunkt: () -> LocalDateTime = { LocalDateTime.now() },
+    ): Vilkaarsvurdering {
+        val vilkaarsvurdering =
+            vilkaarsvurderingService.hentVilkaarsvurdering(behandlingId)
+                ?: vilkaarsvurderingService.kopierVilkaarsvurdering(behandlingId, loependeBehandlingId, brukerTokenInfo)
+
+        val aldersvilkaar =
+            vilkaarsvurdering.vilkaar.single {
+                it.hovedvilkaar.type in
+                    listOf(
+                        VilkaarType.BP_ALDER_BARN_2024,
+                        VilkaarType.OMS_OVERLAPPENDE_YTELSER,
+                    )
+            }
+
+        // Aldersvilkår => ikke oppfylt
+        vilkaarsvurderingService.oppdaterVurderingPaaVilkaar(
+            behandlingId = behandlingId,
+            brukerTokenInfo = brukerTokenInfo,
+            vurdertVilkaar =
+                VurdertVilkaar(
+                    vilkaarId = aldersvilkaar.id,
+                    hovedvilkaar =
+                        VilkaarTypeOgUtfall(
+                            type = aldersvilkaar.hovedvilkaar.type,
+                            resultat = Utfall.IKKE_OPPFYLT,
+                        ),
+                    vurdering =
+                        VilkaarVurderingData(
+                            kommentar = "Aldersgrensen er passert",
+                            tidspunkt = tidspunkt(),
+                            saksbehandler = Fagsaksystem.EY.navn,
+                        ),
+                ),
+        )
+
+        // Resultat på hele vurderingen => ikke oppfylt
+        return vilkaarsvurderingService.oppdaterTotalVurdering(
+            behandlingId,
+            brukerTokenInfo,
+            VilkaarsvurderingResultat(
+                utfall = VilkaarsvurderingUtfall.IKKE_OPPFYLT,
+                kommentar = "Automatisk aldersovergang",
+                tidspunkt = tidspunkt(),
+                saksbehandler = Fagsaksystem.EY.navn,
+            ),
+        )
+    }
+}

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
@@ -185,6 +185,13 @@ fun Route.vilkaarsvurdering(
             }
         }
 
+        post("/{$BEHANDLINGID_CALL_PARAMETER}/aldersovergang/opphoer") {
+            withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
+                logger.info("Aldersovergang for $behandlingId")
+                vilkaarsvurderingService.opphoerAlder(behandlingId)
+            }
+        }
+
         delete("/{$BEHANDLINGID_CALL_PARAMETER}/{vilkaarId}") {
             withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
                 withParam("vilkaarId") { vilkaarId ->

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
@@ -185,13 +185,6 @@ fun Route.vilkaarsvurdering(
             }
         }
 
-        post("/{$BEHANDLINGID_CALL_PARAMETER}/aldersovergang/opphoer") {
-            withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
-                logger.info("Aldersovergang for $behandlingId")
-                vilkaarsvurderingService.opphoerAlder(behandlingId)
-            }
-        }
-
         delete("/{$BEHANDLINGID_CALL_PARAMETER}/{vilkaarId}") {
             withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
                 withParam("vilkaarId") { vilkaarId ->

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
@@ -17,18 +17,15 @@ import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.Utfall
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.Vilkaar
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarType
-import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarVurderingData
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.kopier
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
-import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
 import no.nav.etterlatte.vilkaarsvurdering.klienter.BehandlingKlient
 import no.nav.etterlatte.vilkaarsvurdering.klienter.GrunnlagKlient
 import no.nav.etterlatte.vilkaarsvurdering.vilkaar.BarnepensjonVilkaar1967
 import no.nav.etterlatte.vilkaarsvurdering.vilkaar.BarnepensjonVilkaar2024
 import no.nav.etterlatte.vilkaarsvurdering.vilkaar.OmstillingstoenadVilkaar
 import org.slf4j.LoggerFactory
-import java.time.LocalDateTime
 import java.util.UUID
 
 class VirkningstidspunktIkkeSattException(behandlingId: UUID) :
@@ -358,37 +355,6 @@ class VilkaarsvurderingService(
             behandlingId = behandlingId,
             grunnlagVersjon = grunnlag.metadata.versjon,
         )
-    }
-
-    fun opphoerAlder(behandlingId: UUID) {
-        vilkaarsvurderingRepository.hent(behandlingId)?.let { vilkaarsvurdering ->
-            vilkaarsvurdering.vilkaar.single {
-                it.hovedvilkaar.type in
-                    listOf(
-                        VilkaarType.BP_ALDER_BARN_2024,
-                        VilkaarType.OMS_OVERLAPPENDE_YTELSER,
-                    )
-            }
-                .let {
-                    vilkaarsvurderingRepository.lagreVilkaarResultat(
-                        behandlingId,
-                        VurdertVilkaar(
-                            vilkaarId = it.id,
-                            hovedvilkaar =
-                                VilkaarTypeOgUtfall(
-                                    type = it.hovedvilkaar.type,
-                                    resultat = Utfall.IKKE_OPPFYLT,
-                                ),
-                            vurdering =
-                                VilkaarVurderingData(
-                                    kommentar = "Automatisk opphør ved aldersgrense",
-                                    tidspunkt = LocalDateTime.now(),
-                                    saksbehandler = Fagsaksystem.EY.navn,
-                                ),
-                        ),
-                    )
-                }
-        } ?: throw VilkaarsvurderingIkkeFunnet()
     }
 
     private suspend fun <T> tilstandssjekkFoerKjoering(

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
@@ -17,15 +17,18 @@ import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.Utfall
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.Vilkaar
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarType
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarVurderingData
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.kopier
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
 import no.nav.etterlatte.vilkaarsvurdering.klienter.BehandlingKlient
 import no.nav.etterlatte.vilkaarsvurdering.klienter.GrunnlagKlient
 import no.nav.etterlatte.vilkaarsvurdering.vilkaar.BarnepensjonVilkaar1967
 import no.nav.etterlatte.vilkaarsvurdering.vilkaar.BarnepensjonVilkaar2024
 import no.nav.etterlatte.vilkaarsvurdering.vilkaar.OmstillingstoenadVilkaar
 import org.slf4j.LoggerFactory
+import java.time.LocalDateTime
 import java.util.UUID
 
 class VirkningstidspunktIkkeSattException(behandlingId: UUID) :
@@ -98,7 +101,7 @@ class VilkaarsvurderingService(
             return vilkaarsvurdering
         }
 
-        throw BehandlingstilstandException
+        throw BehandlingstilstandException()
     }
 
     suspend fun oppdaterVurderingPaaVilkaar(
@@ -261,7 +264,7 @@ class VilkaarsvurderingService(
         vilkaarsvurderingRepository.slettVilkaarvurdering(vilkaarsvurdering.id)
         behandlingKlient.settBehandlingStatusOpprettet(behandlingId, brukerTokenInfo, true)
     } else {
-        throw BehandlingstilstandException
+        throw BehandlingstilstandException()
     }
 
     private fun opprettNyVilkaarsvurdering(
@@ -357,6 +360,37 @@ class VilkaarsvurderingService(
         )
     }
 
+    fun opphoerAlder(behandlingId: UUID) {
+        vilkaarsvurderingRepository.hent(behandlingId)?.let { vilkaarsvurdering ->
+            vilkaarsvurdering.vilkaar.single {
+                it.hovedvilkaar.type in
+                    listOf(
+                        VilkaarType.BP_ALDER_BARN_2024,
+                        VilkaarType.OMS_OVERLAPPENDE_YTELSER,
+                    )
+            }
+                .let {
+                    vilkaarsvurderingRepository.lagreVilkaarResultat(
+                        behandlingId,
+                        VurdertVilkaar(
+                            vilkaarId = it.id,
+                            hovedvilkaar =
+                                VilkaarTypeOgUtfall(
+                                    type = it.hovedvilkaar.type,
+                                    resultat = Utfall.IKKE_OPPFYLT,
+                                ),
+                            vurdering =
+                                VilkaarVurderingData(
+                                    kommentar = "Automatisk opphør ved aldersgrense",
+                                    tidspunkt = LocalDateTime.now(),
+                                    saksbehandler = Fagsaksystem.EY.navn,
+                                ),
+                        ),
+                    )
+                }
+        } ?: throw VilkaarsvurderingIkkeFunnet()
+    }
+
     private suspend fun <T> tilstandssjekkFoerKjoering(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
@@ -365,7 +399,7 @@ class VilkaarsvurderingService(
         val kanVilkaarsvurdere = behandlingKlient.kanSetteBehandlingStatusVilkaarsvurdert(behandlingId, brukerTokenInfo)
 
         if (!kanVilkaarsvurdere) {
-            throw BehandlingstilstandException
+            throw BehandlingstilstandException()
         }
 
         return block()
@@ -384,7 +418,7 @@ class VilkaarsvurderingService(
     }
 }
 
-object BehandlingstilstandException : IllegalStateException()
+class BehandlingstilstandException : IllegalStateException()
 
 class VilkaarsvurderingTilstandException(message: String) : IllegalStateException(message)
 

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/config/ApplicationContext.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/config/ApplicationContext.kt
@@ -5,6 +5,7 @@ import com.typesafe.config.ConfigFactory
 import no.nav.etterlatte.libs.database.ApplicationProperties
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.ktor.httpClient
+import no.nav.etterlatte.vilkaarsvurdering.AldersovergangService
 import no.nav.etterlatte.vilkaarsvurdering.DelvilkaarRepository
 import no.nav.etterlatte.vilkaarsvurdering.VilkaarsvurderingRepository
 import no.nav.etterlatte.vilkaarsvurdering.VilkaarsvurderingService
@@ -26,4 +27,5 @@ class ApplicationContext {
             grunnlagKlient = GrunnlagKlientImpl(config, httpClient()),
         )
     val migreringService = MigreringService(vilkaarsvurderingRepository)
+    val aldersovergangService = AldersovergangService(vilkaarsvurderingService)
 }

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangRoutesTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangRoutesTest.kt
@@ -1,0 +1,73 @@
+package no.nav.etterlatte.vilkaarsvurdering
+
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.etterlatte.ktor.issueSystembrukerToken
+import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.vilkaarsvurdering.klienter.BehandlingKlient
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.UUID
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class AldersovergangRoutesTest {
+    private val server = MockOAuth2Server()
+    private val behandlingKlient = mockk<BehandlingKlient>()
+    private val aldersovergangService = mockk<AldersovergangService>()
+
+    private val behandlingId = UUID.randomUUID()
+    private val behandlingDetSkalKopieresFraId = UUID.randomUUID()
+
+    @BeforeAll
+    fun before() {
+        server.start()
+    }
+
+    @AfterAll
+    fun after() {
+        server.shutdown()
+    }
+
+    private val token: String by lazy { server.issueSystembrukerToken() }
+
+    @Test
+    fun `skal delegere til aldersovergangservice`() {
+        testApplication {
+            runServer(server) {
+                aldersovergang(behandlingKlient, aldersovergangService)
+            }
+
+            val vilkaarsvurdering =
+                mockk<Vilkaarsvurdering> {
+                    every { id } returns UUID.randomUUID()
+                }
+            coEvery {
+                aldersovergangService.behandleOpphoerAldersovergang(behandlingId, behandlingDetSkalKopieresFraId, any())
+            } returns vilkaarsvurdering
+
+            val response =
+                client.post("/api/vilkaarsvurdering/aldersovergang/$behandlingId?fra=$behandlingDetSkalKopieresFraId") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    header(HttpHeaders.Authorization, "Bearer $token")
+                }
+
+            response.status shouldBe HttpStatusCode.OK
+
+            coVerify { aldersovergangService.behandleOpphoerAldersovergang(behandlingId, behandlingDetSkalKopieresFraId, any()) }
+            verify { vilkaarsvurdering.id }
+        }
+    }
+}

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangServiceTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangServiceTest.kt
@@ -1,0 +1,139 @@
+package no.nav.etterlatte.vilkaarsvurdering
+
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.Delvilkaar
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.Lovreferanse
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.Utfall
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.Vilkaar
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarType
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarVurderingData
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.time.Month
+import java.time.YearMonth
+import java.util.UUID
+
+class AldersovergangServiceTest {
+    private val vilkaarsvurderingService = mockk<VilkaarsvurderingService>()
+    private val aldersAldersovergangService = AldersovergangService(vilkaarsvurderingService)
+
+    private val behandlingId = UUID.randomUUID()
+    private val loependeBehandlingId = UUID.randomUUID()
+    private val idVilkaarForOppdatering = UUID.randomUUID()
+    private val brukerTokenInfo = mockk<BrukerTokenInfo>()
+
+    @Test
+    fun `aldersovergang skal orkestrere opprettelse av vilkaarsvurdering, avslag paa vilkar og totalresultat`() {
+        val vilkaarsvurdering =
+            Vilkaarsvurdering(
+                behandlingId = behandlingId,
+                grunnlagVersjon = 1,
+                virkningstidspunkt = YearMonth.now(),
+                vilkaar =
+                    listOf(
+                        Vilkaar(
+                            id = idVilkaarForOppdatering,
+                            hovedvilkaar =
+                                Delvilkaar(
+                                    type = VilkaarType.BP_ALDER_BARN_2024,
+                                    tittel = "Aldersvilkår",
+                                    lovreferanse = Lovreferanse(paragraf = "§dummy"),
+                                ),
+                        ),
+                        Vilkaar(
+                            id = UUID.randomUUID(),
+                            hovedvilkaar =
+                                Delvilkaar(
+                                    type = VilkaarType.BP_FORTSATT_MEDLEMSKAP_2024,
+                                    tittel = "Fortsatt medlemskap",
+                                    lovreferanse = Lovreferanse(paragraf = "§dummy"),
+                                ),
+                        ),
+                    ),
+            )
+
+        val tidspunkt = LocalDateTime.of(2024, Month.MARCH, 13, 10, 28)
+
+        val ikkeOppfyltVilkaar =
+            VurdertVilkaar(
+                vilkaarId = idVilkaarForOppdatering,
+                hovedvilkaar =
+                    VilkaarTypeOgUtfall(
+                        type = VilkaarType.BP_ALDER_BARN_2024,
+                        resultat = Utfall.IKKE_OPPFYLT,
+                    ),
+                vurdering =
+                    VilkaarVurderingData(
+                        kommentar = "Aldersgrensen er passert",
+                        tidspunkt = tidspunkt,
+                        saksbehandler = Fagsaksystem.EY.navn,
+                    ),
+            )
+
+        val vilkaarsvurderingResultat =
+            VilkaarsvurderingResultat(
+                utfall = VilkaarsvurderingUtfall.IKKE_OPPFYLT,
+                kommentar = "Automatisk aldersovergang",
+                tidspunkt = tidspunkt,
+                saksbehandler = Fagsaksystem.EY.navn,
+            )
+
+        coEvery { vilkaarsvurderingService.hentVilkaarsvurdering(behandlingId) } returns null
+        coEvery {
+            vilkaarsvurderingService.kopierVilkaarsvurdering(
+                behandlingId,
+                loependeBehandlingId,
+                brukerTokenInfo,
+            )
+        } returns vilkaarsvurdering
+        coEvery {
+            vilkaarsvurderingService.oppdaterVurderingPaaVilkaar(behandlingId, brukerTokenInfo, ikkeOppfyltVilkaar)
+        } returns vilkaarsvurdering
+        coEvery {
+            vilkaarsvurderingService.oppdaterTotalVurdering(behandlingId, brukerTokenInfo, vilkaarsvurderingResultat)
+        } returns vilkaarsvurdering
+
+        runBlocking {
+            val res =
+                aldersAldersovergangService.behandleOpphoerAldersovergang(
+                    behandlingId = behandlingId,
+                    loependeBehandlingId = loependeBehandlingId,
+                    brukerTokenInfo = brukerTokenInfo,
+                    tidspunkt = { tidspunkt },
+                )
+
+            res shouldBe vilkaarsvurdering
+        }
+
+        coVerify { vilkaarsvurderingService.hentVilkaarsvurdering(behandlingId) }
+        coVerify {
+            vilkaarsvurderingService.kopierVilkaarsvurdering(
+                behandlingId,
+                loependeBehandlingId,
+                brukerTokenInfo,
+            )
+        }
+        coVerify {
+            vilkaarsvurderingService.oppdaterVurderingPaaVilkaar(
+                behandlingId,
+                brukerTokenInfo,
+                ikkeOppfyltVilkaar,
+            )
+        }
+        coVerify {
+            vilkaarsvurderingService.oppdaterTotalVurdering(
+                behandlingId,
+                brukerTokenInfo,
+                vilkaarsvurderingResultat,
+            )
+        }
+    }
+}

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
@@ -35,6 +35,7 @@ import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarVurderingData
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
 import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.kilde
@@ -732,6 +733,22 @@ internal class VilkaarsvurderingServiceTest(private val ds: DataSource) {
 
             assertThrows<VirkningstidspunktSamsvarerIkke> {
                 service.sjekkGyldighetOgOppdaterBehandlingStatus(uuid, brukerTokenInfo)
+            }
+        }
+    }
+
+    @Test
+    fun `aldersovergang - skal oppdatere aldersvilkaar for BP med utfall ikke_oppfylt`() {
+        runBlocking {
+            service.opprettVilkaarsvurdering(uuid, brukerTokenInfo)
+            service.opphoerAlder(behandlingId = uuid)
+
+            with(
+                service.hentVilkaarsvurdering(behandlingId = uuid)!!
+                    .vilkaar.first { it.hovedvilkaar.type == VilkaarType.BP_ALDER_BARN_2024 },
+            ) {
+                hovedvilkaar.resultat shouldBe Utfall.IKKE_OPPFYLT
+                vurdering!!.saksbehandler shouldBe Fagsaksystem.EY.navn
             }
         }
     }

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
@@ -35,7 +35,6 @@ import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarVurderingData
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
-import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
 import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.kilde
@@ -733,22 +732,6 @@ internal class VilkaarsvurderingServiceTest(private val ds: DataSource) {
 
             assertThrows<VirkningstidspunktSamsvarerIkke> {
                 service.sjekkGyldighetOgOppdaterBehandlingStatus(uuid, brukerTokenInfo)
-            }
-        }
-    }
-
-    @Test
-    fun `aldersovergang - skal oppdatere aldersvilkaar for BP med utfall ikke_oppfylt`() {
-        runBlocking {
-            service.opprettVilkaarsvurdering(uuid, brukerTokenInfo)
-            service.opphoerAlder(behandlingId = uuid)
-
-            with(
-                service.hentVilkaarsvurdering(behandlingId = uuid)!!
-                    .vilkaar.first { it.hovedvilkaar.type == VilkaarType.BP_ALDER_BARN_2024 },
-            ) {
-                hovedvilkaar.resultat shouldBe Utfall.IKKE_OPPFYLT
-                vurdering!!.saksbehandler shouldBe Fagsaksystem.EY.navn
             }
         }
     }

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Omregningshendelse.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Omregningshendelse.kt
@@ -8,4 +8,6 @@ data class Omregningshendelse(
     val fradato: LocalDate,
     val omregningsId: UUID? = null,
     val prosesstype: Prosesstype,
+    val revurderingaarsak: Revurderingaarsak = Revurderingaarsak.REGULERING,
+    val oppgavefrist: LocalDate? = null,
 )

--- a/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/VedtakAldersovergangStepEvents.kt
+++ b/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/VedtakAldersovergangStepEvents.kt
@@ -10,4 +10,14 @@ enum class VedtakAldersovergangStepEvents {
      *  Etter at løpende ytelser er vurdert for sakId fra #SAK_IDENTIFISERT
      */
     VURDERT_LOEPENDE_YTELSE,
+
+    /**
+     * SKal fatte (opphørs-)vedtak etter dette
+     */
+    VILKAARSVURDERT,
+
+    /**
+     * Vedtak er fattet og attestert (og sendt videre for iverksetting)
+     */
+    VEDTAK_ATTESTERT,
 }


### PR DESCRIPTION
Beklager størrelsen, men det er mest tester samt refaktorering (extract method) som drar opp.

Flyt etter at `vedtaksvurdering` har identifisert om det er løpende ytelse, og dermed skal behandles
1. `oppdater-behandling` forsøker å opprette omregning, hvis ikke fallback til eksisterende oppgaveløsning
2. `vilkårsvurdering` kopierer forutgående vilkårsvurdering, men setter aldersvilkår og totalvurdering til ikke oppfylt
3. `vedtaksvurdering` fatter og attesterer vedtak, kafka-biten sender ut både vedtakshendelse som medfører at vedtaket blir iverksatt samt markerer tidshendelsen som behandlet
4. `tidshendelser` markerer hendelsen som ferdig