### PR TITLE
Sorterer perioder før det sjekkes for overlapp

### DIFF
--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/PeriodisertBeregningGrunnlagTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/PeriodisertBeregningGrunnlagTest.kt
@@ -19,6 +19,16 @@ class PeriodisertBeregningGrunnlagTest {
             YearMonth.of(2023, Month.JANUARY).atDay(1) to null,
         )
 
+    private val perioderSomErKomplettIkkeSortert =
+        listOf<Pair<LocalDate, LocalDate?>>(
+            YearMonth.of(2023, Month.JANUARY).atDay(1) to null,
+            YearMonth.of(2022, Month.AUGUST).atDay(1) to
+                YearMonth.of(
+                    2022,
+                    Month.DECEMBER,
+                ).atEndOfMonth(),
+        )
+
     private val perioderMedHull =
         listOf<Pair<LocalDate, LocalDate?>>(
             YearMonth.of(2022, Month.AUGUST).atDay(1) to
@@ -86,6 +96,19 @@ class PeriodisertBeregningGrunnlagTest {
         assertDoesNotThrow {
             PeriodisertBeregningGrunnlag.lagKomplettPeriodisertGrunnlag(
                 perioderTilGrunnlagMedPerioder(perioderSomErKomplett, null),
+                fom,
+                tom,
+            )
+        }
+    }
+
+    @Test
+    fun `lagKomlettPeriodisertGrunnlag kaster ikke feil selv om periodene som sendes inn ikke er sortert`() {
+        val fom = perioderSomErKomplett.minBy { it.first }.first
+        val tom = null
+        assertDoesNotThrow {
+            PeriodisertBeregningGrunnlag.lagKomplettPeriodisertGrunnlag(
+                perioderTilGrunnlagMedPerioder(perioderSomErKomplettIkkeSortert, null),
                 fom,
                 tom,
             )

--- a/libs/etterlatte-beregning-model/src/main/kotlin/GrunnlagMedPeriode.kt
+++ b/libs/etterlatte-beregning-model/src/main/kotlin/GrunnlagMedPeriode.kt
@@ -42,10 +42,10 @@ object PeriodisertBeregningGrunnlag {
         val senesteTom: LocalDate?
 
         init {
-            if (opplysninger.isEmpty()) {
+            if (sorterteOpplysninger.isEmpty()) {
                 throw PeriodiseringAvGrunnlagFeil.IngenPerioder()
             }
-            if (perioderOverlapper(opplysninger)) {
+            if (perioderOverlapper(sorterteOpplysninger)) {
                 throw PeriodiseringAvGrunnlagFeil.PerioderOverlapper()
             }
 


### PR DESCRIPTION
Flere manuelle beregninger feilet fordi grunnlaget tilsynelatende overlappet. Dette stemmer ikke, men skjedde fordi resultatet fra db ikke nødvendigvis kommer i riktig rekkefølge. Bruker `sorterteOpplysninger` i sjekk for om perioder overlapper. Dette løser problemet.