### PR TITLE
Vis riktig feilmelding for avkorting mangler i OMS

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
@@ -18,9 +18,11 @@ import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
 export const Avkorting = ({
   behandling,
   resetBrevutfallvalidering,
+  resetInntektsavkortingValidering,
 }: {
   behandling: IBehandlingReducer
   resetBrevutfallvalidering: () => void
+  resetInntektsavkortingValidering: () => void
 }) => {
   const dispatch = useAppDispatch()
   const [avkortingStatus, hentAvkortingRequest] = useApiCall(hentAvkorting)
@@ -59,6 +61,7 @@ export const Avkorting = ({
             avkorting={avkorting}
             setAvkorting={setAvkorting}
             redigerbar={redigerbar}
+            resetInntektsavkortingValidering={resetInntektsavkortingValidering}
           />
         )
       )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -37,11 +37,13 @@ export const AvkortingInntekt = ({
   avkorting,
   redigerbar,
   setAvkorting,
+  resetInntektsavkortingValidering,
 }: {
   behandling: IBehandlingReducer
   avkorting: IAvkorting | undefined
   redigerbar: boolean
   setAvkorting: (avkorting: IAvkorting) => void
+  resetInntektsavkortingValidering: () => void
 }) => {
   if (!behandling) return <Alert variant="error">Manlge behandling</Alert>
 
@@ -296,6 +298,7 @@ export const AvkortingInntekt = ({
                   onClick={(e) => {
                     e.preventDefault()
                     setVisForm(true)
+                    resetInntektsavkortingValidering()
                   }}
                 >
                   {finnesRedigerbartGrunnlag() ? 'Rediger' : 'Legg til'}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
@@ -57,7 +57,11 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
   const brevutfallOgEtterbetaling = useAppSelector(
     (state) => state.behandlingReducer.behandling?.brevutfallOgEtterbetaling
   )
+
+  const behandlingsstatus = useAppSelector((state) => state.behandlingReducer.behandling?.status)
+
   const [manglerBrevutfall, setManglerbrevutfall] = useState(false)
+  const [manglerAvkorting, setManglerAvkorting] = useState(false)
 
   const erOpphoer = behandling.vilkaarsvurdering?.resultat?.utfall == VilkaarsvurderingResultat.IKKE_OPPFYLT
 
@@ -70,6 +74,14 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
   const opprettEllerOppdaterVedtak = () => {
     const erBarnepensjon = behandling.sakType === SakType.BARNEPENSJON
     const skalSendeBrev = behandling.sendeBrev
+
+    if (!erBarnepensjon && behandlingsstatus == IBehandlingStatus.BEREGNET) {
+      setManglerAvkorting(true)
+      return
+    } else {
+      setManglerAvkorting(false)
+    }
+
     if (skalSendeBrev && !brevutfallOgEtterbetaling?.brevutfall) {
       setManglerbrevutfall(true)
       return
@@ -138,13 +150,23 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
                           <Avkorting
                             behandling={behandling}
                             resetBrevutfallvalidering={() => setManglerbrevutfall(false)}
+                            resetInntektsavkortingValidering={() => setManglerAvkorting(false)}
                           />
                           {visSanksjon && <Sanksjon behandling={behandling} />}
                         </>
                       )
                   }
                 })()}
-                {manglerBrevutfall && <Alert variant="error">Du må fylle ut utfall i brev</Alert>}
+                {manglerBrevutfall && (
+                  <Alert style={{ maxWidth: '16em' }} variant="error">
+                    Du må fylle ut utfall i brev
+                  </Alert>
+                )}
+                {manglerAvkorting && (
+                  <Alert style={{ maxWidth: '16em' }} variant="error">
+                    Du må legge til inntektsavkorting
+                  </Alert>
+                )}
               </BeregningWrapper>
             )
           )}


### PR DESCRIPTION
Nå vises "Du må fylle ut utfall i brev" som ikke forsvinner om du fyller ut avkorting heller, men først når du har fylt ut avkorting også brevutfall...