### PR TITLE
FAGSYSTEM-324425 - ikke valider og sett status hvis avslag

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidVisning.tsx
@@ -46,7 +46,7 @@ const TrygdetidVisning = (props: { behandling: IDetaljertBehandling }) => {
 
   const sjekkGyldighetOgOppdaterStatus = () => {
     oppdaterStatusRequest(behandling.id, (result) => {
-      if (result.statusOppdatert) {
+      if (result.statusOppdatert && vedtaksresultat != 'avslag') {
         dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.TRYGDETID_OPPDATERT))
       }
       next()

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidVisning.tsx
@@ -46,7 +46,7 @@ const TrygdetidVisning = (props: { behandling: IDetaljertBehandling }) => {
 
   const sjekkGyldighetOgOppdaterStatus = () => {
     oppdaterStatusRequest(behandling.id, (result) => {
-      if (result.statusOppdatert && vedtaksresultat != 'avslag') {
+      if (result.statusOppdatert && vedtaksresultat !== 'avslag') {
         dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.TRYGDETID_OPPDATERT))
       }
       next()


### PR DESCRIPTION
Dette vises ved avslag kun for utlandssaker - og her er TT opsjonelt. Det brukes ikke til noe annet enn at sh. vil ha et kopi lagret.