### PR TITLE
EY-4086 oppdaterer stønadsrader i statistikk

### DIFF
--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiverTest.kt
@@ -144,6 +144,7 @@ internal class JournalfoerVedtaksbrevRiverTest {
                     virkningstidspunkt = YearMonth.now(),
                     behandling = Behandling(behandlingType, behandlingId),
                     utbetalingsperioder = emptyList(),
+                    opphoerFraOgMed = null,
                 ),
         )
     }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
@@ -142,6 +142,7 @@ internal class OpprettJournalfoerOgDistribuer {
                             revurderingInfo = null,
                         ),
                     utbetalingsperioder = listOf(),
+                    opphoerFraOgMed = null,
                 ),
         )
 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/VedtaksbrevUnderkjentRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/VedtaksbrevUnderkjentRiverTest.kt
@@ -115,6 +115,7 @@ internal class VedtaksbrevUnderkjentRiverTest {
                     virkningstidspunkt = YearMonth.now(),
                     behandling = Behandling(behandlingType, behandlingsid),
                     utbetalingsperioder = emptyList(),
+                    opphoerFraOgMed = null,
                 ),
         )
     }

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/domain/StoenadRad.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/domain/StoenadRad.kt
@@ -2,7 +2,10 @@ package no.nav.etterlatte.statistikk.domain
 
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
+import no.nav.etterlatte.libs.common.vedtak.UtbetalingsperiodeType
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
 import java.util.UUID
@@ -35,4 +38,35 @@ data class StoenadRad(
     val kilde: Vedtaksloesning,
     val pesysId: Long?,
     val sakYtelsesgruppe: SakYtelsesgruppe?,
+    val opphoerFom: YearMonth?,
+    val vedtaksperioder: List<StoenadUtbetalingsperiode>?,
 )
+
+enum class StoenadPeriodeType {
+    OPPHOER,
+    UTBETALING,
+    ;
+
+    companion object {
+        fun fra(type: UtbetalingsperiodeType): StoenadPeriodeType =
+            when (type) {
+                UtbetalingsperiodeType.OPPHOER -> OPPHOER
+                UtbetalingsperiodeType.UTBETALING -> UTBETALING
+            }
+    }
+}
+
+data class StoenadUtbetalingsperiode(
+    val type: StoenadPeriodeType,
+    val beloep: BigDecimal?,
+    val fraOgMed: YearMonth,
+    val tilOgMed: YearMonth?,
+)
+
+fun tilStoenadUtbetalingsperiode(utbetalingsperiode: Utbetalingsperiode): StoenadUtbetalingsperiode =
+    StoenadUtbetalingsperiode(
+        type = StoenadPeriodeType.fra(utbetalingsperiode.type),
+        beloep = utbetalingsperiode.beloep,
+        fraOgMed = utbetalingsperiode.periode.fom,
+        tilOgMed = utbetalingsperiode.periode.tom,
+    )

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/service/StatistikkService.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/service/StatistikkService.kt
@@ -41,6 +41,7 @@ import no.nav.etterlatte.statistikk.domain.SakUtland
 import no.nav.etterlatte.statistikk.domain.SakYtelsesgruppe
 import no.nav.etterlatte.statistikk.domain.SoeknadFormat
 import no.nav.etterlatte.statistikk.domain.StoenadRad
+import no.nav.etterlatte.statistikk.domain.tilStoenadUtbetalingsperiode
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
 import java.time.YearMonth
@@ -243,6 +244,8 @@ class StatistikkService(
                 YearMonth.of(vedtattDato.year, vedtattDato.monthValue).plusMonths(1).atDay(20)
             }
         val vedtakInnhold = (vedtak.innhold as VedtakInnholdDto.VedtakBehandlingDto)
+        val vedtaksperioder = vedtakInnhold.utbetalingsperioder.map { tilStoenadUtbetalingsperiode(it) }
+
         return StoenadRad(
             id = -1,
             fnrSoeker = vedtak.sak.ident,
@@ -276,6 +279,8 @@ class StatistikkService(
             kilde = vedtaksloesning,
             pesysId = pesysid,
             sakYtelsesgruppe = hentSakYtelsesgruppe(sakType = vedtak.sak.sakType, avdoede = persongalleri.avdoed),
+            opphoerFom = vedtakInnhold.opphoerFraOgMed,
+            vedtaksperioder = vedtaksperioder,
         )
     }
 

--- a/apps/etterlatte-statistikk/src/main/resources/db/migration/V46__opphoer_fom_og_vedtaksperioder.sql
+++ b/apps/etterlatte-statistikk/src/main/resources/db/migration/V46__opphoer_fom_og_vedtaksperioder.sql
@@ -1,0 +1,2 @@
+alter table stoenad add column opphoerFom DATE;
+alter table stoenad add column vedtaksperioder JSONB;

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/database/StoenadRepositoryTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/database/StoenadRepositoryTest.kt
@@ -12,7 +12,9 @@ import no.nav.etterlatte.statistikk.domain.Beregningstype
 import no.nav.etterlatte.statistikk.domain.MaanedStoenadRad
 import no.nav.etterlatte.statistikk.domain.SakUtland
 import no.nav.etterlatte.statistikk.domain.SakYtelsesgruppe
