### PR TITLE
Øker min/max pods for samordning-vedtak pga høyere last enn da verdiene ble initielt satt

### DIFF
--- a/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
@@ -37,8 +37,8 @@ spec:
       cpu: 10m
       memory: 320Mi
   replicas:
-    min: 1
-    max: 2
+    min: 2
+    max: 4
   maskinporten:
     enabled: true
     scopes:

--- a/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
@@ -37,8 +37,8 @@ spec:
       cpu: 10m
       memory: 320Mi
   replicas:
-    min: 1
-    max: 2
+    min: 2
+    max: 4
   maskinporten:
     enabled: true
     scopes:


### PR DESCRIPTION
Ref https://nav-it.slack.com/archives/C01KJ597UAU/p1720083496893589

Initielt: kun TP-leverandørene.

Mens spesielt Pesys, selvbetjening og nå etterhvert den nye pensjonskalkulatoren trykker vesentlig mer enn TP.
I tillegg så er det jo på trappene at dette blir etterlatte sin generelle API-app utad.