### PR TITLE
EY-4115 Manuell behandling av samordningsmeldinger v1

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
@@ -138,7 +138,7 @@ export const Person = () => {
               </Tabs.Panel>
             )}
             <Tabs.Panel value={PersonOversiktFane.SAMORDNING}>
-              <SamordningSak sakResult={sakResult} />
+              <SamordningSak fnr={person.foedselsnummer} sakResult={sakResult} />
             </Tabs.Panel>
           </Tabs>
         )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningOppdaterMeldingModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningOppdaterMeldingModal.tsx
@@ -1,0 +1,122 @@
+import {
+    BodyShort,
+    Button,
+    Heading,
+    HStack, Label,
+    Modal,
+    Radio,
+    RadioGroup,
+    VStack
+} from "@navikt/ds-react";
+import React, {useState} from "react";
+import {useNavigate} from "react-router-dom";
+import {useApiCall} from "~shared/hooks/useApiCall";
+import {isPending, isSuccess, mapFailure} from "~shared/api/apiUtils";
+import {ApiErrorAlert} from "~ErrorBoundary";
+import {oppdaterSamordningsmeldingForSak} from "~shared/api/vedtaksvurdering";
+import {DocPencilIcon} from "@navikt/aksel-icons";
+import {Samordningsmelding} from "~components/vedtak/typer";
+import {JaNei} from "~shared/types/ISvar";
+import {Toast} from "~shared/alerts/Toast";
+
+export default function SamordningOppdaterMeldingModal({fnr, sakId, mld}: {
+    fnr: string,
+    sakId: number,
+    mld: Samordningsmelding
+}) {
+    const [open, setOpen] = useState(false)
+    const navigate = useNavigate()
+
+    const [erRefusjonskrav, setErRefusjonskrav] = useState<JaNei>()
+    const [oppdaterSamordningsmeldingStatus, oppdaterSamordningsmelding] = useApiCall(oppdaterSamordningsmeldingForSak)
+
+    const oppdaterMelding = () => {
+        oppdaterSamordningsmelding({
+            sakId: sakId,
+            oppdaterSamordningsmelding: {
+                samId: mld.samId,
+                pid: fnr,
+                tpNr: mld.tpNr,
+                refusjonskrav: erRefusjonskrav === JaNei.JA,
+                periodisertBelopListe: []
+            },
+        }, () => {
+            setOpen(false)
+            //navigate(`/person/${fnr}/?fane=SAMORDNING`)
+        })
+    }
+
+    return (
+        <>
+            <Button variant="primary" onClick={() => setOpen(true)}>
+                <DocPencilIcon title="Overstyr"/>
+            </Button>
+
+            <Modal open={open} aria-labelledby="modal-heading" onClose={() => setOpen(false)}>
+                <Modal.Body>
+                    <Heading size="medium" id="modal-heading" spacing>
+                        Overstyr samordningsmelding
+                    </Heading>
+
+                    <VStack gap="4">
+                        <HStack gap="4">
+                            <Label>SamordningsmeldingID:</Label>
+                            <BodyShort>{mld.samId}</BodyShort>
+                        </HStack>
+                        <HStack gap="4">
+                            <Label>Tjenestepensjonsordning:</Label>
+                            <BodyShort>{mld.tpNr}</BodyShort>
+                        </HStack>
+
+                        <RadioGroup
+                            legend="Refusjonskrav?"
+                            onChange={(event) => {
+                                setErRefusjonskrav(JaNei[event as JaNei])
+                            }}
+                            value={erRefusjonskrav || ''}
+                        >
+                            <HStack gap="4">
+                                <Radio size="small" value={JaNei.JA}>Ja</Radio>
+                                <Radio size="small" value={JaNei.NEI}>Nei</Radio>
+                            </HStack>
+                        </RadioGroup>
+
+                        {isSuccess(oppdaterSamordningsmeldingStatus) ? (
+                            <>
+                                <Toast melding="Melding oppdatert"/>
+
+                                <HStack gap="4" justify="center">
+                                    <Button variant="primary"
+                                            onClick={() => navigate(`/person/${fnr}/?fane=SAMORDNING`)}>
+                                        Gå til samordningsoversikten
+                                    </Button>
+                                </HStack>
+                            </>
+                        ) : (
+                            <HStack gap="4" justify="center">
+                                <Button variant="secondary" onClick={() => setOpen(false)}
+                                        disabled={isPending(oppdaterSamordningsmeldingStatus)}>
+                                    Avbryt
+                                </Button>
+                                <Button
+                                    variant="primary"
+                                    disabled={erRefusjonskrav === undefined}
+                                    onClick={oppdaterMelding}
+                                    loading={isPending(oppdaterSamordningsmeldingStatus)}
+                                >
+                                    Lagre
+                                </Button>
+                            </HStack>
+                        )}
+
+                        {mapFailure(oppdaterSamordningsmeldingStatus, (error) => (
+                            <Modal.Footer>
+                                <ApiErrorAlert>{error.detail || 'Det oppsto en feil ved oppdatering av samordningsmelding'}</ApiErrorAlert>
+                            </Modal.Footer>
+                        ))}
+                    </VStack>
+                </Modal.Body>
+            </Modal>
+        </>
+    )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningOppdaterMeldingModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningOppdaterMeldingModal.tsx
@@ -19,10 +19,11 @@ import {Samordningsmelding} from "~components/vedtak/typer";
 import {JaNei} from "~shared/types/ISvar";
 import {Toast} from "~shared/alerts/Toast";
 
-export default function SamordningOppdaterMeldingModal({fnr, sakId, mld}: {
+export default function SamordningOppdaterMeldingModal({fnr, sakId, mld, refresh}: {
     fnr: string,
     sakId: number,
-    mld: Samordningsmelding
+    mld: Samordningsmelding,
+    refresh: () => void
 }) {
     const [open, setOpen] = useState(false)
     const navigate = useNavigate()
@@ -42,7 +43,7 @@ export default function SamordningOppdaterMeldingModal({fnr, sakId, mld}: {
             },
         }, () => {
             setOpen(false)
-            //navigate(`/person/${fnr}/?fane=SAMORDNING`)
+            refresh()
         })
     }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningOppdaterMeldingModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningOppdaterMeldingModal.tsx
@@ -48,9 +48,11 @@ export default function SamordningOppdaterMeldingModal({fnr, sakId, mld}: {
 
     return (
         <>
-            <Button variant="primary" onClick={() => setOpen(true)}>
-                <DocPencilIcon title="Overstyr"/>
-            </Button>
+            <Button
+                variant="primary"
+                icon={<DocPencilIcon title="Overstyr"/>}
+                onClick={() => setOpen(true)}
+            />
 
             <Modal open={open} aria-labelledby="modal-heading" onClose={() => setOpen(false)}>
                 <Modal.Body>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningSak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningSak.tsx
@@ -26,7 +26,12 @@ export const SamordningSak = ({ fnr, sakResult }: { fnr: string, sakResult: Resu
       <Heading size="medium">Samordningsmeldinger</Heading>
 
       {mapResult(samordningdataStatus, {
-        success: (data) => <SamordningTabell fnr={fnr} sakId={sakId!} samordningsdata={data}/>,
+        success: (data) => <SamordningTabell
+            fnr={fnr}
+            sakId={sakId!}
+            samordningsdata={data}
+            refresh={() => hent(sakId!)}
+        />,
         pending: <Spinner visible={true} label="Henter samordningsdata" />,
         error: () => <ApiErrorAlert>Kunne ikke hente samordningsdata</ApiErrorAlert>,
       })}
@@ -34,10 +39,11 @@ export const SamordningSak = ({ fnr, sakResult }: { fnr: string, sakResult: Resu
   )
 }
 
-function SamordningTabell({fnr, sakId, samordningsdata}: {
+function SamordningTabell({fnr, sakId, samordningsdata, refresh}: {
   fnr: string,
   sakId: number,
-  samordningsdata: Array<Samordningsvedtak>
+  samordningsdata: Array<Samordningsvedtak>,
+  refresh: () => void
 }) {
   return samordningsdata.length == 0 ? (
     <p>Ingen samordningsmeldinger</p>
@@ -77,7 +83,12 @@ function SamordningTabell({fnr, sakId, samordningsdata}: {
                 <Table.DataCell>{mld.purretDato && formaterStringDato(mld.purretDato)}</Table.DataCell>
                 <Table.DataCell>{mld.svartDato && (mld.refusjonskrav ? 'Ja' : 'Nei')}</Table.DataCell>
                 {!mld.svartDato && (<Table.DataCell>
-                  <SamordningOppdaterMeldingModal fnr={fnr} sakId={sakId} mld={mld}/>
+                  <SamordningOppdaterMeldingModal
+                      fnr={fnr}
+                      sakId={sakId}
+                      mld={mld}
+                      refresh={refresh}
+                  />
                 </Table.DataCell>)}
               </Table.Row>
             ))

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningSak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningSak.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, {useEffect, useState} from 'react'
 import { Box, Heading, Link, Table } from '@navikt/ds-react'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { hentSamordningsdataForSak } from '~shared/api/vedtaksvurdering'
@@ -8,12 +8,15 @@ import { formaterStringDato } from '~utils/formattering'
 import { SakMedBehandlinger } from '~components/person/typer'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { Samordningsvedtak } from '~components/vedtak/typer'
+import SamordningOppdaterMeldingModal from "~components/person/SamordningOppdaterMeldingModal";
 
-export const SamordningSak = ({ sakResult }: { sakResult: Result<SakMedBehandlinger> }) => {
+export const SamordningSak = ({ fnr, sakResult }: { fnr: string, sakResult: Result<SakMedBehandlinger> }) => {
   const [samordningdataStatus, hent] = useApiCall(hentSamordningsdataForSak)
+  const [sakId, setSakId] = useState<number>()
 
   useEffect(() => {
     if (isSuccess(sakResult)) {
+      setSakId(sakResult.data.sak.id)
       hent(sakResult.data.sak.id)
     }
   }, [sakResult])
@@ -23,7 +26,7 @@ export const SamordningSak = ({ sakResult }: { sakResult: Result<SakMedBehandlin
       <Heading size="medium">Samordningsmeldinger</Heading>
 
       {mapResult(samordningdataStatus, {
-        success: (data) => <SamordningTabell samordningsdata={data} />,
+        success: (data) => <SamordningTabell fnr={fnr} sakId={sakId!} samordningsdata={data}/>,
         pending: <Spinner visible={true} label="Henter samordningsdata" />,
         error: () => <ApiErrorAlert>Kunne ikke hente samordningsdata</ApiErrorAlert>,
       })}
@@ -31,7 +34,11 @@ export const SamordningSak = ({ sakResult }: { sakResult: Result<SakMedBehandlin
   )
 }
 
-function SamordningTabell({ samordningsdata }: { samordningsdata: Array<Samordningsvedtak> }) {
+function SamordningTabell({fnr, sakId, samordningsdata}: {
+  fnr: string,
+  sakId: number,
+  samordningsdata: Array<Samordningsvedtak>
+}) {
   return samordningsdata.length == 0 ? (
     <p>Ingen samordningsmeldinger</p>
   ) : (
@@ -47,6 +54,7 @@ function SamordningTabell({ samordningsdata }: { samordningsdata: Array<Samordni
           <Table.HeaderCell>Mottatt dato</Table.HeaderCell>
           <Table.HeaderCell>Purret dato</Table.HeaderCell>
           <Table.HeaderCell>Refusjonskrav</Table.HeaderCell>
+          <Table.HeaderCell>Overstyr</Table.HeaderCell>
         </Table.Row>
       </Table.Header>
       <Table.Body>
@@ -68,6 +76,9 @@ function SamordningTabell({ samordningsdata }: { samordningsdata: Array<Samordni
                 <Table.DataCell>{mld.svartDato && formaterStringDato(mld.svartDato)}</Table.DataCell>
                 <Table.DataCell>{mld.purretDato && formaterStringDato(mld.purretDato)}</Table.DataCell>
                 <Table.DataCell>{mld.svartDato && (mld.refusjonskrav ? 'Ja' : 'Nei')}</Table.DataCell>
+                {!mld.svartDato && (<Table.DataCell>
+                  <SamordningOppdaterMeldingModal fnr={fnr} sakId={sakId} mld={mld}/>
+                </Table.DataCell>)}
               </Table.Row>
             ))
           )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/vedtak/typer.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/vedtak/typer.tsx
@@ -43,3 +43,18 @@ export interface Samordningsmelding {
   purretDato?: string
   refusjonskrav: boolean
 }
+
+export interface OppdaterSamordningsmelding {
+  samId: number,
+  pid: string,
+  tpNr: string,
+  refusjonskrav: boolean,
+  periodisertBelopListe: Refusjonstrekk[]
+}
+
+export interface Refusjonstrekk {
+  fom: string,
+  tom?: string,
+  belop: number,
+  kravstillerReferanse?: String
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vedtaksvurdering.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/vedtaksvurdering.ts
@@ -1,5 +1,5 @@
 import { apiClient, ApiResponse } from './apiClient'
-import { Samordningsvedtak, VedtakSammendrag } from '~components/vedtak/typer'
+import {OppdaterSamordningsmelding, Samordningsvedtak, VedtakSammendrag} from '~components/vedtak/typer'
 
 export const hentVedtakSammendrag = async (behandlingId: string): Promise<ApiResponse<VedtakSammendrag>> => {
   return apiClient.get(`vedtak/${behandlingId}/sammendrag`)
@@ -38,4 +38,11 @@ export const underkjennVedtak = async ({
 
 export const hentSamordningsdataForSak = async (sakId: number): Promise<ApiResponse<Samordningsvedtak[]>> => {
   return apiClient.get(`vedtak/sak/${sakId}/samordning`)
+}
+
+export const oppdaterSamordningsmeldingForSak = async (args: {
+  sakId: number,
+  oppdaterSamordningsmelding: OppdaterSamordningsmelding
+}): Promise<ApiResponse<unknown>> => {
+  return apiClient.post(`vedtak/sak/${args.sakId}/samordning/melding`, {...args.oppdaterSamordningsmelding})
 }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Samordningsdata.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Samordningsdata.kt
@@ -36,3 +36,18 @@ data class SamordningsvedtakWrapper(
     val samordningsvedtak: Samordningsvedtak,
     val behandlingId: UUID,
 )
+
+data class OppdaterSamordningsmelding(
+    val pid: String,
+    val tpNr: String,
+    val samId: Long,
+    val refusjonskrav: Boolean,
+    val periodisertBelopListe: List<Refusjonstrekk>,
+)
+
+data class Refusjonstrekk(
+    val fom: LocalDate,
+    val tom: LocalDate?,
+    val belop: Double,
+    val kravstillerReferanse: String,
+)

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
@@ -28,6 +28,7 @@ import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingDto
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.OppdaterSamordningsmelding
 import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.Samordningsvedtak
 import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.SamordningsvedtakWrapper
 import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.VedtakOgBeregningSammenligner
@@ -403,6 +404,13 @@ class VedtakBehandlingService(
                     detail = "Fant ikke vedtak med id=${samordningsvedtak.vedtakId}",
                 )
         return SamordningsvedtakWrapper(samordningsvedtak, vedtak.behandlingId)
+    }
+
+    suspend fun oppdaterSamordningsmelding(
+        samordningmelding: OppdaterSamordningsmelding,
+        brukerTokenInfo: BrukerTokenInfo,
+    ) {
+        samordningsKlient.oppdaterSamordningsmelding(samordningmelding, brukerTokenInfo)
     }
 
     suspend fun iverksattVedtak(

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -28,6 +28,7 @@ import no.nav.etterlatte.libs.ktor.route.behandlingId
 import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.route.withBehandlingId
 import no.nav.etterlatte.libs.ktor.route.withSakId
+import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.OppdaterSamordningsmelding
 import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.VedtakKlageService
 import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
 import java.time.LocalDate
@@ -54,6 +55,15 @@ fun Route.vedtaksvurderingRoute(
                 logger.info("Henter samordningsinfo for sak $sakId")
                 val samordningsinfo = vedtakBehandlingService.samordningsinfo(sakId)
                 call.respond(samordningsinfo)
+            }
+        }
+
+        post("/sak/{$SAKID_CALL_PARAMETER}/samordning/melding") {
+            withSakId(behandlingKlient) { sakId ->
+                val oppdatering = requireNotNull(call.receive<OppdaterSamordningsmelding>())
+                logger.info("Oppdaterer samordningsmelding=${oppdatering.samId}, sak=$sakId")
+                vedtakBehandlingService.oppdaterSamordningsmelding(oppdatering, brukerTokenInfo)
+                call.respond(HttpStatusCode.OK)
             }
         }
 


### PR DESCRIPTION
Dette dekker opp manglende funksjonalitet, som man har i Pesys (litt annerledes der).

Rutinen er at om noe haster så ringer saksbehandler opp aktuell TP-ordning for å sjekke opp refusjon, og så legger det inn manuelt i stedet for at systemet venter (i opptil 6 uker, + eventuell purreperiode).

Første versjon her har ikke mulighet for å legge inn refusjonsperiode (fom, tom, beløp, referanse). Tar det separat for ikke å forsinke denne.

Avhengig av deploy av SAM til prod: https://nav-it.slack.com/archives/CQ08JC3UG/p1719301589297069?thread_ts=1719213332.280149&cid=CQ08JC3UG

![image](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/8087437/dbfc4d43-5c66-4897-8b9b-52864578b5b4)
