### PR TITLE
EY-4080 Benytte data fra avkortet_ytelse_periode tabell i stedet for vedtak.avkorting

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
@@ -342,13 +342,14 @@ class VedtaksvurderingRepository(
         }
 
     fun hentAvkortetYtelsePerioder(
-        vedtakId: Long,
+        vedtakIds: Set<Long>,
         tx: TransactionalSession? = null,
     ): List<AvkortetYtelsePeriode> =
         tx.session {
+            val idArray = this.connection.underlying.createArrayOf("bigint", vedtakIds.toTypedArray())
             hentListe(
-                queryString = "SELECT * FROM avkortet_ytelse_periode WHERE vedtakid = :vedtakid",
-                params = { mapOf("vedtakid" to vedtakId) },
+                queryString = "SELECT * FROM avkortet_ytelse_periode WHERE vedtakid = ANY (:vedtakIds)",
+                params = { mapOf("vedtakIds" to idArray) },
             ) { it.toAvkortetYtelsePeriode() }
         }
 

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
@@ -15,6 +15,7 @@ import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.vedtak.Attestasjon
+import no.nav.etterlatte.libs.common.vedtak.AvkortetYtelsePeriode
 import no.nav.etterlatte.libs.common.vedtak.Periode
 import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
 import no.nav.etterlatte.libs.common.vedtak.UtbetalingsperiodeType
@@ -340,6 +341,17 @@ class VedtaksvurderingRepository(
             ) { it.toUtbetalingsperiode() }
         }
 
+    fun hentAvkortetYtelsePerioder(
+        vedtakId: Long,
+        tx: TransactionalSession? = null,
+    ): List<AvkortetYtelsePeriode> =
+        tx.session {
+            hentListe(
+                queryString = "SELECT * FROM avkortet_ytelse_periode WHERE vedtakid = :vedtakid",
+                params = { mapOf("vedtakid" to vedtakId) },
+            ) { it.toAvkortetYtelsePeriode() }
+        }
+
     fun fattVedtak(
         behandlingId: UUID,
         vedtakFattet: VedtakFattet,
@@ -527,6 +539,17 @@ class VedtaksvurderingRepository(
                 ),
             beloep = bigDecimalOrNull("beloep"),
             type = UtbetalingsperiodeType.valueOf(string("type")),
+        )
+
+    private fun Row.toAvkortetYtelsePeriode() =
+        AvkortetYtelsePeriode(
+            id = uuid("id"),
+            vedtakId = long("vedtakid"),
+            fom = YearMonth.from(localDate("datofom")),
+            tom = localDateOrNull("datotom")?.let(YearMonth::from),
+            type = string("type"),
+            ytelseFoerAvkorting = int("ytelseFoer"),
+            ytelseEtterAvkorting = int("ytelseEtter"),
         )
 
     fun tilbakestillIkkeIverksatteVedtak(

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakSamordningServiceTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakSamordningServiceTest.kt
@@ -52,7 +52,7 @@ class VedtakSamordningServiceTest {
                         ),
                     ),
             )
-        every { vedtakRepository.hentAvkortetYtelsePerioder(1234) } returns emptyList()
+        every { vedtakRepository.hentAvkortetYtelsePerioder(setOf(1234)) } returns emptyList()
 
         val resultat = samordningService.hentVedtak(1234)!!
 
@@ -117,20 +117,17 @@ class VedtakSamordningServiceTest {
                         ),
                 ),
             )
