### PR TITLE
Lagrer hele søknaden-json som en opplysningstype

### DIFF
--- a/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/no/nav/etterlatte/opplysningerfrasoknad/opplysningsuthenter/BarnepensjonUthenter.kt
+++ b/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/no/nav/etterlatte/opplysningerfrasoknad/opplysningsuthenter/BarnepensjonUthenter.kt
@@ -106,7 +106,19 @@ internal object BarnepensjonUthenter {
                 spraak(barnepensjonssoknad, Opplysningstype.SPRAAK),
                 soeknadMottattDato(barnepensjonssoknad, Opplysningstype.SOEKNAD_MOTTATT_DATO),
                 soeknadsType(barnepensjonssoknad, Opplysningstype.SOEKNADSTYPE_V1),
+                soeknad(barnepensjonssoknad, Opplysningstype.SOEKNAD_BP),
             )
+    }
+
+    private fun soeknad(
+        barnepensjon: Barnepensjon,
+        opplysningsType: Opplysningstype,
+    ): Grunnlagsopplysning<out Barnepensjon> {
+        return setBehandlingsopplysninger(
+            barnepensjon,
+            opplysningsType,
+            barnepensjon,
+        )
     }
 
     private fun <T> setBehandlingsopplysninger(

--- a/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/no/nav/etterlatte/opplysningerfrasoknad/opplysningsuthenter/OmstillingsstoenadUthenter.kt
+++ b/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/no/nav/etterlatte/opplysningerfrasoknad/opplysningsuthenter/OmstillingsstoenadUthenter.kt
@@ -31,6 +31,7 @@ internal object OmstillingsstoenadUthenter {
             spraak(omstillingsstoenad),
             soeknadMottattDato(omstillingsstoenad),
             soeknadsType(omstillingsstoenad),
+            soeknad(omstillingsstoenad),
         )
     }
 
@@ -40,6 +41,10 @@ internal object OmstillingsstoenadUthenter {
                 mottattDato = soknad.mottattDato,
             )
         return lagOpplysning(Opplysningstype.SOEKNAD_MOTTATT_DATO, kilde(soknad), opplysning, null)
+    }
+
+    private fun soeknad(soknad: Omstillingsstoenad): Grunnlagsopplysning<Omstillingsstoenad> {
+        return lagOpplysning(Opplysningstype.SOEKNAD_OMS, kilde(soknad), soknad, null)
     }
 
     private fun kilde(soknad: Omstillingsstoenad): Grunnlagsopplysning.Kilde {

--- a/libs/saksbehandling-common/src/main/kotlin/grunnlag/opplysningstyper/Opplysningstype.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/grunnlag/opplysningstyper/Opplysningstype.kt
@@ -50,4 +50,8 @@ enum class Opplysningstype {
     VERGES_ADRESSE,
     FORELDRELOES,
     UFOERE,
+
+    // opplysningstyper for søknaden BP / OMS
+    SOEKNAD_OMS,
+    SOEKNAD_BP,
 }


### PR DESCRIPTION
Motivasjonen er å unngå at vi mister strukturerte data på hva søker har angitt i søknaden. Det er elementer som vi ikke har tatt vare på i dagens uthenting, og nå er kun tilgjengelig i pdf-format. (svar på brukers situasjon for OMS f.eks., men det er potensielt flere)

Legger ikke i utgangspunktet opp til noen versjonering av json-clob'en, som gjør denne opplysningen litt pain å jobbe med over tid. åpen for innspill på hvordan vi lagre det ned bærekraftig.