### PR TITLE
Samanlikne med avkorting når vi verifiserer match vedtak - beregning/avkorting

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakOgBeregningSammenligner.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakOgBeregningSammenligner.kt
@@ -43,7 +43,7 @@ object VedtakOgBeregningSammenligner {
                 }
         check(perioder.size == beregningsperioder.size) {
             "Forventa like mange perioder i vedtak som i beregning for vedtak ${vedtak.id} i sak ${vedtak.sakId}. " +
-                "Vedtak hadde ${perioder.size}, mens beregning hadde ${beregningsperioder.size}" +
+                "Vedtak hadde ${perioder.size}, mens beregning hadde ${beregningsperioder.size}. " +
                 "Alle perioder fra vedtak: ${perioder.map { "${it.periode}: ${it.beloep}" }}. " +
                 "Alle perioder fra beregning: ${beregningsperioder.map {
                     "${it.fom}-${it.tom} - ${it.beloep}"

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakOgBeregningSammenligner.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakOgBeregningSammenligner.kt
@@ -8,6 +8,7 @@ import no.nav.etterlatte.vedtaksvurdering.Vedtak
 import no.nav.etterlatte.vedtaksvurdering.VedtakInnhold
 import org.slf4j.LoggerFactory
 import java.math.BigDecimal
+import java.time.YearMonth
 
 object VedtakOgBeregningSammenligner {
     private val logger = LoggerFactory.getLogger(this::class.java)
@@ -32,35 +33,37 @@ object VedtakOgBeregningSammenligner {
     ) {
         val innhold = vedtak.innhold as VedtakInnhold.Behandling
         val perioder = innhold.utbetalingsperioder.sortedBy { it.periode.fom }.filter { it.type == UtbetalingsperiodeType.UTBETALING }
-        val beregningsperioder = beregning.beregning.beregningsperioder.sortedBy { it.datoFOM }
+        val beregningsperioder =
+            beregning.avkorting
+                ?.avkortetYtelse
+                ?.sortedBy { it.fom }
+                ?.map { PeriodeMedBeloep(fom = it.fom, tom = it.tom, beloep = it.ytelseEtterAvkorting) }
+                ?: beregning.beregning.beregningsperioder.sortedBy { it.datoFOM }.map {
+                    PeriodeMedBeloep(fom = it.datoFOM, tom = it.datoTOM, beloep = it.utbetaltBeloep)
+                }
         check(perioder.size == beregningsperioder.size) {
             "Forventa like mange perioder i vedtak som i beregning for vedtak ${vedtak.id} i sak ${vedtak.sakId}. " +
                 "Vedtak hadde ${perioder.size}, mens beregning hadde ${beregningsperioder.size}" +
                 "Alle perioder fra vedtak: ${perioder.map { "${it.periode}: ${it.beloep}" }}. " +
                 "Alle perioder fra beregning: ${beregningsperioder.map {
-                    "${it.datoFOM}-${it.datoTOM} - ${it.utbetaltBeloep}"
+                    "${it.fom}-${it.tom} - ${it.beloep}"
                 } }"
         }
         for (i in perioder.indices) {
             val periode = perioder[i]
             val beregningsperiode = beregningsperioder[i]
-            val avkorting =
-                beregning.avkorting?.avkortetYtelse?.firstOrNull {
-                    it.fom == beregningsperiode.datoFOM && it.tom == beregningsperiode.datoTOM
-                }
 
-            val sumFraBeregningOgEvAvkorting = BigDecimal(avkorting?.ytelseEtterAvkorting ?: beregningsperiode.utbetaltBeloep)
-            check(sumFraBeregningOgEvAvkorting == periode.beloep) {
-                "Beløp for periode ${periode.periode} i vedtak ${vedtak.id} og behandling ${vedtak.behandlingId} var ${periode.beloep} i vedtak, men $sumFraBeregningOgEvAvkorting fra beregning og eventuell avkorting"
+            check(BigDecimal(beregningsperiode.beloep) == periode.beloep) {
+                "Beløp for periode ${periode.periode} i vedtak ${vedtak.id} og behandling ${vedtak.behandlingId} var ${periode.beloep} i vedtak, men ${beregningsperiode.beloep} fra beregning og eventuell avkorting"
             }
-            check(Periode(beregningsperiode.datoFOM, beregningsperiode.datoTOM) == periode.periode) {
+            check(Periode(beregningsperiode.fom, beregningsperiode.tom) == periode.periode) {
                 "FOM og TOM for periode ${periode.periode} i vedtak ${vedtak.id} " +
                     "og behandling ${vedtak.behandlingId} i vedtak, men ${Periode(
-                        beregningsperiode.datoFOM,
-                        beregningsperiode.datoTOM,
+                        beregningsperiode.fom,
+                        beregningsperiode.tom,
                     )} fra beregning. Alle perioder fra vedtak:" +
                     "${perioder.map { it.periode }}. " +
-                    "Alle perioder fra beregning: ${beregningsperioder.map { "${it.datoFOM}-${it.datoTOM}" } }"
+                    "Alle perioder fra beregning: ${beregningsperioder.map { "${it.fom}-${it.tom}" } }"
             }
         }
     }