-        every { vedtakRepository.hentAvkortetYtelsePerioder(1) } returns
+        every { vedtakRepository.hentAvkortetYtelsePerioder(setOf(1, 2)) } returns
             listOf(
                 AvkortetYtelsePeriode(
                     id = UUID.randomUUID(),
-                    vedtakId = 2,
+                    vedtakId = 1,
                     fom = virkFom2024Januar,
                     tom = virkFom2024Januar,
                     type = "FORVENTET_INNTEKT",
                     ytelseFoerAvkorting = 3000,
                     ytelseEtterAvkorting = 2500,
                 ),
-            )
-        every { vedtakRepository.hentAvkortetYtelsePerioder(2) } returns
-            listOf(
                 AvkortetYtelsePeriode(
                     id = UUID.randomUUID(),
                     vedtakId = 2,

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakSamordningServiceTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakSamordningServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.vedtaksvurdering
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -12,26 +13,35 @@ import no.nav.etterlatte.libs.common.beregning.AvkortingDto
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.vedtak.AvkortetYtelsePeriode
 import no.nav.etterlatte.libs.common.vedtak.Periode
 import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
 import no.nav.etterlatte.libs.common.vedtak.UtbetalingsperiodeType
 import no.nav.etterlatte.libs.common.vedtak.VedtakFattet
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.Month
 import java.time.YearMonth
+import java.util.UUID
 
 class VedtakSamordningServiceTest {
     private val vedtakRepository: VedtaksvurderingRepository = mockk()
     private val samordningService = VedtakSamordningService(vedtakRepository)
 
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
     @Test
     fun `skal hente vedtak`() {
         every { vedtakRepository.hentVedtak(1234) } returns
             vedtak(
+                id = 1234,
                 status = VedtakStatus.IVERKSATT,
                 avkorting =
                     objectMapper.valueToTree(
@@ -42,6 +52,7 @@ class VedtakSamordningServiceTest {
                         ),
                     ),
             )
+        every { vedtakRepository.hentAvkortetYtelsePerioder(1234) } returns emptyList()
 
         val resultat = samordningService.hentVedtak(1234)!!
 
@@ -60,6 +71,7 @@ class VedtakSamordningServiceTest {
         every { vedtakRepository.hentFerdigstilteVedtak(ident, SakType.OMSTILLINGSSTOENAD) } returns
             listOf(
                 vedtak(
+                    id = 1,
                     status = VedtakStatus.IVERKSATT,
                     virkningstidspunkt = virkFom2024Januar,
                     vedtakFattet =
@@ -82,6 +94,7 @@ class VedtakSamordningServiceTest {
                         ),
                 ),
                 vedtak(
+                    id = 2,
                     status = VedtakStatus.IVERKSATT,
                     virkningstidspunkt = virkFom2024Februar,
                     vedtakFattet =
@@ -102,6 +115,30 @@ class VedtakSamordningServiceTest {
                         objectMapper.valueToTree(
                             avkortingDto(fom = virkFom2024Februar, ytelseFoer = 3200, ytelseEtter = 2900),
                         ),
+                ),
+            )
+        every { vedtakRepository.hentAvkortetYtelsePerioder(1) } returns
+            listOf(
+                AvkortetYtelsePeriode(
+                    id = UUID.randomUUID(),
+                    vedtakId = 2,
+                    fom = virkFom2024Januar,
+                    tom = virkFom2024Januar,
+                    type = "FORVENTET_INNTEKT",
+                    ytelseFoerAvkorting = 3000,
+                    ytelseEtterAvkorting = 2500,
+                ),
+            )
+        every { vedtakRepository.hentAvkortetYtelsePerioder(2) } returns
+            listOf(
+                AvkortetYtelsePeriode(
+                    id = UUID.randomUUID(),
+                    vedtakId = 2,
+                    fom = virkFom2024Februar,
+                    tom = null,
+                    type = "FORVENTET_INNTEKT",
+                    ytelseFoerAvkorting = 3200,
+                    ytelseEtterAvkorting = 2900,
                 ),
             )
 

--- a/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/VedtakDto.kt
+++ b/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/VedtakDto.kt
@@ -114,6 +114,16 @@ enum class UtbetalingsperiodeType {
     UTBETALING,
 }
 
+data class AvkortetYtelsePeriode(
+    val id: UUID,
+    val vedtakId: Long,
+    val fom: YearMonth,
+    val tom: YearMonth?,
+    val type: String,
+    val ytelseFoerAvkorting: Int,
+    val ytelseEtterAvkorting: Int,
+)
+
 data class VedtakSamordningDto(
     val vedtakId: Long,
     val fnr: String,


### PR DESCRIPTION
oppfølger til #5166 og  #5173 