### PR TITLE
Vi må hente historiske sivilstander for gjenlevende og avdøde

### DIFF
--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/ParallelleSannheterKlient.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/ParallelleSannheterKlient.kt
@@ -54,7 +54,11 @@ class ParallelleSannheterKlient(
     suspend fun avklarStatsborgerskap(pdlStatsborgerskap: List<PdlStatsborgerskap>) =
         avklarNullable(pdlStatsborgerskap, Avklaring.STATSBORGERSKAP)
 
-    suspend fun avklarSivilstand(pdlSivilstand: List<PdlSivilstand>) = avklarNullable(pdlSivilstand, Avklaring.SIVILSTAND)
+    suspend fun avklarSivilstand(pdlSivilstand: List<PdlSivilstand>) =
+        avklarNullable(
+            list = pdlSivilstand.filterNot { it.metadata.historisk },
+            avklaring = Avklaring.SIVILSTAND,
+        )
 
     suspend fun avklarFoedsel(pdlFoedsel: List<PdlFoedsel>) = avklar(pdlFoedsel, Avklaring.FOEDSEL)
 

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlKlient.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlKlient.kt
@@ -286,6 +286,7 @@ class PdlKlient(private val httpClient: HttpClient, private val apiUrl: String) 
                 oppholdsadresseHistorikk = false,
                 utland = true,
                 sivilstand = true,
+                sivilstandHistorikk = true,
                 familieRelasjon = true,
                 vergemaal = true,
             )
@@ -302,6 +303,7 @@ class PdlKlient(private val httpClient: HttpClient, private val apiUrl: String) 
                 oppholdsadresseHistorikk = true,
                 utland = true,
                 sivilstand = true,
+                sivilstandHistorikk = true,
                 familieRelasjon = true,
                 vergemaal = false,
             )

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
@@ -35,6 +35,7 @@ data class PdlVariables(
     val kontaktadresseHistorikk: Boolean = false,
     val utland: Boolean = false,
     val sivilstand: Boolean = false,
+    val sivilstandHistorikk: Boolean = false,
     val familieRelasjon: Boolean = false,
     val vergemaal: Boolean = false,
 )

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/SivilstandMapper.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/SivilstandMapper.kt
@@ -16,6 +16,7 @@ object SivilstandMapper {
                     gyldigFraOgMed = it.gyldigFraOgMed,
                     bekreftelsesdato = it.bekreftelsesdato,
                     kilde = it.metadata.master,
+                    historisk = it.metadata.historisk,
                 )
             }
         }

--- a/apps/etterlatte-pdltjenester/src/main/resources/pdl/hentPerson.graphql
+++ b/apps/etterlatte-pdltjenester/src/main/resources/pdl/hentPerson.graphql
@@ -101,6 +101,7 @@ query(
     $kontaktadresseHistorikk: Boolean!,
     $utland: Boolean!,
     $sivilstand: Boolean!,
+    $sivilstandHistorikk: Boolean!,
     $familieRelasjon: Boolean!,
     $vergemaal: Boolean!,
 ) {
@@ -132,7 +133,7 @@ query(
                 ...metadata
             }
         }
-        sivilstand @include(if: $sivilstand){
+        sivilstand(historikk: $sivilstandHistorikk) @include(if: $sivilstand){
             type
             gyldigFraOgMed
             relatertVedSivilstand

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/omstillingsstoenad/Sivilstand.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/omstillingsstoenad/Sivilstand.tsx
@@ -18,7 +18,7 @@ type Props = {
 }
 
 export const Sivilstand = ({ familieforhold, avdoed }: Props) => {
-  const sivilstand = familieforhold.gjenlevende.flatMap((it) => it.opplysning.sivilstand) ?? []
+  const sivilstand = familieforhold.soeker?.opplysning.sivilstand?.filter((ss) => !ss.historisk)
 
   return (
     <SivilstandWrapper>
@@ -42,7 +42,7 @@ export const Sivilstand = ({ familieforhold, avdoed }: Props) => {
           </Table.Header>
           <Table.Body>
             {sivilstand ? (
-              sivilstand?.flatMap(
+              sivilstand.map(
                 (ss, index) =>
                   ss && (
                     <Table.Row key={index}>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Person.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Person.ts
@@ -76,6 +76,7 @@ export interface Sivilstand {
   relatertVedSiviltilstand?: string
   gyldigFraOgMed?: Date
   bekreftetDato?: Date
+  historisk: boolean
   kilde: string
 }
 

--- a/libs/saksbehandling-common/src/main/kotlin/person/Person.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/person/Person.kt
@@ -94,7 +94,9 @@ data class Sivilstand(
     val relatertVedSiviltilstand: Folkeregisteridentifikator?,
     val gyldigFraOgMed: LocalDate?,
     val bekreftelsesdato: LocalDate?,
-    val historisk: Boolean,
+    // Alle sivilstander hentet frem til nå har vært aktive
+    // Setter default til false for å støtte sivilstander uten dette feltet frem til en migrering er gjennomført
+    val historisk: Boolean = false,
     val kilde: String,
 )
 

--- a/libs/saksbehandling-common/src/main/kotlin/person/Person.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/person/Person.kt
@@ -94,6 +94,7 @@ data class Sivilstand(
     val relatertVedSiviltilstand: Folkeregisteridentifikator?,
     val gyldigFraOgMed: LocalDate?,
     val bekreftelsesdato: LocalDate?,
+    val historisk: Boolean,
     val kilde: String,
 )
 


### PR DESCRIPTION
Trengs for å finne tidligere ektefeller og partnere ifm. dødsmelding.

Usikker på om dette kan ha uønskede effekter andre steder? 