### PR TITLE
EY-2586 standardisere tokenoppsett

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktRoute.kt
@@ -21,7 +21,6 @@ import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.OPPGAVEID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.behandlingId
-import no.nav.etterlatte.libs.ktor.route.hentNavidentFraToken
 import no.nav.etterlatte.libs.ktor.route.kunSystembruker
 import no.nav.etterlatte.libs.ktor.route.oppgaveId
 import no.nav.etterlatte.libs.ktor.route.routeLogger
@@ -47,20 +46,18 @@ internal fun Route.aktivitetspliktRoutes(aktivitetspliktService: Aktivitetsplikt
 
         post {
             kunSkrivetilgang {
-                hentNavidentFraToken { navIdent ->
-                    val oppfolging = call.receive<OpprettAktivitetspliktOppfolging>()
+                val oppfolging = call.receive<OpprettAktivitetspliktOppfolging>()
 
-                    try {
-                        val result =
-                            aktivitetspliktService.lagreAktivitetspliktOppfolging(
-                                behandlingId,
-                                oppfolging,
-                                navIdent,
-                            )
-                        call.respond(result)
-                    } catch (e: TilstandException.UgyldigTilstand) {
-                        call.respond(HttpStatusCode.BadRequest, "Kunne ikke endre på feltet")
-                    }
+                try {
+                    val result =
+                        aktivitetspliktService.lagreAktivitetspliktOppfolging(
+                            behandlingId,
+                            oppfolging,
+                            brukerTokenInfo.ident(),
+                        )
+                    call.respond(result)
+                } catch (e: TilstandException.UgyldigTilstand) {
+                    call.respond(HttpStatusCode.BadRequest, "Kunne ikke endre på feltet")
                 }
             }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
@@ -11,10 +11,10 @@ import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.behandling.RevurderingInfo
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.behandlingId
-import no.nav.etterlatte.libs.ktor.route.hentNavidentFraToken
 import no.nav.etterlatte.libs.ktor.route.medBody
 import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.route.sakId
@@ -30,18 +30,16 @@ internal fun Route.revurderingRoutes(revurderingService: RevurderingService) {
             route("revurderinginfo") {
                 post {
                     kunSkrivetilgang {
-                        hentNavidentFraToken { navIdent ->
-                            logger.info("Lagrer revurderinginfo på behandling $behandlingId")
-                            medBody<RevurderingInfoDto> {
-                                inTransaction {
-                                    revurderingService.lagreRevurderingInfo(
-                                        behandlingId,
-                                        RevurderingInfoMedBegrunnelse(it.info, it.begrunnelse),
-                                        navIdent,
-                                    )
-                                }
-                                call.respond(HttpStatusCode.NoContent)
+                        logger.info("Lagrer revurderinginfo på behandling $behandlingId")
+                        medBody<RevurderingInfoDto> {
+                            inTransaction {
+                                revurderingService.lagreRevurderingInfo(
+                                    behandlingId,
+                                    RevurderingInfoMedBegrunnelse(it.info, it.begrunnelse),
+                                    brukerTokenInfo.ident(),
+                                )
                             }
+                            call.respond(HttpStatusCode.NoContent)
                         }
                     }
                 }

--- a/apps/etterlatte-behandling/src/main/kotlin/institusjonsopphold/InstitusjonsoppholdRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/institusjonsopphold/InstitusjonsoppholdRoutes.kt
@@ -9,8 +9,8 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.SAKID_CALL_PARAMETER
-import no.nav.etterlatte.libs.ktor.route.hentNavidentFraToken
 import no.nav.etterlatte.libs.ktor.route.sakId
 import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
 
@@ -18,15 +18,13 @@ internal fun Route.institusjonsoppholdRoute(institusjonsoppholdService: Institus
     route("/api/institusjonsoppholdbegrunnelse/{$SAKID_CALL_PARAMETER}") {
         post {
             kunSkrivetilgang {
-                hentNavidentFraToken { navIdent ->
-                    val institusjonsoppholdBegrunnelse = call.receive<InstitusjonsoppholdBegrunnelseWrapper>()
-                    institusjonsoppholdService.leggInnInstitusjonsoppholdBegrunnelse(
-                        sakId,
-                        Grunnlagsopplysning.Saksbehandler.create(navIdent),
-                        institusjonsoppholdBegrunnelse.institusjonsopphold,
-                    )
-                    call.respond(HttpStatusCode.OK)
-                }
+                val institusjonsoppholdBegrunnelse = call.receive<InstitusjonsoppholdBegrunnelseWrapper>()
+                institusjonsoppholdService.leggInnInstitusjonsoppholdBegrunnelse(
+                    sakId,
+                    Grunnlagsopplysning.Saksbehandler.create(brukerTokenInfo.ident()),
+                    institusjonsoppholdBegrunnelse.institusjonsopphold,
+                )
+                call.respond(HttpStatusCode.OK)
             }
         }
     }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/PersonRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/PersonRoutes.kt
@@ -8,7 +8,7 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.grunnlag.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.person.InvalidFoedselsnummerException
-import no.nav.etterlatte.libs.ktor.route.hentNavidentFraToken
+import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.route.kunSystembruker
 import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.route.withFoedselsnummer
@@ -35,36 +35,34 @@ fun Route.personRoute(
         }
         // TODO: brukes denne lenger?
         post("/navn") {
-            hentNavidentFraToken { navIdent ->
-                try {
-                    withFoedselsnummer(behandlingKlient, skrivetilgang = false) { foedselsnummer ->
-                        val opplysning =
-                            grunnlagService.hentOpplysningstypeNavnFraFnr(
-                                foedselsnummer,
-                                navIdent,
-                            )
+            try {
+                withFoedselsnummer(behandlingKlient, skrivetilgang = false) { foedselsnummer ->
+                    val opplysning =
+                        grunnlagService.hentOpplysningstypeNavnFraFnr(
+                            foedselsnummer,
+                            brukerTokenInfo.ident(),
+                        )
 
-                        if (opplysning != null) {
-                            call.respond(opplysning)
-                        } else {
-                            call.respond(
-                                HttpStatusCode.NotFound,
-                                "Gjenny har ingen navnedata på fødselsnummeret som ble etterspurt",
-                            )
-                        }
+                    if (opplysning != null) {
+                        call.respond(opplysning)
+                    } else {
+                        call.respond(
+                            HttpStatusCode.NotFound,
+                            "Gjenny har ingen navnedata på fødselsnummeret som ble etterspurt",
+                        )
                     }
-                } catch (ex: InvalidFoedselsnummerException) {
-                    call.respond(
-                        HttpStatusCode.BadRequest,
-                        "Gjenny har ingen navnedata på fødselsnummeret som ble etterspurt",
-                    )
-                } catch (ex: Exception) {
-                    routeLogger.error("Fikk feilmelding under henting av navn fra grunnlag", ex)
-                    call.respond(
-                        HttpStatusCode.NotFound,
-                        "Gjenny har ingen navnedata på fødselsnummeret som ble etterspurt",
-                    )
                 }
+            } catch (ex: InvalidFoedselsnummerException) {
+                call.respond(
+                    HttpStatusCode.BadRequest,
+                    "Gjenny har ingen navnedata på fødselsnummeret som ble etterspurt",
+                )
+            } catch (ex: Exception) {
+                routeLogger.error("Fikk feilmelding under henting av navn fra grunnlag", ex)
+                call.respond(
+                    HttpStatusCode.NotFound,
+                    "Gjenny har ingen navnedata på fødselsnummeret som ble etterspurt",
+                )
             }
         }
 

--- a/apps/etterlatte-testdata/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/Application.kt
@@ -26,7 +26,6 @@ import io.ktor.server.mustache.Mustache
 import io.ktor.server.plugins.callloging.CallLogging
 import io.ktor.server.plugins.callloging.processingTimeMillis
 import io.ktor.server.plugins.statuspages.StatusPages
-import io.ktor.server.request.header
 import io.ktor.server.request.httpMethod
 import io.ktor.server.request.path
 import io.ktor.server.response.respond
@@ -41,6 +40,7 @@ import no.nav.etterlatte.kafka.GcpKafkaConfig
 import no.nav.etterlatte.kafka.LocalKafkaConfig
 import no.nav.etterlatte.kafka.standardProducer
 import no.nav.etterlatte.libs.ktor.X_USER
+import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.firstValidTokenClaims
 import no.nav.etterlatte.libs.ktor.httpClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.AzureAdClient
@@ -58,7 +58,6 @@ import no.nav.etterlatte.testdata.features.egendefinert.EgendefinertMeldingFeatu
 import no.nav.etterlatte.testdata.features.index.IndexFeature
 import no.nav.etterlatte.testdata.features.samordning.SamordningMottattFeature
 import no.nav.etterlatte.testdata.features.soeknad.OpprettSoeknadFeature
-import no.nav.security.token.support.core.jwt.JwtToken
 import no.nav.security.token.support.v2.tokenValidationSupport
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -127,14 +126,7 @@ fun main() {
                         )
                     }
 
-                    mdc(X_USER) { call ->
-                        call.request.header("Authorization")?.let {
-                            val token = JwtToken(it.substringAfterLast("Bearer "))
-                            val jwtTokenClaims = token.jwtTokenClaims
-                            jwtTokenClaims.get("NAVident") as? String // human
-                                ?: token.jwtTokenClaims.get("azp_name") as? String // system/app-user
-                        }
-                    }
+                    mdc(X_USER) { call -> call.brukerTokenInfo.ident() }
                 }
                 install(StatusPages) {
                     exception<Throwable> { call, cause ->

--- a/apps/etterlatte-testdata/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/Application.kt
@@ -178,8 +178,6 @@ private fun Route.api() {
     }
 }
 
-fun PipelineContext<Unit, ApplicationCall>.navIdentFraToken() = call.firstValidTokenClaims()?.get("NAVident")?.toString()
-
 fun PipelineContext<Unit, ApplicationCall>.brukerIdFraToken() = call.firstValidTokenClaims()?.get("oid")?.toString()
 
 fun getDollyAccessToken(): String =

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/OpprettOgBehandle.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/OpprettOgBehandle.kt
@@ -12,7 +12,7 @@ import no.nav.etterlatte.TestDataFeature
 import no.nav.etterlatte.brukerIdFraToken
 import no.nav.etterlatte.getDollyAccessToken
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.SoeknadType
-import no.nav.etterlatte.navIdentFraToken
+import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.no.nav.etterlatte.testdata.features.automatisk.Familieoppretter
 import no.nav.etterlatte.rapidsandrivers.Behandlingssteg
 import no.nav.etterlatte.testdata.dolly.DollyService
@@ -66,7 +66,7 @@ class OpprettOgBehandle(
                             it,
                         )
                     } ?: throw IllegalArgumentException("Mangler behandlingssteg")
-                val navIdent = navIdentFraToken()
+                val navIdent = brukerTokenInfo.ident()
 
                 opprettOgSendInn(oenskaAntall, antallDagerSidenDoedsfall, gruppeid, soeknadType, navIdent, behandlingssteg)
                 call.respond(HttpStatusCode.Created)

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/dolly/DollyFeature.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/dolly/DollyFeature.kt
@@ -13,7 +13,7 @@ import no.nav.etterlatte.brukerIdFraToken
 import no.nav.etterlatte.getDollyAccessToken
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.SoeknadType
 import no.nav.etterlatte.libs.common.toJson
-import no.nav.etterlatte.navIdentFraToken
+import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.objectMapper
 import no.nav.etterlatte.rapidsandrivers.Behandlingssteg
 import no.nav.etterlatte.testdata.dolly.BestillingRequest
@@ -119,8 +119,7 @@ class DollyFeature(
                             )
                         }
 
-                    val navIdent = navIdentFraToken()
-                    val noekkel = dollyService.sendSoeknad(request, navIdent, Behandlingssteg.BEHANDLING_OPPRETTA)
+                    val noekkel = dollyService.sendSoeknad(request, brukerTokenInfo.ident(), Behandlingssteg.BEHANDLING_OPPRETTA)
 
                     call.respond(SoeknadResponse(200, noekkel).toJson())
                 } catch (e: Exception) {

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/egendefinert/EgendefinertMeldingFeature.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/egendefinert/EgendefinertMeldingFeature.kt
@@ -14,7 +14,6 @@ import io.ktor.util.pipeline.PipelineContext
 import no.nav.etterlatte.TestDataFeature
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.logger
-import no.nav.etterlatte.navIdentFraToken
 import no.nav.etterlatte.producer
 import no.nav.etterlatte.testdata.JsonMessage
 
@@ -43,7 +42,7 @@ object EgendefinertMeldingFeature : TestDataFeature {
                 kunEtterlatteUtvikling {
                     try {
                         val navIdent =
-                            requireNotNull(navIdentFraToken()) {
+                            requireNotNull(brukerTokenInfo.ident()) {
                                 "Nav ident mangler. Du må være innlogget for å sende søknad."
                             }
 

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/index/IndexFeature.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/index/IndexFeature.kt
@@ -7,7 +7,7 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import no.nav.etterlatte.TestDataFeature
 import no.nav.etterlatte.features
-import no.nav.etterlatte.navIdentFraToken
+import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 
 object IndexFeature : TestDataFeature {
     override val beskrivelse: String
@@ -21,7 +21,7 @@ object IndexFeature : TestDataFeature {
                     MustacheContent(
                         "index.hbs",
                         mapOf(
-                            "navIdent" to (navIdentFraToken() ?: "Anonym"),
+                            "navIdent" to (brukerTokenInfo.ident()),
                             "features" to
                                 features.filter { it != IndexFeature }.map {
                                     mapOf(

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/samordning/SamordningMottattFeature.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/samordning/SamordningMottattFeature.kt
@@ -11,8 +11,8 @@ import io.ktor.server.routing.post
 import no.nav.etterlatte.TestDataFeature
 import no.nav.etterlatte.libs.common.rapidsandrivers.lagParMedEventNameKey
 import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseHendelseType
+import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.logger
-import no.nav.etterlatte.navIdentFraToken
 import no.nav.etterlatte.producer
 import no.nav.etterlatte.testdata.JsonMessage
 
@@ -38,7 +38,7 @@ object SamordningMottattFeature : TestDataFeature {
             post {
                 try {
                     val navIdent =
-                        requireNotNull(navIdentFraToken()) {
+                        requireNotNull(brukerTokenInfo.ident()) {
                             "Nav ident mangler. Du må være innlogget for å sende samordningsmelding."
                         }
 

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/soeknad/OpprettSoeknad.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/soeknad/OpprettSoeknad.kt
@@ -12,8 +12,8 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import no.nav.etterlatte.TestDataFeature
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.SoeknadType
+import no.nav.etterlatte.libs.ktor.brukerTokenInfo
 import no.nav.etterlatte.logger
-import no.nav.etterlatte.navIdentFraToken
 import no.nav.etterlatte.producer
 import no.nav.etterlatte.rapidsandrivers.Behandlingssteg
 
@@ -49,7 +49,7 @@ object OpprettSoeknadFeature : TestDataFeature {
                                     barnFnr = it["fnrBarn"]!!,
                                     behandlingssteg = Behandlingssteg.BEHANDLING_OPPRETTA,
                                 ),
-                                mapOf("NavIdent" to (navIdentFraToken()!!.toByteArray())),
+                                mapOf("NavIdent" to (brukerTokenInfo.ident().toByteArray())),
                             )
                         }
                     logger.info("Publiserer melding med partisjon: $partisjon offset: $offset")

--- a/libs/etterlatte-ktor/src/main/kotlin/route/RouteUtils.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/route/RouteUtils.kt
@@ -14,7 +14,6 @@ import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.ktor.brukerTokenInfo
-import no.nav.etterlatte.libs.ktor.firstValidTokenClaims
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.libs.ktor.token.Systembruker
@@ -208,25 +207,6 @@ suspend inline fun PipelineContext<*, ApplicationCall>.withParam(
         onSuccess(uuidParam)
     } else {
         call.respond(HttpStatusCode.BadRequest, "$param var null, forventet en UUID")
-    }
-}
-
-suspend inline fun PipelineContext<*, ApplicationCall>.hentNavidentFraToken(onSuccess: (navident: String) -> Unit) {
-    val navident = call.firstValidTokenClaims()?.get("NAVident")?.toString()
-    if (navident.isNullOrEmpty()) {
-        val bruker = call.brukerTokenInfo
-        if (bruker is Systembruker && bruker.ident != null) {
-            logger.debug("Er systembruker, så fortsetter med ident fra brukerTokenInfo")
-            onSuccess(bruker.ident)
-        }
-
-        logger.warn("Kunne ikke hente ut navident fra token, avviser forespørselen")
-        call.respond(
-            HttpStatusCode.Unauthorized,
-            "Kunne ikke hente ut navident ",
-        )
-    } else {
-        onSuccess(navident)
     }
 }
 


### PR DESCRIPTION
Ved å fase ut `hentNavidentFraToken` til fordel for å bruke `brukerTokenInfo` som vi gjer elles. Forenklar også testdata-appen til å bruke mykje av det samme oppsettet som vi bruker elles.