### PR TITLE
EY-3748: Legger til felt harUtbetaling for innvilgelsesbrev

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
@@ -32,6 +32,7 @@ data class BarnepensjonInnvilgelse(
     val bosattUtland: Boolean,
     val kunNyttRegelverk: Boolean,
     val erGjenoppretting: Boolean,
+    val harUtbetaling: Boolean,
 ) : BrevDataFerdigstilling {
     companion object {
         val tidspunktNyttRegelverk: LocalDate = LocalDate.of(2024, 1, 1)
@@ -62,6 +63,7 @@ data class BarnepensjonInnvilgelse(
                         it.datoFOM.isAfter(tidspunktNyttRegelverk) || it.datoFOM.isEqual(tidspunktNyttRegelverk)
                     },
                 erGjenoppretting = erGjenoppretting,
+                harUtbetaling = beregningsperioder.any { it.utbetaltBeloep.value > 0 },
             )
         }
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelseForeldreloes.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelseForeldreloes.kt
@@ -26,9 +26,8 @@ data class BarnepensjonInnvilgelseForeldreloes(
     val brukerUnder18Aar: Boolean,
     val bosattUtland: Boolean,
     val kunNyttRegelverk: Boolean,
-    val bareEnPeriode: Boolean,
     val flerePerioder: Boolean,
-    val ingenUtbetaling: Boolean,
+    val harUtbetaling: Boolean,
     val vedtattIPesys: Boolean,
 ) : BrevDataFerdigstilling {
     companion object {
@@ -75,9 +74,8 @@ data class BarnepensjonInnvilgelseForeldreloes(
                     utbetalingsinfo.beregningsperioder.all {
                         it.datoFOM.isAfter(tidspunktNyttRegelverk) || it.datoFOM.isEqual(tidspunktNyttRegelverk)
                     },
-                bareEnPeriode = utbetalingsinfo.beregningsperioder.size < 2,
                 flerePerioder = utbetalingsinfo.beregningsperioder.size > 1,
-                ingenUtbetaling = utbetalingsinfo.beregningsperioder.none { it.utbetaltBeloep.value > 0 },
+                harUtbetaling = utbetalingsinfo.beregningsperioder.any { it.utbetaltBeloep.value > 0 },
                 vedtattIPesys = vedtattIPesys,
             )
         }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelse.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelse.kt
@@ -28,6 +28,7 @@ data class OmstillingsstoenadInnvilgelse(
     val innvilgetMindreEnnFireMndEtterDoedsfall: Boolean,
     val lavEllerIngenInntekt: Boolean,
     val etterbetaling: OmstillingsstoenadEtterbetaling?,
+    val harUtbetaling: Boolean,
 ) : BrevDataFerdigstilling {
     companion object {
         fun fra(
@@ -85,6 +86,7 @@ data class OmstillingsstoenadInnvilgelse(
                         .plusMonths(4)
                         .isAfter(avkortingsinfo.virkningsdato),
                 lavEllerIngenInntekt = brevutfall.lavEllerIngenInntekt == LavEllerIngenInntekt.JA,
+                harUtbetaling = beregningsperioder.any { it.utbetaltBeloep.value > 0 },
                 etterbetaling =
                     etterbetaling
                         ?.let { dto -> Etterbetaling.fraOmstillingsstoenadBeregningsperioder(dto, beregningsperioder) },


### PR DESCRIPTION
- Legger til felt `harUtbetaling`
- Fjerner ubrukt felt `bareEnPeriode` fra foreldreløs-brev og endrer `ingenUtbetaling` til `harUtbetaling` for å være mer konsistent med andre maler.