### PR TITLE
EY-3899 Støtte nytt bruker-felt fra gosys

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -468,7 +468,7 @@ internal class ApplicationContext(
 
     val saksbehandlerJobService = SaksbehandlerJobService(saksbehandlerInfoDao, navAnsattKlient, axsysKlient)
     val saksbehandlerService: SaksbehandlerService = SaksbehandlerServiceImpl(saksbehandlerInfoDao, axsysKlient, navAnsattKlient)
-    val gosysOppgaveService = GosysOppgaveServiceImpl(gosysOppgaveKlient, pdlTjenesterKlient, oppgaveService, saksbehandlerService)
+    val gosysOppgaveService = GosysOppgaveServiceImpl(gosysOppgaveKlient, oppgaveService, saksbehandlerService)
     val behandlingFactory =
         BehandlingFactory(
             oppgaveService = oppgaveService,

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgave.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgave.kt
@@ -1,3 +1,6 @@
+package no.nav.etterlatte.oppgaveGosys
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import no.nav.etterlatte.libs.common.oppgave.OppgaveSaksbehandler
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 
@@ -11,7 +14,19 @@ data class GosysOppgave(
     val enhet: String,
     val opprettet: Tidspunkt,
     val frist: Tidspunkt?,
-    val fnr: String? = null,
     val beskrivelse: String?,
     val journalpostId: String?,
+    val bruker: GosysOppgaveBruker?,
 )
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class GosysOppgaveBruker(
+    val ident: String?,
+    val type: Type?,
+) {
+    enum class Type {
+        PERSON,
+        ARBEIDSGIVER,
+        SAMHANDLER,
+    }
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveKlient.kt
@@ -36,10 +36,10 @@ data class GosysApiOppgave(
     val opprettetTidspunkt: Tidspunkt,
     val tildeltEnhetsnr: String,
     val tilordnetRessurs: String?,
-    val aktoerId: String?,
     val beskrivelse: String?,
     val status: String,
     val fristFerdigstillelse: LocalDate? = null,
+    val bruker: GosysOppgaveBruker?,
 )
 
 data class GosysEndreSaksbehandlerRequest(

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
@@ -344,10 +344,10 @@ class GosysOppgaveKlientTest : GosysOppgaveKlient {
             Tidspunkt.now(),
             "4808",
             null,
-            "aktoerId",
             "beskrivelse",
             "NY",
             LocalDate.now(),
+            bruker = null,
         )
     }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/gosys/GosysBrukerWrapper.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/gosys/GosysBrukerWrapper.tsx
@@ -1,0 +1,18 @@
+import { GosysBrukerType, GosysOppgaveBruker } from '~shared/types/Gosys'
+import SaksoversiktLenke from '~components/oppgavebenk/components/SaksoversiktLenke'
+import React from 'react'
+
+export const GosysBrukerWrapper = ({ bruker }: { bruker?: GosysOppgaveBruker }) => {
+  if (!bruker?.type || !bruker?.ident) return '-'
+
+  switch (bruker.type) {
+    case GosysBrukerType.PERSON:
+      return <SaksoversiktLenke fnr={bruker.ident} />
+    case GosysBrukerType.ARBEIDSGIVER:
+      return `${bruker.ident} (arbeidsgiver)`
+    case GosysBrukerType.SAMHANDLER:
+      return `${bruker.ident} (samhandler)`
+    default:
+      return `${bruker?.ident} (ukjent type)`
+  }
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/gosys/GosysOppgaveRow.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/gosys/GosysOppgaveRow.tsx
@@ -1,12 +1,12 @@
 import { formaterOppgavetype, formaterStatus, GosysOppgave } from '~shared/types/Gosys'
 import { Table } from '@navikt/ds-react'
 import { formaterStringDato } from '~utils/formattering'
-import SaksoversiktLenke from '~components/oppgavebenk/components/SaksoversiktLenke'
 import { TemaTag } from '~components/oppgavebenk/components/Tags'
 import { VelgSaksbehandler } from '~components/oppgavebenk/gosys/VelgSaksbehandler'
 import { GosysOppgaveModal } from '~components/oppgavebenk/oppgaveModal/GosysOppgaveModal'
 import React, { useState } from 'react'
 import { Saksbehandler } from '~shared/types/saksbehandler'
+import { GosysBrukerWrapper } from '~components/oppgavebenk/gosys/GosysBrukerWrapper'
 
 export const GosysOppgaveRow = (props: { oppgave: GosysOppgave; saksbehandlereIEnhet: Array<Saksbehandler> }) => {
   const [oppgave, setOppgave] = useState(props.oppgave)
@@ -15,7 +15,9 @@ export const GosysOppgaveRow = (props: { oppgave: GosysOppgave; saksbehandlereIE
     <Table.Row>
       <Table.DataCell>{formaterStringDato(oppgave.opprettet)}</Table.DataCell>
       <Table.DataCell>{oppgave.frist ? formaterStringDato(oppgave.frist) : 'Mangler'}</Table.DataCell>
-      <Table.DataCell>{oppgave.fnr ? <SaksoversiktLenke fnr={oppgave.fnr} /> : 'Mangler'}</Table.DataCell>
+      <Table.DataCell>
+        <GosysBrukerWrapper bruker={oppgave.bruker} />
+      </Table.DataCell>
       <Table.DataCell>{formaterOppgavetype(oppgave.oppgavetype)}</Table.DataCell>
       <Table.DataCell>
         <TemaTag tema={oppgave.tema} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/gosys/GosysOppgaver.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/gosys/GosysOppgaver.tsx
@@ -20,7 +20,7 @@ export interface Props {
 export const GosysOppgaver = ({ oppgaver, saksbehandlereIEnhet, fnrFilter }: Props): ReactNode => {
   const [sortering, setSortering] = useState<OppgaveSortering>(hentSorteringFraLocalStorage())
 
-  const filtrerteOppgaver = fnrFilter ? oppgaver.filter(({ fnr }) => fnr === fnrFilter.trim()) : oppgaver
+  const filtrerteOppgaver = fnrFilter ? oppgaver.filter(({ bruker }) => bruker?.ident === fnrFilter.trim()) : oppgaver
   const sorterteOppgaver = sorterGosysOppgaver(filtrerteOppgaver, sortering)
 
   const [page, setPage] = useState<number>(1)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/GosysOppgaveModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/GosysOppgaveModal.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { ChevronDownIcon, ExternalLinkIcon, EyeIcon } from '@navikt/aksel-icons'
 import React, { useContext, useState } from 'react'
 import { TemaTag } from '~components/oppgavebenk/components/Tags'
-import { formaterFnr, formaterStringDato } from '~utils/formattering'
+import { formaterStringDato } from '~utils/formattering'
 import { ConfigContext } from '~clientConfig'
 import { FlexRow } from '~shared/styled'
 import { FristWrapper } from '~components/oppgavebenk/frist/FristWrapper'
@@ -11,6 +11,7 @@ import { FerdigstillGosysOppgave } from '../gosys/FerdigstillGosysOppgave'
 import { OverfoerOppgaveTilGjenny } from '../gosys/OverfoerOppgaveTilGjenny'
 import { formaterOppgavetype, GosysOppgave } from '~shared/types/Gosys'
 import { useInnloggetSaksbehandler } from '~components/behandling/useInnloggetSaksbehandler'
+import { GosysBrukerWrapper } from '~components/oppgavebenk/gosys/GosysBrukerWrapper'
 
 const TagRow = styled.div`
   display: flex;
@@ -36,7 +37,8 @@ export const GosysOppgaveModal = ({ oppgave }: { oppgave: GosysOppgave }) => {
   const [open, setOpen] = useState(false)
   const [toggle, setToggle] = useState<GosysActionToggle>({})
 
-  const { opprettet, frist, status, fnr, enhet, saksbehandler, beskrivelse, tema, oppgavetype, journalpostId } = oppgave
+  const { opprettet, frist, status, bruker, enhet, saksbehandler, beskrivelse, tema, oppgavetype, journalpostId } =
+    oppgave
 
   const configContext = useContext(ConfigContext)
 
@@ -45,6 +47,7 @@ export const GosysOppgaveModal = ({ oppgave }: { oppgave: GosysOppgave }) => {
       <Button variant="primary" size="small" icon={<EyeIcon />} onClick={() => setOpen(true)}>
         Se oppgave
       </Button>
+
       <Modal open={open} aria-labelledby="modal-heading" onClose={() => setOpen(false)}>
         <Modal.Header>
           <Heading size="medium" id="modal-heading">
@@ -77,7 +80,9 @@ export const GosysOppgaveModal = ({ oppgave }: { oppgave: GosysOppgave }) => {
             </div>
             <div>
               <Label>Fødselsnummer</Label>
-              <BodyShort>{fnr ? formaterFnr(fnr) : <i>Mangler</i>}</BodyShort>
+              <BodyShort as="div">
+                <GosysBrukerWrapper bruker={bruker} />
+              </BodyShort>
             </div>
             <div>
               <Label>Enhet</Label>
@@ -144,7 +149,11 @@ export const GosysOppgaveModal = ({ oppgave }: { oppgave: GosysOppgave }) => {
                 size="small"
                 variant="primary"
                 as="a"
-                href={fnr ? `${configContext['gosysUrl']}/personoversikt/fnr=${fnr}` : configContext['gosysUrl']}
+                href={
+                  bruker?.ident
+                    ? `${configContext['gosysUrl']}/personoversikt/fnr=${bruker?.ident}`
+                    : configContext['gosysUrl']
+                }
                 target="_blank"
                 icon={<ExternalLinkIcon />}
               >

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/utils/oppgaveSortering.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/utils/oppgaveSortering.ts
@@ -32,12 +32,12 @@ function sorterDato(retning: Retning, oppgaver: OppgaveDTO[] | GosysOppgave[]) {
   }
 }
 
-const sammenlignFnr = (a: OppgaveDTO | GosysOppgave, b: OppgaveDTO | GosysOppgave) => {
+const sammenlignFnr = (a: OppgaveDTO, b: OppgaveDTO) => {
   // Sammenligner de første 6 sifrene i fødselsnummerene
   return (!!a.fnr ? Number(a.fnr.slice(0, 5)) : 0) - (!!b.fnr ? Number(b.fnr.slice(0, 5)) : 0)
 }
 
-function sorterFnr(retning: Retning, oppgaver: OppgaveDTO[] | GosysOppgave[]) {
+function sorterFnr(retning: Retning, oppgaver: OppgaveDTO[]) {
   switch (retning) {
     case 'ascending':
       return oppgaver.sort(sammenlignFnr)
@@ -48,18 +48,33 @@ function sorterFnr(retning: Retning, oppgaver: OppgaveDTO[] | GosysOppgave[]) {
   }
 }
 
+const sammenlignGosysBruker = (a: GosysOppgave, b: GosysOppgave) =>
+  (!!a.bruker?.ident ? Number(a.bruker?.ident.slice(0, 5)) : 0) -
+  (!!b.bruker?.ident ? Number(b.bruker?.ident.slice(0, 5)) : 0)
+
+const sorterGosysBruker = (retning: Retning, oppgaver: GosysOppgave[]) => {
+  switch (retning) {
+    case 'ascending':
+      return oppgaver.sort(sammenlignGosysBruker)
+    case 'descending':
+      return oppgaver.sort(sammenlignGosysBruker).reverse()
+    case 'none':
+      return oppgaver
+  }
+}
+
 export function sorterOppgaver(oppgaver: OppgaveDTO[], sortering: OppgaveSortering): OppgaveDTO[] {
   const sortertRegistreringsdato = sorterDato(sortering.registreringsdatoSortering, oppgaver)
-  const sortertFrist = sorterDato(sortering.fristSortering, sortertRegistreringsdato)
+  const sortertFrist = sorterDato(sortering.fristSortering, sortertRegistreringsdato) as OppgaveDTO[]
 
-  return sorterFnr(sortering.fnrSortering, sortertFrist) as OppgaveDTO[]
+  return sorterFnr(sortering.fnrSortering, sortertFrist)
 }
 
 export function sorterGosysOppgaver(oppgaver: GosysOppgave[], sortering: OppgaveSortering): GosysOppgave[] {
   const sortertRegistreringsdato = sorterDato(sortering.registreringsdatoSortering, oppgaver)
-  const sortertFrist = sorterDato(sortering.fristSortering, sortertRegistreringsdato)
+  const sortertFrist = sorterDato(sortering.fristSortering, sortertRegistreringsdato) as GosysOppgave[]
 
-  return sorterFnr(sortering.fnrSortering, sortertFrist) as GosysOppgave[]
+  return sorterGosysBruker(sortering.fnrSortering, sortertFrist)
 }
 
 const SORTERING_KEY_LOCAL_STORAGE = 'OPPGAVESORTERING'

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/OppgaveFraJournalpostModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/OppgaveFraJournalpostModal.tsx
@@ -115,7 +115,10 @@ export const OppgaveFraJournalpostModal = ({
                   <Alert variant="warning">
                     Fant {oppgaver.length} oppgave(r) tilknyttet journalposten i Gosys.
                     <br />
-                    <Link href={`${configContext['gosysUrl']}/personoversikt/fnr=${oppgaver[0].fnr}`} target="_blank">
+                    <Link
+                      href={`${configContext['gosysUrl']}/personoversikt/fnr=${oppgaver[0].bruker?.ident}`}
+                      target="_blank"
+                    >
                       Åpne i Gosys <ExternalLinkIcon />
                     </Link>
                   </Alert>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Gosys.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Gosys.ts
@@ -11,9 +11,20 @@ export interface GosysOppgave {
   enhet: string
   opprettet: string
   frist?: string
-  fnr?: string
   beskrivelse?: string
   journalpostId?: string
+  bruker?: GosysOppgaveBruker
+}
+
+export interface GosysOppgaveBruker {
+  ident?: string
+  type?: GosysBrukerType
+}
+
+export enum GosysBrukerType {
+  PERSON = 'PERSON',
+  ARBEIDSGIVER = 'ARBEIDSGIVER',
+  SAMHANDLER = 'SAMHANDLER',
 }
 
 export enum GosysTema {


### PR DESCRIPTION
Gosys har lagt til et nytt felt på oppgaveobjektet: `Bruker`

```
      "bruker": {
        "ident": "string",
        "type": "PERSON"
      }
```

Som en følge av dette kan vi da fjerne kall mot `etterlatte-pdltjenester` og mapping av aktørid.