### PR TITLE
EY-4080 Persistere strukturert avkortingsinformasjon i egen tabell i vedtaksvurdering

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
@@ -7,6 +7,9 @@ import kotliquery.queryOf
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.beregning.AvkortetYtelseDto
+import no.nav.etterlatte.libs.common.beregning.AvkortingDto
+import no.nav.etterlatte.libs.common.deserialize
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
@@ -87,6 +90,9 @@ class VedtaksvurderingRepository(
                 ?.let { vedtakId ->
                     if (opprettVedtak.innhold is VedtakInnhold.Behandling) {
                         opprettUtbetalingsperioder(vedtakId, opprettVedtak.innhold.utbetalingsperioder, this)
+                        opprettVedtak.innhold.avkorting?.let {
+                            opprettAvkortetYtelsePerioder(vedtakId, deserialize<AvkortingDto>(it.toString()).avkortetYtelse, this)
+                        }
                     }
                 } ?: throw Exception("Kunne ikke opprette vedtak for behandling ${opprettVedtak.behandlingId}")
             return@session hentVedtak(opprettVedtak.behandlingId, this)
@@ -139,6 +145,10 @@ class VedtaksvurderingRepository(
             if (oppdatertVedtak.innhold is VedtakInnhold.Behandling) {
                 slettUtbetalingsperioder(oppdatertVedtak.id, this)
                 opprettUtbetalingsperioder(oppdatertVedtak.id, oppdatertVedtak.innhold.utbetalingsperioder, this)
+                slettAvkortetYtelsePerioder(oppdatertVedtak.id, this)
+                oppdatertVedtak.innhold.avkorting?.let {
+                    opprettAvkortetYtelsePerioder(oppdatertVedtak.id, deserialize<AvkortingDto>(it.toString()).avkortetYtelse, this)
+                }
             }
             return@session hentVedtak(oppdatertVedtak.behandlingId, this)
                 ?: throw Exception("Kunne ikke oppdatere vedtak for behandling ${oppdatertVedtak.behandlingId}")
@@ -184,6 +194,42 @@ class VedtaksvurderingRepository(
                 ),
         ).let { query -> tx.run(query.asUpdate) }
     }
