### PR TITLE
Spørre SAM kun på pid inntil videre

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/klienter/SamKlient.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/klienter/SamKlient.kt
@@ -10,7 +10,6 @@ import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.client.request.url
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
@@ -81,11 +80,10 @@ class SamKlientImpl(
     ): List<Samordningsvedtak> {
         try {
             val response =
-                httpClient.get {
-                    url("$resourceUrl/api/vedtak")
+                httpClient.get("$resourceUrl/api/vedtak") {
                     header("pid", vedtak.soeker.value)
                     parameter("fagomrade", "EYO")
-                    parameter("sakId", "${vedtak.sakId}")
+                    // parameter("sakId", "${vedtak.sakId}")
                     if (!alleVedtak) {
                         parameter("vedtakId", "${vedtak.id}")
                     }


### PR DESCRIPTION
Vi har forsøkt å sjekke status i prod, men fikk bare 204 tilbake fra SAM. Sjekket nærmere en sak i Q2 og det viser seg at saksreferansen vi sender med i samordningsforespørselen ikke blir lagret. Dermed filtreres ting vekk når vi spør her. Skrur av det parameteret slik at vi får alle meldinger på bruker for fagområdet. I Gjenny så gjør ikke det noe da kun OMS er samordningspliktig. Når feilen er rettet bør det skrus på igjen, fremstår som mest riktig.