### PR TITLE
Fjerner opphoerFraOgMed fra Vedtakslinje brukt i sammenheng med regulering 2024

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningRoutes.kt
@@ -37,7 +37,6 @@ fun Route.omregningRoutes(omregningService: OmregningService) {
                             forrigeBehandling = forrigeBehandling,
                             persongalleri = persongalleri,
                             oppgavefrist = request.oppgavefrist?.let { Tidspunkt.ofNorskTidssone(it, LocalTime.NOON) },
-                            opphoerFraOgMed = request.opphoerFraOgMed,
                         )
                     }
                 retryOgPakkUt { revurderingOgOppfoelging.leggInnGrunnlag() }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
@@ -16,7 +16,6 @@ import no.nav.etterlatte.libs.common.sak.KjoeringStatus
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.token.Systembruker
 import java.time.LocalDate
-import java.time.YearMonth
 import java.util.UUID
 
 class OmregningService(
@@ -39,7 +38,6 @@ class OmregningService(
         forrigeBehandling: Behandling,
         persongalleri: Persongalleri,
         oppgavefrist: Tidspunkt?,
-        opphoerFraOgMed: YearMonth? = null,
     ): RevurderingOgOppfoelging {
         if (prosessType == Prosesstype.MANUELL) {
             throw StoetterIkkeProsesstypeManuell()
@@ -56,7 +54,6 @@ class OmregningService(
                 kilde = Vedtaksloesning.GJENNY,
                 persongalleri = persongalleri,
                 frist = oppgavefrist,
-                opphoerFraOgMed = opphoerFraOgMed,
             ),
         ) { "Opprettelse av revurdering feilet for $sakId" }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -9,7 +9,6 @@ import no.nav.etterlatte.libs.common.behandling.tilVirkningstidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
 import java.time.LocalDate
-import java.time.YearMonth
 
 class AutomatiskRevurderingService(private val revurderingService: RevurderingService) {
     fun opprettAutomatiskRevurdering(
@@ -22,7 +21,6 @@ class AutomatiskRevurderingService(private val revurderingService: RevurderingSe
         mottattDato: String? = null,
         begrunnelse: String? = null,
         frist: Tidspunkt? = null,
-        opphoerFraOgMed: YearMonth? = null,
     ) = forrigeBehandling.let {
         revurderingService.opprettRevurdering(
             sakId = sakId,
@@ -38,8 +36,7 @@ class AutomatiskRevurderingService(private val revurderingService: RevurderingSe
             begrunnelse = begrunnelse ?: "Automatisk revurdering - ${revurderingAarsak.name.lowercase()}",
             saksbehandlerIdent = Fagsaksystem.EY.navn,
             frist = frist,
-            // TODO kun relevant for regulering 2024 da feltet opphoerFraOgMed er innført i forkant av reguleringen 2024
-            opphoerFraOgMed = forrigeBehandling.opphoerFraOgMed ?: opphoerFraOgMed,
+            opphoerFraOgMed = forrigeBehandling.opphoerFraOgMed,
         )
     }
 

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/LoependeYtelserforespoerselRiver.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/LoependeYtelserforespoerselRiver.kt
@@ -64,7 +64,6 @@ internal class LoependeYtelserforespoerselRiver(
                 sakId = sakId,
                 fradato = respons.dato,
                 prosesstype = Prosesstype.AUTOMATISK,
-                opphoerFraOgMed = respons.opphoerFraOgMed,
             )
         respons.sisteLoependeBehandlingId?.let { b -> packet[BEHANDLING_VI_OMREGNER_FRA_KEY] = b }
         if (respons.erLoepende) {

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Vedtak.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Vedtak.kt
@@ -114,8 +114,6 @@ data class LoependeYtelse(
     val dato: LocalDate,
     val behandlingId: UUID? = null,
     val sisteLoependeBehandlingId: UUID? = null,
-    // TODO kun relevant for regulering 2024 da feltet opphoerFraOgMed er innført i forkant av reguleringen 2024
-    val opphoerFraOgMed: YearMonth? = null,
 )
 
 class UgyldigAttestantException(ident: String) :

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Vedtakstidslinje.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Vedtakstidslinje.kt
@@ -31,19 +31,6 @@ class Vedtakstidslinje(private val vedtak: List<Vedtak>) {
                 } else {
                     null
                 },
-            opphoerFraOgMed =
-                iverksatteVedtak.filter { it.type == VedtakType.OPPHOER }
-                    .maxByOrNull { it.attestasjon?.tidspunkt!! }?.let {
-                        if (erLoepende) {
-                            if (it.attestasjon!!.tidspunkt.isAfter(senesteVedtakPaaDato!!.attestasjon!!.tidspunkt)) {
-                                it.virkningstidspunkt
-                            } else {
-                                null
-                            }
-                        } else {
-                            it.virkningstidspunkt
-                        }
-                    },
         )
     }
 

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -402,7 +402,6 @@ private fun LoependeYtelse.toDto() =
         dato = dato,
         behandlingId = behandlingId,
         sisteLoependeBehandlingId = sisteLoependeBehandlingId,
-        opphoerFraOgMed = opphoerFraOgMed,
     )
 
 data class UnderkjennVedtakDto(val kommentar: String, val valgtBegrunnelse: String)

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Omregningshendelse.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Omregningshendelse.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.libs.common.behandling
 
 import java.time.LocalDate
-import java.time.YearMonth
 import java.util.UUID
 
 data class Omregningshendelse(
@@ -11,6 +10,4 @@ data class Omregningshendelse(
     val prosesstype: Prosesstype,
     val revurderingaarsak: Revurderingaarsak = Revurderingaarsak.REGULERING,
     val oppgavefrist: LocalDate? = null,
-    // TODO kun relevant for regulering 2024 da feltet opphoerFraOgMed er innført i forkant av reguleringen 2024
-    val opphoerFraOgMed: YearMonth? = null,
 )


### PR DESCRIPTION
Utledning av opphoerFraOgMed skal skje basert på forrige revurdering men for regulering 2024 så ble feltet innført i forkant uten å få populert alle revurderinger.
Denne utledningen som fjernes i denne commiten var for å midlertidig kompensere for det.