### PR TITLE
Bytte til po-pensjon tilgang

### DIFF
--- a/apps/etterlatte-testdata/.nais/dev.yaml
+++ b/apps/etterlatte-testdata/.nais/dev.yaml
@@ -34,7 +34,7 @@ spec:
         groups:
           - id: 650684ff-8107-4ae4-98fc-e18b5cf3188b # etterlatte
           - id: 1a424f32-16a4-4b97-9d77-3e9e781a887e # (DG) NAV Team Etterlatte
-          - id: 07371409-3d05-43df-a87b-d01c0cbc8656 # Utviklere NAV IT
+          - id: 20e720b3-4be7-42ec-aff4-af613f25361b # po-pensjon
         extra:
           - NAVident
     sidecar:


### PR DESCRIPTION
Virker som det er litt kluss med de ulike AD-gruppene og at **type** må være `Exchange` eller `Microsoft 365`. 
Gruppen for utviklere i nav er av type `sikkerhet` og fungerer ikke...? 

Bruker derfor `po-pensjon` i stedet. Gir også litt mer mening siden det er mest aktuelt for pensjonsområdet å bruke løsningen. 