### PR TITLE
Status på overstyrt beregning

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/Beregning.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/Beregning.kt
@@ -33,6 +33,7 @@ data class OverstyrBeregning(
     val sakId: Long,
     val beskrivelse: String,
     val tidspunkt: Tidspunkt,
+    val status: OverstyrBeregningStatus = OverstyrBeregningStatus.GYLDIG,
 )
 
 fun OverstyrBeregning.toDTO() = OverstyrBeregningDTO(this.beskrivelse)

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/Beregning.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/Beregning.kt
@@ -33,7 +33,7 @@ data class OverstyrBeregning(
     val sakId: Long,
     val beskrivelse: String,
     val tidspunkt: Tidspunkt,
-    val status: OverstyrBeregningStatus = OverstyrBeregningStatus.GYLDIG,
+    val status: OverstyrBeregningStatus = OverstyrBeregningStatus.AKTIV,
 )
 
 fun OverstyrBeregning.toDTO() = OverstyrBeregningDTO(this.beskrivelse)

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRepository.kt
@@ -81,7 +81,7 @@ class BeregningRepository(private val dataSource: DataSource) {
             }
         }
 
-        if (overstyrBeregning.status == OverstyrBeregningStatus.UGYLDIG) {
+        if (overstyrBeregning.status == OverstyrBeregningStatus.IKKE_AKTIV) {
             return null
         }
         return checkNotNull(hentOverstyrBeregning(overstyrBeregning.sakId)) {
@@ -308,7 +308,7 @@ private object Queries {
         SELECT *
         FROM overstyr_beregning 
         WHERE sak_id = :sakId
-        and status = '${OverstyrBeregningStatus.GYLDIG.name}'
+        and status = '${OverstyrBeregningStatus.AKTIV.name}'
         """.trimIndent()
 
     val opprettOverstyrBeregning =
@@ -320,8 +320,8 @@ private object Queries {
 }
 
 enum class OverstyrBeregningStatus {
-    GYLDIG,
-    UGYLDIG,
+    AKTIV,
+    IKKE_AKTIV,
 }
 
 private data class BeregningsperiodeDAO(

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRepository.kt
@@ -316,6 +316,7 @@ private object Queries {
         """
         INSERT INTO overstyr_beregning (sak_id, beskrivelse, tidspunkt, status)
         VALUES (:sakId, :beskrivelse, :tidspunkt, :status)
+        ON CONFLICT (sak_id) DO UPDATE SET beskrivelse=:beskrivelse, tidspunkt=:tidspunkt, status=:status
         """.trimIndent()
 }
 

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRepository.kt
@@ -124,7 +124,6 @@ class BeregningRepository(private val dataSource: DataSource) {
 
 private fun toOverstyrBeregning(row: Row): OverstyrBeregning =
     with(row) {
-        println(row.underlying.getString("status"))
         OverstyrBeregning(
             sakId = long("sak_id"),
             beskrivelse = string("beskrivelse"),

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRepository.kt
@@ -304,6 +304,7 @@ private object Queries {
         SELECT *
         FROM overstyr_beregning 
         WHERE sak_id = :sakId
+        and status != '${OverstyrBeregningStatus.UGYLDIG.name}'
         """.trimIndent()
 
     val opprettOverstyrBeregning =
@@ -311,6 +312,11 @@ private object Queries {
         INSERT INTO overstyr_beregning (sak_id, beskrivelse, tidspunkt)
         VALUES (:sakId, :beskrivelse, :tidspunkt)
         """.trimIndent()
+}
+
+private enum class OverstyrBeregningStatus {
+    GYLDIG,
+    UGYLDIG,
 }
 
 private data class BeregningsperiodeDAO(

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRoutes.kt
@@ -55,7 +55,7 @@ fun Route.beregning(
                         behandlingId,
                         call.receive<OverstyrBeregningDTO>(),
                         brukerTokenInfo,
-                    ).toDTO()
+                    )!!.toDTO()
 
                 call.respond(overstyrBeregning)
             }

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
@@ -81,7 +81,7 @@ class BeregningService(
         behandlingId: UUID,
         overstyrBeregning: OverstyrBeregningDTO,
         brukerTokenInfo: BrukerTokenInfo,
-    ): OverstyrBeregning {
+    ): OverstyrBeregning? {
         val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
 
         return hentOverstyrBeregning(behandlingId, brukerTokenInfo).takeIf { it != null }

--- a/apps/etterlatte-beregning/src/main/resources/db/migration/V41__status_overstyr_beregning.sql
+++ b/apps/etterlatte-beregning/src/main/resources/db/migration/V41__status_overstyr_beregning.sql
@@ -1,5 +1,5 @@
-ALTER TABLE overstyr_beregning ADD COLUMN status TEXT NOT NULL DEFAULT 'GYLDIG';
+ALTER TABLE overstyr_beregning ADD COLUMN status TEXT NOT NULL DEFAULT 'AKTIV';
 
 -- Det overstyrte beregningsgrunnlaget hører til en behandling som er avbrutt
 -- Ser ut til at noen har satt den saken til overstyrt, også har de avbrutt behandlingen i etterkant.
-UPDATE overstyr_beregning SET status = 'UGYLDIG' WHERE sak_id=2912;
+UPDATE overstyr_beregning SET status = 'IKKE_AKTIV' WHERE sak_id=2912;

--- a/apps/etterlatte-beregning/src/main/resources/db/migration/V41__status_overstyr_beregning.sql
+++ b/apps/etterlatte-beregning/src/main/resources/db/migration/V41__status_overstyr_beregning.sql
@@ -1,0 +1,5 @@
+ALTER TABLE overstyr_beregning ADD COLUMN status TEXT NOT NULL DEFAULT 'GYLDIG';
+
+-- Det overstyrte beregningsgrunnlaget hører til en behandling som er avbrutt
+-- Ser ut til at noen har satt den saken til overstyrt, også har de avbrutt behandlingen i etterkant.
+UPDATE overstyr_beregning SET status = 'UGYLDIG' WHERE sak_id=2912;

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRepositoryTest.kt
@@ -92,6 +92,19 @@ internal class BeregningRepositoryTest(ds: DataSource) {
     }
 
     @Test
+    fun `skal kunne opprette en gyldig overstyr beregning etter en ugyldig`() {
+        beregningRepository.opprettOverstyrBeregning(OverstyrBeregning(10L, "Test", Tidspunkt.now(), OverstyrBeregningStatus.UGYLDIG))
+        beregningRepository.lagreEllerOppdaterBeregning(beregning())
+        assertEquals(null, beregningRepository.hentOverstyrBeregning(10L))
+
+        val overstyrBeregning =
+            beregningRepository.opprettOverstyrBeregning(
+                OverstyrBeregning(10L, "Test", Tidspunkt.now(), OverstyrBeregningStatus.GYLDIG),
+            )
+        assertEquals(overstyrBeregning, beregningRepository.hentOverstyrBeregning(10L))
+    }
+
+    @Test
     fun `skal lagre og hente en overstyr beregning`() {
         val opprettetOverstyrBeregning = beregningRepository.opprettOverstyrBeregning(OverstyrBeregning(1L, "Test", Tidspunkt.now()))
 

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRepositoryTest.kt
@@ -83,7 +83,7 @@ internal class BeregningRepositoryTest(ds: DataSource) {
 
     @Test
     fun `skal ikke hente en overstyr beregning som har status ugyldig`() {
-        beregningRepository.opprettOverstyrBeregning(OverstyrBeregning(10L, "Test", Tidspunkt.now(), OverstyrBeregningStatus.UGYLDIG))
+        beregningRepository.opprettOverstyrBeregning(OverstyrBeregning(10L, "Test", Tidspunkt.now(), OverstyrBeregningStatus.IKKE_AKTIV))
         val beregningLagret = beregning()
         beregningRepository.lagreEllerOppdaterBeregning(beregningLagret)
         val overstyrBeregning = beregningRepository.hentOverstyrBeregning(10L)
@@ -93,13 +93,13 @@ internal class BeregningRepositoryTest(ds: DataSource) {
 
     @Test
     fun `skal kunne opprette en gyldig overstyr beregning etter en ugyldig`() {
-        beregningRepository.opprettOverstyrBeregning(OverstyrBeregning(10L, "Test", Tidspunkt.now(), OverstyrBeregningStatus.UGYLDIG))
+        beregningRepository.opprettOverstyrBeregning(OverstyrBeregning(10L, "Test", Tidspunkt.now(), OverstyrBeregningStatus.IKKE_AKTIV))
         beregningRepository.lagreEllerOppdaterBeregning(beregning())
         assertEquals(null, beregningRepository.hentOverstyrBeregning(10L))
 
         val overstyrBeregning =
             beregningRepository.opprettOverstyrBeregning(
-                OverstyrBeregning(10L, "Test", Tidspunkt.now(), OverstyrBeregningStatus.GYLDIG),
+                OverstyrBeregning(10L, "Test", Tidspunkt.now(), OverstyrBeregningStatus.AKTIV),
             )
         assertEquals(overstyrBeregning, beregningRepository.hentOverstyrBeregning(10L))
     }

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRepositoryTest.kt
@@ -82,6 +82,16 @@ internal class BeregningRepositoryTest(ds: DataSource) {
     }
 
     @Test
+    fun `skal ikke hente en overstyr beregning som har status ugyldig`() {
+        beregningRepository.opprettOverstyrBeregning(OverstyrBeregning(10L, "Test", Tidspunkt.now(), OverstyrBeregningStatus.UGYLDIG))
+        val beregningLagret = beregning()
+        beregningRepository.lagreEllerOppdaterBeregning(beregningLagret)
+        val overstyrBeregning = beregningRepository.hentOverstyrBeregning(10L)
+
+        assertEquals(overstyrBeregning, null)
+    }
+
+    @Test
     fun `skal lagre og hente en overstyr beregning`() {
         val opprettetOverstyrBeregning = beregningRepository.opprettOverstyrBeregning(OverstyrBeregning(1L, "Test", Tidspunkt.now()))
 
@@ -89,8 +99,8 @@ internal class BeregningRepositoryTest(ds: DataSource) {
 
         assertTrue(overstyrBeregning != null)
 
-        assertEquals(opprettetOverstyrBeregning.sakId, overstyrBeregning?.sakId)
-        assertEquals(opprettetOverstyrBeregning.beskrivelse, overstyrBeregning?.beskrivelse)
+        assertEquals(opprettetOverstyrBeregning?.sakId, overstyrBeregning?.sakId)
+        assertEquals(opprettetOverstyrBeregning?.beskrivelse, overstyrBeregning?.beskrivelse)
     }
 
     private fun beregning(

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningServiceTest.kt
@@ -234,8 +234,8 @@ internal class BeregningServiceTest {
 
             overstyrBeregning shouldNotBe null
 
-            overstyrBeregning.sakId shouldBe behandling.sak
-            overstyrBeregning.beskrivelse shouldBe "Test"
+            overstyrBeregning?.sakId shouldBe behandling.sak
+            overstyrBeregning?.beskrivelse shouldBe "Test"
 
             verify(exactly = 1) {
                 beregningRepository.opprettOverstyrBeregning(any())
@@ -262,8 +262,8 @@ internal class BeregningServiceTest {
 
             overstyrBeregning shouldNotBe null
 
-            overstyrBeregning.sakId shouldBe behandling.sak
-            overstyrBeregning.beskrivelse shouldBe "Test"
+            overstyrBeregning?.sakId shouldBe behandling.sak
+            overstyrBeregning?.beskrivelse shouldBe "Test"
 
             verify(exactly = 1) { beregningRepository.hentOverstyrBeregning(any()) }
         }


### PR DESCRIPTION
For å kunne seie at overstyringa ikkje lenger er gyldig.

Regulering avslørte eit scenario der saksbehandlar i ei revurdering la inn overstyrt beregningsgrunnlag og overstyrt beregning, men så avbraut den behandlinga. Dermed vart saka framleis merka som overstyrt beregning, men ingen av dei iverksatte eller pågåande behandlingane hadde overstyrt beregning.

Lager ein mekanisme for å handtere at dette kan skje, sånn at vi da markerer denne overstyringa som ugyldig og i praksis handsamar ho tilsvarande som at det ikkje fins overstyring i det heile tatt.

Forventar ikkje at dette skjer særleg ofte, så trur ein mekanisme kor vi manuelt overstyrer i databasen når det skjer er god nok.