### PR TITLE
Slette feilregistrert sak 17020

### DIFF
--- a/apps/etterlatte-behandling/src/main/resources/db/prod/V125__slette_feilregistrert_sak.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/prod/V125__slette_feilregistrert_sak.sql
@@ -1,0 +1,3 @@
+-- feilregistrert sak
+-- finnes verken grunnlag eller behandling tilknyttet denne.
+DELETE FROM sak WHERE id = 17020;


### PR DESCRIPTION
Hurtigfiks for å sikre at saksbehandler kan fortsette behandling på den gyldige søknaden. 

På sikt må vi få på plass et mer robust system for disse tilfellene med selvbetjening for sb, sakshistorikk, m.m. 