### PR TITLE
EY-4211: Flyttar hardkoding av systembrukarar heilt ut til job og river

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktRoute.kt
@@ -110,7 +110,13 @@ internal fun Route.aktivitetspliktRoutes(aktivitetspliktService: Aktivitetsplikt
             kunSystembruker {
                 logger.info("Sjekker om sak $sakId trenger en ny revurdering etter 6 måneder")
                 val request = call.receive<OpprettRevurderingForAktivitetspliktDto>()
-                val opprettet = inTransaction { aktivitetspliktService.opprettRevurderingHvisKravIkkeOppfylt(request) }
+                val opprettet =
+                    inTransaction {
+                        aktivitetspliktService.opprettRevurderingHvisKravIkkeOppfylt(
+                            request,
+                            brukerTokenInfo,
+                        )
+                    }
                 call.respond(opprettet)
             }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktService.kt
@@ -32,7 +32,6 @@ import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.route.logger
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
-import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.etterlatte.oppgave.OppgaveService
 import java.time.LocalDate
 import java.time.YearMonth
@@ -340,6 +339,7 @@ class AktivitetspliktService(
 
     fun opprettRevurderingHvisKravIkkeOppfylt(
         request: OpprettRevurderingForAktivitetspliktDto,
+        bruker: BrukerTokenInfo,
     ): OpprettRevurderingForAktivitetspliktResponse {
         val forrigeBehandling =
             requireNotNull(behandlingService.hentSisteIverksatte(request.sakId)) {
@@ -351,7 +351,7 @@ class AktivitetspliktService(
                     grunnlagKlient
                         .hentPersongalleri(
                             forrigeBehandling.id,
-                            Systembruker.automatiskJobb,
+                            bruker,
                         )?.opplysning,
                 ) {
                     "Fant ikke persongalleri for behandling ${forrigeBehandling.id}"

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningRoutes.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.libs.common.sak.KjoeringRequest
 import no.nav.etterlatte.libs.common.sak.LagreKjoeringRequest
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.route.routeLogger
+import no.nav.etterlatte.libs.ktor.token.brukerTokenInfo
 import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
 import java.time.LocalTime
 
@@ -57,7 +58,7 @@ fun Route.omregningRoutes(omregningService: OmregningService) {
             val request = call.receive<KjoeringRequest>()
             logger.info("Motter hendelse om at regulering har status ${request.status.name} i sak ${request.sakId}")
             inTransaction {
-                omregningService.oppdaterKjoering(request)
+                omregningService.oppdaterKjoering(request, brukerTokenInfo)
             }
             call.respond(HttpStatusCode.OK)
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningService.kt
@@ -15,7 +15,7 @@ import no.nav.etterlatte.libs.common.sak.KjoeringRequest
 import no.nav.etterlatte.libs.common.sak.KjoeringStatus
 import no.nav.etterlatte.libs.common.sak.LagreKjoeringRequest
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.ktor.token.Systembruker
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import java.time.LocalDate
 import java.util.UUID
 
@@ -59,10 +59,13 @@ class OmregningService(
         ) { "Opprettelse av revurdering feilet for $sakId" }
     }
 
-    fun oppdaterKjoering(request: KjoeringRequest) {
+    fun oppdaterKjoering(
+        request: KjoeringRequest,
+        bruker: BrukerTokenInfo,
+    ) {
         if (request.status == KjoeringStatus.FEILA) {
             behandlingService.hentAapenRegulering(request.sakId)?.let {
-                behandlingService.avbrytBehandling(it, Systembruker.regulering)
+                behandlingService.avbrytBehandling(it, bruker)
             }
         }
         omregningDao.oppdaterKjoering(request)

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
@@ -35,7 +35,9 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
 import no.nav.etterlatte.libs.common.toJsonNode
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
+import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.etterlatte.person.krr.KrrKlient
 import no.nav.etterlatte.sak.SakService
 import org.slf4j.LoggerFactory
@@ -77,16 +79,22 @@ class DoedshendelseJobService(
             doedshendelserSomSkalHaanderes.forEach { doedshendelse ->
                 inTransaction {
                     logger.info("Starter håndtering av dødshendelse for person ${doedshendelse.beroertFnr.maskerFnr()}")
-                    haandterDoedshendelse(doedshendelse)
+                    haandterDoedshendelse(doedshendelse, Systembruker.doedshendelse)
                 }
             }
         }
     }
 
-    private fun haandterDoedshendelse(doedshendelse: DoedshendelseInternal) {
+    private fun haandterDoedshendelse(
+        doedshendelse: DoedshendelseInternal,
+        bruker: BrukerTokenInfo,
+    ) {
         val kontrollpunkter =
             try {
-                doedshendelseKontrollpunktService.identifiserKontrollerpunkter(doedshendelse)
+                doedshendelseKontrollpunktService.identifiserKontrollerpunkter(
+                    doedshendelse,
+                    bruker,
+                )
             } catch (e: Exception) {
                 val sak = doedshendelse.sakId?.toString() ?: "mangler"
                 logger.error("Kunne ikke identifisere kontrollpunkter for sak $sak", e)

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/aktivitetsplikt/AktivitetspliktServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/aktivitetsplikt/AktivitetspliktServiceTest.kt
@@ -40,6 +40,7 @@ import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.oppgave.Status
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.etterlatte.nyKontekstMedBruker
 import no.nav.etterlatte.oppgave.OppgaveService
 import org.junit.jupiter.api.BeforeEach
@@ -628,7 +629,7 @@ class AktivitetspliktServiceTest {
                     },
                 )
 
-            val resultat = service.opprettRevurderingHvisKravIkkeOppfylt(request)
+            val resultat = service.opprettRevurderingHvisKravIkkeOppfylt(request, Systembruker.automatiskJobb)
 
             with(resultat) {
                 opprettetRevurdering shouldBe true
@@ -666,7 +667,7 @@ class AktivitetspliktServiceTest {
                 )
             } returns oppgave
 
-            val resultat = service.opprettRevurderingHvisKravIkkeOppfylt(request)
+            val resultat = service.opprettRevurderingHvisKravIkkeOppfylt(request, Systembruker.automatiskJobb)
 
             with(resultat) {
                 opprettetRevurdering shouldBe false
@@ -690,7 +691,7 @@ class AktivitetspliktServiceTest {
             every { behandlingService.hentSisteIverksatte(sakId) } returns forrigeBehandling
             coEvery { grunnlagKlient.hentPersongalleri(forrigeBehandling.id, any()) } returns persongalleriOpplysning
 
-            val resultat = service.opprettRevurderingHvisKravIkkeOppfylt(request)
+            val resultat = service.opprettRevurderingHvisKravIkkeOppfylt(request, Systembruker.automatiskJobb)
 
             with(resultat) {
                 opprettetRevurdering shouldBe false

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobServiceTest.kt
@@ -24,6 +24,7 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.pdlhendelse.Endringstype
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
+import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED2_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.mockPerson
@@ -120,7 +121,7 @@ class DoedshendelseJobServiceTest {
                     endret = LocalDateTime.now().minusDays(femDagerGammel.toLong()).toTidspunkt(),
                 ),
             )
-        every { kontrollpunktService.identifiserKontrollerpunkter(any()) } returns listOf(AvdoedHarDNummer)
+        every { kontrollpunktService.identifiserKontrollerpunkter(any(), Systembruker.doedshendelse) } returns listOf(AvdoedHarDNummer)
         every { dao.hentDoedshendelserMedStatus(any()) } returns doedshendelser
         every { dao.oppdaterDoedshendelse(any()) } returns Unit
         every { grunnlagsendringshendelseService.opprettDoedshendelseForPerson(any()) } returns
@@ -148,7 +149,7 @@ class DoedshendelseJobServiceTest {
 
         every { dao.hentDoedshendelserMedStatus(any()) } returns listOf(doedshendelseInternal)
         every { dao.oppdaterDoedshendelse(any()) } returns Unit
-        every { kontrollpunktService.identifiserKontrollerpunkter(any()) } returns listOf(AvdoedLeverIPDL)
+        every { kontrollpunktService.identifiserKontrollerpunkter(any(), Systembruker.doedshendelse) } returns listOf(AvdoedLeverIPDL)
         val doedshendelseInternalCapture = slot<DoedshendelseInternal>()
 
         service.setupKontekstAndRun(kontekst)
@@ -178,7 +179,7 @@ class DoedshendelseJobServiceTest {
             mockk {
                 every { id } returns oppgaveId
             }
-        every { kontrollpunktService.identifiserKontrollerpunkter(any()) } returns
+        every { kontrollpunktService.identifiserKontrollerpunkter(any(), Systembruker.doedshendelse) } returns
             listOf(AvdoedHarUtvandret, AvdoedHarDNummer)
         val doedshendelseCapture = slot<DoedshendelseInternal>()
 
@@ -211,7 +212,7 @@ class DoedshendelseJobServiceTest {
                 every { id } returns oppgaveId
             }
         every { toggle.isEnabled(DoedshendelseFeatureToggle.KanSendeBrevOgOppretteOppgave, any()) } returns false
-        every { kontrollpunktService.identifiserKontrollerpunkter(any()) } returns
+        every { kontrollpunktService.identifiserKontrollerpunkter(any(), Systembruker.doedshendelse) } returns
             listOf(AvdoedHarUtvandret, AvdoedHarDNummer)
         val doedshendelseCapture = slot<DoedshendelseInternal>()
 
@@ -244,7 +245,7 @@ class DoedshendelseJobServiceTest {
                 every { id } returns oppgaveId
             }
         every { toggle.isEnabled(DoedshendelseFeatureToggle.KanSendeBrevOgOppretteOppgave, any()) } returns true
-        every { kontrollpunktService.identifiserKontrollerpunkter(any()) } returns
+        every { kontrollpunktService.identifiserKontrollerpunkter(any(), Systembruker.doedshendelse) } returns
             emptyList()
         every { doedshendelserProducer.sendBrevRequestBP(any(), any(), any()) } just runs
         val doedshendelseCapture = slot<DoedshendelseInternal>()

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
@@ -375,11 +375,15 @@ class NavAnsattKlientTest : NavAnsattKlient {
 }
 
 class PesysKlientTest : PesysKlient {
-    override suspend fun hentSaker(fnr: String): List<SakSammendragResponse> = emptyList()
+    override suspend fun hentSaker(
+        fnr: String,
+        bruker: BrukerTokenInfo,
+    ): List<SakSammendragResponse> = emptyList()
 
     override suspend fun erTilstoetendeBehandlet(
         fnr: String,
         doedsdato: LocalDate,
+        bruker: BrukerTokenInfo,
     ): Boolean = false
 }
 

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
@@ -30,7 +30,6 @@ import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.SoeskenMedIBeregn
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vedtak.VedtakSammendragDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
-import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.HALVSOESKEN_ANNEN_FORELDER
@@ -328,6 +327,8 @@ internal class BeregningsGrunnlagServiceTest {
         coVerify(exactly = 1) { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(any()) }
     }
 
+    private val bruker = simpleSaksbehandler()
+
     @Test
     fun `skal lage et kopi av grunnlaget`() {
         val behandling = mockBehandling(SakType.BARNEPENSJON, randomUUID())
@@ -354,7 +355,7 @@ internal class BeregningsGrunnlagServiceTest {
         val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns hentOpplysningsgrunnlag
         runBlocking {
-            beregningsGrunnlagService.dupliserBeregningsGrunnlag(omregningsId, behandlingsId, Systembruker.testdata)
+            beregningsGrunnlagService.dupliserBeregningsGrunnlag(omregningsId, behandlingsId, bruker)
 
             verify(exactly = 1) { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(any()) }
             verify(exactly = 0) { beregningsGrunnlagRepository.lagreOverstyrBeregningGrunnlagForBehandling(any(), any()) }
@@ -395,7 +396,7 @@ internal class BeregningsGrunnlagServiceTest {
         val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns hentOpplysningsgrunnlag
         runBlocking {
-            beregningsGrunnlagService.dupliserBeregningsGrunnlag(omregningsId, behandlingsId, Systembruker.testdata)
+            beregningsGrunnlagService.dupliserBeregningsGrunnlag(omregningsId, behandlingsId, bruker)
 
             verify(exactly = 1) { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(any()) }
             verify(exactly = 1) { beregningsGrunnlagRepository.lagreOverstyrBeregningGrunnlagForBehandling(any(), any()) }
@@ -415,7 +416,7 @@ internal class BeregningsGrunnlagServiceTest {
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns hentOpplysningsgrunnlag
         runBlocking {
             assertThrows<RuntimeException> {
-                beregningsGrunnlagService.dupliserBeregningsGrunnlag(randomUUID(), behandlingsId, Systembruker.testdata)
+                beregningsGrunnlagService.dupliserBeregningsGrunnlag(randomUUID(), behandlingsId, bruker)
 
                 verify(exactly = 0) { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(any()) }
             }
@@ -443,7 +444,7 @@ internal class BeregningsGrunnlagServiceTest {
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns hentOpplysningsgrunnlag
         runBlocking {
             assertThrows<RuntimeException> {
-                beregningsGrunnlagService.dupliserBeregningsGrunnlag(omregningsId, behandlingsId, Systembruker.testdata)
+                beregningsGrunnlagService.dupliserBeregningsGrunnlag(omregningsId, behandlingsId, bruker)
 
                 verify(exactly = 0) { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(any()) }
             }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/JournalfoerBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/JournalfoerBrevService.kt
@@ -46,7 +46,10 @@ class JournalfoerBrevService(
         return journalfoer(brev, sak).journalpostId
     }
 
-    suspend fun journalfoerVedtaksbrev(vedtak: VedtakTilJournalfoering): Pair<OpprettJournalpostResponse, BrevID>? {
+    suspend fun journalfoerVedtaksbrev(
+        vedtak: VedtakTilJournalfoering,
+        bruker: Systembruker,
+    ): Pair<OpprettJournalpostResponse, BrevID>? {
         logger.info("Nytt vedtak med id ${vedtak.vedtakId} er attestert. Ferdigstiller vedtaksbrev.")
         val behandlingId = vedtak.behandlingId
 
@@ -67,7 +70,7 @@ class JournalfoerBrevService(
             return null
         }
 
-        val sak = behandlingService.hentSak(brev.sakId, Systembruker.brev)
+        val sak = behandlingService.hentSak(brev.sakId, bruker)
 
         return journalfoer(brev, sak)
             .also { logger.info("Vedtaksbrev for vedtak med id ${vedtak.vedtakId} er journalfoert OK") }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiver.kt
@@ -12,6 +12,7 @@ import no.nav.etterlatte.libs.common.rapidsandrivers.setEventNameForHendelseType
 import no.nav.etterlatte.libs.common.sak.VedtakSak
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseHendelseType
+import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.etterlatte.rapidsandrivers.BREV_ID_KEY
 import no.nav.etterlatte.rapidsandrivers.ListenerMedLogging
 import no.nav.helse.rapids_rivers.JsonMessage
@@ -55,7 +56,7 @@ internal class JournalfoerVedtaksbrevRiver(
                     saksbehandler = packet["vedtak.vedtakFattet.ansvarligSaksbehandler"].asText(),
                 )
 
-            val response = runBlocking { journalfoerBrevService.journalfoerVedtaksbrev(vedtak) } ?: return
+            val response = runBlocking { journalfoerBrevService.journalfoerVedtaksbrev(vedtak, Systembruker.brev) } ?: return
             rapidsConnection.svarSuksess(
                 packet,
                 response.second,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
@@ -133,7 +133,7 @@ class JournalfoerBrevServiceTest {
 
         val service = JournalfoerBrevService(db, behandlingService, dokarkivService, vedtaksbrevService)
         assertThrows<NoSuchElementException> {
-            runBlocking { service.journalfoerVedtaksbrev(vedtak) }
+            runBlocking { service.journalfoerVedtaksbrev(vedtak, Systembruker.brev) }
         }
 
         verify { vedtaksbrevService.hentVedtaksbrev(vedtak.behandlingId) }
@@ -162,7 +162,7 @@ class JournalfoerBrevServiceTest {
         val vedtak = opprettVedtak()
 
         val service = JournalfoerBrevService(db, behandlingService, dokarkivService, vedtaksbrevService)
-        runBlocking { service.journalfoerVedtaksbrev(vedtak) }
+        runBlocking { service.journalfoerVedtaksbrev(vedtak, Systembruker.brev) }
 
         verify(exactly = 1) { vedtaksbrevService.hentVedtaksbrev(vedtak.behandlingId) }
         coVerify(exactly = 0) { dokarkivService.journalfoer(any()) }
@@ -216,7 +216,7 @@ class JournalfoerBrevServiceTest {
         coEvery { dokarkivService.journalfoer(any()) } returns journalpostResponse
 
         val service = JournalfoerBrevService(db, behandlingService, dokarkivService, vedtaksbrevService)
-        runBlocking { service.journalfoerVedtaksbrev(vedtak) }
+        runBlocking { service.journalfoerVedtaksbrev(vedtak, Systembruker.brev) }
 
         verify(exactly = 1) {
             db.hentBrevInnhold(forventetBrev.id)

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiverTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiverTest.kt
@@ -35,6 +35,7 @@ import no.nav.etterlatte.libs.common.vedtak.VedtakInnholdDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseHendelseType
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
+import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.etterlatte.rapidsandrivers.BREV_ID_KEY
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
@@ -77,7 +78,7 @@ internal class JournalfoerVedtaksbrevRiverTest {
         val response = OpprettJournalpostResponse("1234", true, emptyList())
 
         every { vedtaksbrevService.hentVedtaksbrev(any()) } returns brev
-        coEvery { journalfoerBrevService.journalfoerVedtaksbrev(any()) } returns Pair(response, 1)
+        coEvery { journalfoerBrevService.journalfoerVedtaksbrev(any(), Systembruker.brev) } returns Pair(response, 1)
 
         val vedtak = opprettVedtak()
         val melding = opprettMelding(vedtak)
@@ -86,7 +87,7 @@ internal class JournalfoerVedtaksbrevRiverTest {
 
         val vedtakCapture = slot<VedtakTilJournalfoering>()
         coVerify(exactly = 1) {
-            journalfoerBrevService.journalfoerVedtaksbrev(capture(vedtakCapture))
+            journalfoerBrevService.journalfoerVedtaksbrev(capture(vedtakCapture), Systembruker.brev)
         }
 
         val vedtakActual = vedtakCapture.captured

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
@@ -31,6 +31,7 @@ import no.nav.etterlatte.libs.common.vedtak.VedtakInnholdDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseHendelseType
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
+import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.etterlatte.rapidsandrivers.migrering.KILDE_KEY
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
@@ -46,7 +47,7 @@ internal class OpprettJournalfoerOgDistribuer {
         val brev = lagBrev(behandlingId)
         val journalfoerBrevService =
             mockk<JournalfoerBrevService>().also {
-                coEvery { it.journalfoerVedtaksbrev(any()) } returns
+                coEvery { it.journalfoerVedtaksbrev(any(), Systembruker.brev) } returns
                     Pair(
                         OpprettJournalpostResponse(
                             journalpostId = "123",

--- a/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/AutomatiskBehandlingRiver.kt
+++ b/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/AutomatiskBehandlingRiver.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.testdata
 
 import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.etterlatte.rapidsandrivers.BEHANDLING_ID_KEY
 import no.nav.etterlatte.rapidsandrivers.Behandlingssteg
 import no.nav.etterlatte.rapidsandrivers.EventNames
@@ -31,7 +32,14 @@ class AutomatiskBehandlingRiver(
     ) {
         val behandlingssteg = Behandlingssteg.valueOf(packet[Behandlingssteg.KEY].asText())
         runBlocking {
-            behandler.behandle(packet.sakId, packet.behandlingId, behandlingssteg, packet, context)
+            behandler.behandle(
+                packet.sakId,
+                packet.behandlingId,
+                behandlingssteg,
+                packet,
+                context,
+                Systembruker.testdata,
+            )
         }
     }
 

--- a/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/Behandler.kt
+++ b/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/Behandler.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.testdata
 
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.grunnlag.hentDoedsdato
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
 import no.nav.etterlatte.rapidsandrivers.Behandlingssteg
 import no.nav.etterlatte.testdata.automatisk.AvkortingService
@@ -35,42 +36,43 @@ class Behandler(
         behandlingssteg: Behandlingssteg,
         packet: JsonMessage,
         context: MessageContext,
+        bruker: BrukerTokenInfo,
     ) {
         logger.info("Starter automatisk behandling av sak $sakId og behandling $behandling til steg $behandlingssteg")
         if (behandlingssteg in listOf(Behandlingssteg.KLAR, Behandlingssteg.BEHANDLING_OPPRETTA)) {
             return
         }
-        val sak = behandlingService.hentSak(sakId)
+        val sak = behandlingService.hentSak(sakId, bruker)
         logger.info("Henta sak $sakId")
 
         val doedsdato =
             grunnlagService
-                .hentGrunnlagForBehandling(behandling)
+                .hentGrunnlagForBehandling(behandling, bruker)
                 .hentAvdoede()
                 .first()
                 .hentDoedsdato()
 
-        behandlingService.settKommerBarnetTilGode(behandling)
-        behandlingService.lagreGyldighetsproeving(behandling)
-        behandlingService.lagreUtlandstilknytning(behandling)
-        behandlingService.lagreVirkningstidspunkt(behandling, doedsdato?.verdi!!)
-        behandlingService.tildelSaksbehandler(Fagsaksystem.EY.navn, sakId)
+        behandlingService.settKommerBarnetTilGode(behandling, bruker)
+        behandlingService.lagreGyldighetsproeving(behandling, bruker)
+        behandlingService.lagreUtlandstilknytning(behandling, bruker)
+        behandlingService.lagreVirkningstidspunkt(behandling, doedsdato?.verdi!!, bruker)
+        behandlingService.tildelSaksbehandler(Fagsaksystem.EY.navn, sakId, bruker)
 
         logger.info("Tildelt til saksbehandler, klar til vilkårsvurdering")
-        vilkaarsvurderingService.vilkaarsvurder(behandling)
+        vilkaarsvurderingService.vilkaarsvurder(behandling, bruker)
         logger.info("Vilkårsvurderte behandling $behandling i sak $sakId")
         if (behandlingssteg == Behandlingssteg.VILKAARSVURDERT) {
             return
         }
-        trygdetidService.beregnTrygdetid(behandling)
+        trygdetidService.beregnTrygdetid(behandling, bruker)
         logger.info("Beregna trygdetid for $behandling i sak $sakId")
         if (behandlingssteg == Behandlingssteg.TRYGDETID_OPPRETTA) {
             return
         }
         logger.info("Lagrer beregningsgrunnlag")
-        beregningService.lagreBeregningsgrunnlag(behandling, sak.sakType)
+        beregningService.lagreBeregningsgrunnlag(behandling, sak.sakType, bruker)
         logger.info("Lagra beregningsgrunnlag, klar til beregning")
-        beregningService.beregn(behandling)
+        beregningService.beregn(behandling, bruker)
         logger.info("Beregna behandling $behandling i sak $sakId")
         if (behandlingssteg == Behandlingssteg.BEREGNA) {
             return
@@ -79,24 +81,29 @@ class Behandler(
 
         if (sak.sakType == SakType.OMSTILLINGSSTOENAD) {
             logger.info("Avkorter $behandling")
-            avkortingService.avkort(behandling)
+            avkortingService.avkort(behandling, bruker)
             logger.info("Avkorta behandling $behandling i sak $sakId")
         }
         if (behandlingssteg == Behandlingssteg.AVKORTA) {
             return
         }
         logger.info("Klar til å lagre brevutfall for $behandling")
-        behandlingService.lagreBrevutfall(behandling, sak.sakType)
+        behandlingService.lagreBrevutfall(behandling, sak.sakType, bruker)
         logger.info("Ferdig med å lagre brevutfall for behandling $behandling. Klar til å fatte vedtak")
-        val fattaVedtak = vedtaksvurderingService.fattVedtak(sakId, behandling)
+        val fattaVedtak = vedtaksvurderingService.fattVedtak(sakId, behandling, bruker)
         RapidUtsender.sendUt(fattaVedtak, packet, context)
         if (behandlingssteg == Behandlingssteg.VEDTAK_FATTA) {
             return
         }
 
         logger.info("Fatta vedtak for behandling $behandling. Klar til å lage og distribuere vedtaksbrev")
-        brevService.opprettOgDistribuerVedtaksbrev(sakId, behandling)
-        val attestertVedtak = vedtaksvurderingService.attesterOgIverksettVedtak(sakId, behandling)
+        brevService.opprettOgDistribuerVedtaksbrev(sakId, behandling, bruker)
+        val attestertVedtak =
+            vedtaksvurderingService.attesterOgIverksettVedtak(
+                sakId,
+                behandling,
+                bruker,
+            )
         logger.info("Ferdig attestert behandling $behandling i sak $sakId")
         RapidUtsender.sendUt(attestertVedtak, packet, context)
     }

--- a/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/AvkortingService.kt
+++ b/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/AvkortingService.kt
@@ -4,7 +4,7 @@ import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagLagreDto
 import no.nav.etterlatte.libs.common.retryOgPakkUt
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
-import no.nav.etterlatte.libs.ktor.token.Systembruker
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import java.util.UUID
 
 class AvkortingService(
@@ -12,18 +12,20 @@ class AvkortingService(
     private val url: String,
     private val clientId: String,
 ) {
-    suspend fun avkort(behandlingId: UUID) =
-        retryOgPakkUt {
-            klient.post(
-                Resource(clientId, "$url/api/beregning/avkorting/$behandlingId"),
-                Systembruker.testdata,
-                AvkortingGrunnlagLagreDto(
-                    aarsinntekt = 200_000,
-                    fratrekkInnAar = 50_000,
-                    inntektUtland = 0,
-                    fratrekkInnAarUtland = 0,
-                    spesifikasjon = "kun test",
-                ),
-            )
-        }
+    suspend fun avkort(
+        behandlingId: UUID,
+        bruker: BrukerTokenInfo,
+    ) = retryOgPakkUt {
+        klient.post(
+            Resource(clientId, "$url/api/beregning/avkorting/$behandlingId"),
+            bruker,
+            AvkortingGrunnlagLagreDto(
+                aarsinntekt = 200_000,
+                fratrekkInnAar = 50_000,
+                inntektUtland = 0,
+                fratrekkInnAarUtland = 0,
+                spesifikasjon = "kun test",
+            ),
+        )
+    }
 }

--- a/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/BeregningService.kt
+++ b/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/BeregningService.kt
@@ -8,7 +8,7 @@ import no.nav.etterlatte.libs.common.beregning.BeregningsMetodeBeregningsgrunnla
 import no.nav.etterlatte.libs.common.retryOgPakkUt
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
-import no.nav.etterlatte.libs.ktor.token.Systembruker
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.testdata.BEGRUNNELSE
 import java.util.UUID
 
@@ -17,17 +17,20 @@ class BeregningService(
     private val url: String,
     private val clientId: String,
 ) {
-    suspend fun beregn(behandlingId: UUID) =
-        retryOgPakkUt {
-            klient.post(Resource(clientId, "$url/api/beregning/$behandlingId"), Systembruker.testdata) {}.mapBoth(
-                success = {},
-                failure = { throw it },
-            )
-        }
+    suspend fun beregn(
+        behandlingId: UUID,
+        bruker: BrukerTokenInfo,
+    ) = retryOgPakkUt {
+        klient.post(Resource(clientId, "$url/api/beregning/$behandlingId"), bruker) {}.mapBoth(
+            success = {},
+            failure = { throw it },
+        )
+    }
 
     suspend fun lagreBeregningsgrunnlag(
         behandlingId: UUID,
         sakType: SakType,
+        bruker: BrukerTokenInfo,
     ) = retryOgPakkUt {
         val sakTypeArg =
             when (sakType) {
@@ -38,7 +41,7 @@ class BeregningService(
         klient
             .post(
                 Resource(clientId, "$url/api/beregning/beregningsgrunnlag/$behandlingId/$sakTypeArg"),
-                Systembruker.testdata,
+                bruker,
                 LagreBeregningsGrunnlag(
                     soeskenMedIBeregning = listOf(),
                     institusjonsopphold = listOf(),

--- a/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/BrevService.kt
+++ b/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/BrevService.kt
@@ -4,7 +4,7 @@ import com.github.michaelbull.result.mapBoth
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
-import no.nav.etterlatte.libs.ktor.token.Systembruker
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.readValue
 import java.util.UUID
 
@@ -16,18 +16,20 @@ class BrevService(
     suspend fun opprettOgDistribuerVedtaksbrev(
         sakId: Long,
         behandlingId: UUID,
+        bruker: BrukerTokenInfo,
     ) {
-        val brev = opprettVedtaksbrev(behandlingId, sakId)
-        genererPDF(behandlingId, brev)
-        ferdigstillBrev(behandlingId)
+        val brev = opprettVedtaksbrev(behandlingId, sakId, bruker)
+        genererPDF(behandlingId, brev, bruker)
+        ferdigstillBrev(behandlingId, bruker)
     }
 
     private suspend fun opprettVedtaksbrev(
         behandlingId: UUID,
         sakId: Long,
+        bruker: BrukerTokenInfo,
     ): Brev =
         klient
-            .post(Resource(clientId, "$url/api/brev/behandling/$behandlingId/vedtak?sakId=$sakId"), Systembruker.testdata) {}
+            .post(Resource(clientId, "$url/api/brev/behandling/$behandlingId/vedtak?sakId=$sakId"), bruker) {}
             .mapBoth(
                 success = { readValue(it) },
                 failure = { throw it },
@@ -36,9 +38,12 @@ class BrevService(
     private suspend fun genererPDF(
         behandlingId: UUID,
         brev: Brev,
-    ) = klient.get(Resource(clientId, "$url/api/brev/behandling/$behandlingId/vedtak/pdf?brevId=${brev.id}"), Systembruker.testdata)
+        bruker: BrukerTokenInfo,
+    ) = klient.get(Resource(clientId, "$url/api/brev/behandling/$behandlingId/vedtak/pdf?brevId=${brev.id}"), bruker)
 
-    private suspend fun ferdigstillBrev(behandlingId: UUID) =
-        klient.post(Resource(clientId, "$url/api/brev/behandling/$behandlingId/vedtak/ferdigstill"), Systembruker.testdata) {
-        }
+    private suspend fun ferdigstillBrev(
+        behandlingId: UUID,
+        bruker: BrukerTokenInfo,
+    ) = klient.post(Resource(clientId, "$url/api/brev/behandling/$behandlingId/vedtak/ferdigstill"), bruker) {
+    }
 }

--- a/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/GrunnlagService.kt
+++ b/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/GrunnlagService.kt
@@ -5,7 +5,7 @@ import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.retryOgPakkUt
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
-import no.nav.etterlatte.libs.ktor.token.Systembruker
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.readValue
 import java.util.UUID
 
@@ -14,9 +14,12 @@ class GrunnlagService(
     private val url: String,
     private val clientId: String,
 ) {
-    suspend fun hentGrunnlagForBehandling(behandlingId: UUID): Grunnlag =
+    suspend fun hentGrunnlagForBehandling(
+        behandlingId: UUID,
+        bruker: BrukerTokenInfo,
+    ): Grunnlag =
         retryOgPakkUt {
-            klient.get(Resource(clientId, "$url/api/grunnlag/behandling/$behandlingId"), Systembruker.testdata).mapBoth(
+            klient.get(Resource(clientId, "$url/api/grunnlag/behandling/$behandlingId"), bruker).mapBoth(
                 success = { readValue(it) },
                 failure = { throw it },
             )

--- a/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/TrygdetidService.kt
+++ b/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/TrygdetidService.kt
@@ -4,7 +4,7 @@ import com.github.michaelbull.result.mapBoth
 import no.nav.etterlatte.libs.common.retryOgPakkUt
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
-import no.nav.etterlatte.libs.ktor.token.Systembruker
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import java.util.UUID
 
 class TrygdetidService(
@@ -12,11 +12,13 @@ class TrygdetidService(
     private val url: String,
     private val clientId: String,
 ) {
-    suspend fun beregnTrygdetid(behandlingId: UUID) =
-        retryOgPakkUt {
-            klient.post(Resource(clientId, "$url/api/trygdetid_v2/$behandlingId"), Systembruker.testdata) {}
-        }.mapBoth(
-            success = {},
-            failure = { throw it },
-        )
+    suspend fun beregnTrygdetid(
+        behandlingId: UUID,
+        bruker: BrukerTokenInfo,
+    ) = retryOgPakkUt {
+        klient.post(Resource(clientId, "$url/api/trygdetid_v2/$behandlingId"), bruker) {}
+    }.mapBoth(
+        success = {},
+        failure = { throw it },
+    )
 }

--- a/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/VedtaksvurderingService.kt
+++ b/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/VedtaksvurderingService.kt
@@ -4,7 +4,7 @@ import com.github.michaelbull.result.mapBoth
 import no.nav.etterlatte.libs.common.retryOgPakkUt
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
-import no.nav.etterlatte.libs.ktor.token.Systembruker
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.rapidsandrivers.migrering.MigreringKjoringVariant
 import no.nav.etterlatte.readValue
 import no.nav.etterlatte.vedtaksvurdering.VedtakOgRapid
@@ -18,12 +18,13 @@ class VedtaksvurderingService(
     suspend fun fattVedtak(
         sakId: Long,
         behandlingId: UUID,
+        bruker: BrukerTokenInfo,
     ): VedtakOgRapid =
         retryOgPakkUt {
             klient
                 .post(
                     Resource(clientId, "$url/api/vedtak/$sakId/$behandlingId/automatisk/stegvis"),
-                    Systembruker.testdata,
+                    bruker,
                     MigreringKjoringVariant.MED_PAUSE,
                 ).mapBoth(
                     success = { readValue(it) },
@@ -34,12 +35,13 @@ class VedtaksvurderingService(
     suspend fun attesterOgIverksettVedtak(
         sakId: Long,
         behandlingId: UUID,
+        bruker: BrukerTokenInfo,
     ): VedtakOgRapid =
         retryOgPakkUt {
             klient
                 .post(
                     Resource(clientId, "$url/api/vedtak/$sakId/$behandlingId/automatisk/stegvis"),
-                    Systembruker.testdata,
+                    bruker,
                     MigreringKjoringVariant.FORTSETT_ETTER_PAUSE,
                 ).mapBoth(
                     success = { readValue(it) },

--- a/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/automatisk/VilkaarsvurderingService.kt
@@ -5,7 +5,7 @@ import no.nav.etterlatte.libs.common.retryOgPakkUt
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
-import no.nav.etterlatte.libs.ktor.token.Systembruker
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.vilkaarsvurdering.VurdertVilkaarsvurderingResultatDto
 import no.nav.etterlatte.testdata.BEGRUNNELSE
 import org.slf4j.LoggerFactory
@@ -18,43 +18,50 @@ class VilkaarsvurderingService(
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    suspend fun vilkaarsvurder(behandlingId: UUID) {
+    suspend fun vilkaarsvurder(
+        behandlingId: UUID,
+        bruker: BrukerTokenInfo,
+    ) {
         logger.info("Oppretter vilkårsvurdering for gjenoppretting for $behandlingId")
-        retryOgPakkUt { opprettVilkaarsvurdering(behandlingId) }
+        retryOgPakkUt { opprettVilkaarsvurdering(behandlingId, bruker) }
 
         logger.info("Oppdaterer vilkårene med korrekt utfall for gjenoppretting $behandlingId")
 
-        retryOgPakkUt { settVilkaarsvurderingaSomHelhetSomOppfylt(behandlingId) }
+        retryOgPakkUt { settVilkaarsvurderingaSomHelhetSomOppfylt(behandlingId, bruker) }
     }
 
-    private suspend fun opprettVilkaarsvurdering(behandlingId: UUID) =
-        klient
-            .post(
-                Resource(
-                    clientId = clientId,
-                    url = "$url/api/vilkaarsvurdering/$behandlingId/opprett",
-                ),
-                Systembruker.testdata,
-                {},
-            ).mapBoth(
-                success = {},
-                failure = { throw it },
-            )
+    private suspend fun opprettVilkaarsvurdering(
+        behandlingId: UUID,
+        bruker: BrukerTokenInfo,
+    ) = klient
+        .post(
+            Resource(
+                clientId = clientId,
+                url = "$url/api/vilkaarsvurdering/$behandlingId/opprett",
+            ),
+            bruker,
+            {},
+        ).mapBoth(
+            success = {},
+            failure = { throw it },
+        )
 
-    private suspend fun settVilkaarsvurderingaSomHelhetSomOppfylt(behandlingId: UUID) =
-        klient
-            .post(
-                Resource(
-                    clientId = clientId,
-                    url = "$url/api/vilkaarsvurdering/resultat/$behandlingId",
-                ),
-                Systembruker.testdata,
-                VurdertVilkaarsvurderingResultatDto(
-                    resultat = VilkaarsvurderingUtfall.OPPFYLT,
-                    kommentar = BEGRUNNELSE,
-                ),
-            ).mapBoth(
-                success = {},
-                failure = { throw it },
-            )
+    private suspend fun settVilkaarsvurderingaSomHelhetSomOppfylt(
+        behandlingId: UUID,
+        bruker: BrukerTokenInfo,
+    ) = klient
+        .post(
+            Resource(
+                clientId = clientId,
+                url = "$url/api/vilkaarsvurdering/resultat/$behandlingId",
+            ),
+            bruker,
+            VurdertVilkaarsvurderingResultatDto(
+                resultat = VilkaarsvurderingUtfall.OPPFYLT,
+                kommentar = BEGRUNNELSE,
+            ),
+        ).mapBoth(
+            success = {},
+            failure = { throw it },
+        )
 }

--- a/libs/etterlatte-ktor/src/main/kotlin/token/BrukerTokenInfo.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/token/BrukerTokenInfo.kt
@@ -70,11 +70,8 @@ data class Systembruker(
     override fun kanEndreOppgaverFor(ident: String?) = true
 
     companion object {
-        val migrering = Systembruker(Systembrukere.MIGRERING)
         val brev = Systembruker(Systembrukere.BREV)
         val doedshendelse = Systembruker(Systembrukere.DOEDSHENDELSE)
-        val regulering = Systembruker(Systembrukere.REGULERING)
-        val tekniskRetting = Systembruker(Systembrukere.TEKNISK_RETTING)
         val testdata = Systembruker(Systembrukere.TESTDATA)
         val automatiskJobb = Systembruker(Systembrukere.AUTOMATISK_JOBB)
     }
@@ -150,10 +147,7 @@ enum class Systembrukere(
     val appName: String,
 ) {
     BREV("brev"),
-    MIGRERING("migrering"),
     DOEDSHENDELSE("doedshendelse"),
-    REGULERING("regulering"),
-    TEKNISK_RETTING("teknisk_retting"),
     TESTDATA("testdata"),
     AUTOMATISK_JOBB("automatisk_jobb"),
 }


### PR DESCRIPTION
Og bruker `brukerTokenInfo` frå kallet der vi har det tilgjengeleg.

Målbildet er at vi kun bruker systembruker-hardkodinga frå ein automatisk jobb eller frå rivers, kor vi faktisk ikkje har eit kallande system. Kjem ein eller fleire PRs etter denne som går vidare.

(Denne er første del i ei meir strukturert tilnærming til å ende ca samme plass som https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/5392 )