### PR TITLE
Sett riktig enhet for oppgave tilknyttet endret sak

### DIFF
--- a/apps/etterlatte-behandling/src/main/resources/db/prod/V103__endre_til_riktig_enhet_oppgave.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/prod/V103__endre_til_riktig_enhet_oppgave.sql
@@ -1,0 +1,1 @@
+UPDATE oppgave SET enhet = '4817' where sak_id = '16013';


### PR DESCRIPTION
Bare saken fikk endret enhet i https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/4230
Og oppgavene ble da følgelig utilgjengelig for 4817 sber.