@@ -75,3 +78,9 @@ object VedtakOgBeregningSammenligner {
         logger.info("Sammenligning av innhold i tilbakekreving er ikke implementert enno")
     }
 }
+
+data class PeriodeMedBeloep(
+    val fom: YearMonth,
+    val tom: YearMonth?,
+    val beloep: Int,
+)

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingServiceTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingServiceTest.kt
@@ -509,7 +509,7 @@ internal class VedtakBehandlingServiceTest(
         coEvery { beregningKlientMock.hentBeregningOgAvkorting(any(), any(), any()) } returns
             BeregningOgAvkorting(
                 beregning = mockBeregning(virkningstidspunkt, behandlingId),
-                avkorting = mockAvkorting(),
+                avkorting = null,
             )
         coEvery { trygdetidKlientMock.hentTrygdetid(any(), any()) } returns trygdetidDtoUtenDiff()
 
@@ -739,7 +739,7 @@ internal class VedtakBehandlingServiceTest(
         coEvery { beregningKlientMock.hentBeregningOgAvkorting(any(), any(), any()) } returns
             BeregningOgAvkorting(
                 beregning = mockBeregning(virkningstidspunkt, behandlingId),
-                avkorting = mockAvkorting(),
+                avkorting = null,
             )
         coEvery { trygdetidKlientMock.hentTrygdetid(any(), any()) } returns trygdetidDtoUtenDiff()
 
@@ -790,7 +790,7 @@ internal class VedtakBehandlingServiceTest(
         coEvery { beregningKlientMock.hentBeregningOgAvkorting(any(), any(), any()) } returns
             BeregningOgAvkorting(
                 beregning = mockBeregning(virkningstidspunkt, behandlingId),
-                avkorting = mockAvkorting(),
+                avkorting = null,
             )
         coEvery { trygdetidKlientMock.hentTrygdetid(any(), any()) } returns trygdetidDtoUtenDiff()
 
@@ -859,7 +859,7 @@ internal class VedtakBehandlingServiceTest(
         coEvery { beregningKlientMock.hentBeregningOgAvkorting(any(), any(), any()) } returns
             BeregningOgAvkorting(
                 beregning = mockBeregning(virkningstidspunkt, behandlingId),
-                avkorting = mockAvkorting(),
+                avkorting = null,
             )
         coEvery { trygdetidKlientMock.hentTrygdetid(any(), any()) } returns trygdetidDtoUtenDiff()
 
@@ -901,8 +901,8 @@ internal class VedtakBehandlingServiceTest(
                 behandlingId,
             )
         coEvery { beregningKlientMock.hentBeregningOgAvkorting(any(), any(), any()) } returns
-            mockk<BeregningOgAvkorting>(relaxed = true).also {
-                every { it.beregning } returns
+            BeregningOgAvkorting(
+                beregning =
                     mockk<BeregningDTO>(relaxed = true).also {
                         every {
                             it.beregningsperioder
@@ -917,8 +917,9 @@ internal class VedtakBehandlingServiceTest(
                                     trygdetid = 40,
                                 ),
                             )
-                    }
-            }
+                    },
+                avkorting = null,
+            )
 
         coEvery { trygdetidKlientMock.hentTrygdetid(any(), any()) } returns trygdetidDtoUtenDiff()
 
@@ -971,7 +972,7 @@ internal class VedtakBehandlingServiceTest(
         coEvery { beregningKlientMock.hentBeregningOgAvkorting(any(), any(), any()) } returns
             BeregningOgAvkorting(
                 beregning = mockBeregning(VIRKNINGSTIDSPUNKT_JAN_2023, behandlingId),
-                avkorting = mockAvkorting(),
+                avkorting = null,
             )
         coEvery { trygdetidKlientMock.hentTrygdetid(any(), any()) } returns trygdetidDtoUtenDiff()
 
@@ -1013,7 +1014,7 @@ internal class VedtakBehandlingServiceTest(
         coEvery { beregningKlientMock.hentBeregningOgAvkorting(any(), any(), any()) } returns
             BeregningOgAvkorting(
                 beregning = mockBeregning(virkningstidspunkt, behandlingId),
-                avkorting = mockAvkorting(),
+                avkorting = null,
             )
         coEvery { trygdetidKlientMock.hentTrygdetid(any(), any()) } returns trygdetidDtoUtenDiff()
 
@@ -1059,7 +1060,7 @@ internal class VedtakBehandlingServiceTest(
         coEvery { beregningKlientMock.hentBeregningOgAvkorting(any(), any(), any()) } returns
             BeregningOgAvkorting(
                 beregning = mockBeregning(virkningstidspunkt, behandlingId),
-                avkorting = mockAvkorting(),
+                avkorting = null,
             )
 
         coEvery { behandlingKlientMock.iverksett(any(), any(), any()) } throws RuntimeException("Behandling feilet")
@@ -1124,7 +1125,7 @@ internal class VedtakBehandlingServiceTest(
         coEvery { beregningKlientMock.hentBeregningOgAvkorting(any(), any(), any()) } returns
             BeregningOgAvkorting(
                 beregning = mockBeregning(VIRKNINGSTIDSPUNKT_JAN_2023, behandlingId),
-                avkorting = mockAvkorting(),
+                avkorting = null,
             )
         coEvery { trygdetidKlientMock.hentTrygdetid(any(), any()) } returns trygdetidDtoUtenDiff()
 
@@ -1165,7 +1166,7 @@ internal class VedtakBehandlingServiceTest(
         coEvery { beregningKlientMock.hentBeregningOgAvkorting(any(), any(), any()) } returns
             BeregningOgAvkorting(
                 beregning = mockBeregning(virkningstidspunkt, behandlingId),
-                avkorting = mockAvkorting(),
+                avkorting = null,
             )
         coEvery { trygdetidKlientMock.hentTrygdetid(any(), any()) } returns trygdetidDtoUtenDiff()
 
@@ -1211,8 +1212,8 @@ internal class VedtakBehandlingServiceTest(
                 any(),
             )
         } returns
-            mockk<BeregningOgAvkorting>(relaxed = true).also {
-                every { it.beregning } returns
+            BeregningOgAvkorting(
+                beregning =
                     mockk<BeregningDTO>(relaxed = true).also {
                         every {
                             it.beregningsperioder
@@ -1227,8 +1228,9 @@ internal class VedtakBehandlingServiceTest(
                                     trygdetid = 40,
                                 ),
                             )
-                    }
-            }
+                    },
+                avkorting = null,
+            )
         coEvery { trygdetidKlientMock.hentTrygdetid(any(), any()) } returns trygdetidDtoUtenDiff()
 
         runBlocking {
@@ -1282,7 +1284,7 @@ internal class VedtakBehandlingServiceTest(
         coEvery { beregningKlientMock.hentBeregningOgAvkorting(any(), any(), any()) } returns
             BeregningOgAvkorting(
                 beregning = mockBeregning(VIRKNINGSTIDSPUNKT_JAN_2023, behandlingId),
-                avkorting = mockAvkorting(),
+                avkorting = null,
             )
         coEvery { trygdetidKlientMock.hentTrygdetid(any(), any()) } returns trygdetidDtoUtenDiff()
 

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakOgBeregningSammenlignerTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakOgBeregningSammenlignerTest.kt
@@ -87,6 +87,15 @@ class VedtakOgBeregningSammenlignerTest {
                         restanse = 0,
                         sanksjon = null,
                     ),
+                    AvkortetYtelseDto(
+                        fom = YearMonth.of(2024, Month.MAY),
+                        tom = YearMonth.of(2024, Month.JUNE),
+                        ytelseFoerAvkorting = 2500,
+                        ytelseEtterAvkorting = ytelseEtterAvkorting * 2,
+                        avkortingsbeloep = 500,
+                        restanse = 0,
+                        sanksjon = null,
+                    ),
                 ),
         )
 


### PR DESCRIPTION
Avkorting kan medføre fleire/endra periodar frå kva beregning gir, så eksisterande logikk vart misvisande.