### PR TITLE
Flytte brevmodellen frå brev-api til modellen for å tilgjengeleggjera

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -28,7 +28,6 @@ import no.nav.etterlatte.libs.common.retryOgPakkUt
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
-import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import java.util.UUID
 
 class Brevoppretter(
@@ -206,7 +205,7 @@ fun Vergemaal.toMottaker(): Mottaker {
     if (mottaker.adresse != null) {
         return Mottaker(
             navn = if (mottaker.navn.isNullOrBlank()) "N/A" else mottaker.navn!!,
-            foedselsnummer = mottaker.foedselsnummer?.let { Foedselsnummer(it.value) },
+            foedselsnummer = mottaker.foedselsnummer?.let { Folkeregisteridentifikator.ofNullable(it.value) },
             orgnummer = null,
             adresse =
                 with(mottaker.adresse!!) {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -19,6 +19,7 @@ import no.nav.etterlatte.brev.model.BrevkodeRequest
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.OpprettNyttBrev
 import no.nav.etterlatte.brev.model.Spraak
+import no.nav.etterlatte.brev.model.tomMottaker
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
@@ -223,7 +224,7 @@ fun Vergemaal.toMottaker(): Mottaker {
         )
     }
 
-    return Mottaker.tom(Folkeregisteridentifikator.of(mottaker.foedselsnummer!!.value))
+    return tomMottaker(Folkeregisteridentifikator.of(mottaker.foedselsnummer!!.value))
         .copy(navn = if (mottaker.navn.isNullOrBlank()) "N/A" else mottaker.navn!!)
 }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFService.kt
@@ -7,9 +7,9 @@ import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevInnhold
 import no.nav.etterlatte.brev.model.BrevProsessType
-import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.OpprettNyttBrev
 import no.nav.etterlatte.brev.model.Pdf
+import no.nav.etterlatte.brev.model.tomMottaker
 import no.nav.etterlatte.brev.virusskanning.VirusScanRequest
 import no.nav.etterlatte.brev.virusskanning.VirusScanService
 import no.nav.etterlatte.brev.virusskanning.filErForStor
@@ -65,7 +65,7 @@ class PDFService(private val db: BrevRepository, private val virusScanService: V
                     behandlingId = null,
                     soekerFnr = sak.ident,
                     prosessType = BrevProsessType.OPPLASTET_PDF,
-                    mottaker = Mottaker.tom(Folkeregisteridentifikator.of(sak.ident)),
+                    mottaker = tomMottaker(Folkeregisteridentifikator.of(sak.ident)),
                     opprettet = Tidspunkt.now(),
                     innhold = innhold,
                     innholdVedlegg = null,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/AdresseService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/AdresseService.kt
@@ -4,6 +4,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import no.nav.etterlatte.brev.adresse.navansatt.NavansattKlient
 import no.nav.etterlatte.brev.model.Mottaker
+import no.nav.etterlatte.brev.model.mottakerFraAdresse
+import no.nav.etterlatte.brev.model.tomMottaker
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
@@ -23,9 +25,9 @@ class AdresseService(
         val fnr = Folkeregisteridentifikator.of(ident)
 
         return if (regoppslag == null) {
-            Mottaker.tom(fnr)
+            tomMottaker(fnr)
         } else {
-            Mottaker.fra(fnr, regoppslag)
+            mottakerFraAdresse(fnr, regoppslag)
         }
     }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
@@ -35,6 +35,7 @@ import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
+import no.nav.etterlatte.brev.model.opprettBrevFra
 import no.nav.etterlatte.libs.common.deserialize
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toTimestamp
@@ -292,7 +293,7 @@ class BrevRepository(private val ds: DataSource) {
             tx.lagreHendelse(id, Status.OPPRETTET, ulagretBrev.opprettet)
                 .also { oppdatert -> require(oppdatert == 1) }
 
-            Brev.fra(id, ulagretBrev)
+            opprettBrevFra(id, ulagretBrev)
         }
 
     fun settBrevJournalfoert(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
@@ -37,13 +37,13 @@ import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.brev.model.opprettBrevFra
 import no.nav.etterlatte.libs.common.deserialize
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toTimestamp
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.database.tidspunkt
 import no.nav.etterlatte.libs.database.transaction
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
-import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import java.util.UUID
 import javax.sql.DataSource
 
@@ -382,7 +382,7 @@ class BrevRepository(private val ds: DataSource) {
             mottaker =
                 Mottaker(
                     navn = row.string("navn"),
-                    foedselsnummer = row.stringOrNull("foedselsnummer")?.let { Foedselsnummer(it) },
+                    foedselsnummer = row.stringOrNull("foedselsnummer")?.let { Folkeregisteridentifikator.ofNullable(it) },
                     orgnummer = row.stringOrNull("orgnummer"),
                     adresse =
                         Adresse(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -97,27 +97,25 @@ data class Brev(
     val brevtype: Brevtype,
 ) {
     fun kanEndres() = status in listOf(Status.OPPRETTET, Status.OPPDATERT)
-
-    companion object {
-        fun fra(
-            id: BrevID,
-            opprettNyttBrev: OpprettNyttBrev,
-        ) = Brev(
-            id = id,
-            sakId = opprettNyttBrev.sakId,
-            behandlingId = opprettNyttBrev.behandlingId,
-            tittel = opprettNyttBrev.innhold.tittel,
-            spraak = opprettNyttBrev.innhold.spraak,
-            prosessType = opprettNyttBrev.prosessType,
-            soekerFnr = opprettNyttBrev.soekerFnr,
-            status = opprettNyttBrev.status,
-            statusEndret = opprettNyttBrev.opprettet,
-            mottaker = opprettNyttBrev.mottaker,
-            opprettet = opprettNyttBrev.opprettet,
-            brevtype = opprettNyttBrev.brevtype,
-        )
-    }
 }
+
+fun opprettBrevFra(
+    id: BrevID,
+    opprettNyttBrev: OpprettNyttBrev,
+) = Brev(
+    id = id,
+    sakId = opprettNyttBrev.sakId,
+    behandlingId = opprettNyttBrev.behandlingId,
+    tittel = opprettNyttBrev.innhold.tittel,
+    spraak = opprettNyttBrev.innhold.spraak,
+    prosessType = opprettNyttBrev.prosessType,
+    soekerFnr = opprettNyttBrev.soekerFnr,
+    status = opprettNyttBrev.status,
+    statusEndret = opprettNyttBrev.opprettet,
+    mottaker = opprettNyttBrev.mottaker,
+    opprettet = opprettNyttBrev.opprettet,
+    brevtype = opprettNyttBrev.brevtype,
+)
 
 class Pdf(val bytes: ByteArray)
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -49,40 +49,38 @@ data class Mottaker(
             adresse.erGyldig()
         }
     }
-
-    companion object {
-        fun fra(
-            fnr: Folkeregisteridentifikator,
-            regoppslag: RegoppslagResponseDTO,
-        ) = Mottaker(
-            navn = regoppslag.navn,
-            foedselsnummer = Foedselsnummer(fnr.value),
-            adresse =
-                Adresse(
-                    adresseType = regoppslag.adresse.type.name,
-                    adresselinje1 = regoppslag.adresse.adresselinje1,
-                    adresselinje2 = regoppslag.adresse.adresselinje2,
-                    adresselinje3 = regoppslag.adresse.adresselinje3,
-                    postnummer = regoppslag.adresse.postnummer,
-                    poststed = regoppslag.adresse.poststed,
-                    landkode = regoppslag.adresse.landkode,
-                    land = regoppslag.adresse.land,
-                ),
-        )
-
-        fun tom(fnr: Folkeregisteridentifikator) =
-            Mottaker(
-                navn = "N/A",
-                foedselsnummer = Foedselsnummer(fnr.value),
-                adresse =
-                    Adresse(
-                        adresseType = "",
-                        landkode = "",
-                        land = "",
-                    ),
-            )
-    }
 }
+
+fun mottakerFraAdresse(
+    fnr: Folkeregisteridentifikator,
+    regoppslag: RegoppslagResponseDTO,
+) = Mottaker(
+    navn = regoppslag.navn,
+    foedselsnummer = Foedselsnummer(fnr.value),
+    adresse =
+        Adresse(
+            adresseType = regoppslag.adresse.type.name,
+            adresselinje1 = regoppslag.adresse.adresselinje1,
+            adresselinje2 = regoppslag.adresse.adresselinje2,
+            adresselinje3 = regoppslag.adresse.adresselinje3,
+            postnummer = regoppslag.adresse.postnummer,
+            poststed = regoppslag.adresse.poststed,
+            landkode = regoppslag.adresse.landkode,
+            land = regoppslag.adresse.land,
+        ),
+)
+
+fun tomMottaker(fnr: Folkeregisteridentifikator) =
+    Mottaker(
+        navn = "N/A",
+        foedselsnummer = Foedselsnummer(fnr.value),
+        adresse =
+            Adresse(
+                adresseType = "",
+                landkode = "",
+                land = "",
+            ),
+    )
 
 data class Brev(
     val id: BrevID,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -10,30 +10,6 @@ import java.time.LocalDate
 import java.util.UUID
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class Adresse(
-    val adresseType: String,
-    val adresselinje1: String? = null,
-    val adresselinje2: String? = null,
-    val adresselinje3: String? = null,
-    val postnummer: String? = null,
-    val poststed: String? = null,
-    val landkode: String,
-    val land: String,
-) {
-    fun erGyldig(): Boolean {
-        return if (adresseType.isBlank() || landkode.isBlank() || land.isBlank()) {
-            false
-        } else if (adresseType == "NORSKPOSTADRESSE") {
-            !(postnummer.isNullOrBlank() || poststed.isNullOrBlank())
-        } else if (adresseType == "UTENLANDSKPOSTADRESSE") {
-            !adresselinje1.isNullOrBlank()
-        } else {
-            true
-        }
-    }
-}
-
-@JsonIgnoreProperties(ignoreUnknown = true)
 data class Mottaker(
     val navn: String,
     val foedselsnummer: Foedselsnummer? = null,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -1,30 +1,11 @@
 package no.nav.etterlatte.brev.model
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import no.nav.etterlatte.brev.Brevtype
 import no.nav.etterlatte.brev.adresse.RegoppslagResponseDTO
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.time.LocalDate
 import java.util.UUID
-
-@JsonIgnoreProperties(ignoreUnknown = true)
-data class Mottaker(
-    val navn: String,
-    val foedselsnummer: Folkeregisteridentifikator? = null,
-    val orgnummer: String? = null,
-    val adresse: Adresse,
-) {
-    fun erGyldig(): Boolean {
-        return if (navn.isBlank()) {
-            false
-        } else if (foedselsnummer == null && orgnummer.isNullOrBlank()) {
-            false
-        } else {
-            adresse.erGyldig()
-        }
-    }
-}
 
 fun mottakerFraAdresse(
     fnr: Folkeregisteridentifikator,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -5,21 +5,20 @@ import no.nav.etterlatte.brev.Brevtype
 import no.nav.etterlatte.brev.adresse.RegoppslagResponseDTO
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import java.time.LocalDate
 import java.util.UUID
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Mottaker(
     val navn: String,
-    val foedselsnummer: Foedselsnummer? = null,
+    val foedselsnummer: Folkeregisteridentifikator? = null,
     val orgnummer: String? = null,
     val adresse: Adresse,
 ) {
     fun erGyldig(): Boolean {
         return if (navn.isBlank()) {
             false
-        } else if ((foedselsnummer == null || foedselsnummer.value.isBlank()) && orgnummer.isNullOrBlank()) {
+        } else if (foedselsnummer == null && orgnummer.isNullOrBlank()) {
             false
         } else {
             adresse.erGyldig()
@@ -32,7 +31,7 @@ fun mottakerFraAdresse(
     regoppslag: RegoppslagResponseDTO,
 ) = Mottaker(
     navn = regoppslag.navn,
-    foedselsnummer = Foedselsnummer(fnr.value),
+    foedselsnummer = fnr,
     adresse =
         Adresse(
             adresseType = regoppslag.adresse.type.name,
@@ -49,7 +48,7 @@ fun mottakerFraAdresse(
 fun tomMottaker(fnr: Folkeregisteridentifikator) =
     Mottaker(
         navn = "N/A",
-        foedselsnummer = Foedselsnummer(fnr.value),
+        foedselsnummer = fnr,
         adresse =
             Adresse(
                 adresseType = "",

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -38,23 +38,6 @@ fun tomMottaker(fnr: Folkeregisteridentifikator) =
             ),
     )
 
-data class Brev(
-    val id: BrevID,
-    val sakId: Long,
-    val behandlingId: UUID?,
-    val tittel: String?,
-    val spraak: Spraak,
-    val prosessType: BrevProsessType,
-    val soekerFnr: String,
-    val status: Status,
-    val statusEndret: Tidspunkt,
-    val opprettet: Tidspunkt,
-    val mottaker: Mottaker,
-    val brevtype: Brevtype,
-) {
-    fun kanEndres() = status in listOf(Status.OPPRETTET, Status.OPPDATERT)
-}
-
 fun opprettBrevFra(
     id: BrevID,
     opprettNyttBrev: OpprettNyttBrev,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -9,17 +9,6 @@ import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import java.time.LocalDate
 import java.util.UUID
 
-typealias BrevID = Long
-
-enum class Status {
-    OPPRETTET,
-    OPPDATERT,
-    FERDIGSTILT,
-    JOURNALFOERT,
-    DISTRIBUERT,
-    SLETTET,
-}
-
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Adresse(
     val adresseType: String,
@@ -165,13 +154,6 @@ data class OpprettNyttBrev(
     val brevtype: Brevtype,
 ) {
     val status: Status = Status.OPPRETTET
-}
-
-enum class BrevProsessType {
-    MANUELL,
-    REDIGERBAR,
-    AUTOMATISK,
-    OPPLASTET_PDF,
 }
 
 data class EtterbetalingDTO(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
@@ -137,7 +137,7 @@ class OversendelseBrevServiceImpl(
             )
         }
 
-        val klage = brevdataFacade.hentKlage(brev.behandlingId, brukerTokenInfo)
+        val klage = brevdataFacade.hentKlage(requireNotNull(brev.behandlingId), brukerTokenInfo)
         return pdfGenerator.genererPdf(
             id = brev.id,
             bruker = brukerTokenInfo,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
@@ -32,9 +32,9 @@ import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.ktor.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
-import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
@@ -251,7 +251,7 @@ internal class BrevRouteTest {
         }
 
     companion object {
-        private val STOR_SNERK = Foedselsnummer("11057523044")
+        private val STOR_SNERK = Folkeregisteridentifikator.of("11057523044")
         private val SAK_ID = Random.nextLong(1000)
     }
 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
@@ -24,7 +24,7 @@ import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
-import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
+import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -258,7 +258,7 @@ internal class BrevServiceTest {
     private fun opprettMottaker() =
         Mottaker(
             "Stor Snerk",
-            foedselsnummer = Foedselsnummer("1234567890"),
+            foedselsnummer = SOEKER_FOEDSELSNUMMER,
             orgnummer = null,
             adresse =
                 Adresse(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevdistribuererTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevdistribuererTest.kt
@@ -17,7 +17,7 @@ import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
+import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -113,7 +113,7 @@ class BrevdistribuererTest {
     private fun opprettMottaker() =
         Mottaker(
             "Stor Snerk",
-            foedselsnummer = Foedselsnummer("1234567890"),
+            foedselsnummer = SOEKER_FOEDSELSNUMMER,
             orgnummer = null,
             adresse =
                 Adresse(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
@@ -21,12 +21,13 @@ import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.sak.VedtakSak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import no.nav.etterlatte.rivers.VedtakTilJournalfoering
-import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -150,7 +151,7 @@ class JournalfoerBrevServiceTest {
     @ParameterizedTest
     @EnumSource(SakType::class)
     fun `Journalfoeringsrequest for vedtaksbrev mappes korrekt`(type: SakType) {
-        val forventetBrevMottakerFnr = "01018012345"
+        val forventetBrevMottakerFnr = SOEKER_FOEDSELSNUMMER.value
         val forventetBrev =
             Brev(
                 id = 123,
@@ -166,7 +167,7 @@ class JournalfoerBrevServiceTest {
                 mottaker =
                     Mottaker(
                         "Stor Snerk",
-                        Foedselsnummer(forventetBrevMottakerFnr),
+                        Folkeregisteridentifikator.of(forventetBrevMottakerFnr),
                         null,
                         Adresse(
                             adresseType = "NORSKPOSTADRESSE",
@@ -221,7 +222,7 @@ class JournalfoerBrevServiceTest {
     @ParameterizedTest
     @EnumSource(SakType::class)
     fun `Journalfoeringsrequest for informasjonsbrev mappes korrekt`(type: SakType) {
-        val forventetBrevMottakerFnr = "01018012345"
+        val forventetBrevMottakerFnr = SOEKER_FOEDSELSNUMMER.value
         val forventetBrev =
             Brev(
                 id = 123,
@@ -237,7 +238,7 @@ class JournalfoerBrevServiceTest {
                 mottaker =
                     Mottaker(
                         "Stor Snerk",
-                        Foedselsnummer(forventetBrevMottakerFnr),
+                        Folkeregisteridentifikator.of(forventetBrevMottakerFnr),
                         null,
                         Adresse(
                             adresseType = "NORSKPOSTADRESSE",
@@ -306,7 +307,7 @@ class JournalfoerBrevServiceTest {
     private fun opprettMottaker() =
         Mottaker(
             "Stor Snerk",
-            foedselsnummer = Foedselsnummer("1234567890"),
+            foedselsnummer = SOEKER_FOEDSELSNUMMER,
             orgnummer = null,
             adresse =
                 Adresse(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/OversendelsesbrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/OversendelsesbrevRouteTest.kt
@@ -27,9 +27,9 @@ import no.nav.etterlatte.brev.oversendelsebrev.OversendelseBrevService
 import no.nav.etterlatte.brev.oversendelsebrev.oversendelseBrevRoute
 import no.nav.etterlatte.ktor.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
-import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
@@ -123,7 +123,7 @@ internal class OversendelsesbrevRouteTest {
         )
 
     companion object {
-        private val STOR_SNERK = Foedselsnummer("11057523044")
+        private val STOR_SNERK = Folkeregisteridentifikator.of("11057523044")
         private val BEHANDLING_ID = UUID.randomUUID()
     }
 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
@@ -29,9 +29,9 @@ import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.ktor.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
-import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
@@ -256,7 +256,7 @@ internal class VedtaksbrevRouteTest {
         }
 
     companion object {
-        private val STOR_SNERK = Foedselsnummer("11057523044")
+        private val STOR_SNERK = Folkeregisteridentifikator.of("11057523044")
         private val BEHANDLING_ID = UUID.randomUUID()
         private val SAK_ID = Random.nextLong(1000)
     }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -715,7 +715,7 @@ internal class VedtaksbrevServiceTest {
     private fun opprettMottaker() =
         Mottaker(
             "Rød Blanding",
-            foedselsnummer = Foedselsnummer(SOEKER_FOEDSELSNUMMER.value),
+            foedselsnummer = SOEKER_FOEDSELSNUMMER,
             orgnummer = null,
             adresse =
                 Adresse(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/GrunnlagmapperTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/GrunnlagmapperTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
-import no.nav.etterlatte.brev.model.Mottaker
+import no.nav.etterlatte.brev.model.tomMottaker
 import no.nav.etterlatte.brev.toMottaker
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -115,7 +115,7 @@ class GrunnlagmapperTest {
 
         verge.navn() shouldBe "Vera Verge"
         verge.toMottaker() shouldBeEqual
-            Mottaker.tom(Folkeregisteridentifikator.of(pdlVergeOekonomiskFnr))
+            tomMottaker(Folkeregisteridentifikator.of(pdlVergeOekonomiskFnr))
                 .copy(navn = "Vera Verge")
     }
 

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/db/BrevRepositoryIntegrationTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/db/BrevRepositoryIntegrationTest.kt
@@ -24,9 +24,9 @@ import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJsonNode
-import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -458,6 +458,6 @@ internal class BrevRepositoryIntegrationTest(private val dataSource: DataSource)
         val dbExtension = DatabaseExtension()
 
         private val PDF_BYTES = "Hello world!".toByteArray()
-        private val STOR_SNERK = Foedselsnummer("11057523044")
+        private val STOR_SNERK = Folkeregisteridentifikator.of("11057523044")
     }
 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivServiceTest.kt
@@ -22,11 +22,12 @@ import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.sak.VedtakSak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
+import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER2_FOEDSELSNUMMER
 import no.nav.etterlatte.rivers.VedtakTilJournalfoering
-import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -58,7 +59,7 @@ internal class DokarkivServiceTest {
     fun `Journalfoeringsrequest mappes korrekt`(type: SakType) {
         val forventetInnhold = BrevInnhold("tittel", Spraak.NB, mockk())
         val forventetPdf = Pdf("Hello world!".toByteArray())
-        val forventetBrevMottakerFnr = "01018012345"
+        val forventetBrevMottakerFnr = SOEKER2_FOEDSELSNUMMER.value
 
         val brevId = Random.nextLong()
         val sakId = Random.nextLong()
@@ -78,7 +79,7 @@ internal class DokarkivServiceTest {
                 mottaker =
                     Mottaker(
                         "Stor Snerk",
-                        Foedselsnummer(forventetBrevMottakerFnr),
+                        Folkeregisteridentifikator.of(forventetBrevMottakerFnr),
                         null,
                         Adresse(
                             adresseType = "NORSKPOSTADRESSE",

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/BrevModelTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/BrevModelTest.kt
@@ -1,7 +1,8 @@
 package no.nav.etterlatte.brev.model
 
 import io.kotest.matchers.shouldBe
-import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import org.junit.jupiter.api.Test
 
 internal class BrevModelTest {
@@ -10,7 +11,7 @@ internal class BrevModelTest {
         opprettMottaker(navn = "").erGyldig() shouldBe false
 
         opprettMottaker(foedselsnummer = null).erGyldig() shouldBe false
-        opprettMottaker(foedselsnummer = Foedselsnummer("")).erGyldig() shouldBe false
+        opprettMottaker(foedselsnummer = Folkeregisteridentifikator.ofNullable("")).erGyldig() shouldBe false
 
         opprettMottaker(orgnummer = null).erGyldig() shouldBe false
         opprettMottaker(orgnummer = "").erGyldig() shouldBe false
@@ -41,7 +42,7 @@ internal class BrevModelTest {
 
     private fun opprettMottaker(
         navn: String = "Test Testesen",
-        foedselsnummer: Foedselsnummer? = Foedselsnummer("12345"),
+        foedselsnummer: Folkeregisteridentifikator? = SOEKER_FOEDSELSNUMMER,
         orgnummer: String? = "999888777",
         adresseType: String = "NORSKPOSTADRESSE",
         adresselinje1: String? = null,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/MottakerRequestTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/MottakerRequestTest.kt
@@ -4,7 +4,6 @@ import io.kotest.matchers.shouldBe
 import io.mockk.mockk
 import no.nav.etterlatte.brev.adresse.RegoppslagResponseDTO
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
-import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -86,7 +85,7 @@ internal class MottakerRequestTest {
             val manglerLand =
                 Mottaker(
                     "Navn",
-                    foedselsnummer = Foedselsnummer("fnr"),
+                    foedselsnummer = SOEKER_FOEDSELSNUMMER,
                     adresse = Adresse("type", postnummer = "1234", poststed = "", landkode = "NO", land = ""),
                 )
 
@@ -95,7 +94,7 @@ internal class MottakerRequestTest {
             val manglerLandkode =
                 Mottaker(
                     "Navn",
-                    foedselsnummer = Foedselsnummer("fnr"),
+                    foedselsnummer = SOEKER_FOEDSELSNUMMER,
                     adresse = Adresse("type", postnummer = "1234", poststed = "", landkode = "", land = "Norge"),
                 )
 
@@ -107,7 +106,7 @@ internal class MottakerRequestTest {
             val manglerPoststed =
                 Mottaker(
                     "Navn",
-                    foedselsnummer = Foedselsnummer("fnr"),
+                    foedselsnummer = SOEKER_FOEDSELSNUMMER,
                     adresse = Adresse("NORSKPOSTADRESSE", postnummer = "1234", poststed = "", landkode = "NO", land = "Norge"),
                 )
 
@@ -116,7 +115,7 @@ internal class MottakerRequestTest {
             val manglerPostnummer =
                 Mottaker(
                     "Navn",
-                    foedselsnummer = Foedselsnummer("fnr"),
+                    foedselsnummer = SOEKER_FOEDSELSNUMMER,
                     adresse = Adresse("NORSKPOSTADRESSE", postnummer = "", poststed = "Oslo", landkode = "NO", land = "Norge"),
                 )
 
@@ -128,7 +127,7 @@ internal class MottakerRequestTest {
             val manglerAdresselinje =
                 Mottaker(
                     "Navn",
-                    foedselsnummer = Foedselsnummer("fnr"),
+                    foedselsnummer = SOEKER_FOEDSELSNUMMER,
                     adresse =
                         Adresse(
                             "UTENLANDSKPOSTADRESSE",

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/MottakerRequestTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/MottakerRequestTest.kt
@@ -30,7 +30,7 @@ internal class MottakerRequestTest {
                         ),
                 )
 
-            val mottaker = Mottaker.fra(SOEKER_FOEDSELSNUMMER, regoppslagResponseDTO)
+            val mottaker = mottakerFraAdresse(SOEKER_FOEDSELSNUMMER, regoppslagResponseDTO)
 
             mottaker.navn shouldBe regoppslagResponseDTO.navn
             mottaker.adresse.adresselinje1 shouldBe "Testveien 13A"
@@ -61,7 +61,7 @@ internal class MottakerRequestTest {
                         ),
                 )
 
-            val mottaker = Mottaker.fra(SOEKER_FOEDSELSNUMMER, regoppslagResponseDTO)
+            val mottaker = mottakerFraAdresse(SOEKER_FOEDSELSNUMMER, regoppslagResponseDTO)
 
             mottaker.navn shouldBe regoppslagResponseDTO.navn
             mottaker.adresse.adresselinje1 shouldBe "c/o STOR SNERK"

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevServiceImplTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevServiceImplTest.kt
@@ -126,7 +126,7 @@ class OversendelseBrevServiceImplTest(dataSource: DataSource) {
     private fun opprettMottaker() =
         Mottaker(
             "Rød Blanding",
-            foedselsnummer = Foedselsnummer(SOEKER_FOEDSELSNUMMER.value),
+            foedselsnummer = SOEKER_FOEDSELSNUMMER,
             orgnummer = null,
             adresse =
                 Adresse(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
@@ -17,9 +17,9 @@ import no.nav.etterlatte.brev.brevbaker.BrevbakerService
 import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.model.Brev
-import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.brev.model.Spraak
+import no.nav.etterlatte.brev.model.tomMottaker
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.sak.Sak
@@ -47,7 +47,7 @@ class VarselbrevTest(datasource: DataSource) {
     fun start() {
         val adresseService =
             mockk<AdresseService>().also {
-                coEvery { it.hentMottakerAdresse(any(), any()) } returns Mottaker.tom(SOEKER_FOEDSELSNUMMER)
+                coEvery { it.hentMottakerAdresse(any(), any()) } returns tomMottaker(SOEKER_FOEDSELSNUMMER)
             }
         val brevdataFacade =
             mockk<BrevdataFacade>().also {

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/Brev.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/Brev.kt
@@ -1,5 +1,7 @@
 package no.nav.etterlatte.brev.model
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
 typealias BrevID = Long
 
 enum class Status {
@@ -9,6 +11,30 @@ enum class Status {
     JOURNALFOERT,
     DISTRIBUERT,
     SLETTET,
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Adresse(
+    val adresseType: String,
+    val adresselinje1: String? = null,
+    val adresselinje2: String? = null,
+    val adresselinje3: String? = null,
+    val postnummer: String? = null,
+    val poststed: String? = null,
+    val landkode: String,
+    val land: String,
+) {
+    fun erGyldig(): Boolean {
+        return if (adresseType.isBlank() || landkode.isBlank() || land.isBlank()) {
+            false
+        } else if (adresseType == "NORSKPOSTADRESSE") {
+            !(postnummer.isNullOrBlank() || poststed.isNullOrBlank())
+        } else if (adresseType == "UTENLANDSKPOSTADRESSE") {
+            !adresselinje1.isNullOrBlank()
+        } else {
+            true
+        }
+    }
 }
 
 enum class BrevProsessType {

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/Brev.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/Brev.kt
@@ -1,0 +1,19 @@
+package no.nav.etterlatte.brev.model
+
+typealias BrevID = Long
+
+enum class Status {
+    OPPRETTET,
+    OPPDATERT,
+    FERDIGSTILT,
+    JOURNALFOERT,
+    DISTRIBUERT,
+    SLETTET,
+}
+
+enum class BrevProsessType {
+    MANUELL,
+    REDIGERBAR,
+    AUTOMATISK,
+    OPPLASTET_PDF,
+}

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/Brev.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/Brev.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.brev.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 
 typealias BrevID = Long
 
@@ -33,6 +34,24 @@ data class Adresse(
             !adresselinje1.isNullOrBlank()
         } else {
             true
+        }
+    }
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Mottaker(
+    val navn: String,
+    val foedselsnummer: Folkeregisteridentifikator? = null,
+    val orgnummer: String? = null,
+    val adresse: Adresse,
+) {
+    fun erGyldig(): Boolean {
+        return if (navn.isBlank()) {
+            false
+        } else if (foedselsnummer == null && orgnummer.isNullOrBlank()) {
+            false
+        } else {
+            adresse.erGyldig()
         }
     }
 }

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/Brev.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/Brev.kt
@@ -1,7 +1,10 @@
 package no.nav.etterlatte.brev.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import no.nav.etterlatte.brev.Brevtype
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import java.util.UUID
 
 typealias BrevID = Long
 
@@ -54,6 +57,23 @@ data class Mottaker(
             adresse.erGyldig()
         }
     }
+}
+
+data class Brev(
+    val id: BrevID,
+    val sakId: Long,
+    val behandlingId: UUID?,
+    val tittel: String?,
+    val spraak: Spraak,
+    val prosessType: BrevProsessType,
+    val soekerFnr: String,
+    val status: Status,
+    val statusEndret: Tidspunkt,
+    val opprettet: Tidspunkt,
+    val mottaker: Mottaker,
+    val brevtype: Brevtype,
+) {
+    fun kanEndres() = status in listOf(Status.OPPRETTET, Status.OPPDATERT)
 }
 
 enum class BrevProsessType {

--- a/libs/saksbehandling-common/src/main/kotlin/person/Folkeregisteridentifikator.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/person/Folkeregisteridentifikator.kt
@@ -25,13 +25,20 @@ class Folkeregisteridentifikator private constructor(
             if (fnr.isNullOrEmpty()) {
                 throw InvalidFoedselsnummerException("Fødselsnummer er tomt")
             } else {
-                val fnrMedGyldigeTall = fnr.replace(Regex("[^0-9]"), "")
-                if (FolkeregisteridentifikatorValidator.isValid(fnrMedGyldigeTall)) {
-                    return Folkeregisteridentifikator(fnrMedGyldigeTall)
-                } else {
-                    sikkerlogger().error("Ugyldig fødselsnummer: $fnr")
-                    throw InvalidFoedselsnummerException("Fødselsnummeret er ugyldig")
-                }
+                return requireNotNull(ofNullable(fnr))
+            }
+        }
+
+        fun ofNullable(fnr: String?): Folkeregisteridentifikator? {
+            if (fnr.isNullOrEmpty()) {
+                return null
+            }
+            val fnrMedGyldigeTall = fnr.replace(Regex("[^0-9]"), "")
+            if (FolkeregisteridentifikatorValidator.isValid(fnrMedGyldigeTall)) {
+                return Folkeregisteridentifikator(fnrMedGyldigeTall)
+            } else {
+                sikkerlogger().error("Ugyldig fødselsnummer: $fnr")
+                throw InvalidFoedselsnummerException("Fødselsnummeret er ugyldig")
             }
         }
 


### PR DESCRIPTION
To poeng her:

1. Flytte Brev-klassa med tilhøyrande klassar over til modellen, for å ha denne tilgjengeleg for den som ønskjer å kalle brev-api-endepunkta
2. Liker ikkje heilt at fødselsnummer-klassa frå brevbaker-modellen skal lekkje langt inn i koden vår. Byttar heller over til Folkeregisteridentifikator-klassa, ser ingen grunn til at det skal vera forskjellig her


Har testa å hente eksisterande manuelle brev, hente og oppdatere eksisterande vedtaksbrev, behandle ei ny sak med nytt vedtaksbrev, oppdatert dette, ferdigstilt.