### PR TITLE
FAGSYSTEM-338004: Ikkje hent utbetalingsinfo for varselbrev viss det er avslag

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -195,7 +195,8 @@ class ApplicationBuilder {
             brevDataMapperFerdigstilling,
             behandlingService,
         )
-    private val brevDataMapperFerdigstillVarsel = BrevDataMapperFerdigstillVarsel(beregningService, trygdetidService)
+    private val brevDataMapperFerdigstillVarsel =
+        BrevDataMapperFerdigstillVarsel(beregningService, trygdetidService, vilkaarsvurderingService)
 
     private val varselbrevService =
         VarselbrevService(db, brevoppretter, behandlingService, pdfGenerator, brevDataMapperFerdigstillVarsel)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonVarsel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonVarsel.kt
@@ -7,7 +7,7 @@ import no.nav.etterlatte.brev.model.Slate
 
 data class BarnepensjonVarsel(
     override val innhold: List<Slate.Element>,
-    val beregning: BarnepensjonBeregning,
+    val beregning: BarnepensjonBeregning?,
     val erUnder18Aar: Boolean,
     val erBosattUtlandet: Boolean,
 ) : BrevDataFerdigstilling

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/BrevDataMapperFerdigstillVarsel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/BrevDataMapperFerdigstillVarsel.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.coroutineScope
 import no.nav.etterlatte.brev.EtterlatteBrevKode
 import no.nav.etterlatte.brev.hentinformasjon.beregning.BeregningService
 import no.nav.etterlatte.brev.hentinformasjon.trygdetid.TrygdetidService
+import no.nav.etterlatte.brev.hentinformasjon.vilkaarsvurdering.VilkaarsvurderingService
 import no.nav.etterlatte.brev.model.BarnepensjonBeregning
 import no.nav.etterlatte.brev.model.BrevDataFerdigstillingRequest
 import no.nav.etterlatte.brev.model.ManueltBrevMedTittelData
@@ -15,12 +16,14 @@ import no.nav.etterlatte.brev.model.oms.OmstillingsstoenadAktivitetspliktVarsel
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import java.time.YearMonth
 import java.util.UUID
 
 class BrevDataMapperFerdigstillVarsel(
     private val beregningService: BeregningService,
     private val trygdetidService: TrygdetidService,
+    private val vilkaarsvurderingService: VilkaarsvurderingService,
 ) {
     suspend fun hentBrevDataFerdigstilling(request: BrevDataFerdigstillingRequest) =
         coroutineScope {
@@ -47,13 +50,22 @@ class BrevDataMapperFerdigstillVarsel(
     private suspend fun hentBrevDataFerdigstillingBarnepensjon(request: BrevDataFerdigstillingRequest) =
         coroutineScope {
             val behandlingId = requireNotNull(request.behandlingId)
+            val beregning =
+                if (hentUtfall(request) == VilkaarsvurderingUtfall.IKKE_OPPFYLT) {
+                    null
+                } else {
+                    hentBeregning(behandlingId, request)
+                }
             BarnepensjonVarsel(
                 innhold = request.innholdMedVedlegg.innhold(),
-                beregning = hentBeregning(behandlingId, request),
+                beregning = beregning,
                 erUnder18Aar = request.soekerUnder18 ?: true,
                 erBosattUtlandet = request.utlandstilknytningType == UtlandstilknytningType.BOSATT_UTLAND,
             )
         }
+
+    private suspend fun hentUtfall(request: BrevDataFerdigstillingRequest) =
+        vilkaarsvurderingService.hentVilkaarsvurdering(request.behandlingId!!, request.bruker).resultat?.utfall
 
     private suspend fun hentBeregning(
         behandlingId: UUID,


### PR DESCRIPTION
Når vi no gjer så beregningsvedlegget i varselmalen ikkje blir med viss det er avslag, så kan vi også unngå å hente inn beregningsinformasjonen generelt for avslag. Da omgår vi også alle problema med denne datainnhentinga

FAGSYSTEM-338004


Obs: Heng saman med https://github.com/navikt/pensjonsbrev/pull/811 - så ta QA på denne samtidig.