### PR TITLE
Tilretteleggje for generer testdata - endringane i dei andre appane

### DIFF
--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -195,6 +195,7 @@ spec:
         - application: etterlatte-klage
         - application: etterlatte-tilbakekreving
         - application: etterlatte-brev-api
+        - application: etterlatte-testdata-behandler
         - application: azure-token-generator # https://docs.nais.io/security/auth/azure-ad/usage/#token-generator
           namespace: aura
           cluster: dev-gcp

--- a/apps/etterlatte-beregning/.nais/dev.yaml
+++ b/apps/etterlatte-beregning/.nais/dev.yaml
@@ -103,6 +103,7 @@ spec:
         - application: etterlatte-statistikk
         - application: etterlatte-beregning-kafka
         - application: etterlatte-behandling
+        - application: etterlatte-testdata-behandler
         - application: azure-token-generator # https://docs.nais.io/security/auth/azure-ad/usage/#token-generator
           namespace: aura
           cluster: dev-gcp

--- a/apps/etterlatte-brev-api/.nais/dev.yaml
+++ b/apps/etterlatte-brev-api/.nais/dev.yaml
@@ -141,6 +141,7 @@ spec:
         - application: etterlatte-saksbehandling-ui-lokal # for å åpne for lokal utv. Ikke kopier denne til prod.yaml
         - application: etterlatte-saksbehandling-ui
         - application: etterlatte-behandling
+        - application: etterlatte-testdata-behandler
         - application: azure-token-generator # https://docs.nais.io/security/auth/azure-ad/usage/#token-generator
           namespace: aura
           cluster: dev-gcp

--- a/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/no/nav/etterlatte/opplysningerfrasoknad/StartUthentingFraSoeknadRiver.kt
+++ b/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/no/nav/etterlatte/opplysningerfrasoknad/StartUthentingFraSoeknadRiver.kt
@@ -8,6 +8,7 @@ import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
 import no.nav.etterlatte.libs.common.rapidsandrivers.lagParMedEventNameKey
 import no.nav.etterlatte.opplysningerfrasoknad.opplysningsuthenter.Opplysningsuthenter
 import no.nav.etterlatte.rapidsandrivers.BEHANDLING_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.Behandlingssteg
 import no.nav.etterlatte.rapidsandrivers.EventNames
 import no.nav.etterlatte.rapidsandrivers.ListenerMedLogging
 import no.nav.etterlatte.rapidsandrivers.OPPLYSNING_KEY
@@ -37,6 +38,7 @@ internal class StartUthentingFraSoeknadRiver(
             validate { it.requireKey(GyldigSoeknadVurdert.sakIdKey) }
             validate { it.requireKey(GyldigSoeknadVurdert.behandlingIdKey) }
             validate { it.requireKey(GyldigSoeknadVurdert.skjemaInfoTypeKey) }
+            validate { it.interestedIn(Behandlingssteg.KEY) }
         }
     }
 
@@ -57,6 +59,7 @@ internal class StartUthentingFraSoeknadRiver(
                 BEHANDLING_ID_KEY to packet[GyldigSoeknadVurdert.behandlingIdKey],
                 CORRELATION_ID_KEY to packet[CORRELATION_ID_KEY],
                 OPPLYSNING_KEY to opplysninger,
+                Behandlingssteg.KEY to packet[Behandlingssteg.KEY],
             ),
         ).apply {
             try {

--- a/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/no/nav/etterlatte/opplysningerfrasoknad/StartUthentingFraSoeknadRiver.kt
+++ b/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/no/nav/etterlatte/opplysningerfrasoknad/StartUthentingFraSoeknadRiver.kt
@@ -52,16 +52,16 @@ internal class StartUthentingFraSoeknadRiver(
                 SoeknadType.valueOf(packet[GyldigSoeknadVurdert.skjemaInfoTypeKey].textValue()),
             )
 
-        JsonMessage.newMessage(
-            mapOf(
+        val verdier =
+            mutableMapOf(
                 EventNames.NY_OPPLYSNING.lagParMedEventNameKey(),
                 SAK_ID_KEY to packet[GyldigSoeknadVurdert.sakIdKey],
                 BEHANDLING_ID_KEY to packet[GyldigSoeknadVurdert.behandlingIdKey],
                 CORRELATION_ID_KEY to packet[CORRELATION_ID_KEY],
                 OPPLYSNING_KEY to opplysninger,
-                Behandlingssteg.KEY to packet[Behandlingssteg.KEY],
-            ),
-        ).apply {
+            )
+        packet[Behandlingssteg.KEY].takeUnless { it.isMissingNode }?.also { verdier[Behandlingssteg.KEY] = it }
+        JsonMessage.newMessage(verdier).apply {
             try {
                 rapid.publish(packet[BEHANDLING_ID_KEY].toString(), toJson())
             } catch (err: Exception) {

--- a/apps/etterlatte-trygdetid/.nais/dev.yaml
+++ b/apps/etterlatte-trygdetid/.nais/dev.yaml
@@ -82,6 +82,7 @@ spec:
         - application: etterlatte-trygdetid-kafka
         - application: etterlatte-beregning-kafka
         - application: etterlatte-vedtaksvurdering
+        - application: etterlatte-testdata-behandler
         - application: azure-token-generator # https://docs.nais.io/security/auth/azure-ad/usage/#token-generator
           namespace: aura
           cluster: dev-gcp

--- a/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
@@ -106,6 +106,7 @@ spec:
         - application: etterlatte-saksbehandling-ui-lokal # for å åpne for lokal utv. Ikke kopier denne til prod.yaml
         - application: etterlatte-behandling
         - application: etterlatte-beregning
+        - application: etterlatte-testdata-behandler
         - application: etterlatte-samordning-vedtak
           permissions:
             roles:

--- a/apps/etterlatte-vilkaarsvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vilkaarsvurdering/.nais/dev.yaml
@@ -80,6 +80,7 @@ spec:
         - application: etterlatte-beregning
         - application: etterlatte-vedtaksvurdering
         - application: etterlatte-vilkaarsvurdering-kafka
+        - application: etterlatte-testdata-behandler
         - application: azure-token-generator # https://docs.nais.io/security/auth/azure-ad/usage/#token-generator
           namespace: aura
           cluster: dev-gcp

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/Behandlingssteg.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/Behandlingssteg.kt
@@ -1,0 +1,17 @@
+package no.nav.etterlatte.rapidsandrivers
+
+enum class Behandlingssteg {
+    KLAR,
+    BEHANDLING_OPPRETTA,
+    VILKAARSVURDERT,
+    TRYGDETID_OPPRETTA,
+    BEREGNA,
+    AVKORTA,
+    VEDTAK_FATTA,
+    IVERKSATT,
+    ;
+
+    companion object {
+        const val KEY = "BEHANDLINGSSTEG"
+    }
+}

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/Kontekst.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/Kontekst.kt
@@ -6,4 +6,5 @@ enum class Kontekst {
     MIGRERING,
     REGULERING,
     VENT,
+    TEST,
 }


### PR DESCRIPTION
Dette er endringane i alle andre appar enn testdata og testdata-behandler frå #4579 , sjå der for korleis desse blir brukt (yaml-endringane ser du bakgrunnen for i Behandler.kt, medan StartUthentingFraSoeknadRiver sender meldinga som skal bli plukka opp i den nye riveren)

Tanken er at ved å få inn denne blir det enklare å teste og ferdigstille 4579.