### PR TITLE
Vise kilde i behandlingens sidemeny

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/oversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/oversikt.tsx
@@ -105,23 +105,29 @@ export const Oversikt = ({ behandlingsInfo }: { behandlingsInfo: IBehandlingInfo
           )}
         </li>
       </TagList>
-      <div className="info">
-        <Info>Saksbehandler</Info>
-        {mapApiResult(
-          oppgaveForBehandlingenStatus,
-          <Spinner visible={true} label="Henter oppgave" />,
-          () => (
-            <ApiErrorAlert>Kunne ikke hente saksbehandler fra oppgave</ApiErrorAlert>
-          ),
-          (oppgave) =>
-            !!oppgave?.saksbehandler ? (
-              <Tekst>{oppgave.saksbehandler?.navn || oppgave.saksbehandler?.ident}</Tekst>
-            ) : (
-              <Alert size="small" variant="warning">
-                Ingen saksbehandler har tatt denne oppgaven
-              </Alert>
-            )
-        )}
+      <div className="flex">
+        <div className="info">
+          <Info>Saksbehandler</Info>
+          {mapApiResult(
+            oppgaveForBehandlingenStatus,
+            <Spinner visible={true} label="Henter oppgave" />,
+            () => (
+              <ApiErrorAlert>Kunne ikke hente saksbehandler fra oppgave</ApiErrorAlert>
+            ),
+            (oppgave) =>
+              !!oppgave?.saksbehandler ? (
+                <Tekst>{oppgave.saksbehandler?.navn || oppgave.saksbehandler?.ident}</Tekst>
+              ) : (
+                <Alert size="small" variant="warning">
+                  Ingen saksbehandler har tatt denne oppgaven
+                </Alert>
+              )
+          )}
+        </div>
+        <div className="info">
+          <Info>Kilde</Info>
+          <Tekst>{behandlingsInfo.kilde}</Tekst>
+        </div>
       </div>
       <div className="flex">
         <div>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
@@ -50,6 +50,7 @@ const mapTilBehandlingInfo = (behandling: IBehandlingReducer, vedtak: VedtakSamm
   sakEnhetId: behandling.sakEnhetId,
   nasjonalEllerUtland: finnUtNasjonalitet(behandling),
   status: behandling.status,
+  kilde: behandling.kilde,
   behandlendeSaksbehandler: vedtak?.behandlendeSaksbehandler,
   attesterendeSaksbehandler: vedtak?.attesterendeSaksbehandler,
   virkningsdato: behandling.virkningstidspunkt?.dato,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/IBehandlingInfo.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/IBehandlingInfo.ts
@@ -9,6 +9,7 @@ export interface IBehandlingInfo {
   sakType: SakType
   sakEnhetId: string
   status: IBehandlingStatus
+  kilde: string
   behandlendeSaksbehandler?: string
   attesterendeSaksbehandler?: string
   virkningsdato?: string

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/IBehandlingInfo.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/IBehandlingInfo.ts
@@ -1,4 +1,9 @@
-import { IBehandlingStatus, IBehandlingsType, UtlandstilknytningType } from '~shared/types/IDetaljertBehandling'
+import {
+  IBehandlingStatus,
+  IBehandlingsType,
+  UtlandstilknytningType,
+  Vedtaksloesning,
+} from '~shared/types/IDetaljertBehandling'
 import { IHendelse } from '~shared/types/IHendelse'
 import { SakType } from '~shared/types/sak'
 
@@ -9,7 +14,7 @@ export interface IBehandlingInfo {
   sakType: SakType
   sakEnhetId: string
   status: IBehandlingStatus
-  kilde: string
+  kilde: Vedtaksloesning
   behandlendeSaksbehandler?: string
   attesterendeSaksbehandler?: string
   virkningsdato?: string


### PR DESCRIPTION
Konteksten her er aldersoverganger, mer spesifikt at det må være en måte for saksbehandlere å kunne se at vedkommende har fått med seg yrkesskadefordel pre-01.01.2024, dvs migrert. Da er opphør ved 21 år, ikke 20 år.

Avklart med Mari.

En oppfølger er å vise mer spesifikk informasjon om yrkesskaden på saksoversikten, men det er litt mer jobb så tar denne først da aldersoverganger kjøres for en god bestand i morgen (20. mars). 

![image](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/8087437/fa333798-cc5f-4627-a4c8-7830e054526b)
