### PR TITLE
EY-4102: Endepunkt og databaseoppsett for videreført opphør

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
@@ -139,6 +139,11 @@ interface BehandlingService {
         utlandstilknytning: Utlandstilknytning,
     )
 
+    fun oppdaterViderefoertOpphoer(
+        behandlingId: UUID,
+        viderefoertOpphoer: ViderefoertOpphoer,
+    )
+
     fun oppdaterBoddEllerArbeidetUtlandet(
         behandlingId: UUID,
         boddEllerArbeidetUtlandet: BoddEllerArbeidetUtlandet,
@@ -705,6 +710,22 @@ internal class BehandlingServiceImpl(
             .oppdaterUtlandstilknytning(utlandstilknytning)
             .also {
                 behandlingDao.lagreUtlandstilknytning(behandlingId, utlandstilknytning)
+                behandlingDao.lagreStatus(it)
+            }
+    }
+
+    override fun oppdaterViderefoertOpphoer(
+        behandlingId: UUID,
+        viderefoertOpphoer: ViderefoertOpphoer,
+    ) {
+        val behandling =
+            hentBehandling(behandlingId)
+                ?: throw InternfeilException("Kunne ikke oppdatere videreført opphør fordi behandlingen ikke finnes")
+
+        behandling
+            .oppdaterVidereførtOpphoer(viderefoertOpphoer)
+            .also {
+                behandlingDao.lagreViderefoertOpphoer(behandlingId, viderefoertOpphoer)
                 behandlingDao.lagreStatus(it)
             }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.behandling.domain
 
 import no.nav.etterlatte.behandling.BehandlingSammendrag
+import no.nav.etterlatte.behandling.ViderefoertOpphoer
 import no.nav.etterlatte.behandling.revurdering.RevurderingInfoMedBegrunnelse
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
@@ -102,6 +103,12 @@ sealed class Behandling {
         throw NotImplementedError(
             "Kan ikke oppdatere utlandstilknytning på behandling $id. " +
                 "Denne behandlingstypen støtter ikke oppdatering av utlandstilknyting.",
+        )
+
+    open fun oppdaterVidereførtOpphoer(viderefoertOpphoer: ViderefoertOpphoer): Behandling =
+        throw NotImplementedError(
+            "Kan ikke oppdatere videreført opphør på behandling $id. " +
+                "Denne behandlingstypen støtter ikke oppdatering av videreført opphør.",
         )
 
     protected fun <T : Behandling> hvisRedigerbar(block: () -> T): T {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Foerstegangsbehandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Foerstegangsbehandling.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.behandling.domain
 
+import no.nav.etterlatte.behandling.ViderefoertOpphoer
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
@@ -56,6 +57,11 @@ data class Foerstegangsbehandling(
     override fun oppdaterUtlandstilknytning(utlandstilknytning: Utlandstilknytning) =
         hvisRedigerbar {
             endreTilStatus(BehandlingStatus.OPPRETTET).copy(utlandstilknytning = utlandstilknytning)
+        }
+
+    override fun oppdaterVidereførtOpphoer(viderefoertOpphoer: ViderefoertOpphoer) =
+        hvisRedigerbar {
+            endreTilStatus(BehandlingStatus.OPPRETTET).copy(opphoerFraOgMed = viderefoertOpphoer.dato)
         }
 
     override fun oppdaterBoddEllerArbeidetUtlandnet(boddEllerArbeidetUtlandet: BoddEllerArbeidetUtlandet) =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ManuellRevurdering.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ManuellRevurdering.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.behandling.domain
 
+import no.nav.etterlatte.behandling.ViderefoertOpphoer
 import no.nav.etterlatte.behandling.revurdering.RevurderingInfoMedBegrunnelse
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
@@ -70,6 +71,11 @@ data class ManuellRevurdering(
     override fun oppdaterUtlandstilknytning(utlandstilknytning: Utlandstilknytning) =
         hvisRedigerbar {
             endreTilStatus(BehandlingStatus.OPPRETTET).copy(utlandstilknytning = utlandstilknytning)
+        }
+
+    override fun oppdaterVidereførtOpphoer(viderefoertOpphoer: ViderefoertOpphoer) =
+        hvisRedigerbar {
+            endreTilStatus(BehandlingStatus.OPPRETTET).copy(opphoerFraOgMed = viderefoertOpphoer.dato)
         }
 
     override fun tilOpprettet() = hvisRedigerbar { endreTilStatus(BehandlingStatus.OPPRETTET) }

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V142__viderefoert_opphoer-tabell.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V142__viderefoert_opphoer-tabell.sql
@@ -1,0 +1,12 @@
+CREATE TABLE viderefoert_opphoer
+(
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    dato          TEXT NOT NULL,
+    behandling_id UUID UNIQUE NOT NULL,
+    opprettet     TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    vilkaar       TEXT NOT NULL,
+    kilde         jsonb,
+    kravdato      date,
+    begrunnelse   TEXT,
+    CONSTRAINT fk_behandling_id FOREIGN KEY (behandling_id) REFERENCES behandling (id)
+);

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/ViderefoertOpphoerTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/ViderefoertOpphoerTest.kt
@@ -1,0 +1,80 @@
+package no.nav.etterlatte.behandling
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.etterlatte.ConnectionAutoclosingTest
+import no.nav.etterlatte.DatabaseContextTest
+import no.nav.etterlatte.DatabaseExtension
+import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
+import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeDao
+import no.nav.etterlatte.common.Enheter
+import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
+import no.nav.etterlatte.nyKontekstMedBrukerOgDatabaseContext
+import no.nav.etterlatte.opprettBehandling
+import no.nav.etterlatte.sak.SakDao
+import no.nav.etterlatte.tilgangsstyring.SaksbehandlerMedRoller
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.Month
+import java.time.YearMonth
+import javax.sql.DataSource
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseExtension::class)
+class ViderefoertOpphoerTest(
+    private val dataSource: DataSource,
+) {
+    @Test
+    fun `lagrer viderefoert opphoer`() {
+        val user = mockk<SaksbehandlerMedEnheterOgRoller>()
+        val saksbehandlerMedRoller =
+            mockk<SaksbehandlerMedRoller> {
+                every { harRolleStrengtFortrolig() } returns false
+                every { harRolleEgenAnsatt() } returns true
+            }
+        every { user.saksbehandlerMedRoller } returns saksbehandlerMedRoller
+        every { user.name() } returns "User"
+        nyKontekstMedBrukerOgDatabaseContext(user, DatabaseContextTest(dataSource))
+        val connection = ConnectionAutoclosingTest(dataSource)
+        val kommerBarnetTilGodeDao =
+            mockk<KommerBarnetTilGodeDao>().also { every { it.hentKommerBarnetTilGode(any()) } returns null }
+        val dao = BehandlingDao(kommerBarnetTilGodeDao, mockk(), connection)
+        val service =
+            BehandlingServiceImpl(
+                behandlingDao = dao,
+                behandlingHendelser = mockk(),
+                grunnlagsendringshendelseDao = mockk(),
+                hendelseDao = mockk(),
+                grunnlagKlient = mockk(),
+                behandlingRequestLogger = mockk(),
+                kommerBarnetTilGodeDao = kommerBarnetTilGodeDao,
+                oppgaveService = mockk(),
+                grunnlagService = mockk(),
+                beregningKlient = mockk(),
+            )
+        val sak =
+            SakDao(connection).opprettSak(
+                SOEKER_FOEDSELSNUMMER.value,
+                SakType.BARNEPENSJON,
+                Enheter.defaultEnhet.enhetNr,
+            )
+        val opprettBehandling = opprettBehandling(type = BehandlingType.FØRSTEGANGSBEHANDLING, sakId = sak.id)
+        dao.opprettBehandling(behandling = opprettBehandling)
+        service.oppdaterViderefoertOpphoer(
+            behandlingId = opprettBehandling.id,
+            viderefoertOpphoer =
+                ViderefoertOpphoer(
+                    behandlingId = opprettBehandling.id,
+                    dato = YearMonth.of(2024, Month.JUNE),
+                    begrunnelse = "for testformål",
+                    vilkaar = "BP_FORMAAL_2024",
+                    kilde = Grunnlagsopplysning.Saksbehandler.create("A123"),
+                    kravdato = null,
+                ),
+        )
+    }
+}


### PR DESCRIPTION
Jobbar også med frontend-biten, men for å få testa den trengs opppsettet i backend, så kan jo like godt ta backend-delen her først.

Lagrar vidareført opphør i databasen.

Lagrar ned også vilkåret som ikkje lenger er oppfylt

Opphør fom vi skal lagre på behandlinga her er jo eigentleg akkurat samme som for vanleg opphør, så gjenbruker samme dao-metode.