### PR TITLE
Rydder i avkortingsbildet og viser informasjon om sanksjon

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
@@ -1,4 +1,3 @@
-import styled from 'styled-components'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { hentAvkorting } from '~shared/api/avkorting'
 import React, { useEffect } from 'react'
@@ -13,6 +12,9 @@ import { behandlingErRedigerbar } from '~components/behandling/felles/utils'
 import { mapApiResult } from '~shared/api/apiUtils'
 import { Brevutfall } from '~components/behandling/brevutfall/Brevutfall'
 import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
+import { Sanksjon } from '~components/behandling/sanksjon/Sanksjon'
+import { useFeatureEnabledMedDefault } from '~shared/hooks/useFeatureToggle'
+import { Box, VStack } from '@navikt/ds-react'
 
 export const Avkorting = ({
   behandling,
@@ -27,6 +29,7 @@ export const Avkorting = ({
   const avkorting = useAppSelector((state) => state.behandlingReducer.behandling?.avkorting)
   const [avkortingStatus, hentAvkortingRequest] = useApiCall(hentAvkorting)
   const innloggetSaksbehandler = useInnloggetSaksbehandler()
+  const visSanksjon = useFeatureEnabledMedDefault('sanksjon', false)
 
   const redigerbar = behandlingErRedigerbar(
     behandling.status,
@@ -47,27 +50,27 @@ export const Avkorting = ({
   }, [])
 
   return (
-    <AvkortingWrapper>
-      {mapApiResult(
-        avkortingStatus,
-        <Spinner visible label="Henter avkorting" />,
-        () => (
-          <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>
-        ),
-        () => (
-          <AvkortingInntekt
-            behandling={behandling}
-            redigerbar={redigerbar}
-            resetInntektsavkortingValidering={resetInntektsavkortingValidering}
-          />
-        )
-      )}
-      {avkorting && <YtelseEtterAvkorting />}
-      {avkorting && <Brevutfall behandling={behandling} resetBrevutfallvalidering={resetBrevutfallvalidering} />}
-    </AvkortingWrapper>
+    <Box paddingBlock="8 0">
+      <VStack gap="8">
+        {mapApiResult(
+          avkortingStatus,
+          <Spinner visible label="Henter avkorting" />,
+          () => (
+            <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>
+          ),
+          () => (
+            <AvkortingInntekt
+              behandling={behandling}
+              redigerbar={redigerbar}
+              resetInntektsavkortingValidering={resetInntektsavkortingValidering}
+            />
+          )
+        )}
+
+        {visSanksjon && <Sanksjon behandling={behandling} />}
+        {avkorting && <YtelseEtterAvkorting />}
+        {avkorting && <Brevutfall behandling={behandling} resetBrevutfallvalidering={resetBrevutfallvalidering} />}
+      </VStack>
+    </Box>
   )
 }
-
-const AvkortingWrapper = styled.div`
-  margin: 2em 0 1em 0;
-`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
@@ -5,11 +5,16 @@ import { AvkortingInntekt } from '~components/behandling/avkorting/AvkortingInnt
 import Spinner from '~shared/Spinner'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { YtelseEtterAvkorting } from '~components/behandling/avkorting/YtelseEtterAvkorting'
-import { IBehandlingReducer, oppdaterAvkorting, oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'
+import {
+  IBehandlingReducer,
+  oppdaterAvkorting,
+  oppdaterBehandlingsstatus,
+  resetAvkorting,
+} from '~store/reducers/BehandlingReducer'
 import { useAppDispatch, useAppSelector } from '~store/Store'
 import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
 import { behandlingErRedigerbar } from '~components/behandling/felles/utils'
-import { mapApiResult } from '~shared/api/apiUtils'
+import { mapResult } from '~shared/api/apiUtils'
 import { Brevutfall } from '~components/behandling/brevutfall/Brevutfall'
 import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
 import { Sanksjon } from '~components/behandling/sanksjon/Sanksjon'
@@ -39,6 +44,7 @@ export const Avkorting = ({
 
   useEffect(() => {
     if (!avkorting || avkorting.behandlingId !== behandling.id) {
+      dispatch(resetAvkorting())
       hentAvkortingRequest(behandling.id, (res) => {
         const avkortingFinnesOgErUnderBehandling = res && redigerbar
         if (avkortingFinnesOgErUnderBehandling) {
@@ -52,20 +58,17 @@ export const Avkorting = ({
   return (
     <Box paddingBlock="8 0">
       <VStack gap="8">
-        {mapApiResult(
-          avkortingStatus,
-          <Spinner visible label="Henter avkorting" />,
-          () => (
-            <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>
-          ),
-          () => (
+        {mapResult(avkortingStatus, {
+          pending: <Spinner visible label="Henter avkorting" />,
+          error: <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>,
+          success: () => (
             <AvkortingInntekt
               behandling={behandling}
               redigerbar={redigerbar}
               resetInntektsavkortingValidering={resetInntektsavkortingValidering}
             />
-          )
-        )}
+          ),
+        })}
 
         {visSanksjon && <Sanksjon behandling={behandling} />}
         {avkorting && <YtelseEtterAvkorting />}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -122,11 +122,8 @@ export const AvkortingInntekt = ({
       <Heading spacing size="small" level="2">
         Inntektsavkorting
       </Heading>
-      <HjemmelLenke
-        tittel="Folketrygdloven § 17-9 (mangler lenke)"
-        lenke="https://lovdata.no/lov/" // TODO lenke finnes ikke enda
-      />
-      <BodyShort>
+      <HjemmelLenke tittel="Folketrygdloven § 17-9" lenke="https://lovdata.no/pro/lov/1997-02-28-19/§17-9" />
+      <BodyShort spacing>
         Omstillingsstønaden reduseres med 45 prosent av den gjenlevende sin inntekt som på årsbasis overstiger et halvt
         grunnbeløp. Inntekt rundes ned til nærmeste tusen. Det er forventet årsinntekt for hvert kalenderår som skal
         legges til grunn.
@@ -339,8 +336,7 @@ export const AvkortingInntekt = ({
 }
 
 const AvkortingInntektWrapper = styled.div`
-  width: 57em;
-  margin-bottom: 3em;
+  max-width: 70rem;
 `
 
 const InntektAvkortingTabell = styled.div`
@@ -349,7 +345,7 @@ const InntektAvkortingTabell = styled.div`
 
 const InntektAvkortingForm = styled.form`
   display: flex;
-  margin: 1em 0 1em 0;
+  margin: 1em 0 0 0;
 `
 
 const FormWrapper = styled.div`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/YtelseEtterAvkorting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/YtelseEtterAvkorting.tsx
@@ -7,9 +7,20 @@ import { YtelseEtterAvkortingDetaljer } from '~components/behandling/avkorting/Y
 import { Info } from '~components/behandling/soeknadsoversikt/Info'
 import { lastDayOfMonth } from 'date-fns'
 import { useAppSelector } from '~store/Store'
+import { tekstSanksjon } from '~shared/types/sanksjon'
+import { TableBox } from '~components/behandling/beregne/OmstillingsstoenadSammendrag'
 
 const sorterNyligsteFoerstOgBakover = (a: IAvkortetYtelse, b: IAvkortetYtelse) =>
   new Date(b.fom).getTime() - new Date(a.fom).getTime()
+
+const restanseIKroner = (restanse: number) => (restanse < 0 ? `+ ${NOK(restanse * -1)}` : `- ${NOK(restanse)}`)
+
+const restanseOgSanksjon = (ytelse: IAvkortetYtelse): string => {
+  if (ytelse.sanksjon) {
+    return tekstSanksjon[ytelse.sanksjon.type]
+  }
+  return restanseIKroner(ytelse.restanse)
+}
 
 export const YtelseEtterAvkorting = () => {
   const avkorting = useAppSelector((state) => state.behandlingReducer.behandling?.avkorting)
@@ -27,7 +38,7 @@ export const YtelseEtterAvkorting = () => {
       {ytelser.length > 0 && (
         <TableBox>
           <Heading spacing size="small" level="2">
-            Beregning etter avkorting
+            Beregning etter avkorting og sanksjon
           </Heading>
           <Table className="table" zebraStripes>
             <Table.Header>
@@ -36,15 +47,13 @@ export const YtelseEtterAvkorting = () => {
                 <Table.HeaderCell>Periode</Table.HeaderCell>
                 <Table.HeaderCell>Beregning</Table.HeaderCell>
                 <Table.HeaderCell>Avkorting</Table.HeaderCell>
-                <Table.HeaderCell>Restanse</Table.HeaderCell>
-                <Table.HeaderCell>Brutto stønad etter avkorting</Table.HeaderCell>
+                <Table.HeaderCell>Restanse / sanksjon</Table.HeaderCell>
+                <Table.HeaderCell>Brutto stønad etter avkorting / sanksjon</Table.HeaderCell>
               </Table.Row>
             </Table.Header>
             <Table.Body>
               {ytelser.map((ytelse, key) => {
                 const tidligereYtelse = finnTidligereTidligereYtelseIPeriode(ytelse)
-                const restanseIKroner = (restanse: number) =>
-                  restanse < 0 ? `+ ${NOK(restanse * -1)}` : `- ${NOK(restanse)}`
                 return (
                   <Table.ExpandableRow
                     key={key}
@@ -82,11 +91,9 @@ export const YtelseEtterAvkorting = () => {
                     <Table.DataCell>
                       <SmalCelle>
                         <Info
-                          tekst={restanseIKroner(ytelse.restanse)}
+                          tekst={restanseOgSanksjon(ytelse)}
                           label=""
-                          undertekst={
-                            tidligereYtelse ? `${restanseIKroner(tidligereYtelse.restanse)} (Forrige vedtak)` : ''
-                          }
+                          undertekst={tidligereYtelse ? `${restanseOgSanksjon(ytelse)} (Forrige vedtak)` : ''}
                         />
                       </SmalCelle>
                     </Table.DataCell>
@@ -111,10 +118,6 @@ export const YtelseEtterAvkorting = () => {
     </>
   )
 }
-
-const TableBox = styled(Box)`
-  max-width: 44rem;
-`
 
 const SmalCelle = styled(Box)`
   max-width: 9.35rem;

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/YtelseEtterAvkortingDetaljer.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/YtelseEtterAvkortingDetaljer.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { IAvkortetYtelse } from '~shared/types/IAvkorting'
 import { BodyShort, Box, ReadMore } from '@navikt/ds-react'
 import { NOK } from '~utils/formattering'
+import { tekstSanksjon } from '~shared/types/sanksjon'
 
 export const YtelseEtterAvkortingDetaljer = (props: { ytelse: IAvkortetYtelse }) => {
   const ytelse = props.ytelse
@@ -20,7 +21,13 @@ export const YtelseEtterAvkortingDetaljer = (props: { ytelse: IAvkortetYtelse })
             <Operasjon>-</Operasjon>
             <Verdi>{NOK(ytelse.avkortingsbeloep)}</Verdi>
           </Rad>
-          {ytelse.restanse < 0 ? (
+          {ytelse.sanksjon ? (
+            <Rad>
+              <Navn>{tekstSanksjon[ytelse.sanksjon.type]} i perioden</Navn>
+              <Operasjon>*</Operasjon>
+              <Verdi>0</Verdi>
+            </Rad>
+          ) : ytelse.restanse < 0 ? (
             <Rad>
               <Navn>Månedlig restansebeløp</Navn>
               <Operasjon>+</Operasjon>
@@ -30,12 +37,17 @@ export const YtelseEtterAvkortingDetaljer = (props: { ytelse: IAvkortetYtelse })
             <Rad>
               <Navn>Månedlig restansebeløp</Navn>
               <Operasjon>-</Operasjon>
-              <Verdi>{NOK(ytelse.restanse)} kr</Verdi>
+              <Verdi>{NOK(ytelse.restanse)}</Verdi>
             </Rad>
           )}
+
           <Box paddingBlock="4 0" borderWidth="1 0 0 0" borderColor="border-subtle">
             <Rad>
-              <Navn>Brutto stønad etter avkorting og restanse</Navn>
+              {ytelse.sanksjon ? (
+                <Navn>Brutto stønad etter sanksjon</Navn>
+              ) : (
+                <Navn>Brutto stønad etter avkorting og restanse</Navn>
+              )}
               <Operasjon>=</Operasjon>
               <Verdi>
                 <strong>{NOK(ytelse.ytelseEtterAvkorting)}</strong>
@@ -45,8 +57,7 @@ export const YtelseEtterAvkortingDetaljer = (props: { ytelse: IAvkortetYtelse })
         </ul>
         <Beskrivelse>
           <li>
-            <h4>Hvordan fungerer avkorting av en omstillingstønad?</h4>
-            <ReadMore header="Les mer">
+            <ReadMore header="Hvordan fungerer avkorting av en omstillingstønad?">
               <BodyShort size="small">
                 Omstillingsstønaden avkortes med mottakers forventede årsinntekt/12. Er forventet inntekt satt for
                 lavt/høyt, og en eventuell restanse (se under) ikke klarer å hente inn igjen for mye/lite utbetalt
@@ -55,9 +66,8 @@ export const YtelseEtterAvkortingDetaljer = (props: { ytelse: IAvkortetYtelse })
             </ReadMore>
           </li>
           <li>
-            <h4>Hva er restanse?</h4>
-            <ReadMore header="Les mer">
-              <BodyShort spacing={true} size="small">
+            <ReadMore header="Hva er restanse?">
+              <BodyShort spacing size="small">
                 Hvis man fastsetter en ny forventet inntekt for inneværende år, oppstår det en
                 feilutbetaling/etterbetaling, en restanse. Restansen skal fordeles ut over resterende utbetalingsmåneder
                 for inneværende år. Dette gjøres for å minimere etteroppgjøret.

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
@@ -11,7 +11,6 @@ import { BehandlingHandlingKnapper } from '~components/behandling/handlinger/Beh
 import { Alert, Box, Button, Heading, HStack } from '@navikt/ds-react'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { IBehandlingStatus, Vedtaksloesning } from '~shared/types/IDetaljertBehandling'
-import styled from 'styled-components'
 import { NesteOgTilbake } from '../handlinger/NesteOgTilbake'
 import { SendTilAttesteringModal } from '~components/behandling/handlinger/SendTilAttesteringModal'
 import { Beregningstype } from '~shared/types/Beregning'
@@ -29,8 +28,6 @@ import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { Brevutfall } from '~components/behandling/brevutfall/Brevutfall'
 import { VilkaarsvurderingResultat } from '~shared/api/vilkaarsvurdering'
 import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
-import { Sanksjon } from '~components/behandling/sanksjon/Sanksjon'
-import { useFeatureEnabledMedDefault } from '~shared/hooks/useFeatureToggle'
 
 export const Beregne = (props: { behandling: IBehandlingReducer }) => {
   const { behandling } = props
@@ -43,7 +40,6 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
     ? formaterStringDato(behandling.virkningstidspunkt.dato)
     : undefined
   const innloggetSaksbehandler = useInnloggetSaksbehandler()
-  const visSanksjon = useFeatureEnabledMedDefault('sanksjon', false)
 
   const vedtaksresultat = useVedtaksResultat()
 
@@ -114,9 +110,9 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
         <Vilkaarsresultat vedtaksresultat={vedtaksresultat} virkningstidspunktFormatert={virkningstidspunkt} />
       </Box>
       {erOpphoer ? (
-        <BeregningWrapper>
+        <Box paddingInline="18" paddingBlock="4">
           <Brevutfall behandling={behandling} resetBrevutfallvalidering={() => setManglerbrevutfall(false)} />
-        </BeregningWrapper>
+        </Box>
       ) : (
         <>
           {mapApiResult(
@@ -126,7 +122,7 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
               <ApiErrorAlert>Kunne ikke hente beregning</ApiErrorAlert>
             ),
             (beregning) => (
-              <BeregningWrapper>
+              <Box paddingInline="18" paddingBlock="4">
                 {(() => {
                   switch (beregning.type) {
                     case Beregningstype.BP:
@@ -148,7 +144,6 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
                             resetBrevutfallvalidering={() => setManglerbrevutfall(false)}
                             resetInntektsavkortingValidering={() => setManglerAvkorting(false)}
                           />
-                          {visSanksjon && <Sanksjon behandling={behandling} />}
                         </>
                       )
                   }
@@ -164,7 +159,7 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
                     inntektsfeltene.
                   </Alert>
                 )}
-              </BeregningWrapper>
+              </Box>
             )
           )}
         </>
@@ -198,8 +193,3 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
     </>
   )
 }
-
-const BeregningWrapper = styled.div`
-  padding: 0 4em;
-  margin-bottom: 4em;
-`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/OmstillingsstoenadSammendrag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/OmstillingsstoenadSammendrag.tsx
@@ -67,5 +67,5 @@ export const OmstillingsstoenadSammendrag = ({ beregning }: Props) => {
 }
 
 export const TableBox = styled(Box)`
-  max-width: 63rem;
+  max-width: 70rem;
 `

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sanksjon/Sanksjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sanksjon/Sanksjon.tsx
@@ -14,6 +14,7 @@ import {
   Detail,
   Heading,
   HStack,
+  ReadMore,
   Select,
   Table,
   Textarea,
@@ -29,6 +30,7 @@ import { TableBox } from '~components/behandling/beregne/OmstillingsstoenadSamme
 import { ISanksjon, ISanksjonLagre, SanksjonType, tekstSanksjon } from '~shared/types/sanksjon'
 import { useAppDispatch } from '~store/Store'
 import { hentAvkorting } from '~shared/api/avkorting'
+import { HjemmelLenke } from '~components/behandling/felles/HjemmelLenke'
 
 interface SanksjonDefaultValue {
   datoFom?: Date
@@ -145,7 +147,7 @@ export const Sanksjon = ({ behandling }: { behandling: IBehandlingReducer }) => 
   const sanksjonFraDato = behandling.virkningstidspunkt?.dato ? new Date(behandling.virkningstidspunkt.dato) : undefined
 
   return (
-    <Box paddingBlock="4">
+    <TableBox>
       {mapApiResult(
         hentSanksjonStatus,
         <Spinner visible label="Henter sanksjoner" />,
@@ -154,10 +156,37 @@ export const Sanksjon = ({ behandling }: { behandling: IBehandlingReducer }) => 
         ),
         () => (
           <VStack gap="4">
-            <Heading spacing size="small" level="2">
+            <Heading size="small" level="2">
               Sanksjoner
             </Heading>
-            <BodyShort>Her kommer det informasjon om sanksjoner.</BodyShort>
+            <Box>
+              <HjemmelLenke tittel="Folketrygdloven § 17-8" lenke="https://lovdata.no/pro/lov/1997-02-28-19/§17-8" />
+              <BodyShort spacing>
+                Når en bruker har en sanksjon for en periode, vil 0 ytelse bli utbetalt. Hvis det er restanse fra
+                endringer i forventet årsinntekt vil heller ikke den bli hentet inn i sanksjonsperioden, men forsøkt
+                omfordelt på måneder etter sanksjon.
+              </BodyShort>
+              <ReadMore header="Når skal sanksjoner gis?">
+                <BodyShort spacing>
+                  Dersom den gjenlevende ikke følger opp aktivitetskravet i{' '}
+                  <HjemmelLenke tittel="§ 17-7" lenke="https://lovdata.no/pro/lov/1997-02-28-19/§17-7" />, skal
+                  omstillingsstønaden stanses inntil vilkårene for å motta ytelsen igjen er oppfylt.
+                </BodyShort>
+                <BodyShort spacing>
+                  Dersom den gjenlevende uten rimelig grunn sier opp sin stilling, nekter å ta imot tilbudt arbeid,
+                  unnlater å gjenoppta sitt arbeidsforhold etter endt foreldrepermisjon, nekter å delta i
+                  arbeidsmarkedstiltak eller unnlater å møte ved innkalling til arbeids- og velferdsetaten, faller
+                  omstillingsstønaden bort én måned.
+                </BodyShort>
+                <BodyShort>
+                  Dersom den gjenlevende har gitt uriktige opplysninger om forhold som har betydning for retten til
+                  ytelser etter dette kapitlet, og han eller hun var klar over eller burde vært klar over dette, kan
+                  vedkommende utestenges fra rett til stønad i inntil tre måneder første gang og inntil seks måneder ved
+                  gjentakelser. Det samme gjelder dersom den gjenlevende har unnlatt å gi opplysninger av betydning for
+                  retten til ytelser.
+                </BodyShort>
+              </ReadMore>
+            </Box>
 
             <TableBox>
               <Table className="table" zebraStripes size="medium">
@@ -342,6 +371,6 @@ export const Sanksjon = ({ behandling }: { behandling: IBehandlingReducer }) => 
           </VStack>
         )
       )}
-    </Box>
+    </TableBox>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
@@ -1,3 +1,5 @@
+import { SanksjonType } from '~shared/types/sanksjon'
+
 export interface IAvkorting {
   behandlingId: string
   avkortingGrunnlag: IAvkortingGrunnlag[]
@@ -39,4 +41,10 @@ export interface IAvkortetYtelse {
   avkortingsbeloep: number
   restanse: number
   ytelseEtterAvkorting: number
+  sanksjon?: SanksjonertYtelse
+}
+
+export interface SanksjonertYtelse {
+  id: string
+  type: SanksjonType
 }


### PR DESCRIPTION
Endrer en del på hvordan vi setter spacing / wrapping for å få det konsekvent i beregningsbildet.

Flytter også sanksjoner inn rett ved visning av det som blir beregnet.

![Screenshot 2024-06-17 at 17 25 40](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/4296255/f03b1e20-7cdf-4e72-b063-aa9ee0669cc0)
