### PR TITLE
FAGSYSTEM-328806: For migrert yrkesskadefordel er maksalder for BP 21 år

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/vilkaarsvurdering/VilkaarsvurderingKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/vilkaarsvurdering/VilkaarsvurderingKlient.kt
@@ -13,6 +13,7 @@ import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
+import vilkaarsvurdering.MigrertYrkesskadefordel
 import java.util.UUID
 
 class VilkaarsvurderingKlientException(
@@ -61,4 +62,23 @@ class VilkaarsvurderingKlient(
             }
         }
     }
+
+    internal suspend fun erMigrertYrkesskade(
+        behandlingId: UUID,
+        bruker: BrukerTokenInfo,
+    ): Boolean =
+        downstreamResourceClient
+            .get(
+                resource =
+                    Resource(
+                        clientId = clientId,
+                        url = "$resourceUrl/api/vilkaarsvurdering/$behandlingId",
+                    ),
+                brukerTokenInfo = bruker,
+            ).mapBoth(
+                success = { resource ->
+                    resource.response.let { objectMapper.readValue<MigrertYrkesskadefordel>(it.toString()) }.migrertYrkesskadefordel
+                },
+                failure = { throwableErrorMessage -> throw throwableErrorMessage },
+            )
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/vilkaarsvurdering/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/vilkaarsvurdering/VilkaarsvurderingService.kt
@@ -10,4 +10,9 @@ class VilkaarsvurderingService(
         behandlingId: UUID,
         bruker: BrukerTokenInfo,
     ) = klient.hentVilkaarsvurdering(behandlingId, bruker)
+
+    suspend fun erMigrertYrkesskade(
+        behandlingId: UUID,
+        bruker: BrukerTokenInfo,
+    ) = klient.erMigrertYrkesskade(behandlingId, bruker)
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
@@ -282,6 +282,8 @@ class BrevDataMapperFerdigstillingVedtak(
         val etterbetaling = async { behandlingService.hentEtterbetaling(behandlingId, bruker) }
         val brevutfall = async { behandlingService.hentBrevutfall(behandlingId, bruker) }
 
+        val erMigrertYrkesskade = async { vilkaarsvurderingService.erMigrertYrkesskade(behandlingId, bruker) }
+
         val datoVedtakOmgjoering =
             klage
                 ?.formkrav
@@ -302,6 +304,7 @@ class BrevDataMapperFerdigstillingVedtak(
             erForeldreloes,
             avdoede,
             datoVedtakOmgjoering,
+            erMigrertYrkesskade.await(),
         )
     }
 
