### PR TITLE
Code scanning-bygget har feila nokre gongar på at etterlatte-mq ikkje…

### DIFF
--- a/apps/etterlatte-tilbakekreving/build.gradle.kts
+++ b/apps/etterlatte-tilbakekreving/build.gradle.kts
@@ -4,6 +4,10 @@ plugins {
     id("etterlatte.postgres")
 }
 
+tasks.jar.configure {
+    dependsOn(":libs:etterlatte-mq:jar")
+}
+
 dependencies {
     implementation(project(":libs:saksbehandling-common"))
     implementation(project(":libs:etterlatte-tilbakekreving-model"))

--- a/apps/etterlatte-tilbakekreving/build.gradle.kts
+++ b/apps/etterlatte-tilbakekreving/build.gradle.kts
@@ -50,7 +50,6 @@ dependencies {
     testImplementation(project(":libs:testdata"))
     testImplementation(testFixtures((project(":libs:etterlatte-database"))))
     testImplementation(testFixtures(project(":libs:etterlatte-mq")))
-    evaluationDependsOn(":libs:etterlatte-mq")
     testImplementation(testFixtures((project(":libs:etterlatte-ktor"))))
 
     // Avhengigheter fra patching av sårbarheter i IBM MQ.

--- a/apps/etterlatte-tilbakekreving/build.gradle.kts
+++ b/apps/etterlatte-tilbakekreving/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     testImplementation(project(":libs:testdata"))
     testImplementation(testFixtures((project(":libs:etterlatte-database"))))
     testImplementation(testFixtures(project(":libs:etterlatte-mq")))
+    evaluationDependsOn(":libs:etterlatte-mq")
     testImplementation(testFixtures((project(":libs:etterlatte-ktor"))))
 
     // Avhengigheter fra patching av sårbarheter i IBM MQ.

--- a/apps/etterlatte-utbetaling/build.gradle.kts
+++ b/apps/etterlatte-utbetaling/build.gradle.kts
@@ -4,6 +4,10 @@ plugins {
     id("etterlatte.postgres")
 }
 
+tasks.jar.configure {
+    dependsOn(":libs:etterlatte-mq:jar")
+}
+
 dependencies {
     implementation(project(":libs:saksbehandling-common"))
     implementation(project(":libs:etterlatte-jobs"))


### PR DESCRIPTION
… er bygd før tilbakekrevingsmodulen køyrer. No på kotlin 2.0 fekk eg samme feil også lokalt, så legg inn eksplisitt rekkjefølgjekrav mellom dei