### PR TITLE
EY-4119 Vise hvis bruker er død + standardisere dødsdato tag

### DIFF
--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
@@ -158,6 +158,7 @@ data class PdlHentPersonNavnFoedselsdato(
     val folkeregisteridentifikator: List<PdlFolkeregisteridentifikator>,
     val navn: List<PdlNavn>,
     val foedsel: List<PdlFoedsel>,
+    val doedsfall: List<PdlDoedsfall>,
 )
 
 data class PdlHentPerson(

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/PersonMapper.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/PersonMapper.kt
@@ -188,6 +188,7 @@ object PersonMapper {
                         .identifikasjonsnummer
                 }
             val foedsel = ppsKlient.avklarFoedsel(hentPerson.foedsel)
+            val doedsfall = ppsKlient.avklarDoedsfall(hentPerson.doedsfall)
 
             PersonNavnFoedselsaar(
                 fornavn = navn.fornavn,
@@ -196,6 +197,7 @@ object PersonMapper {
                 foedselsnummer = Folkeregisteridentifikator.of(fnr),
                 foedselsdato = foedsel.foedselsdato,
                 foedselsaar = foedsel.foedselsaar,
+                doedsdato = doedsfall?.doedsdato,
             )
         }
 

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/personweb/dto/PersonNavnFoedselsaar.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/personweb/dto/PersonNavnFoedselsaar.kt
@@ -11,6 +11,7 @@ data class PersonNavnFoedselsaar(
     val foedselsnummer: Folkeregisteridentifikator,
     val foedselsaar: Int,
     val foedselsdato: LocalDate? = null,
+    val doedsdato: LocalDate? = null,
 )
 
 data class PersonSoekSvar(

--- a/apps/etterlatte-pdltjenester/src/main/resources/pdl/hentPersonNavnFoedsel.graphql
+++ b/apps/etterlatte-pdltjenester/src/main/resources/pdl/hentPersonNavnFoedsel.graphql
@@ -53,5 +53,14 @@ query(
                 ...metadata
             }
         }
+        doedsfall {
+            doedsdato
+            folkeregistermetadata {
+                ...folkeregistermetadata
+            }
+            metadata {
+                ...metadata
+            }
+        }
     }
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/Behandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/Behandling.tsx
@@ -98,5 +98,6 @@ const personTilPersonNavnFoedselsAar = (person: IPdlPerson): IPdlPersonNavnFoeds
     etternavn: person.etternavn,
     foedselsaar: person.foedselsaar,
     foedselsdato: person.foedselsdato,
+    doedsdato: person.doedsdato,
   }
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
@@ -62,7 +62,7 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
           Oppfølging av aktivitet
         </Heading>
         <BodyShort spacing>
-          <strong>Dødsdato: </strong> {avdoedesDoedsdato && formaterDato(new Date(avdoedesDoedsdato))}
+          <strong>Dødsdato: </strong> {avdoedesDoedsdato && formaterDato(avdoedesDoedsdato)}
         </BodyShort>
       </Box>
 
@@ -79,8 +79,8 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
           </BodyLong>
         </TekstWrapper>
 
