### PR TITLE
Ikke hente titusenvis av rader i subquery, men begrens til involvert(e) brev

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
@@ -431,9 +431,10 @@ class BrevRepository(private val ds: DataSource) {
             INNER JOIN innhold i on b.id = i.brev_id
             WHERE b.id = ?
             AND h.id IN (
-                SELECT DISTINCT ON (brev_id) id
-                FROM hendelse
-                ORDER  BY brev_id, opprettet DESC
+                SELECT DISTINCT ON (h2.brev_id) h2.id
+                FROM hendelse h2
+                WHERE h2.brev_id = b.id
+                ORDER BY h2.brev_id, h2.opprettet DESC
             )
         """
 
@@ -449,9 +450,10 @@ class BrevRepository(private val ds: DataSource) {
             AND b.brevtype = ?
             AND h.status_id != 'SLETTET'
             AND h.id IN (
-                SELECT DISTINCT ON (brev_id) id
-                FROM hendelse
-                ORDER BY brev_id, opprettet DESC
+                SELECT DISTINCT ON (h2.brev_id) h2.id
+                FROM hendelse h2
+                WHERE h2.brev_id = b.id
+                ORDER BY h2.brev_id, h2.opprettet DESC
             )
         """
 
@@ -466,9 +468,10 @@ class BrevRepository(private val ds: DataSource) {
             WHERE b.sak_id = ?
             AND h.status_id != 'SLETTET'
             AND h.id IN (
-                SELECT DISTINCT ON (brev_id) id
-                FROM hendelse
-                ORDER BY brev_id, opprettet DESC
+                SELECT DISTINCT ON (h2.brev_id) h2.id
+                FROM hendelse h2
+                WHERE h2.brev_id = b.id
+                ORDER BY h2.brev_id, h2.opprettet DESC
             )
         """
 


### PR DESCRIPTION
Basert på GCP-konsollet.

Ser ut til at subqueryen alltid henter rundt 18-19k rader, noe som fremstår veldig rart/unødvendig... tror ikke jeg har misforstått hva som forsøkes oppnådd her. Det er totalt ca 90k rader i `hendelse`.

https://console.cloud.google.com/sql/instances/etterlatte-brev-api/insights;database=etterlatte-brev;duration=P7D;trace=f206505668dc4e4c8e5caafd6e0fdded;span=f6d676ecc49dd811;query_hash=17985515780848363997;sort_by=TOTAL_EXEC_TIME/executed?project=etterlatte-prod-207c

![image](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/8087437/d488efaf-27dc-418a-b31e-9ff6d07b06e6)

Test med db i docker (med data dumpet fra dev) viser forbedring typisk fra 10-15ms til sub-0.5ms.