### PR TITLE
Backend-støtte for å hente og opprette aktiviteter for aktivitetsplikt

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -10,6 +10,7 @@ import io.ktor.server.routing.Route
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asContextElement
 import kotlinx.coroutines.withContext
+import no.nav.etterlatte.behandling.aktivitetsplikt.aktivitetspliktRoutes
 import no.nav.etterlatte.behandling.behandlingRoutes
 import no.nav.etterlatte.behandling.behandlingVedtakRoute
 import no.nav.etterlatte.behandling.behandlinginfo.behandlingInfoRoutes
@@ -160,9 +161,9 @@ private fun Route.settOppRoutes(applicationContext: ApplicationContext) {
         behandlingService = applicationContext.behandlingService,
         gyldighetsproevingService = applicationContext.gyldighetsproevingService,
         kommerBarnetTilGodeService = applicationContext.kommerBarnetTilGodeService,
-        aktivitetspliktService = applicationContext.aktivtetspliktService,
         behandlingFactory = applicationContext.behandlingFactory,
     )
+    aktivitetspliktRoutes(aktivitetspliktService = applicationContext.aktivtetspliktService)
     sjekklisteRoute(sjekklisteService = applicationContext.sjekklisteService)
     statistikkRoutes(behandlingService = applicationContext.behandlingService)
     generellbehandlingRoutes(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -14,7 +14,6 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.put
 import io.ktor.server.routing.route
 import kotlinx.coroutines.runBlocking
-import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktService
 import no.nav.etterlatte.behandling.domain.TilstandException
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeService
 import no.nav.etterlatte.inTransaction
@@ -25,7 +24,6 @@ import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.JaNeiMedBegrunnelse
 import no.nav.etterlatte.libs.common.behandling.KommerBarnetTilgode
 import no.nav.etterlatte.libs.common.behandling.NyBehandlingRequest
-import no.nav.etterlatte.libs.common.behandling.OpprettAktivitetspliktOppfolging
 import no.nav.etterlatte.libs.common.behandling.RedigertFamilieforhold
 import no.nav.etterlatte.libs.common.behandling.SendBrev
 import no.nav.etterlatte.libs.common.behandling.Utlandstilknytning
@@ -43,7 +41,6 @@ internal fun Route.behandlingRoutes(
     behandlingService: BehandlingService,
     gyldighetsproevingService: GyldighetsproevingService,
     kommerBarnetTilGodeService: KommerBarnetTilGodeService,
-    aktivitetspliktService: AktivitetspliktService,
     behandlingFactory: BehandlingFactory,
 ) {
     val logger = application.log
@@ -226,33 +223,6 @@ internal fun Route.behandlingRoutes(
                         )
                     } catch (e: TilstandException.UgyldigTilstand) {
                         call.respond(HttpStatusCode.BadRequest, "Kan ikke endre feltet")
-                    }
-                }
-            }
-        }
-
-        route("/aktivitetsplikt") {
-            get {
-                val result = aktivitetspliktService.hentAktivitetspliktOppfolging(behandlingId)
-                call.respond(result ?: HttpStatusCode.NoContent)
-            }
-
-            post {
-                kunSkrivetilgang {
-                    hentNavidentFraToken { navIdent ->
-                        val oppfolging = call.receive<OpprettAktivitetspliktOppfolging>()
-
-                        try {
-                            val result =
-                                aktivitetspliktService.lagreAktivitetspliktOppfolging(
-                                    behandlingId,
-                                    oppfolging,
-                                    navIdent,
-                                )
-                            call.respond(result)
-                        } catch (e: TilstandException.UgyldigTilstand) {
-                            call.respond(HttpStatusCode.BadRequest, "Kunne ikke endre på feltet")
-                        }
                     }
                 }
             }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
@@ -1,11 +1,17 @@
 package no.nav.etterlatte.behandling.aktivitetsplikt
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.hendelse.getUUID
+import no.nav.etterlatte.behandling.objectMapper
 import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.behandling.AktivitetspliktOppfolging
 import no.nav.etterlatte.libs.common.behandling.OpprettAktivitetspliktOppfolging
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.tidspunkt.getTidspunkt
 import no.nav.etterlatte.libs.database.toList
+import java.sql.Date
+import java.sql.ResultSet
+import java.time.LocalDate
 import java.util.UUID
 
 class AktivitetspliktDao(private val connectionAutoclosing: ConnectionAutoclosing) {
@@ -61,4 +67,93 @@ class AktivitetspliktDao(private val connectionAutoclosing: ConnectionAutoclosin
             }
         }
     }