@@ -330,6 +333,7 @@ class BrevDataMapperFerdigstillingVedtak(
         val grunnbeloep = async { beregningService.hentGrunnbeloep(bruker) }
         val etterbetaling = async { behandlingService.hentEtterbetaling(behandlingId, bruker) }
         val brevutfall = async { behandlingService.hentBrevutfall(behandlingId, bruker) }
+        val erMigrertYrkesskade = async { vilkaarsvurderingService.erMigrertYrkesskade(behandlingId, bruker) }
 
         if (erForeldreloes) {
             BarnepensjonInnvilgelseForeldreloes.fra(
@@ -343,6 +347,7 @@ class BrevDataMapperFerdigstillingVedtak(
                 loependeIPesys,
                 avdoede,
                 erGjenoppretting = systemkilde == Vedtaksloesning.GJENOPPRETTA,
+                erMigrertYrkesskade = erMigrertYrkesskade.await(),
             )
         } else {
             BarnepensjonInnvilgelse.fra(
@@ -355,6 +360,7 @@ class BrevDataMapperFerdigstillingVedtak(
                 utlandstilknytningType,
                 requireNotNull(brevutfall.await()),
                 erGjenoppretting = systemkilde == Vedtaksloesning.GJENOPPRETTA,
+                erMigrertYrkesskade = erMigrertYrkesskade.await(),
             )
         }
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
@@ -30,6 +30,7 @@ data class BarnepensjonInnvilgelse(
     val kunNyttRegelverk: Boolean,
     val erGjenoppretting: Boolean,
     val harUtbetaling: Boolean,
+    val erMigrertYrkesskade: Boolean,
 ) : BrevDataFerdigstilling {
     companion object {
         val tidspunktNyttRegelverk: LocalDate = LocalDate.of(2024, 1, 1)
@@ -44,6 +45,7 @@ data class BarnepensjonInnvilgelse(
             utlandstilknytning: UtlandstilknytningType?,
             brevutfall: BrevutfallDto,
             erGjenoppretting: Boolean,
+            erMigrertYrkesskade: Boolean,
         ): BarnepensjonInnvilgelse {
             val beregningsperioder = barnepensjonBeregningsperioder(utbetalingsinfo)
             return BarnepensjonInnvilgelse(
@@ -59,6 +61,7 @@ data class BarnepensjonInnvilgelse(
                     },
                 erGjenoppretting = erGjenoppretting,
                 harUtbetaling = beregningsperioder.any { it.utbetaltBeloep.value > 0 },
+                erMigrertYrkesskade = erMigrertYrkesskade,
             )
         }
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelseForeldreloes.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelseForeldreloes.kt
@@ -30,6 +30,7 @@ data class BarnepensjonInnvilgelseForeldreloes(
     val harUtbetaling: Boolean,
     val erGjenoppretting: Boolean,
     val vedtattIPesys: Boolean,
+    val erMigrertYrkesskade: Boolean,
 ) : BrevDataFerdigstilling {
     companion object {
         val tidspunktNyttRegelverk: LocalDate = LocalDate.of(2024, 1, 1)
@@ -45,6 +46,7 @@ data class BarnepensjonInnvilgelseForeldreloes(
             vedtattIPesys: Boolean,
             avdoede: List<Avdoed>,
             erGjenoppretting: Boolean,
+            erMigrertYrkesskade: Boolean,
         ): BarnepensjonInnvilgelseForeldreloes {
             val beregningsperioder =
                 barnepensjonBeregningsperioder(utbetalingsinfo)
@@ -71,6 +73,7 @@ data class BarnepensjonInnvilgelseForeldreloes(
                 harUtbetaling = utbetalingsinfo.beregningsperioder.any { it.utbetaltBeloep.value > 0 },
                 erGjenoppretting = erGjenoppretting,
                 vedtattIPesys = vedtattIPesys,
+                erMigrertYrkesskade = erMigrertYrkesskade,
             )
         }
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
@@ -36,6 +36,7 @@ data class BarnepensjonRevurdering(
     val harFlereUtbetalingsperioder: Boolean,
     val harUtbetaling: Boolean,
     val feilutbetaling: FeilutbetalingType,
+    val erMigrertYrkesskade: Boolean,
 ) : BrevDataFerdigstilling {
     companion object {
         fun fra(
@@ -51,6 +52,7 @@ data class BarnepensjonRevurdering(
             erForeldreloes: Boolean,
             avdoede: List<Avdoed>,
             datoVedtakOmgjoering: LocalDate?,
+            erMigrertYrkesskade: Boolean,
         ): BarnepensjonRevurdering {
             val beregningsperioder = barnepensjonBeregningsperioder(utbetalingsinfo)
             val feilutbetaling = toFeilutbetalingType(requireNotNull(brevutfall.feilutbetaling?.valg))
@@ -89,6 +91,7 @@ data class BarnepensjonRevurdering(
                             )
                     },
                 feilutbetaling = feilutbetaling,
+                erMigrertYrkesskade = erMigrertYrkesskade,
             )
         }
     }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgetDTOTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgetDTOTest.kt
@@ -118,6 +118,7 @@ internal class BarnepensjonInnvilgetDTOTest {
                             doedsdato = LocalDate.now(),
                         ),
                     ),
+                erMigrertYrkesskade = false,
             )
 
         Assertions.assertEquals(

--- a/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/services/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/services/VilkaarsvurderingService.kt
@@ -10,6 +10,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.vilkaarsvurdering.OpprettVilkaarsvurderingFraBehandling
+import vilkaarsvurdering.MigrertYrkesskadefordel
 import java.util.UUID
 
 interface VilkaarsvurderingService {
@@ -64,7 +65,8 @@ class VilkaarsvurderingServiceImpl(
         runBlocking {
             vilkaarsvurderingKlient
                 .get("$url/api/vilkaarsvurdering/$behandlingId/migrert-yrkesskadefordel")
-                .body<Map<String, Any>>()["migrertYrkesskadefordel"] as Boolean
+                .body<MigrertYrkesskadefordel>()
+                .migrertYrkesskadefordel
         }
 
     override fun harRettUtenTidsbegrensning(behandlingId: String): Boolean =

--- a/apps/etterlatte-vilkaarsvurdering/build.gradle.kts
+++ b/apps/etterlatte-vilkaarsvurdering/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(project(":libs:etterlatte-database"))
     implementation(project(":libs:etterlatte-vilkaarsvurdering-model"))
     implementation(project(":libs:etterlatte-funksjonsbrytere"))
+    implementation(project(":libs:etterlatte-jobs"))
 
     implementation(libs.ktor2.okhttp)
     implementation(libs.ktor2.servercore)

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/Application.kt
@@ -24,6 +24,7 @@ class Server(
             initEmbeddedServer(
                 httpPort = properties.httpPort,
                 applicationConfig = context.config,
+                cronJobs = listOf(migrertYrkesskadeJob),
             ) {
                 vilkaarsvurdering(vilkaarsvurderingService, behandlingKlient)
                 aldersovergang(behandlingKlient, aldersovergangService)

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/MigrertYrkesskadeOppdaterer.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/MigrertYrkesskadeOppdaterer.kt
@@ -1,0 +1,56 @@
+package no.nav.etterlatte.no.nav.etterlatte.vilkaarsvurdering
+
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.jobs.LoggerInfo
+import no.nav.etterlatte.jobs.fixedRateCancellableTimer
+import no.nav.etterlatte.libs.common.TimerJob
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.libs.ktor.token.Systembruker
+import no.nav.etterlatte.vilkaarsvurdering.VilkaarsvurderingRepository
+import no.nav.etterlatte.vilkaarsvurdering.klienter.BehandlingKlient
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.util.Timer
+import java.util.UUID
+
+class MigrertYrkesskadeJob(
+    private val oppdaterer: MigrertYrkesskadeOppdaterer,
+    private val erLeader: () -> Boolean,
+) : TimerJob {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val jobbNavn = this::class.simpleName
+
+    override fun schedule(): Timer =
+        fixedRateCancellableTimer(
+            name = jobbNavn,
+            initialDelay = Duration.ofMinutes(2).toMillis(),
+            period = Duration.ofDays(1).toMillis(),
+            loggerInfo = LoggerInfo(logger = logger, loggTilSikkerLogg = false),
+        ) {
+            if (erLeader()) {
+                runBlocking {
+                    oppdaterer.settSakPaaAlleMigrerteYrkesskadefordeler(Systembruker.automatiskJobb)
+                }
+            }
+        }
+}
+
+class MigrertYrkesskadeOppdaterer(
+    val behandlingKlient: BehandlingKlient,
+    private val vilkaarsvurderingRepository: VilkaarsvurderingRepository,
+) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    suspend fun settSakPaaAlleMigrerteYrkesskadefordeler(bruker: BrukerTokenInfo) =
+        vilkaarsvurderingRepository.hentAlleMigrertYrkesskadefordel().forEach { settSak(it, bruker) }
+
+    private suspend fun settSak(
+        behandlingID: UUID,
+        bruker: BrukerTokenInfo,
+    ) {
+        val sak = behandlingKlient.hentBehandling(behandlingID, bruker).sak
+        logger.info("Kopler sak $sak til behandling $behandlingID for migrert yrkesskade")
+        vilkaarsvurderingRepository.settSakPaaMigrertYrkesskadefordel(behandlingID, sak)
+        logger.info("Ferdig med å kople sak $sak til behandling $behandlingID for migrert yrkesskade")
+    }
+}

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRepository.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRepository.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import no.nav.etterlatte.libs.database.Transactions
 import no.nav.etterlatte.libs.database.hent
+import no.nav.etterlatte.libs.database.hentListe
 import no.nav.etterlatte.libs.database.oppdater
 import no.nav.etterlatte.libs.database.tidspunkt
 import no.nav.etterlatte.libs.database.transaction
@@ -45,6 +46,29 @@ class VilkaarsvurderingRepository(
                             }.asSingle,
                     )
                 }
+        }
+
+    fun settSakPaaMigrertYrkesskadefordel(
+        behandlingId: UUID,
+        sakId: Long,
+        tx: TransactionalSession? = null,
+    ) = tx.session {
+        oppdater(
+            query = Queries.SETT_SAK_MIGRERT_YRKESSKADE,
+            params =
+                mapOf(
+                    "behandling_id" to behandlingId,
+                    "sak_id" to sakId,
+                ),
+            loggtekst = "Lagrer sak for behandling $behandlingId",
+        )
+    }
+
+    fun hentAlleMigrertYrkesskadefordel(tx: TransactionalSession? = null) =
+        tx.session {
+            hentListe(queryString = Queries.HENT_ALLE_MIGRERT_YRKESSKADE) {
+                it.uuid("behandling_id")
+            }
         }
 
     fun hentMigrertYrkesskadefordel(
@@ -394,6 +418,14 @@ class VilkaarsvurderingRepository(
 
         const val HENT_MIGRERT_YRKESSKADE = """
             SELECT behandling_id FROM migrert_yrkesskade WHERE behandling_id = :behandling_id
+        """
+
+        const val HENT_ALLE_MIGRERT_YRKESSKADE = """
+            SELECT behandling_id FROM migrert_yrkesskade
+        """
+
+        const val SETT_SAK_MIGRERT_YRKESSKADE = """
+            UPDATE migrert_yrkesskade SET sak_id=:sak_id WHERE behandling_id=:behandling_id 
         """
 
         const val HENT_VILKAAR = """

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRepository.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRepository.kt
@@ -72,14 +72,14 @@ class VilkaarsvurderingRepository(
         }
 
     fun hentMigrertYrkesskadefordel(
-        behandlingId: UUID,
+        sakId: Long,
         tx: TransactionalSession? = null,
     ) = tx.session {
         hent(
             queryString = Queries.HENT_MIGRERT_YRKESSKADE,
             params =
                 mapOf(
-                    "behandling_id" to behandlingId,
+                    "sak_id" to sakId,
                 ),
         ) {
             true
@@ -417,7 +417,7 @@ class VilkaarsvurderingRepository(
         """
 
         const val HENT_MIGRERT_YRKESSKADE = """
-            SELECT behandling_id FROM migrert_yrkesskade WHERE behandling_id = :behandling_id
+            SELECT sak_id FROM migrert_yrkesskade WHERE sak_id = :sak_id
         """
 
         const val HENT_ALLE_MIGRERT_YRKESSKADE = """

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
@@ -23,6 +23,7 @@ import no.nav.etterlatte.libs.ktor.route.withParam
 import no.nav.etterlatte.libs.ktor.token.brukerTokenInfo
 import no.nav.etterlatte.libs.vilkaarsvurdering.VurdertVilkaarsvurderingResultatDto
 import no.nav.etterlatte.vilkaarsvurdering.klienter.BehandlingKlient
+import vilkaarsvurdering.MigrertYrkesskadefordel
 import java.util.UUID
 
 fun Route.vilkaarsvurdering(
@@ -55,7 +56,7 @@ fun Route.vilkaarsvurdering(
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Henter vilkårsvurdering for $behandlingId")
                 val result = vilkaarsvurderingService.erMigrertYrkesskadefordel(behandlingId)
-                call.respond(mapOf("migrertYrkesskadefordel" to result))
+                call.respond(MigrertYrkesskadefordel(result))
             }
         }
 

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
@@ -55,7 +55,7 @@ fun Route.vilkaarsvurdering(
         get("/{$BEHANDLINGID_CALL_PARAMETER}/migrert-yrkesskadefordel") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Henter vilkårsvurdering for $behandlingId")
-                val result = vilkaarsvurderingService.erMigrertYrkesskadefordel(behandlingId)
+                val result = vilkaarsvurderingService.erMigrertYrkesskadefordel(behandlingId, brukerTokenInfo)
                 call.respond(MigrertYrkesskadefordel(result))
             }
         }

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
@@ -39,7 +39,13 @@ class VilkaarsvurderingService(
 
     fun hentVilkaarsvurdering(behandlingId: UUID): Vilkaarsvurdering? = vilkaarsvurderingRepository.hent(behandlingId)
 
-    fun erMigrertYrkesskadefordel(behandlingId: UUID): Boolean = vilkaarsvurderingRepository.hentMigrertYrkesskadefordel(behandlingId)
+    suspend fun erMigrertYrkesskadefordel(
+        behandlingId: UUID,
+        bruker: BrukerTokenInfo,
+    ): Boolean =
+        vilkaarsvurderingRepository.hentMigrertYrkesskadefordel(
+            behandlingKlient.hentBehandling(behandlingId, bruker).sak,
+        )
 
     fun harRettUtenTidsbegrensning(behandlingId: UUID): Boolean =
         vilkaarsvurderingRepository

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/config/ApplicationContext.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/config/ApplicationContext.kt
@@ -2,9 +2,13 @@ package no.nav.etterlatte.vilkaarsvurdering.config
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
+import no.nav.etterlatte.libs.common.Miljoevariabler
 import no.nav.etterlatte.libs.database.ApplicationProperties
 import no.nav.etterlatte.libs.database.DataSourceBuilder
+import no.nav.etterlatte.libs.jobs.LeaderElection
 import no.nav.etterlatte.libs.ktor.httpClient
+import no.nav.etterlatte.no.nav.etterlatte.vilkaarsvurdering.MigrertYrkesskadeJob
+import no.nav.etterlatte.no.nav.etterlatte.vilkaarsvurdering.MigrertYrkesskadeOppdaterer
 import no.nav.etterlatte.vilkaarsvurdering.AldersovergangService
 import no.nav.etterlatte.vilkaarsvurdering.DelvilkaarRepository
 import no.nav.etterlatte.vilkaarsvurdering.VilkaarsvurderingRepository
@@ -26,4 +30,8 @@ class ApplicationContext {
             grunnlagKlient = GrunnlagKlientImpl(config, httpClient()),
         )
     val aldersovergangService = AldersovergangService(vilkaarsvurderingService)
+    private val env: Miljoevariabler = Miljoevariabler(System.getenv())
+    private val leaderElectionKlient = LeaderElection(env.maybeEnvValue("ELECTOR_PATH"), httpClient())
+    private val migrertYrkesskadeOppdaterer = MigrertYrkesskadeOppdaterer(behandlingKlient, vilkaarsvurderingRepository)
+    val migrertYrkesskadeJob = MigrertYrkesskadeJob(migrertYrkesskadeOppdaterer) { leaderElectionKlient.isLeader() }
 }

--- a/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V24__migrert_yrkesskade.sql
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V24__migrert_yrkesskade.sql
@@ -1,0 +1,1 @@
+ALTER TABLE migrert_yrkesskade ADD COLUMN sak_id bigint;

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/MigrertYrkesskadeTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/MigrertYrkesskadeTest.kt
@@ -1,14 +1,20 @@
 package no.nav.etterlatte.vilkaarsvurdering
 
+import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.insert
 import no.nav.etterlatte.libs.common.Vedtaksloesning
+import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.Delvilkaar
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.Lovreferanse
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.Utfall
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.Vilkaar
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarType
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarVurderingData
+import no.nav.etterlatte.libs.ktor.token.Systembruker
+import no.nav.etterlatte.vilkaarsvurdering.klienter.BehandlingKlient
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -27,10 +33,19 @@ class MigrertYrkesskadeTest(
     fun `er migrert yrkesskadefordel`() {
         val delvilkaarRepository = DelvilkaarRepository()
         val repository = VilkaarsvurderingRepository(ds = dataSource, delvilkaarRepository = delvilkaarRepository)
+        val sakId = 10L
         val service =
             VilkaarsvurderingService(
                 vilkaarsvurderingRepository = repository,
-                behandlingKlient = mockk(),
+                behandlingKlient =
+                    mockk<BehandlingKlient>().also {
+                        coEvery {
+                            it.hentBehandling(
+                                any(),
+                                any(),
+                            )
+                        } returns mockk<DetaljertBehandling>().also { every { it.sak } returns sakId }
+                    },
                 grunnlagKlient = mockk(),
             )
         val behandlingId = UUID.randomUUID()
@@ -59,12 +74,15 @@ class MigrertYrkesskadeTest(
                 vilkaar = listOf(vilkaarMigrertYrkesskade),
             )
         repository.opprettVilkaarsvurdering(vilkaarsvurdering)
-        Assertions.assertFalse(service.erMigrertYrkesskadefordel(behandlingId))
-        dataSource.insert("migrert_yrkesskade", params = {
-            mapOf(
-                "behandling_id" to behandlingId,
-            )
-        })
-        Assertions.assertTrue(service.erMigrertYrkesskadefordel(behandlingId))
+        runBlocking {
+            Assertions.assertFalse(service.erMigrertYrkesskadefordel(behandlingId, Systembruker.testdata))
+            dataSource.insert("migrert_yrkesskade", params = {
+                mapOf(
+                    "behandling_id" to behandlingId,
+                    "sak_id" to sakId,
+                )
+            })
+            Assertions.assertTrue(service.erMigrertYrkesskadefordel(behandlingId, Systembruker.testdata))
+        }
     }
 }

--- a/libs/etterlatte-vilkaarsvurdering-model/src/main/kotlin/vilkaarsvurdering/MigrertYrkesskadefordel.kt
+++ b/libs/etterlatte-vilkaarsvurdering-model/src/main/kotlin/vilkaarsvurdering/MigrertYrkesskadefordel.kt
@@ -1,0 +1,5 @@
+package vilkaarsvurdering
+
+data class MigrertYrkesskadefordel(
+    val migrertYrkesskadefordel: Boolean,
+)


### PR DESCRIPTION
Avhengig av https://github.com/navikt/pensjonsbrev/pull/823

For migrert yrkesskadefordel er maksalder for å få barnepensjon 21 år. Det må også gjenspeglast i brevet.

Det er nokre fleire brev og brevfragment der vi har hardkoda inn 20 år også. Er litt usikker på kor 21 er relevant der, så tar ikkje det i denne omgang, kun der det faktisk er aktuelt no - altså innvilgelsesbrev.