### PR TITLE
EY-3389 Justert mapping for simulering

### DIFF
--- a/apps/etterlatte-utbetaling/README.md
+++ b/apps/etterlatte-utbetaling/README.md
@@ -38,7 +38,12 @@ Så langt er det ikke definert om simulering er noe vi skal støtte.
 1. Start Kafka lokalt ved å kjøre `docker-compose up -d`
 2. Sett følgende miljøvariabler ved oppstart av applikasjon:
    `KAFKA_RAPID_TOPIC=etterlatte;KAFKA_BOOTSTRAP_SERVERS=0.0.0.0:9092;NAIS_APP_NAME=etterlatte-utbetaling;DB_DATABASE=postgres;DB_HOST=localhost;DB_PORT=5432;DB_USERNAME=postgres;DB_PASSWORD=postgres;OPPDRAG_MQ_HOSTNAME=localhost;OPPDRAG_MQ_PORT=1414;OPPDRAG_MQ_MANAGER=QM1;OPPDRAG_MQ_CHANNEL=DEV.ADMIN.SVRCONN;OPPDRAG_SEND_MQ_NAME=DEV.QUEUE.1;OPPDRAG_KVITTERING_MQ_NAME=DEV.QUEUE.2;OPPDRAG_AVSTEMMING_MQ_NAME=DEV.QUEUE.1;srvuser=admin;srvpwd=passw0rd`
