### PR TITLE
Takle manglande beregningsgrunnlag ved duplisering for overstyrt beregning

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutes.kt
@@ -27,7 +27,7 @@ fun Route.beregningsGrunnlag(
             withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
                 val forrigeBehandlingId = call.uuid("forrigeBehandlingId")
 
-                beregningsGrunnlagService.dupliserBeregningsGrunnlagBP(behandlingId, forrigeBehandlingId)
+                beregningsGrunnlagService.dupliserBeregningsGrunnlagBP(behandlingId, forrigeBehandlingId, brukerTokenInfo)
 
                 call.respond(HttpStatusCode.NoContent)
             }

--- a/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
@@ -34,9 +34,11 @@ class ApplicationContext {
     val behandlingKlient = BehandlingKlientImpl(config, httpClient())
 
     private val beregningsGrunnlagRepository = BeregningsGrunnlagRepository(dataSource)
+    val beregningRepository = BeregningRepository(dataSource)
     val beregningsGrunnlagService =
         BeregningsGrunnlagService(
             beregningsGrunnlagRepository = beregningsGrunnlagRepository,
+            beregningRepository = beregningRepository,
             behandlingKlient = behandlingKlient,
             grunnlagKlient = grunnlagKlient,
         )
@@ -61,7 +63,6 @@ class ApplicationContext {
             grunnlagKlient = grunnlagKlient,
             vilkaarsvurderingKlient = vilkaarsvurderingKlient,
         )
-    val beregningRepository = BeregningRepository(dataSource)
     val beregningService =
         BeregningService(
             beregningRepository = beregningRepository,

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
@@ -17,6 +17,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
+import no.nav.etterlatte.beregning.BeregningRepository
 import no.nav.etterlatte.beregning.regler.toGrunnlag
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.klienter.GrunnlagKlient
@@ -51,8 +52,9 @@ internal class BeregningsGrunnlagRoutesTest {
     private val server = MockOAuth2Server()
     private val behandlingKlient = mockk<BehandlingKlient>()
     private val repository = mockk<BeregningsGrunnlagRepository>()
+    private val beregningRepository = mockk<BeregningRepository>()
     private val grunnlagKlient = mockk<GrunnlagKlient>()
-    private val service = BeregningsGrunnlagService(repository, behandlingKlient, grunnlagKlient)
+    private val service = BeregningsGrunnlagService(repository, beregningRepository, behandlingKlient, grunnlagKlient)
 
     @BeforeAll
     fun before() {

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
@@ -11,6 +11,7 @@ import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.beregning.BeregningRepository
 import no.nav.etterlatte.beregning.regler.toGrunnlag
 import no.nav.etterlatte.klienter.BehandlingKlientImpl
 import no.nav.etterlatte.klienter.GrunnlagKlient
@@ -31,6 +32,7 @@ import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED2_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
@@ -51,10 +53,12 @@ import java.util.UUID.randomUUID
 internal class BeregningsGrunnlagServiceTest {
     private val behandlingKlient = mockk<BehandlingKlientImpl>()
     private val beregningsGrunnlagRepository = mockk<BeregningsGrunnlagRepository>()
+    private val beregningRepository = mockk<BeregningRepository>()
     private val grunnlagKlient = mockk<GrunnlagKlient>()
     private val beregningsGrunnlagService: BeregningsGrunnlagService =
         BeregningsGrunnlagService(
             beregningsGrunnlagRepository,
+            beregningRepository,
             behandlingKlient,
             grunnlagKlient,
         )
@@ -395,7 +399,7 @@ internal class BeregningsGrunnlagServiceTest {
         val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns hentOpplysningsgrunnlag
         runBlocking {
-            beregningsGrunnlagService.dupliserBeregningsGrunnlagBP(omregningsId, behandlingsId)
+            beregningsGrunnlagService.dupliserBeregningsGrunnlagBP(omregningsId, behandlingsId, Systembruker.testdata)
 
             verify(exactly = 1) { beregningsGrunnlagRepository.lagre(any()) }
             verify(exactly = 0) { beregningsGrunnlagRepository.lagreOverstyrBeregningGrunnlagForBehandling(any(), any()) }
@@ -436,7 +440,7 @@ internal class BeregningsGrunnlagServiceTest {
         val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns hentOpplysningsgrunnlag
         runBlocking {
-            beregningsGrunnlagService.dupliserBeregningsGrunnlagBP(omregningsId, behandlingsId)
+            beregningsGrunnlagService.dupliserBeregningsGrunnlagBP(omregningsId, behandlingsId, Systembruker.testdata)
 
             verify(exactly = 1) { beregningsGrunnlagRepository.lagre(any()) }
             verify(exactly = 1) { beregningsGrunnlagRepository.lagreOverstyrBeregningGrunnlagForBehandling(any(), any()) }
@@ -456,7 +460,7 @@ internal class BeregningsGrunnlagServiceTest {
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns hentOpplysningsgrunnlag
         runBlocking {
             assertThrows<RuntimeException> {
-                beregningsGrunnlagService.dupliserBeregningsGrunnlagBP(randomUUID(), behandlingsId)
+                beregningsGrunnlagService.dupliserBeregningsGrunnlagBP(randomUUID(), behandlingsId, Systembruker.testdata)
 
                 verify(exactly = 0) { beregningsGrunnlagRepository.lagre(any()) }
             }
@@ -484,7 +488,7 @@ internal class BeregningsGrunnlagServiceTest {
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns hentOpplysningsgrunnlag
         runBlocking {
             assertThrows<RuntimeException> {
-                beregningsGrunnlagService.dupliserBeregningsGrunnlagBP(omregningsId, behandlingsId)
+                beregningsGrunnlagService.dupliserBeregningsGrunnlagBP(omregningsId, behandlingsId, Systembruker.testdata)
 
                 verify(exactly = 0) { beregningsGrunnlagRepository.lagre(any()) }
             }


### PR DESCRIPTION
Viss vi har manuelt overstyrt beregning, har vi ikkje nødvendigvis eit beregningsgrunnlag inne. Det er forventa, feks ved manuell migrering frå Pesys. Ønskjer derfor ikkje å kræsje viss det manglar og det er sagt at vi overstyrer beregning