### PR TITLE
EY-3389 Oppdatere vedtak når det simuleres på et som ikke er attestert

### DIFF
--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/VedtaksvurderingKlient.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/VedtaksvurderingKlient.kt
@@ -30,9 +30,10 @@ class VedtaksvurderingKlient(config: Config, httpClient: HttpClient) {
         try {
             logger.info("Henter vedtak for behandlingId=$behandlingId")
 
-            return downstreamResourceClient.get(
-                Resource(clientId, "$resourceUrl/api/vedtak/$behandlingId"),
+            return downstreamResourceClient.post(
+                Resource(clientId, "$resourceUrl/api/vedtak/$behandlingId/simulering"),
                 brukerTokenInfo,
+                {},
             ).mapBoth(
                 success = { resource -> deserialize(resource.response.toString()) },
                 failure = { errorResponse -> throw errorResponse },

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Vedtak.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Vedtak.kt
@@ -80,6 +80,10 @@ data class Vedtak(
                 },
         )
     }
+
+    fun underArbeid(): Boolean {
+        return status in listOf(VedtakStatus.OPPRETTET, VedtakStatus.RETURNERT)
+    }
 }
 
 sealed interface VedtakInnhold {

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -88,6 +88,22 @@ fun Route.vedtaksvurderingRoute(
             }
         }
 
+        post("/{$BEHANDLINGID_CALL_PARAMETER}/simulering") {
+            withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
+                logger.info("Henter/oppdaterer vedtak for sinulering (behandling=$behandlingId)")
+
+                vedtakService.hentVedtakMedBehandlingId(behandlingId)?.let {
+                    if (!it.underArbeid()) {
+                        return@post call.respond(it.toDto())
+                    }
+                }
+
+                val vedtak =
+                    vedtakBehandlingService.opprettEllerOppdaterVedtak(behandlingId, brukerTokenInfo)
+                call.respond(vedtak.toDto())
+            }
+        }
+
         post("/{$BEHANDLINGID_CALL_PARAMETER}/upsert") {
             withBehandlingId(behandlingKlient, skrivetilgang = true) { behandlingId ->
                 logger.info("Oppretter eller oppdaterer vedtak for behandling $behandlingId")


### PR DESCRIPTION
Vedtak opprettes tidligere i vilkårsvurdering, men oppdateres jo her og der. Vedtaket som hentes av `utbetaling` for å simulere bør ha så ferske data som mulig - så lenge det ikke er blitt attestert (osv) ennå.

Dette kan forsåvidt orkestreres fra `utbetaling` (eller andre steder), men synes det er litt omstendelig.