### PR TITLE
Flate ut årsoppgjør ved uthenting av avkorting

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -6,6 +6,7 @@ import no.nav.etterlatte.avkorting.AvkortetYtelseType.ETTEROPPJOER
 import no.nav.etterlatte.avkorting.AvkortetYtelseType.FORVENTET_INNTEKT
 import no.nav.etterlatte.beregning.Beregning
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.beregning.AvkortingDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagLagreDto
 import no.nav.etterlatte.libs.common.beregning.SanksjonertYtelse
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -18,36 +19,57 @@ import java.util.UUID
 
 data class Avkorting(
     val aarsoppgjoer: List<Aarsoppgjoer> = emptyList(),
-    val avkortetYtelseFraVirkningstidspunkt: List<AvkortetYtelse> = emptyList(),
-    val avkortetYtelseForrigeVedtak: List<AvkortetYtelse> = emptyList(),
 ) {
     /*
-     * avkortetYtelseFraVirkningstidspunkt - Årsoppgjør inneholder ytelsen sine perioder for hele år
-     * og for behandlinger/vedtak er det kun virknigstidspunkt og fremover som er relevant.
+     * Å skille på år er kun relevant internt for avkorting. Alle perioder på tvers av alle årene blir
+     * derfor flatet ut til sammenhengende perioder når avkorting hentes ut.
      *
-     * avkortetYtelseForrigeVedtak - brukes til å sammenligne med beløper til nye beregna perioder under behandlingen
+     * For AvkortingGrunnlag (inntekter) så er det ønskelig med full historikk.
+     * For AvkortetYtelse er det kun ønskelig å hente fra og med virkningstidspunkt til behandling.
+     *
+     * avkortetYtelseForrigeVedtak - brukes til å sammenligne med beløper til nye beregna perioder i frontend
      */
-    fun medYtelseFraOgMedVirkningstidspunkt(
-        virkningstidspunkt: YearMonth,
+    fun toDto(
+        fraVirkningstidspunkt: YearMonth? = null,
         forrigeAvkorting: Avkorting? = null,
-    ): Avkorting =
-        this.copy(
-            avkortetYtelseFraVirkningstidspunkt =
-                aarsoppgjoer.filter { virkningstidspunkt.year <= it.aar }.flatMap { aarsoppgjoer ->
-                    aarsoppgjoer.avkortetYtelseAar
-                        .filter { it.periode.tom == null || virkningstidspunkt <= it.periode.tom }
-                        .map {
-                            if (virkningstidspunkt > it.periode.fom && (it.periode.tom == null || virkningstidspunkt <= it.periode.tom)) {
-                                it.copy(periode = Periode(fom = virkningstidspunkt, tom = it.periode.tom))
-                            } else {
-                                it
-                            }
-                        }
+    ): AvkortingDto =
+        AvkortingDto(
+            avkortingGrunnlag =
+                aarsoppgjoer.flatMap { aarsoppgjoer ->
+                    aarsoppgjoer.inntektsavkorting.map {
+                        it.grunnlag.toDto(aarsoppgjoer.forventaInnvilgaMaaneder)
+                    }
                 },
-            avkortetYtelseForrigeVedtak =
-                forrigeAvkorting?.aarsoppgjoer?.flatMap {
-                    it.avkortetYtelseAar
-                } ?: emptyList(),
+            avkortetYtelse =
+                if (fraVirkningstidspunkt !=
+                    null
+                ) {
+                    aarsoppgjoer.filter { fraVirkningstidspunkt.year <= it.aar }.flatMap { aarsoppgjoer ->
+                        aarsoppgjoer.avkortetYtelseAar
+                            .filter { it.periode.tom == null || fraVirkningstidspunkt <= it.periode.tom }
+                            .map {
+                                if (fraVirkningstidspunkt > it.periode.fom &&
+                                    (it.periode.tom == null || fraVirkningstidspunkt <= it.periode.tom)
+                                ) {
+                                    it.copy(periode = Periode(fom = fraVirkningstidspunkt, tom = it.periode.tom))
+                                } else {
+                                    it
+                                }
+                            }.map {
+                                it.toDto()
+                            }
+                    }
+                } else {
+                    aarsoppgjoer.flatMap { aarsoppgjoer ->
+                        aarsoppgjoer.avkortetYtelseAar.map { it.toDto() }
+                    }
+                },
+            tidligereAvkortetYtelse =
+                forrigeAvkorting
+                    ?.aarsoppgjoer
+                    ?.flatMap {
+                        it.avkortetYtelseAar
+                    }?.map { it.toDto() } ?: emptyList(),
         )
 
     /*
@@ -94,7 +116,7 @@ data class Avkorting(
         bruker: BrukerTokenInfo,
     ): Avkorting {
         // TODO kreve at det er inneværende år?
-        val aarsoppgjoer = hentAarsoppgjoer(virkningstidspunkt, innvilgelse)
+        val aarsoppgjoer = hentEllerOpprettAarsoppgjoer(virkningstidspunkt, innvilgelse)
         val oppdatert =
             aarsoppgjoer.inntektsavkorting
                 // Fjerner hvis det finnes fra før for å erstatte/redigere
@@ -355,7 +377,7 @@ data class Avkorting(
      * Ved innvilgelse/førstegangsbehandling så skal måneder før virkningsitdspunkt trekkes i fra
      * forventa innvilgede måneder.
      */
-    private fun hentAarsoppgjoer(
+    private fun hentEllerOpprettAarsoppgjoer(
         virkningstidspunkt: YearMonth,
         innvilgelse: Boolean,
     ): Aarsoppgjoer {
@@ -397,7 +419,6 @@ data class Aarsoppgjoer(
     val inntektsavkorting: List<Inntektsavkorting> = emptyList(),
     val avkortetYtelseAar: List<AvkortetYtelse> = emptyList(),
 ) {
-
     fun foersteInnvilgedeMaaned(): YearMonth = YearMonth.of(aar, 12 - forventaInnvilgaMaaneder + 1)
 
     /**

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -11,7 +11,6 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.beregning.AvkortetYtelseDto
-import no.nav.etterlatte.libs.common.beregning.AvkortingDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagKildeDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagLagreDto
@@ -33,7 +32,7 @@ fun Route.avkorting(
                 logger.info("Henter avkorting med behandlingId=$it")
                 when (val avkorting = avkortingService.hentAvkorting(it, brukerTokenInfo)) {
                     null -> call.response.status(HttpStatusCode.NoContent)
-                    else -> call.respond(avkorting.toDto())
+                    else -> call.respond(avkorting)
                 }
             }
         }
@@ -41,7 +40,7 @@ fun Route.avkorting(
         get("ferdig") {
             withBehandlingId(behandlingKlient) {
                 logger.info("Henter ferdig avkorting med behandlingId=$it")
-                call.respond(avkortingService.hentFullfoertAvkorting(it, brukerTokenInfo).toDto())
+                call.respond(avkortingService.hentFullfoertAvkorting(it, brukerTokenInfo))
             }
         }
 
@@ -55,7 +54,7 @@ fun Route.avkorting(
                         brukerTokenInfo,
                         avkortingGrunnlag,
                     )
-                call.respond(avkorting.toDto())
+                call.respond(avkorting)
             }
         }
 
@@ -77,17 +76,6 @@ fun Route.avkorting(
         }
     }
 }
-
-fun Avkorting.toDto() =
-    AvkortingDto(
-        // TODO erstatt single
-        avkortingGrunnlag =
-            aarsoppgjoer.single().inntektsavkorting.map {
-                it.grunnlag.toDto(aarsoppgjoer.single().forventaInnvilgaMaaneder)
-            },
-        avkortetYtelse = avkortetYtelseFraVirkningstidspunkt.map { it.toDto() },
-        tidligereAvkortetYtelse = avkortetYtelseForrigeVedtak.map { it.toDto() },
-    )
 
 fun AvkortingGrunnlag.toDto(forventaInnvilgaMaaneder: Int) =
     AvkortingGrunnlagDto(

--- a/apps/etterlatte-beregning/src/main/kotlin/ytelseMedGrunnlag/YtelseMedGrunnlagService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/ytelseMedGrunnlag/YtelseMedGrunnlagService.kt
@@ -7,6 +7,7 @@ import no.nav.etterlatte.libs.common.behandling.virkningstidspunkt
 import no.nav.etterlatte.libs.common.beregning.YtelseMedGrunnlagDto
 import no.nav.etterlatte.libs.common.beregning.YtelseMedGrunnlagPeriodisertDto
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
+import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import java.util.UUID
 
@@ -21,38 +22,34 @@ class YtelseMedGrunnlagService(
     ): YtelseMedGrunnlagDto? {
         val avkortingUtenLoependeYtelse = avkortingRepository.hentAvkorting(behandlingId) ?: return null
         val virkningstidspunkt = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo).virkningstidspunkt()
-        val avkorting = avkortingUtenLoependeYtelse.medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt.dato)
+        val avkorting = avkortingUtenLoependeYtelse.toDto(virkningstidspunkt.dato)
 
         val beregning = beregningRepository.hent(behandlingId) ?: throw BeregningFinnesIkkeException(behandlingId)
 
         val avkortinger =
-            avkorting.avkortetYtelseFraVirkningstidspunkt.map { avkortetYtelse ->
+            avkorting.avkortetYtelse.map { avkortetYtelse ->
                 val beregningIPeriode =
                     beregning.beregningsperioder
-                        .filter { it.datoFOM <= avkortetYtelse.periode.fom }
+                        .filter { it.datoFOM <= avkortetYtelse.fom }
                         .maxBy { it.datoFOM }
 
-                // TODO erstatt single..
-                val aarsoppgjoer = avkorting.aarsoppgjoer.single()
-                val avkortingsgrunnlagIPeriode =
-                    aarsoppgjoer.inntektsavkorting
-                        .filter { it.grunnlag.periode.fom <= avkortetYtelse.periode.fom }
-                        .maxBy { it.grunnlag.periode.fom }
-
-                val grunnlag = avkortingsgrunnlagIPeriode.grunnlag
+                val grunnlag =
+                    avkorting.avkortingGrunnlag
+                        .filter { it.fom <= avkortetYtelse.fom }
+                        .maxBy { it.fom }
                 val aarsinntekt = grunnlag.aarsinntekt + grunnlag.inntektUtland
                 val fratrekkInnAar = grunnlag.fratrekkInnAar + grunnlag.fratrekkInnAarUtland
 
                 YtelseMedGrunnlagPeriodisertDto(
-                    periode = avkortetYtelse.periode,
+                    periode = Periode(avkortetYtelse.fom, avkortetYtelse.tom),
                     ytelseEtterAvkorting = avkortetYtelse.ytelseEtterAvkorting,
-                    restanse = avkortetYtelse.restanse?.fordeltRestanse ?: 0,
+                    restanse = avkortetYtelse.restanse,
                     avkortingsbeloep = avkortetYtelse.avkortingsbeloep,
                     ytelseFoerAvkorting = beregningIPeriode.utbetaltBeloep,
                     trygdetid = beregningIPeriode.trygdetid,
                     aarsinntekt = aarsinntekt,
                     fratrekkInnAar = fratrekkInnAar,
-                    relevanteMaanederInnAar = aarsoppgjoer.forventaInnvilgaMaaneder,
+                    relevanteMaanederInnAar = grunnlag.relevanteMaanederInnAar,
                     grunnbelop = beregningIPeriode.grunnbelop,
                     grunnbelopMnd = beregningIPeriode.grunnbelopMnd,
                     beregningsMetode = beregningIPeriode.beregningsMetode,

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRoutesTest.kt
@@ -13,7 +13,6 @@ import io.ktor.server.testing.ApplicationTestBuilder
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import no.nav.etterlatte.beregning.regler.aarsoppgjoer
 import no.nav.etterlatte.beregning.regler.avkortetYtelse
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
 import no.nav.etterlatte.klienter.BehandlingKlient
@@ -81,32 +80,7 @@ class AvkortingRoutesTest {
                 kilde = Grunnlagsopplysning.Saksbehandler("Saksbehandler01", tidspunkt),
             )
         val avkortetYtelseId = UUID.randomUUID()
-        val avkortetYtelse =
-            listOf(
-                avkortetYtelse(
-                    id = avkortetYtelseId,
-                    type = AvkortetYtelseType.AARSOPPGJOER,
-                    periode = Periode(fom = dato, tom = dato),
-                ),
-            )
-        val inntektsavkorting =
-            listOf(
-                Inntektsavkorting(
-                    grunnlag = avkortingsgrunnlag,
-                ),
-            )
         val avkorting =
-            Avkorting(
-                aarsoppgjoer =
-                    listOf(
-                        aarsoppgjoer(
-                            inntektsavkorting = inntektsavkorting,
-                        ),
-                    ),
-                avkortetYtelseFraVirkningstidspunkt = avkortetYtelse,
-                avkortetYtelseForrigeVedtak = avkortetYtelse,
-            )
-        val dto =
             AvkortingDto(
                 avkortingGrunnlag =
                     listOf(
@@ -161,14 +135,14 @@ class AvkortingRoutesTest {
         testApplication {
             val response =
                 client.post("/api/beregning/avkorting/$behandlingsId") {
-                    setBody(dto.avkortingGrunnlag[0].toJson())
+                    setBody(avkorting.avkortingGrunnlag[0].toJson())
                     header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     header(HttpHeaders.Authorization, "Bearer ${server.issueSaksbehandlerToken()}")
                 }
 
             response.status shouldBe HttpStatusCode.OK
             val result = objectMapper.readValue(response.bodyAsText(), AvkortingDto::class.java)
-            result shouldBe dto
+            result shouldBe avkorting
             coVerify {
                 avkortingService.beregnAvkortingMedNyttGrunnlag(
                     behandlingsId,

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -17,6 +17,7 @@ import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SisteIverksatteBehandling
+import no.nav.etterlatte.libs.common.beregning.AvkortingDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagLagreDto
 import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
 import no.nav.etterlatte.sanksjon.SanksjonService
@@ -87,18 +88,19 @@ internal class AvkortingServiceTest {
                     status = BehandlingStatus.AVKORTET,
                 )
             val avkorting = mockk<Avkorting>()
+            val avkortingDto = mockk<AvkortingDto>()
 
             coEvery { behandlingKlient.hentBehandling(behandlingId, bruker) } returns behandling
             every { avkortingRepository.hentAvkorting(behandlingId) } returns avkorting
-            every { avkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 1)) } returns avkorting
+            every { avkorting.toDto(YearMonth.of(2024, 1)) } returns avkortingDto
 
             runBlocking {
-                service.hentAvkorting(behandlingId, bruker) shouldBe avkorting
+                service.hentAvkorting(behandlingId, bruker) shouldBe avkortingDto
             }
             coVerify {
                 behandlingKlient.hentBehandling(behandlingId, bruker)
                 avkortingRepository.hentAvkorting(behandlingId)
-                avkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 1))
+                avkorting.toDto(YearMonth.of(2024, 1))
             }
         }
 
@@ -117,6 +119,7 @@ internal class AvkortingServiceTest {
             val beregning = mockk<Beregning>()
             val reberegnetAvkorting = mockk<Avkorting>()
             val lagretAvkorting = mockk<Avkorting>()
+            val avkortinDto = mockk<AvkortingDto>()
 
             coEvery { behandlingKlient.hentBehandling(behandlingId, bruker) } returns behandling
             every { avkortingRepository.hentAvkorting(behandlingId) } returns eksisterendeAvkorting andThen lagretAvkorting
@@ -125,10 +128,10 @@ internal class AvkortingServiceTest {
             every { avkortingRepository.lagreAvkorting(any(), any(), any()) } returns Unit
             every { sanksjonService.hentSanksjon(behandlingId) } returns null
             coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
-            every { lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(any(), any()) } returns lagretAvkorting
+            every { lagretAvkorting.toDto(any(), any()) } returns avkortinDto
 
             runBlocking {
-                service.hentAvkorting(behandlingId, bruker) shouldBe lagretAvkorting
+                service.hentAvkorting(behandlingId, bruker) shouldBe avkortinDto
             }
             coVerify(exactly = 1) {
                 behandlingKlient.avkort(behandlingId, bruker, false)
@@ -138,7 +141,7 @@ internal class AvkortingServiceTest {
                 eksisterendeAvkorting.beregnAvkortingRevurdering(beregning, any())
                 avkortingRepository.lagreAvkorting(behandlingId, sakId, reberegnetAvkorting)
                 behandlingKlient.avkort(behandlingId, bruker, true)
-                lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 1))
+                lagretAvkorting.toDto(YearMonth.of(2024, 1))
             }
             coVerify(exactly = 2) {
                 avkortingRepository.hentAvkorting(behandlingId)
@@ -160,6 +163,7 @@ internal class AvkortingServiceTest {
             val forrigeBehandlingId = UUID.randomUUID()
             val eksisterendeAvkorting = mockk<Avkorting>()
             val forrigeAvkorting = mockk<Avkorting>()
+            val avkortingDto = mockk<AvkortingDto>()
 
             coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
             coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
@@ -168,7 +172,7 @@ internal class AvkortingServiceTest {
                 )
             every { avkortingRepository.hentAvkorting(behandlingId) } returns eksisterendeAvkorting
             every { avkortingRepository.hentAvkorting(forrigeBehandlingId) } returns forrigeAvkorting
-            every { eksisterendeAvkorting.medYtelseFraOgMedVirkningstidspunkt(any(), any()) } returns eksisterendeAvkorting
+            every { eksisterendeAvkorting.toDto(any(), any()) } returns avkortingDto
 
             runBlocking {
                 service.hentAvkorting(behandlingId, bruker)
@@ -179,7 +183,7 @@ internal class AvkortingServiceTest {
                 avkortingRepository.hentAvkorting(behandlingId)
                 behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, bruker)
                 avkortingRepository.hentAvkorting(forrigeBehandlingId)
-                eksisterendeAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 1), forrigeAvkorting)
+                eksisterendeAvkorting.toDto(YearMonth.of(2024, 1), forrigeAvkorting)
             }
         }
 
@@ -198,6 +202,7 @@ internal class AvkortingServiceTest {
             val forrigeBehandlingId = UUID.randomUUID()
             val eksisterendeAvkorting = mockk<Avkorting>()
             val forrigeAvkorting = mockk<Avkorting>()
+            val avkortingDto = mockk<AvkortingDto>()
 
             coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
             coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
@@ -206,7 +211,7 @@ internal class AvkortingServiceTest {
                 )
             every { avkortingRepository.hentAvkorting(behandlingId) } returns eksisterendeAvkorting
             every { avkortingRepository.hentAvkorting(forrigeBehandlingId) } returns forrigeAvkorting
-            every { eksisterendeAvkorting.medYtelseFraOgMedVirkningstidspunkt(any(), any()) } returns eksisterendeAvkorting
+            every { eksisterendeAvkorting.toDto(any(), any()) } returns avkortingDto
 
             runBlocking {
                 service.hentAvkorting(behandlingId, bruker)
@@ -217,7 +222,7 @@ internal class AvkortingServiceTest {
                 avkortingRepository.hentAvkorting(behandlingId)
                 behandlingKlient.hentSisteIverksatteBehandling(behandling.sak, bruker)
                 avkortingRepository.hentAvkorting(forrigeBehandlingId)
-                eksisterendeAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 1), null)
+                eksisterendeAvkorting.toDto(YearMonth.of(2024, 1), null)
             }
         }
 
@@ -238,6 +243,7 @@ internal class AvkortingServiceTest {
             val beregning = mockk<Beregning>()
             val beregnetAvkorting = mockk<Avkorting>()
             val lagretAvkorting = mockk<Avkorting>()
+            val avkortingDto = mockk<AvkortingDto>()
 
             coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
             coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
@@ -251,7 +257,7 @@ internal class AvkortingServiceTest {
             every { forrigeAvkorting.kopierAvkorting() } returns kopiertAvkorting
             every { kopiertAvkorting.beregnAvkortingRevurdering(any(), any()) } returns beregnetAvkorting
             every { avkortingRepository.lagreAvkorting(any(), any(), any()) } returns Unit
-            every { lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(any(), any()) } returns lagretAvkorting
+            every { lagretAvkorting.toDto(any(), any()) } returns avkortingDto
             coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
 
             runBlocking {
@@ -268,7 +274,7 @@ internal class AvkortingServiceTest {
                 forrigeAvkorting.kopierAvkorting()
                 kopiertAvkorting.beregnAvkortingRevurdering(beregning, any())
                 avkortingRepository.lagreAvkorting(behandlingId, sakId, beregnetAvkorting)
-                lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 1), forrigeAvkorting)
+                lagretAvkorting.toDto(YearMonth.of(2024, 1), forrigeAvkorting)
                 behandlingKlient.avkort(behandlingId, bruker, true)
             }
             coVerify(exactly = 2) {
@@ -295,6 +301,7 @@ internal class AvkortingServiceTest {
             val beregning = mockk<Beregning>()
             val reberegnetAvkorting = mockk<Avkorting>()
             val lagretAvkorting = mockk<Avkorting>()
+            val avkortingDto = mockk<AvkortingDto>()
 
             coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
             coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
@@ -308,7 +315,7 @@ internal class AvkortingServiceTest {
             every { eksisterendeAvkorting.beregnAvkortingRevurdering(any(), any()) } returns reberegnetAvkorting
             every { avkortingRepository.lagreAvkorting(any(), any(), any()) } returns Unit
             coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
-            every { lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(any(), any()) } returns lagretAvkorting
+            every { lagretAvkorting.toDto(any(), any()) } returns avkortingDto
 
             runBlocking {
                 service.hentAvkorting(behandlingId, bruker)
@@ -324,7 +331,7 @@ internal class AvkortingServiceTest {
                 eksisterendeAvkorting.beregnAvkortingRevurdering(beregning, any())
                 avkortingRepository.lagreAvkorting(behandlingId, sakId, reberegnetAvkorting)
                 behandlingKlient.avkort(behandlingId, bruker, true)
-                lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 1), forrigeAvkorting)
+                lagretAvkorting.toDto(YearMonth.of(2024, 1), forrigeAvkorting)
             }
             coVerify(exactly = 2) {
                 avkortingRepository.hentAvkorting(behandlingId)
@@ -340,6 +347,7 @@ internal class AvkortingServiceTest {
         val eksisterendeAvkorting = mockk<Avkorting>()
         val beregnetAvkorting = mockk<Avkorting>()
         val lagretAvkorting = mockk<Avkorting>()
+        val avkortingDto = mockk<AvkortingDto>()
 
         @Test
         fun `Skal beregne og lagre avkorting for førstegangsbehandling`() {
@@ -362,10 +370,10 @@ internal class AvkortingServiceTest {
             } returns beregnetAvkorting
             every { avkortingRepository.lagreAvkorting(any(), any(), any()) } returns Unit
             coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
-            every { lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(any()) } returns lagretAvkorting
+            every { lagretAvkorting.toDto(any()) } returns avkortingDto
 
             runBlocking {
-                service.beregnAvkortingMedNyttGrunnlag(behandlingId, bruker, endretGrunnlag) shouldBe lagretAvkorting
+                service.beregnAvkortingMedNyttGrunnlag(behandlingId, bruker, endretGrunnlag) shouldBe avkortingDto
             }
 
             coVerify(exactly = 1) {
@@ -382,7 +390,7 @@ internal class AvkortingServiceTest {
                     any(),
                 )
                 avkortingRepository.lagreAvkorting(behandlingId, sakId, beregnetAvkorting)
-                lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 1))
+                lagretAvkorting.toDto(YearMonth.of(2024, 1))
                 behandlingKlient.avkort(behandlingId, bruker, true)
             }
             coVerify(exactly = 2) {
@@ -417,11 +425,11 @@ internal class AvkortingServiceTest {
                     forrigeBehandling,
                 )
             every { avkortingRepository.hentAvkorting(forrigeBehandling) } returns forrigeAvkorting
-            every { lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(any(), any()) } returns lagretAvkorting
+            every { lagretAvkorting.toDto(any(), any()) } returns avkortingDto
             coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
 
             runBlocking {
-                service.beregnAvkortingMedNyttGrunnlag(revurderingId, bruker, endretGrunnlag) shouldBe lagretAvkorting
+                service.beregnAvkortingMedNyttGrunnlag(revurderingId, bruker, endretGrunnlag) shouldBe avkortingDto
             }
 
             coVerify(exactly = 1) {
@@ -440,7 +448,7 @@ internal class AvkortingServiceTest {
                 avkortingRepository.lagreAvkorting(revurderingId, sakId, beregnetAvkorting)
                 behandlingKlient.hentSisteIverksatteBehandling(sakId, bruker)
                 avkortingRepository.hentAvkorting(forrigeBehandling)
-                lagretAvkorting.medYtelseFraOgMedVirkningstidspunkt(YearMonth.of(2024, 3), forrigeAvkorting)
+                lagretAvkorting.toDto(YearMonth.of(2024, 3), forrigeAvkorting)
                 behandlingKlient.avkort(revurderingId, bruker, true)
             }
             coVerify(exactly = 2) {

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -11,6 +11,7 @@ import no.nav.etterlatte.beregning.regler.avkorting
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlag
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlagLagre
 import no.nav.etterlatte.beregning.regler.bruker
+import no.nav.etterlatte.libs.common.beregning.AvkortetYtelseDto
 import no.nav.etterlatte.libs.common.periode.Periode
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -20,7 +21,7 @@ import java.util.UUID
 
 internal class AvkortingTest {
     @Nested
-    inner class AvkortetYtelseFraVirkningstidspunkt {
+    inner class AvkortigTilDto {
         val avkorting =
             Avkorting(
                 aarsoppgjoer =
@@ -29,6 +30,31 @@ internal class AvkortingTest {
                             id = UUID.randomUUID(),
                             aar = 2024,
                             forventaInnvilgaMaaneder = 10,
+                            inntektsavkorting =
+                                listOf(
+                                    Inntektsavkorting(
+                                        grunnlag =
+                                            avkortinggrunnlag(
+                                                periode =
+                                                    Periode(
+                                                        fom = YearMonth.of(2024, Month.MARCH),
+                                                        tom = YearMonth.of(2024, Month.JULY),
+                                                    ),
+                                                aarsinntekt = 300000,
+                                            ),
+                                    ),
+                                    Inntektsavkorting(
+                                        grunnlag =
+                                            avkortinggrunnlag(
+                                                periode =
+                                                    Periode(
+                                                        fom = YearMonth.of(2024, Month.AUGUST),
+                                                        tom = null,
+                                                    ),
+                                                aarsinntekt = 350000,
+                                            ),
+                                    ),
+                                ),
                             avkortetYtelseAar =
                                 listOf(
                                     avkortetYtelse(
@@ -54,6 +80,20 @@ internal class AvkortingTest {
                             id = UUID.randomUUID(),
                             aar = 2025,
                             forventaInnvilgaMaaneder = 12,
+                            inntektsavkorting =
+                                listOf(
+                                    Inntektsavkorting(
+                                        grunnlag =
+                                            avkortinggrunnlag(
+                                                periode =
+                                                    Periode(
+                                                        fom = YearMonth.of(2024, Month.JANUARY),
+                                                        tom = null,
+                                                    ),
+                                                aarsinntekt = 400000,
+                                            ),
+                                    ),
+                                ),
                             avkortetYtelseAar =
                                 listOf(
                                     avkortetYtelse(
@@ -69,89 +109,128 @@ internal class AvkortingTest {
             )
 
         @Test
+        fun `flater ut inntekter fra alle årsoppgjør`() {
+            avkorting.toDto(fraVirkningstidspunkt = YearMonth.of(2024, Month.MAY)).asClue {
+                it.avkortingGrunnlag.size shouldBe 3
+
+                it.avkortingGrunnlag[0] shouldBe
+                    avkorting.aarsoppgjoer[0]
+                        .inntektsavkorting[0]
+                        .grunnlag
+                        .toDto(10)
+                it.avkortingGrunnlag[1] shouldBe
+                    avkorting.aarsoppgjoer[0]
+                        .inntektsavkorting[1]
+                        .grunnlag
+                        .toDto(10)
+                it.avkortingGrunnlag[2] shouldBe
+                    avkorting.aarsoppgjoer[1]
+                        .inntektsavkorting[0]
+                        .grunnlag
+                        .toDto(12)
+            }
+        }
+
+        @Test
         fun `fyller ut avkortet ytelse foer virkningstidspunkt ved aa kutte aarsoppgjoer fra virkningstidspunkt`() {
-            avkorting.medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2024, Month.MAY)).asClue {
-                it.avkortetYtelseFraVirkningstidspunkt.size shouldBe 3
+            avkorting.toDto(fraVirkningstidspunkt = YearMonth.of(2024, Month.MAY)).asClue {
+                it.avkortetYtelse.size shouldBe 3
 
-                it.avkortetYtelseFraVirkningstidspunkt[0] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[1]
-                it.avkortetYtelseFraVirkningstidspunkt[1] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[2]
+                it.avkortetYtelse[0] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[1].toDto()
+                it.avkortetYtelse[1] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[2].toDto()
 
-                it.avkortetYtelseFraVirkningstidspunkt[2] shouldBe avkorting.aarsoppgjoer[1].avkortetYtelseAar[0]
+                it.avkortetYtelse[2] shouldBe avkorting.aarsoppgjoer[1].avkortetYtelseAar[0].toDto()
             }
         }
 
         @Test
         fun `kutter periode fra aarsoppgjoer hvis virkningstidspunkt begynner midt i periode `() {
-            avkorting.medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2024, Month.APRIL)).asClue {
-                it.avkortetYtelseFraVirkningstidspunkt.size shouldBe 4
-                with(it.avkortetYtelseFraVirkningstidspunkt[0]) {
+            avkorting.toDto(fraVirkningstidspunkt = YearMonth.of(2024, Month.APRIL)).asClue {
+                it.avkortetYtelse.size shouldBe 4
+                with(it.avkortetYtelse[0]) {
                     shouldBeEqualToIgnoringFields(
-                        avkorting.aarsoppgjoer[0].avkortetYtelseAar[0],
-                        AvkortetYtelse::periode,
+                        avkorting.aarsoppgjoer[0].avkortetYtelseAar[0].toDto(),
+                        AvkortetYtelseDto::fom,
+                        AvkortetYtelseDto::tom,
                     )
-                    periode shouldBe
-                        Periode(
-                            fom = YearMonth.of(2024, Month.APRIL),
-                            tom = YearMonth.of(2024, Month.APRIL),
-                        )
+                    fom shouldBe YearMonth.of(2024, Month.APRIL)
+                    tom shouldBe YearMonth.of(2024, Month.APRIL)
                 }
-                it.avkortetYtelseFraVirkningstidspunkt[1] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[1]
-                it.avkortetYtelseFraVirkningstidspunkt[2] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[2]
+                it.avkortetYtelse[1] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[1].toDto()
+                it.avkortetYtelse[2] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[2].toDto()
             }
 
-            avkorting.medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2024, Month.JUNE)).asClue {
-                it.avkortetYtelseFraVirkningstidspunkt.size shouldBe 3
-                with(it.avkortetYtelseFraVirkningstidspunkt[0]) {
+            avkorting.toDto(fraVirkningstidspunkt = YearMonth.of(2024, Month.JUNE)).asClue {
+                it.avkortetYtelse.size shouldBe 3
+                with(it.avkortetYtelse[0]) {
                     shouldBeEqualToIgnoringFields(
-                        avkorting.aarsoppgjoer[0].avkortetYtelseAar[1],
-                        AvkortetYtelse::periode,
+                        avkorting.aarsoppgjoer[0].avkortetYtelseAar[1].toDto(),
+                        AvkortetYtelseDto::fom,
+                        AvkortetYtelseDto::tom,
                     )
-                    periode shouldBe Periode(fom = YearMonth.of(2024, Month.JUNE), tom = YearMonth.of(2024, Month.JULY))
+                    fom shouldBe YearMonth.of(2024, Month.JUNE)
+                    tom shouldBe YearMonth.of(2024, Month.JULY)
                 }
-                it.avkortetYtelseFraVirkningstidspunkt[1] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[2]
+                it.avkortetYtelse[1] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[2].toDto()
             }
 
             avkorting
-                .medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2024, Month.SEPTEMBER))
+                .toDto(fraVirkningstidspunkt = YearMonth.of(2024, Month.SEPTEMBER))
                 .asClue {
-                    it.avkortetYtelseFraVirkningstidspunkt.size shouldBe 2
-                    with(it.avkortetYtelseFraVirkningstidspunkt[0]) {
+                    it.avkortetYtelse.size shouldBe 2
+                    with(it.avkortetYtelse[0]) {
                         shouldBeEqualToIgnoringFields(
-                            avkorting.aarsoppgjoer[0].avkortetYtelseAar[2],
-                            AvkortetYtelse::periode,
+                            avkorting.aarsoppgjoer[0].avkortetYtelseAar[2].toDto(),
+                            AvkortetYtelseDto::fom,
+                            AvkortetYtelseDto::tom,
                         )
-                        periode shouldBe Periode(fom = YearMonth.of(2024, Month.SEPTEMBER), tom = null)
+                        fom shouldBe YearMonth.of(2024, Month.SEPTEMBER)
+                        tom shouldBe null
                     }
                 }
 
             avkorting
-                .medYtelseFraOgMedVirkningstidspunkt(virkningstidspunkt = YearMonth.of(2025, Month.JANUARY))
+                .toDto(fraVirkningstidspunkt = YearMonth.of(2025, Month.JANUARY))
                 .asClue {
-                    it.avkortetYtelseFraVirkningstidspunkt.size shouldBe 1
-                    with(it.avkortetYtelseFraVirkningstidspunkt[0]) {
+                    it.avkortetYtelse.size shouldBe 1
+                    with(it.avkortetYtelse[0]) {
                         shouldBeEqualToIgnoringFields(
-                            avkorting.aarsoppgjoer[1].avkortetYtelseAar[0],
-                            AvkortetYtelse::periode,
+                            avkorting.aarsoppgjoer[1].avkortetYtelseAar[0].toDto(),
+                            AvkortetYtelseDto::fom,
+                            AvkortetYtelseDto::tom,
                         )
-                        periode shouldBe Periode(fom = YearMonth.of(2025, Month.JANUARY), tom = null)
+                        fom shouldBe YearMonth.of(2025, Month.JANUARY)
+                        tom shouldBe null
                     }
                 }
         }
 
         @Test
-        fun `fyller ut avkortetYtelseForrigeVedtak`() {
+        fun `fyller ut alle perioder med avkortet ytelse hvis virkningstidspunkt ikke er angitt`() {
+            avkorting.toDto(fraVirkningstidspunkt = null).asClue {
+                it.avkortetYtelse.size shouldBe 4
+
+                it.avkortetYtelse[0] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[0].toDto()
+                it.avkortetYtelse[1] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[1].toDto()
+                it.avkortetYtelse[2] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[2].toDto()
+                it.avkortetYtelse[3] shouldBe avkorting.aarsoppgjoer[1].avkortetYtelseAar[0].toDto()
+            }
+        }
+
+        @Test
+        fun `fyller ut tidligereAvkortetYtelse`() {
             avkorting
-                .medYtelseFraOgMedVirkningstidspunkt(
-                    virkningstidspunkt = YearMonth.of(2024, Month.MAY),
+                .toDto(
+                    fraVirkningstidspunkt = YearMonth.of(2024, Month.MAY),
                     forrigeAvkorting = avkorting,
                 ).asClue {
-                    it.avkortetYtelseForrigeVedtak.size shouldBe 4
+                    it.tidligereAvkortetYtelse.size shouldBe 4
 
-                    it.avkortetYtelseForrigeVedtak[0] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[0]
-                    it.avkortetYtelseForrigeVedtak[1] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[1]
-                    it.avkortetYtelseForrigeVedtak[2] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[2]
+                    it.tidligereAvkortetYtelse[0] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[0].toDto()
+                    it.tidligereAvkortetYtelse[1] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[1].toDto()
+                    it.tidligereAvkortetYtelse[2] shouldBe avkorting.aarsoppgjoer[0].avkortetYtelseAar[2].toDto()
 
-                    it.avkortetYtelseForrigeVedtak[3] shouldBe avkorting.aarsoppgjoer[1].avkortetYtelseAar[0]
+                    it.tidligereAvkortetYtelse[3] shouldBe avkorting.aarsoppgjoer[1].avkortetYtelseAar[0].toDto()
                 }
         }
     }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -64,6 +64,19 @@ export const AvkortingInntekt = ({
   const finnesRedigerbartGrunnlag = () =>
     avkorting?.avkortingGrunnlag && avkortingGrunnlag[0].fom === virkningstidspunkt(behandling).dato
 
+  const fulltAar = () => {
+    const innvilgelseFraJanuar =
+      behandling.behandlingType == IBehandlingsType.FØRSTEGANGSBEHANDLING &&
+      new Date(virkningstidspunkt(behandling).dato).getMonth() === 1
+
+    const revurderingIFulltAar = avkortingGrunnlag[0].relevanteMaanederInnAar == 12
+
+    const revurderingINyttAar =
+      new Date(avkortingGrunnlag[0].fom).getFullYear() != new Date(virkningstidspunkt(behandling).dato).getFullYear()
+
+    return innvilgelseFraJanuar || revurderingINyttAar || revurderingIFulltAar
+  }
+
   const finnRedigerbartGrunnlagEllerOpprettNytt = (): IAvkortingGrunnlagLagre => {
     if (finnesRedigerbartGrunnlag()) {
       // Returnerer grunnlagsperiode som er opprettet i denne behandlingen

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -29,7 +29,7 @@ import { isPending } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { enhetErSkrivbar } from '~components/behandling/felles/utils'
 import { useForm } from 'react-hook-form'
-import { IBehandlingStatus, virkningstidspunkt } from '~shared/types/IDetaljertBehandling'
+import { IBehandlingStatus, IBehandlingsType, virkningstidspunkt } from '~shared/types/IDetaljertBehandling'
 import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
 import { useAppDispatch, useAppSelector } from '~store/Store'
 import { lastDayOfMonth } from 'date-fns'
@@ -83,6 +83,10 @@ export const AvkortingInntekt = ({
       return avkortingGrunnlag[0]
     }
     if (avkortingGrunnlag.length > 0) {
+      // Setter disabla felter til forventet verdi
+      if (fulltAar()) {
+        return { spesifikasjon: '', fratrekkInnAar: 0, fratrekkInnAarUtland: 0 }
+      }
       // Preutfyller ny grunnlagsperiode med tidligere verdier
       const nyeste = avkortingGrunnlag[0]
       return { ...nyeste, id: undefined, spesifikasjon: '' }
@@ -253,6 +257,7 @@ export const AvkortingInntekt = ({
                       size="medium"
                       type="text"
                       inputMode="numeric"
+                      disabled={fulltAar()}
                       error={errors.fratrekkInnAar?.message}
                     />
                     <TextField
@@ -274,6 +279,7 @@ export const AvkortingInntekt = ({
                       label="Fratrekk inn-år"
                       size="medium"
                       type="text"
+                      disabled={fulltAar()}
                       inputMode="numeric"
                       error={errors.fratrekkInnAarUtland?.message}
                     />


### PR DESCRIPTION
Fjerner transitive felter for avkortetYtelseFraVirk og avkortetYtelseForrigeVedtak.
Siden det er kun relevant gjennom DTO så holder det å utlede det ved maping til dto.