### PR TITLE
leggInnNyttGrunnlagSak alltid

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
@@ -67,7 +67,7 @@ class BehandlingFactory(
         logger.info("Oppretter sak og behandling for persongalleri: ${request.persongalleri}, saktype ${request.sakType}")
         val soeker = request.persongalleri.soeker
 
-        val sak = inTransaction { sakService.finnEllerOpprettSak(soeker, request.sakType) }
+        val sak = inTransaction { sakService.finnEllerOpprettSakMedGrunnlag(soeker, request.sakType) }
 
         if (
             sak.enhet != request.enhet &&

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
@@ -148,7 +148,7 @@ class DoedshendelseJobService(
     private fun opprettSakOgLagGrunnlag(doedshendelse: DoedshendelseInternal): Sak {
         logger.info("Oppretter sak for dødshendelse ${doedshendelse.id} avdøed ${doedshendelse.avdoedFnr.maskerFnr()}")
         val opprettetSak =
-            sakService.finnEllerOpprettSak(
+            sakService.finnEllerOpprettSakMedGrunnlag(
                 fnr = doedshendelse.beroertFnr,
                 type = doedshendelse.sakTypeForEpsEllerBarn(),
             )

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakRoutes.kt
@@ -99,7 +99,7 @@ internal fun Route.sakSystemRoutes(
         withFoedselsnummerInternal(tilgangService) { fnr ->
             val type: SakType =
                 enumValueOf(requireNotNull(call.parameters["type"]) { "Må ha en Saktype for å finne eller opprette sak" })
-            val message = inTransaction { sakService.finnEllerOpprettSak(fnr = fnr.value, type) }
+            val message = inTransaction { sakService.finnEllerOpprettSakMedGrunnlag(fnr = fnr.value, type) }
             requestLogger.loggRequest(brukerTokenInfo, fnr, "personer/saker")
             call.respond(message)
         }
@@ -259,7 +259,7 @@ internal fun Route.sakWebRoutes(
                     val sak =
                         inTransaction {
                             if (opprettHvisIkkeFinnes) {
-                                sakService.opprettSakMedGrunnlag(fnr.value, type)
+                                sakService.finnEllerOpprettSakMedGrunnlag(fnr.value, type)
                             } else {
                                 sakService.finnSak(fnr.value, type)
                             }

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
@@ -43,13 +43,7 @@ interface SakService {
 
     fun finnSaker(person: String): List<Sak>
 
-    fun opprettSakMedGrunnlag(
-        fnr: String,
-        type: SakType,
-        overstyrendeEnhet: String? = null,
-    ): Sak
-
-    fun finnEllerOpprettSak(
+    fun finnEllerOpprettSakMedGrunnlag(
         fnr: String,
         type: SakType,
         overstyrendeEnhet: String? = null,
@@ -179,7 +173,7 @@ class SakServiceImpl(
         dao.markerSakerMedSkjerming(sakIder, skjermet)
     }
 
-    override fun opprettSakMedGrunnlag(
+    override fun finnEllerOpprettSakMedGrunnlag(
         fnr: String,
         type: SakType,
         overstyrendeEnhet: String?,
@@ -216,7 +210,7 @@ class SakServiceImpl(
             } ?: Spraak.NB
     }
 
-    override fun finnEllerOpprettSak(
+    private fun finnEllerOpprettSak(
         fnr: String,
         type: SakType,
         overstyrendeEnhet: String?,

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
@@ -624,7 +624,7 @@ class BehandlingFactoryTest {
                 sendeBrev = true,
             )
 
-        every { sakServiceMock.finnEllerOpprettSak(any(), any()) } returns sak
+        every { sakServiceMock.finnEllerOpprettSakMedGrunnlag(any(), any()) } returns sak
         every { sakServiceMock.finnSak(any<Long>()) } returns sak
         every { behandlingDaoMock.opprettBehandling(capture(behandlingOpprettes)) } just Runs
         every { behandlingDaoMock.hentBehandling(capture(behandlingHentes)) } returns opprettetBehandling
@@ -659,7 +659,7 @@ class BehandlingFactoryTest {
         Assertions.assertEquals(behandlingHentes.captured, behandlingOpprettes.captured.id)
 
         verify(exactly = 1) {
-            sakServiceMock.finnEllerOpprettSak(persongalleri.soeker, SakType.BARNEPENSJON)
+            sakServiceMock.finnEllerOpprettSakMedGrunnlag(persongalleri.soeker, SakType.BARNEPENSJON)
             sakServiceMock.finnSak(sak.id)
             behandlingDaoMock.opprettBehandling(any())
             hendelseDaoMock.behandlingOpprettet(any())

--- a/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattServiceTest.kt
@@ -62,24 +62,24 @@ internal class EgenAnsattServiceTest(
     private lateinit var egenAnsattService: EgenAnsattService
     private lateinit var user: SaksbehandlerMedEnheterOgRoller
     private val hendelser: BehandlingHendelserKafkaProducer = mockk()
-    private val krrKlient =
-        mockk<KrrKlient> {
-            coEvery { hentDigitalKontaktinformasjon(any()) } returns
-                DigitalKontaktinformasjon(
-                    personident = "",
-                    aktiv = true,
-                    kanVarsles = true,
-                    reservert = false,
-                    spraak = "nb",
-                    epostadresse = null,
-                    mobiltelefonnummer = null,
-                    sikkerDigitalPostkasse = null,
-                )
-        }
     private val pdlTjenesterKlient = spyk<PdltjenesterKlientTest>()
 
     @BeforeAll
     fun beforeAll() {
+        val krrKlient =
+            mockk<KrrKlient> {
+                coEvery { hentDigitalKontaktinformasjon(any()) } returns
+                    DigitalKontaktinformasjon(
+                        personident = "",
+                        aktiv = true,
+                        kanVarsles = true,
+                        reservert = false,
+                        spraak = "nb",
+                        epostadresse = null,
+                        mobiltelefonnummer = null,
+                        sikkerDigitalPostkasse = null,
+                    )
+            }
         val norg2Klient = mockk<Norg2Klient>()
         val grunnlagservice =
             mockk<GrunnlagService> {

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobServiceTest.kt
@@ -48,7 +48,7 @@ class DoedshendelseJobServiceTest {
     private val kontekst = Context(Self(this::class.java.simpleName), DatabaseContextTest(dataSource), mockk())
     private val sakService =
         mockk<SakService> {
-            every { finnEllerOpprettSak(any(), any()) } returns
+            every { finnEllerOpprettSakMedGrunnlag(any(), any()) } returns
                 Sak(
                     ident = "12345678901",
                     sakType = SakType.BARNEPENSJON,

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakServiceTest.kt
@@ -50,37 +50,38 @@ import org.junit.jupiter.api.assertThrows
 import kotlin.random.Random
 
 internal class SakServiceTest {
-    private val pdlTjenesterKlient = spyk<PdltjenesterKlientTest>()
-    private val sakDao = mockk<SakDao>()
-    private val norg2Klient = mockk<Norg2Klient>()
-    private val brukerService = BrukerServiceImpl(pdlTjenesterKlient, norg2Klient)
-    private val saksbehandlerService = mockk<SaksbehandlerService>()
-    private val skjermingKlient = mockk<SkjermingKlient>()
-    private val grunnlagservice =
-        mockk<GrunnlagService> {
-            every { leggInnNyttGrunnlagSak(any(), any()) } just runs
-            every { leggTilNyeOpplysningerBareSak(any(), any()) } just runs
-        }
-    private val krrKlient =
-        mockk<KrrKlient> {
-            coEvery { hentDigitalKontaktinformasjon(any()) } returns
-                DigitalKontaktinformasjon(
-                    personident = "",
-                    aktiv = true,
-                    kanVarsles = true,
-                    reservert = false,
-                    spraak = "nb",
-                    epostadresse = null,
-                    mobiltelefonnummer = null,
-                    sikkerDigitalPostkasse = null,
-                )
-        }
-
-    private val service = SakServiceImpl(sakDao, skjermingKlient, brukerService, grunnlagservice, krrKlient, pdlTjenesterKlient)
+    private lateinit var service: SakService
+    val pdlTjenesterKlient = spyk<PdltjenesterKlientTest>()
+    val norg2Klient = mockk<Norg2Klient>()
+    val brukerService = BrukerServiceImpl(pdlTjenesterKlient, norg2Klient)
+    val saksbehandlerService = mockk<SaksbehandlerService>()
+    val skjermingKlient = mockk<SkjermingKlient>()
+    val sakDao = mockk<SakDao>()
 
     @BeforeEach
     fun before() {
         clearAllMocks()
+        val grunnlagservice =
+            mockk<GrunnlagService> {
+                every { leggInnNyttGrunnlagSak(any(), any()) } just runs
+                every { leggTilNyeOpplysningerBareSak(any(), any()) } just runs
+            }
+        val krrKlient =
+            mockk<KrrKlient> {
+                coEvery { hentDigitalKontaktinformasjon(any()) } returns
+                    DigitalKontaktinformasjon(
+                        personident = "",
+                        aktiv = true,
+                        kanVarsles = true,
+                        reservert = false,
+                        spraak = "nb",
+                        epostadresse = null,
+                        mobiltelefonnummer = null,
+                        sikkerDigitalPostkasse = null,
+                    )
+            }
+        service = SakServiceImpl(sakDao, skjermingKlient, brukerService, grunnlagservice, krrKlient, pdlTjenesterKlient)
+
         every {
             sakDao.finnSakMedGraderingOgSkjerming(
                 any(),


### PR DESCRIPTION
Uten dette får man p.t. ikke opprettet manuelt brev da dette trenger grunnlaget for saken.
Fremtidig ønske er å hente grunnlaget for manuelt brev rett fra PDL, da er grunnlagsopplysninger for en sak mindre viktig.