### PR TITLE
Fikser problemer innfoert pga feilhaandtering

### DIFF
--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumer.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumer.kt
@@ -48,15 +48,14 @@ class KravgrunnlagConsumer(
                         logger.info("Mottok melding av type detaljertKravgrunnlagMelding")
                         val detaljertKravgrunnlag = toDetaljertKravgrunnlagDto(payload)
                         val sakId = detaljertKravgrunnlag.fagsystemId.toLong()
-                        val type = TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT
 
                         sjekkAtSisteHendelseForSakErFerdigstilt(sakId, jmsTimestamp)
 
                         val hendelseId =
                             hendelseRepository.lagreTilbakekrevingHendelse(
-                                sakId = detaljertKravgrunnlag.fagsystemId.toLong(),
+                                sakId = sakId,
                                 payload = payload,
-                                type = type,
+                                type = TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT,
                                 jmsTimestamp = jmsTimestamp,
                             )
 
@@ -68,15 +67,14 @@ class KravgrunnlagConsumer(
                         logger.info("Mottok melding av type endringKravOgVedtakstatus")
                         val kravOgVedtakstatusDto = toKravOgVedtakstatus(payload)
                         val sakId = kravOgVedtakstatusDto.fagsystemId.toLong()
-                        val type = TilbakekrevingHendelseType.KRAV_VEDTAK_STATUS_MOTTATT
 
                         sjekkAtSisteHendelseForSakErFerdigstilt(sakId, jmsTimestamp)
 
                         val hendelseId =
                             hendelseRepository.lagreTilbakekrevingHendelse(
-                                sakId = kravOgVedtakstatusDto.fagsystemId.toLong(),
+                                sakId = sakId,
                                 payload = payload,
-                                type = type,
+                                type = TilbakekrevingHendelseType.KRAV_VEDTAK_STATUS_MOTTATT,
                                 jmsTimestamp = jmsTimestamp,
                             )
 

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumer.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumer.kt
@@ -50,7 +50,7 @@ class KravgrunnlagConsumer(
                         val sakId = detaljertKravgrunnlag.fagsystemId.toLong()
                         val type = TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT
 
-                        sjekkAtSisteHendelseForSakErFerdigstilt(sakId, type, jmsTimestamp)
+                        sjekkAtSisteHendelseForSakErFerdigstilt(sakId, jmsTimestamp)
 
                         val hendelseId =
                             hendelseRepository.lagreTilbakekrevingHendelse(
@@ -68,15 +68,15 @@ class KravgrunnlagConsumer(
                         logger.info("Mottok melding av type endringKravOgVedtakstatus")
                         val kravOgVedtakstatusDto = toKravOgVedtakstatus(payload)
                         val sakId = kravOgVedtakstatusDto.fagsystemId.toLong()
-                        val type = TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT
+                        val type = TilbakekrevingHendelseType.KRAV_VEDTAK_STATUS_MOTTATT
 
-                        sjekkAtSisteHendelseForSakErFerdigstilt(sakId, type, jmsTimestamp)
+                        sjekkAtSisteHendelseForSakErFerdigstilt(sakId, jmsTimestamp)
 
                         val hendelseId =
                             hendelseRepository.lagreTilbakekrevingHendelse(
                                 sakId = kravOgVedtakstatusDto.fagsystemId.toLong(),
                                 payload = payload,
-                                type = TilbakekrevingHendelseType.KRAV_VEDTAK_STATUS_MOTTATT,
+                                type = type,
                                 jmsTimestamp = jmsTimestamp,
                             )
 
@@ -98,10 +98,9 @@ class KravgrunnlagConsumer(
 
     private fun sjekkAtSisteHendelseForSakErFerdigstilt(
         sakId: Long,
-        type: TilbakekrevingHendelseType,
         jmsTimestampNyHendelse: Tidspunkt,
     ) {
-        val sisteHendelse = hendelseRepository.hentSisteTilbakekrevingHendelse(sakId, type)
+        val sisteHendelse = hendelseRepository.hentSisteTilbakekrevingHendelse(sakId)
         if (sisteHendelse?.status == TilbakekrevingHendelseStatus.NY) {
             throw Exception("Må ferdigstille forrige hendelse ${sisteHendelse.id} for sak $sakId før ny kan prosesseres")
         }

--- a/apps/etterlatte-tilbakekreving/src/main/resources/db/migration/V5__oppdater_sak_til_ferdigstilt.sql
+++ b/apps/etterlatte-tilbakekreving/src/main/resources/db/migration/V5__oppdater_sak_til_ferdigstilt.sql
@@ -1,0 +1,3 @@
+-- Oppdaterer hendelser til ferdigstilt etter bugfix
+UPDATE tilbakekreving_hendelse SET status = 'FERDIGSTILT' WHERE id = '127636f8-ce1f-4dd9-b825-59ea5875bd41';
+UPDATE tilbakekreving_hendelse SET status = 'FERDIGSTILT' WHERE id = 'b407be18-58df-4e58-8fcb-7c0f37958a71';

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumerTest.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagConsumerTest.kt
@@ -39,7 +39,7 @@ class KravgrunnlagConsumerTest {
         simulerKravgrunnlagsmeldingFraTilbakekrevingskomponenten()
 
         verify(exactly = 1) {
-            tilbakekrevingHendelseRepository.hentSisteTilbakekrevingHendelse(any(), any())
+            tilbakekrevingHendelseRepository.hentSisteTilbakekrevingHendelse(any())
             tilbakekrevingHendelseRepository.lagreTilbakekrevingHendelse(any(), any(), any(), any())
             kravgrunnlagService.haandterKravgrunnlag(any())
             tilbakekrevingHendelseRepository.ferdigstillTilbakekrevingHendelse(any(), any())
@@ -57,7 +57,7 @@ class KravgrunnlagConsumerTest {
 
     @Test
     fun `skal feile ved mottak av kravgrunnlag dersom forrige hendelse for sak ikke er ferdigstilt`() {
-        every { tilbakekrevingHendelseRepository.hentSisteTilbakekrevingHendelse(any(), any()) } returns
+        every { tilbakekrevingHendelseRepository.hentSisteTilbakekrevingHendelse(any()) } returns
             tilbakekrevingHendelse(
                 type = TilbakekrevingHendelseType.KRAVGRUNNLAG_MOTTATT,
                 status = TilbakekrevingHendelseStatus.NY,
@@ -67,7 +67,7 @@ class KravgrunnlagConsumerTest {
 
         verify(exactly = 4) {
             // 3 retries
-            tilbakekrevingHendelseRepository.hentSisteTilbakekrevingHendelse(any(), any())
+            tilbakekrevingHendelseRepository.hentSisteTilbakekrevingHendelse(any())
         }
         verify(exactly = 0) {
             tilbakekrevingHendelseRepository.lagreTilbakekrevingHendelse(any(), any(), any(), any())
@@ -78,7 +78,7 @@ class KravgrunnlagConsumerTest {
 
     @Test
     fun `skal feile ved mottak av kravOgVedtakStatus dersom forrige hendelse for sak ikke er ferdigstilt`() {
-        every { tilbakekrevingHendelseRepository.hentSisteTilbakekrevingHendelse(any(), any()) } returns
+        every { tilbakekrevingHendelseRepository.hentSisteTilbakekrevingHendelse(any()) } returns
             tilbakekrevingHendelse(
                 type = TilbakekrevingHendelseType.KRAV_VEDTAK_STATUS_MOTTATT,
                 status = TilbakekrevingHendelseStatus.NY,
@@ -88,7 +88,7 @@ class KravgrunnlagConsumerTest {
 
         verify(exactly = 4) {
             // 3 retries
-            tilbakekrevingHendelseRepository.hentSisteTilbakekrevingHendelse(any(), any())
+            tilbakekrevingHendelseRepository.hentSisteTilbakekrevingHendelse(any())
         }
         verify(exactly = 0) {
             tilbakekrevingHendelseRepository.lagreTilbakekrevingHendelse(any(), any(), any(), any())

--- a/libs/etterlatte-database/src/main/kotlin/KotliqueryUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/KotliqueryUtils.kt
@@ -74,3 +74,5 @@ fun <T> TransactionalSession.hentListe(
         }
 
 fun Row.tidspunkt(columnLabel: String) = sqlTimestamp(columnLabel).toTidspunkt()
+
+fun Row.tidspunktOrNull(columnLabel: String) = sqlTimestampOrNull(columnLabel)?.toTidspunkt()


### PR DESCRIPTION
Her ble det en god gammeldags testing i prod. Det ble innført noen issues med feilhåndteringen som denne PR'en skal fikse.

- Glemt å oppdatere enum i KravgrunnlagConsumer som resulterte i problemer lenger ned i løypa
- Ferdigstill-funksjonaliteten fungerte ikke som forventet, fikset query og fikk dette inn i tester (som det burde vært i utgangspunktet)
- Endret `hent` metoden i repo til å bruke kotliquery som resten, og fikset et par potensielle issues der
- Migrerer to hendelser til `FERDIGSTILT` da disse kom gjennom hele flyten, men feilet på siste oppdateringen. Disse meldingene blir slettet manuelt fra backout-køen på MQ.