### PR TITLE
EY-3739: Oppretter oppgave for tilbakekreving ved feilutbetaling valgt i brevutfall

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -441,6 +441,7 @@ internal class ApplicationContext(
         BehandlingStatusServiceImpl(
             behandlingDao,
             behandlingService,
+            behandlingInfoDao,
             oppgaveService,
             grunnlagsendringshendelseService,
             generellBehandlingService,

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDao.kt
@@ -71,6 +71,12 @@ interface OppgaveDao {
         oppgaveStatus: Status,
     )
 
+    fun oppdaterReferanseOgMerknad(
+        oppgaveId: UUID,
+        referanse: String,
+        merknad: String,
+    )
+
     fun endreTilKildeBehandlingOgOppdaterReferanse(
         oppgaveId: UUID,
         referanse: String,
@@ -390,6 +396,30 @@ class OppgaveDaoImpl(private val connectionAutoclosing: ConnectionAutoclosing) :
                     )
                 statement.setString(1, merknad)
                 statement.setString(2, oppgaveStatus.name)
+                statement.setObject(3, oppgaveId)
+
+                statement.executeUpdate()
+            }
+        }
+    }
+
+    override fun oppdaterReferanseOgMerknad(
+        oppgaveId: UUID,
+        referanse: String,
+        merknad: String,
+    ) {
+        connectionAutoclosing.hentConnection {
+            with(it) {
+                val statement =
+                    prepareStatement(
+                        """
+                        UPDATE oppgave
+                        SET referanse = ?, merknad = ?
+                        where id = ?::UUID
+                        """.trimIndent(),
+                    )
+                statement.setString(1, referanse)
+                statement.setString(2, merknad)
                 statement.setObject(3, oppgaveId)
 
                 statement.executeUpdate()

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDaoMedEndringssporing.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDaoMedEndringssporing.kt
@@ -179,6 +179,16 @@ class OppgaveDaoMedEndringssporingImpl(
         }
     }
 
+    override fun oppdaterReferanseOgMerknad(
+        oppgaveId: UUID,
+        referanse: String,
+        merknad: String,
+    ) {
+        lagreEndringerPaaOppgave(oppgaveId) {
+            oppgaveDao.oppdaterReferanseOgMerknad(oppgaveId, referanse, merknad)
+        }
+    }
+
     override fun endreTilKildeBehandlingOgOppdaterReferanse(
         oppgaveId: UUID,
         referanse: String,

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -175,6 +175,19 @@ class OppgaveService(
         }
     }
 
+    fun oppdaterReferanseOgMerknad(
+        oppgaveId: UUID,
+        referanse: String,
+        merknad: String,
+    ) {
+        val hentetOppgave =
+            oppgaveDao.hentOppgave(oppgaveId) ?: throw OppgaveIkkeFunnet(oppgaveId)
+
+        sikreAktivOppgaveOgTildeltSaksbehandler(hentetOppgave) {
+            oppgaveDao.oppdaterReferanseOgMerknad(oppgaveId, referanse, merknad)
+        }
+    }
+
     fun endrePaaVent(
         oppgaveId: UUID,
         merknad: String,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/components/HandlingerForOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/components/HandlingerForOppgave.tsx
@@ -38,7 +38,8 @@ export const HandlingerForOppgave = ({
     switch (type) {
       case Oppgavetype.TILBAKEKREVING:
         return (
-          erInnloggetSaksbehandlerOppgave && (
+          erInnloggetSaksbehandlerOppgave &&
+          oppgave.merknad == 'Kravgrunnlag mottatt' && (
             <Button size="small" href={`/tilbakekreving/${referanse}`} as="a">
               Gå til tilbakekreving
             </Button>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/components/HandlingerForOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/components/HandlingerForOppgave.tsx
@@ -39,7 +39,7 @@ export const HandlingerForOppgave = ({
       case Oppgavetype.TILBAKEKREVING:
         return (
           erInnloggetSaksbehandlerOppgave &&
-          oppgave.merknad == 'Kravgrunnlag mottatt' && (
+          oppgave.merknad != 'Venter på kravgrunnlag' && (
             <Button size="small" href={`/tilbakekreving/${referanse}`} as="a">
               Gå til tilbakekreving
             </Button>

--- a/libs/saksbehandling-common/src/main/kotlin/UUID30.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/UUID30.kt
@@ -1,0 +1,7 @@
+package no.nav.etterlatte.libs.common
+
+import java.util.UUID
+
+fun UUID.toUUID30() = this.toString().replace("-", "").substring(0, 30).let { UUID30(it) }
+
+data class UUID30(val value: String)


### PR DESCRIPTION
Dersom feilutbetaling er valgt i brevutfall, opprettes det en oppgave for tilbakekreving. Formålet med denne oppgaven er bare å synliggjøre at behandlingen som ble gjort, resulterte i tilbakekreving.

- Oppgaven opprettes når en behandling settes til Iverksatt med merknad "Venter på kravgrunnlag"
- Når kravgrunnlag er mottatt, opprettes det tilbakekrevingsbehandling, referansen på oppgaven kobles mot denne behandlingen og merknad settes til "Kravgrunnlag mottatt"