### PR TITLE
Sikkerlogg-oppsett for alle apps

### DIFF
--- a/apps/etterlatte-beregning-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-beregning-kafka/.nais/dev.yaml
@@ -21,6 +21,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   kafka:
     pool: nav-dev
   azure:

--- a/apps/etterlatte-beregning-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-beregning-kafka/.nais/prod.yaml
@@ -21,6 +21,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   kafka:
     pool: nav-prod
   azure:

--- a/apps/etterlatte-beregning-kafka/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-beregning-kafka/src/main/resources/logback-secure.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <appender name="secureAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/secure-logs/secure.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>1</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>50MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <logger name="sikkerLogg" level="DEBUG" additivity="false">
+        <appender-ref ref="secureAppender"/>
+    </logger>
+</included>

--- a/apps/etterlatte-beregning-kafka/src/main/resources/logback.xml
+++ b/apps/etterlatte-beregning-kafka/src/main/resources/logback.xml
@@ -11,13 +11,12 @@
     </appender>
 
     <root level="INFO">
-        <appender-ref ref="STDOUT_JSON"/>
+        <appender-ref ref="${LOGBACK_APPENDER:-STDOUT_JSON}"/>
     </root>
 
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="org.apache.kafka" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
-    <logger name="no.nav.helse.rapids_rivers.PingPong" level="DEBUG"/>
     <logger name="no.nav.etterlatte" level="DEBUG"/>
     <include resource="logback-secure.xml"/>
 </configuration>

--- a/apps/etterlatte-gyldig-soeknad/.nais/dev.yaml
+++ b/apps/etterlatte-gyldig-soeknad/.nais/dev.yaml
@@ -25,6 +25,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   resources:
     requests:
       cpu: 25m

--- a/apps/etterlatte-gyldig-soeknad/.nais/prod.yaml
+++ b/apps/etterlatte-gyldig-soeknad/.nais/prod.yaml
@@ -25,6 +25,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   resources:
     requests:
       cpu: 25m

--- a/apps/etterlatte-gyldig-soeknad/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-gyldig-soeknad/src/main/resources/logback-secure.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <appender name="secureAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/secure-logs/secure.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>1</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>50MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <logger name="sikkerLogg" level="DEBUG" additivity="false">
+        <appender-ref ref="secureAppender"/>
+    </logger>
+</included>

--- a/apps/etterlatte-gyldig-soeknad/src/main/resources/logback.xml
+++ b/apps/etterlatte-gyldig-soeknad/src/main/resources/logback.xml
@@ -11,13 +11,12 @@
     </appender>
 
     <root level="INFO">
-        <appender-ref ref="STDOUT_JSON"/>
+        <appender-ref ref="${LOGBACK_APPENDER:-STDOUT_JSON}"/>
     </root>
 
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="org.apache.kafka" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
-    <logger name="no.nav.helse.rapids_rivers.PingPong" level="DEBUG"/>
     <logger name="no.nav.etterlatte" level="DEBUG"/>
     <include resource="logback-secure.xml"/>
 </configuration>

--- a/apps/etterlatte-institusjonsopphold/.nais/dev.yaml
+++ b/apps/etterlatte-institusjonsopphold/.nais/dev.yaml
@@ -25,6 +25,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   resources:
     requests:
       cpu: 25m

--- a/apps/etterlatte-institusjonsopphold/.nais/prod.yaml
+++ b/apps/etterlatte-institusjonsopphold/.nais/prod.yaml
@@ -25,6 +25,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   resources:
     requests:
       cpu: 25m

--- a/apps/etterlatte-institusjonsopphold/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-institusjonsopphold/src/main/resources/logback-secure.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <appender name="secureAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/secure-logs/secure.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>1</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>50MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <logger name="sikkerLogg" level="DEBUG" additivity="false">
+        <appender-ref ref="secureAppender"/>
+    </logger>
+</included>

