### PR TITLE
Sette limit mem hoyere enn request behandling

### DIFF
--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -59,6 +59,8 @@ spec:
     requests:
       cpu: 50m
       memory: 640Mi
+    limits:
+      memory: 1024Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 2

--- a/apps/etterlatte-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-behandling/.nais/prod.yaml
@@ -64,6 +64,8 @@ spec:
     requests:
       cpu: 50m
       memory: 640Mi
+    limits:
+      memory: 1024Mi
   replicas:
     cpuThresholdPercentage: 90
     max: 4


### PR DESCRIPTION
_[2024-03-21T12:31:20.233467153Z] Status: in_progress: Application/etterlatte-behandling (FailedSynchronization): persisting Deployment to Kubernetes: Invalid: Deployment.apps "etterlatte-behandling" is invalid: spec.template.spec.containers[0].resources.requests: Invalid value: "640Mi": must be less than or equal to memory limit of 512Mi_
