### PR TITLE
La saksbehandler legge til sanksjoner i en tabell på beregning siden

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/sanksjon/SanksjonRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/sanksjon/SanksjonRoutes.kt
@@ -36,7 +36,7 @@ fun Route.sanksjon(
         post {
             withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 logger.info("Oppdaterer eller oppretter sanksjon for behandlingId=$it")
-                val sanksjon = call.receive<Sanksjon>()
+                val sanksjon = call.receive<LagreSanksjon>()
                 sanksjonService.opprettEllerOppdaterSanksjon(it, sanksjon, brukerTokenInfo)
 
                 call.respond(HttpStatusCode.OK)

--- a/apps/etterlatte-beregning/src/main/resources/db/migration/V37__endre_opprettet_og_endret_sanksjon.sql
+++ b/apps/etterlatte-beregning/src/main/resources/db/migration/V37__endre_opprettet_og_endret_sanksjon.sql
@@ -1,0 +1,7 @@
+ALTER TABLE sanksjon ALTER COLUMN endret TYPE text USING endret::text;
+
+ALTER TABLE sanksjon
+    ALTER COLUMN opprettet TYPE text USING opprettet::text;
+
+ALTER TABLE sanksjon
+    DROP COLUMN saksbehandler;

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -45,6 +45,7 @@ import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.HELSOESKEN_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.kilde
 import no.nav.etterlatte.regler.Beregningstall
+import no.nav.etterlatte.sanksjon.LagreSanksjon
 import no.nav.etterlatte.sanksjon.Sanksjon
 import java.math.RoundingMode
 import java.time.LocalDate
@@ -324,14 +325,28 @@ fun sanksjon(
     sakId: Long = 123,
     fom: YearMonth = YearMonth.of(2024, 1),
     tom: YearMonth = YearMonth.of(2024, 2),
+    beskrivelse: String = "Ikke i jobb",
 ) = Sanksjon(
     id = id,
     behandlingId = behandlingId,
     sakId = sakId,
     fom = fom,
     tom = tom,
-    saksbehandler = "A12345",
-    opprettet = Tidspunkt.now(),
-    endret = Tidspunkt.now(),
-    beskrivelse = "Ikke i jobb",
+    opprettet = Grunnlagsopplysning.Saksbehandler.create("A12345"),
+    endret = Grunnlagsopplysning.Saksbehandler.create("A12345"),
+    beskrivelse = beskrivelse,
+)
+
+fun lagreSanksjon(
+    id: UUID? = null,
+    sakId: Long = 123,
+    fom: LocalDate = LocalDate.of(2024, 1, 1),
+    tom: LocalDate = LocalDate.of(2024, 2, 1),
+    beskrivelse: String = "Ikke i jobb",
+) = LagreSanksjon(
+    id = id,
+    sakId = sakId,
+    fom = fom,
+    tom = tom,
+    beskrivelse = beskrivelse,
 )

--- a/apps/etterlatte-beregning/src/test/kotlin/sanksjon/SanksjonRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/sanksjon/SanksjonRepositoryTest.kt
@@ -4,11 +4,11 @@ import io.kotest.assertions.asClue
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import no.nav.etterlatte.beregning.regler.DatabaseExtension
-import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.beregning.regler.bruker
+import no.nav.etterlatte.beregning.regler.lagreSanksjon
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
-import java.time.YearMonth
 import java.util.UUID
 import javax.sql.DataSource
 
@@ -16,6 +16,7 @@ import javax.sql.DataSource
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class SanksjonRepositoryTest(ds: DataSource) {
     private val sanksjonRepository = SanksjonRepository(ds)
+    private val sakId = 123L
 
     @Test
     fun `skal returnere null hvis mangler sanksjon`() {
@@ -25,20 +26,9 @@ internal class SanksjonRepositoryTest(ds: DataSource) {
     @Test
     fun `Skal opprette sanksjon`() {
         val behandlingId: UUID = UUID.randomUUID()
-        val sanksjon =
-            Sanksjon(
-                id = null,
-                behandlingId = behandlingId,
-                sakId = 123,
-                fom = YearMonth.of(2024, 1),
-                tom = YearMonth.of(2024, 2),
-                saksbehandler = "A12345",
-                opprettet = Tidspunkt.now(),
-                endret = Tidspunkt.now(),
-                beskrivelse = "Ikke i jobb",
-            )
+        val sanksjon = lagreSanksjon()
 
-        sanksjonRepository.opprettSanksjon(behandlingId, sanksjon)
+        sanksjonRepository.opprettSanksjon(behandlingId, sakId, bruker.ident, sanksjon)
 
         val lagretSanksjon = sanksjonRepository.hentSanksjon(behandlingId)
 
@@ -52,20 +42,9 @@ internal class SanksjonRepositoryTest(ds: DataSource) {
     @Test
     fun `Skal oppdatere sanksjon`() {
         val behandlingId: UUID = UUID.randomUUID()
-        val sanksjon =
-            Sanksjon(
-                id = null,
-                behandlingId = behandlingId,
-                sakId = 123,
-                fom = YearMonth.of(2024, 1),
-                tom = YearMonth.of(2024, 2),
-                saksbehandler = "A12345",
-                opprettet = Tidspunkt.now(),
-                endret = Tidspunkt.now(),
-                beskrivelse = "Ikke i jobb",
-            )
+        val sanksjon = lagreSanksjon()
 
-        sanksjonRepository.opprettSanksjon(behandlingId, sanksjon)
+        sanksjonRepository.opprettSanksjon(behandlingId, sakId, bruker.ident, sanksjon)
 
         val lagretSanksjon = sanksjonRepository.hentSanksjon(behandlingId)
 
@@ -76,19 +55,12 @@ internal class SanksjonRepositoryTest(ds: DataSource) {
         }
 
         val oppdatertSanksjon =
-            Sanksjon(
+            lagreSanksjon(
                 id = lagretSanksjon.first().id,
-                behandlingId = lagretSanksjon.first().behandlingId,
-                sakId = lagretSanksjon.first().sakId,
-                fom = lagretSanksjon.first().fom,
-                tom = lagretSanksjon.first().tom,
-                saksbehandler = lagretSanksjon.first().saksbehandler,
-                opprettet = lagretSanksjon.first().opprettet,
-                endret = lagretSanksjon.first().endret,
                 beskrivelse = "Er nå i full jobb",
             )
 
-        sanksjonRepository.oppdaterSanksjon(oppdatertSanksjon)
+        sanksjonRepository.oppdaterSanksjon(oppdatertSanksjon, bruker.ident)
 
         val lagretOppdatertSanksjon = sanksjonRepository.hentSanksjon(behandlingId)
 

--- a/apps/etterlatte-beregning/src/test/kotlin/sanksjon/SanksjonRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/sanksjon/SanksjonRoutesTest.kt
@@ -11,12 +11,12 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.testApplication
 import io.mockk.coEvery
 import io.mockk.mockk
+import no.nav.etterlatte.beregning.regler.lagreSanksjon
+import no.nav.etterlatte.beregning.regler.sanksjon
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.ktor.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.runServer
-import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJson
-import no.nav.etterlatte.sanksjon.Sanksjon
 import no.nav.etterlatte.sanksjon.SanksjonService
 import no.nav.etterlatte.sanksjon.sanksjon
 import no.nav.security.mock.oauth2.MockOAuth2Server
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import java.time.YearMonth
 import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -66,19 +65,7 @@ internal class SanksjonRoutesTest {
     @Test
     fun `Skal kunne lagre en sanksjon`() {
         val sanksjonId: UUID = UUID.randomUUID()
-        val behandlingId: UUID = UUID.randomUUID()
-        val sanksjon =
-            Sanksjon(
-                id = sanksjonId,
-                behandlingId = behandlingId,
-                sakId = 123,
-                fom = YearMonth.of(2024, 1),
-                tom = YearMonth.of(2024, 2),
-                saksbehandler = "A12345",
-                opprettet = Tidspunkt.now(),
-                endret = Tidspunkt.now(),
-                beskrivelse = "Ikke i jobb",
-            )
+        val sanksjon = lagreSanksjon(sanksjonId)
 
         coEvery { sanksjonService.opprettEllerOppdaterSanksjon(any(), any(), any()) } returns Unit
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
@@ -32,6 +32,7 @@ import { Brevutfall } from '~components/behandling/brevutfall/Brevutfall'
 import { VilkaarsvurderingResultat } from '~shared/api/vilkaarsvurdering'
 import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
 import { Sanksjon } from '~components/behandling/sanksjon/Sanksjon'
+import { useFeatureEnabledMedDefault } from '~shared/hooks/useFeatureToggle'
 
 export const Beregne = (props: { behandling: IBehandlingReducer }) => {
   const { behandling } = props
@@ -44,6 +45,7 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
     ? formaterStringDato(behandling.virkningstidspunkt.dato)
     : undefined
   const innloggetSaksbehandler = useInnloggetSaksbehandler()
+  const visSanksjon = useFeatureEnabledMedDefault('sanksjon', false)
 
   const vedtaksresultat = useVedtaksResultat()
 
@@ -137,7 +139,7 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
                             behandling={behandling}
                             resetBrevutfallvalidering={() => setManglerbrevutfall(false)}
                           />
-                          <Sanksjon behandling={behandling} />
+                          {visSanksjon && <Sanksjon behandling={behandling} />}
                         </>
                       )
                   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
@@ -31,6 +31,7 @@ import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { Brevutfall } from '~components/behandling/brevutfall/Brevutfall'
 import { VilkaarsvurderingResultat } from '~shared/api/vilkaarsvurdering'
 import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
+import { Sanksjon } from '~components/behandling/sanksjon/Sanksjon'
 
 export const Beregne = (props: { behandling: IBehandlingReducer }) => {
   const { behandling } = props
@@ -136,6 +137,7 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
                             behandling={behandling}
                             resetBrevutfallvalidering={() => setManglerbrevutfall(false)}
                           />
+                          <Sanksjon behandling={behandling} />
                         </>
                       )
                   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/OmstillingsstoenadSammendrag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/OmstillingsstoenadSammendrag.tsx
@@ -64,11 +64,13 @@ export const OmstillingsstoenadSammendrag = ({ beregning }: Props) => {
   )
 }
 
-export const TableWrapper = styled.div`
+export const TableWrapper = styled.div<{
+  marginBottom?: string
+}>`
   display: flex;
   flex-wrap: wrap;
   max-width: 1000px;
-  margin-bottom: 5em;
+  margin-bottom: ${(props) => props.marginBottom ?? '5em'};
 
   .table {
     max-width: 1000px;

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sanksjon/Sanksjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sanksjon/Sanksjon.tsx
@@ -230,12 +230,7 @@ export const Sanksjon = ({ behandling }: { behandling: IBehandlingReducer }) => 
                     >
                       Avbryt
                     </Button>
-                    <Button
-                      size="small"
-                      variant="primary"
-                      icon={<PencilIcon aria-hidden fontSize="1.5rem" />}
-                      type="submit"
-                    >
+                    <Button size="small" variant="primary" type="submit">
                       Lagre
                     </Button>
                   </HStack>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sanksjon/Sanksjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sanksjon/Sanksjon.tsx
@@ -223,7 +223,6 @@ export const Sanksjon = ({ behandling }: { behandling: IBehandlingReducer }) => 
                     <Button
                       size="small"
                       variant="secondary"
-                      icon={<PencilIcon title="a11y-title" fontSize="1.5rem" />}
                       onClick={(e) => {
                         e.preventDefault()
                         setVisForm(false)
@@ -234,7 +233,7 @@ export const Sanksjon = ({ behandling }: { behandling: IBehandlingReducer }) => 
                     <Button
                       size="small"
                       variant="primary"
-                      icon={<PencilIcon title="a11y-title" fontSize="1.5rem" />}
+                      icon={<PencilIcon aria-hidden fontSize="1.5rem" />}
                       type="submit"
                     >
                       Lagre
@@ -249,7 +248,7 @@ export const Sanksjon = ({ behandling }: { behandling: IBehandlingReducer }) => 
                 <Button
                   size="small"
                   variant="secondary"
-                  icon={<PencilIcon title="a11y-title" fontSize="1.5rem" />}
+                  icon={<PencilIcon aria-hidden fontSize="1.5rem" />}
                   loading={isPending(lagreSanksjonResponse)}
                   onClick={(e) => {
                     e.preventDefault()

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sanksjon/Sanksjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sanksjon/Sanksjon.tsx
@@ -7,7 +7,7 @@ import { IBehandlingReducer } from '~store/reducers/BehandlingReducer'
 import { behandlingErRedigerbar } from '~components/behandling/felles/utils'
 import { isPending, mapApiResult } from '~shared/api/apiUtils'
 import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
-import { BodyShort, Button, Detail, Heading, HStack, Table, TextField, VStack } from '@navikt/ds-react'
+import { BodyShort, Button, Detail, Heading, HStack, Table, Textarea, VStack } from '@navikt/ds-react'
 import { PencilIcon } from '@navikt/aksel-icons'
 import { formaterStringDato } from '~utils/formattering'
 import { ControlledMaanedVelger } from '~shared/components/maanedVelger/ControlledMaanedVelger'
@@ -70,12 +70,14 @@ export const Sanksjon = ({ behandling }: { behandling: IBehandlingReducer }) => 
   })
 
   const validerFom = (value: Date): string | undefined => {
-    const fom = startOfDay(new Date(value))
-    const tom = startOfDay(new Date(getValues().datoTom!))
-
     if (!value) {
       return 'Fra dato må settes'
-    } else if (fom > tom) {
+    }
+
+    const fom = startOfDay(new Date(value))
+    const tom = getValues().datoTom ? startOfDay(new Date(getValues().datoTom!)) : null
+
+    if (tom && fom > tom) {
       return 'Fra dato kan ikke være etter Til dato.'
     } else if (behandling.virkningstidspunkt?.dato && fom < startOfDay(new Date(behandling.virkningstidspunkt.dato))) {
       return 'Fra dato før virkningstidspunkt.'
@@ -84,10 +86,10 @@ export const Sanksjon = ({ behandling }: { behandling: IBehandlingReducer }) => 
   }
 
   const validerTom = (value: Date): string | undefined => {
-    const fom = startOfDay(new Date(getValues().datoFom!))
+    const fom = getValues().datoFom ? startOfDay(new Date(getValues().datoFom!)) : null
     const tom = startOfDay(new Date(value))
 
-    if (fom > tom) {
+    if (fom && fom > tom) {
       return 'Til dato kan ikke være før Fra dato'
     }
     return undefined
@@ -206,12 +208,14 @@ export const Sanksjon = ({ behandling }: { behandling: IBehandlingReducer }) => 
                       required
                     />
                     <ControlledMaanedVelger
-                      label="Dato til og med"
+                      label="Dato til og med (valgfri)"
                       name="datoTom"
                       control={control}
                       validate={validerTom}
                     />
-                    <TextField
+                  </HStack>
+                  <HStack>
+                    <Textarea
                       {...register('beskrivelse', {
                         required: { value: true, message: 'Må fylles ut' },
                       })}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sanksjon/Sanksjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sanksjon/Sanksjon.tsx
@@ -1,0 +1,272 @@
+import styled from 'styled-components'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import React, { useEffect, useState } from 'react'
+import Spinner from '~shared/Spinner'
+import { ApiErrorAlert } from '~ErrorBoundary'
+import { IBehandlingReducer } from '~store/reducers/BehandlingReducer'
+import { behandlingErRedigerbar } from '~components/behandling/felles/utils'
+import { isPending, mapApiResult } from '~shared/api/apiUtils'
+import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
+import { BodyShort, Button, Detail, Heading, HStack, Table, TextField, VStack } from '@navikt/ds-react'
+import { PencilIcon } from '@navikt/aksel-icons'
+import { formaterStringDato } from '~utils/formattering'
+import { ControlledMaanedVelger } from '~shared/components/maanedVelger/ControlledMaanedVelger'
+import { useForm } from 'react-hook-form'
+import { startOfDay, formatISO } from 'date-fns'
+import { hentSanksjon, lagreSanksjon } from '~shared/api/sanksjon'
+import { TableWrapper } from '~components/behandling/beregne/OmstillingsstoenadSammendrag'
+
+export interface ISanksjon {
+  id?: string
+  behandlingId: string
+  sakId: number
+  fom: string
+  tom?: string
+  opprettet: {
+    tidspunkt: string
+    ident: string
+  }
+  endret?: {
+    tidspunkt: string
+    ident: string
+  }
+  beskrivelse: string
+}
+
+export interface ISanksjonLagre {
+  id?: string
+  sakId: number
+  fom: string
+  tom?: string
+  beskrivelse: string
+}
+
+export const Sanksjon = ({ behandling }: { behandling: IBehandlingReducer }) => {
+  const [lagreSanksjonResponse, lagreSanksjonRequest] = useApiCall(lagreSanksjon)
+  const [sanksjonStatus, hentSanksjonRequest] = useApiCall(hentSanksjon)
+  const [sanksjoner, setSanksjoner] = useState<ISanksjon[]>()
+  const [visForm, setVisForm] = useState(false)
+  const innloggetSaksbehandler = useInnloggetSaksbehandler()
+
+  const redigerbar = behandlingErRedigerbar(
+    behandling.status,
+    behandling.sakEnhetId,
+    innloggetSaksbehandler.skriveEnheter
+  )
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    getValues,
+    reset,
+    formState: { errors },
+  } = useForm({
+    defaultValues: {
+      datoFom: undefined,
+      datoTom: undefined,
+      beskrivelse: '',
+    },
+  })
+
+  const validerFom = (value: Date): string | undefined => {
+    const fom = startOfDay(new Date(value))
+    const tom = startOfDay(new Date(getValues().datoTom!))
+
+    if (!value) {
+      return 'Fra-måned må settes'
+    } else if (fom > tom) {
+      return 'Fra-måned kan ikke være etter til-måned.'
+    } else if (behandling.virkningstidspunkt?.dato && fom < startOfDay(new Date(behandling.virkningstidspunkt.dato))) {
+      return 'Fra-måned før virkningstidspunkt.'
+    }
+    return undefined
+  }
+
+  const validerTom = (value: Date): string | undefined => {
+    const fom = startOfDay(new Date(getValues().datoFom!))
+    const tom = startOfDay(new Date(value))
+
+    if (fom > tom) {
+      return 'Til-måned kan ikke være før Fra-måned'
+    }
+    return undefined
+  }
+
+  const submitSanksjon = (data: { datoFom?: Date; datoTom?: Date; beskrivelse: string }) => {
+    const lagreSanksjon: ISanksjonLagre = {
+      id: undefined,
+      sakId: behandling.sakId,
+      fom: formatISO(data.datoFom!, { representation: 'date' }),
+      tom: data.datoTom ? formatISO(data.datoTom!, { representation: 'date' }) : undefined,
+      beskrivelse: data.beskrivelse,
+    }
+
+    lagreSanksjonRequest(
+      {
+        behandlingId: behandling.id,
+        sanksjon: lagreSanksjon,
+      },
+      () => {
+        reset()
+        hentSanksjoner()
+        setVisForm(false)
+      }
+    )
+  }
+
+  const hentSanksjoner = () => {
+    hentSanksjonRequest(behandling.id, (res) => {
+      setSanksjoner(res)
+    })
+  }
+
+  useEffect(() => {
+    if (!sanksjoner) {
+      hentSanksjoner()
+    }
+  }, [])
+
+  return (
+    <SanksjonWrapper>
+      {mapApiResult(
+        sanksjonStatus,
+        <Spinner visible label="Henter sanksjoner" />,
+        () => (
+          <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>
+        ),
+        () => (
+          <VStack gap="4">
+            <Heading spacing size="small" level="2">
+              Sanksjoner
+            </Heading>
+            <BodyShort>Her kommer det informasjon om sanksjoner.</BodyShort>
+
+            <TableWrapper marginBottom="1rem">
+              <Table className="table" zebraStripes size="medium">
+                <Table.Header>
+                  <Table.Row>
+                    <Table.HeaderCell>Fra dato</Table.HeaderCell>
+                    <Table.HeaderCell>Til dato</Table.HeaderCell>
+                    <Table.HeaderCell>Beskrivelse</Table.HeaderCell>
+                    <Table.HeaderCell>Registrert</Table.HeaderCell>
+                    <Table.HeaderCell>Endret</Table.HeaderCell>
+                  </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                  {sanksjoner && sanksjoner.length > 0 ? (
+                    <>
+                      {sanksjoner.map((lagretSanksjon, index) => (
+                        <Table.Row key={index}>
+                          <Table.DataCell>{formaterStringDato(lagretSanksjon.fom)}</Table.DataCell>
+                          <Table.DataCell>
+                            {lagretSanksjon.tom ? formaterStringDato(lagretSanksjon.tom) : '-'}
+                          </Table.DataCell>
+                          <Table.DataCell>{lagretSanksjon.beskrivelse}</Table.DataCell>
+                          <Table.DataCell>
+                            <BodyShort>{lagretSanksjon.opprettet.ident}</BodyShort>
+                            <Detail>{`saksbehandler: ${formaterStringDato(lagretSanksjon.opprettet.tidspunkt)}`}</Detail>
+                          </Table.DataCell>
+                          <Table.DataCell>
+                            {lagretSanksjon.endret ? (
+                              <>
+                                <BodyShort>{lagretSanksjon.endret.ident}</BodyShort>
+                                <Detail>{`saksbehandler: ${formaterStringDato(lagretSanksjon.endret.tidspunkt)}`}</Detail>
+                              </>
+                            ) : (
+                              '-'
+                            )}
+                          </Table.DataCell>
+                        </Table.Row>
+                      ))}
+                    </>
+                  ) : (
+                    <Table.Row>
+                      <Table.DataCell align="center" colSpan={5}>
+                        Bruker har ingen sanksjoner
+                      </Table.DataCell>
+                    </Table.Row>
+                  )}
+                </Table.Body>
+              </Table>
+            </TableWrapper>
+
+            {visForm && (
+              <form onSubmit={handleSubmit(submitSanksjon)}>
+                <Heading size="small" level="3" spacing>
+                  Ny sanksjon
+                </Heading>
+                <VStack gap="4">
+                  <HStack gap="4">
+                    <ControlledMaanedVelger
+                      label="Dato fra og med"
+                      name="datoFom"
+                      control={control}
+                      validate={validerFom}
+                      required
+                    />
+                    <ControlledMaanedVelger
+                      label="Dato til og med"
+                      name="datoTom"
+                      control={control}
+                      validate={validerTom}
+                    />
+                    <TextField
+                      {...register('beskrivelse', {
+                        required: { value: true, message: 'Må fylles ut' },
+                      })}
+                      label="Beskrivelse"
+                      error={errors.beskrivelse?.message}
+                    />
+                  </HStack>
+                  <HStack gap="4">
+                    <Button
+                      size="small"
+                      variant="secondary"
+                      icon={<PencilIcon title="a11y-title" fontSize="1.5rem" />}
+                      onClick={(e) => {
+                        e.preventDefault()
+                        setVisForm(false)
+                      }}
+                    >
+                      Avbryt
+                    </Button>
+                    <Button
+                      size="small"
+                      variant="primary"
+                      icon={<PencilIcon title="a11y-title" fontSize="1.5rem" />}
+                      type="submit"
+                    >
+                      Lagre
+                    </Button>
+                  </HStack>
+                </VStack>
+              </form>
+            )}
+
+            {!visForm && redigerbar && (
+              <HStack>
+                <Button
+                  size="small"
+                  variant="secondary"
+                  icon={<PencilIcon title="a11y-title" fontSize="1.5rem" />}
+                  loading={isPending(lagreSanksjonResponse)}
+                  onClick={(e) => {
+                    e.preventDefault()
+                    setVisForm(true)
+                  }}
+                >
+                  Legg til sanksjon
+                </Button>
+              </HStack>
+            )}
+          </VStack>
+        )
+      )}
+    </SanksjonWrapper>
+  )
+}
+
+const SanksjonWrapper = styled.div`
+  margin: 2em 0 1em 0;
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sanksjon/Sanksjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sanksjon/Sanksjon.tsx
@@ -74,11 +74,11 @@ export const Sanksjon = ({ behandling }: { behandling: IBehandlingReducer }) => 
     const tom = startOfDay(new Date(getValues().datoTom!))
 
     if (!value) {
-      return 'Fra-måned må settes'
+      return 'Fra dato må settes'
     } else if (fom > tom) {
-      return 'Fra-måned kan ikke være etter til-måned.'
+      return 'Fra dato kan ikke være etter Til dato.'
     } else if (behandling.virkningstidspunkt?.dato && fom < startOfDay(new Date(behandling.virkningstidspunkt.dato))) {
-      return 'Fra-måned før virkningstidspunkt.'
+      return 'Fra dato før virkningstidspunkt.'
     }
     return undefined
   }
@@ -88,7 +88,7 @@ export const Sanksjon = ({ behandling }: { behandling: IBehandlingReducer }) => 
     const tom = startOfDay(new Date(value))
 
     if (fom > tom) {
-      return 'Til-måned kan ikke være før Fra-måned'
+      return 'Til dato kan ikke være før Fra dato'
     }
     return undefined
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/sanksjon.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/sanksjon.ts
@@ -1,0 +1,11 @@
+import { apiClient, ApiResponse } from '~shared/api/apiClient'
+import { ISanksjon, ISanksjonLagre } from '~components/behandling/sanksjon/Sanksjon'
+
+export const hentSanksjon = async (behandlingId: string): Promise<ApiResponse<ISanksjon[]>> => {
+  return apiClient.get(`/beregning/sanksjon/${behandlingId}`)
+}
+
+export const lagreSanksjon = async (args: {
+  behandlingId: string
+  sanksjon: ISanksjonLagre
+}): Promise<ApiResponse<void>> => apiClient.post(`/beregning/sanksjon/${args.behandlingId}`, { ...args.sanksjon })

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/components/maanedVelger/ControlledMaanedVelger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/components/maanedVelger/ControlledMaanedVelger.tsx
@@ -10,6 +10,7 @@ interface Props<T extends FieldValues> {
   fromDate?: Date
   toDate?: Date
   validate: (maaned: Date) => string | undefined
+  required?: boolean
 }
 
 export const ControlledMaanedVelger = <T extends FieldValues>({
@@ -19,6 +20,7 @@ export const ControlledMaanedVelger = <T extends FieldValues>({
   fromDate,
   toDate,
   validate,
+  required = false,
 }: Props<T>): ReactNode => {
   const {
     field,
@@ -40,6 +42,7 @@ export const ControlledMaanedVelger = <T extends FieldValues>({
     toDate: toDate ?? undefined,
     locale: 'nb',
     onValidate: setDateError,
+    required: required,
   } as UseMonthPickerOptions)
 
   return (

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/components/maanedVelger/ControlledMaanedVelger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/components/maanedVelger/ControlledMaanedVelger.tsx
@@ -9,7 +9,7 @@ interface Props<T extends FieldValues> {
   control: Control<T>
   fromDate?: Date
   toDate?: Date
-  validate: (maaned: Date) => string | undefined
+  validate?: (maaned: Date) => string | undefined
   required?: boolean
 }
 
@@ -19,8 +19,7 @@ export const ControlledMaanedVelger = <T extends FieldValues>({
   control,
   fromDate,
   toDate,
-  validate,
-  required = false,
+  validate = undefined,
 }: Props<T>): ReactNode => {
   const {
     field,
@@ -41,8 +40,10 @@ export const ControlledMaanedVelger = <T extends FieldValues>({
     fromDate: fromDate ?? undefined,
     toDate: toDate ?? undefined,
     locale: 'nb',
-    onValidate: setDateError,
-    required: required,
+    onValidate: (val) => {
+      if (val.isEmpty) field.onChange(null)
+      else setDateError(val)
+    },
   } as UseMonthPickerOptions)
 
   return (


### PR DESCRIPTION
Ta gjerne en ekstra titt på hvordan opprettet og endret er løst. Har brukt samme konsept som kilde på begge felter, sånn at man får med data om hvilken saksbehandler som gjør hvilken del.

<img width="857" alt="Skjermbilde 2024-04-12 kl  19 54 45" src="https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/17142094/95056af0-460c-48f0-875a-53c091109acd">


Mulig man burde bruke textarea fremfor textfield for beskrivelse
<img width="542" alt="Skjermbilde 2024-04-12 kl  19 55 53" src="https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/17142094/47949895-41e0-4302-8955-ff9aebfaf22e">

