### PR TITLE
Avkorting aarsoppgjoer liste

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -98,13 +98,13 @@ data class Avkorting(
                             ),
                     ),
                 )
+
+        val oppdatertAarsoppjoer =
+            hentAarsoppgjoer().copy(
+                inntektsavkorting = oppdatert,
+            )
         return this.copy(
-            aarsoppgjoer =
-                aarsoppgjoer.map {
-                    it.copy(
-                        inntektsavkorting = oppdatert,
-                    )
-                },
+            aarsoppgjoer = erstattAarsoppgjoer(oppdatertAarsoppjoer),
         )
     }
 
@@ -126,26 +126,25 @@ data class Avkorting(
                 type = FORVENTET_INNTEKT,
             )
 
+        val oppdatertAarsoppgjoer =
+            hentAarsoppgjoer().copy(
+                ytelseFoerAvkorting = ytelseFoerAvkorting,
+                inntektsavkorting =
+                    hentAarsoppgjoer().inntektsavkorting.map { inntektsavkorting ->
+                        inntektsavkorting.copy(
+                            avkortingsperioder = avkortingsperioder,
+                        )
+                    },
+                avkortetYtelseAar =
+                    beregnetAvkortetYtelse.map { avkortetYtelse ->
+                        avkortetYtelse.copy(
+                            id = UUID.randomUUID(),
+                            type = AARSOPPGJOER,
+                        )
+                    },
+            )
         return this.copy(
-            aarsoppgjoer =
-                this.aarsoppgjoer.map {
-                    it.copy(
-                        ytelseFoerAvkorting = ytelseFoerAvkorting,
-                        inntektsavkorting =
-                            it.inntektsavkorting.map { inntektsavkorting ->
-                                inntektsavkorting.copy(
-                                    avkortingsperioder = avkortingsperioder,
-                                )
-                            },
-                        avkortetYtelseAar =
-                            beregnetAvkortetYtelse.map { avkortetYtelse ->
-                                avkortetYtelse.copy(
-                                    id = UUID.randomUUID(),
-                                    type = AARSOPPGJOER,
-                                )
-                            },
-                    )
-                },
+            aarsoppgjoer = erstattAarsoppgjoer(oppdatertAarsoppgjoer),
         )
     }
 
@@ -200,16 +199,14 @@ data class Avkorting(
                 }
             }
 
-        // Oppdater oppgjøret i lista..
+        val oppdatertAarsoppgjoer =
+            hentAarsoppgjoer().copy(
+                ytelseFoerAvkorting = ytelseFoerAvkorting,
+                inntektsavkorting = reberegnetInntektsavkorting,
+                avkortetYtelseAar = avkortetYtelse,
+            )
         return this.copy(
-            aarsoppgjoer =
-                this.aarsoppgjoer.map {
-                    it.copy(
-                        ytelseFoerAvkorting = ytelseFoerAvkorting,
-                        inntektsavkorting = reberegnetInntektsavkorting,
-                        avkortetYtelseAar = avkortetYtelse,
-                    )
-                },
+            aarsoppgjoer = erstattAarsoppgjoer(oppdatertAarsoppgjoer),
         )
     }
 
@@ -261,6 +258,11 @@ data class Avkorting(
         }
         // TODO skal på sikt utlede etterspurt årsoppgjør
         return aarsoppgjoer.single()
