### PR TITLE
EY-3956: Splitter opp tekst over 40 tegn i utbetalingssplipp for regulering

### DIFF
--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/iverksetting/oppdrag/OppdragMapper.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/iverksetting/oppdrag/OppdragMapper.kt
@@ -55,15 +55,22 @@ object OppdragMapper {
                 )
 
                 if (erGRegulering) {
-                    tekst140.add(
+                    val fraOgMed = utbetaling.utbetalingslinjer.first().periode.fra
+
+                    listOf(
+                        // Ta høyde for maks lengde på 40 chars
+                        "Grunnbeløpet har økt fra 1. mai ${fraOgMed.year}.",
+                        "De fleste vil få etterbetalt i juni.",
+                    ).mapIndexed { index, str ->
                         Tekst140().apply {
-                            val fraOgMed = utbetaling.utbetalingslinjer.first().periode.fra
-                            tekst = "Grunnbeløpet har økt fra 1. mai ${fraOgMed.year}. De aller fleste vil få etterbetalt i juni."
-                            tekstLnr = BigInteger.ONE
+                            tekst = str
+                            tekstLnr = BigInteger.valueOf(index.toLong() + 1)
                             datoTekstFom = fraOgMed.toXMLDate()
                             datoTekstTom = LocalDate.of(fraOgMed.year, fraOgMed.month.plus(1), 20).toXMLDate()
-                        },
-                    )
+                        }
+                    }.let {
+                        tekst140.addAll(it)
+                    }
                 }
 
                 oppdragsLinje150.addAll(

--- a/apps/etterlatte-utbetaling/src/test/kotlin/no/nav/etterlatte/utbetaling/iverksetting/oppdrag/OppdragMapperTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/no/nav/etterlatte/utbetaling/iverksetting/oppdrag/OppdragMapperTest.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.utbetaling.iverksetting.oppdrag
 
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
 import io.kotest.matchers.shouldBe
 import no.nav.etterlatte.utbetaling.common.toXMLDate
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
@@ -7,6 +8,7 @@ import no.nav.etterlatte.utbetaling.utbetaling
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.math.BigInteger
 import java.time.LocalDate
 
 internal class OppdragMapperTest {
@@ -44,19 +46,32 @@ internal class OppdragMapperTest {
             )
 
         @Test
-        fun `Skal inneholde en fra og med dato tilsvarende vedtaket`() {
-            oppdrag.oppdrag110.tekst140.single().datoTekstFom shouldBe LocalDate.parse("2022-01-01").toXMLDate()
+        fun `Skal inneholde fra og med dato tilsvarende vedtaket`() {
+            oppdrag.oppdrag110.tekst140.forEach {
+                it.datoTekstFom shouldBe LocalDate.parse("2022-01-01").toXMLDate()
+            }
         }
 
         @Test
         fun `Skal inneholde til og med dato for tekst som er 20 i utbetalingsmaaned`() {
-            oppdrag.oppdrag110.tekst140.single().datoTekstTom shouldBe LocalDate.parse("2022-02-20").toXMLDate()
+            oppdrag.oppdrag110.tekst140.forEach {
+                it.datoTekstTom shouldBe LocalDate.parse("2022-02-20").toXMLDate()
+            }
         }
 
         @Test
-        fun `Skal inneholde riktig tekst`() {
-            oppdrag.oppdrag110.tekst140.single().tekst shouldBe
-                "Grunnbeløpet har økt fra 1. mai 2022. De aller fleste vil få etterbetalt i juni."
+        fun `Skal inneholde riktig tekst og ikke overstige 40 chars pr linje`() {
+            oppdrag.oppdrag110.tekst140[0].tekst shouldBe "Grunnbeløpet har økt fra 1. mai 2022."
+            oppdrag.oppdrag110.tekst140[0].tekstLnr shouldBe BigInteger.ONE
+
+            oppdrag.oppdrag110.tekst140[1].tekst shouldBe "De fleste vil få etterbetalt i juni."
+            oppdrag.oppdrag110.tekst140[1].tekstLnr shouldBe BigInteger.TWO
+
+            oppdrag.oppdrag110.tekst140.size shouldBe 2
+
+            oppdrag.oppdrag110.tekst140.forEach {
+                it.tekst.length shouldBeLessThanOrEqual 40
+            }
         }
     }
 }


### PR DESCRIPTION
Fikk beskjed av PO-Utbetaling at Tekst140-linjene ikke kan ha flere enn 40 chars. Endrer til to linjer og omformulerer litt for å unngå en tredje linje med to ord. Dette er avklart med fag.