### PR TITLE
Bare opprett hendelse med riktig info, ikke opprett så update

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
@@ -466,7 +466,7 @@ class GrunnlagsendringshendelseService(
             ).filter {
                 it.gjelderPerson == grunnlagsendringshendelse.gjelderPerson && it.type == grunnlagsendringshendelse.type
             }
-        logger.info("Hendelser på samme sakid ${sakId} antall ${relevanteHendelser.size} fnr: ${fnr?.maskerFnr()} grlid: ${grunnlagsendringshendelse.id}")
+        logger.info("Hendelser på samme sakid ${sakId} antall ${relevanteHendelser.size} fnr: ${grunnlagsendringshendelse.gjelderPerson.maskerFnr()} grlid: ${grunnlagsendringshendelse.id}")
         return relevanteHendelser.any { it.samsvarMellomKildeOgGrunnlag == samsvarMellomKildeOgGrunnlag }
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
@@ -386,8 +386,7 @@ class GrunnlagsendringshendelseService(
             val erDuplikat =
                 erDuplikatHendelse(
                     sak.id,
-                    grunnlagsendringshendelse.gjelderPerson,
-                    grunnlagsendringshendelse.type,
+                    grunnlagsendringshendelse,
                     samsvarMellomPdlOgGrunnlag,
                 )
 
@@ -457,8 +456,7 @@ class GrunnlagsendringshendelseService(
 
     internal fun erDuplikatHendelse(
         sakId: Long,
-        fnr: String?,
-        hendelsesType: GrunnlagsendringsType,
+        grunnlagsendringshendelse: Grunnlagsendringshendelse,
         samsvarMellomKildeOgGrunnlag: SamsvarMellomKildeOgGrunnlag,
     ): Boolean {
         val relevanteHendelser =
@@ -466,9 +464,9 @@ class GrunnlagsendringshendelseService(
                 sakId,
                 listOf(GrunnlagsendringStatus.SJEKKET_AV_JOBB),
             ).filter {
-                (fnr == null) || (it.gjelderPerson == fnr && it.type == hendelsesType)
+                it.gjelderPerson == grunnlagsendringshendelse.gjelderPerson && it.type == grunnlagsendringshendelse.type
             }
-        logger.info("Hendelser på samme sakid $sakId antall ${relevanteHendelser.size} fnr: ${fnr?.maskerFnr()}")
+        logger.info("Hendelser på samme sakid ${sakId} antall ${relevanteHendelser.size} fnr: ${fnr?.maskerFnr()} grlid: ${grunnlagsendringshendelse.id}")
         return relevanteHendelser.any { it.samsvarMellomKildeOgGrunnlag == samsvarMellomKildeOgGrunnlag }
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
@@ -443,7 +443,8 @@ class GrunnlagsendringshendelseService(
         samsvarMellomKildeOgGrunnlag: SamsvarMellomKildeOgGrunnlag,
     ) {
         logger.info("Forkaster grunnlagsendringshendelse med id ${hendelse.id}.")
-        grunnlagsendringshendelseDao.opprettGrunnlagsendringshendelse(hendelse.copy(samsvarMellomKildeOgGrunnlag = samsvarMellomKildeOgGrunnlag, status = GrunnlagsendringStatus.FORKASTET))
+        grunnlagsendringshendelseDao.opprettGrunnlagsendringshendelse(
+            hendelse.copy(samsvarMellomKildeOgGrunnlag = samsvarMellomKildeOgGrunnlag, status = GrunnlagsendringStatus.FORKASTET))
     }
 
     private fun hendelseHarKunAvbrytteBehandlinger(

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
@@ -308,7 +308,6 @@ class GrunnlagsendringshendelseService(
         fnr: String,
         grunnlagendringType: GrunnlagsendringsType,
     ): List<Grunnlagsendringshendelse> {
-        val grunnlagsEndringsStatus: GrunnlagsendringStatus = GrunnlagsendringStatus.VENTER_PAA_JOBB
         val tidspunktForMottakAvHendelse = Tidspunkt.now().toLocalDatetimeUTC()
         val sakerOgRoller = runBlocking { grunnlagKlient.hentPersonSakOgRolle(fnr).sakiderOgRoller }
 
@@ -323,7 +322,6 @@ class GrunnlagsendringshendelseService(
                     Grunnlagsendringshendelse(
                         id = UUID.randomUUID(),
                         sakId = rolleOgSak.sak.id,
-                        status = grunnlagsEndringsStatus,
                         type = grunnlagendringType,
                         opprettet = tidspunktForMottakAvHendelse,
                         hendelseGjelderRolle = rolleOgSak.sakiderOgRolle.rolle,
@@ -359,7 +357,6 @@ class GrunnlagsendringshendelseService(
             Grunnlagsendringshendelse(
                 id = hendelseId,
                 sakId = sakId,
-                status = GrunnlagsendringStatus.VENTER_PAA_JOBB,
                 type = grunnlagendringType,
                 opprettet = Tidspunkt.now().toLocalDatetimeUTC(),
                 hendelseGjelderRolle = Saksrolle.SOEKER,
@@ -467,7 +464,7 @@ class GrunnlagsendringshendelseService(
         val relevanteHendelser =
             grunnlagsendringshendelseDao.hentGrunnlagsendringshendelserMedStatuserISak(
                 sakId,
-                listOf(GrunnlagsendringStatus.VENTER_PAA_JOBB, GrunnlagsendringStatus.SJEKKET_AV_JOBB),
+                listOf(GrunnlagsendringStatus.SJEKKET_AV_JOBB),
             ).filter {
                 (fnr == null) || (it.gjelderPerson == fnr && it.type == hendelsesType)
             }

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktService.kt
@@ -125,7 +125,7 @@ class DoedshendelseKontrollpunktService(
         val duplikatHendelse =
             grunnlagsendringshendelseDao.hentGrunnlagsendringshendelserMedStatuserISak(
                 sakId = sak.id,
-                statuser = listOf(GrunnlagsendringStatus.VENTER_PAA_JOBB, GrunnlagsendringStatus.SJEKKET_AV_JOBB),
+                statuser = listOf(GrunnlagsendringStatus.SJEKKET_AV_JOBB),
             ).filter {
                 it.gjelderPerson == hendelse.avdoedFnr && it.type == GrunnlagsendringsType.DOEDSFALL
             }

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
@@ -130,25 +130,26 @@ internal class GrunnlagsendringshendelseServiceTest {
                 fraPdl = listOf(adresse),
                 fraGrunnlag = null,
             )
+        val grlhendelse = grunnlagsendringshendelseMedSamsvar(
+            gjelderPerson = KONTANT_FOT.value,
+            samsvarMellomKildeOgGrunnlag = samsvarBostedAdresse,
+        ).copy(
+            status = GrunnlagsendringStatus.SJEKKET_AV_JOBB,
+            type = GrunnlagsendringsType.BOSTED,
+            hendelseGjelderRolle = Saksrolle.SOESKEN,
+        )
         every {
             grunnlagshendelsesDao.hentGrunnlagsendringshendelserMedStatuserISak(any(), any())
         } returns
             listOf(
-                grunnlagsendringshendelseMedSamsvar(
-                    gjelderPerson = KONTANT_FOT.value,
-                    samsvarMellomKildeOgGrunnlag = samsvarBostedAdresse,
-                ).copy(
-                    status = GrunnlagsendringStatus.SJEKKET_AV_JOBB,
-                    type = GrunnlagsendringsType.BOSTED,
-                    hendelseGjelderRolle = Saksrolle.SOESKEN,
-                ),
+                grlhendelse
             )
 
         val erDuplikat =
             grunnlagsendringshendelseService.erDuplikatHendelse(
                 sakId,
                 KONTANT_FOT.value,
-                GrunnlagsendringsType.BOSTED,
+                grlhendelse,
                 samsvarBostedAdresse,
             )
         assertTrue(erDuplikat)
@@ -157,7 +158,7 @@ internal class GrunnlagsendringshendelseServiceTest {
             grunnlagsendringshendelseService.erDuplikatHendelse(
                 sakId,
                 KONTANT_FOT.value,
-                GrunnlagsendringsType.BOSTED,
+                grlhendelse,
                 samsvarBostedAdresse.copy(
                     fraPdl =
                         listOf(


### PR DESCRIPTION
Dette henger igjen fra da vi hadde en cron-job og måtte opprette hendelsen før jobben kjørte også kjørte resten av koden for verifiseroghaandterhendelse, nå fjerner jeg opprettelsen av hendelsen for å så oppdatere den.
Det reduserer kompleksiteten betraktelig, feks nå så sjekker hendelsen om den er en duplikat mot seg selv. Det blir borte her.

Delvis relatert [EY-3793](https://jira.adeo.no/browse/EY-3793)