### PR TITLE
EY-4062: Setter status ved oppdatert kravgrunnlag og fikser paavent håndtering tk

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
@@ -287,7 +287,12 @@ class TilbakekrevingService(
             // Dersom kontrollfeltet er forskjellig betyr det at kravgrunnlaget har blitt endret hos økonomi
             if (oppdatertKravgrunnlag.kontrollFelt.value != tilbakekreving.tilbakekreving.kravgrunnlag.kontrollFelt.value) {
                 logger.info("Oppdaterer kravgrunnlag tilknyttet tilbakekreving $tilbakekrevingId")
-                val oppdatertTilbakekreving = tilbakekreving.oppdaterKravgrunnlag(oppdatertKravgrunnlag)
+                val oppdatertTilbakekreving =
+                    tilbakekreving
+                        .oppdaterKravgrunnlag(
+                            oppdatertKravgrunnlag,
+                        ).copy(status = TilbakekrevingStatus.UNDER_ARBEID)
+
                 tilbakekrevingDao.lagreTilbakekrevingMedNyePerioder(oppdatertTilbakekreving)
             } else {
                 logger.info("Kravgrunnlag tilknyttet tilbakekreving $tilbakekrevingId er ikke endret - beholder vurderinger")

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -471,16 +471,11 @@ class OppgaveService(
     fun hentForrigeStatus(oppgaveId: UUID): Status {
         val oppgave = hentOppgave(oppgaveId)
 
-        val endringerForOppgave = oppgaveDao.hentEndringerForOppgave(oppgaveId)
-
-        return if (endringerForOppgave.size == 1) {
-            endringerForOppgave.first().oppgaveFoer.status
-        } else {
-            endringerForOppgave
-                .sortedByDescending { it.tidspunkt }
-                .first { it.oppgaveEtter.status != oppgave.status }
-                .oppgaveEtter.status
-        }
+        return oppgaveDao
+            .hentEndringerForOppgave(oppgaveId)
+            .sortedByDescending { it.tidspunkt }
+            .first { it.oppgaveFoer.status != oppgave.status }
+            .oppgaveFoer.status
     }
 
     fun avbrytOppgaveUnderBehandling(

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -1211,7 +1211,7 @@ internal class OppgaveServiceTest(
     }
 
     @Test
-    fun `skal hente forrige status hvis kun flere statusendringer er gjort`() {
+    fun `skal hente forrige status hvis flere statusendringer er gjort`() {
         val opprettetSak = sakDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
         val oppgave =
             oppgaveService.opprettOppgave(


### PR DESCRIPTION
To endringer
- Må tillate å sette oppgave på vent selv om den ikke er tildelt noen saksbehandler for tilbakekreving. Dette fordi vi kan få SPER på kravgrunnlaget fra MQ selv om ingen har begynt på oppgaven.
- Når nytt kravgrunnlag hentes skal tilbakekrevingsbehandlingen settes til UNDER_ARBEID igjen