### PR TITLE
Ikke opprett oppgave for BP ikke søkt hver gang

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/doedshendelse/DoedshendelseReminderService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/doedshendelse/DoedshendelseReminderService.kt
@@ -42,14 +42,17 @@ class DoedshendelseReminderService(
         val behandlingerForSak = behandlingService.hentBehandlingerForSak(hendelse.sakId!!)
         val harSoekt = behandlingerForSak.any { it is Foerstegangsbehandling }
         if (!harSoekt) {
-            oppgaveService.opprettNyOppgaveMedSakOgReferanse(
-                referanse = hendelse.id.toString(),
-                sakId = hendelse.sakId,
-                oppgaveKilde = OppgaveKilde.HENDELSE,
-                oppgaveType = OppgaveType.VURDER_KONSEKVENS,
-                merknad = "${hendelse.beroertFnr} Har ikke søkt om Barnepensjon 2 måneder etter utsendt brev",
-                frist = Tidspunkt.now().plus(30L, ChronoUnit.DAYS),
-            )
+            val oppgaver = oppgaveService.hentOppgaverForSak(hendelse.sakId)
+            if (oppgaver.none { it.type == OppgaveType.VURDER_KONSEKVENS }) {
+                oppgaveService.opprettNyOppgaveMedSakOgReferanse(
+                    referanse = hendelse.id.toString(),
+                    sakId = hendelse.sakId,
+                    oppgaveKilde = OppgaveKilde.HENDELSE,
+                    oppgaveType = OppgaveType.VURDER_KONSEKVENS,
+                    merknad = "${hendelse.beroertFnr} Har ikke søkt om Barnepensjon 2 måneder etter utsendt brev",
+                    frist = Tidspunkt.now().plus(30L, ChronoUnit.DAYS),
+                )
+            }
         }
     }
 


### PR DESCRIPTION
Sakene ble spammet med oppgaver fordi det ble opprettet en ny oppgave hver gang jobben ble kjørt.

![Screenshot 2024-05-07 at 09 57 17](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1083866/fd102361-fc20-43bf-a2b9-c83453f3520e)
