### PR TITLE
Lagt til indekser for behandlingsID i statistikk

### DIFF
--- a/apps/etterlatte-statistikk/src/main/resources/db/migration/V39__indekser.sql
+++ b/apps/etterlatte-statistikk/src/main/resources/db/migration/V39__indekser.sql
@@ -1,0 +1,7 @@
+CREATE INDEX on soeknad_statistikk (gyldig_for_behandling);
+
+CREATE INDEX on sak (behandling_id);
+
+CREATE INDEX on stoenad (behandlingid);
+
+CREATE INDEX on maaned_stoenad (behandlingid);


### PR DESCRIPTION
Basert på informasjon i GCP-konsollet.
![image](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/8087437/66efd6ef-b62d-47c0-b75e-df95be412990)

 Ikke sikkert at det vil ha voldsomt å si her og nå ettersom mengden data påvirker hvorvidt indeksen(e) faktisk blir brukt, men det vil jo bare bli mer og mer data over tid.