### PR TITLE
Ikke vise ja/nei i refusjonskrav med mindre samordningsmelding er besvart

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningSak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningSak.tsx
@@ -67,7 +67,7 @@ function SamordningTabell({ samordningsdata }: { samordningsdata: Array<Samordni
                 <Table.DataCell>{formaterStringDato(mld.sendtDato)}</Table.DataCell>
                 <Table.DataCell>{mld.svartDato && formaterStringDato(mld.svartDato)}</Table.DataCell>
                 <Table.DataCell>{mld.purretDato && formaterStringDato(mld.purretDato)}</Table.DataCell>
-                <Table.DataCell>{mld.refusjonskrav ? 'Ja' : 'Nei'}</Table.DataCell>
+                <Table.DataCell>{mld.svartDato && (mld.refusjonskrav ? 'Ja' : 'Nei')}</Table.DataCell>
               </Table.Row>
             ))
           )}


### PR DESCRIPTION
Liten oppfølger til forrige feilretting av visning. Av en eller annen grunn er refusjonskrav-kolonnen i SAM not-nullable, slik at vi får false tilbake her når samordningsmeldinger har status SENDT. Det gir ingen mening i å vise ettersom det ikke er vi (NAV) som setter det, men snarere når TP-ordningene sender inn svaret på meldingene, altså hvorvidt de mener de har refusjon eller ei.

Hvorvidt dette kanskje burde vært korrigert et annet sted kan diskuteres.