--- a/apps/etterlatte-institusjonsopphold/src/main/resources/logback.xml
+++ b/apps/etterlatte-institusjonsopphold/src/main/resources/logback.xml
@@ -18,4 +18,5 @@
     <logger name="io.netty" level="INFO"/>
     <logger name="no.nav.etterlatte" level="DEBUG"/>
     <include resource="logback-sporing.xml"/>
+    <include resource="logback-secure.xml"/>
 </configuration>

--- a/apps/etterlatte-oppdater-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-oppdater-behandling/.nais/dev.yaml
@@ -21,6 +21,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   kafka:
     pool: nav-dev
   azure:

--- a/apps/etterlatte-oppdater-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-oppdater-behandling/.nais/prod.yaml
@@ -21,6 +21,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   kafka:
     pool: nav-prod
   azure:

--- a/apps/etterlatte-oppdater-behandling/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-oppdater-behandling/src/main/resources/logback-secure.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <appender name="secureAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/secure-logs/secure.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>1</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>50MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <logger name="sikkerLogg" level="DEBUG" additivity="false">
+        <appender-ref ref="secureAppender"/>
+    </logger>
+</included>

--- a/apps/etterlatte-opplysninger-fra-soeknad/.nais/dev.yaml
+++ b/apps/etterlatte-opplysninger-fra-soeknad/.nais/dev.yaml
@@ -21,6 +21,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   kafka:
     pool: nav-dev
   resources:

--- a/apps/etterlatte-opplysninger-fra-soeknad/.nais/prod.yaml
+++ b/apps/etterlatte-opplysninger-fra-soeknad/.nais/prod.yaml
@@ -21,6 +21,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   kafka:
     pool: nav-prod
   resources:

--- a/apps/etterlatte-opplysninger-fra-soeknad/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-opplysninger-fra-soeknad/src/main/resources/logback-secure.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <appender name="secureAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/secure-logs/secure.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>1</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>50MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <logger name="sikkerLogg" level="DEBUG" additivity="false">
+        <appender-ref ref="secureAppender"/>
+    </logger>
+</included>

--- a/apps/etterlatte-opplysninger-fra-soeknad/src/main/resources/logback.xml
+++ b/apps/etterlatte-opplysninger-fra-soeknad/src/main/resources/logback.xml
@@ -19,4 +19,5 @@
     <logger name="io.netty" level="INFO"/>
     <logger name="no.nav.helse.rapids_rivers.PingPong" level="DEBUG"/>
     <logger name="no.nav.etterlatte" level="DEBUG"/>
+    <include resource="logback-secure.xml"/>
 </configuration>

--- a/apps/etterlatte-tidshendelser/.nais/dev.yaml
+++ b/apps/etterlatte-tidshendelser/.nais/dev.yaml
@@ -28,6 +28,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   kafka:
     pool: nav-dev
   azure:

--- a/apps/etterlatte-tidshendelser/.nais/prod.yaml
+++ b/apps/etterlatte-tidshendelser/.nais/prod.yaml
@@ -43,6 +43,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   kafka:
     pool: nav-prod
   azure:

--- a/apps/etterlatte-tidshendelser/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-tidshendelser/src/main/resources/logback-secure.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <appender name="secureAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/secure-logs/secure.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>1</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>50MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <logger name="sikkerLogg" level="DEBUG" additivity="false">
+        <appender-ref ref="secureAppender"/>
+    </logger>
+</included>

--- a/apps/etterlatte-tidshendelser/src/main/resources/logback.xml
+++ b/apps/etterlatte-tidshendelser/src/main/resources/logback.xml
@@ -16,4 +16,5 @@
 
     <logger name="no.nav.helse.rapids_rivers.PingPong" level="DEBUG"/>
     <logger name="no.nav.etterlatte" level="DEBUG"/>
+    <include resource="logback-secure.xml"/>
 </configuration>

--- a/apps/etterlatte-trygdetid-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-trygdetid-kafka/.nais/dev.yaml
@@ -21,6 +21,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   kafka:
     pool: nav-dev
   azure:

