### PR TITLE
Vise PDF-toolbar på brevoversikten

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/ForhaandsvisningBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/ForhaandsvisningBrev.tsx
@@ -33,7 +33,7 @@ export default function ForhaandsvisningBrev({ brev }: { brev: IBrev }) {
   return (
     <Container>
       {isPendingOrInitial(pdf) && <Spinner visible={true} label="Klargjør forhåndsvisning av PDF ..." />}
-      {isSuccess(pdf) && !!fileURL && <PdfViewer src={`${fileURL}#toolbar=0`} />}
+      {isSuccess(pdf) && !!fileURL && <PdfViewer src={`${fileURL}`} />}
       {isFailureHandler({
         apiResult: pdf,
         errorMessage: 'En feil har oppstått ved henting av PDF',


### PR DESCRIPTION
Gjør det lettere for sb å laste ned eller printe brevet i tilfeller hvor noe stopper opp hos oss. 

![Screenshot 2024-03-20 at 08 40 27](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/85ff50eb-f107-4624-92f8-4f249d13afb9)
