### PR TITLE
Sjekke om oppgave er null/undefined

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/OppgaveEndring.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/OppgaveEndring.tsx
@@ -11,7 +11,7 @@ export const OppgaveEndring = ({ oppgaveResult }: { oppgaveResult: Result<Oppgav
   const [endringerResult, hentOppgaveEndringer] = useApiCall(hentEndringer)
 
   useEffect(() => {
-    if (isSuccess(oppgaveResult)) {
+    if (isSuccess(oppgaveResult) && !!oppgaveResult.data) {
       hentOppgaveEndringer(oppgaveResult.data.id)
     }
   }, [oppgaveResult])


### PR DESCRIPTION
Kommer av at behandling henter oppgave under behandling. I tilfeller hvor noe er ferdig behandlet, er det ikke noen oppgave å hente. 