### PR TITLE
Inntektsavkorting slette hvis endret virk

### DIFF
--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -90,6 +90,10 @@ spec:
       value: 069b1b2c-0a06-4cc9-8418-f100b8ff71be
     - name: ETTERLATTE_VEDTAK_URL
       value: http://etterlatte-vedtaksvurdering
+    - name: ETTERLATTE_BEREGNING_CLIENT_ID
+      value: b07cf335-11fb-4efa-bd46-11f51afd5052
+    - name: ETTERLATTE_BEREGNING_URL
+      value: http://etterlatte-beregning
     - name: ETTERLATTE_TILBAKEKREVING_URL
       value: http://etterlatte-tilbakekreving
     - name: AZURE_SCOPE_ETTERLATTE_TILBAKEKREVING
@@ -155,6 +159,7 @@ spec:
         - application: etterlatte-grunnlag
         - application: etterlatte-vedtaksvurdering
         - application: etterlatte-migrering
+        - application: etterlatte-beregning
         - application: etterlatte-tilbakekreving
         - application: skjermede-personer-pip # namespace hører til denne. Ikke legg til ny app i mellom.
           namespace: nom

--- a/apps/etterlatte-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-behandling/.nais/prod.yaml
@@ -100,6 +100,10 @@ spec:
       value: prod-gcp.etterlatte.etterlatte-vedtaksvurdering
     - name: ETTERLATTE_VEDTAK_URL
       value: http://etterlatte-vedtaksvurdering
+    - name: ETTERLATTE_BEREGNING_CLIENT_ID
+      value: prod-gcp.etterlatte.etterlatte-beregning
+    - name: ETTERLATTE_BEREGNING_URL
+      value: http://etterlatte-beregning
     - name: ETTERLATTE_TILBAKEKREVING_URL
       value: http://etterlatte-tilbakekreving
     - name: AZURE_SCOPE_ETTERLATTE_TILBAKEKREVING
@@ -167,6 +171,7 @@ spec:
           cluster: prod-gcp
         - application: etterlatte-migrering
         - application: etterlatte-vedtaksvurdering
+        - application: etterlatte-beregning
         - application: etterlatte-tilbakekreving
         - application: etterlatte-klage
       external:

--- a/apps/etterlatte-behandling/.run/etterlatte-behandling.dev-gcp.run.xml
+++ b/apps/etterlatte-behandling/.run/etterlatte-behandling.dev-gcp.run.xml
@@ -30,6 +30,8 @@
       <env name="ETTERLATTE_MIGRERING_OUTBOUND_SCOPE" value="api://dev-gcp.etterlatte.etterlatte-migrering/.default" />
       <env name="ETTERLATTE_VEDTAK_CLIENT_ID" value="069b1b2c-0a06-4cc9-8418-f100b8ff71be" />
       <env name="ETTERLATTE_VEDTAK_URL" value="https://etterlatte-vedtaksvurdering.intern.dev.nav.no" />
