### PR TITLE
EY-3995: Loggar til Grafana Loki i tillegg til elastic

### DIFF
--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -36,6 +36,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   azure:

--- a/apps/etterlatte-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-behandling/.nais/prod.yaml
@@ -41,6 +41,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   azure:

--- a/apps/etterlatte-beregning-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-beregning-kafka/.nais/dev.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   kafka:

--- a/apps/etterlatte-beregning-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-beregning-kafka/.nais/prod.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   kafka:

--- a/apps/etterlatte-beregning/.nais/dev.yaml
+++ b/apps/etterlatte-beregning/.nais/dev.yaml
@@ -23,6 +23,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   resources:

--- a/apps/etterlatte-beregning/.nais/prod.yaml
+++ b/apps/etterlatte-beregning/.nais/prod.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   resources:

--- a/apps/etterlatte-brev-api/.nais/dev.yaml
+++ b/apps/etterlatte-brev-api/.nais/dev.yaml
@@ -25,6 +25,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   gcp:

--- a/apps/etterlatte-brev-api/.nais/prod.yaml
+++ b/apps/etterlatte-brev-api/.nais/prod.yaml
@@ -23,6 +23,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   gcp:

--- a/apps/etterlatte-egne-ansatte-lytter/.nais/dev.yaml
+++ b/apps/etterlatte-egne-ansatte-lytter/.nais/dev.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   strategy:

--- a/apps/etterlatte-egne-ansatte-lytter/.nais/prod.yaml
+++ b/apps/etterlatte-egne-ansatte-lytter/.nais/prod.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   strategy:

--- a/apps/etterlatte-grunnlag/.nais/dev.yaml
+++ b/apps/etterlatte-grunnlag/.nais/dev.yaml
@@ -33,6 +33,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   azure:

--- a/apps/etterlatte-grunnlag/.nais/prod.yaml
+++ b/apps/etterlatte-grunnlag/.nais/prod.yaml
@@ -43,6 +43,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   azure:

--- a/apps/etterlatte-gyldig-soeknad/.nais/dev.yaml
+++ b/apps/etterlatte-gyldig-soeknad/.nais/dev.yaml
@@ -25,6 +25,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   resources:

--- a/apps/etterlatte-gyldig-soeknad/.nais/prod.yaml
+++ b/apps/etterlatte-gyldig-soeknad/.nais/prod.yaml
@@ -25,6 +25,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   resources:

--- a/apps/etterlatte-hendelser-joark/.nais/dev.yaml
+++ b/apps/etterlatte-hendelser-joark/.nais/dev.yaml
@@ -27,6 +27,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   resources:
     requests:
       cpu: 25m

--- a/apps/etterlatte-hendelser-joark/.nais/prod.yaml
+++ b/apps/etterlatte-hendelser-joark/.nais/prod.yaml
@@ -27,6 +27,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   resources:
     requests:
       cpu: 25m

--- a/apps/etterlatte-hendelser-pdl/.nais/dev.yaml
+++ b/apps/etterlatte-hendelser-pdl/.nais/dev.yaml
@@ -27,6 +27,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   resources:
     requests:
       cpu: 20m

--- a/apps/etterlatte-hendelser-pdl/.nais/prod.yaml
+++ b/apps/etterlatte-hendelser-pdl/.nais/prod.yaml
@@ -27,6 +27,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   resources:
     requests:
       cpu: 20m

--- a/apps/etterlatte-hendelser-samordning/.nais/dev.yaml
+++ b/apps/etterlatte-hendelser-samordning/.nais/dev.yaml
@@ -27,6 +27,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   resources:
     requests:
       cpu: 10m

--- a/apps/etterlatte-hendelser-samordning/.nais/prod.yaml
+++ b/apps/etterlatte-hendelser-samordning/.nais/prod.yaml
@@ -25,6 +25,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   resources:

--- a/apps/etterlatte-institusjonsopphold/.nais/dev.yaml
+++ b/apps/etterlatte-institusjonsopphold/.nais/dev.yaml
@@ -25,6 +25,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   resources:

--- a/apps/etterlatte-institusjonsopphold/.nais/prod.yaml
+++ b/apps/etterlatte-institusjonsopphold/.nais/prod.yaml
@@ -25,6 +25,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   resources:

--- a/apps/etterlatte-klage/.nais/dev.yaml
+++ b/apps/etterlatte-klage/.nais/dev.yaml
@@ -29,6 +29,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   resources:
     requests:
       cpu: 10m

--- a/apps/etterlatte-klage/.nais/prod.yaml
+++ b/apps/etterlatte-klage/.nais/prod.yaml
@@ -27,6 +27,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   resources:
     requests:
       cpu: 10m

--- a/apps/etterlatte-migrering/.nais/dev.yaml
+++ b/apps/etterlatte-migrering/.nais/dev.yaml
@@ -25,6 +25,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   gcp:
     sqlInstances:
       - type: POSTGRES_14

--- a/apps/etterlatte-migrering/.nais/prod.yaml
+++ b/apps/etterlatte-migrering/.nais/prod.yaml
@@ -23,6 +23,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   gcp:
     sqlInstances:
       - type: POSTGRES_14

--- a/apps/etterlatte-oppdater-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-oppdater-behandling/.nais/dev.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   kafka:

--- a/apps/etterlatte-oppdater-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-oppdater-behandling/.nais/prod.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   kafka:

--- a/apps/etterlatte-opplysninger-fra-soeknad/.nais/dev.yaml
+++ b/apps/etterlatte-opplysninger-fra-soeknad/.nais/dev.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   kafka:

