### PR TITLE
EY-4124: Feiler dersom meldinger fra MQ blir forsøkt prosessert i feil rekkefølge

### DIFF
--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingHendelseRepository.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingHendelseRepository.kt
@@ -3,14 +3,36 @@ package no.nav.etterlatte.tilbakekreving
 import kotliquery.queryOf
 import kotliquery.sessionOf
 import kotliquery.using
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.getTidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.getTidspunktOrNull
+import no.nav.etterlatte.libs.common.tidspunkt.toTimestamp
+import no.nav.etterlatte.libs.database.singleOrNull
 import java.util.UUID
 import javax.sql.DataSource
 
-enum class TilbakekrevingHendelseType {
-    KRAVGRUNNLAG_MOTTATT,
+data class TilbakekrevingHendelse(
+    val id: UUID,
+    val opprettet: Tidspunkt,
+    val sakId: Long,
+    val payload: String,
+    val status: TilbakekrevingHendelseStatus,
+    val type: TilbakekrevingHendelseType,
+    val jmsTimestamp: Tidspunkt? = null,
+)
+
+enum class TilbakekrevingHendelseStatus {
+    MOTTATT,
+    FERDIGSTILT,
+}
+
+enum class TilbakekrevingHendelseType(
+    val mqHendelse: Boolean = false,
+) {
+    KRAVGRUNNLAG_MOTTATT(true),
+    KRAV_VEDTAK_STATUS_MOTTATT(true),
     KRAVGRUNNLAG_FORESPOERSEL_SENDT,
     KRAVGRUNNLAG_FORESPOERSEL_KVITTERING,
-    KRAV_VEDTAK_STATUS_MOTTATT,
     TILBAKEKREVINGSVEDTAK_SENDT,
     TILBAKEKREVINGSVEDTAK_KVITTERING,
 }
@@ -22,26 +44,93 @@ class TilbakekrevingHendelseRepository(
         sakId: Long,
         payload: String,
         type: TilbakekrevingHendelseType,
+        jmsTimestamp: Tidspunkt? = null,
+    ): UUID =
+        using(sessionOf(dataSource)) { session ->
+            val id = UUID.randomUUID()
+            queryOf(
+                statement =
+                    """
+                    INSERT INTO tilbakekreving_hendelse(id, opprettet, sak_id, payload, type, jms_timestamp, status)
+                    VALUES(:id, now(), :sakId, :payload, :type, :jmsTimestamp, :status)
+                    """.trimIndent(),
+                paramMap =
+                    mapOf(
+                        "id" to id,
+                        "sakId" to sakId,
+                        "payload" to payload,
+                        "type" to type.name,
+                        "jmsTimestamp" to jmsTimestamp?.toTimestamp(),
+                        "status" to
+                            if (type.mqHendelse) {
+                                TilbakekrevingHendelseStatus.MOTTATT.name
+                            } else {
+                                TilbakekrevingHendelseStatus.FERDIGSTILT.name
+                            },
+                    ),
+            ).let { query ->
+                session.update(query).also {
+                    require(it == 1) {
+                        "Feil under lagring av hendelse for sak $sakId"
+                    }
+                }
+                id
+            }
+        }
+
+    fun hentSisteTilbakekrevingHendelse(
+        sakId: Long,
+        type: TilbakekrevingHendelseType,
+    ): TilbakekrevingHendelse? {
+        dataSource.connection.use {
+            val stmt =
+                it
+                    .prepareStatement(
+                        """
+                        SELECT id, opprettet, sak_id, payload, status, type, jms_timestamp 
+                        FROM tilbakekreving_hendelse 
+                        WHERE sak_id = ? AND type = ?
+                        ORDER BY jms_timestamp DESC
+                        """.trimIndent(),
+                    ).apply {
+                        setLong(1, sakId)
+                        setString(2, type.name)
+                    }
+
+            return stmt.executeQuery().singleOrNull {
+                TilbakekrevingHendelse(
+                    id = UUID.fromString(getString("id")),
+                    opprettet = getTidspunkt("opprettet"),
+                    sakId = getLong("sak_id"),
+                    payload = getString("payload"),
+                    status = TilbakekrevingHendelseStatus.valueOf(getString("status")),
+                    type = TilbakekrevingHendelseType.valueOf(getString("type")),
+                    jmsTimestamp = getTidspunktOrNull("jms_timestamp"),
+                )
+            }
+        }
+    }
+
+    fun ferdigstillTilbakekrevingHendelse(
+        sakId: Long,
+        id: UUID,
     ) = using(sessionOf(dataSource)) { session ->
         queryOf(
             statement =
                 """
-                INSERT INTO tilbakekreving_hendelse(id, opprettet, sak_id, payload, type)
-                VALUES(:id, now(), :sakId, :payload, :type)
+                UPDATE tilbakekreving_hendelse SET status = 'FERIDGSTILT' WHERE id = ?
                 """.trimIndent(),
             paramMap =
                 mapOf(
-                    "id" to UUID.randomUUID(),
-                    "sakId" to sakId,
-                    "payload" to payload,
-                    "type" to type.name,
+                    "id" to id,
                 ),
         ).let { query ->
             session.update(query).also {
                 require(it == 1) {
-                    "Feil under lagring av hendelse for sak $sakId"
+                    "Feil under oppdatering av hendelse for sak $sakId"
                 }
             }
+            id
         }
     }
 }

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingHendelseRepository.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingHendelseRepository.kt
@@ -22,7 +22,7 @@ data class TilbakekrevingHendelse(
 )
 
 enum class TilbakekrevingHendelseStatus {
-    MOTTATT,
+    NY,
     FERDIGSTILT,
 }
 
