### PR TITLE
Restrukturert oppdatering av status på hendelser 

### DIFF
--- a/apps/etterlatte-tidshendelser/.nais/dev.yaml
+++ b/apps/etterlatte-tidshendelser/.nais/dev.yaml
@@ -49,7 +49,7 @@ spec:
     - name: JOBB_POLLER_INITIAL_DELAY
       value: "60"
     - name: JOBB_POLLER_INTERVAL
-      value: "PT30S"
+      value: "PT2M"
     - name: JOBB_POLLER_OPENING_HOURS
       value: "06-23"
     - name: HENDELSE_POLLER_INITIAL_DELAY

--- a/apps/etterlatte-tidshendelser/.nais/prod.yaml
+++ b/apps/etterlatte-tidshendelser/.nais/prod.yaml
@@ -64,7 +64,7 @@ spec:
     - name: JOBB_POLLER_INITIAL_DELAY
       value: "60"
     - name: JOBB_POLLER_INTERVAL
-      value: "PT30S"
+      value: "PT5M"
     - name: JOBB_POLLER_OPENING_HOURS
       value: "09-15"
     - name: HENDELSE_POLLER_INITIAL_DELAY

--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/HendelseDao.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/HendelseDao.kt
@@ -229,11 +229,14 @@ class HendelseDao(private val datasource: DataSource) : Transactions<HendelseDao
             queryOf(
                 """
                 SELECT * FROM hendelse 
-                WHERE status = :status 
+                WHERE (
+                    status = 'NY' OR (
+                        status = 'FEILET' AND versjon < 3
+                    )
+                )
                 ORDER BY opprettet asc
                 LIMIT $limit
                 """.trimIndent(),
-                mapOf("status" to "NY"),
             )
                 .let { query -> it.run(query.map { row -> row.toHendelse() }.asList) }
         }

--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/HendelsePoller.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/HendelsePoller.kt
@@ -60,9 +60,14 @@ class HendelsePoller(
 
                 logger.info(markers, "Behandler hendelse: [id=${it.id}, sakId=${it.sakId}]")
 
-                hendelsePublisher.publish(hendelse = it, jobb = jobsById[it.jobbId]!!)
-
                 hendelseDao.oppdaterHendelseStatus(it.id, HendelseStatus.SENDT)
+
+                try {
+                    hendelsePublisher.publish(hendelse = it, jobb = jobsById[it.jobbId]!!)
+                } catch (e: Exception) {
+                    logger.error(markers, "Feil ved publisering av hendelse", e)
+                    hendelseDao.oppdaterHendelseStatus(it.id, HendelseStatus.FEILET)
+                }
             }
         }
     }

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/DatabaseExtension.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/DatabaseExtension.kt
@@ -2,12 +2,17 @@ package no.nav.etterlatte.tidshendelser
 
 import no.nav.etterlatte.GenerellDatabaseExtension
 import no.nav.etterlatte.ResetDatabaseStatement
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
 
 @ResetDatabaseStatement(
     """
     TRUNCATE hendelse CASCADE;
     TRUNCATE jobb CASCADE;
-    ALTER SEQUENCE jobb_id_seq RESTART WITH 1;
 """,
 )
-class DatabaseExtension : GenerellDatabaseExtension()
+class DatabaseExtension : GenerellDatabaseExtension(), AfterEachCallback {
+    override fun afterEach(context: ExtensionContext) {
+        resetDb()
+    }
+}


### PR DESCRIPTION
Dette er ifb med [denne situasjonen](https://nav-it.slack.com/archives/C043C5ZGW5T/p1710923126770249).

Antagelsen er at utsendingen av eventen og påfølgende oppdateringer av raden (via river) kommer så kjapt at statusoppdateringen går i beina på den. Restrukturert for å unngå dette.

I tillegg lagt på at man forsøker å re-sende hendelsen dersom den har feilet, men først i senere `poll()`