### PR TITLE
Forbedre merknad på oppgave ved attestering

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
@@ -189,7 +189,7 @@ class BehandlingStatusServiceImpl(
             referanse = vedtak.sakIdOgReferanse.referanse,
             type = OppgaveType.fra(behandling.type),
             merknad =
-                listOfNotNull(merknadBehandling, vedtak.vedtakHendelse.kommentar)
+                listOfNotNull(vedtak.vedtakType.tilLesbarString(), merknadBehandling, vedtak.vedtakHendelse.kommentar)
                     .joinToString(separator = ": "),
         )
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseService
 import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.generellbehandling.GenerellBehandling
+import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.oppgave.VedtakEndringDTO
 import no.nav.etterlatte.libs.common.sak.SakIDListe
 import no.nav.etterlatte.libs.common.sak.Saker
@@ -16,6 +17,9 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.libs.ktor.token.Saksbehandler
+import no.nav.etterlatte.libs.ktor.token.Systembruker
+import no.nav.etterlatte.oppgave.OppgaveService
 import no.nav.etterlatte.vedtaksvurdering.VedtakHendelse
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
@@ -56,7 +60,8 @@ interface BehandlingStatusService {
 
     fun settFattetVedtak(
         behandling: Behandling,
-        vedtakHendelse: VedtakHendelse,
+        vedtak: VedtakEndringDTO,
+        brukerTokenInfo: BrukerTokenInfo,
     )
 
     fun sjekkOmKanAttestere(behandlingId: UUID)
@@ -64,13 +69,14 @@ interface BehandlingStatusService {
     fun settAttestertVedtak(
         behandling: Behandling,
         vedtak: VedtakEndringDTO,
+        brukerTokenInfo: BrukerTokenInfo,
     )
 
     fun sjekkOmKanReturnereVedtak(behandlingId: UUID)
 
     fun settReturnertVedtak(
         behandling: Behandling,
-        vedtakHendelse: VedtakHendelse,
+        vedtak: VedtakEndringDTO,
     )
 
     fun settTilSamordnetVedtak(
@@ -94,6 +100,7 @@ interface BehandlingStatusService {
 class BehandlingStatusServiceImpl(
     private val behandlingDao: BehandlingDao,
     private val behandlingService: BehandlingService,
+    private val oppgaveService: OppgaveService,
     private val grunnlagsendringshendelseService: GrunnlagsendringshendelseService,
     private val generellBehandlingService: GenerellBehandlingService,
 ) : BehandlingStatusService {
@@ -161,7 +168,8 @@ class BehandlingStatusServiceImpl(
 
     override fun settFattetVedtak(
         behandling: Behandling,
-        vedtakHendelse: VedtakHendelse,
+        vedtak: VedtakEndringDTO,
+        brukerTokenInfo: BrukerTokenInfo,
     ) {
         if (behandling is ManuellRevurdering) {
             lagreNyBehandlingStatus(behandling.tilFattetVedtakUtvidet())
@@ -169,7 +177,21 @@ class BehandlingStatusServiceImpl(
             lagreNyBehandlingStatus(behandling.tilFattetVedtak())
         }
 
-        registrerVedtakHendelse(behandling.id, vedtakHendelse, HendelseType.FATTET)
+        registrerVedtakHendelse(behandling.id, vedtak.vedtakHendelse, HendelseType.FATTET)
+
+        val merknadBehandling =
+            when (val bruker = brukerTokenInfo) {
+                is Saksbehandler -> "Behandlet av ${bruker.ident}"
+                is Systembruker -> "Behandlet av systemet"
+            }
+
+        oppgaveService.tilAttestering(
+            referanse = vedtak.sakIdOgReferanse.referanse,
+            type = OppgaveType.fra(behandling.type),
+            merknad =
+                listOfNotNull(merknadBehandling, vedtak.vedtakHendelse.kommentar)
+                    .joinToString(separator = ": "),
+        )
     }
 
     override fun sjekkOmKanAttestere(behandlingId: UUID) {
@@ -179,6 +201,7 @@ class BehandlingStatusServiceImpl(
     override fun settAttestertVedtak(
         behandling: Behandling,
         vedtak: VedtakEndringDTO,
+        brukerTokenInfo: BrukerTokenInfo,
     ) {
         if (vedtak.vedtakType == VedtakType.AVSLAG) {
             lagreNyBehandlingStatus(behandling.tilAvslag())
@@ -187,6 +210,13 @@ class BehandlingStatusServiceImpl(
             lagreNyBehandlingStatus(behandling.tilAttestert())
         }
         registrerVedtakHendelse(behandling.id, vedtak.vedtakHendelse, HendelseType.ATTESTERT)
+
+        oppgaveService.ferdigStillOppgaveUnderBehandling(
+            referanse = vedtak.sakIdOgReferanse.referanse,
+            type = OppgaveType.fra(behandling.type),
+            saksbehandler = brukerTokenInfo,
+            merknad = "${vedtak.vedtakType.tilLesbarString()}: ${vedtak.vedtakHendelse.kommentar ?: ""}",
+        )
     }
 
     override fun sjekkOmKanReturnereVedtak(behandlingId: UUID) {
@@ -195,10 +225,19 @@ class BehandlingStatusServiceImpl(
 
     override fun settReturnertVedtak(
         behandling: Behandling,
-        vedtakHendelse: VedtakHendelse,
+        vedtak: VedtakEndringDTO,
     ) {
         lagreNyBehandlingStatus(behandling.tilReturnert())
-        registrerVedtakHendelse(behandling.id, vedtakHendelse, HendelseType.UNDERKJENT)
+        registrerVedtakHendelse(behandling.id, vedtak.vedtakHendelse, HendelseType.UNDERKJENT)
+
+        oppgaveService.tilUnderkjent(
+            referanse = vedtak.sakIdOgReferanse.referanse,
+            type = OppgaveType.fra(behandling.type),
+            merknad =
+                vedtak.vedtakHendelse.let {
+                    listOfNotNull(it.valgtBegrunnelse, it.kommentar).joinToString(separator = ": ")
+                },
+        )
     }
 
     override fun settTilSamordnetVedtak(

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -439,6 +439,7 @@ internal class ApplicationContext(
         BehandlingStatusServiceImpl(
             behandlingDao,
             behandlingService,
+            oppgaveService,
             grunnlagsendringshendelseService,
             generellBehandlingService,
         )

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -292,6 +292,7 @@ class OppgaveService(
         referanse: String,
         type: OppgaveType,
         saksbehandler: BrukerTokenInfo,
+        merknad: String? = null,
     ): OppgaveIntern {
         val behandlingsoppgaver = oppgaveDao.hentOppgaverForReferanse(referanse)
         if (behandlingsoppgaver.isEmpty()) {
@@ -303,7 +304,7 @@ class OppgaveService(
                     .filter { it.type == type }
                     .single { !it.erAvsluttet() }
 
-            ferdigstillOppgave(oppgaveUnderbehandling, saksbehandler)
+            ferdigstillOppgave(oppgaveUnderbehandling, saksbehandler, merknad)
 
             return requireNotNull(oppgaveDao.hentOppgave(oppgaveUnderbehandling.id)) {
                 "Oppgaven vi akkurat ferdigstilte kunne ikke hentes ut"

--- a/libs/etterlatte-oppgave-model/src/main/kotlin/oppgave/OppgaveIntern.kt
+++ b/libs/etterlatte-oppgave-model/src/main/kotlin/oppgave/OppgaveIntern.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.libs.common.oppgave
 
+import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -124,6 +125,15 @@ enum class OppgaveType {
     JOURNALFOERING,
     GJENOPPRETTING_ALDERSOVERGANG, // Saker som ble opphørt i Pesys etter 18 år gammel regelverk
     AKTIVITETSPLIKT,
+    ;
+
+    companion object {
+        fun fra(behandlingType: BehandlingType) =
+            when (behandlingType) {
+                BehandlingType.FØRSTEGANGSBEHANDLING -> OppgaveType.FOERSTEGANGSBEHANDLING
+                BehandlingType.REVURDERING -> OppgaveType.REVURDERING
+            }
+    }
 }
 
 data class SaksbehandlerEndringDto(

--- a/libs/saksbehandling-common/src/main/kotlin/VedtakType.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/VedtakType.kt
@@ -7,4 +7,15 @@ enum class VedtakType {
     ENDRING,
     TILBAKEKREVING,
     AVVIST_KLAGE,
+    ;
+
+    fun tilLesbarString() =
+        when (this) {
+            INNVILGELSE -> "Innvilgelse"
+            OPPHOER -> "Opphør"
+            AVSLAG -> "Avslag"
+            ENDRING -> "Endring"
+            TILBAKEKREVING -> "Tilbakekreving"
+            AVVIST_KLAGE -> "Avvist klage"
+        }
 }


### PR DESCRIPTION
- Flytte kall mot `oppgaveService` ut av `BehandlingVedtakRoute`
- Forbedre merknader på oppgave. Bl.a. legge til vedtaktype slik at sb enkelt kan se om oppgaven førte til innvilgelse, e.l.
- Flere tester 