### PR TITLE
Lagt til scalingStrategy for samordning-vedtak

### DIFF
--- a/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/dev.yaml
@@ -39,6 +39,9 @@ spec:
   replicas:
     min: 2
     max: 4
+    scalingStrategy:
+      cpu:
+        thresholdPercentage: 80
   maskinporten:
     enabled: true
     scopes:

--- a/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
+++ b/apps/etterlatte-samordning-vedtak/.nais/prod.yaml
@@ -39,6 +39,9 @@ spec:
   replicas:
     min: 2
     max: 4
+    scalingStrategy:
+      cpu:
+        thresholdPercentage: 80
   maskinporten:
     enabled: true
     scopes:


### PR DESCRIPTION
Da selv etter å ha økt ressursene en del så spinnes det opp 4 pods i både dev og prod. Men kan nok tyne CPUen mer, derav denne endringen

https://doc.nav.cloud.nais.io/workloads/application/reference/application-spec/#replicasscalingstrategy

NB! Vi bruker ellers cpuThresholdPercentage, men denne er [deprekert](https://doc.nav.cloud.nais.io/workloads/application/reference/application-spec/#replicascputhresholdpercentage)