### PR TITLE
Legg til zoom for timeline

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/AktivitetspliktTidslinje.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/AktivitetspliktTidslinje.tsx
@@ -1,5 +1,5 @@
 import { Buildings2Icon, HatSchoolIcon, PencilIcon, PersonIcon, RulerIcon } from '@navikt/aksel-icons'
-import { Alert, Timeline } from '@navikt/ds-react'
+import { Alert, HStack, Timeline, ToggleGroup, VStack } from '@navikt/ds-react'
 import { hentAktiviteter, slettAktivitet } from '~shared/api/aktivitetsplikt'
 import { formaterDato, formaterDatoMedTidspunkt } from '~utils/formattering'
 import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
@@ -23,6 +23,7 @@ export const AktivitetspliktTidslinje = (props: { behandling: IDetaljertBehandli
   const [aktiviteter, setAktiviteter] = useState<IAktivitet[]>([])
   const [rediger, setRediger] = useState<IAktivitet | undefined>(undefined)
   const [aktivitetsTypeProps, setAktivitetsTypeProps] = useState<AktivitetstypeProps[]>([])
+  const [sluttdato, setSluttdato] = useState<Date>(addYears(doedsdato, 3))
 
   useEffect(() => {
     hent({ behandlingId: behandling.id }, (aktiviteter) => {
@@ -42,13 +43,13 @@ export const AktivitetspliktTidslinje = (props: { behandling: IDetaljertBehandli
   }
 
   return (
-    <div className="min-w-[800px]">
+    <VStack gap="8" className="min-w-[800px]">
       {aktiviteter.length === 0 ? (
         <Alert variant="info" inline>
           Ingen aktiviteter er registrert.
         </Alert>
       ) : (
-        <Timeline startDate={doedsdato} endDate={addYears(doedsdato, 3)}>
+        <Timeline startDate={doedsdato} endDate={sluttdato}>
           <Timeline.Pin date={doedsdato}>
             <p>Dødsdato: {formaterDato(doedsdato)}</p>
           </Timeline.Pin>
@@ -112,18 +113,33 @@ export const AktivitetspliktTidslinje = (props: { behandling: IDetaljertBehandli
         </Timeline>
       )}
 
-      <NyAktivitet
-        key={rediger?.id}
-        behandling={behandling}
-        oppdaterAktiviteter={oppdaterAktiviteter}
-        redigerAktivitet={rediger}
-      />
+      <HStack align="center" justify="space-between">
+        <NyAktivitet
+          key={rediger?.id}
+          behandling={behandling}
+          oppdaterAktiviteter={oppdaterAktiviteter}
+          redigerAktivitet={rediger}
+        />
+
+        {aktiviteter.length > 0 && (
+          <ToggleGroup
+            defaultValue="3"
+            onChange={(value) => setSluttdato(addYears(doedsdato, Number(value)))}
+            size="small"
+            variant="neutral"
+          >
+            <ToggleGroup.Item value="1">1 år</ToggleGroup.Item>
+            <ToggleGroup.Item value="2">2 år</ToggleGroup.Item>
+            <ToggleGroup.Item value="3">3 år</ToggleGroup.Item>
+          </ToggleGroup>
+        )}
+      </HStack>
 
       {isFailureHandler({
         errorMessage: 'En feil oppsto ved henting av aktiviteter',
         apiResult: hentet,
       })}
-    </div>
+    </VStack>
   )
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/NyAktivitet.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/NyAktivitet.tsx
@@ -8,7 +8,6 @@ import { formatISO } from 'date-fns'
 import { isFailure, isPending } from '~shared/api/apiUtils'
 import { Alert, Button, Heading, HStack, Select, Textarea, VStack } from '@navikt/ds-react'
 import { PencilIcon } from '@navikt/aksel-icons'
-import styled from 'styled-components'
 import { AktivitetspliktType, IAktivitet, IOpprettAktivitet } from '~shared/types/Aktivitetsplikt'
 import { opprettAktivitet } from '~shared/api/aktivitetsplikt'
 import { ControlledDatoVelger } from '~shared/components/datoVelger/ControlledDatoVelger'
@@ -99,7 +98,7 @@ export const NyAktivitet = ({
   }
 
   return (
-    <AktivitetspliktWrapper>
+    <>
       {visForm && (
         <form onSubmit={handleSubmit(submitAktivitet)}>
           <Heading size="small" level="3" spacing>
@@ -176,10 +175,6 @@ export const NyAktivitet = ({
           </Button>
         </HStack>
       )}
-    </AktivitetspliktWrapper>
+    </>
   )
 }
-
-const AktivitetspliktWrapper = styled.div`
-  margin: 2em 0 1em 0;
-`


### PR DESCRIPTION
Legger til muligheten for å "zoome" 1, 2 og 3 år fra dødsdato. 
Default verdi er 3 år, men det er opp for diskusjon.

Det er brukt Togglebutton og ikke de innebygde zoom knappene da de ikke støtter å sette en spesifikk startDate
 
![Skjermbilde 2024-06-04 kl  13 03 55](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/17142094/e2b37236-3903-4f61-a8df-419619097557)
