### PR TITLE
EY-3605 Fane for visning av historikk i behandling/oppgave

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -304,7 +304,7 @@ internal class ApplicationContext(
     // Service
     val klageHendelser = KlageHendelserServiceImpl(rapid)
     val tilbakekrevingHendelserService = TilbakekrevingHendelserServiceImpl(rapid)
-    val oppgaveService = OppgaveService(oppgaveDaoEndringer, sakDao, behandlingsHendelser)
+    val oppgaveService = OppgaveService(oppgaveDaoEndringer, sakDao, hendelseDao, behandlingsHendelser)
 
     val grunnlagsService = GrunnlagServiceImpl(grunnlagKlient)
     val behandlingService =

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveEndring.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveEndring.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.oppgave
 
+import no.nav.etterlatte.behandling.hendelse.LagretHendelse
 import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
 import no.nav.etterlatte.libs.common.oppgave.Status
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -15,4 +16,103 @@ data class OppgaveEndring(
     fun sendtTilAttestering(): Boolean =
         oppgaveEtter.erAttestering() &&
             oppgaveFoer.status in listOf(Status.UNDER_BEHANDLING, Status.UNDERKJENT)
+}
+
+data class EndringLinje(
+    val tittel: String,
+    val beskrivelse: String? = null,
+)
+
+data class GenerellEndringshendelse(
+    val tidspunkt: Tidspunkt,
+    val saksbehandler: String?,
+    val endringer: List<EndringLinje>,
+)
+
+object EndringMapper {
+    fun mapOppgaveEndringer(endringer: List<OppgaveEndring>): List<GenerellEndringshendelse> {
+        return endringer.map {
+            GenerellEndringshendelse(
+                tidspunkt = it.tidspunkt,
+                saksbehandler = null, // Ingen logging på HVEM som har gjort en endring på oppgave. Må fikses
+                endringer = tilEndringLinjer(it.oppgaveFoer, it.oppgaveEtter),
+            )
+        }
+    }
+
+    fun mapBehandlingHendelse(hendelse: LagretHendelse): String {
+        return when (hendelse.hendelse) {
+            "BEHANDLING:AVBRUTT" -> "Behandling avbrutt"
+            "BEHANDLING:AVKORTET" -> "Behandling avkortet"
+            "BEHANDLING:BEREGNET" -> "Behandling beregnet"
+            "BEHANDLING:OPPDATERT_GRUNNLAG" -> "Grunnlag oppdatert"
+            "BEHANDLING:OPPRETTET" -> "Behandling opprettet"
+            "BEHANDLING:TRYGDETID_OPPDATERT" -> "Trygdetid oppdatert"
+            "BEHANDLING:VILKAARSVURDERT" -> "Behandling vilkaarsvurdert"
+            "GENERELL_BEHANDLING:ATTESTERT" -> "Attestert"
+            "GENERELL_BEHANDLING:FATTET" -> "Vedtak fattet"
+            "GENERELL_BEHANDLING:OPPRETTET" -> "Generell behandling opprettet"
+            "KLAGE:AVBRUTT" -> "Klage avbrutt"
+            "KLAGE:FERDIGSTILT" -> "Klage ferdigstilt"
+            "KLAGE:OPPRETTET" -> "Klage opprettet"
+            "TILBAKEKREVING:OPPRETTET" -> "Tilbakekreving opprettet"
+            "VEDTAK:ATTESTERT" -> "Vedtak attestert"
+            "VEDTAK:AVSLAG" -> "Vedtak avslag"
+            "VEDTAK:FATTET" -> "Vedtak fattet"
+            "VEDTAK:IVERKSATT" -> "Vedtak iverksatt"
+            "VEDTAK:SAMORDNET" -> "Vedtak samordnet"
+            "VEDTAK:TIL_SAMORDNING" -> "Vedtak til samordning"
+            "VEDTAK:UNDERKJENT" -> "Vedtak underkjent"
+            else -> hendelse.hendelse
+        }
+    }
+
+    private fun tilEndringLinjer(
+        foer: OppgaveIntern,
+        etter: OppgaveIntern,
+    ): List<EndringLinje> {
+        val liste = mutableListOf<EndringLinje>()
+
+        if (foer.status != etter.status) {
+            liste.add(
+                EndringLinje(
+                    "Status endret",
+                    "${foer.status.tilLesbarString()} -> ${etter.status.tilLesbarString()}",
+                ),
+            )
+        }
+        if (foer.saksbehandler != etter.saksbehandler) {
+            liste.add(
+                EndringLinje(
+                    "Tildelt saksbehandler",
+                    "${etter.saksbehandler?.navn?.ellerIngen()}",
+                ),
+            )
+        }
+        if (foer.merknad != etter.merknad) {
+            liste.add(EndringLinje("Ny merknad", etter.merknad?.ellerIngen()))
+        }
+        if (foer.enhet != etter.enhet) {
+            liste.add(EndringLinje("Flyttet til enhet", "${etter.enhet}"))
+        }
+        if (foer.frist != etter.frist) {
+            liste.add(EndringLinje("Endret frist", "ny frist er ${etter.frist?.toNorskLocalDate()}"))
+        }
+
+        return liste
+    }
+
+    private fun Status.tilLesbarString() =
+        when (this) {
+            Status.NY -> "Ny"
+            Status.UNDER_BEHANDLING -> "Under behandling"
+            Status.PAA_VENT -> "På vent"
+            Status.ATTESTERING -> "Til attestering"
+            Status.UNDERKJENT -> "Underkjent"
+            Status.FERDIGSTILT -> "Ferdigstilt"
+            Status.FEILREGISTRERT -> "Feilregistrert"
+            Status.AVBRUTT -> "Avbrutt"
+        }
+
+    private fun String?.ellerIngen() = if (!this.isNullOrBlank()) this else "Ingen"
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
@@ -155,6 +155,15 @@ internal fun Route.oppgaveRoutes(service: OppgaveService) {
                 call.respond(oppgave)
             }
 
+            get("endringer") {
+                val endringer =
+                    inTransaction {
+                        service.hentEndringerOppgave(oppgaveId)
+                    }
+
+                call.respond(endringer)
+            }
+
             put("ferdigstill") {
                 kunSkrivetilgang {
                     val merknad = call.receive<FerdigstillRequest>().merknad

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -8,6 +8,7 @@ import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
 import no.nav.etterlatte.Self
 import no.nav.etterlatte.SystemUser
 import no.nav.etterlatte.behandling.BehandlingHendelserKafkaProducer
+import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseService
 import no.nav.etterlatte.libs.common.behandling.BehandlingHendelseType
 import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
@@ -36,6 +37,7 @@ import java.util.UUID
 class OppgaveService(
     private val oppgaveDao: OppgaveDaoMedEndringssporing,
     private val sakDao: SakDao,
+    private val hendelseDao: HendelseDao,
     private val hendelser: BehandlingHendelserKafkaProducer,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this.javaClass.name)
@@ -348,6 +350,36 @@ class OppgaveService(
                 "Oppgave med id=$id finnes ikke – avbryter ferdigstilling av oppgaven"
             }
         ferdigstillOppgave(oppgave, saksbehandler, merknad)
+    }
+
+    fun hentEndringerOppgave(id: UUID): List<GenerellEndringshendelse> {
+        val oppgave = hentOppgave(id)
+
+        val behandlingHendelser =
+            if (oppgave.kilde == OppgaveKilde.BEHANDLING) {
+                hendelseDao.finnHendelserIBehandling(UUID.fromString(oppgave.referanse))
+                    .map {
+                        val hendelse = EndringMapper.mapBehandlingHendelse(it)
+                        GenerellEndringshendelse(
+                            tidspunkt = it.opprettet,
+                            saksbehandler = "Z12345",
+                            endringer =
+                                listOf(
+                                    EndringLinje(
+                                        hendelse,
+                                        it.kommentar?.let { kommentar -> "Kommentar: $kommentar" },
+                                    ),
+                                ),
+                        )
+                    }
+            } else {
+                emptyList()
+            }
+
+        val oppgaveHendelser = EndringMapper.mapOppgaveEndringer(oppgaveDao.hentEndringerForOppgave(id))
+
+        return (oppgaveHendelser + behandlingHendelser)
+            .sortedByDescending { it.tidspunkt }
     }
 
     private fun ferdigstillOppgave(

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingServiceTest.kt
@@ -96,6 +96,7 @@ class GenerellBehandlingServiceTest(val dataSource: DataSource) {
             OppgaveService(
                 OppgaveDaoMedEndringssporingImpl(oppgaveDao, ConnectionAutoclosingTest(dataSource)),
                 sakRepo,
+                hendelseDao,
                 hendelser,
             )
 

--- a/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattServiceTest.kt
@@ -76,7 +76,7 @@ internal class EgenAnsattServiceTest(val dataSource: DataSource) {
             )
         oppgaveService =
             spyk(
-                OppgaveService(oppgaveRepoMedSporing, sakRepo, hendelser),
+                OppgaveService(oppgaveRepoMedSporing, sakRepo, mockk(), hendelser),
             )
         egenAnsattService = EgenAnsattService(sakService, oppgaveService, sikkerLogg, brukerService)
 

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.azureAdAttestantClaim
 import no.nav.etterlatte.azureAdSaksbehandlerClaim
 import no.nav.etterlatte.azureAdStrengtFortroligClaim
 import no.nav.etterlatte.behandling.BehandlingHendelserKafkaProducer
+import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseService
 import no.nav.etterlatte.libs.common.behandling.BehandlingHendelseType
@@ -55,9 +56,10 @@ internal class OppgaveServiceTest(val dataSource: DataSource) {
     private val sakDao: SakDao = SakDao(ConnectionAutoclosingTest(dataSource))
     private val oppgaveDao: OppgaveDao = spyk(OppgaveDaoImpl(ConnectionAutoclosingTest(dataSource)))
     private val hendelser: BehandlingHendelserKafkaProducer = mockk()
+    private val hendelseDao = mockk<HendelseDao>()
     private val oppgaveDaoMedEndringssporing: OppgaveDaoMedEndringssporing =
         OppgaveDaoMedEndringssporingImpl(oppgaveDao, ConnectionAutoclosingTest(dataSource))
-    private val oppgaveService: OppgaveService = OppgaveService(oppgaveDaoMedEndringssporing, sakDao, hendelser)
+    private val oppgaveService: OppgaveService = OppgaveService(oppgaveDaoMedEndringssporing, sakDao, hendelseDao, hendelser)
     private val saksbehandler = mockk<SaksbehandlerMedEnheterOgRoller>()
 
     private val azureGroupToGroupIDMap =

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
@@ -17,7 +17,7 @@ import { useVedtak } from '~components/vedtak/useVedtak'
 import { VedtakSammendrag } from '~components/vedtak/typer'
 import { updateVedtakSammendrag } from '~store/reducers/VedtakReducer'
 import { Tabs } from '@navikt/ds-react'
-import { DocPencilIcon, FileTextIcon } from '@navikt/aksel-icons'
+import { ClockDashedIcon, DocPencilIcon, FileTextIcon } from '@navikt/aksel-icons'
 import { Sjekkliste } from '~components/behandling/sjekkliste/Sjekkliste'
 import { useSelectorBehandlingSidemenyFane } from '~components/behandling/sidemeny/useSelectorBehandlingSidemeny'
 import { visFane } from '~store/reducers/BehandlingSidemenyReducer'
@@ -31,6 +31,7 @@ import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { DokumentlisteLiten } from '~components/person/dokumenter/DokumentlisteLiten'
 import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
 import { useOppgaveUnderBehandling } from '~shared/hooks/useOppgaveUnderBehandling'
+import { OppgaveEndring } from './OppgaveEndring'
 
 const finnUtNasjonalitet = (behandling: IBehandlingReducer): UtlandstilknytningType | null => {
   if (behandling.utlandstilknytning?.type) {
@@ -141,34 +142,38 @@ export const BehandlingSidemeny = ({ behandling }: { behandling: IBehandlingRedu
         errorMessage: 'Kunne ikke hente saksbehandler gjeldende oppgave. Husk å tildele oppgaven.',
       })}
       {isPending(oppgaveResult) && <Spinner visible={true} label="Henter saksbehandler for oppgave" />}
-      {erFoerstegangsbehandling && (
-        <Tabs value={fane} iconPosition="top" onChange={(val) => dispatch(visFane(val as BehandlingFane))}>
-          <Tabs.List>
-            <Tabs.Tab value={BehandlingFane.DOKUMENTER} label="Dokumenter" icon={<FileTextIcon title="dokumenter" />} />
+      <Tabs value={fane} iconPosition="top" onChange={(val) => dispatch(visFane(val as BehandlingFane))}>
+        <Tabs.List>
+          <Tabs.Tab value={BehandlingFane.DOKUMENTER} label="Dokumenter" icon={<FileTextIcon title="dokumenter" />} />
+          {erFoerstegangsbehandling && (
             <Tabs.Tab
               value={BehandlingFane.SJEKKLISTE}
               label="Sjekkliste"
               icon={<DocPencilIcon title="sjekkliste" />}
             />
-          </Tabs.List>
-          <Tabs.Panel value={BehandlingFane.DOKUMENTER}>
-            {soeker?.foedselsnummer && <DokumentlisteLiten fnr={soeker.foedselsnummer} />}
-          </Tabs.Panel>
+          )}
+          <Tabs.Tab value={BehandlingFane.HISTORIKK} label="Historikk" icon={<ClockDashedIcon />} />
+        </Tabs.List>
+
+        <Tabs.Panel value={BehandlingFane.DOKUMENTER}>
+          {soeker?.foedselsnummer && <DokumentlisteLiten fnr={soeker.foedselsnummer} />}
+        </Tabs.Panel>
+        <Tabs.Panel value={BehandlingFane.HISTORIKK}>
+          <OppgaveEndring oppgaveResult={oppgaveResult} />
+        </Tabs.Panel>
+
+        {erFoerstegangsbehandling && (
           <Tabs.Panel value={BehandlingFane.SJEKKLISTE}>
-            <>
-              <Sjekkliste behandling={behandling} />
-              {isPending(hentSjekklisteResult) && <Spinner label="Henter sjekkliste ..." visible />}
-              {erFoerstegangsbehandling &&
-                !erFerdigBehandlet(behandling.status) &&
-                isFailureHandler({
-                  apiResult: hentSjekklisteResult,
-                  errorMessage: 'Kunne ikke hente konfigurasjonsverdier',
-                })}
-            </>
+            <Sjekkliste behandling={behandling} />
+            {isPending(hentSjekklisteResult) && <Spinner label="Henter sjekkliste ..." visible />}
+            {!erFerdigBehandlet(behandling.status) &&
+              isFailureHandler({
+                apiResult: hentSjekklisteResult,
+                errorMessage: 'Kunne ikke hente konfigurasjonsverdier',
+              })}
           </Tabs.Panel>
-        </Tabs>
-      )}
-      {!erFoerstegangsbehandling && soeker?.foedselsnummer && <DokumentlisteLiten fnr={soeker.foedselsnummer} />}
+        )}
+      </Tabs>
       <AnnullerBehandling />
     </Sidebar>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/IBehandlingInfo.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/IBehandlingInfo.ts
@@ -29,4 +29,5 @@ export interface IBehandlingInfo {
 export enum BehandlingFane {
   DOKUMENTER = 'DOKUMENTER',
   SJEKKLISTE = 'SJEKKLISTE',
+  HISTORIKK = 'HISTORIKK',
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/OppgaveEndring.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/OppgaveEndring.tsx
@@ -1,0 +1,83 @@
+import { GenerellEndringshendelse, OppgaveDTO } from '~shared/types/oppgave'
+import { isSuccess, mapSuccess, Result } from '~shared/api/apiUtils'
+import React, { useEffect } from 'react'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { hentEndringer } from '~shared/api/oppgaver'
+import { formaterDatoMedKlokkeslett } from '~utils/formattering'
+import { BodyShort, Box, Detail } from '@navikt/ds-react'
+import styled from 'styled-components'
+
+export const OppgaveEndring = ({ oppgaveResult }: { oppgaveResult: Result<OppgaveDTO> }) => {
+  const [endringerResult, hentOppgaveEndringer] = useApiCall(hentEndringer)
+
+  useEffect(() => {
+    if (isSuccess(oppgaveResult)) {
+      hentOppgaveEndringer(oppgaveResult.data.id)
+    }
+  }, [oppgaveResult])
+
+  return mapSuccess(endringerResult, (endringer) => (
+    <Box padding="4">
+      <EndringListe>
+        {endringer.map((endring, index) => (
+          <EndringLinje key={`endringlinje-${index}`} endring={endring} />
+        ))}
+      </EndringListe>
+    </Box>
+  ))
+}
+
+const EndringLinje = ({ endring }: { endring: GenerellEndringshendelse }) => {
+  const { tidspunkt, saksbehandler, endringer } = endring
+
+  return (
+    <EndringElement>
+      {endringer.map(({ tittel, beskrivelse }, index) => (
+        <div key={`endring-element-${index}`}>
+          <BodyShort size="small">
+            <strong>{tittel}</strong>
+          </BodyShort>
+          {!!beskrivelse && <BodyShort size="small">{beskrivelse}</BodyShort>}
+        </div>
+      ))}
+      {saksbehandler && <Detail>utført av {saksbehandler}</Detail>}
+      <Detail>{formaterDatoMedKlokkeslett(tidspunkt)}</Detail>
+    </EndringElement>
+  )
+}
+
+const EndringListe = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin-top: 1rem;
+`
+
+const EndringElement = styled.li`
+  padding-bottom: 1rem;
+  border-left: 1px solid #abaaed;
+  position: relative;
+  padding-left: 20px;
+  margin-left: 10px;
+
+  &:first-child:before {
+    background: var(--a-blue-200);
+    border: none;
+  }
+
+  &:last-child {
+    border: 0px;
+    padding-bottom: 0;
+  }
+
+  &:before {
+    content: '';
+    width: 15px;
+    height: 15px;
+    background: white;
+    border: 3px solid var(--a-gray-600);
+    border-radius: 50%;
+    position: absolute;
+    left: -8px;
+    top: 0px;
+  }
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaver.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/oppgaver.ts
@@ -2,7 +2,7 @@ import { apiClient, ApiResponse } from '~shared/api/apiClient'
 import { konverterOppgavestatusFilterValuesTilKeys } from '~components/oppgavebenk/filtreringAvOppgaver/filtrerOppgaver'
 import { Saksbehandler } from '~shared/types/saksbehandler'
 import { OppgavebenkStats } from '~components/oppgavebenk/state/oppgavebenkState'
-import { NyOppgaveDto, OppgaveDTO } from '~shared/types/oppgave'
+import { GenerellEndringshendelse, NyOppgaveDto, OppgaveDTO } from '~shared/types/oppgave'
 
 export const hentOppgaverMedStatus = async (args: {
   oppgavestatusFilter: Array<string>
@@ -25,6 +25,9 @@ export const hentOppgaverMedStatus = async (args: {
 }
 
 export const hentOppgave = async (id: string): Promise<ApiResponse<OppgaveDTO>> => apiClient.get(`/oppgaver/${id}`)
+
+export const hentEndringer = async (id: string): Promise<ApiResponse<GenerellEndringshendelse[]>> =>
+  apiClient.get(`/oppgaver/${id}/endringer`)
 
 export const hentOppgaverMedReferanse = async (referanse: string): Promise<ApiResponse<OppgaveDTO[]>> =>
   apiClient.get(`/oppgaver/referanse/${referanse}`)

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/styled.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/styled.tsx
@@ -52,6 +52,7 @@ export const SidebarTools = styled.div`
   position: fixed;
   bottom: 0;
   width: 100%;
+  z-index: 999;
 `
 
 export const Content = styled.div`

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/oppgave.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/oppgave.ts
@@ -16,6 +16,17 @@ export interface OppgaveDTO {
   saksbehandler: OppgaveSaksbehandler | null
 }
 
+export interface GenerellEndringshendelse {
+  tidspunkt: string
+  saksbehandler?: string
+  endringer: EndringLinje[]
+}
+
+export interface EndringLinje {
+  tittel: string
+  beskrivelse?: string
+}
+
 export interface OppgaveSaksbehandler {
   ident: string
   navn?: string


### PR DESCRIPTION
**MVP** for visning av historikk på oppgave og behandling. 

Fletter sammen hendelser fra oppgave og behandling. Tanken er at det på sikt kan flette flere typer hendelser.

Må gjøres en god del endringer i måten vi håndterer oppgaver og tilknyttede behandlinger for å sikre at dette også vises på avsluttede behandlinger. Vil nå kun være tilgjengelig så lenge en behandling er "under behandling". 

<img width="562" alt="Screenshot 2024-05-06 at 14 31 01" src="https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/69eae2be-59a1-4d30-816c-c95f6579d32a">
