### PR TITLE
Endret til å ferdigstille jobb uten db-trigger

### DIFF
--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/HendelseRiver.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/HendelseRiver.kt
@@ -62,6 +62,7 @@ class HendelseRiver(
             } else if (steg in listOf("VEDTAK_ATTESTERT", "OPPGAVE_OPPRETTET")) {
                 logger.info("Ferdigstiller hendelse")
                 hendelseDao.oppdaterHendelseStatus(hendelseIdUUID, HendelseStatus.FERDIG)
+                hendelseDao.ferdigstillJobbHvisAlleHendelserErFerdige(hendelseIdUUID)
             }
         }
     }

--- a/apps/etterlatte-tidshendelser/src/main/resources/db/migration/V4__drop_trigger.sql
+++ b/apps/etterlatte-tidshendelser/src/main/resources/db/migration/V4__drop_trigger.sql
@@ -1,0 +1,3 @@
+DROP TRIGGER trig_jobb_ferdig ON hendelse;
+
+DROP FUNCTION ferdigstilljobb();


### PR DESCRIPTION
Kommer [problemer](https://logs.adeo.no/app/r?l=DISCOVER_SINGLE_DOC_LOCATOR&v=8.12.2&lz=N4IglgdgJgpgHiAXCAnANhmgLADgMYAMAtCjgQIZECMVMKROAzBUTFQOwBGnU2nWUTiAA0IAE4B7AO4BJaPCQgANhIDmAZwAu5dQAsi5AA6H1RQ5KhECBdtYBMI8dJlRFAOQkBHIgDUAmlgAQjAAVn4AGlQA6hAoMjIw5I5iMABmMGIpYooA9EaGOVBg6ngSAG4ZAMQ5APwA%2BqoAvAAUmmAAtjCIzamS7YgQ0kR2WLoApHYAYrrCmhID0gCUiwBkdeQtpUoAru0Q6ogAhM1KMBVKwp3q6uSqMMIwEGV4SjrqwvlKYHjkbRIQwkMEigi2EkFgcEQAHJ0JhcIQSGRKDQ6AxmJQ2FweHwBJwocJPNsMgBPbqvCCqba3Lo7PCPe6EknQuB1UqZGCvP4QOpgKCIKDkdKMGBQSypFCCohYTi2IicNBUYh0qDsACsqvI5Ds6HIUOWIAAvkA) med triggeren nå. 

Har prøvd ```SET enable_seqscan=off;``` men det så ut til å fungere bare litt..? Ref [denne posten](https://stackoverflow.com/questions/42288808/why-does-postgresql-serializable-transaction-think-this-as-conflict).

Triggeren kjører i samme transaksjonen som update'n, og mye hassle å få den til _ikke_ å gjøre det hva jeg leser. Så enklere å bare trigge via kode.