### PR TITLE
EY-3815 Støtte søk på tema PEN på gosys-oppgaver

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveKlient.kt
@@ -52,6 +52,7 @@ data class GosysEndreFristRequest(
 
 interface GosysOppgaveKlient {
     suspend fun hentOppgaver(
+        tema: List<String>,
         enhetsnr: String? = null,
         brukerTokenInfo: BrukerTokenInfo,
     ): GosysOppgaver
@@ -98,16 +99,17 @@ class GosysOppgaveKlientImpl(config: Config, httpClient: HttpClient) : GosysOppg
     private val resourceUrl = config.getString("oppgave.resource.url")
 
     override suspend fun hentOppgaver(
+        tema: List<String>,
         enhetsnr: String?,
         brukerTokenInfo: BrukerTokenInfo,
     ): GosysOppgaver {
         try {
             logger.info("Henter oppgaver fra Gosys")
 
+            val temaFilter = tema.map { "&tema=$it" }.joinToString(separator = "")
             val filters =
                 "statuskategori=AAPEN"
-                    .plus("&tema=EYB")
-                    .plus("&tema=EYO")
+                    .plus(temaFilter)
                     .plus("&limit=1000")
                     .plus(enhetsnr?.let { "&tildeltEnhetsnr=$it" } ?: "")
 

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveRoute.kt
@@ -20,7 +20,9 @@ internal fun Route.gosysOppgaveRoute(gosysService: GosysOppgaveService) {
     route("/api/oppgaver/gosys") {
         get {
             kunSaksbehandler {
-                call.respond(gosysService.hentOppgaver(brukerTokenInfo))
+                val tema = call.request.queryParameters.getAll("tema") ?: listOf("EYO", "EYB")
+
+                call.respond(gosysService.hentOppgaver(tema, brukerTokenInfo))
             }
         }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveService.kt
@@ -16,7 +16,10 @@ import java.time.Duration
 import java.time.LocalTime
 
 interface GosysOppgaveService {
-    suspend fun hentOppgaver(brukerTokenInfo: BrukerTokenInfo): List<GosysOppgave>
+    suspend fun hentOppgaver(
+        tema: List<String>,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<GosysOppgave>
 
     suspend fun hentOppgave(
         id: Long,
@@ -59,11 +62,15 @@ class GosysOppgaveServiceImpl(
             .expireAfterWrite(Duration.ofMinutes(5))
             .build<Long, GosysOppgave>()
 
-    override suspend fun hentOppgaver(brukerTokenInfo: BrukerTokenInfo): List<GosysOppgave> {
+    override suspend fun hentOppgaver(
+        tema: List<String>,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<GosysOppgave> {
         val saksbehandlerMedRoller = Kontekst.get().appUserAsSaksbehandler().saksbehandlerMedRoller
 
         val gosysOppgaver =
             gosysOppgaveKlient.hentOppgaver(
+                tema,
                 enhetsnr = if (saksbehandlerMedRoller.harRolleStrengtFortrolig()) Enheter.STRENGT_FORTROLIG.enhetNr else null,
                 brukerTokenInfo = brukerTokenInfo,
             )

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
@@ -265,6 +265,7 @@ class BrevApiKlientTest : BrevApiKlient {
 
 class GosysOppgaveKlientTest : GosysOppgaveKlient {
     override suspend fun hentOppgaver(
+        tema: List<String>,
         enhetsnr: String?,
         brukerTokenInfo: BrukerTokenInfo,
     ): GosysOppgaver {

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgaveGosys/GosysOppgaveServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgaveGosys/GosysOppgaveServiceImplTest.kt
@@ -70,7 +70,7 @@ class GosysOppgaveServiceImplTest {
 
         every { saksbehandler.saksbehandlerMedRoller } returns saksbehandlerRoller
 
-        coEvery { gosysOppgaveKlient.hentOppgaver(any(), brukerTokenInfo) } returns
+        coEvery { gosysOppgaveKlient.hentOppgaver(listOf("EYO", "EYB"), any(), brukerTokenInfo) } returns
             GosysOppgaver(
                 antallTreffTotalt = 3,
                 oppgaver =
@@ -130,7 +130,7 @@ class GosysOppgaveServiceImplTest {
 
         val resultat =
             runBlocking {
-                service.hentOppgaver(brukerTokenInfo)
+                service.hentOppgaver(listOf("EYO", "EYB"), brukerTokenInfo)
             }
 
         resultat shouldHaveSize 3
@@ -156,7 +156,7 @@ class GosysOppgaveServiceImplTest {
 
         every { saksbehandler.saksbehandlerMedRoller } returns saksbehandlerRoller
 
-        coEvery { gosysOppgaveKlient.hentOppgaver(Enheter.STRENGT_FORTROLIG.enhetNr, brukerTokenInfo) } returns
+        coEvery { gosysOppgaveKlient.hentOppgaver(listOf("EYO", "EYB"), Enheter.STRENGT_FORTROLIG.enhetNr, brukerTokenInfo) } returns
             enhetsfiltrererGosysOppgaver(
                 Enheter.STRENGT_FORTROLIG.enhetNr,
                 listOf(
@@ -215,7 +215,7 @@ class GosysOppgaveServiceImplTest {
 
         val resultat =
             runBlocking {
-                service.hentOppgaver(brukerTokenInfo)
+                service.hentOppgaver(listOf("EYO", "EYB"), brukerTokenInfo)
             }
 
         resultat shouldHaveSize 1

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/filtreringAvOppgaver/FilterRad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/filtreringAvOppgaver/FilterRad.tsx
@@ -26,6 +26,7 @@ interface Props {
   setFilter: (filter: Filter) => void
   saksbehandlereIEnhet: Array<Saksbehandler>
   oppgavelisteValg?: OppgavelisteValg
+  children?: ReactNode
 }
 
 export const FilterRad = ({
@@ -35,6 +36,7 @@ export const FilterRad = ({
   setFilter,
   saksbehandlereIEnhet,
   oppgavelisteValg,
+  children,
 }: Props): ReactNode => {
   const [sakEllerFnr, setSakEllerFnr] = useState<string>(filter.sakEllerFnrFilter)
 
@@ -122,6 +124,8 @@ export const FilterRad = ({
             />
           </>
         )}
+
+        {children}
       </FlexRow>
 
       <FlexRow $spacing>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaver.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaver.ts
@@ -3,6 +3,7 @@ import { konverterOppgavestatusFilterValuesTilKeys } from '~components/oppgavebe
 import { Saksbehandler } from '~shared/types/saksbehandler'
 import { OppgavebenkStats } from '~components/oppgavebenk/state/oppgavebenkState'
 import { NyOppgaveDto, OppgaveDTO, Oppgavetype } from '~shared/types/oppgave'
+import { GosysTema } from '~shared/types/Gosys'
 
 export const hentOppgaverMedStatus = async (args: {
   oppgavestatusFilter: Array<string>
@@ -37,7 +38,11 @@ export const hentSaksbehandlerForOppgaveUnderBehandling = async (
 ): Promise<ApiResponse<Saksbehandler>> =>
   apiClient.get(`/oppgaver/referanse/${referanse}/saksbehandler-underbehandling`)
 
-export const hentGosysOppgaver = async (): Promise<ApiResponse<OppgaveDTO[]>> => apiClient.get('/oppgaver/gosys')
+export const hentGosysOppgaver = async (tema: GosysTema[]): Promise<ApiResponse<OppgaveDTO[]>> => {
+  const queryParams = tema.map((t) => `tema=${t}`).join('&')
+
+  return apiClient.get(`/oppgaver/gosys?${queryParams}`)
+}
 
 export const hentOppgavebenkStats = async (): Promise<ApiResponse<OppgavebenkStats>> => apiClient.get('/oppgaver/stats')
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Gosys.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Gosys.ts
@@ -1,0 +1,24 @@
+export enum GosysTema {
+  PEN = 'PEN',
+  EYO = 'EYO',
+  EYB = 'EYB',
+}
+
+export const GOSYS_TEMA_FILTER: Record<GosysTema, string> = {
+  PEN: 'Pensjon',
+  EYO: 'Omstillingsstønad',
+  EYB: 'Barnepensjon',
+}
+
+export const konverterStringTilGosysTema = (value: string): GosysTema => {
+  switch (value) {
+    case 'Pensjon':
+      return GosysTema.PEN
+    case 'Omstillingsstønad':
+      return GosysTema.EYO
+    case 'Barnepensjon':
+      return GosysTema.EYB
+    default:
+      throw Error(`Ukjent gosys tema ${value}`)
+  }
+}

--- a/apps/etterlatte-saksbehandling-ui/docker-compose.yml
+++ b/apps/etterlatte-saksbehandling-ui/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       APP_VERSION: 1
       # Lokale URL-er skal kommenteres ut når de ikke er i bruk
 #      BREV_API_URL: http://host.docker.internal:8084
-      BEHANDLING_API_URL: http://host.docker.internal:8090
+#      BEHANDLING_API_URL: http://host.docker.internal:8090
 #      PDLTJENESTER_API_URL: http://host.docker.internal:8091
     env_file:
       - .env.dev-gcp # Opprettes med script get-secret.sh. Les README

--- a/apps/etterlatte-saksbehandling-ui/docker-compose.yml
+++ b/apps/etterlatte-saksbehandling-ui/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       APP_VERSION: 1
       # Lokale URL-er skal kommenteres ut når de ikke er i bruk
 #      BREV_API_URL: http://host.docker.internal:8084
-#      BEHANDLING_API_URL: http://host.docker.internal:8090
+      BEHANDLING_API_URL: http://host.docker.internal:8090
 #      PDLTJENESTER_API_URL: http://host.docker.internal:8091
     env_file:
       - .env.dev-gcp # Opprettes med script get-secret.sh. Les README


### PR DESCRIPTION
Grunnet gammel moro med konvertering av Gosys-oppgave til Gjenny-oppgave, vil det her se litt rart ut siden oppgavetype og saktype mappes til noe vilkårlig. Eks. vil alt av **pensjon** bli mappet til **barnepensjon**. 

Må ryddes opp i fortløpende slik at Gosys-oppgaver blir _helt_ fristilt. 

### Nytt felt på filtrering av Gosys-oppgaver: 

<img width="1186" alt="Screenshot 2024-04-15 at 09 29 22" src="https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/5645b50e-1a66-44a6-9532-27e25540d14d">
