### PR TITLE
Forbedre spinner hentoppgaver + fjerne delay tildeloppg. saksoversikt

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/MinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/MinOppgaveliste.tsx
@@ -81,7 +81,7 @@ export const MinOppgaveliste = ({ saksbehandlereIEnhet }: Props) => {
     if (!oppgavebenkState.minOppgavelisteOppgaver?.length) hentMinOppgavelisteOppgaver()
   }, [])
 
-  return oppgavebenkState.minOppgavelisteOppgaver.length >= 0 && !isPending(minOppgavelisteOppgaverResult) ? (
+  return (
     <>
       <FilterRad
         hentAlleOppgaver={hentMinOppgavelisteOppgaver}
@@ -91,20 +91,23 @@ export const MinOppgaveliste = ({ saksbehandlereIEnhet }: Props) => {
         saksbehandlereIEnhet={saksbehandlereIEnhet}
         oppgavelisteValg={OppgavelisteValg.MIN_OPPGAVELISTE}
       />
-      <Oppgaver
-        oppgaver={oppgavebenkState.minOppgavelisteOppgaver}
-        oppdaterSaksbehandlerTildeling={oppdaterSaksbehandlerTildeling}
-        oppdaterFrist={(id: string, nyfrist: string) =>
-          oppdaterFrist(dispatcher.setMinOppgavelisteOppgaver, oppgavebenkState.minOppgavelisteOppgaver, id, nyfrist)
-        }
-        saksbehandlereIEnhet={saksbehandlereIEnhet}
-        filter={filter}
-      />
+
+      {oppgavebenkState.minOppgavelisteOppgaver.length >= 0 && !isPending(minOppgavelisteOppgaverResult) ? (
+        <Oppgaver
+          oppgaver={oppgavebenkState.minOppgavelisteOppgaver}
+          oppdaterSaksbehandlerTildeling={oppdaterSaksbehandlerTildeling}
+          oppdaterFrist={(id: string, nyfrist: string) =>
+            oppdaterFrist(dispatcher.setMinOppgavelisteOppgaver, oppgavebenkState.minOppgavelisteOppgaver, id, nyfrist)
+          }
+          saksbehandlereIEnhet={saksbehandlereIEnhet}
+          filter={filter}
+        />
+      ) : (
+        mapResult(minOppgavelisteOppgaverResult, {
+          pending: <Spinner visible={true} label="Henter dine oppgaver" />,
+          error: (error) => <ApiErrorAlert>{error.detail || 'Kunne ikke hente dine oppgaver'}</ApiErrorAlert>,
+        })
+      )}
     </>
-  ) : (
-    mapResult(minOppgavelisteOppgaverResult, {
-      pending: <Spinner visible={true} label="Henter dine oppgaver" />,
-      error: (error) => <ApiErrorAlert>{error.detail || 'Kunne ikke hente dine oppgaver'}</ApiErrorAlert>,
-    })
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/Oppgavelista.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/Oppgavelista.tsx
@@ -84,7 +84,7 @@ export const Oppgavelista = ({ saksbehandlereIEnhet }: Props) => {
     }
   }, [])
 
-  return oppgavebenkState.oppgavelistaOppgaver.length >= 0 && !isPending(oppgavelistaOppgaverResult) ? (
+  return (
     <>
       <FilterRad
         hentAlleOppgaver={hentOppgavelistaOppgaver}
@@ -94,17 +94,20 @@ export const Oppgavelista = ({ saksbehandlereIEnhet }: Props) => {
         saksbehandlereIEnhet={saksbehandlereIEnhet}
         oppgavelisteValg={OppgavelisteValg.OPPGAVELISTA}
       />
-      <Oppgaver
-        oppgaver={oppgavebenkState.oppgavelistaOppgaver}
-        saksbehandlereIEnhet={saksbehandlereIEnhet}
-        oppdaterSaksbehandlerTildeling={oppdaterSaksbehandlerTildeling}
-        filter={filter}
-      />
+
+      {oppgavebenkState.oppgavelistaOppgaver.length >= 0 && !isPending(oppgavelistaOppgaverResult) ? (
+        <Oppgaver
+          oppgaver={oppgavebenkState.oppgavelistaOppgaver}
+          saksbehandlereIEnhet={saksbehandlereIEnhet}
+          oppdaterSaksbehandlerTildeling={oppdaterSaksbehandlerTildeling}
+          filter={filter}
+        />
+      ) : (
+        mapResult(oppgavelistaOppgaverResult, {
+          pending: <Spinner visible={true} label="Henter oppgaver" />,
+          error: (error) => <ApiErrorAlert>{error.detail || 'Kunne ikke hente oppgaver'}</ApiErrorAlert>,
+        })
+      )}
     </>
-  ) : (
-    mapResult(oppgavelistaOppgaverResult, {
-      pending: <Spinner visible={true} label="Henter oppgaver" />,
-      error: (error) => <ApiErrorAlert>{error.detail || 'Kunne ikke hente oppgaver'}</ApiErrorAlert>,
-    })
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/ForenkletOppgaverTable.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/ForenkletOppgaverTable.tsx
@@ -40,11 +40,8 @@ export const ForenkletOppgaverTable = ({
 
   const [, saksbehandlereIEnheterFetch] = useApiCall(saksbehandlereIEnhetApi)
 
-  const oppdaterSaksbehandlerTildeling = (oppgave: OppgaveDTO, saksbehandler: OppgaveSaksbehandler | null) => {
-    setTimeout(() => {
-      setFiltrerteOppgaver(finnOgOppdaterSaksbehandlerTildeling(filtrerteOppgaver, oppgave.id, saksbehandler))
-    }, 2000)
-  }
+  const oppdaterSaksbehandlerTildeling = (oppgave: OppgaveDTO, saksbehandler: OppgaveSaksbehandler | null) =>
+    setFiltrerteOppgaver(finnOgOppdaterSaksbehandlerTildeling(filtrerteOppgaver, oppgave.id, saksbehandler))
 
   useEffect(() => {
     setFiltrerteOppgaver(filtrerOppgaverPaaOppgaveValg())


### PR DESCRIPTION
Vise `FilterRad` selv om oppgaver laster. Gjør at grensesnittet "hopper" litt mindre. 

Fjerner også delay som skjer ved tildeling av oppgave fra listen på saksoversikten. 