### PR TITLE
Legge til api app for samordning for overgang til samordning som api

### DIFF
--- a/.github/workflows/app-etterlatte-samordning-vedtak.yaml
+++ b/.github/workflows/app-etterlatte-samordning-vedtak.yaml
@@ -59,3 +59,39 @@ jobs:
       image: ${{ needs.build.outputs.image }}
     secrets: inherit
 
+  deploy-api-dev:
+    name: dev-gcp
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: apps/${{ github.workflow }}/.nais/dev-api.yaml
+          VAR: image=${{ inputs.image }}
+
+  deploy-api-prod:
+    name: prod-gcp
+    if: ${{ github.ref == 'refs/heads/main' || github.event.inputs.deploy-prod == 'true' }}
+    needs: deploy-to-dev-gcp
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: andstor/file-existence-action@v3
+        id: check_files
+        with:
+          files: "apps/${{ github.workflow }}/.nais/prod.yaml"
+      - uses: nais/deploy/actions/deploy@v2
+        if: steps.check_files.outputs.files_exists == 'true'
+        env:
+          CLUSTER: prod-gcp
+          RESOURCE: apps/${{ github.workflow }}/.nais/prod-api.yaml
+          VAR: image=${{ inputs.image }}

--- a/apps/etterlatte-samordning-vedtak/.nais/dev-api.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/dev-api.yaml
@@ -9,7 +9,7 @@ spec:
   image: "{{image}}"
   port: 8080
   ingresses:
-    - "https://etterlatte-api.ekstern.dev.nav.no"  # Skru av etterhvert, skal nås via etterlatte-gw
+    - "https://etterlatte-api.ekstern.dev.nav.no"  # For TP-leverandører
     - "https://etterlatte-api.intern.dev.nav.no"
   liveness:
     path: /health/isalive
@@ -37,8 +37,8 @@ spec:
       cpu: 10m
       memory: 320Mi
   replicas:
-    min: 1
-    max: 2
+    min: 2
+    max: 4
   maskinporten:
     enabled: true
     scopes:

--- a/apps/etterlatte-samordning-vedtak/.nais/dev-api.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/dev-api.yaml
@@ -1,0 +1,180 @@
+apiVersion: "nais.io/v1alpha1"
+kind: "Application"
+metadata:
+  name: etterlatte-api
+  namespace: etterlatte
+  labels:
+    team: etterlatte
+spec:
+  image: "{{image}}"
+  port: 8080
+  ingresses:
+    - "https://etterlatte-samordning-vedtak.ekstern.dev.nav.no"  # Skru av etterhvert, skal nås via etterlatte-gw
+    - "https://etterlatte-samordning-vedtak.intern.dev.nav.no"
+  liveness:
+    path: /health/isalive
+    initialDelay: 5
+  readiness:
+    path: /health/isready
+    initialDelay: 5
+  prometheus:
+    enabled: true
+    path: /metrics
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
+  secureLogs:
+    enabled: true
+  resources:
+    limits:
+      memory: 640Mi
+    requests:
+      cpu: 10m
+      memory: 320Mi
+  replicas:
+    min: 1
+    max: 2
+  maskinporten:
+    enabled: true
+    scopes:
+      exposes:
+        - name: "vedtaksinformasjon.read"
+          enabled: true
+          product: "etterlatteytelser"
+          allowedIntegrations:
+            - maskinporten
+          atMaxAge: 120
+          consumers:
+            - name: SPK
+              orgno: "982583462"
+            - name: OSLO PENSJONSFORSIKRING AS
+              orgno: "982759412"
+            - name: KLP
+              orgno: "938708606"
+            - name: GABLER PENSJONSTJENESTER AS
+              orgno: "916833520"
+            - name: Storebrand Pensjonstjenester AS
+              orgno: "931936492"
+            - name: Storebrand Livsforsikring AS
+              orgno: "958995369"
+            - name: Arendal kommunale pensjonskasse
+              orgno: "940380014"
+            - name: Elverum kommunale pensjonskasse
+              orgno: "940360293"
+            - name: Maritim pensjonskasse
+              orgno: "940415683"
+            - name: Garantikassen for fiskere
+              orgno: "974652382"
+            - name: NAV
+              orgno: "889640782"
+  azure:
+    application:
+      enabled: true
+      allowAllUsers: false
+      claims:
+        groups:
+          - id: 8bb9b8d1-f46a-4ade-8ee8-5895eccdf8cf #SAKSBEHANDLER
+          - id: 5b6745de-b65d-40eb-a6f5-860c8b61c27f # 0000-GA-GJENNY_SAKSBEHANDLER
+        extra:
+          - "NAVident"
+          - "azp_name"
+  tokenx:
+    enabled: true
+  env:
+    - name: MASKINPORTEN_WELL_KNOWN_URL
+      value: https://test.maskinporten.no/.well-known/oauth-authorization-server
+    - name: ETTERLATTE_VEDTAKSVURDERING_URL
+      value: http://etterlatte-vedtaksvurdering
+    - name: ETTERLATTE_VEDTAKSVURDERING_SCOPE
+      value: api://dev-gcp.etterlatte.etterlatte-vedtaksvurdering/.default
+    - name: ETTERLATTE_BEHANDLING_URL
+      value: http://etterlatte-behandling
+    - name: ETTERLATTE_BEHANDLING_SCOPE
+      value: api://dev-gcp.etterlatte.etterlatte-behandling/.default
+    - name: TJENESTEPENSJON_URL
+      value: https://tp-api-q1.dev-fss-pub.nais.io
+    - name: TJENESTEPENSJON_SCOPE
+      value: api://dev-fss.pensjonsamhandling.tp-q1/.default
+    - name: ROLLE_PENSJONSAKSBEHANDLER
+      value: 8bb9b8d1-f46a-4ade-8ee8-5895eccdf8cf
+  accessPolicy:
+    inbound:
+      rules:
+        - application: arbeid-og-inntekt
+          namespace: team-inntekt
+          cluster: dev-fss
+          permissions:
+            roles: les-bp-sak-for-person
+        - application: pensjon-pen-q0
+          namespace: pensjon-q0
+          cluster: dev-fss
+          permissions:
+            roles:
+              - les-oms-vedtak
+              - les-bp-vedtak
+        - application: pensjon-pen-q1
+          namespace: pensjon-q1
+          cluster: dev-fss
+          permissions:
+            roles:
+              - les-oms-vedtak
+              - les-bp-vedtak
+        - application: pensjon-pen-q2
+          namespace: pensjon-q2
+          cluster: dev-fss
+          permissions:
+            roles:
+              - les-oms-vedtak
+              - les-bp-vedtak
+        - application: pensjon-pen-q5
+          namespace: pensjon-q5
+          cluster: dev-fss
+          permissions:
+            roles:
+              - les-oms-vedtak
+              - les-bp-vedtak
+        - application: pensjon-selvbetjening-soknad-alder-backend
+          namespace: pensjonselvbetjening
+          cluster: dev-gcp
+          permissions:
+            roles:
+              - les-oms-vedtak
+        - application: alderspensjon-endringssoknad-backend-q2
+          namespace: pensjonselvbetjening
+          cluster: dev-gcp
+          permissions:
+            roles:
+              - les-oms-vedtak
+        - application: pensjonskalkulator-backend
+          namespace: pensjonskalkulator
+          cluster: dev-gcp
+          permissions:
+            roles:
+              - les-oms-vedtak
+        - application: tilleggsstonader-integrasjoner
+          namespace: tilleggsstonader
+          cluster: dev-gcp
+          permissions:
+            roles:
+              - les-oms-vedtak
+        - application: azure-token-generator
+          namespace: aura
+          cluster: dev-gcp
+          permissions:
+            roles:
+              - les-oms-vedtak
+              - les-bp-vedtak
+        - application: tokenx-token-generator
+          namespace: aura
+          cluster: dev-gcp
+    outbound:
+      rules:
+        - application: etterlatte-vedtaksvurdering
+        - application: etterlatte-behandling
+      external:
+        - host: tp-api-q1.dev-fss-pub.nais.io

