### PR TITLE
Bruk transient props, ikke rendre ukjente til dom

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/innvilget.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/innvilget.tsx
@@ -33,7 +33,7 @@ export const Innvilget = ({ behandlingsInfo }: { behandlingsInfo: IBehandlingInf
     : formaterDato(new Date())
 
   return (
-    <Wrapper innvilget={true}>
+    <Wrapper $innvilget={true}>
       <Overskrift>{formaterBehandlingstype(behandlingsInfo.type)}</Overskrift>
       <Resultat vedtaksresultat={vedtaksResultat} />
       <div className="flex">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/oversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/oversikt.tsx
@@ -54,7 +54,7 @@ export const Oversikt = ({ behandlingsInfo }: { behandlingsInfo: IBehandlingInfo
   }
 
   return (
-    <SidebarPanel border>
+    <SidebarPanel $border>
       <Heading size="small">
         {formaterBehandlingstype(behandlingsInfo.type)}
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/underkjent.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/underkjent.tsx
@@ -20,7 +20,7 @@ export const Underkjent = ({ behandlingsInfo }: { behandlingsInfo: IBehandlingIn
   const attestant = erReturnert ? underkjentSiste?.ident : innloggetId
 
   return (
-    <Wrapper innvilget={false}>
+    <Wrapper $innvilget={false}>
       <Overskrift>{formaterBehandlingstype(behandlingsInfo.type)}</Overskrift>
       <UnderOverskrift innvilget={false}>Underkjent</UnderOverskrift>
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/styled.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/styled.tsx
@@ -23,11 +23,11 @@ export const RadioGroupWrapper = styled.div`
   }
 `
 
-export const Wrapper = styled.div<{ innvilget: boolean }>`
+export const Wrapper = styled.div<{ $innvilget: boolean }>`
   margin: 20px 8px 0px 8px;
   padding: 1em;
   border: 1px solid #c7c0c0;
-  border-left: 5px solid ${(props) => (props.innvilget ? '#007C2E' : '#881d0c')};
+  border-left: 5px solid ${(props) => (props.$innvilget ? '#007C2E' : '#881d0c')};
   border-radius: 3px;
 
   .flex {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/PeriodeAccordion.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/PeriodeAccordion.tsx
@@ -21,7 +21,7 @@ const PeriodeAccordion = (props: PeriodeAccordionProps) => {
   const [open, setOpen] = useState<boolean>(defaultOpen)
   const topContent = topSummary instanceof Function ? topSummary(open) : topSummary
   return (
-    <PeriodeAccordionWrapper {...rest} feilBorder={feilBorder}>
+    <PeriodeAccordionWrapper {...rest} $feilBorder={feilBorder}>
       <PeriodeAccordionHead>
         <ExpandButton onClick={() => setOpen((o) => !o)} aria-expanded={open}>
           {open ? <ChevronUpIcon fontSize={20} aria-hidden /> : <ChevronDownIcon fontSize={20} aria-hidden />}
@@ -36,8 +36,8 @@ const PeriodeAccordion = (props: PeriodeAccordionProps) => {
   )
 }
 
-const PeriodeAccordionWrapper = styled.div<{ feilBorder: boolean }>`
-  border: ${(props) => (props.feilBorder ? '2px solid var(--a-border-danger)' : '1px solid')};
+const PeriodeAccordionWrapper = styled.div<{ $feilBorder: boolean }>`
+  border: ${(props) => (props.$feilBorder ? '2px solid var(--a-border-danger)' : '1px solid')};
   margin: 0 3em 2em 3em;
   padding: 1em 0;
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/SlateEditor.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/SlateEditor.tsx
@@ -110,7 +110,7 @@ const BlockButton = ({ format, icon }: { format: any; icon: any }) => {
   const editor = useSlate()
   return (
     <StyleButton
-      active={isBlockActive(editor, format)}
+      $active={isBlockActive(editor, format)}
       onMouseDown={(event) => {
         event.preventDefault()
         toggleBlock(editor, format)
@@ -125,7 +125,7 @@ const MarkButton = ({ format, icon }: { format: Format; icon: any }) => {
   const editor = useSlate()
   return (
     <StyleButton
-      active={isMarkActive(editor, format)}
+      $active={isMarkActive(editor, format)}
       onMouseDown={(event) => {
         event.preventDefault()
         toggleMark(editor, format)
@@ -136,9 +136,9 @@ const MarkButton = ({ format, icon }: { format: Format; icon: any }) => {
   )
 }
 
-const StyleButton = styled.span<{ reversed?: boolean; active: boolean }>`
+const StyleButton = styled.span<{ $reversed?: boolean; $active: boolean }>`
   cursor: pointer;
-  color: ${(props) => (props.reversed ? (props.active ? 'white' : '#aaa') : props.active ? 'black' : '#ccc')};
+  color: ${(props) => (props.$reversed ? (props.$active ? 'white' : '#aaa') : props.$active ? 'black' : '#ccc')};
 `
 
 const Toolbar = styled.div`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sjekkliste/Sjekkliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sjekkliste/Sjekkliste.tsx
@@ -70,7 +70,7 @@ export const Sjekkliste = ({ behandling }: { behandling: IBehandlingReducer }) =
   }, [])
 
   return (
-    <SidebarPanel border id="sjekklistePanel">
+    <SidebarPanel $border id="sjekklistePanel">
       {sjekklisteValideringsfeil && (
         <Alert variant="error">Før du kan sende til attestering må du bekrefte at alle punkter er gjennomgått</Alert>
       )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/RedigerFamilieforhold.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/RedigerFamilieforhold.tsx
@@ -90,7 +90,7 @@ export const RedigerFamilieforhold = ({ behandling, personopplysninger }: Props)
           </Heading>
         </Modal.Header>
         <Modal.Body>
-          <FormWrapper column={true}>
+          <FormWrapper $column={true}>
             <Box padding="4" borderWidth="1" borderRadius="small">
               <InputList>
                 {avdoedListe.fields?.map((field, index) => (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/Barn.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/Barn.tsx
@@ -30,7 +30,7 @@ export const Barn = ({ person, doedsdato }: Props) => {
         <PersonInfoFnr fnr={person.foedselsnummer} />
         <PersonInfoAdresse adresser={adresserEtterDoedsdato} visHistorikk={true} adresseDoedstidspunkt={false} />
         {aktivAdresse && (
-          <PersonDetailWrapper adresse={true}>
+          <PersonDetailWrapper $adresse={true}>
             <div>
               <strong>Aktiv adresse</strong>
             </div>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/personinfo/PersonInfoAdresse.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/personinfo/PersonInfoAdresse.tsx
@@ -24,7 +24,7 @@ export const PersonInfoAdresse = (props: Props) => {
   }
 
   return (
-    <PersonDetailWrapper adresse={true}>
+    <PersonDetailWrapper $adresse={true}>
       <Label as="p">{props.adresseDoedstidspunkt ? 'Bostedadresse dødsfallstidspunkt' : 'Bostedadresse'}</Label>
       {sisteEllerAktivAdresse ? (
         <span>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/personinfo/PersonInfoFnr.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/personinfo/PersonInfoFnr.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export const PersonInfoFnr = ({ fnr }: Props) => {
   return (
-    <PersonDetailWrapper adresse={false}>
+    <PersonDetailWrapper $adresse={false}>
       <div>
         <strong>Fødselsnummer</strong>
       </div>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/personinfo/StatsborgerskapVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/personinfo/StatsborgerskapVisning.tsx
@@ -10,7 +10,7 @@ export function StatsborgerskapVisning(props: { statsborgerskap?: string; pdlSta
 
   if (!pdlStatsborgerskap) {
     return (
-      <PersonDetailWrapper adresse={false}>
+      <PersonDetailWrapper $adresse={false}>
         <Label as="p">Statsborgerskap</Label>
         <span>{statsborgerskap ?? 'Ukjent'}</span>
       </PersonDetailWrapper>
@@ -18,7 +18,7 @@ export function StatsborgerskapVisning(props: { statsborgerskap?: string; pdlSta
   }
 
   return (
-    <PersonDetailWrapper adresse={false}>
+    <PersonDetailWrapper $adresse={false}>
       <Label as="p">Statsborgerskap</Label>
       <UstiletListe>
         {pdlStatsborgerskap!!.map((statsborgerskap, index) => (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/personinfo/UtvandringInnvandring.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/personinfo/UtvandringInnvandring.tsx
@@ -18,7 +18,7 @@ export function Utlandsopphold(props: { utland: Utland }) {
 
   return (
     <>
-      <PersonDetailWrapper adresse={false}>
+      <PersonDetailWrapper $adresse={false}>
         <Label as="p">Utvandring</Label>
         {utflyttinger.length > 0 ? (
           <UstiletListe>
@@ -37,7 +37,7 @@ export function Utlandsopphold(props: { utland: Utland }) {
           <span>Ingen</span>
         )}
       </PersonDetailWrapper>
-      <PersonDetailWrapper adresse={false}>
+      <PersonDetailWrapper $adresse={false}>
         <Label as="p">Innvandring</Label>
         {innflyttinger.length > 0 ? (
           <UstiletListe>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/styled.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/styled.tsx
@@ -64,9 +64,9 @@ export const VurderingsTitle = ({ title }: { title: string }) => {
   )
 }
 
-export const PersonDetailWrapper = styled.div<{ adresse: boolean }>`
+export const PersonDetailWrapper = styled.div<{ $adresse: boolean }>`
   padding-top: 0.5em;
-  min-width: ${(props) => (props.adresse ? '300px' : '100px')};
+  min-width: ${(props) => (props.$adresse ? '300px' : '100px')};
 `
 
 export const Historikk = styled.div`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/generellbehandling/AttestertVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/generellbehandling/AttestertVisning.tsx
@@ -10,7 +10,7 @@ export const AttestertVisning = (props: {
   const { utlandsBehandling } = props
 
   return (
-    <Wrapper innvilget={true}>
+    <Wrapper $innvilget={true}>
       <Overskrift>{genbehandlingTypeTilLesbartNavn(utlandsBehandling.type)}</Overskrift>
       <div className="flex">
         <div>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/AvsluttKlage.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/AvsluttKlage.tsx
@@ -52,7 +52,7 @@ export default function AvsluttKlage() {
           </SidebarPanel>
         )}
         {showAvsluttForm && (
-          <SidebarPanel border>
+          <SidebarPanel $border>
             <AvsluttKlageForm />
           </SidebarPanel>
         )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/sidemeny/KlageSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/sidemeny/KlageSidemeny.tsx
@@ -49,7 +49,7 @@ export function KlageSidemeny() {
 
   return (
     <Sidebar>
-      <SidebarPanel border>
+      <SidebarPanel $border>
         <Heading size="small">Klage</Heading>
         <Heading size="xsmall" spacing>
           {teksterKlagestatus[klage.status]}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/frist/FristHandlinger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/frist/FristHandlinger.tsx
@@ -9,9 +9,9 @@ import { add, isBefore } from 'date-fns'
 import { isPending, isSuccess } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
 
-const FristWrapper = styled.span<{ fristHarPassert: boolean; utenKnapp?: boolean }>`
-  color: ${(p) => p.fristHarPassert && 'var(--a-text-danger)'};
-  padding: ${(p) => p.utenKnapp && '12px 20px'};
+const FristWrapper = styled.span<{ $fristHarPassert: boolean; $utenKnapp?: boolean }>`
+  color: ${(p) => p.$fristHarPassert && 'var(--a-text-danger)'};
+  padding: ${(p) => p.$utenKnapp && '12px 20px'};
 `
 
 export const FristHandlinger = (props: {
@@ -120,12 +120,12 @@ export const FristHandlinger = (props: {
               icon={<PencilIcon title="a11y-title" fontSize="1.5rem" />}
               onClick={() => setOpen(!open)}
             >
-              <FristWrapper fristHarPassert={isBefore(new Date(frist), new Date())}>
+              <FristWrapper $fristHarPassert={isBefore(new Date(frist), new Date())}>
                 {formaterStringDato(frist)}
               </FristWrapper>
             </Button>
           ) : (
-            <FristWrapper fristHarPassert={isBefore(new Date(frist), new Date())} utenKnapp>
+            <FristWrapper $fristHarPassert={isBefore(new Date(frist), new Date())} $utenKnapp>
               <Label>{formaterStringDato(frist)}</Label>
             </FristWrapper>
           )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottakerModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottakerModal.tsx
@@ -173,7 +173,7 @@ export function BrevMottakerModal({ brev, setBrev, vergeadresse }: Props) {
               <TextField {...register('adresse.adresselinje3')} label="Adresselinje 3" />
             </SkjemaGruppe>
 
-            <SkjemaGruppe inline>
+            <SkjemaGruppe $inline>
               <TextField
                 {...register('adresse.postnummer', {
                   required: {
@@ -202,7 +202,7 @@ export function BrevMottakerModal({ brev, setBrev, vergeadresse }: Props) {
               />
             </SkjemaGruppe>
 
-            <SkjemaGruppe inline>
+            <SkjemaGruppe $inline>
               <TextField
                 {...register('adresse.landkode', {
                   required: {
@@ -249,13 +249,13 @@ export function BrevMottakerModal({ brev, setBrev, vergeadresse }: Props) {
   )
 }
 
-const SkjemaGruppe = styled.div<{ inline?: boolean }>`
+const SkjemaGruppe = styled.div<{ $inline?: boolean }>`
   & > * {
     margin-bottom: 1rem;
   }
 
   ${(props) => {
-    if (props.inline)
+    if (props.$inline)
       return css`
         display: flex;
         flex-direction: row;

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentlisteLiten.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentlisteLiten.tsx
@@ -24,7 +24,7 @@ export const DokumentlisteLiten = ({ fnr }: { fnr: string }) => {
   )
 
   return (
-    <SidebarPanel border>
+    <SidebarPanel $border>
       <Heading size="small" spacing>
         Dokumenter
       </Heading>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/BehandleJournalfoeringOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/BehandleJournalfoeringOppgave.tsx
@@ -134,7 +134,7 @@ export default function BehandleJournalfoeringOppgave() {
             journalpostStatus,
             (journalpost) =>
               !kanEndreJournalpost(journalpost) && (
-                <SidebarPanel border>
+                <SidebarPanel $border>
                   <JournalpostInnhold journalpost={journalpost} />
                 </SidebarPanel>
               )
@@ -145,8 +145,8 @@ export default function BehandleJournalfoeringOppgave() {
   )
 }
 
-export const FormWrapper = styled.div<{ column?: boolean }>`
+export const FormWrapper = styled.div<{ $column?: boolean }>`
   display: flex;
-  flex-direction: ${(props) => (!!props.column ? 'column' : 'row')};
+  flex-direction: ${(props) => (props.$column ? 'column' : 'row')};
   gap: 1rem;
 `

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/ferdigstilloppgave/FerdigstillOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/ferdigstilloppgave/FerdigstillOppgave.tsx
@@ -31,7 +31,7 @@ export default function FerdigstillOppgave() {
   const kanFerdigstilleOppgaven = journalpostErFerdigstilt || journalpostTilhoererAnnetTema
 
   return (
-    <FormWrapper column>
+    <FormWrapper $column>
       <Heading size="medium" spacing>
         Ferdigstill oppgave
       </Heading>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/handling/StartOppgavebehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/handling/StartOppgavebehandling.tsx
@@ -35,7 +35,7 @@ export default function StartOppgavebehandling({ antallBehandlinger }: { antallB
     return <Alert variant="success">Oppgaven er allerede ferdigbehandlet!</Alert>
 
   return (
-    <FormWrapper column>
+    <FormWrapper $column>
       <Heading size="medium" spacing>
         Behandle journalføringsoppgave
       </Heading>
@@ -92,7 +92,7 @@ export default function StartOppgavebehandling({ antallBehandlinger }: { antallB
 }
 
 export const OppgaveDetaljer = ({ oppgave }: { oppgave: OppgaveDTO }) => (
-  <SidebarPanel border>
+  <SidebarPanel $border>
     <Heading size="small" spacing>
       Oppgavedetaljer
     </Heading>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/EndreTema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/EndreTema.tsx
@@ -35,7 +35,7 @@ export const EndreTema = ({
     <Spinner label="Henter tilgjengelige temakoder ..." visible />,
     () => <ApiErrorAlert>Feil ved henting av temakoder</ApiErrorAlert>,
     (koder) => (
-      <FormWrapper column={true}>
+      <FormWrapper $column={true}>
         <UNSAFE_Combobox
           label="Tema"
           options={koder.sort((a, b) => a.term.localeCompare(b.term)).map((kode) => kode.term)}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/OppdaterJournalpost.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/OppdaterJournalpost.tsx
@@ -55,7 +55,7 @@ export const OppdaterJournalpost = ({ initialJournalpost, oppgaveId, sak }: Prop
         Gjelder
       </Heading>
 
-      <FormWrapper column={true}>
+      <FormWrapper $column={true}>
         <EndreTema journalpost={journalpost} oppdater={(kode) => setJournalpost({ ...journalpost, tema: kode.navn })} />
 
         <EndreBruker bruker={journalpost.bruker} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/nybehandling/OpprettNyBehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/nybehandling/OpprettNyBehandling.tsx
@@ -111,7 +111,7 @@ export default function OpprettNyBehandling() {
   }, [valgtSakType])
 
   return (
-    <FormWrapper column>
+    <FormWrapper $column>
       <FormProvider {...methods}>
         <VStack gap="4">
           <Heading size="medium" spacing>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/nybehandling/OppsummeringOppgavebehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/nybehandling/OppsummeringOppgavebehandling.tsx
@@ -34,7 +34,7 @@ export default function OppsummeringOppgavebehandling() {
   }
 
   return (
-    <FormWrapper column>
+    <FormWrapper $column>
       <Heading size="medium" spacing>
         Opprett behandling fra oppgave
       </Heading>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/oppretteklage/OpprettKlagebehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/oppretteklage/OpprettKlagebehandling.tsx
@@ -32,7 +32,7 @@ export default function OpprettKlagebehandling() {
   const tilbake = () => navigate('../', { relative: 'path' })
 
   return (
-    <FormWrapper column>
+    <FormWrapper $column>
       <Heading size="medium" spacing>
         Opprett klage fra oppgave{' '}
         <Tag variant="success" size="medium">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/oppretteklage/OppsummeringKlagebehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/oppretteklage/OppsummeringKlagebehandling.tsx
@@ -35,7 +35,7 @@ export default function OppsummeringKlagebehandling() {
   const tilbake = () => navigate('../', { relative: 'path' })
 
   return (
-    <FormWrapper column>
+    <FormWrapper $column>
       <Heading size="medium" spacing>
         Opprett klage fra oppgave{' '}
         <Tag variant="success" size="medium">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/sidemeny/TilbakekrevingSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/sidemeny/TilbakekrevingSidemeny.tsx
@@ -62,14 +62,14 @@ export function TilbakekrevingSidemeny() {
   const [oppgaveResult] = useOppgaveUnderBehandling({ referanse: tilbakekreving.id })
 
   return (
-    <CollapsibleSidebar collapsed={collapsed}>
+    <CollapsibleSidebar $collapsed={collapsed}>
       <SidebarTools>
         <Button variant={collapsed ? 'primary' : 'tertiary'} onClick={() => setCollapsed((collapsed) => !collapsed)}>
           {collapsed ? <ChevronLeftDoubleIcon /> : <ChevronRightDoubleIcon />}
         </Button>
       </SidebarTools>
-      <SidebarContent collapsed={collapsed}>
-        <SidebarPanel border>
+      <SidebarContent $collapsed={collapsed}>
+        <SidebarPanel $border>
           <Heading size="small">Tilbakekreving</Heading>
           <Heading size="xsmall" spacing>
             {teksterTilbakekrevingStatus[tilbakekreving!!.status]}

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/Spinner.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/Spinner.tsx
@@ -12,7 +12,7 @@ const Spinner = ({ visible, label, margin = '3em', variant }: Props) => {
   if (!visible) return null
 
   return (
-    <SpinnerWrap margin={margin}>
+    <SpinnerWrap $margin={margin}>
       <div className="spinner-overlay">
         <div className="spinner-content">
           <Loader variant={variant} />
@@ -23,10 +23,10 @@ const Spinner = ({ visible, label, margin = '3em', variant }: Props) => {
   )
 }
 
-const SpinnerWrap = styled.div<{ margin: string }>`
+const SpinnerWrap = styled.div<{ $margin: string }>`
   display: flex;
   justify-content: center;
-  margin: ${(props) => props.margin};
+  margin: ${(props) => props.$margin};
   text-align: center;
 `
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/components/Sidebar.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/components/Sidebar.tsx
@@ -8,25 +8,25 @@ export const Sidebar = ({ children }: { children: ReactNode }) => {
   const [collapsed, setCollapsed] = useState(false)
 
   return (
-    <CollapsibleSidebar collapsed={collapsed}>
+    <CollapsibleSidebar $collapsed={collapsed}>
       <SidebarTools>
         <Button variant={collapsed ? 'primary' : 'tertiary'} onClick={() => setCollapsed(!collapsed)}>
           {collapsed ? <ChevronLeftDoubleIcon /> : <ChevronRightDoubleIcon />}
         </Button>
       </SidebarTools>
 
-      <SidebarContent collapsed={collapsed}>{children}</SidebarContent>
+      <SidebarContent $collapsed={collapsed}>{children}</SidebarContent>
     </CollapsibleSidebar>
   )
 }
 
-export const SidebarPanel = styled.div<{ border?: boolean }>`
+export const SidebarPanel = styled.div<{ $border?: boolean }>`
   margin: 20px 8px 0 8px;
   padding: 1em;
   max-width: 800px;
 
   ${(props) =>
-    props.border
+    props.$border
       ? css`
           border-radius: 3px;
           border: 1px solid #c7c0c0;

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/header/Search.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/header/Search.tsx
@@ -66,7 +66,7 @@ export const Search = () => {
       )}
 
       {feilInput && (
-        <Dropdown info={true}>
+        <Dropdown $info={true}>
           <span className="icon">
             <InformationSquareIcon stroke={ABlue500} fill={ABlue500} />
           </span>
@@ -77,7 +77,7 @@ export const Search = () => {
       )}
 
       {mapFailure(funnetSak, (error) => (
-        <Dropdown error={true}>
+        <Dropdown $error={true}>
           <span className="icon">
             <XMarkOctagonIcon color={ANavRed} fill={AGray900} />
           </span>
@@ -92,13 +92,13 @@ export const Search = () => {
   )
 }
 
-const Dropdown = styled.div<{ error?: boolean; info?: boolean }>`
+const Dropdown = styled.div<{ $error?: boolean; $info?: boolean }>`
   display: flex;
-  background-color: ${(props) => (props.error ? '#f9d2cc' : props.info ? '#cce1ff' : '#fff')};
+  background-color: ${(props) => (props.$error ? '#f9d2cc' : props.$info ? '#cce1ff' : '#fff')};
   width: 300px;
   height: fit-content;
   top: 53px;
-  border: 1px solid ${(props) => (props.error ? '#ba3a26' : props.info ? '#368da8' : '#000')};
+  border: 1px solid ${(props) => (props.$error ? '#ba3a26' : props.$info ? '#368da8' : '#000')};
   position: absolute;
   color: #000;
 
@@ -115,9 +115,7 @@ const SearchWrapper = styled.span`
   padding: 0.5em;
 `
 
-const SearchResult = styled.div<{ link?: boolean }>`
-  cursor: ${(props) => (props.onClick ? 'pointer' : 'default')};
-
+const SearchResult = styled.div`
   padding: 0.5em;
   padding-left: 1em;
   align-self: center;

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/icons/genderIcon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/icons/genderIcon.tsx
@@ -8,15 +8,15 @@ export enum GenderList {
 
 export const GenderIcon = (props: { gender: GenderList }) => {
   return (
-    <Gender gender={props.gender}>
+    <Gender $gender={props.gender}>
       {props.gender === GenderList.female ? <FigureOutwardIcon color="#fff" /> : <FigureInwardIcon color="#fff" />}
     </Gender>
   )
 }
 
-const Gender = styled.div<{ gender: GenderList }>`
+const Gender = styled.div<{ $gender: GenderList }>`
   line-height: 30px;
-  background-color: ${(props) => (props.gender === GenderList.female ? '#c86151' : 'blue')};
+  background-color: ${(props) => (props.$gender === GenderList.female ? '#c86151' : 'blue')};
   padding: 3px;
   width: 30px;
   height: 30px;

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/icons/statusIcon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/icons/statusIcon.tsx
@@ -18,10 +18,10 @@ export const StatusIcon = (props: { status: StatusIconProps }) => {
     }
   }
 
-  return <SvgWrapper status={props.status}>{symbol}</SvgWrapper>
+  return <SvgWrapper>{symbol}</SvgWrapper>
 }
 
-const SvgWrapper = styled.div<{ status: StatusIconProps }>`
+const SvgWrapper = styled.div`
   display: inline-flex;
   justify-content: center;
   align-items: center;

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/styled.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/styled.tsx
@@ -30,15 +30,15 @@ export const MainContent = styled.div`
   border-right: 1px solid #c6c2bf;
 `
 
-export const CollapsibleSidebar = styled.div<{ collapsed: boolean }>`
+export const CollapsibleSidebar = styled.div<{ $collapsed: boolean }>`
   background: var(--a-white);
   position: relative;
   max-height: fit-content;
-  min-width: ${(props) => (props.collapsed ? '50px' : '20%')};
+  min-width: ${(props) => (props.$collapsed ? '50px' : '20%')};
 `
 
-export const SidebarContent = styled.div<{ collapsed: boolean }>`
-  display: ${(props) => (props.collapsed ? 'none' : 'block')};
+export const SidebarContent = styled.div<{ $collapsed: boolean }>`
+  display: ${(props) => (props.$collapsed ? 'none' : 'block')};
   margin-bottom: 4rem;
 `
 


### PR DESCRIPTION
Får bort slike feilmeldinger som vi har overalt som feks denne:
```
Warning: Received `true` for a non-boolean attribute `adresse`.

If you want to write it to the DOM, pass a string instead: adresse="true" or adresse={value.toString()}.
div
```
https://styled-components.com/docs/api#transient-props
se https://github.com/styled-components/styled-components/issues/1198