### PR TITLE
EY-4115 Opprette notat ved manuell samordning

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -73,8 +73,8 @@ import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import no.nav.etterlatte.rivers.DistribuerBrevRiver
 import no.nav.etterlatte.rivers.FerdigstillJournalfoerOgDistribuerBrev
 import no.nav.etterlatte.rivers.JournalfoerVedtaksbrevRiver
-import no.nav.etterlatte.rivers.NotatRiver
 import no.nav.etterlatte.rivers.OpprettJournalfoerOgDistribuerRiver
+import no.nav.etterlatte.rivers.SamordningsnotatRiver
 import no.nav.etterlatte.rivers.StartBrevgenereringRepository
 import no.nav.etterlatte.rivers.StartInformasjonsbrevgenereringRiver
 import no.nav.etterlatte.rivers.VedtaksbrevUnderkjentRiver
@@ -271,7 +271,7 @@ class ApplicationBuilder {
                 JournalfoerVedtaksbrevRiver(this, journalfoerBrevService)
                 VedtaksbrevUnderkjentRiver(this, vedtaksbrevService)
                 DistribuerBrevRiver(this, brevdistribuerer)
-                NotatRiver(this, nyNotatService)
+                SamordningsnotatRiver(this, nyNotatService)
             }
 
     fun start() = setReady().also { rapidsConnection.start() }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -73,6 +73,7 @@ import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import no.nav.etterlatte.rivers.DistribuerBrevRiver
 import no.nav.etterlatte.rivers.FerdigstillJournalfoerOgDistribuerBrev
 import no.nav.etterlatte.rivers.JournalfoerVedtaksbrevRiver
+import no.nav.etterlatte.rivers.NotatRiver
 import no.nav.etterlatte.rivers.OpprettJournalfoerOgDistribuerRiver
 import no.nav.etterlatte.rivers.StartBrevgenereringRepository
 import no.nav.etterlatte.rivers.StartInformasjonsbrevgenereringRiver
@@ -270,6 +271,7 @@ class ApplicationBuilder {
                 JournalfoerVedtaksbrevRiver(this, journalfoerBrevService)
                 VedtaksbrevUnderkjentRiver(this, vedtaksbrevService)
                 DistribuerBrevRiver(this, brevdistribuerer)
+                NotatRiver(this, nyNotatService)
             }
 
     fun start() = setReady().also { rapidsConnection.start() }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/Notat.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/Notat.kt
