### PR TITLE
Løfter og endrer "relevanteMaanederInnAar" til årsoppgjør som "forventaInnvilgedeMaaneder"

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -188,7 +188,7 @@ data class Avkorting(
                     aarsoppgjoer.inntektsavkorting.map { inntektsavkorting ->
                         val periode =
                             Periode(
-                                fom = aarsoppgjoer.foersteMaanedDetteAar(),
+                                fom = aarsoppgjoer.foersteInnvilgedeMaaned(),
                                 tom = inntektsavkorting.grunnlag.periode.tom,
                             )
 
@@ -285,7 +285,7 @@ data class Avkorting(
                     0 -> null
                     else ->
                         AvkortingRegelkjoring.beregnRestanse(
-                            aarsoppgjoer.foersteMaanedDetteAar(),
+                            aarsoppgjoer.foersteInnvilgedeMaaned(),
                             inntektsavkorting,
                             avkortetYtelseMedAllForventetInntekt,
                             kjenteSanksjonerForInntektsavkorting,
@@ -311,7 +311,7 @@ data class Avkorting(
         if (senesteSanksjonFom != null && senesteSanksjonFom >= senesteInntektsjusteringFom) {
             val restanse =
                 AvkortingRegelkjoring.beregnRestanse(
-                    aarsoppgjoer.foersteMaanedDetteAar(),
+                    aarsoppgjoer.foersteInnvilgedeMaaned(),
                     reberegnetInntektsavkorting.last(),
                     avkortetYtelseMedAllForventetInntekt,
                     sorterteSanksjonerInnenforAarsoppgjoer,
@@ -398,16 +398,7 @@ data class Aarsoppgjoer(
     val avkortetYtelseAar: List<AvkortetYtelse> = emptyList(),
 ) {
 
-    /*
-     * Det er tilfeller hvor det er nødvendig å vite når første periode i inneværende begynner.
-     * Ved inngangsår så vil ikke første måned nødvendgivis være januar så det må baseres på fom første periode.
-     */
-    fun foersteMaanedDetteAar(): YearMonth =
-        if (ytelseFoerAvkorting.isEmpty()) {
-            YearMonth.of(aar, 1)
-        } else {
-            ytelseFoerAvkorting.minOf { it.periode.fom }
-        }
+    fun foersteInnvilgedeMaaned(): YearMonth = YearMonth.of(aar, 12 - forventaInnvilgaMaaneder + 1)
 
     /**
      * Gir kun de sanksjonene som har en periode som overlapper med dette årsoppgjøret.

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -75,12 +75,13 @@ data class Avkorting(
         beregning: Beregning,
         sanksjoner: List<Sanksjon>,
     ) = if (behandlingstype == BehandlingType.FØRSTEGANGSBEHANDLING) {
-        oppdaterMedInntektsgrunnlag(nyttGrunnlag, virkningstidspunkt, bruker).beregnAvkortingForstegangs(
+        oppdaterMedInntektsgrunnlag(nyttGrunnlag, virkningstidspunkt, true, bruker).beregnAvkortingForstegangs(
             beregning,
             sanksjoner,
         )
     } else {
-        oppdaterMedInntektsgrunnlag(nyttGrunnlag, virkningstidspunkt, bruker).beregnAvkortingRevurdering(
+        // TODO parameter innvilgelse vil ikke være tilstrekkelig når vi skal revurdere for å endre første virk..
+        oppdaterMedInntektsgrunnlag(nyttGrunnlag, virkningstidspunkt, false, bruker).beregnAvkortingRevurdering(
             beregning,
             sanksjoner,
         )
@@ -89,10 +90,11 @@ data class Avkorting(
     fun oppdaterMedInntektsgrunnlag(
         nyttGrunnlag: AvkortingGrunnlagLagreDto,
         virkningstidspunkt: YearMonth,
+        innvilgelse: Boolean,
         bruker: BrukerTokenInfo,
     ): Avkorting {
         // TODO kreve at det er inneværende år?
-        val aarsoppgjoer = hentAarsoppgjoer(virkningstidspunkt)
+        val aarsoppgjoer = hentAarsoppgjoer(virkningstidspunkt, innvilgelse)
         val oppdatert =
             aarsoppgjoer.inntektsavkorting
                 // Fjerner hvis det finnes fra før for å erstatte/redigere
@@ -106,7 +108,6 @@ data class Avkorting(
                                 periode = Periode(fom = virkningstidspunkt, tom = null),
                                 aarsinntekt = nyttGrunnlag.aarsinntekt,
                                 fratrekkInnAar = nyttGrunnlag.fratrekkInnAar,
-                                relevanteMaanederInnAar = aarsoppgjoer.utledRelevanteMaaneder(virkningstidspunkt),
                                 inntektUtland = nyttGrunnlag.inntektUtland,
                                 fratrekkInnAarUtland = nyttGrunnlag.fratrekkInnAarUtland,
                                 spesifikasjon = nyttGrunnlag.spesifikasjon,
@@ -135,7 +136,8 @@ data class Avkorting(
         val avkortingsperioder =
             AvkortingRegelkjoring.beregnInntektsavkorting(
                 periode = grunnlag.periode,
-                avkortingGrunnlag = listOf(grunnlag),
+                avkortingGrunnlag = grunnlag,
+                aarsoppgjoer.forventaInnvilgaMaaneder,
             )
 
         val avkortetYtelseAar =
@@ -193,7 +195,8 @@ data class Avkorting(
                         val avkortinger =
                             AvkortingRegelkjoring.beregnInntektsavkorting(
                                 periode = periode,
-                                avkortingGrunnlag = listOf(inntektsavkorting.grunnlag.copy(periode = periode)),
+                                avkortingGrunnlag = inntektsavkorting.grunnlag.copy(periode = periode),
+                                aarsoppgjoer.forventaInnvilgaMaaneder,
                             )
 
                         val avkortetYtelseForventetInntekt =
@@ -345,9 +348,23 @@ data class Avkorting(
         return avkortetYtelseMedAllForventetInntekt
     }
 
-    fun hentAarsoppgjoer(fom: YearMonth): Aarsoppgjoer {
-        val funnet = aarsoppgjoer.find { it.aar == fom.year }
-        return funnet ?: Aarsoppgjoer(UUID.randomUUID(), aar = fom.year)
+    /*
+     * Hvilket årsoppgjør som er relevant basers på virkningstidspunkt.
+     * Hvis det ikke finnes et fra før på virkningstidspunkt opprettes et nytt.
+     *
+     * Ved innvilgelse/førstegangsbehandling så skal måneder før virkningsitdspunkt trekkes i fra
+     * forventa innvilgede måneder.
+     */
+    private fun hentAarsoppgjoer(
+        virkningstidspunkt: YearMonth,
+        innvilgelse: Boolean,
+    ): Aarsoppgjoer {
+        val funnet = aarsoppgjoer.find { it.aar == virkningstidspunkt.year }
+        return funnet ?: Aarsoppgjoer(
+            id = UUID.randomUUID(),
+            aar = virkningstidspunkt.year,
+            forventaInnvilgaMaaneder = if (innvilgelse) (12 - virkningstidspunkt.monthValue + 1) else 12,
+        )
     }
 
     private fun erstattAarsoppgjoer(nytt: Aarsoppgjoer): List<Aarsoppgjoer> {
@@ -366,7 +383,6 @@ data class AvkortingGrunnlag(
     val periode: Periode,
     val aarsinntekt: Int,
     val fratrekkInnAar: Int,
-    val relevanteMaanederInnAar: Int,
     val inntektUtland: Int,
     val fratrekkInnAarUtland: Int,
     val spesifikasjon: String,
@@ -376,25 +392,11 @@ data class AvkortingGrunnlag(
 data class Aarsoppgjoer(
     val id: UUID,
     val aar: Int,
+    val forventaInnvilgaMaaneder: Int,
     val ytelseFoerAvkorting: List<YtelseFoerAvkorting> = emptyList(),
     val inntektsavkorting: List<Inntektsavkorting> = emptyList(),
     val avkortetYtelseAar: List<AvkortetYtelse> = emptyList(),
 ) {
-    /*
-     * Relevante månder (innvilga måneder i gjeldende år) viderføres i alle grunnlagsperioder. så når man skal
-     * utlede det til ny inntektsperiode kan man ta fra hvilken som helst periode i gjeldende år.
-     * Hvis det ikke finnes noen inntekt for gjeldende år enda (førstegangsbehandling) regnes den ut basert på
-     *  ny virk/innvilgelsesdato.
-     */
-    fun utledRelevanteMaaneder(virkningstidspunkt: YearMonth): Int {
-        val aaretsFoersteForventaInntekt =
-            inntektsavkorting
-                .sortedBy { it.grunnlag.periode.fom }
-                .firstOrNull {
-                    it.grunnlag.periode.fom.year == virkningstidspunkt.year
-                }?.grunnlag
-        return aaretsFoersteForventaInntekt?.relevanteMaanederInnAar ?: (12 - virkningstidspunkt.monthValue + 1)
-    }
 
     /*
      * Det er tilfeller hvor det er nødvendig å vite når første periode i inneværende begynner.

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
@@ -31,7 +31,8 @@ object AvkortingRegelkjoring {
 
     fun beregnInntektsavkorting(
         periode: Periode,
-        avkortingGrunnlag: List<AvkortingGrunnlag>,
+        avkortingGrunnlag: AvkortingGrunnlag,
+        innvilgaMaaneder: Int,
     ): List<Avkortingsperiode> {
         logger.info("Beregner inntektsavkorting")
 
@@ -39,7 +40,7 @@ object AvkortingRegelkjoring {
             PeriodisertInntektAvkortingGrunnlag(
                 periodisertInntektAvkortingGrunnlag =
                     PeriodisertBeregningGrunnlag.lagGrunnlagMedDefaultUtenforPerioder(
-                        avkortingGrunnlag
+                        listOf(avkortingGrunnlag)
                             .map {
                                 GrunnlagMedPeriode(
                                     data = it,
@@ -54,7 +55,7 @@ object AvkortingRegelkjoring {
                                             fratrekkInnAar = Beregningstall(it.fratrekkInnAar),
                                             inntektUtland = Beregningstall(it.inntektUtland),
                                             fratrekkInnAarUtland = Beregningstall(it.fratrekkInnAarUtland),
-                                            relevanteMaaneder = Beregningstall(it.relevanteMaanederInnAar),
+                                            relevanteMaaneder = Beregningstall(innvilgaMaaneder),
                                             it.id,
                                         ),
                                     kilde = it.kilde,

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
@@ -30,6 +30,7 @@ class AvkortingRepository(
                                 Aarsoppgjoer(
                                     id = row.uuid("id"),
                                     aar = row.int("aar"),
+                                    forventaInnvilgaMaaneder = row.string("innvilga_maaneder").toInt(),
                                 )
                             }.asList,
                     )
@@ -122,9 +123,7 @@ class AvkortingRepository(
                                 )
                             }
 
-                        Aarsoppgjoer(
-                            id = aarsoppgjoer.id,
-                            aar = aarsoppgjoer.aar,
+                        aarsoppgjoer.copy(
                             ytelseFoerAvkorting = ytelseFoerAvkorting,
                             inntektsavkorting = inntektsavkorting,
                             avkortetYtelseAar = avkortetYtelseAar,
@@ -214,9 +213,9 @@ class AvkortingRepository(
         statement =
             """
             INSERT INTO avkorting_aarsoppgjoer(
-            	id, behandling_id, sak_id, aar
+            	id, behandling_id, sak_id, aar, innvilga_maaneder
             ) VALUES (
-            	:id, :behandling_id, :sak_id, :aar
+            	:id, :behandling_id, :sak_id, :aar, :innvilga_maaneder
             )
             """.trimIndent(),
         paramMap =
@@ -225,6 +224,7 @@ class AvkortingRepository(
                 "behandling_id" to behandlingId,
                 "sak_id" to sakId,
                 "aar" to aarsoppgjoer.aar,
+                "innvilga_maaneder" to aarsoppgjoer.forventaInnvilgaMaaneder,
             ),
     ).let { query -> tx.run(query.asUpdate) }
 
@@ -238,10 +238,10 @@ class AvkortingRepository(
             """
             INSERT INTO avkortingsgrunnlag(
                 id, behandling_id, fom, tom, aarsinntekt, fratrekk_inn_ut, inntekt_utland, fratrekk_inn_aar_utland,
-                relevante_maaneder, spesifikasjon, kilde, aarsoppgjoer_id
+                spesifikasjon, kilde, aarsoppgjoer_id
             ) VALUES (
                 :id, :behandlingId, :fom, :tom, :aarsinntekt, :fratrekkInnAar, :inntektUtland, :fratrekkInnAarUtland,
-                :relevanteMaanederInnAar, :spesifikasjon, :kilde, :aarsoppgjoerId
+                :spesifikasjon, :kilde, :aarsoppgjoerId
             )
             """.trimIndent(),
         paramMap =
@@ -255,7 +255,6 @@ class AvkortingRepository(
                 "fratrekkInnAar" to avkortingsgrunnlag.fratrekkInnAar,
                 "inntektUtland" to avkortingsgrunnlag.inntektUtland,
                 "fratrekkInnAarUtland" to avkortingsgrunnlag.fratrekkInnAarUtland,
-                "relevanteMaanederInnAar" to avkortingsgrunnlag.relevanteMaanederInnAar,
                 "spesifikasjon" to avkortingsgrunnlag.spesifikasjon,
                 "kilde" to avkortingsgrunnlag.kilde.toJson(),
             ),
@@ -399,7 +398,6 @@ class AvkortingRepository(
                 ),
             aarsinntekt = int("aarsinntekt"),
             fratrekkInnAar = int("fratrekk_inn_ut"),
-            relevanteMaanederInnAar = int("relevante_maaneder"),
             inntektUtland = int("inntekt_utland"),
             fratrekkInnAarUtland = int("fratrekk_inn_aar_utland"),
             spesifikasjon = string("spesifikasjon"),

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -81,12 +81,15 @@ fun Route.avkorting(
 fun Avkorting.toDto() =
     AvkortingDto(
         // TODO erstatt single
-        avkortingGrunnlag = aarsoppgjoer.single().inntektsavkorting.map { it.grunnlag.toDto() },
+        avkortingGrunnlag =
+            aarsoppgjoer.single().inntektsavkorting.map {
+                it.grunnlag.toDto(aarsoppgjoer.single().forventaInnvilgaMaaneder)
+            },
         avkortetYtelse = avkortetYtelseFraVirkningstidspunkt.map { it.toDto() },
         tidligereAvkortetYtelse = avkortetYtelseForrigeVedtak.map { it.toDto() },
     )
 
-fun AvkortingGrunnlag.toDto() =
+fun AvkortingGrunnlag.toDto(forventaInnvilgaMaaneder: Int) =
     AvkortingGrunnlagDto(
         id = id,
         fom = periode.fom,
@@ -95,6 +98,7 @@ fun AvkortingGrunnlag.toDto() =
         fratrekkInnAar = fratrekkInnAar,
         inntektUtland = inntektUtland,
         fratrekkInnAarUtland = fratrekkInnAarUtland,
+        forventaInnvilgaMaaneder = forventaInnvilgaMaaneder,
         spesifikasjon = spesifikasjon,
         kilde = AvkortingGrunnlagKildeDto(kilde.tidspunkt.toString(), kilde.ident),
     )

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -80,6 +80,7 @@ fun Route.avkorting(
 
 fun Avkorting.toDto() =
     AvkortingDto(
+        // TODO erstatt single
         avkortingGrunnlag = aarsoppgjoer.single().inntektsavkorting.map { it.grunnlag.toDto() },
         avkortetYtelse = avkortetYtelseFraVirkningstidspunkt.map { it.toDto() },
         tidligereAvkortetYtelse = avkortetYtelseForrigeVedtak.map { it.toDto() },
@@ -92,7 +93,6 @@ fun AvkortingGrunnlag.toDto() =
         tom = periode.tom,
         aarsinntekt = aarsinntekt,
         fratrekkInnAar = fratrekkInnAar,
-        relevanteMaanederInnAar = relevanteMaanederInnAar,
         inntektUtland = inntektUtland,
         fratrekkInnAarUtland = fratrekkInnAarUtland,
         spesifikasjon = spesifikasjon,

--- a/apps/etterlatte-beregning/src/main/kotlin/ytelseMedGrunnlag/YtelseMedGrunnlagService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/ytelseMedGrunnlag/YtelseMedGrunnlagService.kt
@@ -32,10 +32,10 @@ class YtelseMedGrunnlagService(
                         .filter { it.datoFOM <= avkortetYtelse.periode.fom }
                         .maxBy { it.datoFOM }
 
+                // TODO erstatt single..
+                val aarsoppgjoer = avkorting.aarsoppgjoer.single()
                 val avkortingsgrunnlagIPeriode =
-                    avkorting.aarsoppgjoer
-                        .single()
-                        .inntektsavkorting
+                    aarsoppgjoer.inntektsavkorting
                         .filter { it.grunnlag.periode.fom <= avkortetYtelse.periode.fom }
                         .maxBy { it.grunnlag.periode.fom }
 
@@ -52,7 +52,7 @@ class YtelseMedGrunnlagService(
                     trygdetid = beregningIPeriode.trygdetid,
                     aarsinntekt = aarsinntekt,
                     fratrekkInnAar = fratrekkInnAar,
-                    relevanteMaanederInnAar = grunnlag.relevanteMaanederInnAar,
+                    relevanteMaanederInnAar = aarsoppgjoer.forventaInnvilgaMaaneder,
                     grunnbelop = beregningIPeriode.grunnbelop,
                     grunnbelopMnd = beregningIPeriode.grunnbelopMnd,
                     beregningsMetode = beregningIPeriode.beregningsMetode,

--- a/apps/etterlatte-beregning/src/main/resources/db/migration/V47__innvilga_maaneder_aarsoppgjoer.sql
+++ b/apps/etterlatte-beregning/src/main/resources/db/migration/V47__innvilga_maaneder_aarsoppgjoer.sql
@@ -1,0 +1,7 @@
+ALTER TABLE avkorting_aarsoppgjoer ADD COLUMN innvilga_maaneder TEXT;
+
+update avkorting_aarsoppgjoer set innvilga_maaneder = grunnlag.relevante_maaneder
+from (select * from avkortingsgrunnlag) grunnlag
+where avkorting_aarsoppgjoer.id = grunnlag.aarsoppgjoer_id;
+
+ALTER TABLE avkorting_aarsoppgjoer  ALTER COLUMN innvilga_maaneder SET NOT NULL;

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -112,9 +112,9 @@ fun avkorting(
     aarsoppgjoer =
         listOf(
             aarsoppgjoer(
-                ytelseFoerAvkorting,
-                inntektsavkorting,
-                avkortetYtelseAar,
+                ytelseFoerAvkorting = ytelseFoerAvkorting,
+                inntektsavkorting = inntektsavkorting,
+                avkortetYtelseAar = avkortetYtelseAar,
             ),
         ),
 )
@@ -123,7 +123,6 @@ fun avkortinggrunnlag(
     id: UUID = UUID.randomUUID(),
     aarsinntekt: Int = 100000,
     fratrekkInnAar: Int = 10000,
-    relevanteMaanederInnAar: Int = 12,
     periode: Periode = Periode(fom = YearMonth.of(2024, 1), tom = null),
     kilde: Grunnlagsopplysning.Saksbehandler = Grunnlagsopplysning.Saksbehandler.create("Z123456"),
 ) = AvkortingGrunnlag(
@@ -133,7 +132,6 @@ fun avkortinggrunnlag(
     fratrekkInnAar = fratrekkInnAar,
     inntektUtland = 0,
     fratrekkInnAarUtland = 0,
-    relevanteMaanederInnAar = relevanteMaanederInnAar,
     spesifikasjon = "Spesifikasjon",
     kilde = kilde,
 )
@@ -174,12 +172,15 @@ fun inntektAvkortingGrunnlag(
 )
 
 fun aarsoppgjoer(
+    aar: Int = 2024,
+    forventaInnvilgaMaaneder: Int = 12,
     ytelseFoerAvkorting: List<YtelseFoerAvkorting> = emptyList(),
     inntektsavkorting: List<Inntektsavkorting> = emptyList(),
     avkortetYtelseAar: List<AvkortetYtelse> = emptyList(),
 ) = Aarsoppgjoer(
     id = UUID.randomUUID(),
-    aar = 2024,
+    aar = aar,
+    forventaInnvilgaMaaneder = forventaInnvilgaMaaneder,
     ytelseFoerAvkorting = ytelseFoerAvkorting,
     inntektsavkorting = inntektsavkorting,
     avkortetYtelseAar = avkortetYtelseAar,

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRegelkjoringTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRegelkjoringTest.kt
@@ -2,13 +2,11 @@ package no.nav.etterlatte.avkorting
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import no.nav.etterlatte.beregning.grunnlag.PeriodiseringAvGrunnlagFeil
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
 import no.nav.etterlatte.beregning.regler.avkortingsperiode
 import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import java.time.Month
 import java.time.YearMonth
 import java.util.UUID
@@ -18,70 +16,32 @@ class AvkortingRegelkjoringTest {
     fun `skal beregne avkorting for inntekt til en foerstegangsbehandling`() {
         val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, Month.JANUARY))
         val avkortingGrunnlag =
-            listOf(
-                avkortinggrunnlag(
-                    aarsinntekt = 300000,
-                    fratrekkInnAar = 50000,
-                    relevanteMaanederInnAar = 10,
-                    periode = Periode(fom = YearMonth.of(2024, Month.JANUARY), tom = YearMonth.of(2024, Month.FEBRUARY)),
-                ),
-                avkortinggrunnlag(
-                    aarsinntekt = 600000,
-                    fratrekkInnAar = 100000,
-                    relevanteMaanederInnAar = 10,
-                    periode = Periode(fom = YearMonth.of(2024, Month.MARCH), tom = null),
-                ),
+            avkortinggrunnlag(
+                aarsinntekt = 300000,
+                fratrekkInnAar = 50000,
+                periode = Periode(fom = YearMonth.of(2024, Month.JANUARY), tom = null),
             )
 
         val avkortingsperioder =
             AvkortingRegelkjoring.beregnInntektsavkorting(
                 Periode(fom = virkningstidspunkt.dato, tom = null),
                 avkortingGrunnlag,
+                12,
             )
 
         with(avkortingsperioder[0]) {
             regelResultat shouldNotBe null
             tidspunkt shouldNotBe null
             periode.fom shouldBe YearMonth.of(2024, Month.JANUARY)
-            periode.tom shouldBe YearMonth.of(2024, Month.FEBRUARY)
-            avkorting shouldBe 9026
+            periode.tom shouldBe YearMonth.of(2024, Month.APRIL)
+            avkorting shouldBe 7151
         }
         with(avkortingsperioder[1]) {
             regelResultat shouldNotBe null
             tidspunkt shouldNotBe null
-            periode.fom shouldBe YearMonth.of(2024, Month.MARCH)
-            periode.tom shouldBe YearMonth.of(2024, Month.APRIL)
-            avkorting shouldBe 20276
-        }
-        with(avkortingsperioder[2]) {
-            regelResultat shouldNotBe null
-            tidspunkt shouldNotBe null
             periode.fom shouldBe YearMonth.of(2024, Month.MAY)
             periode.tom shouldBe null
-            avkorting shouldBe 20174
-        }
-    }
-
-    @Test
-    fun `skal ikke tillate aa beregne avkorting for inntekt med feil perioder`() {
-        val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, Month.JANUARY))
-        val avkortingGrunnlag =
-            listOf(
-                avkortinggrunnlag(
-                    aarsinntekt = 300000,
-                    periode = Periode(fom = YearMonth.of(2024, Month.JANUARY), tom = null),
-                ),
-                avkortinggrunnlag(
-                    aarsinntekt = 500000,
-                    periode = Periode(fom = YearMonth.of(2024, Month.APRIL), tom = null),
-                ),
-            )
-
-        assertThrows<PeriodiseringAvGrunnlagFeil> {
-            AvkortingRegelkjoring.beregnInntektsavkorting(
-                Periode(fom = virkningstidspunkt.dato, tom = null),
-                avkortingGrunnlag,
-            )
+            avkorting shouldBe 7049
         }
     }
 

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
@@ -29,7 +29,7 @@ internal class AvkortingRepositoryTest(
     @Test
     fun `Skal lagre og oppdatere avkorting`() {
         val behandlingId: UUID = UUID.randomUUID()
-        val aarsoppgjoer = nyAvkorting(2024, avkortinggrunnlag())
+        val aarsoppgjoer = nyAvkorting(2024, grunnlag = avkortinggrunnlag())
 
         avkortingRepository.lagreAvkorting(
             behandlingId,
@@ -58,7 +58,7 @@ internal class AvkortingRepositoryTest(
                 avkortetYtelseAar = aarsoppgjoer.avkortetYtelseAar.map { it.copy(avkortingsbeloep = 444) },
             )
 
-        val nyttArsoppgjoer = nyAvkorting(2025, avkortinggrunnlag())
+        val nyttArsoppgjoer = nyAvkorting(2025, grunnlag = avkortinggrunnlag())
 
         avkortingRepository.lagreAvkorting(
             behandlingId,
@@ -118,10 +118,12 @@ internal class AvkortingRepositoryTest(
 
     private fun nyAvkorting(
         aar: Int,
+        forventaInnvilgaMaaneder: Int = 12,
         grunnlag: AvkortingGrunnlag,
     ) = Aarsoppgjoer(
         id = UUID.randomUUID(),
         aar = aar,
+        forventaInnvilgaMaaneder = forventaInnvilgaMaaneder,
         ytelseFoerAvkorting = listOf(ytelseFoerAvkorting()),
         inntektsavkorting =
             listOf(

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
@@ -119,6 +119,7 @@ class AvkortingRoutesTest {
                             spesifikasjon = "Spesifikasjon",
                             inntektUtland = 0,
                             fratrekkInnAarUtland = 0,
+                            forventaInnvilgaMaaneder = 12,
                             kilde =
                                 AvkortingGrunnlagKildeDto(
                                     tidspunkt = tidspunkt.toString(),

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
@@ -116,7 +116,6 @@ class AvkortingRoutesTest {
                             tom = dato,
                             aarsinntekt = 100000,
                             fratrekkInnAar = 10000,
-                            relevanteMaanederInnAar = 12,
                             spesifikasjon = "Spesifikasjon",
                             inntektUtland = 0,
                             fratrekkInnAarUtland = 0,

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingTest.kt
@@ -1320,7 +1320,7 @@ class BeregnAvkortingTest {
     @Test
     fun `Revurdering inntektsendring nytt år`() {
         val avkorting = `Revurdering ny inntekt for nytt år`()
-        with(avkorting.hentAarsoppgjoer(YearMonth.of(2024, 1)).avkortetYtelseAar) {
+        with(avkorting.aarsoppgjoer[0].avkortetYtelseAar) {
             size shouldBe 5
             get(0).asClue {
                 it.shouldBeEqualToIgnoringFields(
@@ -1452,7 +1452,7 @@ class BeregnAvkortingTest {
                 )
             }
         }
-        with(avkorting.hentAarsoppgjoer(YearMonth.of(2025, 1)).avkortetYtelseAar) {
+        with(avkorting.aarsoppgjoer[1].avkortetYtelseAar) {
             size shouldBe 1
             get(0).asClue {
                 it.shouldBeEqualToIgnoringFields(
@@ -1483,7 +1483,7 @@ class BeregnAvkortingTest {
     @Test
     fun `Revurdering på tvers av år`() {
         val avkorting = `Revurdering med virk tilbake i tidligere år`()
-        with(avkorting.hentAarsoppgjoer(YearMonth.of(2024, 1)).avkortetYtelseAar) {
+        with(avkorting.aarsoppgjoer[0].avkortetYtelseAar) {
             size shouldBe 6
             get(0).asClue {
                 it.shouldBeEqualToIgnoringFields(
@@ -1651,7 +1651,7 @@ class BeregnAvkortingTest {
                 )
             }
         }
-        with(avkorting.hentAarsoppgjoer(YearMonth.of(2025, 1)).avkortetYtelseAar) {
+        with(avkorting.aarsoppgjoer[1].avkortetYtelseAar) {
             size shouldBe 1
             get(0).asClue {
                 it.shouldBeEqualToIgnoringFields(
@@ -1682,7 +1682,7 @@ class BeregnAvkortingTest {
     @Test
     fun `Revurdering enda en inntektsendring nytt år`() {
         val avkorting = `Revurdering enda en ny inntekt nytt år`()
-        with(avkorting.hentAarsoppgjoer(YearMonth.of(2024, 1)).avkortetYtelseAar) {
+        with(avkorting.aarsoppgjoer[0].avkortetYtelseAar) {
             size shouldBe 6
             get(0).asClue {
                 it.shouldBeEqualToIgnoringFields(
@@ -1850,7 +1850,7 @@ class BeregnAvkortingTest {
                 )
             }
         }
-        with(avkorting.hentAarsoppgjoer(YearMonth.of(2025, 1)).avkortetYtelseAar) {
+        with(avkorting.aarsoppgjoer[1].avkortetYtelseAar) {
             size shouldBe 1
             get(0).asClue {
                 it.shouldBeEqualToIgnoringFields(
@@ -1876,7 +1876,7 @@ class BeregnAvkortingTest {
                 it.restanse shouldBe null
             }
         }
-        with(avkorting.hentAarsoppgjoer(YearMonth.of(2026, 1)).avkortetYtelseAar) {
+        with(avkorting.aarsoppgjoer[2].avkortetYtelseAar) {
             size shouldBe 1
             get(0).asClue {
                 it.shouldBeEqualToIgnoringFields(

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -193,7 +193,7 @@ export const AvkortingInntekt = ({
                     <Table.DataCell key="InntektTotalt">
                       {NOK(forventetInntekt + forventetInntektUtland)}
                     </Table.DataCell>
-                    <Table.DataCell>{inntektsgrunnlag.relevanteMaanederInnAar}</Table.DataCell>
+                    <Table.DataCell>{inntektsgrunnlag.forventaInnvilgaMaaneder}</Table.DataCell>
                     <Table.DataCell key="Periode">
                       {inntektsgrunnlag.fom && formaterStringDato(inntektsgrunnlag.fom)} -{' '}
                       {inntektsgrunnlag.tom && formaterDato(lastDayOfMonth(new Date(inntektsgrunnlag.tom)))}

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
@@ -11,7 +11,7 @@ export interface IAvkortingGrunnlag {
   tom?: string
   aarsinntekt: number
   fratrekkInnAar: number
-  relevanteMaanederInnAar: number
+  forventaInnvilgaMaaneder: number
   inntektUtland: number
   fratrekkInnAarUtland: number
   spesifikasjon: string

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/domain/Beregning.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/domain/Beregning.kt
@@ -153,7 +153,7 @@ data class AvkortingGrunnlag(
                 tom = dto.tom,
                 aarsinntekt = dto.aarsinntekt,
                 fratrekkInnAar = dto.fratrekkInnAar,
-                relevanteMaanederInnAar = dto.relevanteMaanederInnAar,
+                relevanteMaanederInnAar = dto.forventaInnvilgaMaaneder,
                 spesifikasjon = dto.spesifikasjon,
             )
     }

--- a/libs/etterlatte-beregning-model/src/main/kotlin/BeregningDTO.kt
+++ b/libs/etterlatte-beregning-model/src/main/kotlin/BeregningDTO.kt
@@ -59,6 +59,7 @@ data class AvkortingGrunnlagDto(
     val fratrekkInnAar: Int,
     val inntektUtland: Int,
     val fratrekkInnAarUtland: Int,
+    val forventaInnvilgaMaaneder: Int,
     val spesifikasjon: String,
     val kilde: AvkortingGrunnlagKildeDto,
 )

--- a/libs/etterlatte-beregning-model/src/main/kotlin/BeregningDTO.kt
+++ b/libs/etterlatte-beregning-model/src/main/kotlin/BeregningDTO.kt
@@ -57,7 +57,6 @@ data class AvkortingGrunnlagDto(
     val tom: YearMonth?,
     val aarsinntekt: Int,
     val fratrekkInnAar: Int,
-    val relevanteMaanederInnAar: Int,
     val inntektUtland: Int,
     val fratrekkInnAarUtland: Int,
     val spesifikasjon: String,


### PR DESCRIPTION


Det vil alltid forbli det samme etter årsoppgjøret blir opprettet til et eventuelt opphør som først håndteres i et etteroppgjør.