### PR TITLE
Ryddar opp i sporingslogg-konfig

### DIFF
--- a/apps/etterlatte-egne-ansatte-lytter/src/main/resources/logback.xml
+++ b/apps/etterlatte-egne-ansatte-lytter/src/main/resources/logback.xml
@@ -17,6 +17,5 @@
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
     <logger name="no.nav.etterlatte" level="DEBUG"/>
-    <include resource="logback-sporing.xml"/>
     <include resource="logback-secure.xml"/>
 </configuration>

--- a/apps/etterlatte-institusjonsopphold/src/main/resources/logback.xml
+++ b/apps/etterlatte-institusjonsopphold/src/main/resources/logback.xml
@@ -17,6 +17,5 @@
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
     <logger name="no.nav.etterlatte" level="DEBUG"/>
-    <include resource="logback-sporing.xml"/>
     <include resource="logback-secure.xml"/>
 </configuration>

--- a/apps/etterlatte-klage/src/main/resources/logback.xml
+++ b/apps/etterlatte-klage/src/main/resources/logback.xml
@@ -17,6 +17,5 @@
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
     <logger name="no.nav.etterlatte" level="DEBUG"/>
-    <include resource="logback-sporing.xml"/>
     <include resource="logback-secure.xml" />
 </configuration>

--- a/apps/etterlatte-pdltjenester/src/main/resources/logback.xml
+++ b/apps/etterlatte-pdltjenester/src/main/resources/logback.xml
@@ -16,4 +16,5 @@
 
     <logger name="no.nav.etterlatte" level="DEBUG"/>
     <include resource="logback-secure.xml"/>
+    <include resource="logback-sporing.xml"/>
 </configuration>


### PR DESCRIPTION
For at sporingslogging skal funke, må applikasjonen ha ei `logback-sporing.xml`-fil, og denne må vera referert til frå `logback.xml` på tilsvarande vis som vi elles gjer for sikkerlogg.

Tar bort konfigen der det ser ut til å vera malplassert, og legg på referansen der det ser ut som han manglar.