### PR TITLE
Fjerne unødvendig kode

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.grunnlagsendring
 
-import io.ktor.server.plugins.BadRequestException
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.BehandlingService
 import no.nav.etterlatte.behandling.BrukerService
@@ -91,14 +90,6 @@ class GrunnlagsendringshendelseService(
         inTransaction {
             grunnlagsendringshendelseDao.arkiverGrunnlagsendringStatus(hendelse = hendelse)
             try {
-                val oppgaveForReferanse =
-                    oppgaveService.hentOppgaverForReferanse(hendelse.id.toString())
-                        .singleOrNull { it.erUnderBehandling() }
-                        ?: throw BadRequestException("Ugyldig antall oppgaver med referanse: ${hendelse.id}")
-
-                if (oppgaveForReferanse.manglerSaksbehandler()) {
-                    oppgaveService.tildelSaksbehandler(oppgaveForReferanse.id, saksbehandler.ident)
-                }
                 oppgaveService.ferdigStillOppgaveUnderBehandling(
                     referanse = hendelse.id.toString(),
                     type = OppgaveType.VURDER_KONSEKVENS,


### PR DESCRIPTION
Liten fortsettelse av d3990de1b72f51891466131321a4c9e62735b1db 

Fjerner koden siden den samme funksjonaliteten er bygget inn i `ferdigStillOppgaveUnderBehandling`