### PR TITLE
EY-3754 Sende ut vedtakshendelser til eksterne

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
@@ -67,6 +67,8 @@ spec:
       value: "07-18"
     - name: KAFKA_RAPID_TOPIC
       value: etterlatte.dodsmelding
+    - name: KAFKA_VEDTAKSHENDELSER_TOPIC
+      value: etterlatte.vedtakshendelser
     - name: ETTERLATTE_BEREGNING_CLIENT_ID
       value: b07cf335-11fb-4efa-bd46-11f51afd5052
     - name: ETTERLATTE_BEREGNING_URL

--- a/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
@@ -77,6 +77,8 @@ spec:
       value: "07-18"
     - name: KAFKA_RAPID_TOPIC
       value: etterlatte.etterlatteytelser
+    - name: KAFKA_VEDTAKSHENDELSER_TOPIC
+      value: etterlatte.vedtakshendelser
     - name: ETTERLATTE_BEREGNING_CLIENT_ID
       value: prod-gcp.etterlatte.etterlatte-beregning
     - name: ETTERLATTE_BEREGNING_URL

--- a/apps/etterlatte-vedtaksvurdering/.run/etterlatte-vedtaksvurdering.dev-gcp.run.xml
+++ b/apps/etterlatte-vedtaksvurdering/.run/etterlatte-vedtaksvurdering.dev-gcp.run.xml
@@ -5,6 +5,7 @@
       <env name="LOGBACK_APPENDER" value="STDOUT" />
       <env name="NAIS_APP_NAME" value="etterlatte-vedtaksvurdering" />
       <env name="KAFKA_RAPID_TOPIC" value="etterlatte" />
+      <env name="KAFKA_VEDTAKSHENDELSER_TOPIC" value="vedtakshendelser" />
       <env name="KAFKA_BOOTSTRAP_SERVERS" value="0.0.0.0:9092" />
       <env name="DB_JDBC_URL" value="jdbc:postgresql://localhost:5433/postgres" />
       <env name="DB_USERNAME" value="postgres" />

