### PR TITLE
EY-3389 Simulere mot oppdragssystemet

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
@@ -91,6 +91,10 @@ spec:
       value: http://etterlatte-trygdetid
     - name: ETTERLATTE_TRYGDETID_CLIENT_ID
       value: dev-gcp.etterlatte.etterlatte-trygdetid
+    - name: ETTERLATTE_PROXY_URL
+      value: https://etterlatte-proxy.dev-fss-pub.nais.io/aad
+    - name: ETTERLATTE_PROXY_SCOPE
+      value: api://dev-fss.etterlatte.etterlatte-proxy/.default
   envFrom:
     - secret: my-application-unleash-api-token
   accessPolicy:

--- a/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
@@ -101,6 +101,10 @@ spec:
       value: http://etterlatte-trygdetid
     - name: ETTERLATTE_TRYGDETID_CLIENT_ID
       value: prod-gcp.etterlatte.etterlatte-trygdetid
+    - name: ETTERLATTE_PROXY_URL
+      value: https://etterlatte-proxy.prod-fss-pub.nais.io/aad
+    - name: ETTERLATTE_PROXY_SCOPE
+      value: api://prod-fss.etterlatte.etterlatte-proxy/.default
   envFrom:
     - secret: my-application-unleash-api-token
   accessPolicy:

--- a/apps/etterlatte-vedtaksvurdering/.run/etterlatte-vedtaksvurdering.dev-gcp.run.xml
+++ b/apps/etterlatte-vedtaksvurdering/.run/etterlatte-vedtaksvurdering.dev-gcp.run.xml
@@ -20,6 +20,8 @@
       <env name="ETTERLATTE_VEDTAKSVURDERING_URL" value="https://etterlatte-vedtaksvurdering.intern.dev.nav.no" />
       <env name="ETTERLATTE_TRYGDETID_CLIENT_ID" value="8385435e-f3d7-45ec-be59-ebd1c71df735" />
       <env name="ETTERLATTE_TRYGDETID_URL" value="https://etterlatte-trygdetid.intern.dev.nav.no" />
+      <env name="ETTERLATTE_PROXY_SCOPE" value="api://dev-fss.etterlatte.etterlatte-proxy/.default" />
+      <env name="ETTERLATTE_PROXY_URL" value="https://etterlatte-proxy.dev-fss-pub.nais.io/aad" />
       <env name="BEHANDLING_AZURE_SCOPE" value="api://dev-gcp.etterlatte.etterlatte-behandling/.default" />
       <env name="SAMORDNEVEDTAK_URL" value="https://sam-q2.dev-fss-pub.nais.io" />
       <env name="SAMORDNEVEDTAK_AZURE_SCOPE" value="api://dev-fss.pensjonsamhandling.sam-q2/.default" />

--- a/apps/etterlatte-vedtaksvurdering/build.gradle.kts
+++ b/apps/etterlatte-vedtaksvurdering/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
 
     implementation(libs.bundles.jackson)
 
+    implementation(libs.navfelles.tjenestespesifikasjoner.oppdragsimulering)
     implementation(libs.navfelles.tokenvalidationktor2)
     implementation(libs.database.kotliquery)
 

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/Application.kt
@@ -8,6 +8,7 @@ import no.nav.etterlatte.vedtaksvurdering.automatiskBehandlingRoutes
 import no.nav.etterlatte.vedtaksvurdering.config.ApplicationContext
 import no.nav.etterlatte.vedtaksvurdering.klagevedtakRoute
 import no.nav.etterlatte.vedtaksvurdering.samordningsvedtakRoute
+import no.nav.etterlatte.vedtaksvurdering.simulering.simuleringOsRoutes
 import no.nav.etterlatte.vedtaksvurdering.tilbakekrevingvedtakRoute
 import no.nav.etterlatte.vedtaksvurdering.vedtaksvurderingRoute
 