-3. Dersom man ønsker å sjekke avstemmingsjobb må `hostname` settes under feltet "name" i `api-mock/elector-response.json`
+3. Kjør `get-secret.sh` for applikasjonen for å få riktige ids m.m. i envFile
+4. Kalle applikasjonen fra saksbehandling-ui:
+    - legg til følgende linje nederst i `.env.dev-gcp` fila til saksbehandling-ui.
+      ```
+         UTBETALING_API_URL=http://host.docker.internal:8096
+      ```
 
 #### Teste mot rapid
 Kjør følgende for å poste innholdet i en fil til kafka:

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/UtbetalingRoutes.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/UtbetalingRoutes.kt
@@ -20,7 +20,7 @@ internal fun Route.utbetalingRoutes(
     val logger = application.log
 
     route("/api/utbetaling") {
-        route("{$BEHANDLINGID_CALL_PARAMETER}") {
+        route("/behandling/{$BEHANDLINGID_CALL_PARAMETER}") {
             post("/simulering") {
                 withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
                     logger.info("Foretar simulering mot Oppdrag for behandling=$behandlingId")

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/common/OppdragDefaults.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/common/OppdragDefaults.kt
@@ -4,6 +4,7 @@ import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.OppdragKlassifikasjo
 import no.trygdeetaten.skjema.oppdrag.OppdragsEnhet120
 import no.trygdeetaten.skjema.oppdrag.TfradragTillegg
 import java.time.LocalDate
+import java.time.Month
 
 object OppdragDefaults {
     const val AVLEVERENDE_KOMPONENTKODE = "ETTERLAT" // felles for alle etterlatteytelser
@@ -15,11 +16,12 @@ object OppdragDefaults {
     const val AKSJONSKODE_OPPDATER = "1"
     val KODEKOMPONENT = OppdragKlassifikasjonskode.BARNEPENSJON_OPTP
     val DATO_OPPDRAG_GJELDER_FOM = LocalDate.EPOCH.toXMLDate()
+    val OPPDRAGSENHET_DATO_FOM: LocalDate = LocalDate.of(1900, Month.JANUARY, 1)
     val OPPDRAGSENHET =
         OppdragsEnhet120().apply {
             typeEnhet = "BOS"
             enhet = "4819"
-            datoEnhetFom = LocalDate.parse("1900-01-01").toXMLDate()
+            datoEnhetFom = OPPDRAGSENHET_DATO_FOM.toXMLDate()
         }
     val TILLEGG = TfradragTillegg.T
 }

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
@@ -134,7 +134,12 @@ class ApplicationContext(
         )
     }
 
-    val simuleringOsService = SimuleringOsService(vedtaksvurderingKlient, simuleringOsKlient)
+    private val simuleringOsService =
+        SimuleringOsService(
+            utbetalingDao,
+            vedtaksvurderingKlient,
+            simuleringOsKlient,
+        )
 
     val leaderElection = LeaderElection(properties.leaderElectorPath)
 

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/iverksetting/oppdrag/OppdragMapper.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/iverksetting/oppdrag/OppdragMapper.kt
@@ -28,11 +28,7 @@ object OppdragMapper {
             Oppdrag110().apply {
                 kodeAksjon = OppdragDefaults.AKSJONSKODE_OPPDATER
                 kodeEndring = if (erFoersteUtbetalingPaaSak) "NY" else "ENDR"
-                kodeFagomraade =
-                    when (utbetaling.sakType) {
-                        Saktype.BARNEPENSJON -> "BARNEPE"
-                        Saktype.OMSTILLINGSSTOENAD -> "OMSTILL"
-                    }
+                kodeFagomraade = utbetaling.sakType.tilKodeFagomraade()
                 fagsystemId = utbetaling.sakId.value.toString()
                 utbetFrekvens = OppdragDefaults.UTBETALINGSFREKVENS
                 oppdragGjelderId = utbetaling.stoenadsmottaker.value
@@ -72,11 +68,7 @@ object OppdragMapper {
 
                             vedtakId = utbetaling.vedtakId.value.toString()
                             delytelseId = it.id.value.toString()
-                            kodeKlassifik =
-                                when (utbetaling.sakType) {
-                                    Saktype.BARNEPENSJON -> OppdragKlassifikasjonskode.BARNEPENSJON_OPTP.toString()
-                                    Saktype.OMSTILLINGSSTOENAD -> OppdragKlassifikasjonskode.OMSTILLINGSTOENAD_OPTP.toString()
-                                }
+                            kodeKlassifik = utbetaling.sakType.tilKodeklassifikasjon()
                             datoVedtakFom = it.periode.fra.toXMLDate()
                             datoVedtakTom = it.periode.til?.toXMLDate()
                             sats = it.beloep
@@ -102,6 +94,18 @@ object OppdragMapper {
         }
     }
 }
+
+fun Saktype.tilKodeFagomraade(): String =
+    when (this) {
+        Saktype.BARNEPENSJON -> "BARNEPE"
+        Saktype.OMSTILLINGSSTOENAD -> "OMSTILL"
+    }
+
+fun Saktype.tilKodeklassifikasjon(): String =
+    when (this) {
+        Saktype.BARNEPENSJON -> OppdragKlassifikasjonskode.BARNEPENSJON_OPTP.toString()
+        Saktype.OMSTILLINGSSTOENAD -> OppdragKlassifikasjonskode.OMSTILLINGSTOENAD_OPTP.toString()
+    }
 
 fun Oppdrag.vedtakId() = oppdrag110.oppdragsLinje150.first().vedtakId.toLong()
 

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/iverksetting/utbetaling/Utbetalingsvedtak.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/iverksetting/utbetaling/Utbetalingsvedtak.kt
@@ -15,7 +15,11 @@ data class Utbetalingsvedtak(
     val attestasjon: Attestasjon,
 ) {
     companion object {
-        fun fra(vedtak: VedtakDto): Utbetalingsvedtak {
+        fun fra(
+            vedtak: VedtakDto,
+            vedtakFattet: VedtakFattet? = null,
+            attestasjon: Attestasjon? = null,
+        ): Utbetalingsvedtak {
             val innhold = (vedtak.innhold as VedtakInnholdDto.VedtakBehandlingDto)
             return Utbetalingsvedtak(
                 vedtakId = vedtak.id,
@@ -41,14 +45,14 @@ data class Utbetalingsvedtak(
                         )
                     },
                 vedtakFattet =
-                    vedtak.vedtakFattet?.let {
+                    vedtakFattet ?: vedtak.vedtakFattet?.let {
                         VedtakFattet(
                             ansvarligSaksbehandler = it.ansvarligSaksbehandler,
                             ansvarligEnhet = it.ansvarligEnhet,
                         )
                     } ?: throw Exception("Mangler saksbehandler og enhet på vedtak"),
                 attestasjon =
-                    vedtak.attestasjon?.let {
+                    attestasjon ?: vedtak.attestasjon?.let {
                         Attestasjon(
                             attestant = it.attestant,
                             attesterendeEnhet = it.attesterendeEnhet,

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/simulering/SimuleringOsService.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/simulering/SimuleringOsService.kt
@@ -1,16 +1,21 @@
 package no.nav.etterlatte.utbetaling.simulering
 
-import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.tidspunkt.norskTidssone
-import no.nav.etterlatte.libs.common.toUUID30
-import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
-import no.nav.etterlatte.libs.common.vedtak.UtbetalingsperiodeType
-import no.nav.etterlatte.libs.common.vedtak.VedtakDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakInnholdDto
-import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.utbetaling.VedtaksvurderingKlient
+import no.nav.etterlatte.utbetaling.common.OppdragDefaults
+import no.nav.etterlatte.utbetaling.iverksetting.oppdrag.tilKodeFagomraade
+import no.nav.etterlatte.utbetaling.iverksetting.oppdrag.tilKodeklassifikasjon
+import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Attestasjon
+import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Utbetaling
+import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.UtbetalingDao
+import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.UtbetalingMapper
+import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Utbetalingslinje
+import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Utbetalingslinjetype
+import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Utbetalingsvedtak
+import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.VedtakFattet
 import no.nav.system.os.entiteter.oppdragskjema.Enhet
 import no.nav.system.os.entiteter.typer.simpletypes.FradragTillegg
 import no.nav.system.os.entiteter.typer.simpletypes.KodeStatusLinje
@@ -25,6 +30,7 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 class SimuleringOsService(
+    private val utbetalingDao: UtbetalingDao,
     private val vedtaksvurderingKlient: VedtaksvurderingKlient,
     private val simuleringOsKlient: SimuleringOsKlient,
 ) {
@@ -37,127 +43,144 @@ class SimuleringOsService(
         val vedtak =
             vedtaksvurderingKlient.hentVedtak(behandlingId, brukerTokenInfo)
 
-        if (vedtak.innhold is VedtakInnholdDto.VedtakBehandlingDto) {
-            val request = mapTilSimuleringRequest(vedtak, brukerTokenInfo)
+        val innhold = vedtak.innhold
+        if (innhold is VedtakInnholdDto.VedtakBehandlingDto) {
+            val sakensUtbetalinger = utbetalingDao.hentUtbetalinger(vedtak.sak.id)
+            val utbetalingsvedtak =
+                Utbetalingsvedtak.fra(
+                    vedtak = vedtak,
+                    vedtakFattet =
+                        VedtakFattet(
+                            ansvarligSaksbehandler = brukerTokenInfo.ident(),
+                            ansvarligEnhet = OppdragDefaults.OPPDRAGSENHET.enhet,
+                        ),
+                    attestasjon =
+                        Attestasjon(
+                            attestant = OppdragDefaults.SAKSBEHANDLER_ID_SYSTEM_ETTERLATTEYTELSER,
+                            attesterendeEnhet = OppdragDefaults.OPPDRAGSENHET.enhet,
+                        ),
+                )
+            val utbetalingMapper =
+                UtbetalingMapper(
+                    tidligereUtbetalinger = sakensUtbetalinger,
+                    vedtak = utbetalingsvedtak,
+                )
+            val opprettetUtbetaling = utbetalingMapper.opprettUtbetaling()
+            val erFoersteUtbetalingPaaSak = utbetalingMapper.tidligereUtbetalinger.isEmpty()
+            val vedtakVirkFom = innhold.virkningstidspunkt
+
+            val request =
+                mapTilSimuleringRequest(
+                    opprettetUtbetaling,
+                    erFoersteUtbetalingPaaSak,
+                    vedtakVirkFom,
+                    brukerTokenInfo,
+                )
 
             return simuleringOsKlient.simuler(request).also {
                 it.infomelding?.beskrMelding?.trim().let { melding -> logger.info(melding) }
             }
         } else {
-            throw IkkeStoettetSimulering(vedtak.type, behandlingId)
+            throw IkkeStoettetSimulering(behandlingId)
         }
     }
 
     private fun mapTilSimuleringRequest(
-        vedtak: VedtakDto,
+        utbetaling: Utbetaling,
+        erFoersteUtbetalingPaaSak: Boolean,
+        vedtakVirkFom: YearMonth,
         brukerTokenInfo: BrukerTokenInfo,
     ): SimulerBeregningRequest {
         val request =
             SimulerBeregningRequest().apply {
-                oppdrag = tilOppdrag(vedtak, brukerTokenInfo)
-                simuleringsPeriode = simuleringsperiode(vedtak.virkningstidspunkt)
+                oppdrag = tilOppdrag(utbetaling, erFoersteUtbetalingPaaSak, vedtakVirkFom, brukerTokenInfo)
+                simuleringsPeriode = simuleringsperiode(vedtakVirkFom, utbetaling.utbetalingslinjer)
             }
         return request
     }
 
-    private fun simuleringsperiode(virkningstidspunkt: YearMonth) =
-        SimulerBeregningRequest.SimuleringsPeriode().apply {
-            datoSimulerFom = virkningstidspunkt.atDay(1).toOppdragDate()
-        }
+    private fun simuleringsperiode(
+        vedtakVirkFom: YearMonth,
+        utbetalingsperioder: List<Utbetalingslinje>,
+    ) = SimulerBeregningRequest.SimuleringsPeriode().apply {
+        datoSimulerFom = vedtakVirkFom.atDay(1).toOppdragDate()
+        datoSimulerTom = utbetalingsperioder.lastOrNull()?.periode?.til?.toOppdragDate()
+    }
 
     private fun tilOppdrag(
-        vedtak: VedtakDto,
+        utbetaling: Utbetaling,
+        erFoersteUtbetalingPaaSak: Boolean,
+        vedtakVirkFom: YearMonth,
         brukerTokenInfo: BrukerTokenInfo,
     ): Oppdrag {
         return Oppdrag().apply {
-            fagsystemId = vedtak.sak.id.toString()
-            oppdragGjelderId = vedtak.sak.ident
+            fagsystemId = utbetaling.sakId.value.toString()
+            oppdragGjelderId = utbetaling.stoenadsmottaker.value
             saksbehId = brukerTokenInfo.ident()
 
-            utbetFrekvens = "MND"
-            kodeEndring = vedtak.type.toKodeEndring()
-            kodeFagomraade = vedtak.sak.sakType.toKodeFagomrade()
+            utbetFrekvens = OppdragDefaults.UTBETALINGSFREKVENS
+            kodeEndring = if (erFoersteUtbetalingPaaSak) "NY" else "ENDR"
+            kodeFagomraade = utbetaling.sakType.tilKodeFagomraade()
 
-            val innhold = vedtak.innhold
-            if (innhold is VedtakInnholdDto.VedtakBehandlingDto) {
-                datoOppdragGjelderFom = innhold.virkningstidspunkt.atDay(1).toOppdragDate()
-                oppdragslinje.addAll(
-                    innhold.utbetalingsperioder.map {
-                        tilOppdragsLinje(
-                            it,
-                            vedtak,
-                            brukerTokenInfo,
-                        )
-                    },
-                )
-                enhet.add(
-                    Enhet().apply {
-                        typeEnhet = "BOS"
-                        enhet = "4819"
-                        datoEnhetFom = LocalDate.parse("1900-01-01").toOppdragDate()
-                    },
-                )
-            }
+            datoOppdragGjelderFom = vedtakVirkFom.atDay(1).toOppdragDate()
+            oppdragslinje.addAll(
+                utbetaling.utbetalingslinjer.map {
+                    tilOppdragsLinje(
+                        utbetaling,
+                        it,
+                        brukerTokenInfo,
+                    )
+                },
+            )
+            enhet.add(
+                Enhet().apply {
+                    typeEnhet = OppdragDefaults.OPPDRAGSENHET.typeEnhet
+                    enhet = OppdragDefaults.OPPDRAGSENHET.enhet
+                    datoEnhetFom = OppdragDefaults.OPPDRAGSENHET_DATO_FOM.toOppdragDate()
+                },
+            )
         }
     }
 
     private fun tilOppdragsLinje(
-        up: Utbetalingsperiode,
-        vedtak: VedtakDto,
+        utbetaling: Utbetaling,
+        utbetalingslinje: Utbetalingslinje,
         brukerTokenInfo: BrukerTokenInfo,
     ): Oppdragslinje =
         Oppdragslinje().apply {
-            vedtakId = vedtak.id.toString()
-            delytelseId = up.id.toString()
-            datoVedtakFom = up.periode.fom.atDay(1).toOppdragDate()
-            datoVedtakTom = up.periode.tom?.atEndOfMonth()?.toOppdragDate()
-            utbetalesTilId = vedtak.sak.ident
-            henvisning = vedtak.behandlingId.toUUID30().value
+            vedtakId = utbetaling.vedtak.vedtakId.toString()
+            delytelseId = utbetalingslinje.id.value.toString()
+            datoVedtakFom = utbetalingslinje.periode.fra.toOppdragDate()
+            datoVedtakTom = utbetalingslinje.periode.til?.toOppdragDate()
+            utbetalesTilId = utbetaling.stoenadsmottaker.value
+            henvisning = utbetaling.behandlingId.shortValue.value
             saksbehId = brukerTokenInfo.ident()
 
-            kodeEndringLinje = vedtak.type.toKodeEndring()
-            kodeKlassifik = vedtak.sak.sakType.toKodeKlassifikasjon()
-            sats = up.beloep
+            kodeEndringLinje = "NY"
+            kodeKlassifik = utbetaling.sakType.tilKodeklassifikasjon()
+            sats = utbetalingslinje.beloep
             typeSats = "MND"
             fradragTillegg = FradragTillegg.T
             brukKjoreplan = "N"
 
-            if (up.type == UtbetalingsperiodeType.OPPHOER) {
+            if (utbetalingslinje.type == Utbetalingslinjetype.OPPHOER) {
                 kodeStatusLinje = KodeStatusLinje.OPPH
-                datoStatusFom = up.periode.fom.atDay(1).toOppdragDate()
+                datoStatusFom = utbetalingslinje.periode.fra.toOppdragDate()
+            }
+
+            if (utbetalingslinje.erstatterId != null) {
+                refFagsystemId = utbetaling.sakId.value.toString()
+                refDelytelseId = utbetalingslinje.erstatterId.value.toString()
             }
         }
-
-    private fun SakType.toKodeFagomrade() =
-        when (this) {
-            SakType.BARNEPENSJON -> "BARNEPE"
-            SakType.OMSTILLINGSSTOENAD -> "OMSTILL"
-        }
-
-    private fun SakType.toKodeKlassifikasjon() =
-        when (this) {
-            SakType.BARNEPENSJON -> "BARNEPENSJON-OPTP"
-            SakType.OMSTILLINGSSTOENAD -> "OMSTILLINGOR"
-        }
-
-    private fun VedtakType.toKodeEndring() =
-        when (this) {
-            VedtakType.INNVILGELSE,
-            VedtakType.AVSLAG,
-            -> "NY"
-            else -> "ENDR"
-        }
 }
-
-private val VedtakDto.virkningstidspunkt: YearMonth
-    get() = (this.innhold as VedtakInnholdDto.VedtakBehandlingDto).virkningstidspunkt
 
 private fun LocalDate.toOppdragDate(): String =
     DateTimeFormatter.ofPattern("yyyy-MM-dd")
         .withZone(norskTidssone).format(this)
 
-class IkkeStoettetSimulering(vedtakType: VedtakType, behandlingId: UUID) : UgyldigForespoerselException(
+class IkkeStoettetSimulering(behandlingId: UUID) : UgyldigForespoerselException(
     code = "SIMULERING_IKKE_STOETTET",
-    detail = "Kan ikke simulere for vedtak av type $vedtakType",
+    detail = "Kan ikke simulere for behandlingId=$behandlingId",
     meta = mapOf("behandlingId" to behandlingId),
 )


### PR DESCRIPTION
- Delvis gjenbruk av mappingen fra oppdrag (som brukes ved iverksetting), men ikke fullt pga forskjellige namespace/mindre variasjoner på typene i kontraktene. Ser ikke verdien i å innføre noe abstraksjon for å hindre litt duplisering, det hadde blitt like mye (om ikke mer) kode.
- Testet ok med en revurdering