### PR TITLE
EY-3936: Sette tidligere dødsdato for avdød i testdata

### DIFF
--- a/apps/etterlatte-grunnlag/.nais/dev.yaml
+++ b/apps/etterlatte-grunnlag/.nais/dev.yaml
@@ -97,6 +97,7 @@ spec:
         - application: etterlatte-saksbehandling-ui
         - application: etterlatte-saksbehandling-ui-lokal # for å åpne for lokal utv. Ikke kopier denne til prod.yaml
         - application: etterlatte-tidshendelser
+        - application: etterlatte-testdata-behandler
         - application: azure-token-generator # https://docs.nais.io/security/auth/azure-ad/usage/#token-generator
           namespace: aura
           cluster: dev-gcp

--- a/apps/etterlatte-testdata-behandler/.nais/dev.yaml
+++ b/apps/etterlatte-testdata-behandler/.nais/dev.yaml
@@ -40,6 +40,8 @@ spec:
       value: etterlatte.dodsmelding
     - name: KAFKA_RESET_POLICY
       value: earliest
+    - name: GRUNNLAG_AZURE_SCOPE
+      value: api://dev-gcp.etterlatte.etterlatte-grunnlag/.default
     - name: BEHANDLING_AZURE_SCOPE
       value: api://dev-gcp.etterlatte.etterlatte-behandling/.default
     - name: BEREGNING_AZURE_SCOPE
@@ -54,6 +56,8 @@ spec:
       value: api://dev-gcp.etterlatte.etterlatte-vedtaksvurdering/.default
     - name: ETTERLATTE_BEREGNING_CLIENT_ID
       value: b07cf335-11fb-4efa-bd46-11f51afd5052
+    - name: ETTERLATTE_GRUNNLAG_CLIENT_ID
+      value: ce96a301-13db-4409-b277-5b27f464d08b
     - name: ETTERLATTE_BEHANDLING_CLIENT_ID
       value: 59967ac8-009c-492e-a618-e5a0f6b3e4e4
     - name: ETTERLATTE_BREV_API_CLIENT_ID
@@ -67,6 +71,7 @@ spec:
   accessPolicy:
     outbound:
       rules:
+        - application: etterlatte-grunnlag
         - application: etterlatte-behandling
         - application: etterlatte-beregning
         - application: etterlatte-trygdetid

--- a/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/AppBuilder.kt
+++ b/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/AppBuilder.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.testdata.automatisk.AvkortingService
 import no.nav.etterlatte.testdata.automatisk.BehandlingService
 import no.nav.etterlatte.testdata.automatisk.BeregningService
 import no.nav.etterlatte.testdata.automatisk.BrevService
+import no.nav.etterlatte.testdata.automatisk.GrunnlagService
 import no.nav.etterlatte.testdata.automatisk.TrygdetidService
 import no.nav.etterlatte.testdata.automatisk.VedtaksvurderingService
 import no.nav.etterlatte.testdata.automatisk.VilkaarsvurderingService