@@ -41,6 +42,7 @@ class Server(private val context: ApplicationContext) {
                 samordningsvedtakRoute(vedtakSamordningService)
                 tilbakekrevingvedtakRoute(vedtakTilbakekrevingService, behandlingKlient)
                 klagevedtakRoute(vedtakKlageService, behandlingKlient)
+                simuleringOsRoutes(simuleringOsService, behandlingKlient)
             }
         }
 

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/config/ApplicationContext.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/config/ApplicationContext.kt
@@ -40,6 +40,7 @@ import no.nav.etterlatte.vedtaksvurdering.outbox.OutboxRepository
 import no.nav.etterlatte.vedtaksvurdering.outbox.OutboxService
 import no.nav.etterlatte.vedtaksvurdering.simulering.SimuleringOsKlient
 import no.nav.etterlatte.vedtaksvurdering.simulering.SimuleringOsService
+import no.nav.etterlatte.vedtaksvurdering.simulering.simuleringObjectMapper
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 import java.util.UUID
@@ -135,6 +136,7 @@ class ApplicationContext {
                         azureAppWellKnownUrl = config.getString("azure.app.well.known.url"),
                         azureAppScope = config.getString("etterlatteproxy.azure.scope"),
                     ),
+                    objectMapper = simuleringObjectMapper(),
                 ),
         )
 

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/config/ApplicationContext.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/config/ApplicationContext.kt
@@ -38,6 +38,8 @@ import no.nav.etterlatte.vedtaksvurdering.klienter.VilkaarsvurderingKlientImpl
 import no.nav.etterlatte.vedtaksvurdering.outbox.OutboxJob
 import no.nav.etterlatte.vedtaksvurdering.outbox.OutboxRepository
 import no.nav.etterlatte.vedtaksvurdering.outbox.OutboxService
