### PR TITLE
La saksbehandler selv avgjøre om journalpost skal feilregistreres

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/HaandterAvvikModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/HaandterAvvikModal.tsx
@@ -48,7 +48,7 @@ export const HaandterAvvikModal = ({
         <Modal.Body>
           <Box borderWidth="1" padding="4" borderRadius="medium" borderColor="border-subtle" background="bg-subtle">
             <Heading size="xsmall" spacing>
-              Journalpostdetailjer
+              Journalpostdetaljer
             </Heading>
 
             <InfoWrapper>
@@ -78,7 +78,7 @@ export const HaandterAvvikModal = ({
             value={aarsak || ''}
             onChange={(checked) => setAarsak(checked as AvvikHandling)}
           >
-            <Radio value={AvvikHandling.OVERFOER}>Overfør til annen sak</Radio>
+            <Radio value={AvvikHandling.OVERFOER}>Overfør til Gjenny</Radio>
             <Radio value={AvvikHandling.FEILREGISTRER}>
               {journalpost.journalstatus === Journalstatus.FEILREGISTRERT ? 'Opphev feilregistrering' : 'Feilregistrer'}
             </Radio>


### PR DESCRIPTION
Ønske fra saksbehandler siden de i en del tilfeller har behov for å beholde journalposter i både Pesys _og_ Gjenny. 

<img width="860" alt="Screenshot 2024-05-23 at 13 48 15" src="https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/0ea053d7-592c-4484-8815-412f1b0d6292">