@@ -34,6 +35,12 @@ class AppBuilder {
                 settOppHttpClient("vilkaarsvurdering"),
                 "http://etterlatte-vilkaarsvurdering",
                 config.getString("vilkaarsvurdering.client.id"),
+            )
+        val grunnlagService =
+            GrunnlagService(
+                settOppHttpClient("grunnlag"),
+                "http://etterlatte-grunnlag",
+                config.getString("grunnlag.client.id"),
             )
         val behandlingService =
             BehandlingService(
@@ -77,6 +84,7 @@ class AppBuilder {
             avkortingService = avkortingService,
             beregningService = beregningService,
             brevService = brevService,
+            grunnlagService = grunnlagService,
             behandlingService = behandlingService,
             trygdetidService = trygdetidService,
             vedtaksvurderingService = vedtaksvurderingService,

--- a/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/Behandler.kt
+++ b/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/Behandler.kt
@@ -1,12 +1,14 @@
 package no.nav.etterlatte.testdata
 
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.grunnlag.hentDoedsdato
 import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
 import no.nav.etterlatte.rapidsandrivers.Behandlingssteg
 import no.nav.etterlatte.testdata.automatisk.AvkortingService
 import no.nav.etterlatte.testdata.automatisk.BehandlingService
 import no.nav.etterlatte.testdata.automatisk.BeregningService
 import no.nav.etterlatte.testdata.automatisk.BrevService
+import no.nav.etterlatte.testdata.automatisk.GrunnlagService
 import no.nav.etterlatte.testdata.automatisk.TrygdetidService
 import no.nav.etterlatte.testdata.automatisk.VedtaksvurderingService
 import no.nav.etterlatte.testdata.automatisk.VilkaarsvurderingService
@@ -16,6 +18,7 @@ import org.slf4j.LoggerFactory
 import java.util.UUID
 
 class Behandler(
+    private val grunnlagService: GrunnlagService,
     private val behandlingService: BehandlingService,
     private val vilkaarsvurderingService: VilkaarsvurderingService,
     private val trygdetidService: TrygdetidService,
@@ -40,10 +43,12 @@ class Behandler(
         val sak = behandlingService.hentSak(sakId)
         logger.info("Henta sak $sakId")
 
+        val doedsdato = grunnlagService.hentGrunnlagForBehandling(behandling).hentAvdoede().first().hentDoedsdato()
+
         behandlingService.settKommerBarnetTilGode(behandling)
         behandlingService.lagreGyldighetsproeving(behandling)
         behandlingService.lagreUtlandstilknytning(behandling)
-        behandlingService.lagreVirkningstidspunkt(behandling)
+        behandlingService.lagreVirkningstidspunkt(behandling, doedsdato?.verdi!!)
         behandlingService.tildelSaksbehandler(Fagsaksystem.EY.navn, sakId)
 
         logger.info("Tildelt til saksbehandler, klar til vilkårsvurdering")

--- a/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/BehandlingService.kt
+++ b/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/BehandlingService.kt
@@ -20,6 +20,7 @@ import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.etterlatte.readValue
 import no.nav.etterlatte.sak.UtlandstilknytningRequest
 import no.nav.etterlatte.testdata.BEGRUNNELSE
+import java.time.LocalDate
 import java.time.YearMonth
 import java.util.UUID
 
@@ -79,13 +80,18 @@ class BehandlingService(private val klient: DownstreamResourceClient, private va
         }
     }
 
-    suspend fun lagreVirkningstidspunkt(behandling: UUID) {
+    suspend fun lagreVirkningstidspunkt(
+        behandling: UUID,
+        doedsdato: LocalDate,
+    ) {
+        val virkningstidspunkt = doedsdato.plusMonths(1)
+
         retryOgPakkUt {
             klient.post(
                 Resource(clientId, "$url/api/behandling/$behandling/virkningstidspunkt"),
                 Systembruker.testdata,
                 VirkningstidspunktRequest(
-                    _dato = YearMonth.now().plusMonths(1).toString(),
+                    _dato = YearMonth.of(virkningstidspunkt.year, virkningstidspunkt.month).toString(),
                     begrunnelse = BEGRUNNELSE,
                     kravdato = null,
                 ),

--- a/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/GrunnlagService.kt
+++ b/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/GrunnlagService.kt
@@ -1,0 +1,20 @@
+package no.nav.etterlatte.testdata.automatisk
+
+import com.github.michaelbull.result.mapBoth
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
+import no.nav.etterlatte.libs.common.retryOgPakkUt
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
+import no.nav.etterlatte.libs.ktor.token.Systembruker
+import no.nav.etterlatte.readValue
+import java.util.UUID
+
+class GrunnlagService(private val klient: DownstreamResourceClient, private val url: String, private val clientId: String) {
+    suspend fun hentGrunnlagForBehandling(behandlingId: UUID): Grunnlag =
+        retryOgPakkUt {
+            klient.get(Resource(clientId, "$url/api/grunnlag/behandling/$behandlingId"), Systembruker.testdata).mapBoth(
+                success = { readValue(it) },
+                failure = { throw it },
+            )
+        }
+}

--- a/apps/etterlatte-testdata-behandler/src/main/resources/application.conf
+++ b/apps/etterlatte-testdata-behandler/src/main/resources/application.conf
@@ -3,6 +3,7 @@ azure.app.jwk = ${?AZURE_APP_JWK}
 azure.app.client.secret = ${?AZURE_APP_CLIENT_SECRET}
 azure.app.well.known.url = ${?AZURE_APP_WELL_KNOWN_URL}
 
+grunnlag.azure.scope = ${?GRUNNLAG_AZURE_SCOPE}
 behandling.azure.scope = ${?BEHANDLING_AZURE_SCOPE}
 beregning.azure.scope = ${?BEREGNING_AZURE_SCOPE}
 brev.azure.scope = ${?BREV_AZURE_SCOPE}
@@ -10,6 +11,7 @@ trygdetid.azure.scope = ${?TRYGDETID_AZURE_SCOPE}
 vedtaksvurdering.azure.scope = ${?VEDTAKSVURDERING_AZURE_SCOPE}
 vilkaarsvurdering.azure.scope = ${?VILKAARSVURDERING_AZURE_SCOPE}
 
+grunnlag.client.id = ${?ETTERLATTE_GRUNNLAG_CLIENT_ID}
 behandling.client.id = ${?ETTERLATTE_BEHANDLING_CLIENT_ID}
 beregning.client.id = ${?ETTERLATTE_BEREGNING_CLIENT_ID}
 brev.client.id = ${?ETTERLATTE_BREV_API_CLIENT_ID}

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/dolly/Model.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/dolly/Model.kt
@@ -72,4 +72,5 @@ data class BestillingRequest(
     val halvsoeskenGjenlevende: Int,
     val gruppeId: Long,
     val antall: Int,
+    val antallDagerSidenDoedsfall: Int = 7,
 )

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/automatisk/Familieoppretter.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/automatisk/Familieoppretter.kt
@@ -19,6 +19,7 @@ class Familieoppretter(
         accessToken: String,
         gruppeid: Long,
         antall: Int,
+        antallDagerSidenDoedsfall: Int,
     ): BestillingStatus {
         val req =
             BestillingRequest(
@@ -28,6 +29,7 @@ class Familieoppretter(
                 halvsoeskenGjenlevende = 0,
                 gruppeId = gruppeid,
                 antall = antall,
+                antallDagerSidenDoedsfall = antallDagerSidenDoedsfall,
             )
 
         logger.info("Oppretter bestilling for gruppeid $gruppeid")

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/dolly/BestillingUtil.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/dolly/BestillingUtil.kt
@@ -34,7 +34,10 @@ fun generererBestilling(bestilling: BestillingRequest): String {
 
     val barnListe = listOf(listOf(soeker), helsoesken, halvsoeskenAvdoed).flatten()
 
-    return bestillingTemplateStart(Random.nextInt(20, 60), bestilling.antall) + barnListe + BESTLLING_TEMPLATE_END
+    return bestillingTemplateStart(
+        Random.nextInt(20, 60),
+        bestilling.antall,
+    ) + barnListe + bestillingTemplateEnd(LocalDateTime.now().minusDays(bestilling.antallDagerSidenDoedsfall.toLong()))
 }
 
 private fun alder18Til20() = Random.nextInt(18, 20)
@@ -86,7 +89,8 @@ fun bestillingTemplateStart(
       ],
       "forelderBarnRelasjon": """
 
-val BESTLLING_TEMPLATE_END = """,
+fun bestillingTemplateEnd(doedsdato: LocalDateTime) =
+    """,
       "sivilstand": [
         {
           "id": null,
@@ -121,7 +125,7 @@ val BESTLLING_TEMPLATE_END = """,
           "kilde": "Dolly",
           "master": "PDL",
           "folkeregistermetadata": null,
-          "doedsdato": "${LocalDateTime.now().minusWeeks(1)}"
+          "doedsdato": "$doedsdato"
         }
       ],
       "foreldreansvar": [

--- a/apps/etterlatte-testdata/src/main/resources/templates/dolly/opprett-og-behandle.hbs
+++ b/apps/etterlatte-testdata/src/main/resources/templates/dolly/opprett-og-behandle.hbs
@@ -77,13 +77,25 @@
 
         // Antall
         const antallLabel= document.createElement('label')
-        antallLabel.innerHTML = "Antall: "
+        antallLabel.innerHTML = "Antall saker: "
         antallLabel.htmlFor = "antall"
         inputTableElement.appendChild(antallLabel)
 
         const antallInput = document.createElement('input')
         antallInput.setAttribute('id', 'antall')
         inputTableElement.appendChild(antallInput)
+
+        inputTableElement.appendChild(document.createElement('br'))
+
+        // Antall dager siden dødsfall
+        const antallDagerSidenDoedsfallLabel = document.createElement('label')
+        antallDagerSidenDoedsfallLabel.innerHTML = "Antall dager siden dødsfall: "
+        antallDagerSidenDoedsfallLabel.htmlFor = "antallDagerSidenDoedsfall"
+        inputTableElement.appendChild(antallDagerSidenDoedsfallLabel)
+
+        const antallDagerSidenDoedsfallInput = document.createElement('input')
+        antallDagerSidenDoedsfallInput.setAttribute('id', 'antallDagerSidenDoedsfall')
+        inputTableElement.appendChild(antallDagerSidenDoedsfallInput)
 
         inputTableElement.appendChild(document.createElement('br'))
 
@@ -144,6 +156,7 @@
         soeknadInnsendtAlert.style.display = "none"
 
         const antall = document.getElementById("antall").value
+        const antallDagerSidenDoedsfall = document.getElementById("antallDagerSidenDoedsfall").value
         const steg = document.getElementById("behandlingsstegDropdown").value
 
         await fetch('opprett-og-behandle', {
@@ -151,7 +164,7 @@
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded'
             },
-            body: `type=${type}&antall=${antall}&behandlingssteg=${steg}&gruppeId={{gruppeId}}`
+            body: `type=${type}&antall=${antall}&antallDagerSidenDoedsfall=${antallDagerSidenDoedsfall}&behandlingssteg=${steg}&gruppeId={{gruppeId}}`
         }).then(res => res.json()).then(data => {
             if ((data.status === 200)) {
                 soeknadInnsendtAlert.firstElementChild.innerHTML = `Søknad er innsendt og registrert`


### PR DESCRIPTION
Gjør det mulig å sette tidligere dødsdato for avdød i testdata når man oppretter søknader som blir automatisk behandlet. Dette har vi behov for når vi tester regulering og trenger saker som er løpende før reguleringstidspunkt, og ikke bare etter.