### PR TITLE
EY-4183 rette feil som oppstår ved deaktivering av overstyrt beregning

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Beregningsgrunnlag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/Beregningsgrunnlag.tsx
@@ -54,11 +54,9 @@ const Beregningsgrunnlag = (props: { behandling: IDetaljertBehandling }) => {
     }
   }, [])
 
-  /* For å håndtere første aktivering av overstyrt beregning */
+  /* For å håndtere første aktivering og deaktivering av overstyrt beregning */
   useEffect(() => {
-    if (!erBehandlingFerdigstilt && overstyrtBeregning) {
-      setVisOverstyrtBeregningGrunnlag(true)
-    }
+    setVisOverstyrtBeregningGrunnlag(!erBehandlingFerdigstilt && overstyrtBeregning)
   }, [overstyrtBeregning])
 
   return (


### PR DESCRIPTION
Hvis en overstyrt beregning deaktiveres, oppdateres ikke visningen korrekt før siden lastes på nytt

Årsaken er feil logikk i endring EY-4168