--- a/apps/etterlatte-trygdetid-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-trygdetid-kafka/.nais/prod.yaml
@@ -21,6 +21,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   kafka:
     pool: nav-prod
   azure:

--- a/apps/etterlatte-trygdetid-kafka/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-trygdetid-kafka/src/main/resources/logback-secure.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <appender name="secureAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/secure-logs/secure.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>1</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>50MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <logger name="sikkerLogg" level="DEBUG" additivity="false">
+        <appender-ref ref="secureAppender"/>
+    </logger>
+</included>

--- a/apps/etterlatte-trygdetid-kafka/src/main/resources/logback.xml
+++ b/apps/etterlatte-trygdetid-kafka/src/main/resources/logback.xml
@@ -11,13 +11,12 @@
     </appender>
 
     <root level="INFO">
-        <appender-ref ref="STDOUT_JSON"/>
+        <appender-ref ref="${LOGBACK_APPENDER:-STDOUT_JSON}"/>
     </root>
 
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="org.apache.kafka" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
-    <logger name="no.nav.helse.rapids_rivers.PingPong" level="DEBUG"/>
     <logger name="no.nav.etterlatte" level="DEBUG"/>
     <include resource="logback-secure.xml"/>
 </configuration>

--- a/apps/etterlatte-vedtaksvurdering-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/.nais/dev.yaml
@@ -21,6 +21,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   kafka:
     pool: nav-dev
   azure:

--- a/apps/etterlatte-vedtaksvurdering-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/.nais/prod.yaml
@@ -21,6 +21,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   kafka:
     pool: nav-prod
   azure:

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/resources/logback-secure.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <appender name="secureAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/secure-logs/secure.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>1</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>50MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <logger name="sikkerLogg" level="DEBUG" additivity="false">
+        <appender-ref ref="secureAppender"/>
+    </logger>
+</included>

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/resources/logback.xml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/resources/logback.xml
@@ -19,4 +19,5 @@
     <logger name="io.netty" level="INFO"/>
     <logger name="no.nav.helse.rapids_rivers.PingPong" level="DEBUG"/>
     <logger name="no.nav.etterlatte" level="DEBUG"/>
+    <include resource="logback-secure.xml"/>
 </configuration>

--- a/apps/etterlatte-vilkaarsvurdering-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/.nais/dev.yaml
@@ -21,6 +21,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   kafka:
     pool: nav-dev
   azure:

--- a/apps/etterlatte-vilkaarsvurdering-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/.nais/prod.yaml
@@ -21,6 +21,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+  secureLogs:
+    enabled: true
   kafka:
     pool: nav-prod
   azure:

--- a/apps/etterlatte-vilkaarsvurdering-kafka/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/src/main/resources/logback-secure.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <appender name="secureAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/secure-logs/secure.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>1</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>50MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <logger name="sikkerLogg" level="DEBUG" additivity="false">
+        <appender-ref ref="secureAppender"/>
+    </logger>
+</included>

--- a/apps/etterlatte-vilkaarsvurdering-kafka/src/main/resources/logback.xml
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/src/main/resources/logback.xml
@@ -19,4 +19,5 @@
     <logger name="io.netty" level="INFO"/>
     <logger name="no.nav.helse.rapids_rivers.PingPong" level="DEBUG"/>
     <logger name="no.nav.etterlatte" level="DEBUG"/>
+    <include resource="logback-secure.xml"/>
 </configuration>


### PR DESCRIPTION
Risikohandtering.

Med https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/4393 , men også i andre samanhengar, legg vi opp frå biblioteka våre til å bruke sikkerlogg. Da er det ein risiko for at vi tar i bruk kode som loggar til det vi tenkjer er sikkerlogg utan at vi tenkjer medvite over det - men viss appen ikkje har sikkerlogg-konfig sett opp, hamnar det da i den vanlege loggen.