### PR TITLE
EY-4186, del 6: Kutte ned bruken av GenerellBrevData til fordel for eksplisitte argument (avhengig av del 4)

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -163,7 +163,12 @@ class ApplicationBuilder {
         BrevDataMapperRedigerbartUtfallVedtak(behandlingService, beregningService, migreringBrevDataService)
 
     private val brevDataMapperFerdigstilling =
-        BrevDataMapperFerdigstillingVedtak(beregningService, trygdetidService, behandlingService, vilkaarsvurderingService, brevdataFacade)
+        BrevDataMapperFerdigstillingVedtak(
+            beregningService,
+            trygdetidService,
+            behandlingService,
+            vilkaarsvurderingService,
+        )
 
     private val brevKodeMapperVedtak = BrevKodeMapperVedtak()
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -219,8 +219,8 @@ class ApplicationBuilder {
             brevRepository = db,
             pdfGenerator = pdfGenerator,
             adresseService = adresseService,
-            brevdataFacade = brevdataFacade,
             behandlingService = behandlingService,
+            grunnlagService = grunnlagService,
         )
 
     private val notatRepository = NotatRepository(datasource)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -271,7 +271,7 @@ class ApplicationBuilder {
                     )
                 OpprettJournalfoerOgDistribuerRiver(
                     this,
-                    brevdataFacade,
+                    grunnlagService,
                     brevoppretter,
                     ferdigstillJournalfoerOgDistribuerBrev,
                 )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -160,7 +160,7 @@ class ApplicationBuilder {
     private val migreringBrevDataService = MigreringBrevDataService(beregningService)
 
     private val brevDataMapperRedigerbartUtfallVedtak =
-        BrevDataMapperRedigerbartUtfallVedtak(brevdataFacade, behandlingService, beregningService, migreringBrevDataService)
+        BrevDataMapperRedigerbartUtfallVedtak(behandlingService, beregningService, migreringBrevDataService)
 
     private val brevDataMapperFerdigstilling =
         BrevDataMapperFerdigstillingVedtak(beregningService, trygdetidService, behandlingService, vilkaarsvurderingService, brevdataFacade)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.brev
 
+import no.nav.etterlatte.brev.behandling.opprettAvsenderRequest
 import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevDataRedigerbar
@@ -120,7 +121,7 @@ class BrevService(
         pdfGenerator.genererPdf(
             id,
             bruker,
-            avsenderRequest = { b, g -> g.avsenderRequest(b) },
+            avsenderRequest = { b, g -> opprettAvsenderRequest(b, g.forenkletVedtak, g.sak.enhet) },
             brevKode = { Brevkoder.TOMT_INFORMASJONSBREV },
             brevData = { ManueltBrevMedTittelData(it.innholdMedVedlegg.innhold(), it.tittel) },
         )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -121,7 +121,7 @@ class BrevService(
         pdfGenerator.genererPdf(
             id,
             bruker,
-            avsenderRequest = { b, g -> opprettAvsenderRequest(b, g.forenkletVedtak, g.sak.enhet) },
+            avsenderRequest = { b, vedtak, enhet -> opprettAvsenderRequest(b, vedtak, enhet) },
             brevKode = { Brevkoder.TOMT_INFORMASJONSBREV },
             brevData = { ManueltBrevMedTittelData(it.innholdMedVedlegg.innhold(), it.tittel) },
         )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -3,7 +3,6 @@ package no.nav.etterlatte.brev
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import no.nav.etterlatte.brev.adresse.AdresseService
-import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.behandling.PersonerISak
 import no.nav.etterlatte.brev.behandling.opprettAvsenderRequest
 import no.nav.etterlatte.brev.brevbaker.BrevbakerRequest
@@ -91,14 +90,14 @@ class Brevoppretter(
                     sakId = sakId,
                     behandlingId = behandlingId,
                     prosessType = BrevProsessType.REDIGERBAR,
-                    soekerFnr = generellBrevData.personerISak.soeker.fnr.value,
-                    mottaker = finnMottaker(generellBrevData.sak.sakType, generellBrevData.personerISak),
+                    soekerFnr = soekerFnr,
+                    mottaker = finnMottaker(sakType, personerISak),
                     opprettet = Tidspunkt.now(),
                     innhold = innhold,
                     innholdVedlegg = innholdVedlegg,
                     brevtype = brevtype,
                 )
-            return Pair(db.opprettBrev(nyttBrev), generellBrevData.sak.enhet)
+            return Pair(db.opprettBrev(nyttBrev), enhet)
         }
 
     suspend fun hentNyttInnhold(
@@ -196,9 +195,12 @@ class Brevoppretter(
             val innholdVedlegg = async { redigerbartVedleggHenter.hentInitiellPayloadVedlegg(bruker, generellBrevData, kode.brevtype) }
 
             OpprettBrevRequest(
-                generellBrevData,
-                BrevInnhold(tittel, generellBrevData.spraak, innhold.await()),
-                innholdVedlegg.await(),
+                soekerFnr = generellBrevData.personerISak.soeker.fnr.value,
+                sakType = generellBrevData.sak.sakType,
+                enhet = generellBrevData.sak.enhet,
+                personerISak = generellBrevData.personerISak,
+                innhold = BrevInnhold(tittel, generellBrevData.spraak, innhold.await()),
+                innholdVedlegg = innholdVedlegg.await(),
             )
         }
     }
@@ -234,7 +236,10 @@ class Brevoppretter(
 }
 
 private data class OpprettBrevRequest(
-    val generellBrevData: GenerellBrevData,
+    val soekerFnr: String,
+    val sakType: SakType,
+    val enhet: String,
+    val personerISak: PersonerISak,
     val innhold: BrevInnhold,
     val innholdVedlegg: List<BrevInnholdVedlegg>?,
 )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -170,7 +170,6 @@ class Brevoppretter(
                     loependeIPesys = generellBrevData.loependeIPesys(),
                     systemkilde = generellBrevData.systemkilde,
                     avdoede = generellBrevData.personerISak.avdoede,
-                    generellBrevData = generellBrevData,
                 )
             val brevData: BrevDataRedigerbar = brevDataMapping(redigerbarTekstRequest)
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -76,7 +76,7 @@ class Brevoppretter(
         brevKode: (b: BrevkodeRequest) -> EtterlatteBrevKode,
         brevtype: Brevtype,
         brevDataMapping: suspend (RedigerbarTekstRequest) -> BrevDataRedigerbar,
-    ): Pair<Brev, GenerellBrevData> =
+    ): Pair<Brev, String> =
         with(
             hentInnData(
                 sakId,
@@ -98,7 +98,7 @@ class Brevoppretter(
                     innholdVedlegg = innholdVedlegg,
                     brevtype = brevtype,
                 )
-            return Pair(db.opprettBrev(nyttBrev), generellBrevData)
+            return Pair(db.opprettBrev(nyttBrev), generellBrevData.sak.enhet)
         }
 
     suspend fun hentNyttInnhold(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/MigreringBrevDataService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/MigreringBrevDataService.kt
@@ -1,37 +1,48 @@
 package no.nav.etterlatte.brev
 
 import kotlinx.coroutines.coroutineScope
-import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.hentinformasjon.beregning.BeregningService
 import no.nav.etterlatte.brev.model.bp.BarnepensjonOmregnetNyttRegelverkRedigerbartUtfall
 import no.nav.etterlatte.libs.common.Vedtaksloesning
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import java.time.YearMonth
+import java.util.UUID
 
 class MigreringBrevDataService(
     private val beregningService: BeregningService,
 ) {
     suspend fun opprettMigreringBrevdata(
-        generellBrevData: GenerellBrevData,
         brukerTokenInfo: BrukerTokenInfo,
+        systemkilde: Vedtaksloesning,
+        virkningstidspunkt: YearMonth,
+        behandlingId: UUID,
+        sakType: SakType,
+        loependeIPesys: Boolean,
+        utlandstilknytningType: UtlandstilknytningType,
+        erForeldreloes: Boolean,
+        erSystembruker: Boolean,
     ): BarnepensjonOmregnetNyttRegelverkRedigerbartUtfall {
-        if (generellBrevData.systemkilde != Vedtaksloesning.PESYS) {
+        if (systemkilde != Vedtaksloesning.PESYS) {
             throw InternfeilException("Kan ikke opprette et migreringsbrev fra pesys hvis kilde ikke er pesys")
         }
         return coroutineScope {
-            val virkningstidspunkt =
-                requireNotNull(generellBrevData.forenkletVedtak!!.virkningstidspunkt) {
-                    "Migreringsvedtaket må ha et virkningstidspunkt"
-                }
-
             val utbetalingsinfo =
                 beregningService.finnUtbetalingsinfo(
-                    generellBrevData.behandlingId!!,
+                    behandlingId,
                     virkningstidspunkt,
                     brukerTokenInfo,
-                    generellBrevData.sak.sakType,
+                    sakType,
                 )
-            BarnepensjonOmregnetNyttRegelverkRedigerbartUtfall.fra(generellBrevData, utbetalingsinfo)
+            BarnepensjonOmregnetNyttRegelverkRedigerbartUtfall.fra(
+                utbetalingsinfo,
+                erForeldreloes,
+                loependeIPesys,
+                utlandstilknytningType,
+                erSystembruker,
+            )
         }
     }
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
@@ -5,6 +5,7 @@ import no.nav.etterlatte.brev.adresse.AvsenderRequest
 import no.nav.etterlatte.brev.behandling.ForenkletVedtak
 import no.nav.etterlatte.brev.brevbaker.BrevbakerRequest
 import no.nav.etterlatte.brev.brevbaker.BrevbakerService
+import no.nav.etterlatte.brev.brevbaker.formaterNavn
 import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.model.Brev
@@ -94,11 +95,26 @@ class PDFGenerator(
                 brevData =
                     brevData(
                         BrevDataFerdigstillingRequest(
-                            generellBrevData,
-                            bruker,
-                            InnholdMedVedlegg({ hentLagretInnhold(brev) }, { hentLagretInnholdVedlegg(brev) }),
-                            brevkodePar,
-                            brev.tittel,
+                            loependeIPesys = generellBrevData.loependeIPesys(),
+                            behandlingId = generellBrevData.behandlingId,
+                            sakType = generellBrevData.sak.sakType,
+                            erForeldreloes = generellBrevData.erForeldreloes(),
+                            utlandstilknytningType = generellBrevData.utlandstilknytning?.type,
+                            avdoede = generellBrevData.personerISak.avdoede,
+                            systemkilde = generellBrevData.systemkilde,
+                            soekerUnder18 = generellBrevData.personerISak.soeker.under18,
+                            soekerNavn = generellBrevData.personerISak.soeker.formaterNavn(),
+                            sakId = generellBrevData.sak.id,
+                            virkningstidspunkt = generellBrevData.forenkletVedtak?.virkningstidspunkt,
+                            vedtakType = generellBrevData.forenkletVedtak?.type,
+                            revurderingsaarsak = generellBrevData.revurderingsaarsak,
+                            tilbakekreving = generellBrevData.forenkletVedtak?.tilbakekreving,
+                            klage = generellBrevData.forenkletVedtak?.klage,
+                            harVerge = generellBrevData.personerISak.verge != null,
+                            bruker = bruker,
+                            innholdMedVedlegg = InnholdMedVedlegg({ hentLagretInnhold(brev) }, { hentLagretInnholdVedlegg(brev) }),
+                            kode = brevkodePar,
+                            tittel = brev.tittel,
                         ),
                     ),
                 avsender = avsender,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.brev
 
 import no.nav.etterlatte.brev.adresse.AdresseService
 import no.nav.etterlatte.brev.adresse.AvsenderRequest
+import no.nav.etterlatte.brev.behandling.ForenkletVedtak
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.brevbaker.BrevbakerRequest
 import no.nav.etterlatte.brev.brevbaker.BrevbakerService
@@ -30,7 +31,7 @@ class PDFGenerator(
     suspend fun ferdigstillOgGenererPDF(
         id: BrevID,
         bruker: BrukerTokenInfo,
-        avsenderRequest: (BrukerTokenInfo, GenerellBrevData) -> AvsenderRequest,
+        avsenderRequest: (BrukerTokenInfo, ForenkletVedtak?, String) -> AvsenderRequest,
         brevKode: (BrevkodeRequest) -> Brevkoder,
         brevData: suspend (BrevDataFerdigstillingRequest) -> BrevDataFerdigstilling,
         lagrePdfHvisVedtakFattet: (GenerellBrevData, Brev, Pdf) -> Unit = { _, _, _ -> run {} },
@@ -56,7 +57,7 @@ class PDFGenerator(
     suspend fun genererPdf(
         id: BrevID,
         bruker: BrukerTokenInfo,
-        avsenderRequest: (BrukerTokenInfo, GenerellBrevData) -> AvsenderRequest,
+        avsenderRequest: (BrukerTokenInfo, ForenkletVedtak?, String) -> AvsenderRequest,
         brevKode: (BrevkodeRequest) -> Brevkoder,
         brevData: suspend (BrevDataFerdigstillingRequest) -> BrevDataFerdigstilling,
         lagrePdfHvisVedtakFattet: (GenerellBrevData, Brev, Pdf) -> Unit = { _, _, _ -> run {} },
@@ -74,7 +75,7 @@ class PDFGenerator(
 
         val generellBrevData =
             retryOgPakkUt { brevDataFacade.hentGenerellBrevData(brev.sakId, behandlingId, brev.spraak, bruker) }
-        val avsender = adresseService.hentAvsender(avsenderRequest(bruker, generellBrevData))
+        val avsender = adresseService.hentAvsender(avsenderRequest(bruker, generellBrevData.forenkletVedtak, generellBrevData.sak.enhet))
 
         val brevkodePar =
             brevKode(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/RedigerbarTekstRequest.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/RedigerbarTekstRequest.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.brev
 
 import no.nav.etterlatte.brev.behandling.Avdoed
 import no.nav.etterlatte.brev.behandling.ForenkletVedtak
-import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.brevbaker.SoekerOgEventuellVerge
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
@@ -23,6 +22,4 @@ data class RedigerbarTekstRequest(
     val loependeIPesys: Boolean,
     val systemkilde: Vedtaksloesning,
     val avdoede: List<Avdoed>,
-    val generellBrevData: GenerellBrevData,
-    // TODO: Denne skal bort i ein av dei seinare delane, men tar med no for å ikkje måtte ta alt på ein gong
 )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
@@ -65,12 +65,7 @@ class VedtaksbrevService(
         pdfGenerator.genererPdf(
             id = id,
             bruker = bruker,
-            avsenderRequest = {
-                    brukerToken,
-                    generellBrevData,
-                ->
-                opprettAvsenderRequest(brukerToken, generellBrevData.forenkletVedtak, generellBrevData.sak.enhet)
-            },
+            avsenderRequest = { brukerToken, vedtak, enhet -> opprettAvsenderRequest(brukerToken, vedtak, enhet) },
             brevKode = { brevKodeMapperVedtak.brevKode(it) },
             brevData = { brevDataMapperFerdigstilling.brevDataFerdigstilling(it) },
         ) { generellBrevData, brev, pdf ->

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.brev
 
 import com.fasterxml.jackson.databind.JsonNode
 import no.nav.etterlatte.brev.behandling.ForenkletVedtak
+import no.nav.etterlatte.brev.behandling.opprettAvsenderRequest
 import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.hentinformasjon.behandling.BehandlingService
 import no.nav.etterlatte.brev.hentinformasjon.vedtaksvurdering.VedtaksvurderingService
@@ -64,7 +65,12 @@ class VedtaksbrevService(
         pdfGenerator.genererPdf(
             id = id,
             bruker = bruker,
-            avsenderRequest = { brukerToken, generellBrevData -> generellBrevData.avsenderRequest(brukerToken) },
+            avsenderRequest = {
+                    brukerToken,
+                    generellBrevData,
+                ->
+                opprettAvsenderRequest(brukerToken, generellBrevData.forenkletVedtak, generellBrevData.sak.enhet)
+            },
             brevKode = { brevKodeMapperVedtak.brevKode(it) },
             brevData = { brevDataMapperFerdigstilling.brevDataFerdigstilling(it) },
         ) { generellBrevData, brev, pdf ->

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.brev
 
 import com.fasterxml.jackson.databind.JsonNode
-import no.nav.etterlatte.brev.behandling.ForenkletVedtak
 import no.nav.etterlatte.brev.behandling.opprettAvsenderRequest
 import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.hentinformasjon.behandling.BehandlingService
@@ -68,12 +67,13 @@ class VedtaksbrevService(
             avsenderRequest = { brukerToken, vedtak, enhet -> opprettAvsenderRequest(brukerToken, vedtak, enhet) },
             brevKode = { brevKodeMapperVedtak.brevKode(it) },
             brevData = { brevDataMapperFerdigstilling.brevDataFerdigstilling(it) },
-        ) { generellBrevData, brev, pdf ->
+        ) { vedtakStatus, saksbehandler, brev, pdf ->
             lagrePdfHvisVedtakFattet(
                 brev.id,
-                generellBrevData.forenkletVedtak!!,
                 pdf,
                 bruker,
+                vedtakStatus!!,
+                saksbehandler!!,
             )
         }
 
@@ -158,22 +158,23 @@ class VedtaksbrevService(
 
     private fun lagrePdfHvisVedtakFattet(
         brevId: BrevID,
-        vedtak: ForenkletVedtak,
         pdf: Pdf,
         brukerTokenInfo: BrukerTokenInfo,
+        vedtakStatus: VedtakStatus,
+        saksbehandlerVedtak: String,
     ) {
-        if (vedtak.status != VedtakStatus.FATTET_VEDTAK) {
-            logger.info("Vedtak status er ${vedtak.status}. Avventer ferdigstilling av brev (id=$brevId)")
+        if (vedtakStatus != VedtakStatus.FATTET_VEDTAK) {
+            logger.info("Vedtak status er $vedtakStatus. Avventer ferdigstilling av brev (id=$brevId)")
             return
         }
 
-        if (!brukerTokenInfo.erSammePerson(vedtak.saksbehandlerIdent)) {
+        if (!brukerTokenInfo.erSammePerson(saksbehandlerVedtak)) {
             logger.info("Lagrer PDF for brev med id=$brevId")
 
             db.lagrePdf(brevId, pdf)
         } else {
             logger.warn(
-                "Kan ikke ferdigstille/låse brev når saksbehandler (${vedtak.saksbehandlerIdent})" +
+                "Kan ikke ferdigstille/låse brev når saksbehandler ($saksbehandlerVedtak)" +
                     " og attestant (${brukerTokenInfo.ident()}) er samme person.",
             )
         }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/Behandling.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/Behandling.kt
@@ -41,8 +41,6 @@ data class GenerellBrevData(
     val utlandstilknytning: Utlandstilknytning? = null,
     val revurderingsaarsak: Revurderingaarsak? = null,
 ) {
-    fun avsenderRequest(bruker: BrukerTokenInfo) = opprettAvsenderRequest(bruker, forenkletVedtak, sak.enhet)
-
     // TODO På tide å fjerne?
     // Tidligere erMigrering - Vil si saker som er løpende i Pesys når det vedtas i Gjenny og opphøres etter vedtaket.
     fun loependeIPesys() = systemkilde == Vedtaksloesning.PESYS && behandlingId != null && revurderingsaarsak == null

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/grunnlag/GrunnlagService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/grunnlag/GrunnlagService.kt
@@ -1,8 +1,12 @@
 package no.nav.etterlatte.brev.hentinformasjon.grunnlag
 
 import no.nav.etterlatte.brev.adresse.AdresseService
+import no.nav.etterlatte.brev.behandling.PersonerISak
 import no.nav.etterlatte.brev.behandling.erOver18
 import no.nav.etterlatte.brev.behandling.hentForelderVerge
+import no.nav.etterlatte.brev.behandling.mapAvdoede
+import no.nav.etterlatte.brev.behandling.mapInnsender
+import no.nav.etterlatte.brev.behandling.mapSoeker
 import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
@@ -36,6 +40,17 @@ class GrunnlagService(
         null -> hentGrunnlagForSak(sakId, bruker)
         else -> klient.hentGrunnlag(behandlingId!!, bruker)
     }
+
+    suspend fun hentPersonerISak(
+        grunnlag: Grunnlag,
+        brevutfallDto: BrevutfallDto?,
+        sakType: SakType?,
+    ) = PersonerISak(
+        innsender = grunnlag.mapInnsender(),
+        soeker = grunnlag.mapSoeker(brevutfallDto),
+        avdoede = grunnlag.mapAvdoede(),
+        verge = sakType?.let { hentVergeForSak(it, brevutfallDto, grunnlag) },
+    )
 
     suspend fun hentGrunnlagForSak(
         sakId: Long,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
@@ -144,7 +144,11 @@ class BrevDataMapperFerdigstillingVedtak(
                         generellBrevData.forenkletVedtak.virkningstidspunkt!!,
                     )
 
-                OMSTILLINGSSTOENAD_AVSLAG -> OmstillingsstoenadAvslag.fra(generellBrevData, innholdMedVedlegg.innhold())
+                OMSTILLINGSSTOENAD_AVSLAG ->
+                    OmstillingsstoenadAvslag.fra(
+                        innholdMedVedlegg.innhold(),
+                        generellBrevData.utlandstilknytning?.type,
+                    )
                 OMSTILLINGSSTOENAD_OPPHOER ->
                     omstillingsstoenadOpphoer(
                         bruker,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
@@ -17,7 +17,6 @@ import no.nav.etterlatte.brev.EtterlatteBrevKode.TILBAKEKREVING_FERDIG
 import no.nav.etterlatte.brev.behandling.Avdoed
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.brevbaker.formaterNavn
-import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.hentinformasjon.behandling.BehandlingService
 import no.nav.etterlatte.brev.hentinformasjon.beregning.BeregningService
 import no.nav.etterlatte.brev.hentinformasjon.trygdetid.TrygdetidService
@@ -57,7 +56,6 @@ class BrevDataMapperFerdigstillingVedtak(
     private val trygdetidService: TrygdetidService,
     private val behandlingService: BehandlingService,
     private val vilkaarsvurderingService: VilkaarsvurderingService,
-    private val brevdataFacade: BrevdataFacade,
 ) {
     suspend fun brevDataFerdigstilling(request: BrevDataFerdigstillingRequest): BrevDataFerdigstilling {
         with(request) {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
@@ -155,7 +155,11 @@ class BrevDataMapperFerdigstillingVedtak(
 
                 TILBAKEKREVING_FERDIG -> TilbakekrevingBrevDTO.fra(generellBrevData, innholdMedVedlegg.innhold())
 
-                AVVIST_KLAGE_FERDIG -> AvvistKlageFerdigData.fra(generellBrevData, innholdMedVedlegg)
+                AVVIST_KLAGE_FERDIG ->
+                    AvvistKlageFerdigData.fra(
+                        innholdMedVedlegg,
+                        generellBrevData.forenkletVedtak?.klage,
+                    )
 
                 else -> throw IllegalStateException("Klarte ikke å finne brevdata for brevkode $kode for ferdigstilling.")
             }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
@@ -61,7 +61,19 @@ class BrevDataMapperFerdigstillingVedtak(
     suspend fun brevDataFerdigstilling(request: BrevDataFerdigstillingRequest): BrevDataFerdigstilling {
         with(request) {
             if (generellBrevData.loependeIPesys()) {
-                return fraPesys(bruker, generellBrevData, innholdMedVedlegg)
+                return fraPesys(
+                    bruker,
+                    innholdMedVedlegg,
+                    generellBrevData.behandlingId!!,
+                    generellBrevData.forenkletVedtak?.virkningstidspunkt!!,
+                    generellBrevData.sak.sakType,
+                    generellBrevData.erForeldreloes(),
+                    generellBrevData.utlandstilknytning?.type,
+                    generellBrevData.loependeIPesys(),
+                    generellBrevData.personerISak.avdoede,
+                    generellBrevData.systemkilde,
+                    generellBrevData.personerISak.soeker.under18,
+                )
             }
             return when (kode.ferdigstilling) {
                 BARNEPENSJON_REVURDERING ->
@@ -153,46 +165,53 @@ class BrevDataMapperFerdigstillingVedtak(
     // TODO På tide å fjerne? Nei
     private suspend fun fraPesys(
         bruker: BrukerTokenInfo,
-        generellBrevData: GenerellBrevData,
         innholdMedVedlegg: InnholdMedVedlegg,
+        behandlingId: UUID,
+        virkningstidspunkt: YearMonth,
+        sakType: SakType,
+        erForeldreloes: Boolean,
+        utlandstilknytningType: UtlandstilknytningType?,
+        loependeIPesys: Boolean,
+        avdoede: List<Avdoed>,
+        systemkilde: Vedtaksloesning,
+        soekerUnder18: Boolean?,
     ) = coroutineScope {
-        val behandlingId = generellBrevData.behandlingId!!
         val utbetalingsinfo =
             async {
                 beregningService.finnUtbetalingsinfo(
                     behandlingId,
-                    generellBrevData.forenkletVedtak?.virkningstidspunkt!!,
+                    virkningstidspunkt,
                     bruker,
-                    generellBrevData.sak.sakType,
+                    sakType,
                 )
             }
         val trygdetid = async { trygdetidService.hentTrygdetid(behandlingId, bruker) }
         val grunnbeloep = async { beregningService.hentGrunnbeloep(bruker) }
         val etterbetaling = async { behandlingService.hentEtterbetaling(behandlingId, bruker) }
 
-        if (generellBrevData.erForeldreloes()) {
+        if (erForeldreloes) {
             barnepensjonInnvilgelse(
                 bruker,
                 innholdMedVedlegg,
-                generellBrevData.behandlingId!!,
-                generellBrevData.forenkletVedtak?.virkningstidspunkt!!,
-                generellBrevData.sak.sakType,
-                generellBrevData.erForeldreloes(),
-                generellBrevData.utlandstilknytning?.type,
-                generellBrevData.loependeIPesys(),
-                generellBrevData.personerISak.avdoede,
-                generellBrevData.systemkilde,
+                behandlingId,
+                virkningstidspunkt,
+                sakType,
+                erForeldreloes,
+                utlandstilknytningType,
+                loependeIPesys,
+                avdoede,
+                systemkilde,
             )
         } else {
             BarnepensjonOmregnetNyttRegelverk.fra(
                 innhold = innholdMedVedlegg,
-                erUnder18Aar = generellBrevData.personerISak.soeker.under18,
+                erUnder18Aar = soekerUnder18,
                 utbetalingsinfo = utbetalingsinfo.await(),
                 etterbetaling = etterbetaling.await(),
                 trygdetid = requireNotNull(trygdetid.await()),
                 grunnbeloep = grunnbeloep.await(),
-                utlandstilknytning = generellBrevData.utlandstilknytning?.type,
-                avdoede = generellBrevData.personerISak.avdoede,
+                utlandstilknytning = utlandstilknytningType,
+                avdoede = avdoede,
             )
         }
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.brev.EtterlatteBrevKode.OMSTILLINGSSTOENAD_REVURDERING
 import no.nav.etterlatte.brev.EtterlatteBrevKode.TILBAKEKREVING_FERDIG
 import no.nav.etterlatte.brev.behandling.Avdoed
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
+import no.nav.etterlatte.brev.brevbaker.formaterNavn
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.hentinformasjon.behandling.BehandlingService
 import no.nav.etterlatte.brev.hentinformasjon.beregning.BeregningService
@@ -153,7 +154,14 @@ class BrevDataMapperFerdigstillingVedtak(
                         generellBrevData.utlandstilknytning?.type,
                     )
 
-                TILBAKEKREVING_FERDIG -> TilbakekrevingBrevDTO.fra(generellBrevData, innholdMedVedlegg.innhold())
+                TILBAKEKREVING_FERDIG ->
+                    TilbakekrevingBrevDTO.fra(
+                        innholdMedVedlegg.innhold(),
+                        generellBrevData.forenkletVedtak?.tilbakekreving,
+                        generellBrevData.sak.sakType,
+                        generellBrevData.utlandstilknytning?.type,
+                        generellBrevData.personerISak.soeker.formaterNavn(),
+                    )
 
                 AVVIST_KLAGE_FERDIG ->
                     AvvistKlageFerdigData.fra(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
@@ -96,9 +96,10 @@ class BrevDataMapperRedigerbartUtfallVedtak(
 
         if (generellBrevData.erForeldreloes()) {
             BarnepensjonForeldreloesRedigerbar.fra(
-                generellBrevData,
                 etterbetaling.await(),
                 utbetalingsinfo = utbetalingsinfo.await(),
+                generellBrevData.systemkilde,
+                generellBrevData.loependeIPesys(),
             )
         } else {
             BarnepensjonInnvilgelseRedigerbartUtfall.fra(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
@@ -6,7 +6,6 @@ import no.nav.etterlatte.brev.MigreringBrevDataService
 import no.nav.etterlatte.brev.RedigerbarTekstRequest
 import no.nav.etterlatte.brev.behandling.Avdoed
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
-import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.hentinformasjon.behandling.BehandlingService
 import no.nav.etterlatte.brev.hentinformasjon.beregning.BeregningService
 import no.nav.etterlatte.brev.model.bp.BarnepensjonForeldreloesRedigerbar
@@ -26,7 +25,6 @@ import java.time.YearMonth
 import java.util.UUID
 
 class BrevDataMapperRedigerbartUtfallVedtak(
-    private val brevdataFacade: BrevdataFacade,
     private val behandlingService: BehandlingService,
     private val beregningService: BeregningService,
     private val migreringBrevDataService: MigreringBrevDataService,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
@@ -57,7 +57,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
                     VedtakType.ENDRING -> barnepensjonEndring(brukerTokenInfo, generellBrevData)
                     VedtakType.OPPHOER -> barnepensjonOpphoer(brukerTokenInfo, generellBrevData)
                     VedtakType.AVSLAG -> ManueltBrevData()
-                    VedtakType.AVVIST_KLAGE -> AvvistKlageInnholdBrevData.fra(generellBrevData)
+                    VedtakType.AVVIST_KLAGE -> AvvistKlageInnholdBrevData.fra(generellBrevData.forenkletVedtak?.klage)
                     VedtakType.TILBAKEKREVING,
                     null,
                     -> ManueltBrevData()
@@ -70,7 +70,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
                     VedtakType.ENDRING -> omstillingsstoenadEndring(brukerTokenInfo, generellBrevData)
                     VedtakType.OPPHOER -> omstillingsstoenadOpphoer(brukerTokenInfo, generellBrevData)
                     VedtakType.AVSLAG -> OmstillingsstoenadAvslagRedigerbartUtfall.fra(generellBrevData)
-                    VedtakType.AVVIST_KLAGE -> AvvistKlageInnholdBrevData.fra(generellBrevData)
+                    VedtakType.AVVIST_KLAGE -> AvvistKlageInnholdBrevData.fra(generellBrevData.forenkletVedtak?.klage)
                     VedtakType.TILBAKEKREVING,
                     null,
                     -> ManueltBrevData()

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
@@ -32,7 +32,17 @@ class BrevDataMapperRedigerbartUtfallVedtak(
     suspend fun brevData(redigerbarTekstRequest: RedigerbarTekstRequest) =
         with(redigerbarTekstRequest) {
             if (generellBrevData.loependeIPesys()) {
-                fraPesys(generellBrevData, brukerTokenInfo)
+                fraPesys(
+                    generellBrevData,
+                    brukerTokenInfo,
+                    generellBrevData.erForeldreloes(),
+                    generellBrevData.behandlingId!!,
+                    generellBrevData.forenkletVedtak?.virkningstidspunkt,
+                    generellBrevData.sak.sakType,
+                    generellBrevData.systemkilde,
+                    generellBrevData.loependeIPesys(),
+                    generellBrevData.personerISak.avdoede,
+                )
             } else {
                 brevData(generellBrevData, brukerTokenInfo)
             }
@@ -41,17 +51,24 @@ class BrevDataMapperRedigerbartUtfallVedtak(
     private suspend fun fraPesys(
         generellBrevData: GenerellBrevData,
         brukerTokenInfo: BrukerTokenInfo,
+        erForeldreloes: Boolean,
+        behandlingId: UUID,
+        virkningstidspunkt: YearMonth?,
+        sakType: SakType,
+        systemkilde: Vedtaksloesning,
+        loependeIPesys: Boolean,
+        avdoede: List<Avdoed>,
     ): BrevDataRedigerbar {
-        if (generellBrevData.erForeldreloes()) {
+        if (erForeldreloes) {
             return barnepensjonInnvilgelse(
                 brukerTokenInfo,
-                generellBrevData.behandlingId!!,
-                generellBrevData.forenkletVedtak?.virkningstidspunkt,
-                generellBrevData.sak.sakType,
-                generellBrevData.erForeldreloes(),
-                generellBrevData.systemkilde,
-                generellBrevData.loependeIPesys(),
-                generellBrevData.personerISak.avdoede,
+                behandlingId,
+                virkningstidspunkt,
+                sakType,
+                erForeldreloes,
+                systemkilde,
+                loependeIPesys,
+                avdoede,
             )
         }
         return migreringBrevDataService.opprettMigreringBrevdata(generellBrevData, brukerTokenInfo)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
@@ -69,7 +69,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
                     VedtakType.INNVILGELSE -> omstillingsstoenadInnvilgelse(brukerTokenInfo, generellBrevData)
                     VedtakType.ENDRING -> omstillingsstoenadEndring(brukerTokenInfo, generellBrevData)
                     VedtakType.OPPHOER -> omstillingsstoenadOpphoer(brukerTokenInfo, generellBrevData)
-                    VedtakType.AVSLAG -> OmstillingsstoenadAvslagRedigerbartUtfall.fra(generellBrevData)
+                    VedtakType.AVSLAG -> OmstillingsstoenadAvslagRedigerbartUtfall.fra(generellBrevData.personerISak.avdoede)
                     VedtakType.AVVIST_KLAGE -> AvvistKlageInnholdBrevData.fra(generellBrevData.forenkletVedtak?.klage)
                     VedtakType.TILBAKEKREVING,
                     null,
@@ -103,9 +103,10 @@ class BrevDataMapperRedigerbartUtfallVedtak(
             )
         } else {
             BarnepensjonInnvilgelseRedigerbartUtfall.fra(
-                generellBrevData,
                 utbetalingsinfo.await(),
                 etterbetaling.await(),
+                generellBrevData.personerISak.avdoede,
+                generellBrevData.systemkilde,
             )
         }
     }
@@ -173,10 +174,10 @@ class BrevDataMapperRedigerbartUtfallVedtak(
         val etterbetaling = async { behandlingService.hentEtterbetaling(behandlingId, bruker) }
 
         OmstillingsstoenadInnvilgelseRedigerbartUtfall.fra(
-            generellBrevData,
             utbetalingsinfo.await(),
             requireNotNull(avkortingsinfo.await()),
             etterbetaling.await(),
+            generellBrevData.personerISak.avdoede,
         )
     }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
@@ -34,40 +34,37 @@ class BrevDataMapperRedigerbartUtfallVedtak(
 ) {
     suspend fun brevData(redigerbarTekstRequest: RedigerbarTekstRequest) =
         with(redigerbarTekstRequest) {
-            if (generellBrevData.loependeIPesys()) {
+            if (loependeIPesys) {
                 fraPesys(
                     brukerTokenInfo = brukerTokenInfo,
-                    erForeldreloes = generellBrevData.erForeldreloes(),
-                    behandlingId = generellBrevData.behandlingId!!,
-                    virkningstidspunkt = generellBrevData.forenkletVedtak?.virkningstidspunkt,
-                    sakType = generellBrevData.sak.sakType,
-                    systemkilde = generellBrevData.systemkilde,
-                    loependeIPesys = generellBrevData.loependeIPesys(),
-                    avdoede = generellBrevData.personerISak.avdoede,
-                    utlandstilknytningType = generellBrevData.utlandstilknytning!!.type,
+                    erForeldreloes = erForeldreloes,
+                    behandlingId = behandlingId!!,
+                    virkningstidspunkt = forenkletVedtak?.virkningstidspunkt,
+                    sakType = sakType,
+                    systemkilde = systemkilde,
+                    loependeIPesys = true,
+                    avdoede = avdoede,
+                    utlandstilknytningType = utlandstilknytningType!!,
                     erForeldreloesUtenForeldreverge =
-                        generellBrevData.personerISak.soeker.foreldreloes ||
-                            (
-                                generellBrevData.personerISak.avdoede.size > 1 &&
-                                    generellBrevData.personerISak.verge !is ForelderVerge
-                            ),
+                        soekerOgEventuellVerge.soeker.foreldreloes ||
+                            (avdoede.size > 1 && soekerOgEventuellVerge.verge !is ForelderVerge),
                     // Er litt usikker på hvorfor denne bruker en annen foreldreløs-sjekk enn resten av koden,
                     // men frister lite å endre på det nå når migreringa/gjenopprettinga fra pesys
                     // nærmer seg veldig ferdig
-                    erSystembruker = generellBrevData.forenkletVedtak?.saksbehandlerIdent == Fagsaksystem.EY.navn,
+                    erSystembruker = forenkletVedtak?.saksbehandlerIdent == Fagsaksystem.EY.navn,
                 )
             } else {
                 brevData(
                     brukerTokenInfo,
-                    generellBrevData.sak.sakType,
-                    generellBrevData.forenkletVedtak?.type,
-                    generellBrevData.behandlingId!!,
-                    generellBrevData.forenkletVedtak?.virkningstidspunkt,
-                    generellBrevData.erForeldreloes(),
-                    generellBrevData.systemkilde,
-                    generellBrevData.loependeIPesys(),
-                    generellBrevData.personerISak.avdoede,
-                    generellBrevData.forenkletVedtak?.klage,
+                    sakType,
+                    forenkletVedtak?.type,
+                    behandlingId!!,
+                    forenkletVedtak?.virkningstidspunkt,
+                    erForeldreloes,
+                    systemkilde,
+                    false,
+                    avdoede,
+                    forenkletVedtak?.klage,
                 )
             }
         }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInformasjonDoedsfall.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInformasjonDoedsfall.kt
@@ -1,6 +1,6 @@
 package no.nav.etterlatte.brev.model.bp
 
-import no.nav.etterlatte.brev.behandling.GenerellBrevData
+import no.nav.etterlatte.brev.behandling.Avdoed
 import no.nav.etterlatte.brev.model.BrevDataRedigerbar
 import no.nav.etterlatte.brev.model.BrevdataMedInnhold
 import no.nav.etterlatte.brev.model.Slate
@@ -14,16 +14,13 @@ data class BarnepensjonInformasjonDoedsfall(
     BrevdataMedInnhold {
     companion object {
         fun fra(
-            generellBrevData: GenerellBrevData,
             borIutland: Boolean,
             erOver18aar: Boolean,
+            avdoede: List<Avdoed>,
         ): BarnepensjonInformasjonDoedsfall =
             BarnepensjonInformasjonDoedsfall(
                 innhold = emptyList(),
-                avdoedNavn =
-                    generellBrevData.personerISak.avdoede
-                        .first()
-                        .navn,
+                avdoedNavn = avdoede.first().navn,
                 borIutland = borIutland,
                 erOver18aar = erOver18aar,
             )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.brev.model.bp
 
 import no.nav.etterlatte.brev.behandling.Avdoed
-import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
 import no.nav.etterlatte.brev.model.BarnepensjonBeregning
 import no.nav.etterlatte.brev.model.BarnepensjonBeregningsperiode
@@ -79,9 +78,10 @@ data class BarnepensjonInnvilgelseRedigerbartUtfall(
 ) : BrevDataRedigerbar {
     companion object {
         fun fra(
-            generellBrevData: GenerellBrevData,
             utbetalingsinfo: Utbetalingsinfo,
             etterbetaling: EtterbetalingDTO?,
+            avdoede: List<Avdoed>,
+            systemkilde: Vedtaksloesning,
         ): BarnepensjonInnvilgelseRedigerbartUtfall {
             val beregningsperioder =
                 utbetalingsinfo.beregningsperioder.map {
@@ -97,7 +97,7 @@ data class BarnepensjonInnvilgelseRedigerbartUtfall(
             return BarnepensjonInnvilgelseRedigerbartUtfall(
                 virkningsdato = utbetalingsinfo.virkningsdato,
                 avdoed =
-                    generellBrevData.personerISak.avdoede.minByOrNull { it.doedsdato }
+                    avdoede.minByOrNull { it.doedsdato }
                         ?: throw UgyldigForespoerselException(
                             code = "AVDOED_MED_DOEDSDATO_MANGLER",
                             detail = "Ingen avdød med dødsdato",
@@ -116,7 +116,7 @@ data class BarnepensjonInnvilgelseRedigerbartUtfall(
                         ),
                 erEtterbetaling = etterbetaling != null,
                 harFlereUtbetalingsperioder = utbetalingsinfo.beregningsperioder.size > 1,
-                erGjenoppretting = generellBrevData.systemkilde == Vedtaksloesning.GJENOPPRETTA,
+                erGjenoppretting = systemkilde == Vedtaksloesning.GJENOPPRETTA,
                 harUtbetaling = beregningsperioder.any { it.utbetaltBeloep.value > 0 },
             )
         }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelseForeldreloes.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelseForeldreloes.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.brev.model.bp
 
 import no.nav.etterlatte.brev.behandling.Avdoed
-import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
 import no.nav.etterlatte.brev.model.BarnepensjonBeregning
 import no.nav.etterlatte.brev.model.BarnepensjonEtterbetaling
@@ -91,9 +90,10 @@ data class BarnepensjonForeldreloesRedigerbar(
 ) : BrevDataRedigerbar {
     companion object {
         fun fra(
-            generellBrevData: GenerellBrevData,
             etterbetaling: EtterbetalingDTO?,
             utbetalingsinfo: Utbetalingsinfo,
+            vedtaksloesning: Vedtaksloesning,
+            loependeIPesys: Boolean,
         ): BarnepensjonForeldreloesRedigerbar {
             val beregningsperioder = barnepensjonBeregningsperioder(utbetalingsinfo)
 
@@ -114,8 +114,8 @@ data class BarnepensjonForeldreloesRedigerbar(
                 erEtterbetaling = etterbetaling != null,
                 flerePerioder = utbetalingsinfo.beregningsperioder.size > 1,
                 harUtbetaling = beregningsperioder.any { it.utbetaltBeloep.value > 0 },
-                erGjenoppretting = generellBrevData.systemkilde == Vedtaksloesning.GJENOPPRETTA,
-                vedtattIPesys = generellBrevData.loependeIPesys(),
+                erGjenoppretting = vedtaksloesning == Vedtaksloesning.GJENOPPRETTA,
+                vedtattIPesys = loependeIPesys,
             )
         }
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOpphoer.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOpphoer.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.brev.model.bp
 
-import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
 import no.nav.etterlatte.brev.model.BrevDataRedigerbar
 import no.nav.etterlatte.brev.model.BrevVedleggKey
@@ -25,9 +24,9 @@ data class BarnepensjonOpphoer(
     companion object {
         fun fra(
             innhold: InnholdMedVedlegg,
-            generellBrevData: GenerellBrevData,
             utlandstilknytning: UtlandstilknytningType?,
             brevutfall: BrevutfallDto,
+            virkningsdato: LocalDate?,
         ): BarnepensjonOpphoer {
             val feilutbetaling = toFeilutbetalingType(requireNotNull(brevutfall.feilutbetaling?.valg))
 
@@ -41,7 +40,7 @@ data class BarnepensjonOpphoer(
                     ),
                 brukerUnder18Aar = brevutfall.aldersgruppe == Aldersgruppe.UNDER_18,
                 bosattUtland = utlandstilknytning == UtlandstilknytningType.BOSATT_UTLAND,
-                virkningsdato = requireNotNull(generellBrevData.forenkletVedtak?.virkningstidspunkt?.atDay(1)),
+                virkningsdato = requireNotNull(virkningsdato),
                 feilutbetaling = feilutbetaling,
             )
         }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/klage/AvvistKlageFerdigData.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/klage/AvvistKlageFerdigData.kt
@@ -1,10 +1,10 @@
 package no.nav.etterlatte.brev.model.klage
 
-import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
 import no.nav.etterlatte.brev.model.BrevDataRedigerbar
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
 import no.nav.etterlatte.brev.model.Slate
+import no.nav.etterlatte.libs.common.behandling.Klage
 import no.nav.etterlatte.libs.common.behandling.SakType
 import java.time.LocalDate
 
@@ -14,12 +14,12 @@ data class AvvistKlageFerdigData(
 ) : BrevDataFerdigstilling {
     companion object {
         fun fra(
-            generellBrevData: GenerellBrevData,
             innholdMedVedlegg: InnholdMedVedlegg,
+            klage: Klage?,
         ): AvvistKlageFerdigData =
             AvvistKlageFerdigData(
                 innhold = innholdMedVedlegg.innhold(),
-                data = AvvistKlageInnholdBrevData.fra(generellBrevData),
+                data = AvvistKlageInnholdBrevData.fra(klage),
             )
     }
 }
@@ -30,8 +30,8 @@ data class AvvistKlageInnholdBrevData(
     val datoForVedtaketKlagenGjelder: LocalDate?,
 ) : BrevDataRedigerbar {
     companion object {
-        fun fra(generellBrevData: GenerellBrevData): AvvistKlageInnholdBrevData {
-            val klage = generellBrevData.forenkletVedtak?.klage ?: throw IllegalArgumentException("Vedtak mangler klage")
+        fun fra(muligKlage: Klage?): AvvistKlageInnholdBrevData {
+            val klage = muligKlage ?: throw IllegalArgumentException("Vedtak mangler klage")
             return AvvistKlageInnholdBrevData(
                 sakType = klage.sak.sakType,
                 klageDato = klage.innkommendeDokument?.mottattDato ?: klage.opprettet.toLocalDate(),

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadAvslag.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadAvslag.kt
@@ -1,6 +1,6 @@
 package no.nav.etterlatte.brev.model.oms
 
-import no.nav.etterlatte.brev.behandling.GenerellBrevData
+import no.nav.etterlatte.brev.behandling.Avdoed
 import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
 import no.nav.etterlatte.brev.model.BrevDataRedigerbar
 import no.nav.etterlatte.brev.model.Slate
@@ -12,11 +12,11 @@ data class OmstillingsstoenadAvslag(
 ) : BrevDataFerdigstilling {
     companion object {
         fun fra(
-            generellBrevData: GenerellBrevData,
             innhold: List<Slate.Element>,
+            utlandstilknytningType: UtlandstilknytningType?,
         ): OmstillingsstoenadAvslag =
             OmstillingsstoenadAvslag(
-                bosattUtland = generellBrevData.utlandstilknytning?.type == UtlandstilknytningType.BOSATT_UTLAND,
+                bosattUtland = utlandstilknytningType == UtlandstilknytningType.BOSATT_UTLAND,
                 innhold = innhold,
             )
     }
@@ -26,12 +26,10 @@ data class OmstillingsstoenadAvslagRedigerbartUtfall(
     val avdoedNavn: String,
 ) : BrevDataRedigerbar {
     companion object {
-        fun fra(generellBrevData: GenerellBrevData) =
+        fun fra(avdoede: List<Avdoed>) =
             OmstillingsstoenadAvslagRedigerbartUtfall(
                 avdoedNavn =
-                    generellBrevData.personerISak.avdoede
-                        .firstOrNull()
-                        ?.navn
+                    avdoede.firstOrNull()?.navn
                         ?: "<Klarte ikke å finne navn automatisk, du må sette inn her>",
             )
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInformasjonDoedsfall.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInformasjonDoedsfall.kt
@@ -1,6 +1,6 @@
 package no.nav.etterlatte.brev.model.oms
 
-import no.nav.etterlatte.brev.behandling.GenerellBrevData
+import no.nav.etterlatte.brev.behandling.Avdoed
 import no.nav.etterlatte.brev.model.BrevDataRedigerbar
 import no.nav.etterlatte.brev.model.BrevdataMedInnhold
 import no.nav.etterlatte.brev.model.Slate
@@ -13,15 +13,12 @@ class OmstillingsstoenadInformasjonDoedsfall(
     BrevdataMedInnhold {
     companion object {
         fun fra(
-            generellBrevData: GenerellBrevData,
             borIutland: Boolean,
+            avdoede: List<Avdoed>,
         ): OmstillingsstoenadInformasjonDoedsfall =
             OmstillingsstoenadInformasjonDoedsfall(
                 innhold = emptyList(),
-                avdoedNavn =
-                    generellBrevData.personerISak.avdoede
-                        .first()
-                        .navn,
+                avdoedNavn = avdoede.first().navn,
                 borIutland = borIutland,
             )
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelse.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelse.kt
@@ -34,11 +34,11 @@ data class OmstillingsstoenadInnvilgelse(
     companion object {
         fun fra(
             innholdMedVedlegg: InnholdMedVedlegg,
-            generellBrevData: GenerellBrevData,
             avkortingsinfo: Avkortingsinfo,
             etterbetaling: EtterbetalingDTO?,
             trygdetid: TrygdetidDto,
             vilkaarsVurdering: VilkaarsvurderingDto,
+            avdoede: List<Avdoed>,
         ): OmstillingsstoenadInnvilgelse {
             val beregningsperioder =
                 avkortingsinfo.beregningsperioder.map {
@@ -59,7 +59,7 @@ data class OmstillingsstoenadInnvilgelse(
                     )
                 }
 
-            val avdoed = generellBrevData.personerISak.avdoede.single()
+            val avdoed = avdoede.single()
             val sisteBeregningsperiode = beregningsperioder.maxBy { it.datoFOM }
 
             val omsRettUtenTidsbegrensning =
@@ -72,7 +72,7 @@ data class OmstillingsstoenadInnvilgelse(
 
             return OmstillingsstoenadInnvilgelse(
                 innhold = innholdMedVedlegg.innhold(),
-                avdoed = generellBrevData.personerISak.avdoede.minBy { it.doedsdato },
+                avdoed = avdoede.minBy { it.doedsdato },
                 beregning =
                     OmstillingsstoenadBeregning(
                         innhold = innholdMedVedlegg.finnVedlegg(BrevVedleggKey.OMS_BEREGNING),

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelse.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelse.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.brev.model.oms
 
 import no.nav.etterlatte.brev.behandling.Avdoed
 import no.nav.etterlatte.brev.behandling.Avkortingsinfo
-import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
 import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
 import no.nav.etterlatte.brev.model.BrevDataRedigerbar
@@ -108,14 +107,14 @@ data class OmstillingsstoenadInnvilgelseRedigerbartUtfall(
 ) : BrevDataRedigerbar {
     companion object {
         fun fra(
-            generellBrevData: GenerellBrevData,
             utbetalingsinfo: Utbetalingsinfo,
             avkortingsinfo: Avkortingsinfo,
             etterbetaling: EtterbetalingDTO?,
+            avdoede: List<Avdoed>,
         ): OmstillingsstoenadInnvilgelseRedigerbartUtfall =
             OmstillingsstoenadInnvilgelseRedigerbartUtfall(
                 virkningsdato = utbetalingsinfo.virkningsdato,
-                avdoed = generellBrevData.personerISak.avdoede.minBy { it.doedsdato },
+                avdoed = avdoede.minBy { it.doedsdato },
                 utbetalingsbeloep = avkortingsinfo.beregningsperioder.first().utbetaltBeloep,
                 etterbetaling = etterbetaling != null,
             )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadOpphoer.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadOpphoer.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.brev.model.oms
 
-import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
 import no.nav.etterlatte.brev.model.BrevDataRedigerbar
 import no.nav.etterlatte.brev.model.BrevVedleggKey
@@ -10,7 +9,6 @@ import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.brev.model.toFeilutbetalingType
 import no.nav.etterlatte.brev.model.vedleggHvisFeilutbetaling
 import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
-import no.nav.etterlatte.libs.common.behandling.Utlandstilknytning
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
 import java.time.LocalDate
 
@@ -24,9 +22,9 @@ data class OmstillingsstoenadOpphoer(
     companion object {
         fun fra(
             innholdMedVedlegg: InnholdMedVedlegg,
-            generellBrevData: GenerellBrevData,
-            utlandstilknytning: Utlandstilknytning?,
             brevutfall: BrevutfallDto,
+            virkningsdato: LocalDate?,
+            utlandstilknytningType: UtlandstilknytningType?,
         ): OmstillingsstoenadOpphoer {
             val feilutbetaling = toFeilutbetalingType(requireNotNull(brevutfall.feilutbetaling?.valg))
 
@@ -38,8 +36,8 @@ data class OmstillingsstoenadOpphoer(
                         innholdMedVedlegg,
                         BrevVedleggKey.OMS_FORHAANDSVARSEL_FEILUTBETALING,
                     ),
-                bosattUtland = utlandstilknytning?.type == UtlandstilknytningType.BOSATT_UTLAND,
-                virkningsdato = requireNotNull(generellBrevData.forenkletVedtak?.virkningstidspunkt?.atDay(1)),
+                bosattUtland = utlandstilknytningType == UtlandstilknytningType.BOSATT_UTLAND,
+                virkningsdato = requireNotNull(virkningsdato),
                 feilutbetaling = feilutbetaling,
             )
         }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/tilbakekreving/TilbakekrevingBrevData.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/tilbakekreving/TilbakekrevingBrevData.kt
@@ -1,7 +1,5 @@
 package no.nav.etterlatte.brev.model.tilbakekreving
 
-import no.nav.etterlatte.brev.behandling.GenerellBrevData
-import no.nav.etterlatte.brev.brevbaker.formaterNavn
 import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
 import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -25,20 +23,23 @@ data class TilbakekrevingBrevDTO(
 ) : BrevDataFerdigstilling {
     companion object {
         fun fra(
-            generellBrevData: GenerellBrevData,
             redigerbart: List<Slate.Element>,
+            muligTilbakekreving: Tilbakekreving?,
+            sakType: SakType,
+            utlandstilknytningType: UtlandstilknytningType?,
+            soekerNavn: String,
         ): TilbakekrevingBrevDTO {
             val tilbakekreving =
-                generellBrevData.forenkletVedtak?.tilbakekreving
+                muligTilbakekreving
                     ?: throw BrevDataTilbakerevingHarManglerException("Vedtak mangler tilbakekreving")
 
             val perioderSortert = tilbakekreving.perioder.sortedBy { it.maaned }
 
             return TilbakekrevingBrevDTO(
                 innhold = redigerbart,
-                sakType = generellBrevData.sak.sakType,
-                bosattUtland = generellBrevData.utlandstilknytning?.type == UtlandstilknytningType.BOSATT_UTLAND,
-                brukerNavn = generellBrevData.personerISak.soeker.formaterNavn(),
+                sakType = sakType,
+                bosattUtland = utlandstilknytningType == UtlandstilknytningType.BOSATT_UTLAND,
+                brukerNavn = soekerNavn,
                 doedsbo = tilbakekreving.vurdering?.doedsbosak == JaNei.JA,
                 varselVedlagt = tilbakekreving.vurdering?.forhaandsvarsel != null,
                 datoVarselEllerVedtak = requireNotNull(tilbakekreving.vurdering?.forhaandsvarselDato),

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
@@ -142,7 +142,7 @@ class OversendelseBrevServiceImpl(
         return pdfGenerator.genererPdf(
             id = brev.id,
             bruker = brukerTokenInfo,
-            avsenderRequest = { bruker, generellData -> AvsenderRequest(bruker.ident(), generellData.sak.enhet) },
+            avsenderRequest = { bruker, _, enhet -> AvsenderRequest(bruker.ident(), enhet) },
             brevKode = { Brevkoder.OVERSENDELSE_KLAGE },
             brevData = { req -> OversendelseBrevFerdigstillingData.fra(req, klage) },
         )
@@ -200,12 +200,7 @@ class OversendelseBrevServiceImpl(
                 pdfGenerator.ferdigstillOgGenererPDF(
                     id = brev.id,
                     bruker = brukerTokenInfo,
-                    avsenderRequest = { bruker, generellData ->
-                        AvsenderRequest(
-                            bruker.ident(),
-                            generellData.sak.enhet,
-                        )
-                    },
+                    avsenderRequest = { bruker, _, enhet -> AvsenderRequest(bruker.ident(), enhet) },
                     brevKode = { Brevkoder.OVERSENDELSE_KLAGE },
                     brevData = { req -> OversendelseBrevFerdigstillingData.fra(req, klage) },
                 )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
@@ -295,7 +295,7 @@ data class OversendelseBrevFerdigstillingData(
                 }
 
             return OversendelseBrevFerdigstillingData(
-                sakType = request.generellBrevData.sak.sakType,
+                sakType = request.sakType,
                 klageDato = klage.innkommendeDokument?.mottattDato ?: klage.opprettet.toLocalDate(),
                 vedtakDato =
                     checkNotNull(
@@ -308,8 +308,8 @@ data class OversendelseBrevFerdigstillingData(
                         "Klagen har en ugyldig referanse til når originalt vedtak ble attestert, klageId=${klage.id}"
                     },
                 innstillingTekst = innstilling.innstillingTekst,
-                under18Aar = request.generellBrevData.personerISak.soeker.under18 ?: false,
-                harVerge = request.generellBrevData.personerISak.verge != null,
+                under18Aar = request.soekerUnder18 ?: false,
+                harVerge = request.harVerge,
                 // TODO: støtte bosatt utland klage
                 bosattIUtlandet = false,
             )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
@@ -9,9 +9,13 @@ import no.nav.etterlatte.brev.VedtaksbrevKanIkkeSlettes
 import no.nav.etterlatte.brev.adresse.AdresseService
 import no.nav.etterlatte.brev.adresse.AvsenderRequest
 import no.nav.etterlatte.brev.behandling.PersonerISak
+import no.nav.etterlatte.brev.behandling.mapAvdoede
+import no.nav.etterlatte.brev.behandling.mapInnsender
+import no.nav.etterlatte.brev.behandling.mapSoeker
+import no.nav.etterlatte.brev.behandling.mapSpraak
 import no.nav.etterlatte.brev.db.BrevRepository
-import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.hentinformasjon.behandling.BehandlingService
+import no.nav.etterlatte.brev.hentinformasjon.grunnlag.GrunnlagService
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevDataFerdigstilling
@@ -23,6 +27,7 @@ import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.OpprettNyttBrev
 import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Slate
+import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.behandling.Klage
 import no.nav.etterlatte.libs.common.behandling.KlageUtfallMedData
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -67,8 +72,8 @@ class OversendelseBrevServiceImpl(
     private val brevRepository: BrevRepository,
     private val pdfGenerator: PDFGenerator,
     private val adresseService: AdresseService,
-    private val brevdataFacade: BrevdataFacade,
     private val behandlingService: BehandlingService,
+    private val grunnlagService: GrunnlagService,
 ) : OversendelseBrevService {
     override fun hentOversendelseBrev(behandlingId: UUID): Brev? =
         brevRepository.hentBrevForBehandling(behandlingId, Brevtype.OVERSENDELSE_KLAGE).singleOrNull()
@@ -85,14 +90,8 @@ class OversendelseBrevServiceImpl(
             return eksisterendeBrev
         }
         val klage = behandlingService.hentKlage(behandlingId, brukerTokenInfo)
+        val (spraak, personerISak) = hentSpraakOgPersonerISak(klage, brukerTokenInfo)
 
-        val generellBrevData =
-            brevdataFacade.hentGenerellBrevData(
-                sakId = klage.sak.id,
-                // Setter behandlingId som null for å unngå å hente en behandling med klageId'en
-                behandlingId = null,
-                brukerTokenInfo = brukerTokenInfo,
-            )
         val brev =
             brevRepository.opprettBrev(
                 OpprettNyttBrev(
@@ -100,18 +99,46 @@ class OversendelseBrevServiceImpl(
                     behandlingId = behandlingId,
                     soekerFnr = klage.sak.ident,
                     prosessType = BrevProsessType.AUTOMATISK,
-                    mottaker = finnMottaker(klage.sak.sakType, generellBrevData.personerISak),
+                    mottaker = finnMottaker(klage.sak.sakType, personerISak),
                     opprettet = Tidspunkt.now(),
                     innhold =
                         BrevInnhold(
                             tittel = EtterlatteBrevKode.KLAGE_OVERSENDELSE_BRUKER.tittel ?: "Klage oversendelse",
-                            spraak = generellBrevData.spraak,
+                            spraak = spraak,
                         ),
                     innholdVedlegg = listOf(),
                     brevtype = Brevtype.OVERSENDELSE_KLAGE,
                 ),
             )
         return brev
+    }
+
+    suspend fun hentSpraakOgPersonerISak(
+        klage: Klage,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Pair<Spraak, PersonerISak> {
+        val grunnlag =
+            grunnlagService.hentGrunnlag(
+                vedtakType = null,
+                sakId = klage.sak.id,
+                bruker = brukerTokenInfo,
+                // Setter behandlingId som null for å unngå å hente en behandling med klageId'en
+                behandlingId = null,
+            )
+        val verge =
+            grunnlagService.hentVergeForSak(
+                sakType = behandlingService.hentSak(klage.sak.id, brukerTokenInfo).sakType,
+                brevutfallDto = null,
+                grunnlag = grunnlag,
+            )
+        val personerISak =
+            PersonerISak(
+                innsender = grunnlag.mapInnsender(),
+                soeker = grunnlag.mapSoeker(null),
+                avdoede = grunnlag.mapAvdoede(),
+                verge = verge,
+            )
+        return Pair(grunnlag.mapSpraak(), personerISak)
     }
 
     override suspend fun pdf(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevRoute.kt
@@ -48,7 +48,7 @@ internal fun Route.varselbrevRoute(
                 logger.info("Oppretter varselbrev for behandling (sakId=$sakId, behandlingId=$behandlingId)")
 
                 measureTimedValue {
-                    service.opprettVarselbrev(sakId, behandlingId, brukerTokenInfo).brev
+                    service.opprettVarselbrev(sakId, behandlingId, brukerTokenInfo)
                 }.let { (brev, varighet) ->
                     logger.info("Oppretting av brev tok ${varighet.toString(DurationUnit.SECONDS, 2)}")
                     call.respond(HttpStatusCode.Created, brev)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
@@ -7,6 +7,7 @@ import no.nav.etterlatte.brev.Brevtype
 import no.nav.etterlatte.brev.PDFGenerator
 import no.nav.etterlatte.brev.adresse.AvsenderRequest
 import no.nav.etterlatte.brev.behandling.GenerellBrevData
+import no.nav.etterlatte.brev.behandling.opprettAvsenderRequest
 import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.hentinformasjon.behandling.BehandlingService
 import no.nav.etterlatte.brev.model.Brev
@@ -73,7 +74,12 @@ internal class VarselbrevService(
         brevId: BrevID,
         bruker: BrukerTokenInfo,
         avsenderRequest: (BrukerTokenInfo, GenerellBrevData) -> AvsenderRequest =
-            { brukerToken, generellBrevData -> generellBrevData.avsenderRequest(brukerToken) },
+            {
+                    brukerToken,
+                    generellBrevData,
+                ->
+                opprettAvsenderRequest(brukerToken, generellBrevData.forenkletVedtak, generellBrevData.sak.enhet)
+            },
     ) = pdfGenerator.ferdigstillOgGenererPDF(
         id = brevId,
         bruker = bruker,
@@ -89,7 +95,12 @@ internal class VarselbrevService(
         brevId: Long,
         bruker: BrukerTokenInfo,
         avsenderRequest: (BrukerTokenInfo, GenerellBrevData) -> AvsenderRequest =
-            { brukerToken, generellBrevData -> generellBrevData.avsenderRequest(brukerToken) },
+            {
+                    brukerToken,
+                    generellBrevData,
+                ->
+                opprettAvsenderRequest(brukerToken, generellBrevData.forenkletVedtak, generellBrevData.sak.enhet)
+            },
     ) = pdfGenerator.genererPdf(
         id = brevId,
         bruker = bruker,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
@@ -6,7 +6,7 @@ import no.nav.etterlatte.brev.Brevoppretter
 import no.nav.etterlatte.brev.Brevtype
 import no.nav.etterlatte.brev.PDFGenerator
 import no.nav.etterlatte.brev.adresse.AvsenderRequest
-import no.nav.etterlatte.brev.behandling.GenerellBrevData
+import no.nav.etterlatte.brev.behandling.ForenkletVedtak
 import no.nav.etterlatte.brev.behandling.opprettAvsenderRequest
 import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.hentinformasjon.behandling.BehandlingService
@@ -73,13 +73,8 @@ internal class VarselbrevService(
     suspend fun ferdigstillOgGenererPDF(
         brevId: BrevID,
         bruker: BrukerTokenInfo,
-        avsenderRequest: (BrukerTokenInfo, GenerellBrevData) -> AvsenderRequest =
-            {
-                    brukerToken,
-                    generellBrevData,
-                ->
-                opprettAvsenderRequest(brukerToken, generellBrevData.forenkletVedtak, generellBrevData.sak.enhet)
-            },
+        avsenderRequest: (BrukerTokenInfo, ForenkletVedtak?, String) -> AvsenderRequest =
+            { brukerToken, vedtak, enhet -> opprettAvsenderRequest(brukerToken, vedtak, enhet) },
     ) = pdfGenerator.ferdigstillOgGenererPDF(
         id = brevId,
         bruker = bruker,
@@ -94,13 +89,8 @@ internal class VarselbrevService(
     suspend fun genererPdf(
         brevId: Long,
         bruker: BrukerTokenInfo,
-        avsenderRequest: (BrukerTokenInfo, GenerellBrevData) -> AvsenderRequest =
-            {
-                    brukerToken,
-                    generellBrevData,
-                ->
-                opprettAvsenderRequest(brukerToken, generellBrevData.forenkletVedtak, generellBrevData.sak.enhet)
-            },
+        avsenderRequest: (BrukerTokenInfo, ForenkletVedtak?, String) -> AvsenderRequest =
+            { brukerToken, vedtak, enhet -> opprettAvsenderRequest(brukerToken, vedtak, enhet) },
     ) = pdfGenerator.genererPdf(
         id = brevId,
         bruker = bruker,
@@ -112,7 +102,3 @@ internal class VarselbrevService(
         brevData = { brevDataMapperFerdigstillVarsel.hentBrevDataFerdigstilling(it) },
     )
 }
-
-data class VarselbrevResponse(
-    val brev: Brev,
-)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
@@ -29,7 +29,7 @@ internal class VarselbrevService(
         sakId: Long,
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
-    ): VarselbrevResponse {
+    ): Brev {
         val sakType = behandlingService.hentSak(sakId, brukerTokenInfo).sakType
         val brevkode = hentBrevkode(sakType, behandlingId, brukerTokenInfo)
 
@@ -47,9 +47,7 @@ internal class VarselbrevService(
                     it.utlandstilknytningType,
                     it.revurderingsaarsak,
                 )
-            }.let {
-                VarselbrevResponse(it.first, it.second, brevkode)
-            }
+            }.first
     }
 
     private suspend fun hentBrevkode(
@@ -106,6 +104,4 @@ internal class VarselbrevService(
 
 data class VarselbrevResponse(
     val brev: Brev,
-    val generellBrevData: GenerellBrevData,
-    val brevkoder: Brevkoder,
 )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/FerdigstillJournalfoerOgDistribuerBrev.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/FerdigstillJournalfoerOgDistribuerBrev.kt
@@ -33,7 +33,7 @@ class FerdigstillJournalfoerOgDistribuerBrev(
             pdfGenerator.ferdigstillOgGenererPDF(
                 id = brevId,
                 bruker = brukerTokenInfo,
-                avsenderRequest = { _, _ ->
+                avsenderRequest = { _, _, _ ->
                     AvsenderRequest(
                         saksbehandlerIdent = Fagsaksystem.EY.navn,
                         sakenhet = brevOgData.second.sak.enhet,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/FerdigstillJournalfoerOgDistribuerBrev.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/FerdigstillJournalfoerOgDistribuerBrev.kt
@@ -4,9 +4,7 @@ import no.nav.etterlatte.brev.Brevkoder
 import no.nav.etterlatte.brev.JournalfoerBrevService
 import no.nav.etterlatte.brev.PDFGenerator
 import no.nav.etterlatte.brev.adresse.AvsenderRequest
-import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.distribusjon.Brevdistribuerer
-import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevID
 import no.nav.etterlatte.brev.model.ManueltBrevMedTittelData
 import no.nav.etterlatte.libs.common.retryOgPakkUt
@@ -24,11 +22,11 @@ class FerdigstillJournalfoerOgDistribuerBrev(
     suspend fun ferdigstillOgGenererPDF(
         brevKode: Brevkoder,
         sakId: Long,
-        brevOgData: Pair<Brev, GenerellBrevData>,
         brukerTokenInfo: BrukerTokenInfo,
+        enhet: String,
+        brevId: BrevID,
     ): BrevID {
         logger.info("Ferdigstiller $brevKode-brev i sak $sakId")
-        val brevId = brevOgData.first.id
         retryOgPakkUt {
             pdfGenerator.ferdigstillOgGenererPDF(
                 id = brevId,
@@ -36,7 +34,7 @@ class FerdigstillJournalfoerOgDistribuerBrev(
                 avsenderRequest = { _, _, _ ->
                     AvsenderRequest(
                         saksbehandlerIdent = Fagsaksystem.EY.navn,
-                        sakenhet = brevOgData.second.sak.enhet,
+                        sakenhet = enhet,
                         attestantIdent = Fagsaksystem.EY.navn,
                     )
                 },

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
@@ -164,13 +164,13 @@ class OpprettJournalfoerOgDistribuerRiver(
         sakId: Long,
         borIutland: Boolean,
     ) = OmstillingsstoenadInformasjonDoedsfall.fra(
-        generellBrevData =
-            brevdataFacade.hentGenerellBrevData(
+        borIutland,
+        brevdataFacade
+            .hentGenerellBrevData(
                 sakId = sakId,
                 behandlingId = null,
                 brukerTokenInfo = Systembruker.brev,
-            ),
-        borIutland,
+            ).personerISak.avdoede,
     )
 }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
@@ -7,7 +7,8 @@ import no.nav.etterlatte.brev.BrevRequestHendelseType
 import no.nav.etterlatte.brev.Brevkoder
 import no.nav.etterlatte.brev.Brevoppretter
 import no.nav.etterlatte.brev.EtterlatteBrevKode
-import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
+import no.nav.etterlatte.brev.behandling.Avdoed
+import no.nav.etterlatte.brev.hentinformasjon.grunnlag.GrunnlagService
 import no.nav.etterlatte.brev.model.BrevID
 import no.nav.etterlatte.brev.model.ManueltBrevData
 import no.nav.etterlatte.brev.model.bp.BarnepensjonInformasjonDoedsfall
@@ -36,7 +37,7 @@ class OpprettJournalfoerOgDistribuerRiverException(
 
 class OpprettJournalfoerOgDistribuerRiver(
     private val rapidsConnection: RapidsConnection,
-    private val brevdataFacade: BrevdataFacade,
+    private val grunnlagService: GrunnlagService,
     private val brevoppretter: Brevoppretter,
     private val ferdigstillJournalfoerOgDistribuerBrev: FerdigstillJournalfoerOgDistribuerBrev,
 ) : ListenerMedLoggingOgFeilhaandtering() {
@@ -153,12 +154,7 @@ class OpprettJournalfoerOgDistribuerRiver(
     ) = BarnepensjonInformasjonDoedsfall.fra(
         borIutland,
         erOver18aar,
-        brevdataFacade
-            .hentGenerellBrevData(
-                sakId = sakId,
-                behandlingId = null,
-                brukerTokenInfo = Systembruker.brev,
-            ).personerISak.avdoede,
+        hentAvdoede(sakId),
     )
 
     private suspend fun opprettOmstillingsstoenadInformasjonDoedsfall(
@@ -166,13 +162,11 @@ class OpprettJournalfoerOgDistribuerRiver(
         borIutland: Boolean,
     ) = OmstillingsstoenadInformasjonDoedsfall.fra(
         borIutland,
-        brevdataFacade
-            .hentGenerellBrevData(
-                sakId = sakId,
-                behandlingId = null,
-                brukerTokenInfo = Systembruker.brev,
-            ).personerISak.avdoede,
+        hentAvdoede(sakId),
     )
+
+    private suspend fun hentAvdoede(sakId: Long): List<Avdoed> =
+        grunnlagService.hentPersonerISak(grunnlagService.hentGrunnlagForSak(sakId, Systembruker.brev), null, null).avdoede
 }
 
 private fun JsonMessage.hentVerdiEllerKastFeil(key: String): String {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
@@ -112,8 +112,9 @@ class OpprettJournalfoerOgDistribuerRiver(
             ferdigstillJournalfoerOgDistribuerBrev.ferdigstillOgGenererPDF(
                 brevKode,
                 sakId,
-                brevOgData,
                 brukerTokenInfo,
+                brevOgData.second,
+                brevOgData.first.id,
             )
         ferdigstillJournalfoerOgDistribuerBrev.journalfoerOgDistribuer(
             brevKode,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
@@ -150,14 +150,14 @@ class OpprettJournalfoerOgDistribuerRiver(
         borIutland: Boolean,
         erOver18aar: Boolean,
     ) = BarnepensjonInformasjonDoedsfall.fra(
-        generellBrevData =
-            brevdataFacade.hentGenerellBrevData(
+        borIutland,
+        erOver18aar,
+        brevdataFacade
+            .hentGenerellBrevData(
                 sakId = sakId,
                 behandlingId = null,
                 brukerTokenInfo = Systembruker.brev,
-            ),
-        borIutland,
-        erOver18aar,
+            ).personerISak.avdoede,
     )
 
     private suspend fun opprettOmstillingsstoenadInformasjonDoedsfall(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -129,7 +129,7 @@ internal class VedtaksbrevServiceTest {
             brevKodeMapperVedtak,
             brevoppretter,
             pdfGenerator,
-            BrevDataMapperRedigerbartUtfallVedtak(brevdataFacade, behandlingService, beregningService, migreringBrevDataService),
+            BrevDataMapperRedigerbartUtfallVedtak(behandlingService, beregningService, migreringBrevDataService),
             brevDataMapperFerdigstilling,
             behandlingService,
         )

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -119,7 +119,6 @@ internal class VedtaksbrevServiceTest {
                 trygdetidService,
                 behandlingService,
                 vilkaarsvurderingService,
-                brevdataFacade,
             ),
         )
     private val vedtaksbrevService =

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/tilbakekreving/TilbakekrevingInnholdDTOTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/tilbakekreving/TilbakekrevingInnholdDTOTest.kt
@@ -7,6 +7,7 @@ import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.behandling.Innsender
 import no.nav.etterlatte.brev.behandling.PersonerISak
 import no.nav.etterlatte.brev.behandling.Soeker
+import no.nav.etterlatte.brev.brevbaker.formaterNavn
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -26,7 +27,14 @@ import java.util.UUID
 class TilbakekrevingInnholdDTOTest {
     @Test
     fun `skal inneholde saktype`() {
-        TilbakekrevingBrevDTO.fra(brevData(), emptyList()).sakType shouldBe SakType.OMSTILLINGSSTOENAD
+        TilbakekrevingBrevDTO
+            .fra(
+                emptyList(),
+                brevData().forenkletVedtak?.tilbakekreving,
+                brevData().sak.sakType,
+                brevData().utlandstilknytning?.type,
+                brevData().personerISak.soeker.formaterNavn(),
+            ).sakType shouldBe SakType.OMSTILLINGSSTOENAD
     }
 
     @Test
@@ -46,7 +54,14 @@ class TilbakekrevingInnholdDTOTest {
                     ),
             )
 
-        val data = TilbakekrevingBrevDTO.fra(brevData, emptyList())
+        val data =
+            TilbakekrevingBrevDTO.fra(
+                emptyList(),
+                brevData.forenkletVedtak?.tilbakekreving,
+                brevData.sak.sakType,
+                brevData.utlandstilknytning?.type,
+                brevData.personerISak.soeker.formaterNavn(),
+            )
 
         data.tilbakekreving.perioder.size shouldBe 1
         with(data.tilbakekreving.perioder[0]) {
@@ -86,7 +101,14 @@ class TilbakekrevingInnholdDTOTest {
                         ),
                     ),
             )
-        TilbakekrevingBrevDTO.fra(brevData, emptyList()).tilbakekreving.summer shouldBe
+        TilbakekrevingBrevDTO
+            .fra(
+                emptyList(),
+                brevData.forenkletVedtak?.tilbakekreving,
+                brevData.sak.sakType,
+                brevData.utlandstilknytning?.type,
+                brevData.personerISak.soeker.formaterNavn(),
+            ).tilbakekreving.summer shouldBe
             TilbakekrevingBeloeperData(
                 feilutbetaling = Kroner(200),
                 bruttoTilbakekreving = Kroner(400),

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevServiceImplTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevServiceImplTest.kt
@@ -18,6 +18,7 @@ import no.nav.etterlatte.brev.behandling.Soeker
 import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.hentinformasjon.behandling.BehandlingService
+import no.nav.etterlatte.brev.hentinformasjon.grunnlag.GrunnlagService
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Spraak
@@ -31,6 +32,8 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
+import no.nav.etterlatte.libs.testdata.grunnlag.INNSENDER_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import org.junit.jupiter.api.BeforeEach
@@ -52,6 +55,7 @@ class OversendelseBrevServiceImplTest(
     private val saksbehandler = BrukerTokenInfo.of("token", "saksbehandler", null, null, null)
     private val brevdataFacade = mockk<BrevdataFacade>()
     private val adresseService = mockk<AdresseService>()
+    private val grunnlagService = mockk<GrunnlagService>()
     private val brevRepository = spyk(BrevRepository(dataSource))
     private val behandlingService = mockk<BehandlingService>()
     private val service =
@@ -59,8 +63,8 @@ class OversendelseBrevServiceImplTest(
             brevRepository,
             mockk(),
             adresseService,
-            brevdataFacade,
             behandlingService,
+            grunnlagService,
         )
 
     @BeforeEach
@@ -73,10 +77,26 @@ class OversendelseBrevServiceImplTest(
 
     @Test
     fun `slett oversendelsesbrev`() {
-        runBlocking { service.opprettOversendelseBrev(behandlingId, saksbehandler) }
+        val serviceSpy =
+            spyk(service).also {
+                coEvery { it.hentSpraakOgPersonerISak(any(), any()) } returns
+                    Pair(
+                        Spraak.NN,
+                        PersonerISak(
+                            innsender = Innsender(Foedselsnummer(INNSENDER_FOEDSELSNUMMER.value)),
+                            soeker = Soeker("GRØNN", "MELLOMNAVN", "KOPP", Foedselsnummer(SOEKER_FOEDSELSNUMMER.value)),
+                            avdoede =
+                                listOf(
+                                    Avdoed(Foedselsnummer(AVDOED_FOEDSELSNUMMER.value), "DØD TESTPERSON", LocalDate.now().minusMonths(1)),
+                                ),
+                            verge = null,
+                        ),
+                    )
+            }
+        runBlocking { serviceSpy.opprettOversendelseBrev(behandlingId, saksbehandler) }
         val oversendelsesbrev = brevRepository.hentBrevForBehandling(behandlingId, Brevtype.OVERSENDELSE_KLAGE).single()
 
-        runBlocking { service.slettOversendelseBrev(behandlingId, saksbehandler) }
+        runBlocking { serviceSpy.slettOversendelseBrev(behandlingId, saksbehandler) }
 
         brevRepository.hentBrevForBehandling(behandlingId, Brevtype.OVERSENDELSE_KLAGE) shouldBe emptyList()
         verify { brevRepository.settBrevSlettet(oversendelsesbrev.id, any()) }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
@@ -133,6 +133,6 @@ class VarselbrevTest(
             }
 
         val henta = service.hentVarselbrev(behandling)
-        assertEquals(varselbrev.brev, henta.first())
+        assertEquals(varselbrev, henta.first())
     }
 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/InformasjonsbrevTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/InformasjonsbrevTest.kt
@@ -67,7 +67,7 @@ class InformasjonsbrevTest(
                         any(),
                         any(),
                     )
-                } returns Pair(mockk<Brev>().also { every { it.id } returns brevId }, mockk())
+                } returns Pair(mockk<Brev>().also { every { it.id } returns brevId }, "enhet1")
             }
         val pdfGenerator =
             mockk<PDFGenerator>().also {

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/InformasjonsbrevTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/InformasjonsbrevTest.kt
@@ -13,7 +13,7 @@ import no.nav.etterlatte.brev.DatabaseExtension
 import no.nav.etterlatte.brev.JournalfoerBrevService
 import no.nav.etterlatte.brev.PDFGenerator
 import no.nav.etterlatte.brev.distribusjon.Brevdistribuerer
-import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
+import no.nav.etterlatte.brev.hentinformasjon.grunnlag.GrunnlagService
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.rapidsandrivers.SAK_TYPE_KEY
@@ -89,7 +89,7 @@ class InformasjonsbrevTest(
         val brevdistribuerer = mockk<Brevdistribuerer>().also { every { it.distribuer(brevId) } returns "" }
         OpprettJournalfoerOgDistribuerRiver(
             testRapid,
-            mockk<BrevdataFacade>(),
+            mockk<GrunnlagService>(),
             brevoppretter,
             FerdigstillJournalfoerOgDistribuerBrev(
                 pdfGenerator,


### PR DESCRIPTION
Trur dette er nest siste PR. Gjenståande etter denne:

- fase ut også frå RedigerbarVedleggHenter. Bør komme etter #5347 er merga inn for å unngå krøll
- flytt DTO-ar frå `Behandling.kt` og over til plassar dei høyrer meir heime (feks dei beregningsrelevante til beregning)
- døpe om _brevData_ til _brevDataMapper_ og tilsvarande for brevkode
- og så er det noko med pakkestrukturen som kjens litt off, men eg klarer ikkje heilt å setje fingeren på kva