+    }
+
+    private fun erstattAarsoppgjoer(nytt: Aarsoppgjoer): List<Aarsoppgjoer> {
+        // TODO Her skal det returneres eksisterend eliste hvor relevant årsoppgjør erstattes basert på året det gjelder
+        return listOf(nytt)
     }
 }
 

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -15,7 +15,6 @@ import java.time.YearMonth
 import java.util.UUID
 
 data class Avkorting(
-    // TODO skal bli List<Aarsoppgjoer> når vi implementerer revurdering tilbake til tidligere år og etteroppgjør
     val aarsoppgjoer: List<Aarsoppgjoer> = emptyList(),
     val avkortetYtelseFraVirkningstidspunkt: List<AvkortetYtelse> = emptyList(),
     val avkortetYtelseForrigeVedtak: List<AvkortetYtelse> = emptyList(),
@@ -149,8 +148,6 @@ data class Avkorting(
     }
 
     fun beregnAvkortingRevurdering(beregning: Beregning): Avkorting {
-        // finn relevant årsoppgjøre
-
         val ytelseFoerAvkorting = hentAarsoppgjoer().ytelseFoerAvkorting.leggTilNyeBeregninger(beregning)
 
         val reberegnetInntektsavkorting =

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
@@ -68,10 +68,12 @@ class AvkortingRepository(private val dataSource: DataSource) {
 
                 Avkorting(
                     aarsoppgjoer =
-                        Aarsoppgjoer(
-                            ytelseFoerAvkorting = ytelseFoerAvkorting,
-                            inntektsavkorting = inntektsavkorting,
-                            avkortetYtelseAar = avkortetYtelseAar,
+                        listOf(
+                            Aarsoppgjoer(
+                                ytelseFoerAvkorting = ytelseFoerAvkorting,
+                                inntektsavkorting = inntektsavkorting,
+                                avkortetYtelseAar = avkortetYtelseAar,
+                            ),
                         ),
                 )
             }
@@ -83,7 +85,7 @@ class AvkortingRepository(private val dataSource: DataSource) {
     ) {
         dataSource.transaction { tx ->
             slettAvkorting(behandlingId, tx)
-            with(avkorting.aarsoppgjoer) {
+            with(avkorting.aarsoppgjoer.single()) {
                 lagreYtelseFoerAvkorting(behandlingId, ytelseFoerAvkorting, tx)
                 inntektsavkorting.forEach {
                     lagreAvkortingGrunnlag(behandlingId, it.grunnlag, tx)

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -85,7 +85,7 @@ fun Route.avkorting(
 
 fun Avkorting.toDto() =
     AvkortingDto(
-        avkortingGrunnlag = aarsoppgjoer.inntektsavkorting.map { it.grunnlag.toDto() },
+        avkortingGrunnlag = aarsoppgjoer.single().inntektsavkorting.map { it.grunnlag.toDto() },
         avkortetYtelse = avkortetYtelseFraVirkningstidspunkt.map { it.toDto() },
         tidligereAvkortetYtelse = avkortetYtelseForrigeVedtak.map { it.toDto() },
     )

--- a/apps/etterlatte-beregning/src/main/kotlin/ytelseMedGrunnlag/YtelseMedGrunnlagService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/ytelseMedGrunnlag/YtelseMedGrunnlagService.kt
@@ -33,7 +33,7 @@ class YtelseMedGrunnlagService(
                         .maxBy { it.datoFOM }
 
                 val avkortingsgrunnlagIPeriode =
-                    avkorting.aarsoppgjoer.inntektsavkorting
+                    avkorting.aarsoppgjoer.single().inntektsavkorting
                         .filter { it.grunnlag.periode.fom <= avkortetYtelse.periode.fom }
                         .maxBy { it.grunnlag.periode.fom }
 

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -109,10 +109,12 @@ fun avkorting(
     avkortetYtelseAar: List<AvkortetYtelse> = emptyList(),
 ) = Avkorting(
     aarsoppgjoer =
-        aarsoppgjoer(
-            ytelseFoerAvkorting,
-            inntektsavkorting,
-            avkortetYtelseAar,
+        listOf(
+            aarsoppgjoer(
+                ytelseFoerAvkorting,
+                inntektsavkorting,
+                avkortetYtelseAar,
+            ),
         ),
 )
 

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
@@ -51,7 +51,7 @@ internal class AvkortingRepositoryTest(ds: DataSource) {
         avkortingRepository.lagreAvkorting(
             behandlingId,
             Avkorting(
-                aarsoppgjoer = aarsoppgjoer,
+                aarsoppgjoer = listOf(aarsoppgjoer),
             ),
         )
         val endretGrunnlag = aarsoppgjoer.inntektsavkorting[0].grunnlag.copy(spesifikasjon = "Endret")
@@ -75,16 +75,18 @@ internal class AvkortingRepositoryTest(ds: DataSource) {
             behandlingId,
             Avkorting(
                 aarsoppgjoer =
-                    aarsoppgjoer(
-                        ytelseFoerAvkorting = endretYtelseFoerAvkorting,
-                        inntektsavkorting = endretInntektsavkorting,
-                        avkortetYtelseAar = endretAvkortetYtelseAar,
+                    listOf(
+                        aarsoppgjoer(
+                            ytelseFoerAvkorting = endretYtelseFoerAvkorting,
+                            inntektsavkorting = endretInntektsavkorting,
+                            avkortetYtelseAar = endretAvkortetYtelseAar,
+                        ),
                     ),
             ),
         )
         val avkorting = avkortingRepository.hentAvkorting(behandlingId)
 
-        with(avkorting!!.aarsoppgjoer) {
+        with(avkorting!!.aarsoppgjoer.single()) {
             ytelseFoerAvkorting.asClue {
                 it.size shouldBe 1
                 it shouldBe endretYtelseFoerAvkorting

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
@@ -98,8 +98,10 @@ class AvkortingRoutesTest {
         val avkorting =
             Avkorting(
                 aarsoppgjoer =
-                    aarsoppgjoer(
-                        inntektsavkorting = inntektsavkorting,
+                    listOf(
+                        aarsoppgjoer(
+                            inntektsavkorting = inntektsavkorting,
+                        ),
                     ),
                 avkortetYtelseFraVirkningstidspunkt = avkortetYtelse,
                 avkortetYtelseForrigeVedtak = avkortetYtelse,

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -133,7 +133,7 @@ internal class AvkortingTest {
         private val nyAvkorting = eksisterendeAvkorting.kopierAvkorting()
 
         @Test
-        fun `Skal kopiere tidligere grunnlag men erstatte id`() {
+        fun `Skal kopiere tidligere inntekt men erstatte id`() {
             with(nyAvkorting) {
                 aarsoppgjoer.single().inntektsavkorting.asClue {
                     it.size shouldBe 2
@@ -159,12 +159,12 @@ internal class AvkortingTest {
 
     @Nested
     inner class OppdaterMedInntektsgrunnlag {
-        private val foersteGrunnlag =
+        private val foersteInntekt =
             avkortinggrunnlag(
                 periode = Periode(fom = YearMonth.of(2024, Month.JANUARY), tom = YearMonth.of(2024, Month.MARCH)),
                 relevanteMaanederInnAar = 12,
             )
-        private val andreGrunnlag =
+        private val andreInntekt =
             avkortinggrunnlag(
                 aarsinntekt = 1000000,
                 periode = Periode(fom = YearMonth.of(2024, Month.APRIL), tom = null),
@@ -174,19 +174,19 @@ internal class AvkortingTest {
             avkorting(
                 inntektsavkorting =
                     listOf(
-                        Inntektsavkorting(foersteGrunnlag),
-                        Inntektsavkorting(andreGrunnlag),
+                        Inntektsavkorting(foersteInntekt),
+                        Inntektsavkorting(andreInntekt),
                     ),
             )
 
         @Test
-        fun `Eksisterer det grunnlag med samme id skal eksisterende grunnlag oppdateres uten aa legge til nytt`() {
-            val endretGrunnlag = avkortinggrunnlagLagre(id = andreGrunnlag.id, aarsinntekt = 200000)
+        fun `Eksisterer det inntekt med samme id skal eksisterende inntekt oppdateres uten aa legge til nytt`() {
+            val endretInntekt = avkortinggrunnlagLagre(id = andreInntekt.id, aarsinntekt = 200000)
             val virkningstidspunkt = YearMonth.of(2024, Month.MARCH)
 
             val oppdatertAvkorting =
                 avkorting.oppdaterMedInntektsgrunnlag(
-                    endretGrunnlag,
+                    endretInntekt,
                     virkningstidspunkt,
                     bruker,
                 )
@@ -198,19 +198,19 @@ internal class AvkortingTest {
             )
             with(oppdatertAvkorting.aarsoppgjoer.single().inntektsavkorting) {
                 size shouldBe 2
-                get(0).grunnlag shouldBe foersteGrunnlag
+                get(0).grunnlag shouldBe foersteInntekt
                 with(get(1).grunnlag) {
-                    aarsinntekt shouldBe endretGrunnlag.aarsinntekt
-                    fratrekkInnAar shouldBe endretGrunnlag.fratrekkInnAar
-                    inntektUtland shouldBe endretGrunnlag.inntektUtland
-                    fratrekkInnAarUtland shouldBe endretGrunnlag.fratrekkInnAarUtland
-                    spesifikasjon shouldBe endretGrunnlag.spesifikasjon
+                    aarsinntekt shouldBe endretInntekt.aarsinntekt
+                    fratrekkInnAar shouldBe endretInntekt.fratrekkInnAar
+                    inntektUtland shouldBe endretInntekt.inntektUtland
+                    fratrekkInnAarUtland shouldBe endretInntekt.fratrekkInnAarUtland
+                    spesifikasjon shouldBe endretInntekt.spesifikasjon
                 }
             }
         }
 
         @Test
-        fun `Eksisterer ikke grunnlag skal det legges til og til og med paa periode til siste grunnlag skal settes`() {
+        fun `Eksisterer ikke inntekt skal det legges til og til og med paa periode til siste inntekt skal settes`() {
             val nyttGrunnlag = avkortinggrunnlagLagre()
             val virkningstidspunkt = YearMonth.of(2024, Month.AUGUST)
 
@@ -228,8 +228,8 @@ internal class AvkortingTest {
             )
             with(oppdatertAvkorting.aarsoppgjoer.single().inntektsavkorting) {
                 size shouldBe 3
-                get(0).grunnlag shouldBe foersteGrunnlag
-                get(1).grunnlag.shouldBeEqualToIgnoringFields(andreGrunnlag, AvkortingGrunnlag::periode)
+                get(0).grunnlag shouldBe foersteInntekt
+                get(1).grunnlag.shouldBeEqualToIgnoringFields(andreInntekt, AvkortingGrunnlag::periode)
                 get(1).grunnlag.periode shouldBe
                     Periode(
                         fom = YearMonth.of(2024, Month.APRIL),
@@ -247,11 +247,11 @@ internal class AvkortingTest {
 
         @Test
         fun `Relvante maaneder skal utledes basert paa virkningstidspunkt`() {
-            val grunnlag = avkortinggrunnlagLagre()
+            val inntektDto = avkortinggrunnlagLagre()
             val virkningstidspunkt = YearMonth.of(2024, Month.MARCH)
 
             avkorting(inntektsavkorting = emptyList()).oppdaterMedInntektsgrunnlag(
-                grunnlag,
+                inntektDto,
                 virkningstidspunkt,
                 bruker,
             ).let {
@@ -261,11 +261,11 @@ internal class AvkortingTest {
 
         @Test
         fun `Relvante maaneder skal skal viderfoeres fra forrige inntekt for samme aar`() {
-            val grunnlag = avkortinggrunnlagLagre()
+            val inntektDto = avkortinggrunnlagLagre()
             val virkningstidspunkt = YearMonth.of(2024, Month.AUGUST)
 
             avkorting.oppdaterMedInntektsgrunnlag(
-                grunnlag,
+                inntektDto,
                 virkningstidspunkt,
                 bruker,
             ).let {

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -23,27 +23,29 @@ internal class AvkortingTest {
         val avkorting =
             Avkorting(
                 aarsoppgjoer =
-                    Aarsoppgjoer(
-                        avkortetYtelseAar =
-                            listOf(
-                                avkortetYtelse(
-                                    periode =
-                                        Periode(
-                                            fom = YearMonth.of(2024, Month.MARCH),
-                                            tom = YearMonth.of(2024, Month.APRIL),
-                                        ),
+                    listOf(
+                        Aarsoppgjoer(
+                            avkortetYtelseAar =
+                                listOf(
+                                    avkortetYtelse(
+                                        periode =
+                                            Periode(
+                                                fom = YearMonth.of(2024, Month.MARCH),
+                                                tom = YearMonth.of(2024, Month.APRIL),
+                                            ),
+                                    ),
+                                    avkortetYtelse(
+                                        periode =
+                                            Periode(
+                                                fom = YearMonth.of(2024, Month.MAY),
+                                                tom = YearMonth.of(2024, Month.JULY),
+                                            ),
+                                    ),
+                                    avkortetYtelse(
+                                        periode = Periode(fom = YearMonth.of(2024, Month.AUGUST), tom = null),
+                                    ),
                                 ),
-                                avkortetYtelse(
-                                    periode =
-                                        Periode(
-                                            fom = YearMonth.of(2024, Month.MAY),
-                                            tom = YearMonth.of(2024, Month.JULY),
-                                        ),
-                                ),
-                                avkortetYtelse(
-                                    periode = Periode(fom = YearMonth.of(2024, Month.AUGUST), tom = null),
-                                ),
-                            ),
+                        ),
                     ),
             )
 
@@ -51,8 +53,8 @@ internal class AvkortingTest {
         fun `fyller ut avkortet ytelse foer virkningstidspunkt ved aa kutte aarsoppgjoer fra virkningstidspunkt`() {
             avkorting.medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2024, Month.MAY)).asClue {
                 it.avkortetYtelseFraVirkningstidspunkt.size shouldBe 2
-                it.avkortetYtelseFraVirkningstidspunkt[0] shouldBe avkorting.aarsoppgjoer.avkortetYtelseAar[1]
-                it.avkortetYtelseFraVirkningstidspunkt[1] shouldBe avkorting.aarsoppgjoer.avkortetYtelseAar[2]
+                it.avkortetYtelseFraVirkningstidspunkt[0] shouldBe avkorting.aarsoppgjoer.single().avkortetYtelseAar[1]
+                it.avkortetYtelseFraVirkningstidspunkt[1] shouldBe avkorting.aarsoppgjoer.single().avkortetYtelseAar[2]
             }
         }
 
@@ -61,24 +63,30 @@ internal class AvkortingTest {
             avkorting.medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2024, Month.APRIL)).asClue {
                 it.avkortetYtelseFraVirkningstidspunkt.size shouldBe 3
                 with(it.avkortetYtelseFraVirkningstidspunkt[0]) {
-                    shouldBeEqualToIgnoringFields(avkorting.aarsoppgjoer.avkortetYtelseAar[0], AvkortetYtelse::periode)
+                    shouldBeEqualToIgnoringFields(
+                        avkorting.aarsoppgjoer.single().avkortetYtelseAar[0],
+                        AvkortetYtelse::periode,
+                    )
                     periode shouldBe
                         Periode(
                             fom = YearMonth.of(2024, Month.APRIL),
                             tom = YearMonth.of(2024, Month.APRIL),
                         )
                 }
-                it.avkortetYtelseFraVirkningstidspunkt[1] shouldBe avkorting.aarsoppgjoer.avkortetYtelseAar[1]
-                it.avkortetYtelseFraVirkningstidspunkt[2] shouldBe avkorting.aarsoppgjoer.avkortetYtelseAar[2]
+                it.avkortetYtelseFraVirkningstidspunkt[1] shouldBe avkorting.aarsoppgjoer.single().avkortetYtelseAar[1]
+                it.avkortetYtelseFraVirkningstidspunkt[2] shouldBe avkorting.aarsoppgjoer.single().avkortetYtelseAar[2]
             }
 
             avkorting.medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2024, Month.JUNE)).asClue {
                 it.avkortetYtelseFraVirkningstidspunkt.size shouldBe 2
                 with(it.avkortetYtelseFraVirkningstidspunkt[0]) {
-                    shouldBeEqualToIgnoringFields(avkorting.aarsoppgjoer.avkortetYtelseAar[1], AvkortetYtelse::periode)
+                    shouldBeEqualToIgnoringFields(
+                        avkorting.aarsoppgjoer.single().avkortetYtelseAar[1],
+                        AvkortetYtelse::periode,
+                    )
                     periode shouldBe Periode(fom = YearMonth.of(2024, Month.JUNE), tom = YearMonth.of(2024, Month.JULY))
                 }
-                it.avkortetYtelseFraVirkningstidspunkt[1] shouldBe avkorting.aarsoppgjoer.avkortetYtelseAar[2]
+                it.avkortetYtelseFraVirkningstidspunkt[1] shouldBe avkorting.aarsoppgjoer.single().avkortetYtelseAar[2]
             }
 
             avkorting.medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2024, Month.SEPTEMBER))
@@ -86,7 +94,7 @@ internal class AvkortingTest {
                     it.avkortetYtelseFraVirkningstidspunkt.size shouldBe 1
                     with(it.avkortetYtelseFraVirkningstidspunkt[0]) {
                         shouldBeEqualToIgnoringFields(
-                            avkorting.aarsoppgjoer.avkortetYtelseAar[2],
+                            avkorting.aarsoppgjoer.single().avkortetYtelseAar[2],
                             AvkortetYtelse::periode,
                         )
                         periode shouldBe Periode(fom = YearMonth.of(2024, Month.SEPTEMBER), tom = null)
@@ -103,20 +111,22 @@ internal class AvkortingTest {
         private val eksisterendeAvkorting =
             Avkorting(
                 aarsoppgjoer =
-                    Aarsoppgjoer(
-                        ytelseFoerAvkorting =
-                            listOf(
-                                YtelseFoerAvkorting(
-                                    beregning = 20902,
-                                    periode = Periode(virkningstidspunkt, null),
-                                    beregningsreferanse = beregningId,
+                    listOf(
+                        Aarsoppgjoer(
+                            ytelseFoerAvkorting =
+                                listOf(
+                                    YtelseFoerAvkorting(
+                                        beregning = 20902,
+                                        periode = Periode(virkningstidspunkt, null),
+                                        beregningsreferanse = beregningId,
+                                    ),
                                 ),
-                            ),
-                        inntektsavkorting =
-                            listOf(
-                                Inntektsavkorting(avkortinggrunnlag()),
-                                Inntektsavkorting(avkortinggrunnlag()),
-                            ),
+                            inntektsavkorting =
+                                listOf(
+                                    Inntektsavkorting(avkortinggrunnlag()),
+                                    Inntektsavkorting(avkortinggrunnlag()),
+                                ),
+                        ),
                     ),
             )
 
@@ -125,10 +135,10 @@ internal class AvkortingTest {
         @Test
         fun `Skal kopiere tidligere grunnlag men erstatte id`() {
             with(nyAvkorting) {
-                aarsoppgjoer.inntektsavkorting.asClue {
+                aarsoppgjoer.single().inntektsavkorting.asClue {
                     it.size shouldBe 2
-                    it[0].grunnlag.id shouldNotBe eksisterendeAvkorting.aarsoppgjoer.inntektsavkorting[0].grunnlag.id
-                    it[1].grunnlag.id shouldNotBe eksisterendeAvkorting.aarsoppgjoer.inntektsavkorting[1].grunnlag.id
+                    it[0].grunnlag.id shouldNotBe eksisterendeAvkorting.aarsoppgjoer.single().inntektsavkorting[0].grunnlag.id
+                    it[1].grunnlag.id shouldNotBe eksisterendeAvkorting.aarsoppgjoer.single().inntektsavkorting[1].grunnlag.id
                 }
             }
         }
@@ -136,7 +146,7 @@ internal class AvkortingTest {
         @Test
         fun `Skal kopiere ytelse foer avkorting til aarsoppgjoer`() {
             nyAvkorting.asClue {
-                it.aarsoppgjoer.ytelseFoerAvkorting.shouldContainExactly(
+                it.aarsoppgjoer.single().ytelseFoerAvkorting.shouldContainExactly(
                     YtelseFoerAvkorting(
                         beregning = 20902,
                         periode = Periode(fom = virkningstidspunkt, tom = null),
@@ -182,11 +192,11 @@ internal class AvkortingTest {
                 )
 
             oppdatertAvkorting.shouldBeEqualToIgnoringFields(avkorting, Avkorting::aarsoppgjoer)
-            oppdatertAvkorting.aarsoppgjoer.shouldBeEqualToIgnoringFields(
-                avkorting.aarsoppgjoer,
+            oppdatertAvkorting.aarsoppgjoer.single().shouldBeEqualToIgnoringFields(
+                avkorting.aarsoppgjoer.single(),
                 Aarsoppgjoer::inntektsavkorting,
             )
-            with(oppdatertAvkorting.aarsoppgjoer.inntektsavkorting) {
+            with(oppdatertAvkorting.aarsoppgjoer.single().inntektsavkorting) {
                 size shouldBe 2
                 get(0).grunnlag shouldBe foersteGrunnlag
                 with(get(1).grunnlag) {
@@ -212,11 +222,11 @@ internal class AvkortingTest {
                 )
 
             oppdatertAvkorting.shouldBeEqualToIgnoringFields(avkorting, Avkorting::aarsoppgjoer)
-            oppdatertAvkorting.aarsoppgjoer.shouldBeEqualToIgnoringFields(
-                avkorting.aarsoppgjoer,
+            oppdatertAvkorting.aarsoppgjoer.single().shouldBeEqualToIgnoringFields(
+                avkorting.aarsoppgjoer.single(),
                 Aarsoppgjoer::inntektsavkorting,
             )
-            with(oppdatertAvkorting.aarsoppgjoer.inntektsavkorting) {
+            with(oppdatertAvkorting.aarsoppgjoer.single().inntektsavkorting) {
                 size shouldBe 3
                 get(0).grunnlag shouldBe foersteGrunnlag
                 get(1).grunnlag.shouldBeEqualToIgnoringFields(andreGrunnlag, AvkortingGrunnlag::periode)
@@ -245,7 +255,7 @@ internal class AvkortingTest {
                 virkningstidspunkt,
                 bruker,
             ).let {
-                it.aarsoppgjoer.inntektsavkorting.single().grunnlag.relevanteMaanederInnAar shouldBe 10
+                it.aarsoppgjoer.single().inntektsavkorting.single().grunnlag.relevanteMaanederInnAar shouldBe 10
             }
         }
 
@@ -259,7 +269,7 @@ internal class AvkortingTest {
                 virkningstidspunkt,
                 bruker,
             ).let {
-                with(it.aarsoppgjoer.inntektsavkorting) {
+                with(it.aarsoppgjoer.single().inntektsavkorting) {
                     size shouldBe 3
                     last().grunnlag.relevanteMaanederInnAar shouldBe 12
                 }

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingTest.kt
@@ -3,7 +3,6 @@ package no.nav.etterlatte.beregning.regler.avkorting
 import io.kotest.assertions.asClue
 import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
 import io.kotest.matchers.shouldBe
-import no.nav.etterlatte.avkorting.Aarsoppgjoer
 import no.nav.etterlatte.avkorting.AvkortetYtelse
 import no.nav.etterlatte.avkorting.AvkortetYtelseType
 import no.nav.etterlatte.avkorting.Avkorting
@@ -624,9 +623,7 @@ class BeregnAvkortingTest {
     }
 
     private fun `Avkorting foerstegangsbehandling`() =
-        Avkorting(
-            aarsoppgjoer = listOf(Aarsoppgjoer()),
-        ).beregnAvkortingMedNyttGrunnlag(
+        Avkorting().beregnAvkortingMedNyttGrunnlag(
             nyttGrunnlag =
                 avkortinggrunnlagLagre(
                     aarsinntekt = 300000,

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingTest.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.beregning.regler.avkorting
 import io.kotest.assertions.asClue
 import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
 import io.kotest.matchers.shouldBe
+import no.nav.etterlatte.avkorting.Aarsoppgjoer
 import no.nav.etterlatte.avkorting.AvkortetYtelse
 import no.nav.etterlatte.avkorting.AvkortetYtelseType
 import no.nav.etterlatte.avkorting.Avkorting
@@ -24,7 +25,7 @@ class BeregnAvkortingTest {
     @Test
     fun `Beregner avkortet ytelse for foerstegangsbehandling`() {
         val avkorting = `Avkorting foerstegangsbehandling`()
-        with(avkorting.aarsoppgjoer.avkortetYtelseAar) {
+        with(avkorting.aarsoppgjoer.single().avkortetYtelseAar) {
             size shouldBe 2
             get(0).shouldBeEqualToIgnoringFields(
                 avkortetYtelse(
@@ -64,7 +65,7 @@ class BeregnAvkortingTest {
     @Test
     fun `Revurdering inntektsendring - foerste inntektsendring`() {
         val avkorting = `Avkorting ny inntekt en`()
-        with(avkorting.aarsoppgjoer.avkortetYtelseAar) {
+        with(avkorting.aarsoppgjoer.single().avkortetYtelseAar) {
             size shouldBe 3
             get(0).asClue {
                 it.shouldBeEqualToIgnoringFields(
@@ -146,7 +147,7 @@ class BeregnAvkortingTest {
     @Test
     fun `Revurdering inntektsendring - andre inntektsendring`() {
         val avkorting = `Avkorting ny inntekt to`()
-        with(avkorting.aarsoppgjoer.avkortetYtelseAar) {
+        with(avkorting.aarsoppgjoer.single().avkortetYtelseAar) {
             size shouldBe 4
             get(0).asClue {
                 it.shouldBeEqualToIgnoringFields(
@@ -260,7 +261,7 @@ class BeregnAvkortingTest {
     @Test
     fun `Revurdering hevet beregnng`() {
         val avkorting = `Avkorting revurdert beregning`()
-        with(avkorting.aarsoppgjoer.avkortetYtelseAar) {
+        with(avkorting.aarsoppgjoer.single().avkortetYtelseAar) {
             size shouldBe 4
             get(0).asClue {
                 it.shouldBeEqualToIgnoringFields(
@@ -374,7 +375,7 @@ class BeregnAvkortingTest {
     @Test
     fun `Revurdering inntektsendring - korrigere siste inntekt`() {
         val avkorting = `Avkorting korrigere siste inntekt`()
-        with(avkorting.aarsoppgjoer.avkortetYtelseAar) {
+        with(avkorting.aarsoppgjoer.single().avkortetYtelseAar) {
             size shouldBe 4
             get(0).asClue {
                 it.shouldBeEqualToIgnoringFields(
@@ -488,7 +489,7 @@ class BeregnAvkortingTest {
     @Test
     fun `Skal kunne reberegne avkorting uten endring for en revurdering med virk i mellom inntektsperioder`() {
         val avkorting = `Revurdering med virk mellom inntektsperioder`()
-        with(avkorting.aarsoppgjoer.avkortetYtelseAar) {
+        with(avkorting.aarsoppgjoer.single().avkortetYtelseAar) {
             size shouldBe 5
             get(0).asClue {
                 it.shouldBeEqualToIgnoringFields(
@@ -623,32 +624,33 @@ class BeregnAvkortingTest {
     }
 
     private fun `Avkorting foerstegangsbehandling`() =
-        Avkorting()
-            .beregnAvkortingMedNyttGrunnlag(
-                nyttGrunnlag =
-                    avkortinggrunnlagLagre(
-                        aarsinntekt = 300000,
-                        fratrekkInnAar = 50000,
-                    ),
-                behandlingstype = BehandlingType.FØRSTEGANGSBEHANDLING,
-                virkningstidspunkt = YearMonth.of(2024, Month.MARCH),
-                bruker = bruker,
-                beregning =
-                    beregning(
-                        beregninger =
-                            listOf(
-                                beregningsperiode(
-                                    datoFOM = YearMonth.of(2024, Month.MARCH),
-                                    datoTOM = YearMonth.of(2024, Month.APRIL),
-                                    utbetaltBeloep = 15676,
-                                ),
-                                beregningsperiode(
-                                    datoFOM = YearMonth.of(2024, Month.MAY),
-                                    utbetaltBeloep = 16682,
-                                ),
+        Avkorting(
+            aarsoppgjoer = listOf(Aarsoppgjoer()),
+        ).beregnAvkortingMedNyttGrunnlag(
+            nyttGrunnlag =
+                avkortinggrunnlagLagre(
+                    aarsinntekt = 300000,
+                    fratrekkInnAar = 50000,
+                ),
+            behandlingstype = BehandlingType.FØRSTEGANGSBEHANDLING,
+            virkningstidspunkt = YearMonth.of(2024, Month.MARCH),
+            bruker = bruker,
+            beregning =
+                beregning(
+                    beregninger =
+                        listOf(
+                            beregningsperiode(
+                                datoFOM = YearMonth.of(2024, Month.MARCH),
+                                datoTOM = YearMonth.of(2024, Month.APRIL),
+                                utbetaltBeloep = 15676,
                             ),
-                    ),
-            )
+                            beregningsperiode(
+                                datoFOM = YearMonth.of(2024, Month.MAY),
+                                utbetaltBeloep = 16682,
+                            ),
+                        ),
+                ),
+        )
 
     private fun `Avkorting ny inntekt en`() =
         `Avkorting foerstegangsbehandling`()
@@ -726,7 +728,7 @@ class BeregnAvkortingTest {
                 it.beregnAvkortingMedNyttGrunnlag(
                     nyttGrunnlag =
                         avkortinggrunnlagLagre(
-                            id = it.aarsoppgjoer.inntektsavkorting.last().grunnlag.id,
+                            id = it.aarsoppgjoer.single().inntektsavkorting.last().grunnlag.id,
                             aarsinntekt = 425000,
                             fratrekkInnAar = 50000,
                         ),


### PR DESCRIPTION
Refaktorering av avkorting / årsoppgjør for å legge til rette for at det vil være avkorting relevant for flere år.
Endrer feltet aarsoppgjoer til å være en liste med samme klasse.