### PR TITLE
Feature/fiks grunnlagshenting vv

### DIFF
--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangService.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangService.kt
@@ -21,12 +21,13 @@ class AldersovergangService(
     ): Vilkaarsvurdering {
         val vilkaarsvurdering =
             vilkaarsvurderingService.hentVilkaarsvurdering(behandlingId)
-                ?: vilkaarsvurderingService.kopierVilkaarsvurdering(
-                    behandlingId = behandlingId,
-                    kopierFraBehandling = loependeBehandlingId,
-                    brukerTokenInfo = brukerTokenInfo,
-                    kopierResultat = false,
-                )
+                ?: vilkaarsvurderingService
+                    .kopierVilkaarsvurdering(
+                        behandlingId = behandlingId,
+                        kopierFraBehandling = loependeBehandlingId,
+                        brukerTokenInfo = brukerTokenInfo,
+                        kopierResultat = false,
+                    ).vilkaarsvurdering
 
         val aldersvilkaar =
             vilkaarsvurdering.vilkaar.single {

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangService.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangService.kt
@@ -60,15 +60,16 @@ class AldersovergangService(
         )
 
         // Resultat på hele vurderingen => ikke oppfylt
-        return vilkaarsvurderingService.oppdaterTotalVurdering(
-            behandlingId,
-            brukerTokenInfo,
-            VilkaarsvurderingResultat(
-                utfall = VilkaarsvurderingUtfall.IKKE_OPPFYLT,
-                kommentar = "Automatisk aldersovergang",
-                tidspunkt = tidspunkt(),
-                saksbehandler = Fagsaksystem.EY.navn,
-            ),
-        )
+        return vilkaarsvurderingService
+            .oppdaterTotalVurdering(
+                behandlingId,
+                brukerTokenInfo,
+                VilkaarsvurderingResultat(
+                    utfall = VilkaarsvurderingUtfall.IKKE_OPPFYLT,
+                    kommentar = "Automatisk aldersovergang",
+                    tidspunkt = tidspunkt(),
+                    saksbehandler = Fagsaksystem.EY.navn,
+                ),
+            ).vilkaarsvurdering
     }
 }

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/Vilkaarsvurdering.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/Vilkaarsvurdering.kt
@@ -8,7 +8,7 @@ import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat
 import java.time.YearMonth
 import java.util.UUID
 
