### PR TITLE
EY-3731: Cache resultatet av tilgangssjekk i 1 min

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -36,7 +36,6 @@ import no.nav.etterlatte.brev.hentinformasjon.BeregningKlient
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.hentinformasjon.GrunnlagKlient
 import no.nav.etterlatte.brev.hentinformasjon.SakService
-import no.nav.etterlatte.brev.hentinformasjon.Tilgangssjekker
 import no.nav.etterlatte.brev.hentinformasjon.TrygdetidKlient
 import no.nav.etterlatte.brev.hentinformasjon.TrygdetidService
 import no.nav.etterlatte.brev.hentinformasjon.VedtaksvurderingKlient
@@ -66,6 +65,7 @@ import no.nav.etterlatte.libs.ktor.httpClient
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 import no.nav.etterlatte.libs.ktor.ktor.clientCredential
 import no.nav.etterlatte.libs.ktor.restModule
+import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.etterlatte.libs.ktor.setReady
 import no.nav.etterlatte.rapidsandrivers.BEHANDLING_ID_KEY
 import no.nav.etterlatte.rapidsandrivers.getRapidEnv

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
@@ -14,7 +14,6 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.util.pipeline.PipelineContext
 import no.nav.etterlatte.brev.distribusjon.Brevdistribuerer
-import no.nav.etterlatte.brev.hentinformasjon.Tilgangssjekker
 import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
 import no.nav.etterlatte.brev.model.ManueltBrevData
 import no.nav.etterlatte.brev.model.Mottaker
@@ -24,6 +23,7 @@ import no.nav.etterlatte.libs.common.brev.BestillingsIdDto
 import no.nav.etterlatte.libs.common.brev.JournalpostIdDto
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.SAKID_CALL_PARAMETER
+import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.etterlatte.libs.ktor.route.withSakId
 import org.slf4j.LoggerFactory
 import kotlin.time.DurationUnit

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/NotatRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/NotatRoute.kt
@@ -8,7 +8,6 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
-import no.nav.etterlatte.brev.hentinformasjon.Tilgangssjekker
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.behandling.BrevbakerBlankettDTO
 import no.nav.etterlatte.libs.common.behandling.Klage
@@ -16,6 +15,7 @@ import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselExceptio
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.SAKID_CALL_PARAMETER
+import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.etterlatte.libs.ktor.route.medBody
 import no.nav.etterlatte.libs.ktor.route.withSakId
 import org.slf4j.LoggerFactory

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevRoute.kt
@@ -10,9 +10,9 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.put
 import io.ktor.server.routing.route
-import no.nav.etterlatte.brev.hentinformasjon.Tilgangssjekker
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.etterlatte.libs.ktor.route.behandlingId
 import no.nav.etterlatte.libs.ktor.route.sakId
 import no.nav.etterlatte.libs.ktor.route.withBehandlingId

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/DokumentRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/DokumentRoute.kt
@@ -14,9 +14,9 @@ import io.ktor.util.pipeline.PipelineContext
 import no.nav.etterlatte.brev.dokarkiv.DokarkivService
 import no.nav.etterlatte.brev.dokarkiv.KnyttTilAnnenSakRequest
 import no.nav.etterlatte.brev.dokarkiv.OppdaterJournalpostRequest
