### PR TITLE
EY-3747 - bruk GCP url for kodeverk for lokal kjøring av trygdetid

### DIFF
--- a/apps/etterlatte-trygdetid/.run/etterlatte-trygdetid.dev-gcp.run.xml
+++ b/apps/etterlatte-trygdetid/.run/etterlatte-trygdetid.dev-gcp.run.xml
@@ -1,9 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="etterlatte-trygdetid.dev-gcp" type="JetRunConfigurationType">
     <envs>
-      <env name="HTTP_PORT" value="8088" />
-      <env name="LOGBACK_APPENDER" value="STDOUT" />
-      <env name="NAIS_APP_NAME" value="etterlatte-trygdetid" />
       <env name="DB_JDBC_URL" value="jdbc:postgresql://localhost:5434/postgres" />
       <env name="DB_PASSWORD" value="postgres" />
       <env name="DB_USERNAME" value="postgres" />
@@ -11,9 +8,12 @@
       <env name="ETTERLATTE_BEHANDLING_URL" value="https://etterlatte-behandling.intern.dev.nav.no" />
       <env name="ETTERLATTE_GRUNNLAG_CLIENT_ID" value="ce96a301-13db-4409-b277-5b27f464d08b" />
       <env name="ETTERLATTE_GRUNNLAG_URL" value="https://etterlatte-grunnlag.intern.dev.nav.no" />
-      <env name="KODEVERK_URL" value="https://kodeverk.dev-fss-pub.nais.io/api/v1/kodeverk" />
       <env name="ETTERLATTE_VILKAARSVURDERING_CLIENT_ID" value="dev-gcp.etterlatte.etterlatte-vilkaarsvurdering" />
       <env name="ETTERLATTE_VILKAARSVURDERING_URL" value="https://etterlatte-vilkaarsvurdering.intern.dev.nav.no" />
+      <env name="HTTP_PORT" value="8088" />
+      <env name="KODEVERK_URL" value="https://kodeverk-api.nav.no/api/v1/kodeverk" />
+      <env name="LOGBACK_APPENDER" value="STDOUT" />
+      <env name="NAIS_APP_NAME" value="etterlatte-trygdetid" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="no.nav.etterlatte.ApplicationKt" />
     <module name="pensjon-etterlatte-saksbehandling.apps.etterlatte-trygdetid.main" />


### PR DESCRIPTION
Samme URL som brukes nå i dev/prod nais (gamle FSS URL er skrudd av i dev)