### PR TITLE
EY-4211: Førebuing del 2 av 2: Tar i bruk hjelpemetode for å opprette saksbehandler

### DIFF
--- a/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
@@ -19,6 +19,7 @@ import no.nav.etterlatte.behandling.revurdering.RevurderingInfoMedBegrunnelse
 import no.nav.etterlatte.common.DatabaseContext
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.grunnlagsendring.samsvarDoedsdatoer
+import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
@@ -53,7 +54,6 @@ import no.nav.etterlatte.libs.common.person.VergemaalEllerFremtidsfullmakt
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import no.nav.etterlatte.sak.SakMedGraderingOgSkjermet
 import no.nav.etterlatte.sak.SakTilgangDao
@@ -158,7 +158,7 @@ fun mockSaksbehandler(
     mockk<SaksbehandlerMedEnheterOgRoller> {
         every { saksbehandlerMedRoller } returns
             mockk<SaksbehandlerMedRoller> {
-                every { saksbehandler } returns Saksbehandler("accessToken", ident, null)
+                every { saksbehandler } returns simpleSaksbehandler()
                 every { harRolleAttestant() } returns harRolleAttestant
                 every { harRolleStrengtFortrolig() } returns harRolleStrengtFortrolig
                 every { harRolleEgenAnsatt() } returns harRolleEgenAnsatt

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
@@ -30,6 +30,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tilbakekreving.Tilbakekreving
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingBehandling
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingStatus
+import no.nav.etterlatte.libs.ktor.token.Claims
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.opprettBehandling
 import no.nav.etterlatte.person.krr.KrrKlient
@@ -116,7 +117,7 @@ internal class TilgangServiceTest(
 
         val saksbehandlerMedStrengtfortrolig =
             SaksbehandlerMedRoller(
-                simpleSaksbehandler(ident = "ident", claims = mapOf("groups" to azureAdStrengtFortroligClaim)),
+                simpleSaksbehandler(ident = "ident", claims = mapOf(Claims.groups to azureAdStrengtFortroligClaim)),
                 mapOf(AzureGroup.STRENGT_FORTROLIG to azureAdStrengtFortroligClaim),
             )
         sakService.oppdaterAdressebeskyttelse(sak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
@@ -133,7 +134,7 @@ internal class TilgangServiceTest(
 
         val saksbehandlerUtenStrengtFortrolig =
             SaksbehandlerMedRoller(
-                simpleSaksbehandler(ident = "annenIdent", claims = mapOf("groups" to azureAdStrengtFortroligClaim)),
+                simpleSaksbehandler(ident = "annenIdent", claims = mapOf(Claims.groups to azureAdStrengtFortroligClaim)),
                 mapOf(),
             )
         val harTilgangStrengtFortroligBehandling =
@@ -165,7 +166,7 @@ internal class TilgangServiceTest(
 
         val saksbehandlerMedStrengtfortrolig =
             SaksbehandlerMedRoller(
-                simpleSaksbehandler(ident = "ident", claims = mapOf("groups" to azureAdStrengtFortroligClaim)),
+                simpleSaksbehandler(ident = "ident", claims = mapOf(Claims.groups to azureAdStrengtFortroligClaim)),
                 mapOf(AzureGroup.STRENGT_FORTROLIG to azureAdStrengtFortroligClaim),
             )
         sakService.oppdaterAdressebeskyttelse(sak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
@@ -182,7 +183,7 @@ internal class TilgangServiceTest(
 
         val saksbehandlerUtenStrengtFortrolig =
             SaksbehandlerMedRoller(
-                simpleSaksbehandler(ident = "annenIdent", claims = mapOf("groups" to azureAdStrengtFortroligClaim)),
+                simpleSaksbehandler(ident = "annenIdent", claims = mapOf(Claims.groups to azureAdStrengtFortroligClaim)),
                 mapOf(),
             )
         val harTilgangStrengtFortroligBehandling =
@@ -221,7 +222,7 @@ internal class TilgangServiceTest(
 
         val saksbehandlerMedStrengtfortrolig =
             SaksbehandlerMedRoller(
-                simpleSaksbehandler(claims = mapOf("groups" to azureAdStrengtFortroligClaim)),
+                simpleSaksbehandler(claims = mapOf(Claims.groups to azureAdStrengtFortroligClaim)),
                 mapOf(AzureGroup.STRENGT_FORTROLIG to azureAdStrengtFortroligClaim),
             )
         sakService.oppdaterAdressebeskyttelse(sakId, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
@@ -242,7 +243,7 @@ internal class TilgangServiceTest(
 
         val saksbehandlerMedFortrolig =
             SaksbehandlerMedRoller(
-                simpleSaksbehandler(claims = mapOf("groups" to azureAdFortroligClaim)),
+                simpleSaksbehandler(claims = mapOf(Claims.groups to azureAdFortroligClaim)),
                 mapOf(AzureGroup.FORTROLIG to azureAdFortroligClaim),
             )
         val harTilgangTilBehandlingSomfortrolig =
@@ -260,7 +261,7 @@ internal class TilgangServiceTest(
         val sakId = sakRepo.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.EGNE_ANSATTE.enhetNr).id
         val saksbehandlerMedStrengtfortrolig =
             SaksbehandlerMedRoller(
-                simpleSaksbehandler(claims = mapOf("groups" to azureAdStrengtFortroligClaim)),
+                simpleSaksbehandler(claims = mapOf(Claims.groups to azureAdStrengtFortroligClaim)),
                 mapOf(AzureGroup.STRENGT_FORTROLIG to azureAdStrengtFortroligClaim),
             )
 
@@ -290,7 +291,7 @@ internal class TilgangServiceTest(
 
         val saksbehandlerMedEgenansatt =
             SaksbehandlerMedRoller(
-                simpleSaksbehandler(claims = mapOf("groups" to azureAdEgenAnsattClaim)),
+                simpleSaksbehandler(claims = mapOf(Claims.groups to azureAdEgenAnsattClaim)),
                 mapOf(AzureGroup.EGEN_ANSATT to azureAdEgenAnsattClaim),
             )
         val harTilgangTilBehandlingMedEgenAnsattRolle =

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
@@ -20,6 +20,7 @@ import no.nav.etterlatte.behandling.tilbakekreving.TilbakekrevingDao
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.common.klienter.PdlTjenesterKlient
 import no.nav.etterlatte.common.klienter.SkjermingKlient
+import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.InnkommendeKlage
 import no.nav.etterlatte.libs.common.behandling.Klage
@@ -29,7 +30,6 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tilbakekreving.Tilbakekreving
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingBehandling
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingStatus
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.opprettBehandling
 import no.nav.etterlatte.person.krr.KrrKlient
@@ -41,7 +41,6 @@ import no.nav.etterlatte.sak.TilgangService
 import no.nav.etterlatte.sak.TilgangServiceImpl
 import no.nav.etterlatte.tilgangsstyring.AzureGroup
 import no.nav.etterlatte.tilgangsstyring.SaksbehandlerMedRoller
-import no.nav.security.token.support.core.jwt.JwtTokenClaims
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -90,7 +89,7 @@ internal class TilgangServiceTest(
         val sakId = sakRepo.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr).id
         val saksbehandlerMedRoller =
             SaksbehandlerMedRoller(
-                Saksbehandler("", "ident", null),
+                simpleSaksbehandler(),
                 emptyMap(),
             )
         sakService.oppdaterAdressebeskyttelse(sakId, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
@@ -114,11 +113,10 @@ internal class TilgangServiceTest(
     fun `Skal sjekke tilganger til klager med klageId for behandlingId`() {
         val fnr = AVDOED_FOEDSELSNUMMER.value
         val sak = sakRepo.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr)
-        val jwtclaims = JWTClaimsSet.Builder().claim("groups", azureAdStrengtFortroligClaim).build()
 
         val saksbehandlerMedStrengtfortrolig =
             SaksbehandlerMedRoller(
-                Saksbehandler("", "ident", JwtTokenClaims(jwtclaims)),
+                simpleSaksbehandler(ident = "ident", claims = mapOf("groups" to azureAdStrengtFortroligClaim)),
                 mapOf(AzureGroup.STRENGT_FORTROLIG to azureAdStrengtFortroligClaim),
             )
         sakService.oppdaterAdressebeskyttelse(sak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
@@ -135,7 +133,7 @@ internal class TilgangServiceTest(
 
         val saksbehandlerUtenStrengtFortrolig =
             SaksbehandlerMedRoller(
-                Saksbehandler("", "annenIdent", JwtTokenClaims(jwtclaims)),
+                simpleSaksbehandler(ident = "annenIdent", claims = mapOf("groups" to azureAdStrengtFortroligClaim)),
                 mapOf(),
             )
         val harTilgangStrengtFortroligBehandling =
@@ -167,7 +165,7 @@ internal class TilgangServiceTest(
 
         val saksbehandlerMedStrengtfortrolig =
             SaksbehandlerMedRoller(
-                Saksbehandler("", "ident", JwtTokenClaims(jwtclaims)),
+                simpleSaksbehandler(ident = "ident", claims = mapOf("groups" to azureAdStrengtFortroligClaim)),
                 mapOf(AzureGroup.STRENGT_FORTROLIG to azureAdStrengtFortroligClaim),
             )
         sakService.oppdaterAdressebeskyttelse(sak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
@@ -184,7 +182,7 @@ internal class TilgangServiceTest(
 
         val saksbehandlerUtenStrengtFortrolig =
             SaksbehandlerMedRoller(
-                Saksbehandler("", "annenIdent", JwtTokenClaims(jwtclaims)),
+                simpleSaksbehandler(ident = "annenIdent", claims = mapOf("groups" to azureAdStrengtFortroligClaim)),
                 mapOf(),
             )
         val harTilgangStrengtFortroligBehandling =
@@ -220,11 +218,10 @@ internal class TilgangServiceTest(
     fun `Skal kunne sette strengt fortrolig på sak og se på den med riktig rolle men ikke fortrolig rolle`() {
         val fnr = AVDOED_FOEDSELSNUMMER.value
         val sakId = sakRepo.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr).id
-        val jwtclaims = JWTClaimsSet.Builder().claim("groups", azureAdStrengtFortroligClaim).build()
 
         val saksbehandlerMedStrengtfortrolig =
             SaksbehandlerMedRoller(
-                Saksbehandler("", "ident", JwtTokenClaims(jwtclaims)),
+                simpleSaksbehandler(claims = mapOf("groups" to azureAdStrengtFortroligClaim)),
                 mapOf(AzureGroup.STRENGT_FORTROLIG to azureAdStrengtFortroligClaim),
             )
         sakService.oppdaterAdressebeskyttelse(sakId, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
@@ -243,10 +240,9 @@ internal class TilgangServiceTest(
 
         Assertions.assertEquals(true, harTilgangTilBehandlingSomStrengtFortrolig)
 
-        val jwtclaimsFortrolig = JWTClaimsSet.Builder().claim("groups", azureAdFortroligClaim).build()
         val saksbehandlerMedFortrolig =
             SaksbehandlerMedRoller(
-                Saksbehandler("", "ident", JwtTokenClaims(jwtclaimsFortrolig)),
+                simpleSaksbehandler(claims = mapOf("groups" to azureAdFortroligClaim)),
                 mapOf(AzureGroup.FORTROLIG to azureAdFortroligClaim),
             )
         val harTilgangTilBehandlingSomfortrolig =
@@ -262,10 +258,9 @@ internal class TilgangServiceTest(
     fun `Skal kunne se på skjermet sak hvis riktig rolle`() {
         val fnr = AVDOED_FOEDSELSNUMMER.value
         val sakId = sakRepo.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.EGNE_ANSATTE.enhetNr).id
-        val jwtclaims = JWTClaimsSet.Builder().claim("groups", azureAdStrengtFortroligClaim).build()
         val saksbehandlerMedStrengtfortrolig =
             SaksbehandlerMedRoller(
-                Saksbehandler("", "ident", JwtTokenClaims(jwtclaims)),
+                simpleSaksbehandler(claims = mapOf("groups" to azureAdStrengtFortroligClaim)),
                 mapOf(AzureGroup.STRENGT_FORTROLIG to azureAdStrengtFortroligClaim),
             )
 
@@ -293,10 +288,9 @@ internal class TilgangServiceTest(
 
         Assertions.assertEquals(false, hartilgangSomStrengtFortroligMotEgenAnsattSak)
 
-        val jwtclaimsEgenAnsatt = JWTClaimsSet.Builder().claim("groups", azureAdEgenAnsattClaim).build()
         val saksbehandlerMedEgenansatt =
             SaksbehandlerMedRoller(
-                Saksbehandler("", "ident", JwtTokenClaims(jwtclaimsEgenAnsatt)),
+                simpleSaksbehandler(claims = mapOf("groups" to azureAdEgenAnsattClaim)),
                 mapOf(AzureGroup.EGEN_ANSATT to azureAdEgenAnsattClaim),
             )
         val harTilgangTilBehandlingMedEgenAnsattRolle =

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
@@ -29,6 +29,7 @@ import no.nav.etterlatte.behandling.revurdering.RevurderingService
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.common.klienter.PdlTjenesterKlient
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseDao
+import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingHendelseType
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
@@ -452,7 +453,7 @@ class BehandlingFactoryTest {
     fun `skal ikke kunne opprette omgjøring førstegangsbehandling hvis det er innvilget førstegangsbehandling`() {
         val sakId = 1L
         val iverksattBehandlingId = UUID.randomUUID()
-        val saksbehandler = Saksbehandler("", "sakbehandler", null)
+        val saksbehandler = simpleSaksbehandler()
         val iverksattBehandling =
             foerstegangsbehandling(
                 status = BehandlingStatus.IVERKSATT,
@@ -479,7 +480,7 @@ class BehandlingFactoryTest {
     @Test
     fun `skal ikke omgjøre hvis vi ikke har en førstegangsbehandling i saken`() {
         val sak = sak()
-        val saksbehandler = Saksbehandler("", "sakbehandler", null)
+        val saksbehandler = simpleSaksbehandler()
 
         every { sakServiceMock.finnSak(sak.id) } returns sak
         every { behandlingDaoMock.hentBehandlingerForSak(sak.id) } returns emptyList()
@@ -497,7 +498,7 @@ class BehandlingFactoryTest {
     @Test
     fun `skal ikke omgjøre hvis vi har en åpen behandling i saken`() {
         val sak = sak()
-        val saksbehandler = Saksbehandler("", "sakbehandler", null)
+        val saksbehandler = simpleSaksbehandler()
         val avslaattFoerstegangsbehandling = foerstegangsbehandling(sak = sak, status = BehandlingStatus.AVSLAG)
         val revurdering =
             revurdering(
@@ -520,7 +521,7 @@ class BehandlingFactoryTest {
     @Test
     fun `omgjøring skal lage ny førstegangsbehandling og kopiere vurdering hvis flagg er satt`() {
         val sak = sak()
-        val saksbehandler = Saksbehandler("", "sakbehandler", null)
+        val saksbehandler = simpleSaksbehandler()
         val avslaattFoerstegangsbehandling = foerstegangsbehandling(sak = sak, status = BehandlingStatus.AVSLAG)
         val revurdering =
             revurdering(
@@ -589,7 +590,7 @@ class BehandlingFactoryTest {
     @Test
     fun `skal lage ny førstegangsbehandling, oppgave og sende statisitkkmelding hvis omgjøring er lov`() {
         val sak = sak()
-        val saksbehandler = Saksbehandler("", "sakbehandler", null)
+        val saksbehandler = simpleSaksbehandler()
         val avslaattFoerstegangsbehandling = foerstegangsbehandling(sak = sak, status = BehandlingStatus.AVSLAG)
         val revurdering =
             revurdering(
@@ -1022,7 +1023,7 @@ class BehandlingFactoryTest {
                         null,
                         null,
                     ),
-                    Saksbehandler("token", "Z123456", null),
+                    simpleSaksbehandler(),
                 )
             }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
@@ -53,7 +53,6 @@ import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeNorskTid
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.GJENLEVENDE_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.INNSENDER_FOEDSELSNUMMER

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
@@ -236,7 +236,7 @@ internal class BehandlingServiceImplTest {
 
         coEvery { grunnlagKlientMock.hentPersongalleri(any(), any()) } returns mockPersongalleri()
 
-        val saksbehandler = Saksbehandler("", "saksbehandler", null)
+        val saksbehandler = simpleSaksbehandler()
         assertThrows<BehandlingKanIkkeAvbrytesException> {
             behandlingService.avbrytBehandling(avbruttBehandling.id, saksbehandler)
         }
@@ -269,7 +269,7 @@ internal class BehandlingServiceImplTest {
         every { oppgaveServiceMock.avbrytOppgaveUnderBehandling(any(), any()) } returns mockk<OppgaveIntern>()
         coEvery { grunnlagKlientMock.hentPersongalleri(any(), any()) } returns mockPersongalleri()
 
-        behandlingService.avbrytBehandling(nyFoerstegangsbehandling.id, Saksbehandler("", "saksbehandler", null))
+        behandlingService.avbrytBehandling(nyFoerstegangsbehandling.id, simpleSaksbehandler())
 
         verify {
             hendelseDaoMock.behandlingAvbrutt(any(), any())
@@ -317,7 +317,7 @@ internal class BehandlingServiceImplTest {
             inTransaction {
                 behandlingService.avbrytBehandling(
                     nyFoerstegangsbehandling.id,
-                    Saksbehandler("", "saksbehandler", null),
+                    simpleSaksbehandler(),
                 )
             }
         }
@@ -346,7 +346,7 @@ internal class BehandlingServiceImplTest {
         every { oppgaveServiceMock.avbrytOppgaveUnderBehandling(any(), any()) } returns mockk<OppgaveIntern>()
         coEvery { grunnlagKlientMock.hentPersongalleri(any(), any()) } returns mockPersongalleri()
 
-        behandlingService.avbrytBehandling(nyFoerstegangsbehandling.id, Saksbehandler("", "saksbehandler", null))
+        behandlingService.avbrytBehandling(nyFoerstegangsbehandling.id, simpleSaksbehandler())
 
         verify {
             behandlingHendelser.sendMeldingForHendelseStatisitkk(
@@ -377,7 +377,7 @@ internal class BehandlingServiceImplTest {
         every { oppgaveServiceMock.avbrytOppgaveUnderBehandling(any(), any()) } returns mockk<OppgaveIntern>()
         coEvery { grunnlagKlientMock.hentPersongalleri(any(), any()) } returns mockPersongalleri()
 
-        behandlingService.avbrytBehandling(nyFoerstegangsbehandling.id, Saksbehandler("", "saksbehandler", null))
+        behandlingService.avbrytBehandling(nyFoerstegangsbehandling.id, simpleSaksbehandler())
         verify(exactly = 1) {
             grunnlagsendringshendelseDaoMock.kobleGrunnlagsendringshendelserFraBehandlingId(nyFoerstegangsbehandling.id)
         }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
@@ -38,7 +38,6 @@ import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toObjectNode
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.mockSaksbehandler
 import no.nav.etterlatte.nyKontekstMedBruker
 import no.nav.etterlatte.nyKontekstMedBrukerOgDatabaseContext

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoServiceTest.kt
@@ -6,6 +6,7 @@ import io.mockk.verify
 import no.nav.etterlatte.behandling.BehandlingService
 import no.nav.etterlatte.behandling.BehandlingStatusService
 import no.nav.etterlatte.behandling.domain.Behandling
+import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.behandling.Aldersgruppe
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
@@ -17,7 +18,6 @@ import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.YearMonth
@@ -32,7 +32,7 @@ internal class BehandlingInfoServiceTest {
         BehandlingInfoService(behandlingInfoDao, behandlingService, behandlingsstatusService)
 
     companion object {
-        val bruker = Saksbehandler("token", "ident", null)
+        val bruker = simpleSaksbehandler()
     }
 
     @Test

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingServiceTest.kt
@@ -37,7 +37,6 @@ import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.oppgave.Status
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.mockSaksbehandler
 import no.nav.etterlatte.nyKontekstMedBrukerOgDatabase
 import no.nav.etterlatte.oppgave.OppgaveDao

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingServiceTest.kt
@@ -21,6 +21,7 @@ import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeDao
 import no.nav.etterlatte.behandling.revurdering.RevurderingDao
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.grunnlagsOpplysningMedPersonopplysning
+import no.nav.etterlatte.ktor.token.simpleAttestant
 import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.BoddEllerArbeidetUtlandet
@@ -708,7 +709,7 @@ internal class GenerellBehandlingServiceTest(
         )
 
     private companion object {
-        val SAKSBEHANDLER = Saksbehandler("token", "saksbehandler", null)
-        val ATTESTANT = Saksbehandler("token", "attestant", null)
+        val SAKSBEHANDLER = simpleSaksbehandler()
+        val ATTESTANT = simpleAttestant()
     }
 }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/klage/KlageServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/klage/KlageServiceImplTest.kt
@@ -20,6 +20,8 @@ import no.nav.etterlatte.behandling.klienter.OpprettetBrevDto
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.funksjonsbrytere.DummyFeatureToggleService
 import no.nav.etterlatte.inTransaction
+import no.nav.etterlatte.ktor.token.simpleAttestant
+import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.behandling.Formkrav
 import no.nav.etterlatte.libs.common.behandling.GrunnForOmgjoering
 import no.nav.etterlatte.libs.common.behandling.InitieltUtfallMedBegrunnelseDto
@@ -51,7 +53,6 @@ import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.ktor.route.FeatureIkkeStoettetException
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.nyKontekstMedBrukerOgDatabase
 import no.nav.etterlatte.oppgave.OppgaveService
@@ -83,8 +84,8 @@ internal class KlageServiceImplTest : BehandlingIntegrationTest() {
     private lateinit var klageDao: KlageDao
     private val brevApiKlientMock = mockk<BrevApiKlient>()
 
-    private val saksbehandler = Saksbehandler("token", saksbehandlerIdent, null)
-    private val attestant = Saksbehandler("tokenAttestant", attestantIdent, null)
+    private val saksbehandler = simpleSaksbehandler(ident = saksbehandlerIdent)
+    private val attestant = simpleAttestant(ident = attestantIdent)
     private val klagerFnr = GrunnlagTestData().gjenlevende.foedselsnummer.value
     private val enhet = "1337"
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingServiceIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/RevurderingServiceIntegrationTest.kt
@@ -54,7 +54,6 @@ import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import no.nav.etterlatte.nyKontekstMedBrukerOgDatabase
 import no.nav.etterlatte.oppgave.OppgaveService
@@ -150,7 +149,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
                     aarsak = Revurderingaarsak.ANNEN,
                     paaGrunnAvHendelseId = null,
                     begrunnelse = null,
-                    saksbehandler = Saksbehandler("", "saksbehandler", null),
+                    saksbehandler = simpleSaksbehandler(),
                 )
             }
 
@@ -204,7 +203,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
                     aarsak = Revurderingaarsak.SOESKENJUSTERING,
                     paaGrunnAvHendelseId = null,
                     begrunnelse = null,
-                    saksbehandler = Saksbehandler("", "saksbehandler", null),
+                    saksbehandler = simpleSaksbehandler(),
                 )
             }
 
@@ -286,7 +285,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
         val hendelser = spyk(applicationContext.behandlingsHendelser)
         val grunnlagService = spyk(applicationContext.grunnlagsService)
         val oppgaveService = spyk(applicationContext.oppgaveService)
-        val saksbehandler = Saksbehandler("", "saksbehandler", null)
+        val saksbehandler = simpleSaksbehandler()
 
         val revurderingService =
             revurderingService(
@@ -457,7 +456,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
                     aarsak = Revurderingaarsak.SLUTTBEHANDLING_UTLAND,
                     paaGrunnAvHendelseId = null,
                     begrunnelse = null,
-                    saksbehandler = Saksbehandler("", "saksbehandler", null),
+                    saksbehandler = simpleSaksbehandler(),
                 )
             }
 
@@ -531,7 +530,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
                     aarsak = Revurderingaarsak.REGULERING,
                     begrunnelse = null,
                     paaGrunnAvHendelseId = null,
-                    saksbehandler = Saksbehandler("", "saksbehandler", null),
+                    saksbehandler = simpleSaksbehandler(),
                 )
             }
         inTransaction {
@@ -548,7 +547,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
                     aarsak = Revurderingaarsak.SLUTTBEHANDLING_UTLAND,
                     paaGrunnAvHendelseId = null,
                     begrunnelse = null,
-                    saksbehandler = Saksbehandler("", "saksbehandler", null),
+                    saksbehandler = simpleSaksbehandler(),
                 )
             }
 
@@ -610,7 +609,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
                     aarsak = Revurderingaarsak.REGULERING,
                     paaGrunnAvHendelseId = "124124124",
                     begrunnelse = null,
-                    saksbehandler = Saksbehandler("", "Jenny", null),
+                    saksbehandler = simpleSaksbehandler(),
                 )
             }
         assertTrue(
@@ -634,7 +633,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
                     aarsak = Revurderingaarsak.REGULERING,
                     paaGrunnAvHendelseId = UUID.randomUUID().toString(),
                     begrunnelse = null,
-                    saksbehandler = Saksbehandler("", "saksbehandler", null),
+                    saksbehandler = simpleSaksbehandler(),
                 )
             }
         }
@@ -657,7 +656,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
                 aarsak = revurderingsAarsakIkkeStoettetIMiljoeBarn,
                 paaGrunnAvHendelseId = UUID.randomUUID().toString(),
                 begrunnelse = null,
-                saksbehandler = Saksbehandler("", "saksbehandler", null),
+                saksbehandler = simpleSaksbehandler(),
             )
         }
     }
@@ -680,7 +679,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
                     aarsak = Revurderingaarsak.REGULERING,
                     paaGrunnAvHendelseId = UUID.randomUUID().toString(),
                     begrunnelse = null,
-                    saksbehandler = Saksbehandler("", "saksbehandler", null),
+                    saksbehandler = simpleSaksbehandler(),
                 )
             }
         }
@@ -696,7 +695,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
         val oppgaveForFoerstegangsbehandling = hentOppgaverForSak.single { it.status == Status.NY }
 
         val saksbehandlerIdent = "saksbehandler"
-        val saksbehandler = Saksbehandler("", saksbehandlerIdent, null)
+        val saksbehandler = simpleSaksbehandler()
         inTransaction {
             applicationContext.oppgaveService.tildelSaksbehandler(
                 oppgaveForFoerstegangsbehandling.id,
@@ -874,7 +873,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
                 aarsak = Revurderingaarsak.REGULERING,
                 paaGrunnAvHendelseId = UUID.randomUUID().toString(),
                 begrunnelse = null,
-                saksbehandler = Saksbehandler("", "saksbehandler", null),
+                saksbehandler = simpleSaksbehandler(),
             )
         }
 
@@ -922,7 +921,7 @@ class RevurderingServiceIntegrationTest : BehandlingIntegrationTest() {
                     paaGrunnAvHendelseId = null,
                     paaGrunnAvOppgaveId = oppgaveHendelse.id.toString(),
                     begrunnelse = oppgaveHendelse.merknad,
-                    saksbehandler = Saksbehandler("", "Z123456", null),
+                    saksbehandler = simpleSaksbehandler(),
                 )
             }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingServiceIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingServiceIntegrationTest.kt
@@ -26,6 +26,8 @@ import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.funksjonsbrytere.DummyFeatureToggleService
 import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.kafka.TestProdusent
+import no.nav.etterlatte.ktor.token.simpleAttestant
+import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.behandling.Mottaker
 import no.nav.etterlatte.libs.common.behandling.Mottakerident
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -74,8 +76,8 @@ internal class TilbakekrevingServiceIntegrationTest : BehandlingIntegrationTest(
     private val tilbakekrevingKlient: TilbakekrevingKlient = mockk()
     private val rapid: TestProdusent<String, String> = spyk(TestProdusent())
 
-    private val saksbehandler = Saksbehandler("tokenSaksbehandler", "saksbehandlerIdent", null)
-    private val attestant = Saksbehandler("tokenAttestant", "attestantIdent", null)
+    private val saksbehandler = simpleSaksbehandler()
+    private val attestant = simpleAttestant()
     private val bruker = GrunnlagTestData().gjenlevende.foedselsnummer.value
     private val enhet = "123456"
 
@@ -410,7 +412,7 @@ internal class TilbakekrevingServiceIntegrationTest : BehandlingIntegrationTest(
         runBlocking { service.fattVedtak(tilbakekreving.id, saksbehandler) }
 
         // Tildeler oppgaven til attestant
-        inTransaction { oppgaveService.tildelSaksbehandler(oppgave.id, attestant.ident) }
+        inTransaction { oppgaveService.tildelSaksbehandler(oppgave.id, attestant.ident()) }
 
         // Attesterer vedtaket
         val tilbakekrevingMedAttestertVedtak = runBlocking { service.attesterVedtak(tilbakekreving.id, "kommentar", attestant) }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingServiceIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingServiceIntegrationTest.kt
@@ -46,7 +46,7 @@ import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingSkyld
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingStatus
 import no.nav.etterlatte.libs.common.toUUID30
 import no.nav.etterlatte.libs.common.vedtak.TilbakekrevingVedtakLagretDto
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.nyKontekstMedBrukerOgDatabase
 import no.nav.etterlatte.oppgave.OppgaveService
@@ -522,12 +522,12 @@ internal class TilbakekrevingServiceIntegrationTest : BehandlingIntegrationTest(
     }
 
     private fun tilbakekrevingsvedtak(
-        saksbehandler: Saksbehandler,
+        saksbehandler: BrukerTokenInfo,
         enhet: String,
     ): TilbakekrevingVedtakLagretDto =
         TilbakekrevingVedtakLagretDto(
             id = 1L,
-            fattetAv = saksbehandler.ident,
+            fattetAv = saksbehandler.ident(),
             enhet = enhet,
             dato = LocalDate.now(),
         )

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -32,6 +32,7 @@ import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
+import no.nav.etterlatte.libs.ktor.token.Claims
 import no.nav.etterlatte.nyKontekstMedBruker
 import no.nav.etterlatte.nyKontekstMedBrukerOgDatabaseContext
 import no.nav.etterlatte.sak.SakDao
@@ -74,7 +75,7 @@ internal class OppgaveServiceTest(
     private fun generateSaksbehandlerMedRoller(azureGroup: AzureGroup): SaksbehandlerMedRoller {
         val groupId = azureGroupToGroupIDMap[azureGroup]!!
         return SaksbehandlerMedRoller(
-            simpleSaksbehandler(ident = azureGroup.name, claims = mapOf("groups" to groupId)),
+            simpleSaksbehandler(ident = azureGroup.name, claims = mapOf(Claims.groups to groupId)),
             mapOf(azureGroup to groupId),
         )
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.oppgave
 
-import com.nimbusds.jwt.JWTClaimsSet
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -33,13 +32,11 @@ import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.nyKontekstMedBruker
 import no.nav.etterlatte.nyKontekstMedBrukerOgDatabaseContext
 import no.nav.etterlatte.sak.SakDao
 import no.nav.etterlatte.tilgangsstyring.AzureGroup
 import no.nav.etterlatte.tilgangsstyring.SaksbehandlerMedRoller
-import no.nav.security.token.support.core.jwt.JwtTokenClaims
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -76,9 +73,8 @@ internal class OppgaveServiceTest(
 
     private fun generateSaksbehandlerMedRoller(azureGroup: AzureGroup): SaksbehandlerMedRoller {
         val groupId = azureGroupToGroupIDMap[azureGroup]!!
-        val jwtclaimsSaksbehandler = JWTClaimsSet.Builder().claim("groups", groupId).build()
         return SaksbehandlerMedRoller(
-            Saksbehandler("", azureGroup.name, JwtTokenClaims(jwtclaimsSaksbehandler)),
+            simpleSaksbehandler(ident = azureGroup.name, claims = mapOf("groups" to groupId)),
             mapOf(azureGroup to groupId),
         )
     }
@@ -673,7 +669,7 @@ internal class OppgaveServiceTest(
         assertThrows<OppgaveTilhoererAnnenSaksbehandler> {
             oppgaveService.ferdigstillOppgave(
                 nyOppgave.id,
-                Saksbehandler("", "Feilsaksbehandler", null),
+                simpleSaksbehandler(ident = "Feilsaksbehandler"),
                 null,
             )
         }
@@ -957,7 +953,7 @@ internal class OppgaveServiceTest(
             oppgaveService.ferdigStillOppgaveUnderBehandling(
                 behandlingsref,
                 OppgaveType.FOERSTEGANGSBEHANDLING,
-                Saksbehandler("", "feilSaksbehandler", null),
+                simpleSaksbehandler(ident = "feilSaksbehandler"),
             )
         }
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -311,7 +311,7 @@ internal class OppgaveServiceTest(
         val sak = sakDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
         val behandlingId = UUID.randomUUID().toString()
         val annenBehandlingId = UUID.randomUUID().toString()
-        val saksbehandler = Saksbehandler("", "saksbehandler", null)
+        val saksbehandler = simpleSaksbehandler()
 
         val oppgaveFerdigstilt =
             oppgaveService.opprettOppgave(
@@ -332,7 +332,7 @@ internal class OppgaveServiceTest(
                 type = OppgaveType.FOERSTEGANGSBEHANDLING,
                 merknad = null,
             )
-        val saksbehandlerforstegangs = Saksbehandler("", "forstegangssaksbehandler", null)
+        val saksbehandlerforstegangs = simpleSaksbehandler()
         oppgaveService.tildelSaksbehandler(annenbehandlingfoerstegangs.id, saksbehandlerforstegangs.ident)
         oppgaveService.ferdigStillOppgaveUnderBehandling(annenBehandlingId, OppgaveType.FOERSTEGANGSBEHANDLING, saksbehandlerforstegangs)
         val oppgaveUnderBehandlingAnnenBehandling =
@@ -610,7 +610,7 @@ internal class OppgaveServiceTest(
                 null,
             )
 
-        val saksbehandler1 = Saksbehandler("", "saksbehandler", null)
+        val saksbehandler1 = simpleSaksbehandler()
         oppgaveService.tildelSaksbehandler(nyOppgave.id, saksbehandler1.ident)
 
         val sakIdOgReferanse =
@@ -640,7 +640,7 @@ internal class OppgaveServiceTest(
                 null,
             )
 
-        val saksbehandler1 = Saksbehandler("", "saksbehandler", null)
+        val saksbehandler1 = simpleSaksbehandler()
         oppgaveService.tildelSaksbehandler(nyOppgave.id, saksbehandler1.ident)
         oppgaveService.tilAttestering(
             referanse,
@@ -732,7 +732,7 @@ internal class OppgaveServiceTest(
                 OppgaveType.FOERSTEGANGSBEHANDLING,
                 null,
             )
-        val saksbehandler1 = Saksbehandler("", "saksbehandler", null)
+        val saksbehandler1 = simpleSaksbehandler()
         oppgaveService.tildelSaksbehandler(oppgaveEn.id, saksbehandler1.ident)
         oppgaveService.tildelSaksbehandler(oppgaveTo.id, saksbehandler1.ident)
 
@@ -931,7 +931,7 @@ internal class OppgaveServiceTest(
                 null,
             )
 
-        val saksbehandler1 = Saksbehandler("", "saksbehandler01", null)
+        val saksbehandler1 = simpleSaksbehandler()
         oppgaveService.tildelSaksbehandler(oppgave.id, saksbehandler1.ident)
         oppgaveService.ferdigStillOppgaveUnderBehandling(behandlingsref, OppgaveType.FOERSTEGANGSBEHANDLING, saksbehandler1)
         val ferdigstiltOppgave = oppgaveService.hentOppgave(oppgave.id)
@@ -1080,7 +1080,7 @@ internal class OppgaveServiceTest(
                 OppgaveType.FOERSTEGANGSBEHANDLING,
                 null,
             )
-        val saksbehandler = Saksbehandler("", "saksbehandler", null)
+        val saksbehandler = simpleSaksbehandler()
 
         oppgaveService.tildelSaksbehandler(foerstegangsbehandling.id, saksbehandler.ident)
 

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgaveGosys/GosysOppgaveServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgaveGosys/GosysOppgaveServiceImplTest.kt
@@ -18,6 +18,7 @@ import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.libs.ktor.token.Claims
 import no.nav.etterlatte.nyKontekstMedBruker
 import no.nav.etterlatte.oppgave.OppgaveService
 import no.nav.etterlatte.saksbehandler.SaksbehandlerService
@@ -67,7 +68,7 @@ class GosysOppgaveServiceImplTest {
     private fun generateSaksbehandlerMedRoller(azureGroup: AzureGroup): SaksbehandlerMedRoller {
         val groupId = azureGroupToGroupIDMap[azureGroup]!!
         return SaksbehandlerMedRoller(
-            simpleSaksbehandler(ident = azureGroup.name, claims = mapOf("groups" to groupId)),
+            simpleSaksbehandler(ident = azureGroup.name, claims = mapOf(Claims.groups to groupId)),
             mapOf(azureGroup to groupId),
         )
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgaveGosys/GosysOppgaveServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgaveGosys/GosysOppgaveServiceImplTest.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.oppgaveGosys
 
-import com.nimbusds.jwt.JWTClaimsSet
 import io.kotest.matchers.collections.shouldHaveSize
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
@@ -19,13 +18,11 @@ import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.nyKontekstMedBruker
 import no.nav.etterlatte.oppgave.OppgaveService
 import no.nav.etterlatte.saksbehandler.SaksbehandlerService
 import no.nav.etterlatte.tilgangsstyring.AzureGroup
 import no.nav.etterlatte.tilgangsstyring.SaksbehandlerMedRoller
-import no.nav.security.token.support.core.jwt.JwtTokenClaims
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -69,9 +66,8 @@ class GosysOppgaveServiceImplTest {
 
     private fun generateSaksbehandlerMedRoller(azureGroup: AzureGroup): SaksbehandlerMedRoller {
         val groupId = azureGroupToGroupIDMap[azureGroup]!!
-        val jwtclaimsSaksbehandler = JWTClaimsSet.Builder().claim("groups", groupId).build()
         return SaksbehandlerMedRoller(
-            Saksbehandler("", azureGroup.name, JwtTokenClaims(jwtclaimsSaksbehandler)),
+            simpleSaksbehandler(ident = azureGroup.name, claims = mapOf("groups" to groupId)),
             mapOf(azureGroup to groupId),
         )
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakServiceTest.kt
@@ -37,7 +37,6 @@ import no.nav.etterlatte.libs.common.person.HentAdressebeskyttelseRequest
 import no.nav.etterlatte.libs.common.person.PersonIdent
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.nyKontekstMedBruker
 import no.nav.etterlatte.person.krr.DigitalKontaktinformasjon
 import no.nav.etterlatte.person.krr.KrrKlient
@@ -108,35 +107,32 @@ internal class SakServiceTest {
 
         val token = mockk<JwtToken>()
 
-        val claims = mockk<JwtTokenClaims>()
-
-        every { claims.getAsList(any()) } returns listOf("")
-
-        every { claims.getStringClaim(any()) } returns "Z123456"
-
-        every { claims.containsClaim("groups", AzureGroup.NASJONAL_MED_LOGG.name) } returns nasjonalTilgang
-        every { claims.containsClaim("groups", AzureGroup.NASJONAL_UTEN_LOGG.name) } returns nasjonalTilgang
-        every { claims.containsClaim("groups", AzureGroup.STRENGT_FORTROLIG.name) } returns strentFortrolig
-        every { claims.containsClaim("groups", AzureGroup.EGEN_ANSATT.name) } returns egenAnsatt
-
-        every { token.jwtTokenClaims } returns claims
+        val tilgangsgrupper = mutableSetOf<AzureGroup>()
+        if (nasjonalTilgang) {
+            tilgangsgrupper.add(AzureGroup.NASJONAL_MED_LOGG)
+            tilgangsgrupper.add(AzureGroup.NASJONAL_UTEN_LOGG)
+        }
+        if (strentFortrolig) {
+            tilgangsgrupper.add(AzureGroup.STRENGT_FORTROLIG)
+        }
+        if (egenAnsatt) {
+            tilgangsgrupper.add(AzureGroup.EGEN_ANSATT)
+        }
 
         every { tokenValidationContext.getJwtToken(any()) } returns token
 
         val groups = AzureGroup.entries.associateWith { it.name }
 
-        val saksbehandler = "Z123456"
-        val accessToken = "a"
-        val brukerTokenInfo = simpleSaksbehandler(saksbehandler)
+        val saksbehandler = simpleSaksbehandler(claims = mapOf("groups" to tilgangsgrupper.map { it.name }))
         nyKontekstMedBruker(
             SaksbehandlerMedEnheterOgRoller(
                 tokenValidationContext,
                 saksbehandlerService,
                 SaksbehandlerMedRoller(
-                    Saksbehandler(accessToken, saksbehandler, claims),
+                    saksbehandler,
                     groups,
                 ),
-                brukerTokenInfo,
+                saksbehandler,
             ),
         )
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakServiceTest.kt
@@ -37,6 +37,7 @@ import no.nav.etterlatte.libs.common.person.HentAdressebeskyttelseRequest
 import no.nav.etterlatte.libs.common.person.PersonIdent
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.libs.ktor.token.Claims
 import no.nav.etterlatte.nyKontekstMedBruker
 import no.nav.etterlatte.person.krr.DigitalKontaktinformasjon
 import no.nav.etterlatte.person.krr.KrrKlient
@@ -123,7 +124,7 @@ internal class SakServiceTest {
 
         val groups = AzureGroup.entries.associateWith { it.name }
 
-        val saksbehandler = simpleSaksbehandler(claims = mapOf("groups" to tilgangsgrupper.map { it.name }))
+        val saksbehandler = simpleSaksbehandler(claims = mapOf(Claims.groups to tilgangsgrupper.map { it.name }))
         nyKontekstMedBruker(
             SaksbehandlerMedEnheterOgRoller(
                 tokenValidationContext,

--- a/apps/etterlatte-behandling/src/test/kotlin/saksbehandler/SaksbehandlerServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/saksbehandler/SaksbehandlerServiceImplTest.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.saksbehandler
 
-import com.nimbusds.jwt.JWTClaimsSet
 import io.kotest.matchers.shouldBe
 import io.mockk.clearMocks
 import io.mockk.coEvery
@@ -16,11 +15,10 @@ import no.nav.etterlatte.behandling.klienter.AxsysKlient
 import no.nav.etterlatte.behandling.klienter.NavAnsattKlient
 import no.nav.etterlatte.behandling.klienter.SaksbehandlerInfo
 import no.nav.etterlatte.common.Enheter
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
+import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.nyKontekstMedBrukerOgDatabase
 import no.nav.etterlatte.tilgangsstyring.AzureGroup
 import no.nav.etterlatte.tilgangsstyring.SaksbehandlerMedRoller
-import no.nav.security.token.support.core.jwt.JwtTokenClaims
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -66,10 +64,9 @@ class SaksbehandlerServiceImplTest(
         } returns SaksbehandlerInfo(nyidentSaksbehandler, "navn navnesen")
         every { user.enheter() } returns listOf(Enheter.defaultEnhet.enhetNr)
 
-        val jwtclaimsEgenAnsatt = JWTClaimsSet.Builder().claim("groups", azureAdSaksbehandlerClaim).build()
         val saksbehandlerMedRoller =
             SaksbehandlerMedRoller(
-                Saksbehandler("", "ident", JwtTokenClaims(jwtclaimsEgenAnsatt)),
+                simpleSaksbehandler(claims = mapOf("groups" to azureAdSaksbehandlerClaim)),
                 mapOf(AzureGroup.SAKSBEHANDLER to azureAdSaksbehandlerClaim),
             )
         every { user.saksbehandlerMedRoller } returns saksbehandlerMedRoller
@@ -95,10 +92,9 @@ class SaksbehandlerServiceImplTest(
         } returns SaksbehandlerInfo(nyidentSaksbehandler, "navn navnesen")
         every { user.enheter() } returns listOf(Enheter.defaultEnhet.enhetNr)
 
-        val jwtclaimsEgenAnsatt = JWTClaimsSet.Builder().claim("groups", azureAdSaksbehandlerClaim).build()
         val saksbehandlerMedRoller =
             SaksbehandlerMedRoller(
-                Saksbehandler("", "ident", JwtTokenClaims(jwtclaimsEgenAnsatt)),
+                simpleSaksbehandler(claims = mapOf("groups" to azureAdSaksbehandlerClaim)),
                 mapOf(AzureGroup.SAKSBEHANDLER to azureAdSaksbehandlerClaim),
             )
         every { user.saksbehandlerMedRoller } returns saksbehandlerMedRoller

--- a/apps/etterlatte-behandling/src/test/kotlin/saksbehandler/SaksbehandlerServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/saksbehandler/SaksbehandlerServiceImplTest.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.behandling.klienter.NavAnsattKlient
 import no.nav.etterlatte.behandling.klienter.SaksbehandlerInfo
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.ktor.token.simpleSaksbehandler
+import no.nav.etterlatte.libs.ktor.token.Claims
 import no.nav.etterlatte.nyKontekstMedBrukerOgDatabase
 import no.nav.etterlatte.tilgangsstyring.AzureGroup
 import no.nav.etterlatte.tilgangsstyring.SaksbehandlerMedRoller
@@ -66,7 +67,7 @@ class SaksbehandlerServiceImplTest(
 
         val saksbehandlerMedRoller =
             SaksbehandlerMedRoller(
-                simpleSaksbehandler(claims = mapOf("groups" to azureAdSaksbehandlerClaim)),
+                simpleSaksbehandler(claims = mapOf(Claims.groups to azureAdSaksbehandlerClaim)),
                 mapOf(AzureGroup.SAKSBEHANDLER to azureAdSaksbehandlerClaim),
             )
         every { user.saksbehandlerMedRoller } returns saksbehandlerMedRoller
@@ -94,7 +95,7 @@ class SaksbehandlerServiceImplTest(
 
         val saksbehandlerMedRoller =
             SaksbehandlerMedRoller(
-                simpleSaksbehandler(claims = mapOf("groups" to azureAdSaksbehandlerClaim)),
+                simpleSaksbehandler(claims = mapOf(Claims.groups to azureAdSaksbehandlerClaim)),
                 mapOf(AzureGroup.SAKSBEHANDLER to azureAdSaksbehandlerClaim),
             )
         every { user.saksbehandlerMedRoller } returns saksbehandlerMedRoller

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -40,7 +40,6 @@ import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.common.toObjectNode
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.libs.regler.FaktumNode
 import no.nav.etterlatte.libs.regler.RegelPeriode
 import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.beregning.Beregning
 import no.nav.etterlatte.beregning.OverstyrBeregning
 import no.nav.etterlatte.beregning.grunnlag.InstitusjonsoppholdBeregningsgrunnlag
 import no.nav.etterlatte.beregning.regler.barnepensjon.BarnepensjonGrunnlag
+import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.IntBroek
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
@@ -102,7 +103,7 @@ fun Int.toBeregningstall(
     roundingMode: RoundingMode = RoundingMode.UNNECESSARY,
 ) = Beregningstall(this).setScale(decimals, roundingMode)
 
-val bruker = Saksbehandler("token", "ident", null)
+val bruker = simpleSaksbehandler()
 
 fun avkorting(
     ytelseFoerAvkorting: List<YtelseFoerAvkorting> = emptyList(),

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/NotatServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/NotatServiceTest.kt
@@ -15,6 +15,7 @@ import no.nav.etterlatte.brev.hentinformasjon.grunnlag.GrunnlagService
 import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.brev.notat.StrukturertBrev
+import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.behandling.Formkrav
 import no.nav.etterlatte.libs.common.behandling.FormkravMedBeslutter
 import no.nav.etterlatte.libs.common.behandling.InnstillingTilKabal
@@ -29,7 +30,6 @@ import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import no.nav.pensjon.brevbaker.api.model.Telefonnummer
@@ -90,7 +90,7 @@ class NotatServiceTest(
                     StrukturertBrev.KlageBlankett(
                         klage = klage,
                     ),
-                bruker = Saksbehandler("", "Z999999", null),
+                bruker = simpleSaksbehandler(),
             )
         }
 
@@ -132,7 +132,7 @@ class NotatServiceTest(
                         StrukturertBrev.KlageBlankett(
                             klage = klage,
                         ),
-                    bruker = Saksbehandler("", "Z999999", null),
+                    bruker = simpleSaksbehandler(),
                 )
             }
         } catch (_: Exception) {

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TestHelper.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TestHelper.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.trygdetid
 
+import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
@@ -19,7 +20,7 @@ import java.time.Period
 import java.util.UUID
 import java.util.UUID.randomUUID
 
-val saksbehandler = Saksbehandler("token", "ident", null)
+val saksbehandler = simpleSaksbehandler()
 
 private val pdlKilde: Grunnlagsopplysning.Pdl = Grunnlagsopplysning.Pdl(Tidspunkt.now(), null, "opplysningsId1")
 

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TestHelper.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TestHelper.kt
@@ -13,7 +13,6 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.common.trygdetid.DetaljertBeregnetTrygdetidResultat
 import no.nav.etterlatte.libs.common.trygdetid.avtale.Trygdeavtale
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import java.time.LocalDate
 import java.time.Period

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceIntegrationTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceIntegrationTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.deserialize
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -17,7 +18,6 @@ import no.nav.etterlatte.libs.common.trygdetid.GrunnlagOpplysningerDto
 import no.nav.etterlatte.libs.common.trygdetid.OpplysningerDifferanse
 import no.nav.etterlatte.libs.common.trygdetid.OpplysningsgrunnlagDto
 import no.nav.etterlatte.libs.common.trygdetid.UKJENT_AVDOED
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.kilde
 import no.nav.etterlatte.trygdetid.klienter.BehandlingKlient
@@ -41,7 +41,7 @@ internal class TrygdetidServiceIntegrationTest(
         val dbExtension = DatabaseExtension()
     }
 
-    private val saksbehandler = Saksbehandler("token", "ident", null)
+    private val saksbehandler = simpleSaksbehandler()
 
     private val repository = TrygdetidRepository(dataSource)
     private lateinit var trygdetidService: TrygdetidService

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/TestHelper.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/TestHelper.kt
@@ -1,6 +1,8 @@
 package no.nav.etterlatte.vedtaksvurdering
 
 import com.fasterxml.jackson.databind.node.ObjectNode
+import no.nav.etterlatte.ktor.token.simpleAttestant
+import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -13,7 +15,6 @@ import no.nav.etterlatte.libs.common.vedtak.UtbetalingsperiodeType
 import no.nav.etterlatte.libs.common.vedtak.VedtakFattet
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import java.math.BigDecimal
 import java.time.Month
@@ -28,8 +29,8 @@ const val SAKSBEHANDLER_2 = "saksbehandler2"
 const val ENHET_1 = "1234"
 const val ENHET_2 = "4321"
 
-val saksbehandler = Saksbehandler("token", SAKSBEHANDLER_1, null)
-val attestant = Saksbehandler("token", SAKSBEHANDLER_2, null)
+val saksbehandler = simpleSaksbehandler(ident = SAKSBEHANDLER_1)
+val attestant = simpleAttestant(ident = SAKSBEHANDLER_2)
 
 fun opprettVedtak(
     virkningstidspunkt: YearMonth = YearMonth.of(2023, Month.JANUARY),

--- a/libs/etterlatte-ktor/src/test/kotlin/no/nav/etterlatte/libs/ktorobo/AzureAdClientTest.kt
+++ b/libs/etterlatte-ktor/src/test/kotlin/no/nav/etterlatte/libs/ktorobo/AzureAdClientTest.kt
@@ -191,7 +191,7 @@ internal class AzureAdClientTest {
         }
 
     @Test
-    fun `bruker client credentials viss JWT-claims sub og oid er like`() {
+    fun `bruker client credentials viss JWT-claims er systembruker`() {
         val client =
             spyk(AzureAdClient(config, FakeAzureAdHttpClient())).also {
                 coEvery { it.getAccessTokenForResource(any()) } returns Ok(mockk())
@@ -199,7 +199,7 @@ internal class AzureAdClientTest {
 
         runBlocking {
             client.hentTokenFraAD(
-                systembruker(claims = mapOf(Claims.idtyp to "app", Claims.azp_name to "cluster:appname:dev")),
+                systembruker(claims = mapOf(Claims.azp_name to "cluster:appname:dev")),
                 listOf(),
             )
         }

--- a/libs/etterlatte-ktor/src/test/kotlin/no/nav/etterlatte/libs/ktorobo/AzureAdClientTest.kt
+++ b/libs/etterlatte-ktor/src/test/kotlin/no/nav/etterlatte/libs/ktorobo/AzureAdClientTest.kt
@@ -199,7 +199,7 @@ internal class AzureAdClientTest {
 
         runBlocking {
             client.hentTokenFraAD(
-                systembruker(claims = mapOf(Claims.idtyp.name to "app", Claims.azp_name.name to "cluster:appname:dev")),
+                systembruker(claims = mapOf(Claims.idtyp to "app", Claims.azp_name to "cluster:appname:dev")),
                 listOf(),
             )
         }

--- a/libs/etterlatte-ktor/src/testFixtures/kotlin/no/nav/etterlatte/ktor/token/BrukerTokenInfoTestGenerator.kt
+++ b/libs/etterlatte-ktor/src/testFixtures/kotlin/no/nav/etterlatte/ktor/token/BrukerTokenInfoTestGenerator.kt
@@ -24,7 +24,7 @@ fun systembruker(claims: Map<Claims, Any?>): Systembruker =
     BrukerTokenInfo.of(
         accessToken = "token",
         saksbehandler = null,
-        claims = extracted(claims),
+        claims = extracted(claims + mapOf(Claims.idtyp to "app")),
         idtyp = "app",
     ) as Systembruker
 

--- a/libs/etterlatte-ktor/src/testFixtures/kotlin/no/nav/etterlatte/ktor/token/BrukerTokenInfoTestGenerator.kt
+++ b/libs/etterlatte-ktor/src/testFixtures/kotlin/no/nav/etterlatte/ktor/token/BrukerTokenInfoTestGenerator.kt
@@ -2,13 +2,14 @@ package no.nav.etterlatte.ktor.token
 
 import com.nimbusds.jwt.JWTClaimsSet
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.libs.ktor.token.Claims
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.security.token.support.core.jwt.JwtTokenClaims
 
 fun simpleSaksbehandler(
     ident: String = "saksbehandler",
-    claims: Map<String, Any?> = mapOf(),
+    claims: Map<Claims, Any?> = mapOf(),
 ): Saksbehandler =
     BrukerTokenInfo.of(
         accessToken = "token",
@@ -19,7 +20,7 @@ fun simpleSaksbehandler(
 
 fun simpleAttestant(ident: String = "attestant") = BrukerTokenInfo.of("token", ident, null, null) as Saksbehandler
 
-fun systembruker(claims: Map<String, Any?>): Systembruker =
+fun systembruker(claims: Map<Claims, Any?>): Systembruker =
     BrukerTokenInfo.of(
         accessToken = "token",
         saksbehandler = null,
@@ -27,9 +28,9 @@ fun systembruker(claims: Map<String, Any?>): Systembruker =
         idtyp = "app",
     ) as Systembruker
 
-private fun extracted(claims: Map<String, Any?>) =
+private fun extracted(claims: Map<Claims, Any?>) =
     claims.entries
         .fold(JWTClaimsSet.Builder()) { acc, next ->
-            acc.claim(next.key, next.value)
+            acc.claim(next.key.name, next.value)
         }.build()
         .let { JwtTokenClaims(it) }

--- a/libs/etterlatte-ktor/src/testFixtures/kotlin/no/nav/etterlatte/ktor/token/BrukerTokenInfoTestGenerator.kt
+++ b/libs/etterlatte-ktor/src/testFixtures/kotlin/no/nav/etterlatte/ktor/token/BrukerTokenInfoTestGenerator.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.ktor.token
 import com.nimbusds.jwt.JWTClaimsSet
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
+import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.security.token.support.core.jwt.JwtTokenClaims
 
 fun simpleSaksbehandler(
@@ -12,13 +13,23 @@ fun simpleSaksbehandler(
     BrukerTokenInfo.of(
         accessToken = "token",
         saksbehandler = ident,
-        claims =
-            claims.entries
-                .fold(JWTClaimsSet.Builder()) { acc, next ->
-                    acc.claim(next.key, next.value)
-                }.build()
-                .let { JwtTokenClaims(it) },
+        claims = extracted(claims),
         idtyp = null,
     ) as Saksbehandler
 
 fun simpleAttestant(ident: String = "attestant") = BrukerTokenInfo.of("token", ident, null, null) as Saksbehandler
+
+fun systembruker(claims: Map<String, Any?>): Systembruker =
+    BrukerTokenInfo.of(
+        accessToken = "token",
+        saksbehandler = null,
+        claims = extracted(claims),
+        idtyp = "app",
+    ) as Systembruker
+
+private fun extracted(claims: Map<String, Any?>) =
+    claims.entries
+        .fold(JWTClaimsSet.Builder()) { acc, next ->
+            acc.claim(next.key, next.value)
+        }.build()
+        .let { JwtTokenClaims(it) }

--- a/libs/etterlatte-ktor/src/testFixtures/kotlin/no/nav/etterlatte/ktor/token/BrukerTokenInfoTestGenerator.kt
+++ b/libs/etterlatte-ktor/src/testFixtures/kotlin/no/nav/etterlatte/ktor/token/BrukerTokenInfoTestGenerator.kt
@@ -1,7 +1,8 @@
 package no.nav.etterlatte.ktor.token
 
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 
-fun simpleSaksbehandler(ident: String = "saksbehandler") = BrukerTokenInfo.of("token", ident, null, null)
+fun simpleSaksbehandler(ident: String = "saksbehandler") = BrukerTokenInfo.of("token", ident, null, null) as Saksbehandler
 
-fun simpleAttestant() = BrukerTokenInfo.of("token", "attestant", null, null)
+fun simpleAttestant(ident: String = "attestant") = BrukerTokenInfo.of("token", ident, null, null) as Saksbehandler

--- a/libs/etterlatte-ktor/src/testFixtures/kotlin/no/nav/etterlatte/ktor/token/BrukerTokenInfoTestGenerator.kt
+++ b/libs/etterlatte-ktor/src/testFixtures/kotlin/no/nav/etterlatte/ktor/token/BrukerTokenInfoTestGenerator.kt
@@ -1,8 +1,24 @@
 package no.nav.etterlatte.ktor.token
 
+import com.nimbusds.jwt.JWTClaimsSet
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
+import no.nav.security.token.support.core.jwt.JwtTokenClaims
 
-fun simpleSaksbehandler(ident: String = "saksbehandler") = BrukerTokenInfo.of("token", ident, null, null) as Saksbehandler
+fun simpleSaksbehandler(
+    ident: String = "saksbehandler",
+    claims: Map<String, String> = mapOf(),
+): Saksbehandler =
+    BrukerTokenInfo.of(
+        accessToken = "token",
+        saksbehandler = ident,
+        claims =
+            claims.entries
+                .fold(JWTClaimsSet.Builder()) { acc, next ->
+                    acc.claim(next.key, next.value)
+                }.build()
+                .let { JwtTokenClaims(it) },
+        idtyp = null,
+    ) as Saksbehandler
 
 fun simpleAttestant(ident: String = "attestant") = BrukerTokenInfo.of("token", ident, null, null) as Saksbehandler

--- a/libs/etterlatte-ktor/src/testFixtures/kotlin/no/nav/etterlatte/ktor/token/BrukerTokenInfoTestGenerator.kt
+++ b/libs/etterlatte-ktor/src/testFixtures/kotlin/no/nav/etterlatte/ktor/token/BrukerTokenInfoTestGenerator.kt
@@ -7,7 +7,7 @@ import no.nav.security.token.support.core.jwt.JwtTokenClaims
 
 fun simpleSaksbehandler(
     ident: String = "saksbehandler",
-    claims: Map<String, String> = mapOf(),
+    claims: Map<String, Any?> = mapOf(),
 ): Saksbehandler =
     BrukerTokenInfo.of(
         accessToken = "token",


### PR DESCRIPTION
Lager også ein parameter som tar inn claims, og ein hjelpemetode for å opprette systembrukar.

Etter denne har vi berre éin plass vi opprettar saksbehandlar-token i testane.