### PR TITLE
Markerer varselbrev som er journalført utan adresse som sletta

### DIFF
--- a/apps/etterlatte-brev-api/src/main/resources/db/prod/V16__slett_varselbrev_gjenoppretting_uten_adresse.sql
+++ b/apps/etterlatte-brev-api/src/main/resources/db/prod/V16__slett_varselbrev_gjenoppretting_uten_adresse.sql
@@ -1,0 +1,2 @@
+-- Varselbrev som er journalført uten adresse
+insert into hendelse (brev_id, status_id, payload) values (17625, 'SLETTET', 'gjenoppretting');


### PR DESCRIPTION
Trur det ryddigaste og enklaste er at sb opprettar nytt varselbrev etter adresse er på plass