### PR TITLE
EY-4000: Oppgraderer til nyaste micrometer

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -76,7 +76,7 @@ logging-slf4japi = { module = "org.slf4j:slf4j-api", version = "2.0.13" }
 logging-logbackclassic = { module = "ch.qos.logback:logback-classic", version = "1.5.6" }
 logging-logstashlogbackencoder = { module = "net.logstash.logback:logstash-logback-encoder", version = "7.4" }
 
-metrics-micrometer-prometheus = { module = "io.micrometer:micrometer-registry-prometheus", version = "1.12.5" }
+metrics-micrometer-prometheus = { module = "io.micrometer:micrometer-registry-prometheus-simpleclient", version = "1.13.0" }
 metrics-prometheus-simpleclientcommon = { module = "io.prometheus:simpleclient_common", version.ref = "prometheus-version" }
 metrics-prometheus-simpleclienthotspot = { module = "io.prometheus:simpleclient_hotspot", version.ref = "prometheus-version" }
 


### PR DESCRIPTION
Merk at oppgraderinga er til simpleclients-versjonen. Dette er fordi den vanlege versjonen har breaking changes, som også er dårleg dokumentert i migreringsguiden.

Å bytte til simpleclients-versjonen er det dei tilrår viss du vil ha ei enkel og smertefri oppgradering, så går for det i denne omgang, og satsar på at innan det er på tide å gå bort frå den (den er jo deprecated) så er dokumentasjonen både frå micrometer-folka sjølv og andre langt betre enn det som er no.