### PR TITLE
EY-4091: Deserialisering er kronisk sårbart i den Java-baserte verda

### DIFF
--- a/libs/etterlatte-ktor/src/main/kotlin/RestModule.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/RestModule.kt
@@ -37,6 +37,7 @@ import no.nav.security.token.support.core.jwt.JwtToken
 import no.nav.security.token.support.v2.tokenValidationSupport
 import org.slf4j.Logger
 import org.slf4j.event.Level
+import java.io.ObjectInputFilter
 import java.util.UUID
 
 fun Application.restModule(
@@ -130,6 +131,8 @@ fun Application.restModule(
     if (withMetrics) {
         metricsRoute(additionalMetrics)
     }
+
+    ObjectInputFilter.Config.setSerialFilter(Serialiseringsfilter())
 }
 
 internal fun Throwable.erDeserialiseringsException(): Boolean {

--- a/libs/etterlatte-ktor/src/main/kotlin/RestModule.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/RestModule.kt
@@ -132,7 +132,9 @@ fun Application.restModule(
         metricsRoute(additionalMetrics)
     }
 
-    ObjectInputFilter.Config.setSerialFilter(Serialiseringsfilter())
+    if (ObjectInputFilter.Config.getSerialFilter() !is Serialiseringsfilter) {
+        ObjectInputFilter.Config.setSerialFilter(Serialiseringsfilter())
+    }
 }
 
 internal fun Throwable.erDeserialiseringsException(): Boolean {

--- a/libs/etterlatte-ktor/src/main/kotlin/Serialiseringsfilter.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/Serialiseringsfilter.kt
@@ -11,8 +11,14 @@ class Serialiseringsfilter : ObjectInputFilter {
     override fun checkInput(info: FilterInfo): Status {
         val serialClass = info.serialClass()
         return when {
-            serialClass == null -> Status.UNDECIDED
-            tillatt(serialClass) -> Status.ALLOWED
+            serialClass == null -> {
+                logger.warn("Serialclass er null, dette er rart. Info: $info")
+                Status.UNDECIDED
+            }
+            tillatt(serialClass) -> {
+                logger.info("Tillater klasse $serialClass for deserialisering")
+                Status.ALLOWED
+            }
             else -> {
                 logger.warn("Klasse ${serialClass.name} er ikke tillatt for deserialisering")
                 Status.REJECTED

--- a/libs/etterlatte-ktor/src/main/kotlin/Serialiseringsfilter.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/Serialiseringsfilter.kt
@@ -1,0 +1,21 @@
+package no.nav.etterlatte.libs.ktor
+
+import java.io.ObjectInputFilter
+import java.io.ObjectInputFilter.FilterInfo
+import java.io.ObjectInputFilter.Status
+
+class Serialiseringsfilter : ObjectInputFilter {
+    override fun checkInput(info: FilterInfo): Status {
+        val serialClass = info.serialClass()
+        return when {
+            serialClass == null -> Status.UNDECIDED
+            tillatt(serialClass) -> Status.ALLOWED
+            else -> Status.REJECTED
+        }
+    }
+
+    private fun tillatt(serialClass: Class<*>) =
+        serialClass.module.name == "java.base" ||
+            serialClass.module.name == "kotlin" ||
+            serialClass.packageName.startsWith("no.nav.etterlatte")
+}

--- a/libs/etterlatte-ktor/src/main/kotlin/Serialiseringsfilter.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/Serialiseringsfilter.kt
@@ -1,16 +1,22 @@
 package no.nav.etterlatte.libs.ktor
 
+import org.slf4j.LoggerFactory
 import java.io.ObjectInputFilter
 import java.io.ObjectInputFilter.FilterInfo
 import java.io.ObjectInputFilter.Status
 
 class Serialiseringsfilter : ObjectInputFilter {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
     override fun checkInput(info: FilterInfo): Status {
         val serialClass = info.serialClass()
         return when {
             serialClass == null -> Status.UNDECIDED
             tillatt(serialClass) -> Status.ALLOWED
-            else -> Status.REJECTED
+            else -> {
+                logger.warn("Klasse ${serialClass.name} er ikke tillatt for deserialisering")
+                Status.REJECTED
+            }
         }
     }
 


### PR DESCRIPTION
Med ObjectInputFilter kan vi sikre at vi kun prøver å deserialisere klassar frå gitte modular og gitte pakkar, sånn at eventuelle deserialiserings-sårbarheiter, som det fins mange av, i særleg eksterne bibliotek ikkje kan ramme oss, ved at deserialiseringskoden da ikkje blir eksekvert.

Er litt usikker på akkurat kva vi skal tillate og ikkje i request-objekta våre. Har lagt sjekken no på at det er kode i java base-modulen, altså basisklassane i Java som er string, collections etc, og vår eigen frå no.nav.etterlatte, samt basisklassane frå Kotlin