+import no.nav.etterlatte.statistikk.domain.StoenadPeriodeType
 import no.nav.etterlatte.statistikk.domain.StoenadRad
+import no.nav.etterlatte.statistikk.domain.StoenadUtbetalingsperiode
 import no.nav.etterlatte.statistikk.domain.stoenadRad
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -22,6 +24,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.RegisterExtension
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.Month
 import java.time.YearMonth
@@ -107,6 +110,22 @@ class StoenadRepositoryTest(
                 kilde = Vedtaksloesning.GJENNY,
                 pesysId = 123L,
                 sakYtelsesgruppe = SakYtelsesgruppe.EN_AVDOED_FORELDER,
+                opphoerFom = YearMonth.of(2024, 1),
+                vedtaksperioder =
+                    listOf(
+                        StoenadUtbetalingsperiode(
+                            type = StoenadPeriodeType.UTBETALING,
+                            beloep = BigDecimal(1000),
+                            fraOgMed = YearMonth.of(2023, 6),
+                            tilOgMed = YearMonth.of(2023, 12),
+                        ),
+                        StoenadUtbetalingsperiode(
+                            type = StoenadPeriodeType.UTBETALING,
+                            beloep = null,
+                            fraOgMed = YearMonth.of(2024, 1),
+                            tilOgMed = null,
+                        ),
+                    ),
             ),
         )
         repo.hentStoenadRader().also {
@@ -121,6 +140,8 @@ class StoenadRepositoryTest(
             assertEquals(stoenadRad.avkorting, mockAvkorting)
             assertEquals(stoenadRad.vedtakType, VedtakType.INNVILGELSE)
             assertEquals(stoenadRad.sakUtland, SakUtland.NASJONAL)
+            assertEquals(2, stoenadRad.vedtaksperioder?.size)
+            assertEquals(YearMonth.of(2024, 1), stoenadRad.opphoerFom)
         }
     }
 
@@ -156,6 +177,8 @@ class StoenadRepositoryTest(
                 kilde = Vedtaksloesning.GJENNY,
                 pesysId = 123L,
                 sakYtelsesgruppe = SakYtelsesgruppe.EN_AVDOED_FORELDER,
+                opphoerFom = null,
+                vedtaksperioder = null,
             ),
         )
         repo.hentStoenadRader().also {
@@ -368,6 +391,8 @@ class StoenadRepositoryTest(
                     kilde = Vedtaksloesning.GJENNY,
                     pesysId = 123L,
                     sakYtelsesgruppe = SakYtelsesgruppe.EN_AVDOED_FORELDER,
+                    opphoerFom = null,
+                    vedtaksperioder = null,
                 ),
             )
 

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/domain/MaanedStatistikkTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/domain/MaanedStatistikkTest.kt
@@ -87,6 +87,7 @@ fun stoenadRad(
     pesysId: Long = 123L,
     sakYtelsesgruppe: SakYtelsesgruppe? = SakYtelsesgruppe.EN_AVDOED_FORELDER,
     opphoerFom: YearMonth? = null,
+    vedtaksperioder: List<StoenadUtbetalingsperiode>? = null,
 ): StoenadRad =
     StoenadRad(
         id = id,
@@ -117,4 +118,5 @@ fun stoenadRad(
         pesysId = pesysId,
         sakYtelsesgruppe = sakYtelsesgruppe,
         opphoerFom = opphoerFom,
+        vedtaksperioder = vedtaksperioder,
     )

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/domain/MaanedStatistikkTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/domain/MaanedStatistikkTest.kt
@@ -86,6 +86,7 @@ fun stoenadRad(
     kilde: Vedtaksloesning = Vedtaksloesning.GJENNY,
     pesysId: Long = 123L,
     sakYtelsesgruppe: SakYtelsesgruppe? = SakYtelsesgruppe.EN_AVDOED_FORELDER,
+    opphoerFom: YearMonth? = null,
 ): StoenadRad =
     StoenadRad(
         id = id,
@@ -115,4 +116,5 @@ fun stoenadRad(
         kilde = kilde,
         pesysId = pesysId,
         sakYtelsesgruppe = sakYtelsesgruppe,
+        opphoerFom = opphoerFom,
     )

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/river/VedtakhendelserRiverTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/river/VedtakhendelserRiverTest.kt
@@ -64,6 +64,7 @@ internal class VedtakhendelserRiverTest {
             kilde = Vedtaksloesning.GJENNY,
             pesysId = 123L,
             sakYtelsesgruppe = SakYtelsesgruppe.EN_AVDOED_FORELDER,
+            opphoerFom = null,
         )
 
     @Test

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/river/VedtakhendelserRiverTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/river/VedtakhendelserRiverTest.kt
@@ -65,6 +65,7 @@ internal class VedtakhendelserRiverTest {
             pesysId = 123L,
             sakYtelsesgruppe = SakYtelsesgruppe.EN_AVDOED_FORELDER,
             opphoerFom = null,
+            vedtaksperioder = null,
         )
 
     @Test

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/service/StatistikkServiceTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/service/StatistikkServiceTest.kt
@@ -321,6 +321,7 @@ fun vedtak(
     pensjonTilUtbetaling: List<Utbetalingsperiode>? = null,
     vedtakFattet: VedtakFattet? = null,
     attestasjon: Attestasjon? = null,
+    opphoerFom: YearMonth? = null,
 ) = VedtakDto(
     id = vedtakId,
     behandlingId = behandlingId,
@@ -334,6 +335,7 @@ fun vedtak(
             virkningstidspunkt = virk,
             behandling = Behandling(type = behandlingType, id = behandlingId),
             utbetalingsperioder = pensjonTilUtbetaling ?: emptyList(),
+            opphoerFraOgMed = opphoerFom,
         ),
 )
 

--- a/apps/etterlatte-utbetaling/src/test/kotlin/no/nav/etterlatte/utbetaling/VedtakHelper.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/no/nav/etterlatte/utbetaling/VedtakHelper.kt
@@ -42,6 +42,7 @@ fun vedtak(
         ),
     saktype: SakType = SakType.BARNEPENSJON,
     virkningstidspunkt: YearMonth? = null,
+    opphoerFraOgMed: YearMonth? = null,
 ) = VedtakDto(
     id = vedtakId,
     behandlingId = behandling.id,
@@ -70,6 +71,7 @@ fun vedtak(
             behandling = behandling,
             virkningstidspunkt = virkningstidspunkt ?: YearMonth.of(2022, 1),
             utbetalingsperioder = utbetalingsperioder,
+            opphoerFraOgMed = opphoerFraOgMed,
         ),
 )
 
@@ -112,6 +114,7 @@ fun ugyldigVedtakTilUtbetaling(
                         UtbetalingsperiodeType.UTBETALING,
                     ),
                 ),
