### PR TITLE
Å samanlikne storleik med maks batchstorleik vil kunne stoppe unødig …

### DIFF
--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/ReguleringsforespoerselRiver.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/ReguleringsforespoerselRiver.kt
@@ -92,7 +92,7 @@ internal class ReguleringsforespoerselRiver(
             }
             tatt += sakerTilOmregning.saker.size
             logger.info("Ferdig med $tatt av totalt $antall saker")
-            if (sakerTilOmregning.saker.isEmpty() || sakerTilOmregning.saker.size < maksBatchstoerrelse) {
+            if (sakerTilOmregning.saker.isEmpty() || saker.saker.size < maksBatchstoerrelse) {
                 break
             }
         }


### PR DESCRIPTION
…i dei høva kor vi har filtrert saker. Løysar det enkelt ved å samanlikne storleiken før filtrering heller