### PR TITLE
Støtte oppretting av ny overskrevet trygdetid

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/EnkelPersonTrygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/EnkelPersonTrygdetid.tsx
@@ -83,6 +83,7 @@ export const EnkelPersonTrygdetid = (props: Props) => {
         <TrygdetidManueltOverstyrt
           behandlingId={behandling.id}
           trygdetidId={trygdetid.id}
+          ident={trygdetid.ident}
           oppdaterTrygdetid={oppdaterTrygdetid}
           beregnetTrygdetid={trygdetid.beregnetTrygdetid}
         />

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
@@ -124,8 +124,11 @@ export const lagreTrygdeavtaleForBehandling = async (args: {
 }): Promise<ApiResponse<Trygdeavtale>> =>
   apiClient.post<Trygdeavtale>(`/trygdetid/avtaler/${args.behandlingId}`, { ...args.avtaleRequest })
 
-export const opprettTrygdetidOverstyrtMigrering = async (args: { behandlingId: string }): Promise<ApiResponse<void>> =>
-  apiClient.post(`/trygdetid_v2/${args.behandlingId}/migrering/manuell/opprett`, {})
+export const opprettTrygdetidOverstyrtMigrering = async (args: {
+  behandlingId: string
+  overskriv?: boolean
+}): Promise<ApiResponse<void>> =>
+  apiClient.post(`/trygdetid_v2/${args.behandlingId}/migrering/manuell/opprett?overskriv=${args.overskriv}`, {})
 
 export const oppdaterTrygdetidOverstyrtMigrering = async (args: {
   behandlingId: string

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
@@ -218,8 +218,10 @@ fun Route.trygdetid(
 
             post("/manuell/opprett") {
                 withBehandlingId(behandlingKlient, skrivetilgang = true) {
-                    logger.info("Oppretter trygdetid med overstyrt for behandling $behandlingId")
-                    trygdetidService.opprettOverstyrtBeregnetTrygdetid(behandlingId, brukerTokenInfo)
+                    val overskriv = call.request.queryParameters["overskriv"]?.toBoolean() ?: false
+
+                    logger.info("Oppretter trygdetid med overstyrt for behandling $behandlingId (overskriv: $overskriv)")
+                    trygdetidService.opprettOverstyrtBeregnetTrygdetid(behandlingId, overskriv, brukerTokenInfo)
                     call.respond(HttpStatusCode.OK)
                 }
             }


### PR DESCRIPTION
Får stadig meldinger fra saksbehandlere på teams som sitter fast fordi de glemmer å legge til avdøde ved oppretting av ny behandling når de har huket av "overstyrt trygdetid". Dette sparer oss og dem for mye unødvendig bruk av tid...

Kjenner ikke trygdetid godt nok til å si om dette kan ha uheldige bivirkninger, så her må noen med erfaring på trygdetid kontrollere. 

![Screenshot 2024-05-08 at 21 37 34](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/6b24a633-c3f7-4aca-8527-3a2069ccce31)
