### PR TITLE
fix: Sjekker på flere statuser og returnerer kontrollpunkt fremfor å kaste exception.

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseService.kt
@@ -247,7 +247,7 @@ class DoedshendelseService(
         val avdoedesSivilstander = avdoed.sivilstand ?: emptyList()
 
         return avdoedesSivilstander.asSequence()
-            .filter { it.verdi.relatertVedSiviltilstand?.value !== null }
+            .filter { it.verdi.relatertVedSiviltilstand?.value != null }
             .filter {
                 it.verdi.sivilstatus in
                     listOf(

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunkt.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunkt.kt
@@ -265,6 +265,16 @@ sealed class DoedshendelseKontrollpunkt {
         override val oppgaveTekst: String? = null
         override val avbryt: Boolean = true
     }
+
+    @JsonTypeName("AVDOED_HAR_IKKE_VAERT_GIFT")
+    data object AvdoedHarIkkeVaertGift : DoedshendelseKontrollpunkt() {
+        override val kode = "AVDOED_HAR_IKKE_VAERT_GIFT"
+        override val beskrivelse: String = "Avdød er ikke tidligere gift. Gjenlevende er ikke registerert som tidligere ektefelle."
+        override val sendBrev: Boolean = false
+        override val opprettOppgave: Boolean = false
+        override val oppgaveTekst: String? = null
+        override val avbryt: Boolean = true
+    }
 }
 
 fun List<DoedshendelseKontrollpunkt>.finnSak(): Sak? {

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktEktefelleService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktEktefelleService.kt
@@ -61,15 +61,14 @@ internal class DoedshendelseKontrollpunktEktefelleService {
         val giftSivilstander =
             avdoed.sivilstand
                 ?.map { it.verdi }
-                ?.filter { it.relatertVedSiviltilstand == eps.foedselsnummer.verdi }
-                ?.filter { it.sivilstatus in listOf(GIFT, REGISTRERT_PARTNER) }
+                ?.filter { it.sivilstatus in listOf(GIFT, SEPARERT, REGISTRERT_PARTNER, SEPARERT_PARTNER) }
                 ?.sortedBy { it.gyldigFraOgMed }
 
         if (giftSivilstander.isNullOrEmpty()) {
-            throw IllegalStateException("Fant ingen gift sivilstander for avdoed med tidligere ektefelle")
+            return DoedshendelseKontrollpunkt.AvdoedHarIkkeVaertGift
         }
 
-        val gift = giftSivilstander.first().gyldigFraOgMed
+        val gift = giftSivilstander.firstOrNull { it.relatertVedSiviltilstand == eps.foedselsnummer.verdi }?.gyldigFraOgMed
 
         val skiltSivilstander =
             avdoed.sivilstand

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktEktefelleServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktEktefelleServiceTest.kt
@@ -17,7 +17,6 @@ import no.nav.etterlatte.libs.common.person.Sivilstand
 import no.nav.etterlatte.libs.common.person.Sivilstatus
 import no.nav.etterlatte.mockPerson
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 
 internal class DoedshendelseKontrollpunktEktefelleServiceTest {
@@ -273,10 +272,13 @@ internal class DoedshendelseKontrollpunktEktefelleServiceTest {
     }
 
     @Test
-    fun `Skal kaste feil hvis vi ikke finner noen relaterte sivilstander`() {
-        assertThrows<IllegalStateException> {
-            kontrollpunktService.identifiser(gjenlevende, avdoed)
-        }
+    fun `Skal returnere AvdoedHarIkkeVaertGift hvis avdoed ikke har vaert registert som gift eller partner`() {
+        val kontrollpunkter = kontrollpunktService.identifiser(gjenlevende, avdoed)
+
+        kontrollpunkter shouldContainExactly
+            listOf(
+                DoedshendelseKontrollpunkt.AvdoedHarIkkeVaertGift,
+            )
     }
 
     companion object {


### PR DESCRIPTION
Dersom vi ikke finner et giftemål/partnerskap på avdød opprettes nå et kontrollpunkt.