### PR TITLE
EY-3889: Tilgangsstyring for tilbakekreving slik det ble gjort for klage

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -233,6 +233,9 @@ private fun Route.settOppTilganger(
             harTilgangTilGenerellBehandling = { generellbehandlingId, saksbehandlerMedRoller ->
                 tilgangService.harTilgangTilGenerellBehandling(generellbehandlingId, saksbehandlerMedRoller)
             }
+            harTilgangTilTilbakekreving = { tilbakekrevingId, saksbehandlerMedRoller ->
+                tilgangService.harTilgangTilTilbakekreving(tilbakekrevingId, saksbehandlerMedRoller)
+            }
         }
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingDao.kt
@@ -131,6 +131,7 @@ class TilbakekrevingDao(private val connectionAutoclosing: ConnectionAutoclosing
                 prepareStatement(
                     """
                     SELECT * FROM tilbakekrevingsperiode WHERE tilbakekreving_id = ?
+                    ORDER BY maaned
                     """.trimIndent(),
                 )
             statement.setObject(1, tilbakekrevingId)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingRoutes.kt
@@ -12,62 +12,62 @@ import io.ktor.server.routing.route
 import no.nav.etterlatte.libs.common.tilbakekreving.Kravgrunnlag
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingPeriode
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingVurdering
-import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.SAKID_CALL_PARAMETER
-import no.nav.etterlatte.libs.ktor.route.behandlingId
+import no.nav.etterlatte.libs.ktor.route.TILBAKEKREVINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.kunSystembruker
 import no.nav.etterlatte.libs.ktor.route.medBody
 import no.nav.etterlatte.libs.ktor.route.sakId
+import no.nav.etterlatte.libs.ktor.route.tilbakekrevingId
 import no.nav.etterlatte.tilgangsstyring.kunSaksbehandlerMedSkrivetilgang
 
 internal fun Route.tilbakekrevingRoutes(service: TilbakekrevingService) {
     route("/api/tilbakekreving") {
-        route("{$BEHANDLINGID_CALL_PARAMETER}") {
+        route("{$TILBAKEKREVINGID_CALL_PARAMETER}") {
             get {
-                call.respond(service.hentTilbakekreving(behandlingId))
+                call.respond(service.hentTilbakekreving(tilbakekrevingId))
             }
             put("/vurdering") {
                 kunSaksbehandlerMedSkrivetilgang {
                     val vurdering = call.receive<TilbakekrevingVurdering>()
-                    call.respond(service.lagreVurdering(behandlingId, vurdering, it))
+                    call.respond(service.lagreVurdering(tilbakekrevingId, vurdering, it))
                 }
             }
             put("/perioder") {
                 kunSaksbehandlerMedSkrivetilgang {
                     val request = call.receive<TilbakekrevingPerioderRequest>()
-                    call.respond(service.lagrePerioder(behandlingId, request.perioder, it))
+                    call.respond(service.lagrePerioder(tilbakekrevingId, request.perioder, it))
                 }
             }
             put("/skal-sende-brev") {
                 kunSaksbehandlerMedSkrivetilgang {
                     val request = call.receive<TilbakekrevingSendeBrevRequest>()
-                    call.respond(service.lagreSkalSendeBrev(behandlingId, request.skalSendeBrev, it))
+                    call.respond(service.lagreSkalSendeBrev(tilbakekrevingId, request.skalSendeBrev, it))
                 }
             }
             post("/valider") {
                 kunSaksbehandlerMedSkrivetilgang {
-                    call.respond(service.validerVurderingOgPerioder(behandlingId, it))
+                    call.respond(service.validerVurderingOgPerioder(tilbakekrevingId, it))
                 }
             }
 
             route("vedtak") {
                 post("fatt") {
                     kunSaksbehandlerMedSkrivetilgang {
-                        service.fattVedtak(behandlingId, it)
+                        service.fattVedtak(tilbakekrevingId, it)
                         call.respond(HttpStatusCode.OK)
                     }
                 }
                 post("attester") {
                     kunSaksbehandlerMedSkrivetilgang {
                         val (kommentar) = call.receive<TilbakekrevingAttesterRequest>()
-                        service.attesterVedtak(behandlingId, kommentar, it)
+                        service.attesterVedtak(tilbakekrevingId, kommentar, it)
                         call.respond(HttpStatusCode.OK)
                     }
                 }
                 post("underkjenn") {
                     kunSaksbehandlerMedSkrivetilgang {
                         val (kommentar, valgtBegrunnelse) = call.receive<TilbakekrevingUnderkjennRequest>()
-                        service.underkjennVedtak(behandlingId, kommentar, valgtBegrunnelse, it)
+                        service.underkjennVedtak(tilbakekrevingId, kommentar, valgtBegrunnelse, it)
                         call.respond(HttpStatusCode.OK)
                     }
                 }

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakTilgangDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakTilgangDao.kt
@@ -145,4 +145,30 @@ class SakTilgangDao(private val datasource: DataSource) {
             }
         }
     }
+
+    fun hentSakMedGraderingOgSkjermingPaaTilbakekreving(tilbakekrevingId: String): SakMedGraderingOgSkjermet? {
+        datasource.connection.use { connection ->
+            val statement =
+                connection.prepareStatement(
+                    """
+                    SELECT s.id as sak_id, adressebeskyttelse, erskjermet, enhet 
+                    FROM tilbakekreving t
+                    INNER JOIN sak s on t.sak_id = s.id
+                    WHERE t.id = ?::uuid
+                    """.trimIndent(),
+                )
+            statement.setString(1, tilbakekrevingId)
+            return statement.executeQuery().singleOrNull {
+                SakMedGraderingOgSkjermet(
+                    id = getLong("sak_id"),
+                    adressebeskyttelseGradering =
+                        getString("adressebeskyttelse")?.let {
+                            AdressebeskyttelseGradering.valueOf(it)
+                        },
+                    erSkjermet = getBoolean("erskjermet"),
+                    enhetNr = getString("enhet"),
+                )
+            }
+        }
+    }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/TilgangService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/TilgangService.kt
@@ -34,6 +34,11 @@ interface TilgangService {
         behandlingId: String,
         saksbehandlerMedRoller: SaksbehandlerMedRoller,
     ): Boolean
+
+    fun harTilgangTilTilbakekreving(
+        tilbakekrevingId: String,
+        saksbehandlerMedRoller: SaksbehandlerMedRoller,
+    ): Boolean
 }
 
 data class SakMedGraderingOgSkjermet(
@@ -88,6 +93,15 @@ class TilgangServiceImpl(
     ): Boolean {
         val sakMedGraderingOgSkjermet =
             dao.hentSakMedGraderingOgSkjermingPaaGenerellbehandling(behandlingId) ?: throw GenerellIkkeFunnetException()
+        return harTilgangSjekker(sakMedGraderingOgSkjermet, saksbehandlerMedRoller)
+    }
+
+    override fun harTilgangTilTilbakekreving(
+        tilbakekrevingId: String,
+        saksbehandlerMedRoller: SaksbehandlerMedRoller,
+    ): Boolean {
+        val sakMedGraderingOgSkjermet =
+            dao.hentSakMedGraderingOgSkjermingPaaTilbakekreving(tilbakekrevingId) ?: throw GenerellIkkeFunnetException()
         return harTilgangSjekker(sakMedGraderingOgSkjermet, saksbehandlerMedRoller)
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
@@ -37,6 +37,8 @@ class PluginConfiguration {
     -> Boolean = { _, _ -> false }
     var harTilgangTilGenerellBehandling: (generellbehandlingId: String, saksbehandlerMedRoller: SaksbehandlerMedRoller)
     -> Boolean = { _, _ -> false }
+    var harTilgangTilTilbakekreving: (klageId: String, saksbehandlerMedRoller: SaksbehandlerMedRoller)
+    -> Boolean = { _, _ -> false }
     var saksbehandlerGroupIdsByKey: Map<AzureGroup, String> = emptyMap()
 }
 
@@ -131,6 +133,16 @@ val adressebeskyttelsePlugin: RouteScopedPlugin<PluginConfiguration> =
                             }
                             return@on
                         }
+                        CallParamAuthId.TILBAKEKREVINGID -> {
+                            if (!pluginConfig.harTilgangTilTilbakekreving(
+                                    idForRequest,
+                                    SaksbehandlerMedRoller(bruker, saksbehandlerGroupIdsByKey),
+                                )
+                            ) {
+                                call.respond(HttpStatusCode.NotFound)
+                            }
+                            return@on
+                        }
                     }
                 }
             }
