### PR TITLE
EY-3852 Sjekk for åpen behandling ved omregning må sjekke flere oppgavestatuser

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -35,7 +35,6 @@ import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
 import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
-import no.nav.etterlatte.libs.common.oppgave.Status
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
@@ -115,13 +114,10 @@ class RevurderingService(
 
     fun maksEnOppgaveUnderbehandlingForKildeBehandling(sakId: Long) {
         val oppgaverForSak = oppgaveService.hentOppgaverForSak(sakId)
-        val ingenBehandlingerUnderarbeid =
-            oppgaverForSak.filter {
+        if (oppgaverForSak.filter {
                 it.kilde == OppgaveKilde.BEHANDLING
-            }.none { it.status === Status.UNDER_BEHANDLING }
-        if (ingenBehandlingerUnderarbeid) {
-            return
-        } else {
+            }.any { !it.erAvsluttet() }
+        ) {
             throw MaksEnAktivOppgavePaaBehandling(sakId)
         }
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingServiceIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingServiceIntegrationTest.kt
@@ -130,11 +130,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
         assertNotNull(behandling)
 
         inTransaction {
-            applicationContext.behandlingDao.lagreStatus(
-                behandling!!.id,
-                BehandlingStatus.IVERKSATT,
-                Tidspunkt.now().toLocalDatetimeUTC(),
-            )
+            iverksett(behandling!!)
         }
 
         val revurdering =
@@ -185,11 +181,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
         assertNotNull(behandling)
 
         inTransaction {
-            applicationContext.behandlingDao.lagreStatus(
-                behandling!!.id,
-                BehandlingStatus.IVERKSATT,
-                Tidspunkt.now().toLocalDatetimeUTC(),
-            )
+            iverksett(behandling!!)
         }
         val revurderingService =
             revurderingService(
@@ -311,11 +303,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
         assertNotNull(behandling)
 
         inTransaction {
-            applicationContext.behandlingDao.lagreStatus(
-                behandling!!.id,
-                BehandlingStatus.IVERKSATT,
-                Tidspunkt.now().toLocalDatetimeUTC(),
-            )
+            iverksett(behandling!!)
         }
         val hendelse =
             inTransaction {
@@ -423,11 +411,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
         assertNotNull(behandling)
 
         inTransaction {
-            applicationContext.behandlingDao.lagreStatus(
-                behandling!!.id,
-                BehandlingStatus.IVERKSATT,
-                Tidspunkt.now().toLocalDatetimeUTC(),
-            )
+            iverksett(behandling!!)
         }
 
         inTransaction {
@@ -494,11 +478,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
         assertNotNull(behandling)
 
         inTransaction {
-            applicationContext.behandlingDao.lagreStatus(
-                behandling!!.id,
-                BehandlingStatus.IVERKSATT,
-                Tidspunkt.now().toLocalDatetimeUTC(),
-            )
+            iverksett(behandling!!)
         }
         assertThrows<RevurderingSluttbehandlingUtlandMaaHaEnBehandlingMedSkalSendeKravpakke> {
             inTransaction {
@@ -555,6 +535,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
                 BehandlingStatus.IVERKSATT,
                 Tidspunkt.now().toLocalDatetimeUTC(),
             )
+            ferdigstillOppgaver(behandling, saksbehandler)
         }
         val revurderingen =
             inTransaction {
@@ -629,7 +610,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
     }
 
     @Test
-    fun `Skal få bad request hvis man mangler hendelsesid`() {
+    fun `Skal faa bad request hvis man mangler hendelsesid`() {
         val revurderingService = revurderingService()
         val behandlingFactory = behandlingFactory()
 
@@ -653,9 +634,11 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
     @Test
     fun `Skal faa bad request hvis man mangler forrige iverksattebehandling`() {
         val revurderingService = revurderingService()
-        val behandlingFactory = behandlingFactory()
 
-        val (sak, _) = opprettSakMedFoerstegangsbehandling(fnr, behandlingFactory)
+        val sak =
+            inTransaction {
+                applicationContext.sakDao.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr)
+            }
 
         assertThrows<RevurderingManglerIverksattBehandling> {
             inTransaction {
@@ -717,7 +700,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
     }
 
     @Test
-    fun `Kan opprette revurdering for omgjøring av klage`() {
+    fun `Kan opprette revurdering for omgjoering av klage`() {
         val revurderingService = revurderingService()
         val behandlingFactory = behandlingFactory()
 
@@ -881,6 +864,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
                 BehandlingStatus.IVERKSATT,
                 Tidspunkt.now().toLocalDatetimeUTC(),
             )
+            ferdigstillOppgaver(behandling, saksbehandler)
         }
 
         val utlandsoppgaveref =
@@ -920,11 +904,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
         // Forutsetninger - sak med iverksatt behandling
         val (sak, behandling) = opprettSakMedFoerstegangsbehandling(fnr, behandlingFactory)
         inTransaction {
-            applicationContext.behandlingDao.lagreStatus(
-                behandling!!.id,
-                BehandlingStatus.IVERKSATT,
-                Tidspunkt.now().toLocalDatetimeUTC(),
-            )
+            iverksett(behandling!!)
         }
 
         // Opprett en revurderingsoppgave som gjelder en hendelse
@@ -960,11 +940,37 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
 
         with(
             inTransaction {
-                oppgaveService.hentOppgave(oppgaveHendelse.id)!!
+                oppgaveService.hentOppgave(oppgaveHendelse.id)
             },
         ) {
             status shouldBe Status.UNDER_BEHANDLING
             referanse shouldBe revurdering.id.toString()
+        }
+    }
+
+    private fun iverksett(behandling: Behandling) {
+        applicationContext.behandlingDao.lagreStatus(
+            behandling.id,
+            BehandlingStatus.IVERKSATT,
+            Tidspunkt.now().toLocalDatetimeUTC(),
+        )
+        ferdigstillOppgaver(behandling)
+    }
+
+    private fun ferdigstillOppgaver(
+        behandling: Behandling,
+        saksbehandlerId: String = "sbh",
+    ) {
+        with(applicationContext.oppgaveService) {
+            this.hentOppgaverForReferanse(behandling.id.toString()).forEach {
+                if (it.manglerSaksbehandler()) {
+                    this.byttSaksbehandler(it.id, saksbehandlerId) // for aa kunne ferdgistille oppgaven
+                }
+                this.ferdigstillOppgave(
+                    id = it.id,
+                    saksbehandler = BrukerTokenInfo.of("acc", saksbehandlerId, oid = null, sub = "sub", claims = null),
+                )
+            }
         }
     }
 


### PR DESCRIPTION
Fra jira:

> Det har vært et par tilfeller hvor aldersovergang har kjørt, hvor det var åpen behandling på aktuell sak, men det likevel har blitt utført et automatisk opphør. Se [FAGSYSTEM-326368](https://jira.adeo.no/browse/FAGSYSTEM-326368) (https://nav-it.slack.com/archives/C01PG1JM9D4/p1713349531997109), og 20. april saksid 16735. Forventningen var at det ble opprettet oppgave om opphør.
> 
> Bjørn har også testet å kjøre regulering der det finnes åpen behandling og den gikk gjennom.
> 
> Det ser ut til at denne endringen i oppførsel skyldes den store omskrivingen av oppgave, hvor oppgavene ble slått sammen og det ble innført nye statuser i stedet.