### PR TITLE
Småforbetringar på regulering

### DIFF
--- a/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/beregningkafka/OmregningHendelserRiver.kt
+++ b/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/beregningkafka/OmregningHendelserRiver.kt
@@ -31,7 +31,7 @@ internal class OmregningHendelserRiver(
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        initialiserRiver(rapidsConnection, ReguleringHendelseType.BEREGN) {
+        initialiserRiver(rapidsConnection, ReguleringHendelseType.VILKAARSVURDERT) {
             validate { it.requireKey(BEHANDLING_ID_KEY) }
             validate { it.requireKey(SAK_TYPE) }
             validate { it.rejectKey(BEREGNING_KEY) }
@@ -62,7 +62,7 @@ internal class OmregningHendelserRiver(
                         .body<AvkortingDto>()
                 packet[AVKORTING_KEY] = avkorting
             }
-            packet.setEventNameForHendelseType(ReguleringHendelseType.OPPRETT_VEDTAK)
+            packet.setEventNameForHendelseType(ReguleringHendelseType.BEREGNA)
             context.publish(packet.toJson())
         }
         logger.info("Publiserte oppdatert omregningshendelse")

--- a/apps/etterlatte-beregning-kafka/src/test/resources/omregningshendelse.json
+++ b/apps/etterlatte-beregning-kafka/src/test/resources/omregningshendelse.json
@@ -1,6 +1,6 @@
 {
   "system_read_count": 0,
-  "@event_name": "REGULERING:BEREGN",
+  "@event_name": "REGULERING:VILKAARSVURDERT",
   "hendelse_data": {
     "sakId": 1,
     "fradato": "2023-02-08",

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/OmregningsHendelserRiver.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/OmregningsHendelserRiver.kt
@@ -22,7 +22,7 @@ internal class OmregningsHendelserRiver(rapidsConnection: RapidsConnection, priv
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        initialiserRiver(rapidsConnection, ReguleringHendelseType.OMREGNINGSHENDELSE) {
+        initialiserRiver(rapidsConnection, ReguleringHendelseType.LOEPENDE_YTELSE_FUNNET) {
             validate { it.rejectKey(BEHANDLING_ID_KEY) }
             validate { it.requireKey(HENDELSE_DATA_KEY) }
         }
@@ -39,7 +39,7 @@ internal class OmregningsHendelserRiver(rapidsConnection: RapidsConnection, priv
         packet.behandlingId = behandlingId
         packet[BEHANDLING_VI_OMREGNER_FRA_KEY] = behandlingViOmregnerFra
         packet[SAK_TYPE] = sakType
-        packet.setEventNameForHendelseType(ReguleringHendelseType.VILKAARSVURDER)
+        packet.setEventNameForHendelseType(ReguleringHendelseType.BEHANDLING_OPPRETTA)
         context.publish(packet.toJson())
         logger.info("Publiserte oppdatert omregningshendelse")
     }

--- a/apps/etterlatte-oppdater-behandling/src/test/resources/omregningshendelse.json
+++ b/apps/etterlatte-oppdater-behandling/src/test/resources/omregningshendelse.json
@@ -1,6 +1,6 @@
 {
   "system_read_count": 0,
-  "@event_name": "REGULERING:OMREGNINGSHENDELSE",
+  "@event_name": "REGULERING:LOEPENDE_YTELSE_FUNNET",
   "hendelse_data": {
     "sakId": 1,
     "fradato": "2023-02-08",

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/LoependeYtelserforespoerselRiver.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/LoependeYtelserforespoerselRiver.kt
@@ -53,7 +53,7 @@ internal class LoependeYtelserforespoerselRiver(
 
         val respons = vedtak.harLoependeYtelserFra(sakId, reguleringsdato)
         respons.takeIf { it.erLoepende }?.let {
-            packet.setEventNameForHendelseType(ReguleringHendelseType.OMREGNINGSHENDELSE)
+            packet.setEventNameForHendelseType(ReguleringHendelseType.LOEPENDE_YTELSE_FUNNET)
             packet[HENDELSE_DATA_KEY] =
                 Omregningshendelse(
                     sakId = sakId,
@@ -61,7 +61,7 @@ internal class LoependeYtelserforespoerselRiver(
                     prosesstype = Prosesstype.AUTOMATISK,
                 )
             context.publish(packet.toJson())
-            logger.info("Grunnlopesreguleringmelding ble sendt for sak $sakId. Dato=${respons.dato}")
-        } ?: logger.info("Grunnlopesreguleringmelding ble ikke sendt for sak $sakId. Dato=${respons.dato}")
+            logger.info("Grunnbeløpsreguleringmelding ble sendt for sak $sakId. Dato=${respons.dato}")
+        } ?: logger.info("Grunnbeløpsreguleringmelding ble ikke sendt for sak $sakId. Dato=${respons.dato}")
     }
 }

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiver.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiver.kt
@@ -22,7 +22,7 @@ internal class OpprettVedtakforespoerselRiver(
     private val logger = LoggerFactory.getLogger(OpprettVedtakforespoerselRiver::class.java)
 
     init {
-        initialiserRiver(rapidsConnection, ReguleringHendelseType.OPPRETT_VEDTAK) {
+        initialiserRiver(rapidsConnection, ReguleringHendelseType.BEREGNA) {
             validate { it.requireKey(SAK_ID_KEY) }
             validate { it.requireKey(DATO_KEY) }
             validate { it.requireKey(BEHANDLING_ID_KEY) }
@@ -37,7 +37,7 @@ internal class OpprettVedtakforespoerselRiver(
         logger.info("Leser opprett-vedtak forespoersel for sak $sakId")
         val behandlingId = packet.behandlingId
 
-        withFeilhaandtering(packet, context, ReguleringHendelseType.OPPRETT_VEDTAK.lagEventnameForType()) {
+        withFeilhaandtering(packet, context, ReguleringHendelseType.BEREGNA.lagEventnameForType()) {
             val respons = vedtak.opprettVedtakFattOgAttester(packet.sakId, behandlingId)
             logger.info("Opprettet vedtak ${respons.vedtak.id} for sak: $sakId og behandling: $behandlingId")
             RapidUtsender.sendUt(respons, packet, context)

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/regulering/LoependeYtelserforespoerselRiverTest.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/regulering/LoependeYtelserforespoerselRiverTest.kt
@@ -61,7 +61,10 @@ internal class LoependeYtelserforespoerselRiverTest {
 
         inspector.sendTestMessage(melding.toJson())
         val sendtMelding = inspector.inspektør.message(0)
-        Assertions.assertEquals(ReguleringHendelseType.OMREGNINGSHENDELSE.lagEventnameForType(), sendtMelding.get(EVENT_NAME_KEY).asText())
+        Assertions.assertEquals(
+            ReguleringHendelseType.LOEPENDE_YTELSE_FUNNET.lagEventnameForType(),
+            sendtMelding.get(EVENT_NAME_KEY).asText(),
+        )
         Assertions.assertEquals(
             Omregningshendelse(
                 sakId = sakId,

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiverTest.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiverTest.kt
@@ -21,7 +21,7 @@ internal class OpprettVedtakforespoerselRiverTest {
     private fun genererOpprettVedtakforespoersel(behandlingId: UUID) =
         JsonMessage.newMessage(
             mapOf(
-                ReguleringHendelseType.OPPRETT_VEDTAK.lagParMedEventNameKey(),
+                ReguleringHendelseType.BEREGNA.lagParMedEventNameKey(),
                 SAK_ID_KEY to sakId,
                 DATO_KEY to foersteMai2023,
                 BEHANDLING_ID_KEY to behandlingId,

--- a/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRiver.kt
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRiver.kt
@@ -22,7 +22,7 @@ internal class VilkaarsvurderingRiver(
     private val logger = LoggerFactory.getLogger(VilkaarsvurderingRiver::class.java)
 
     init {
-        initialiserRiver(rapidsConnection, ReguleringHendelseType.VILKAARSVURDER) {
+        initialiserRiver(rapidsConnection, ReguleringHendelseType.BEHANDLING_OPPRETTA) {
             validate { it.requireKey(SAK_ID_KEY) }
             validate { it.requireKey(BEHANDLING_ID_KEY) }
             validate { it.requireKey(BEHANDLING_VI_OMREGNER_FRA_KEY) }
@@ -37,7 +37,7 @@ internal class VilkaarsvurderingRiver(
         val behandlingViOmregnerFra = packet[BEHANDLING_VI_OMREGNER_FRA_KEY].asText().toUUID()
 
         vilkaarsvurderingService.kopierForrigeVilkaarsvurdering(behandlingId, behandlingViOmregnerFra)
-        packet.setEventNameForHendelseType(ReguleringHendelseType.BEREGN)
+        packet.setEventNameForHendelseType(ReguleringHendelseType.VILKAARSVURDERT)
         context.publish(packet.toJson())
         logger.info(
             "Vilkaarsvurdert ferdig for behandling $behandlingId og melding beregningsmelding ble sendt.",

--- a/apps/etterlatte-vilkaarsvurdering-kafka/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRiverTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRiverTest.kt
@@ -31,7 +31,7 @@ internal class VilkaarsvurderingRiverTest {
         val melding =
             JsonMessage.newMessage(
                 mapOf(
-                    ReguleringHendelseType.VILKAARSVURDER.lagParMedEventNameKey(),
+                    ReguleringHendelseType.BEHANDLING_OPPRETTA.lagParMedEventNameKey(),
                     SAK_ID_KEY to 1,
                     BEHANDLING_ID_KEY to behandlingId,
                     BEHANDLING_VI_OMREGNER_FRA_KEY to behandlingViOmregnerFra,
@@ -46,7 +46,7 @@ internal class VilkaarsvurderingRiverTest {
             )
         }
         with(testRapid.inspektør.message(0)) {
-            Assertions.assertEquals(ReguleringHendelseType.BEREGN.lagEventnameForType(), this[EVENT_NAME_KEY].asText())
+            Assertions.assertEquals(ReguleringHendelseType.VILKAARSVURDERT.lagEventnameForType(), this[EVENT_NAME_KEY].asText())
         }
     }
 }

--- a/jobs/start-regulering/Dockerfile
+++ b/jobs/start-regulering/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java17
+FROM gcr.io/distroless/java21
 ENV TZ="Europe/Oslo"
 WORKDIR /app
 COPY build/libs/*.jar ./

--- a/jobs/start-regulering/src/main/kotlin/Application.kt
+++ b/jobs/start-regulering/src/main/kotlin/Application.kt
@@ -9,10 +9,11 @@ import no.nav.etterlatte.rapidsandrivers.ReguleringHendelseType
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
+import java.time.Month
 import java.util.UUID
 import kotlin.system.exitProcess
 
-val GRUNNBELOEP_REGULERING_DATO: LocalDate = LocalDate.of(2024, 5, 1)
+val GRUNNBELOEP_REGULERING_DATO: LocalDate = LocalDate.of(LocalDate.now().year, Month.MAY, 1)
 
 val logger: Logger = LoggerFactory.getLogger("StartReguleringJob")
 

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/ReguleringHendelseType.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/ReguleringHendelseType.kt
@@ -4,10 +4,10 @@ import no.nav.etterlatte.libs.common.event.EventnameHendelseType
 
 enum class ReguleringHendelseType : EventnameHendelseType {
     FINN_LOEPENDE_YTELSER,
-    OMREGNINGSHENDELSE,
-    VILKAARSVURDER,
-    BEREGN,
-    OPPRETT_VEDTAK,
+    LOEPENDE_YTELSE_FUNNET,
+    BEHANDLING_OPPRETTA,
+    VILKAARSVURDERT,
+    BEREGNA,
     START_REGULERING,
     ;
 

--- a/libs/rapidsandrivers-extras/src/test/kotlin/rapidsandrivers/FeilhaandteringKtTest.kt
+++ b/libs/rapidsandrivers-extras/src/test/kotlin/rapidsandrivers/FeilhaandteringKtTest.kt
@@ -13,7 +13,7 @@ internal class FeilhaandteringKtTest {
     fun `feilhaandtering kaster ikke feilen videre, men publiserer på feilkø`() {
         val packet = JsonMessage("{}", MessageProblems(""))
         val context = mockk<MessageContext>().also { every { it.publish(any()) } returns Unit }
-        withFeilhaandtering(packet, context, ReguleringHendelseType.OPPRETT_VEDTAK.lagEventnameForType()) {
+        withFeilhaandtering(packet, context, ReguleringHendelseType.BEREGNA.lagEventnameForType()) {
             throw RuntimeException()
         }
         verify { context.publish(any()) }
@@ -23,7 +23,7 @@ internal class FeilhaandteringKtTest {
     fun `feilhaandtering gjoer ingenting hvis ingenting feiler`() {
         val packet = JsonMessage("{}", MessageProblems(""))
         val context = mockk<MessageContext>().also { every { it.publish(any()) } returns Unit }
-        withFeilhaandtering(packet, context, ReguleringHendelseType.OPPRETT_VEDTAK.lagEventnameForType()) {
+        withFeilhaandtering(packet, context, ReguleringHendelseType.BEREGNA.lagEventnameForType()) {
         }
         verify(exactly = 0) { context.publish(any()) }
     }


### PR DESCRIPTION
- Unngår å hardkode inn årstal i jobben, trur det er ganske trygt å gå ut frå at den gjeld for inneverande år
- Døper om hendingane til å ha namn om kva som faktisk har skjedd heller enn kva som er tenkt å skje. Det er lettare å resonnere rundt og også meir eintydig
- Oppgraderer imaget til Java 21, som vi bruker overalt elles