### PR TITLE
getMonth() tar utgangspunkt i at januar har indeks 0

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -65,7 +65,7 @@ export const AvkortingInntekt = ({
 
   const fulltAar = () => {
     if (behandling.behandlingType == IBehandlingsType.FØRSTEGANGSBEHANDLING) {
-      const innvilgelseFraJanuar = new Date(virkningstidspunkt(behandling).dato).getMonth() === 1
+      const innvilgelseFraJanuar = new Date(virkningstidspunkt(behandling).dato).getMonth() === 0
       return innvilgelseFraJanuar
     } else {
       const revurderingIFulltAar = avkortingGrunnlag[0].relevanteMaanederInnAar === 12


### PR DESCRIPTION
Sjekker januar og ikke februar da getMonth() returnerer 0-indeksert resultat.