### PR TITLE
Gir en mer konstruktiv feilmelding ved manglende vedtaktype

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapperVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapperVedtak.kt
@@ -32,8 +32,9 @@ class BrevKodeMapperVedtak {
                     VedtakType.TILBAKEKREVING -> Brevkoder.TILBAKEKREVING
                     VedtakType.AVVIST_KLAGE -> Brevkoder.AVVIST_KLAGE
                     null -> throw UgyldigForespoerselException(
-                        "MANGLENDE_VEDTAKSTYPE_VEDTAKSBREV",
-                        "Skal ikke kunne komme hit med manglande vedtakstype, for request $request",
+                        code = "MANGLENDE_VEDTAKSTYPE_VEDTAKSBREV",
+                        detail = "Skal ikke kunne komme hit med manglande vedtakstype. Gå igjennom steg fra beregning på nytt.",
+                        meta = mapOf("request" to request),
                     )
                 }
             }
@@ -47,8 +48,9 @@ class BrevKodeMapperVedtak {
                     VedtakType.TILBAKEKREVING -> Brevkoder.TILBAKEKREVING
                     VedtakType.AVVIST_KLAGE -> Brevkoder.AVVIST_KLAGE
                     null -> throw UgyldigForespoerselException(
-                        "MANGLENDE_VEDTAKSTYPE_VEDTAKSBREV",
-                        "Skal ikke kunne komme hit med manglande vedtakstype, for request $request",
+                        code = "MANGLENDE_VEDTAKSTYPE_VEDTAKSBREV",
+                        detail = "Skal ikke kunne komme hit med manglande vedtakstype. Gå igjennom steg fra beregning på nytt.",
+                        meta = mapOf("request" to request),
                     )
                 }
             }


### PR DESCRIPTION
Eksisterende feilmelding er heller uforståelig for bruker:

![image](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/4296255/999e74b0-586c-4c74-b1a5-380e93f48ac8)

