### PR TITLE
Caching i code-scanning-jobben

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Assemble
-        run: ./gradlew assemble --no-build-cache --no-configuration-cache
+        run: ./gradlew assemble
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
CodeQL-bygga har tima ut eit par gongar dei siste dagane. Prøver å skru på gradle-cachen, kanskje det hjelper. Synes uansett det verkar fornuftig å ha denne aktivert