--- a/apps/etterlatte-opplysninger-fra-soeknad/.nais/prod.yaml
+++ b/apps/etterlatte-opplysninger-fra-soeknad/.nais/prod.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   kafka:

--- a/apps/etterlatte-pdltjenester/.nais/dev.yaml
+++ b/apps/etterlatte-pdltjenester/.nais/dev.yaml
@@ -23,6 +23,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   resources:

--- a/apps/etterlatte-pdltjenester/.nais/prod.yaml
+++ b/apps/etterlatte-pdltjenester/.nais/prod.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   resources:

--- a/apps/etterlatte-saksbehandling-ui/.nais/dev.yaml
+++ b/apps/etterlatte-saksbehandling-ui/.nais/dev.yaml
@@ -61,6 +61,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: nodejs
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   resources:
     limits:
       memory: 512Mi

--- a/apps/etterlatte-saksbehandling-ui/.nais/prod.yaml
+++ b/apps/etterlatte-saksbehandling-ui/.nais/prod.yaml
@@ -61,6 +61,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: nodejs
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   resources:
     limits:
       memory: 512Mi

--- a/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
@@ -24,6 +24,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   resources:

--- a/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
@@ -24,6 +24,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   resources:

--- a/apps/etterlatte-statistikk/.nais/dev.yaml
+++ b/apps/etterlatte-statistikk/.nais/dev.yaml
@@ -28,6 +28,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   leaderElection: true
   kafka:
     pool: nav-dev

--- a/apps/etterlatte-statistikk/.nais/prod.yaml
+++ b/apps/etterlatte-statistikk/.nais/prod.yaml
@@ -43,6 +43,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   leaderElection: true
   kafka:
     pool: nav-prod

--- a/apps/etterlatte-testdata-behandler/.nais/dev.yaml
+++ b/apps/etterlatte-testdata-behandler/.nais/dev.yaml
@@ -23,6 +23,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   resources:
     requests:
       cpu: 10m

--- a/apps/etterlatte-testdata/.nais/dev.yaml
+++ b/apps/etterlatte-testdata/.nais/dev.yaml
@@ -23,6 +23,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   resources:
     requests:
       cpu: 10m

--- a/apps/etterlatte-tidshendelser/.nais/dev.yaml
+++ b/apps/etterlatte-tidshendelser/.nais/dev.yaml
@@ -28,6 +28,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   kafka:

--- a/apps/etterlatte-tidshendelser/.nais/prod.yaml
+++ b/apps/etterlatte-tidshendelser/.nais/prod.yaml
@@ -43,6 +43,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   kafka:

--- a/apps/etterlatte-tilbakekreving/.nais/dev.yaml
+++ b/apps/etterlatte-tilbakekreving/.nais/dev.yaml
@@ -23,6 +23,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   gcp:

--- a/apps/etterlatte-tilbakekreving/.nais/prod.yaml
+++ b/apps/etterlatte-tilbakekreving/.nais/prod.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   gcp:

--- a/apps/etterlatte-trygdetid-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-trygdetid-kafka/.nais/dev.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   kafka:

--- a/apps/etterlatte-trygdetid-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-trygdetid-kafka/.nais/prod.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   kafka:

--- a/apps/etterlatte-trygdetid/.nais/dev.yaml
+++ b/apps/etterlatte-trygdetid/.nais/dev.yaml
@@ -25,6 +25,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   gcp:
     sqlInstances:
       - type: POSTGRES_14

--- a/apps/etterlatte-trygdetid/.nais/prod.yaml
+++ b/apps/etterlatte-trygdetid/.nais/prod.yaml
@@ -23,6 +23,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   gcp:
     sqlInstances:
       - type: POSTGRES_14

--- a/apps/etterlatte-utbetaling/.nais/dev.yaml
+++ b/apps/etterlatte-utbetaling/.nais/dev.yaml
@@ -23,6 +23,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   leaderElection: true

--- a/apps/etterlatte-utbetaling/.nais/prod.yaml
+++ b/apps/etterlatte-utbetaling/.nais/prod.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   leaderElection: true

--- a/apps/etterlatte-vedtaksvurdering-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/.nais/dev.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   kafka:

--- a/apps/etterlatte-vedtaksvurdering-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/.nais/prod.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   kafka:

--- a/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
@@ -33,6 +33,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   azure:

--- a/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
@@ -43,6 +43,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   azure:

--- a/apps/etterlatte-vilkaarsvurdering-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/.nais/dev.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   kafka:

--- a/apps/etterlatte-vilkaarsvurdering-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/.nais/prod.yaml
@@ -21,6 +21,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   kafka:

--- a/apps/etterlatte-vilkaarsvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vilkaarsvurdering/.nais/dev.yaml
@@ -25,6 +25,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   gcp:
     sqlInstances:
       - type: POSTGRES_14

--- a/apps/etterlatte-vilkaarsvurdering/.nais/prod.yaml
+++ b/apps/etterlatte-vilkaarsvurdering/.nais/prod.yaml
@@ -23,6 +23,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   gcp:
     sqlInstances:
       - type: POSTGRES_14


### PR DESCRIPTION
For å få loggane inn i Grafana og dermed kunne få den automatiske koplinga opp mot sporinga frå Grafana Tempo. Opnar for enklare feilsøking av distribuerte kall når vi har alt enkelt samla der

Ref https://docs.nais.io/observability/logging/how-to/loki/