### PR TITLE
Oppdaterer vedtak med hentede data ved fatting

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
@@ -98,6 +98,17 @@ class VedtakBehandlingService(
 
         val (behandling, vilkaarsvurdering, beregningOgAvkorting, _, trygdetider) = hentDataForVedtak(behandlingId, brukerTokenInfo)
         validerVersjon(vilkaarsvurdering, beregningOgAvkorting, trygdetider, behandling)
+        oppdaterVedtak(
+            behandling = behandling,
+            eksisterendeVedtak = vedtak,
+            vedtakType = vedtak.type,
+            virkningstidspunkt =
+                checkNotNull(behandling.virkningstidspunkt?.dato) {
+                    "Kan ikke fatte vedtak som ikke har et virkningstidspunkt"
+                },
+            beregningOgAvkorting = beregningOgAvkorting,
+            vilkaarsvurdering = vilkaarsvurdering,
+        )
 
         val sak = behandlingKlient.hentSak(vedtak.sakId, brukerTokenInfo)
 

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
@@ -98,14 +98,14 @@ class VedtakBehandlingService(
 
         val (behandling, vilkaarsvurdering, beregningOgAvkorting, _, trygdetider) = hentDataForVedtak(behandlingId, brukerTokenInfo)
         validerVersjon(vilkaarsvurdering, beregningOgAvkorting, trygdetider, behandling)
+
+        val vedtakType = vedtakType(behandling.behandlingType, vilkaarsvurdering)
+        val virkningstidspunkt = behandling.virkningstidspunkt().dato
         oppdaterVedtak(
             behandling = behandling,
             eksisterendeVedtak = vedtak,
-            vedtakType = vedtak.type,
-            virkningstidspunkt =
-                checkNotNull(behandling.virkningstidspunkt?.dato) {
-                    "Kan ikke fatte vedtak som ikke har et virkningstidspunkt"
-                },
+            vedtakType = vedtakType,
+            virkningstidspunkt = virkningstidspunkt,
             beregningOgAvkorting = beregningOgAvkorting,
             vilkaarsvurdering = vilkaarsvurdering,
         )

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingServiceTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingServiceTest.kt
@@ -753,7 +753,13 @@ internal class VedtakBehandlingServiceTest(private val dataSource: DataSource) {
                 revurderingsaarsak = Revurderingaarsak.REGULERING,
                 soeker = SOEKER_FOEDSELSNUMMER.value,
                 status = BehandlingStatus.VILKAARSVURDERT,
-                virkningstidspunkt = null,
+                virkningstidspunkt =
+                    Virkningstidspunkt(
+                        dato = virkningstidspunkt.withMonth(Month.MAY.value),
+                        kilde = Grunnlagsopplysning.automatiskSaksbehandler,
+                        begrunnelse = "",
+                        kravdato = null,
+                    ),
                 boddEllerArbeidetUtlandet = null,
                 utlandstilknytning = null,
                 prosesstype = Prosesstype.MANUELL,


### PR DESCRIPTION
Fikser muligheten for å oppdatere beregning / avkorting uten å oppdatere vedtaket før fatting, som gjør det mulig å ha mismatch mellom den siste beregningen og det vi utbetaler