-        {visTidslinje && isValid(new Date(avdoedesDoedsdato!!)) && (
-          <AktivitetspliktTidslinje behandling={behandling} doedsdato={new Date(avdoedesDoedsdato!!)} />
+        {visTidslinje && isValid(avdoedesDoedsdato!!) && (
+          <AktivitetspliktTidslinje behandling={behandling} doedsdato={avdoedesDoedsdato!!} />
         )}
         {visTidslinje && (
           <AktivitetspliktVurdering

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/Soeskenjustering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/Soeskenjustering.tsx
@@ -116,8 +116,6 @@ const Soeskenjustering = (props: SoeskenjusteringProps) => {
     }
   }
 
-  const doedsdato = avdoede?.opplysning.doedsdato ?? null
-
   return (
     <>
       <Box paddingInline="16" paddingBlock="16 4">
@@ -126,7 +124,9 @@ const Soeskenjustering = (props: SoeskenjusteringProps) => {
         </Heading>
       </Box>
       <FamilieforholdWrapper>
-        {personopplysninger.soeker && <Barn person={personopplysninger.soeker?.opplysning} doedsdato={doedsdato} />}
+        {personopplysninger.soeker && (
+          <Barn person={personopplysninger.soeker?.opplysning} doedsdato={avdoede?.opplysning.doedsdato} />
+        )}
       </FamilieforholdWrapper>
       <Box paddingBlock="4 0" borderWidth="1 0 0 0" borderColor="border-subtle">
         {visFeil && feil.length > 0 && behandles ? <FeilIPerioder feil={feil} /> : null}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.ts
@@ -27,11 +27,11 @@ export function soeknadsoversiktErFerdigUtfylt(behandling: IDetaljertBehandling)
   }
 }
 
-export function hentAdresserEtterDoedsdato(adresser: IAdresse[], doedsdato: string | null): IAdresse[] {
+export function hentAdresserEtterDoedsdato(adresser: IAdresse[], doedsdato: Date | undefined): IAdresse[] {
   if (doedsdato == null) {
     return adresser
   }
-  return adresser?.filter((adresse) => adresse.aktiv || isAfter(new Date(adresse.gyldigTilOgMed!), new Date(doedsdato)))
+  return adresser?.filter((adresse) => adresse.aktiv || isAfter(new Date(adresse.gyldigTilOgMed!), doedsdato))
 }
 
 export const hentGyldigeNavigeringsStatuser = (status: IBehandlingStatus) => {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/GrunnlagForVirkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/GrunnlagForVirkningstidspunkt.tsx
@@ -24,7 +24,7 @@ const SoekerDoedsdatoGrunnlag = () => {
   return (
     <Info
       label="Dødsdato mottaker av ytelsen"
-      tekst={soekerDoedsdato ? formaterStringDato(soekerDoedsdato) : 'Ingen dødsdato registrert'}
+      tekst={soekerDoedsdato ? formaterDato(soekerDoedsdato) : 'Ingen dødsdato registrert'}
     />
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/GrunnlagForVirkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/GrunnlagForVirkningstidspunkt.tsx
@@ -1,6 +1,6 @@
 import { useBehandling } from '~components/behandling/useBehandling'
 import { Info } from '~components/behandling/soeknadsoversikt/Info'
-import { formaterStringDato } from '~utils/formattering'
+import { formaterDato, formaterStringDato } from '~utils/formattering'
 import { usePersonopplysninger } from '~components/person/usePersonopplysninger'
 import { formaterGrunnlagKilde } from '~components/behandling/soeknadsoversikt/utils'
 
@@ -18,13 +18,13 @@ export const GrunnlagForVirkningstidspunkt = () => {
             <>
               {`${avdod.opplysning.fornavn} ${avdod.opplysning.etternavn}`}
               <br />
-              {avdod.opplysning.doedsdato ? formaterStringDato(avdod?.opplysning.doedsdato) : 'Ikke registrert'}
+              {avdod.opplysning.doedsdato ? formaterDato(avdod?.opplysning.doedsdato) : 'Ikke registrert'}
             </>
           }
           undertekst={formaterGrunnlagKilde(avdod?.kilde)}
         />
       ))}
-      {avdoede.length == 0 && <Info key="manglerDoedsdato" label="Dødsdato" tekst="Ikke registrert" />}
+      {!avdoede.length && <Info key="manglerDoedsdato" label="Dødsdato" tekst="Ikke registrert" />}
       {behandling?.soeknadMottattDato && (
         <Info key="soeknadMottatt" label="Søknad mottatt" tekst={formaterStringDato(behandling.soeknadMottattDato)} />
       )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/omstillingsstoenad/Sivilstand.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/omstillingsstoenad/Sivilstand.tsx
@@ -4,7 +4,7 @@ import { Familieforhold, IPdlPerson } from '~shared/types/Person'
 import { format } from 'date-fns'
 import styled from 'styled-components'
 import { IconSize } from '~shared/types/Icon'
-import { DatoFormat } from '~utils/formattering'
+import { DatoFormat, formaterDato } from '~utils/formattering'
 
 type Props = {
   familieforhold: Familieforhold
@@ -49,9 +49,7 @@ export const Sivilstand = ({ familieforhold, avdoed }: Props) => {
                         : 'Annen person'}
                     </Table.DataCell>
                     <Table.DataCell>
-                      {ss.relatertVedSiviltilstand === avdoed.foedselsnummer
-                        ? format(new Date(avdoed.doedsdato!), DatoFormat.DAG_MAANED_AAR)
-                        : ''}
+                      {ss.relatertVedSiviltilstand === avdoed.foedselsnummer ? formaterDato(avdoed.doedsdato!) : ''}
                     </Table.DataCell>
                   </Table.Row>
                 )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/Barn.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/Barn.tsx
@@ -6,7 +6,7 @@ import { BodyShort, HStack, Label, VStack } from '@navikt/ds-react'
 
 type Props = {
   person: IPdlPerson
-  doedsdato: string | null
+  doedsdato: Date | undefined
 }
 
 export const Barn = ({ person, doedsdato }: Props) => {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/Soesken.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/Soesken.tsx
@@ -27,10 +27,7 @@ export const Soesken = ({ person, familieforhold }: { person: IPdlPerson; famili
         <BodyShort>{person.foedselsnummer}</BodyShort>
       </VStack>
       <PersonInfoAdresse
-        adresser={hentAdresserEtterDoedsdato(
-          person.bostedsadresse!!,
-          avdoede.opplysning.doedsdato ? avdoede.opplysning.doedsdato.toString() : 'Ingen dødsdato for avdød'
-        )}
+        adresser={hentAdresserEtterDoedsdato(person.bostedsadresse!!, avdoede.opplysning.doedsdato)}
         visHistorikk={true}
         adresseDoedstidspunkt={false}
       />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/utils.test.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/utils.test.ts
@@ -4,7 +4,7 @@ import { SakType } from '~shared/types/sak'
 
 describe('minimumstidspunkt for virkningstidspunkt er', () => {
   it('maaned etter doedsdato hvis soknad er mottatt innenfor tre aar', () => {
-    const avdoedDoedsdato = '2020-01-01'
+    const avdoedDoedsdato = new Date('2020-01-01')
     const soeknadMottattDato = '2020-03-01'
 
     const minimumsVirkningstidspunkt = hentMinimumsVirkningstidspunkt(
@@ -18,7 +18,7 @@ describe('minimumstidspunkt for virkningstidspunkt er', () => {
   })
 
   it('tre aar fra mottatt soknad hvis soknad er mottatt tre aar etter doedsdato', () => {
-    const avdoedDoedsdato = '2016-12-31'
+    const avdoedDoedsdato = new Date('2016-12-31')
     const soeknadMottattDato = '2020-01-01'
 
     const minimumsVirkningstidspunkt = hentMinimumsVirkningstidspunkt(

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/utils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/utils.ts
@@ -3,7 +3,7 @@ import { Hjemmel } from '~components/behandling/virkningstidspunkt/Virkningstids
 import { SakType } from '~shared/types/sak'
 
 export function hentMinimumsVirkningstidspunkt(
-  avdoedDoedsdato: string | undefined,
+  avdoedDoedsdato: Date | undefined,
   soeknadMottattDato: Date,
   sakType: SakType
 ): Date {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/personopplysninger/Foreldre.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/personopplysninger/Foreldre.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import { Personopplysning } from '~components/person/personopplysninger/Personopplysning'
 import { PersonIcon } from '@navikt/aksel-icons'
-import { Heading, HStack, Table, Tag } from '@navikt/ds-react'
-import { formaterDato } from '~utils/formattering'
+import { Heading, HStack, Table } from '@navikt/ds-react'
 import { AlderTag } from '~components/person/personopplysninger/components/AlderTag'
 import { BostedsadresseDataCell } from '~components/person/personopplysninger/components/BostedsadresseDataCell'
 import { KopierbarVerdi } from '~shared/statusbar/kopierbarVerdi'
 import { Familiemedlem } from '~shared/types/familieOpplysninger'
+import { DoedsdatoTag } from '~shared/tags/DoedsdatoTag'
 
 export const Foreldre = ({
   avdoed,
@@ -39,12 +39,8 @@ export const Foreldre = ({
                 <Table.Row key={index}>
                   <Table.DataCell>
                     <HStack gap="4">
-                      {`${doed.fornavn} ${doed.etternavn}`}
-                      {!!doed.doedsdato && (
-                        <Tag variant="error-filled" size="small">
-                          Død {formaterDato(doed.doedsdato)}
-                        </Tag>
-                      )}
+                      {doed.fornavn} {doed.etternavn}
+                      <DoedsdatoTag doedsdato={doed.doedsdato} />
                     </HStack>
                   </Table.DataCell>
                   <Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/personopplysninger/Sivilstatus.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/personopplysninger/Sivilstatus.tsx
@@ -1,12 +1,12 @@
 import React, { ReactNode } from 'react'
 import { Personopplysning } from '~components/person/personopplysninger/Personopplysning'
 import { HeartIcon } from '@navikt/aksel-icons'
-import { Heading, HStack, Table, Tag } from '@navikt/ds-react'
+import { Heading, HStack, Table } from '@navikt/ds-react'
 import { formaterDato } from '~utils/formattering'
-import styled from 'styled-components'
 import { lowerCase, startCase } from 'lodash'
 import { KopierbarVerdi } from '~shared/statusbar/kopierbarVerdi'
 import { Familiemedlem, Sivilstand } from '~shared/types/familieOpplysninger'
+import { DoedsdatoTag } from '~shared/tags/DoedsdatoTag'
 
 export const Sivilstatus = ({
   sivilstand,
@@ -15,15 +15,8 @@ export const Sivilstatus = ({
   sivilstand?: Sivilstand[]
   avdoede?: Familiemedlem[]
 }): ReactNode => {
-  const relatertVedSivilstandDoedsdato = (
-    relatertVedSiviltilstand: string,
-    avdoede: Familiemedlem[]
-  ): string | undefined => {
-    const relaterteAvdoed = avdoede.find((val) => val.foedselsnummer === relatertVedSiviltilstand)
-
-    if (!!relaterteAvdoed?.doedsdato) return formaterDato(relaterteAvdoed.doedsdato)
-    else return undefined
-  }
+  const relatertAvdoed = (relatertVedSiviltilstand: string, avdoede: Familiemedlem[]): Familiemedlem | undefined =>
+    avdoede.find((val) => val.foedselsnummer === relatertVedSiviltilstand)
 
   return (
     <Personopplysning heading="Sivilstatus" icon={<HeartIcon />}>
@@ -48,15 +41,7 @@ export const Sivilstatus = ({
                         <>
                           <KopierbarVerdi value={stand.relatertVedSivilstand} iconPosition="right" />
                           {avdoede && avdoede.length >= 0 && (
-                            <>
-                              {!!relatertVedSivilstandDoedsdato(stand.relatertVedSivilstand, avdoede) && (
-                                <DoedsDatoWrapper>
-                                  <Tag variant="error-filled" size="small">
-                                    Død {relatertVedSivilstandDoedsdato(stand.relatertVedSivilstand, avdoede)}
-                                  </Tag>
-                                </DoedsDatoWrapper>
-                              )}
-                            </>
+                            <DoedsdatoTag doedsdato={relatertAvdoed(stand.relatertVedSivilstand, avdoede)?.doedsdato} />
                           )}
                         </>
                       )}
@@ -77,9 +62,3 @@ export const Sivilstatus = ({
     </Personopplysning>
   )
 }
-
-const DoedsDatoWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-`

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/statusbar/Statusbar.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/statusbar/Statusbar.tsx
@@ -9,6 +9,8 @@ import { useEffect } from 'react'
 import { hentPersonNavnogFoedsel } from '~shared/api/pdltjenester'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { hentAlderForDato } from '~components/behandling/felles/utils'
+import { differenceInYears } from 'date-fns'
+import { DoedsdatoTag } from '~shared/tags/DoedsdatoTag'
 
 export const PdlPersonStatusBar = ({ person }: { person: IPdlPersonNavnFoedsel }) => (
   <StatusBar
@@ -21,6 +23,7 @@ export const PdlPersonStatusBar = ({ person }: { person: IPdlPersonNavnFoedsel }
         etternavn: person.etternavn,
         foedselsaar: person.foedselsaar,
         foedselsdato: person.foedselsdato,
+        doedsdato: person.doedsdato,
       },
     }}
   />
@@ -55,7 +58,11 @@ export const StatusBar = ({ result }: { result: Result<IPdlPersonNavnFoedsel> })
           <Label>
             <Link href={`/person/${person.foedselsnummer}`}>{genererNavn(person)}</Link>
           </Label>
-          <VisAlderForPerson foedselsdato={person.foedselsdato} foedselsaar={person.foedselsaar} />
+
+          <DoedsdatoTag doedsdato={person.doedsdato} />
+
+          <Alder foedselsdato={person.foedselsdato} doedsdato={person.doedsdato} foedselsaar={person.foedselsaar} />
+
           <BodyShort>|</BodyShort>
           <KopierbarVerdi value={person.foedselsnummer} />
         </HStack>
@@ -64,9 +71,25 @@ export const StatusBar = ({ result }: { result: Result<IPdlPersonNavnFoedsel> })
   )
 }
 
-const VisAlderForPerson = ({ foedselsdato, foedselsaar }: { foedselsdato: Date | undefined; foedselsaar: number }) => {
+const finnAlder = (foedselsdato: Date, doedsdato?: Date) => {
+  if (doedsdato) {
+    return differenceInYears(doedsdato, foedselsdato)
+  } else {
+    return hentAlderForDato(foedselsdato)
+  }
+}
+
+const Alder = ({
+  foedselsdato,
+  doedsdato,
+  foedselsaar,
+}: {
+  foedselsdato?: Date
+  doedsdato?: Date
+  foedselsaar: number
+}) => {
   if (foedselsdato) {
-    const alder = hentAlderForDato(foedselsdato)
+    const alder = finnAlder(foedselsdato, doedsdato)
     return <BodyShort textColor="subtle">({alder} år)</BodyShort>
   } else {
     return (

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/tags/DoedsdatoTag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/tags/DoedsdatoTag.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { Tag } from '@navikt/ds-react'
+import { formaterDato } from '~utils/formattering'
+
+export const DoedsdatoTag = ({ doedsdato }: { doedsdato?: Date }) =>
+  doedsdato && (
+    <Tag variant="neutral-filled" size="small">
+      &#10013; {formaterDato(doedsdato)}
+    </Tag>
+  )

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Person.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Person.ts
@@ -63,6 +63,7 @@ export interface IPdlPersonNavnFoedsel {
   foedselsnummer: string
   foedselsaar: number
   foedselsdato: Date | undefined
+  doedsdato: Date | undefined
 }
 
 export interface Utland {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Person.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Person.ts
@@ -41,7 +41,7 @@ export interface IPdlPerson {
   foedselsnummer: string
   foedselsdato: Date
   foedselsaar: number
-  doedsdato: string | undefined
+  doedsdato: Date | undefined
   bostedsadresse?: IAdresse[]
   deltBostedsadresse?: IAdresse[]
   kontaktadresse?: IAdresse[]


### PR DESCRIPTION
Har også fikset at alder regnes ut korrekt i tilfeller hvor bruker er død. 


### Bruker er død 
![Screenshot 2024-06-26 at 13 08 09](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/4cbe1f71-64ea-4daa-b14f-d05e04dacd54)

### Sivilstand dødsdato tag
![Screenshot 2024-06-26 at 13 08 00](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/1ce5e6b6-0eb7-4ad7-9fed-b4c7997cdd68)

### Foreldre dødsdato tag
![Screenshot 2024-06-26 at 13 05 33](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/4b948c50-57dd-462d-b2e7-979232cb08d1)