-import no.nav.etterlatte.brev.hentinformasjon.Tilgangssjekker
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
+import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 
 fun Route.dokumentRoute(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevRoute.kt
@@ -10,10 +10,10 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.brev.BREV_ID_CALL_PARAMETER
 import no.nav.etterlatte.brev.brevId
-import no.nav.etterlatte.brev.hentinformasjon.Tilgangssjekker
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.etterlatte.libs.ktor.route.withBehandlingId
 import no.nav.etterlatte.libs.ktor.route.withSakId
 import org.slf4j.LoggerFactory

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevRoute.kt
@@ -8,9 +8,9 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.brev.BREV_ID_CALL_PARAMETER
-import no.nav.etterlatte.brev.hentinformasjon.Tilgangssjekker
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.etterlatte.libs.ktor.route.behandlingId
 import no.nav.etterlatte.libs.ktor.route.sakId
 import no.nav.etterlatte.libs.ktor.route.withBehandlingId

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
@@ -21,7 +21,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.etterlatte.brev.BrevService.BrevPayload
 import no.nav.etterlatte.brev.distribusjon.Brevdistribuerer
-import no.nav.etterlatte.brev.hentinformasjon.Tilgangssjekker
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevID
@@ -34,6 +33,7 @@ import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.ktor.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.runServer
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/OversendelsesbrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/OversendelsesbrevRouteTest.kt
@@ -17,7 +17,6 @@ import io.mockk.coVerify
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
-import no.nav.etterlatte.brev.hentinformasjon.Tilgangssjekker
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
@@ -29,6 +28,7 @@ import no.nav.etterlatte.brev.oversendelsebrev.oversendelseBrevRoute
 import no.nav.etterlatte.ktor.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.runServer
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
@@ -20,7 +20,6 @@ import io.mockk.coVerify
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
-import no.nav.etterlatte.brev.hentinformasjon.Tilgangssjekker
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevProsessType
@@ -31,6 +30,7 @@ import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.ktor.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.runServer
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokument/DokumentRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokument/DokumentRouteTest.kt
@@ -12,9 +12,9 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.etterlatte.brev.dokarkiv.DokarkivService
-import no.nav.etterlatte.brev.hentinformasjon.Tilgangssjekker
 import no.nav.etterlatte.ktor.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/klienter/BehandlingKlient.kt
@@ -21,6 +21,7 @@ import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
 import no.nav.etterlatte.libs.ktor.route.BehandlingTilgangsSjekk
 import no.nav.etterlatte.libs.ktor.route.SakTilgangsSjekk
+import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
@@ -111,6 +112,8 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
 
     private val clientId = config.getString("behandling.client.id")
     private val resourceUrl = config.getString("behandling.resource.url")
+
+    private val tilgangssjekker = Tilgangssjekker(config, httpClient)
 
     override suspend fun hentBehandling(
         behandlingId: UUID,
@@ -365,49 +368,13 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
         behandlingId: UUID,
         skrivetilgang: Boolean,
         bruker: Saksbehandler,
-    ): Boolean {
-        try {
-            return downstreamResourceClient
-                .get(
-                    resource =
-                        Resource(
-                            clientId = clientId,
-                            url = "$resourceUrl/tilgang/behandling/$behandlingId?skrivetilgang=$skrivetilgang",
-                        ),
-                    brukerTokenInfo = bruker,
-                )
-                .mapBoth(
-                    success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },
-                    failure = { throwableErrorMessage -> throw throwableErrorMessage },
-                )
-        } catch (e: Exception) {
-            throw BehandlingKlientException("Sjekking av tilgang for behandling feilet", e)
-        }
-    }
+    ): Boolean = tilgangssjekker.harTilgangTilBehandling(behandlingId, skrivetilgang, bruker)
 
     override suspend fun harTilgangTilSak(
         sakId: Long,
         skrivetilgang: Boolean,
         bruker: Saksbehandler,
-    ): Boolean {
-        try {
-            return downstreamResourceClient
-                .get(
-                    resource =
-                        Resource(
-                            clientId = clientId,
-                            url = "$resourceUrl/tilgang/sak/$sakId?skrivetilgang=$skrivetilgang",
-                        ),
-                    brukerTokenInfo = bruker,
-                )
-                .mapBoth(
-                    success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },
-                    failure = { throwableErrorMessage -> throw throwableErrorMessage },
-                )
-        } catch (e: Exception) {
-            throw BehandlingKlientException("Sjekking av tilgang for sak feilet", e)
-        }
-    }
+    ): Boolean = tilgangssjekker.harTilgangTilSak(sakId, skrivetilgang, bruker)
 
     private suspend fun statussjekkForBehandling(
         behandlingId: UUID,

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/klienter/BehandlingKlient.kt
@@ -15,6 +15,7 @@ import no.nav.etterlatte.libs.ktor.ktor.ktorobo.AzureAdClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
 import no.nav.etterlatte.libs.ktor.route.BehandlingTilgangsSjekk
+import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import org.slf4j.LoggerFactory
@@ -58,6 +59,8 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
 
     private val clientId = config.getString("behandling.client.id")
     private val resourceUrl = config.getString("behandling.resource.url")
+
+    private val tilgangssjekker = Tilgangssjekker(config, httpClient)
 
     override suspend fun hentBehandling(
         behandlingId: UUID,
@@ -189,23 +192,5 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
         behandlingId: UUID,
         skrivetilgang: Boolean,
         bruker: Saksbehandler,
-    ): Boolean {
-        try {
-            return downstreamResourceClient
-                .get(
-                    resource =
-                        Resource(
-                            clientId = clientId,
-                            url = "$resourceUrl/tilgang/behandling/$behandlingId?skrivetilgang=$skrivetilgang",
-                        ),
-                    brukerTokenInfo = bruker,
-                )
-                .mapBoth(
-                    success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },
-                    failure = { throwableErrorMessage -> throw throwableErrorMessage },
-                )
-        } catch (e: Exception) {
-            throw BehandlingKlientException("Sjekking av tilgang for behandling feilet", e)
-        }
-    }
+    ): Boolean = tilgangssjekker.harTilgangTilBehandling(behandlingId, skrivetilgang, bruker)
 }

