### PR TITLE
Revert "Bump jvm from 1.9.22 to 1.9.23 (#4348)"

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,6 @@
 rootProject.name = "pensjon-etterlatte-saksbehandling"
 plugins {
-    kotlin("jvm") version "1.9.23" apply false
+    kotlin("jvm") version "1.9.22" apply false
 }
 include(
     "apps:etterlatte-fordeler",


### PR DESCRIPTION
This reverts commit 503fa018ca2e18c6c6cd8b747176c70c49cbae36.

Pga feil med `.addFirst(String)` 
Burde se på hvorfor vi ikke bygger noe som følge av denne endringen