### PR TITLE
EY-3879: Oppgraderer det transitive bouncycastle-biblioteket

### DIFF
--- a/apps/etterlatte-tilbakekreving/build.gradle.kts
+++ b/apps/etterlatte-tilbakekreving/build.gradle.kts
@@ -30,7 +30,11 @@ dependencies {
     implementation(libs.navfelles.tokenclientcore)
     implementation(libs.navfelles.tokenvalidationktor2)
 
-    implementation(libs.mq.jakarta.client)
+    implementation(libs.mq.jakarta.client) {
+        exclude("org.bouncycastle:bcutil-jdk18on")
+        exclude("org.bouncycastle:bcpkix-jdk18on")
+        exclude("org.bouncycastle:bcprov-jdk18on")
+    }
     implementation(libs.messaginghub.pooled.jms)
     implementation(libs.navfelles.tjenestespesifikasjoner.tilbakekreving)
 
@@ -47,4 +51,10 @@ dependencies {
     testImplementation(testFixtures((project(":libs:etterlatte-database"))))
     testImplementation(testFixtures(project(":libs:etterlatte-mq")))
     testImplementation(testFixtures((project(":libs:etterlatte-ktor"))))
+
+    // Avhengigheter fra patching av sårbarheter i IBM MQ.
+    // Vi bør kunne ta bort alle disse og exclude-lista for neste IBM MQ-versjon
+    implementation(libs.bcpkix)
+    implementation(libs.bcprov)
+    implementation(libs.bcutil)
 }

--- a/apps/etterlatte-utbetaling/build.gradle.kts
+++ b/apps/etterlatte-utbetaling/build.gradle.kts
@@ -20,7 +20,11 @@ dependencies {
     implementation(libs.ktor2.clientcontentnegotiation)
     implementation(libs.ktor2.jackson)
 
-    implementation(libs.mq.jakarta.client)
+    implementation(libs.mq.jakarta.client) {
+        exclude("org.bouncycastle:bcutil-jdk18on")
+        exclude("org.bouncycastle:bcpkix-jdk18on")
+        exclude("org.bouncycastle:bcprov-jdk18on")
+    }
     implementation(libs.messaginghub.pooled.jms)
     implementation(libs.navfelles.tjenestespesifikasjoner.oppdragsbehandling)
     implementation(libs.navfelles.tjenestespesifikasjoner.oppdragsimulering)
@@ -39,4 +43,10 @@ dependencies {
     testImplementation(testFixtures((project(":libs:etterlatte-database"))))
     testImplementation(testFixtures((project(":libs:etterlatte-ktor"))))
     testImplementation(testFixtures(project(":libs:etterlatte-mq")))
+
+    // Avhengigheter fra patching av sårbarheter i IBM MQ.
+    // Vi bør kunne ta bort alle disse og exclude-lista for neste IBM MQ-versjon
+    implementation(libs.bcpkix)
+    implementation(libs.bcprov)
+    implementation(libs.bcutil)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ jackson-version = "2.17.0"
 jupiter-version = "5.10.2"
 kotlinx-version = "1.8.0"
 ktor2-version = "2.3.10"
+bcpkix-version = "1.78.1"
 navfelles-token-version = "4.1.4"
 prometheus-version = "0.16.0"
 testcontainer-version = "1.19.7"
@@ -104,7 +105,11 @@ test-testcontainer-postgresql = { module = "org.testcontainers:postgresql", vers
 commons-compress = { module = "org.apache.commons:commons-compress", version = "1.26.1"}
 unleash-client = { module = "io.getunleash:unleash-client-java", version = "9.2.0" }
 
+#Workarounds
+bcpkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bcpkix-version"}
+bcprov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bcpkix-version"}
+bcutil = { module = "org.bouncycastle:bcutil-jdk18on", version.ref = "bcpkix-version"}
+
 [bundles]
 jackson = ["jackson-datatypejsr310", "jackson-datatypejdk8", "jackson-modulekotlin"]
 navfelles-token = ["navfelles-tokenclientcore", "navfelles-tokenvalidationktor2"]
-


### PR DESCRIPTION
MQ-biblioteket vi bruker trekkjer med seg bouncycastle-versjonar med kjente sårbarheiter, korav nokre er tagga med risiko høg. Det er ikkje så kult å ha i prod.

Det er ikkje meir enn eit par veker sia forrige versjon av MQ-biblioteket kom heller, så det er ikkje grunn til å tru at det blir retta med det første. Innfører derfor samme workaround som vi per no bruker i etterlatte-proxy, altså at vi eksplisitt overstyrer versjoneringa for dette biblioteket.

Har kikka på release notes for bouncycastle, og ved å gå frå 1.77 som vi bruker i dag til 1.78.1 ser det ut som vi får retta fleire CVE-ar, og at det utover det ser det ut som berre småting.