### PR TITLE
Tynt skall for ny app testdata-behandler

### DIFF
--- a/.github/workflows/app-etterlatte-testdata-behandler.yaml
+++ b/.github/workflows/app-etterlatte-testdata-behandler.yaml
@@ -1,0 +1,42 @@
+name: etterlatte-testdata-behandler
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - apps/etterlatte-testdata-behandler/**
+      - libs/etterlatte-ktor/**
+      - gradle/libs.versions.toml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - apps/etterlatte-testdata-behandler/**
+      - "!apps/etterlatte-testdata-behandler/.nais/*"
+      - libs/etterlatte-ktor/**
+      - gradle/libs.versions.toml
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/.test.yaml
+    secrets: inherit
+
+  build:
+    if: github.event_name != 'pull_request'
+    uses: ./.github/workflows/.build.yaml
+    secrets: inherit
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    uses: ./.github/workflows/.deploy.yaml
+    with:
+      image: ${{ needs.build.outputs.image }}
+    secrets: inherit

--- a/apps/etterlatte-testdata-behandler/.nais/dev.yaml
+++ b/apps/etterlatte-testdata-behandler/.nais/dev.yaml
@@ -1,0 +1,67 @@
+apiVersion: "nais.io/v1alpha1"
+kind: "Application"
+metadata:
+  name: etterlatte-testdata-behandler
+  namespace: etterlatte
+  labels:
+    team: etterlatte
+spec:
+  image: "{{image}}"
+  port: 8080
+  ingresses:
+    - https://etterlatte-testdata-behandler.intern.dev.nav.no
+  liveness:
+    initialDelay: 20
+    path: /isalive
+  readiness:
+    initialDelay: 5
+    path: /isready
+  prometheus:
+    enabled: true
+    path: /metrics
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
+  resources:
+    requests:
+      cpu: 10m
+  replicas:
+    cpuThresholdPercentage: 90
+    max: 1
+    min: 1
+  azure:
+    application:
+      enabled: true
+      tenant: trygdeetaten.no
+      allowAllUsers: false
+      claims:
+        groups:
+          - id: 63f46f74-84a8-4d1c-87a8-78532ab3ae60 # 0000-GA-PENSJON_ATTESTERING
+          - id: 8bb9b8d1-f46a-4ade-8ee8-5895eccdf8cf # 0000-GA-PENSJON_SAKSBEHANDLER
+          - id: 5b6745de-b65d-40eb-a6f5-860c8b61c27f # 0000-GA-GJENNY_SAKSBEHANDLER
+          - id: 5ef775f2-61f8-4283-bf3d-8d03f428aa14 # 0000-GA-Strengt_Fortrolig_Adresse
+          - id: ea930b6b-9397-44d9-b9e6-f4cf527a632a #0000-GA-Fortrolig_Adresse
+          - id: dbe4ad45-320b-4e9a-aaa1-73cca4ee124d # 0000-GA-Egne_ansatte
+          - id: 753805ea-65a7-4855-bdc3-e6130348df9f # 0000-GA-PENSJON_NASJONAL_M_LOGG
+          - id: ea7411eb-8b48-41a0-bc56-7b521fbf0c25 # 0000-GA-PENSJON_NASJONAL_U_LOGG
+        extra:
+          - NAVident
+    sidecar:
+      enabled: true
+      autoLogin: true
+      autoLoginIgnorePaths:
+        - /internal/**
+  kafka:
+    pool: nav-dev
+  env:
+    - name: KAFKA_TARGET_TOPIC
+      value: etterlatte.dodsmelding
+    - name: KAFKA_RESET_POLICY
+      value: earliest
+  accessPolicy:
+    inbound:
+      rules:
+        - application: azure-token-generator # https://docs.nais.io/security/auth/azure-ad/usage/#token-generator
+          namespace: aura
+          cluster: dev-gcp

--- a/apps/etterlatte-testdata-behandler/README.md
+++ b/apps/etterlatte-testdata-behandler/README.md
@@ -1,0 +1,29 @@
+# etterlatte-testdata-behandler
+
+En app med et enkelt gui som behandler saker automatisk for å gjøre det enklere å teste de ulike appene til team etterlatte.
+
+### Teknologi
+Appen er bygget med kotlin/ktor.
+
+## Lokal utvikling
+Du kan kjøre `ApplicationKt` med følgende environment variables:
+
+```
+DEV=true;KAFKA_BROKERS=0.0.0.0:9092;KAFKA_TARGET_TOPIC=etterlatte.dodsmelding
+```
+
+## Bygg og deploy
+
+En app bygges og deployes automatisk når en endring legges til i `main`.
+
+For å trigge **manuell deploy** kan du gå til `Actions -> (velg workflow) -> Run workflow from <branch>`
+
+
+## Henvendelser
+
+Spørsmål knyttet til koden eller prosjektet kan stilles som issues her på GitHub.
+
+
+## For NAV-ansatte
+
+Interne henvendelser kan sendes via Slack i kanalen #po-pensjon-team-etterlatte.

--- a/apps/etterlatte-testdata-behandler/build.gradle.kts
+++ b/apps/etterlatte-testdata-behandler/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    id("etterlatte.common")
+    id("etterlatte.rapids-and-rivers-ktor2")
+}
+
+dependencies {
+}

--- a/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -1,0 +1,10 @@
+package no.nav.etterlatte
+
+import no.nav.etterlatte.rapidsandrivers.getRapidEnv
+import no.nav.helse.rapids_rivers.RapidApplication
+
+fun main() {
+    val rapidEnv = getRapidEnv()
+    RapidApplication.create(rapidEnv).also { rapidsConnection ->
+    }.start()
+}

--- a/apps/etterlatte-testdata-behandler/src/main/resources/application.conf
+++ b/apps/etterlatte-testdata-behandler/src/main/resources/application.conf
@@ -1,0 +1,4 @@
+azure.app.client.id = ${?AZURE_APP_CLIENT_ID}
+azure.app.jwk = ${?AZURE_APP_JWK}
+azure.app.client.secret = ${?AZURE_APP_CLIENT_SECRET}
+azure.app.well.known.url = ${?AZURE_APP_WELL_KNOWN_URL}

--- a/apps/etterlatte-testdata-behandler/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-testdata-behandler/src/main/resources/logback-secure.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <appender name="secureAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/secure-logs/secure.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>1</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>50MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <logger name="sikkerLogg" level="DEBUG" additivity="false">
+        <appender-ref ref="secureAppender"/>
+    </logger>
+</included>

--- a/apps/etterlatte-testdata-behandler/src/main/resources/logback.xml
+++ b/apps/etterlatte-testdata-behandler/src/main/resources/logback.xml
@@ -1,0 +1,23 @@
+<configuration>
+    <conversionRule conversionWord="msg" converterClass="no.nav.etterlatte.libs.common.person.FnrCoverConverter"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT_JSON"/>
+    </root>
+
+    <logger name="org.eclipse.jetty" level="INFO"/>
+    <logger name="org.apache.kafka" level="INFO"/>
+    <logger name="io.netty" level="INFO"/>
+    <logger name="no.nav.helse.rapids_rivers.PingPong" level="DEBUG"/>
+    <logger name="no.nav.etterlatte" level="DEBUG"/>
+    <include resource="logback-secure.xml"/>
+</configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ include(
     "apps:etterlatte-egne-ansatte-lytter",
     "apps:etterlatte-institusjonsopphold",
     "apps:etterlatte-testdata",
+    "apps:etterlatte-testdata-behandler",
     "apps:etterlatte-utbetaling",
     "apps:etterlatte-oppdater-behandling",
     "apps:etterlatte-beregning",


### PR DESCRIPTION
Tanken er at denne skal køyre orkestreringskoden frå https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/4579

Den eksisterande testdata-appen køyrer med tenant nav.no (prod), og kan dermed ikkje kommunisere direkte med api-a i trygdeetaten.no (dev).

Kan nok løyse det her på fleire måtar, men sånn som det er no er saksbehandlingsflyten frå #4579 så brute-force-rett fram at eg ikkje er komfortabel med å ha han i prodkoden.

Ein alternativ veg er sjølvsagt å implementere ordentleg i kafka-appane, omtrent tilsvarande som vi hadde for migrering, eller å la ein av dei eksisterande appane (typ oppdater-behandling eller vedtaksvurdering-kafka) gjera kalla her. Men å utvide kafka-appane er omfattande, og å bruke ein eksisterande app kjens rotete.