### PR TITLE
fix: Se alltid på avdødes sivilstander for å avgjøre tidspunkt for ekteskap

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseUtil.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseUtil.kt
@@ -85,7 +85,7 @@ fun varEktefelleVedDoedsfall(
                     Sivilstatus.SEPARERT_PARTNER,
                 )
             ) {
-                return it.relatertVedSiviltilstand?.value == eps
+                return it.relatertVedSiviltilstand?.value == eps && !harSkiltSivilstandUtenGyldigFomDato(avdoed)
             }
             return false
         }
@@ -117,3 +117,10 @@ fun finnAntallAarGiftVedDoedsfall(
                 null
             }
         }
+
+fun harSkiltSivilstandUtenGyldigFomDato(person: PersonDTO): Boolean =
+    person.sivilstand
+        ?.map { it.verdi }
+        ?.filter { it.sivilstatus in listOf(Sivilstatus.SKILT, Sivilstatus.SKILT_PARTNER) }
+        ?.any { it.gyldigFraOgMed == null }
+        ?: false

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktEktefelleServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktEktefelleServiceTest.kt
@@ -86,12 +86,20 @@ internal class DoedshendelseKontrollpunktEktefelleServiceTest {
 
     @Test
     fun `Skal opprette kontrollpunkt for tidligere ektefeller som har vaert gift i mer enn 25 aar`() {
-        val gjenlevende =
-            gjenlevende.copy(
+        val avdoed =
+            avdoed.copy(
                 sivilstand =
                     listOf(
-                        sivilstand(antallAarSiden = 30, sivilstatus = Sivilstatus.GIFT, relatertPerson = avdoed.foedselsnummer.verdi.value),
-                        sivilstand(antallAarSiden = 3, sivilstatus = Sivilstatus.SKILT, relatertPerson = avdoed.foedselsnummer.verdi.value),
+                        sivilstand(
+                            antallAarSiden = 30,
+                            sivilstatus = Sivilstatus.GIFT,
+                            relatertPerson = gjenlevende.foedselsnummer.verdi.value,
+                        ),
+                        sivilstand(
+                            antallAarSiden = 3,
+                            sivilstatus = Sivilstatus.SKILT,
+                            relatertPerson = gjenlevende.foedselsnummer.verdi.value,
+                        ),
                     ).flatten(),
             )
         val kontrollpunkter = kontrollpunktService.identifiser(gjenlevende, avdoed)
@@ -106,20 +114,20 @@ internal class DoedshendelseKontrollpunktEktefelleServiceTest {
 
     @Test
     fun `Skal opprette kontrollpunkt for tidligere ektefeller som har vaert gift i mer enn 15 aar og felles barn`() {
-        val avdoed = avdoed.copy(familieRelasjon = familieRelasjonMedBarn())
-        val gjenlevende =
+        val gjenlevende = avdoed.copy(familieRelasjon = familieRelasjonMedBarn())
+        val avdoed =
             gjenlevende.copy(
                 sivilstand =
                     listOf(
                         sivilstand(
                             antallAarSiden = 20,
                             sivilstatus = Sivilstatus.GIFT,
-                            relatertPerson = Companion.avdoed.foedselsnummer.verdi.value,
+                            relatertPerson = gjenlevende.foedselsnummer.verdi.value,
                         ),
                         sivilstand(
                             antallAarSiden = 3,
                             sivilstatus = Sivilstatus.SKILT,
-                            relatertPerson = Companion.avdoed.foedselsnummer.verdi.value,
+                            relatertPerson = gjenlevende.foedselsnummer.verdi.value,
                         ),
                     ).flatten(),
                 familieRelasjon = familieRelasjonMedBarn(),
@@ -137,15 +145,19 @@ internal class DoedshendelseKontrollpunktEktefelleServiceTest {
 
     @Test
     fun `Skal opprette kontrollpunkt for tidligere ektefeller som har vaert gift i under 25 aar og uten felles barn`() {
-        val gjenlevende =
-            gjenlevende.copy(
+        val avdoed =
+            avdoed.copy(
                 sivilstand =
                     listOf(
-                        sivilstand(antallAarSiden = 30, sivilstatus = Sivilstatus.GIFT, relatertPerson = avdoed.foedselsnummer.verdi.value),
+                        sivilstand(
+                            antallAarSiden = 30,
+                            sivilstatus = Sivilstatus.GIFT,
+                            relatertPerson = gjenlevende.foedselsnummer.verdi.value,
+                        ),
                         sivilstand(
                             antallAarSiden = 10,
                             sivilstatus = Sivilstatus.SKILT,
-                            relatertPerson = avdoed.foedselsnummer.verdi.value,
+                            relatertPerson = gjenlevende.foedselsnummer.verdi.value,
                         ),
                     ).flatten(),
             )
@@ -159,20 +171,20 @@ internal class DoedshendelseKontrollpunktEktefelleServiceTest {
 
     @Test
     fun `Skal opprette kontrollpunkt for tidligere ektefeller som har vaert gift i under 15 aar og med felles barn`() {
-        val avdoed = avdoed.copy(familieRelasjon = familieRelasjonMedBarn())
-        val gjenlevende =
-            gjenlevende.copy(
+        val gjenlevende = avdoed.copy(familieRelasjon = familieRelasjonMedBarn())
+        val avdoed =
+            avdoed.copy(
                 sivilstand =
                     listOf(
                         sivilstand(
                             antallAarSiden = 10,
                             sivilstatus = Sivilstatus.GIFT,
-                            relatertPerson = Companion.avdoed.foedselsnummer.verdi.value,
+                            relatertPerson = gjenlevende.foedselsnummer.verdi.value,
                         ),
                         sivilstand(
                             antallAarSiden = 3,
                             sivilstatus = Sivilstatus.SKILT,
-                            relatertPerson = Companion.avdoed.foedselsnummer.verdi.value,
+                            relatertPerson = gjenlevende.foedselsnummer.verdi.value,
                         ),
                     ).flatten(),
                 familieRelasjon = familieRelasjonMedBarn(),
@@ -187,17 +199,28 @@ internal class DoedshendelseKontrollpunktEktefelleServiceTest {
     }
 
     @Test
-    fun `Skal opprette kontrollpunkt for tidligere ektefeller som har vaert gift naar status SKILT mangler`() {
-        val gjenlevende =
-            gjenlevende.copy(
+    fun `Skal opprette kontrollpunkt for tidligere ektefeller som har vaert gift naar status SKILT manger fom dato`() {
+        val skiltUtenDatoOgRelasjon =
+            OpplysningDTO(
+                verdi =
+                    Sivilstand(
+                        sivilstatus = Sivilstatus.SKILT,
+                        relatertVedSiviltilstand = null,
+                        gyldigFraOgMed = null,
+                        bekreftelsesdato = null,
+                        kilde = "",
+                    ),
+                opplysningsid = "sivilstand",
+            )
+
+        val avdoed =
+            avdoed.copy(
                 sivilstand =
-                    listOf(
-                        sivilstand(
-                            antallAarSiden = 10,
-                            sivilstatus = Sivilstatus.GIFT,
-                            relatertPerson = avdoed.foedselsnummer.verdi.value,
-                        ),
-                    ).flatten(),
+                    sivilstand(
+                        antallAarSiden = 10,
+                        sivilstatus = Sivilstatus.GIFT,
+                        relatertPerson = gjenlevende.foedselsnummer.verdi.value,
+                    ) + skiltUtenDatoOgRelasjon,
                 familieRelasjon = familieRelasjonMedBarn(),
             )
 
@@ -218,22 +241,22 @@ internal class DoedshendelseKontrollpunktEktefelleServiceTest {
                 verdi =
                     Sivilstand(
                         sivilstatus = Sivilstatus.GIFT,
-                        relatertVedSiviltilstand = Folkeregisteridentifikator.of(doedshendelse.avdoedFnr),
+                        relatertVedSiviltilstand = Folkeregisteridentifikator.of(doedshendelse.beroertFnr),
                         gyldigFraOgMed = null,
                         bekreftelsesdato = null,
                         kilde = "",
                     ),
                 opplysningsid = "sivilstand",
             )
-        val gjenlevende =
-            gjenlevende.copy(
+        val avdoed =
+            avdoed.copy(
                 sivilstand =
                     listOf(
                         listOf(giftUkjentDato),
                         sivilstand(
                             antallAarSiden = 3,
                             sivilstatus = Sivilstatus.SKILT,
-                            relatertPerson = avdoed.foedselsnummer.verdi.value,
+                            relatertPerson = gjenlevende.foedselsnummer.verdi.value,
                         ),
                     ).flatten(),
                 familieRelasjon = familieRelasjonMedBarn(),
@@ -279,13 +302,13 @@ internal class DoedshendelseKontrollpunktEktefelleServiceTest {
         fun sivilstand(
             antallAarSiden: Long,
             sivilstatus: Sivilstatus = Sivilstatus.GIFT,
-            relatertPerson: String = doedshendelse.beroertFnr,
+            relatertPerson: String? = doedshendelse.beroertFnr,
         ) = listOf(
             OpplysningDTO(
                 verdi =
                     Sivilstand(
                         sivilstatus = sivilstatus,
-                        relatertVedSiviltilstand = Folkeregisteridentifikator.of(relatertPerson),
+                        relatertVedSiviltilstand = relatertPerson?.let { Folkeregisteridentifikator.of(it) },
                         gyldigFraOgMed = doedsdato.minusYears(antallAarSiden),
                         bekreftelsesdato = null,
                         kilde = "",


### PR DESCRIPTION
Mistenker at det er en diff i sivilstandshistorikken på avdød og ektefelle, så velger å benytte avdødes historikk som "master", siden det er det som blir brukt for å velge ektefeller i utgangspunktet.

Gjør også noen endringer for å støtte nullable datafelter bedre på gyldigFom og relatertVedSivilstand.