### PR TITLE
FAGSYSTEM-334552 Sette maks filstørrelse på opplastet brev

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/LastOppBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/LastOppBrev.tsx
@@ -28,7 +28,7 @@ export const LastOppBrev = ({ sak }: { sak: ISak }) => {
   const onFileChange = (event: any) => {
     const fil = event.target.files[0]
 
-    const filstoerrelseMegabytes = fil.size / 1000000
+    const filstoerrelseMegabytes = fil.size / (1024 * 1024)
 
     if (filstoerrelseMegabytes > MAKS_FILSTOERRELSE_MB) {
       setError(`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/LastOppBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/LastOppBrev.tsx
@@ -9,6 +9,10 @@ import { isPending } from '~shared/api/apiUtils'
 import { ISak } from '~shared/types/sak'
 import { round } from 'lodash'
 
+/**
+ * Husk å endre [proxy_body_size] i nais-filene hvis du skal øke maks filstørrelse.
+ * Mer info: https://docs.nais.io
+ **/
 const MAKS_FILSTOERRELSE_MB = 1
 
 export const LastOppBrev = ({ sak }: { sak: ISak }) => {


### PR DESCRIPTION
Sikrer at saksbehandler får bedre varsel i tilfeller hvor filen er for stor. Blir da også forhindret i å laste opp slik at vi slipper å få `HTTP 413 Content too large`. 

![Screenshot 2024-06-28 at 16 11 41](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/1224956/fca53314-113d-49ee-bf63-11bdc36aa4f5)