--- a/libs/etterlatte-ktor/src/main/kotlin/route/Tilgangssjekker.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/route/Tilgangssjekker.kt
@@ -1,4 +1,4 @@
-package no.nav.etterlatte.brev.hentinformasjon
+package no.nav.etterlatte.libs.ktor.route
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.github.michaelbull.result.mapBoth
@@ -10,9 +10,6 @@ import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.AzureAdClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
-import no.nav.etterlatte.libs.ktor.route.BehandlingTilgangsSjekk
-import no.nav.etterlatte.libs.ktor.route.PersonTilgangsSjekk
-import no.nav.etterlatte.libs.ktor.route.SakTilgangsSjekk
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import java.util.UUID
 

--- a/libs/etterlatte-ktor/src/main/kotlin/route/Tilgangssjekker.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/route/Tilgangssjekker.kt
@@ -29,6 +29,7 @@ class Tilgangssjekker(
         bruker: Saksbehandler,
     ): Boolean {
         try {
+            logger.info("Sjekker tilgang til behandling $behandlingId")
             return downstreamResourceClient
                 .get(
                     resource =

--- a/libs/etterlatte-ktor/src/main/kotlin/route/Tilgangssjekker.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/route/Tilgangssjekker.kt
@@ -11,7 +11,6 @@ import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.AzureAdClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
-import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import java.time.Duration
 import java.util.UUID
@@ -36,13 +35,15 @@ class Tilgangssjekker(
         skrivetilgang: Boolean,
         bruker: Saksbehandler,
     ): Boolean {
-        val tilgangsrequest = Tilgangsrequest(behandlingId, skrivetilgang, bruker)
+        val tilgangsrequest = Tilgangsrequest(behandlingId, skrivetilgang, bruker.ident)
         val fraCache = tilgangscache.getIfPresent(tilgangsrequest)
         if (fraCache != null) {
+            logger.debug("Cache hit for behandling")
             return fraCache
         }
+        logger.debug("Cache miss for behandling")
         try {
-            logger.info("Sjekker tilgang til behandling $behandlingId")
+            logger.debug("Sjekker tilgang til behandling {}", behandlingId)
             return downstreamResourceClient
                 .get(
                     resource =
@@ -69,11 +70,13 @@ class Tilgangssjekker(
         skrivetilgang: Boolean,
         bruker: Saksbehandler,
     ): Boolean {
-        val tilgangsrequest = Tilgangsrequest(foedselsnummer, skrivetilgang, bruker)
+        val tilgangsrequest = Tilgangsrequest(foedselsnummer, skrivetilgang, bruker.ident)
         val fraCache = tilgangscache.getIfPresent(tilgangsrequest)
         if (fraCache != null) {
+            logger.debug("Cache hit for person")
             return fraCache
         }
+        logger.debug("Cache miss for person")
         try {
             return downstreamResourceClient
                 .post(
@@ -102,11 +105,13 @@ class Tilgangssjekker(
         skrivetilgang: Boolean,
         bruker: Saksbehandler,
     ): Boolean {
-        val tilgangsrequest = Tilgangsrequest(sakId, skrivetilgang, bruker)
+        val tilgangsrequest = Tilgangsrequest(sakId, skrivetilgang, bruker.ident)
         val fraCache = tilgangscache.getIfPresent(tilgangsrequest)
         if (fraCache != null) {
+            logger.debug("Cache hit for sak")
             return fraCache
         }
+        logger.debug("Cache miss for sak")
         try {
             return downstreamResourceClient
                 .get(
@@ -136,5 +141,5 @@ class TilgangssjekkException(override val message: String, override val cause: T
 data class Tilgangsrequest(
     val id: Any,
     val skrivetilgang: Boolean,
-    val bruker: BrukerTokenInfo,
+    val bruker: String,
 )


### PR DESCRIPTION
To første commits er å skrive om til å bruke samme tilgangssjekker-klasse overalt, siste commit er faktisk endring.