### PR TITLE
Fjernet protokoll fra integrasjonsverdier i dok slik at det ikke genereres klikkbare lenker

### DIFF
--- a/apps/etterlatte-samordning-vedtak/README.md
+++ b/apps/etterlatte-samordning-vedtak/README.md
@@ -50,10 +50,10 @@ Det må foreligge et tjenestepensjonsforhold og -ytelse i Tjenestepensjonsregist
 
 ## Integrasjon
 
-| Miljø | Ingress                                                 |
-|:------|:--------------------------------------------------------|
-| dev   | https://etterlatte-samordning-vedtak.ekstern.dev.nav.no |
-| prod  | https://etterlatte-samordning-vedtak.nav.no             |    
+| Miljø | Ingress                                         |
+|:------|:------------------------------------------------|
+| dev   | etterlatte-samordning-vedtak.ekstern.dev.nav.no |
+| prod  | etterlatte-samordning-vedtak.nav.no             |    
 
 ## Feilkoder
 


### PR DESCRIPTION
bakgrunn er at jeg fikk et spørsmål vedr at lenkene ikke fungerte, noe som jo aldri har vært intensjonen