### PR TITLE
Lagt til GIN-basert index på grunnlagshendelse.opplysning for vesentlig raskere LIKE-søk med fnr

### DIFF
--- a/apps/etterlatte-grunnlag/src/main/resources/db/migration/V21__gin_index_opplysning_tekst.sql
+++ b/apps/etterlatte-grunnlag/src/main/resources/db/migration/V21__gin_index_opplysning_tekst.sql
@@ -1,0 +1,8 @@
+-- Hent opplysninger gjør oppslag på fnr i opplysning som fulltekst, med LIKE som ikke er spesielt performant.
+-- Indeksen reduserer responstiden på et ikke-cachet oppslag fra ca 30ms til 2ms
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE EXTENSION IF NOT EXISTS btree_gin;
+
+CREATE INDEX grunnlagshendelse_opplysning_gin_idx ON grunnlagshendelse USING GIN (opplysning gin_trgm_ops);


### PR DESCRIPTION
Dette er pga veldig hyppig bruk av dette oppslaget i `OpplysningDao`:
```
SELECT * FROM grunnlagshendelse
                WHERE opplysning LIKE ?
                AND opplysning_type = ?;
```

![image](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/8087437/9215933b-3a7f-43f1-bd79-e4d31051ac50)

60ms er drøyt for noe som kalles sååå ofte.