### PR TITLE
EY-3679: Nullstiller utfall og initielt utfall ved gitte endringer i formkrav

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/brev/KlageBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/brev/KlageBrev.tsx
@@ -14,7 +14,6 @@ import { hentBrev } from '~shared/api/brev'
 import styled from 'styled-components'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { JaNei } from '~shared/types/ISvar'
-import { Innhold } from '~components/klage/styled'
 import { isSuccess, mapApiResult } from '~shared/api/apiUtils'
 import BrevTittel from '~components/person/brev/tittel/BrevTittel'
 import { forrigeSteg } from '~components/klage/stegmeny/KlageStegmeny'
@@ -57,30 +56,28 @@ export function KlageBrev() {
         <Sidebar>
           <ContentHeader>
             <HeadingWrapper>
-              <Heading level="1" size="large">
+              <Heading spacing level="1" size="large">
                 Brev
               </Heading>
             </HeadingWrapper>
+            {klage.formkrav?.formkrav.erKlagenFramsattInnenFrist === JaNei.JA ? (
+              <BodyShort spacing> Skriv oversendelsesbrevet til klager</BodyShort>
+            ) : (
+              <BodyShort>Skriv avvisningsbrev her</BodyShort>
+            )}
+            {isSuccess(hentetBrev) && (
+              <>
+                <BrevTittel
+                  brevId={hentetBrev.data.id}
+                  sakId={hentetBrev.data.sakId}
+                  tittel={hentetBrev.data.tittel}
+                  kanRedigeres={true}
+                />
+                <br />
+                <BrevMottaker brev={hentetBrev.data} kanRedigeres={true} />
+              </>
+            )}
           </ContentHeader>
-          {klage.formkrav?.formkrav.erKlagenFramsattInnenFrist === JaNei.JA ? (
-            <Innhold>
-              <BodyShort>Skriv oversendelsesbrevet til klager</BodyShort>
-            </Innhold>
-          ) : (
-            <BodyShort>Skriv avvisningsbrev her</BodyShort>
-          )}
-          {/* TODO lar være å bytte ut med ny brevmottaker komponent her, siden dette virker å være ganske wip */}
-          {isSuccess(hentetBrev) && (
-            <>
-              <BrevTittel
-                brevId={hentetBrev.data.id}
-                sakId={hentetBrev.data.sakId}
-                tittel={hentetBrev.data.tittel}
-                kanRedigeres={true}
-              />
-              <BrevMottaker brev={hentetBrev.data} kanRedigeres={true} />
-            </>
-          )}
         </Sidebar>
 
         {mapApiResult(
@@ -119,8 +116,6 @@ export function KlageBrev() {
 
 const BrevContent = styled.div`
   display: flex;
-  height: 75vh;
-  max-height: 75vh;
 `
 
 const SpinnerContainer = styled.div`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/EndeligVurderingVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/EndeligVurderingVisning.tsx
@@ -1,15 +1,10 @@
-import { FlexRow } from '~shared/styled'
 import React from 'react'
-import { BodyShort, Button, Heading } from '@navikt/ds-react'
-import { useNavigate } from 'react-router-dom'
-import { forrigeSteg, nesteSteg } from '~components/klage/stegmeny/KlageStegmeny'
+import { BodyShort, Heading } from '@navikt/ds-react'
 import { formaterKlageutfall, VisInnstilling, VisOmgjoering } from '~components/klage/vurdering/KlageVurderingFelles'
 import { Klage } from '~shared/types/Klage'
 
 export function EndeligVurderingVisning(props: { klage: Klage }) {
   const klage = props.klage
-
-  const navigate = useNavigate()
 
   const { utfall, sak } = klage
   return (
@@ -32,17 +27,11 @@ export function EndeligVurderingVisning(props: { klage: Klage }) {
           utfall?.utfall === 'AVVIST_MED_OMGJOERING' ? (
             <VisOmgjoering omgjoering={utfall.omgjoering} kanRedigere={false} />
           ) : null}
-          <FlexRow justify="center">
-            <Button className="button" variant="secondary" onClick={() => navigate(forrigeSteg(klage, 'vurdering'))}>
-              Gå tilbake
-            </Button>
-            <Button className="button" variant="primary" onClick={() => navigate(nesteSteg(klage, 'vurdering'))}>
-              Neste side
-            </Button>
-          </FlexRow>
         </>
       ) : (
-        <BodyShort>Ikke registrert</BodyShort>
+        <>
+          <BodyShort>Ikke registrert</BodyShort>
+        </>
       )}
     </>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/InitiellVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/InitiellVurdering.tsx
@@ -44,13 +44,7 @@ export const InitiellVurdering = (props: { klage: Klage }) => {
   const [redigeres, setRedigeres] = useState<boolean>(!klage?.initieltUtfall)
 
   const [lagreInitiellStatus, lagreInitiellKlageUtfall] = useApiCall(oppdaterInitieltUtfallForKlage)
-  const {
-    handleSubmit,
-    control,
-    register,
-    watch,
-    formState: { errors },
-  } = useForm<InitiellVurderingForm>({
+  const { handleSubmit, control, register, watch } = useForm<InitiellVurderingForm>({
     defaultValues: klage.initieltUtfall?.utfallMedBegrunnelse ?? { begrunnelse: null, utfall: null },
   })
 
@@ -111,17 +105,7 @@ export const InitiellVurdering = (props: { klage: Klage }) => {
             {formUtfall && (
               <>
                 <BredVurderingWrapper>
-                  <Textarea
-                    size="medium"
-                    label={getTextFromutfall(formUtfall)}
-                    error={errors.begrunnelse?.message}
-                    {...register('begrunnelse', {
-                      required: {
-                        value: true,
-                        message: 'Du må skrive en begrunnelse for utfallet.',
-                      },
-                    })}
-                  />
+                  <Textarea size="medium" label={getTextFromutfall(formUtfall)} {...register('begrunnelse')} />
                 </BredVurderingWrapper>
 
                 <BredVurderingWrapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/InitiellVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/InitiellVurdering.tsx
@@ -44,7 +44,13 @@ export const InitiellVurdering = (props: { klage: Klage }) => {
   const [redigeres, setRedigeres] = useState<boolean>(!klage?.initieltUtfall)
 
   const [lagreInitiellStatus, lagreInitiellKlageUtfall] = useApiCall(oppdaterInitieltUtfallForKlage)
-  const { handleSubmit, control, register, watch } = useForm<InitiellVurderingForm>({
+  const {
+    handleSubmit,
+    control,
+    register,
+    watch,
+    formState: { errors },
+  } = useForm<InitiellVurderingForm>({
     defaultValues: klage.initieltUtfall?.utfallMedBegrunnelse ?? { begrunnelse: null, utfall: null },
   })
 
@@ -105,7 +111,17 @@ export const InitiellVurdering = (props: { klage: Klage }) => {
             {formUtfall && (
               <>
                 <BredVurderingWrapper>
-                  <Textarea size="medium" label={getTextFromutfall(formUtfall)} {...register('begrunnelse')} />
+                  <Textarea
+                    size="medium"
+                    label={getTextFromutfall(formUtfall)}
+                    error={errors.begrunnelse?.message}
+                    {...register('begrunnelse', {
+                      required: {
+                        value: true,
+                        message: 'Du må skrive en begrunnelse for utfallet.',
+                      },
+                    })}
+                  />
                 </BredVurderingWrapper>
 
                 <BredVurderingWrapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/KlageVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/KlageVurdering.tsx
@@ -6,15 +6,19 @@ import React from 'react'
 import { JaNei } from '~shared/types/ISvar'
 import { KlageAvvisning } from '~components/klage/vurdering/KlageAvvisning'
 import { HeadingWrapper } from '~components/person/SakOversikt'
-import { Heading } from '@navikt/ds-react'
-import { ContentHeader } from '~shared/styled'
+import { Button, Heading } from '@navikt/ds-react'
+import { ContentHeader, FlexRow } from '~shared/styled'
 import { InnholdPadding } from '~components/behandling/soeknadsoversikt/styled'
 import { EndeligVurdering } from '~components/klage/vurdering/EndeligVurdering'
 import { EndeligVurderingVisning } from '~components/klage/vurdering/EndeligVurderingVisning'
 import { Klage } from '~shared/types/Klage'
+import { forrigeSteg } from '~components/klage/stegmeny/KlageStegmeny'
+import { useNavigate } from 'react-router'
 
 export function KlageVurdering({ kanRedigere }: { kanRedigere: boolean }) {
   const klage = useKlage()
+  const navigate = useNavigate()
+
   if (!klage) {
     return <Spinner visible label="Henter klage" />
   }
@@ -36,11 +40,19 @@ export function KlageVurdering({ kanRedigere }: { kanRedigere: boolean }) {
         {kanRedigere ? (
           <>
             <InitiellVurdering klage={klage} />
-            {klage.initieltUtfall && <EndeligVurdering klage={klage} />}
+            {klage.initieltUtfall ? (
+              <EndeligVurdering klage={klage} />
+            ) : (
+              <FlexRow justify="center">
+                <Button type="button" variant="secondary" onClick={() => navigate(forrigeSteg(klage, 'vurdering'))}>
+                  Gå tilbake
+                </Button>
+              </FlexRow>
+            )}
           </>
         ) : (
           <>
-            <InitiellVurderingVisning klage={klage} />
+            {klage.initieltUtfall && <InitiellVurderingVisning klage={klage} />}
             <EndeligVurderingVisning klage={klage} />
           </>
         )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/KlageVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/KlageVurdering.tsx
@@ -12,8 +12,9 @@ import { InnholdPadding } from '~components/behandling/soeknadsoversikt/styled'
 import { EndeligVurdering } from '~components/klage/vurdering/EndeligVurdering'
 import { EndeligVurderingVisning } from '~components/klage/vurdering/EndeligVurderingVisning'
 import { Klage } from '~shared/types/Klage'
-import { forrigeSteg } from '~components/klage/stegmeny/KlageStegmeny'
+import { forrigeSteg, klageKanSeBrev, nesteSteg } from '~components/klage/stegmeny/KlageStegmeny'
 import { useNavigate } from 'react-router'
+import { NavigateFunction } from 'react-router/dist/lib/hooks'
 
 export function KlageVurdering({ kanRedigere }: { kanRedigere: boolean }) {
   const klage = useKlage()
@@ -40,15 +41,7 @@ export function KlageVurdering({ kanRedigere }: { kanRedigere: boolean }) {
         {kanRedigere ? (
           <>
             <InitiellVurdering klage={klage} />
-            {klage.initieltUtfall ? (
-              <EndeligVurdering klage={klage} />
-            ) : (
-              <FlexRow justify="center">
-                <Button type="button" variant="secondary" onClick={() => navigate(forrigeSteg(klage, 'vurdering'))}>
-                  Gå tilbake
-                </Button>
-              </FlexRow>
-            )}
+            {klage.initieltUtfall && <EndeligVurdering klage={klage} />}
           </>
         ) : (
           <>
@@ -56,6 +49,9 @@ export function KlageVurdering({ kanRedigere }: { kanRedigere: boolean }) {
             <EndeligVurderingVisning klage={klage} />
           </>
         )}
+
+        {/* Hvis vi ikke viser redigering av endelig utfall (inkl. knapper) så legges knappene inn her*/}
+        {(!klage.initieltUtfall || !kanRedigere) && <Navigeringsknapper klage={klage} navigate={navigate} />}
       </InnholdPadding>
     </>
   )
@@ -64,4 +60,17 @@ export function KlageVurdering({ kanRedigere }: { kanRedigere: boolean }) {
 function skalAvvises(klage: Klage) {
   const formkrav = klage.formkrav?.formkrav
   return formkrav?.erKlagenFramsattInnenFrist === JaNei.NEI
+}
+
+function Navigeringsknapper({ klage, navigate }: { klage: Klage; navigate: NavigateFunction }) {
+  return (
+    <FlexRow justify="center">
+      <Button className="button" variant="secondary" onClick={() => navigate(forrigeSteg(klage, 'vurdering'))}>
+        Gå tilbake
+      </Button>
+      <Button className="button" variant="primary" onClick={() => navigate(nesteSteg(klage, 'vurdering'))}>
+        {klageKanSeBrev(klage) ? 'Gå til brev' : 'Gå til oppsummering'}
+      </Button>
+    </FlexRow>
+  )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Klage.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Klage.ts
@@ -139,7 +139,7 @@ export interface InitieltUtfallMedBegrunnelseOgMeta {
 
 export interface IniteltUtfallMedBegrunnelseDto {
   utfall: Utfall
-  begrunnelse?: string
+  begrunnelse: string | null
 }
 
 export const teksterKlageutfall: Record<Utfall | 'UKJENT', string> = {

--- a/libs/etterlatte-behandling-model/build.gradle.kts
+++ b/libs/etterlatte-behandling-model/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     testRuntimeOnly(libs.test.jupiter.engine)
     testImplementation(libs.test.kotest.assertionscore)
     testImplementation(project(":libs:testdata"))
+    testImplementation(libs.test.jupiter.params)
 }
 
 tasks {

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Klage.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Klage.kt
@@ -165,9 +165,20 @@ data class Klage(
                     JaNei.NEI -> KlageStatus.FORMKRAV_IKKE_OPPFYLT
                 },
             utfall =
-                when (formkrav.erFormkraveneOppfylt) {
-                    JaNei.JA -> this.utfall
-                    JaNei.NEI -> null
+                if (this.erFormkraveneOppfylt() != formkrav.erFormkraveneOppfylt ||
+                    this.erKlagenFramsattInnenFrist() != formkrav.erKlagenFramsattInnenFrist
+                ) {
+                    null
+                } else {
+                    this.utfall
+                },
+            initieltUtfall =
+                if (this.erFormkraveneOppfylt() != formkrav.erFormkraveneOppfylt ||
+                    this.erKlagenFramsattInnenFrist() != formkrav.erKlagenFramsattInnenFrist
+                ) {
+                    null
+                } else {
+                    this.initieltUtfall
                 },
         )
     }
@@ -179,7 +190,7 @@ data class Klage(
                     "til klagen (${this.status})",
             )
         }
-        if (formkrav?.formkrav?.erKlagenFramsattInnenFrist == JaNei.JA &&
+        if (erKlagenFramsattInnenFrist() == JaNei.JA &&
             initieltUtfall == null
         ) {
             throw IllegalStateException(
@@ -278,6 +289,10 @@ data class Klage(
             else -> false
         }
     }
+
+    private fun erFormkraveneOppfylt() = this.formkrav?.formkrav?.erFormkraveneOppfylt
+
+    private fun erKlagenFramsattInnenFrist() = this.formkrav?.formkrav?.erKlagenFramsattInnenFrist
 
     fun kanAvbryte(): Boolean {
         return KlageStatus.kanAvbryte(this.status)

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Klage.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Klage.kt
@@ -153,6 +153,10 @@ data class Klage(
                     "tilstanden til klagen: ${this.status}",
             )
         }
+        val utfallFortsattGyldig =
+            this.erFormkraveneOppfylt() == formkrav.erFormkraveneOppfylt &&
+                this.erKlagenFramsattInnenFrist() == formkrav.erKlagenFramsattInnenFrist
+
         return this.copy(
             formkrav =
                 FormkravMedBeslutter(
@@ -164,22 +168,8 @@ data class Klage(
                     JaNei.JA -> KlageStatus.FORMKRAV_OPPFYLT
                     JaNei.NEI -> KlageStatus.FORMKRAV_IKKE_OPPFYLT
                 },
-            utfall =
-                if (this.erFormkraveneOppfylt() != formkrav.erFormkraveneOppfylt ||
-                    this.erKlagenFramsattInnenFrist() != formkrav.erKlagenFramsattInnenFrist
-                ) {
-                    null
-                } else {
-                    this.utfall
-                },
-            initieltUtfall =
-                if (this.erFormkraveneOppfylt() != formkrav.erFormkraveneOppfylt ||
-                    this.erKlagenFramsattInnenFrist() != formkrav.erKlagenFramsattInnenFrist
-                ) {
-                    null
-                } else {
-                    this.initieltUtfall
-                },
+            utfall = this.utfall.takeIf { utfallFortsattGyldig },
+            initieltUtfall = this.initieltUtfall.takeIf { utfallFortsattGyldig },
         )
     }
 

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Klage.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Klage.kt
@@ -118,7 +118,7 @@ data class InitieltUtfallMedBegrunnelseOgSaksbehandler(
 
 data class InitieltUtfallMedBegrunnelseDto(
     val utfall: KlageUtfall,
-    val begrunnelse: String,
+    val begrunnelse: String?,
 )
 
 enum class KlageUtfall {


### PR DESCRIPTION
Nullstiller hvis "formkrav oppfylt" eller "framsatt innen frist" endres. Viser felter for initielt utfall bare hvis klagen har initielt utfall. Navigeringsknapp ved redigering av initielt utfall. Required settes på feltet initielt_utfall.begrunnelse.