@@ -204,9 +216,9 @@ private fun PipelineContext<*, ApplicationCall>.finnSkriveTilgangForId(sakId: Lo
             CallParamAuthId.OPPGAVEID -> sakTilgangDao.hentSakMedGraderingOgSkjermingPaaOppgave(idForRequest)?.enhetNr
             CallParamAuthId.KLAGEID -> sakTilgangDao.hentSakMedGraderingOgSkjermingPaaKlage(idForRequest)?.enhetNr
             CallParamAuthId.GENERELLBEHANDLINGID ->
-                sakTilgangDao.hentSakMedGraderingOgSkjermingPaaGenerellbehandling(
-                    idForRequest,
-                )?.enhetNr
+                sakTilgangDao.hentSakMedGraderingOgSkjermingPaaGenerellbehandling(idForRequest)?.enhetNr
+            CallParamAuthId.TILBAKEKREVINGID ->
+                sakTilgangDao.hentSakMedGraderingOgSkjermingPaaTilbakekreving(idForRequest)?.enhetNr
         }
     }
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/attesterTilbakekreving.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/attesterTilbakekreving.tsx
@@ -25,7 +25,7 @@ export const AttesterTilbakekreving = ({
 
   const attester = () => {
     apiAttesterVedtak(
-      { behandlingsId: tilbakekreving.id, kommentar },
+      { tilbakekrevingId: tilbakekreving.id, kommentar },
       () => navigate(`/person/${tilbakekreving.sak.ident}`),
       (error) => {
         setError(`Ukjent feil oppsto ved attestering av vedtaket: ${error.detail}`)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/underkjennTilbakekreving.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/handinger/underkjennTilbakekreving.tsx
@@ -21,7 +21,7 @@ export const UnderkjennTilbakekreving = ({ tilbakekreving, kommentar, valgtBegru
   const [underkjennStatus, apiUnderkjennVedtak] = useApiCall(underkjennVedtak)
 
   const underkjenn = () => {
-    apiUnderkjennVedtak({ behandlingsId: tilbakekreving.id, kommentar, valgtBegrunnelse }, () => {
+    apiUnderkjennVedtak({ tilbakekrevingId: tilbakekreving.id, kommentar, valgtBegrunnelse }, () => {
       navigate(`/person/${tilbakekreving.sak.ident}`)
     })
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/oppsummering/TilbakekrevingOppsummering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/oppsummering/TilbakekrevingOppsummering.tsx
@@ -45,7 +45,7 @@ export function TilbakekrevingOppsummering({
 
   const lagreOppsummering = (skalSendeBrev: ISkalSendeBrev) => {
     lagreSkalSendeBrevRequest(
-      { behandlingsId: behandling.id, skalSendeBrev: skalSendeBrev.skalSendeBrev },
+      { tilbakekrevingId: behandling.id, skalSendeBrev: skalSendeBrev.skalSendeBrev },
       (lagretTilbakekreving) => {
         dispatch(addTilbakekreving(lagretTilbakekreving))
         reset({ skalSendeBrev: lagretTilbakekreving.sendeBrev })

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderSkjema.tsx
@@ -54,7 +54,7 @@ export function TilbakekrevingVurderingPerioderSkjema({
   }, [formState])
 
   const lagrePerioderOgFortsett = (data: { values: TilbakekrevingPeriode[] }) => {
-    lagrePerioderRequest({ behandlingsId: behandling.id, perioder: data.values }, (lagretTilbakekreving) => {
+    lagrePerioderRequest({ tilbakekrevingId: behandling.id, perioder: data.values }, (lagretTilbakekreving) => {
       dispatch(addTilbakekreving(lagretTilbakekreving))
       reset({ values: lagretTilbakekreving.tilbakekreving.perioder })
       navigate(`/tilbakekreving/${behandling?.id}/oppsummering`)
@@ -62,7 +62,7 @@ export function TilbakekrevingVurderingPerioderSkjema({
   }
 
   const lagrePerioder = (data: { values: TilbakekrevingPeriode[] }) => {
-    lagrePerioderRequest({ behandlingsId: behandling.id, perioder: data.values }, (lagretTilbakekreving) => {
+    lagrePerioderRequest({ tilbakekrevingId: behandling.id, perioder: data.values }, (lagretTilbakekreving) => {
       dispatch(addTilbakekreving(lagretTilbakekreving))
       reset({ values: lagretTilbakekreving.tilbakekreving.perioder })
     })

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderSkjema.tsx
@@ -56,7 +56,7 @@ export function TilbakekrevingVurderingPerioderSkjema({
   const lagrePerioderOgFortsett = (data: { values: TilbakekrevingPeriode[] }) => {
     lagrePerioderRequest({ tilbakekrevingId: behandling.id, perioder: data.values }, (lagretTilbakekreving) => {
       dispatch(addTilbakekreving(lagretTilbakekreving))
-      reset({ values: lagretTilbakekreving.tilbakekreving.perioder })
+      reset({ values: lagretTilbakekreving.tilbakekreving.perioder }, { keepDirtyValues: true })
       navigate(`/tilbakekreving/${behandling?.id}/oppsummering`)
     })
   }
@@ -64,7 +64,7 @@ export function TilbakekrevingVurderingPerioderSkjema({
   const lagrePerioder = (data: { values: TilbakekrevingPeriode[] }) => {
     lagrePerioderRequest({ tilbakekrevingId: behandling.id, perioder: data.values }, (lagretTilbakekreving) => {
       dispatch(addTilbakekreving(lagretTilbakekreving))
-      reset({ values: lagretTilbakekreving.tilbakekreving.perioder })
+      reset({ values: lagretTilbakekreving.tilbakekreving.perioder }, { keepDirtyValues: true })
     })
   }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderSkjema.tsx
@@ -39,13 +39,14 @@ export function TilbakekrevingVurderingPerioderSkjema({
     watch,
     formState,
     reset,
+    getValues,
   } = useForm<{ values: TilbakekrevingPeriode[] }>({
     defaultValues: { values: behandling.tilbakekreving.perioder },
   })
 
   useEffect(() => {
     if (formState.isDirty && Object.keys(formState.dirtyFields).length) {
-      const delay = setTimeout(handleSubmit(lagrePerioder), 2000)
+      const delay = setTimeout(handleSubmit(autolagrePerioder), 2000)
 
       return () => {
         clearTimeout(delay)
@@ -53,19 +54,27 @@ export function TilbakekrevingVurderingPerioderSkjema({
     }
   }, [formState])
 
-  const lagrePerioderOgFortsett = (data: { values: TilbakekrevingPeriode[] }) => {
-    lagrePerioderRequest({ tilbakekrevingId: behandling.id, perioder: data.values }, (lagretTilbakekreving) => {
-      dispatch(addTilbakekreving(lagretTilbakekreving))
-      reset({ values: lagretTilbakekreving.tilbakekreving.perioder }, { keepDirtyValues: true })
-      navigate(`/tilbakekreving/${behandling?.id}/oppsummering`)
-    })
+  const autolagrePerioder = (data: { values: TilbakekrevingPeriode[] }) => {
+    lagrePerioder(data)
   }
 
-  const lagrePerioder = (data: { values: TilbakekrevingPeriode[] }) => {
-    lagrePerioderRequest({ tilbakekrevingId: behandling.id, perioder: data.values }, (lagretTilbakekreving) => {
-      dispatch(addTilbakekreving(lagretTilbakekreving))
-      reset({ values: lagretTilbakekreving.tilbakekreving.perioder }, { keepDirtyValues: true })
-    })
+  const lagrePerioderOgFortsett = (data: { values: TilbakekrevingPeriode[] }) => {
+    lagrePerioder(data, () => navigate(`/tilbakekreving/${behandling?.id}/oppsummering`))
+  }
+
+  const lagrePerioder = (data: { values: TilbakekrevingPeriode[] }, onSuccess?: () => void) => {
+    reset(getValues())
+    lagrePerioderRequest(
+      { tilbakekrevingId: behandling.id, perioder: data.values },
+      (lagretTilbakekreving) => {
+        dispatch(addTilbakekreving(lagretTilbakekreving))
+        reset({ values: lagretTilbakekreving.tilbakekreving.perioder }, { keepDirtyValues: true })
+        onSuccess?.()
+      },
+      () => {
+        reset(getValues())
+      }
+    )
   }
 
   return (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingSkjema.tsx
@@ -66,31 +66,39 @@ export function TilbakekrevingVurderingSkjema({
   const navigate = useNavigate()
   const [lagreVurderingStatus, lagreVurderingRequest] = useApiCall(lagreTilbakekrevingsvurdering)
 
-  const { register, handleSubmit, watch, control, formState, reset } = useForm<TilbakekrevingVurdering>({
+  const { register, handleSubmit, watch, control, formState, reset, getValues } = useForm<TilbakekrevingVurdering>({
     defaultValues: behandling.tilbakekreving.vurdering || initialVurdering,
   })
 
   useEffect(() => {
     if (formState.isDirty && Object.keys(formState.dirtyFields).length) {
-      const delay = setTimeout(handleSubmit(lagreVurdering), 2000)
+      const delay = setTimeout(handleSubmit(autolagreVurdering), 2000)
 
       return () => clearTimeout(delay)
     }
   }, [formState])
 
-  const lagreVurdering = (vurdering: TilbakekrevingVurdering) => {
-    lagreVurderingRequest({ tilbakekrevingId: behandling.id, vurdering: vurdering }, (lagretBehandling) => {
-      dispatch(addTilbakekreving(lagretBehandling))
-      reset(lagretBehandling.tilbakekreving.vurdering || initialVurdering, { keepDirtyValues: true })
-    })
+  const autolagreVurdering = (vurdering: TilbakekrevingVurdering) => {
+    lagreVurdering(vurdering)
   }
 
   const lagreVurderingOgFortsett = (vurdering: TilbakekrevingVurdering) => {
-    lagreVurderingRequest({ tilbakekrevingId: behandling.id, vurdering: vurdering }, (lagretBehandling) => {
-      dispatch(addTilbakekreving(lagretBehandling))
-      reset(lagretBehandling.tilbakekreving.vurdering || initialVurdering, { keepDirtyValues: true })
-      navigate(`/tilbakekreving/${behandling?.id}/utbetalinger`)
-    })
+    lagreVurdering(vurdering, () => navigate(`/tilbakekreving/${behandling?.id}/utbetalinger`))
+  }
+
+  const lagreVurdering = (vurdering: TilbakekrevingVurdering, onSuccess?: () => void) => {
+    reset(getValues())
+    lagreVurderingRequest(
+      { tilbakekrevingId: behandling.id, vurdering: vurdering },
+      (lagretBehandling) => {
+        dispatch(addTilbakekreving(lagretBehandling))
+        reset(lagretBehandling.tilbakekreving.vurdering || initialVurdering, { keepDirtyValues: true })
+        onSuccess?.()
+      },
+      () => {
+        reset(getValues())
+      }
+    )
   }
 
   const vilkaarOppfylt = () =>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingSkjema.tsx
@@ -79,14 +79,14 @@ export function TilbakekrevingVurderingSkjema({
   }, [formState])
 
   const lagreVurdering = (vurdering: TilbakekrevingVurdering) => {
-    lagreVurderingRequest({ behandlingsId: behandling.id, vurdering: vurdering }, (lagretBehandling) => {
+    lagreVurderingRequest({ tilbakekrevingId: behandling.id, vurdering: vurdering }, (lagretBehandling) => {
       dispatch(addTilbakekreving(lagretBehandling))
       reset(lagretBehandling.tilbakekreving.vurdering || initialVurdering)
     })
   }
 
   const lagreVurderingOgFortsett = (vurdering: TilbakekrevingVurdering) => {
-    lagreVurderingRequest({ behandlingsId: behandling.id, vurdering: vurdering }, (lagretBehandling) => {
+    lagreVurderingRequest({ tilbakekrevingId: behandling.id, vurdering: vurdering }, (lagretBehandling) => {
       dispatch(addTilbakekreving(lagretBehandling))
       reset(lagretBehandling.tilbakekreving.vurdering || initialVurdering)
       navigate(`/tilbakekreving/${behandling?.id}/utbetalinger`)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingSkjema.tsx
@@ -81,14 +81,14 @@ export function TilbakekrevingVurderingSkjema({
   const lagreVurdering = (vurdering: TilbakekrevingVurdering) => {
     lagreVurderingRequest({ tilbakekrevingId: behandling.id, vurdering: vurdering }, (lagretBehandling) => {
       dispatch(addTilbakekreving(lagretBehandling))
-      reset(lagretBehandling.tilbakekreving.vurdering || initialVurdering)
+      reset(lagretBehandling.tilbakekreving.vurdering || initialVurdering, { keepDirtyValues: true })
     })
   }
 
   const lagreVurderingOgFortsett = (vurdering: TilbakekrevingVurdering) => {
     lagreVurderingRequest({ tilbakekrevingId: behandling.id, vurdering: vurdering }, (lagretBehandling) => {
       dispatch(addTilbakekreving(lagretBehandling))
-      reset(lagretBehandling.tilbakekreving.vurdering || initialVurdering)
+      reset(lagretBehandling.tilbakekreving.vurdering || initialVurdering, { keepDirtyValues: true })
       navigate(`/tilbakekreving/${behandling?.id}/utbetalinger`)
     })
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/tilbakekreving.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/tilbakekreving.ts
@@ -10,51 +10,55 @@ export function hentTilbakekrevingerISak(sakId: number): Promise<ApiResponse<Arr
 }
 
 export function lagreTilbakekrevingsvurdering(args: {
-  behandlingsId: string
+  tilbakekrevingId: string
   vurdering: TilbakekrevingVurdering
 }): Promise<ApiResponse<TilbakekrevingBehandling>> {
-  return apiClient.put(`/tilbakekreving/${args.behandlingsId}/vurdering`, { ...args.vurdering })
+  return apiClient.put(`/tilbakekreving/${args.tilbakekrevingId}/vurdering`, { ...args.vurdering })
 }
 
 export function lagreSkalSendeBrev(args: {
-  behandlingsId: string
+  tilbakekrevingId: string
   skalSendeBrev: boolean
 }): Promise<ApiResponse<TilbakekrevingBehandling>> {
-  return apiClient.put(`/tilbakekreving/${args.behandlingsId}/skal-sende-brev`, { skalSendeBrev: args.skalSendeBrev })
+  return apiClient.put(`/tilbakekreving/${args.tilbakekrevingId}/skal-sende-brev`, {
+    skalSendeBrev: args.skalSendeBrev,
+  })
 }
 
 export function lagreTilbakekrevingsperioder(args: {
-  behandlingsId: string
+  tilbakekrevingId: string
   perioder: TilbakekrevingPeriode[]
 }): Promise<ApiResponse<TilbakekrevingBehandling>> {
-  return apiClient.put(`/tilbakekreving/${args.behandlingsId}/perioder`, { perioder: args.perioder })
+  return apiClient.put(`/tilbakekreving/${args.tilbakekrevingId}/perioder`, { perioder: args.perioder })
 }
 
-export const validerTilbakekreving = async (behandlingsId: string): Promise<ApiResponse<TilbakekrevingBehandling>> => {
-  return apiClient.post(`/tilbakekreving/${behandlingsId}/valider`, {})
+export const validerTilbakekreving = async (
+  tilbakekrevingId: string
+): Promise<ApiResponse<TilbakekrevingBehandling>> => {
+  return apiClient.post(`/tilbakekreving/${tilbakekrevingId}/valider`, {})
 }
 
-export const opprettVedtak = async (behandlingsId: string): Promise<ApiResponse<unknown>> => {
-  return apiClient.post(`/tilbakekreving/${behandlingsId}/vedtak/opprett`, {})
+export const opprettVedtak = async (tilbakekrevingId: string): Promise<ApiResponse<unknown>> => {
+  return apiClient.post(`/tilbakekreving/${tilbakekrevingId}/vedtak/opprett`, {})
 }
 
-export const fattVedtak = async (behandlingsId: string): Promise<ApiResponse<unknown>> => {
-  return apiClient.post(`/tilbakekreving/${behandlingsId}/vedtak/fatt`, {})
+export const fattVedtak = async (tilbakekrevingId: string): Promise<ApiResponse<unknown>> => {
+  return apiClient.post(`/tilbakekreving/${tilbakekrevingId}/vedtak/fatt`, {})
 }
 
 export const attesterVedtak = async (args: {
-  behandlingsId: string
+  tilbakekrevingId: string
   kommentar: string
 }): Promise<ApiResponse<unknown>> => {
-  return apiClient.post(`/tilbakekreving/${args.behandlingsId}/vedtak/attester`, { kommentar: args.kommentar })
+  return apiClient.post(`/tilbakekreving/${args.tilbakekrevingId}/vedtak/attester`, { kommentar: args.kommentar })
 }
 
 export const underkjennVedtak = async (args: {
-  behandlingsId: string
+  tilbakekrevingId: string
   kommentar: string
   valgtBegrunnelse: string
 }): Promise<ApiResponse<unknown>> => {
-  return apiClient.post(`/tilbakekreving/${args.behandlingsId}/vedtak/underkjenn`, {
+  return apiClient.post(`/tilbakekreving/${args.tilbakekrevingId}/vedtak/underkjenn`, {
     kommentar: args.kommentar,
     valgtBegrunnelse: args.valgtBegrunnelse,
   })

--- a/libs/etterlatte-ktor/src/main/kotlin/route/RouteUtils.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/route/RouteUtils.kt
@@ -27,6 +27,7 @@ const val SAKID_CALL_PARAMETER = "sakId"
 const val OPPGAVEID_CALL_PARAMETER = "oppgaveId"
 const val KLAGEID_CALL_PARAMETER = "klageId"
 const val GENERELLBEHANDLINGID_CALL_PARAMETER = "generellBehandlingId"
+const val TILBAKEKREVINGID_CALL_PARAMETER = "tilbakekrevingId"
 
 enum class CallParamAuthId(val value: String) {
     BEHANDLINGID(BEHANDLINGID_CALL_PARAMETER),
@@ -34,6 +35,7 @@ enum class CallParamAuthId(val value: String) {
     OPPGAVEID(OPPGAVEID_CALL_PARAMETER),
     KLAGEID(KLAGEID_CALL_PARAMETER),
     GENERELLBEHANDLINGID(GENERELLBEHANDLINGID_CALL_PARAMETER),
+    TILBAKEKREVINGID(TILBAKEKREVINGID_CALL_PARAMETER),
 }
 
 const val OPPGAVEID_GOSYS_CALL_PARAMETER = "gosysOppgaveId"
@@ -73,6 +75,12 @@ inline val PipelineContext<*, ApplicationCall>.gosysOppgaveId: String
         requireNotNull(call.parameters[OPPGAVEID_GOSYS_CALL_PARAMETER]) {
             "Gosys oppgaveId er ikke i path params"
         }
+
+inline val PipelineContext<*, ApplicationCall>.tilbakekrevingId: UUID
+    get() =
+        call.parameters[TILBAKEKREVINGID_CALL_PARAMETER]?.let { UUID.fromString(it) } ?: throw NullPointerException(
+            "TilbakekrevingId er ikke i path params",
+        )
 
 val logger = LoggerFactory.getLogger("TilgangsSjekk")
 


### PR DESCRIPTION
Denne sjekker tilgang bare i tilbakekreving-tabellen, i motsetning til klage, behandling og tilbakekreving. Ny call parameter TILBAKEKREVINGID_CALL_PARAMETER, som brukes i tilbakekrevingRoutes.