### PR TITLE
Droppe validering på virk for behandlinger som er migrering eller gjenoppretting fra Pesys

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
@@ -18,6 +18,7 @@ import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.common.tidligsteIverksatteVirkningstidspunkt
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseDao
 import no.nav.etterlatte.inTransaction
+import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingHendelseType
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
@@ -290,6 +291,10 @@ internal class BehandlingServiceImpl(
     ): Boolean {
         val behandling =
             requireNotNull(hentBehandling(behandlingId)) { "Fant ikke behandling $behandlingId" }
+
+        if (behandling.kilde in listOf(Vedtaksloesning.PESYS, Vedtaksloesning.GJENOPPRETTA)) {
+            return true
+        }
 
         return when (behandling.type) {
             BehandlingType.REVURDERING -> erGyldigVirkningstidspunktRevurdering(request, behandling)


### PR DESCRIPTION

Validering på virk er basert på rettigheter basert på når bruker søker og det er ikke noen ny søknad i disse tilfellene