### PR TITLE
OpenAPI-konfigurasjon for å enkelt få oversikt over REST-endepunkta i…

### DIFF
--- a/buildSrc/akseptable-lisenser.json
+++ b/buildSrc/akseptable-lisenser.json
@@ -96,6 +96,10 @@
       "moduleLicense": "The Apache License, Version 2.0"
     },
     {
+      "moduleLicense": "Mozilla Public License, Version 2.0",
+      "moduleName": "org.mozilla:rhino"
+    },
+    {
       "moduleName": "no.nav.*"
     }
   ]

--- a/buildSrc/akseptable-lisenser.json
+++ b/buildSrc/akseptable-lisenser.json
@@ -78,6 +78,9 @@
       "moduleLicense": "The MIT License (MIT)"
     },
     {
+      "moduleLicense": "The MIT License"
+    },
+    {
       "moduleLicense": "Public Domain"
     },
     {
@@ -85,6 +88,9 @@
     },
     {
       "moduleLicense": "The Apache Software License, Version 2.0"
+    },
+    {
+      "moduleLicense": "Apache Software License, version 2.0"
     },
     {
       "moduleLicense": "The Apache License, Version 2.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -104,6 +104,7 @@ test-testcontainer-postgresql = { module = "org.testcontainers:postgresql", vers
 
 commons-compress = { module = "org.apache.commons:commons-compress", version = "1.26.2"}
 unleash-client = { module = "io.getunleash:unleash-client-java", version = "9.2.2" }
+openapi = { module = "io.github.smiley4:ktor-swagger-ui", version = "3.0.0" }
 
 #Workarounds
 bcpkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bcpkix-version"}

--- a/libs/etterlatte-ktor/build.gradle.kts
+++ b/libs/etterlatte-ktor/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     api(kotlin("reflect"))
 
     implementation(project(":libs:saksbehandling-common"))
+    implementation(libs.openapi)
 
     implementation(libs.ktor2.servercore)
     implementation(libs.ktor2.servercio)

--- a/libs/etterlatte-ktor/src/main/kotlin/RestModule.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/RestModule.kt
@@ -1,6 +1,9 @@
 package no.nav.etterlatte.libs.ktor
 
 import com.fasterxml.jackson.core.JacksonException
+import io.github.smiley4.ktorswaggerui.SwaggerUI
+import io.github.smiley4.ktorswaggerui.routing.openApiSpec
+import io.github.smiley4.ktorswaggerui.routing.swaggerUI
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.serialization.jackson.JacksonConverter
@@ -23,6 +26,7 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import io.micrometer.core.instrument.binder.MeterBinder
+import no.nav.etterlatte.libs.common.isProd
 import no.nav.etterlatte.libs.common.logging.CORRELATION_ID
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.ktor.feilhaandtering.StatusPagesKonfigurasjon
@@ -92,12 +96,28 @@ fun Application.restModule(
     }
 
     install(StatusPages, StatusPagesKonfigurasjon(sikkerLogg).config)
+    install(SwaggerUI) {
+        info {
+            title = "Etterlatte"
+            contact {
+                url = "https://github.com/navikt/pensjon-etterlatte-saksbehandling"
+            }
+        }
+    }
 
     routing {
         healthApi()
         authenticate {
             route(routePrefix ?: "") {
                 authenticatedRoutes()
+            }
+        }
+        if (!isProd()) {
+            route("swagger") {
+                swaggerUI("/api.json")
+            }
+            route("api.json") {
+                openApiSpec()
             }
         }
         if (routes != null) {


### PR DESCRIPTION
… applikasjonane våre.

Dette oppsettet her genererer automatisk opp swagger-ui-side for alle applikasjonane som bruker etterlatte-ktor-biblioteket, som jo er dei aller fleste applikasjonane våre. Vi får generert opp liste med URL og med type endepunkt (get/post/etc).

Ordentleg oversikt over parametre, responstypar og så vidare, pluss det å kunne faktisk køyre requestane frå UI-et, er ikkje fungerande her. Det ser ut som det i så fall må skildrast per requestobjekt eller per endepunkt. Støtte for det hadde jo vore fint å ha, men hovudpoenget her er å få oversikt over kva vi har av endepunkt.

Leita ein del for å finne eit bibliotek som gjer dette oppsettet for oss, men fann ingen som tilfredsstilte krava mine om å 1) vera retta mot Ktor, 2) vera nyleg oppdatert, 3) ha fleire enn ein committers og 4) ikkje krev manuell generering av yaml via intellij eller på anna vis. Alt anna verka også knotete å få konfigurert opp. Tenkjer derfor å starte med dette, og heller bytte viss det trengs.