### PR TITLE
Rydder litt i typene for overstyrberegning-route

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/Beregning.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/Beregning.kt
@@ -25,7 +25,7 @@ data class Beregning(
             beregningsperioder = beregningsperioder,
             beregnetDato = beregnetDato,
             grunnlagMetadata = grunnlagMetadata,
-            overstyrBeregning = overstyrBeregning.toDTO(),
+            overstyrBeregning = overstyrBeregning?.toDTO(),
         )
 }
 
@@ -35,4 +35,4 @@ data class OverstyrBeregning(
     val tidspunkt: Tidspunkt,
 )
 
-fun OverstyrBeregning?.toDTO() = this?.let { OverstyrBeregningDTO(it.beskrivelse) }
+fun OverstyrBeregning.toDTO() = OverstyrBeregningDTO(this.beskrivelse)

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRepository.kt
@@ -65,7 +65,7 @@ class BeregningRepository(private val dataSource: DataSource) {
         }
     }
 
-    fun opprettOverstyrBeregning(overstyrBeregning: OverstyrBeregning): OverstyrBeregning? {
+    fun opprettOverstyrBeregning(overstyrBeregning: OverstyrBeregning): OverstyrBeregning {
         dataSource.transaction { tx ->
             queryOf(
                 statement = Queries.opprettOverstyrBeregning,
@@ -80,7 +80,9 @@ class BeregningRepository(private val dataSource: DataSource) {
             }
         }
 
-        return hentOverstyrBeregning(overstyrBeregning.sakId)
+        return checkNotNull(hentOverstyrBeregning(overstyrBeregning.sakId)) {
+            "Vi opprettet en overstyrt beregning akkurat nå men den finnes ikke >:("
+        }
     }
 
     private fun createMapFromBeregningsperiode(

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRoutes.kt
@@ -38,7 +38,7 @@ fun Route.beregning(
             withBehandlingId(behandlingKlient) {
                 logger.info("Henter overstyrBeregning med behandlingId=$it")
 
-                val overstyrBeregning = beregningService.hentOverstyrBeregning(behandlingId, brukerTokenInfo).toDTO()
+                val overstyrBeregning = beregningService.hentOverstyrBeregning(behandlingId, brukerTokenInfo)?.toDTO()
 
                 when (overstyrBeregning) {
                     null -> call.response.status(HttpStatusCode.NoContent)
@@ -58,10 +58,7 @@ fun Route.beregning(
                         brukerTokenInfo,
                     ).toDTO()
 
-                when (overstyrBeregning) {
-                    null -> call.response.status(HttpStatusCode.NoContent)
-                    else -> call.respond(overstyrBeregning)
-                }
+                call.respond(overstyrBeregning)
             }
         }
 

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
@@ -73,7 +73,7 @@ class BeregningService(
         behandlingId: UUID,
         overstyrBeregning: OverstyrBeregningDTO,
         brukerTokenInfo: BrukerTokenInfo,
-    ): OverstyrBeregning? {
+    ): OverstyrBeregning {
         val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
 
         return hentOverstyrBeregning(behandlingId, brukerTokenInfo).takeIf { it != null }


### PR DESCRIPTION
Hvis opprett returnerer null har noe galt skjedd, og vi kaster heller en IllegalStateException i stedet for å returnere null