### PR TITLE
Kjør ktlint -F på hele etterlatte-beregning

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/Application.kt
@@ -16,7 +16,9 @@ fun main() {
     ApplicationContext().let { Server(it).run() }
 }
 
-class Server(private val context: ApplicationContext) {
+class Server(
+    private val context: ApplicationContext,
+) {
     init {
         sikkerLoggOppstartOgAvslutning("etterlatte-beregning")
     }

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -31,7 +31,8 @@ data class Avkorting(
     ): Avkorting =
         this.copy(
             avkortetYtelseFraVirkningstidspunkt =
-                hentAarsoppgjoer().avkortetYtelseAar
+                hentAarsoppgjoer()
+                    .avkortetYtelseAar
                     .filter { it.periode.tom == null || virkningstidspunkt <= it.periode.tom }
                     .map {
                         if (virkningstidspunkt > it.periode.fom && (it.periode.tom == null || virkningstidspunkt <= it.periode.tom)) {
@@ -77,7 +78,8 @@ data class Avkorting(
         bruker: BrukerTokenInfo,
     ): Avkorting {
         val oppdatert =
-            hentAarsoppgjoer().inntektsavkorting
+            hentAarsoppgjoer()
+                .inntektsavkorting
                 // Fjerner hvis det finnes fra før for å erstatte/redigere
                 .filter { it.grunnlag.id != nyttGrunnlag.id }
                 .map { it.lukkSisteInntektsperiode(virkningstidspunkt) } +
@@ -247,7 +249,11 @@ data class Avkorting(
 	 * Det er tilfeller hvor det er nødvendig å vite når første periode i inneværende begynner.
 	 * Ved inngangsår så vil ikke første måned nødvendgivis være januar så det må baseres på fom første periode.
 	 */
-    private fun foersteMaanedDetteAar() = hentAarsoppgjoer().ytelseFoerAvkorting.first().periode.fom
+    private fun foersteMaanedDetteAar() =
+        hentAarsoppgjoer()
+            .ytelseFoerAvkorting
+            .first()
+            .periode.fom
 
     private fun hentAarsoppgjoer(): Aarsoppgjoer {
         if (aarsoppgjoer.isEmpty()) {
@@ -291,9 +297,11 @@ data class Aarsoppgjoer(
 	 */
     fun utledRelevanteMaaneder(virkningstidspunkt: YearMonth): Int {
         val aaretsFoersteForventaInntekt =
-            inntektsavkorting.sortedBy { it.grunnlag.periode.fom }.firstOrNull {
-                it.grunnlag.periode.fom.year == virkningstidspunkt.year
-            }?.grunnlag
+            inntektsavkorting
+                .sortedBy { it.grunnlag.periode.fom }
+                .firstOrNull {
+                    it.grunnlag.periode.fom.year == virkningstidspunkt.year
+                }?.grunnlag
         return aaretsFoersteForventaInntekt?.relevanteMaanederInnAar ?: (12 - virkningstidspunkt.monthValue + 1)
     }
 }

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
@@ -38,27 +38,28 @@ object AvkortingRegelkjoring {
             PeriodisertInntektAvkortingGrunnlag(
                 periodisertInntektAvkortingGrunnlag =
                     PeriodisertBeregningGrunnlag.lagGrunnlagMedDefaultUtenforPerioder(
-                        avkortingGrunnlag.map {
-                            GrunnlagMedPeriode(
-                                data = it,
-                                fom = it.periode.fom.atDay(1),
-                                tom = it.periode.tom?.atEndOfMonth(),
-                            )
-                        }.mapVerdier {
-                            FaktumNode(
-                                verdi =
-                                    InntektAvkortingGrunnlag(
-                                        inntekt = Beregningstall(it.aarsinntekt),
-                                        fratrekkInnAar = Beregningstall(it.fratrekkInnAar),
-                                        inntektUtland = Beregningstall(it.inntektUtland),
-                                        fratrekkInnAarUtland = Beregningstall(it.fratrekkInnAarUtland),
-                                        relevanteMaaneder = Beregningstall(it.relevanteMaanederInnAar),
-                                        it.id,
-                                    ),
-                                kilde = it.kilde,
-                                beskrivelse = "Forventet årsinntekt",
-                            )
-                        },
+                        avkortingGrunnlag
+                            .map {
+                                GrunnlagMedPeriode(
+                                    data = it,
+                                    fom = it.periode.fom.atDay(1),
+                                    tom = it.periode.tom?.atEndOfMonth(),
+                                )
+                            }.mapVerdier {
+                                FaktumNode(
+                                    verdi =
+                                        InntektAvkortingGrunnlag(
+                                            inntekt = Beregningstall(it.aarsinntekt),
+                                            fratrekkInnAar = Beregningstall(it.fratrekkInnAar),
+                                            inntektUtland = Beregningstall(it.inntektUtland),
+                                            fratrekkInnAarUtland = Beregningstall(it.fratrekkInnAarUtland),
+                                            relevanteMaaneder = Beregningstall(it.relevanteMaanederInnAar),
+                                            it.id,
+                                        ),
+                                    kilde = it.kilde,
+                                    beskrivelse = "Forventet årsinntekt",
+                                )
+                            },
                     ) { _, _, _ -> throw IllegalArgumentException("Noe gikk galt ved uthenting av periodiserte beregninger") },
             )
 
@@ -85,9 +86,10 @@ object AvkortingRegelkjoring {
                                 versjon = periodisertResultat.reglerVersjon,
                             ),
                         inntektsgrunnlag =
-                            grunnlag.finnGrunnlagForPeriode(
-                                periodisertResultat.periode.fraDato,
-                            ).inntektAvkortingGrunnlag.verdi.grunnlagId,
+                            grunnlag
+                                .finnGrunnlagForPeriode(
+                                    periodisertResultat.periode.fraDato,
+                                ).inntektAvkortingGrunnlag.verdi.grunnlagId,
                     )
                 }
             }
@@ -150,36 +152,38 @@ object AvkortingRegelkjoring {
 
     private fun periodiserteBeregninger(beregninger: List<YtelseFoerAvkorting>): PeriodisertGrunnlag<FaktumNode<Int>> =
         PeriodisertBeregningGrunnlag.lagGrunnlagMedDefaultUtenforPerioder(
-            beregninger.map {
-                GrunnlagMedPeriode(
-                    data = it,
-                    fom = it.periode.fom.atDay(1),
-                    tom = it.periode.tom?.atEndOfMonth(),
-                )
-            }.mapVerdier {
-                FaktumNode(
-                    verdi = it.beregning,
-                    kilde = it.beregningsreferanse,
-                    beskrivelse = "Beregnet ytelse før avkorting for periode",
-                )
-            },
+            beregninger
+                .map {
+                    GrunnlagMedPeriode(
+                        data = it,
+                        fom = it.periode.fom.atDay(1),
+                        tom = it.periode.tom?.atEndOfMonth(),
+                    )
+                }.mapVerdier {
+                    FaktumNode(
+                        verdi = it.beregning,
+                        kilde = it.beregningsreferanse,
+                        beskrivelse = "Beregnet ytelse før avkorting for periode",
+                    )
+                },
         ) { _, _, _ -> throw IllegalArgumentException("Noe gikk galt ved uthenting av periodiserte beregninger") }
 
     private fun periodiserteAvkortinger(avkortingGrunnlag: List<Avkortingsperiode>): PeriodisertGrunnlag<FaktumNode<Int>> =
         PeriodisertBeregningGrunnlag.lagGrunnlagMedDefaultUtenforPerioder(
-            avkortingGrunnlag.map {
-                GrunnlagMedPeriode(
-                    data = it,
-                    fom = it.periode.fom.atDay(1),
-                    tom = it.periode.tom?.atEndOfMonth(),
-                )
-            }.mapVerdier {
-                FaktumNode(
-                    verdi = it.avkorting,
-                    kilde = "Avkorting:${it.id}",
-                    beskrivelse = "Beregnet avkorting for periode",
-                )
-            },
+            avkortingGrunnlag
+                .map {
+                    GrunnlagMedPeriode(
+                        data = it,
+                        fom = it.periode.fom.atDay(1),
+                        tom = it.periode.tom?.atEndOfMonth(),
+                    )
+                }.mapVerdier {
+                    FaktumNode(
+                        verdi = it.avkorting,
+                        kilde = "Avkorting:${it.id}",
+                        beskrivelse = "Beregnet avkorting for periode",
+                    )
+                },
         ) { _, _, _ -> throw IllegalArgumentException("Noe gikk galt ved uthenting av periodiserte avkortinger") }
 
     private fun restansegrunnlag(restanse: Restanse?): KonstantGrunnlag<FaktumNode<Int>> =
@@ -230,7 +234,10 @@ object AvkortingRegelkjoring {
             )
         return when (resultat) {
             is RegelkjoeringResultat.Suksess -> {
-                val (totalRestanse, fordeltRestanse) = resultat.periodiserteResultater.first().resultat.verdi
+                val (totalRestanse, fordeltRestanse) =
+                    resultat.periodiserteResultater
+                        .first()
+                        .resultat.verdi
                 val tidspunkt = Tidspunkt.now()
                 Restanse(
                     id = UUID.randomUUID(),

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
@@ -14,7 +14,9 @@ import java.time.YearMonth
 import java.util.UUID
 import javax.sql.DataSource
 
-class AvkortingRepository(private val dataSource: DataSource) {
+class AvkortingRepository(
+    private val dataSource: DataSource,
+) {
     fun hentAvkorting(behandlingId: UUID): Avkorting? =
         dataSource.transaction { tx ->
             val avkortingGrunnlag =

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -184,17 +184,23 @@ class AvkortingService(
     }
 }
 
-class AvkortingFinnesIkkeException(behandlingId: UUID) : IkkeFunnetException(
-    code = "AVKORTING_IKKE_FUNNET",
-    detail = "Uthenting av avkorting for behandling $behandlingId finnes ikke",
-)
+class AvkortingFinnesIkkeException(
+    behandlingId: UUID,
+) : IkkeFunnetException(
+        code = "AVKORTING_IKKE_FUNNET",
+        detail = "Uthenting av avkorting for behandling $behandlingId finnes ikke",
+    )
 
-class TidligereAvkortingFinnesIkkeException(behandlingId: UUID) : IkkeFunnetException(
-    code = "TIDLIGERE_AVKORTING_IKKE_FUNNET",
-    detail = "Fant ikke avkorting for tidligere behandling $behandlingId",
-)
+class TidligereAvkortingFinnesIkkeException(
+    behandlingId: UUID,
+) : IkkeFunnetException(
+        code = "TIDLIGERE_AVKORTING_IKKE_FUNNET",
+        detail = "Fant ikke avkorting for tidligere behandling $behandlingId",
+    )
 
-class AvkortingBehandlingFeilStatus(behandlingId: UUID) : IkkeTillattException(
-    code = "BEHANDLING_FEIL_STATUS_FOR_AVKORTING",
-    detail = "Kan ikke avkorte da behandling med id=$behandlingId har feil status",
-)
+class AvkortingBehandlingFeilStatus(
+    behandlingId: UUID,
+) : IkkeTillattException(
+        code = "BEHANDLING_FEIL_STATUS_FOR_AVKORTING",
+        detail = "Kan ikke avkorte da behandling med id=$behandlingId har feil status",
+    )

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/AvkortetYtelse.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/AvkortetYtelse.kt
@@ -20,17 +20,15 @@ data class PeriodisertAvkortetYtelseGrunnlag(
     val avkortingsperioder: PeriodisertGrunnlag<FaktumNode<Int>>,
     val fordeltRestanse: KonstantGrunnlag<FaktumNode<Int>>,
 ) : PeriodisertGrunnlag<AvkortetYtelseGrunnlag> {
-    override fun finnAlleKnekkpunkter(): Set<LocalDate> {
-        return beregningsperioder.finnAlleKnekkpunkter() + avkortingsperioder.finnAlleKnekkpunkter()
-    }
+    override fun finnAlleKnekkpunkter(): Set<LocalDate> =
+        beregningsperioder.finnAlleKnekkpunkter() + avkortingsperioder.finnAlleKnekkpunkter()
 
-    override fun finnGrunnlagForPeriode(datoIPeriode: LocalDate): AvkortetYtelseGrunnlag {
-        return AvkortetYtelseGrunnlag(
+    override fun finnGrunnlagForPeriode(datoIPeriode: LocalDate): AvkortetYtelseGrunnlag =
+        AvkortetYtelseGrunnlag(
             beregning = beregningsperioder.finnGrunnlagForPeriode(datoIPeriode),
             avkorting = avkortingsperioder.finnGrunnlagForPeriode(datoIPeriode),
             fordeltRestanse = fordeltRestanse.finnGrunnlagForPeriode(datoIPeriode),
         )
-    }
 }
 
 data class AvkortetYtelseGrunnlag(
@@ -78,7 +76,8 @@ val avkortetYtelseMedRestanse =
         beskrivelse = "Legger til restanse fra endret avkorting til tidligere måneder",
         regelReferanse = RegelReferanse(id = "REGEL-AVKORTET-YTELSE-MED-RESTANSE"),
     ) benytter avkorteYtelse og fordeltRestanseGrunnlag med { avkorteYtelse, fordeltRestanse ->
-        avkorteYtelse.minus(Beregningstall(fordeltRestanse))
+        avkorteYtelse
+            .minus(Beregningstall(fordeltRestanse))
             .toInteger()
             .let { max(it, 0) }
     }

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/InntektAvkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/regler/InntektAvkorting.kt
@@ -36,15 +36,12 @@ data class InntektAvkortingGrunnlagWrapper(
 data class PeriodisertInntektAvkortingGrunnlag(
     val periodisertInntektAvkortingGrunnlag: PeriodisertGrunnlag<FaktumNode<InntektAvkortingGrunnlag>>,
 ) : PeriodisertGrunnlag<InntektAvkortingGrunnlagWrapper> {
-    override fun finnAlleKnekkpunkter(): Set<LocalDate> {
-        return periodisertInntektAvkortingGrunnlag.finnAlleKnekkpunkter()
-    }
+    override fun finnAlleKnekkpunkter(): Set<LocalDate> = periodisertInntektAvkortingGrunnlag.finnAlleKnekkpunkter()
 
-    override fun finnGrunnlagForPeriode(datoIPeriode: LocalDate): InntektAvkortingGrunnlagWrapper {
-        return InntektAvkortingGrunnlagWrapper(
+    override fun finnGrunnlagForPeriode(datoIPeriode: LocalDate): InntektAvkortingGrunnlagWrapper =
+        InntektAvkortingGrunnlagWrapper(
             periodisertInntektAvkortingGrunnlag.finnGrunnlagForPeriode(datoIPeriode),
         )
-    }
 }
 
 val historiskeGrunnbeloep =

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnOmstillingsstoenadService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnOmstillingsstoenadService.kt
@@ -89,11 +89,12 @@ class BeregnOmstillingsstoenadService(
 
             BehandlingType.REVURDERING -> {
                 val vilkaarsvurderingUtfall =
-                    vilkaarsvurderingKlient.hentVilkaarsvurdering(
-                        behandling.id,
-                        brukerTokenInfo,
-                    )
-                        .resultat?.utfall
+                    vilkaarsvurderingKlient
+                        .hentVilkaarsvurdering(
+                            behandling.id,
+                            brukerTokenInfo,
+                        ).resultat
+                        ?.utfall
                         ?: throw Exception("Forventa å ha vilkårsvurderingsresultat for behandlingId=${behandling.id}")
 
                 when (vilkaarsvurderingUtfall) {
@@ -136,8 +137,10 @@ class BeregnOmstillingsstoenadService(
                                 periodisertResultat.periode.fraDato,
                                 periodisertResultat.periode.tilDato,
                                 periodisertResultat.resultat.verdi,
-                                periodisertResultat.resultat.finnAnvendteRegler()
-                                    .map { "${it.regelReferanse.id} (${it.beskrivelse})" }.toSet(),
+                                periodisertResultat.resultat
+                                    .finnAnvendteRegler()
+                                    .map { "${it.regelReferanse.id} (${it.beskrivelse})" }
+                                    .toSet(),
                             )
 
                             val grunnbeloep =
@@ -152,18 +155,20 @@ class BeregnOmstillingsstoenadService(
                                     )
 
                             val trygdetidGrunnlagForPeriode =
-                                beregningsgrunnlag.avdoed.finnGrunnlagForPeriode(
-                                    periodisertResultat.periode.fraDato,
-                                ).verdi.trygdetid
+                                beregningsgrunnlag.avdoed
+                                    .finnGrunnlagForPeriode(
+                                        periodisertResultat.periode.fraDato,
+                                    ).verdi.trygdetid
 
                             Beregningsperiode(
                                 datoFOM = YearMonth.from(periodisertResultat.periode.fraDato),
                                 datoTOM = periodisertResultat.periode.tilDato?.let { YearMonth.from(it) },
                                 utbetaltBeloep = periodisertResultat.resultat.verdi,
                                 institusjonsopphold =
-                                    beregningsgrunnlag.institusjonsopphold.finnGrunnlagForPeriode(
-                                        periodisertResultat.periode.fraDato,
-                                    ).verdi,
+                                    beregningsgrunnlag.institusjonsopphold
+                                        .finnGrunnlagForPeriode(
+                                            periodisertResultat.periode.fraDato,
+                                        ).verdi,
                                 grunnbelopMnd = grunnbeloep.grunnbeloepPerMaaned,
                                 grunnbelop = grunnbeloep.grunnbeloep,
                                 trygdetid = trygdetid.trygdetid.toInteger(),

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnOverstyrBeregningService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnOverstyrBeregningService.kt
@@ -188,8 +188,10 @@ class BeregnOverstyrBeregningService(
                                 periodisertResultat.periode.fraDato,
                                 periodisertResultat.periode.tilDato,
                                 periodisertResultat.resultat.verdi,
-                                periodisertResultat.resultat.finnAnvendteRegler()
-                                    .map { "${it.regelReferanse.id} (${it.beskrivelse})" }.toSet(),
+                                periodisertResultat.resultat
+                                    .finnAnvendteRegler()
+                                    .map { "${it.regelReferanse.id} (${it.beskrivelse})" }
+                                    .toSet(),
                             )
 
                             val grunnbeloep =
@@ -200,8 +202,10 @@ class BeregnOverstyrBeregningService(
                             val broek =
                                 IntBroek.fra(
                                     Pair(
-                                        periodisertResultat.resultat.verdi.prorataBroekTeller?.toInt(),
-                                        periodisertResultat.resultat.verdi.prorataBroekNevner?.toInt(),
+                                        periodisertResultat.resultat.verdi.prorataBroekTeller
+                                            ?.toInt(),
+                                        periodisertResultat.resultat.verdi.prorataBroekNevner
+                                            ?.toInt(),
                                     ),
                                 )
 
@@ -212,7 +216,9 @@ class BeregnOverstyrBeregningService(
                             Beregningsperiode(
                                 datoFOM = YearMonth.from(periodisertResultat.periode.fraDato),
                                 datoTOM = periodisertResultat.periode.tilDato?.let { YearMonth.from(it) },
-                                utbetaltBeloep = periodisertResultat.resultat.verdi.utbetaltBeloep.toInt(),
+                                utbetaltBeloep =
+                                    periodisertResultat.resultat.verdi.utbetaltBeloep
+                                        .toInt(),
                                 institusjonsopphold = null,
                                 grunnbelopMnd = grunnbeloep.grunnbeloepPerMaaned,
                                 grunnbelop = grunnbeloep.grunnbeloep,
@@ -224,10 +230,12 @@ class BeregnOverstyrBeregningService(
                                         else -> BeregningsMetode.PRORATA
                                     },
                                 samletNorskTrygdetid =
-                                    periodisertResultat.resultat.verdi.trygdetid.takeIf { broek == null }
+                                    periodisertResultat.resultat.verdi.trygdetid
+                                        .takeIf { broek == null }
                                         ?.toInt(),
                                 samletTeoretiskTrygdetid =
-                                    periodisertResultat.resultat.verdi.trygdetid.takeIf { broek != null }
+                                    periodisertResultat.resultat.verdi.trygdetid
+                                        .takeIf { broek != null }
                                         ?.toInt(),
                                 broek = broek,
                                 regelResultat = objectMapper.valueToTree(periodisertResultat),

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRepository.kt
@@ -22,7 +22,9 @@ import java.time.YearMonth
 import java.util.UUID
 import javax.sql.DataSource
 
-class BeregningRepository(private val dataSource: DataSource) {
+class BeregningRepository(
+    private val dataSource: DataSource,
+) {
     fun hent(behandlingId: UUID): Beregning? =
         dataSource.transaction { tx ->
             val beregningsperioder =
@@ -54,8 +56,8 @@ class BeregningRepository(private val dataSource: DataSource) {
         return hent(beregning.behandlingId)!!
     }
 
-    fun hentOverstyrBeregning(sakId: Long): OverstyrBeregning? {
-        return dataSource.transaction { tx ->
+    fun hentOverstyrBeregning(sakId: Long): OverstyrBeregning? =
+        dataSource.transaction { tx ->
             queryOf(
                 statement = Queries.hentOverstyrBeregning,
                 paramMap = mapOf("sakId" to sakId),
@@ -63,7 +65,6 @@ class BeregningRepository(private val dataSource: DataSource) {
                 tx.run(query.map { toOverstyrBeregning(it) }.asSingle)
             }
         }
-    }
 
     fun opprettOverstyrBeregning(overstyrBeregning: OverstyrBeregning): OverstyrBeregning? {
         dataSource.transaction { tx ->
@@ -92,8 +93,8 @@ class BeregningRepository(private val dataSource: DataSource) {
     private fun createMapFromBeregningsperiode(
         beregningsperiode: Beregningsperiode,
         beregning: Beregning,
-    ): Map<String, Serializable?> {
-        return mapOf(
+    ): Map<String, Serializable?> =
+        mapOf(
             "id" to UUID.randomUUID(),
             "beregningId" to beregning.beregningId,
             "behandlingId" to beregning.behandlingId,
@@ -119,7 +120,6 @@ class BeregningRepository(private val dataSource: DataSource) {
             "regelVersjon" to beregningsperiode.regelVersjon,
             "kilde" to beregningsperiode.kilde?.toJson(),
         )
-    }
 }
 
 private fun toOverstyrBeregning(row: Row): OverstyrBeregning =
@@ -230,7 +230,9 @@ private fun toBeregning(beregningsperioder: List<BeregningsperiodeDAO>): Beregni
     )
 }
 
-private enum class BeregningsperiodeDatabaseColumns(val navn: String) {
+private enum class BeregningsperiodeDatabaseColumns(
+    val navn: String,
+) {
     Id("id"),
     BeregningId("beregningId"),
     BehandlingId("behandlingId"),

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRoutes.kt
@@ -51,11 +51,13 @@ fun Route.beregning(
                 logger.info("Oppretter overstyrBeregning med behandlingId=$it")
 
                 val overstyrBeregning =
-                    beregningService.opprettOverstyrBeregning(
-                        behandlingId,
-                        call.receive<OverstyrBeregningDTO>(),
-                        brukerTokenInfo,
-                    )!!.toDTO()
+                    beregningService
+                        .opprettOverstyrBeregning(
+                            behandlingId,
+                            call.receive<OverstyrBeregningDTO>(),
+                            brukerTokenInfo,
+                        )!!
+                        .toDTO()
 
                 call.respond(overstyrBeregning)
             }

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
@@ -27,9 +27,8 @@ class BeregningService(
         brukerTokenInfo: BrukerTokenInfo,
     ) = hentBeregning(behandlingId).berikMedOverstyrBeregning(brukerTokenInfo)
 
-    fun hentBeregningNonnull(behandlingId: UUID): Beregning {
-        return hentBeregning(behandlingId) ?: throw Exception("Mangler beregning for behandlingId=$behandlingId")
-    }
+    fun hentBeregningNonnull(behandlingId: UUID): Beregning =
+        hentBeregning(behandlingId) ?: throw Exception("Mangler beregning for behandlingId=$behandlingId")
 
     suspend fun opprettBeregning(
         behandlingId: UUID,
@@ -105,37 +104,49 @@ class BeregningService(
         this?.copy(overstyrBeregning = hentOverstyrBeregning(behandlingId, brukerTokenInfo))
 }
 
-class TrygdetidMangler(behandlingId: UUID) : UgyldigForespoerselException(
-    code = "TRYGDETID_MANGLER",
-    detail = "Trygdetid ikke satt for behandling $behandlingId",
-)
+class TrygdetidMangler(
+    behandlingId: UUID,
+) : UgyldigForespoerselException(
+        code = "TRYGDETID_MANGLER",
+        detail = "Trygdetid ikke satt for behandling $behandlingId",
+    )
 
-class ForeldreloesTrygdetid(behandlingId: UUID) : UgyldigForespoerselException(
-    code = "FORELDRELOES_TRYGDETID",
-    detail = "Flere avdødes trygdetid er ikke støttet for behandling $behandlingId",
-)
+class ForeldreloesTrygdetid(
+    behandlingId: UUID,
+) : UgyldigForespoerselException(
+        code = "FORELDRELOES_TRYGDETID",
+        detail = "Flere avdødes trygdetid er ikke støttet for behandling $behandlingId",
+    )
 
-class BeregningsgrunnlagMangler(behandlingId: UUID) : UgyldigForespoerselException(
-    code = "BEREGNINGSGRUNNLAG_MANGLER",
-    detail = "Behandling med id: $behandlingId mangler beregningsgrunnlag oms",
-)
+class BeregningsgrunnlagMangler(
+    behandlingId: UUID,
+) : UgyldigForespoerselException(
+        code = "BEREGNINGSGRUNNLAG_MANGLER",
+        detail = "Behandling med id: $behandlingId mangler beregningsgrunnlag oms",
+    )
 
-class AnvendtGrunnbeloepIkkeFunnet : UgyldigForespoerselException(
-    code = "ANVENDT_GRUNNBELOEP_IKKE_FUNNET",
-    detail = "Anvendt grunnbeløp ikke funnet for perioden",
-)
+class AnvendtGrunnbeloepIkkeFunnet :
+    UgyldigForespoerselException(
+        code = "ANVENDT_GRUNNBELOEP_IKKE_FUNNET",
+        detail = "Anvendt grunnbeløp ikke funnet for perioden",
+    )
 
-class AnvendtTrygdetidIkkeFunnet(fom: LocalDate, tom: LocalDate?) : UgyldigForespoerselException(
-    code = "ANVENDT_TRYGDETID_IKKE_FUNNET",
-    detail = "Anvendt trygdetid ikke funnet for perioden $fom - $tom",
-)
+class AnvendtTrygdetidIkkeFunnet(
+    fom: LocalDate,
+    tom: LocalDate?,
+) : UgyldigForespoerselException(
+        code = "ANVENDT_TRYGDETID_IKKE_FUNNET",
+        detail = "Anvendt trygdetid ikke funnet for perioden $fom - $tom",
+    )
 
-class AnvendtTrygdetidIdentIkkeFunnet : UgyldigForespoerselException(
-    code = "ANVENDT_TRYGDETID_IDENT_IKKE_FUNNET",
-    detail = "Anvendt trygdetid ikke funnet for avdøde",
-)
+class AnvendtTrygdetidIdentIkkeFunnet :
+    UgyldigForespoerselException(
+        code = "ANVENDT_TRYGDETID_IDENT_IKKE_FUNNET",
+        detail = "Anvendt trygdetid ikke funnet for avdøde",
+    )
 
-class TrygdetidIkkeOpprettet : UgyldigForespoerselException(
-    code = "MÅ_FASTSETTE_TRYGDETID",
-    detail = "Mangler trygdetid, gå tilbake til trygdetidsiden for å opprette dette",
-)
+class TrygdetidIkkeOpprettet :
+    UgyldigForespoerselException(
+        code = "MÅ_FASTSETTE_TRYGDETID",
+        detail = "Mangler trygdetid, gå tilbake til trygdetidsiden for å opprette dette",
+    )

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagRepository.kt
@@ -12,7 +12,9 @@ import org.postgresql.util.PGobject
 import java.util.UUID
 import javax.sql.DataSource
 
-class BeregningsGrunnlagRepository(private val dataSource: DataSource) {
+class BeregningsGrunnlagRepository(
+    private val dataSource: DataSource,
+) {
     fun finnBeregningsGrunnlag(id: UUID): BeregningsGrunnlag? =
         using(sessionOf(dataSource)) { session ->
             session.run(
@@ -229,8 +231,8 @@ inline fun <reified T> T.somJsonb(): PGobject {
     return jsonObject
 }
 
-private fun Row.asBeregningsGrunnlag(): BeregningsGrunnlag {
-    return BeregningsGrunnlag(
+private fun Row.asBeregningsGrunnlag(): BeregningsGrunnlag =
+    BeregningsGrunnlag(
         behandlingId = this.uuid("behandlings_id"),
         soeskenMedIBeregning =
             this.stringOrNull("soesken_med_i_beregning_perioder")?.let {
@@ -254,10 +256,9 @@ private fun Row.asBeregningsGrunnlag(): BeregningsGrunnlag {
                 objectMapper.readValue(it)
             } ?: emptyList(),
     )
-}
 
-private fun Row.asOverstyrBeregningGrunnlag(): OverstyrBeregningGrunnlagDao {
-    return OverstyrBeregningGrunnlagDao(
+private fun Row.asOverstyrBeregningGrunnlag(): OverstyrBeregningGrunnlagDao =
+    OverstyrBeregningGrunnlagDao(
         id = this.uuid("id"),
         behandlingId = this.uuid("behandlings_id"),
         datoFOM = this.sqlDate("dato_fra_og_med").toLocalDate(),
@@ -273,4 +274,3 @@ private fun Row.asOverstyrBeregningGrunnlag(): OverstyrBeregningGrunnlagDao {
         kilde = objectMapper.readValue(this.string("kilde")),
         reguleringRegelresultat = this.stringOrNull("regulering_regelresultat")?.let { objectMapper.readValue(it) },
     )
-}

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutes.kt
@@ -97,9 +97,10 @@ fun Route.beregningsGrunnlag(
                 val grunnlag =
                     OverstyrBeregningGrunnlagDTO(
                         perioder =
-                            beregningsGrunnlagService.hentOverstyrBeregningGrunnlag(
-                                behandlingId,
-                            ).perioder,
+                            beregningsGrunnlagService
+                                .hentOverstyrBeregningGrunnlag(
+                                    behandlingId,
+                                ).perioder,
                     )
 
                 call.respond(HttpStatusCode.OK, grunnlag)

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
@@ -22,10 +22,11 @@ import java.util.UUID
 
 val REFORM_TIDSPUNKT_BP = YearMonth.of(2024, 1)
 
-class ManglerVirkningstidspunktBP : UgyldigForespoerselException(
-    code = "MANGLER_VIRK_BP",
-    detail = "Mangler virkningstidspunkt for barnepensjon.",
-)
+class ManglerVirkningstidspunktBP :
+    UgyldigForespoerselException(
+        code = "MANGLER_VIRK_BP",
+        detail = "Mangler virkningstidspunkt for barnepensjon.",
+    )
 
 class BeregningsGrunnlagService(
     private val beregningsGrunnlagRepository: BeregningsGrunnlagRepository,
@@ -51,7 +52,8 @@ class BeregningsGrunnlagService(
                     if (behandling.behandlingType == BehandlingType.REVURDERING) {
                         // Her vil vi sjekke opp om det vi lagrer ned ikke er modifisert før virk på revurderingen
                         val sisteIverksatteBehandling =
-                            vedtaksvurderingKlient.hentIverksatteVedtak(behandling.sak, brukerTokenInfo)
+                            vedtaksvurderingKlient
+                                .hentIverksatteVedtak(behandling.sak, brukerTokenInfo)
                                 .sortedByDescending { it.datoFattet }
                                 .first { it.vedtakType != VedtakType.OPPHOER }
 
@@ -115,7 +117,8 @@ class BeregningsGrunnlagService(
         val grunnlag = grunnlagKlient.hentGrunnlag(behandlingId, brukerTokenInfo)
 
         val soeskensFoedselsnummere =
-            barnepensjonBeregningsGrunnlag.soeskenMedIBeregning.flatMap { soeskenGrunnlag -> soeskenGrunnlag.data }
+            barnepensjonBeregningsGrunnlag.soeskenMedIBeregning
+                .flatMap { soeskenGrunnlag -> soeskenGrunnlag.data }
                 .map { it.foedselsnummer.value }
 
         if (soeskensFoedselsnummere.isNotEmpty()) {
@@ -244,30 +247,31 @@ class BeregningsGrunnlagService(
     fun hentOverstyrBeregningGrunnlag(behandlingId: UUID): OverstyrBeregningGrunnlag {
         logger.info("Henter overstyr beregning grunnlag $behandlingId")
 
-        return beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(
-            behandlingId,
-        ).let { overstyrBeregningGrunnlagDaoListe ->
-            OverstyrBeregningGrunnlag(
-                perioder =
-                    overstyrBeregningGrunnlagDaoListe.map { periode ->
-                        GrunnlagMedPeriode(
-                            data =
-                                OverstyrBeregningGrunnlagData(
-                                    utbetaltBeloep = periode.utbetaltBeloep,
-                                    trygdetid = periode.trygdetid,
-                                    trygdetidForIdent = periode.trygdetidForIdent,
-                                    prorataBroekTeller = periode.prorataBroekTeller,
-                                    prorataBroekNevner = periode.prorataBroekNevner,
-                                    beskrivelse = periode.beskrivelse,
-                                    aarsak = periode.aarsak,
-                                ),
-                            fom = periode.datoFOM,
-                            tom = periode.datoTOM,
-                        )
-                    },
-                kilde = overstyrBeregningGrunnlagDaoListe.firstOrNull()?.kilde ?: automatiskSaksbehandler,
-            )
-        }
+        return beregningsGrunnlagRepository
+            .finnOverstyrBeregningGrunnlagForBehandling(
+                behandlingId,
+            ).let { overstyrBeregningGrunnlagDaoListe ->
+                OverstyrBeregningGrunnlag(
+                    perioder =
+                        overstyrBeregningGrunnlagDaoListe.map { periode ->
+                            GrunnlagMedPeriode(
+                                data =
+                                    OverstyrBeregningGrunnlagData(
+                                        utbetaltBeloep = periode.utbetaltBeloep,
+                                        trygdetid = periode.trygdetid,
+                                        trygdetidForIdent = periode.trygdetidForIdent,
+                                        prorataBroekTeller = periode.prorataBroekTeller,
+                                        prorataBroekNevner = periode.prorataBroekNevner,
+                                        beskrivelse = periode.beskrivelse,
+                                        aarsak = periode.aarsak,
+                                    ),
+                                fom = periode.datoFOM,
+                                tom = periode.datoTOM,
+                            )
+                        },
+                    kilde = overstyrBeregningGrunnlagDaoListe.firstOrNull()?.kilde ?: automatiskSaksbehandler,
+                )
+            }
     }
 
     suspend fun lagreOverstyrBeregningGrunnlag(
@@ -359,14 +363,18 @@ class BeregningsGrunnlagService(
     }
 }
 
-class BPBeregningsgrunnlagSoeskenIkkeAvdoedesBarnException(behandlingId: UUID) : UgyldigForespoerselException(
-    code = "BP_BEREGNING_SOESKEN_IKKE_AVDOEDES_BARN",
-    detail = "Barnepensjon beregningsgrunnlag har søsken fnr som ikke er avdødeds barn",
-    meta = mapOf("behandlingId" to behandlingId),
-)
+class BPBeregningsgrunnlagSoeskenIkkeAvdoedesBarnException(
+    behandlingId: UUID,
+) : UgyldigForespoerselException(
+        code = "BP_BEREGNING_SOESKEN_IKKE_AVDOEDES_BARN",
+        detail = "Barnepensjon beregningsgrunnlag har søsken fnr som ikke er avdødeds barn",
+        meta = mapOf("behandlingId" to behandlingId),
+    )
 
-class BPBeregningsgrunnlagSoeskenMarkertDoedException(behandlingId: UUID) : UgyldigForespoerselException(
-    code = "BP_BEREGNING_SOESKEN_MARKERT_DOED",
-    detail = "Barnpensjon beregningsgrunnlag bruker søsken som er døde i beregningen",
-    meta = mapOf("behandlingId" to behandlingId),
-)
+class BPBeregningsgrunnlagSoeskenMarkertDoedException(
+    behandlingId: UUID,
+) : UgyldigForespoerselException(
+        code = "BP_BEREGNING_SOESKEN_MARKERT_DOED",
+        detail = "Barnpensjon beregningsgrunnlag bruker søsken som er døde i beregningen",
+        meta = mapOf("behandlingId" to behandlingId),
+    )

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/Visitors.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/Visitors.kt
@@ -6,7 +6,9 @@ import no.nav.etterlatte.libs.regler.Regel
 import no.nav.etterlatte.libs.regler.SubsumsjonsNode
 import no.nav.etterlatte.libs.regler.Visitor
 
-class FinnAnvendtGrunnbeloepVisitor(private val grunnbeloepRegel: Regel<*, *>) : Visitor {
+class FinnAnvendtGrunnbeloepVisitor(
+    private val grunnbeloepRegel: Regel<*, *>,
+) : Visitor {
     var anvendtGrunnbeloep: Grunnbeloep? = null
 
     override fun visit(node: Node<*>) {}
@@ -24,7 +26,9 @@ fun SubsumsjonsNode<*>.finnAnvendtGrunnbeloep(grunnbeloepRegel: Regel<*, *>): Gr
         anvendtGrunnbeloep
     }
 
-class FinnAnvendtTrygdetidVisitor(private val trygdetidRegel: Regel<*, *>) : Visitor {
+class FinnAnvendtTrygdetidVisitor(
+    private val trygdetidRegel: Regel<*, *>,
+) : Visitor {
     var anvendtTrygdetid: AnvendtTrygdetid? = null
 
     override fun visit(node: Node<*>) {}
@@ -42,7 +46,9 @@ fun SubsumsjonsNode<*>.finnAnvendtTrygdetid(trygdetidRegel: Regel<*, *>): Anvend
         anvendtTrygdetid
     }
 
-class FinnAvdodeForeldre2024Visitor(private val avdodeForeldre2024Regel: Regel<*, *>) : Visitor {
+class FinnAvdodeForeldre2024Visitor(
+    private val avdodeForeldre2024Regel: Regel<*, *>,
+) : Visitor {
     var avdodeForeldre: List<String?>? = null
 
     override fun visit(node: Node<*>) {}

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/barnepensjon/BeregnBarnepensjon.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/barnepensjon/BeregnBarnepensjon.kt
@@ -21,7 +21,8 @@ data class PeriodisertBarnepensjonGrunnlag(
 ) : PeriodisertGrunnlag<BarnepensjonGrunnlag> {
     override fun finnAlleKnekkpunkter(): Set<LocalDate> {
         val soeskenkullKnekkpunkter =
-            soeskenKull.finnAlleKnekkpunkter()
+            soeskenKull
+                .finnAlleKnekkpunkter()
                 .filter { it.isBefore(BP_2024_DATO) }
                 .toSet()
 
@@ -30,13 +31,12 @@ data class PeriodisertBarnepensjonGrunnlag(
             institusjonsopphold.finnAlleKnekkpunkter()
     }
 
-    override fun finnGrunnlagForPeriode(datoIPeriode: LocalDate): BarnepensjonGrunnlag {
-        return BarnepensjonGrunnlag(
+    override fun finnGrunnlagForPeriode(datoIPeriode: LocalDate): BarnepensjonGrunnlag =
+        BarnepensjonGrunnlag(
             soeskenKull.finnGrunnlagForPeriode(datoIPeriode),
             avdoedesTrygdetid.finnGrunnlagForPeriode(datoIPeriode),
             institusjonsopphold.finnGrunnlagForPeriode(datoIPeriode),
         )
-    }
 }
 
 data class BarnepensjonGrunnlag(

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/barnepensjon/sats/BarnepensjonSats.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/barnepensjon/sats/BarnepensjonSats.kt
@@ -97,8 +97,7 @@ val beloepHvertBarnEnForelderAvdoed2024 =
         gjelderFra = BP_2024_DATO,
         beskrivelse = "Prosentsats benyttet for hvert barn når en forelder er død",
         regelReferanse = RegelReferanse(id = "BP-BEREGNING-2024-BELOEP-EN-FORELDER-AVDOED"),
-    ) benytter prosentsatsHvertBarnEnForelderAvdoed2024 og grunnbeloep med {
-            sats, grunnbeloep ->
+    ) benytter prosentsatsHvertBarnEnForelderAvdoed2024 og grunnbeloep med { sats, grunnbeloep ->
         sats.multiply(grunnbeloep.grunnbeloepPerMaaned)
     }
 
@@ -107,8 +106,7 @@ val beloepHvertBarnToForeldreAvdoed2024 =
         gjelderFra = BP_2024_DATO,
         beskrivelse = "Prosentsats benyttet for hvert barn når to foreldre er døde",
         regelReferanse = RegelReferanse(id = "BP-BEREGNING-2024-BELOEP-TO-FORELDRE-AVDOED"),
-    ) benytter prosentsatsHvertBarnToForeldreAvdoed2024 og grunnbeloep med {
-            sats, grunnbeloep ->
+    ) benytter prosentsatsHvertBarnToForeldreAvdoed2024 og grunnbeloep med { sats, grunnbeloep ->
         sats.multiply(grunnbeloep.grunnbeloepPerMaaned)
     }
 
@@ -144,7 +142,10 @@ val barnepensjonSatsRegel1967 =
         beskrivelse = "Beregn uavkortet barnepensjon basert på størrelsen på barnekullet",
         regelReferanse = RegelReferanse(id = "BP-BEREGNING-1967-UAVKORTET"),
     ) benytter belopForFoersteBarn1967 og belopForEtterfoelgendeBarn1967 og antallSoeskenIKullet1967 med {
-            foerstebarnSats, etterfoelgendeBarnSats, antallSoesken ->
+            foerstebarnSats,
+            etterfoelgendeBarnSats,
+            antallSoesken,
+        ->
         foerstebarnSats
             .plus(etterfoelgendeBarnSats.multiply(antallSoesken))
             .divide(antallSoesken.plus(1))
@@ -156,7 +157,10 @@ val barnepensjonSatsRegel2024 =
         beskrivelse = "Beregn barnepensjon etter 2024-regelverk",
         regelReferanse = RegelReferanse(id = "BP-BEREGNING-2024-UAVKORTET"),
     ) benytter harToAvdodeForeldre2024 og beloepHvertBarnEnForelderAvdoed2024 og beloepHvertBarnToForeldreAvdoed2024 med {
-            harToAvdodeForeldre2024, beloepEnAvdoedForelder, beloepToAvdoedeForeldre ->
+            harToAvdodeForeldre2024,
+            beloepEnAvdoedForelder,
+            beloepToAvdoedeForeldre,
+        ->
         if (harToAvdodeForeldre2024) {
             beloepToAvdoedeForeldre
         } else {

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/omstillingstoenad/BeregnOmstillingstoenad.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/omstillingstoenad/BeregnOmstillingstoenad.kt
@@ -13,23 +13,23 @@ import no.nav.etterlatte.libs.regler.med
 import no.nav.etterlatte.libs.regler.og
 import java.time.LocalDate
 
-data class Avdoed(val trygdetid: SamletTrygdetidMedBeregningsMetode)
+data class Avdoed(
+    val trygdetid: SamletTrygdetidMedBeregningsMetode,
+)
 
 data class PeriodisertOmstillingstoenadGrunnlag(
     val avdoed: PeriodisertGrunnlag<FaktumNode<Avdoed>>,
     val institusjonsopphold: PeriodisertGrunnlag<FaktumNode<InstitusjonsoppholdBeregningsgrunnlag?>>,
 ) : PeriodisertGrunnlag<OmstillingstoenadGrunnlag> {
-    override fun finnAlleKnekkpunkter(): Set<LocalDate> {
-        return avdoed.finnAlleKnekkpunkter() +
+    override fun finnAlleKnekkpunkter(): Set<LocalDate> =
+        avdoed.finnAlleKnekkpunkter() +
             institusjonsopphold.finnAlleKnekkpunkter()
-    }
 
-    override fun finnGrunnlagForPeriode(datoIPeriode: LocalDate): OmstillingstoenadGrunnlag {
-        return OmstillingstoenadGrunnlag(
+    override fun finnGrunnlagForPeriode(datoIPeriode: LocalDate): OmstillingstoenadGrunnlag =
+        OmstillingstoenadGrunnlag(
             avdoed.finnGrunnlagForPeriode(datoIPeriode),
             institusjonsopphold.finnGrunnlagForPeriode(datoIPeriode),
         )
-    }
 }
 
 data class OmstillingstoenadGrunnlag(

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/overstyr/BeregnOverstyr.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/overstyr/BeregnOverstyr.kt
@@ -24,15 +24,12 @@ data class OverstyrGrunnlag(
 data class PeriodisertOverstyrGrunnlag(
     val overstyrGrunnlag: PeriodisertGrunnlag<FaktumNode<OverstyrBeregningGrunnlagData>>,
 ) : PeriodisertGrunnlag<OverstyrGrunnlag> {
-    override fun finnAlleKnekkpunkter(): Set<LocalDate> {
-        return overstyrGrunnlag.finnAlleKnekkpunkter()
-    }
+    override fun finnAlleKnekkpunkter(): Set<LocalDate> = overstyrGrunnlag.finnAlleKnekkpunkter()
 
-    override fun finnGrunnlagForPeriode(datoIPeriode: LocalDate): OverstyrGrunnlag {
-        return OverstyrGrunnlag(
+    override fun finnGrunnlagForPeriode(datoIPeriode: LocalDate): OverstyrGrunnlag =
+        OverstyrGrunnlag(
             overstyrGrunnlag.finnGrunnlagForPeriode(datoIPeriode),
         )
-    }
 }
 
 val historiskeGrunnbeloep =

--- a/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
@@ -35,7 +35,9 @@ private fun featureToggleProperties(config: Config) =
         apiKey = config.getString("funksjonsbrytere.unleash.token"),
     )
 
-enum class BeregningFeatureToggle(private val key: String) : FeatureToggle {
+enum class BeregningFeatureToggle(
+    private val key: String,
+) : FeatureToggle {
     Foreldreloes("foreldreloes"),
     ;
 

--- a/apps/etterlatte-beregning/src/main/kotlin/grunnbeloep/GrunnbeloepRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/grunnbeloep/GrunnbeloepRepository.kt
@@ -13,16 +13,19 @@ object GrunnbeloepRepository {
         GrunnbeloepRepository::class.java.getResource(file)?.readText()
             ?: throw FileNotFoundException("Fant ikke filen $file")
 
-    fun hentGjeldendeGrunnbeloep(dato: YearMonth): Grunnbeloep {
-        return historiskeGrunnbeloep.first {
+    fun hentGjeldendeGrunnbeloep(dato: YearMonth): Grunnbeloep =
+        historiskeGrunnbeloep.first {
             it.dato.isBefore(dato) || it.dato == dato && beregnTom(it)?.isAfter(dato) ?: true
         }
-    }
 
-    private fun beregnTom(grunnbeloep: Grunnbeloep): YearMonth? {
-        return historiskeGrunnbeloep.sortedBy { it.dato }.zipWithNext()
-            .find { it.first.dato == grunnbeloep.dato }?.second?.dato?.minusMonths(1)
-    }
+    private fun beregnTom(grunnbeloep: Grunnbeloep): YearMonth? =
+        historiskeGrunnbeloep
+            .sortedBy { it.dato }
+            .zipWithNext()
+            .find { it.first.dato == grunnbeloep.dato }
+            ?.second
+            ?.dato
+            ?.minusMonths(1)
 }
 
 data class GrunnbeloepListe(

--- a/apps/etterlatte-beregning/src/main/kotlin/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/klienter/BehandlingKlient.kt
@@ -44,9 +44,15 @@ interface BehandlingKlient : BehandlingTilgangsSjekk {
     ): Boolean
 }
 
-class BehandlingKlientException(override val message: String, override val cause: Throwable) : Exception(message, cause)
+class BehandlingKlientException(
+    override val message: String,
+    override val cause: Throwable,
+) : Exception(message, cause)
 
-class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingKlient {
+class BehandlingKlientImpl(
+    config: Config,
+    httpClient: HttpClient,
+) : BehandlingKlient {
     private val logger = LoggerFactory.getLogger(BehandlingKlient::class.java)
 
     private val azureAdClient = AzureAdClient(config)
@@ -72,8 +78,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
                             url = "$resourceUrl/behandlinger/$behandlingId",
                         ),
                     brukerTokenInfo = brukerTokenInfo,
-                )
-                .mapBoth(
+                ).mapBoth(
                     success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },
                     failure = { throwableErrorMessage -> throw throwableErrorMessage },
                 )
@@ -93,8 +98,8 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
     override suspend fun hentSisteIverksatteBehandling(
         sakId: Long,
         brukerTokenInfo: BrukerTokenInfo,
-    ): SisteIverksatteBehandling {
-        return retry<SisteIverksatteBehandling> {
+    ): SisteIverksatteBehandling =
+        retry<SisteIverksatteBehandling> {
             downstreamResourceClient
                 .get(
                     resource =
@@ -103,8 +108,7 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
                             url = "$resourceUrl/saker/$sakId/behandlinger/sisteIverksatte",
                         ),
                     brukerTokenInfo = brukerTokenInfo,
-                )
-                .mapBoth(
+                ).mapBoth(
                     success = { deserialize(it.response.toString()) },
                     failure = { throwableErrorMessage -> throw throwableErrorMessage },
                 )
@@ -119,7 +123,6 @@ class BehandlingKlientImpl(config: Config, httpClient: HttpClient) : BehandlingK
                 }
             }
         }
-    }
 
     override suspend fun kanBeregnes(
         behandlingId: UUID,

--- a/apps/etterlatte-beregning/src/main/kotlin/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/klienter/GrunnlagKlient.kt
@@ -22,9 +22,15 @@ interface GrunnlagKlient {
     ): Grunnlag
 }
 
-class GrunnlagKlientException(override val message: String, override val cause: Throwable) : Exception(message, cause)
+class GrunnlagKlientException(
+    override val message: String,
+    override val cause: Throwable,
+) : Exception(message, cause)
 
-class GrunnlagKlientImpl(config: Config, httpClient: HttpClient) : GrunnlagKlient {
+class GrunnlagKlientImpl(
+    config: Config,
+    httpClient: HttpClient,
+) : GrunnlagKlient {
     private val logger = LoggerFactory.getLogger(GrunnlagKlient::class.java)
 
     private val azureAdClient = AzureAdClient(config)
@@ -48,8 +54,7 @@ class GrunnlagKlientImpl(config: Config, httpClient: HttpClient) : GrunnlagKlien
                             url = "$resourceUrl/api/grunnlag/behandling/$behandlingId",
                         ),
                     brukerTokenInfo = brukerTokenInfo,
-                )
-                .mapBoth(
+                ).mapBoth(
                     success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },
                     failure = { throwableErrorMessage -> throw throwableErrorMessage },
                 )

--- a/apps/etterlatte-beregning/src/main/kotlin/klienter/TrygdetidKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/klienter/TrygdetidKlient.kt
@@ -15,10 +15,15 @@ import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
-class TrygdetidKlientException(override val message: String, override val cause: Throwable) :
-    Exception(message, cause)
+class TrygdetidKlientException(
+    override val message: String,
+    override val cause: Throwable,
+) : Exception(message, cause)
 
-class TrygdetidKlient(config: Config, httpClient: HttpClient) {
+class TrygdetidKlient(
+    config: Config,
+    httpClient: HttpClient,
+) {
     private val logger = LoggerFactory.getLogger(TrygdetidKlient::class.java)
     private val azureAdClient = AzureAdClient(config)
     private val downstreamResourceClient = DownstreamResourceClient(azureAdClient, httpClient)
@@ -40,8 +45,7 @@ class TrygdetidKlient(config: Config, httpClient: HttpClient) {
                             url = "$resourceUrl/api/trygdetid_v2/$behandlingId",
                         ),
                     brukerTokenInfo = brukerTokenInfo,
-                )
-                .mapBoth(
+                ).mapBoth(
                     success = { resource ->
                         resource.response?.let { objectMapper.readValue(it.toString()) } ?: emptyList()
                     },

--- a/apps/etterlatte-beregning/src/main/kotlin/klienter/VedtaksvurderingKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/klienter/VedtaksvurderingKlient.kt
@@ -21,10 +21,15 @@ interface VedtaksvurderingKlient {
     ): List<VedtakSammendragDto>
 }
 
-class VedtaksvurderingKlientException(override val message: String, override val cause: Throwable) :
-    Exception(message, cause)
+class VedtaksvurderingKlientException(
+    override val message: String,
+    override val cause: Throwable,
+) : Exception(message, cause)
 
-class VedtaksvurderingKlientImpl(config: Config, httpClient: HttpClient) : VedtaksvurderingKlient {
+class VedtaksvurderingKlientImpl(
+    config: Config,
+    httpClient: HttpClient,
+) : VedtaksvurderingKlient {
     private val logger = LoggerFactory.getLogger(VedtaksvurderingKlientImpl::class.java)
     private val azureAdClient = AzureAdClient(config)
     private val downstreamResourceClient = DownstreamResourceClient(azureAdClient, httpClient)
@@ -46,8 +51,7 @@ class VedtaksvurderingKlientImpl(config: Config, httpClient: HttpClient) : Vedta
                             url = "$resourceUrl/api/vedtak/sak/$sakId/iverksatte",
                         ),
                     brukerTokenInfo = brukerTokenInfo,
-                )
-                .mapBoth(
+                ).mapBoth(
                     success = { resource -> objectMapper.readValue(resource.response.toString()) },
                     failure = { throwableErrorMessage -> throw throwableErrorMessage },
                 )

--- a/apps/etterlatte-beregning/src/main/kotlin/klienter/VilkaarsvurderingKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/klienter/VilkaarsvurderingKlient.kt
@@ -22,10 +22,15 @@ interface VilkaarsvurderingKlient {
     ): VilkaarsvurderingDto
 }
 
-class VilkaarsvurderingKlientException(override val message: String, override val cause: Throwable) :
-    Exception(message, cause)
+class VilkaarsvurderingKlientException(
+    override val message: String,
+    override val cause: Throwable,
+) : Exception(message, cause)
 
-class VilkaarsvurderingKlientImpl(config: Config, httpClient: HttpClient) : VilkaarsvurderingKlient {
+class VilkaarsvurderingKlientImpl(
+    config: Config,
+    httpClient: HttpClient,
+) : VilkaarsvurderingKlient {
     private val logger = LoggerFactory.getLogger(VilkaarsvurderingKlientImpl::class.java)
     private val azureAdClient = AzureAdClient(config)
     private val downstreamResourceClient = DownstreamResourceClient(azureAdClient, httpClient)
@@ -47,8 +52,7 @@ class VilkaarsvurderingKlientImpl(config: Config, httpClient: HttpClient) : Vilk
                             url = "$resourceUrl/api/vilkaarsvurdering/$behandlingId",
                         ),
                     brukerTokenInfo = brukerTokenInfo,
-                )
-                .mapBoth(
+                ).mapBoth(
                     success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },
                     failure = { throwableErrorMessage -> throw throwableErrorMessage },
                 )

--- a/apps/etterlatte-beregning/src/main/kotlin/no/nav/etterlatte/grunnbeloep/GrunnbeloepService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/no/nav/etterlatte/grunnbeloep/GrunnbeloepService.kt
@@ -3,6 +3,8 @@ package no.nav.etterlatte.no.nav.etterlatte.grunnbeloep
 import no.nav.etterlatte.grunnbeloep.GrunnbeloepRepository
 import java.time.YearMonth
 
-class GrunnbeloepService(private val repository: GrunnbeloepRepository) {
+class GrunnbeloepService(
+    private val repository: GrunnbeloepRepository,
+) {
     fun hentGrunnbeloep(maaned: YearMonth) = repository.hentGjeldendeGrunnbeloep(maaned)
 }

--- a/apps/etterlatte-beregning/src/main/kotlin/sanksjon/SanksjonRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/sanksjon/SanksjonRepository.kt
@@ -11,7 +11,9 @@ import java.time.YearMonth
 import java.util.UUID
 import javax.sql.DataSource
 
-class SanksjonRepository(private val dataSource: DataSource) {
+class SanksjonRepository(
+    private val dataSource: DataSource,
+) {
     fun hentSanksjon(behandlingId: UUID): List<Sanksjon>? =
         dataSource.transaction { tx ->
             queryOf(

--- a/apps/etterlatte-beregning/src/main/kotlin/sanksjon/SanksjonService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/sanksjon/SanksjonService.kt
@@ -50,10 +50,11 @@ class SanksjonService(
 
         if (behandling.virkningstidspunkt == null) throw ManglerVirkningstidspunktException()
         if (sanksjon.sakId != behandling.sak) throw SakidTilhoererIkkeBehandlingException()
-        if (YearMonth.of(
-                sanksjon.fom.year,
-                sanksjon.fom.month,
-            ).isBefore(behandling.virkningstidspunkt?.dato)
+        if (YearMonth
+                .of(
+                    sanksjon.fom.year,
+                    sanksjon.fom.month,
+                ).isBefore(behandling.virkningstidspunkt?.dato)
         ) {
             throw FomErFoerVirkningstidpunktException()
         }

--- a/apps/etterlatte-beregning/src/main/kotlin/ytelseMedGrunnlag/YtelseMedGrunnlagService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/ytelseMedGrunnlag/YtelseMedGrunnlagService.kt
@@ -33,7 +33,9 @@ class YtelseMedGrunnlagService(
                         .maxBy { it.datoFOM }
 
                 val avkortingsgrunnlagIPeriode =
-                    avkorting.aarsoppgjoer.single().inntektsavkorting
+                    avkorting.aarsoppgjoer
+                        .single()
+                        .inntektsavkorting
                         .filter { it.grunnlag.periode.fom <= avkortetYtelse.periode.fom }
                         .maxBy { it.grunnlag.periode.fom }
 
@@ -63,7 +65,9 @@ class YtelseMedGrunnlagService(
     }
 }
 
-class BeregningFinnesIkkeException(behandlingId: UUID) : IkkeFunnetException(
-    code = "BEREGNING_IKKE_FUNNET",
-    detail = "Mangler beregning for behandling $behandlingId",
-)
+class BeregningFinnesIkkeException(
+    behandlingId: UUID,
+) : IkkeFunnetException(
+        code = "BEREGNING_IKKE_FUNNET",
+        detail = "Mangler beregning for behandling $behandlingId",
+    )

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
@@ -16,7 +16,9 @@ import javax.sql.DataSource
 
 @ExtendWith(DatabaseExtension::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-internal class AvkortingRepositoryTest(ds: DataSource) {
+internal class AvkortingRepositoryTest(
+    ds: DataSource,
+) {
     private val avkortingRepository = AvkortingRepository(ds)
 
     @Test

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -89,7 +89,8 @@ internal class AvkortingTest {
                 it.avkortetYtelseFraVirkningstidspunkt[1] shouldBe avkorting.aarsoppgjoer.single().avkortetYtelseAar[2]
             }
 
-            avkorting.medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2024, Month.SEPTEMBER))
+            avkorting
+                .medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2024, Month.SEPTEMBER))
                 .asClue {
                     it.avkortetYtelseFraVirkningstidspunkt.size shouldBe 1
                     with(it.avkortetYtelseFraVirkningstidspunkt[0]) {
@@ -137,8 +138,16 @@ internal class AvkortingTest {
             with(nyAvkorting) {
                 aarsoppgjoer.single().inntektsavkorting.asClue {
                     it.size shouldBe 2
-                    it[0].grunnlag.id shouldNotBe eksisterendeAvkorting.aarsoppgjoer.single().inntektsavkorting[0].grunnlag.id
-                    it[1].grunnlag.id shouldNotBe eksisterendeAvkorting.aarsoppgjoer.single().inntektsavkorting[1].grunnlag.id
+                    it[0].grunnlag.id shouldNotBe
+                        eksisterendeAvkorting.aarsoppgjoer
+                            .single()
+                            .inntektsavkorting[0]
+                            .grunnlag.id
+                    it[1].grunnlag.id shouldNotBe
+                        eksisterendeAvkorting.aarsoppgjoer
+                            .single()
+                            .inntektsavkorting[1]
+                            .grunnlag.id
                 }
             }
         }
@@ -250,13 +259,18 @@ internal class AvkortingTest {
             val inntektDto = avkortinggrunnlagLagre()
             val virkningstidspunkt = YearMonth.of(2024, Month.MARCH)
 
-            avkorting(inntektsavkorting = emptyList()).oppdaterMedInntektsgrunnlag(
-                inntektDto,
-                virkningstidspunkt,
-                bruker,
-            ).let {
-                it.aarsoppgjoer.single().inntektsavkorting.single().grunnlag.relevanteMaanederInnAar shouldBe 10
-            }
+            avkorting(inntektsavkorting = emptyList())
+                .oppdaterMedInntektsgrunnlag(
+                    inntektDto,
+                    virkningstidspunkt,
+                    bruker,
+                ).let {
+                    it.aarsoppgjoer
+                        .single()
+                        .inntektsavkorting
+                        .single()
+                        .grunnlag.relevanteMaanederInnAar shouldBe 10
+                }
         }
 
         @Test
@@ -264,16 +278,17 @@ internal class AvkortingTest {
             val inntektDto = avkortinggrunnlagLagre()
             val virkningstidspunkt = YearMonth.of(2024, Month.AUGUST)
 
-            avkorting.oppdaterMedInntektsgrunnlag(
-                inntektDto,
-                virkningstidspunkt,
-                bruker,
-            ).let {
-                with(it.aarsoppgjoer.single().inntektsavkorting) {
-                    size shouldBe 3
-                    last().grunnlag.relevanteMaanederInnAar shouldBe 12
+            avkorting
+                .oppdaterMedInntektsgrunnlag(
+                    inntektDto,
+                    virkningstidspunkt,
+                    bruker,
+                ).let {
+                    with(it.aarsoppgjoer.single().inntektsavkorting) {
+                        size shouldBe 3
+                        last().grunnlag.relevanteMaanederInnAar shouldBe 12
+                    }
                 }
-            }
         }
     }
 }

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingTest.kt
@@ -721,11 +721,17 @@ class BeregnAvkortingTest {
 
     private fun `Avkorting korrigere siste inntekt`() =
         `Avkorting revurdert beregning`()
-            .kopierAvkorting().let {
+            .kopierAvkorting()
+            .let {
                 it.beregnAvkortingMedNyttGrunnlag(
                     nyttGrunnlag =
                         avkortinggrunnlagLagre(
-                            id = it.aarsoppgjoer.single().inntektsavkorting.last().grunnlag.id,
+                            id =
+                                it.aarsoppgjoer
+                                    .single()
+                                    .inntektsavkorting
+                                    .last()
+                                    .grunnlag.id,
                             aarsinntekt = 425000,
                             fratrekkInnAar = 50000,
                         ),

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRepositoryTest.kt
@@ -24,7 +24,9 @@ import javax.sql.DataSource
 
 @ExtendWith(DatabaseExtension::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-internal class BeregningRepositoryTest(ds: DataSource) {
+internal class BeregningRepositoryTest(
+    ds: DataSource,
+) {
     private val beregningRepository = BeregningRepository(ds)
 
     @Test
@@ -129,7 +131,9 @@ internal class BeregningRepositoryTest(ds: DataSource) {
         behandlingId = behandlingId,
         type = Beregningstype.BP,
         beregnetDato = Tidspunkt.now(),
-        grunnlagMetadata = no.nav.etterlatte.libs.common.grunnlag.Metadata(1, 1),
+        grunnlagMetadata =
+            no.nav.etterlatte.libs.common.grunnlag
+                .Metadata(1, 1),
         beregningsperioder =
             listOf(
                 Beregningsperiode(

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRoutesTest.kt
@@ -128,12 +128,13 @@ internal class BeregningRoutesTest {
                 beregning(beregningService, behandlingKlient)
             }
 
-            client.get("/api/beregning/${beregning.behandlingId}") {
-                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                header(HttpHeaders.Authorization, "Bearer $token")
-            }.let {
-                it.status shouldBe HttpStatusCode.NotFound
-            }
+            client
+                .get("/api/beregning/${beregning.behandlingId}") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    header(HttpHeaders.Authorization, "Bearer $token")
+                }.let {
+                    it.status shouldBe HttpStatusCode.NotFound
+                }
         }
     }
 
@@ -233,7 +234,9 @@ internal class BeregningRoutesTest {
         behandlingId = behandlingId,
         type = Beregningstype.BP,
         beregnetDato = Tidspunkt.now(),
-        grunnlagMetadata = no.nav.etterlatte.libs.common.grunnlag.Metadata(1, 1),
+        grunnlagMetadata =
+            no.nav.etterlatte.libs.common.grunnlag
+                .Metadata(1, 1),
         beregningsperioder =
             listOf(
                 Beregningsperiode(

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRepositoryIntegrationTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRepositoryIntegrationTest.kt
@@ -26,7 +26,9 @@ import java.util.UUID
 import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-internal class BeregningsGrunnlagRepositoryIntegrationTest(dataSource: DataSource) {
+internal class BeregningsGrunnlagRepositoryIntegrationTest(
+    dataSource: DataSource,
+) {
     companion object {
         @RegisterExtension
         val dbExtension = DatabaseExtension()
@@ -479,13 +481,12 @@ internal class BeregningsGrunnlagRepositoryIntegrationTest(dataSource: DataSourc
     private fun List<SoeskenMedIBeregning>.somPeriodisertGrunnlag(
         periodeFra: LocalDate = foerstePeriodeFra,
         periodeTil: LocalDate? = null,
-    ): List<GrunnlagMedPeriode<List<SoeskenMedIBeregning>>> {
-        return listOf(
+    ): List<GrunnlagMedPeriode<List<SoeskenMedIBeregning>>> =
+        listOf(
             GrunnlagMedPeriode(
                 fom = periodeFra,
                 tom = periodeTil,
                 data = this,
             ),
         )
-    }
 }

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
@@ -227,12 +227,13 @@ internal class BeregningsGrunnlagRoutesTest {
                 beregningsGrunnlag(service, behandlingKlient)
             }
 
-            client.get("/api/beregning/beregningsgrunnlag/${randomUUID()}/barnepensjon") {
-                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                header(HttpHeaders.Authorization, "Bearer $token")
-            }.let {
-                it.status shouldBe HttpStatusCode.NotFound
-            }
+            client
+                .get("/api/beregning/beregningsgrunnlag/${randomUUID()}/barnepensjon") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    header(HttpHeaders.Authorization, "Bearer $token")
+                }.let {
+                    it.status shouldBe HttpStatusCode.NotFound
+                }
         }
     }
 
@@ -246,18 +247,19 @@ internal class BeregningsGrunnlagRoutesTest {
                     beregningsGrunnlag(service, behandlingKlient)
                 }
 
-            client.post("/api/beregning/beregningsgrunnlag/${randomUUID()}/barnepensjon") {
-                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                header(HttpHeaders.Authorization, "Bearer $token")
-                setBody(
-                    LagreBeregningsGrunnlag(
-                        emptyList(),
-                        emptyList(),
-                    ),
-                )
-            }.let {
-                it.status shouldBe HttpStatusCode.NotFound
-            }
+            client
+                .post("/api/beregning/beregningsgrunnlag/${randomUUID()}/barnepensjon") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    header(HttpHeaders.Authorization, "Bearer $token")
+                    setBody(
+                        LagreBeregningsGrunnlag(
+                            emptyList(),
+                            emptyList(),
+                        ),
+                    )
+                }.let {
+                    it.status shouldBe HttpStatusCode.NotFound
+                }
         }
     }
 
@@ -303,18 +305,19 @@ internal class BeregningsGrunnlagRoutesTest {
                     beregningsGrunnlag(service, behandlingKlient)
                 }
 
-            client.post("/api/beregning/beregningsgrunnlag/${randomUUID()}/barnepensjon") {
-                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                header(HttpHeaders.Authorization, "Bearer $token")
-                setBody(
-                    LagreBeregningsGrunnlag(
-                        emptyList(),
-                        emptyList(),
-                    ),
-                )
-            }.let {
-                it.status shouldBe HttpStatusCode.NoContent
-            }
+            client
+                .post("/api/beregning/beregningsgrunnlag/${randomUUID()}/barnepensjon") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    header(HttpHeaders.Authorization, "Bearer $token")
+                    setBody(
+                        LagreBeregningsGrunnlag(
+                            emptyList(),
+                            emptyList(),
+                        ),
+                    )
+                }.let {
+                    it.status shouldBe HttpStatusCode.NoContent
+                }
         }
     }
 
@@ -371,18 +374,19 @@ internal class BeregningsGrunnlagRoutesTest {
                             ),
                     ),
                 )
-            client.post("/api/beregning/beregningsgrunnlag/${randomUUID()}/barnepensjon") {
-                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                header(HttpHeaders.Authorization, "Bearer $token")
-                setBody(
-                    LagreBeregningsGrunnlag(
-                        soeskenMedIBeregning,
-                        emptyList(),
-                    ),
-                )
-            }.let {
-                it.status shouldBe HttpStatusCode.Conflict
-            }
+            client
+                .post("/api/beregning/beregningsgrunnlag/${randomUUID()}/barnepensjon") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    header(HttpHeaders.Authorization, "Bearer $token")
+                    setBody(
+                        LagreBeregningsGrunnlag(
+                            soeskenMedIBeregning,
+                            emptyList(),
+                        ),
+                    )
+                }.let {
+                    it.status shouldBe HttpStatusCode.Conflict
+                }
         }
     }
 
@@ -410,12 +414,13 @@ internal class BeregningsGrunnlagRoutesTest {
                 beregningsGrunnlag(service, behandlingKlient)
             }
 
-            client.post("/api/beregning/beregningsgrunnlag/$nye/fra/$forrige") {
-                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                header(HttpHeaders.Authorization, "Bearer $token")
-            }.let {
-                it.status shouldBe HttpStatusCode.NoContent
-            }
+            client
+                .post("/api/beregning/beregningsgrunnlag/$nye/fra/$forrige") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    header(HttpHeaders.Authorization, "Bearer $token")
+                }.let {
+                    it.status shouldBe HttpStatusCode.NoContent
+                }
         }
     }
 
@@ -443,12 +448,13 @@ internal class BeregningsGrunnlagRoutesTest {
                 beregningsGrunnlag(service, behandlingKlient)
             }
 
-            client.post("/api/beregning/beregningsgrunnlag/$nye/fra/$forrige") {
-                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                header(HttpHeaders.Authorization, "Bearer $systemToken")
-            }.let {
-                it.status shouldBe HttpStatusCode.NoContent
-            }
+            client
+                .post("/api/beregning/beregningsgrunnlag/$nye/fra/$forrige") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    header(HttpHeaders.Authorization, "Bearer $systemToken")
+                }.let {
+                    it.status shouldBe HttpStatusCode.NoContent
+                }
         }
     }
 
@@ -467,12 +473,13 @@ internal class BeregningsGrunnlagRoutesTest {
                 beregningsGrunnlag(service, behandlingKlient)
             }
 
-            client.post("/api/beregning/beregningsgrunnlag/$nye/fra/$forrige") {
-                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                header(HttpHeaders.Authorization, "Bearer $systemToken")
-            }.let {
-                it.status shouldBe HttpStatusCode.InternalServerError
-            }
+            client
+                .post("/api/beregning/beregningsgrunnlag/$nye/fra/$forrige") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    header(HttpHeaders.Authorization, "Bearer $systemToken")
+                }.let {
+                    it.status shouldBe HttpStatusCode.InternalServerError
+                }
         }
     }
 
@@ -506,12 +513,13 @@ internal class BeregningsGrunnlagRoutesTest {
                 beregningsGrunnlag(service, behandlingKlient)
             }
 
-            client.post("/api/beregning/beregningsgrunnlag/$nye/fra/$forrige") {
-                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                header(HttpHeaders.Authorization, "Bearer $systemToken")
-            }.let {
-                it.status shouldBe HttpStatusCode.InternalServerError
-            }
+            client
+                .post("/api/beregning/beregningsgrunnlag/$nye/fra/$forrige") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    header(HttpHeaders.Authorization, "Bearer $systemToken")
+                }.let {
+                    it.status shouldBe HttpStatusCode.InternalServerError
+                }
         }
     }
 
@@ -569,30 +577,31 @@ internal class BeregningsGrunnlagRoutesTest {
                     beregningsGrunnlag(service, behandlingKlient)
                 }
 
-            client.get("/api/beregning/beregningsgrunnlag/$behandlingId/overstyr") {
-                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                header(HttpHeaders.Authorization, "Bearer $token")
-            }.let { response ->
-                response.status shouldBe HttpStatusCode.OK
+            client
+                .get("/api/beregning/beregningsgrunnlag/$behandlingId/overstyr") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    header(HttpHeaders.Authorization, "Bearer $token")
+                }.let { response ->
+                    response.status shouldBe HttpStatusCode.OK
 
-                val grunnlag = objectMapper.readValue(response.bodyAsText(), OverstyrBeregningGrunnlagDTO::class.java)
+                    val grunnlag = objectMapper.readValue(response.bodyAsText(), OverstyrBeregningGrunnlagDTO::class.java)
 
-                grunnlag.perioder.let { perioder ->
-                    perioder.size shouldBe 2
-                    perioder.minBy { it.fom }.let { periode ->
-                        periode.fom shouldBe LocalDate.now().minusYears(12L)
-                        periode.tom shouldBe LocalDate.now().minusYears(6L)
-                        periode.data.utbetaltBeloep shouldBe 123L
-                        periode.data.trygdetid shouldBe 10L
-                    }
-                    perioder.maxBy { it.fom }.let { periode ->
-                        periode.fom shouldBe LocalDate.now().minusYears(6L)
-                        periode.tom shouldBe null
-                        periode.data.utbetaltBeloep shouldBe 456L
-                        periode.data.trygdetid shouldBe 20L
+                    grunnlag.perioder.let { perioder ->
+                        perioder.size shouldBe 2
+                        perioder.minBy { it.fom }.let { periode ->
+                            periode.fom shouldBe LocalDate.now().minusYears(12L)
+                            periode.tom shouldBe LocalDate.now().minusYears(6L)
+                            periode.data.utbetaltBeloep shouldBe 123L
+                            periode.data.trygdetid shouldBe 10L
+                        }
+                        perioder.maxBy { it.fom }.let { periode ->
+                            periode.fom shouldBe LocalDate.now().minusYears(6L)
+                            periode.tom shouldBe null
+                            periode.data.utbetaltBeloep shouldBe 456L
+                            periode.data.trygdetid shouldBe 20L
+                        }
                     }
                 }
-            }
         }
     }
 
@@ -672,89 +681,90 @@ internal class BeregningsGrunnlagRoutesTest {
                     beregningsGrunnlag(service, behandlingKlient)
                 }
 
-            client.post("/api/beregning/beregningsgrunnlag/$behandlingId/overstyr") {
-                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                header(HttpHeaders.Authorization, "Bearer $token")
-                setBody(
-                    OverstyrBeregningGrunnlag(
-                        perioder =
-                            listOf(
-                                GrunnlagMedPeriode(
-                                    data =
-                                        OverstyrBeregningGrunnlagData(
-                                            utbetaltBeloep = 123L,
-                                            trygdetid = 10L,
-                                            trygdetidForIdent = null,
-                                            prorataBroekTeller = null,
-                                            prorataBroekNevner = null,
-                                            beskrivelse = "test periode 1",
-                                            aarsak = "ANNET",
-                                        ),
-                                    fom = LocalDate.now().minusYears(12L),
-                                    tom = LocalDate.now().minusYears(6L),
+            client
+                .post("/api/beregning/beregningsgrunnlag/$behandlingId/overstyr") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    header(HttpHeaders.Authorization, "Bearer $token")
+                    setBody(
+                        OverstyrBeregningGrunnlag(
+                            perioder =
+                                listOf(
+                                    GrunnlagMedPeriode(
+                                        data =
+                                            OverstyrBeregningGrunnlagData(
+                                                utbetaltBeloep = 123L,
+                                                trygdetid = 10L,
+                                                trygdetidForIdent = null,
+                                                prorataBroekTeller = null,
+                                                prorataBroekNevner = null,
+                                                beskrivelse = "test periode 1",
+                                                aarsak = "ANNET",
+                                            ),
+                                        fom = LocalDate.now().minusYears(12L),
+                                        tom = LocalDate.now().minusYears(6L),
+                                    ),
+                                    GrunnlagMedPeriode(
+                                        data =
+                                            OverstyrBeregningGrunnlagData(
+                                                utbetaltBeloep = 456L,
+                                                trygdetid = 20L,
+                                                trygdetidForIdent = null,
+                                                prorataBroekTeller = null,
+                                                prorataBroekNevner = null,
+                                                beskrivelse = "test periode 2",
+                                                aarsak = "ANNET",
+                                            ),
+                                        fom = LocalDate.now().minusYears(6L),
+                                        tom = null,
+                                    ),
                                 ),
-                                GrunnlagMedPeriode(
-                                    data =
-                                        OverstyrBeregningGrunnlagData(
-                                            utbetaltBeloep = 456L,
-                                            trygdetid = 20L,
-                                            trygdetidForIdent = null,
-                                            prorataBroekTeller = null,
-                                            prorataBroekNevner = null,
-                                            beskrivelse = "test periode 2",
-                                            aarsak = "ANNET",
-                                        ),
-                                    fom = LocalDate.now().minusYears(6L),
-                                    tom = null,
+                            kilde =
+                                Grunnlagsopplysning.Saksbehandler(
+                                    ident = "Z123456",
+                                    Tidspunkt.now(),
                                 ),
-                            ),
-                        kilde =
-                            Grunnlagsopplysning.Saksbehandler(
-                                ident = "Z123456",
-                                Tidspunkt.now(),
-                            ),
-                    ),
-                )
-            }.let { response ->
-                response.status shouldBe HttpStatusCode.OK
+                        ),
+                    )
+                }.let { response ->
+                    response.status shouldBe HttpStatusCode.OK
 
-                val grunnlag = objectMapper.readValue(response.bodyAsText(), OverstyrBeregningGrunnlag::class.java)
+                    val grunnlag = objectMapper.readValue(response.bodyAsText(), OverstyrBeregningGrunnlag::class.java)
 
-                grunnlag.perioder.let { perioder ->
-                    perioder.size shouldBe 2
-                    perioder.minBy { it.fom }.let { periode ->
-                        periode.fom shouldBe LocalDate.now().minusYears(12L)
-                        periode.tom shouldBe LocalDate.now().minusYears(6L)
-                        periode.data.utbetaltBeloep shouldBe 123L
-                        periode.data.trygdetid shouldBe 10L
+                    grunnlag.perioder.let { perioder ->
+                        perioder.size shouldBe 2
+                        perioder.minBy { it.fom }.let { periode ->
+                            periode.fom shouldBe LocalDate.now().minusYears(12L)
+                            periode.tom shouldBe LocalDate.now().minusYears(6L)
+                            periode.data.utbetaltBeloep shouldBe 123L
+                            periode.data.trygdetid shouldBe 10L
+                        }
+                        perioder.maxBy { it.fom }.let { periode ->
+                            periode.fom shouldBe LocalDate.now().minusYears(6L)
+                            periode.tom shouldBe null
+                            periode.data.utbetaltBeloep shouldBe 456L
+                            periode.data.trygdetid shouldBe 20L
+                        }
                     }
-                    perioder.maxBy { it.fom }.let { periode ->
-                        periode.fom shouldBe LocalDate.now().minusYears(6L)
-                        periode.tom shouldBe null
-                        periode.data.utbetaltBeloep shouldBe 456L
-                        periode.data.trygdetid shouldBe 20L
+
+                    slot.captured.let { daoList ->
+                        daoList.size shouldBe 2
+
+                        daoList.minBy { it.datoFOM }.let { dao ->
+                            dao.datoFOM shouldBe LocalDate.now().minusYears(12L)
+                            dao.datoTOM shouldBe LocalDate.now().minusYears(6L)
+                            dao.utbetaltBeloep shouldBe 123L
+                            dao.trygdetid shouldBe 10L
+                            dao.sakId shouldBe 222L
+                        }
+                        daoList.maxBy { it.datoFOM }.let { dao ->
+                            dao.datoFOM shouldBe LocalDate.now().minusYears(6L)
+                            dao.datoTOM shouldBe null
+                            dao.utbetaltBeloep shouldBe 456L
+                            dao.trygdetid shouldBe 20L
+                            dao.sakId shouldBe 222L
+                        }
                     }
                 }
-
-                slot.captured.let { daoList ->
-                    daoList.size shouldBe 2
-
-                    daoList.minBy { it.datoFOM }.let { dao ->
-                        dao.datoFOM shouldBe LocalDate.now().minusYears(12L)
-                        dao.datoTOM shouldBe LocalDate.now().minusYears(6L)
-                        dao.utbetaltBeloep shouldBe 123L
-                        dao.trygdetid shouldBe 10L
-                        dao.sakId shouldBe 222L
-                    }
-                    daoList.maxBy { it.datoFOM }.let { dao ->
-                        dao.datoFOM shouldBe LocalDate.now().minusYears(6L)
-                        dao.datoTOM shouldBe null
-                        dao.utbetaltBeloep shouldBe 456L
-                        dao.trygdetid shouldBe 20L
-                        dao.sakId shouldBe 222L
-                    }
-                }
-            }
         }
     }
 

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
@@ -957,15 +957,14 @@ internal class BeregningsGrunnlagServiceTest {
         institusjonsoppholdBeregningsgrunnlag: List<GrunnlagMedPeriode<InstitusjonsoppholdBeregningsgrunnlag>> =
             emptyList(),
         kilde: Grunnlagsopplysning.Saksbehandler = Grunnlagsopplysning.Saksbehandler("test", Tidspunkt.now()),
-    ): BeregningsGrunnlag {
-        return BeregningsGrunnlag(
+    ): BeregningsGrunnlag =
+        BeregningsGrunnlag(
             behandlingId = behandlingId,
             kilde = kilde,
             soeskenMedIBeregning = soeskenMedIBeregning,
             institusjonsoppholdBeregningsgrunnlag = institusjonsoppholdBeregningsgrunnlag,
             beregningsMetode = BeregningsMetode.NASJONAL.toGrunnlag(),
         )
-    }
 
     private fun mockVedtak(
         behandlingId: UUID,

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/PeriodisertBeregningGrunnlagTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/PeriodisertBeregningGrunnlagTest.kt
@@ -12,10 +12,11 @@ class PeriodisertBeregningGrunnlagTest {
     private val perioderSomErKomplett =
         listOf<Pair<LocalDate, LocalDate?>>(
             YearMonth.of(2022, Month.AUGUST).atDay(1) to
-                YearMonth.of(
-                    2022,
-                    Month.DECEMBER,
-                ).atEndOfMonth(),
+                YearMonth
+                    .of(
+                        2022,
+                        Month.DECEMBER,
+                    ).atEndOfMonth(),
             YearMonth.of(2023, Month.JANUARY).atDay(1) to null,
         )
 
@@ -23,19 +24,21 @@ class PeriodisertBeregningGrunnlagTest {
         listOf<Pair<LocalDate, LocalDate?>>(
             YearMonth.of(2023, Month.JANUARY).atDay(1) to null,
             YearMonth.of(2022, Month.AUGUST).atDay(1) to
-                YearMonth.of(
-                    2022,
-                    Month.DECEMBER,
-                ).atEndOfMonth(),
+                YearMonth
+                    .of(
+                        2022,
+                        Month.DECEMBER,
+                    ).atEndOfMonth(),
         )
 
     private val perioderMedHull =
         listOf<Pair<LocalDate, LocalDate?>>(
             YearMonth.of(2022, Month.AUGUST).atDay(1) to
-                YearMonth.of(
-                    2022,
-                    Month.AUGUST,
-                ).atEndOfMonth(),
+                YearMonth
+                    .of(
+                        2022,
+                        Month.AUGUST,
+                    ).atEndOfMonth(),
             YearMonth.of(2022, Month.DECEMBER).atDay(1) to YearMonth.of(2022, Month.DECEMBER).atEndOfMonth(),
         )
 
@@ -76,7 +79,12 @@ class PeriodisertBeregningGrunnlagTest {
         val fom = perioderSomErKomplett.minBy { it.first }.first
         val tom = null
         val ekstraPeriodeFoerst =
-            YearMonth.from(fom).minusYears(1).atDay(1) to YearMonth.from(fom).minusYears(1).plusMonths(2).atEndOfMonth()
+            YearMonth.from(fom).minusYears(1).atDay(1) to
+                YearMonth
+                    .from(fom)
+                    .minusYears(1)
+                    .plusMonths(2)
+                    .atEndOfMonth()
         assertDoesNotThrow {
             PeriodisertBeregningGrunnlag.lagKomplettPeriodisertGrunnlag(
                 perioderTilGrunnlagMedPerioder(
@@ -136,9 +144,10 @@ class PeriodisertBeregningGrunnlagTest {
         val default = "konstant"
         Assertions.assertEquals(
             default,
-            PeriodisertBeregningGrunnlag.lagPotensieltTomtGrunnlagMedDefaultUtenforPerioder(
-                emptyList(),
-            ) { _, _, _ -> default }
+            PeriodisertBeregningGrunnlag
+                .lagPotensieltTomtGrunnlagMedDefaultUtenforPerioder(
+                    emptyList(),
+                ) { _, _, _ -> default }
                 .finnGrunnlagForPeriode(perioderMedOverlapp.minBy { it.first }.first),
         )
     }
@@ -146,9 +155,10 @@ class PeriodisertBeregningGrunnlagTest {
     @Test
     fun `lagPotensieltTomtGrunnlagMedDefaultUtenforPerioder returnerer  hvis ingen perioder er gitt`() {
         assertDoesNotThrow {
-            PeriodisertBeregningGrunnlag.lagPotensieltTomtGrunnlagMedDefaultUtenforPerioder(
-                perioderTilGrunnlagMedPerioder(perioderSomErKomplett, null),
-            ) { _, _, _ -> "konstant" }
+            PeriodisertBeregningGrunnlag
+                .lagPotensieltTomtGrunnlagMedDefaultUtenforPerioder(
+                    perioderTilGrunnlagMedPerioder(perioderSomErKomplett, null),
+                ) { _, _, _ -> "konstant" }
                 .finnGrunnlagForPeriode(perioderSomErKomplett.minBy { it.first }.first)
         }
     }
@@ -200,16 +210,14 @@ class PeriodisertBeregningGrunnlagTest {
         )
     }
 
-    private fun List<Pair<LocalDate, LocalDate?>>.somPeriodegrunnlag(): List<GrunnlagMedPeriode<String>> {
-        return perioderTilGrunnlagMedPerioder(this, "hei")
-    }
+    private fun List<Pair<LocalDate, LocalDate?>>.somPeriodegrunnlag(): List<GrunnlagMedPeriode<String>> =
+        perioderTilGrunnlagMedPerioder(this, "hei")
 
     private fun <T> perioderTilGrunnlagMedPerioder(
         perioder: List<Pair<LocalDate, LocalDate?>>,
         opplysning: T,
-    ): List<GrunnlagMedPeriode<T>> {
-        return perioder.map {
+    ): List<GrunnlagMedPeriode<T>> =
+        perioder.map {
             GrunnlagMedPeriode(data = opplysning, fom = it.first, tom = it.second)
         }
-    }
 }

--- a/apps/etterlatte-beregning/src/test/kotlin/sanksjon/SanksjonRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/sanksjon/SanksjonRepositoryTest.kt
@@ -14,7 +14,9 @@ import javax.sql.DataSource
 
 @ExtendWith(DatabaseExtension::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-internal class SanksjonRepositoryTest(ds: DataSource) {
+internal class SanksjonRepositoryTest(
+    ds: DataSource,
+) {
     private val sanksjonRepository = SanksjonRepository(ds)
     private val sakId = 123L
 


### PR DESCRIPTION
Slett litt med at alle PRer i beregning ga stor lint utslag som gjorde det veldig vanskelig å tyde.

Dette er resultat av å kjøre følgende på main:

```
cd apps/etterlatte-beregning/src
for F in  **/*kt; do
  ktlint -F $F
done
```