### PR TITLE
Vise info om at søker har yrkesskadefordel fra før reformtidspunktet

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingResource.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingResource.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.behandling
 
+import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.BoddEllerArbeidetUtlandet
@@ -25,4 +26,5 @@ data class BehandlingSammendrag(
     val aarsak: String?,
     val virkningstidspunkt: Virkningstidspunkt?,
     val boddEllerArbeidetUtlandet: BoddEllerArbeidetUtlandet?,
+    val kilde: Vedtaksloesning,
 )

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
@@ -262,4 +262,5 @@ fun Behandling.toBehandlingSammendrag() =
             },
         virkningstidspunkt = this.virkningstidspunkt,
         boddEllerArbeidetUtlandet = this.boddEllerArbeidetUtlandet,
+        kilde = this.kilde,
     )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/SakOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/SakOversikt.tsx
@@ -8,7 +8,7 @@ import { formaterEnumTilLesbarString, formaterSakstype, formaterStringDato } fro
 import { KlageListe } from '~components/person/KlageListe'
 import { tagColors } from '~shared/Tags'
 import { SakMedBehandlinger } from '~components/person/typer'
-import { isSuccess, mapApiResult, Result } from '~shared/api/apiUtils'
+import { isSuccess, mapApiResult, mapResult, Result } from '~shared/api/apiUtils'
 import React, { useEffect } from 'react'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { EndreEnhet } from '~components/person/EndreEnhet'
@@ -93,19 +93,20 @@ export const SakOversikt = ({ sakStatus, fnr }: { sakStatus: Result<SakMedBehand
                 apiResult: hentFlyktningStatus,
                 errorMessage: 'Klarte ikke hente informasjon om flyktningstatus',
               })}
-              {isSuccess(yrkesskadefordelStatus) && yrkesskadefordelStatus.data && (
-                <>
-                  <FlexRow>
-                    <Alert variant="info">
-                      Søker har yrkesskadefordel fra før 01.01.2024 og har rett til stønad til fylte 21 år.
-                    </Alert>
-                  </FlexRow>
-                  <hr />
-                </>
-              )}
-              {isFailureHandler({
-                apiResult: yrkesskadefordelStatus,
-                errorMessage: 'Klarte ikke hente informasjon om yrkesskadefordel',
+              {mapResult(yrkesskadefordelStatus, {
+                success: (data) =>
+                  data && (
+                    <>
+                      <FlexRow>
+                        <Alert variant="info">
+                          Søker har yrkesskadefordel fra før 01.01.2024 og har rett til stønad til fylte 21 år.
+                        </Alert>
+                      </FlexRow>
+                      <hr />
+                    </>
+                  ),
+                pending: <Spinner visible={true} label="Henter status yrkesskadefordel" />,
+                error: () => <ApiErrorAlert>Klarte ikke hente informasjon om yrkesskadefordel</ApiErrorAlert>,
               })}
               {mapApiResult(
                 hentNavkontorStatus,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/SakOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/SakOversikt.tsx
@@ -94,8 +94,8 @@ export const SakOversikt = ({ sakStatus, fnr }: { sakStatus: Result<SakMedBehand
                 errorMessage: 'Klarte ikke hente informasjon om flyktningstatus',
               })}
               {mapResult(yrkesskadefordelStatus, {
-                success: (data) =>
-                  data && (
+                success: (harYrkesskadeFordel) =>
+                  harYrkesskadeFordel && (
                     <>
                       <FlexRow>
                         <Alert variant="info">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/typer.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/typer.tsx
@@ -2,6 +2,7 @@ import {
   IBehandlingStatus,
   IBehandlingsType,
   IBoddEllerArbeidetUtlandet,
+  Vedtaksloesning,
   Virkningstidspunkt,
 } from '~shared/types/IDetaljertBehandling'
 import { Revurderingaarsak } from '~shared/types/Revurderingaarsak'
@@ -32,6 +33,7 @@ export interface IBehandlingsammendrag {
   aarsak: BehandlingOgRevurderingsAarsakerType
   virkningstidspunkt?: Virkningstidspunkt
   boddEllerArbeidetUtlandet?: IBoddEllerArbeidetUtlandet
+  kilde: Vedtaksloesning
 }
 
 export enum AarsaksTyper {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vilkaarsvurdering.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vilkaarsvurdering.ts
@@ -43,6 +43,9 @@ export const lagreTotalVurdering = async (args: {
 export const oppdaterStatus = async (behandlingId: string): Promise<ApiResponse<StatusOppdatert>> =>
   apiClient.post(`/vilkaarsvurdering/${behandlingId}/oppdater-status`, {})
 
+export const hentMigrertYrkesskadeFordel = async (behandlingId: string): Promise<ApiResponse<Boolean>> =>
+  apiClient.get(`/vilkaarsvurdering/${behandlingId}/migrert-yrkesskadefordel`)
+
 export interface StatusOppdatert {
   statusOppdatert: boolean
 }


### PR DESCRIPTION
Så saksbehandler får grei input om at ytelsen da varer til vedkommende fyller 21 år, ikke 20.
- Dette er ønsket av Mari, slik at man også kan skjønne eventuelle automatiserte aldersoverganger.
- Benytter samme stil som melding om at søker er markert som flyktning

![image](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/8087437/5a61ced5-3905-4d2a-a021-26a220c35237)
