### PR TITLE
Refaktorering tilbakekreving

### DIFF
--- a/apps/etterlatte-tilbakekreving/.run/etterlatte-tilbakekreving.dev-gcp.run.xml
+++ b/apps/etterlatte-tilbakekreving/.run/etterlatte-tilbakekreving.dev-gcp.run.xml
@@ -22,6 +22,7 @@
       <env name="ETTERLATTE_BEHANDLING_URL" value="https://etterlatte-behandling.intern.dev.nav.no" />
       <env name="ETTERLATTE_PROXY_SCOPE" value="api://dev-fss.etterlatte.etterlatte-proxy/.default" />
       <env name="ETTERLATTE_PROXY_URL" value="https://etterlatte-proxy.dev-fss-pub.nais.io/aad" />
+      <env name="ENABLE_KRAVGRUNNLAG_ROUTES" value="true" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="no.nav.etterlatte.ApplicationKt" />
     <module name="pensjon-etterlatte-saksbehandling.apps.etterlatte-tilbakekreving.main" />

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/Application.kt
@@ -7,7 +7,7 @@ import no.nav.etterlatte.libs.ktor.initialisering.initEmbeddedServer
 import no.nav.etterlatte.libs.ktor.setReady
 import no.nav.etterlatte.tilbakekreving.config.ApplicationContext
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.testKravgrunnlagRoutes
-import no.nav.etterlatte.tilbakekreving.vedtak.tilbakekrevingRoutes
+import no.nav.etterlatte.tilbakekreving.tilbakekrevingRoutes
 
 fun main() {
     ApplicationContext().let { Server(it).run() }

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/Application.kt
@@ -1,12 +1,14 @@
 package no.nav.etterlatte
 
 import com.typesafe.config.ConfigFactory
+import io.ktor.server.application.log
+import io.ktor.server.routing.application
 import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.initialisering.initEmbeddedServer
 import no.nav.etterlatte.libs.ktor.setReady
 import no.nav.etterlatte.tilbakekreving.config.ApplicationContext
-import no.nav.etterlatte.tilbakekreving.kravgrunnlag.testKravgrunnlagRoutes
+import no.nav.etterlatte.tilbakekreving.kravgrunnlag.kravgrunnlagRoutes
 import no.nav.etterlatte.tilbakekreving.tilbakekrevingRoutes
 
 fun main() {
@@ -26,8 +28,12 @@ class Server(
             applicationConfig = ConfigFactory.load(),
             withMetrics = false,
         ) {
-            testKravgrunnlagRoutes(context.kravgrunnlagService)
             tilbakekrevingRoutes(context.tilbakekrevingService)
+
+            if (context.properties.enableKravgrunnlagRoutes) {
+                application.log.warn("Legger på endepunkter for kravgrunnlag (kun tilgjengelig lokalt)")
+                kravgrunnlagRoutes(context.kravgrunnlagService)
+            }
         }
 
     fun run() =

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingHendelseRepository.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingHendelseRepository.kt
@@ -1,4 +1,4 @@
-package no.nav.etterlatte.tilbakekreving.hendelse
+package no.nav.etterlatte.tilbakekreving
 
 import kotliquery.queryOf
 import kotliquery.sessionOf

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingRoutes.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingRoutes.kt
@@ -1,4 +1,4 @@
-package no.nav.etterlatte.tilbakekreving.vedtak
+package no.nav.etterlatte.tilbakekreving
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingRoutes.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingRoutes.kt
@@ -18,8 +18,10 @@ fun Route.tilbakekrevingRoutes(tilbakekrevingService: TilbakekrevingService) {
     route("/api/tilbakekreving/{sakId}") {
         post("/vedtak") {
             kunSystembruker {
-                logger.info("Sender tilbakekrevingsvedtak")
                 val vedtak = call.receive<TilbakekrevingVedtak>()
+
+                logger.info("Sender tilbakekrevingsvedtak for sak ${vedtak.sakId}")
+
                 tilbakekrevingService.sendTilbakekrevingsvedtak(vedtak)
                 call.respond(HttpStatusCode.Created)
             }
@@ -27,9 +29,10 @@ fun Route.tilbakekrevingRoutes(tilbakekrevingService: TilbakekrevingService) {
 
         get("/kravgrunnlag/{kravgrunnlagId}") {
             kunSystembruker {
-                logger.info("Henter oppdatert kravgrunnlag")
                 val sakId = requireNotNull(call.parameters["sakId"]).toLong()
                 val kravgrunnlagId = requireNotNull(call.parameters["kravgrunnlagId"]).toLong()
+
+                logger.info("Henter oppdatert kravgrunnlag for sak $sakId med kravgrunnlagId $kravgrunnlagId")
 
                 val oppdatertKravgrunnlag =
                     tilbakekrevingService.hentKravgrunnlag(

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingService.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingService.kt
@@ -1,7 +1,8 @@
-package no.nav.etterlatte.tilbakekreving.vedtak
+package no.nav.etterlatte.tilbakekreving
 
 import no.nav.etterlatte.libs.common.tilbakekreving.Kravgrunnlag
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingVedtak
+import no.nav.etterlatte.tilbakekreving.klienter.TilbakekrevingKlient
 import org.slf4j.LoggerFactory
 
 class TilbakekrevingService(

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingService.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingService.kt
@@ -2,24 +2,16 @@ package no.nav.etterlatte.tilbakekreving
 
 import no.nav.etterlatte.libs.common.tilbakekreving.Kravgrunnlag
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingVedtak
-import no.nav.etterlatte.tilbakekreving.klienter.TilbakekrevingKlient
-import org.slf4j.LoggerFactory
+import no.nav.etterlatte.tilbakekreving.klienter.TilbakekrevingskomponentenKlient
 
 class TilbakekrevingService(
-    private val tilbakekrevingKlient: TilbakekrevingKlient,
+    private val tilbakekrevingskomponentenKlient: TilbakekrevingskomponentenKlient,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
-
-    fun sendTilbakekrevingsvedtak(tilbakekrevingsvedtak: TilbakekrevingVedtak) {
-        logger.info("Sender tilbakekrevingsvedtak (${tilbakekrevingsvedtak.vedtakId}) til tilbakekrevingskomponenten")
-        tilbakekrevingKlient.sendTilbakekrevingsvedtak(tilbakekrevingsvedtak)
-    }
+    fun sendTilbakekrevingsvedtak(tilbakekrevingsvedtak: TilbakekrevingVedtak) =
+        tilbakekrevingskomponentenKlient.sendTilbakekrevingsvedtak(tilbakekrevingsvedtak)
 
     fun hentKravgrunnlag(
         kravgrunnlagId: Long,
         sakId: Long,
-    ): Kravgrunnlag {
-        logger.info("Henter oppdatert kravgrunnlag for sak $sakId fra tilbakekrevingskomponenten")
-        return tilbakekrevingKlient.hentKravgrunnlag(sakId, kravgrunnlagId)
-    }
+    ): Kravgrunnlag = tilbakekrevingskomponentenKlient.hentKravgrunnlag(sakId, kravgrunnlagId)
 }

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/config/ApplicationContext.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/config/ApplicationContext.kt
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 import no.nav.etterlatte.mq.JmsConnectionFactory
+import no.nav.etterlatte.tilbakekreving.TilbakekrevingService
 import no.nav.etterlatte.tilbakekreving.hendelse.TilbakekrevingHendelseRepository
 import no.nav.etterlatte.tilbakekreving.klienter.BehandlingKlient
+import no.nav.etterlatte.tilbakekreving.klienter.TilbakekrevingKlient
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.KravgrunnlagConsumer
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.KravgrunnlagService
-import no.nav.etterlatte.tilbakekreving.vedtak.TilbakekrevingKlient
-import no.nav.etterlatte.tilbakekreving.vedtak.TilbakekrevingService
 
 class ApplicationContext(
     val properties: ApplicationProperties = ApplicationProperties.fromEnv(System.getenv()),

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/config/ApplicationContext.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/config/ApplicationContext.kt
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 import no.nav.etterlatte.mq.JmsConnectionFactory
+import no.nav.etterlatte.tilbakekreving.TilbakekrevingHendelseRepository
 import no.nav.etterlatte.tilbakekreving.TilbakekrevingService
-import no.nav.etterlatte.tilbakekreving.hendelse.TilbakekrevingHendelseRepository
 import no.nav.etterlatte.tilbakekreving.klienter.BehandlingKlient
-import no.nav.etterlatte.tilbakekreving.klienter.TilbakekrevingKlient
+import no.nav.etterlatte.tilbakekreving.klienter.TilbakekrevingskomponentenKlient
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.KravgrunnlagConsumer
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.KravgrunnlagService
 
@@ -47,7 +47,7 @@ class ApplicationContext(
     val tilbakekrevingHendelseRepository = TilbakekrevingHendelseRepository(dataSource)
 
     val tilbakekrevingKlient =
-        TilbakekrevingKlient(
+        TilbakekrevingskomponentenKlient(
             url = properties.proxyUrl,
             httpClient =
                 httpClientClientCredentials(

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/config/ApplicationProperties.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/config/ApplicationProperties.kt
@@ -21,6 +21,7 @@ data class ApplicationProperties(
     val behandlingScope: String,
     val proxyUrl: String,
     val proxyScope: String,
+    val enableKravgrunnlagRoutes: Boolean,
 ) {
     companion object {
         fun fromEnv(env: Map<String, String>) =
@@ -49,6 +50,7 @@ data class ApplicationProperties(
                     behandlingScope = value("ETTERLATTE_BEHANDLING_SCOPE"),
                     proxyUrl = value("ETTERLATTE_PROXY_URL"),
                     proxyScope = value("ETTERLATTE_PROXY_SCOPE"),
+                    enableKravgrunnlagRoutes = valueOrNull("ENABLE_KRAVGRUNNLAG_ROUTES").toBoolean(),
                 )
             }
 

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/klienter/TilbakekrevingskomponentenKlient.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/klienter/TilbakekrevingskomponentenKlient.kt
@@ -1,4 +1,4 @@
-package no.nav.etterlatte.tilbakekreving.vedtak
+package no.nav.etterlatte.tilbakekreving.klienter
 
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.JsonSerializer
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.module.SimpleModule
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
@@ -22,8 +21,8 @@ import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingVedtak
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingsbelopFeilkontoVedtak
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingsbelopYtelseVedtak
 import no.nav.etterlatte.libs.common.toJson
-import no.nav.etterlatte.tilbakekreving.hendelse.TilbakekrevingHendelseRepository
-import no.nav.etterlatte.tilbakekreving.hendelse.TilbakekrevingHendelseType
+import no.nav.etterlatte.tilbakekreving.TilbakekrevingHendelseRepository
+import no.nav.etterlatte.tilbakekreving.TilbakekrevingHendelseType
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.KravgrunnlagMapper
 import no.nav.okonomi.tilbakekrevingservice.KravgrunnlagHentDetaljRequest
 import no.nav.okonomi.tilbakekrevingservice.KravgrunnlagHentDetaljResponse
@@ -39,13 +38,16 @@ import java.time.LocalDate
 import javax.xml.datatype.DatatypeFactory
 import javax.xml.datatype.XMLGregorianCalendar
 
-class TilbakekrevingKlient(
+class TilbakekrevingskomponentenKlient(
     private val url: String,
     private val httpClient: HttpClient,
     private val hendelseRepository: TilbakekrevingHendelseRepository,
 ) {
     // Egen objectmapper for å fjerne timestamp fra xml-datoer da dette ikke blir riktig mot tilbakekrevingskomponenten
-    private val tilbakekrevingObjectMapper: ObjectMapper = objectMapper.copy().registerModule(CustomXMLGregorianCalendarModule())
+    private val tilbakekrevingObjectMapper: ObjectMapper =
+        objectMapper.copy().registerModule(
+            CustomXMLGregorianCalendarModule(),
+        )
 
     private val logger = LoggerFactory.getLogger(javaClass)
     private val sikkerLogg = sikkerlogger()

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumer.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumer.kt
@@ -7,8 +7,8 @@ import net.logstash.logback.argument.StructuredArguments.kv
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.common.logging.withLogContext
 import no.nav.etterlatte.mq.EtterlatteJmsConnectionFactory
-import no.nav.etterlatte.tilbakekreving.hendelse.TilbakekrevingHendelseRepository
-import no.nav.etterlatte.tilbakekreving.hendelse.TilbakekrevingHendelseType
+import no.nav.etterlatte.tilbakekreving.TilbakekrevingHendelseRepository
+import no.nav.etterlatte.tilbakekreving.TilbakekrevingHendelseType
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.KravgrunnlagJaxb.toDetaljertKravgrunnlagDto
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.KravgrunnlagJaxb.toKravOgVedtakstatus
 import org.slf4j.Logger

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagRoutes.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagRoutes.kt
@@ -9,7 +9,10 @@ import io.ktor.server.routing.route
 import no.nav.tilbakekreving.kravgrunnlag.detalj.v1.DetaljertKravgrunnlagDto
 import no.nav.tilbakekreving.status.v1.KravOgVedtakstatus
 
-fun Route.testKravgrunnlagRoutes(service: KravgrunnlagService) {
+/**
+ * Brukes kun for lokal testing
+ */
+fun Route.kravgrunnlagRoutes(service: KravgrunnlagService) {
     route("kravgrunnlag") {
         post {
             val dto = call.receive<DetaljertKravgrunnlagDto>()

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/DatabaseExtension.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/DatabaseExtension.kt
@@ -1,4 +1,4 @@
-package tilbakekreving
+package no.nav.etterlatte.tilbakekreving
 
 import no.nav.etterlatte.GenerellDatabaseExtension
 import no.nav.etterlatte.ResetDatabaseStatement

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/TilbakekrevingHendelseRepositoryTest.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/TilbakekrevingHendelseRepositoryTest.kt
@@ -1,4 +1,4 @@
-package no.nav.etterlatte.tilbakekreving.hendelse
+package no.nav.etterlatte.tilbakekreving
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.RegisterExtension
-import tilbakekreving.DatabaseExtension
 import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/TilbakekrevingRoutesTest.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/TilbakekrevingRoutesTest.kt
@@ -1,4 +1,4 @@
-package no.nav.etterlatte.tilbakekreving.vedtak
+package no.nav.etterlatte.tilbakekreving
 
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.get
@@ -18,8 +18,6 @@ import io.mockk.runs
 import no.nav.etterlatte.ktor.issueSystembrukerToken
 import no.nav.etterlatte.ktor.runServer
 import no.nav.etterlatte.libs.common.toJson
-import no.nav.etterlatte.tilbakekreving.kravgrunnlag
-import no.nav.etterlatte.tilbakekreving.tilbakekrevingsvedtak
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/klienter/TilbakekrevingskomponentenKlientTest.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/klienter/TilbakekrevingskomponentenKlientTest.kt
@@ -1,4 +1,4 @@
-package no.nav.etterlatte.tilbakekreving.vedtak
+package no.nav.etterlatte.tilbakekreving.klienter
 
 import io.kotest.matchers.shouldNotBe
 import io.ktor.client.HttpClient
@@ -15,8 +15,8 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.toJson
-import no.nav.etterlatte.tilbakekreving.hendelse.TilbakekrevingHendelseRepository
-import no.nav.etterlatte.tilbakekreving.hendelse.TilbakekrevingHendelseType
+import no.nav.etterlatte.tilbakekreving.TilbakekrevingHendelseRepository
+import no.nav.etterlatte.tilbakekreving.TilbakekrevingHendelseType
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.KravgrunnlagJaxb
 import no.nav.etterlatte.tilbakekreving.readFile
 import no.nav.etterlatte.tilbakekreving.tilbakekrevingsvedtak
@@ -26,7 +26,7 @@ import no.nav.tilbakekreving.typer.v1.MmelDto
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
-internal class TilbakekrevingKlientTest {
+internal class TilbakekrevingskomponentenKlientTest {
     private val hendelseRepository = mockk<TilbakekrevingHendelseRepository>(relaxed = true)
 
     @Test
@@ -37,7 +37,7 @@ internal class TilbakekrevingKlientTest {
             }
 
         val httpClient = mockedHttpClient("/tilbakekreving/tilbakekrevingsvedtak", HttpMethod.Post, response)
-        val tilbakekrevingKlient = TilbakekrevingKlient("", httpClient, hendelseRepository)
+        val tilbakekrevingKlient = TilbakekrevingskomponentenKlient("", httpClient, hendelseRepository)
 
         val tilbakekrevingsvedtak = tilbakekrevingsvedtak()
         tilbakekrevingKlient.sendTilbakekrevingsvedtak(tilbakekrevingsvedtak)
@@ -64,12 +64,12 @@ internal class TilbakekrevingKlientTest {
             }
 
         val httpClient = mockedHttpClient("/tilbakekreving/tilbakekrevingsvedtak", HttpMethod.Post, response)
-        val tilbakekrevingKlient = TilbakekrevingKlient("", httpClient, hendelseRepository)
+        val tilbakekrevingskomponentenKlient = TilbakekrevingskomponentenKlient("", httpClient, hendelseRepository)
 
         val tilbakekrevingsvedtak = tilbakekrevingsvedtak()
 
         assertThrows<Exception>("Tilbakekrevingsvedtak feilet med alvorlighetsgrad 08") {
-            tilbakekrevingKlient.sendTilbakekrevingsvedtak(tilbakekrevingsvedtak)
+            tilbakekrevingskomponentenKlient.sendTilbakekrevingsvedtak(tilbakekrevingsvedtak)
         }
 
         verify {
@@ -98,10 +98,10 @@ internal class TilbakekrevingKlientTest {
             }
 
         val httpClient = mockedHttpClient("/tilbakekreving/kravgrunnlag", HttpMethod.Post, response)
-        val tilbakekrevingKlient = TilbakekrevingKlient("", httpClient, hendelseRepository)
+        val tilbakekrevingskomponentenKlient = TilbakekrevingskomponentenKlient("", httpClient, hendelseRepository)
         val sakId = 1L
 
-        val kravgrunnlagResponse = tilbakekrevingKlient.hentKravgrunnlag(sakId, 123L)
+        val kravgrunnlagResponse = tilbakekrevingskomponentenKlient.hentKravgrunnlag(sakId, 123L)
 
         kravgrunnlagResponse shouldNotBe null
 

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumerTest.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumerTest.kt
@@ -5,7 +5,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.etterlatte.mq.DummyJmsConnectionFactory
 import no.nav.etterlatte.mq.EtterlatteJmsConnectionFactory
-import no.nav.etterlatte.tilbakekreving.hendelse.TilbakekrevingHendelseRepository
+import no.nav.etterlatte.tilbakekreving.TilbakekrevingHendelseRepository
 import no.nav.etterlatte.tilbakekreving.readFile
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
Kort oppsummert:
- Flytter ting ut av `vedtak` da klienten nå også inneholder metode for å hente kravgrunnlag
- Døper om `TilbakekrevingKlient` til `TilbakekrevingskomponentenKlient`
- Legger på namespace på testklasser
- Tilgjengeliggjør endepunkter for kravgrunnlag kun ved lokal kjøring