--- a/apps/etterlatte-samordning-vedtak/.nais/dev-api.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/dev-api.yaml
@@ -9,8 +9,8 @@ spec:
   image: "{{image}}"
   port: 8080
   ingresses:
-    - "https://etterlatte-samordning-vedtak.ekstern.dev.nav.no"  # Skru av etterhvert, skal nås via etterlatte-gw
-    - "https://etterlatte-samordning-vedtak.intern.dev.nav.no"
+    - "https://etterlatte-api.ekstern.dev.nav.no"  # Skru av etterhvert, skal nås via etterlatte-gw
+    - "https://etterlatte-api.intern.dev.nav.no"
   liveness:
     path: /health/isalive
     initialDelay: 5

--- a/apps/etterlatte-samordning-vedtak/.nais/prod-api.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/prod-api.yaml
@@ -9,8 +9,8 @@ spec:
   image: "{{image}}"
   port: 8080
   ingresses:
-    - "https://etterlatte-samordning-vedtak.nav.no"   # Skru av etterhvert, skal nås via etterlatte-gw
-    - "https://etterlatte-samordning-vedtak.intern.nav.no"
+    - "https://etterlatte-api.nav.no"   # Skru av etterhvert, skal nås via etterlatte-gw
+    - "https://etterlatte-api.intern.nav.no"
   liveness:
     path: /health/isalive
     initialDelay: 5

