### PR TITLE
Hotfix - flere rader med mellomrom i fnr i opplysning som skaper trøbbel

### DIFF
--- a/apps/etterlatte-grunnlag/src/main/resources/db/prod/V20__fjerne_space_persongalleri_resterende.sql
+++ b/apps/etterlatte-grunnlag/src/main/resources/db/prod/V20__fjerne_space_persongalleri_resterende.sql
@@ -1,0 +1,4 @@
+-- Persongalleri har blitt lagret med mellomrom i fnr som fører til feil flere steder
+UPDATE grunnlagshendelse SET opplysning=replace(opplysning, ' ', '')
+WHERE opplysning LIKE '% %'
+AND opplysning_type = 'PERSONGALLERI_V1';


### PR DESCRIPTION
Har sjekket i prod med:

```sql
SELECT * FROM grunnlagshendelse WHERE opplysning LIKE '% %' AND opplysning_type = 'PERSONGALLERI_V1'
```

Det er 29 rader som er påvirket.

SQLen kjørte fint på lokalkopi (168ms).