### PR TITLE
EY-3387: Støtte ulike statuser i kravgrunnlag

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
@@ -19,7 +19,6 @@ import no.nav.etterlatte.libs.common.sak.SakIDListe
 import no.nav.etterlatte.libs.common.sak.Saker
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
-import no.nav.etterlatte.libs.common.toUUID30
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
@@ -303,7 +302,7 @@ class BehandlingStatusServiceImpl(
         if (brevutfall?.feilutbetaling?.valg in listOf(FeilutbetalingValg.JA_VARSEL, FeilutbetalingValg.JA_INGEN_TK)) {
             logger.info("Oppretter oppgave av type ${OppgaveType.TILBAKEKREVING} for behandling ${behandling.id}")
             oppgaveService.opprettNyOppgaveMedSakOgReferanse(
-                referanse = behandling.id.toUUID30().value,
+                referanse = behandling.sak.id.toString(),
                 sakId = behandling.sak.id,
                 oppgaveKilde = OppgaveKilde.TILBAKEKREVING,
                 oppgaveType = OppgaveType.TILBAKEKREVING,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/HendelseDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/HendelseDao.kt
@@ -10,6 +10,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.getTidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.getTidspunktOrNull
 import no.nav.etterlatte.libs.common.tidspunkt.setTidspunkt
+import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingHendelseType
 import no.nav.etterlatte.libs.database.toList
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -128,17 +129,27 @@ class HendelseDao(private val connectionAutoclosing: ConnectionAutoclosing) {
         ),
     )
 
-    fun tilbakekrevingOpprettet(
+    fun tilbakekrevingHendelse(
         tilbakekrevingId: UUID,
         sakId: Long,
-    ) = behandlingOpprettet(
-        hendelseType = "TILBAKEKREVING:OPPRETTET",
-        behandling =
-            BehandlingOpprettet(
-                Tidspunkt.now(),
-                tilbakekrevingId,
-                sakId,
-            ),
+        vedtakId: Long?,
+        hendelse: TilbakekrevingHendelseType,
+        inntruffet: Tidspunkt,
+        saksbehandler: String?,
+        kommentar: String?,
+        begrunnelse: String?,
+    ) = lagreHendelse(
+        UlagretHendelse(
+            hendelse = "TILBAKEKREVING:${hendelse.name}",
+            inntruffet = inntruffet,
+            vedtakId = vedtakId,
+            behandlingId = tilbakekrevingId,
+            sakId = sakId,
+            ident = saksbehandler,
+            identType = "SAKSBEHANDLER".takeIf { saksbehandler != null },
+            kommentar = kommentar,
+            valgtBegrunnelse = begrunnelse,
+        ),
     )
 
     fun vedtakHendelse(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingDao.kt
@@ -73,6 +73,38 @@ class TilbakekrevingDao(private val connectionAutoclosing: ConnectionAutoclosing
         }
     }
 
+    fun hentNyesteTilbakekreving(sakId: Long): TilbakekrevingBehandling {
+        return connectionAutoclosing.hentConnection {
+            with(it) {
+                val tilbakekreving = hentNyesteTilbakekrevingForSak(this, sakId)
+                tilbakekreving?.copy(
+                    tilbakekreving =
+                        tilbakekreving.tilbakekreving.copy(
+                            perioder = selectTilbakekrevingsperioder(this, tilbakekreving.id),
+                        ),
+                ) ?: throw TilbakekrevingFinnesIkkeException("Tilbakekreving for sakId=$sakId finnes ikke")
+            }
+        }
+    }
+
+    private fun hentNyesteTilbakekrevingForSak(
+        connection: Connection,
+        sakId: Long,
+    ): TilbakekrevingBehandling? =
+        with(connection) {
+            val statement =
+                prepareStatement(
+                    """
+                    SELECT t.id, t.sak_id, s.saktype, s.fnr, s.enhet, t.opprettet, t.status, t.kravgrunnlag, t.vurdering, t.sende_brev 
+                    FROM tilbakekreving t INNER JOIN sak s on t.sak_id = s.id
+                    WHERE t.sak_id = ? 
+                    ORDER BY t.opprettet DESC LIMIT 1
+                    """.trimIndent(),
+                )
+            statement.setObject(1, sakId)
+            statement.executeQuery().singleOrNull { toTilbakekreving() }
+        }
+
     private fun selectTilbakekreving(
         connection: Connection,
         tilbakekrevingId: UUID,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingFeilmeldinger.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingFeilmeldinger.kt
@@ -5,6 +5,8 @@ import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 
 class TilbakekrevingHarMangelException(message: String) : InternfeilException(detail = message)
 
+class TilbakekrevingUnderBehandlingFinnesAlleredeException(message: String) : InternfeilException(detail = message)
+
 class TilbakekrevingFinnesIkkeException(message: String) : IkkeFunnetException(code = "NOT_FOUND", detail = message)
 
 class TilbakekrevingFeilTilstandException(message: String) : InternfeilException(detail = message)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingRoutes.kt
@@ -97,7 +97,7 @@ internal fun Route.tilbakekrevingRoutes(service: TilbakekrevingService) {
             }
         }
 
-        post("/oppgave-status") {
+        put("/oppgave-status") {
             kunSystembruker {
                 medBody<OppgaveStatusRequest> {
                     val sakId = requireNotNull(call.parameters["sakId"]).toLong()
@@ -107,7 +107,7 @@ internal fun Route.tilbakekrevingRoutes(service: TilbakekrevingService) {
             }
         }
 
-        post("/avbryt") {
+        put("/avbryt") {
             kunSystembruker {
                 val sakId = requireNotNull(call.parameters["sakId"]).toLong()
                 service.avbrytTilbakekreving(sakId)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingRoutes.kt
@@ -80,10 +80,10 @@ internal fun Route.tilbakekrevingRoutes(service: TilbakekrevingService) {
         }
     }
 
-    route("/tilbakekreving") {
+    route("/tilbakekreving/{$SAKID_CALL_PARAMETER}") {
         post {
-            medBody<Kravgrunnlag> {
-                kunSystembruker {
+            kunSystembruker {
+                medBody<Kravgrunnlag> {
                     try {
                         val tilbakekreving = service.opprettTilbakekreving(it)
                         call.respond(HttpStatusCode.OK, tilbakekreving)
@@ -96,8 +96,30 @@ internal fun Route.tilbakekrevingRoutes(service: TilbakekrevingService) {
                 }
             }
         }
+
+        post("/oppgave-status") {
+            kunSystembruker {
+                medBody<OppgaveStatusRequest> {
+                    val sakId = requireNotNull(call.parameters["sakId"]).toLong()
+                    service.endreTilbakekrevingOppgaveStatus(sakId, it.paaVent)
+                    call.respond(HttpStatusCode.OK)
+                }
+            }
+        }
+
+        post("/avbryt") {
+            kunSystembruker {
+                val sakId = requireNotNull(call.parameters["sakId"]).toLong()
+                service.avbrytTilbakekreving(sakId)
+                call.respond(HttpStatusCode.OK)
+            }
+        }
     }
 }
+
+data class OppgaveStatusRequest(
+    val paaVent: Boolean,
+)
 
 data class TilbakekrevingSendeBrevRequest(
     val skalSendeBrev: Boolean,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
@@ -55,6 +55,15 @@ class TilbakekrevingService(
                 sakDao.hentSak(kravgrunnlag.sakId.value)
                     ?: throw TilbakekrevingHarMangelException("Tilbakekreving mangler sak")
 
+            tilbakekrevingDao.hentTilbakekrevinger(sak.id)
+                .find { it.underBehandlingEllerFattetVedtak() }
+                ?.let {
+                    throw TilbakekrevingUnderBehandlingFinnesAlleredeException(
+                        "Det finnes allerede en tilbakekreving under behandling i denne saken. Denne må ferdigstilles " +
+                            "eller avbrytes før det kan opprettes en ny tilbakekrevingsbehandling",
+                    )
+                }
+
             val tilbakekreving =
                 tilbakekrevingDao.lagreTilbakekreving(
                     TilbakekrevingBehandling.ny(kravgrunnlag, sak),

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
@@ -502,7 +502,7 @@ class TilbakekrevingService(
     }
 
     private fun sjekkAtTilbakekrevingKanAvbrytes(tilbakekreving: TilbakekrevingBehandling) {
-        if (!tilbakekreving.kanAvbrytes()) {
+        if (!tilbakekreving.underBehandlingEllerFattetVedtak()) {
             throw TilbakekrevingFeilTilstandException(
                 "Tilbakekreving har status ${tilbakekreving.status} og kan ikke avbrytes",
             )

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
@@ -60,28 +60,28 @@ class TilbakekrevingService(
                     TilbakekrevingBehandling.ny(kravgrunnlag, sak),
                 )
 
-            oppgaveService.hentOppgaverForReferanse(kravgrunnlag.sisteUtbetalingslinjeId.value)
-                .filter { it.type == OppgaveType.TILBAKEKREVING }.let {
-                    if (it.isEmpty()) {
-                        logger.info("Fant ingen tilbakekrevingsoppgave, oppretter ny")
-                        oppgaveService.opprettNyOppgaveMedSakOgReferanse(
-                            referanse = tilbakekreving.id.toString(),
-                            sakId = tilbakekreving.sak.id,
-                            oppgaveKilde = OppgaveKilde.TILBAKEKREVING,
-                            oppgaveType = OppgaveType.TILBAKEKREVING,
-                            merknad = "Kravgrunnlag mottatt",
-                        )
-                    } else {
-                        val eksisterendeOppgave = it.single()
+            val oppgaveFraBehandlingMedFeilutbetaling =
+                oppgaveService.hentOppgaverForReferanse(kravgrunnlag.sakId.value.toString())
+                    .filter { it.type == OppgaveType.TILBAKEKREVING && it.merknad == "Venter på kravgrunnlag" }
+                    .maxByOrNull { it.opprettet }
 
-                        logger.info("Kobler nytt kravgrunnlag med eksisterende oppgave ${eksisterendeOppgave.id}")
-                        oppgaveService.oppdaterReferanseOgMerknad(
-                            oppgaveId = eksisterendeOppgave.id,
-                            referanse = tilbakekreving.id.toString(),
-                            merknad = "Kravgrunnlag mottatt",
-                        )
-                    }
-                }
+            if (oppgaveFraBehandlingMedFeilutbetaling != null) {
+                logger.info("Kobler nytt kravgrunnlag med eksisterende oppgave ${oppgaveFraBehandlingMedFeilutbetaling.id}")
+                oppgaveService.oppdaterReferanseOgMerknad(
+                    oppgaveId = oppgaveFraBehandlingMedFeilutbetaling.id,
+                    referanse = tilbakekreving.id.toString(),
+                    merknad = "Kravgrunnlag mottatt",
+                )
+            } else {
+                logger.info("Fant ingen tilbakekrevingsoppgave, oppretter ny")
+                oppgaveService.opprettNyOppgaveMedSakOgReferanse(
+                    referanse = tilbakekreving.id.toString(),
+                    sakId = tilbakekreving.sak.id,
+                    oppgaveKilde = OppgaveKilde.TILBAKEKREVING,
+                    oppgaveType = OppgaveType.TILBAKEKREVING,
+                    merknad = "Kravgrunnlag mottatt",
+                )
+            }
 
             tilbakekrevingHendelse(tilbakekreving, TilbakekrevingHendelseType.OPPRETTET)
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
@@ -71,7 +71,7 @@ class TilbakekrevingService(
 
             val oppgaveFraBehandlingMedFeilutbetaling =
                 oppgaveService.hentOppgaverForReferanse(kravgrunnlag.sakId.value.toString())
-                    .filter { it.type == OppgaveType.TILBAKEKREVING && it.merknad == "Venter på kravgrunnlag" }
+                    .filter { it.type == OppgaveType.TILBAKEKREVING }
                     .maxByOrNull { it.opprettet }
 
             if (oppgaveFraBehandlingMedFeilutbetaling != null) {
@@ -292,7 +292,7 @@ class TilbakekrevingService(
                 tilbakekreving.copy(status = TilbakekrevingStatus.FATTET_VEDTAK),
             )
 
-        tilbakekrevingHendelse(tilbakekreving, vedtakId, saksbehandler, TilbakekrevingHendelseType.FATTET_VEDTAK)
+        tilbakekrevingHendelse(tilbakekreving, TilbakekrevingHendelseType.FATTET_VEDTAK, vedtakId, saksbehandler)
 
         tilbakekrevinghendelser.sendTilbakekreving(
             statistikkTilbakekreving = tilbakekrevingForStatistikk(tilbakekreving),
@@ -341,7 +341,7 @@ class TilbakekrevingService(
                     tilbakekreving.copy(status = TilbakekrevingStatus.ATTESTERT),
                 )
 
-            tilbakekrevingHendelse(tilbakekreving, vedtak.id, saksbehandler, TilbakekrevingHendelseType.ATTESTERT, kommentar)
+            tilbakekrevingHendelse(tilbakekreving, TilbakekrevingHendelseType.ATTESTERT, vedtak.id, saksbehandler, kommentar)
 
             oppgaveService.ferdigStillOppgaveUnderBehandling(
                 referanse = tilbakekreving.id.toString(),
@@ -414,15 +414,8 @@ class TilbakekrevingService(
     private fun tilbakekrevingHendelse(
         tilbakekreving: TilbakekrevingBehandling,
         hendelseType: TilbakekrevingHendelseType,
-    ) {
-        tilbakekrevingHendelse(tilbakekreving, null, null, hendelseType, null, null)
-    }
-
-    private fun tilbakekrevingHendelse(
-        tilbakekreving: TilbakekrevingBehandling,
-        vedtakId: Long?,
-        saksbehandler: Saksbehandler?,
-        hendelseType: TilbakekrevingHendelseType,
+        vedtakId: Long? = null,
+        saksbehandler: Saksbehandler? = null,
         kommentar: String? = null,
         begrunnelse: String? = null,
     ) {

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingStatusServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingStatusServiceTest.kt
@@ -32,7 +32,6 @@ import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.oppgave.SakIdOgReferanse
 import no.nav.etterlatte.libs.common.oppgave.VedtakEndringDTO
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.common.toUUID30
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.nyKontekstMedBruker
@@ -353,7 +352,7 @@ internal class BehandlingStatusServiceTest {
             behandlingService.registrerVedtakHendelse(behandlingId, iverksettVedtak, HendelseType.IVERKSATT)
             behandlingInfoDao.hentBrevutfall(behandlingId)
             oppgaveService.opprettNyOppgaveMedSakOgReferanse(
-                referanse = behandlingId.toUUID30().value,
+                referanse = sakId.toString(),
                 sakId = sakId,
                 oppgaveKilde = OppgaveKilde.TILBAKEKREVING,
                 oppgaveType = OppgaveType.TILBAKEKREVING,

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingDaoTest.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.behandling.tilbakekreving
 import behandling.tilbakekreving.kravgrunnlag
 import behandling.tilbakekreving.tilbakekrevingVurdering
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.mockk
 import no.nav.etterlatte.ConnectionAutoclosingTest
 import no.nav.etterlatte.DatabaseExtension
@@ -84,6 +85,16 @@ class TilbakekrevingDaoTest(val dataSource: DataSource) {
         tilbakekrevinger.forEach {
             it.tilbakekreving.perioder.size shouldBe 1
         }
+    }
+
+    @Test
+    fun `Hente tilbakekreving med sakid`() {
+        tilbakekrevingDao.lagreTilbakekreving(tilbakekreving(sak))
+        val tilbakekrevingNyeste = tilbakekrevingDao.lagreTilbakekreving(tilbakekreving(sak))
+        val tilbakekreving = tilbakekrevingDao.hentNyesteTilbakekreving(sak.id)
+
+        tilbakekreving shouldNotBe null
+        tilbakekreving.id shouldBe tilbakekrevingNyeste.id
     }
 
     companion object {

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingRoutesIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingRoutesIntegrationTest.kt
@@ -236,7 +236,7 @@ class TilbakekrevingRoutesIntegrationTest : BehandlingIntegrationTest() {
         withTestApplication { client ->
             val tilbakekreving = opprettTilbakekrevingOgTildelOppgave(client)
 
-            client.postAndAssertOk(
+            client.putAndAssertOk(
                 "/tilbakekreving/${tilbakekreving.sak.id}/oppgave-status",
                 systemBruker,
                 OppgaveStatusRequest(paaVent = true),
@@ -248,7 +248,7 @@ class TilbakekrevingRoutesIntegrationTest : BehandlingIntegrationTest() {
                 oppgave.merknad shouldBe "Kravgrunnlag er sperret"
             }
 
-            client.postAndAssertOk(
+            client.putAndAssertOk(
                 "/tilbakekreving/${tilbakekreving.sak.id}/oppgave-status",
                 systemBruker,
                 OppgaveStatusRequest(paaVent = false),
@@ -267,7 +267,7 @@ class TilbakekrevingRoutesIntegrationTest : BehandlingIntegrationTest() {
         withTestApplication { client ->
             val tilbakekreving = opprettTilbakekrevingOgTildelOppgave(client)
 
-            client.postAndAssertOk(
+            client.putAndAssertOk(
                 "/tilbakekreving/${tilbakekreving.sak.id}/avbryt",
                 systemBruker,
             )

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingRoutesIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingRoutesIntegrationTest.kt
@@ -257,7 +257,7 @@ class TilbakekrevingRoutesIntegrationTest : BehandlingIntegrationTest() {
             inTransaction {
                 val oppgave = oppgaveService.hentOppgaverForReferanse(tilbakekreving.id.toString()).first()
                 oppgave.status shouldBe Status.UNDER_BEHANDLING
-                oppgave.merknad shouldBe ""
+                oppgave.merknad shouldBe "Sperre på kravgrunnlag opphevet"
             }
         }
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingServiceIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingServiceIntegrationTest.kt
@@ -21,6 +21,7 @@ import no.nav.etterlatte.behandling.klienter.TilbakekrevingKlient
 import no.nav.etterlatte.behandling.klienter.VedtakKlient
 import no.nav.etterlatte.behandling.tilbakekreving.TilbakekrevingDao
 import no.nav.etterlatte.behandling.tilbakekreving.TilbakekrevingService
+import no.nav.etterlatte.behandling.tilbakekreving.TilbakekrevingUnderBehandlingFinnesAlleredeException
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.funksjonsbrytere.DummyFeatureToggleService
 import no.nav.etterlatte.inTransaction
@@ -54,6 +55,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 import java.util.UUID
 import kotlin.random.Random
@@ -194,6 +196,18 @@ internal class TilbakekrevingServiceIntegrationTest : BehandlingIntegrationTest(
                 it[EVENT_NAME_KEY].textValue() shouldBe TilbakekrevingHendelseType.OPPRETTET.lagEventnameForType()
                 it[TILBAKEKREVING_STATISTIKK_RIVER_KEY] shouldNotBe null
             }
+        }
+    }
+
+    @Test
+    fun `skal ikke kunne opprette tilbakekrevingsbehandling dersom det allerede finnes en`() {
+        val sak = inTransaction { sakDao.opprettSak(bruker, SakType.BARNEPENSJON, enhet) }
+
+        val tilbakekreving = service.opprettTilbakekreving(kravgrunnlag(sak))
+        tilbakekreving.status shouldBe TilbakekrevingStatus.OPPRETTET
+
+        assertThrows<TilbakekrevingUnderBehandlingFinnesAlleredeException> {
+            service.opprettTilbakekreving(kravgrunnlag(sak))
         }
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingServiceIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingServiceIntegrationTest.kt
@@ -122,12 +122,11 @@ internal class TilbakekrevingServiceIntegrationTest : BehandlingIntegrationTest(
     @Test
     fun `skal opprette tilbakekrevingsbehandling fra kravgrunnlag og koble mot eksisterende oppgave`() {
         val sak = inTransaction { sakDao.opprettSak(bruker, SakType.BARNEPENSJON, enhet) }
-        val behandlingId = UUID.randomUUID()
 
         val oppgaveFraBehandlingMedFeilutbetaling =
             inTransaction {
                 oppgaveService.opprettNyOppgaveMedSakOgReferanse(
-                    referanse = behandlingId.toUUID30().value,
+                    referanse = sak.id.toString(),
                     sakId = sak.id,
                     oppgaveKilde = OppgaveKilde.TILBAKEKREVING,
                     oppgaveType = OppgaveType.TILBAKEKREVING,
@@ -135,11 +134,11 @@ internal class TilbakekrevingServiceIntegrationTest : BehandlingIntegrationTest(
                 )
             }
 
-        oppgaveFraBehandlingMedFeilutbetaling.referanse shouldBe behandlingId.toUUID30().value
+        oppgaveFraBehandlingMedFeilutbetaling.referanse shouldBe sak.id.toString()
         oppgaveFraBehandlingMedFeilutbetaling.status shouldBe Status.NY
         oppgaveFraBehandlingMedFeilutbetaling.merknad shouldBe "Venter på kravgrunnlag"
 
-        val tilbakekreving = service.opprettTilbakekreving(kravgrunnlag(sak, behandlingId.toUUID30()))
+        val tilbakekreving = service.opprettTilbakekreving(kravgrunnlag(sak))
         val sisteLagretHendelse = inTransaction { hendelseDao.hentHendelserISak(sak.id).maxBy { it.opprettet } }
         val oppgave = inTransaction { oppgaveService.hentOppgaverForReferanse(tilbakekreving.id.toString()).first() }
 
@@ -182,7 +181,7 @@ internal class TilbakekrevingServiceIntegrationTest : BehandlingIntegrationTest(
 
         oppgaverFraReferanse.size shouldBe 0
 
-        val tilbakekreving = service.opprettTilbakekreving(kravgrunnlag(sak, behandlingId.toUUID30()))
+        val tilbakekreving = service.opprettTilbakekreving(kravgrunnlag(sak))
         val oppgave = inTransaction { oppgaveService.hentOppgaverForReferanse(tilbakekreving.id.toString()).first() }
 
         oppgave.referanse shouldBe tilbakekreving.id.toString()

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/klienter/BehandlingKlient.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.tilbakekreving.klienter
 
 import io.ktor.client.HttpClient
 import io.ktor.client.request.post
+import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
@@ -40,7 +41,7 @@ class BehandlingKlient(
     ) {
         logger.info("Setter tilbakekreving på vent i sak ${sakId.value}")
         try {
-            httpClient.post("$url/tilbakekreving/${sakId.value}/oppgave-status") {
+            httpClient.put("$url/tilbakekreving/${sakId.value}/oppgave-status") {
                 contentType(ContentType.Application.Json)
                 setBody(OppgaveStatusRequest(paaVent))
             }
@@ -52,7 +53,7 @@ class BehandlingKlient(
     suspend fun avbrytTilbakekreving(sakId: SakId) {
         logger.info("Avbryter tilbakekreving i sak ${sakId.value}")
         try {
-            httpClient.post("$url/tilbakekreving/${sakId.value}/avbryt") {
+            httpClient.put("$url/tilbakekreving/${sakId.value}/avbryt") {
                 contentType(ContentType.Application.Json)
             }
         } catch (e: Exception) {

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/klienter/BehandlingKlient.kt
@@ -6,6 +6,7 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import no.nav.etterlatte.libs.common.tilbakekreving.Kravgrunnlag
+import no.nav.etterlatte.libs.common.tilbakekreving.SakId
 import org.slf4j.LoggerFactory
 
 class BehandlingKlient(
@@ -14,15 +15,52 @@ class BehandlingKlient(
 ) {
     private val logger = LoggerFactory.getLogger(BehandlingKlient::class.java)
 
-    suspend fun opprettTilbakekreving(kravgrunnlag: Kravgrunnlag) {
-        logger.info("Oppretter tilbakekreving i behandling")
+    suspend fun opprettTilbakekreving(
+        sakId: SakId,
+        kravgrunnlag: Kravgrunnlag,
+    ) {
+        logger.info("Oppretter tilbakekreving for ${sakId.value} og kravgrunnlag ${kravgrunnlag.kravgrunnlagId.value}")
         try {
-            httpClient.post("$url/tilbakekreving") {
+            httpClient.post("$url/tilbakekreving/${sakId.value}") {
                 contentType(ContentType.Application.Json)
                 setBody(kravgrunnlag)
             }
         } catch (e: Exception) {
-            throw Exception("Klarte ikke å opprette behandling for tilbakekreving=${kravgrunnlag.kravgrunnlagId.value}", e)
+            throw Exception(
+                "Klarte ikke å opprette tilbakekreving i sak ${sakId.value} og " +
+                    "kravgrunnlag ${kravgrunnlag.kravgrunnlagId.value}",
+                e,
+            )
+        }
+    }
+
+    suspend fun endreOppgaveStatusForTilbakekreving(
+        sakId: SakId,
+        paaVent: Boolean,
+    ) {
+        logger.info("Setter tilbakekreving på vent i sak ${sakId.value}")
+        try {
+            httpClient.post("$url/tilbakekreving/${sakId.value}/oppgave-status") {
+                contentType(ContentType.Application.Json)
+                setBody(OppgaveStatusRequest(paaVent))
+            }
+        } catch (e: Exception) {
+            throw Exception("Klarte ikke å sette tilbakekreving for sak ${sakId.value} på vent", e)
+        }
+    }
+
+    suspend fun avbrytTilbakekreving(sakId: SakId) {
+        logger.info("Avbryter tilbakekreving i sak ${sakId.value}")
+        try {
+            httpClient.post("$url/tilbakekreving/${sakId.value}/avbryt") {
+                contentType(ContentType.Application.Json)
+            }
+        } catch (e: Exception) {
+            throw Exception("Klarte ikke å avbryte tilbakekreving for sak $sakId", e)
         }
     }
 }
+
+data class OppgaveStatusRequest(
+    val paaVent: Boolean,
+)

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumer.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumer.kt
@@ -9,7 +9,6 @@ import no.nav.etterlatte.libs.common.logging.withLogContext
 import no.nav.etterlatte.mq.EtterlatteJmsConnectionFactory
 import no.nav.etterlatte.tilbakekreving.hendelse.TilbakekrevingHendelseRepository
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.KravgrunnlagJaxb.toDetaljertKravgrunnlagDto
-import no.nav.tilbakekreving.kravgrunnlag.detalj.v1.DetaljertKravgrunnlagDto
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import kotlin.system.exitProcess
@@ -44,9 +43,9 @@ class KravgrunnlagConsumer(
                     payload,
                 )
 
-                sjekkForventetStatus(detaljertKravgrunnlag)
+                val kravgrunnlag = KravgrunnlagMapper.toKravgrunnlag(detaljertKravgrunnlag)
 
-                kravgrunnlagService.opprettTilbakekreving(detaljertKravgrunnlag)
+                kravgrunnlagService.haandterKravgrunnlag(kravgrunnlag)
             } catch (t: Throwable) {
                 logger.error("Feilet under mottak av kravgrunnlag (Sjekk sikkerlogg for payload", t)
                 sikkerLogg.error("Feilet under mottak av kravgrunnlag: ${kv("kravgrunnlag", payload)}", t)
@@ -55,13 +54,6 @@ class KravgrunnlagConsumer(
                 throw t
             }
         }
-
-    private fun sjekkForventetStatus(detaljertKravgrunnlag: DetaljertKravgrunnlagDto) {
-        val status = detaljertKravgrunnlag.kodeStatusKrav
-        if (detaljertKravgrunnlag.kodeStatusKrav != "NY") {
-            throw Error("KodeStatusKrav hadde verdien $status, men forventet verdien NY - Dette må håndteres manuelt")
-        }
-    }
 
     private fun exceptionListener() =
         ExceptionListener {

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagService.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagService.kt
@@ -1,14 +1,72 @@
 package no.nav.etterlatte.tilbakekreving.kravgrunnlag
 
 import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.libs.common.tilbakekreving.Kravgrunnlag
+import no.nav.etterlatte.libs.common.tilbakekreving.KravgrunnlagStatus
 import no.nav.etterlatte.tilbakekreving.klienter.BehandlingKlient
-import no.nav.tilbakekreving.kravgrunnlag.detalj.v1.DetaljertKravgrunnlagDto
+import org.slf4j.LoggerFactory
 
 class KravgrunnlagService(private val behandlingKlient: BehandlingKlient) {
-    fun opprettTilbakekreving(detaljertKravgrunnlagDto: DetaljertKravgrunnlagDto) {
-        val kravgrunnlag = KravgrunnlagMapper.toKravgrunnlag(detaljertKravgrunnlagDto)
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun haandterKravgrunnlag(kravgrunnlag: Kravgrunnlag) {
         runBlocking {
-            behandlingKlient.opprettTilbakekreving(kravgrunnlag)
+            logger.info("Håndterer kravgrunnlag ${kravgrunnlag.kravgrunnlagId} med status ${kravgrunnlag.status}")
+
+            when (kravgrunnlag.status) {
+                KravgrunnlagStatus.NY -> opprettTilbakekreving(kravgrunnlag)
+                KravgrunnlagStatus.SPER -> settTilbakekrevingPaaVent(kravgrunnlag)
+                KravgrunnlagStatus.ENDR -> endreTilbakekreving(kravgrunnlag)
+                KravgrunnlagStatus.AVSL -> avsluttTilbakekreving(kravgrunnlag)
+                else -> {
+                    throw Error(
+                        "Kravgrunnlag hadde status ${kravgrunnlag.status}, denne statusen er ikke støttet og " +
+                            "må håndteres manuelt. Kravgrunnlaget er lagret i databasen.",
+                    )
+                }
+            }
         }
     }
+
+    private fun opprettTilbakekreving(kravgrunnlag: Kravgrunnlag) {
+        runBlocking {
+            logger.info("Oppretter tilbakekreving fra kravgrunnlag ${kravgrunnlag.kravgrunnlagId}")
+            behandlingKlient.opprettTilbakekreving(kravgrunnlag.sakId, kravgrunnlag)
+        }
+    }
+
+    private fun settTilbakekrevingPaaVent(kravgrunnlag: Kravgrunnlag) {
+        runBlocking {
+            logger.info("Setter tilbakekreving på vent pga endret status i kravgrunnlag ${kravgrunnlag.kravgrunnlagId}")
+            behandlingKlient.endreOppgaveStatusForTilbakekreving(kravgrunnlag.sakId, paaVent = true)
+        }
+    }
+
+    private fun endreTilbakekreving(kravgrunnlag: Kravgrunnlag) {
+        runBlocking {
+            if (kravgrunnlag.perioder.isEmpty()) {
+                logger.info("Kravgrunnlag er ikke endret - setter oppgave tilbake dersom den har status \"På vent\"")
+                behandlingKlient.endreOppgaveStatusForTilbakekreving(kravgrunnlag.sakId, paaVent = false)
+            } else {
+                logger.info("Kravgrunnlag er endret - avbryter eksisterende tilbakekreving og oppretter ny")
+                behandlingKlient.avbrytTilbakekreving(kravgrunnlag.sakId)
+                behandlingKlient.opprettTilbakekreving(kravgrunnlag.sakId, kravgrunnlag)
+            }
+        }
+    }
+
+    private fun avsluttTilbakekreving(kravgrunnlag: Kravgrunnlag) {
+        runBlocking {
+            logger.info("Kravgrunnlag har blitt nullet ut og er ikke lenger aktuelt - avbryter tilbakekreving")
+            behandlingKlient.avbrytTilbakekreving(kravgrunnlag.sakId)
+        }
+    }
+}
+
+data class Test(val str1: String, val str2: String)
+
+fun main() {
+    val list = listOf(Test("123", "123"), Test("456", "789"))
+
+    list
 }

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagService.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagService.kt
@@ -62,11 +62,3 @@ class KravgrunnlagService(private val behandlingKlient: BehandlingKlient) {
         }
     }
 }
-
-data class Test(val str1: String, val str2: String)
-
-fun main() {
-    val list = listOf(Test("123", "123"), Test("456", "789"))
-
-    list
-}

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagService.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagService.kt
@@ -30,14 +30,16 @@ class KravgrunnlagService(private val behandlingKlient: BehandlingKlient) {
 
     private fun opprettTilbakekreving(kravgrunnlag: Kravgrunnlag) {
         runBlocking {
-            logger.info("Oppretter tilbakekreving fra kravgrunnlag ${kravgrunnlag.kravgrunnlagId}")
+            logger.info("Oppretter tilbakekreving fra kravgrunnlag ${kravgrunnlag.kravgrunnlagId.value}")
             behandlingKlient.opprettTilbakekreving(kravgrunnlag.sakId, kravgrunnlag)
         }
     }
 
     private fun settTilbakekrevingPaaVent(kravgrunnlag: Kravgrunnlag) {
         runBlocking {
-            logger.info("Setter tilbakekreving på vent pga endret status i kravgrunnlag ${kravgrunnlag.kravgrunnlagId}")
+            logger.info(
+                "Setter tilbakekreving på vent pga endret status i kravgrunnlag ${kravgrunnlag.kravgrunnlagId.value}",
+            )
             behandlingKlient.endreOppgaveStatusForTilbakekreving(kravgrunnlag.sakId, paaVent = true)
         }
     }
@@ -45,10 +47,16 @@ class KravgrunnlagService(private val behandlingKlient: BehandlingKlient) {
     private fun endreTilbakekreving(kravgrunnlag: Kravgrunnlag) {
         runBlocking {
             if (kravgrunnlag.perioder.isEmpty()) {
-                logger.info("Kravgrunnlag er ikke endret - setter oppgave tilbake dersom den har status \"På vent\"")
+                logger.info(
+                    "Kravgrunnlag ${kravgrunnlag.kravgrunnlagId.value} er ikke endret - setter oppgave tilbake " +
+                        "dersom den har status \"På vent\"",
+                )
                 behandlingKlient.endreOppgaveStatusForTilbakekreving(kravgrunnlag.sakId, paaVent = false)
             } else {
-                logger.info("Kravgrunnlag er endret - avbryter eksisterende tilbakekreving og oppretter ny")
+                logger.info(
+                    "Kravgrunnlag ${kravgrunnlag.kravgrunnlagId.value} er endret - avbryter eksisterende " +
+                        "tilbakekreving og oppretter ny",
+                )
                 behandlingKlient.avbrytTilbakekreving(kravgrunnlag.sakId)
                 behandlingKlient.opprettTilbakekreving(kravgrunnlag.sakId, kravgrunnlag)
             }
@@ -57,7 +65,10 @@ class KravgrunnlagService(private val behandlingKlient: BehandlingKlient) {
 
     private fun avsluttTilbakekreving(kravgrunnlag: Kravgrunnlag) {
         runBlocking {
-            logger.info("Kravgrunnlag har blitt nullet ut og er ikke lenger aktuelt - avbryter tilbakekreving")
+            logger.info(
+                "Kravgrunnlag ${kravgrunnlag.kravgrunnlagId.value} har blitt nullet ut og er ikke lenger aktuelt - " +
+                    "avbryter tilbakekreving",
+            )
             behandlingKlient.avbrytTilbakekreving(kravgrunnlag.sakId)
         }
     }

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/TestKravgrunnlagRoutes.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/TestKravgrunnlagRoutes.kt
@@ -11,9 +11,10 @@ import no.nav.tilbakekreving.kravgrunnlag.detalj.v1.DetaljertKravgrunnlagDto
 fun Route.testKravgrunnlagRoutes(service: KravgrunnlagService) {
     route("kravgrunnlag") {
         post {
-            val xml = call.receive<DetaljertKravgrunnlagDto>()
-            service.opprettTilbakekreving(xml)
-            call.respond(xml)
+            val dto = call.receive<DetaljertKravgrunnlagDto>()
+            val kravgrunnlag = KravgrunnlagMapper.toKravgrunnlag(dto)
+            service.haandterKravgrunnlag(kravgrunnlag)
+            call.respond(dto)
         }
     }
 }

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/TestHelper.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/TestHelper.kt
@@ -1,6 +1,20 @@
 package no.nav.etterlatte.tilbakekreving
 
+import no.nav.etterlatte.libs.common.UUID30
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tilbakekreving.FattetVedtak
+import no.nav.etterlatte.libs.common.tilbakekreving.Grunnlagsbeloep
+import no.nav.etterlatte.libs.common.tilbakekreving.KlasseKode
+import no.nav.etterlatte.libs.common.tilbakekreving.KlasseType
+import no.nav.etterlatte.libs.common.tilbakekreving.Kontrollfelt
+import no.nav.etterlatte.libs.common.tilbakekreving.Kravgrunnlag
+import no.nav.etterlatte.libs.common.tilbakekreving.KravgrunnlagId
+import no.nav.etterlatte.libs.common.tilbakekreving.KravgrunnlagPeriode
+import no.nav.etterlatte.libs.common.tilbakekreving.KravgrunnlagStatus
+import no.nav.etterlatte.libs.common.tilbakekreving.NavIdent
+import no.nav.etterlatte.libs.common.tilbakekreving.Periode
+import no.nav.etterlatte.libs.common.tilbakekreving.SakId
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingAarsak
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingHjemmel
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingPeriodeVedtak
@@ -9,10 +23,13 @@ import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingSkyld
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingVedtak
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingsbelopFeilkontoVedtak
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingsbelopYtelseVedtak
+import no.nav.etterlatte.libs.common.tilbakekreving.VedtakId
+import no.nav.etterlatte.libs.common.toUUID30
 import java.io.FileNotFoundException
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
+import java.util.UUID
 
 fun readFile(file: String) =
     object {}.javaClass.getResource(file)?.readText()
@@ -60,3 +77,56 @@ fun tilbakekrevingsvedtak(vedtakId: Long = 1) =
         kravgrunnlagId = "1",
         kontrollfelt = "2023-09-19-10.01.03.842916",
     )
+
+fun kravgrunnlag(
+    sak: Sak = Sak("12345678901", SakType.BARNEPENSJON, 1L, "12345"),
+    behandlingId: UUID30 = UUID.randomUUID().toUUID30(),
+    status: KravgrunnlagStatus = KravgrunnlagStatus.NY,
+    perioder: List<KravgrunnlagPeriode>? = null,
+) = Kravgrunnlag(
+    kravgrunnlagId = KravgrunnlagId(123L),
+    sakId = SakId(sak.id),
+    vedtakId = VedtakId(2L),
+    kontrollFelt = Kontrollfelt(""),
+    status = status,
+    saksbehandler = NavIdent(""),
+    sisteUtbetalingslinjeId = behandlingId,
+    perioder =
+        perioder ?: listOf(
+            KravgrunnlagPeriode(
+                periode =
+                    Periode(
+                        fraOgMed = YearMonth.of(2023, 1),
+                        tilOgMed = YearMonth.of(2023, 2),
+                    ),
+                skatt = BigDecimal(200),
+                grunnlagsbeloep =
+                    listOf(
+                        Grunnlagsbeloep(
+                            klasseKode = KlasseKode(""),
+                            klasseType = KlasseType.YTEL,
+                            bruttoUtbetaling = BigDecimal(1000),
+                            nyBruttoUtbetaling = BigDecimal(1200),
+                            bruttoTilbakekreving = BigDecimal(200),
+                            beloepSkalIkkeTilbakekreves = BigDecimal(200),
+                            skatteProsent = BigDecimal(20),
+                            resultat = null,
+                            skyld = null,
+                            aarsak = null,
+                        ),
+                        Grunnlagsbeloep(
+                            klasseKode = KlasseKode(""),
+                            klasseType = KlasseType.FEIL,
+                            bruttoUtbetaling = BigDecimal(0),
+                            nyBruttoUtbetaling = BigDecimal(0),
+                            bruttoTilbakekreving = BigDecimal(0),
+                            beloepSkalIkkeTilbakekreves = BigDecimal(0),
+                            skatteProsent = BigDecimal(0),
+                            resultat = null,
+                            skyld = null,
+                            aarsak = null,
+                        ),
+                    ),
+            ),
+        ),
+)

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumerTest.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumerTest.kt
@@ -9,7 +9,6 @@ import no.nav.etterlatte.tilbakekreving.hendelse.TilbakekrevingHendelseRepositor
 import no.nav.etterlatte.tilbakekreving.readFile
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.math.BigInteger
 
 class KravgrunnlagConsumerTest {
     private val connectionFactory: EtterlatteJmsConnectionFactory = DummyJmsConnectionFactory()
@@ -35,17 +34,17 @@ class KravgrunnlagConsumerTest {
         simulerKravgrunnlagsmeldingFraTilbakekrevingskomponenten()
 
         verify(exactly = 1) {
-            kravgrunnlagService.opprettTilbakekreving(match { it.kravgrunnlagId == BigInteger.valueOf(302004) })
+            kravgrunnlagService.haandterKravgrunnlag(any())
         }
     }
 
     @Test
     fun `skal motta kravgrunnlag paa nytt dersom noe feiler`() {
-        every { kravgrunnlagService.opprettTilbakekreving(any()) } throws Exception("Noe feilet") andThen Unit
+        every { kravgrunnlagService.haandterKravgrunnlag(any()) } throws Exception("Noe feilet") andThen Unit
         simulerKravgrunnlagsmeldingFraTilbakekrevingskomponenten()
 
         verify(exactly = 2) {
-            kravgrunnlagService.opprettTilbakekreving(match { it.kravgrunnlagId == BigInteger.valueOf(302004) })
+            kravgrunnlagService.haandterKravgrunnlag(any())
         }
     }
 

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagServiceTest.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagServiceTest.kt
@@ -1,0 +1,97 @@
+package no.nav.etterlatte.tilbakekreving.kravgrunnlag
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.confirmVerified
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import no.nav.etterlatte.libs.common.tilbakekreving.KravgrunnlagStatus
+import no.nav.etterlatte.tilbakekreving.klienter.BehandlingKlient
+import no.nav.etterlatte.tilbakekreving.kravgrunnlag
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class KravgrunnlagServiceTest {
+    private lateinit var kravgrunnlagService: KravgrunnlagService
+    private lateinit var behandlingKlient: BehandlingKlient
+
+    @BeforeEach
+    fun beforeEach() {
+        behandlingKlient = mockk<BehandlingKlient>()
+        kravgrunnlagService = KravgrunnlagService(behandlingKlient)
+    }
+
+    @AfterEach
+    fun afterEach() {
+        confirmVerified(behandlingKlient)
+    }
+
+    @Test
+    fun `skal opprette ny tilbakekreving naar kravgrunnlag har status NY`() {
+        val kravgrunnlag = kravgrunnlag(status = KravgrunnlagStatus.NY)
+
+        coEvery { behandlingKlient.opprettTilbakekreving(any(), any()) } just runs
+
+        kravgrunnlagService.haandterKravgrunnlag(kravgrunnlag)
+
+        coVerify(exactly = 1) {
+            behandlingKlient.opprettTilbakekreving(kravgrunnlag.sakId, kravgrunnlag)
+        }
+    }
+
+    @Test
+    fun `skal avbryte tilbakekreving naar kravgrunnlag har status AVSL`() {
+        val kravgrunnlag = kravgrunnlag(status = KravgrunnlagStatus.AVSL)
+
+        coEvery { behandlingKlient.avbrytTilbakekreving(any()) } just runs
+
+        kravgrunnlagService.haandterKravgrunnlag(kravgrunnlag)
+
+        coVerify(exactly = 1) {
+            behandlingKlient.avbrytTilbakekreving(kravgrunnlag.sakId)
+        }
+    }
+
+    @Test
+    fun `skal sette tilbakekreving paa vent naar kravgrunnlag har status SPER`() {
+        val kravgrunnlag = kravgrunnlag(status = KravgrunnlagStatus.SPER)
+
+        coEvery { behandlingKlient.endreOppgaveStatusForTilbakekreving(any(), any()) } just runs
+
+        kravgrunnlagService.haandterKravgrunnlag(kravgrunnlag)
+
+        coVerify(exactly = 1) {
+            behandlingKlient.endreOppgaveStatusForTilbakekreving(kravgrunnlag.sakId, paaVent = true)
+        }
+    }
+
+    @Test
+    fun `skal sette tilbakekreving tilbake fra paa vent naar kravgrunnlag har status ENDR og ingen perioder`() {
+        val kravgrunnlag = kravgrunnlag(status = KravgrunnlagStatus.ENDR, perioder = emptyList())
+
+        coEvery { behandlingKlient.endreOppgaveStatusForTilbakekreving(any(), any()) } just runs
+
+        kravgrunnlagService.haandterKravgrunnlag(kravgrunnlag)
+
+        coVerify(exactly = 1) {
+            behandlingKlient.endreOppgaveStatusForTilbakekreving(kravgrunnlag.sakId, paaVent = false)
+        }
+    }
+
+    @Test
+    fun `skal avbryte gjeldende tilbakekreving og opprette ny naar kravgrunnlag har status ENDR og perioder`() {
+        val kravgrunnlag = kravgrunnlag(status = KravgrunnlagStatus.ENDR)
+
+        coEvery { behandlingKlient.avbrytTilbakekreving(any()) } just runs
+        coEvery { behandlingKlient.opprettTilbakekreving(any(), any()) } just runs
+
+        kravgrunnlagService.haandterKravgrunnlag(kravgrunnlag)
+
+        coVerify(exactly = 1) {
+            behandlingKlient.avbrytTilbakekreving(kravgrunnlag.sakId)
+            behandlingKlient.opprettTilbakekreving(kravgrunnlag.sakId, kravgrunnlag)
+        }
+    }
+}

--- a/libs/etterlatte-tilbakekreving-model/src/main/kotlin/StatistikkTilbakekreving.kt
+++ b/libs/etterlatte-tilbakekreving-model/src/main/kotlin/StatistikkTilbakekreving.kt
@@ -15,6 +15,7 @@ enum class TilbakekrevingHendelseType : EventnameHendelseType {
     FATTET_VEDTAK,
     ATTESTERT,
     UNDERKJENT,
+    AVBRUTT,
     ;
 
     override fun lagEventnameForType(): String = "TILBAKEKREVING:${this.name}"

--- a/libs/etterlatte-tilbakekreving-model/src/main/kotlin/TilbakekrevingBehandling.kt
+++ b/libs/etterlatte-tilbakekreving-model/src/main/kotlin/TilbakekrevingBehandling.kt
@@ -32,6 +32,8 @@ data class TilbakekrevingBehandling(
 
     fun kanAvbrytes() = underBehandling() || status == TilbakekrevingStatus.FATTET_VEDTAK
 
+    fun underBehandlingEllerFattetVedtak() = underBehandling() || status == TilbakekrevingStatus.FATTET_VEDTAK
+
     companion object {
         fun ny(
             kravgrunnlag: Kravgrunnlag,

--- a/libs/etterlatte-tilbakekreving-model/src/main/kotlin/TilbakekrevingBehandling.kt
+++ b/libs/etterlatte-tilbakekreving-model/src/main/kotlin/TilbakekrevingBehandling.kt
@@ -30,8 +30,6 @@ data class TilbakekrevingBehandling(
             else -> false
         }
 
-    fun kanAvbrytes() = underBehandling() || status == TilbakekrevingStatus.FATTET_VEDTAK
-
     fun underBehandlingEllerFattetVedtak() = underBehandling() || status == TilbakekrevingStatus.FATTET_VEDTAK
 
     companion object {

--- a/libs/etterlatte-tilbakekreving-model/src/main/kotlin/TilbakekrevingBehandling.kt
+++ b/libs/etterlatte-tilbakekreving-model/src/main/kotlin/TilbakekrevingBehandling.kt
@@ -30,6 +30,8 @@ data class TilbakekrevingBehandling(
             else -> false
         }
 
+    fun kanAvbrytes() = underBehandling() || status == TilbakekrevingStatus.FATTET_VEDTAK
+
     companion object {
         fun ny(
             kravgrunnlag: Kravgrunnlag,
@@ -56,7 +58,9 @@ enum class TilbakekrevingStatus {
     VALIDERT,
     FATTET_VEDTAK,
     ATTESTERT,
-    UNDERKJENT, ;
+    UNDERKJENT,
+    AVBRUTT,
+    ;
 
     fun kanEndres(): Boolean {
         return this in listOf(OPPRETTET, UNDER_ARBEID, VALIDERT, UNDERKJENT)


### PR DESCRIPTION
Lagt til støtte for ENDR, SPER og AVSL i tillegg til NY som støttes allerede.

- SPER: Betyr at det kan komme endringer i kravgrunnlaget - Her settes oppgaven på vent.
- ENDR: Kommer typisk etter en SPER. Hvis den ikke inneholder perioder, er kravet uendret - oppgaven kan settes aktiv igjen. Hvis denne koden kommer med perioder, betyr det at kravgrunnlaget er endret. Eksisterende tilbakekreving vil avbrytes og ny vil bli opprettet.
- AVSL: Her har kravgrunnlaget blitt nullet ut og er ikke lenger aktuelt. Eksisterende behandling avbrytes.