### PR TITLE
fix: Dersom en person har flere sivilstander som er like, så velger vi den som er registrert sist.

### DIFF
--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/ParallelleSannheterKlient.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/ParallelleSannheterKlient.kt
@@ -54,11 +54,22 @@ class ParallelleSannheterKlient(
     suspend fun avklarStatsborgerskap(pdlStatsborgerskap: List<PdlStatsborgerskap>) =
         avklarNullable(pdlStatsborgerskap, Avklaring.STATSBORGERSKAP)
 
-    suspend fun avklarSivilstand(pdlSivilstand: List<PdlSivilstand>) =
-        avklarNullable(
-            list = pdlSivilstand.filterNot { it.metadata.historisk },
+    suspend fun avklarSivilstand(pdlSivilstand: List<PdlSivilstand>): PdlSivilstand? {
+        val aktiveSivilstander = pdlSivilstand.filterNot { it.metadata.historisk }
+
+        if (aktiveSivilstander.size > 1) {
+            logger.warn("Fant ${aktiveSivilstander.size} aktive sivilstander")
+            if (aktiveSivilstander.all { it.type == aktiveSivilstander.first().type }) {
+                logger.warn("Fant flere aktive sivilstander av samme type")
+                return aktiveSivilstander.sortedByDescending { it.gyldigFraOgMed }.first()
+            }
+        }
+
+        return avklarNullable(
+            list = aktiveSivilstander,
             avklaring = Avklaring.SIVILSTAND,
         )
+    }
 
     suspend fun avklarFoedsel(pdlFoedsel: List<PdlFoedsel>) = avklar(pdlFoedsel, Avklaring.FOEDSEL)
 


### PR DESCRIPTION
Konsekvensen her er at vi ikke kan styre hvilke "kilde" vi potensielt får (det vil være flere), men alternativet er at det krasjer. Vi benytter ikke dette til noe automatisk, så får leve med den ulempen.

PPS har heller ikke støtte for å prioritere kilde.