### PR TITLE
EY-4103 Sletter rader for opphørte vedtak

### DIFF
--- a/apps/etterlatte-statistikk/src/main/resources/db/migration/V48__fjerner_opphoerte_vedtak_fra_maanedsstatistikk.sql
+++ b/apps/etterlatte-statistikk/src/main/resources/db/migration/V48__fjerner_opphoerte_vedtak_fra_maanedsstatistikk.sql
@@ -1,0 +1,7 @@
+delete
+from maaned_stoenad ms
+where id in (select m.id
+             from maaned_stoenad m
+                      left outer join stoenad s on m.behandlingid = s.behandlingid
+             where s.opphoerfom is not null
+               and s.opphoerfom <= date(statistikkmaaned || '-01'::text));


### PR DESCRIPTION
Disse radene ble med på grunn av feil / manglende logikk i månedsstatistikk