+
+    fun hentAktiviteter(behandlingId: UUID): List<AktivitetspliktAktivitet> {
+        return connectionAutoclosing.hentConnection {
+            with(it) {
+                val stmt =
+                    prepareStatement(
+                        """
+                        SELECT id, sak_id, behandling_id, aktivitet_type, fom, tom, opprettet, endret, beskrivelse
+                        FROM aktivitetsplikt_aktivitet
+                        WHERE behandling_id = ?
+                        """.trimMargin(),
+                    )
+                stmt.setObject(1, behandlingId)
+
+                stmt.executeQuery().toList { toAktivitet() }
+            }
+        }
+    }
+
+    fun opprettAktivitet(
+        behandlingId: UUID,
+        aktivitet: OpprettAktivitetspliktAktivitet,
+        kilde: Grunnlagsopplysning.Kilde,
+    ) {
+        return connectionAutoclosing.hentConnection {
+            with(it) {
+                val stmt =
+                    prepareStatement(
+                        """
+                        INSERT INTO aktivitetsplikt_aktivitet(id, sak_id, behandling_id, aktivitet_type, fom, tom, opprettet, endret, beskrivelse) 
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """.trimMargin(),
+                    )
+                stmt.setObject(1, UUID.randomUUID())
+                stmt.setLong(2, aktivitet.sakId)
+                stmt.setObject(3, behandlingId)
+                stmt.setString(4, aktivitet.type.name)
+                stmt.setDate(5, Date.valueOf(aktivitet.fom))
+                stmt.setDate(6, aktivitet.tom?.let { tom -> Date.valueOf(tom) })
+                stmt.setString(7, kilde.toJson())
+                stmt.setString(8, kilde.toJson())
+                stmt.setString(9, aktivitet.beskrivelse)
+
+                stmt.executeUpdate()
+            }
+        }
+    }
+
+    private fun ResultSet.toAktivitet() =
+        AktivitetspliktAktivitet(
+            id = getUUID("id"),
+            sakId = getLong("sak_id"),
+            behandlingId = getUUID("behandling_id"),
+            type = AktivitetspliktAktivitetType.valueOf(getString("aktivitet_type")),
+            fom = getDate("fom").toLocalDate(),
+            tom = getDate("tom")?.toLocalDate(),
+            opprettet = objectMapper.readValue(getString("opprettet")),
+            endret = objectMapper.readValue(getString("endret")),
+            beskrivelse = getString("beskrivelse"),
+        )
+}
+
+data class AktivitetspliktAktivitet(
+    val id: UUID,
+    val sakId: Long,
+    val behandlingId: UUID,
+    val type: AktivitetspliktAktivitetType,
+    val fom: LocalDate,
+    val tom: LocalDate?,
+    val opprettet: Grunnlagsopplysning.Kilde,
+    val endret: Grunnlagsopplysning.Kilde?,
+    val beskrivelse: String,
+)
+
+data class OpprettAktivitetspliktAktivitet(
+    val id: UUID? = null,
+    val sakId: Long,
+    val type: AktivitetspliktAktivitetType,
+    val fom: LocalDate,
+    val tom: LocalDate? = null,
+    val beskrivelse: String,
+)
+
+enum class AktivitetspliktAktivitetType {
+    ARBEIDSTAKER,
+    SELVSTENDIG_NAERINGSDRIVENDE,
+    ETABLERER_VIRKSOMHET,
+    ARBEIDSSOEKER,
+    UTDANNING,
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktRoute.kt
@@ -1,0 +1,45 @@
+package no.nav.etterlatte.behandling.aktivitetsplikt
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import no.nav.etterlatte.behandling.domain.TilstandException
+import no.nav.etterlatte.libs.common.behandling.OpprettAktivitetspliktOppfolging
+import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.ktor.route.behandlingId
+import no.nav.etterlatte.libs.ktor.route.hentNavidentFraToken
+import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
+
+internal fun Route.aktivitetspliktRoutes(aktivitetspliktService: AktivitetspliktService) {
+    route("/api/behandling/{$BEHANDLINGID_CALL_PARAMETER}/aktivitetsplikt") {
+        get {
+            val result = aktivitetspliktService.hentAktivitetspliktOppfolging(behandlingId)
+            call.respond(result ?: HttpStatusCode.NoContent)
+        }
+
+        post {
+            kunSkrivetilgang {
+                hentNavidentFraToken { navIdent ->
+                    val oppfolging = call.receive<OpprettAktivitetspliktOppfolging>()
+
+                    try {
+                        val result =
+                            aktivitetspliktService.lagreAktivitetspliktOppfolging(
+                                behandlingId,
+                                oppfolging,
+                                navIdent,
+                            )
+                        call.respond(result)
+                    } catch (e: TilstandException.UgyldigTilstand) {
+                        call.respond(HttpStatusCode.BadRequest, "Kunne ikke endre på feltet")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktRoute.kt
@@ -2,20 +2,25 @@ package no.nav.etterlatte.behandling.aktivitetsplikt
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
+import io.ktor.server.application.log
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.behandling.domain.TilstandException
 import no.nav.etterlatte.libs.common.behandling.OpprettAktivitetspliktOppfolging
+import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.behandlingId
 import no.nav.etterlatte.libs.ktor.route.hentNavidentFraToken
 import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
 
 internal fun Route.aktivitetspliktRoutes(aktivitetspliktService: AktivitetspliktService) {
+    val logger = application.log
+
     route("/api/behandling/{$BEHANDLINGID_CALL_PARAMETER}/aktivitetsplikt") {
         get {
             val result = aktivitetspliktService.hentAktivitetspliktOppfolging(behandlingId)
@@ -38,6 +43,24 @@ internal fun Route.aktivitetspliktRoutes(aktivitetspliktService: Aktivitetsplikt
                     } catch (e: TilstandException.UgyldigTilstand) {
                         call.respond(HttpStatusCode.BadRequest, "Kunne ikke endre på feltet")
                     }
+                }
+            }
+        }
+
+        route("/aktivitet") {
+            get {
+                logger.info("Henter aktiviteter for behandlingId=$behandlingId")
+                call.respond(aktivitetspliktService.hentAktiviteter(behandlingId))
+            }
+
+            post {
+                kunSkrivetilgang {
+                    logger.info("Oppretter aktivitet for behandlingId=$behandlingId")
+                    val aktivitet = call.receive<OpprettAktivitetspliktAktivitet>()
+
+                    aktivitetspliktService.opprettAktivitet(behandlingId, aktivitet, brukerTokenInfo)
+
+                    call.respond(aktivitetspliktService.hentAktiviteter(behandlingId))
                 }
             }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktService.kt
@@ -1,11 +1,20 @@
 package no.nav.etterlatte.behandling.aktivitetsplikt
 
+import no.nav.etterlatte.behandling.BehandlingService
+import no.nav.etterlatte.behandling.revurdering.BehandlingKanIkkeEndres
 import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.behandling.AktivitetspliktOppfolging
 import no.nav.etterlatte.libs.common.behandling.OpprettAktivitetspliktOppfolging
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import java.util.UUID
 
-class AktivitetspliktService(private val aktivitetspliktDao: AktivitetspliktDao) {
+class AktivitetspliktService(
+    private val aktivitetspliktDao: AktivitetspliktDao,
+    private val behandlingService: BehandlingService,
+) {
     fun hentAktivitetspliktOppfolging(behandlingId: UUID): AktivitetspliktOppfolging? {
         return inTransaction {
             aktivitetspliktDao.finnSenesteAktivitetspliktOppfolging(behandlingId)
@@ -23,4 +32,47 @@ class AktivitetspliktService(private val aktivitetspliktDao: AktivitetspliktDao)
 
         return hentAktivitetspliktOppfolging(behandlingId)!!
     }
+
+    fun hentAktiviteter(behandlingId: UUID) =
+        inTransaction {
+            aktivitetspliktDao.hentAktiviteter(behandlingId)
+        }
+
+    fun opprettAktivitet(
+        behandlingId: UUID,
+        aktivitet: OpprettAktivitetspliktAktivitet,
+        brukerTokenInfo: BrukerTokenInfo,
+    ) {
+        val behandling =
+            requireNotNull(behandlingService.hentBehandling(behandlingId)) { "Fant ikke behandling $behandlingId" }
+
+        if (!behandling.status.kanEndres()) {
+            throw BehandlingKanIkkeEndres()
+        }
+
+        if (aktivitet.sakId != behandling.sak.id) {
+            throw SakidTilhoererIkkeBehandlingException()
+        }
+
+        if (aktivitet.tom != null && aktivitet.tom < aktivitet.fom) {
+            throw TomErFoerFomException()
+        }
+
+        val kilde = Grunnlagsopplysning.Saksbehandler(brukerTokenInfo.ident(), Tidspunkt.now())
+        inTransaction {
+            aktivitetspliktDao.opprettAktivitet(behandlingId, aktivitet, kilde)
+        }
+    }
 }
+
+class SakidTilhoererIkkeBehandlingException :
+    UgyldigForespoerselException(
+        code = "SAK_ID_TILHOERER_IKKE_BEHANDLING",
+        detail = "Sak id stemmer ikke over ens med behandling",
+    )
+
+class TomErFoerFomException :
+    UgyldigForespoerselException(
+        code = "TOM_ER_FOER_FOM",
+        detail = "Til og med dato er kan ikke være før fra og med dato",
+    )

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -334,7 +334,7 @@ internal class ApplicationContext(
         )
     val kommerBarnetTilGodeService =
         KommerBarnetTilGodeService(kommerBarnetTilGodeDao, behandlingDao)
-    val aktivtetspliktService = AktivitetspliktService(aktivitetspliktDao)
+    val aktivtetspliktService = AktivitetspliktService(aktivitetspliktDao, behandlingService)
     val sjekklisteService = SjekklisteService(sjekklisteDao, behandlingService, oppgaveService)
 
     val klageBrevService = KlageBrevService(brevApiKlient)

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V112__ny_tabell_aktivitetsplikt_aktivitet.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V112__ny_tabell_aktivitetsplikt_aktivitet.sql
@@ -1,0 +1,12 @@
+CREATE TABLE aktivitetsplikt_aktivitet
+(
+    id             UUID PRIMARY KEY,
+    behandling_id  UUID, -- skal kunne kobles til kun sak i fremtiden
+    sak_id         BIGINT NOT NULL,
+    aktivitet_type TEXT   NOT NULL,
+    fom            Date,
+    tom            Date,
+    opprettet      TEXT,
+    endret         TEXT,
+    beskrivelse    TEXT
+);

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V112__ny_tabell_aktivitetsplikt_aktivitet.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V112__ny_tabell_aktivitetsplikt_aktivitet.sql
@@ -8,5 +8,6 @@ CREATE TABLE aktivitetsplikt_aktivitet
     tom            Date,
     opprettet      TEXT,
     endret         TEXT,
-    beskrivelse    TEXT
+    beskrivelse    TEXT,
+    CONSTRAINT fk_sak_id FOREIGN KEY (sak_id) REFERENCES sak(id)
 );

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
@@ -17,7 +17,6 @@ import io.mockk.runs
 import io.mockk.verify
 import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
 import no.nav.etterlatte.attachMockContext
-import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktService
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeService
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.ktor.issueSaksbehandlerToken
@@ -44,7 +43,6 @@ internal class BehandlingRoutesTest {
     private val behandlingService = mockk<BehandlingService>(relaxUnitFun = true)
     private val gyldighetsproevingService = mockk<GyldighetsproevingService>()
     private val kommerBarnetTilGodeService = mockk<KommerBarnetTilGodeService>()
-    private val aktivitetspliktService = mockk<AktivitetspliktService>()
     private val behandlingFactory = mockk<BehandlingFactory>()
 
     @BeforeAll
@@ -185,7 +183,6 @@ internal class BehandlingRoutesTest {
                         behandlingService,
                         gyldighetsproevingService,
                         kommerBarnetTilGodeService,
-                        aktivitetspliktService,
                         behandlingFactory,
                     )
                 }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/aktivitetsplikt/AktivitetspliktDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/aktivitetsplikt/AktivitetspliktDaoTest.kt
@@ -1,0 +1,65 @@
+package behandling.aktivitetsplikt
+
+import io.kotest.assertions.asClue
+import io.kotest.matchers.shouldBe
+import no.nav.etterlatte.ConnectionAutoclosingTest
+import no.nav.etterlatte.DatabaseExtension
+import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktAktivitetType
+import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktDao
+import no.nav.etterlatte.behandling.aktivitetsplikt.OpprettAktivitetspliktAktivitet
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDate
+import java.util.UUID
+import javax.sql.DataSource
+
+@ExtendWith(DatabaseExtension::class)
+class AktivitetspliktDaoTest(ds: DataSource) {
+    private val dao = AktivitetspliktDao(ConnectionAutoclosingTest(ds))
+
+    @Test
+    fun `skal hente aktiviteter for behandling`() {
+        val behandlingId = UUID.randomUUID()
+        val nyAktivtet = opprettAktivitet()
+        dao.opprettAktivitet(behandlingId, nyAktivtet, kilde)
+        dao.opprettAktivitet(UUID.randomUUID(), nyAktivtet, kilde)
+
+        val aktiviteter = dao.hentAktiviteter(behandlingId)
+
+        aktiviteter.size shouldBe 1
+    }
+
+    @Test
+    fun `skal opprette ny aktivetet`() {
+        val behandlingId = UUID.randomUUID()
+        val nyAktivitet = opprettAktivitet()
+
+        dao.opprettAktivitet(behandlingId, nyAktivitet, kilde)
+
+        val hentAktiviteter = dao.hentAktiviteter(behandlingId)
+        hentAktiviteter.first().asClue { aktivitet ->
+            aktivitet.sakId shouldBe nyAktivitet.sakId
+            aktivitet.behandlingId shouldBe behandlingId
+            aktivitet.type shouldBe nyAktivitet.type
+            aktivitet.fom shouldBe nyAktivitet.fom
+            aktivitet.tom shouldBe nyAktivitet.tom
+            aktivitet.opprettet shouldBe kilde
+            aktivitet.endret shouldBe kilde
+            aktivitet.beskrivelse shouldBe nyAktivitet.beskrivelse
+        }
+    }
+
+    companion object {
+        fun opprettAktivitet() =
+            OpprettAktivitetspliktAktivitet(
+                sakId = 1L,
+                type = AktivitetspliktAktivitetType.ARBEIDSTAKER,
+                fom = LocalDate.now(),
+                beskrivelse = "Beskrivelse",
+            )
+
+        val kilde = Grunnlagsopplysning.Saksbehandler("Z123456", Tidspunkt.now())
+    }
+}

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/aktivitetsplikt/AktivitetspliktDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/aktivitetsplikt/AktivitetspliktDaoTest.kt
@@ -7,8 +7,11 @@ import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktAktivitetType
 import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktDao
 import no.nav.etterlatte.behandling.aktivitetsplikt.OpprettAktivitetspliktAktivitet
+import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.sak.SakDao
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDate
@@ -18,11 +21,12 @@ import javax.sql.DataSource
 @ExtendWith(DatabaseExtension::class)
 class AktivitetspliktDaoTest(ds: DataSource) {
     private val dao = AktivitetspliktDao(ConnectionAutoclosingTest(ds))
+    private val sakDao = SakDao(ConnectionAutoclosingTest(ds))
 
     @Test
     fun `skal hente aktiviteter for behandling`() {
         val behandlingId = UUID.randomUUID()
-        val nyAktivtet = opprettAktivitet()
+        val nyAktivtet = opprettAktivitet(sakDao.opprettSak("Person1", SakType.OMSTILLINGSSTOENAD, "0000"))
         dao.opprettAktivitet(behandlingId, nyAktivtet, kilde)
         dao.opprettAktivitet(UUID.randomUUID(), nyAktivtet, kilde)
 
@@ -34,7 +38,7 @@ class AktivitetspliktDaoTest(ds: DataSource) {
     @Test
     fun `skal opprette ny aktivetet`() {
         val behandlingId = UUID.randomUUID()
-        val nyAktivitet = opprettAktivitet()
+        val nyAktivitet = opprettAktivitet(sakDao.opprettSak("Person1", SakType.OMSTILLINGSSTOENAD, "0000"))
 
         dao.opprettAktivitet(behandlingId, nyAktivitet, kilde)
 
@@ -52,9 +56,9 @@ class AktivitetspliktDaoTest(ds: DataSource) {
     }
 
     companion object {
-        fun opprettAktivitet() =
+        fun opprettAktivitet(sak: Sak) =
             OpprettAktivitetspliktAktivitet(
-                sakId = 1L,
+                sakId = sak.id,
                 type = AktivitetspliktAktivitetType.ARBEIDSTAKER,
                 fom = LocalDate.now(),
                 beskrivelse = "Beskrivelse",

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/aktivitetsplikt/AktivitetspliktServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/aktivitetsplikt/AktivitetspliktServiceTest.kt
@@ -1,0 +1,121 @@
+package behandling.aktivitetsplikt
+
+import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
+import no.nav.etterlatte.behandling.BehandlingService
+import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktAktivitet
+import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktAktivitetType
+import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktDao
+import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktService
+import no.nav.etterlatte.behandling.aktivitetsplikt.OpprettAktivitetspliktAktivitet
+import no.nav.etterlatte.behandling.aktivitetsplikt.SakidTilhoererIkkeBehandlingException
+import no.nav.etterlatte.behandling.aktivitetsplikt.TomErFoerFomException
+import no.nav.etterlatte.behandling.domain.Behandling
+import no.nav.etterlatte.behandling.revurdering.BehandlingKanIkkeEndres
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.nyKontekstMedBruker
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.util.UUID
+
+class AktivitetspliktServiceTest {
+    private val aktivitetspliktDao: AktivitetspliktDao = mockk()
+    private val behandlingService: BehandlingService = mockk()
+    private val service = AktivitetspliktService(aktivitetspliktDao, behandlingService)
+    private val user = mockk<SaksbehandlerMedEnheterOgRoller>()
+    private val brukerTokenInfo =
+        mockk<BrukerTokenInfo> {
+            every { ident() } returns "Z999999"
+        }
+
+    @BeforeEach
+    fun setup() {
+        nyKontekstMedBruker(user)
+        every { behandlingService.hentBehandling(behandling.id) } returns behandling
+    }
+
+    @Nested
+    inner class HentAktiviteter {
+        @Test
+        fun `Skal returnere liste med aktiviteter`() {
+            val behandlingId = UUID.randomUUID()
+            val aktivitet = mockk<AktivitetspliktAktivitet>()
+            every { aktivitetspliktDao.hentAktiviteter(behandlingId) } returns listOf(aktivitet)
+
+            val result = service.hentAktiviteter(behandlingId)
+
+            result shouldBe listOf(aktivitet)
+        }
+    }
+
+    @Nested
+    inner class OpprettAktivitet {
+        @Test
+        fun `Skal opprette en aktivitet`() {
+            every { aktivitetspliktDao.opprettAktivitet(behandling.id, aktivitet, any()) } just runs
+
+            service.opprettAktivitet(behandling.id, aktivitet, brukerTokenInfo)
+
+            coVerify { aktivitetspliktDao.opprettAktivitet(behandling.id, aktivitet, any()) }
+        }
+
+        @Test
+        fun `Skal kaste feil hvis sakId ikke stemmer overens med behandling`() {
+            val aktivitet = aktivitet.copy(sakId = 2)
+
+            assertThrows<SakidTilhoererIkkeBehandlingException> {
+                service.opprettAktivitet(behandling.id, aktivitet, brukerTokenInfo)
+            }
+        }
+
+        @Test
+        fun `Skal kaste feil hvis tom er foer fom`() {
+            val aktivitet = aktivitet.copy(tom = LocalDate.now().minusYears(1))
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+
+            assertThrows<TomErFoerFomException> {
+                service.opprettAktivitet(behandling.id, aktivitet, brukerTokenInfo)
+            }
+        }
+
+        @Test
+        fun `Skal kaste feil hvis behandlingen ikke kan endres`() {
+            val behandling =
+                behandling.apply {
+                    every { status } returns BehandlingStatus.ATTESTERT
+                }
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+
+            assertThrows<BehandlingKanIkkeEndres> {
+                service.opprettAktivitet(behandling.id, aktivitet, brukerTokenInfo)
+            }
+        }
+    }
+
+    companion object {
+        val behandling =
+            mockk<Behandling> {
+                every { status } returns BehandlingStatus.VILKAARSVURDERT
+                every { sak } returns
+                    mockk {
+                        every { id } returns 1L
+                    }
+            }
+        val aktivitet =
+            OpprettAktivitetspliktAktivitet(
+                sakId = 1L,
+                type = AktivitetspliktAktivitetType.ARBEIDSTAKER,
+                fom = LocalDate.now(),
+                beskrivelse = "Beskrivelse",
+            )
+    }
+}


### PR DESCRIPTION
På sikt skal vi nok støtte å kunne legge til aktiviteter kun basert på sak, men for nå må det gjøres i en behandlings-kontekst.