+      <env name="ETTERLATTE_BEREGNING_CLIENT_ID" value="b07cf335-11fb-4efa-bd46-11f51afd5052" />
+      <env name="ETTERLATTE_BEREGNING_URL" value="https://etterlatte-beregning.intern.dev.nav.no" />
       <env name="GRUNNLAG_AZURE_SCOPE" value="api://dev-gcp.etterlatte.etterlatte-grunnlag/.default" />
       <env name="HTTP_PORT" value="8090" />
       <env name="LOGBACK_APPENDER" value="STDOUT" />

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -134,17 +134,20 @@ internal fun Route.behandlingRoutes(
                     if (!erGyldigVirkningstidspunkt) {
                         return@post call.respond(HttpStatusCode.BadRequest, "Ugyldig virkningstidspunkt")
                     }
-
+                    val bruker = brukerTokenInfo
                     try {
                         val virkningstidspunkt =
                             inTransaction {
-                                behandlingService.oppdaterVirkningstidspunkt(
-                                    behandlingId,
-                                    body.dato,
-                                    navIdent,
-                                    body.begrunnelse!!,
-                                    kravdato = body.kravdato,
-                                )
+                                runBlocking {
+                                    behandlingService.oppdaterVirkningstidspunkt(
+                                        behandlingId,
+                                        body.dato,
+                                        navIdent,
+                                        bruker,
+                                        body.begrunnelse!!,
+                                        kravdato = body.kravdato,
+                                    )
+                                }
                             }
 
                         call.respondText(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -134,7 +134,6 @@ internal fun Route.behandlingRoutes(
                     if (!erGyldigVirkningstidspunkt) {
                         return@post call.respond(HttpStatusCode.BadRequest, "Ugyldig virkningstidspunkt")
                     }
-                    val bruker = brukerTokenInfo
                     try {
                         val virkningstidspunkt =
                             inTransaction {
@@ -143,7 +142,7 @@ internal fun Route.behandlingRoutes(
                                         behandlingId,
                                         body.dato,
                                         navIdent,
-                                        bruker,
+                                        brukerTokenInfo,
                                         body.begrunnelse!!,
                                         kravdato = body.kravdato,
                                     )

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/BeregningKlientImpl.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/BeregningKlientImpl.kt
@@ -1,0 +1,40 @@
+package no.nav.etterlatte.behandling.klienter
+
+import com.github.michaelbull.result.mapError
+import com.typesafe.config.Config
+import io.ktor.client.HttpClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.AzureAdClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+interface BeregningKlient {
+    suspend fun slettAvkorting(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    )
+}
+
+class BeregningKlientImpl(config: Config, httpClient: HttpClient) : BeregningKlient {
+    private val logger = LoggerFactory.getLogger(BeregningKlientImpl::class.java)
+
+    private val azureAdClient = AzureAdClient(config)
+    private val downstreamResourceClient = DownstreamResourceClient(azureAdClient, httpClient)
+
+    private val clientId = config.getString("beregning.client.id")
+    private val resourceUrl = config.getString("beregning.resource.url")
+
+    override suspend fun slettAvkorting(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ) {
+        logger.info("Sletter avkorting for behandling id=$behandlingId")
+        downstreamResourceClient.delete(
+            resource = Resource(clientId = clientId, url = "$resourceUrl/api/beregning/avkorting/$behandlingId"),
+            brukerTokenInfo = brukerTokenInfo,
+            postBody = "",
+        ).mapError { error -> throw error }
+    }
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/migrering/MigreringRoutes.kt
@@ -23,7 +23,7 @@ fun Route.migreringRoutes(migreringService: MigreringService) {
             kunSkrivetilgang(enhetNr = migreringRequest.enhet.nr) {
                 val behandling =
                     try {
-                        migreringService.migrer(migreringRequest).let {
+                        migreringService.migrer(migreringRequest, brukerTokenInfo).let {
                             when (it) {
                                 is RetryResult.Success -> it.content
                                 is RetryResult.Failure -> throw it.samlaExceptions()

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -34,6 +34,8 @@ import no.nav.etterlatte.behandling.klage.KlageHendelserServiceImpl
 import no.nav.etterlatte.behandling.klage.KlageServiceImpl
 import no.nav.etterlatte.behandling.klienter.AxsysKlient
 import no.nav.etterlatte.behandling.klienter.AxsysKlientImpl
+import no.nav.etterlatte.behandling.klienter.BeregningKlient
+import no.nav.etterlatte.behandling.klienter.BeregningKlientImpl
 import no.nav.etterlatte.behandling.klienter.BrevApiKlient
 import no.nav.etterlatte.behandling.klienter.BrevApiKlientObo
 import no.nav.etterlatte.behandling.klienter.GrunnlagKlient
@@ -236,6 +238,7 @@ internal class ApplicationContext(
     val norg2Klient: Norg2Klient = Norg2KlientImpl(httpClient(), env.getValue("NORG2_URL")),
     val leaderElectionHttpClient: HttpClient = httpClient(),
     val grunnlagKlientObo: GrunnlagKlient = GrunnlagKlientObo(config, httpClient()),
+    val beregningsKlient: BeregningKlient = BeregningKlientImpl(config, httpClient()),
     val gosysOppgaveKlient: GosysOppgaveKlient = GosysOppgaveKlientImpl(config, httpClient()),
     val vedtakKlient: VedtakKlient = VedtakKlientImpl(config, httpClient()),
     val brevApiKlient: BrevApiKlient = BrevApiKlientObo(config, httpClient(forventSuksess = true)),
@@ -314,6 +317,7 @@ internal class ApplicationContext(
             kommerBarnetTilGodeDao = kommerBarnetTilGodeDao,
             oppgaveService = oppgaveService,
             grunnlagService = grunnlagsService,
+            beregningKlient = beregningsKlient,
         )
     val generellBehandlingService =
         GenerellBehandlingService(

--- a/apps/etterlatte-behandling/src/main/resources/application.conf
+++ b/apps/etterlatte-behandling/src/main/resources/application.conf
@@ -20,6 +20,9 @@ grunnlag.azure.scope = ${?GRUNNLAG_AZURE_SCOPE}
 vedtak.client.id = ${?ETTERLATTE_VEDTAK_CLIENT_ID}
 vedtak.resource.url = ${?ETTERLATTE_VEDTAK_URL}
 
+beregning.client.id = ${?ETTERLATTE_BEREGNING_CLIENT_ID}
+beregning.resource.url = ${?ETTERLATTE_BEREGNING_URL}
+
 tilbakekreving.resource.url = ${?ETTERLATTE_TILBAKEKREVING_URL}
 tilbakekreving.azure.scope = ${?AZURE_SCOPE_ETTERLATTE_TILBAKEKREVING}
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
@@ -209,11 +209,12 @@ internal class BehandlingRoutesTest {
                 Grunnlagsopplysning.Saksbehandler.create(NAV_IDENT),
                 bodyBegrunnelse,
             )
-        every {
+        coEvery {
             behandlingService.oppdaterVirkningstidspunkt(
                 behandlingId,
                 parsetVirkningstidspunkt,
                 NAV_IDENT,
+                any(),
                 bodyBegrunnelse,
             )
         } returns virkningstidspunkt

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
@@ -112,6 +112,7 @@ class BehandlingServiceImplTest {
                 kommerBarnetTilGodeDao = mockk(),
                 oppgaveService = mockk(),
                 grunnlagService = mockk(),
+                beregningKlient = mockk(),
             )
 
         val behandlinger = sut.hentBehandlingerForSak(1)
@@ -163,6 +164,7 @@ class BehandlingServiceImplTest {
                 kommerBarnetTilGodeDao = mockk(),
                 oppgaveService = mockk(),
                 grunnlagService = mockk(),
+                beregningKlient = mockk(),
             )
 
         val behandlinger = sut.hentBehandlingerForSak(1)
@@ -203,6 +205,7 @@ class BehandlingServiceImplTest {
                 kommerBarnetTilGodeDao = mockk(),
                 oppgaveService = mockk(),
                 grunnlagService = mockk(),
+                beregningKlient = mockk(),
             )
 
         val behandlinger = sut.hentBehandlingerForSak(1)
@@ -239,6 +242,7 @@ class BehandlingServiceImplTest {
                 kommerBarnetTilGodeDao = mockk(),
                 oppgaveService = mockk(),
                 grunnlagService = mockk(),
+                beregningKlient = mockk(),
             )
 
         val behandlinger = sut.hentBehandlingerForSak(1)
@@ -275,6 +279,7 @@ class BehandlingServiceImplTest {
                 kommerBarnetTilGodeDao = mockk(),
                 oppgaveService = mockk(),
                 grunnlagService = mockk(),
+                beregningKlient = mockk(),
             )
 
         val behandlinger = sut.hentBehandlingerForSak(1)
@@ -835,6 +840,7 @@ class BehandlingServiceImplTest {
                 kommerBarnetTilGodeDao = mockk(),
                 oppgaveService = mockk(),
                 grunnlagService = mockk(),
+                beregningKlient = mockk(),
             )
 
         val behandlinger = sut.hentBehandlingerForSak(1)
@@ -882,6 +888,7 @@ class BehandlingServiceImplTest {
                 kommerBarnetTilGodeDao = mockk(),
                 oppgaveService = mockk(),
                 grunnlagService = mockk(),
+                beregningKlient = mockk(),
             )
 
         inTransaction {
@@ -989,6 +996,7 @@ class BehandlingServiceImplTest {
             kommerBarnetTilGodeDao = mockk(),
             oppgaveService = oppgaveService,
             grunnlagService = mockk(),
+            beregningKlient = mockk(),
         )
 
     companion object {

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/BehandlingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/BehandlingIntegrationTest.kt
@@ -85,6 +85,7 @@ abstract class BehandlingIntegrationTest {
                 norg2Klient = norg2Klient ?: Norg2KlientTest(),
                 grunnlagKlientObo = GrunnlagKlientTest(),
                 vedtakKlient = spyk(VedtakKlientTest()),
+                beregningsKlient = BeregningKlientTest(),
                 gosysOppgaveKlient = GosysOppgaveKlientTest(),
                 brevApiKlient = brevApiKlient ?: BrevApiKlientTest(),
                 klageHttpClient = klageHttpClientTest(),

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
@@ -6,6 +6,7 @@ import no.nav.etterlatte.behandling.domain.ArbeidsFordelingEnhet
 import no.nav.etterlatte.behandling.domain.ArbeidsFordelingRequest
 import no.nav.etterlatte.behandling.domain.Navkontor
 import no.nav.etterlatte.behandling.klienter.AxsysKlient
+import no.nav.etterlatte.behandling.klienter.BeregningKlient
 import no.nav.etterlatte.behandling.klienter.BrevApiKlient
 import no.nav.etterlatte.behandling.klienter.BrevStatus
 import no.nav.etterlatte.behandling.klienter.GrunnlagKlient
@@ -75,6 +76,13 @@ class GrunnlagKlientTest : GrunnlagKlient {
                 ),
         )
     }
+}
+
+class BeregningKlientTest : BeregningKlient {
+    override suspend fun slettAvkorting(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ) {}
 }
 
 class VedtakKlientTest : VedtakKlient {
@@ -223,7 +231,8 @@ class BrevApiKlientTest : BrevApiKlient {
     override suspend fun slettOversendelsesbrev(
         klageId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
-    ) {}
+    ) {
+    }
 
     override suspend fun hentVedtaksbrev(
         behandlingId: UUID,

--- a/apps/etterlatte-beregning/.nais/dev.yaml
+++ b/apps/etterlatte-beregning/.nais/dev.yaml
@@ -96,3 +96,4 @@ spec:
         - application: etterlatte-vedtaksvurdering
         - application: etterlatte-statistikk
         - application: etterlatte-beregning-kafka
+        - application: etterlatte-behandling

--- a/apps/etterlatte-beregning/.nais/prod.yaml
+++ b/apps/etterlatte-beregning/.nais/prod.yaml
@@ -105,3 +105,4 @@ spec:
         - application: etterlatte-vedtaksvurdering
         - application: etterlatte-statistikk
         - application: etterlatte-beregning-kafka
+        - application: etterlatte-behandling

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -266,10 +266,19 @@ data class Aarsoppgjoer(
     val inntektsavkorting: List<Inntektsavkorting> = emptyList(),
     val avkortetYtelseAar: List<AvkortetYtelse> = emptyList(),
 ) {
-    fun utledRelevanteMaaneder(virkningstidspunkt: YearMonth) =
-        inntektsavkorting.firstOrNull {
-            it.grunnlag.periode.fom.year == virkningstidspunkt.year
-        }?.grunnlag?.relevanteMaanederInnAar ?: (12 - virkningstidspunkt.monthValue + 1)
+	/*
+	 * Relevante månder (innvilga måneder i gjeldende år) viderføres i alle grunnlagsperioder. så når man skal
+	 * utlede det til ny inntektsperiode kan man ta fra hvilken som helst periode i gjeldende år.
+	 * Hvis det ikke finnes noen inntekt for gjeldende år enda (førstegangsbehandling) regnes den ut basert på
+	 *  ny virk/innvilgelsesdato.
+	 */
+    fun utledRelevanteMaaneder(virkningstidspunkt: YearMonth): Int {
+        val aaretsFoersteForventaInntekt =
+            inntektsavkorting.sortedBy { it.grunnlag.periode.fom }.firstOrNull {
+                it.grunnlag.periode.fom.year == virkningstidspunkt.year
+            }?.grunnlag
+        return aaretsFoersteForventaInntekt?.relevanteMaanederInnAar ?: (12 - virkningstidspunkt.monthValue + 1)
+    }
 }
 
 /**

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -6,9 +6,11 @@ import no.nav.etterlatte.avkorting.AvkortetYtelseType.ETTEROPPJOER
 import no.nav.etterlatte.avkorting.AvkortetYtelseType.FORVENTET_INNTEKT
 import no.nav.etterlatte.beregning.Beregning
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagLagreDto
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import java.time.YearMonth
 import java.util.UUID
 
@@ -18,12 +20,12 @@ data class Avkorting(
     val avkortetYtelseFraVirkningstidspunkt: List<AvkortetYtelse> = emptyList(),
     val avkortetYtelseForrigeVedtak: List<AvkortetYtelse> = emptyList(),
 ) {
-    /*
-     * avkortetYtelseFraVirkningstidspunkt - Årsoppgjør inneholder ytelsen sine perioder for hele år
-     * og for behandlinger/vedtak er det kun virknigstidspunkt og fremover som er relevant.
-     *
-     * avkortetYtelseForrigeVedtak - brukes til å sammenligne med beløper til nye beregna perioder under behandlingen
-     */
+	/*
+	 * avkortetYtelseFraVirkningstidspunkt - Årsoppgjør inneholder ytelsen sine perioder for hele år
+	 * og for behandlinger/vedtak er det kun virknigstidspunkt og fremover som er relevant.
+	 *
+	 * avkortetYtelseForrigeVedtak - brukes til å sammenligne med beløper til nye beregna perioder under behandlingen
+	 */
     fun medYtelseFraOgMedVirkningstidspunkt(
         virkningstidspunkt: YearMonth,
         forrigeAvkorting: Avkorting? = null,
@@ -42,9 +44,9 @@ data class Avkorting(
             avkortetYtelseForrigeVedtak = forrigeAvkorting?.aarsoppgjoer?.avkortetYtelseAar ?: emptyList(),
         )
 
-    /*
-     * Skal kun benyttes ved opprettelse av ny avkorting ved revurdering.
-     */
+	/*
+	 * Skal kun benyttes ved opprettelse av ny avkorting ved revurdering.
+	 */
     fun kopierAvkorting(): Avkorting =
         Avkorting(
             aarsoppgjoer =
@@ -58,42 +60,47 @@ data class Avkorting(
         )
 
     fun beregnAvkortingMedNyttGrunnlag(
-        nyttGrunnlag: AvkortingGrunnlag,
+        nyttGrunnlag: AvkortingGrunnlagLagreDto,
         behandlingstype: BehandlingType,
+        virkningstidspunkt: YearMonth,
+        bruker: BrukerTokenInfo,
         beregning: Beregning,
     ) = if (behandlingstype == BehandlingType.FØRSTEGANGSBEHANDLING) {
-        oppdaterMedInntektsgrunnlag(nyttGrunnlag).beregnAvkortingForstegangs(beregning)
+        oppdaterMedInntektsgrunnlag(nyttGrunnlag, virkningstidspunkt, bruker).beregnAvkortingForstegangs(beregning)
     } else {
-        oppdaterMedInntektsgrunnlag(nyttGrunnlag).beregnAvkortingRevurdering(beregning)
+        oppdaterMedInntektsgrunnlag(nyttGrunnlag, virkningstidspunkt, bruker).beregnAvkortingRevurdering(beregning)
     }
 
-    fun oppdaterMedInntektsgrunnlag(nyttGrunnlag: AvkortingGrunnlag): Avkorting {
-        val inntektsavkorting =
+    fun oppdaterMedInntektsgrunnlag(
+        nyttGrunnlag: AvkortingGrunnlagLagreDto,
+        virkningstidspunkt: YearMonth,
+        bruker: BrukerTokenInfo,
+    ): Avkorting {
+        val oppdatert =
             aarsoppgjoer.inntektsavkorting
                 // Fjerner hvis det finnes fra før for å erstatte/redigere
                 .filter { it.grunnlag.id != nyttGrunnlag.id }
-                .map {
-                    when (it.grunnlag.periode.tom) {
-                        // Lukker grunnlag fra forrige behandling
-                        null ->
-                            it.copy(
-                                grunnlag =
-                                    it.grunnlag.copy(
-                                        periode =
-                                            Periode(
-                                                fom = it.grunnlag.periode.fom,
-                                                tom = nyttGrunnlag.periode.fom.minusMonths(1),
-                                            ),
-                                    ),
-                            )
-
-                        else -> it
-                    }
-                } + listOf(Inntektsavkorting(grunnlag = nyttGrunnlag))
+                .map { it.lukkSisteInntektsperiode(virkningstidspunkt) } +
+                listOf(
+                    Inntektsavkorting(
+                        grunnlag =
+                            AvkortingGrunnlag(
+                                id = nyttGrunnlag.id,
+                                periode = Periode(fom = virkningstidspunkt, tom = null),
+                                aarsinntekt = nyttGrunnlag.aarsinntekt,
+                                fratrekkInnAar = nyttGrunnlag.fratrekkInnAar,
+                                relevanteMaanederInnAar = aarsoppgjoer.utledRelevanteMaaneder(virkningstidspunkt),
+                                inntektUtland = nyttGrunnlag.inntektUtland,
+                                fratrekkInnAarUtland = nyttGrunnlag.fratrekkInnAarUtland,
+                                spesifikasjon = nyttGrunnlag.spesifikasjon,
+                                kilde = Grunnlagsopplysning.Saksbehandler(bruker.ident(), Tidspunkt.now()),
+                            ),
+                    ),
+                )
         return this.copy(
             aarsoppgjoer =
                 aarsoppgjoer.copy(
-                    inntektsavkorting = inntektsavkorting,
+                    inntektsavkorting = oppdatert,
                 ),
         )
     }
@@ -232,10 +239,10 @@ data class Avkorting(
         return avkortetYtelseMedAllForventetInntekt
     }
 
-    /*
-     * Det er tilfeller hvor det er nødvendig å vite når første periode i inneværende begynner.
-     * Ved inngangsår så vil ikke første måned nødvendgivis være januar så det må baseres på fom første periode.
-     */
+	/*
+	 * Det er tilfeller hvor det er nødvendig å vite når første periode i inneværende begynner.
+	 * Ved inngangsår så vil ikke første måned nødvendgivis være januar så det må baseres på fom første periode.
+	 */
     private fun foersteMaanedDetteAar() = this.aarsoppgjoer.ytelseFoerAvkorting.first().periode.fom
 }
 
@@ -258,7 +265,12 @@ data class Aarsoppgjoer(
     val ytelseFoerAvkorting: List<YtelseFoerAvkorting> = emptyList(),
     val inntektsavkorting: List<Inntektsavkorting> = emptyList(),
     val avkortetYtelseAar: List<AvkortetYtelse> = emptyList(),
-)
+) {
+    fun utledRelevanteMaaneder(virkningstidspunkt: YearMonth) =
+        inntektsavkorting.firstOrNull {
+            it.grunnlag.periode.fom.year == virkningstidspunkt.year
+        }?.grunnlag?.relevanteMaanederInnAar ?: (12 - virkningstidspunkt.monthValue + 1)
+}
 
 /**
  * [avkortingsperioder] utregnet basert på en årsinntekt ([grunnlag]).
@@ -271,7 +283,24 @@ data class Inntektsavkorting(
     val grunnlag: AvkortingGrunnlag,
     val avkortingsperioder: List<Avkortingsperiode> = emptyList(),
     val avkortetYtelseForventetInntekt: List<AvkortetYtelse> = emptyList(),
-)
+) {
+    fun lukkSisteInntektsperiode(virkningstidspunkt: YearMonth) =
+        when (grunnlag.periode.tom) {
+            null ->
+                copy(
+                    grunnlag =
+                        grunnlag.copy(
+                            periode =
+                                Periode(
+                                    fom = grunnlag.periode.fom,
+                                    tom = virkningstidspunkt.minusMonths(1),
+                                ),
+                        ),
+                )
+
+            else -> this
+        }
+}
 
 /**
  * Beregnet ytelse (ytelse før avkorting / [Beregning]) persisteres for hele år for å kunne

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
@@ -95,6 +95,12 @@ class AvkortingRepository(private val dataSource: DataSource) {
         }
     }
 
+    fun slettForBehandling(behandling: UUID) {
+        dataSource.transaction { tx ->
+            slettAvkorting(behandling, tx)
+        }
+    }
+
     private fun slettAvkorting(
         behandlingId: UUID,
         tx: TransactionalSession,

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -15,14 +15,11 @@ import no.nav.etterlatte.libs.common.beregning.AvkortetYtelseDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagKildeDto
-import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
-import no.nav.etterlatte.libs.common.periode.Periode
-import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagLagreDto
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.uuid
 import no.nav.etterlatte.libs.ktor.route.withBehandlingId
-import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 
 fun Route.avkorting(
     avkortingService: AvkortingService,
@@ -45,12 +42,12 @@ fun Route.avkorting(
         post {
             withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 logger.info("Lagre avkorting for behandlingId=$it")
-                val avkortingGrunnlag = call.receive<AvkortingGrunnlagDto>()
+                val avkortingGrunnlag = call.receive<AvkortingGrunnlagLagreDto>()
                 val avkorting =
                     avkortingService.beregnAvkortingMedNyttGrunnlag(
                         it,
                         brukerTokenInfo,
-                        avkortingGrunnlag.fromDto(brukerTokenInfo),
+                        avkortingGrunnlag,
                     )
                 call.respond(avkorting.toDto())
             }
@@ -98,17 +95,4 @@ fun AvkortetYtelse.toDto() =
         avkortingsbeloep = avkortingsbeloep,
         restanse = restanse?.fordeltRestanse ?: 0,
         ytelseEtterAvkorting = ytelseEtterAvkorting,
-    )
-
-fun AvkortingGrunnlagDto.fromDto(brukerTokenInfo: BrukerTokenInfo) =
-    AvkortingGrunnlag(
-        id = id,
-        periode = Periode(fom = fom, tom = tom),
-        aarsinntekt = aarsinntekt,
-        fratrekkInnAar = fratrekkInnAar,
-        relevanteMaanederInnAar = relevanteMaanederInnAar ?: (12 - fom.monthValue + 1),
-        inntektUtland = inntektUtland,
-        fratrekkInnAarUtland = fratrekkInnAarUtland,
-        spesifikasjon = spesifikasjon,
-        kilde = Grunnlagsopplysning.Saksbehandler(brukerTokenInfo.ident(), Tidspunkt.now()),
     )

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -7,6 +7,7 @@ import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.application
+import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
@@ -59,6 +60,14 @@ fun Route.avkorting(
                 val forrigeBehandlingId = call.uuid("forrigeBehandlingId")
                 val avkorting = avkortingService.kopierAvkorting(it, forrigeBehandlingId, brukerTokenInfo)
                 call.respond(avkorting.toDto())
+            }
+        }
+
+        delete {
+            withBehandlingId(behandlingKlient, skrivetilgang = true) {
+                logger.info("Sletter avkorting for behandlingId=$it")
+                avkortingService.slettAvkorting(it)
+                call.respond(HttpStatusCode.OK)
             }
         }
     }

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -93,6 +93,8 @@ class AvkortingService(
         return lagretAvkorting
     }
 
+    fun slettAvkorting(behandlingId: UUID) = avkortingRepository.slettForBehandling(behandlingId)
+
     /*
      * Brukes ved automatisk regulering
      */

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -1,11 +1,13 @@
 package no.nav.etterlatte.avkorting
 
+import no.nav.etterlatte.avkorting.regler.virkningstidspunkt
 import no.nav.etterlatte.beregning.BeregningService
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.virkningstidspunkt
+import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagLagreDto
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
@@ -54,7 +56,7 @@ class AvkortingService(
     suspend fun beregnAvkortingMedNyttGrunnlag(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
-        avkortingGrunnlag: AvkortingGrunnlag,
+        avkortingGrunnlagLagre: AvkortingGrunnlagLagreDto,
     ): Avkorting {
         tilstandssjekk(behandlingId, brukerTokenInfo)
         logger.info("Lagre og beregne avkorting og avkortet ytelse for behandlingId=$behandlingId")
@@ -64,8 +66,13 @@ class AvkortingService(
         val beregning = beregningService.hentBeregningNonnull(behandlingId)
         val beregnetAvkorting =
             avkorting.beregnAvkortingMedNyttGrunnlag(
-                avkortingGrunnlag,
+                avkortingGrunnlagLagre,
                 behandling.behandlingType,
+                behandling.virkningstidspunkt?.dato ?: throw IkkeTillattException(
+                    code = "MANGLER_VIRK",
+                    detail = "Behandling mangler virkningstidspunkt",
+                ),
+                brukerTokenInfo,
                 beregning,
             )
 

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -24,6 +24,7 @@ import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
+import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagLagreDto
 import no.nav.etterlatte.libs.common.beregning.BeregningsMetode
 import no.nav.etterlatte.libs.common.beregning.BeregningsMetodeBeregningsgrunnlag
 import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
@@ -129,6 +130,19 @@ fun avkortinggrunnlag(
     relevanteMaanederInnAar = relevanteMaanederInnAar,
     spesifikasjon = "Spesifikasjon",
     kilde = kilde,
+)
+
+fun avkortinggrunnlagLagre(
+    id: UUID = UUID.randomUUID(),
+    aarsinntekt: Int = 100000,
+    fratrekkInnAar: Int = 10000,
+) = AvkortingGrunnlagLagreDto(
+    id = id,
+    aarsinntekt = aarsinntekt,
+    fratrekkInnAar = fratrekkInnAar,
+    inntektUtland = 0,
+    fratrekkInnAarUtland = 0,
+    spesifikasjon = "Spesifikasjon",
 )
 
 fun inntektAvkortingGrunnlag(

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
@@ -16,7 +16,6 @@ import io.mockk.mockk
 import no.nav.etterlatte.beregning.regler.aarsoppgjoer
 import no.nav.etterlatte.beregning.regler.avkortetYtelse
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
-import no.nav.etterlatte.beregning.regler.bruker
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.ktor.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.runServer
@@ -171,41 +170,13 @@ class AvkortingRoutesTest {
                     behandlingsId,
                     any(),
                     withArg {
-                        it.periode shouldBe avkortingsgrunnlag.periode
                         it.aarsinntekt shouldBe avkortingsgrunnlag.aarsinntekt
                         it.fratrekkInnAar shouldBe avkortingsgrunnlag.fratrekkInnAar
-                        it.relevanteMaanederInnAar shouldBe 12
                         it.spesifikasjon shouldBe avkortingsgrunnlag.spesifikasjon
-                        it.kilde.ident shouldBe avkortingsgrunnlag.kilde.ident
                     },
                 )
             }
         }
-    }
-
-    @Test
-    fun `skal regne ut relevant antall maaneder inkludert innevaerende hvis det ikke finnes fra foer`() {
-        val startenAvAaret =
-            AvkortingGrunnlagDto(
-                relevanteMaanederInnAar = null,
-                id = UUID.randomUUID(),
-                fom = YearMonth.of(2023, 1),
-                tom = null,
-                aarsinntekt = 100000,
-                fratrekkInnAar = 10000,
-                inntektUtland = 0,
-                fratrekkInnAarUtland = 0,
-                spesifikasjon = "Spesifikasjon",
-                kilde =
-                    AvkortingGrunnlagKildeDto(
-                        tidspunkt = Tidspunkt.now().toString(),
-                        ident = "Saksbehandler01",
-                    ),
-            )
-        val sluttenavAaret = startenAvAaret.copy(fom = YearMonth.of(2023, 12))
-
-        startenAvAaret.fromDto(bruker).relevanteMaanederInnAar shouldBe 12
-        sluttenavAaret.fromDto(bruker).relevanteMaanederInnAar shouldBe 1
     }
 
     private fun testApplication(block: suspend ApplicationTestBuilder.() -> Unit) {

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -10,13 +10,14 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.beregning.Beregning
 import no.nav.etterlatte.beregning.BeregningService
-import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
+import no.nav.etterlatte.beregning.regler.avkortinggrunnlagLagre
 import no.nav.etterlatte.beregning.regler.behandling
 import no.nav.etterlatte.beregning.regler.bruker
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SisteIverksatteBehandling
+import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagLagreDto
 import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -320,7 +321,7 @@ internal class AvkortingServiceTest {
 
     @Nested
     inner class LagreAvkorting {
-        val endretGrunnlag = mockk<AvkortingGrunnlag>()
+        val endretGrunnlag = mockk<AvkortingGrunnlagLagreDto>()
         val beregning = mockk<Beregning>()
 
         val eksisterendeAvkorting = mockk<Avkorting>()
@@ -341,7 +342,7 @@ internal class AvkortingServiceTest {
             coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
             every { beregningService.hentBeregningNonnull(any()) } returns beregning
             every {
-                eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(any(), any(), any())
+                eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(any(), any(), any(), any(), any())
             } returns beregnetAvkorting
             every { avkortingRepository.lagreAvkorting(any(), any()) } returns Unit
             coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
@@ -358,6 +359,8 @@ internal class AvkortingServiceTest {
                 eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(
                     endretGrunnlag,
                     behandling.behandlingType,
+                    behandling.virkningstidspunkt!!.dato,
+                    bruker,
                     beregning,
                 )
                 avkortingRepository.lagreAvkorting(behandlingId, beregnetAvkorting)
@@ -387,7 +390,7 @@ internal class AvkortingServiceTest {
             coEvery { behandlingKlient.hentBehandling(any(), any()) } returns revurdering
             every { beregningService.hentBeregningNonnull(any()) } returns beregning
             every {
-                eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(any(), any(), any())
+                eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(any(), any(), any(), any(), any())
             } returns beregnetAvkorting
             every { avkortingRepository.lagreAvkorting(any(), any()) } returns Unit
             coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
@@ -409,6 +412,8 @@ internal class AvkortingServiceTest {
                 eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(
                     endretGrunnlag,
                     revurdering.behandlingType,
+                    revurdering.virkningstidspunkt!!.dato,
+                    bruker,
                     beregning,
                 )
                 avkortingRepository.lagreAvkorting(revurderingId, beregnetAvkorting)
@@ -429,7 +434,7 @@ internal class AvkortingServiceTest {
 
             runBlocking {
                 assertThrows<Exception> {
-                    service.beregnAvkortingMedNyttGrunnlag(behandlingId, bruker, avkortinggrunnlag())
+                    service.beregnAvkortingMedNyttGrunnlag(behandlingId, bruker, avkortinggrunnlagLagre())
                 }
             }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -14,7 +14,7 @@ import {
 } from '@navikt/ds-react'
 import styled from 'styled-components'
 import React, { useState } from 'react'
-import { IAvkorting, IAvkortingGrunnlag } from '~shared/types/IAvkorting'
+import { IAvkorting, IAvkortingGrunnlag, IAvkortingGrunnlagLagre } from '~shared/types/IAvkorting'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { lagreAvkortingGrunnlag } from '~shared/api/avkorting'
 import { formaterStringDato, NOK } from '~utils/formattering'
@@ -57,32 +57,25 @@ export const AvkortingInntekt = ({
   const [visHistorikk, setVisHistorikk] = useState(false)
 
   // Er det utregnet avkorting finnes det grunnlag lagt til i denne behandlingen
-  const finnesRedigerbartGrunnlag = () => avkorting?.avkortetYtelse && avkorting?.avkortetYtelse.length !== 0
+  const finnesRedigerbartGrunnlag = () =>
+    avkorting?.avkortingGrunnlag && avkorting?.avkortingGrunnlag[0].fom === virkningstidspunkt(behandling).dato
 
   const mismatchGrunnlagsperioderOgVirkningstidspunkt = (sisteGrunnlag: IAvkortingGrunnlag) =>
     sisteGrunnlag.fom !== behandling.virkningstidspunkt?.dato
 
-  const finnRedigerbartGrunnlagEllerOpprettNytt = (): IAvkortingGrunnlag => {
+  const finnRedigerbartGrunnlagEllerOpprettNytt = (): IAvkortingGrunnlagLagre => {
     if (finnesRedigerbartGrunnlag()) {
       // Returnerer grunnlagsperiode som er opprettet i denne behandlingen
-      const redigerbartGrunnlag = avkortingGrunnlag[0]
-      if (mismatchGrunnlagsperioderOgVirkningstidspunkt(redigerbartGrunnlag)) {
-        // Korrigerer fom hvis virkningstidspunkt er endret
-        return {
-          ...redigerbartGrunnlag,
-          fom: virkningstidspunkt(behandling).dato,
-        }
-      }
-      return redigerbartGrunnlag
+      return avkortingGrunnlag[0]
     }
     if (avkortingGrunnlag.length > 0) {
       // Preutfyller ny grunnlagsperiode med tidligere verdier
       const nyligste = avkortingGrunnlag[0]
-      return { ...nyligste, id: undefined, fom: virkningstidspunkt(behandling).dato }
+      return { ...nyligste, id: undefined }
     }
     // Første grunnlagsperiode
     return {
-      fom: virkningstidspunkt(behandling).dato,
+      //fom: virkningstidspunkt(behandling).dato,
       spesifikasjon: '',
     }
   }
@@ -96,12 +89,11 @@ export const AvkortingInntekt = ({
     reset,
     handleSubmit,
     formState: { errors },
-    watch,
-  } = useForm<IAvkortingGrunnlag>({
+  } = useForm<IAvkortingGrunnlagLagre>({
     defaultValues: finnRedigerbartGrunnlagEllerOpprettNytt(),
   })
 
-  const onSubmit = (data: IAvkortingGrunnlag) =>
+  const onSubmit = (data: IAvkortingGrunnlagLagre) =>
     requestLagreAvkortingGrunnlag(
       {
         behandlingId: behandling.id,
@@ -261,7 +253,7 @@ export const AvkortingInntekt = ({
                     />
                     <VStack gap="4">
                       <Label>Fra og med dato</Label>
-                      <BodyShort>{formaterStringDato(watch('fom')!)}</BodyShort>
+                      <BodyShort>{formaterStringDato(virkningstidspunkt(behandling).dato)}</BodyShort>
                     </VStack>
                   </HStack>
                 </FormWrapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -14,7 +14,7 @@ import {
 } from '@navikt/ds-react'
 import styled from 'styled-components'
 import React, { useState } from 'react'
-import { IAvkorting, IAvkortingGrunnlag, IAvkortingGrunnlagLagre } from '~shared/types/IAvkorting'
+import { IAvkorting, IAvkortingGrunnlagLagre } from '~shared/types/IAvkorting'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { lagreAvkortingGrunnlag } from '~shared/api/avkorting'
 import { formaterStringDato, NOK } from '~utils/formattering'
@@ -58,10 +58,7 @@ export const AvkortingInntekt = ({
 
   // Er det utregnet avkorting finnes det grunnlag lagt til i denne behandlingen
   const finnesRedigerbartGrunnlag = () =>
-    avkorting?.avkortingGrunnlag && avkorting?.avkortingGrunnlag[0].fom === virkningstidspunkt(behandling).dato
-
-  const mismatchGrunnlagsperioderOgVirkningstidspunkt = (sisteGrunnlag: IAvkortingGrunnlag) =>
-    sisteGrunnlag.fom !== behandling.virkningstidspunkt?.dato
+    avkorting?.avkortingGrunnlag && avkortingGrunnlag[0].fom === virkningstidspunkt(behandling).dato
 
   const finnRedigerbartGrunnlagEllerOpprettNytt = (): IAvkortingGrunnlagLagre => {
     if (finnesRedigerbartGrunnlag()) {
@@ -309,11 +306,6 @@ export const AvkortingInntekt = ({
           </Rows>
         </InntektAvkortingForm>
       )}
-      {avkortingGrunnlag.length > 0 && mismatchGrunnlagsperioderOgVirkningstidspunkt(avkortingGrunnlag[0]) && (
-        <WarningAlert variant="warning">
-          Siste inntektsperiode stemmer ikke overens med virkningstidspunkt. Du må redigere for å korrigere.
-        </WarningAlert>
-      )}
       {isFailureHandler({
         apiResult: inntektGrunnlagStatus,
         errorMessage: 'En feil har oppstått',
@@ -370,8 +362,4 @@ const SpesifikasjonLabel = styled.div``
 
 const Rows = styled.div`
   flex-direction: column;
-`
-
-const WarningAlert = styled(Alert)`
-  max-width: fit-content;
 `

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -72,7 +72,6 @@ export const AvkortingInntekt = ({
     }
     // Første grunnlagsperiode
     return {
-      //fom: virkningstidspunkt(behandling).dato,
       spesifikasjon: '',
     }
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/avkorting.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/avkorting.ts
@@ -1,5 +1,5 @@
 import { apiClient, ApiResponse } from '~shared/api/apiClient'
-import { IAvkorting, IAvkortingGrunnlag } from '~shared/types/IAvkorting'
+import { IAvkorting, IAvkortingGrunnlagLagre } from '~shared/types/IAvkorting'
 
 export const hentAvkorting = async (behandlingId: string): Promise<ApiResponse<IAvkorting>> => {
   return apiClient.get(`/beregning/avkorting/${behandlingId}`)
@@ -7,6 +7,6 @@ export const hentAvkorting = async (behandlingId: string): Promise<ApiResponse<I
 
 export const lagreAvkortingGrunnlag = async (args: {
   behandlingId: string
-  avkortingGrunnlag: IAvkortingGrunnlag
+  avkortingGrunnlag: IAvkortingGrunnlagLagre
 }): Promise<ApiResponse<IAvkorting>> =>
   apiClient.post(`/beregning/avkorting/${args.behandlingId}`, { ...args.avkortingGrunnlag })

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
@@ -6,19 +6,28 @@ export interface IAvkorting {
 }
 
 export interface IAvkortingGrunnlag {
-  id?: string
-  fom?: string
+  id: string
+  fom: string
   tom?: string
+  aarsinntekt: number
+  fratrekkInnAar: number
+  relevanteMaanederInnAar: number
+  inntektUtland: number
+  fratrekkInnAarUtland: number
+  spesifikasjon: string
+  kilde: {
+    tidspunkt: string
+    ident: string
+  }
+}
+
+export interface IAvkortingGrunnlagLagre {
+  id?: string
   aarsinntekt?: number
   fratrekkInnAar?: number
-  relevanteMaanederInnAar?: number
   inntektUtland?: number
   fratrekkInnAarUtland?: number
   spesifikasjon: string
-  kilde?: {
-    tidspunkt: ''
-    ident: ''
-  }
 }
 
 export interface IAvkortetYtelse {

--- a/libs/etterlatte-beregning-model/src/main/kotlin/BeregningDTO.kt
+++ b/libs/etterlatte-beregning-model/src/main/kotlin/BeregningDTO.kt
@@ -50,16 +50,25 @@ data class AvkortingDto(
 )
 
 data class AvkortingGrunnlagDto(
-    val id: UUID = UUID.randomUUID(),
+    val id: UUID,
     val fom: YearMonth,
     val tom: YearMonth?,
     val aarsinntekt: Int,
     val fratrekkInnAar: Int,
-    val relevanteMaanederInnAar: Int?,
+    val relevanteMaanederInnAar: Int,
     val inntektUtland: Int,
     val fratrekkInnAarUtland: Int,
     val spesifikasjon: String,
-    val kilde: AvkortingGrunnlagKildeDto?,
+    val kilde: AvkortingGrunnlagKildeDto,
+)
+
+data class AvkortingGrunnlagLagreDto(
+    val id: UUID = UUID.randomUUID(),
+    val aarsinntekt: Int,
+    val fratrekkInnAar: Int,
+    val inntektUtland: Int,
+    val fratrekkInnAarUtland: Int,
+    val spesifikasjon: String,
 )
 
 data class AvkortingGrunnlagKildeDto(


### PR DESCRIPTION
- Hoved endring er at når virkningstidspunkt endres så fjernes avkorting fra behandling istedenfor å kun varsle om at inntekt lagt til må oppdateres.
- Behandling trenger beregningsklient for å kunne slette avkortingen
- Har også gjort en del refaktorering i avkorting i forkant av endringen (flytte logikk fra frontend og route til service og domeneklasse).