+            opphoerFraOgMed = null,
         ),
 )
 
@@ -170,6 +173,7 @@ fun revurderingVedtak(
             behandling = behandling,
             virkningstidspunkt = YearMonth.of(2022, 1),
             utbetalingsperioder = utbetalingsperioder,
+            opphoerFraOgMed = null,
         ),
 )
 
@@ -199,18 +203,18 @@ fun opphoersVedtak(
             tidspunkt = Tidspunkt.now(),
         ),
     innhold =
-        VedtakInnholdDto.VedtakBehandlingDto(
-            virkningstidspunkt = YearMonth.of(2022, 1),
-            behandling = behandling,
-            utbetalingsperioder =
-                (vedtak.innhold as VedtakInnholdDto.VedtakBehandlingDto).let {
+        with(vedtak.innhold as VedtakInnholdDto.VedtakBehandlingDto) {
+            VedtakInnholdDto.VedtakBehandlingDto(
+                virkningstidspunkt = YearMonth.of(2022, 1),
+                behandling = behandling,
+                utbetalingsperioder =
                     listOf(
                         Utbetalingsperiode(
-                            id = it.utbetalingsperioder.last().id!! + 1,
+                            id = this.utbetalingsperioder.last().id!! + 1,
                             periode =
                                 Periode(
                                     fom =
-                                        it.utbetalingsperioder
+                                        this.utbetalingsperioder
                                             .first()
                                             .periode.fom
                                             .plusMonths(1),
@@ -219,9 +223,14 @@ fun opphoersVedtak(
                             beloep = null,
                             type = UtbetalingsperiodeType.OPPHOER,
                         ),
-                    )
-                },
-        ),
+                    ),
+                opphoerFraOgMed =
+                    this.utbetalingsperioder
+                        .first()
+                        .periode.fom
+                        .plusMonths(1),
+            )
+        },
 )
 
 fun genererEtterfolgendeUtbetalingsperioder(

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Vedtak.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Vedtak.kt
@@ -65,6 +65,7 @@ data class Vedtak(
                                     innhold.revurderingInfo,
                                 ),
                             utbetalingsperioder = innhold.utbetalingsperioder,
+                            opphoerFraOgMed = innhold.opphoerFraOgMed,
                         )
 
                     is VedtakInnhold.Tilbakekreving ->

--- a/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/VedtakDto.kt
+++ b/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/VedtakDto.kt
@@ -47,6 +47,7 @@ sealed class VedtakInnholdDto {
         val virkningstidspunkt: YearMonth,
         val behandling: Behandling,
         val utbetalingsperioder: List<Utbetalingsperiode>,
+        val opphoerFraOgMed: YearMonth?,
     ) : VedtakInnholdDto()
 
     @JsonTypeName("TILBAKEKREVING")


### PR DESCRIPTION
For å utlede riktig statistikk på måneder må statistikk vite om opphør fra og med, og utbetalingsperiodene sendt i vedtaket.

Oppdatering av eksisterende vedtak, samt oppdatering av hvordan vi mapper ut månedsstatistikken med tanke på opphør kommer i senere PR!