### PR TITLE
Unngår adopsjons-kræsjen som skjer i dev ved å definere opp adopsjon …

### DIFF
--- a/libs/saksbehandling-common/src/main/kotlin/behandling/RevurderingInfo.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/behandling/RevurderingInfo.kt
@@ -23,6 +23,9 @@ sealed class RevurderingInfo {
         val aarsak: String,
     ) : RevurderingInfo()
 
+    @JsonTypeName("ADOPSJON")
+    data object Adopsjon : RevurderingInfo()
+
     @JsonTypeName("ANNEN_UTEN_BREV")
     data class RevurderingAarsakAnnenUtenBrev(
         val aarsak: String,


### PR DESCRIPTION
…som ein type revurderinginfo, det gir for så vidt greitt meining å ha han her når vi også har han i enumen