### PR TITLE
Ny config for apper som kjører mot kafka lokalt

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -64,6 +64,7 @@ import no.nav.etterlatte.libs.ktor.ktor.clientCredential
 import no.nav.etterlatte.libs.ktor.restModule
 import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.etterlatte.libs.ktor.setReady
+import no.nav.etterlatte.rapidsandrivers.configFromEnvironment
 import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import no.nav.etterlatte.rivers.DistribuerBrevRiver
 import no.nav.etterlatte.rivers.FerdigstillJournalfoerOgDistribuerBrev
@@ -215,7 +216,9 @@ class ApplicationBuilder {
     private val tilgangssjekker = Tilgangssjekker(config, httpClient())
 
     private val rapidsConnection: RapidsConnection =
-        RapidApplication.Builder(RapidApplication.RapidApplicationConfig.fromEnv(env))
+        RapidApplication.Builder(
+            RapidApplication.RapidApplicationConfig.fromEnv(env, configFromEnvironment(env)),
+        )
             .withKtorModule {
                 restModule(sikkerLogg, routePrefix = "api", config = HoconApplicationConfig(config)) {
                     brevRoute(brevService, pdfService, brevdistribuerer, tilgangssjekker)

--- a/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
@@ -30,6 +30,7 @@ import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 import no.nav.etterlatte.libs.ktor.restModule
 import no.nav.etterlatte.libs.ktor.setReady
 import no.nav.etterlatte.libs.sporingslogg.Sporingslogg
+import no.nav.etterlatte.rapidsandrivers.configFromEnvironment
 import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import no.nav.helse.rapids_rivers.RapidApplication
 import org.slf4j.Logger
@@ -93,7 +94,7 @@ class ApplicationBuilder {
     private val aldersovergangService = AldersovergangService(aldersovergangDao)
 
     private val rapidsConnection =
-        RapidApplication.Builder(RapidApplication.RapidApplicationConfig.fromEnv(env))
+        RapidApplication.Builder(RapidApplication.RapidApplicationConfig.fromEnv(env, configFromEnvironment(env)))
             .withKtorModule {
                 restModule(sikkerLogg, routePrefix = "api", config = HoconApplicationConfig(config)) {
                     route("grunnlag") {

--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte
 
 import no.nav.etterlatte.libs.common.Miljoevariabler
 import no.nav.etterlatte.libs.database.migrate
+import no.nav.etterlatte.rapidsandrivers.configFromEnvironment
 import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import no.nav.etterlatte.tidshendelser.AppContext
 import no.nav.etterlatte.tidshendelser.HendelseRiver
@@ -13,7 +14,9 @@ fun main() {
     val rapidEnv = getRapidEnv()
     val miljoevariabler = Miljoevariabler(rapidEnv)
 
-    RapidApplication.create(rapidEnv).also { rapidsConnection ->
+    RapidApplication.Builder(
+        RapidApplication.RapidApplicationConfig.fromEnv(rapidEnv, configFromEnvironment(rapidEnv)),
+    ).build().also { rapidsConnection ->
         val appContext = AppContext(miljoevariabler) { key, message -> rapidsConnection.publish(key.toString(), message) }
 
         HendelseRiver(rapidsConnection, appContext.hendelseDao)

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.libs.database.jdbcUrl
 import no.nav.etterlatte.libs.jobs.LeaderElection
 import no.nav.etterlatte.mq.EtterlatteJmsConnectionFactory
 import no.nav.etterlatte.mq.JmsConnectionFactory
+import no.nav.etterlatte.rapidsandrivers.configFromEnvironment
 import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import no.nav.etterlatte.utbetaling.avstemming.AvstemmingDao
 import no.nav.etterlatte.utbetaling.avstemming.GrensesnittsavstemmingJob
@@ -42,8 +43,12 @@ import java.time.LocalTime
 import java.time.temporal.ChronoUnit
 
 class ApplicationContext(
-    val properties: ApplicationProperties = ApplicationProperties.fromEnv(System.getenv()),
-    val rapidsConnection: RapidsConnection = RapidApplication.create(getRapidEnv()),
+    val env: Map<String, String> = getRapidEnv(),
+    val properties: ApplicationProperties = ApplicationProperties.fromEnv(env),
+    val rapidsConnection: RapidsConnection =
+        RapidApplication.Builder(
+            RapidApplication.RapidApplicationConfig.fromEnv(env, configFromEnvironment(env)),
+        ).build(),
     val jmsConnectionFactory: EtterlatteJmsConnectionFactory =
         JmsConnectionFactory(
             hostname = properties.mqHost,

--- a/apps/etterlatte-utbetaling/src/test/kotlin/no/nav/etterlatte/ApplicationIntegrationTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/no/nav/etterlatte/ApplicationIntegrationTest.kt
@@ -64,7 +64,7 @@ class ApplicationIntegrationTest {
                 konsistensavstemmingOMSEnabled = false,
             )
 
-        ApplicationContext(applicationProperties, rapidsConnection, jmsConnectionFactory = connectionFactory).also {
+        ApplicationContext(System.getenv(), applicationProperties, rapidsConnection, jmsConnectionFactory = connectionFactory).also {
             rapidApplication(it).start()
         }
     }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/RapidEnv.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/RapidEnv.kt
@@ -1,7 +1,60 @@
 package no.nav.etterlatte.rapidsandrivers
 
+import no.nav.helse.rapids_rivers.AivenConfig
+import no.nav.helse.rapids_rivers.Config
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.config.SaslConfigs
+import java.util.Properties
+
 fun getRapidEnv(): Map<String, String> {
     return System.getenv().toMutableMap().apply {
         put("KAFKA_CONSUMER_GROUP_ID", get("NAIS_APP_NAME")!!.replace("-", ""))
     }
+}
+
+fun configFromEnvironment(env: Map<String, String>): Config {
+    val gcpConfigAvailable = env.containsKey("KAFKA_BROKERS") && env.containsKey("KAFKA_CREDSTORE_PASSWORD")
+    return if (gcpConfigAvailable) {
+        AivenConfig.default
+    } else {
+        LocalKafkaConfig(env)
+    }
+}
+
+class LocalKafkaConfig(private val env: Map<String, String>) : Config {
+    override fun producerConfig(properties: Properties): Properties {
+        return properties.apply {
+            connectionConfig(this)
+            put(ProducerConfig.ACKS_CONFIG, "all")
+            put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "1")
+            put(ProducerConfig.LINGER_MS_CONFIG, "0")
+            put(ProducerConfig.RETRIES_CONFIG, "0")
+        }
+    }
+
+    override fun consumerConfig(
+        groupId: String,
+        properties: Properties,
+    ): Properties {
+        return properties.apply {
+            connectionConfig(this)
+            put(ConsumerConfig.GROUP_ID_CONFIG, groupId)
+            put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+        }
+    }
+
+    override fun adminConfig(properties: Properties): Properties {
+        return properties.apply {
+            connectionConfig(this)
+        }
+    }
+
+    private fun connectionConfig(properties: Properties) =
+        properties.apply {
+            put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, env["KAFKA_BOOTSTRAP_SERVERS"])
+            put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "PLAINTEXT")
+            put(SaslConfigs.SASL_MECHANISM, "PLAIN")
+        }
 }


### PR DESCRIPTION
Configen som tidligere ble brukt for lokal kjøring er fjernet i nyere versjon av rapids & rivers. Har lagt til en lokal konfig som kopierer den lokale configen som ligger i rapids & rivers, men som ikke krever TestContainer som parameter. 

Se forøvrig endringen som gjør at vi må endre dette her: https://github.com/navikt/rapids-and-rivers/commit/009c5dd149c50f9fd24fcde8cc06fc452c33df02