### PR TITLE
Rydd bort duplikate sakrader gjenoppretting

### DIFF
--- a/apps/etterlatte-statistikk/src/main/resources/db/migration/V36__sett_riktig_patch_status.sql
+++ b/apps/etterlatte-statistikk/src/main/resources/db/migration/V36__sett_riktig_patch_status.sql
@@ -1,0 +1,1 @@
+update utlandstilknytning_fiksing set patch_status = 'IKKE_PATCHET' where patch_status = 'IKKE_PACHET';

--- a/apps/etterlatte-statistikk/src/main/resources/db/migration/V37__rydd_bort_duplikate_sak_rader.sql
+++ b/apps/etterlatte-statistikk/src/main/resources/db/migration/V37__rydd_bort_duplikate_sak_rader.sql
@@ -1,0 +1,4 @@
+-- Disse behandlingene har duplikate gjenopprettet-meldinger for opprettelse av behandlinger
+with duplikater_fra_gjenoppretting as (select behandling_id from sak where kilde = 'GJENOPPRETTA' and behandling_status='OPPRETTET' group by behandling_id having count(*) = 2)
+-- for de duplikate gjenopprettet-meldingene har en av de satt pesysid, mens en har ikke. Vi beholder den som har satt pesysid
+delete from sak where id in (select id from sak where pesysid is null and sak.behandling_status = 'OPPRETTET' and sak.behandling_id in (select * from duplikater_fra_gjenoppretting));


### PR DESCRIPTION
Det ble sendt duplikate opprettet-rader for alle automatisk opprettede behandlinger i gjenopprettingen. Det er litt hipp som happ mellom de to radene, men vi velger å beholde radene som har satt en pesysid for original behandling.