### PR TITLE
fix: sivilstandshistorikk hadde blitt fjernet fra avdøde og gjenlevende

### DIFF
--- a/apps/etterlatte-pdltjenester/src/main/kotlin/utils/PdlKlientUtils.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/utils/PdlKlientUtils.kt
@@ -52,6 +52,7 @@ fun toPdlVariables(
             oppholdsadresseHistorikk = false,
             utland = true,
             sivilstand = true,
+            sivilstandHistorikk = true,
             familieRelasjon = true,
             vergemaal = true,
         )
@@ -68,6 +69,7 @@ fun toPdlVariables(
             oppholdsadresseHistorikk = true,
             utland = true,
             sivilstand = true,
+            sivilstandHistorikk = true,
             familieRelasjon = true,
             vergemaal = false,
         )


### PR DESCRIPTION
Tidligere endringer som ble gjort for å hente ut sivilstandshistorikk fra PDL ble fjernet i https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/4268 ved refaktorering.