### PR TITLE
Henter tidligste dødsdato for flere avdøde i virkningstidspunkt-sjekk

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
@@ -335,7 +335,6 @@ internal class BehandlingServiceImpl(
                 else -> virkningstidspunkt.isAfter(doedsdato)
             }
 
-        println(doedsdato)
         return harGyldigFormat && datoForVirkningstidspunktErGydligInnenforMaksBegrensninger
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/VerdikjedeTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/VerdikjedeTest.kt
@@ -217,13 +217,13 @@ class VerdikjedeTest : BehandlingIntegrationTest() {
                 addAuthToken(tokenSaksbehandler)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody(
-                    mapOf("dato" to "2022-02-01T01:00:00.000Z", "begrunnelse" to "En begrunnelse"),
+                    mapOf("dato" to "2022-09-01T01:00:00.000Z", "begrunnelse" to "En begrunnelse"),
                 )
             }.also {
                 assertEquals(HttpStatusCode.OK, it.status)
                 val expected =
                     FastsettVirkningstidspunktResponse(
-                        YearMonth.of(2022, 2),
+                        YearMonth.of(2022, 9),
                         Grunnlagsopplysning.Saksbehandler.create("Saksbehandler01"),
                         "En begrunnelse",
                         null,

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
@@ -24,6 +24,7 @@ import no.nav.etterlatte.libs.common.behandling.Mottakerident
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.brev.BestillingsIdDto
 import no.nav.etterlatte.libs.common.brev.JournalpostIdDto
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.person.Person
@@ -36,6 +37,7 @@ import no.nav.etterlatte.libs.ktor.PingResult
 import no.nav.etterlatte.libs.ktor.PingResultUp
 import no.nav.etterlatte.libs.ktor.ServiceStatus
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.migrering.person.krr.DigitalKontaktinformasjon
 import no.nav.etterlatte.migrering.person.krr.KrrKlient
 import no.nav.etterlatte.oppgaveGosys.EndreStatusRequest
@@ -54,6 +56,13 @@ class GrunnlagKlientTest : GrunnlagKlient {
     ): Grunnlagsopplysning<Person> {
         val personopplysning = personOpplysning(doedsdato = LocalDate.parse("2022-01-01"))
         return grunnlagsOpplysningMedPersonopplysning(personopplysning)
+    }
+
+    override suspend fun hentGrunnlag(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Grunnlag {
+        return GrunnlagTestData().hentOpplysningsgrunnlag()
     }
 
     override suspend fun hentPersongalleri(


### PR DESCRIPTION
Justerer henting av dødsdato for sjekk på virkningstidspunkt til å ta høyde for flere avdøde. Hvis vi har flere avdøde vil henting av opplysningstypen AVDOED_PDL_V1 gi potensielt feile svar, og vi tar heller å henter den tidligste dødsdatoen for avdøde i grunnlaget