### PR TITLE
EY-3550 Gå bort ifra jsonb før/etter oppgave

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveEndring.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveEndring.kt
@@ -1,13 +1,29 @@
 package no.nav.etterlatte.oppgave
 
-import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
+import no.nav.etterlatte.libs.common.oppgave.Status
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.util.UUID
 
 data class OppgaveEndring(
     val id: UUID,
     val oppgaveId: UUID,
-    val oppgaveFoer: OppgaveIntern,
-    val oppgaveEtter: OppgaveIntern,
     val tidspunkt: Tidspunkt,
+    val saksbehandler: String?,
+    val status: Status,
+    val merknad: String?,
+    val enhet: String?,
+    val kilde: String?,
+    val type: EndringType,
 )
+
+enum class EndringType {
+    OPPRETTET_OPPGAVE,
+    ENDRET_TILDELING,
+    FJERN_TILDELING,
+    ENDRET_STATUS,
+    ENDRET_STATUS_OG_MERKNAD,
+    ENDRET_ENHET,
+    ENDRET_FRIST,
+    ENDRET_MERKNAD,
+    ENDRET_KILDE,
+}

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V105__oppdatere_oppgaveendringer.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V105__oppdatere_oppgaveendringer.sql
@@ -1,0 +1,52 @@
+
+-- Opprette kolonner i stedet
+ALTER TABLE oppgaveendringer
+    ADD COLUMN saksbehandler TEXT,
+    ADD COLUMN status        TEXT,
+    ADD COLUMN merknad       TEXT,
+    ADD COLUMN frist         TEXT,
+    ADD COLUMN enhet         TEXT,
+    ADD COLUMN kilde         TEXT,
+    ADD COLUMN type          TEXT;
+
+
+UPDATE oppgaveendringer
+SET saksbehandler = to_json(oppgaveetter) #>> '{saksbehandler}',
+    status        = to_json(oppgaveetter) #>> '{status}',
+    merknad       = to_json(oppgaveetter) #>> '{merknad}',
+    frist         = to_json(oppgaveetter) #>> '{frist}',
+    enhet         = to_json(oppgaveetter) #>> '{enhet}',
+    kilde         = to_json(oppgaveetter) #>> '{kilde}',
+    type          = CASE
+                        WHEN oppgavefoer::JSONB ->> 'saksbehandler' IS NOT NULL AND
+                             oppgaveetter::JSONB ->> 'saksbehandler' IS NULL
+                            THEN 'FJERN_TILDELING'
+                        WHEN oppgavefoer::JSONB ->> 'saksbehandler' IS DISTINCT FROM oppgaveetter::JSONB ->> 'saksbehandler'
+                            THEN 'ENDRE_TILDELING'
+                        WHEN oppgavefoer::JSONB ->> 'status' IS DISTINCT FROM oppgaveetter::JSONB ->> 'status'
+                            AND oppgavefoer::JSONB ->> 'merknad' IS DISTINCT FROM oppgaveetter::JSONB ->> 'merknad'
+                            THEN 'ENDRET_STATUS_OG_MERKNAD'
+                        WHEN oppgavefoer::JSONB ->> 'status' IS DISTINCT FROM oppgaveetter::JSONB ->> 'status'
+                            THEN 'ENDRET_STATUS'
+                        WHEN oppgavefoer::JSONB ->> 'merknad' IS DISTINCT FROM oppgaveetter::JSONB ->> 'merknad'
+                            THEN 'ENDRET_MERKNAD'
+                        WHEN oppgavefoer::JSONB ->> 'merknad' IS DISTINCT FROM oppgaveetter::JSONB ->> 'merknad'
+                            THEN 'ENDRET_MERKNAD'
+                        WHEN oppgavefoer::JSONB ->> 'frist' IS DISTINCT FROM oppgaveetter::JSONB ->> 'frist'
+                            THEN 'ENDRET_FRIST'
+                        WHEN oppgavefoer::JSONB ->> 'enhet' IS DISTINCT FROM oppgaveetter::JSONB ->> 'enhet'
+                            THEN 'ENDRET_ENHET'
+                        WHEN oppgavefoer::JSONB ->> 'kilde' IS DISTINCT FROM oppgaveetter::JSONB ->> 'kilde'
+                            THEN 'ENDRET_KILDE'
+                        ELSE
+                            null
+        END
+;
+
+UPDATE oppgaveendringer
+SET saksbehandler = to_json(saksbehandler::JSONB) #>> '{ident}'
+WHERE saksbehandler LIKE '{%}';
+
+ALTER TABLE oppgaveendringer
+    DROP COLUMN oppgavefoer,
+    DROP COLUMN oppgaveetter;

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -38,6 +38,7 @@ import no.nav.security.token.support.core.jwt.JwtTokenClaims
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -407,7 +408,7 @@ internal class OppgaveServiceTest(val dataSource: DataSource) {
         oppgaveService.fjernSaksbehandler(nyOppgave.id)
         val oppgaveUtenSaksbehandler = oppgaveService.hentOppgave(nyOppgave.id)
         Assertions.assertNotNull(oppgaveUtenSaksbehandler?.id)
-        Assertions.assertNull(oppgaveUtenSaksbehandler?.saksbehandler)
+        assertNull(oppgaveUtenSaksbehandler?.saksbehandler)
         assertEquals(Status.NY, oppgaveUtenSaksbehandler?.status)
     }
 
