### PR TITLE
FAGSYSTEM-329157 - fiks normalization av trygdetid perioder

### DIFF
--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/Trygdetid.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/Trygdetid.kt
@@ -137,7 +137,7 @@ data class TrygdetidPeriode(
 }
 
 fun List<TrygdetidGrunnlag>.normaliser() =
-    this.mapIndexed { idx, trygdetidGrunnlag ->
+    this.sortedBy { it.periode.fra }.mapIndexed { idx, trygdetidGrunnlag ->
         var fra = trygdetidGrunnlag.periode.fra
         var til = trygdetidGrunnlag.periode.til
 

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TestHelper.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TestHelper.kt
@@ -100,10 +100,11 @@ fun trygdetidGrunnlag(
     poengUtAar: Boolean = false,
     prorata: Boolean = false,
     trygdetidType: TrygdetidType = TrygdetidType.FAKTISK,
+    bosted: String = LandNormalisert.NORGE.isoCode,
 ) = TrygdetidGrunnlag(
     id = randomUUID(),
     type = trygdetidType,
-    bosted = LandNormalisert.NORGE.isoCode,
+    bosted = bosted,
     periode = periode,
     beregnetTrygdetid = beregnetTrygdetidGrunnlag,
     kilde = Grunnlagsopplysning.Saksbehandler(ident = "Z123", tidspunkt = Tidspunkt.now()),

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidTest.kt
@@ -130,4 +130,33 @@ internal class TrygdetidTest {
             trygdetid.leggTilEllerOppdaterTrygdetidGrunnlag(overlappendePeriode)
         }
     }
+
+    @Test
+    fun `Skal normaliser riktig`() {
+        val grunnlag =
+            listOf(
+                trygdetidGrunnlag(
+                    periode = TrygdetidPeriode(LocalDate.of(2014, 5, 20), LocalDate.of(2027, 12, 31)),
+                    trygdetidType = TrygdetidType.FREMTIDIG,
+                ),
+                trygdetidGrunnlag(
+                    periode = TrygdetidPeriode(LocalDate.of(2006, 1, 1), LocalDate.of(2014, 4, 30)),
+                    poengInnAar = true,
+                    trygdetidType = TrygdetidType.FAKTISK,
+                ),
+                trygdetidGrunnlag(
+                    periode = TrygdetidPeriode(LocalDate.of(2002, 1, 1), LocalDate.of(2005, 12, 31)),
+                    trygdetidType = TrygdetidType.FAKTISK,
+                    bosted = LandNormalisert.POLEN.isoCode,
+                ),
+                trygdetidGrunnlag(
+                    periode = TrygdetidPeriode(LocalDate.of(2000, 6, 1), LocalDate.of(2000, 6, 18)),
+                    trygdetidType = TrygdetidType.FAKTISK,
+                ),
+            )
+
+        val normalisert = grunnlag.normaliser()
+
+        normalisert.size shouldBe 4
+    }
 }

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidTest.kt
@@ -132,31 +132,36 @@ internal class TrygdetidTest {
     }
 
     @Test
-    fun `Skal normaliser riktig`() {
-        val grunnlag =
-            listOf(
-                trygdetidGrunnlag(
-                    periode = TrygdetidPeriode(LocalDate.of(2014, 5, 20), LocalDate.of(2027, 12, 31)),
-                    trygdetidType = TrygdetidType.FREMTIDIG,
-                ),
-                trygdetidGrunnlag(
-                    periode = TrygdetidPeriode(LocalDate.of(2006, 1, 1), LocalDate.of(2014, 4, 30)),
-                    poengInnAar = true,
-                    trygdetidType = TrygdetidType.FAKTISK,
-                ),
-                trygdetidGrunnlag(
-                    periode = TrygdetidPeriode(LocalDate.of(2002, 1, 1), LocalDate.of(2005, 12, 31)),
-                    trygdetidType = TrygdetidType.FAKTISK,
-                    bosted = LandNormalisert.POLEN.isoCode,
-                ),
+    fun `Skal kunne legge til uansett input sorteringsrekkefølge`() {
+        val usortertTrygdetid =
+            trygdetid(
+                trygdetidGrunnlag =
+                    listOf(
+                        trygdetidGrunnlag(
+                            periode = TrygdetidPeriode(LocalDate.of(2014, 5, 20), LocalDate.of(2027, 12, 31)),
+                            trygdetidType = TrygdetidType.FREMTIDIG,
+                        ),
+                        trygdetidGrunnlag(
+                            periode = TrygdetidPeriode(LocalDate.of(2006, 1, 1), LocalDate.of(2014, 4, 30)),
+                            poengInnAar = true,
+                            trygdetidType = TrygdetidType.FAKTISK,
+                        ),
+                        trygdetidGrunnlag(
+                            periode = TrygdetidPeriode(LocalDate.of(2002, 1, 1), LocalDate.of(2005, 12, 31)),
+                            trygdetidType = TrygdetidType.FAKTISK,
+                            bosted = LandNormalisert.POLEN.isoCode,
+                        ),
+                    ),
+            )
+
+        val oppdatert =
+            usortertTrygdetid.leggTilEllerOppdaterTrygdetidGrunnlag(
                 trygdetidGrunnlag(
                     periode = TrygdetidPeriode(LocalDate.of(2000, 6, 1), LocalDate.of(2000, 6, 18)),
                     trygdetidType = TrygdetidType.FAKTISK,
                 ),
             )
 
-        val normalisert = grunnlag.normaliser()
-
-        normalisert.size shouldBe 4
+        oppdatert.trygdetidGrunnlag.size shouldBe 4
     }
 }


### PR DESCRIPTION
Før så var det en forventning at input til normalize var sortert. Det har forsvunnet. Sorter innvendig - da er det garantert