### PR TITLE
EY-3815 fristille gosysoppgaver helt + div forbedringer

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgave.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgave.kt
@@ -1,0 +1,17 @@
+import no.nav.etterlatte.libs.common.oppgave.OppgaveSaksbehandler
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+
+data class GosysOppgave(
+    val id: Long,
+    val versjon: Long,
+    val status: String,
+    val tema: String,
+    val oppgavetype: String,
+    val saksbehandler: OppgaveSaksbehandler?,
+    val enhet: String,
+    val opprettet: Tidspunkt,
+    val frist: Tidspunkt?,
+    val fnr: String? = null,
+    val beskrivelse: String?,
+    val journalpostId: String?,
+)

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveKlient.kt
@@ -52,6 +52,7 @@ data class GosysEndreFristRequest(
 
 interface GosysOppgaveKlient {
     suspend fun hentOppgaver(
+        saksbehandler: String?,
         tema: List<String>,
         enhetsnr: String? = null,
         brukerTokenInfo: BrukerTokenInfo,
@@ -99,6 +100,7 @@ class GosysOppgaveKlientImpl(config: Config, httpClient: HttpClient) : GosysOppg
     private val resourceUrl = config.getString("oppgave.resource.url")
 
     override suspend fun hentOppgaver(
+        saksbehandler: String?,
         tema: List<String>,
         enhetsnr: String?,
         brukerTokenInfo: BrukerTokenInfo,
@@ -112,6 +114,7 @@ class GosysOppgaveKlientImpl(config: Config, httpClient: HttpClient) : GosysOppg
                     .plus(temaFilter)
                     .plus("&limit=1000")
                     .plus(enhetsnr?.let { "&tildeltEnhetsnr=$it" } ?: "")
+                    .plus(saksbehandler?.let { "&tilordnetRessurs=$it" } ?: "")
 
             return downstreamResourceClient
                 .get(

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveRoute.kt
@@ -20,9 +20,11 @@ internal fun Route.gosysOppgaveRoute(gosysService: GosysOppgaveService) {
     route("/api/oppgaver/gosys") {
         get {
             kunSaksbehandler {
-                val tema = call.request.queryParameters.getAll("tema") ?: listOf("EYO", "EYB")
+                val saksbehandler = call.request.queryParameters["saksbehandler"].takeUnless { it.isNullOrBlank() }
+                val tema = call.request.queryParameters["tema"].takeUnless { it.isNullOrBlank() }
+                val enhet = call.request.queryParameters["enhet"].takeUnless { it.isNullOrBlank() }
 
-                call.respond(gosysService.hentOppgaver(tema, brukerTokenInfo))
+                call.respond(gosysService.hentOppgaver(saksbehandler, tema, enhet, brukerTokenInfo))
             }
         }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveService.kt
@@ -1,15 +1,13 @@
 package no.nav.etterlatte.oppgaveGosys
 
+import GosysOppgave
 import com.github.benmanes.caffeine.cache.Caffeine
 import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
 import no.nav.etterlatte.User
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.common.klienter.PdlTjenesterKlient
-import no.nav.etterlatte.libs.common.behandling.SakType
-import no.nav.etterlatte.libs.common.oppgave.GosysOppgave
 import no.nav.etterlatte.libs.common.oppgave.OppgaveSaksbehandler
-import no.nav.etterlatte.libs.common.oppgave.Status
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
@@ -18,7 +16,9 @@ import java.time.LocalTime
 
 interface GosysOppgaveService {
     suspend fun hentOppgaver(
-        tema: List<String>,
+        saksbehandler: String?,
+        tema: String?,
+        enhet: String?,
         brukerTokenInfo: BrukerTokenInfo,
     ): List<GosysOppgave>
 
@@ -66,15 +66,18 @@ class GosysOppgaveServiceImpl(
             .build<Long, GosysOppgave>()
 
     override suspend fun hentOppgaver(
-        tema: List<String>,
+        saksbehandler: String?,
+        tema: String?,
+        enhet: String?,
         brukerTokenInfo: BrukerTokenInfo,
     ): List<GosysOppgave> {
         val saksbehandlerMedRoller = Kontekst.get().appUserAsSaksbehandler().saksbehandlerMedRoller
 
         val gosysOppgaver =
             gosysOppgaveKlient.hentOppgaver(
-                tema,
-                enhetsnr = if (saksbehandlerMedRoller.harRolleStrengtFortrolig()) Enheter.STRENGT_FORTROLIG.enhetNr else null,
+                saksbehandler = saksbehandler,
+                tema = if (tema.isNullOrBlank()) listOf("EYO", "EYB") else listOf(tema),
+                enhetsnr = if (saksbehandlerMedRoller.harRolleStrengtFortrolig()) Enheter.STRENGT_FORTROLIG.enhetNr else enhet,
                 brukerTokenInfo = brukerTokenInfo,
             )
 
@@ -163,29 +166,22 @@ class GosysOppgaveServiceImpl(
     }
 
     companion object {
-        private val temaTilSakType =
-            mapOf(
-                "PEN" to SakType.BARNEPENSJON,
-                "EYB" to SakType.BARNEPENSJON,
-                "EYO" to SakType.OMSTILLINGSSTOENAD,
-            )
-
         private fun GosysApiOppgave.fraGosysOppgaveTilNy(fnrByAktoerId: Map<String, String?>): GosysOppgave {
             return GosysOppgave(
                 id = this.id,
                 versjon = this.versjon,
-                status = Status.NY,
+                status = this.status,
+                tema = this.tema,
+                oppgavetype = this.oppgavetype,
                 opprettet = this.opprettetTidspunkt,
                 frist =
                     this.fristFerdigstillelse?.let { frist ->
                         Tidspunkt.ofNorskTidssone(frist, LocalTime.MIDNIGHT)
                     },
                 fnr = fnrByAktoerId[this.aktoerId],
-                gjelder = temaTilSakType[this.tema]!!.name,
                 enhet = this.tildeltEnhetsnr,
                 saksbehandler = this.tilordnetRessurs?.let { OppgaveSaksbehandler(it) },
                 beskrivelse = this.beskrivelse,
-                sakType = temaTilSakType[this.tema]!!,
                 journalpostId = this.journalpostId,
             )
         }

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
@@ -265,6 +265,7 @@ class BrevApiKlientTest : BrevApiKlient {
 
 class GosysOppgaveKlientTest : GosysOppgaveKlient {
     override suspend fun hentOppgaver(
+        saksbehandler: String?,
         tema: List<String>,
         enhetsnr: String?,
         brukerTokenInfo: BrukerTokenInfo,

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgaveGosys/GosysOppgaveServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgaveGosys/GosysOppgaveServiceImplTest.kt
@@ -70,7 +70,7 @@ class GosysOppgaveServiceImplTest {
 
         every { saksbehandler.saksbehandlerMedRoller } returns saksbehandlerRoller
 
-        coEvery { gosysOppgaveKlient.hentOppgaver(listOf("EYO", "EYB"), any(), brukerTokenInfo) } returns
+        coEvery { gosysOppgaveKlient.hentOppgaver(null, listOf("EYO", "EYB"), any(), brukerTokenInfo) } returns
             GosysOppgaver(
                 antallTreffTotalt = 3,
                 oppgaver =
@@ -130,7 +130,7 @@ class GosysOppgaveServiceImplTest {
 
         val resultat =
             runBlocking {
-                service.hentOppgaver(listOf("EYO", "EYB"), brukerTokenInfo)
+                service.hentOppgaver(null, null, null, brukerTokenInfo)
             }
 
         resultat shouldHaveSize 3
@@ -156,7 +156,7 @@ class GosysOppgaveServiceImplTest {
 
         every { saksbehandler.saksbehandlerMedRoller } returns saksbehandlerRoller
 
-        coEvery { gosysOppgaveKlient.hentOppgaver(listOf("EYO", "EYB"), Enheter.STRENGT_FORTROLIG.enhetNr, brukerTokenInfo) } returns
+        coEvery { gosysOppgaveKlient.hentOppgaver(any(), any(), Enheter.STRENGT_FORTROLIG.enhetNr, brukerTokenInfo) } returns
             enhetsfiltrererGosysOppgaver(
                 Enheter.STRENGT_FORTROLIG.enhetNr,
                 listOf(
@@ -215,7 +215,7 @@ class GosysOppgaveServiceImplTest {
 
         val resultat =
             runBlocking {
-                service.hentOppgaver(listOf("EYO", "EYB"), brukerTokenInfo)
+                service.hentOppgaver(null, null, null, brukerTokenInfo)
             }
 
         resultat shouldHaveSize 1

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/SettPaaVent.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/SettPaaVent.tsx
@@ -61,8 +61,6 @@ export const SettPaaVent = ({
                   oppgaveId={oppgave.id}
                   oppdaterFrist={(_, frist: string) => setFrist(frist)}
                   erRedigerbar={erOppgaveRedigerbar(oppgave.status)}
-                  oppgaveVersjon={oppgave.versjon}
-                  type={oppgave.type}
                 />
               </FlexRow>
             </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/MinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/MinOppgaveliste.tsx
@@ -40,31 +40,22 @@ export const MinOppgaveliste = ({ saksbehandlereIEnhet, revurderingsaarsaker }: 
     return oppgaver.filter((o) => o.saksbehandler?.ident === innloggetSaksbehandler.ident)
   }
 
-  const oppdaterSaksbehandlerTildeling = (
-    oppgave: OppgaveDTO,
-    saksbehandler: OppgaveSaksbehandler | null,
-    versjon: number | null
-  ) => {
+  const oppdaterSaksbehandlerTildeling = (oppgave: OppgaveDTO, saksbehandler: OppgaveSaksbehandler | null) => {
     setTimeout(() => {
       dispatcher.setOppgavelistaOppgaver(
-        finnOgOppdaterSaksbehandlerTildeling(oppgavebenkState.oppgavelistaOppgaver, oppgave.id, saksbehandler, versjon)
+        finnOgOppdaterSaksbehandlerTildeling(oppgavebenkState.oppgavelistaOppgaver, oppgave.id, saksbehandler)
       )
       if (innloggetSaksbehandler.ident === saksbehandler?.ident) {
         dispatcher.setMinOppgavelisteOppgaver(
           sorterOppgaverEtterOpprettet(
-            leggTilOppgavenIMinliste(oppgavebenkState.minOppgavelisteOppgaver, oppgave, saksbehandler, versjon)
+            leggTilOppgavenIMinliste(oppgavebenkState.minOppgavelisteOppgaver, oppgave, saksbehandler)
           )
         )
       } else {
         dispatcher.setMinOppgavelisteOppgaver(
           sorterOppgaverEtterOpprettet(
             filtrerKunInnloggetBrukerOppgaver(
-              finnOgOppdaterSaksbehandlerTildeling(
-                oppgavebenkState.minOppgavelisteOppgaver,
-                oppgave.id,
-                saksbehandler,
-                versjon
-              )
+              finnOgOppdaterSaksbehandlerTildeling(oppgavebenkState.minOppgavelisteOppgaver, oppgave.id, saksbehandler)
             )
           )
         )
@@ -98,14 +89,8 @@ export const MinOppgaveliste = ({ saksbehandlereIEnhet, revurderingsaarsaker }: 
       <Oppgaver
         oppgaver={oppgavebenkState.minOppgavelisteOppgaver}
         oppdaterSaksbehandlerTildeling={oppdaterSaksbehandlerTildeling}
-        oppdaterFrist={(id: string, nyfrist: string, versjon: number | null) =>
-          oppdaterFrist(
-            dispatcher.setMinOppgavelisteOppgaver,
-            oppgavebenkState.minOppgavelisteOppgaver,
-            id,
-            nyfrist,
-            versjon
-          )
+        oppdaterFrist={(id: string, nyfrist: string) =>
+          oppdaterFrist(dispatcher.setMinOppgavelisteOppgaver, oppgavebenkState.minOppgavelisteOppgaver, id, nyfrist)
         }
         saksbehandlereIEnhet={saksbehandlereIEnhet}
         revurderingsaarsaker={revurderingsaarsaker}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/Oppgavelista.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/Oppgavelista.tsx
@@ -42,31 +42,22 @@ export const Oppgavelista = ({ saksbehandlereIEnhet, revurderingsaarsaker }: Pro
     return oppgaver.filter((o) => o.saksbehandler?.ident === innloggetSaksbehandler.ident)
   }
 
-  const oppdaterSaksbehandlerTildeling = (
-    oppgave: OppgaveDTO,
-    saksbehandler: OppgaveSaksbehandler | null,
-    versjon: number | null
-  ) => {
+  const oppdaterSaksbehandlerTildeling = (oppgave: OppgaveDTO, saksbehandler: OppgaveSaksbehandler | null) => {
     setTimeout(() => {
       dispatcher.setOppgavelistaOppgaver(
-        finnOgOppdaterSaksbehandlerTildeling(oppgavebenkState.oppgavelistaOppgaver, oppgave.id, saksbehandler, versjon)
+        finnOgOppdaterSaksbehandlerTildeling(oppgavebenkState.oppgavelistaOppgaver, oppgave.id, saksbehandler)
       )
       if (innloggetSaksbehandler.ident === saksbehandler?.ident) {
         dispatcher.setMinOppgavelisteOppgaver(
           sorterOppgaverEtterOpprettet(
-            leggTilOppgavenIMinliste(oppgavebenkState.minOppgavelisteOppgaver, oppgave, saksbehandler, versjon)
+            leggTilOppgavenIMinliste(oppgavebenkState.minOppgavelisteOppgaver, oppgave, saksbehandler)
           )
         )
       } else {
         dispatcher.setMinOppgavelisteOppgaver(
           sorterOppgaverEtterOpprettet(
             filtrerKunInnloggetBrukerOppgaver(
-              finnOgOppdaterSaksbehandlerTildeling(
-                oppgavebenkState.minOppgavelisteOppgaver,
-                oppgave.id,
-                saksbehandler,
-                versjon
-              )
+              finnOgOppdaterSaksbehandlerTildeling(oppgavebenkState.minOppgavelisteOppgaver, oppgave.id, saksbehandler)
             )
           )
         )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/components/HandlingerForOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/components/HandlingerForOppgave.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@navikt/ds-react'
 import { EyeIcon } from '@navikt/aksel-icons'
-import { GosysOppgaveModal } from '~components/oppgavebenk/oppgaveModal/GosysOppgaveModal'
 import { OmgjoerVedtakModal } from '~components/oppgavebenk/oppgaveModal/OmgjoerVedtakModal'
 import React from 'react'
 import { RevurderingsaarsakerBySakstype } from '~shared/types/Revurderingaarsak'
@@ -84,8 +83,6 @@ export const HandlingerForOppgave = ({
           )}
         </>
       )
-    case Oppgavetype.GOSYS:
-      return <GosysOppgaveModal oppgave={oppgave} tilhoererInnloggetSaksbehandler={erInnloggetSaksbehandlerOppgave} />
     case Oppgavetype.KLAGE:
       return erInnloggetSaksbehandlerOppgave ? (
         <Button size="small" href={`/klage/${referanse}`} as="a">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/components/Tags.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/components/Tags.tsx
@@ -2,6 +2,7 @@ import { Tag } from '@navikt/ds-react'
 import { Variants } from '~shared/Tags'
 import { SakType } from '~shared/types/sak'
 import { Oppgavetype } from '~shared/types/oppgave'
+import { GosysTema } from '~shared/types/Gosys'
 
 const SAKTYPE_TIL_TAGDATA: Record<SakType, { variant: Variants; text: string }> = {
   BARNEPENSJON: { variant: Variants.INFO, text: 'Barnepensjon' },
@@ -18,7 +19,6 @@ const OPPGAVETYPE_TIL_TAGDATA: Record<Oppgavetype, { variant: Variants; text: st
   FOERSTEGANGSBEHANDLING: { variant: Variants.INFO, text: 'Førstegangsbehandling' },
   REVURDERING: { variant: Variants.NEUTRAL, text: 'Revurdering' },
   VURDER_KONSEKVENS: { variant: Variants.ALT1, text: 'Hendelse' },
-  GOSYS: { variant: Variants.INFO_FILLED, text: 'Gosys-oppgave' },
   KRAVPAKKE_UTLAND: { variant: Variants.ALT2_FILLED, text: 'Kravpakke utland' },
   KLAGE: { variant: Variants.ALT2, text: 'Klage' },
   OMGJOERING: { variant: Variants.ALT2_MODERATE, text: 'Omgjøring' },
@@ -36,5 +36,16 @@ export const OppgavetypeTag = (props: { oppgavetype: Oppgavetype }) => {
     return <Tag variant={tagdata.variant}>{tagdata.text}</Tag>
   } else {
     return <Tag variant={Variants.ALT1_FILLED}>Ukjent oppgave</Tag>
+  }
+}
+
+export const TemaTag = ({ tema }: { tema: GosysTema }) => {
+  switch (tema) {
+    case 'EYO':
+      return <Tag variant={Variants.ALT2}>Omstillingsstønad</Tag>
+    case 'EYB':
+      return <Tag variant={Variants.INFO}>Barnepensjon</Tag>
+    case 'PEN':
+      return <Tag variant={Variants.ALT1}>Pensjon</Tag>
   }
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/filtreringAvOppgaver/GosysFilterRad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/filtreringAvOppgaver/GosysFilterRad.tsx
@@ -1,0 +1,86 @@
+import { Button, Select, TextField } from '@navikt/ds-react'
+import React, { ReactNode, useEffect, useState } from 'react'
+import { FlexRow } from '~shared/styled'
+import {
+  ENHETFILTER,
+  EnhetFilterKeys,
+  GOSYS_TEMA_FILTER,
+  GosysFilter,
+} from '~components/oppgavebenk/filtreringAvOppgaver/typer'
+import { ArrowCirclepathIcon, ArrowUndoIcon } from '@navikt/aksel-icons'
+import { GosysTema } from '~shared/types/Gosys'
+
+interface Props {
+  hentAlleOppgaver: () => void
+  filter: GosysFilter
+  setFilter: (filter: GosysFilter) => void
+  filterFoedselsnummer: (fnr?: string) => void
+}
+
+export const GosysFilterRad = ({ hentAlleOppgaver, filter, setFilter, filterFoedselsnummer }: Props): ReactNode => {
+  const [fnr, setFnr] = useState<string>()
+
+  useEffect(() => {
+    const delay = setTimeout(() => filterFoedselsnummer(fnr), 500)
+    return () => clearTimeout(delay)
+  }, [fnr])
+
+  return (
+    <>
+      <FlexRow $spacing align="start">
+        <TextField
+          label="Fødselsnummer"
+          width="1rem"
+          value={fnr || ''}
+          onChange={(e) => setFnr(e.target.value?.replace(/[^0-9+]/, ''))}
+          type="tel"
+          min={0}
+          placeholder="Søk"
+        />
+
+        <Select
+          label="Enhet"
+          value={filter.enhetFilter}
+          onChange={(e) => setFilter({ ...filter, enhetFilter: e.target.value as EnhetFilterKeys })}
+        >
+          {Object.entries(ENHETFILTER).map(([enhetsnummer, enhetBeskrivelse]) => (
+            <option key={enhetsnummer} value={enhetsnummer}>
+              {enhetBeskrivelse}
+            </option>
+          ))}
+        </Select>
+
+        <Select
+          label="Tema"
+          value={filter.temaFilter}
+          onChange={(e) => setFilter({ ...filter, temaFilter: e.target.value as GosysTema })}
+        >
+          <option value="">Barnepensjon og omstillingsstønad</option>
+          {Object.entries(GOSYS_TEMA_FILTER).map(([tema, beskrivelse]) => (
+            <option key={tema} value={tema}>
+              {beskrivelse}
+            </option>
+          ))}
+        </Select>
+      </FlexRow>
+
+      <FlexRow $spacing>
+        <Button onClick={() => hentAlleOppgaver()} size="small" icon={<ArrowCirclepathIcon />} iconPosition="right">
+          Hent oppgaver
+        </Button>
+        <Button
+          variant="secondary"
+          onClick={() => {
+            setFilter({})
+            hentAlleOppgaver()
+          }}
+          size="small"
+          icon={<ArrowUndoIcon />}
+          iconPosition="right"
+        >
+          Tilbakestill filtre
+        </Button>
+      </FlexRow>
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/filtreringAvOppgaver/typer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/filtreringAvOppgaver/typer.ts
@@ -1,4 +1,5 @@
 import { Oppgavestatus, Oppgavetype } from '~shared/types/oppgave'
+import { GosysTema } from '~shared/types/Gosys'
 
 type visAlle = 'visAlle'
 
@@ -20,6 +21,13 @@ export const YTELSEFILTER = {
   OMSTILLINGSSTOENAD: 'Omstillingsstønad',
 }
 export type YtelseFilterKeys = keyof typeof YTELSEFILTER
+
+export type TemaFilterKeys = GosysTema
+export const GOSYS_TEMA_FILTER: Record<TemaFilterKeys, string> = {
+  PEN: 'Pensjon',
+  EYO: 'Omstillingsstønad',
+  EYB: 'Barnepensjon',
+}
 
 export const SAKSBEHANDLERFILTER = {
   visAlle: 'Vis alle',
@@ -46,7 +54,6 @@ export const OPPGAVETYPEFILTER: Record<OppgavetypeFilterKeys, string> = {
   FOERSTEGANGSBEHANDLING: 'Førstegangsbehandling',
   REVURDERING: 'Revurdering',
   VURDER_KONSEKVENS: 'Hendelse',
-  GOSYS: 'Gosys',
   KRAVPAKKE_UTLAND: 'Kravpakke utland',
   KLAGE: 'Klage',
   TILBAKEKREVING: 'Tilbakekreving',
@@ -71,4 +78,10 @@ export interface Filter {
   ytelseFilter: YtelseFilterKeys
   oppgavestatusFilter: Array<string>
   oppgavetypeFilter: Array<string>
+}
+
+export interface GosysFilter {
+  enhetFilter?: EnhetFilterKeys
+  saksbehandlerFilter?: string
+  temaFilter?: TemaFilterKeys
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/frist/FristHandlinger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/frist/FristHandlinger.tsx
@@ -10,7 +10,6 @@ import { FlexRow } from '~shared/styled'
 
 import { isPending, isSuccess } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
-import { Oppgavetype } from '~shared/types/oppgave'
 
 const FristWrapper = styled.span<{ fristHarPassert: boolean; utenKnapp?: boolean }>`
   color: ${(p) => p.fristHarPassert && 'var(--a-text-danger)'};
@@ -20,12 +19,10 @@ const FristWrapper = styled.span<{ fristHarPassert: boolean; utenKnapp?: boolean
 export const FristHandlinger = (props: {
   orginalFrist: string
   oppgaveId: string
-  oppgaveVersjon: number | null
-  type: Oppgavetype
-  oppdaterFrist: (id: string, nyfrist: string, versjon: number | null) => void
+  oppdaterFrist: (id: string, nyfrist: string) => void
   erRedigerbar: boolean
 }) => {
-  const { orginalFrist, oppgaveId, oppdaterFrist, erRedigerbar, oppgaveVersjon, type } = props
+  const { orginalFrist, oppgaveId, oppdaterFrist, erRedigerbar } = props
   const [open, setOpen] = useState(false)
   const [frist, setFrist] = useState<string>()
   const [nyFrist, setnyFrist] = useState<Date>(new Date())
@@ -92,7 +89,7 @@ export const FristHandlinger = (props: {
                   <Button
                     variant="secondary"
                     onClick={() => {
-                      oppdaterFrist(oppgaveId, nyFrist.toISOString(), oppgaveVersjon)
+                      oppdaterFrist(oppgaveId, nyFrist.toISOString())
                       setOpen(false)
                     }}
                   >
@@ -108,7 +105,7 @@ export const FristHandlinger = (props: {
                   loading={isPending(redigerfristSvar)}
                   disabled={!nyFrist}
                   onClick={() => {
-                    redigerFrist({ oppgaveId, type, redigerFristRequest: { frist: nyFrist, versjon: oppgaveVersjon } })
+                    redigerFrist({ oppgaveId, redigerFristRequest: { frist: nyFrist, versjon: null } })
                   }}
                 >
                   Lagre ny frist

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/gosys/FerdigstillGosysOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/gosys/FerdigstillGosysOppgave.tsx
@@ -1,17 +1,17 @@
-import { ferdigstilleGosysOppgave } from '~shared/api/oppgaver'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { mapResult } from '~shared/api/apiUtils'
 import { Alert, Button, Loader } from '@navikt/ds-react'
 import { FlexRow } from '~shared/styled'
 import { GosysActionToggle } from '~components/oppgavebenk/oppgaveModal/GosysOppgaveModal'
 import Spinner from '~shared/Spinner'
-import { OppgaveDTO } from '~shared/types/oppgave'
+import { ferdigstilleGosysOppgave } from '~shared/api/gosys'
+import { GosysOppgave } from '~shared/types/Gosys'
 
 export const FerdigstillGosysOppgave = ({
   oppgave,
   setToggle,
 }: {
-  oppgave: OppgaveDTO
+  oppgave: GosysOppgave
   setToggle: (toggle: GosysActionToggle) => void
 }) => {
   const [ferdigstillResult, ferdigstillOppgave] = useApiCall(ferdigstilleGosysOppgave)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/gosys/GosysOppgaveRow.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/gosys/GosysOppgaveRow.tsx
@@ -1,0 +1,38 @@
+import { formaterOppgavetype, formaterStatus, GosysOppgave } from '~shared/types/Gosys'
+import { Table } from '@navikt/ds-react'
+import { formaterStringDato } from '~utils/formattering'
+import SaksoversiktLenke from '~components/oppgavebenk/components/SaksoversiktLenke'
+import { TemaTag } from '~components/oppgavebenk/components/Tags'
+import { VelgSaksbehandler } from '~components/oppgavebenk/gosys/VelgSaksbehandler'
+import { GosysOppgaveModal } from '~components/oppgavebenk/oppgaveModal/GosysOppgaveModal'
+import React, { useState } from 'react'
+import { Saksbehandler } from '~shared/types/saksbehandler'
+
+export const GosysOppgaveRow = (props: { oppgave: GosysOppgave; saksbehandlereIEnhet: Array<Saksbehandler> }) => {
+  const [oppgave, setOppgave] = useState(props.oppgave)
+
+  return (
+    <Table.Row>
+      <Table.DataCell>{formaterStringDato(oppgave.opprettet)}</Table.DataCell>
+      <Table.DataCell>{oppgave.frist ? formaterStringDato(oppgave.frist) : 'Mangler'}</Table.DataCell>
+      <Table.DataCell>{oppgave.fnr ? <SaksoversiktLenke fnr={oppgave.fnr} /> : 'Mangler'}</Table.DataCell>
+      <Table.DataCell>{formaterOppgavetype(oppgave.oppgavetype)}</Table.DataCell>
+      <Table.DataCell>
+        <TemaTag tema={oppgave.tema} />
+      </Table.DataCell>
+      <Table.DataCell>{oppgave.beskrivelse}</Table.DataCell>
+      <Table.DataCell>{formaterStatus(oppgave.status)}</Table.DataCell>
+      <Table.DataCell>{oppgave.enhet}</Table.DataCell>
+      <Table.DataCell>
+        <VelgSaksbehandler
+          saksbehandlereIEnhet={props.saksbehandlereIEnhet}
+          oppgave={oppgave}
+          oppdaterTildeling={(saksbehandler) => setOppgave({ ...oppgave, saksbehandler })}
+        />
+      </Table.DataCell>
+      <Table.DataCell>
+        <GosysOppgaveModal oppgave={oppgave} />
+      </Table.DataCell>
+    </Table.Row>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/gosys/GosysOppgaver.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/gosys/GosysOppgaver.tsx
@@ -1,51 +1,27 @@
 import { Alert } from '@navikt/ds-react'
 import React, { ReactNode, useEffect, useState } from 'react'
-import { OppgaverTable } from '~components/oppgavebenk/oppgaverTable/OppgaverTable'
 import { PagineringsKontroller } from '~components/oppgavebenk/oppgaver/PagineringsKontroller'
 import {
   hentSorteringFraLocalStorage,
   OppgaveSortering,
-  sorterOppgaver,
+  sorterGosysOppgaver,
 } from '~components/oppgavebenk/utils/oppgaveSortering'
 import { Saksbehandler } from '~shared/types/saksbehandler'
 import { hentPagineringSizeFraLocalStorage } from '~components/oppgavebenk/utils/oppgaveutils'
-import { filtrerOppgaver } from '~components/oppgavebenk/filtreringAvOppgaver/filtrerOppgaver'
-import { RevurderingsaarsakerBySakstype } from '~shared/types/Revurderingaarsak'
-import { Filter } from '~components/oppgavebenk/filtreringAvOppgaver/typer'
-import { OppgaveDTO, OppgaveSaksbehandler } from '~shared/types/oppgave'
+import { GosysOppgave } from '~shared/types/Gosys'
+import { GosysOppgaverTable } from './GosysOppgaverTable'
 
 export interface Props {
-  oppgaver: OppgaveDTO[]
+  oppgaver: GosysOppgave[]
   saksbehandlereIEnhet: Array<Saksbehandler>
-  oppdaterSaksbehandlerTildeling: (oppgave: OppgaveDTO, saksbehandler: OppgaveSaksbehandler | null) => void
-  oppdaterFrist?: (id: string, nyfrist: string) => void
-  filter?: Filter
-  revurderingsaarsaker: RevurderingsaarsakerBySakstype
+  fnrFilter?: string
 }
 
-export const Oppgaver = ({
-  oppgaver,
-  saksbehandlereIEnhet,
-  oppdaterSaksbehandlerTildeling,
-  oppdaterFrist,
-  filter,
-  revurderingsaarsaker,
-}: Props): ReactNode => {
+export const GosysOppgaver = ({ oppgaver, saksbehandlereIEnhet, fnrFilter }: Props): ReactNode => {
   const [sortering, setSortering] = useState<OppgaveSortering>(hentSorteringFraLocalStorage())
-  const filtrerteOppgaver = filter
-    ? filtrerOppgaver(
-        filter.sakEllerFnrFilter,
-        filter.enhetsFilter,
-        filter.fristFilter,
-        filter.saksbehandlerFilter,
-        filter.ytelseFilter,
-        filter.oppgavestatusFilter,
-        filter.oppgavetypeFilter,
-        [...oppgaver]
-      )
-    : oppgaver
 
-  const sorterteOppgaver = sorterOppgaver(filtrerteOppgaver, sortering)
+  const filtrerteOppgaver = fnrFilter ? oppgaver.filter(({ fnr }) => fnr === fnrFilter.trim()) : oppgaver
+  const sorterteOppgaver = sorterGosysOppgaver(filtrerteOppgaver, sortering)
 
   const [page, setPage] = useState<number>(1)
   const [rowsPerPage, setRowsPerPage] = useState<number>(hentPagineringSizeFraLocalStorage())
@@ -53,8 +29,8 @@ export const Oppgaver = ({
   let paginerteOppgaver = sorterteOppgaver
 
   useEffect(() => {
-    if (paginerteOppgaver.length === 0 && filtrerteOppgaver.length > 0) setPage(1)
-  }, [sorterteOppgaver, filtrerteOppgaver])
+    if (paginerteOppgaver.length === 0 && oppgaver.length > 0) setPage(1)
+  }, [oppgaver, sorterteOppgaver])
 
   paginerteOppgaver = paginerteOppgaver.slice((page - 1) * rowsPerPage, page * rowsPerPage)
 
@@ -68,13 +44,10 @@ export const Oppgaver = ({
         antallSider={Math.ceil(filtrerteOppgaver.length / rowsPerPage)}
       />
 
-      <OppgaverTable
+      <GosysOppgaverTable
         oppgaver={paginerteOppgaver}
-        oppdaterTildeling={oppdaterSaksbehandlerTildeling}
-        oppdaterFrist={oppdaterFrist}
         saksbehandlereIEnhet={saksbehandlereIEnhet}
         setSortering={setSortering}
-        revurderingsaarsaker={revurderingsaarsaker}
       />
 
       <PagineringsKontroller

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/gosys/GosysOppgaverTable.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/gosys/GosysOppgaverTable.tsx
@@ -1,15 +1,13 @@
 import React, { ReactNode, useEffect, useState } from 'react'
 import { SortState, Table } from '@navikt/ds-react'
-import { OppgaverTableHeader } from '~components/oppgavebenk/oppgaverTable/OppgaverTableHeader'
-import { OppgaverTableRow } from '~components/oppgavebenk/oppgaverTable/OppgaverTableRow'
 import {
   initialSortering,
   leggTilSorteringILocalStorage,
   OppgaveSortering,
 } from '~components/oppgavebenk/utils/oppgaveSortering'
 import { Saksbehandler } from '~shared/types/saksbehandler'
-import { RevurderingsaarsakerBySakstype } from '~shared/types/Revurderingaarsak'
-import { OppgaveDTO, OppgaveSaksbehandler } from '~shared/types/oppgave'
+import { GosysOppgave } from '~shared/types/Gosys'
+import { GosysOppgaveRow } from '~components/oppgavebenk/gosys/GosysOppgaveRow'
 
 export enum SortKey {
   REGISTRERINGSDATO = 'registreringsdato',
@@ -18,22 +16,12 @@ export enum SortKey {
 }
 
 interface Props {
-  oppgaver: ReadonlyArray<OppgaveDTO>
-  oppdaterTildeling: (oppgave: OppgaveDTO, saksbehandler: OppgaveSaksbehandler | null) => void
-  oppdaterFrist?: (id: string, nyfrist: string) => void
-  revurderingsaarsaker: RevurderingsaarsakerBySakstype
+  oppgaver: ReadonlyArray<GosysOppgave>
   saksbehandlereIEnhet: Array<Saksbehandler>
   setSortering: (nySortering: OppgaveSortering) => void
 }
 
-export const OppgaverTable = ({
-  oppgaver,
-  oppdaterTildeling,
-  oppdaterFrist,
-  revurderingsaarsaker,
-  saksbehandlereIEnhet,
-  setSortering,
-}: Props): ReactNode => {
+export const GosysOppgaverTable = ({ oppgaver, saksbehandlereIEnhet, setSortering }: Props): ReactNode => {
   const [sort, setSort] = useState<SortState>()
 
   const handleSort = (sortKey: SortKey) => {
@@ -82,17 +70,29 @@ export const OppgaverTable = ({
       sort={sort && sort.direction !== 'none' ? { direction: sort.direction, orderBy: sort.orderBy } : undefined}
       onSortChange={(sortKey) => handleSort(sortKey as SortKey)}
     >
-      <OppgaverTableHeader />
+      <Table.Header>
+        <Table.Row>
+          <Table.ColumnHeader scope="col" sortKey={SortKey.REGISTRERINGSDATO} sortable>
+            Opprettet
+          </Table.ColumnHeader>
+          <Table.ColumnHeader scope="col" sortKey={SortKey.FRIST} sortable>
+            Frist
+          </Table.ColumnHeader>
+          <Table.ColumnHeader scope="col" sortKey={SortKey.FNR} sortable>
+            Fødselsnummer
+          </Table.ColumnHeader>
+          <Table.HeaderCell scope="col">Oppgavetype</Table.HeaderCell>
+          <Table.HeaderCell scope="col">Tema</Table.HeaderCell>
+          <Table.HeaderCell scope="col">Beskrivelse</Table.HeaderCell>
+          <Table.HeaderCell scope="col">Status</Table.HeaderCell>
+          <Table.HeaderCell scope="col">Enhet</Table.HeaderCell>
+          <Table.HeaderCell scope="col">Saksbehandler</Table.HeaderCell>
+          <Table.HeaderCell scope="col">Handlinger</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
       <Table.Body>
-        {oppgaver?.map((oppgave: OppgaveDTO) => (
-          <OppgaverTableRow
-            key={oppgave.id}
-            oppgave={oppgave}
-            saksbehandlereIEnhet={saksbehandlereIEnhet}
-            oppdaterTildeling={oppdaterTildeling}
-            oppdaterFrist={oppdaterFrist}
-            revurderingsaarsaker={revurderingsaarsaker}
-          />
+        {oppgaver?.map((oppgave: GosysOppgave) => (
+          <GosysOppgaveRow key={oppgave.id} oppgave={oppgave} saksbehandlereIEnhet={saksbehandlereIEnhet} />
         ))}
       </Table.Body>
     </Table>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/GosysOppgaveModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/GosysOppgaveModal.tsx
@@ -1,15 +1,16 @@
 import { BodyShort, Box, Button, Dropdown, Heading, Label, Modal } from '@navikt/ds-react'
 import styled from 'styled-components'
 import { ChevronDownIcon, ExternalLinkIcon, EyeIcon } from '@navikt/aksel-icons'
-import { useContext, useState } from 'react'
-import { OppgavetypeTag, SaktypeTag } from '~components/oppgavebenk/components/Tags'
+import React, { useContext, useState } from 'react'
+import { TemaTag } from '~components/oppgavebenk/components/Tags'
 import { formaterFnr, formaterStringDato } from '~utils/formattering'
 import { ConfigContext } from '~clientConfig'
 import { FlexRow } from '~shared/styled'
 import { FristWrapper } from '~components/oppgavebenk/frist/FristWrapper'
 import { FerdigstillGosysOppgave } from '../gosys/FerdigstillGosysOppgave'
 import { OverfoerOppgaveTilGjenny } from '../gosys/OverfoerOppgaveTilGjenny'
-import { OppgaveDTO, Oppgavetype } from '~shared/types/oppgave'
+import { formaterOppgavetype, GosysOppgave } from '~shared/types/Gosys'
+import { useInnloggetSaksbehandler } from '~components/behandling/useInnloggetSaksbehandler'
 
 const TagRow = styled.div`
   display: flex;
@@ -29,17 +30,13 @@ export interface GosysActionToggle {
   konverter?: boolean
 }
 
-export const GosysOppgaveModal = ({
-  oppgave,
-  tilhoererInnloggetSaksbehandler,
-}: {
-  oppgave: OppgaveDTO
-  tilhoererInnloggetSaksbehandler: boolean
-}) => {
+export const GosysOppgaveModal = ({ oppgave }: { oppgave: GosysOppgave }) => {
+  const innloggetSaksbehandler = useInnloggetSaksbehandler()
+
   const [open, setOpen] = useState(false)
   const [toggle, setToggle] = useState<GosysActionToggle>({})
 
-  const { opprettet, frist, status, fnr, gjelder, enhet, saksbehandler, beskrivelse, sakType, journalpostId } = oppgave
+  const { opprettet, frist, status, fnr, enhet, saksbehandler, beskrivelse, tema, oppgavetype, journalpostId } = oppgave
 
   const configContext = useContext(ConfigContext)
 
@@ -57,8 +54,7 @@ export const GosysOppgaveModal = ({
 
         <Modal.Body>
           <TagRow>
-            <SaktypeTag sakType={sakType} />
-            <OppgavetypeTag oppgavetype={Oppgavetype.GOSYS} />
+            <TemaTag tema={tema} />
           </TagRow>
           <InfoGrid>
             <div>
@@ -76,12 +72,12 @@ export const GosysOppgaveModal = ({
               <BodyShort>{status}</BodyShort>
             </div>
             <div>
-              <Label>Fødselsnummer</Label>
-              <BodyShort>{fnr ? formaterFnr(fnr) : <i>Mangler</i>}</BodyShort>
+              <Label>Oppgavetype</Label>
+              <BodyShort>{formaterOppgavetype(oppgavetype)}</BodyShort>
             </div>
             <div>
-              <Label>Gjelder</Label>
-              <BodyShort>{gjelder}</BodyShort>
+              <Label>Fødselsnummer</Label>
+              <BodyShort>{fnr ? formaterFnr(fnr) : <i>Mangler</i>}</BodyShort>
             </div>
             <div>
               <Label>Enhet</Label>
@@ -115,7 +111,7 @@ export const GosysOppgaveModal = ({
                 Avbryt
               </Button>
 
-              {tilhoererInnloggetSaksbehandler && (
+              {innloggetSaksbehandler.ident === oppgave.saksbehandler?.ident && (
                 <Dropdown>
                   <Button
                     size="small"

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaverTable/OppgaverTableRow.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaverTable/OppgaverTableRow.tsx
@@ -15,8 +15,8 @@ import { erOppgaveRedigerbar, OppgaveDTO, OppgaveSaksbehandler } from '~shared/t
 interface Props {
   oppgave: OppgaveDTO
   saksbehandlereIEnhet: Array<Saksbehandler>
-  oppdaterTildeling: (oppgave: OppgaveDTO, saksbehandler: OppgaveSaksbehandler | null, versjon: number | null) => void
-  oppdaterFrist?: (id: string, nyfrist: string, versjon: number | null) => void
+  oppdaterTildeling: (oppgave: OppgaveDTO, saksbehandler: OppgaveSaksbehandler | null) => void
+  oppdaterFrist?: (id: string, nyfrist: string) => void
   revurderingsaarsaker: RevurderingsaarsakerBySakstype
 }
 
@@ -37,8 +37,6 @@ export const OppgaverTableRow = ({
           oppgaveId={oppgave.id}
           oppdaterFrist={oppdaterFrist}
           erRedigerbar={erOppgaveRedigerbar(oppgave.status)}
-          oppgaveVersjon={oppgave.versjon}
-          type={oppgave.type}
         />
       ) : (
         <FristWrapper dato={oppgave.frist} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/state/OppgavebenkContext.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/state/OppgavebenkContext.tsx
@@ -7,11 +7,12 @@ import {
 import { hentOppgavebenkStats } from '~shared/api/oppgaver'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { OppgaveDTO } from '~shared/types/oppgave'
+import { GosysOppgave } from '~shared/types/Gosys'
 
 export interface OppgavebenkStateDispatcher {
   setOppgavelistaOppgaver: (oppgaver: OppgaveDTO[]) => void
   setMinOppgavelisteOppgaver: (oppgaver: OppgaveDTO[]) => void
-  setGosysOppgavelisteOppgaver: (oppgaver: OppgaveDTO[]) => void
+  setGosysOppgavelisteOppgaver: (oppgaver: GosysOppgave[]) => void
   setOppgavebenkStats: (stats: OppgavebenkStats) => void
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/state/oppgavebenkState.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/state/oppgavebenkState.ts
@@ -1,9 +1,10 @@
 import { OppgaveDTO } from '~shared/types/oppgave'
+import { GosysOppgave } from '~shared/types/Gosys'
 
 export interface OppgavebenkState {
   oppgavelistaOppgaver: OppgaveDTO[]
   minOppgavelisteOppgaver: OppgaveDTO[]
-  gosysOppgavelisteOppgaver: OppgaveDTO[]
+  gosysOppgavelisteOppgaver: GosysOppgave[]
   oppgpavebenkStats: OppgavebenkStats
 }
 export interface OppgavebenkStats {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/utils/oppgaveSortering.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/utils/oppgaveSortering.ts
@@ -1,5 +1,6 @@
 import { logger } from '~utils/logger'
 import { OppgaveDTO } from '~shared/types/oppgave'
+import { GosysOppgave } from '~shared/types/Gosys'
 
 export interface OppgaveSortering {
   registreringsdatoSortering: Retning
@@ -15,12 +16,12 @@ export const initialSortering: OppgaveSortering = {
 
 type Retning = 'ascending' | 'descending' | 'none'
 
-const sammenlignDato = (a: OppgaveDTO, b: OppgaveDTO) => {
+const sammenlignDato = (a: OppgaveDTO | GosysOppgave, b: OppgaveDTO | GosysOppgave) => {
   // Konverterer datoene til en numerisk verdi og sammenligner dem
   return (!!a.frist ? new Date(a.frist).getTime() : 0) - (!!b.frist ? new Date(b.frist).getTime() : 0)
 }
 
-export function sorterDato(retning: Retning, oppgaver: OppgaveDTO[]) {
+function sorterDato(retning: Retning, oppgaver: OppgaveDTO[] | GosysOppgave[]) {
   switch (retning) {
     case 'ascending':
       return oppgaver.sort(sammenlignDato)
@@ -31,12 +32,12 @@ export function sorterDato(retning: Retning, oppgaver: OppgaveDTO[]) {
   }
 }
 
-const sammenlignFnr = (a: OppgaveDTO, b: OppgaveDTO) => {
+const sammenlignFnr = (a: OppgaveDTO | GosysOppgave, b: OppgaveDTO | GosysOppgave) => {
   // Sammenligner de første 6 sifrene i fødselsnummerene
   return (!!a.fnr ? Number(a.fnr.slice(0, 5)) : 0) - (!!b.fnr ? Number(b.fnr.slice(0, 5)) : 0)
 }
 
-export function sorterFnr(retning: Retning, oppgaver: OppgaveDTO[]) {
+function sorterFnr(retning: Retning, oppgaver: OppgaveDTO[] | GosysOppgave[]) {
   switch (retning) {
     case 'ascending':
       return oppgaver.sort(sammenlignFnr)
@@ -45,6 +46,20 @@ export function sorterFnr(retning: Retning, oppgaver: OppgaveDTO[]) {
     case 'none':
       return oppgaver
   }
+}
+
+export function sorterOppgaver(oppgaver: OppgaveDTO[], sortering: OppgaveSortering): OppgaveDTO[] {
+  const sortertRegistreringsdato = sorterDato(sortering.registreringsdatoSortering, oppgaver)
+  const sortertFrist = sorterDato(sortering.fristSortering, sortertRegistreringsdato)
+
+  return sorterFnr(sortering.fnrSortering, sortertFrist) as OppgaveDTO[]
+}
+
+export function sorterGosysOppgaver(oppgaver: GosysOppgave[], sortering: OppgaveSortering): GosysOppgave[] {
+  const sortertRegistreringsdato = sorterDato(sortering.registreringsdatoSortering, oppgaver)
+  const sortertFrist = sorterDato(sortering.fristSortering, sortertRegistreringsdato)
+
+  return sorterFnr(sortering.fnrSortering, sortertFrist) as GosysOppgave[]
 }
 
 const SORTERING_KEY_LOCAL_STORAGE = 'OPPGAVESORTERING'

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/utils/oppgaveutils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/utils/oppgaveutils.ts
@@ -4,15 +4,13 @@ import { OppgaveDTO, OppgaveSaksbehandler, Oppgavestatus } from '~shared/types/o
 export const finnOgOppdaterSaksbehandlerTildeling = (
   oppgaver: OppgaveDTO[],
   oppgaveId: string,
-  saksbehandler: OppgaveSaksbehandler | null,
-  versjon: number | null
+  saksbehandler: OppgaveSaksbehandler | null
 ) => {
   const index = oppgaver.findIndex((o) => o.id === oppgaveId)
   if (index > -1) {
     const oppdatertOppgaveState = [...oppgaver]
     oppdatertOppgaveState[index].saksbehandler = saksbehandler
     oppdatertOppgaveState[index].status = Oppgavestatus.UNDER_BEHANDLING
-    oppdatertOppgaveState[index].versjon = versjon
     return oppdatertOppgaveState
   } else {
     return oppgaver
@@ -22,14 +20,12 @@ export const finnOgOppdaterSaksbehandlerTildeling = (
 export const leggTilOppgavenIMinliste = (
   oppgaver: OppgaveDTO[],
   oppgave: OppgaveDTO,
-  saksbehandler: OppgaveSaksbehandler | null,
-  versjon: number | null
+  saksbehandler: OppgaveSaksbehandler | null
 ): OppgaveDTO[] => {
   return oppgaver.concat({
     ...oppgave,
     saksbehandler: saksbehandler,
     status: Oppgavestatus.UNDER_BEHANDLING,
-    versjon: versjon,
   })
 }
 
@@ -37,14 +33,12 @@ export const oppdaterFrist = (
   setHentedeOppgaver: (oppdatertListe: OppgaveDTO[]) => void,
   hentedeOppgaver: OppgaveDTO[],
   id: string,
-  frist: string,
-  versjon: number | null
+  frist: string
 ) => {
   setTimeout(() => {
     const oppdatertOppgaveState = [...hentedeOppgaver]
     const index = oppdatertOppgaveState.findIndex((o) => o.id === id)
     oppdatertOppgaveState[index].frist = frist
-    oppdatertOppgaveState[index].versjon = versjon
     setHentedeOppgaver(oppdatertOppgaveState)
   }, 2000)
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/OppgaveFraJournalpostModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/OppgaveFraJournalpostModal.tsx
@@ -61,7 +61,6 @@ export const OppgaveFraJournalpostModal = ({
           tildelSaksbehandler(
             {
               oppgaveId: oppgave.id,
-              type: oppgaveType,
               nysaksbehandler: { saksbehandler: innloggetSaksbehandler.ident, versjon: null },
             },
             () => navigate(`/oppgave/${oppgave.id}`)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/KnyttTilAnnenBruker.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/KnyttTilAnnenBruker.tsx
@@ -69,7 +69,6 @@ export const KnyttTilAnnentBruker = ({
           (oppgave) => {
             tildelSaksbehandler({
               oppgaveId: oppgave.id,
-              type: oppgaveType,
               nysaksbehandler: { saksbehandler: innloggetSaksbehandler.ident, versjon: null },
             })
           }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/ForenkletOppgaverTable.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/ForenkletOppgaverTable.tsx
@@ -41,13 +41,9 @@ export const ForenkletOppgaverTable = ({
 
   const [, saksbehandlereIEnheterFetch] = useApiCall(saksbehandlereIEnhetApi)
 
-  const oppdaterSaksbehandlerTildeling = (
-    oppgave: OppgaveDTO,
-    saksbehandler: OppgaveSaksbehandler | null,
-    versjon: number | null
-  ) => {
+  const oppdaterSaksbehandlerTildeling = (oppgave: OppgaveDTO, saksbehandler: OppgaveSaksbehandler | null) => {
     setTimeout(() => {
-      setFiltrerteOppgaver(finnOgOppdaterSaksbehandlerTildeling(filtrerteOppgaver, oppgave.id, saksbehandler, versjon))
+      setFiltrerteOppgaver(finnOgOppdaterSaksbehandlerTildeling(filtrerteOppgaver, oppgave.id, saksbehandler))
     }, 2000)
   }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/gosys.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/gosys.ts
@@ -1,0 +1,45 @@
+import { apiClient, ApiResponse } from '~shared/api/apiClient'
+import { OppdatertOppgaveversjonResponseDto, RedigerFristRequest, SaksbehandlerEndringDto } from '~shared/api/oppgaver'
+import { OppgaveDTO } from '~shared/types/oppgave'
+import { GosysFilter } from '~components/oppgavebenk/filtreringAvOppgaver/typer'
+import { GosysOppgave } from '~shared/types/Gosys'
+
+export const hentGosysOppgaver = async (filter: GosysFilter): Promise<ApiResponse<GosysOppgave[]>> => {
+  const queryParams = new URLSearchParams({
+    saksbehandler: filter.saksbehandlerFilter || '',
+    tema: filter.temaFilter || '',
+    enhet: filter.enhetFilter ? filter.enhetFilter.replace('E', '') : '',
+  })
+
+  return apiClient.get(`/oppgaver/gosys?${queryParams}`)
+}
+
+export const tildelSaksbehandlerApi = async (args: {
+  oppgaveId: number
+  nysaksbehandler: SaksbehandlerEndringDto
+}): Promise<ApiResponse<OppdatertOppgaveversjonResponseDto>> => {
+  return apiClient.post(`/oppgaver/gosys/${args.oppgaveId}/tildel-saksbehandler`, { ...args.nysaksbehandler })
+}
+
+export const redigerFristApi = async (args: {
+  oppgaveId: number
+  redigerFristRequest: RedigerFristRequest
+}): Promise<ApiResponse<void>> => {
+  return apiClient.post(`/oppgaver/gosys/${args.oppgaveId}/endre-frist`, { ...args.redigerFristRequest })
+}
+
+export const ferdigstilleGosysOppgave = async (args: {
+  oppgaveId: number
+  versjon: number
+}): Promise<ApiResponse<OppgaveDTO>> =>
+  apiClient.post(`/oppgaver/gosys/${args.oppgaveId}/ferdigstill?versjon=${args.versjon}`, {})
+
+export const feilregistrerGosysOppgave = async (args: {
+  oppgaveId: number
+  beskrivelse: string
+  versjon: number
+}): Promise<ApiResponse<OppgaveDTO>> =>
+  apiClient.post(`/oppgaver/gosys/${args.oppgaveId}/feilregistrer`, {
+    versjon: args.versjon,
+    beskrivelse: args.beskrivelse,
+  })

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaver.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaver.ts
@@ -2,8 +2,7 @@ import { apiClient, ApiResponse } from '~shared/api/apiClient'
 import { konverterOppgavestatusFilterValuesTilKeys } from '~components/oppgavebenk/filtreringAvOppgaver/filtrerOppgaver'
 import { Saksbehandler } from '~shared/types/saksbehandler'
 import { OppgavebenkStats } from '~components/oppgavebenk/state/oppgavebenkState'
-import { NyOppgaveDto, OppgaveDTO, Oppgavetype } from '~shared/types/oppgave'
-import { GosysTema } from '~shared/types/Gosys'
+import { NyOppgaveDto, OppgaveDTO } from '~shared/types/oppgave'
 
 export const hentOppgaverMedStatus = async (args: {
   oppgavestatusFilter: Array<string>
@@ -38,12 +37,6 @@ export const hentSaksbehandlerForOppgaveUnderBehandling = async (
 ): Promise<ApiResponse<Saksbehandler>> =>
   apiClient.get(`/oppgaver/referanse/${referanse}/saksbehandler-underbehandling`)
 
-export const hentGosysOppgaver = async (tema: GosysTema[]): Promise<ApiResponse<OppgaveDTO[]>> => {
-  const queryParams = tema.map((t) => `tema=${t}`).join('&')
-
-  return apiClient.get(`/oppgaver/gosys?${queryParams}`)
-}
-
 export const hentOppgavebenkStats = async (): Promise<ApiResponse<OppgavebenkStats>> => apiClient.get('/oppgaver/stats')
 
 export const hentOppgaverTilknyttetSak = async (sakId: number): Promise<ApiResponse<Array<OppgaveDTO>>> => {
@@ -71,32 +64,11 @@ export interface SaksbehandlerEndringDto {
   versjon: number | null
 }
 
-export const ferdigstilleGosysOppgave = async (args: {
-  oppgaveId: string
-  versjon: number
-}): Promise<ApiResponse<OppgaveDTO>> =>
-  apiClient.post(`/oppgaver/gosys/${args.oppgaveId}/ferdigstill?versjon=${args.versjon}`, {})
-
-export const feilregistrerGosysOppgave = async (args: {
-  oppgaveId: string
-  beskrivelse: string
-  versjon: number
-}): Promise<ApiResponse<OppgaveDTO>> =>
-  apiClient.post(`/oppgaver/gosys/${args.oppgaveId}/feilregistrer`, {
-    versjon: args.versjon,
-    beskrivelse: args.beskrivelse,
-  })
-
 export const tildelSaksbehandlerApi = async (args: {
   oppgaveId: string
-  type: Oppgavetype
   nysaksbehandler: SaksbehandlerEndringDto
 }): Promise<ApiResponse<OppdatertOppgaveversjonResponseDto>> => {
-  if (args.type == Oppgavetype.GOSYS) {
-    return apiClient.post(`/oppgaver/gosys/${args.oppgaveId}/tildel-saksbehandler`, { ...args.nysaksbehandler })
-  } else {
-    return apiClient.post(`/oppgaver/${args.oppgaveId}/tildel-saksbehandler`, { ...args.nysaksbehandler })
-  }
+  return apiClient.post(`/oppgaver/${args.oppgaveId}/tildel-saksbehandler`, { ...args.nysaksbehandler })
 }
 
 export const saksbehandlereIEnhetApi = async (args: {
@@ -107,30 +79,16 @@ export const saksbehandlereIEnhetApi = async (args: {
 
 export const byttSaksbehandlerApi = async (args: {
   oppgaveId: string
-  type: Oppgavetype
   nysaksbehandler: SaksbehandlerEndringDto
 }): Promise<ApiResponse<OppdatertOppgaveversjonResponseDto>> => {
-  if (args.type == Oppgavetype.GOSYS) {
-    return apiClient.post(`/oppgaver/gosys/${args.oppgaveId}/tildel-saksbehandler`, { ...args.nysaksbehandler })
-  } else {
-    return apiClient.post(`/oppgaver/${args.oppgaveId}/bytt-saksbehandler`, { ...args.nysaksbehandler })
-  }
+  return apiClient.post(`/oppgaver/${args.oppgaveId}/bytt-saksbehandler`, { ...args.nysaksbehandler })
 }
 
 export const fjernSaksbehandlerApi = async (args: {
   oppgaveId: string
   sakId: number
-  type: Oppgavetype
-  versjon: number | null
 }): Promise<ApiResponse<OppdatertOppgaveversjonResponseDto>> => {
-  if (args.type == Oppgavetype.GOSYS) {
-    return apiClient.post(`/oppgaver/gosys/${args.oppgaveId}/tildel-saksbehandler`, {
-      saksbehandler: '',
-      versjon: args.versjon,
-    })
-  } else {
-    return apiClient.delete(`/oppgaver/${args.oppgaveId}/saksbehandler`)
-  }
+  return apiClient.delete(`/oppgaver/${args.oppgaveId}/saksbehandler`)
 }
 
 export interface RedigerFristRequest {
@@ -145,14 +103,9 @@ export interface EndrePaaVentRequest {
 
 export const redigerFristApi = async (args: {
   oppgaveId: string
-  type: Oppgavetype
   redigerFristRequest: RedigerFristRequest
 }): Promise<ApiResponse<void>> => {
-  if (args.type == Oppgavetype.GOSYS) {
-    return apiClient.post(`/oppgaver/gosys/${args.oppgaveId}/endre-frist`, { ...args.redigerFristRequest })
-  } else {
-    return apiClient.put(`/oppgaver/${args.oppgaveId}/frist`, { ...args.redigerFristRequest })
-  }
+  return apiClient.put(`/oppgaver/${args.oppgaveId}/frist`, { ...args.redigerFristRequest })
 }
 
 export const settOppgavePaaVentApi = async (args: {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Gosys.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Gosys.ts
@@ -1,13 +1,25 @@
+import { OppgaveSaksbehandler } from '~shared/types/oppgave'
+import { SakType } from '~shared/types/sak'
+
+export interface GosysOppgave {
+  id: number
+  versjon: number
+  status: string
+  tema: GosysTema
+  oppgavetype: string
+  saksbehandler?: OppgaveSaksbehandler
+  enhet: string
+  opprettet: string
+  frist?: string
+  fnr?: string
+  beskrivelse?: string
+  journalpostId?: string
+}
+
 export enum GosysTema {
   PEN = 'PEN',
   EYO = 'EYO',
   EYB = 'EYB',
-}
-
-export const GOSYS_TEMA_FILTER: Record<GosysTema, string> = {
-  PEN: 'Pensjon',
-  EYO: 'Omstillingsstønad',
-  EYB: 'Barnepensjon',
 }
 
 export const konverterStringTilGosysTema = (value: string): GosysTema => {
@@ -20,5 +32,48 @@ export const konverterStringTilGosysTema = (value: string): GosysTema => {
       return GosysTema.EYB
     default:
       throw Error(`Ukjent gosys tema ${value}`)
+  }
+}
+
+export const formaterStatus = (status: string) => {
+  switch (status) {
+    case 'OPPRETTET':
+      return 'Opprettet'
+    case 'AAPNET':
+      return 'Åpnet'
+    default:
+      return status
+  }
+}
+
+export const formaterOppgavetype = (type: string) => {
+  switch (type) {
+    case 'GEN':
+      return 'Generell'
+    case 'BEH_SED':
+      return 'Behandle SED'
+    case 'BEH_SAK':
+      return 'Behandle sak'
+    case 'KRA':
+      return 'Krav'
+    case 'ATT':
+      return 'Attestering'
+    case 'JFR':
+      return 'Journalføring'
+    case 'VURD_HENV':
+      return 'Vurder henvendelse'
+    default:
+      return type
+  }
+}
+
+export const sakTypeFraTema = (tema: GosysTema) => {
+  switch (tema) {
+    case GosysTema.EYB:
+      return SakType.BARNEPENSJON
+    case GosysTema.EYO:
+      return SakType.OMSTILLINGSSTOENAD
+    case GosysTema.PEN:
+      return undefined
   }
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/oppgave.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/oppgave.ts
@@ -14,12 +14,6 @@ export interface OppgaveDTO {
   fnr: string | null
   frist: string
   saksbehandler: OppgaveSaksbehandler | null
-
-  // GOSYS-spesifikt
-  beskrivelse: string | null
-  journalpostId: string | null
-  gjelder: string | null
-  versjon: number | null
 }
 
 export interface OppgaveSaksbehandler {
@@ -58,7 +52,6 @@ export enum Oppgavetype {
   FOERSTEGANGSBEHANDLING = 'FOERSTEGANGSBEHANDLING',
   REVURDERING = 'REVURDERING',
   VURDER_KONSEKVENS = 'VURDER_KONSEKVENS',
-  GOSYS = 'GOSYS',
   KRAVPAKKE_UTLAND = 'KRAVPAKKE_UTLAND',
   KLAGE = 'KLAGE',
   TILBAKEKREVING = 'TILBAKEKREVING',

--- a/libs/etterlatte-oppgave-model/src/main/kotlin/oppgave/OppgaveIntern.kt
+++ b/libs/etterlatte-oppgave-model/src/main/kotlin/oppgave/OppgaveIntern.kt
@@ -8,17 +8,6 @@ import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.vedtaksvurdering.VedtakHendelse
 import java.util.UUID
 
-abstract class Oppgave {
-    abstract val status: Status
-    abstract val type: OppgaveType
-    abstract val enhet: String
-    abstract val saksbehandler: OppgaveSaksbehandler?
-    abstract val opprettet: Tidspunkt
-    abstract val sakType: SakType
-    abstract val fnr: String?
-    abstract val frist: Tidspunkt?
-}
-
 data class OppgaveSaksbehandler(
     val ident: String,
     val navn: String? = null,
@@ -26,19 +15,19 @@ data class OppgaveSaksbehandler(
 
 data class OppgaveIntern(
     val id: UUID,
-    override val status: Status,
-    override val enhet: String,
+    val status: Status,
+    val enhet: String,
     val sakId: Long,
     val kilde: OppgaveKilde? = null,
-    override val type: OppgaveType,
-    override val saksbehandler: OppgaveSaksbehandler? = null,
+    val type: OppgaveType,
+    val saksbehandler: OppgaveSaksbehandler? = null,
     val referanse: String,
     val merknad: String? = null,
-    override val opprettet: Tidspunkt,
-    override val sakType: SakType,
-    override val fnr: String? = null,
-    override val frist: Tidspunkt?,
-) : Oppgave() {
+    val opprettet: Tidspunkt,
+    val sakType: SakType,
+    val fnr: String? = null,
+    val frist: Tidspunkt?,
+) {
     fun manglerSaksbehandler(): Boolean {
         return saksbehandler == null
     }
@@ -51,24 +40,6 @@ data class OppgaveIntern(
 }
 
 data class OppgavebenkStats(val antallOppgavelistaOppgaver: Long, val antallMinOppgavelisteOppgaver: Long)
-
-data class GosysOppgave(
-    val id: Long,
-    val versjon: Long,
-    override val status: Status,
-    override val saksbehandler: OppgaveSaksbehandler?,
-    override val enhet: String,
-    override val opprettet: Tidspunkt,
-    override val frist: Tidspunkt?,
-    override val sakType: SakType,
-    override val fnr: String? = null,
-    val gjelder: String,
-    val beskrivelse: String?,
-    val journalpostId: String?,
-) : Oppgave() {
-    override val type: OppgaveType
-        get() = OppgaveType.GOSYS
-}
 
 enum class Status {
     NY,


### PR DESCRIPTION
**Hva er gjort?**
- Fristille gosys-oppgaver og ikke lenger mappe til Gjenny sitt oppgaveformat.
- Viser nå den _faktiske_ oppgavetypen, statusen, og beskrivelsen i oppgavelisten. 
- Filtrering går direkte mot Oppgave sitt API (med unntak av fnr). Dette fordi det i prod og dev finnes vanvittig mange oppgaver på tema PEN, og på sikt helt sikkert vil gjøre det på våre temaer også. 

**Et par todos:** 
- Gjøre det mulig å søke på gosys oppgavetype 
- Støtte søk på andre saksbehandlere (ev. ingen)
- Gjøre `VelgSaksbehandler` mer generell slik at den ikke er låst til bestemt type oppgave. Vil redusere duplikatkode. 
- Burde brukersiden også vise gosys-oppgaver? 


### Eksempel på visning nå: 
<img width="1679" alt="Screenshot 2024-04-16 at 16 15 16" src="https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/54c4f603-4a28-4cfa-98d4-a0bfac530586">
