### PR TITLE
Fjern opprett oppgave om oppfølging av aktivitetsplikt i gosys 

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/sjekkliste/Sjekkliste.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/sjekkliste/Sjekkliste.kt
@@ -53,7 +53,6 @@ internal val defaultSjekklisteItemsOMS =
         "Ikke søkt om, men kan ha rett på stønad til barnetilsyn - informert søker",
         "Mulighet for, og ikke søkt om (utvidet) barnetrygd. Oppgave til barnetrygd sendt",
         "Gjenlevende har gradert uføretrygd. Oppgave til NAY sendt.",
-        "Opprettet oppgave i Gosys for videre oppfølging av aktivitetsplikt",
         "Ikke registrert/feil kontonummer i saken - opprettet oppgave til NØP",
         "Refusjonskrav (annen NAV-ytelse) i etterbetaling av OMS - opprettet oppgave til NØP",
         "Bosatt Norge: Innhenter EØS og bank-opplysninger",

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/sjekkliste/SjekklisteIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/sjekkliste/SjekklisteIntegrationTest.kt
@@ -84,7 +84,7 @@ class SjekklisteIntegrationTest(val dataSource: DataSource) {
         opprettet.versjon shouldBe 1
         opprettet.sjekklisteItems.map { it.beskrivelse } shouldContainExactlyInAnyOrder defaultFoerstegangsbehandlingItemsOms
 
-        opprettet.sjekklisteItems shouldHaveAtLeastSize 13
+        opprettet.sjekklisteItems shouldHaveAtLeastSize 12
         opprettet.sjekklisteItems.forEach {
             it.avkrysset shouldBe false
             it.versjon shouldBe 1

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
@@ -136,6 +136,31 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
         )}
 
         <Heading size="small" spacing>
+          OPPFØLGING
+        </Heading>
+        <BodyLong spacing>
+          Etterlatte skal følges opp og minnes på aktivitetskravet med informasjonsbrev når det er gått 3 til 4 måneder
+          etter dødsfallet. Interne oppfølgingsoppgaver opprettes automatisk ut fra dødstidspunktet og må vurderes før
+          informasjonsbrevet sendes ut. Automatiske oppgaver blir opprettet som følge av hva du registrerer om burkers
+          situasjon.
+          <br />
+          <br />
+          Er det andre grunner til at den etterlatte skal følges opp utenfor normalen, så kan oppfølgingsoppgave lages
+          her:
+        </BodyLong>
+        <SpacingWrapper>
+          <Button
+            variant="secondary"
+            size="small"
+            as="a"
+            href={`${configContext['gosysUrl']}/personoversikt/fnr=${soeker?.foedselsnummer}`}
+            target="_blank"
+          >
+            Lag oppfølgingsoppgave i Gosys <ExternalLinkIcon />
+          </Button>
+        </SpacingWrapper>
+
+        <Heading size="small" spacing>
           Er oppfølging av lokalkontor nødvendig?
         </Heading>
         <BodyLong spacing>
@@ -153,14 +178,6 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
             Lag oppgave til lokalkontor <ExternalLinkIcon />
           </Button>
         </SpacingWrapper>
-
-        <Heading size="small" spacing>
-          Intern oppfølgingsoppgave med riktig frist blir opprettet automatisk
-        </Heading>
-        <BodyLong spacing>
-          Etterlatte skal følges opp og minnes på aktivitetskravet når det har gått 3-4 måneder og på nytt når det har
-          gått 9-10 måneder etter dødsfall.
-        </BodyLong>
       </AktivitetspliktWrapper>
 
       <Border />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
@@ -21,7 +21,7 @@ import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { useInnloggetSaksbehandler } from '~components/behandling/useInnloggetSaksbehandler'
 import { AktivitetspliktTidslinje } from '~components/behandling/aktivitetsplikt/AktivitetspliktTidslinje'
 import { useFeatureEnabledMedDefault } from '~shared/hooks/useFeatureToggle'
-import { formaterDato } from '~utils/formattering'
+import { formaterDato, formaterDatoMedKlokkeslett } from '~utils/formattering'
 
 export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => {
   const { behandling } = props
@@ -106,7 +106,7 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
               </Button>
             )}
             <Detail>Manuelt av {aktivitetOppfolging?.opprettetAv}</Detail>
-            <Detail>Sist endret {aktivitetOppfolging?.opprettet}</Detail>
+            <Detail>Sist endret {formaterDatoMedKlokkeslett(aktivitetOppfolging?.opprettet)}</Detail>
           </SpacingWrapper>
         )}
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
@@ -136,27 +136,6 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
         )}
 
         <Heading size="small" spacing>
-          Lag intern oppfølgingsoppgave med riktig frist
-        </Heading>
-        <BodyLong spacing>
-          Etterlatte skal følges opp og minnes på aktivitetskravet når det har gått 3-4 måneder og på nytt når det har
-          gått 9-10 måneder etter dødsfall. Om den etterlatte har andre ytelser eller annen grunn til videre oppfølging
-          bør man vurdere andre frister.
-        </BodyLong>
-        <BodyShort spacing>Huk av i sjekklista når oppfølgingsoppgave er opprettet.</BodyShort>
-        <SpacingWrapper>
-          <Button
-            variant="primary"
-            size="small"
-            as="a"
-            href={`${configContext['gosysUrl']}/personoversikt/fnr=${soeker?.foedselsnummer}`}
-            target="_blank"
-          >
-            Lag oppfølgingsoppgave i Gosys <ExternalLinkIcon />
-          </Button>
-        </SpacingWrapper>
-
-        <Heading size="small" spacing>
           Er oppfølging av lokalkontor nødvendig?
         </Heading>
         <BodyLong spacing>
@@ -174,6 +153,14 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
             Lag oppgave til lokalkontor <ExternalLinkIcon />
           </Button>
         </SpacingWrapper>
+
+        <Heading size="small" spacing>
+          Intern oppfølgingsoppgave med riktig frist blir opprettet automatisk
+        </Heading>
+        <BodyLong spacing>
+          Etterlatte skal følges opp og minnes på aktivitetskravet når det har gått 3-4 måneder og på nytt når det har
+          gått 9-10 måneder etter dødsfall.
+        </BodyLong>
       </AktivitetspliktWrapper>
 
       <Border />


### PR DESCRIPTION
Er fjernet fra sjekkliste og side om oppfølging av aktivitet da det nå gjøres automatisk i gjenny.

Er også flyttet til bunn da det nå er informasjon om at det skjer og ikke lenger en oppgave.
![Skjermbilde 2024-05-21 kl  13 24 44](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/17142094/7f05e132-045f-4fa6-b18b-2ef8ea124d9a)
