### PR TITLE
Tilgang for etterlatte-api

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
@@ -114,6 +114,10 @@ spec:
           permissions:
             roles:
               - samordning-read
+        - application: etterlatte-api    # tar over for samordning-vedtak
+          permissions:
+            roles:
+              - samordning-read
         - application: etterlatte-vedtaksvurdering-kafka
           permissions:
             roles:

--- a/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
@@ -123,6 +123,10 @@ spec:
           permissions:
             roles:
               - samordning-read
+        - application: etterlatte-api    # tar over for samordning-vedtak
+          permissions:
+            roles:
+              - samordning-read
         - application: etterlatte-vedtaksvurdering-kafka
           permissions:
             roles:


### PR DESCRIPTION
må ha både samordning og api mens man får eksterne konsumenter over