+import no.nav.etterlatte.vedtaksvurdering.simulering.SimuleringOsKlient
+import no.nav.etterlatte.vedtaksvurdering.simulering.SimuleringOsService
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 import java.util.UUID
@@ -118,6 +120,22 @@ class ApplicationContext {
         AutomatiskBehandlingService(
             vedtakBehandlingService,
             behandlingKlient,
+        )
+
+    val simuleringOsService =
+        SimuleringOsService(
+            vedtaksvurderingService = vedtaksvurderingService,
+            vedtakBehandlingService = vedtakBehandlingService,
+            simuleringOsKlient =
+                SimuleringOsKlient(
+                    config,
+                    httpClientClientCredentials(
+                        azureAppClientId = config.getString("azure.app.client.id"),
+                        azureAppJwk = config.getString("azure.app.jwk"),
+                        azureAppWellKnownUrl = config.getString("azure.app.well.known.url"),
+                        azureAppScope = config.getString("etterlatteproxy.azure.scope"),
+                    ),
+                ),
         )
 
     val metrikkerJob: MetrikkerJob by lazy {

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsKlient.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsKlient.kt
@@ -1,0 +1,63 @@
+package no.nav.etterlatte.vedtaksvurdering.simulering
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.typesafe.config.Config
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
+import no.nav.etterlatte.libs.common.logging.getCorrelationId
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.system.os.tjenester.simulerfpservice.simulerfpserviceservicetypes.SimulerBeregningRequest
+import no.nav.system.os.tjenester.simulerfpservice.simulerfpserviceservicetypes.SimulerBeregningResponse
+import org.slf4j.LoggerFactory
+
+private typealias RequestWrapper = no.nav.system.os.tjenester.simulerfpservice.simulerfpservicegrensesnitt.SimulerBeregningRequest
+private typealias ResponseWrapper = no.nav.system.os.tjenester.simulerfpservice.simulerfpservicegrensesnitt.SimulerBeregningResponse
+
+class SimuleringOsKlient(config: Config, private val client: HttpClient) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    private val url = config.getString("etterlatteproxy.resource.url")
+
+    suspend fun simuler(request: SimulerBeregningRequest): SimulerBeregningResponse {
+        logger.info("Kaller simuleringstjeneste i Oppdrag (via proxy)")
+
+        val response =
+            client.post("$url/simuleringoppdrag/simulerberegning") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    RequestWrapper().apply {
+                        this.request = request
+                    },
+                )
+            }
+        if (!response.status.isSuccess()) {
+            throw SimuleringOsKlientException(
+                response.status,
+                "Simulering mot Oppdrag feilet",
+            )
+        } else {
+            return response.body<String>().let {
+                objectMapper.readValue<ResponseWrapper>(it).response
+            }
+        }
+    }
+}
+
+class SimuleringOsKlientException(statusCode: HttpStatusCode, override val message: String) : ForespoerselException(
+    status = statusCode.value,
+    code = "SIMULERING_OPPDRAG_FEIL",
+    detail = message,
+    meta =
+        mapOf(
+            "correlation-id" to getCorrelationId(),
+            "tidspunkt" to Tidspunkt.now(),
+        ),
+)

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsRoutes.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsRoutes.kt
@@ -20,7 +20,7 @@ internal fun Route.simuleringOsRoutes(
 ) {
     val logger = application.log
 
-    route("/api/simulering/os") {
+    route("/api/vedtak/simulering/os") {
         route("{$BEHANDLINGID_CALL_PARAMETER}") {
             post {
                 withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsRoutes.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsRoutes.kt
@@ -1,0 +1,34 @@
+package no.nav.etterlatte.vedtaksvurdering.simulering
+
+import io.ktor.server.application.call
+import io.ktor.server.application.log
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.application
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import no.nav.etterlatte.libs.ktor.brukerTokenInfo
+import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.ktor.route.behandlingId
+import no.nav.etterlatte.libs.ktor.route.withBehandlingId
+import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
+
+internal fun Route.simuleringOsRoutes(
+    service: SimuleringOsService,
+    behandlingKlient: BehandlingKlient,
+) {
+    val logger = application.log
+
+    route("/api/simulering/os") {
+        route("{$BEHANDLINGID_CALL_PARAMETER}") {
+            post {
+                withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
+                    logger.info("Foretar simulering mot Oppdrag for behandling=$behandlingId")
+                    val beregning = service.simuler(behandlingId, brukerTokenInfo)
+                    call.respond(beregning)
+                }
+            }
+        }
+    }
+}

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsService.kt
@@ -1,0 +1,150 @@
+package no.nav.etterlatte.vedtaksvurdering.simulering
+
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.common.tidspunkt.norskTidssone
+import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
+import no.nav.etterlatte.libs.common.vedtak.UtbetalingsperiodeType
+import no.nav.etterlatte.libs.common.vedtak.VedtakType
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.vedtaksvurdering.Vedtak
+import no.nav.etterlatte.vedtaksvurdering.VedtakBehandlingService
+import no.nav.etterlatte.vedtaksvurdering.VedtakInnhold
+import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingService
+import no.nav.system.os.entiteter.typer.simpletypes.FradragTillegg
+import no.nav.system.os.entiteter.typer.simpletypes.KodeStatusLinje
+import no.nav.system.os.tjenester.simulerfpservice.simulerfpserviceservicetypes.Oppdrag
+import no.nav.system.os.tjenester.simulerfpservice.simulerfpserviceservicetypes.Oppdragslinje
+import no.nav.system.os.tjenester.simulerfpservice.simulerfpserviceservicetypes.SimulerBeregningRequest
+import no.nav.system.os.tjenester.simulerfpservice.simulerfpserviceservicetypes.SimulerBeregningResponse
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+class SimuleringOsService(
+    private val vedtaksvurderingService: VedtaksvurderingService,
+    private val vedtakBehandlingService: VedtakBehandlingService,
+    private val simuleringOsKlient: SimuleringOsKlient,
+) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    suspend fun simuler(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): SimulerBeregningResponse {
+        val vedtak =
+            vedtaksvurderingService.hentVedtakMedBehandlingId(behandlingId)
+                ?: vedtakBehandlingService.opprettEllerOppdaterVedtak(behandlingId, brukerTokenInfo)
+
+        if (vedtak.innhold is VedtakInnhold.Behandling) {
+            val request = mapTilSimuleringRequest(vedtak, brukerTokenInfo)
+
+            return simuleringOsKlient.simuler(request).also {
+                logger.info(it.infomelding.beskrMelding.trim())
+            }
+        } else {
+            throw IkkeStoettetSimulering(vedtak.type, behandlingId)
+        }
+    }
+
+    private fun mapTilSimuleringRequest(
+        vedtak: Vedtak,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): SimulerBeregningRequest {
+        val request =
+            SimulerBeregningRequest().apply {
+                oppdrag = tilOppdrag(vedtak, brukerTokenInfo)
+                simuleringsPeriode = simuleringsperiode(vedtak.virkningstidspunkt)
+            }
+        return request
+    }
+
+    private fun simuleringsperiode(virkningstidspunkt: YearMonth) =
+        SimulerBeregningRequest.SimuleringsPeriode().apply {
+            datoSimulerFom = virkningstidspunkt.atDay(1).toOppdragDate()
+        }
+
+    private fun tilOppdrag(
+        vedtak: Vedtak,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Oppdrag {
+        return Oppdrag().apply {
+            fagsystemId = vedtak.sakId.toString()
+            oppdragGjelderId = vedtak.soeker.value
+            saksbehId = brukerTokenInfo.ident()
+
+            utbetFrekvens = "MND"
+            kodeEndring = "ENDR"
+            kodeFagomraade = vedtak.sakType.toKodeFagomrade()
+
+            if (vedtak.innhold is VedtakInnhold.Behandling) {
+                datoOppdragGjelderFom = vedtak.innhold.virkningstidspunkt.atDay(1).toOppdragDate()
+                oppdragslinje.addAll(
+                    vedtak.innhold.utbetalingsperioder.map {
+                        tilOppdragsLinje(
+                            it,
+                            vedtak,
+                            brukerTokenInfo,
+                        )
+                    },
+                )
+            }
+        }
+    }
+
+    private fun tilOppdragsLinje(
+        up: Utbetalingsperiode,
+        vedtak: Vedtak,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Oppdragslinje =
+        Oppdragslinje().apply {
+            vedtakId = vedtak.id.toString()
+            delytelseId = up.id.toString()
+            datoVedtakFom = up.periode.fom.atDay(1).toOppdragDate()
+            datoVedtakTom = up.periode.tom?.atEndOfMonth()?.toOppdragDate()
+            utbetalesTilId = vedtak.soeker.value
+            henvisning = vedtak.behandlingId.toUUID30()
+            saksbehId = brukerTokenInfo.ident()
+
+            kodeEndringLinje = "ENDR"
+            kodeKlassifik = vedtak.sakType.toKodeKlassifikasjon()
+            sats = up.beloep
+            typeSats = "MND"
+            fradragTillegg = FradragTillegg.T
+            brukKjoreplan = "N"
+
+            if (up.type == UtbetalingsperiodeType.OPPHOER) {
+                kodeStatusLinje = KodeStatusLinje.OPPH
+                datoStatusFom = up.periode.fom.atDay(1).toOppdragDate()
+            }
+        }
+
+    private fun SakType.toKodeFagomrade() =
+        when (this) {
+            SakType.BARNEPENSJON -> "BARNEPE"
+            SakType.OMSTILLINGSSTOENAD -> "OMSTILL"
+        }
+
+    private fun SakType.toKodeKlassifikasjon() =
+        when (this) {
+            SakType.BARNEPENSJON -> "BARNEPENSJON-OPTP"
+            SakType.OMSTILLINGSSTOENAD -> "OMSTILLINGOR"
+        }
+}
+
+private val Vedtak.virkningstidspunkt: YearMonth
+    get() = (this.innhold as VedtakInnhold.Behandling).virkningstidspunkt
+
+private fun LocalDate.toOppdragDate(): String =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        .withZone(norskTidssone).format(this)
+
+internal fun UUID.toUUID30() = this.toString().replace("-", "").substring(0, 30)
+
+class IkkeStoettetSimulering(vedtakType: VedtakType, behandlingId: UUID) : UgyldigForespoerselException(
+    code = "SIMULERING_IKKE_STOETTET",
+    detail = "Kan ikke simulere for vedtak av type $vedtakType",
+    meta = mapOf("behandlingId" to behandlingId),
+)

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsService.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.vedtaksvurdering.simulering
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.tidspunkt.norskTidssone
+import no.nav.etterlatte.libs.common.toUUID30
 import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
 import no.nav.etterlatte.libs.common.vedtak.UtbetalingsperiodeType
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
@@ -105,7 +106,7 @@ class SimuleringOsService(
             datoVedtakFom = up.periode.fom.atDay(1).toOppdragDate()
             datoVedtakTom = up.periode.tom?.atEndOfMonth()?.toOppdragDate()
             utbetalesTilId = vedtak.soeker.value
-            henvisning = vedtak.behandlingId.toUUID30()
+            henvisning = vedtak.behandlingId.toUUID30().value
             saksbehId = brukerTokenInfo.ident()
 
             kodeEndringLinje = "ENDR"
@@ -140,8 +141,6 @@ private val Vedtak.virkningstidspunkt: YearMonth
 private fun LocalDate.toOppdragDate(): String =
     DateTimeFormatter.ofPattern("yyyy-MM-dd")
         .withZone(norskTidssone).format(this)
-
-internal fun UUID.toUUID30() = this.toString().replace("-", "").substring(0, 30)
 
 class IkkeStoettetSimulering(vedtakType: VedtakType, behandlingId: UUID) : UgyldigForespoerselException(
     code = "SIMULERING_IKKE_STOETTET",

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsService.kt
@@ -77,7 +77,7 @@ class SimuleringOsService(
             saksbehId = brukerTokenInfo.ident()
 
             utbetFrekvens = "MND"
-            kodeEndring = "ENDR"
+            kodeEndring = vedtak.type.toKodeEndring()
             kodeFagomraade = vedtak.sakType.toKodeFagomrade()
 
             if (vedtak.innhold is VedtakInnhold.Behandling) {
@@ -109,7 +109,7 @@ class SimuleringOsService(
             henvisning = vedtak.behandlingId.toUUID30().value
             saksbehId = brukerTokenInfo.ident()
 
-            kodeEndringLinje = "ENDR"
+            kodeEndringLinje = vedtak.type.toKodeEndring()
             kodeKlassifik = vedtak.sakType.toKodeKlassifikasjon()
             sats = up.beloep
             typeSats = "MND"
@@ -132,6 +132,14 @@ class SimuleringOsService(
         when (this) {
             SakType.BARNEPENSJON -> "BARNEPENSJON-OPTP"
             SakType.OMSTILLINGSSTOENAD -> "OMSTILLINGOR"
+        }
+
+    private fun VedtakType.toKodeEndring() =
+        when (this) {
+            VedtakType.INNVILGELSE,
+            VedtakType.AVSLAG,
+            -> "NY"
+            else -> "ENDR"
         }
 }
 

--- a/apps/etterlatte-vedtaksvurdering/src/main/resources/application.conf
+++ b/apps/etterlatte-vedtaksvurdering/src/main/resources/application.conf
@@ -25,6 +25,9 @@ samordnevedtak.azure.scope = ${?SAMORDNEVEDTAK_AZURE_SCOPE}
 trygdetid.client.id = ${?ETTERLATTE_TRYGDETID_CLIENT_ID}
 trygdetid.resource.url = ${?ETTERLATTE_TRYGDETID_URL}
 
+etterlatteproxy.resource.url = ${?ETTERLATTE_PROXY_URL}
+etterlatteproxy.azure.scope = ${?ETTERLATTE_PROXY_SCOPE}
+
 azure.app.client.id = ${?AZURE_APP_CLIENT_ID}
 azure.app.client.secret = ${?AZURE_APP_CLIENT_SECRET}
 azure.app.jwk = ${?AZURE_APP_JWK}

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsRouteTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsRouteTest.kt
@@ -93,7 +93,7 @@ class SimuleringOsRouteTest {
                 virkningstidspunkt = of(2024, FEBRUARY),
                 sakId = 1000223L,
                 status = VedtakStatus.OPPRETTET,
-                revurderingAarsak = Revurderingaarsak.INNTEKTSENDRING,
+                revurderingAarsak = Revurderingaarsak.NY_SOEKNAD,
                 utbetalingsperioder = listOf(utbetalingsperiodeFeb2024, utbetalingsperiodeMai2024),
             )
 
@@ -115,7 +115,7 @@ class SimuleringOsRouteTest {
             }
 
             val response =
-                client.post("/api/simulering/os/$behandlingId") {
+                client.post("/api/vedtak/simulering/os/$behandlingId") {
                     header(HttpHeaders.Authorization, "Bearer $token")
                 }
             response.status shouldBe HttpStatusCode.OK
@@ -128,7 +128,7 @@ class SimuleringOsRouteTest {
                 oppdragGjelderId shouldBe SOEKER_FOEDSELSNUMMER.value
                 saksbehId shouldBe "Z991122"
                 utbetFrekvens shouldBe "MND"
-                kodeEndring shouldBe "ENDR"
+                kodeEndring shouldBe "NY"
                 kodeFagomraade shouldBe "BARNEPE"
                 datoOppdragGjelderFom shouldBe "2024-02-01"
                 oppdragslinje shouldHaveSize 2
@@ -139,7 +139,7 @@ class SimuleringOsRouteTest {
                     it.henvisning shouldBe vedtak.behandlingId.toUUID30().value
                     it.utbetalesTilId shouldBe vedtak.soeker.value
                     it.saksbehId shouldBe "Z991122"
-                    it.kodeEndringLinje shouldBe "ENDR"
+                    it.kodeEndringLinje shouldBe "NY"
                     it.kodeKlassifik shouldBe "BARNEPENSJON-OPTP"
                     it.typeSats shouldBe "MND"
                     it.fradragTillegg shouldBe FradragTillegg.T

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsRouteTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsRouteTest.kt
@@ -15,6 +15,7 @@ import io.mockk.slot
 import no.nav.etterlatte.ktor.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.runServer
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
+import no.nav.etterlatte.libs.common.toUUID30
 import no.nav.etterlatte.libs.common.vedtak.Periode
 import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
 import no.nav.etterlatte.libs.common.vedtak.UtbetalingsperiodeType
@@ -135,7 +136,7 @@ class SimuleringOsRouteTest {
                 // Verifiser verdier uavhengig av periode
                 oppdragslinje.forEach {
                     it.vedtakId shouldBe vedtak.id.toString()
-                    it.henvisning shouldBe vedtak.behandlingId.toUUID30()
+                    it.henvisning shouldBe vedtak.behandlingId.toUUID30().value
                     it.utbetalesTilId shouldBe vedtak.soeker.value
                     it.saksbehId shouldBe "Z991122"
                     it.kodeEndringLinje shouldBe "ENDR"

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsRouteTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/simulering/SimuleringOsRouteTest.kt
@@ -1,0 +1,166 @@
+package no.nav.etterlatte.vedtaksvurdering.simulering
+
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import no.nav.etterlatte.ktor.issueSaksbehandlerToken
+import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
+import no.nav.etterlatte.libs.common.vedtak.Periode
+import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
+import no.nav.etterlatte.libs.common.vedtak.UtbetalingsperiodeType
+import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
+import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
+import no.nav.etterlatte.vedtaksvurdering.VedtakBehandlingService
+import no.nav.etterlatte.vedtaksvurdering.VedtaksvurderingService
+import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
+import no.nav.etterlatte.vedtaksvurdering.vedtak
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import no.nav.system.os.entiteter.infomelding.Infomelding
+import no.nav.system.os.entiteter.typer.simpletypes.FradragTillegg
+import no.nav.system.os.tjenester.simulerfpservice.simulerfpserviceservicetypes.SimulerBeregningRequest
+import no.nav.system.os.tjenester.simulerfpservice.simulerfpserviceservicetypes.SimulerBeregningResponse
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.math.BigDecimal
+import java.time.Month
+import java.time.Month.APRIL
+import java.time.Month.FEBRUARY
+import java.time.YearMonth.of
+import java.util.UUID
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SimuleringOsRouteTest {
+    private val server = MockOAuth2Server()
+    private val vedtaksvurderingService: VedtaksvurderingService = mockk()
+    private val vedtaksbehandlingService: VedtakBehandlingService = mockk()
+    private val simuleringOsKlient: SimuleringOsKlient = mockk()
+    private val behandlingKlient: BehandlingKlient = mockk()
+    private val simuleringOsService: SimuleringOsService =
+        SimuleringOsService(
+            vedtaksvurderingService,
+            vedtaksbehandlingService,
+            simuleringOsKlient,
+        )
+
+    @BeforeAll
+    fun before() {
+        server.start()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        clearAllMocks()
+    }
+
+    @AfterAll
+    fun after() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `mappe informasjon fra revurderingsvedtak til simuleringsinput`() {
+        val behandlingId = UUID.randomUUID()
+        val utbetalingsperiodeFeb2024 =
+            Utbetalingsperiode(
+                id = 444L,
+                periode = Periode(of(2024, FEBRUARY), of(2024, APRIL)),
+                beloep = BigDecimal(2500),
+                type = UtbetalingsperiodeType.UTBETALING,
+            )
+        val utbetalingsperiodeMai2024 =
+            Utbetalingsperiode(
+                id = 445L,
+                periode = Periode(of(2024, Month.MAY), null),
+                beloep = BigDecimal(3233),
+                type = UtbetalingsperiodeType.UTBETALING,
+            )
+        val vedtak =
+            vedtak(
+                virkningstidspunkt = of(2024, FEBRUARY),
+                sakId = 1000223L,
+                status = VedtakStatus.OPPRETTET,
+                revurderingAarsak = Revurderingaarsak.INNTEKTSENDRING,
+                utbetalingsperioder = listOf(utbetalingsperiodeFeb2024, utbetalingsperiodeMai2024),
+            )
+
+        coEvery { vedtaksvurderingService.hentVedtakMedBehandlingId(behandlingId) } returns vedtak
+        coEvery {
+            behandlingKlient.harTilgangTilBehandling(behandlingId, true, bruker = any())
+        } returns true
+        coEvery { simuleringOsKlient.simuler(any()) } returns
+            SimulerBeregningResponse().apply {
+                infomelding =
+                    Infomelding().apply {
+                        beskrMelding = "Simulering OK"
+                    }
+            }
+
+        testApplication {
+            runServer(server) {
+                simuleringOsRoutes(simuleringOsService, behandlingKlient)
+            }
+
+            val response =
+                client.post("/api/simulering/os/$behandlingId") {
+                    header(HttpHeaders.Authorization, "Bearer $token")
+                }
+            response.status shouldBe HttpStatusCode.OK
+
+            val mappedRequest = slot<SimulerBeregningRequest>()
+            coVerify { simuleringOsKlient.simuler(capture(mappedRequest)) }
+
+            with(mappedRequest.captured.oppdrag) {
+                fagsystemId shouldBe "1000223"
+                oppdragGjelderId shouldBe SOEKER_FOEDSELSNUMMER.value
+                saksbehId shouldBe "Z991122"
+                utbetFrekvens shouldBe "MND"
+                kodeEndring shouldBe "ENDR"
+                kodeFagomraade shouldBe "BARNEPE"
+                datoOppdragGjelderFom shouldBe "2024-02-01"
+                oppdragslinje shouldHaveSize 2
+
+                // Verifiser verdier uavhengig av periode
+                oppdragslinje.forEach {
+                    it.vedtakId shouldBe vedtak.id.toString()
+                    it.henvisning shouldBe vedtak.behandlingId.toUUID30()
+                    it.utbetalesTilId shouldBe vedtak.soeker.value
+                    it.saksbehId shouldBe "Z991122"
+                    it.kodeEndringLinje shouldBe "ENDR"
+                    it.kodeKlassifik shouldBe "BARNEPENSJON-OPTP"
+                    it.typeSats shouldBe "MND"
+                    it.fradragTillegg shouldBe FradragTillegg.T
+                    it.brukKjoreplan shouldBe "N"
+                }
+
+                with(oppdragslinje[0]) {
+                    delytelseId shouldBe utbetalingsperiodeFeb2024.id.toString()
+                    datoVedtakFom shouldBe "2024-02-01"
+                    datoVedtakTom shouldBe "2024-04-30"
+                    sats shouldBe utbetalingsperiodeFeb2024.beloep
+                }
+
+                with(oppdragslinje[1]) {
+                    delytelseId shouldBe utbetalingsperiodeMai2024.id.toString()
+                    datoVedtakFom shouldBe "2024-05-01"
+                    datoVedtakTom shouldBe null
+                    sats shouldBe utbetalingsperiodeMai2024.beloep
+                }
+            }
+        }
+    }
+
+    private val token: String by lazy { server.issueSaksbehandlerToken(navIdent = "Z991122") }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ ktor2-version = "2.3.10"
 navfelles-token-version = "4.1.4"
 prometheus-version = "0.16.0"
 testcontainer-version = "1.19.7"
-tjenestespesifikasjoner-version = "1.99612d7"
+tjenestespesifikasjoner-version = "1.d27898d"
 
 [libraries]
 cache-caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version = "3.1.8" }
@@ -86,6 +86,7 @@ mq-jakarta-client = { module ="com.ibm.mq:com.ibm.mq.jakarta.client", version = 
 navfelles-rapidandriversktor2 = { module = "com.github.navikt:rapids-and-rivers", version = "2024010209171704183456.6d035b91ffb4" }
 navfelles-tjenestespesifikasjoner-avstemming = { module = "com.github.navikt.pensjon-etterlatte-tjenestespesifikasjoner:avstemming-v1-tjenestespesifikasjon", version.ref = "tjenestespesifikasjoner-version" }
 navfelles-tjenestespesifikasjoner-oppdragsbehandling = { module = "com.github.navikt.pensjon-etterlatte-tjenestespesifikasjoner:nav-virksomhet-oppdragsbehandling-v1-meldingsdefinisjon", version.ref = "tjenestespesifikasjoner-version" }
+navfelles-tjenestespesifikasjoner-oppdragsimulering = { module ="com.github.navikt.pensjon-etterlatte-tjenestespesifikasjoner:nav-system-os-simuler-fp-service-tjenestespesifikasjon", version.ref = "tjenestespesifikasjoner-version" }
 navfelles-tjenestespesifikasjoner-tilbakekreving = { module ="com.github.navikt.pensjon-etterlatte-tjenestespesifikasjoner:tilbakekreving-v1-tjenestespesifikasjon", version.ref = "tjenestespesifikasjoner-version" }
 navfelles-tokenclientcore = { module = "no.nav.security:token-client-core", version.ref = "navfelles-token-version" }
 navfelles-tokenvalidationktor2 = { module = "no.nav.security:token-validation-ktor-v2", version.ref = "navfelles-token-version" }


### PR DESCRIPTION
- kun backenddel i denne
- bevisst gjort enkel/direkte i returverdien her inntil videre, da UI på ingen måte er designet.
- ikke gjort noe mtp å eventuelt persistere simuleringen, slik at man kan se den senere for ferdigstilte behandlinger.