### PR TITLE
Det held ikkje å leggje inn ny status slettet for varselbrev eller an…

### DIFF
--- a/apps/etterlatte-brev-api/src/main/resources/db/prod/V17__slett_varselbrev_take2.sql
+++ b/apps/etterlatte-brev-api/src/main/resources/db/prod/V17__slett_varselbrev_take2.sql
@@ -1,0 +1,2 @@
+-- Varselbrev som er journalført uten adresse
+update brev set brevtype = 'SLETTET_VARSEL' where id = 17625

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/EtterlatteBrevkode.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/EtterlatteBrevkode.kt
@@ -58,6 +58,7 @@ enum class Brevtype {
     VEDLEGG,
     NOTAT,
     OVERSENDELSE_KLAGE,
+    SLETTET_VARSEL,
     ;
 
     fun erKobletTilEnBehandling(): Boolean {


### PR DESCRIPTION
…dre brev som det kun kan vera ei av per sak, da støtar vi på database-unique-avgrensinga som seier maks eitt for koplinga behandling+brevtype.

Spørs om vi eigentleg burde løyse dette med eit heilskapleg feilføringskonsept, eller iallfall revurdere noko av det grunnleggjande vi antar her, men det er eit lengre lerret å bleike, så går i første runde for ein enkel workaround med spesifikk brevtype for sletta brev