+
+    private fun slettAvkortetYtelsePerioder(
+        vedtakId: Long,
+        tx: TransactionalSession,
+    ) = queryOf(
+        statement = """
+                DELETE FROM avkortet_ytelse_periode
+                WHERE vedtakid = :vedtakid
+                """,
+        paramMap =
+            mapOf(
+                "vedtakid" to vedtakId,
+            ),
+    ).let { query -> tx.run(query.asUpdate) }
+
+    private fun opprettAvkortetYtelsePerioder(
+        vedtakId: Long,
+        avkortetYtelse: List<AvkortetYtelseDto>,
+        tx: TransactionalSession,
+    ) = tx.batchPreparedNamedStatement(
+        statement = """
+                    INSERT INTO avkortet_ytelse_periode(vedtakid, datofom, datotom, type, ytelseFoer, ytelseEtter) 
+                    VALUES (:vedtakid, :datofom, :datotom, :type, :ytelseFoer, :ytelseEtter)
+                    """,
+        params =
+            avkortetYtelse.map {
+                mapOf(
+                    "vedtakid" to vedtakId,
+                    "datofom" to it.fom.atDay(1).let(Date::valueOf),
+                    "datotom" to it.tom?.atEndOfMonth()?.let(Date::valueOf),
+                    "type" to it.type,
+                    "ytelseFoer" to it.ytelseFoerAvkorting,
+                    "ytelseEtter" to it.ytelseEtterAvkorting,
+                )
+            },
+    )
 
     fun hentVedtak(
         vedtakId: Long,

--- a/apps/etterlatte-vedtaksvurdering/src/main/resources/db/migration/V29__avkortet_ytelse.sql
+++ b/apps/etterlatte-vedtaksvurdering/src/main/resources/db/migration/V29__avkortet_ytelse.sql
@@ -1,0 +1,12 @@
+CREATE TABLE avkortet_ytelse_periode
+(
+    id          UUID PRIMARY KEY DEFAULT (uuid_generate_v4()),
+    vedtakId    BIGINT NOT NULL REFERENCES vedtak (id),
+    datoFom     DATE   NOT NULL,
+    datoTom     DATE,
+    type        TEXT   NOT NULL,
+    ytelseFoer  INT    NOT NULL,
+    ytelseEtter INT    NOT NULL
+);
+
+CREATE INDEX ON avkortet_ytelse_periode (vedtakId);

--- a/apps/etterlatte-vedtaksvurdering/src/main/resources/db/migration/V29__avkortet_ytelse.sql
+++ b/apps/etterlatte-vedtaksvurdering/src/main/resources/db/migration/V29__avkortet_ytelse.sql
@@ -1,12 +1,13 @@
 CREATE TABLE avkortet_ytelse_periode
 (
-    id          UUID PRIMARY KEY DEFAULT (uuid_generate_v4()),
-    vedtakId    BIGINT NOT NULL REFERENCES vedtak (id),
-    datoFom     DATE   NOT NULL,
+    id          UUID PRIMARY KEY         DEFAULT (uuid_generate_v4()),
+    vedtakId    BIGINT                                                      NOT NULL REFERENCES vedtak (id),
+    opprettet   TIMESTAMP WITH TIME ZONE DEFAULT (now() AT TIME ZONE 'UTC') NOT NULL,
+    datoFom     DATE                                                        NOT NULL,
     datoTom     DATE,
-    type        TEXT   NOT NULL,
-    ytelseFoer  INT    NOT NULL,
-    ytelseEtter INT    NOT NULL
+    type        TEXT                                                        NOT NULL,
+    ytelseFoer  INT                                                         NOT NULL,
+    ytelseEtter INT                                                         NOT NULL
 );
 
 CREATE INDEX ON avkortet_ytelse_periode (vedtakId);

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/TestHelper.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/TestHelper.kt
@@ -40,7 +40,7 @@ fun opprettVedtak(
     status: VedtakStatus = VedtakStatus.OPPRETTET,
     vilkaarsvurdering: ObjectNode? = objectMapper.createObjectNode(),
     beregning: ObjectNode? = objectMapper.createObjectNode(),
-    avkorting: ObjectNode? = objectMapper.createObjectNode(),
+    avkorting: ObjectNode? = null,
     sakType: SakType = SakType.BARNEPENSJON,
     behandlingType: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
     revurderingAarsak: Revurderingaarsak? = null,

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepositoryTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepositoryTest.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.beInstanceOf
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.beregning.AvkortingDto
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -56,7 +57,16 @@ internal class VedtaksvurderingRepositoryTest(
 
     @Test
     fun `skal opprette vedtak for behandling`() {
-        val nyttVedtak = opprettVedtak()
+        val avkorting =
+            AvkortingDto(
+                avkortingGrunnlag = emptyList(),
+                avkortetYtelse = emptyList(),
+            ).toObjectNode()
+
+        val nyttVedtak =
+            opprettVedtak(
+                avkorting = avkorting,
+            )
 
         val vedtak = repository.opprettVedtak(nyttVedtak)
 
@@ -75,7 +85,7 @@ internal class VedtaksvurderingRepositoryTest(
                 it.virkningstidspunkt shouldBe YearMonth.of(2023, Month.JANUARY)
                 it.vilkaarsvurdering shouldBe objectMapper.createObjectNode()
                 it.beregning shouldBe objectMapper.createObjectNode()
-                it.avkorting shouldBe objectMapper.createObjectNode()
+                it.avkorting shouldBe avkorting
                 it.utbetalingsperioder.first().let { utbetalingsperiode ->
                     utbetalingsperiode.id shouldNotBe null
                     utbetalingsperiode.periode shouldBe Periode(YearMonth.of(2023, Month.JANUARY), null)


### PR DESCRIPTION
Tenker å ta dette stegvis.
1) Opprette tabell, begynne å populere ved normal operasjon.
2) SQL for å etterpopulere
3) Ta ny tabell i bruk ved uthenting av data