@@ -27,4 +27,5 @@ enum class NotatMal(
 ) {
     TOM_MAL("tom_mal"),
     NORDISK_VEDLEGG("nordisk_vedlegg"),
+    MANUELL_SAMORDNING("manuell_samordning"),
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NotatRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NotatRoute.kt
@@ -129,7 +129,12 @@ fun Route.notatRoute(
                 withSakId(tilgangsSjekk, skrivetilgang = true) { sakId ->
                     val mal = NotatMal.valueOf(call.request.queryParameters["mal"]!!)
 
-                    val notat = nyNotatService.opprett(sakId, mal, brukerTokenInfo)
+                    val notat =
+                        nyNotatService.opprett(
+                            sakId = sakId,
+                            mal = mal,
+                            bruker = brukerTokenInfo,
+                        )
 
                     call.respond(notat)
                 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NotatSamordning.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NotatSamordning.kt
@@ -1,0 +1,49 @@
+package no.nav.etterlatte.brev.notat
+
+import no.nav.etterlatte.brev.NotatParametre
+import no.nav.etterlatte.brev.model.Slate
+
+class SamordningsnotatParametre(
+    val sakId: Long,
+    val vedtakId: Long,
+    val samordningsmeldingId: Long,
+    val kommentar: String,
+    val saksbehandlerId: String,
+) : NotatParametre
+
+fun opprettSamordningsnotatPayload(params: NotatParametre?): Slate {
+    if (params !is SamordningsnotatParametre) {
+        throw IllegalArgumentException("Samordningsnotat krever SamordningsnotatParametre")
+    }
+    return Slate(
+        listOf(
+            Slate.Element(
+                Slate.ElementType.HEADING_TWO,
+                listOf(Slate.InnerElement(Slate.ElementType.PARAGRAPH, "Samordning")),
+            ),
+            Slate.Element(
+                Slate.ElementType.PARAGRAPH,
+                listOf(Slate.InnerElement(Slate.ElementType.PARAGRAPH, params.kommentar)),
+            ),
+            Slate.Element(
+                Slate.ElementType.HEADING_THREE,
+                listOf(Slate.InnerElement(Slate.ElementType.PARAGRAPH, "Tekniske data")),
+            ),
+            Slate.Element(
+                Slate.ElementType.BULLETED_LIST,
+                listOf(
+                    listeelement("Saksbehandler: ${params.saksbehandlerId}"),
+                    listeelement("SaksID: ${params.sakId}"),
+                    listeelement("VedtakID: ${params.vedtakId}"),
+                    listeelement("SamordningsmeldingID: ${params.samordningsmeldingId}"),
+                ),
+            ),
+        ),
+    )
+}
+
+private fun listeelement(tekst: String) =
+    Slate.InnerElement(
+        type = Slate.ElementType.LIST_ITEM,
+        children = listOf(Slate.InnerElement(Slate.ElementType.PARAGRAPH, tekst)),
+    )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NyNotatService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NyNotatService.kt
@@ -72,6 +72,8 @@ class NyNotatService(
     suspend fun opprett(
         sakId: Long,
         mal: NotatMal,
+        tittel: String = "Mangler tittel",
+        paragraf: String = "Tomt notat",
         bruker: BrukerTokenInfo,
     ): Notat {
         val sak = sakService.hentSak(sakId, bruker)
@@ -80,7 +82,7 @@ class NyNotatService(
             notatRepository.opprett(
                 NyttNotat(
                     sak.id,
-                    "Mangler tittel",
+                    tittel,
                     payload =
                         when (mal) {
                             NotatMal.TOM_MAL ->
@@ -88,7 +90,7 @@ class NyNotatService(
                                     listOf(
                                         Slate.Element(
                                             Slate.ElementType.PARAGRAPH,
-                                            listOf(Slate.InnerElement(Slate.ElementType.PARAGRAPH, "Tomt notat")),
+                                            listOf(Slate.InnerElement(Slate.ElementType.PARAGRAPH, paragraf)),
                                         ),
                                     ),
                                 )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NyNotatService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NyNotatService.kt
@@ -18,6 +18,7 @@ import no.nav.etterlatte.brev.notat.NotatRepository
 import no.nav.etterlatte.brev.notat.NyttNotat
 import no.nav.etterlatte.brev.notat.PdfGenRequest
 import no.nav.etterlatte.brev.notat.PdfGeneratorKlient
+import no.nav.etterlatte.brev.notat.opprettSamordningsnotatPayload
 import no.nav.etterlatte.libs.common.deserialize
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.sak.Sak
@@ -110,36 +111,6 @@ class NyNotatService(
             )
 
         return notatRepository.hent(id)
-    }
-
-    private fun opprettSamordningsnotatPayload(params: NotatParametre?): Slate {
-        if (params !is SamordningsnotatParametre) {
-            throw IllegalArgumentException("Samordningsnotat krever SamordningsnotatParametre")
-        }
-        return Slate(
-            listOf(
-                Slate.Element(
-                    Slate.ElementType.HEADING_THREE,
-                    listOf(Slate.InnerElement(Slate.ElementType.PARAGRAPH, "Manuell samordning")),
-                ),
-                Slate.Element(
-                    Slate.ElementType.BULLETED_LIST,
-                    listOf(
-                        Slate.InnerElement(Slate.ElementType.LIST_ITEM, "Saksbehandler: ${params.saksbehandlerId}"),
-                        Slate.InnerElement(Slate.ElementType.LIST_ITEM, "SaksID: ${params.sakId}"),
-                        Slate.InnerElement(Slate.ElementType.LIST_ITEM, "VedtakID: ${params.vedtakId}"),
-                        Slate.InnerElement(
-                            Slate.ElementType.LIST_ITEM,
-                            "SamordningsmeldingID: ${params.samordningsmeldingId}",
-                        ),
-                    ),
-                ),
-                Slate.Element(
-                    Slate.ElementType.PARAGRAPH,
-                    listOf(Slate.InnerElement(Slate.ElementType.PARAGRAPH, params.kommentar)),
-                ),
-            ),
-        )
     }
 
     fun oppdaterTittel(
@@ -240,11 +211,3 @@ class NotatAlleredeJournalfoert :
     )
 
 interface NotatParametre
-
-class SamordningsnotatParametre(
-    val sakId: Long,
-    val vedtakId: Long,
-    val samordningsmeldingId: Long,
-    val kommentar: String,
-    val saksbehandlerId: String,
-) : NotatParametre

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/NotatRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/NotatRiver.kt
@@ -1,0 +1,57 @@
+package no.nav.etterlatte.rivers
+
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.brev.NyNotatService
+import no.nav.etterlatte.brev.notat.NotatMal
+import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseHendelseType
+import no.nav.etterlatte.libs.ktor.token.Systembruker
+import no.nav.etterlatte.rapidsandrivers.ListenerMedLogging
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.MessageContext
+import no.nav.helse.rapids_rivers.RapidsConnection
+import org.slf4j.LoggerFactory
+
+class NotatRiver(
+    rapidsConnection: RapidsConnection,
+    private val notatService: NyNotatService,
+) : ListenerMedLogging() {
+    private val logger = LoggerFactory.getLogger(JournalfoerVedtaksbrevRiver::class.java)
+
+    init {
+        initialiserRiver(rapidsConnection, VedtakKafkaHendelseHendelseType.SAMORDNING_MANUELT_BEHANDLET) {
+            validate { it.requireKey("sakId") }
+            validate { it.requireKey("samordningsmeldingId") }
+            validate { it.requireKey("kommentar") }
+        }
+    }
+
+    override fun haandterPakke(
+        packet: JsonMessage,
+        context: MessageContext,
+    ) {
+        try {
+            val sakId = packet["sakId"].asLong()
+            val samordningsmeldingId = packet["samordningsmeldingId"].asLong()
+            val kommentar = packet["kommentar"].asText()
+
+            runBlocking {
+                val notat =
+                    notatService.opprett(
+                        sakId = sakId,
+                        mal = NotatMal.TOM_MAL,
+                        tittel = "Manuelt samordnet $samordningsmeldingId",
+                        paragraf = kommentar,
+                        bruker = Systembruker.brev,
+                    )
+
+                notatService.journalfoer(
+                    id = notat.id,
+                    bruker = Systembruker.brev,
+                )
+            }
+        } catch (e: Exception) {
+            logger.error("Feil ved opprettelse av notat", e)
+            throw e
+        }
+    }
+}

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/NotatRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/NotatRiver.kt
@@ -31,15 +31,18 @@ class NotatRiver(
     ) {
         try {
             val sakId = packet["sakId"].asLong()
+            val vedtakId = packet["vedtakId"].asLong()
             val samordningsmeldingId = packet["samordningsmeldingId"].asLong()
             val kommentar = packet["kommentar"].asText()
+
+            logger.info("Oppretter notat for sak $sakId, samID $samordningsmeldingId")
 
             runBlocking {
                 val notat =
                     notatService.opprett(
                         sakId = sakId,
                         mal = NotatMal.TOM_MAL,
-                        tittel = "Manuelt samordnet $samordningsmeldingId",
+                        tittel = "Manuell samordning - vedtak $vedtakId",
                         paragraf = kommentar,
                         bruker = Systembruker.brev,
                     )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/NotatRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/NotatRiver.kt
@@ -16,7 +16,7 @@ class NotatRiver(
     rapidsConnection: RapidsConnection,
     private val notatService: NyNotatService,
 ) : ListenerMedLogging() {
-    private val logger = LoggerFactory.getLogger(JournalfoerVedtaksbrevRiver::class.java)
+    private val logger = LoggerFactory.getLogger(NotatRiver::class.java)
 
     init {
         initialiserRiver(rapidsConnection, VedtakKafkaHendelseHendelseType.SAMORDNING_MANUELT_BEHANDLET) {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/NotatRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/NotatRiver.kt
@@ -21,7 +21,9 @@ class NotatRiver(
     init {
         initialiserRiver(rapidsConnection, VedtakKafkaHendelseHendelseType.SAMORDNING_MANUELT_BEHANDLET) {
             validate { it.requireKey("sakId") }
+            validate { it.requireKey("vedtakId") }
             validate { it.requireKey("samordningsmeldingId") }
+            validate { it.requireKey("saksbehandlerId") }
             validate { it.requireKey("kommentar") }
         }
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/NotatRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/NotatRiver.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.rivers
 
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.brev.NyNotatService
+import no.nav.etterlatte.brev.SamordningsnotatParametre
 import no.nav.etterlatte.brev.notat.NotatMal
 import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseHendelseType
 import no.nav.etterlatte.libs.ktor.token.Systembruker
@@ -34,6 +35,7 @@ class NotatRiver(
             val vedtakId = packet["vedtakId"].asLong()
             val samordningsmeldingId = packet["samordningsmeldingId"].asLong()
             val kommentar = packet["kommentar"].asText()
+            val saksbehandlerId = packet["saksbehandlerId"].asText()
 
             logger.info("Oppretter notat for sak $sakId, samID $samordningsmeldingId")
 
@@ -41,9 +43,16 @@ class NotatRiver(
                 val notat =
                     notatService.opprett(
                         sakId = sakId,
-                        mal = NotatMal.TOM_MAL,
+                        mal = NotatMal.MANUELL_SAMORDNING,
                         tittel = "Manuell samordning - vedtak $vedtakId",
-                        paragraf = kommentar,
+                        params =
+                            SamordningsnotatParametre(
+                                sakId = sakId,
+                                vedtakId = vedtakId,
+                                samordningsmeldingId = samordningsmeldingId,
+                                kommentar = kommentar,
+                                saksbehandlerId = saksbehandlerId,
+                            ),
                         bruker = Systembruker.brev,
                     )
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/NotatRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/NotatRiver.kt
@@ -2,8 +2,8 @@ package no.nav.etterlatte.rivers
 
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.brev.NyNotatService
-import no.nav.etterlatte.brev.SamordningsnotatParametre
 import no.nav.etterlatte.brev.notat.NotatMal
+import no.nav.etterlatte.brev.notat.SamordningsnotatParametre
 import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseHendelseType
 import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.etterlatte.rapidsandrivers.ListenerMedLogging

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/SamordningsnotatRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/SamordningsnotatRiver.kt
@@ -12,11 +12,11 @@ import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
 import org.slf4j.LoggerFactory
 
-class NotatRiver(
+class SamordningsnotatRiver(
     rapidsConnection: RapidsConnection,
     private val notatService: NyNotatService,
 ) : ListenerMedLogging() {
-    private val logger = LoggerFactory.getLogger(NotatRiver::class.java)
+    private val logger = LoggerFactory.getLogger(SamordningsnotatRiver::class.java)
 
     init {
         initialiserRiver(rapidsConnection, VedtakKafkaHendelseHendelseType.SAMORDNING_MANUELT_BEHANDLET) {

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/notat/NyNotatServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/notat/NyNotatServiceTest.kt
@@ -72,7 +72,11 @@ internal class NyNotatServiceTest(
 
         val nyttNotat =
             runBlocking {
-                nyNotatService.opprett(sakId, NotatMal.TOM_MAL, saksbehandler)
+                nyNotatService.opprett(
+                    sakId = sakId,
+                    mal = NotatMal.TOM_MAL,
+                    bruker = saksbehandler,
+                )
             }
 
         assertEquals(sakId, nyttNotat.sakId)
@@ -92,14 +96,18 @@ internal class NyNotatServiceTest(
     }
 
     @Test
-    fun `Oppdater tittel på notat`() {
+    fun `Oppdater tittel paa notat`() {
         val sakId = Random.nextLong()
 
         coEvery { sakServiceMock.hentSak(any(), any()) } returns Sak("ident", SakType.BARNEPENSJON, sakId, "4808")
 
         val nyttNotat =
             runBlocking {
-                nyNotatService.opprett(sakId, NotatMal.TOM_MAL, saksbehandler)
+                nyNotatService.opprett(
+                    sakId = sakId,
+                    mal = NotatMal.TOM_MAL,
+                    bruker = saksbehandler,
+                )
             }
         assertEquals("Mangler tittel", nyttNotat.tittel)
 
@@ -119,7 +127,7 @@ internal class NyNotatServiceTest(
     }
 
     @Test
-    fun `Journalfør notat`() {
+    fun `Journalfoer notat`() {
         val sakId = Random.nextLong()
 
         val sak = Sak("ident", SakType.BARNEPENSJON, sakId, "4808")
@@ -127,7 +135,14 @@ internal class NyNotatServiceTest(
         coEvery { dokarkivServiceMock.journalfoer(any()) } returns OpprettJournalpostResponse("123", true)
         coEvery { pdfGeneratorKlientMock.genererPdf(any()) } returns "pdf".toByteArray()
 
-        val nyttNotat = runBlocking { nyNotatService.opprett(sakId, NotatMal.TOM_MAL, saksbehandler) }
+        val nyttNotat =
+            runBlocking {
+                nyNotatService.opprett(
+                    sakId = sakId,
+                    mal = NotatMal.TOM_MAL,
+                    bruker = saksbehandler,
+                )
+            }
         val payload = nyNotatService.hentPayload(nyttNotat.id)
 
         runBlocking { nyNotatService.journalfoer(nyttNotat.id, saksbehandler) }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRapidService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRapidService.kt
@@ -43,4 +43,16 @@ class VedtaksvurderingRapidService(
                 ) + extraParams,
             ).toJson(),
     )
+
+    fun sendGenerellHendelse(
+        hendelsestype: VedtakKafkaHendelseHendelseType,
+        parametre: Map<String, Any>,
+    ) = publiser(
+        UUID.randomUUID(),
+        JsonMessage
+            .newMessage(
+                parametre +
+                    hendelsestype.lagParMedEventNameKey(),
+            ).toJson(),
+    )
 }

--- a/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/VedtakKafkaHendelseHendelseType.kt
+++ b/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/VedtakKafkaHendelseHendelseType.kt
@@ -10,6 +10,7 @@ enum class VedtakKafkaHendelseHendelseType : EventnameHendelseType {
     SAMORDNET,
     IVERKSATT,
     SAMORDNING_MOTTATT,
+    SAMORDNING_MANUELT_BEHANDLET,
     ;
 
     override fun lagEventnameForType() = "VEDTAK:$name"


### PR DESCRIPTION
Regner med det kanskje kommer noe endringsønsker her, men a) fint å få funksjonaliten/løypa på plass, og b) ikke akkurat verdens mest sentrale logikk. Jeg var inne på tanken og bare gjøre det fra UI, men virker kronglete og virkelig ikke nødvendig.

![Skjermbilde 2024-07-03 kl  10 00 36](https://github.com/navikt/pensjon-etterlatte-saksbehandling/assets/8087437/2c79962c-2372-4bd8-9493-ca568077c5a5)
