### PR TITLE
Dødsmeldinger blir ignorert for brukere som har ytelse i Gjenny

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringsHendelseFilter.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringsHendelseFilter.kt
@@ -37,7 +37,7 @@ class GrunnlagsendringsHendelseFilter(val vedtakKlient: VedtakKlient, val behand
 
     private fun ikkeRelevanteHendelserForOpphoertSak(grunnlagendringType: GrunnlagsendringsType) =
         when (grunnlagendringType) {
-            GrunnlagsendringsType.DOEDSFALL -> false
+            GrunnlagsendringsType.DOEDSFALL -> true
             GrunnlagsendringsType.UTFLYTTING -> true
             GrunnlagsendringsType.FORELDER_BARN_RELASJON -> true
             GrunnlagsendringsType.VERGEMAAL_ELLER_FREMTIDSFULLMAKT -> true


### PR DESCRIPTION
Logikken starter i grunnlagsendringshendelseService#131, og må være der intill dødsmelding er på lufta (som ikke er langt unna).

Ser ut som det ble innført noen endringer i https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/4757 