### PR TITLE
Separat logger for routes

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -3,12 +3,10 @@ package no.nav.etterlatte.behandling
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.put
@@ -36,6 +34,7 @@ import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.behandlingId
 import no.nav.etterlatte.libs.ktor.route.lagGrunnlagsopplysning
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.sak.UtlandstilknytningRequest
 import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
@@ -46,7 +45,7 @@ internal fun Route.behandlingRoutes(
     kommerBarnetTilGodeService: KommerBarnetTilGodeService,
     behandlingFactory: BehandlingFactory,
 ) {
-    val logger = application.log
+    val logger = routeLogger
 
     post("/api/behandling") {
         val request = call.receive<NyBehandlingRequest>()

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktRoute.kt
@@ -3,11 +3,9 @@ package no.nav.etterlatte.behandling.aktivitetsplikt
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
@@ -19,6 +17,7 @@ import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.behandlingId
 import no.nav.etterlatte.libs.ktor.route.hentNavidentFraToken
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
 import java.util.UUID
 
@@ -30,7 +29,7 @@ inline val PipelineContext<*, ApplicationCall>.aktivitetId: UUID
         )
 
 internal fun Route.aktivitetspliktRoutes(aktivitetspliktService: AktivitetspliktService) {
-    val logger = application.log
+    val logger = routeLogger
 
     route("/api/behandling/{$BEHANDLINGID_CALL_PARAMETER}/aktivitetsplikt") {
         get {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoRoutes.kt
@@ -2,10 +2,8 @@ package no.nav.etterlatte.behandling.behandlinginfo
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
@@ -20,12 +18,13 @@ import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.behandlingId
 import no.nav.etterlatte.libs.ktor.route.medBody
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
 import java.util.UUID
 
 internal fun Route.behandlingInfoRoutes(service: BehandlingInfoService) {
-    val logger = application.log
+    val logger = routeLogger
 
     route("/api/behandling/{$BEHANDLINGID_CALL_PARAMETER}/info") {
         route("/brevutfall") {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/generellbehandling/GenerellBehandlingRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/generellbehandling/GenerellBehandlingRoute.kt
@@ -2,11 +2,9 @@ package no.nav.etterlatte.behandling.generellbehandling
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.put
@@ -17,6 +15,7 @@ import no.nav.etterlatte.libs.ktor.route.GENERELLBEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.generellBehandlingId
 import no.nav.etterlatte.libs.ktor.route.kunSaksbehandler
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.route.sakId
 import no.nav.etterlatte.sak.SakService
 import no.nav.etterlatte.tilgangsstyring.kunSaksbehandlerMedSkrivetilgang
@@ -25,7 +24,7 @@ internal fun Route.generellbehandlingRoutes(
     generellBehandlingService: GenerellBehandlingService,
     sakService: SakService,
 ) {
-    val logger = application.log
+    val logger = routeLogger
 
     post("/api/generellbehandling/{$SAKID_CALL_PARAMETER}") {
         kunSaksbehandlerMedSkrivetilgang { saksbehandler ->

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
@@ -2,10 +2,8 @@ package no.nav.etterlatte.behandling.revurdering
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
@@ -18,13 +16,14 @@ import no.nav.etterlatte.libs.ktor.route.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.behandlingId
 import no.nav.etterlatte.libs.ktor.route.hentNavidentFraToken
 import no.nav.etterlatte.libs.ktor.route.medBody
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.route.sakId
 import no.nav.etterlatte.tilgangsstyring.kunSaksbehandlerMedSkrivetilgang
 import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
 import java.util.UUID
 
 internal fun Route.revurderingRoutes(revurderingService: RevurderingService) {
-    val logger = application.log
+    val logger = routeLogger
 
     route("/api/revurdering") {
         route("{$BEHANDLINGID_CALL_PARAMETER}") {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/statistikk/StatistikkRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/statistikk/StatistikkRoute.kt
@@ -2,10 +2,8 @@ package no.nav.etterlatte.behandling.statistikk
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
 import no.nav.etterlatte.behandling.BehandlingService
@@ -13,9 +11,10 @@ import no.nav.etterlatte.libs.common.behandling.StatistikkBehandling
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.behandlingId
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 
 internal fun Route.statistikkRoutes(behandlingService: BehandlingService) {
-    val logger = application.log
+    val logger = routeLogger
 
     route("/behandlinger/statistikk/{$BEHANDLINGID_CALL_PARAMETER}") {
         get {

--- a/apps/etterlatte-behandling/src/main/kotlin/egenansatt/EgenAnsattRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/egenansatt/EgenAnsattRoute.kt
@@ -2,11 +2,9 @@ package no.nav.etterlatte.egenansatt
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.behandling.BehandlingRequestLogger
@@ -15,12 +13,13 @@ import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.skjermet.EgenAnsattSkjermet
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.kunSystembruker
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 
 internal fun Route.egenAnsattRoute(
     egenAnsattService: EgenAnsattService,
     requestLogger: BehandlingRequestLogger,
 ) {
-    val logger = application.log
+    val logger = routeLogger
 
     route("/egenansatt") {
         post {

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseRoute.kt
@@ -2,11 +2,9 @@ package no.nav.etterlatte.grunnlagsendring
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
@@ -28,13 +26,14 @@ import no.nav.etterlatte.libs.common.sak.KjoeringStatus
 import no.nav.etterlatte.libs.common.sak.ReguleringFeiletHendelse
 import no.nav.etterlatte.libs.ktor.route.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.kunSystembruker
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.route.sakId
 
 internal fun Route.grunnlagsendringshendelseRoute(
     grunnlagsendringshendelseService: GrunnlagsendringshendelseService,
     omregningService: OmregningService,
 ) {
-    val logger = application.log
+    val logger = routeLogger
 
     route("/grunnlagsendringshendelse") {
         post("/doedshendelse") {

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseRoutes.kt
@@ -2,19 +2,18 @@ package no.nav.etterlatte.grunnlagsendring.doedshendelse
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.behandling.DoedshendelseBrevDistribuert
 import no.nav.etterlatte.libs.ktor.route.kunSystembruker
 import no.nav.etterlatte.libs.ktor.route.medBody
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 
 internal fun Route.doedshendelseRoute(doedshendelseService: DoedshendelseService) {
-    val logger = application.log
+    val logger = routeLogger
     route("/doedshendelse") {
         post("/brevdistribuert") {
             kunSystembruker {

--- a/apps/etterlatte-behandling/src/main/resources/logback.xml
+++ b/apps/etterlatte-behandling/src/main/resources/logback.xml
@@ -10,10 +10,11 @@
         <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
     </appender>
 
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="${LOGBACK_APPENDER:-STDOUT_JSON}"/>
     </root>
 
+    <logger name="Route" level="DEBUG"/>
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
     <logger name="no.nav.etterlatte" level="DEBUG"/>

--- a/apps/etterlatte-behandling/src/main/resources/logback.xml
+++ b/apps/etterlatte-behandling/src/main/resources/logback.xml
@@ -10,7 +10,7 @@
         <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="${LOGBACK_APPENDER:-STDOUT_JSON}"/>
     </root>
 

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -2,11 +2,9 @@ package no.nav.etterlatte.avkorting
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
@@ -19,6 +17,7 @@ import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagKildeDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagLagreDto
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.route.uuid
 import no.nav.etterlatte.libs.ktor.route.withBehandlingId
 
@@ -27,7 +26,7 @@ fun Route.avkorting(
     behandlingKlient: BehandlingKlient,
 ) {
     route("/api/beregning/avkorting/{$BEHANDLINGID_CALL_PARAMETER}") {
-        val logger = application.log
+        val logger = routeLogger
 
         get {
             withBehandlingId(behandlingKlient) {

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRoutes.kt
@@ -2,11 +2,9 @@ package no.nav.etterlatte.beregning
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
@@ -15,6 +13,7 @@ import no.nav.etterlatte.libs.common.beregning.OverstyrBeregningDTO
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.behandlingId
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.route.withBehandlingId
 
 fun Route.beregning(
@@ -22,7 +21,7 @@ fun Route.beregning(
     behandlingKlient: BehandlingKlient,
 ) {
     route("/api/beregning") {
-        val logger = application.log
+        val logger = routeLogger
 
         get("/{$BEHANDLINGID_CALL_PARAMETER}") {
             withBehandlingId(behandlingKlient) {

--- a/apps/etterlatte-beregning/src/main/kotlin/ytelseMedGrunnlag/YtelseMedGrunnlagRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/ytelseMedGrunnlag/YtelseMedGrunnlagRoutes.kt
@@ -2,15 +2,14 @@ package no.nav.etterlatte.ytelseMedGrunnlag
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.route.withBehandlingId
 
 fun Route.ytelseMedGrunnlag(
@@ -18,7 +17,7 @@ fun Route.ytelseMedGrunnlag(
     behandlingKlient: BehandlingKlient,
 ) {
     route("/api/beregning/ytelse-med-grunnlag/{$BEHANDLINGID_CALL_PARAMETER}") {
-        val logger = application.log
+        val logger = routeLogger
         get {
             withBehandlingId(behandlingKlient) {
                 logger.info("Henter utregnet ytelse med grunnlag for behandlingId=$it")

--- a/apps/etterlatte-beregning/src/main/resources/logback.xml
+++ b/apps/etterlatte-beregning/src/main/resources/logback.xml
@@ -14,6 +14,7 @@
         <appender-ref ref="${LOGBACK_APPENDER:-STDOUT_JSON}"/>
     </root>
 
+    <logger name="Route" level="DEBUG"/>
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="org.apache.kafka" level="INFO"/>
     <logger name="io.netty" level="INFO"/>

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/PersonRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/PersonRoutes.kt
@@ -1,9 +1,7 @@
 package no.nav.etterlatte.grunnlag
 
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.application
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
@@ -12,6 +10,7 @@ import no.nav.etterlatte.grunnlag.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.person.InvalidFoedselsnummerException
 import no.nav.etterlatte.libs.ktor.route.hentNavidentFraToken
 import no.nav.etterlatte.libs.ktor.route.kunSystembruker
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.route.withFoedselsnummer
 
 fun Route.personRoute(
@@ -60,7 +59,7 @@ fun Route.personRoute(
                         "Gjenny har ingen navnedata på fødselsnummeret som ble etterspurt",
                     )
                 } catch (ex: Exception) {
-                    application.log.error("Fikk feilmelding under henting av navn fra grunnlag", ex)
+                    routeLogger.error("Fikk feilmelding under henting av navn fra grunnlag", ex)
                     call.respond(
                         HttpStatusCode.NotFound,
                         "Gjenny har ingen navnedata på fødselsnummeret som ble etterspurt",

--- a/apps/etterlatte-grunnlag/src/main/resources/logback.xml
+++ b/apps/etterlatte-grunnlag/src/main/resources/logback.xml
@@ -14,6 +14,7 @@
         <appender-ref ref="${LOGBACK_APPENDER:-STDOUT_JSON}"/>
     </root>
 
+    <logger name="Route" level="DEBUG"/>
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
     <logger name="no.nav.etterlatte" level="DEBUG"/>

--- a/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRouteTest.kt
+++ b/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRouteTest.kt
@@ -19,6 +19,7 @@ import io.mockk.confirmVerified
 import io.mockk.mockk
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.ktor.restModule
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
@@ -282,7 +283,7 @@ class SamordningVedtakRouteTest {
     }
 
     private fun Application.samordningVedtakApi() {
-        restModule(log) {
+        restModule(routeLogger) {
             samordningVedtakRoute(
                 samordningVedtakService = samordningVedtakService,
                 config = config,

--- a/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRouteTest.kt
+++ b/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRouteTest.kt
@@ -10,7 +10,6 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
-import io.ktor.server.application.log
 import io.ktor.server.config.HoconApplicationConfig
 import io.ktor.server.testing.testApplication
 import io.mockk.clearAllMocks

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/vedtak/TilbakekrevingVedtakRoutes.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/vedtak/TilbakekrevingVedtakRoutes.kt
@@ -2,18 +2,17 @@ package no.nav.etterlatte.tilbakekreving.vedtak
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingVedtak
 import no.nav.etterlatte.libs.ktor.route.kunSystembruker
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 
 fun Route.tilbakekrevingVedtakRoutes(tilbakekrevingVedtakService: TilbakekrevingVedtakService) {
-    val logger = application.log
+    val logger = routeLogger
 
     route("/api/tilbakekreving/tilbakekrevingsvedtak") {
         post {

--- a/apps/etterlatte-tilbakekreving/src/main/resources/logback.xml
+++ b/apps/etterlatte-tilbakekreving/src/main/resources/logback.xml
@@ -14,6 +14,7 @@
         <appender-ref ref="${LOGBACK_APPENDER:-STDOUT_JSON}"/>
     </root>
 
+    <logger name="Route" level="DEBUG"/>
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="org.apache.kafka" level="INFO"/>
     <logger name="io.netty" level="INFO"/>

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/avtale/AvtaleRoutes.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/avtale/AvtaleRoutes.kt
@@ -2,11 +2,9 @@ package no.nav.etterlatte.trygdetid.avtale
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
@@ -16,6 +14,7 @@ import no.nav.etterlatte.libs.common.trygdetid.avtale.Trygdeavtale
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.behandlingId
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.route.withBehandlingId
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.trygdetid.klienter.BehandlingKlient
@@ -26,7 +25,7 @@ fun Route.avtale(
     behandlingKlient: BehandlingKlient,
 ) {
     route("/api/trygdetid/avtaler") {
-        val logger = application.log
+        val logger = routeLogger
 
         get {
             logger.info("Henter alle avtaler")

--- a/apps/etterlatte-trygdetid/src/main/resources/logback.xml
+++ b/apps/etterlatte-trygdetid/src/main/resources/logback.xml
@@ -14,6 +14,7 @@
         <appender-ref ref="${LOGBACK_APPENDER:-STDOUT_JSON}"/>
     </root>
 
+    <logger name="Route" level="DEBUG"/>
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="org.apache.kafka" level="INFO"/>
     <logger name="io.netty" level="INFO"/>

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/UtbetalingRoutes.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/UtbetalingRoutes.kt
@@ -2,14 +2,13 @@ package no.nav.etterlatte.utbetaling
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.route.withBehandlingId
 import no.nav.etterlatte.utbetaling.simulering.SimuleringOsService
 
@@ -17,7 +16,7 @@ internal fun Route.utbetalingRoutes(
     service: SimuleringOsService,
     behandlingKlient: BehandlingKlient,
 ) {
-    val logger = application.log
+    val logger = routeLogger
 
     route("/api/utbetaling") {
         route("{$BEHANDLINGID_CALL_PARAMETER}") {

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/AutomatiskBehandlingRoutes.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/AutomatiskBehandlingRoutes.kt
@@ -1,16 +1,15 @@
 package no.nav.etterlatte.vedtaksvurdering
 
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.SAKID_CALL_PARAMETER
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.route.sakId
 import no.nav.etterlatte.libs.ktor.route.withBehandlingId
 import no.nav.etterlatte.rapidsandrivers.migrering.MigreringKjoringVariant
@@ -21,7 +20,7 @@ fun Route.automatiskBehandlingRoutes(
     behandlingKlient: BehandlingKlient,
 ) {
     route("/api/vedtak") {
-        val logger = application.log
+        val logger = routeLogger
 
         post("/{$SAKID_CALL_PARAMETER}/{$BEHANDLINGID_CALL_PARAMETER}/automatisk") {
             withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -3,11 +3,9 @@ package no.nav.etterlatte.vedtaksvurdering
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.application.install
-import io.ktor.server.application.log
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.patch
 import io.ktor.server.routing.post
@@ -26,6 +24,7 @@ import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.behandlingId
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.route.withBehandlingId
 import no.nav.etterlatte.libs.ktor.route.withSakId
 import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.VedtakKlageService
@@ -39,7 +38,7 @@ fun Route.vedtaksvurderingRoute(
     behandlingKlient: BehandlingKlient,
 ) {
     route("/api/vedtak") {
-        val logger = application.log
+        val logger = routeLogger
 
         get("/sak/{$SAKID_CALL_PARAMETER}/iverksatte") {
             withSakId(behandlingKlient) { sakId ->
@@ -262,7 +261,7 @@ fun Route.tilbakekrevingvedtakRoute(
     service: VedtakTilbakekrevingService,
     behandlingKlient: BehandlingKlient,
 ) {
-    val logger = application.log
+    val logger = routeLogger
 
     route("/tilbakekreving/{$BEHANDLINGID_CALL_PARAMETER}") {
         post("/lagre-vedtak") {
@@ -299,7 +298,7 @@ fun Route.klagevedtakRoute(
     service: VedtakKlageService,
     behandlingKlient: BehandlingKlient,
 ) {
-    val logger = application.log
+    val logger = routeLogger
 
     route("/vedtak/klage/{$BEHANDLINGID_CALL_PARAMETER}") {
         post("/upsert") {

--- a/apps/etterlatte-vedtaksvurdering/src/main/resources/logback.xml
+++ b/apps/etterlatte-vedtaksvurdering/src/main/resources/logback.xml
@@ -14,6 +14,7 @@
         <appender-ref ref="${LOGBACK_APPENDER:-STDOUT_JSON}"/>
     </root>
 
+    <logger name="Route" level="DEBUG"/>
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="org.apache.kafka" level="INFO"/>
     <logger name="io.netty" level="INFO"/>

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangRoutes.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangRoutes.kt
@@ -2,14 +2,13 @@ package no.nav.etterlatte.vilkaarsvurdering
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.route.withBehandlingId
 import no.nav.etterlatte.vilkaarsvurdering.klienter.BehandlingKlient
 import java.util.UUID
@@ -19,7 +18,7 @@ fun Route.aldersovergang(
     aldersovergangService: AldersovergangService,
 ) {
     route("/api/vilkaarsvurdering/aldersovergang") {
-        val logger = application.log
+        val logger = routeLogger
 
         post("/{$BEHANDLINGID_CALL_PARAMETER}") {
             withBehandlingId(behandlingKlient) { behandlingId ->

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
@@ -3,11 +3,9 @@ package no.nav.etterlatte.vilkaarsvurdering
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
-import io.ktor.server.application.log
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.application
 import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
@@ -20,6 +18,7 @@ import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingDto
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
+import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.route.withBehandlingId
 import no.nav.etterlatte.libs.ktor.route.withParam
 import no.nav.etterlatte.libs.vilkaarsvurdering.VurdertVilkaarsvurderingResultatDto
@@ -31,7 +30,7 @@ fun Route.vilkaarsvurdering(
     behandlingKlient: BehandlingKlient,
 ) {
     route("/api/vilkaarsvurdering") {
-        val logger = application.log
+        val logger = routeLogger
 
         get("/{$BEHANDLINGID_CALL_PARAMETER}") {
             withBehandlingId(behandlingKlient) { behandlingId ->

--- a/apps/etterlatte-vilkaarsvurdering/src/main/resources/logback.xml
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/resources/logback.xml
@@ -14,6 +14,7 @@
         <appender-ref ref="${LOGBACK_APPENDER:-STDOUT_JSON}"/>
     </root>
 
+    <logger name="Route" level="DEBUG"/>
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="org.apache.kafka" level="INFO"/>
     <logger name="io.netty" level="INFO"/>

--- a/libs/etterlatte-ktor/src/main/kotlin/route/RouteUtils.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/route/RouteUtils.kt
@@ -249,3 +249,5 @@ fun BrukerTokenInfo.lagGrunnlagsopplysning() =
     } else {
         Grunnlagsopplysning.Gjenny.create(ident())
     }
+
+val routeLogger = LoggerFactory.getLogger("Route")


### PR DESCRIPTION
Alle debug-kall til application.log blir berre slukt, sia denne er udefinert i logback-konfigen, og dermed går som eit barn av root-logger, som er vår catch-all og denne har nivået info. Dermed mistar vi debuglogginga.

Innfører derfor ein spesifikk route-logger, for å unngå støy, og endrar konfig i alle appane der vi bruker routeLogger-en til å ta med også debuglogging. Denne loggeren bruker vi jo kun der vi eksplisitt ønskjer å få logga