@@ -63,7 +63,7 @@ class TilbakekrevingHendelseRepository(
                         "jmsTimestamp" to jmsTimestamp?.toTimestamp(),
                         "status" to
                             if (type.mqHendelse) {
-                                TilbakekrevingHendelseStatus.MOTTATT.name
+                                TilbakekrevingHendelseStatus.NY.name
                             } else {
                                 TilbakekrevingHendelseStatus.FERDIGSTILT.name
                             },
@@ -118,7 +118,9 @@ class TilbakekrevingHendelseRepository(
         queryOf(
             statement =
                 """
-                UPDATE tilbakekreving_hendelse SET status = 'FERIDGSTILT' WHERE id = ?
+                UPDATE tilbakekreving_hendelse 
+                SET status = '${TilbakekrevingHendelseStatus.FERDIGSTILT.name}' 
+                WHERE id = ?
                 """.trimIndent(),
             paramMap =
                 mapOf(

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/config/ApplicationContext.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/config/ApplicationContext.kt
@@ -46,7 +46,7 @@ class ApplicationContext(
 
     val tilbakekrevingHendelseRepository = TilbakekrevingHendelseRepository(dataSource)
 
-    val tilbakekrevingKlient =
+    val tilbakekrevingskomponentenKlient =
         TilbakekrevingskomponentenKlient(
             url = properties.proxyUrl,
             httpClient =
@@ -59,7 +59,7 @@ class ApplicationContext(
             hendelseRepository = tilbakekrevingHendelseRepository,
         )
 
-    val tilbakekrevingService = TilbakekrevingService(tilbakekrevingKlient)
+    val tilbakekrevingService = TilbakekrevingService(tilbakekrevingskomponentenKlient)
 
     val kravgrunnlagService = KravgrunnlagService(behandlingKlient)
 

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumer.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumer.kt
@@ -102,11 +102,11 @@ class KravgrunnlagConsumer(
         jmsTimestampNyHendelse: Tidspunkt,
     ) {
         val sisteHendelse = hendelseRepository.hentSisteTilbakekrevingHendelse(sakId, type)
-        if (sisteHendelse?.status == TilbakekrevingHendelseStatus.MOTTATT) {
-            throw Exception("Må ferdigstille forrige melding for sak $sakId før ny kan prosesseres")
+        if (sisteHendelse?.status == TilbakekrevingHendelseStatus.NY) {
+            throw Exception("Må ferdigstille forrige hendelse ${sisteHendelse.id} for sak $sakId før ny kan prosesseres")
         }
         if (sisteHendelse?.jmsTimestamp?.isAfter(jmsTimestampNyHendelse) == true) {
-            throw Exception("Meldinger har blitt behandlet i feil rekkefølge for $sakId - dette må undersøkes videre")
+            throw Exception("Hendelser har blitt behandlet i feil rekkefølge for $sakId - dette må undersøkes videre")
         }
     }
 

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumer.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumer.kt
@@ -6,13 +6,16 @@ import jakarta.jms.MessageListener
 import net.logstash.logback.argument.StructuredArguments.kv
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.common.logging.withLogContext
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.mq.EtterlatteJmsConnectionFactory
 import no.nav.etterlatte.tilbakekreving.TilbakekrevingHendelseRepository
+import no.nav.etterlatte.tilbakekreving.TilbakekrevingHendelseStatus
 import no.nav.etterlatte.tilbakekreving.TilbakekrevingHendelseType
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.KravgrunnlagJaxb.toDetaljertKravgrunnlagDto
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.KravgrunnlagJaxb.toKravOgVedtakstatus
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.time.Instant
 import kotlin.system.exitProcess
 
 class KravgrunnlagConsumer(
@@ -38,33 +41,48 @@ class KravgrunnlagConsumer(
             try {
                 logger.info("Melding (id=${message.jmsMessageID}) mottatt ${message.deliveryCount()} gang(er)")
                 payload = message.getBody(String::class.java)
+                val jmsTimestamp = Tidspunkt(Instant.ofEpochMilli(message.jmsTimestamp))
 
                 when {
                     payload.contains("detaljertKravgrunnlagMelding") -> {
                         logger.info("Mottok melding av type detaljertKravgrunnlagMelding")
                         val detaljertKravgrunnlag = toDetaljertKravgrunnlagDto(payload)
+                        val sakId = detaljertKravgrunnlag.fagsystemId.toLong()
+                        val type = TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT
 
-                        hendelseRepository.lagreTilbakekrevingHendelse(
-                            sakId = detaljertKravgrunnlag.fagsystemId.toLong(),
-                            payload = payload,
-                            type = TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT,
-                        )
+                        sjekkAtSisteHendelseForSakErFerdigstilt(sakId, type, jmsTimestamp)
+
+                        val hendelseId =
+                            hendelseRepository.lagreTilbakekrevingHendelse(
+                                sakId = detaljertKravgrunnlag.fagsystemId.toLong(),
+                                payload = payload,
+                                type = type,
+                                jmsTimestamp = jmsTimestamp,
+                            )
 
                         val kravgrunnlag = KravgrunnlagMapper.toKravgrunnlag(detaljertKravgrunnlag)
                         kravgrunnlagService.haandterKravgrunnlag(kravgrunnlag)
+                        hendelseRepository.ferdigstillTilbakekrevingHendelse(sakId, hendelseId)
                     }
                     payload.contains("endringKravOgVedtakstatus") -> {
                         logger.info("Mottok melding av type endringKravOgVedtakstatus")
                         val kravOgVedtakstatusDto = toKravOgVedtakstatus(payload)
+                        val sakId = kravOgVedtakstatusDto.fagsystemId.toLong()
+                        val type = TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT
 
-                        hendelseRepository.lagreTilbakekrevingHendelse(
-                            sakId = kravOgVedtakstatusDto.fagsystemId.toLong(),
-                            payload = payload,
-                            type = TilbakekrevingHendelseType.KRAV_VEDTAK_STATUS_MOTTATT,
-                        )
+                        sjekkAtSisteHendelseForSakErFerdigstilt(sakId, type, jmsTimestamp)
+
+                        val hendelseId =
+                            hendelseRepository.lagreTilbakekrevingHendelse(
+                                sakId = kravOgVedtakstatusDto.fagsystemId.toLong(),
+                                payload = payload,
+                                type = TilbakekrevingHendelseType.KRAV_VEDTAK_STATUS_MOTTATT,
+                                jmsTimestamp = jmsTimestamp,
+                            )
 
                         val kravOgVedtakstatus = KravgrunnlagMapper.toKravOgVedtakstatus(kravOgVedtakstatusDto)
                         kravgrunnlagService.haandterKravOgVedtakStatus(kravOgVedtakstatus)
+                        hendelseRepository.ferdigstillTilbakekrevingHendelse(sakId, hendelseId)
                     }
 
                     else -> throw Exception("Ukjent meldingstype, sjekk sikkerlogg og feilkø")
@@ -77,6 +95,20 @@ class KravgrunnlagConsumer(
                 throw t
             }
         }
+
+    private fun sjekkAtSisteHendelseForSakErFerdigstilt(
+        sakId: Long,
+        type: TilbakekrevingHendelseType,
+        jmsTimestampNyHendelse: Tidspunkt,
+    ) {
+        val sisteHendelse = hendelseRepository.hentSisteTilbakekrevingHendelse(sakId, type)
+        if (sisteHendelse?.status == TilbakekrevingHendelseStatus.MOTTATT) {
+            throw Exception("Må ferdigstille forrige melding for sak $sakId før ny kan prosesseres")
+        }
+        if (sisteHendelse?.jmsTimestamp?.isAfter(jmsTimestampNyHendelse) == true) {
+            throw Exception("Meldinger har blitt behandlet i feil rekkefølge for $sakId - dette må undersøkes videre")
+        }
+    }
 
     private fun exceptionListener() =
         ExceptionListener {

--- a/apps/etterlatte-tilbakekreving/src/main/resources/db/migration/V4__legg_til_status_og_jms_timestamp.sql
+++ b/apps/etterlatte-tilbakekreving/src/main/resources/db/migration/V4__legg_til_status_og_jms_timestamp.sql
@@ -1,0 +1,13 @@
+-- Legger til nye kolonner for status og jms_timestamp
+ALTER TABLE tilbakekreving_hendelse ADD COLUMN status TEXT;
+ALTER TABLE tilbakekreving_hendelse ADD COLUMN jms_timestamp TIMESTAMP WITH TIME ZONE;
+
+-- Migrerer eksisterende rader med verdier for nye kolonner
+UPDATE tilbakekreving_hendelse SET status = 'FERDIGSTILT' WHERE status IS NULL;
+UPDATE tilbakekreving_hendelse t SET jms_timestamp = (SELECT opprettet FROM tilbakekreving_hendelse WHERE id = t.id) WHERE jms_timestamp IS NULL;
+
+-- Setter påkrevet constraint for status
+ALTER TABLE tilbakekreving_hendelse ALTER COLUMN status SET NOT NULL;
+
+-- Fjerner ubrukt kolonne for kravgrunnlag_id
+ALTER TABLE tilbakekreving_hendelse DROP COLUMN kravgrunnlag_id;

--- a/apps/etterlatte-tilbakekreving/src/main/resources/db/migration/V4__legg_til_status_og_jms_timestamp.sql
+++ b/apps/etterlatte-tilbakekreving/src/main/resources/db/migration/V4__legg_til_status_og_jms_timestamp.sql
@@ -4,7 +4,7 @@ ALTER TABLE tilbakekreving_hendelse ADD COLUMN jms_timestamp TIMESTAMP WITH TIME
 
 -- Migrerer eksisterende rader med verdier for nye kolonner
 UPDATE tilbakekreving_hendelse SET status = 'FERDIGSTILT' WHERE status IS NULL;
-UPDATE tilbakekreving_hendelse t SET jms_timestamp = (SELECT opprettet FROM tilbakekreving_hendelse WHERE id = t.id) WHERE jms_timestamp IS NULL;
+UPDATE tilbakekreving_hendelse t SET jms_timestamp = (SELECT opprettet FROM tilbakekreving_hendelse WHERE id = t.id) WHERE jms_timestamp IS NULL AND (type = 'KRAVGRUNNLAG_MOTTATT' OR type = 'KRAV_VEDTAK_STATUS_MOTTATT');
 
 -- Setter påkrevet constraint for status
 ALTER TABLE tilbakekreving_hendelse ALTER COLUMN status SET NOT NULL;

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/TilbakekrevingHendelseRepositoryTest.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/TilbakekrevingHendelseRepositoryTest.kt
@@ -2,11 +2,12 @@ package no.nav.etterlatte.tilbakekreving
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import no.nav.etterlatte.libs.database.singleOrNull
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.RegisterExtension
+import java.time.temporal.ChronoUnit
 import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -29,34 +30,50 @@ internal class TilbakekrevingHendelseRepositoryTest(
     fun `skal lagre hendelse for mottatt kravgrunnlag`() {
         val sakId = 1L
         val kravgrunnlag = "<kravgrunnlag>payload</kravgrunnlag>"
+        val jmsTimestamp = Tidspunkt.now()
 
-        repository.lagreTilbakekrevingHendelse(sakId, kravgrunnlag, TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT)
+        repository.lagreTilbakekrevingHendelse(
+            sakId,
+            kravgrunnlag,
+            TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT,
+            jmsTimestamp,
+        )
 
         val tilbakekrevingHendelse =
-            hentTilbakekrevingHendelse(sakId, TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT)
+            repository.hentSisteTilbakekrevingHendelse(sakId, TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT)
 
         tilbakekrevingHendelse?.id shouldNotBe null
         tilbakekrevingHendelse?.opprettet shouldNotBe null
         tilbakekrevingHendelse?.sakId shouldBe sakId
         tilbakekrevingHendelse?.payload shouldBe kravgrunnlag
         tilbakekrevingHendelse?.type shouldBe TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT
+        tilbakekrevingHendelse?.status shouldBe TilbakekrevingHendelseStatus.MOTTATT
+        tilbakekrevingHendelse?.jmsTimestamp shouldBe jmsTimestamp
     }
 
     @Test
     fun `skal lagre hendelse for mottatt kravOgVedtakStatus`() {
         val sakId = 1L
         val melding = "payload"
+        val jmsTimestamp = Tidspunkt.now()
 
-        repository.lagreTilbakekrevingHendelse(sakId, melding, TilbakekrevingHendelseType.KRAV_VEDTAK_STATUS_MOTTATT)
+        repository.lagreTilbakekrevingHendelse(
+            sakId,
+            melding,
+            TilbakekrevingHendelseType.KRAV_VEDTAK_STATUS_MOTTATT,
+            jmsTimestamp,
+        )
 
         val tilbakekrevingHendelse =
-            hentTilbakekrevingHendelse(sakId, TilbakekrevingHendelseType.KRAV_VEDTAK_STATUS_MOTTATT)
+            repository.hentSisteTilbakekrevingHendelse(sakId, TilbakekrevingHendelseType.KRAV_VEDTAK_STATUS_MOTTATT)
 
         tilbakekrevingHendelse?.id shouldNotBe null
         tilbakekrevingHendelse?.opprettet shouldNotBe null
         tilbakekrevingHendelse?.sakId shouldBe sakId
         tilbakekrevingHendelse?.payload shouldBe melding
         tilbakekrevingHendelse?.type shouldBe TilbakekrevingHendelseType.KRAV_VEDTAK_STATUS_MOTTATT
+        tilbakekrevingHendelse?.status shouldBe TilbakekrevingHendelseStatus.MOTTATT
+        tilbakekrevingHendelse?.jmsTimestamp shouldBe jmsTimestamp
     }
 
     @Test
@@ -67,13 +84,14 @@ internal class TilbakekrevingHendelseRepositoryTest(
         repository.lagreTilbakekrevingHendelse(sakId, vedtakRequest, TilbakekrevingHendelseType.TILBAKEKREVINGSVEDTAK_SENDT)
 
         val tilbakekrevingHendelse =
-            hentTilbakekrevingHendelse(sakId, TilbakekrevingHendelseType.TILBAKEKREVINGSVEDTAK_SENDT)
+            repository.hentSisteTilbakekrevingHendelse(sakId, TilbakekrevingHendelseType.TILBAKEKREVINGSVEDTAK_SENDT)
 
         tilbakekrevingHendelse?.id shouldNotBe null
         tilbakekrevingHendelse?.opprettet shouldNotBe null
         tilbakekrevingHendelse?.sakId shouldBe sakId
         tilbakekrevingHendelse?.payload shouldBe vedtakRequest
         tilbakekrevingHendelse?.type shouldBe TilbakekrevingHendelseType.TILBAKEKREVINGSVEDTAK_SENDT
+        tilbakekrevingHendelse?.status shouldBe TilbakekrevingHendelseStatus.FERDIGSTILT
     }
 
     @Test
@@ -84,45 +102,43 @@ internal class TilbakekrevingHendelseRepositoryTest(
         repository.lagreTilbakekrevingHendelse(sakId, vedtakResponse, TilbakekrevingHendelseType.TILBAKEKREVINGSVEDTAK_KVITTERING)
 
         val tilbakekrevingHendelse =
-            hentTilbakekrevingHendelse(sakId, TilbakekrevingHendelseType.TILBAKEKREVINGSVEDTAK_KVITTERING)
+            repository.hentSisteTilbakekrevingHendelse(sakId, TilbakekrevingHendelseType.TILBAKEKREVINGSVEDTAK_KVITTERING)
 
         tilbakekrevingHendelse?.id shouldNotBe null
         tilbakekrevingHendelse?.opprettet shouldNotBe null
         tilbakekrevingHendelse?.sakId shouldBe sakId
         tilbakekrevingHendelse?.payload shouldBe vedtakResponse
         tilbakekrevingHendelse?.type shouldBe TilbakekrevingHendelseType.TILBAKEKREVINGSVEDTAK_KVITTERING
+        tilbakekrevingHendelse?.status shouldBe TilbakekrevingHendelseStatus.FERDIGSTILT
     }
 
-    private fun hentTilbakekrevingHendelse(
-        sakId: Long,
-        type: TilbakekrevingHendelseType,
-    ): TilbakekrevingHendelse? {
-        dataSource.connection.use {
-            val stmt =
-                it
-                    .prepareStatement("SELECT * FROM tilbakekreving_hendelse WHERE sak_id = ? AND type = ?")
-                    .apply {
-                        setLong(1, sakId)
-                        setString(2, type.name)
-                    }
+    @Test
+    fun `skal hente siste hendelse for sak basert paa jms timestamp`() {
+        val sakId = 1L
+        val kravgrunnlag = "<kravgrunnlag>payload</kravgrunnlag>"
+        val jmsTimestampKravgrunnlag = Tidspunkt.now().plus(1, ChronoUnit.MINUTES)
 
-            return stmt.executeQuery().singleOrNull {
-                TilbakekrevingHendelse(
-                    id = getString("id"),
-                    opprettet = getString("opprettet"),
-                    sakId = getLong("sak_id"),
-                    payload = getString("payload"),
-                    type = TilbakekrevingHendelseType.valueOf(getString("type")),
-                )
-            }
-        }
+        repository.lagreTilbakekrevingHendelse(
+            sakId,
+            kravgrunnlag,
+            TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT,
+            jmsTimestampKravgrunnlag,
+        )
+
+        val status = "payload"
+        val jmsTimestampStatus = Tidspunkt.now()
+
+        repository.lagreTilbakekrevingHendelse(
+            sakId,
+            status,
+            TilbakekrevingHendelseType.KRAV_VEDTAK_STATUS_MOTTATT,
+            jmsTimestampStatus,
+        )
+
+        val sisteTilbakekrevingHendelse =
+            repository.hentSisteTilbakekrevingHendelse(sakId, TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT)
+
+        sisteTilbakekrevingHendelse?.type shouldBe TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT
+        sisteTilbakekrevingHendelse?.jmsTimestamp shouldBe jmsTimestampKravgrunnlag
     }
-
-    private data class TilbakekrevingHendelse(
-        val id: String,
-        val opprettet: String,
-        val sakId: Long,
-        val payload: String,
-        val type: TilbakekrevingHendelseType,
-    )
 }

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/TilbakekrevingHendelseRepositoryTest.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/TilbakekrevingHendelseRepositoryTest.kt
@@ -47,7 +47,7 @@ internal class TilbakekrevingHendelseRepositoryTest(
         tilbakekrevingHendelse?.sakId shouldBe sakId
         tilbakekrevingHendelse?.payload shouldBe kravgrunnlag
         tilbakekrevingHendelse?.type shouldBe TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT
-        tilbakekrevingHendelse?.status shouldBe TilbakekrevingHendelseStatus.MOTTATT
+        tilbakekrevingHendelse?.status shouldBe TilbakekrevingHendelseStatus.NY
         tilbakekrevingHendelse?.jmsTimestamp shouldBe jmsTimestamp
     }
 
@@ -72,7 +72,7 @@ internal class TilbakekrevingHendelseRepositoryTest(
         tilbakekrevingHendelse?.sakId shouldBe sakId
         tilbakekrevingHendelse?.payload shouldBe melding
         tilbakekrevingHendelse?.type shouldBe TilbakekrevingHendelseType.KRAV_VEDTAK_STATUS_MOTTATT
-        tilbakekrevingHendelse?.status shouldBe TilbakekrevingHendelseStatus.MOTTATT
+        tilbakekrevingHendelse?.status shouldBe TilbakekrevingHendelseStatus.NY
         tilbakekrevingHendelse?.jmsTimestamp shouldBe jmsTimestamp
     }
 

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumerTest.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumerTest.kt
@@ -3,12 +3,17 @@ package no.nav.etterlatte.tilbakekreving.kravgrunnlag
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.mq.DummyJmsConnectionFactory
 import no.nav.etterlatte.mq.EtterlatteJmsConnectionFactory
+import no.nav.etterlatte.tilbakekreving.TilbakekrevingHendelse
 import no.nav.etterlatte.tilbakekreving.TilbakekrevingHendelseRepository
+import no.nav.etterlatte.tilbakekreving.TilbakekrevingHendelseStatus
+import no.nav.etterlatte.tilbakekreving.TilbakekrevingHendelseType
 import no.nav.etterlatte.tilbakekreving.readFile
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.UUID
 
 class KravgrunnlagConsumerTest {
     private val connectionFactory: EtterlatteJmsConnectionFactory = DummyJmsConnectionFactory()
@@ -34,7 +39,10 @@ class KravgrunnlagConsumerTest {
         simulerKravgrunnlagsmeldingFraTilbakekrevingskomponenten()
 
         verify(exactly = 1) {
+            tilbakekrevingHendelseRepository.hentSisteTilbakekrevingHendelse(any(), any())
+            tilbakekrevingHendelseRepository.lagreTilbakekrevingHendelse(any(), any(), any(), any())
             kravgrunnlagService.haandterKravgrunnlag(any())
+            tilbakekrevingHendelseRepository.ferdigstillTilbakekrevingHendelse(any(), any())
         }
     }
 
@@ -48,6 +56,48 @@ class KravgrunnlagConsumerTest {
     }
 
     @Test
+    fun `skal feile ved mottak av kravgrunnlag dersom forrige hendelse for sak ikke er ferdigstilt`() {
+        every { tilbakekrevingHendelseRepository.hentSisteTilbakekrevingHendelse(any(), any()) } returns
+            tilbakekrevingHendelse(
+                type = TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT,
+                status = TilbakekrevingHendelseStatus.MOTTATT,
+            )
+
+        simulerKravgrunnlagsmeldingFraTilbakekrevingskomponenten()
+
+        verify(exactly = 4) {
+            // 3 retries
+            tilbakekrevingHendelseRepository.hentSisteTilbakekrevingHendelse(any(), any())
+        }
+        verify(exactly = 0) {
+            tilbakekrevingHendelseRepository.lagreTilbakekrevingHendelse(any(), any(), any(), any())
+            kravgrunnlagService.haandterKravgrunnlag(any())
+            tilbakekrevingHendelseRepository.ferdigstillTilbakekrevingHendelse(any(), any())
+        }
+    }
+
+    @Test
+    fun `skal feile ved mottak av kravOgVedtakStatus dersom forrige hendelse for sak ikke er ferdigstilt`() {
+        every { tilbakekrevingHendelseRepository.hentSisteTilbakekrevingHendelse(any(), any()) } returns
+            tilbakekrevingHendelse(
+                type = TilbakekrevingHendelseType.KRAV_VEDTAK_STATUS_MOTTATT,
+                status = TilbakekrevingHendelseStatus.MOTTATT,
+            )
+
+        simulerKravgrunnlagsmeldingFraTilbakekrevingskomponenten()
+
+        verify(exactly = 4) {
+            // 3 retries
+            tilbakekrevingHendelseRepository.hentSisteTilbakekrevingHendelse(any(), any())
+        }
+        verify(exactly = 0) {
+            tilbakekrevingHendelseRepository.lagreTilbakekrevingHendelse(any(), any(), any(), any())
+            kravgrunnlagService.haandterKravgrunnlag(any())
+            tilbakekrevingHendelseRepository.ferdigstillTilbakekrevingHendelse(any(), any())
+        }
+    }
+
+    @Test
     fun `skal motta kravgrunnlag paa nytt dersom noe feiler`() {
         every { kravgrunnlagService.haandterKravgrunnlag(any()) } throws Exception("Noe feilet") andThen Unit
         simulerKravgrunnlagsmeldingFraTilbakekrevingskomponenten()
@@ -56,6 +106,19 @@ class KravgrunnlagConsumerTest {
             kravgrunnlagService.haandterKravgrunnlag(any())
         }
     }
+
+    private fun tilbakekrevingHendelse(
+        type: TilbakekrevingHendelseType,
+        status: TilbakekrevingHendelseStatus,
+    ) = TilbakekrevingHendelse(
+        id = UUID.randomUUID(),
+        opprettet = Tidspunkt.now(),
+        sakId = 1,
+        payload = "payload",
+        status = status,
+        type = type,
+        jmsTimestamp = Tidspunkt.now(),
+    )
 
     private fun simulerKravgrunnlagsmeldingFraTilbakekrevingskomponenten() {
         connectionFactory.send(queue = QUEUE, xml = readFile("/kravgrunnlag.xml"))

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumerTest.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumerTest.kt
@@ -60,7 +60,7 @@ class KravgrunnlagConsumerTest {
         every { tilbakekrevingHendelseRepository.hentSisteTilbakekrevingHendelse(any(), any()) } returns
             tilbakekrevingHendelse(
                 type = TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT,
-                status = TilbakekrevingHendelseStatus.MOTTATT,
+                status = TilbakekrevingHendelseStatus.NY,
             )
 
         simulerKravgrunnlagsmeldingFraTilbakekrevingskomponenten()
@@ -81,7 +81,7 @@ class KravgrunnlagConsumerTest {
         every { tilbakekrevingHendelseRepository.hentSisteTilbakekrevingHendelse(any(), any()) } returns
             tilbakekrevingHendelse(
                 type = TilbakekrevingHendelseType.KRAV_VEDTAK_STATUS_MOTTATT,
-                status = TilbakekrevingHendelseStatus.MOTTATT,
+                status = TilbakekrevingHendelseStatus.NY,
             )
 
         simulerKravgrunnlagsmeldingFraTilbakekrevingskomponenten()

--- a/libs/etterlatte-mq/src/testFixtures/kotlin/etterlatte/DummyJmsConnectionFactory.kt
+++ b/libs/etterlatte-mq/src/testFixtures/kotlin/etterlatte/DummyJmsConnectionFactory.kt
@@ -7,6 +7,7 @@ import jakarta.jms.Message
 import jakarta.jms.MessageListener
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.libs.common.retry
+import java.time.Instant
 
 class DummyJmsConnectionFactory : EtterlatteJmsConnectionFactory {
     private var mq: MutableMap<String, String> = mutableMapOf()
@@ -38,6 +39,7 @@ class DummyJmsConnectionFactory : EtterlatteJmsConnectionFactory {
                             every { it.jmsMessageID } returns System.currentTimeMillis().toString()
                             every { it.getBody(String::class.java) } returns xml
                             every { it.getLongProperty(any()) } returns 1L
+                            every { it.jmsTimestamp } returns Instant.now().toEpochMilli()
                         },
                     )
                 }


### PR DESCRIPTION
Vi har i produksjon opplevd at en melding har kommet inn og feilet, blitt lagt på backout-queue, mens en ny melding har kommet inn og blitt prosessert. I den aktuelle saken var det ikke et problem da meldingen som feilet kun var en status-oppdatering på tilbakekrevingsoppgaven, men det kan muligens oppstå større problemer med dette i andre saker. 

Legger på en status for hendelser (NY, FERDIGSTILT) og lagrer også `jmsTimestamp` som er tidpunktet meldingen ble lagt på MQ. 

Vi kan da bruke dette for å sikre at en melding som leses fra MQ ikke behandles hvis forrige melding i en sak har status `NY`. I tillegg kan vi bruke `jmsTimestamp` til å sjekke at meldingene ikke prosesseres i feil rekkefølge.