--- a/apps/etterlatte-vedtaksvurdering/README.md
+++ b/apps/etterlatte-vedtaksvurdering/README.md
@@ -14,6 +14,20 @@ Oppdateringer av ACL er ikke automatisk, og må kjøres inn manuelt med `kubectl
 | dev-gcp  | .nais/topic-vedtakshendelser-dev.yaml   |
 | prod-gcp | .nais/topic-vedtakshendelser-prod.yaml  |
 
+### Meldingsinnhold
+
+| Felt        | Data                                                        |
+|:------------|:------------------------------------------------------------|
+| ident       | Fødselsnummer hendelsen gjelder                             |
+| sakstype    | Sakstype: OMS, BP                                           |
+| type        | Hva gjelder vedtaket: AVSLAG, INNVILGELSE, ENDRING, OPPHOER |
+| vedtakId    | Unik identifikator for vedtaket                             |
+| vedtaksdato | Dato vedtaket ble fattet                                    |
+| virkningFom | Dato vedtaket gjelder fra                                   |
+
+Se [Vedtakshendelse](./src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxService.kt) for implementasjon.
+
+
 ## Kom i gang
 
 ### Hvordan kjøre lokalt mot dev-gcp

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/Application.kt
@@ -25,7 +25,11 @@ class Server(private val context: ApplicationContext) {
             initEmbeddedServer(
                 httpPort = context.httpPort,
                 applicationConfig = context.config,
-                cronJobs = listOf(context.metrikkerJob),
+                cronJobs =
+                    listOf(
+                        context.metrikkerJob,
+                        context.outboxJob,
+                    ),
             ) {
                 vedtaksvurderingRoute(
                     vedtaksvurderingService,

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxItem.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxItem.kt
@@ -1,0 +1,16 @@
+package no.nav.etterlatte.vedtaksvurdering.outbox
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class OutboxItem(
+    val id: UUID,
+    val vedtakId: Long,
+    val opprettet: LocalDateTime,
+    val type: OutboxItemType,
+    val publisert: Boolean,
+)
+
+enum class OutboxItemType {
+    ATTESTERT,
+}

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxJob.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxJob.kt
@@ -1,0 +1,33 @@
+package no.nav.etterlatte.vedtaksvurdering.outbox
+
+import no.nav.etterlatte.jobs.LoggerInfo
+import no.nav.etterlatte.jobs.fixedRateCancellableTimer
+import no.nav.etterlatte.libs.common.TimerJob
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.util.Timer
+
+class OutboxJob(
+    private val outboxService: OutboxService,
+    private val erLeader: () -> Boolean,
+    private val initialDelay: Long,
+    private val periode: Duration,
+) : TimerJob {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val jobbNavn = this::class.simpleName
+
+    override fun schedule(): Timer {
+        logger.info("$jobbNavn er satt til å kjøre med service=${outboxService::class.simpleName} og periode $periode")
+
+        return fixedRateCancellableTimer(
+            name = jobbNavn,
+            initialDelay = initialDelay,
+            loggerInfo = LoggerInfo(logger = logger, loggTilSikkerLogg = false),
+            period = periode.toMillis(),
+        ) {
+            if (erLeader()) {
+                outboxService.run()
+            }
+        }
+    }
+}

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxRepository.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxRepository.kt
@@ -1,0 +1,44 @@
+package no.nav.etterlatte.vedtaksvurdering.outbox
+
+import kotliquery.Row
+import kotliquery.queryOf
+import no.nav.etterlatte.libs.database.transaction
+import java.util.UUID
+import javax.sql.DataSource
+
+class OutboxRepository(private val datasource: DataSource) {
+    fun hentUpubliserte(): List<OutboxItem> {
+        return datasource.transaction { tx ->
+            queryOf(
+                """
+                SELECT * FROM outbox_vedtakshendelse 
+                WHERE publisert = false
+                ORDER BY opprettet
+                """.trimIndent(),
+            ).let { query -> tx.run(query.map { row -> row.toOutboxItem() }.asList) }
+        }
+    }
+
+    fun merkSomPublisert(id: UUID) {
+        datasource.transaction { tx ->
+            queryOf(
+                """
+                UPDATE outbox_vedtakshendelse
+                SET publisert = true
+                WHERE id = ?
+                """.trimIndent(),
+                id,
+            ).let { query -> tx.run(query.asUpdate) }
+                .also { require(it == 1) { "Fant ikke hendelse med id $id og status upublisert" } }
+        }
+    }
+
+    private fun Row.toOutboxItem() =
+        OutboxItem(
+            id = uuid("id"),
+            vedtakId = long("vedtakId"),
+            opprettet = localDateTime("opprettet"),
+            type = OutboxItemType.valueOf(string("type")),
+            publisert = boolean("publisert"),
+        )
+}

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxService.kt
@@ -1,0 +1,84 @@
+package no.nav.etterlatte.vedtaksvurdering.outbox
+
+import net.logstash.logback.marker.Markers
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.toJson
+import no.nav.etterlatte.libs.common.vedtak.VedtakType
+import no.nav.etterlatte.vedtaksvurdering.Vedtak
+import no.nav.etterlatte.vedtaksvurdering.VedtakInnhold
+import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingService
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+import java.util.UUID
+
+class OutboxService(
+    private val outboxRepository: OutboxRepository,
+    private val vedtaksvurderingService: VedtaksvurderingService,
+    private val publiserEksternHendelse: (UUID, String) -> Unit,
+) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    internal fun run() {
+        outboxRepository.hentUpubliserte().forEach {
+            vedtaksvurderingService.hentVedtak(it.vedtakId)?.let { vedtak ->
+                publiserVedtakshendelse(it, vedtak)
+                outboxRepository.merkSomPublisert(it.id)
+            }
+        }
+    }
+
+    private fun publiserVedtakshendelse(
+        item: OutboxItem,
+        vedtak: Vedtak,
+    ) {
+        if (vedtak.innhold is VedtakInnhold.Behandling) {
+            publiserEksternHendelse(
+                item.id,
+                Vedtakshendelse(
+                    ident = vedtak.soeker.value,
+                    sakstype = vedtak.sakType.toEksternApi(),
+                    type = vedtak.type.toEksternApi(),
+                    vedtakId = vedtak.id,
+                    vedtaksdato = vedtak.attestasjon?.tidspunkt?.toLocalDate(),
+                    virkningFom = vedtak.innhold.virkningstidspunkt.atDay(1),
+                ).toJson(),
+            )
+        } else {
+            val markers =
+                Markers.appendEntries(
+                    mapOf(
+                        "behandlingId" to vedtak.behandlingId,
+                        "outboxId" to item.id,
+                    ),
+                )
+
+            logger.warn(markers, "Støtter ikke vedtakshendelse for vedtak=${vedtak.id}, skipper")
+        }
+    }
+}
+
+internal fun VedtakType.toEksternApi(): String {
+    return when (this) {
+        VedtakType.AVSLAG -> "AVSLAG"
+        VedtakType.ENDRING -> "ENDRING"
+        VedtakType.INNVILGELSE -> "INNVILGELSE"
+        VedtakType.OPPHOER -> "OPPHOER"
+        else -> throw IllegalArgumentException("Støtter ikke vedtakstype $this")
+    }
+}
+
+internal fun SakType.toEksternApi(): String {
+    return when (this) {
+        SakType.BARNEPENSJON -> "BP"
+        SakType.OMSTILLINGSSTOENAD -> "OMS"
+    }
+}
+
+internal data class Vedtakshendelse(
+    val ident: String,
+    val sakstype: String,
+    val type: String,
+    val vedtakId: Long,
+    val vedtaksdato: LocalDate?,
+    val virkningFom: LocalDate,
+)

--- a/apps/etterlatte-vedtaksvurdering/src/main/resources/db/migration/V26__create_outbox.sql
+++ b/apps/etterlatte-vedtaksvurdering/src/main/resources/db/migration/V26__create_outbox.sql
@@ -1,0 +1,12 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE outbox_vedtakshendelse
+(
+    id        UUID PRIMARY KEY         DEFAULT (uuid_generate_v4()),
+    vedtakId  BIGINT                                                      NOT NULL REFERENCES vedtak (id),
+    type      TEXT                                                        NOT NULL,
+    opprettet TIMESTAMP WITH TIME ZONE DEFAULT (now() AT TIME ZONE 'UTC') NOT NULL,
+    publisert BOOLEAN                  DEFAULT FALSE
+);
+
+CREATE INDEX ON outbox_vedtakshendelse (publisert);

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepositoryTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepositoryTest.kt
@@ -21,6 +21,8 @@ import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import no.nav.etterlatte.vedtaksvurdering.database.DatabaseExtension
+import no.nav.etterlatte.vedtaksvurdering.outbox.OutboxItemType
+import no.nav.etterlatte.vedtaksvurdering.outbox.OutboxRepository
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -261,6 +263,12 @@ internal class VedtaksvurderingRepositoryTest(private val dataSource: DataSource
             attestant shouldBe SAKSBEHANDLER_2
             attesterendeEnhet shouldBe ENHET_2
             tidspunkt shouldNotBe null
+        }
+
+        with(OutboxRepository(dataSource).hentUpubliserte()) {
+            size shouldBeExactly 1
+            first().vedtakId shouldBe vedtak.id
+            first().type shouldBe OutboxItemType.ATTESTERT
         }
     }
 

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxIntegrationTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxIntegrationTest.kt
@@ -1,0 +1,111 @@
+package no.nav.etterlatte.vedtaksvurdering.outbox
+
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import no.nav.etterlatte.kafka.TestProdusent
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.deserialize
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
+import no.nav.etterlatte.libs.common.vedtak.VedtakType
+import no.nav.etterlatte.libs.database.single
+import no.nav.etterlatte.vedtaksvurdering.VedtakInnhold
+import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingRepository
+import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingService
+import no.nav.etterlatte.vedtaksvurdering.database.DatabaseExtension
+import no.nav.etterlatte.vedtaksvurdering.opprettVedtak
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.Month
+import java.time.YearMonth
+import java.util.UUID
+import javax.sql.DataSource
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseExtension::class)
+class OutboxIntegrationTest(private val dataSource: DataSource) {
+    private val testProdusent = TestProdusent<UUID, String>()
+    private val vedtaksvurderingRepository = VedtaksvurderingRepository(dataSource)
+    private val vedtaksvurderingService = VedtaksvurderingService(vedtaksvurderingRepository)
+    private val outboxRepository = OutboxRepository(dataSource)
+    private val outboxService = OutboxService(outboxRepository, vedtaksvurderingService, testProdusent::publiser)
+
+    @Test
+    fun `skal publisere hendelser for alle upubliserte innslag i outbox`() {
+        val vedtakAttestertInnvilgelse =
+            vedtaksvurderingRepository.opprettVedtak(
+                opprettVedtak(
+                    virkningstidspunkt = YearMonth.of(2024, Month.APRIL),
+                    soeker = Folkeregisteridentifikator.of("08815997000"),
+                    sakId = 1011L,
+                    type = VedtakType.INNVILGELSE,
+                    behandlingId = UUID.randomUUID(),
+                    status = VedtakStatus.ATTESTERT,
+                    sakType = SakType.OMSTILLINGSSTOENAD,
+                ),
+            )
+        val vedtakAttestertAlleredePublisert =
+            vedtaksvurderingRepository.opprettVedtak(
+                opprettVedtak(
+                    virkningstidspunkt = YearMonth.of(2024, Month.FEBRUARY),
+                    soeker = Folkeregisteridentifikator.of("04417103428"),
+                    sakId = 2022L,
+                    type = VedtakType.INNVILGELSE,
+                    behandlingId = UUID.randomUUID(),
+                    status = VedtakStatus.ATTESTERT,
+                    sakType = SakType.OMSTILLINGSSTOENAD,
+                ),
+            )
+        val vedtakAttestertEndring =
+            vedtaksvurderingRepository.opprettVedtak(
+                opprettVedtak(
+                    virkningstidspunkt = YearMonth.of(2024, Month.MAY),
+                    soeker = Folkeregisteridentifikator.of("04417103428"),
+                    sakId = 2022L,
+                    type = VedtakType.ENDRING,
+                    behandlingId = UUID.randomUUID(),
+                    status = VedtakStatus.ATTESTERT,
+                    sakType = SakType.OMSTILLINGSSTOENAD,
+                ),
+            )
+
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute(
+                    """
+                    INSERT INTO outbox_vedtakshendelse (vedtakId, type, publisert)
+                    VALUES 
+                    (${vedtakAttestertAlleredePublisert.id}, '${OutboxItemType.ATTESTERT.name}', true),
+                    (${vedtakAttestertInnvilgelse.id}, '${OutboxItemType.ATTESTERT.name}', false),
+                    (${vedtakAttestertEndring.id}, '${OutboxItemType.ATTESTERT.name}', false)
+                    """,
+                )
+            }
+        }
+
+        outboxService.run()
+
+        // Verifiser at rett antall hendelser er publisert med rett innhold
+        testProdusent.publiserteMeldinger.map { deserialize<Vedtakshendelse>(it.verdi) } shouldContainExactlyInAnyOrder
+            listOf(vedtakAttestertEndring, vedtakAttestertInnvilgelse)
+                .map {
+                    Vedtakshendelse(
+                        ident = it.soeker.value,
+                        sakstype = it.sakType.toEksternApi(),
+                        type = it.type.toEksternApi(),
+                        vedtakId = it.id,
+                        vedtaksdato = it.vedtakFattet?.tidspunkt?.toLocalDate(),
+                        virkningFom = (it.innhold as VedtakInnhold.Behandling).virkningstidspunkt.atDay(1),
+                    )
+                }
+
+        // Verifiser at hendelsene er merket som publisert
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.executeQuery("SELECT COUNT(1) FROM outbox_vedtakshendelse WHERE publisert = false")
+                    .single { getLong(1) } shouldBe 0
+            }
+        }
+    }
+}


### PR DESCRIPTION
Benytter outbox-patternet for å ikke involvere enda en ikke-transaksjonell komponent inn i alt som foregår i statusoppdateringene rundt vedtak. Custom enkel poller i stedet for CDC (typ Debezium) fordi behovet, volum osv er veldig lite. Betyr ingenting om det tar litt tid  før hendelsen kommer til Pesys. 