### PR TITLE
Resett dødshendelser som ble prosessert mens vi manglet sivilstandshistorikk

### DIFF
--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V111__resett_doedshendelser_hvor_sivilstandshistorikk_manglet.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V111__resett_doedshendelser_hvor_sivilstandshistorikk_manglet.sql
@@ -1,0 +1,9 @@
+UPDATE doedshendelse
+SET endret = opprettet,
+    status = 'NY',
+    utfall = null,
+    kontrollpunkter = null
+WHERE relasjon = 'EKTEFELLE'
+  AND status = 'FERDIG'
+  AND utfall = 'AVBRUTT'
+  AND text(kontrollpunkter) like '%AVDOED_HAR_IKKE_VAERT_GIFT%'


### PR DESCRIPTION
Motivasjonen for å kjøre disse på nytt, er å avdekke eventuelle feil før vi kan teste på nytt om 5 dager.