### PR TITLE
Hotfix: Viser seg at AdresseSamsvar kan mangle gyldigFraDato

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/Adressevisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/Adressevisning.tsx
@@ -1,6 +1,6 @@
 import { IAdresse } from '~shared/types/IAdresse'
 import { VStack } from '@navikt/ds-react'
-import { formaterDato, formaterKanskjeStringDato } from '~utils/formatering/dato'
+import { formaterKanskjeStringDatoMedFallback } from '~utils/formatering/dato'
 
 export const Adressevisning = ({
   adresser,
@@ -25,8 +25,11 @@ export const Adressevisning = ({
 }
 
 export const Adresse = ({ adresse, soeknadsoversikt }: { adresse: IAdresse; soeknadsoversikt: boolean }) => {
-  const fra = formaterDato(adresse.gyldigFraOgMed)
-  const til = adresse.aktiv ? 'nå' : formaterKanskjeStringDato(adresse.gyldigTilOgMed)
+  /**
+   * Både fra og til dato er nullable i [AdresseSamsvar]
+   **/
+  const fra = formaterKanskjeStringDatoMedFallback('-', adresse.gyldigFraOgMed)
+  const til = adresse.aktiv ? 'nå' : formaterKanskjeStringDatoMedFallback('-', adresse.gyldigTilOgMed)
 
   return (
     <>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAdresse.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAdresse.ts
@@ -4,7 +4,7 @@ export interface IAdresse {
   adresseLinje3?: string
   aktiv: boolean
   coAdresseNavn?: string
-  gyldigFraOgMed: string
+  gyldigFraOgMed?: string
   gyldigTilOgMed?: string
   kilde: string
   land?: string


### PR DESCRIPTION
Har bare på magisk vis fungert tidligere siden alle nullable strings ble automatisk konvertert til dato. 

Når respons fra backend er `null` blir det med `new Date` bare konvertert til `1 januar 1970`... flotte greier. 