-data class VilkaarsvuderingMedBehandlingGrunnlagsversjon(
+data class VilkaarsvurderingMedBehandlingGrunnlagsversjon(
     val vilkaarsvurdering: Vilkaarsvurdering,
     val behandlingGrunnlagVersjon: Long,
 )

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/Vilkaarsvurdering.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/Vilkaarsvurdering.kt
@@ -8,6 +8,11 @@ import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat
 import java.time.YearMonth
 import java.util.UUID
 
+data class VilkaarsvuderingMedBehandlingGrunnlagsversjon(
+    val vilkaarsvurdering: Vilkaarsvurdering,
+    val behandlingGrunnlagVersjon: Long,
+)
+
 data class Vilkaarsvurdering(
     val id: UUID = UUID.randomUUID(),
     val behandlingId: UUID,

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
@@ -107,7 +107,7 @@ fun Route.vilkaarsvurdering(
 
                 try {
                     logger.info("Kopierer vilkårsvurdering for $behandlingId fra $forrigeBehandling")
-                    val vilkaarsvurdering =
+                    val (vilkaarsvurdering, behandlingGrunnversjon) =
                         vilkaarsvurderingService.kopierVilkaarsvurdering(
                             behandlingId = behandlingId,
                             kopierFraBehandling = forrigeBehandling,
@@ -117,7 +117,7 @@ fun Route.vilkaarsvurdering(
                     call.respond(
                         toDto(
                             vilkaarsvurdering,
-                            behandlingGrunnlagVersjon(vilkaarsvurderingService, behandlingId),
+                            behandlingGrunnversjon,
                         ),
                     )
                 } catch (e: VirkningstidspunktIkkeSattException) {

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
@@ -242,7 +242,7 @@ fun Route.vilkaarsvurdering(
 
                     logger.info("Oppdaterer vilkårsvurderingsresultat for $behandlingId")
                     try {
-                        val vilkaarsvurdering =
+                        val (vilkaarsvurdering, behandlingGrunnlagversjon) =
                             vilkaarsvurderingService.oppdaterTotalVurdering(
                                 behandlingId,
                                 brukerTokenInfo,
@@ -251,7 +251,7 @@ fun Route.vilkaarsvurdering(
                         call.respond(
                             toDto(
                                 vilkaarsvurdering,
-                                behandlingGrunnlagVersjon(vilkaarsvurderingService, behandlingId),
+                                behandlingGrunnlagversjon,
                             ),
                         )
                     } catch (e: BehandlingstilstandException) {

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
@@ -75,7 +75,7 @@ fun Route.vilkaarsvurdering(
                             ?: true
 
                     logger.info("Oppretter vilkårsvurdering for $behandlingId")
-                    val vilkaarsvurdering =
+                    val (vilkaarsvurdering, behandlingGrunnlagsversjon) =
                         vilkaarsvurderingService.opprettVilkaarsvurdering(
                             behandlingId,
                             brukerTokenInfo,
@@ -85,7 +85,7 @@ fun Route.vilkaarsvurdering(
                     call.respond(
                         toDto(
                             vilkaarsvurdering,
-                            behandlingGrunnlagVersjon(vilkaarsvurderingService, behandlingId),
+                            behandlingGrunnlagsversjon,
                         ),
                     )
                 } catch (e: VirkningstidspunktIkkeSattException) {

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
@@ -137,9 +137,9 @@ class VilkaarsvurderingService(
         kopierFraBehandling: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         kopierResultat: Boolean = true,
-    ): Vilkaarsvurdering {
-        logger.info("Oppretter og kopierer vilkårsvurdering for $behandlingId fra $kopierFraBehandling")
-        return tilstandssjekkFoerKjoering(behandlingId, brukerTokenInfo) {
+    ): VilkaarsvuderingMedBehandlingGrunnlagsversjon =
+        tilstandssjekkFoerKjoering(behandlingId, brukerTokenInfo) {
+            logger.info("Oppretter og kopierer vilkårsvurdering for $behandlingId fra $kopierFraBehandling")
             val (behandling, grunnlag) = hentDataForVilkaarsvurdering(behandlingId, brukerTokenInfo)
             val tidligereVilkaarsvurdering =
                 vilkaarsvurderingRepository.hent(kopierFraBehandling)
@@ -180,13 +180,15 @@ class VilkaarsvurderingService(
                         nyVilkaarsvurdering.vilkaar.any { v -> v.vurdering == null }
                 )
             ) {
-                vilkaarsvurderingRepository.slettVilkaarsvurderingResultat(nyVilkaarsvurdering.behandlingId)
+                VilkaarsvuderingMedBehandlingGrunnlagsversjon(
+                    vilkaarsvurderingRepository.slettVilkaarsvurderingResultat(nyVilkaarsvurdering.behandlingId),
+                    grunnlag.metadata.versjon,
+                )
             } else {
                 behandlingKlient.settBehandlingStatusVilkaarsvurdert(behandlingId, brukerTokenInfo)
-                nyVilkaarsvurdering
+                VilkaarsvuderingMedBehandlingGrunnlagsversjon(nyVilkaarsvurdering, grunnlag.metadata.versjon)
             }
         }
-    }
 
     // Her legges det til nye vilkår og det filtreres bort vilkår som ikke lenger er aktuelle.
     // Oppdatering av vilkår med endringer er ennå ikke støttet.
@@ -257,7 +259,7 @@ class VilkaarsvurderingService(
                                 brukerTokenInfo,
                             )
                         VilkaarsvuderingMedBehandlingGrunnlagsversjon(
-                            kopierVilkaarsvurdering(behandlingId, sisteIverksatteBehandling.id, brukerTokenInfo),
+                            kopierVilkaarsvurdering(behandlingId, sisteIverksatteBehandling.id, brukerTokenInfo).vilkaarsvurdering,
                             grunnlag.metadata.versjon,
                         )
                     } else {

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
@@ -66,7 +66,7 @@ class VilkaarsvurderingService(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         resultat: VilkaarsvurderingResultat,
-    ): VilkaarsvuderingMedBehandlingGrunnlagsversjon =
+    ): VilkaarsvurderingMedBehandlingGrunnlagsversjon =
         tilstandssjekkFoerKjoering(behandlingId, brukerTokenInfo) {
             val (behandling, grunnlag) = hentDataForVilkaarsvurdering(behandlingId, brukerTokenInfo)
             val virkningstidspunkt =
@@ -82,7 +82,7 @@ class VilkaarsvurderingService(
                 vilkaarsvurderingRepository.oppdaterGrunnlagsversjon(behandlingId, grunnlag.metadata.versjon)
             }
             behandlingKlient.settBehandlingStatusVilkaarsvurdert(behandlingId, brukerTokenInfo)
-            VilkaarsvuderingMedBehandlingGrunnlagsversjon(vilkaarsvurdering, grunnlag.metadata.versjon)
+            VilkaarsvurderingMedBehandlingGrunnlagsversjon(vilkaarsvurdering, grunnlag.metadata.versjon)
         }
 
     suspend fun slettTotalVurdering(
@@ -137,7 +137,7 @@ class VilkaarsvurderingService(
         kopierFraBehandling: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         kopierResultat: Boolean = true,
-    ): VilkaarsvuderingMedBehandlingGrunnlagsversjon =
+    ): VilkaarsvurderingMedBehandlingGrunnlagsversjon =
         tilstandssjekkFoerKjoering(behandlingId, brukerTokenInfo) {
             logger.info("Oppretter og kopierer vilkårsvurdering for $behandlingId fra $kopierFraBehandling")
             val (behandling, grunnlag) = hentDataForVilkaarsvurdering(behandlingId, brukerTokenInfo)
@@ -180,13 +180,13 @@ class VilkaarsvurderingService(
                         nyVilkaarsvurdering.vilkaar.any { v -> v.vurdering == null }
                 )
             ) {
-                VilkaarsvuderingMedBehandlingGrunnlagsversjon(
+                VilkaarsvurderingMedBehandlingGrunnlagsversjon(
                     vilkaarsvurderingRepository.slettVilkaarsvurderingResultat(nyVilkaarsvurdering.behandlingId),
                     grunnlag.metadata.versjon,
                 )
             } else {
                 behandlingKlient.settBehandlingStatusVilkaarsvurdert(behandlingId, brukerTokenInfo)
-                VilkaarsvuderingMedBehandlingGrunnlagsversjon(nyVilkaarsvurdering, grunnlag.metadata.versjon)
+                VilkaarsvurderingMedBehandlingGrunnlagsversjon(nyVilkaarsvurdering, grunnlag.metadata.versjon)
             }
         }
 
@@ -225,7 +225,7 @@ class VilkaarsvurderingService(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         kopierVedRevurdering: Boolean = true,
-    ): VilkaarsvuderingMedBehandlingGrunnlagsversjon =
+    ): VilkaarsvurderingMedBehandlingGrunnlagsversjon =
         tilstandssjekkFoerKjoering(behandlingId, brukerTokenInfo) {
             vilkaarsvurderingRepository.hent(behandlingId)?.let {
                 throw IllegalArgumentException("Vilkårsvurdering finnes allerede for behandling $behandlingId")
@@ -244,7 +244,7 @@ class VilkaarsvurderingService(
 
             when (behandling.behandlingType) {
                 BehandlingType.FØRSTEGANGSBEHANDLING -> {
-                    VilkaarsvuderingMedBehandlingGrunnlagsversjon(
+                    VilkaarsvurderingMedBehandlingGrunnlagsversjon(
                         opprettNyVilkaarsvurdering(grunnlag, virkningstidspunkt, behandling, behandlingId),
                         grunnlag.metadata.versjon,
                     )
@@ -258,12 +258,12 @@ class VilkaarsvurderingService(
                                 behandling.sak,
                                 brukerTokenInfo,
                             )
-                        VilkaarsvuderingMedBehandlingGrunnlagsversjon(
+                        VilkaarsvurderingMedBehandlingGrunnlagsversjon(
                             kopierVilkaarsvurdering(behandlingId, sisteIverksatteBehandling.id, brukerTokenInfo).vilkaarsvurdering,
                             grunnlag.metadata.versjon,
                         )
                     } else {
-                        VilkaarsvuderingMedBehandlingGrunnlagsversjon(
+                        VilkaarsvurderingMedBehandlingGrunnlagsversjon(
                             opprettNyVilkaarsvurdering(grunnlag, virkningstidspunkt, behandling, behandlingId),
                             grunnlag.metadata.versjon,
                         )

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
@@ -223,7 +223,7 @@ class VilkaarsvurderingService(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         kopierVedRevurdering: Boolean = true,
-    ): Vilkaarsvurdering =
+    ): VilkaarsvuderingMedBehandlingGrunnlagsversjon =
         tilstandssjekkFoerKjoering(behandlingId, brukerTokenInfo) {
             vilkaarsvurderingRepository.hent(behandlingId)?.let {
                 throw IllegalArgumentException("Vilkårsvurdering finnes allerede for behandling $behandlingId")
@@ -242,7 +242,10 @@ class VilkaarsvurderingService(
 
             when (behandling.behandlingType) {
                 BehandlingType.FØRSTEGANGSBEHANDLING -> {
-                    opprettNyVilkaarsvurdering(grunnlag, virkningstidspunkt, behandling, behandlingId)
+                    VilkaarsvuderingMedBehandlingGrunnlagsversjon(
+                        opprettNyVilkaarsvurdering(grunnlag, virkningstidspunkt, behandling, behandlingId),
+                        grunnlag.metadata.versjon,
+                    )
                 }
 
                 BehandlingType.REVURDERING -> {
@@ -253,9 +256,15 @@ class VilkaarsvurderingService(
                                 behandling.sak,
                                 brukerTokenInfo,
                             )
-                        kopierVilkaarsvurdering(behandlingId, sisteIverksatteBehandling.id, brukerTokenInfo)
+                        VilkaarsvuderingMedBehandlingGrunnlagsversjon(
+                            kopierVilkaarsvurdering(behandlingId, sisteIverksatteBehandling.id, brukerTokenInfo),
+                            grunnlag.metadata.versjon,
+                        )
                     } else {
-                        opprettNyVilkaarsvurdering(grunnlag, virkningstidspunkt, behandling, behandlingId)
+                        VilkaarsvuderingMedBehandlingGrunnlagsversjon(
+                            opprettNyVilkaarsvurdering(grunnlag, virkningstidspunkt, behandling, behandlingId),
+                            grunnlag.metadata.versjon,
+                        )
                     }
                 }
             }

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
@@ -66,7 +66,7 @@ class VilkaarsvurderingService(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         resultat: VilkaarsvurderingResultat,
-    ): Vilkaarsvurdering =
+    ): VilkaarsvuderingMedBehandlingGrunnlagsversjon =
         tilstandssjekkFoerKjoering(behandlingId, brukerTokenInfo) {
             val (behandling, grunnlag) = hentDataForVilkaarsvurdering(behandlingId, brukerTokenInfo)
             val virkningstidspunkt =
@@ -82,7 +82,7 @@ class VilkaarsvurderingService(
                 vilkaarsvurderingRepository.oppdaterGrunnlagsversjon(behandlingId, grunnlag.metadata.versjon)
             }
             behandlingKlient.settBehandlingStatusVilkaarsvurdert(behandlingId, brukerTokenInfo)
-            vilkaarsvurdering
+            VilkaarsvuderingMedBehandlingGrunnlagsversjon(vilkaarsvurdering, grunnlag.metadata.versjon)
         }
 
     suspend fun slettTotalVurdering(

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.vilkaarsvurdering
 
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
@@ -183,7 +182,7 @@ class VilkaarsvurderingService(
             ) {
                 vilkaarsvurderingRepository.slettVilkaarsvurderingResultat(nyVilkaarsvurdering.behandlingId)
             } else {
-                runBlocking { behandlingKlient.settBehandlingStatusVilkaarsvurdert(behandlingId, brukerTokenInfo) }
+                behandlingKlient.settBehandlingStatusVilkaarsvurdert(behandlingId, brukerTokenInfo)
                 nyVilkaarsvurdering
             }
         }

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangServiceTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangServiceTest.kt
@@ -94,13 +94,13 @@ class AldersovergangServiceTest {
                 brukerTokenInfo,
                 false,
             )
-        } returns VilkaarsvuderingMedBehandlingGrunnlagsversjon(vilkaarsvurdering, 1L)
+        } returns VilkaarsvurderingMedBehandlingGrunnlagsversjon(vilkaarsvurdering, 1L)
         coEvery {
             vilkaarsvurderingService.oppdaterVurderingPaaVilkaar(behandlingId, brukerTokenInfo, ikkeOppfyltVilkaar)
         } returns vilkaarsvurdering
         coEvery {
             vilkaarsvurderingService.oppdaterTotalVurdering(behandlingId, brukerTokenInfo, vilkaarsvurderingResultat)
-        } returns VilkaarsvuderingMedBehandlingGrunnlagsversjon(vilkaarsvurdering, 1L)
+        } returns VilkaarsvurderingMedBehandlingGrunnlagsversjon(vilkaarsvurdering, 1L)
 
         runBlocking {
             val res =

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangServiceTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangServiceTest.kt
@@ -100,7 +100,7 @@ class AldersovergangServiceTest {
         } returns vilkaarsvurdering
         coEvery {
             vilkaarsvurderingService.oppdaterTotalVurdering(behandlingId, brukerTokenInfo, vilkaarsvurderingResultat)
-        } returns vilkaarsvurdering
+        } returns VilkaarsvuderingMedBehandlingGrunnlagsversjon(vilkaarsvurdering, 1L)
 
         runBlocking {
             val res =

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangServiceTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangServiceTest.kt
@@ -94,7 +94,7 @@ class AldersovergangServiceTest {
                 brukerTokenInfo,
                 false,
             )
-        } returns vilkaarsvurdering
+        } returns VilkaarsvuderingMedBehandlingGrunnlagsversjon(vilkaarsvurdering, 1L)
         coEvery {
             vilkaarsvurderingService.oppdaterVurderingPaaVilkaar(behandlingId, brukerTokenInfo, ikkeOppfyltVilkaar)
         } returns vilkaarsvurdering

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
@@ -238,7 +238,7 @@ internal class VilkaarsvurderingRoutesTest(
                 vilkaarsvurdering(vilkaarsvurderingServiceImpl, behandlingKlient)
             }
 
-            val vilkaarsvurdering = opprettVilkaarsvurdering(vilkaarsvurderingServiceImpl)
+            val (vilkaarsvurdering) = opprettVilkaarsvurdering(vilkaarsvurderingServiceImpl)
 
             val vurdertVilkaarDto =
                 VurdertVilkaarDto(
@@ -284,7 +284,7 @@ internal class VilkaarsvurderingRoutesTest(
                 vilkaarsvurdering(vilkaarsvurderingServiceImpl, behandlingKlient)
             }
 
-            val vilkaarsvurdering = opprettVilkaarsvurdering(vilkaarsvurderingServiceImpl)
+            val (vilkaarsvurdering) = opprettVilkaarsvurdering(vilkaarsvurderingServiceImpl)
 
             val vurdertVilkaarDto =
                 VurdertVilkaarDto(
@@ -370,7 +370,7 @@ internal class VilkaarsvurderingRoutesTest(
                 vilkaarsvurdering(vilkaarsvurderingServiceImpl, behandlingKlient)
             }
 
-            val vilkaarsvurdering = opprettVilkaarsvurdering(vilkaarsvurderingServiceImpl)
+            val (vilkaarsvurdering) = opprettVilkaarsvurdering(vilkaarsvurderingServiceImpl)
 
             val vurdertVilkaarDto =
                 VurdertVilkaarDto(
@@ -473,7 +473,7 @@ internal class VilkaarsvurderingRoutesTest(
                 vilkaarsvurdering(vilkaarsvurderingServiceImpl, behandlingKlient)
             }
 
-            val vilkaarsvurdering = opprettVilkaarsvurdering(vilkaarsvurderingServiceImpl)
+            val (vilkaarsvurdering) = opprettVilkaarsvurdering(vilkaarsvurderingServiceImpl)
             val resultat =
                 VurdertVilkaarsvurderingResultatDto(
                     resultat = VilkaarsvurderingUtfall.OPPFYLT,
@@ -727,7 +727,7 @@ internal class VilkaarsvurderingRoutesTest(
                 vilkaarsvurdering(vilkaarsvurderingServiceImpl, behandlingKlient)
             }
 
-            val vilkaarsvurdering = opprettVilkaarsvurdering(vilkaarsvurderingServiceImpl)
+            val (vilkaarsvurdering) = opprettVilkaarsvurdering(vilkaarsvurderingServiceImpl)
 
             val vurdertVilkaarDto =
                 VurdertVilkaarDto(
@@ -787,7 +787,9 @@ internal class VilkaarsvurderingRoutesTest(
         }
     }
 
-    private fun opprettVilkaarsvurdering(vilkaarsvurderingService: VilkaarsvurderingService): Vilkaarsvurdering =
+    private fun opprettVilkaarsvurdering(
+        vilkaarsvurderingService: VilkaarsvurderingService,
+    ): VilkaarsvuderingMedBehandlingGrunnlagsversjon =
         runBlocking {
             vilkaarsvurderingService.opprettVilkaarsvurdering(behandlingId, oboToken)
         }

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
@@ -789,7 +789,7 @@ internal class VilkaarsvurderingRoutesTest(
 
     private fun opprettVilkaarsvurdering(
         vilkaarsvurderingService: VilkaarsvurderingService,
-    ): VilkaarsvuderingMedBehandlingGrunnlagsversjon =
+    ): VilkaarsvurderingMedBehandlingGrunnlagsversjon =
         runBlocking {
             vilkaarsvurderingService.opprettVilkaarsvurdering(behandlingId, oboToken)
         }

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
@@ -112,7 +112,7 @@ internal class VilkaarsvurderingServiceTest(
 
     @Test
     fun `Skal opprette vilkaarsvurdering for foerstegangsbehandling barnepensjon med grunnlagsopplysninger`() {
-        val vilkaarsvurdering =
+        val (vilkaarsvurdering) =
             runBlocking {
                 service.opprettVilkaarsvurdering(uuid, brukerTokenInfo)
             }
@@ -148,7 +148,7 @@ internal class VilkaarsvurderingServiceTest(
                 every { revurderingsaarsak } returns null
             }
 
-        val vilkaarsvurdering =
+        val (vilkaarsvurdering) =
             runBlocking {
                 service.opprettVilkaarsvurdering(uuid, brukerTokenInfo)
             }
@@ -205,7 +205,7 @@ internal class VilkaarsvurderingServiceTest(
 
         coEvery { grunnlagKlient.hentGrunnlagForBehandling(any(), any()) } returns grunnlag
 
-        val vilkaarsvurdering =
+        val (vilkaarsvurdering) =
             runBlocking {
                 service.opprettVilkaarsvurdering(uuid, brukerTokenInfo)
             }
@@ -458,7 +458,7 @@ internal class VilkaarsvurderingServiceTest(
                 service.hentVilkaarsvurdering(uuid)!!
             }
 
-        val revurderingsvilkaar = runBlocking { service.opprettVilkaarsvurdering(revurderingId, brukerTokenInfo) }
+        val (revurderingsvilkaar) = runBlocking { service.opprettVilkaarsvurdering(revurderingId, brukerTokenInfo) }
         assertIsSimilar(foerstegangsvilkaar, revurderingsvilkaar)
         coVerify(exactly = 1) { behandlingKlient.settBehandlingStatusVilkaarsvurdert(revurderingId, brukerTokenInfo) }
     }
@@ -512,7 +512,7 @@ internal class VilkaarsvurderingServiceTest(
             service.hentVilkaarsvurdering(uuid)!!
         }
 
-        val nyeVilkaar = runBlocking { service.opprettVilkaarsvurdering(revurderingId, brukerTokenInfo, false) }
+        val (nyeVilkaar) = runBlocking { service.opprettVilkaarsvurdering(revurderingId, brukerTokenInfo, false) }
 
         nyeVilkaar.resultat shouldBe null
         nyeVilkaar.vilkaar.forEach { it.vurdering shouldBe null }
@@ -629,7 +629,7 @@ internal class VilkaarsvurderingServiceTest(
 
     @Test
     fun `Er ikke yrkesskade hvis ikke det er en yrkesskade oppfylt delvilkaar`() {
-        val vilkaarsvurdering =
+        val (vilkaarsvurdering) =
             runBlocking {
                 service.opprettVilkaarsvurdering(uuid, brukerTokenInfo)
             }
@@ -641,7 +641,7 @@ internal class VilkaarsvurderingServiceTest(
 
     @Test
     fun `Er yrkesskade hvis det er en yrkesskade oppfylt delvilkaar`() {
-        val vilkaarsvurdering =
+        val (vilkaarsvurdering) =
             runBlocking {
                 service.opprettVilkaarsvurdering(uuid, brukerTokenInfo)
             }
@@ -832,7 +832,8 @@ internal class VilkaarsvurderingServiceTest(
         }
     }
 
-    private suspend fun opprettVilkaarsvurdering(): Vilkaarsvurdering = service.opprettVilkaarsvurdering(uuid, brukerTokenInfo)
+    private suspend fun opprettVilkaarsvurdering(): Vilkaarsvurdering =
+        service.opprettVilkaarsvurdering(uuid, brukerTokenInfo).vilkaarsvurdering
 
     private fun vilkaarsVurderingData() = VilkaarVurderingData("en kommentar", Tidspunkt.now().toLocalDatetimeUTC(), "saksbehandler")
 

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
@@ -391,7 +391,7 @@ internal class VilkaarsvurderingServiceTest(
         }
 
         val vilkaarsvurdering = service.hentVilkaarsvurdering(uuid)!!
-        val kopiertVilkaarsvurdering =
+        val (kopiertVilkaarsvurdering) =
             runBlocking {
                 service.kopierVilkaarsvurdering(
                     nyBehandlingId,
@@ -538,7 +538,7 @@ internal class VilkaarsvurderingServiceTest(
             vilkaar = ikkeGjeldendeVilkaar(),
         )
 
-        val vilkaarsvurderingMedKopierteOppdaterteVilkaar =
+        val (vilkaarsvurderingMedKopierteOppdaterteVilkaar) =
             runBlocking {
                 service.kopierVilkaarsvurdering(nyBehandlingId, opprinneligBehandlingId, brukerTokenInfo)
             }
@@ -580,7 +580,7 @@ internal class VilkaarsvurderingServiceTest(
                 },
         )
 
-        val vilkaarsvurderingMedKopierteOppdaterteVilkaar =
+        val (vilkaarsvurderingMedKopierteOppdaterteVilkaar) =
             runBlocking {
                 service.kopierVilkaarsvurdering(nyBehandlingId, opprinneligBehandlingId, brukerTokenInfo)
             }
@@ -615,7 +615,7 @@ internal class VilkaarsvurderingServiceTest(
                 },
         )
 
-        val vilkaarsvurderingMedKopierteOppdaterteVilkaar =
+        val (vilkaarsvurderingMedKopierteOppdaterteVilkaar) =
             runBlocking {
                 service.kopierVilkaarsvurdering(nyBehandlingId, opprinneligBehandlingId, brukerTokenInfo)
             }


### PR DESCRIPTION
Vi henter grunnlag og behandling i vv dobbelt kun for å vise grunnlagsversjonen for behandlingen som allerede er hentet. Gjenbruker de stedene det allerede er hentet. Eks i grafana tempo: 7eb64364f1b5e3dc548024bd068b7781