### PR TITLE
Fratrekk-innår skal ikke være påkrevet når disse feltene er disabled ved inngang i januar  

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -115,7 +115,11 @@ export const AvkortingInntekt = ({
     requestLagreAvkortingGrunnlag(
       {
         behandlingId: behandling.id,
-        avkortingGrunnlag: data,
+        avkortingGrunnlag: {
+          ...data,
+          fratrekkInnAar: data.fratrekkInnAar ?? 0,
+          fratrekkInnAarUtland: data.fratrekkInnAarUtland ?? 0,
+        },
       },
       (respons) => {
         dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.AVKORTET))
@@ -243,7 +247,7 @@ export const AvkortingInntekt = ({
                     />
                     <TekstFelt
                       {...register('fratrekkInnAar', {
-                        required: { value: true, message: 'Må fylles ut' },
+                        required: { value: !fulltAar(), message: 'Må fylles ut' },
                         max: { value: watch('aarsinntekt') || 0, message: 'Kan ikke være høyere enn årsinntekt' },
                         pattern: { value: /^\d+$/, message: 'Kun tall' },
                       })}
@@ -267,7 +271,7 @@ export const AvkortingInntekt = ({
                     />
                     <TekstFelt
                       {...register('fratrekkInnAarUtland', {
-                        required: { value: true, message: 'Må fylles ut' },
+                        required: { value: !fulltAar(), message: 'Må fylles ut' },
                         max: {
                           value: watch('inntektUtland') || 0,
                           message: 'Kan ikke være høyere enn årsinntekt utland',


### PR DESCRIPTION
Ved virk i januar er det ikke nødvendig å oppgi fratrekk-innår. Dette er løst ved å disable disse feltene, men react-form har validering på feltene slik at det ikke er mulig å lagre. Løser dette med å fjerne at feltene er påkrevet ved `fulltAar`, samt å sette disse til 0 dersom de ikke er satt siden det er påkrevet at de har en verdi i backend.