### PR TITLE
EY-4115 Kreve kommentar ved manuell håndtering av samordningsmelding

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningOppdaterMeldingModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningOppdaterMeldingModal.tsx
@@ -87,8 +87,8 @@ export default function SamordningOppdaterMeldingModal({
             <Textarea
               label="Kommentar/dialog med TP-ordning"
               description="Det opprettes et notat på saken for å dokumentere handlingen."
-              minRows="5"
-              maxRows="10"
+              minRows={5}
+              maxRows={10}
               onChange={(event) => setKommentar(event.target.value)}
             />
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningOppdaterMeldingModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningOppdaterMeldingModal.tsx
@@ -1,4 +1,4 @@
-import { BodyShort, Button, Heading, HStack, Label, Modal, Radio, RadioGroup, VStack } from '@navikt/ds-react'
+import { BodyShort, Button, Heading, HStack, Label, Modal, Radio, RadioGroup, Textarea, VStack } from '@navikt/ds-react'
 import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useApiCall } from '~shared/hooks/useApiCall'
@@ -25,6 +25,7 @@ export default function SamordningOppdaterMeldingModal({
   const navigate = useNavigate()
 
   const [erRefusjonskrav, setErRefusjonskrav] = useState<JaNei>()
+  const [kommentar, setKommentar] = useState<string>('')
   const [oppdaterSamordningsmeldingStatus, oppdaterSamordningsmelding] = useApiCall(oppdaterSamordningsmeldingForSak)
 
   const oppdaterMelding = () => {
@@ -36,7 +37,7 @@ export default function SamordningOppdaterMeldingModal({
           pid: fnr,
           tpNr: mld.tpNr,
           refusjonskrav: erRefusjonskrav === JaNei.JA,
-          periodisertBelopListe: [],
+          kommentar: kommentar,
         },
       },
       () => {
@@ -83,6 +84,14 @@ export default function SamordningOppdaterMeldingModal({
               </HStack>
             </RadioGroup>
 
+            <Textarea
+              label="Kommentar/dialog med TP-ordning"
+              description="Det opprettes et notat på saken for å dokumentere handlingen."
+              minRows="5"
+              maxRows="10"
+              onChange={(event) => setKommentar(event.target.value)}
+            />
+
             {isSuccess(oppdaterSamordningsmeldingStatus) ? (
               <>
                 <Toast melding="Melding oppdatert" />
@@ -104,7 +113,7 @@ export default function SamordningOppdaterMeldingModal({
                 </Button>
                 <Button
                   variant="primary"
-                  disabled={erRefusjonskrav === undefined}
+                  disabled={erRefusjonskrav === undefined || !kommentar.length}
                   onClick={oppdaterMelding}
                   loading={isPending(oppdaterSamordningsmeldingStatus)}
                 >

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningOppdaterMeldingModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningOppdaterMeldingModal.tsx
@@ -1,14 +1,12 @@
 import { BodyShort, Button, Heading, HStack, Label, Modal, Radio, RadioGroup, Textarea, VStack } from '@navikt/ds-react'
 import React, { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { useApiCall } from '~shared/hooks/useApiCall'
-import { isPending, isSuccess, mapFailure } from '~shared/api/apiUtils'
+import { isPending, mapFailure } from '~shared/api/apiUtils'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { oppdaterSamordningsmeldingForSak } from '~shared/api/vedtaksvurdering'
 import { DocPencilIcon } from '@navikt/aksel-icons'
 import { Samordningsmelding } from '~components/vedtak/typer'
 import { JaNei } from '~shared/types/ISvar'
-import { Toast } from '~shared/alerts/Toast'
 
 export default function SamordningOppdaterMeldingModal({
   fnr,
@@ -24,7 +22,6 @@ export default function SamordningOppdaterMeldingModal({
   refresh: () => void
 }) {
   const [open, setOpen] = useState(false)
-  const navigate = useNavigate()
 
   const [erRefusjonskrav, setErRefusjonskrav] = useState<JaNei>()
   const [kommentar, setKommentar] = useState<string>('')
@@ -95,35 +92,23 @@ export default function SamordningOppdaterMeldingModal({
               onChange={(event) => setKommentar(event.target.value)}
             />
 
-            {isSuccess(oppdaterSamordningsmeldingStatus) ? (
-              <>
-                <Toast melding="Melding oppdatert" />
-
-                <HStack gap="4" justify="center">
-                  <Button variant="primary" onClick={() => navigate(`/person/${fnr}/?fane=SAMORDNING`)}>
-                    Gå til samordningsoversikten
-                  </Button>
-                </HStack>
-              </>
-            ) : (
-              <HStack gap="4" justify="center">
-                <Button
-                  variant="secondary"
-                  onClick={() => setOpen(false)}
-                  disabled={isPending(oppdaterSamordningsmeldingStatus)}
-                >
-                  Avbryt
-                </Button>
-                <Button
-                  variant="primary"
-                  disabled={erRefusjonskrav === undefined || !kommentar.length}
-                  onClick={oppdaterMelding}
-                  loading={isPending(oppdaterSamordningsmeldingStatus)}
-                >
-                  Lagre
-                </Button>
-              </HStack>
-            )}
+            <HStack gap="4" justify="center">
+              <Button
+                variant="secondary"
+                onClick={() => setOpen(false)}
+                disabled={isPending(oppdaterSamordningsmeldingStatus)}
+              >
+                Avbryt
+              </Button>
+              <Button
+                variant="primary"
+                disabled={erRefusjonskrav === undefined || !kommentar.length}
+                onClick={oppdaterMelding}
+                loading={isPending(oppdaterSamordningsmeldingStatus)}
+              >
+                Lagre
+              </Button>
+            </HStack>
 
             {mapFailure(oppdaterSamordningsmeldingStatus, (error) => (
               <Modal.Footer>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningOppdaterMeldingModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningOppdaterMeldingModal.tsx
@@ -13,11 +13,13 @@ import { Toast } from '~shared/alerts/Toast'
 export default function SamordningOppdaterMeldingModal({
   fnr,
   sakId,
+  vedtakId,
   mld,
   refresh,
 }: {
   fnr: string
   sakId: number
+  vedtakId: number
   mld: Samordningsmelding
   refresh: () => void
 }) {
@@ -38,6 +40,7 @@ export default function SamordningOppdaterMeldingModal({
           tpNr: mld.tpNr,
           refusjonskrav: erRefusjonskrav === JaNei.JA,
           kommentar: kommentar,
+          vedtakId: vedtakId,
         },
       },
       () => {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningOppdaterMeldingModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningOppdaterMeldingModal.tsx
@@ -102,7 +102,7 @@ export default function SamordningOppdaterMeldingModal({
               </Button>
               <Button
                 variant="primary"
-                disabled={erRefusjonskrav === undefined || !kommentar.length}
+                disabled={!erRefusjonskrav || !kommentar.length}
                 onClick={oppdaterMelding}
                 loading={isPending(oppdaterSamordningsmeldingStatus)}
               >

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningSak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningSak.tsx
@@ -97,7 +97,13 @@ function SamordningTabell({
                 {redigerbar && (
                   <Table.DataCell>
                     {!mld.svartDato && (
-                      <SamordningOppdaterMeldingModal fnr={fnr} sakId={sakId} mld={mld} refresh={refresh} />
+                      <SamordningOppdaterMeldingModal
+                        fnr={fnr}
+                        sakId={sakId}
+                        mld={mld}
+                        vedtakId={vedtak.vedtakId}
+                        refresh={refresh}
+                      />
                     )}
                   </Table.DataCell>
                 )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/vedtak/typer.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/vedtak/typer.tsx
@@ -49,12 +49,5 @@ export interface OppdaterSamordningsmelding {
   pid: string
   tpNr: string
   refusjonskrav: boolean
-  periodisertBelopListe: Refusjonstrekk[]
-}
-
-export interface Refusjonstrekk {
-  fom: string
-  tom?: string
-  belop: number
-  kravstillerReferanse?: String
+  kommentar: string
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/vedtak/typer.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/vedtak/typer.tsx
@@ -50,4 +50,5 @@ export interface OppdaterSamordningsmelding {
   tpNr: string
   refusjonskrav: boolean
   kommentar: string
+  vedtakId: number
 }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Samordningsdata.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Samordningsdata.kt
@@ -42,12 +42,4 @@ data class OppdaterSamordningsmelding(
     val tpNr: String,
     val samId: Long,
     val refusjonskrav: Boolean,
-    val periodisertBelopListe: List<Refusjonstrekk>,
-)
-
-data class Refusjonstrekk(
-    val fom: LocalDate,
-    val tom: LocalDate?,
-    val belop: Double,
-    val kravstillerReferanse: String,
 )

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Samordningsdata.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Samordningsdata.kt
@@ -1,4 +1,4 @@
-package no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering
+package no.nav.etterlatte.vedtaksvurdering
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import java.time.LocalDate

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Samordningsdata.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Samordningsdata.kt
@@ -41,5 +41,7 @@ data class OppdaterSamordningsmelding(
     val pid: String,
     val tpNr: String,
     val samId: Long,
+    val vedtakId: Long,
     val refusjonskrav: Boolean,
+    val kommentar: String,
 )

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
@@ -28,9 +28,6 @@ import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingDto
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
-import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.OppdaterSamordningsmelding
-import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.Samordningsvedtak
-import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.SamordningsvedtakWrapper
 import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.VedtakOgBeregningSammenligner
 import no.nav.etterlatte.rapidsandrivers.migrering.KILDE_KEY
 import no.nav.etterlatte.vedtaksvurdering.grunnlag.GrunnlagVersjonValidering.validerVersjon

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
@@ -410,7 +410,14 @@ class VedtakBehandlingService(
         samordningmelding: OppdaterSamordningsmelding,
         brukerTokenInfo: BrukerTokenInfo,
     ) {
-        samordningsKlient.oppdaterSamordningsmelding(samordningmelding, brukerTokenInfo)
+        repository.lagreManuellBehandlingSamordningsmelding(samordningmelding, brukerTokenInfo)
+
+        try {
+            samordningsKlient.oppdaterSamordningsmelding(samordningmelding, brukerTokenInfo)
+        } catch (e: Exception) {
+            repository.slettManuellBehandlingSamordningsmelding(samordningmelding.samId)
+            throw e
+        }
     }
 
     suspend fun iverksattVedtak(

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
@@ -28,6 +28,8 @@ import no.nav.etterlatte.libs.database.hentListe
 import no.nav.etterlatte.libs.database.oppdater
 import no.nav.etterlatte.libs.database.opprett
 import no.nav.etterlatte.libs.database.transaction
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.OppdaterSamordningsmelding
 import java.sql.Date
 import java.time.YearMonth
 import java.util.UUID
@@ -577,5 +579,38 @@ class VedtaksvurderingRepository(
             ).also { require(it == 1) }
             return@session hentVedtakNonNull(behandlingId, this)
         }
+    }
+
+    fun lagreManuellBehandlingSamordningsmelding(
+        oppdatering: OppdaterSamordningsmelding,
+        brukerTokenInfo: BrukerTokenInfo,
+        tx: TransactionalSession? = null,
+    ) = tx.session {
+        opprett(
+            query = """
+                    INSERT INTO samordning_manuell (opprettet_av, vedtakId, samId, refusjonskrav, kommentar) 
+                    VALUES (:opprettetAv, :vedtakId, :samId, :refusjonskrav, :kommentar)
+                    """,
+            params =
+                mapOf(
+                    "opprettetAv" to brukerTokenInfo.ident(),
+                    "vedtakId" to oppdatering.vedtakId,
+                    "samId" to oppdatering.samId,
+                    "refusjonskrav" to oppdatering.refusjonskrav,
+                    "kommentar" to oppdatering.kommentar,
+                ),
+            loggtekst = "Lagt til innslag for manuell behandling av samordningsmelding",
+        )
+    }
+
+    fun slettManuellBehandlingSamordningsmelding(
+        samId: Long,
+        tx: TransactionalSession? = null,
+    ) = tx.session {
+        oppdater(
+            query = "DELETE FROM samordning_manuell WHERE samId = :samId",
+            params = mapOf("samId" to samId),
+            loggtekst = "Sletter innslag for manuell samordning pga feil ved ekstern oppdatering",
+        )
     }
 }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
@@ -29,7 +29,6 @@ import no.nav.etterlatte.libs.database.oppdater
 import no.nav.etterlatte.libs.database.opprett
 import no.nav.etterlatte.libs.database.transaction
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
-import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.OppdaterSamordningsmelding
 import java.sql.Date
 import java.time.YearMonth
 import java.util.UUID

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -28,7 +28,6 @@ import no.nav.etterlatte.libs.ktor.route.behandlingId
 import no.nav.etterlatte.libs.ktor.route.routeLogger
 import no.nav.etterlatte.libs.ktor.route.withBehandlingId
 import no.nav.etterlatte.libs.ktor.route.withSakId
-import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.OppdaterSamordningsmelding
 import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.VedtakKlageService
 import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
 import java.time.LocalDate

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/klienter/SamordningsKlient.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/klienter/SamordningsKlient.kt
@@ -18,8 +18,8 @@ import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselExceptio
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
-import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.OppdaterSamordningsmelding
-import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.Samordningsvedtak
+import no.nav.etterlatte.vedtaksvurdering.OppdaterSamordningsmelding
+import no.nav.etterlatte.vedtaksvurdering.Samordningsvedtak
 import no.nav.etterlatte.vedtaksvurdering.Vedtak
 import no.nav.etterlatte.vedtaksvurdering.VedtakInnhold
 import org.slf4j.LoggerFactory

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/klienter/SamordningsKlient.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/klienter/SamordningsKlient.kt
@@ -117,7 +117,6 @@ class SamordningsKlientImpl(
                     parameter("tpNr", samordningmelding.tpNr)
                     parameter("samId", samordningmelding.samId)
                     parameter("refusjonskrav", samordningmelding.refusjonskrav)
-                    // parameter("periodisertBelopListe", ...)
                 }
 
             if (!response.status.isSuccess()) {

--- a/apps/etterlatte-vedtaksvurdering/src/main/resources/db/migration/V31__samordning_manuell.sql
+++ b/apps/etterlatte-vedtaksvurdering/src/main/resources/db/migration/V31__samordning_manuell.sql
@@ -1,0 +1,12 @@
+CREATE TABLE samordning_manuell
+(
+    id            UUID PRIMARY KEY         DEFAULT (uuid_generate_v4()),
+    opprettet     TIMESTAMP WITH TIME ZONE DEFAULT (now() AT TIME ZONE 'UTC') NOT NULL,
+    opprettet_av  TEXT                                                        NOT NULL,
+    vedtakId      BIGINT                                                      NOT NULL REFERENCES vedtak (id),
+    samId         BIGINT                                                      NOT NULL,
+    refusjonskrav BOOLEAN                                                     NOT NULL,
+    kommentar     TEXT                                                        NOT NULL
+);
+
+CREATE INDEX ON samordning_manuell (vedtakId);


### PR DESCRIPTION
- Ønsket sluttstatus i operasjonen fra saksbehandler er at det opprettes et notat med denne informasjonen, men uansett så fremstår det riktig å lagre dette i relevant ey-db.
- Informasjonen som lagres her bør nok også brukes i opphentingen av meldingene, slik at man kan se i samordningsUIet at det er manuelt håndtert (med eller uten kommentaren)