### PR TITLE
Litt mindre agressiv logging når vi får dårlig sivilstandsdata fra PDL

### DIFF
--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/ParallelleSannheterKlient.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/ParallelleSannheterKlient.kt
@@ -68,8 +68,11 @@ class ParallelleSannheterKlient(
                 logger.warn("Fant flere aktive sivilstander av samme type")
                 return aktiveSivilstander.sortedByDescending { it.gyldigFraOgMed }.first()
             } else {
-                logger.error("Fant flere aktive sivilstander av ulik type for $foedselsnummer. Se sikkerlogg for detaljer.")
-                sikkerLogg.info("Fant flere aktive sivilstander for ${foedselsnummer.value}: ${aktiveSivilstander.toJson()}")
+                val toSiste = aktiveSivilstander.sortedByDescending { it.gyldigFraOgMed }.takeLast(2)
+                if (toSiste.first().gyldigFraOgMed == toSiste.last().gyldigFraOgMed) {
+                    logger.warn("Fant flere aktive sivilstander av ulik type for $foedselsnummer. Se sikkerlogg for detaljer.")
+                    sikkerLogg.info("Fant flere aktive sivilstander for ${foedselsnummer.value}: ${aktiveSivilstander.toJson()}")
+                }
             }
         }
 


### PR DESCRIPTION
Parallelle-sannheter takler at vi får flere av samme type, dersom de har ulik dato. Velger derfor å ikke logge disse.
Endrer også til `warning`, så ser man det dersom man skal følge opp en feil som kastes fra PPS.