### PR TITLE
Fjerner feature toggle for oppgave aktivitetsplikt

### DIFF
--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/AppBuilder.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/AppBuilder.kt
@@ -20,7 +20,6 @@ class AppBuilder(props: Miljoevariabler) {
     val tidshendelserService: TidshendelseService by lazy {
         TidshendelseService(
             behandlingService,
-            featureToggleService,
         )
     }
 

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/TidshendelseRiver.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/TidshendelseRiver.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte
 
-import no.nav.etterlatte.funksjonsbrytere.FeatureToggle
 import no.nav.etterlatte.libs.common.logging.getCorrelationId
 import no.nav.etterlatte.libs.common.logging.withLogContext
 import no.nav.etterlatte.rapidsandrivers.ALDERSOVERGANG_ID_KEY
@@ -77,11 +76,4 @@ class TidshendelseRiver(
         }
         return packetUpdates
     }
-}
-
-enum class TidshendelserFeatureToggle(private val key: String) : FeatureToggle {
-    OpprettOppgaveForVarselbrevAktivitetsplikt("opprett-oppgave-for-varselbrev-aktivitetsplikt"),
-    ;
-
-    override fun key() = key
 }

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/TidshendelseService.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/TidshendelseService.kt
@@ -6,7 +6,6 @@ import no.nav.etterlatte.TidshendelseService.TidshendelserJobbType.AO_OMS67
 import no.nav.etterlatte.TidshendelseService.TidshendelserJobbType.OMS_DOED_3AAR
 import no.nav.etterlatte.TidshendelseService.TidshendelserJobbType.OMS_DOED_4MND
 import no.nav.etterlatte.TidshendelseService.TidshendelserJobbType.OMS_DOED_5AAR
-import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.libs.common.behandling.Omregningshendelse
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
@@ -20,7 +19,6 @@ import java.util.UUID
 
 class TidshendelseService(
     private val behandlingService: BehandlingService,
-    private val featureToggleService: FeatureToggleService,
 ) {
     private val logger = LoggerFactory.getLogger(TidshendelseService::class.java)
 
@@ -55,10 +53,6 @@ class TidshendelseService(
                     .let { oppgaveId -> TidshendelseResult.OpprettetOppgave(oppgaveId) }
             }
         } else {
-            if (hendelse.jobbtype == OMS_DOED_4MND && !kanOppretteOppgaveForAktivitetsplikt()) {
-                logger.info("Oppgave for varselbrev aktivitetsplikt er skrudd av.")
-                return TidshendelseResult.Skipped
-            }
             return opprettOppgave(hendelse)
                 .let { oppgaveId -> TidshendelseResult.OpprettetOppgave(oppgaveId) }
         }
@@ -108,9 +102,6 @@ class TidshendelseService(
         logger.info("Opprettet oppgave $oppgaveId [sak=${hendelse.sakId}]")
         return oppgaveId
     }
-
-    private fun kanOppretteOppgaveForAktivitetsplikt() =
-        featureToggleService.isEnabled(TidshendelserFeatureToggle.OpprettOppgaveForVarselbrevAktivitetsplikt, false)
 
     private fun skalLageOmregning(hendelse: TidshendelsePacket) =
         when (hendelse.jobbtype) {

--- a/apps/etterlatte-oppdater-behandling/src/test/kotlin/TidshendelseServiceTest.kt
+++ b/apps/etterlatte-oppdater-behandling/src/test/kotlin/TidshendelseServiceTest.kt
@@ -8,7 +8,6 @@ import io.mockk.verify
 import no.nav.etterlatte.TidshendelseService.TidshendelserJobbType
 import no.nav.etterlatte.TidshendelseService.TidshendelserJobbType.AO_BP20
 import no.nav.etterlatte.TidshendelseService.TidshendelserJobbType.OMS_DOED_3AAR
-import no.nav.etterlatte.funksjonsbrytere.DummyFeatureToggleService
 import no.nav.etterlatte.libs.common.behandling.Omregningshendelse
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
@@ -22,17 +21,14 @@ import java.time.YearMonth
 import java.util.UUID
 
 class TidshendelseServiceTest {
-    private val featureToggleService = DummyFeatureToggleService()
     private val behandlingService = mockk<BehandlingService>()
-    private val tidshendelseService = TidshendelseService(behandlingService, featureToggleService)
+    private val tidshendelseService = TidshendelseService(behandlingService)
     private val opprettetOppgaveId = UUID.randomUUID()
     private val forrigeBehandlingId = UUID.randomUUID()
     private val behandlingId = UUID.randomUUID()
 
     @BeforeEach
     fun setUp() {
-        featureToggleService.settBryter(TidshendelserFeatureToggle.OpprettOppgaveForVarselbrevAktivitetsplikt, true)
-
         every { behandlingService.opprettOppgave(any(), any(), any(), any(), any()) } returns opprettetOppgaveId
     }
 
@@ -154,27 +150,6 @@ class TidshendelseServiceTest {
                 merknad = "Aldersovergang v/20 år",
                 frist = any(),
             )
-        }
-    }
-
-    @Test
-    fun `skal ikke opprette noe hvis feature toggle er av for oms aktivitetsplikt`() {
-        val melding =
-            lagMeldingForVurdertLoependeYtelse(
-                sakId = 37465L,
-                behandlingsmaaned = YearMonth.of(2024, Month.MARCH),
-                type = TidshendelserJobbType.OMS_DOED_4MND,
-            )
-        featureToggleService.settBryter(
-            TidshendelserFeatureToggle.OpprettOppgaveForVarselbrevAktivitetsplikt,
-            false,
-        )
-
-        tidshendelseService.haandterHendelse(TidshendelsePacket(melding))
-
-        verify(exactly = 0) { behandlingService.opprettOmregning(any()) }
-        verify(exactly = 0) {
-            behandlingService.opprettOppgave(any(), any(), any(), any(), any())
         }
     }
 }


### PR DESCRIPTION
Vi styrer det uansett med hvordan vi legger inn jobbkjøringer, så denne er forvirrende å ha som et "ekstra" steg å sjekke av