### PR TITLE
Cronjobb for å slette gamle workflow runs

### DIFF
--- a/.github/workflows/vaktmesteren.yml
+++ b/.github/workflows/vaktmesteren.yml
@@ -1,0 +1,21 @@
+name: Vaktmesteren
+
+on:
+  schedule:
+    - cron: "0 10 * * 6"
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  prune_workflows:
+    name: "Slette gamle workflow runs"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          keep_minimum_runs: 30


### PR DESCRIPTION
~Ingen grunn til å ta vare på alle imagene, og vi har hundre/tusenvis av dem. Har testet det tidligere (https://github.com/navikt/pensjon-docs-site/blob/main/.github/workflows/prune.yml), men da uten matrix.
Tenker også å få inn at man rydder i workflow executions, er bare unødvendig å ta vare på historikk i evighet.~

Rydder nå kun workflow executions, som vi i skrivende stund har 87749 stykker av.