### PR TITLE
EY-3721: Feiler litt penere når backend ikke sender med errorinfo som JSON-objekt

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/apiClient.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/apiClient.ts
@@ -91,7 +91,8 @@ async function apiFetcher<T>(props: Options): Promise<ApiResponse<T>> {
         return { status: 401, ok: false, detail: 'Du er utlogget, last på siden på nytt.' }
       }
 
-      const error: JsonError = await response.json()
+      const error: JsonError = await errorFrom(response)
+
       if (response.status >= 500) {
         if (shouldLogError) {
           logger.generalError({
@@ -127,6 +128,15 @@ async function apiFetcher<T>(props: Options): Promise<ApiResponse<T>> {
         cause: e,
       },
     }
+  }
+}
+
+async function errorFrom(response: Response): Promise<JsonError> {
+  try {
+    return await response.json()
+  } catch (err) {
+    logger.generalError({ msg: 'Feilet ved henting av JSON-error fra backend', errorInfo: response.text() })
+    return { status: response.status, detail: 'Fikk feil i kall mot backend' }
   }
 }
 


### PR DESCRIPTION
Her er det kanskje mer å rydde opp i, men dette er da noe. Uten denne fiksen så viser vi "fikk en feil i parsing av data / rejection i fetch. Feilen ligger i meta' i GUI når vi får 503 :)

Sett i klagebehandling hvor vi skal hente dokumenter for sidemenyen og får 503.