### PR TITLE
EY-3732: Legger til utledet hjemmel i tilbakekreving

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
@@ -255,7 +255,7 @@ class TilbakekrevingService(
                             dato = vedtak.dato,
                         ),
                     aarsak = requireNotNull(behandling.tilbakekreving.vurdering?.aarsak),
-                    hjemmel = requireNotNull(behandling.tilbakekreving.vurdering?.rettsligGrunnlag),
+                    hjemmel = requireNotNull(behandling.tilbakekreving.vurdering?.hjemmel),
                     kravgrunnlagId = behandling.tilbakekreving.kravgrunnlag.kravgrunnlagId.value.toString(),
                     kontrollfelt = behandling.tilbakekreving.kravgrunnlag.kontrollFelt.value,
                     perioder =

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingDaoTest.kt
@@ -23,7 +23,7 @@ import no.nav.etterlatte.libs.common.tilbakekreving.Periode
 import no.nav.etterlatte.libs.common.tilbakekreving.SakId
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingAarsak
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingBehandling
-import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingRettsligGrunnlag
+import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingHjemmel
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingStatus
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingVurdering
 import no.nav.etterlatte.libs.common.tilbakekreving.UUID30
@@ -96,7 +96,7 @@ class TilbakekrevingDaoTest(val dataSource: DataSource) {
                                 doedsbosak = null,
                                 foraarsaketAv = null,
                                 tilsvar = null,
-                                rettsligGrunnlag = TilbakekrevingRettsligGrunnlag.TJUETO_FEMTEN_FOERSTE_LEDD_FOERSTE_PUNKTUM,
+                                rettsligGrunnlag = TilbakekrevingHjemmel.TJUETO_FEMTEN_FOERSTE_LEDD_FOERSTE_PUNKTUM,
                                 objektivtVilkaarOppfylt = null,
                                 subjektivtVilkaarOppfylt = null,
                                 uaktsomtForaarsaketFeilutbetaling = null,
@@ -109,6 +109,7 @@ class TilbakekrevingDaoTest(val dataSource: DataSource) {
                                 rentevurdering = null,
                                 vedtak = "konklusjon",
                                 vurderesForPaatale = null,
+                                hjemmel = TilbakekrevingHjemmel.TJUETO_FEMTEN_FOERSTE_LEDD_FOERSTE_OG_ANDRE_PUNKTUM,
                             ),
                         perioder =
                             lagret.tilbakekreving.perioder.map {

--- a/apps/etterlatte-brev-api/.run/etterlatte-brev-api.dev-gcp.run.xml
+++ b/apps/etterlatte-brev-api/.run/etterlatte-brev-api.dev-gcp.run.xml
@@ -10,7 +10,7 @@
       <env name="DOKDIST_URL" value="https://dokdistfordeling.dev-fss-pub.nais.io/rest/v1" />
       <env name="CLAMAV_ENDPOINT_URL" value="http://clamav.nais-system.svc.cluster.local" />
       <env name="ETTERLATTE_BEHANDLING_CLIENT_ID" value="59967ac8-009c-492e-a618-e5a0f6b3e4e4" />
-      <env name="ETTERLATTE_BEHANDLING_URL" value="http://localhost:8090" />
+      <env name="ETTERLATTE_BEHANDLING_URL" value="https://etterlatte-behandling.intern.dev.nav.no" />
       <env name="ETTERLATTE_BEREGNING_CLIENT_ID" value="b07cf335-11fb-4efa-bd46-11f51afd5052" />
       <env name="ETTERLATTE_BEREGNING_URL" value="https://etterlatte-beregning.intern.dev.nav.no" />
       <env name="ETTERLATTE_GRUNNLAG_CLIENT_ID" value="ce96a301-13db-4409-b277-5b27f464d08b" />

--- a/apps/etterlatte-brev-api/.run/etterlatte-brev-api.dev-gcp.run.xml
+++ b/apps/etterlatte-brev-api/.run/etterlatte-brev-api.dev-gcp.run.xml
@@ -10,7 +10,7 @@
       <env name="DOKDIST_URL" value="https://dokdistfordeling.dev-fss-pub.nais.io/rest/v1" />
       <env name="CLAMAV_ENDPOINT_URL" value="http://clamav.nais-system.svc.cluster.local" />
       <env name="ETTERLATTE_BEHANDLING_CLIENT_ID" value="59967ac8-009c-492e-a618-e5a0f6b3e4e4" />
-      <env name="ETTERLATTE_BEHANDLING_URL" value="https://etterlatte-behandling.intern.dev.nav.no" />
+      <env name="ETTERLATTE_BEHANDLING_URL" value="http://localhost:8090" />
       <env name="ETTERLATTE_BEREGNING_CLIENT_ID" value="b07cf335-11fb-4efa-bd46-11f51afd5052" />
       <env name="ETTERLATTE_BEREGNING_URL" value="https://etterlatte-beregning.intern.dev.nav.no" />
       <env name="ETTERLATTE_GRUNNLAG_CLIENT_ID" value="ce96a301-13db-4409-b277-5b27f464d08b" />

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/tilbakekreving/TilbakekrevingTesthjelper.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/tilbakekreving/TilbakekrevingTesthjelper.kt
@@ -13,9 +13,9 @@ import no.nav.etterlatte.libs.common.tilbakekreving.Periode
 import no.nav.etterlatte.libs.common.tilbakekreving.SakId
 import no.nav.etterlatte.libs.common.tilbakekreving.Tilbakekreving
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingAarsak
+import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingHjemmel
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingPeriode
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingResultat
-import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingRettsligGrunnlag
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingVarsel
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingVurdering
 import no.nav.etterlatte.libs.common.tilbakekreving.Tilbakekrevingsbelop
@@ -44,7 +44,7 @@ fun tilbakekrevingvurdering() =
         doedsbosak = null,
         foraarsaketAv = null,
         tilsvar = null,
-        rettsligGrunnlag = TilbakekrevingRettsligGrunnlag.TJUETO_FEMTEN_FOERSTE_LEDD_FOERSTE_PUNKTUM,
+        rettsligGrunnlag = TilbakekrevingHjemmel.TJUETO_FEMTEN_FOERSTE_LEDD_FOERSTE_PUNKTUM,
         objektivtVilkaarOppfylt = null,
         subjektivtVilkaarOppfylt = null,
         uaktsomtForaarsaketFeilutbetaling = null,
@@ -57,6 +57,7 @@ fun tilbakekrevingvurdering() =
         rentevurdering = null,
         vedtak = "konklusjon",
         vurderesForPaatale = null,
+        hjemmel = TilbakekrevingHjemmel.TJUETO_FEMTEN_FOERSTE_LEDD_FOERSTE_PUNKTUM,
     )
 
 fun kravgrunnlag() =

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Tilbakekreving.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Tilbakekreving.ts
@@ -22,7 +22,7 @@ export interface TilbakekrevingVurdering {
   doedsbosak: JaNei | null
   foraarsaketAv: string | null
   tilsvar: TilbakekrevingTilsvar | null
-  rettsligGrunnlag: TilbakekrevingRettsligGrunnlag | null
+  rettsligGrunnlag: TilbakekrevingHjemmel | null
   objektivtVilkaarOppfylt: string | null
   subjektivtVilkaarOppfylt: string | null
   uaktsomtForaarsaketFeilutbetaling: string | null
@@ -35,6 +35,7 @@ export interface TilbakekrevingVurdering {
   rentevurdering: string | null
   vedtak: string | null
   vurderesForPaatale: string | null
+  hjemmel: TilbakekrevingHjemmel | null
 }
 
 export interface TilbakekrevingTilsvar {
@@ -165,15 +166,17 @@ export const teksterTilbakekrevingResultat: Record<TilbakekrevingResultat, strin
   FORELDET: 'Foreldet',
 }
 
-export enum TilbakekrevingRettsligGrunnlag {
+export enum TilbakekrevingHjemmel {
   TJUETO_FEMTEN_FOERSTE_LEDD_FOERSTE_PUNKTUM = 'TJUETO_FEMTEN_FOERSTE_LEDD_FOERSTE_PUNKTUM',
   TJUETO_FEMTEN_FOERSTE_LEDD_ANDRE_PUNKTUM = 'TJUETO_FEMTEN_FOERSTE_LEDD_ANDRE_PUNKTUM',
   TJUETO_FEMTEN_FOERSTE_LEDD_FOERSTE_OG_ANDRE_PUNKTUM = 'TJUETO_FEMTEN_FOERSTE_LEDD_FOERSTE_OG_ANDRE_PUNKTUM',
+  TJUETO_FEMTEN_FEMTE_LEDD = 'TJUETO_FEMTEN_FEMTE_LEDD',
 }
 
-export const teksterTilbakekrevingHjemmel: Record<TilbakekrevingRettsligGrunnlag, string> = {
+export const teksterTilbakekrevingHjemmel: Record<TilbakekrevingHjemmel, string> = {
   TJUETO_FEMTEN_FOERSTE_LEDD_FOERSTE_PUNKTUM: 'Folketrygdloven § 22-15 første ledd, første punktum',
   TJUETO_FEMTEN_FOERSTE_LEDD_ANDRE_PUNKTUM: 'Folketrygdloven § 22-15 første ledd, andre punktum',
   TJUETO_FEMTEN_FOERSTE_LEDD_FOERSTE_OG_ANDRE_PUNKTUM:
     'Kombinasjon folketrygdloven § 22-15 første ledd, første og andre punktum ',
+  TJUETO_FEMTEN_FEMTE_LEDD: 'Folketrygdloven § 22-15 femte ledd',
 } as const

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/TestHelper.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/TestHelper.kt
@@ -2,9 +2,9 @@ package no.nav.etterlatte.tilbakekreving
 
 import no.nav.etterlatte.libs.common.tilbakekreving.FattetVedtak
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingAarsak
+import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingHjemmel
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingPeriodeVedtak
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingResultat
-import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingRettsligGrunnlag
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingSkyld
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingVedtak
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingsbelopFeilkontoVedtak
@@ -56,7 +56,7 @@ fun tilbakekrevingsvedtak(vedtakId: Long = 1) =
                 ),
             ),
         aarsak = TilbakekrevingAarsak.ANNET,
-        hjemmel = TilbakekrevingRettsligGrunnlag.TJUETO_FEMTEN_FEMTE_LEDD,
+        hjemmel = TilbakekrevingHjemmel.TJUETO_FEMTEN_FEMTE_LEDD,
         kravgrunnlagId = "1",
         kontrollfelt = "2023-09-19-10.01.03.842916",
     )

--- a/libs/etterlatte-tilbakekreving-model/src/main/kotlin/Tilbakekreving.kt
+++ b/libs/etterlatte-tilbakekreving-model/src/main/kotlin/Tilbakekreving.kt
@@ -19,7 +19,7 @@ data class TilbakekrevingVurdering(
     val doedsbosak: JaNei?,
     val foraarsaketAv: String?,
     val tilsvar: TilbakekrevingTilsvar?,
-    val rettsligGrunnlag: TilbakekrevingRettsligGrunnlag?,
+    val rettsligGrunnlag: TilbakekrevingHjemmel?,
     val objektivtVilkaarOppfylt: String?,
     val subjektivtVilkaarOppfylt: String?,
     val uaktsomtForaarsaketFeilutbetaling: String?,
@@ -32,6 +32,7 @@ data class TilbakekrevingVurdering(
     val rentevurdering: String?,
     val vedtak: String?,
     val vurderesForPaatale: String?,
+    val hjemmel: TilbakekrevingHjemmel?,
 )
 
 enum class TilbakekrevingVarsel {
@@ -65,13 +66,6 @@ enum class TilbakekrevingBeloepBeholdSvar {
     BELOEP_I_BEHOLD,
     BELOEP_IKKE_I_BEHOLD,
 }
-
-data class TilbakekrevingVurderingUaktsomhet(
-    val aktsomhet: TilbakekrevingAktsomhet?,
-    val reduseringAvKravet: String?,
-    val strafferettsligVurdering: String?,
-    val rentevurdering: String?,
-)
 
 data class TilbakekrevingPeriode(
     val maaned: YearMonth,
@@ -182,13 +176,7 @@ enum class TilbakekrevingAarsak {
     ANNET,
 }
 
-enum class TilbakekrevingAktsomhet {
-    GOD_TRO,
-    SIMPEL_UAKTSOMHET,
-    GROV_UAKTSOMHET,
-}
-
-enum class TilbakekrevingRettsligGrunnlag(val kode: String) {
+enum class TilbakekrevingHjemmel(val kode: String) {
     TJUETO_FEMTEN_FOERSTE_LEDD_FOERSTE_PUNKTUM("22-15-1-1"),
     TJUETO_FEMTEN_FOERSTE_LEDD_ANDRE_PUNKTUM("22-15-1-2"),
     TJUETO_FEMTEN_FOERSTE_LEDD_FOERSTE_OG_ANDRE_PUNKTUM("22-15-1-1/22-15-1-2"),
@@ -217,7 +205,7 @@ data class TilbakekrevingVedtak(
     val vedtakId: Long,
     val fattetVedtak: FattetVedtak,
     val aarsak: TilbakekrevingAarsak,
-    val hjemmel: TilbakekrevingRettsligGrunnlag,
+    val hjemmel: TilbakekrevingHjemmel,
     val kravgrunnlagId: String,
     val kontrollfelt: String,
     val perioder: List<TilbakekrevingPeriodeVedtak>,


### PR DESCRIPTION
Vi har rettslig grunnlag - men denne vil ikke inneholde hjemler utledet senere i flyten. Har derfor behov for et eget felt som er den utledede hjemmelen som også sendes i vedtaket.