### PR TITLE
Folkeregisteridentifikator-klassa vår har inline deserialisering, sån…

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -23,6 +23,7 @@ import no.nav.etterlatte.brev.model.tomMottaker
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.person.Vergemaal
 import no.nav.etterlatte.libs.common.retryOgPakkUt
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -205,7 +206,7 @@ fun Vergemaal.toMottaker(): Mottaker {
     if (mottaker.adresse != null) {
         return Mottaker(
             navn = if (mottaker.navn.isNullOrBlank()) "N/A" else mottaker.navn!!,
-            foedselsnummer = mottaker.foedselsnummer?.let { Folkeregisteridentifikator.ofNullable(it.value) },
+            foedselsnummer = mottaker.foedselsnummer?.let { MottakerFoedselsnummer(it.value) },
             orgnummer = null,
             adresse =
                 with(mottaker.adresse!!) {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
@@ -37,7 +37,7 @@ import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.brev.model.opprettBrevFra
 import no.nav.etterlatte.libs.common.deserialize
-import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toTimestamp
 import no.nav.etterlatte.libs.common.toJson
@@ -382,7 +382,7 @@ class BrevRepository(private val ds: DataSource) {
             mottaker =
                 Mottaker(
                     navn = row.string("navn"),
-                    foedselsnummer = row.stringOrNull("foedselsnummer")?.let { Folkeregisteridentifikator.ofNullable(it) },
+                    foedselsnummer = row.stringOrNull("foedselsnummer")?.let { MottakerFoedselsnummer(it) },
                     orgnummer = row.stringOrNull("orgnummer"),
                     adresse =
                         Adresse(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.brev.model
 import no.nav.etterlatte.brev.Brevtype
 import no.nav.etterlatte.brev.adresse.RegoppslagResponseDTO
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.time.LocalDate
 import java.util.UUID
@@ -12,7 +13,7 @@ fun mottakerFraAdresse(
     regoppslag: RegoppslagResponseDTO,
 ) = Mottaker(
     navn = regoppslag.navn,
-    foedselsnummer = fnr,
+    foedselsnummer = MottakerFoedselsnummer(fnr.value),
     adresse =
         Adresse(
             adresseType = regoppslag.adresse.type.name,
@@ -29,7 +30,7 @@ fun mottakerFraAdresse(
 fun tomMottaker(fnr: Folkeregisteridentifikator) =
     Mottaker(
         navn = "N/A",
-        foedselsnummer = fnr,
+        foedselsnummer = MottakerFoedselsnummer(fnr.value),
         adresse =
             Adresse(
                 adresseType = "",

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.brev
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
@@ -32,7 +33,8 @@ import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.ktor.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.runServer
-import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.security.mock.oauth2.MockOAuth2Server
@@ -117,6 +119,25 @@ internal class BrevRouteTest {
             brevService.genererPdf(brevId, any())
             tilgangssjekker.harTilgangTilSak(any(), any(), any())
         }
+    }
+
+    @Test
+    fun deserialiser() {
+        val mottaker =
+            """{
+            "navn": "Peder Ås",
+            "foedselsnummer": {
+                "value": "25478323363"
+            },
+            "orgnummer": null,
+            "adresse": {
+                "adresseType": "123",
+                "landkode": "NO",
+                "land": "Norge"
+            }
+        }
+            """.trimMargin()
+        objectMapper.readValue<Mottaker>(mottaker)
     }
 
     @Test
@@ -251,7 +272,7 @@ internal class BrevRouteTest {
         }
 
     companion object {
-        private val STOR_SNERK = Folkeregisteridentifikator.of("11057523044")
+        private val STOR_SNERK = MottakerFoedselsnummer("11057523044")
         private val SAK_ID = Random.nextLong(1000)
     }
 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
@@ -22,6 +22,7 @@ import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
+import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
@@ -258,7 +259,7 @@ internal class BrevServiceTest {
     private fun opprettMottaker() =
         Mottaker(
             "Stor Snerk",
-            foedselsnummer = SOEKER_FOEDSELSNUMMER,
+            foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
             orgnummer = null,
             adresse =
                 Adresse(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevdistribuererTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevdistribuererTest.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
+import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import org.junit.jupiter.api.Test
@@ -113,7 +114,7 @@ class BrevdistribuererTest {
     private fun opprettMottaker() =
         Mottaker(
             "Stor Snerk",
-            foedselsnummer = SOEKER_FOEDSELSNUMMER,
+            foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
             orgnummer = null,
             adresse =
                 Adresse(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
@@ -21,7 +21,7 @@ import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.libs.common.behandling.SakType
-import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.sak.VedtakSak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -167,7 +167,7 @@ class JournalfoerBrevServiceTest {
                 mottaker =
                     Mottaker(
                         "Stor Snerk",
-                        Folkeregisteridentifikator.of(forventetBrevMottakerFnr),
+                        MottakerFoedselsnummer(forventetBrevMottakerFnr),
                         null,
                         Adresse(
                             adresseType = "NORSKPOSTADRESSE",
@@ -238,7 +238,7 @@ class JournalfoerBrevServiceTest {
                 mottaker =
                     Mottaker(
                         "Stor Snerk",
-                        Folkeregisteridentifikator.of(forventetBrevMottakerFnr),
+                        MottakerFoedselsnummer(forventetBrevMottakerFnr),
                         null,
                         Adresse(
                             adresseType = "NORSKPOSTADRESSE",
@@ -307,7 +307,7 @@ class JournalfoerBrevServiceTest {
     private fun opprettMottaker() =
         Mottaker(
             "Stor Snerk",
-            foedselsnummer = SOEKER_FOEDSELSNUMMER,
+            foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
             orgnummer = null,
             adresse =
                 Adresse(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/OversendelsesbrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/OversendelsesbrevRouteTest.kt
@@ -27,7 +27,7 @@ import no.nav.etterlatte.brev.oversendelsebrev.OversendelseBrevService
 import no.nav.etterlatte.brev.oversendelsebrev.oversendelseBrevRoute
 import no.nav.etterlatte.ktor.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.runServer
-import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.security.mock.oauth2.MockOAuth2Server
@@ -123,7 +123,7 @@ internal class OversendelsesbrevRouteTest {
         )
 
     companion object {
-        private val STOR_SNERK = Folkeregisteridentifikator.of("11057523044")
+        private val STOR_SNERK = MottakerFoedselsnummer("11057523044")
         private val BEHANDLING_ID = UUID.randomUUID()
     }
 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
@@ -29,7 +29,7 @@ import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.ktor.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.runServer
-import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.security.mock.oauth2.MockOAuth2Server
@@ -256,7 +256,7 @@ internal class VedtaksbrevRouteTest {
         }
 
     companion object {
-        private val STOR_SNERK = Folkeregisteridentifikator.of("11057523044")
+        private val STOR_SNERK = MottakerFoedselsnummer("11057523044")
         private val BEHANDLING_ID = UUID.randomUUID()
         private val SAK_ID = Random.nextLong(1000)
     }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -53,6 +53,7 @@ import no.nav.etterlatte.libs.common.behandling.FeilutbetalingValg
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.beregning.BeregningsMetode
+import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJsonNode
@@ -715,7 +716,7 @@ internal class VedtaksbrevServiceTest {
     private fun opprettMottaker() =
         Mottaker(
             "Rød Blanding",
-            foedselsnummer = SOEKER_FOEDSELSNUMMER,
+            foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
             orgnummer = null,
             adresse =
                 Adresse(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/db/BrevRepositoryIntegrationTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/db/BrevRepositoryIntegrationTest.kt
@@ -24,7 +24,7 @@ import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
-import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJsonNode
 import org.junit.jupiter.api.AfterEach
@@ -458,6 +458,6 @@ internal class BrevRepositoryIntegrationTest(private val dataSource: DataSource)
         val dbExtension = DatabaseExtension()
 
         private val PDF_BYTES = "Hello world!".toByteArray()
-        private val STOR_SNERK = Folkeregisteridentifikator.of("11057523044")
+        private val STOR_SNERK = MottakerFoedselsnummer("11057523044")
     }
 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokarkiv/DokarkivServiceTest.kt
@@ -22,7 +22,7 @@ import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.behandling.SakType
-import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.sak.VedtakSak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
@@ -79,7 +79,7 @@ internal class DokarkivServiceTest {
                 mottaker =
                     Mottaker(
                         "Stor Snerk",
-                        Folkeregisteridentifikator.of(forventetBrevMottakerFnr),
+                        MottakerFoedselsnummer(forventetBrevMottakerFnr),
                         null,
                         Adresse(
                             adresseType = "NORSKPOSTADRESSE",

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/BrevModelTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/BrevModelTest.kt
@@ -1,7 +1,7 @@
 package no.nav.etterlatte.brev.model
 
 import io.kotest.matchers.shouldBe
-import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import org.junit.jupiter.api.Test
 
@@ -11,7 +11,7 @@ internal class BrevModelTest {
         opprettMottaker(navn = "").erGyldig() shouldBe false
 
         opprettMottaker(foedselsnummer = null).erGyldig() shouldBe false
-        opprettMottaker(foedselsnummer = Folkeregisteridentifikator.ofNullable("")).erGyldig() shouldBe false
+        opprettMottaker(foedselsnummer = MottakerFoedselsnummer("")).erGyldig() shouldBe false
 
         opprettMottaker(orgnummer = null).erGyldig() shouldBe false
         opprettMottaker(orgnummer = "").erGyldig() shouldBe false
@@ -42,7 +42,7 @@ internal class BrevModelTest {
 
     private fun opprettMottaker(
         navn: String = "Test Testesen",
-        foedselsnummer: Folkeregisteridentifikator? = SOEKER_FOEDSELSNUMMER,
+        foedselsnummer: MottakerFoedselsnummer? = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
         orgnummer: String? = "999888777",
         adresseType: String = "NORSKPOSTADRESSE",
         adresselinje1: String? = null,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/MottakerRequestTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/MottakerRequestTest.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.brev.model
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
 import no.nav.etterlatte.brev.adresse.RegoppslagResponseDTO
+import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -85,7 +86,7 @@ internal class MottakerRequestTest {
             val manglerLand =
                 Mottaker(
                     "Navn",
-                    foedselsnummer = SOEKER_FOEDSELSNUMMER,
+                    foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
                     adresse = Adresse("type", postnummer = "1234", poststed = "", landkode = "NO", land = ""),
                 )
 
@@ -94,7 +95,7 @@ internal class MottakerRequestTest {
             val manglerLandkode =
                 Mottaker(
                     "Navn",
-                    foedselsnummer = SOEKER_FOEDSELSNUMMER,
+                    foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
                     adresse = Adresse("type", postnummer = "1234", poststed = "", landkode = "", land = "Norge"),
                 )
 
@@ -106,7 +107,7 @@ internal class MottakerRequestTest {
             val manglerPoststed =
                 Mottaker(
                     "Navn",
-                    foedselsnummer = SOEKER_FOEDSELSNUMMER,
+                    foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
                     adresse = Adresse("NORSKPOSTADRESSE", postnummer = "1234", poststed = "", landkode = "NO", land = "Norge"),
                 )
 
@@ -115,7 +116,7 @@ internal class MottakerRequestTest {
             val manglerPostnummer =
                 Mottaker(
                     "Navn",
-                    foedselsnummer = SOEKER_FOEDSELSNUMMER,
+                    foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
                     adresse = Adresse("NORSKPOSTADRESSE", postnummer = "", poststed = "Oslo", landkode = "NO", land = "Norge"),
                 )
 
@@ -127,7 +128,7 @@ internal class MottakerRequestTest {
             val manglerAdresselinje =
                 Mottaker(
                     "Navn",
-                    foedselsnummer = SOEKER_FOEDSELSNUMMER,
+                    foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
                     adresse =
                         Adresse(
                             "UTENLANDSKPOSTADRESSE",

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevServiceImplTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevServiceImplTest.kt
@@ -25,6 +25,7 @@ import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.Klage
 import no.nav.etterlatte.libs.common.behandling.KlageStatus
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
@@ -126,7 +127,7 @@ class OversendelseBrevServiceImplTest(dataSource: DataSource) {
     private fun opprettMottaker() =
         Mottaker(
             "Rød Blanding",
-            foedselsnummer = SOEKER_FOEDSELSNUMMER,
+            foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
             orgnummer = null,
             adresse =
                 Adresse(

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/Brev.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/Brev.kt
@@ -2,7 +2,7 @@ package no.nav.etterlatte.brev.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import no.nav.etterlatte.brev.Brevtype
-import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.util.UUID
 
@@ -44,14 +44,14 @@ data class Adresse(
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Mottaker(
     val navn: String,
-    val foedselsnummer: Folkeregisteridentifikator? = null,
+    val foedselsnummer: MottakerFoedselsnummer? = null,
     val orgnummer: String? = null,
     val adresse: Adresse,
 ) {
     fun erGyldig(): Boolean {
         return if (navn.isBlank()) {
             false
-        } else if (foedselsnummer == null && orgnummer.isNullOrBlank()) {
+        } else if ((foedselsnummer == null || foedselsnummer.value.isBlank()) && orgnummer.isNullOrBlank()) {
             false
         } else {
             adresse.erGyldig()


### PR DESCRIPTION
…n at requesten og responsen blir annleis enn frå før dagens refaktorisering, da vi brukte Foedselsnummer-klassa frå brevbakeren i nokre samanhengar. Endrar i første omgang til MottakerFoedselsnummer-klassa vår, som vart laga for litt sia for å korrespondere med akkurat dette problemet.

Trur vi i neste omgang bør skrive om så vi er konsekvente med å kun bruke vår eigen Folkeregisteridentifikator i alt utanfor akkurat integrasjonen mot brevbakeren, men startar eit skritt til sida for å få alt til å funke igjen