### PR TITLE
Ved sjekk om etterbetaling, ikke sjekke mot vedtak under behandling

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakEtterbetaling.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakEtterbetaling.kt
@@ -20,7 +20,9 @@ internal fun Vedtak.erVedtakMedEtterbetaling(
             val now = YearMonth.now(clock)
 
             if (innhold.virkningstidspunkt < now) {
-                val ferdigstilteVedtak = vedtaksvurderingRepository.hentFerdigstilteVedtak(this.soeker)
+                val ferdigstilteVedtak =
+                    vedtaksvurderingRepository.hentFerdigstilteVedtak(this.soeker)
+                        .filter { it.id != this.id }
                 val tidligereVedtakTidslinje = Vedtakstidslinje(ferdigstilteVedtak).sammenstill(OMS_START_YTELSE)
                 val tidligereUtbetalingsperioder =
                     tidligereVedtakTidslinje

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/TestHelper.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/TestHelper.kt
@@ -101,6 +101,7 @@ fun opprettVedtakKlage(
 )
 
 fun vedtak(
+    id: Long = 1L,
     virkningstidspunkt: YearMonth = YearMonth.of(2023, Month.JANUARY),
     sakId: Long = 1L,
     behandlingId: UUID = UUID.randomUUID(),
@@ -112,7 +113,7 @@ fun vedtak(
     vedtakFattet: VedtakFattet? = null,
     utbetalingsperioder: List<Utbetalingsperiode>? = null,
 ) = Vedtak(
-    id = 1L,
+    id = id,
     status = status,
     soeker = SOEKER_FOEDSELSNUMMER,
     sakId = sakId,

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakEtterbetalingTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakEtterbetalingTest.kt
@@ -65,6 +65,7 @@ class VedtakEtterbetalingTest {
     fun `ikke etterbetaling, tidligere periode men samme beloep`() {
         val nyttVedtak =
             aVedtakMedUtbetalingsperiode(
+                id = 2L,
                 virkningstidspunkt = februar2024,
                 beloep = 2500,
                 fattetTidspunkt = "2024-01-29T14:05:00Z",
@@ -73,6 +74,7 @@ class VedtakEtterbetalingTest {
         every { repository.hentFerdigstilteVedtak(nyttVedtak.soeker) } returns
             listOf(
                 aVedtakMedUtbetalingsperiode(
+                    id = 1L,
                     virkningstidspunkt = januar2024,
                     beloep = 2500,
                     fattetTidspunkt = "2024-01-26T11:25:00Z",
@@ -88,6 +90,7 @@ class VedtakEtterbetalingTest {
     fun `etterbetaling - ny periode har hoeyere beloep`() {
         val nyttVedtak =
             aVedtakMedUtbetalingsperiode(
+                id = 2L,
                 virkningstidspunkt = februar2024,
                 beloep = 3500,
                 fattetTidspunkt = "2024-01-26T11:25:00Z",
@@ -96,6 +99,7 @@ class VedtakEtterbetalingTest {
         every { repository.hentFerdigstilteVedtak(nyttVedtak.soeker) } returns
             listOf(
                 aVedtakMedUtbetalingsperiode(
+                    id = 1L,
                     virkningstidspunkt = januar2024,
                     beloep = 2500,
                     fattetTidspunkt = "2023-12-16T13:30:00Z",
@@ -111,6 +115,7 @@ class VedtakEtterbetalingTest {
     fun `etterbetaling - flere tidligere perioder, ny periode har hoeyere beloep`() {
         val nyttVedtak =
             aVedtakMedUtbetalingsperiode(
+                id = 10L,
                 virkningstidspunkt = februar2024,
                 beloep = 3500,
                 fattetTidspunkt = "2024-03-06T13:30:00Z",
@@ -119,16 +124,19 @@ class VedtakEtterbetalingTest {
         every { repository.hentFerdigstilteVedtak(nyttVedtak.soeker) } returns
             listOf(
                 aVedtakMedUtbetalingsperiode(
+                    id = 1L,
                     virkningstidspunkt = januar2024,
                     beloep = 2000,
                     fattetTidspunkt = "2024-01-07T13:30:00Z",
                 ),
                 aVedtakMedUtbetalingsperiode(
+                    id = 2L,
                     virkningstidspunkt = februar2024,
                     beloep = 2500,
                     fattetTidspunkt = "2024-01-26T14:00:00Z",
                 ),
                 aVedtakMedUtbetalingsperiode(
+                    id = 3L,
                     virkningstidspunkt = mars2024,
                     beloep = 3000,
                     fattetTidspunkt = "2024-03-05T10:00:00Z",
@@ -141,10 +149,12 @@ class VedtakEtterbetalingTest {
     }
 
     private fun aVedtakMedUtbetalingsperiode(
+        id: Long,
         virkningstidspunkt: YearMonth,
         beloep: Long,
         fattetTidspunkt: String,
     ) = vedtak(
+        id = id,
         virkningstidspunkt = virkningstidspunkt,
         vedtakFattet =
             VedtakFattet(


### PR DESCRIPTION
Dette er pga repository-kallet `hentFerdigstilteVedtak` inkluderer TIL_SAMORDNING, SAMORDNING. Dette da de er ferdig fra et saksbehandlerperspektiv.

Det er ikke umulig at dette kan ha medført noen feil hittil, dvs manglende samordning. Har ikke sjekket hvor mange OMS-revurderinger som er gjennomført i prod.