--- a/apps/etterlatte-samordning-vedtak/.nais/prod-api.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/prod-api.yaml
@@ -1,0 +1,137 @@
+apiVersion: "nais.io/v1alpha1"
+kind: "Application"
+metadata:
+  name: etterlatte-api
+  namespace: etterlatte
+  labels:
+    team: etterlatte
+spec:
+  image: "{{image}}"
+  port: 8080
+  ingresses:
+    - "https://etterlatte-samordning-vedtak.nav.no"   # Skru av etterhvert, skal nås via etterlatte-gw
+    - "https://etterlatte-samordning-vedtak.intern.nav.no"
+  liveness:
+    path: /health/isalive
+    initialDelay: 5
+  readiness:
+    path: /health/isready
+    initialDelay: 5
+  prometheus:
+    enabled: true
+    path: /metrics
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
+  secureLogs:
+    enabled: true
+  resources:
+    limits:
+      memory: 640Mi
+    requests:
+      cpu: 10m
+      memory: 320Mi
+  replicas:
+    min: 1
+    max: 2
+  maskinporten:
+    enabled: true
+    scopes:
+      exposes:
+        - name: "vedtaksinformasjon.read"
+          enabled: true
+          product: "etterlatteytelser"
+          allowedIntegrations:
+            - maskinporten
+          atMaxAge: 60
+          consumers:
+            - name: SPK
+              orgno: "982583462"
+            - name: OSLO PENSJONSFORSIKRING AS
+              orgno: "982759412"
+            - name: KLP
+              orgno: "938708606"
+            - name: GABLER PENSJONSTJENESTER AS
+              orgno: "916833520"
+            - name: Storebrand Pensjonstjenester AS
+              orgno: "931936492"
+            - name: Storebrand Livsforsikring AS
+              orgno: "958995369"
+            - name: Arendal kommunale pensjonskasse
+              orgno: "940380014"
+            - name: Elverum kommunale pensjonskasse
+              orgno: "940360293"
+            - name: Maritim pensjonskasse
+              orgno: "940415683"
+            - name: Garantikassen for fiskere
+              orgno: "974652382"
+  azure:
+    application:
+      enabled: true
+      allowAllUsers: false
+      claims:
+        groups:
+          - id: 0af3955f-df85-4eb0-b5b2-45bf2c8aeb9e #SAKSBEHANDLER
+          - id: e4eb614b-d37d-4721-ba1b-df8f0fd16f85 # 0000-GA-GJENNY_SAKSBEHANDLER
+
+        extra:
+          - "NAVident"
+          - "azp_name"
+  tokenx:
+    enabled: true
+  env:
+    - name: MASKINPORTEN_WELL_KNOWN_URL
+      value: https://maskinporten.no/.well-known/oauth-authorization-server
+    - name: ETTERLATTE_VEDTAKSVURDERING_URL
+      value: http://etterlatte-vedtaksvurdering
+    - name: ETTERLATTE_VEDTAKSVURDERING_SCOPE
+      value: api://prod-gcp.etterlatte.etterlatte-vedtaksvurdering/.default
+    - name: ETTERLATTE_BEHANDLING_URL
+      value: http://etterlatte-behandling
+    - name: ETTERLATTE_BEHANDLING_SCOPE
+      value: api://prod-gcp.etterlatte.etterlatte-behandling/.default
+    - name: TJENESTEPENSJON_URL
+      value: https://tp-api.prod-fss-pub.nais.io
+    - name: TJENESTEPENSJON_SCOPE
+      value: api://prod-fss.pensjonsamhandling.tp/.default
+    - name: ROLLE_PENSJONSAKSBEHANDLER
+      value: 0af3955f-df85-4eb0-b5b2-45bf2c8aeb9e
+  accessPolicy:
+    inbound:
+      rules:
+        - application: pensjon-pen
+          namespace: pensjondeployer
+          cluster: prod-fss
+          permissions:
+            roles:
+              - les-oms-vedtak
+              - les-bp-vedtak
+        - application: pensjon-selvbetjening-soknad-alder-backend
+          namespace: pensjonselvbetjening
+          cluster: prod-gcp
+          permissions:
+            roles:
+              - les-oms-vedtak
+        - application: pensjonskalkulator-backend
+          namespace: pensjonskalkulator
+          cluster: prod-gcp
+          permissions:
+            roles:
+              - les-oms-vedtak
+        - application: tilleggsstonader-integrasjoner
+          namespace: tilleggsstonader
+          cluster: prod-gcp
+          permissions:
+            roles:
+              - les-oms-vedtak
+    outbound:
+      rules:
+        - application: etterlatte-vedtaksvurdering
+        - application: etterlatte-behandling
+      external:
+        - host: tp-api.prod-fss-pub.nais.io

--- a/apps/etterlatte-samordning-vedtak/.nais/prod-api.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/prod-api.yaml
@@ -9,7 +9,7 @@ spec:
   image: "{{image}}"
   port: 8080
   ingresses:
-    - "https://etterlatte-api.nav.no"   # Skru av etterhvert, skal nås via etterlatte-gw
+    - "https://etterlatte-api.nav.no"   # For TP-leverandører
     - "https://etterlatte-api.intern.nav.no"
   liveness:
     path: /health/isalive
@@ -37,8 +37,8 @@ spec:
       cpu: 10m
       memory: 320Mi
   replicas:
-    min: 1
-    max: 2
+    min: 2
+    max: 4
   maskinporten:
     enabled: true
     scopes:


### PR DESCRIPTION
Siden samordning-vedtak skal bli vårt eksterne grensesnitt feks "etterlatte-api" utad er det greit å ha en overgangsperiode der nye konsumenter går mot api delen mens de eksterne som ikke har fått migrert går mot den gamle. På sikt skal de nye api yamlene erstattene dagens dev/prod yamler når konsumentene får byttet over.