@@ -841,12 +842,17 @@ internal class OppgaveServiceTest(val dataSource: DataSource) {
         assertEquals(nysaksbehandler, oppgaveMedNySaksbehandler?.saksbehandler?.ident)
 
         val hentEndringerForOppgave = oppgaveDaoMedEndringssporing.hentEndringerForOppgave(nyOppgave.id)
-        assertEquals(1, hentEndringerForOppgave.size)
-        val endringPaaOppgave = hentEndringerForOppgave[0]
-        Assertions.assertNull(endringPaaOppgave.oppgaveFoer.saksbehandler)
-        assertEquals("nysaksbehandler", endringPaaOppgave.oppgaveEtter.saksbehandler?.ident)
-        assertEquals(Status.NY, endringPaaOppgave.oppgaveFoer.status)
-        assertEquals(Status.UNDER_BEHANDLING, endringPaaOppgave.oppgaveEtter.status)
+        assertEquals(2, hentEndringerForOppgave.size)
+
+        val oppgaveOpprettetEndring = hentEndringerForOppgave[0]
+        assertNull(oppgaveOpprettetEndring.saksbehandler)
+        assertEquals(Status.NY, oppgaveOpprettetEndring.status)
+        assertEquals(EndringType.OPPRETTET_OPPGAVE, oppgaveOpprettetEndring.type)
+
+        val oppgaveTildeltEndring = hentEndringerForOppgave[1]
+        assertEquals(Status.UNDER_BEHANDLING, oppgaveTildeltEndring.status)
+        assertEquals(nysaksbehandler, oppgaveTildeltEndring.saksbehandler)
+        assertEquals(EndringType.ENDRET_TILDELING, oppgaveTildeltEndring.type)
     }
 
     @Test
@@ -867,6 +873,14 @@ internal class OppgaveServiceTest(val dataSource: DataSource) {
         oppgaveService.ferdigStillOppgaveUnderBehandling(behandlingsref, saksbehandler1)
         val ferdigstiltOppgave = oppgaveService.hentOppgave(oppgave.id)
         assertEquals(Status.FERDIGSTILT, ferdigstiltOppgave?.status)
+
+        val hentEndringerForOppgave = oppgaveDaoMedEndringssporing.hentEndringerForOppgave(oppgave.id)
+        assertEquals(3, hentEndringerForOppgave.size)
+
+        val oppgaveFerdigstiltEndring = hentEndringerForOppgave[2]
+        assertEquals(Status.FERDIGSTILT, oppgaveFerdigstiltEndring.status)
+        assertEquals(saksbehandler1.ident, oppgaveFerdigstiltEndring.saksbehandler)
+        assertEquals(EndringType.ENDRET_STATUS, oppgaveFerdigstiltEndring.type)
     }
 
     @Test
@@ -1069,7 +1083,7 @@ internal class OppgaveServiceTest(val dataSource: DataSource) {
         val saksbehandlerHentet =
             oppgaveService.hentSisteSaksbehandlerIkkeAttestertOppgave(behandlingId)
 
-        Assertions.assertNull(saksbehandlerHentet?.ident)
+        assertNull(saksbehandlerHentet?.ident)
     }
 
     @Test


### PR DESCRIPTION
Forslag til endring på oppgaveendringer. Gjør det enklere å lese og vedlikeholde. 
Det meste av informasjonen på oppgave-objektet vil uansett aldri endres, så det er lite vits å lagre ned _alt_.

Har slengt på en enum som forteller hva slags "endringstype" det er. Ikke sikkert det er noen vits, men har en tanke om at den kanskje kan brukes ifm. visning av endringen i frontend. 

Oppretter nå også en hendelse ved "ny oppgave" slik at vi vet hva som er initiell data i oppgaven. 


Kom gjerne med forslag til forbedringer, innspill eller tanker!


#### Endringshendelser vil da se slik ut i databasen: 

![Screenshot 2024-03-20 at 20 54 17](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/d44ce66e-5d1f-40bc-96f9-d43cf6868542)
