### PR TITLE
EY-3798 Spesifiere REGULERING i vedtakshendelser til NAV-interne systemer

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/README.md
+++ b/apps/etterlatte-vedtaksvurdering/README.md
@@ -16,18 +16,18 @@ Oppdateringer av ACL er ikke automatisk, og må kjøres inn manuelt med `kubectl
 
 ### Meldingsinnhold
 
-| Felt        | Datatype   | Beskrivelse                                                 |
-|:------------|:-----------|-------------------------------------------------------------|
-| ident       | String     | Fødselsnummer hendelsen gjelder                             |
-| sakstype    | String     | Sakstype: OMS, BP                                           |
-| type        | String     | Hva vedtaket gjelder: AVSLAG, INNVILGELSE, ENDRING, OPPHOER |
-| vedtakId    | Long       | Unik identifikator for vedtaket                             |
-| vedtaksdato | yyyy-mm-dd | Dato vedtaket ble fattet                                    |
-| virkningFom | yyyy-mm-dd | Dato vedtaket gjelder fra                                   |
+| Felt        | Datatype   | Beskrivelse                                                             |
+|:------------|:-----------|-------------------------------------------------------------------------|
+| ident       | String     | Fødselsnummer hendelsen gjelder                                         |
+| sakstype    | String     | Sakstype: OMS, BP                                                       |
+| type        | String     | Hva vedtaket gjelder: AVSLAG, INNVILGELSE, ENDRING, REGULERING, OPPHOER |
+| vedtakId    | Long       | Unik identifikator for vedtaket                                         |
+| vedtaksdato | yyyy-mm-dd | Dato vedtaket ble fattet                                                |
+| virkningFom | yyyy-mm-dd | Dato vedtaket gjelder fra                                               |
 
-Se [Vedtakshendelse](./src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxService.kt) for implementasjon.
-
-Dette er designet til å gå i tospann med denne [vedtaksinformasjonstjenesten](../etterlatte-samordning-vedtak/README.md), dersom en trenger informasjon om utbetalt ytelse.
+- Se [Vedtakshendelse](./src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxService.kt) for implementasjon.
+- Dette er designet til å gå i tospann med denne [vedtaksinformasjonstjenesten](../etterlatte-samordning-vedtak/README.md), dersom en trenger informasjon om utbetalt ytelse.
+- **NB:** _REGULERING_ er en spesifikk variant av _ENDRING_. Spesialhåndtert da det vil komme et større volum av denne under den årlige reguleringen.
 
 ## Kom i gang
 

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxService.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.vedtaksvurdering.outbox
 
 import net.logstash.logback.marker.Markers
+import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
@@ -45,7 +46,7 @@ class OutboxService(
                 Vedtakshendelse(
                     ident = vedtak.soeker.value,
                     sakstype = vedtak.sakType.toEksternApi(),
-                    type = vedtak.type.toEksternApi(),
+                    type = vedtak.typeToEksternApi(),
                     vedtakId = vedtak.id,
                     vedtaksdato = vedtak.attestasjon?.tidspunkt?.toLocalDate(),
                     virkningFom = vedtak.innhold.virkningstidspunkt.atDay(1),
@@ -58,8 +59,13 @@ class OutboxService(
     }
 }
 
-internal fun VedtakType.toEksternApi(): String {
-    return when (this) {
+internal fun VedtakInnhold.Behandling.isRegulering() = Revurderingaarsak.REGULERING == this.revurderingAarsak
+
+internal fun Vedtak.typeToEksternApi(): String {
+    if ((this.innhold as VedtakInnhold.Behandling).isRegulering()) {
+        return "REGULERING"
+    }
+    return when (this.type) {
         VedtakType.AVSLAG -> "AVSLAG"
         VedtakType.ENDRING -> "ENDRING"
         VedtakType.INNVILGELSE -> "INNVILGELSE"

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/TestHelper.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/TestHelper.kt
@@ -42,6 +42,7 @@ fun opprettVedtak(
     beregning: ObjectNode? = objectMapper.createObjectNode(),
     avkorting: ObjectNode? = objectMapper.createObjectNode(),
     sakType: SakType = SakType.BARNEPENSJON,
+    behandlingType: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
 ) = OpprettVedtak(
     soeker = soeker,
     sakId = sakId,
@@ -51,7 +52,7 @@ fun opprettVedtak(
     status = status,
     innhold =
         VedtakInnhold.Behandling(
-            behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+            behandlingType = behandlingType,
             revurderingAarsak = null,
             virkningstidspunkt = virkningstidspunkt,
             beregning = beregning,

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxIntegrationTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxIntegrationTest.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.vedtaksvurdering.outbox
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import no.nav.etterlatte.kafka.TestProdusent
+import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.deserialize
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
@@ -64,6 +65,7 @@ class OutboxIntegrationTest(private val dataSource: DataSource) {
                     soeker = Folkeregisteridentifikator.of("04417103428"),
                     sakId = 2022L,
                     type = VedtakType.ENDRING,
+                    behandlingType = BehandlingType.REVURDERING,
                     behandlingId = UUID.randomUUID(),
                     status = VedtakStatus.ATTESTERT,
                     sakType = SakType.OMSTILLINGSSTOENAD,
@@ -93,7 +95,7 @@ class OutboxIntegrationTest(private val dataSource: DataSource) {
                     Vedtakshendelse(
                         ident = it.soeker.value,
                         sakstype = it.sakType.toEksternApi(),
-                        type = it.type.toEksternApi(),
+                        type = it.typeToEksternApi(),
                         vedtakId = it.id,
                         vedtaksdato = it.vedtakFattet?.tidspunkt?.toLocalDate(),
                         virkningFom = (it.innhold as VedtakInnhold.Behandling).virkningstidspunkt.atDay(1),


### PR DESCRIPTION
Ønsker ikke et eget felt for revurderingsårsak ettersom det da må være nullable.

Hovedformålet er å unngå at andre systemer må slå opp mot oss for å finne ut av om det er regulering, som er litt spesielt kasus med høyt-ish volum (i Gjenny-målestokk).