### PR TITLE
Legge til prefix for MDC logg keys

### DIFF
--- a/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/LoggingPlugins.kt
+++ b/apps/etterlatte-samordning-vedtak/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/LoggingPlugins.kt
@@ -65,7 +65,7 @@ val userIdMdcPlugin: RouteScopedPlugin<PluginConfiguration> =
                     call.orgNummer
                 }
 
-            MDC.put("user", user)
+            MDC.put("x_user", user)
             call.attributes.put(userAttribute, user)
 
             return@on
@@ -89,11 +89,11 @@ val serverRequestLoggerPlugin =
                 val markers =
                     Markers.appendEntries(
                         mapOf(
-                            "method" to method,
-                            "response_code" to responseCode,
-                            "response_time" to duration,
-                            "request_uri" to requestUriTemplate,
-                            "user" to (call.attributes.getOrNull(userAttribute) ?: "unknown"),
+                            "x_method" to method,
+                            "x_response_code" to responseCode,
+                            "x_response_time" to duration,
+                            "x_request_uri" to requestUriTemplate,
+                            "x_user" to (call.attributes.getOrNull(userAttribute) ?: "unknown"),
                         ),
                     )
 

--- a/libs/saksbehandling-common/src/main/kotlin/logging/LogUtils.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/logging/LogUtils.kt
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import java.util.UUID
 
-const val CORRELATION_ID: String = "correlation_id"
+const val CORRELATION_ID: String = "x_correlation_id"
 
 fun <T> withLogContext(
     correlationId: String? = null,


### PR DESCRIPTION
Kibana logger ikke lenger `user`, `correlation_id`, m.m. 
Før det nylig ble oppdatert kom det advarsel om "duplicate key", så min mistanke er at disse nøklene er reservert. Legger til prefiks for å se om det utgjør en forskjell 