### PR TITLE
Flyttar eventname-key for ny opplysning over til enum-standardformatet

### DIFF
--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/rivers/GrunnlagHendelserRiver.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/rivers/GrunnlagHendelserRiver.kt
@@ -16,7 +16,6 @@ import no.nav.etterlatte.rapidsandrivers.EventNames
 import no.nav.etterlatte.rapidsandrivers.FNR_KEY
 import no.nav.etterlatte.rapidsandrivers.GRUNNLAG_OPPDATERT
 import no.nav.etterlatte.rapidsandrivers.ListenerMedLogging
-import no.nav.etterlatte.rapidsandrivers.NY_OPPLYSNING_KEY
 import no.nav.etterlatte.rapidsandrivers.OPPLYSNING_KEY
 import no.nav.etterlatte.rapidsandrivers.SAK_ID_KEY
 import no.nav.etterlatte.rapidsandrivers.migrering.VILKAARSVURDERT_KEY
@@ -50,7 +49,7 @@ class GrunnlagHendelserRiver(
         val eventName = packet[EVENT_NAME_KEY].asText()
         val opplysningType = packet[BEHOV_NAME_KEY].asText()
 
-        if (eventName == NY_OPPLYSNING_KEY || opplysningType in OPPLYSNING_TYPER) {
+        if (eventName == EventNames.NY_OPPLYSNING.eventname || opplysningType in OPPLYSNING_TYPER) {
             val sakId = packet[SAK_ID_KEY].asLong()
             val behandlingId = packet[BEHANDLING_ID_KEY].let { UUID.fromString(it.asText()) }
 

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/itest/RapidTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/itest/RapidTest.kt
@@ -11,14 +11,14 @@ import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.rapidsandrivers.BEHOV_NAME_KEY
-import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
+import no.nav.etterlatte.libs.common.rapidsandrivers.lagParMedEventNameKey
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.statiskUuid
 import no.nav.etterlatte.rapidsandrivers.BEHANDLING_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.EventNames
 import no.nav.etterlatte.rapidsandrivers.FNR_KEY
-import no.nav.etterlatte.rapidsandrivers.NY_OPPLYSNING_KEY
 import no.nav.etterlatte.rapidsandrivers.OPPLYSNING_KEY
 import no.nav.etterlatte.rapidsandrivers.SAK_ID_KEY
 import no.nav.helse.rapids_rivers.JsonMessage
@@ -69,7 +69,7 @@ internal class RapidTest(private val dataSource: DataSource) {
         private val melding =
             JsonMessage.newMessage(
                 mapOf(
-                    EVENT_NAME_KEY to NY_OPPLYSNING_KEY,
+                    EventNames.NY_OPPLYSNING.lagParMedEventNameKey(),
                     OPPLYSNING_KEY to listOf(nyOpplysning),
                     FNR_KEY to fnr,
                     SAK_ID_KEY to 1,

--- a/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/no/nav/etterlatte/opplysningerfrasoknad/StartUthentingFraSoeknadRiver.kt
+++ b/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/no/nav/etterlatte/opplysningerfrasoknad/StartUthentingFraSoeknadRiver.kt
@@ -5,10 +5,11 @@ import no.nav.etterlatte.libs.common.event.SoeknadInnsendtHendelseType
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.SoeknadType
 import no.nav.etterlatte.libs.common.rapidsandrivers.CORRELATION_ID_KEY
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
+import no.nav.etterlatte.libs.common.rapidsandrivers.lagParMedEventNameKey
 import no.nav.etterlatte.opplysningerfrasoknad.opplysningsuthenter.Opplysningsuthenter
 import no.nav.etterlatte.rapidsandrivers.BEHANDLING_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.EventNames
 import no.nav.etterlatte.rapidsandrivers.ListenerMedLogging
-import no.nav.etterlatte.rapidsandrivers.NY_OPPLYSNING_KEY
 import no.nav.etterlatte.rapidsandrivers.OPPLYSNING_KEY
 import no.nav.etterlatte.rapidsandrivers.SAK_ID_KEY
 import no.nav.helse.rapids_rivers.JsonMessage
@@ -50,8 +51,8 @@ internal class StartUthentingFraSoeknadRiver(
             )
 
         JsonMessage.newMessage(
-            NY_OPPLYSNING_KEY,
             mapOf(
+                EventNames.NY_OPPLYSNING.lagParMedEventNameKey(),
                 SAK_ID_KEY to packet[GyldigSoeknadVurdert.sakIdKey],
                 BEHANDLING_ID_KEY to packet[GyldigSoeknadVurdert.behandlingIdKey],
                 CORRELATION_ID_KEY to packet[CORRELATION_ID_KEY],

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/EventNames.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/EventNames.kt
@@ -6,6 +6,7 @@ enum class EventNames(val eventname: String) : EventnameHendelseType {
     FEILA("FEILA"),
     FORDELER_STATISTIKK("FORDELER:STATISTIKK"),
     ALDERSOVERGANG("ALDERSOVERGANG"),
+    NY_OPPLYSNING("OPPLYSNING:NY"),
     ;
 
     override fun lagEventnameForType(): String = this.eventname

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/IkkeStandardiserteKeys.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/IkkeStandardiserteKeys.kt
@@ -22,7 +22,6 @@ const val TILBAKESTILTE_BEHANDLINGER_KEY = "tilbakestilte_behandlinger"
 const val GRUNNLAG_OPPDATERT = "grunnlag_oppdatert" // TODO: eventname
 const val OPPLYSNING_KEY = "opplysning"
 const val FNR_KEY = "fnr"
-const val NY_OPPLYSNING_KEY = "OPPLYSNING:NY"
 const val DRYRUN = "dry_run"
 const val BOR_I_UTLAND_KEY = "bor_i_utland"
 const val ER_OVER_18_AAR = "er_over_18_aar"


### PR DESCRIPTION
Primært for å tilretteleggje for eksperimentering med automatisk behandling i test, men dette er uansett ei fin standardisering i retning sånn vi vanlegvis gjer det for resten.