### PR TITLE
EY-4233: Samkøyrer initialiseringa av R&R-appane våre

### DIFF
--- a/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -7,7 +7,7 @@ import no.nav.etterlatte.libs.common.Miljoevariabler
 import rapidsandrivers.initRogR
 
 fun main() =
-    initRogR { rapidsConnection, rapidEnv ->
+    initRogR("beregning-kafka") { rapidsConnection, rapidEnv ->
         val beregningService = AppBuilder(Miljoevariabler(rapidEnv)).createBeregningService()
         OmregningHendelserBeregningRiver(
             rapidsConnection,

--- a/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -4,22 +4,17 @@ import no.nav.etterlatte.beregningkafka.AppBuilder
 import no.nav.etterlatte.beregningkafka.OmregningHendelserBeregningRiver
 import no.nav.etterlatte.beregningkafka.SjekkOmOverstyrtBeregningRiver
 import no.nav.etterlatte.libs.common.Miljoevariabler
-import no.nav.etterlatte.rapidsandrivers.getRapidEnv
-import no.nav.helse.rapids_rivers.RapidApplication
+import rapidsandrivers.initRogR
 
-fun main() {
-    val rapidEnv = getRapidEnv()
-    RapidApplication
-        .create(rapidEnv)
-        .also { rapidsConnection ->
-            val beregningService = AppBuilder(Miljoevariabler(rapidEnv)).createBeregningService()
-            OmregningHendelserBeregningRiver(
-                rapidsConnection,
-                beregningService,
-            )
-            SjekkOmOverstyrtBeregningRiver(
-                rapidsConnection,
-                beregningService,
-            )
-        }.start()
-}
+fun main() =
+    initRogR { rapidsConnection, rapidEnv ->
+        val beregningService = AppBuilder(Miljoevariabler(rapidEnv)).createBeregningService()
+        OmregningHendelserBeregningRiver(
+            rapidsConnection,
+            beregningService,
+        )
+        SjekkOmOverstyrtBeregningRiver(
+            rapidsConnection,
+            beregningService,
+        )
+    }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte
 
 fun main() {
-    val application = ApplicationBuilder()
-    application.start()
+    ApplicationBuilder()
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -70,6 +70,7 @@ import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 import no.nav.etterlatte.libs.ktor.ktor.clientCredential
 import no.nav.etterlatte.libs.ktor.restModule
 import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
+import no.nav.etterlatte.libs.ktor.setReady
 import no.nav.etterlatte.rapidsandrivers.configFromEnvironment
 import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import no.nav.etterlatte.rivers.DistribuerBrevRiver
@@ -283,7 +284,7 @@ class ApplicationBuilder {
             VedtaksbrevUnderkjentRiver(rapidsConnection, vedtaksbrevService)
             DistribuerBrevRiver(rapidsConnection, brevdistribuerer)
             SamordningsnotatRiver(rapidsConnection, nyNotatService)
-        }
+        }.also { setReady() }
 
     private fun httpClient(
         scope: String? = null,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -61,7 +61,6 @@ import no.nav.etterlatte.brev.varselbrev.varselbrevRoute
 import no.nav.etterlatte.brev.vedtaksbrevRoute
 import no.nav.etterlatte.brev.virusskanning.ClamAvClient
 import no.nav.etterlatte.brev.virusskanning.VirusScanService
-import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.common.requireEnvValue
 import no.nav.etterlatte.libs.database.DataSourceBuilder
@@ -90,10 +89,6 @@ val sikkerLogg: Logger = sikkerlogger()
 
 class ApplicationBuilder {
     private val config = ConfigFactory.load()
-
-    init {
-        sikkerLoggOppstartOgAvslutning("etterlatte-brev-api")
-    }
 
     private val env = getRapidEnv()
 
@@ -245,6 +240,7 @@ class ApplicationBuilder {
 
     private val rapidsConnection =
         initRogR(
+            applikasjonsnavn = "brev-api",
             restModule = {
                 restModule(sikkerLogg, routePrefix = "api", config = HoconApplicationConfig(config)) {
                     brevRoute(brevService, pdfService, brevdistribuerer, tilgangssjekker, grunnlagService, behandlingService)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -253,6 +253,7 @@ class ApplicationBuilder {
                 }
             },
             configFromEnvironment = { configFromEnvironment(it) },
+            setReady = { setReady() },
         ) { rapidsConnection, _ ->
             val brevgenerering =
                 StartInformasjonsbrevgenereringRiver(
@@ -284,7 +285,7 @@ class ApplicationBuilder {
             VedtaksbrevUnderkjentRiver(rapidsConnection, vedtaksbrevService)
             DistribuerBrevRiver(rapidsConnection, brevdistribuerer)
             SamordningsnotatRiver(rapidsConnection, nyNotatService)
-        }.also { setReady() }
+        }
 
     private fun httpClient(
         scope: String? = null,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/ApplicationLocalhost.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/ApplicationLocalhost.kt
@@ -3,4 +3,4 @@ package no.nav.etterlatte
 /*
 * Brukes ved lokal kjøring for å få logging med test logback.xml som ikke bruker JSON_STDOUT
 */
-fun main() = ApplicationBuilder().start()
+fun main() = ApplicationBuilder()

--- a/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
@@ -26,7 +26,6 @@ import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.httpClient
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 import no.nav.etterlatte.libs.ktor.restModule
-import no.nav.etterlatte.libs.ktor.setReady
 import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import org.slf4j.Logger
 import rapidsandrivers.initRogR
@@ -77,7 +76,6 @@ class ApplicationBuilder {
                     }
                 }
             },
-            setReady = { setReady() },
         ) { rapidsConnection, _ ->
             GrunnlagsversjoneringRiver(rapidsConnection, grunnlagService)
             GrunnlagHendelserRiver(rapidsConnection, grunnlagService)

--- a/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
@@ -25,6 +25,8 @@ import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.httpClient
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 import no.nav.etterlatte.libs.ktor.restModule
+import no.nav.etterlatte.libs.ktor.setReady
+import no.nav.etterlatte.rapidsandrivers.configFromEnvironment
 import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import org.slf4j.Logger
 import rapidsandrivers.initRogR
@@ -72,8 +74,9 @@ class ApplicationBuilder {
                     }
                 }
             },
+            configFromEnvironment = { configFromEnvironment(env) },
         ) { rapidsConnection, _ ->
             GrunnlagsversjoneringRiver(rapidsConnection, grunnlagService)
             GrunnlagHendelserRiver(rapidsConnection, grunnlagService)
-        }
+        }.also { setReady() }
 }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
@@ -74,7 +74,7 @@ class ApplicationBuilder {
                     }
                 }
             },
-            configFromEnvironment = { configFromEnvironment(env) },
+            configFromEnvironment = { configFromEnvironment(it) },
         ) { rapidsConnection, _ ->
             GrunnlagsversjoneringRiver(rapidsConnection, grunnlagService)
             GrunnlagHendelserRiver(rapidsConnection, grunnlagService)

--- a/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
@@ -33,7 +33,7 @@ import rapidsandrivers.initRogR
 val sikkerLogg: Logger = sikkerlogger()
 
 fun main() {
-    ApplicationBuilder()
+    ApplicationBuilder().init()
 }
 
 class ApplicationBuilder {
@@ -64,7 +64,7 @@ class ApplicationBuilder {
     private val aldersovergangDao = AldersovergangDao(ds)
     private val aldersovergangService = AldersovergangService(aldersovergangDao)
 
-    init {
+    fun init() =
         initRogR(
             restModule = {
                 restModule(sikkerLogg, routePrefix = "api", config = HoconApplicationConfig(config)) {
@@ -80,5 +80,4 @@ class ApplicationBuilder {
             GrunnlagsversjoneringRiver(rapidsConnection, grunnlagService)
             GrunnlagHendelserRiver(rapidsConnection, grunnlagService)
         }
-    }
 }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
@@ -19,7 +19,6 @@ import no.nav.etterlatte.grunnlag.personRoute
 import no.nav.etterlatte.grunnlag.rivers.GrunnlagHendelserRiver
 import no.nav.etterlatte.grunnlag.rivers.GrunnlagsversjoneringRiver
 import no.nav.etterlatte.grunnlag.sakGrunnlagRoute
-import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.database.migrate
@@ -37,10 +36,6 @@ fun main() {
 }
 
 class ApplicationBuilder {
-    init {
-        sikkerLoggOppstartOgAvslutning("etterlatte-grunnlag")
-    }
-
     private val env = getRapidEnv()
     private val ds = DataSourceBuilder.createDataSource(env).also { it.migrate() }
     private val config: Config = ConfigFactory.load()
@@ -66,6 +61,7 @@ class ApplicationBuilder {
 
     fun init() =
         initRogR(
+            applikasjonsnavn = "grunnlag",
             restModule = {
                 restModule(sikkerLogg, routePrefix = "api", config = HoconApplicationConfig(config)) {
                     route("grunnlag") {

--- a/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
@@ -78,9 +78,9 @@ class ApplicationBuilder {
                 }
             },
             setReady = { setReady() },
-        ) {
-            GrunnlagsversjoneringRiver(it, grunnlagService)
-            GrunnlagHendelserRiver(it, grunnlagService)
+        ) { rapidsConnection, _ ->
+            GrunnlagsversjoneringRiver(rapidsConnection, grunnlagService)
+            GrunnlagHendelserRiver(rapidsConnection, grunnlagService)
         }
     }
 }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
@@ -75,8 +75,9 @@ class ApplicationBuilder {
                 }
             },
             configFromEnvironment = { configFromEnvironment(it) },
+            setReady = { setReady() },
         ) { rapidsConnection, _ ->
             GrunnlagsversjoneringRiver(rapidsConnection, grunnlagService)
             GrunnlagHendelserRiver(rapidsConnection, grunnlagService)
-        }.also { setReady() }
+        }
 }

--- a/apps/etterlatte-gyldig-soeknad/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-gyldig-soeknad/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -5,27 +5,26 @@ import no.nav.etterlatte.gyldigsoeknad.OpprettBehandlingRiver
 import no.nav.etterlatte.gyldigsoeknad.config.AppBuilder
 import no.nav.etterlatte.libs.common.Miljoevariabler
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
-import no.nav.etterlatte.rapidsandrivers.getRapidEnv
-import no.nav.helse.rapids_rivers.RapidApplication
+import no.nav.etterlatte.libs.ktor.setReady
+import rapidsandrivers.initRogR
 
 val sikkerLogg = sikkerlogger()
 
-fun main() {
-    val rapidEnv = getRapidEnv()
-    RapidApplication
-        .create(rapidEnv)
-        .also { rapidsConnection ->
-            val ab = AppBuilder(Miljoevariabler(rapidEnv))
+fun main() =
+    initRogR(
+        restModule = null,
+        setReady = { setReady() },
+    ) { rapidsConnection, rapidEnv ->
+        val ab = AppBuilder(Miljoevariabler(rapidEnv))
 
-            NySoeknadRiver(
-                rapidsConnection = rapidsConnection,
-                behandlingKlient = ab.behandlingKlient,
-                journalfoerSoeknadService = ab.journalfoerSoeknadService,
-            )
+        NySoeknadRiver(
+            rapidsConnection = rapidsConnection,
+            behandlingKlient = ab.behandlingKlient,
+            journalfoerSoeknadService = ab.journalfoerSoeknadService,
+        )
 
-            OpprettBehandlingRiver(
-                rapidsConnection,
-                ab.behandlingKlient,
-            )
-        }.start()
-}
+        OpprettBehandlingRiver(
+            rapidsConnection,
+            ab.behandlingKlient,
+        )
+    }

--- a/apps/etterlatte-gyldig-soeknad/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-gyldig-soeknad/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -10,9 +10,7 @@ import rapidsandrivers.initRogR
 val sikkerLogg = sikkerlogger()
 
 fun main() =
-    initRogR(
-        restModule = null,
-    ) { rapidsConnection, rapidEnv ->
+    initRogR { rapidsConnection, rapidEnv ->
         val ab = AppBuilder(Miljoevariabler(rapidEnv))
 
         NySoeknadRiver(

--- a/apps/etterlatte-gyldig-soeknad/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-gyldig-soeknad/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -10,7 +10,7 @@ import rapidsandrivers.initRogR
 val sikkerLogg = sikkerlogger()
 
 fun main() =
-    initRogR { rapidsConnection, rapidEnv ->
+    initRogR("gyldig-soeknad") { rapidsConnection, rapidEnv ->
         val ab = AppBuilder(Miljoevariabler(rapidEnv))
 
         NySoeknadRiver(

--- a/apps/etterlatte-gyldig-soeknad/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-gyldig-soeknad/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -5,7 +5,6 @@ import no.nav.etterlatte.gyldigsoeknad.OpprettBehandlingRiver
 import no.nav.etterlatte.gyldigsoeknad.config.AppBuilder
 import no.nav.etterlatte.libs.common.Miljoevariabler
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
-import no.nav.etterlatte.libs.ktor.setReady
 import rapidsandrivers.initRogR
 
 val sikkerLogg = sikkerlogger()
@@ -13,7 +12,6 @@ val sikkerLogg = sikkerlogger()
 fun main() =
     initRogR(
         restModule = null,
-        setReady = { setReady() },
     ) { rapidsConnection, rapidEnv ->
         val ab = AppBuilder(Miljoevariabler(rapidEnv))
 

--- a/apps/etterlatte-migrering/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/Application.kt
@@ -3,7 +3,6 @@ package no.nav.etterlatte
 import com.typesafe.config.ConfigFactory
 import io.ktor.server.application.Application
 import io.ktor.server.config.HoconApplicationConfig
-import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.restModule
@@ -19,10 +18,6 @@ fun main() = ApplicationContext().let { Server(it).run() }
 internal class Server(
     private val context: ApplicationContext,
 ) {
-    init {
-        sikkerLoggOppstartOgAvslutning("etterlatte-migrering")
-    }
-
     fun run() =
         with(context) {
             dataSource.migrate()
@@ -34,7 +29,7 @@ internal class Server(
                     migreringRoute(pesysRepository)
                 }
             }
-            initRogR(restModule) { rapidsConnection, _ ->
+            initRogR("migrering", restModule) { rapidsConnection, _ ->
                 LyttPaaIverksattVedtakRiver(rapidsConnection, pesysRepository)
                 LyttPaaDistribuerBrevRiver(rapidsConnection, pesysRepository)
                 FeilendeMigreringLytterRiver(rapidsConnection, pesysRepository)

--- a/apps/etterlatte-migrering/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/Application.kt
@@ -7,7 +7,6 @@ import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.restModule
-import no.nav.etterlatte.libs.ktor.setReady
 import no.nav.etterlatte.migrering.ApplicationContext
 import no.nav.etterlatte.migrering.FeilendeMigreringLytterRiver
 import no.nav.etterlatte.migrering.LyttPaaDistribuerBrevRiver
@@ -35,7 +34,7 @@ internal class Server(
                     migreringRoute(pesysRepository)
                 }
             }
-            initRogR(restModule, { setReady() }) { rapidsConnection, _ ->
+            initRogR(restModule) { rapidsConnection, _ ->
                 LyttPaaIverksattVedtakRiver(rapidsConnection, pesysRepository)
                 LyttPaaDistribuerBrevRiver(rapidsConnection, pesysRepository)
                 FeilendeMigreringLytterRiver(rapidsConnection, pesysRepository)

--- a/apps/etterlatte-migrering/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/Application.kt
@@ -35,7 +35,7 @@ internal class Server(
                     migreringRoute(pesysRepository)
                 }
             }
-            initRogR(restModule, { setReady() }) { rapidsConnection ->
+            initRogR(restModule, { setReady() }) { rapidsConnection, _ ->
                 LyttPaaIverksattVedtakRiver(rapidsConnection, pesysRepository)
                 LyttPaaDistribuerBrevRiver(rapidsConnection, pesysRepository)
                 FeilendeMigreringLytterRiver(rapidsConnection, pesysRepository)

--- a/apps/etterlatte-migrering/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-migrering/src/main/kotlin/Application.kt
@@ -7,6 +7,7 @@ import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.restModule
+import no.nav.etterlatte.libs.ktor.setReady
 import no.nav.etterlatte.migrering.ApplicationContext
 import no.nav.etterlatte.migrering.FeilendeMigreringLytterRiver
 import no.nav.etterlatte.migrering.LyttPaaDistribuerBrevRiver
@@ -34,7 +35,7 @@ internal class Server(
                     migreringRoute(pesysRepository)
                 }
             }
-            initRogR(restModule) { rapidsConnection ->
+            initRogR(restModule, { setReady() }) { rapidsConnection ->
                 LyttPaaIverksattVedtakRiver(rapidsConnection, pesysRepository)
                 LyttPaaDistribuerBrevRiver(rapidsConnection, pesysRepository)
                 FeilendeMigreringLytterRiver(rapidsConnection, pesysRepository)

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/Application.kt
@@ -12,9 +12,7 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import rapidsandrivers.initRogR
 
 fun main() {
-    initRogR(
-        restModule = null,
-    ) { rapidsConnection, rapidEnv -> settOppRivers(rapidsConnection, AppBuilder(Miljoevariabler(rapidEnv))) }
+    initRogR { rapidsConnection, rapidEnv -> settOppRivers(rapidsConnection, AppBuilder(Miljoevariabler(rapidEnv))) }
 }
 
 private fun settOppRivers(

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/Application.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte
 
 import no.nav.etterlatte.libs.common.Miljoevariabler
-import no.nav.etterlatte.libs.ktor.setReady
 import no.nav.etterlatte.migrering.AvbrytBehandlingHvisMigreringFeilaRiver
 import no.nav.etterlatte.regulering.FinnSakerTilReguleringRiver
 import no.nav.etterlatte.regulering.OmregningsHendelserBehandlingRiver
@@ -15,7 +14,6 @@ import rapidsandrivers.initRogR
 fun main() {
     initRogR(
         restModule = null,
-        setReady = { setReady() },
     ) { rapidsConnection, rapidEnv -> settOppRivers(rapidsConnection, AppBuilder(Miljoevariabler(rapidEnv))) }
 }
 

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/Application.kt
@@ -1,25 +1,22 @@
 package no.nav.etterlatte
 
 import no.nav.etterlatte.libs.common.Miljoevariabler
+import no.nav.etterlatte.libs.ktor.setReady
 import no.nav.etterlatte.migrering.AvbrytBehandlingHvisMigreringFeilaRiver
-import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import no.nav.etterlatte.regulering.FinnSakerTilReguleringRiver
 import no.nav.etterlatte.regulering.OmregningsHendelserBehandlingRiver
 import no.nav.etterlatte.regulering.ReguleringFeiletRiver
 import no.nav.etterlatte.regulering.ReguleringsforespoerselRiver
 import no.nav.etterlatte.regulering.VedtakAttestertRiver
 import no.nav.etterlatte.regulering.YtelseIkkeLoependeRiver
-import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helse.rapids_rivers.RapidsConnection
+import rapidsandrivers.initRogR
 
 fun main() {
-    val rapidEnv = getRapidEnv()
-    val appBuilder = AppBuilder(Miljoevariabler(rapidEnv))
-    RapidApplication
-        .create(rapidEnv)
-        .also { rapidsConnection ->
-            settOppRivers(rapidsConnection, appBuilder)
-        }.start()
+    initRogR(
+        restModule = null,
+        setReady = { setReady() },
+    ) { rapidsConnection, rapidEnv -> settOppRivers(rapidsConnection, AppBuilder(Miljoevariabler(rapidEnv))) }
 }
 
 private fun settOppRivers(

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/Application.kt
@@ -12,7 +12,7 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import rapidsandrivers.initRogR
 
 fun main() {
-    initRogR { rapidsConnection, rapidEnv -> settOppRivers(rapidsConnection, AppBuilder(Miljoevariabler(rapidEnv))) }
+    initRogR("oppdater-behandling") { rapidsConnection, rapidEnv -> settOppRivers(rapidsConnection, AppBuilder(Miljoevariabler(rapidEnv))) }
 }
 
 private fun settOppRivers(

--- a/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/Application.kt
@@ -2,13 +2,9 @@ package no.nav.etterlatte
 
 import no.nav.etterlatte.opplysningerfrasoknad.StartUthentingFraSoeknadRiver
 import no.nav.etterlatte.opplysningerfrasoknad.opplysningsuthenter.Opplysningsuthenter
-import no.nav.etterlatte.rapidsandrivers.getRapidEnv
-import no.nav.helse.rapids_rivers.RapidApplication
+import rapidsandrivers.initRogR
 
-fun main() {
-    RapidApplication
-        .create(getRapidEnv())
-        .also { rapidsConnection ->
-            StartUthentingFraSoeknadRiver(rapidsConnection, Opplysningsuthenter())
-        }.start()
-}
+fun main() =
+    initRogR { rapidsConnection, _ ->
+        StartUthentingFraSoeknadRiver(rapidsConnection, Opplysningsuthenter())
+    }

--- a/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/Application.kt
@@ -5,6 +5,6 @@ import no.nav.etterlatte.opplysningerfrasoknad.opplysningsuthenter.Opplysningsut
 import rapidsandrivers.initRogR
 
 fun main() =
-    initRogR { rapidsConnection, _ ->
+    initRogR("opplysninger-fra-soeknad") { rapidsConnection, _ ->
         StartUthentingFraSoeknadRiver(rapidsConnection, Opplysningsuthenter())
     }

--- a/apps/etterlatte-statistikk/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/Application.kt
@@ -2,29 +2,11 @@ package no.nav.etterlatte
 
 import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
 import no.nav.etterlatte.statistikk.config.ApplicationContext
-import no.nav.helse.rapids_rivers.RapidsConnection
 
-fun main() {
+fun main() =
     with(ApplicationContext()) {
-        jobs(this)
-        rapidApplication(this).start()
+        maanedligStatistikkJob.schedule().also { addShutdownHook(it) }
+        oppdaterVedtakJob.schedule().also { addShutdownHook(it) }
+        initRapidsConnection()
         sikkerLoggOppstartOgAvslutning("etterlatte-statistikk")
     }
-}
-
-fun jobs(applicationContext: ApplicationContext) {
-    applicationContext.maanedligStatistikkJob.schedule().also { addShutdownHook(it) }
-    applicationContext.oppdaterVedtakJob.schedule().also { addShutdownHook(it) }
-}
-
-fun rapidApplication(applicationContext: ApplicationContext): RapidsConnection =
-    applicationContext.rapidsConnection
-        .apply {
-            applicationContext.vedtakhendelserRiver
-            applicationContext.avbruttOpprettetBehandlinghendelseRiver
-            applicationContext.behandlingPaaVentHendelseRiver
-            applicationContext.tilbakekrevingriver
-            applicationContext.soeknadStatistikkRiver
-            applicationContext.klageHendelseRiver
-            applicationContext.aktivitetspliktRiver
-        }

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/config/ApplicationContext.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/config/ApplicationContext.kt
@@ -6,7 +6,6 @@ import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.jobs.LeaderElection
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
-import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import no.nav.etterlatte.statistikk.clients.BehandlingKlient
 import no.nav.etterlatte.statistikk.clients.BehandlingKlientImpl
 import no.nav.etterlatte.statistikk.clients.BeregningKlient
@@ -30,35 +29,27 @@ import no.nav.etterlatte.statistikk.service.AktivitetspliktService
 import no.nav.etterlatte.statistikk.service.SoeknadStatistikkService
 import no.nav.etterlatte.statistikk.service.SoeknadStatistikkServiceImpl
 import no.nav.etterlatte.statistikk.service.StatistikkService
-import no.nav.helse.rapids_rivers.RapidApplication
-import no.nav.helse.rapids_rivers.RapidsConnection
+import rapidsandrivers.initRogR
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 import javax.sql.DataSource
 
 class ApplicationContext {
     private val env = System.getenv()
-    val rapidsConnection: RapidsConnection = RapidApplication.create(getRapidEnv())
-
     private val statistikkService: StatistikkService by lazy {
         StatistikkService(statistikkRepository, sakstatistikkRepository, behandlingKlient, beregningKlient, aktivitetspliktService)
     }
 
-    val avbruttOpprettetBehandlinghendelseRiver: AvbruttOpprettetBehandlinghendelseRiver by lazy {
-        AvbruttOpprettetBehandlinghendelseRiver(rapidsConnection, statistikkService)
-    }
-
-    val behandlingPaaVentHendelseRiver: BehandlingPaaVentHendelseRiver by lazy {
-        BehandlingPaaVentHendelseRiver(rapidsConnection, statistikkService)
-    }
-
-    val tilbakekrevingriver: TilbakekrevinghendelseRiver by lazy {
-        TilbakekrevinghendelseRiver(rapidsConnection, statistikkService)
-    }
-
-    val vedtakhendelserRiver: VedtakhendelserRiver by lazy {
-        VedtakhendelserRiver(rapidsConnection, statistikkService)
-    }
+    fun initRapidsConnection() =
+        initRogR { rapidsConnection, _ ->
+            AvbruttOpprettetBehandlinghendelseRiver(rapidsConnection, statistikkService)
+            BehandlingPaaVentHendelseRiver(rapidsConnection, statistikkService)
+            TilbakekrevinghendelseRiver(rapidsConnection, statistikkService)
+            VedtakhendelserRiver(rapidsConnection, statistikkService)
+            SoeknadStatistikkRiver(rapidsConnection, soeknadStatistikkService)
+            KlagehendelseRiver(rapidsConnection, statistikkService)
+            AktivitetspliktHendelseRiver(rapidsConnection, aktivitetspliktService)
+        }
 
     private val behandlingKlient: BehandlingKlient by lazy {
         BehandlingKlientImpl(behandlingHttpClient, "http://etterlatte-behandling")
@@ -103,24 +94,12 @@ class ApplicationContext {
         SoeknadStatistikkServiceImpl(soeknadStatistikkRepository)
     }
 
-    val soeknadStatistikkRiver: SoeknadStatistikkRiver by lazy {
-        SoeknadStatistikkRiver(rapidsConnection, soeknadStatistikkService)
-    }
-
-    val klageHendelseRiver: KlagehendelseRiver by lazy {
-        KlagehendelseRiver(rapidsConnection, statistikkService)
-    }
-
     private val aktivitetspliktRepo: AktivitetspliktRepo by lazy {
         AktivitetspliktRepo(datasource)
     }
 
     private val aktivitetspliktService: AktivitetspliktService by lazy {
         AktivitetspliktService(aktivitetspliktRepo)
-    }
-
-    val aktivitetspliktRiver: AktivitetspliktHendelseRiver by lazy {
-        AktivitetspliktHendelseRiver(rapidsConnection, aktivitetspliktService)
     }
 
     val maanedligStatistikkJob: MaanedligStatistikkJob by lazy {

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/config/ApplicationContext.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/config/ApplicationContext.kt
@@ -41,7 +41,7 @@ class ApplicationContext {
     }
 
     fun initRapidsConnection() =
-        initRogR { rapidsConnection, _ ->
+        initRogR("statistikk") { rapidsConnection, _ ->
             AvbruttOpprettetBehandlinghendelseRiver(rapidsConnection, statistikkService)
             BehandlingPaaVentHendelseRiver(rapidsConnection, statistikkService)
             TilbakekrevinghendelseRiver(rapidsConnection, statistikkService)

--- a/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -4,4 +4,5 @@ import no.nav.etterlatte.testdata.AppBuilder
 import no.nav.etterlatte.testdata.AutomatiskBehandlingRiver
 import rapidsandrivers.initRogR
 
-fun main() = initRogR { rapidsConnection, _ -> AutomatiskBehandlingRiver(rapidsConnection, AppBuilder().lagBehandler()) }
+fun main() =
+    initRogR("testdata-behandler") { rapidsConnection, _ -> AutomatiskBehandlingRiver(rapidsConnection, AppBuilder().lagBehandler()) }

--- a/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -1,15 +1,7 @@
 package no.nav.etterlatte
 
-import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import no.nav.etterlatte.testdata.AppBuilder
 import no.nav.etterlatte.testdata.AutomatiskBehandlingRiver
-import no.nav.helse.rapids_rivers.RapidApplication
+import rapidsandrivers.initRogR
 
-fun main() {
-    val rapidEnv = getRapidEnv()
-    RapidApplication
-        .create(rapidEnv)
-        .also { rapidsConnection ->
-            AutomatiskBehandlingRiver(rapidsConnection, AppBuilder().lagBehandler())
-        }.start()
-}
+fun main() = initRogR { rapidsConnection, _ -> AutomatiskBehandlingRiver(rapidsConnection, AppBuilder().lagBehandler()) }

--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -3,42 +3,35 @@ package no.nav.etterlatte
 import no.nav.etterlatte.libs.common.Miljoevariabler
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.rapidsandrivers.configFromEnvironment
-import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import no.nav.etterlatte.tidshendelser.AppContext
 import no.nav.etterlatte.tidshendelser.HendelseRiver
-import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helse.rapids_rivers.RapidsConnection
+import rapidsandrivers.initRogR
 import java.util.Timer
 
-fun main() {
-    val rapidEnv = getRapidEnv()
-    val miljoevariabler = Miljoevariabler(rapidEnv)
+fun main() =
+    initRogR(configFromEnvironment = { configFromEnvironment(it) }) { rapidsConnection, rapidEnv ->
+        val miljoevariabler = Miljoevariabler(rapidEnv)
+        val appContext =
+            AppContext(miljoevariabler) { key, message -> rapidsConnection.publish(key.toString(), message) }
 
-    RapidApplication
-        .Builder(
-            RapidApplication.RapidApplicationConfig.fromEnv(rapidEnv, configFromEnvironment(rapidEnv)),
-        ).build()
-        .also { rapidsConnection ->
-            val appContext = AppContext(miljoevariabler) { key, message -> rapidsConnection.publish(key.toString(), message) }
+        HendelseRiver(rapidsConnection, appContext.hendelseDao)
 
-            HendelseRiver(rapidsConnection, appContext.hendelseDao)
+        rapidsConnection.apply {
+            val timers = mutableListOf<Timer>()
 
-            rapidsConnection.apply {
-                val timers = mutableListOf<Timer>()
+            register(
+                object : RapidsConnection.StatusListener {
+                    override fun onStartup(rapidsConnection: RapidsConnection) {
+                        appContext.dataSource.migrate()
+                        timers.add(appContext.jobbPollerTask.schedule())
+                        timers.add(appContext.hendelsePollerTask.schedule())
+                    }
 
-                register(
-                    object : RapidsConnection.StatusListener {
-                        override fun onStartup(rapidsConnection: RapidsConnection) {
-                            appContext.dataSource.migrate()
-                            timers.add(appContext.jobbPollerTask.schedule())
-                            timers.add(appContext.hendelsePollerTask.schedule())
-                        }
-
-                        override fun onShutdownSignal(rapidsConnection: RapidsConnection) {
-                            timers.forEach { it.cancel() }
-                        }
-                    },
-                )
-            }
-        }.start()
-}
+                    override fun onShutdownSignal(rapidsConnection: RapidsConnection) {
+                        timers.forEach { it.cancel() }
+                    }
+                },
+            )
+        }
+    }

--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -10,7 +10,7 @@ import rapidsandrivers.initRogR
 import java.util.Timer
 
 fun main() =
-    initRogR(configFromEnvironment = { configFromEnvironment(it) }) { rapidsConnection, rapidEnv ->
+    initRogR("tidshendelser", configFromEnvironment = { configFromEnvironment(it) }) { rapidsConnection, rapidEnv ->
         val miljoevariabler = Miljoevariabler(rapidEnv)
         val appContext =
             AppContext(miljoevariabler) { key, message -> rapidsConnection.publish(key.toString(), message) }

--- a/apps/etterlatte-trygdetid-kafka/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-trygdetid-kafka/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -6,6 +6,6 @@ import no.nav.etterlatte.trygdetid.kafka.KopierTrygdetidRiver
 import rapidsandrivers.initRogR
 
 fun main() =
-    initRogR { rapidsConnection, rapidEnv ->
+    initRogR("trygdetid-kafka") { rapidsConnection, rapidEnv ->
         KopierTrygdetidRiver(rapidsConnection, AppBuilder(Miljoevariabler(rapidEnv)).createTrygdetidService())
     }

--- a/apps/etterlatte-trygdetid-kafka/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-trygdetid-kafka/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -1,21 +1,11 @@
 package no.nav.etterlatte
 
 import no.nav.etterlatte.libs.common.Miljoevariabler
-import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import no.nav.etterlatte.trygdetid.kafka.AppBuilder
 import no.nav.etterlatte.trygdetid.kafka.KopierTrygdetidRiver
-import no.nav.helse.rapids_rivers.RapidApplication
+import rapidsandrivers.initRogR
 
-fun main() {
-    val rapidEnv = getRapidEnv()
-    RapidApplication
-        .create(rapidEnv)
-        .also { rapidsConnection ->
-            KopierTrygdetidRiver(
-                rapidsConnection,
-                AppBuilder(
-                    Miljoevariabler(rapidEnv),
-                ).createTrygdetidService(),
-            )
-        }.start()
-}
+fun main() =
+    initRogR { rapidsConnection, rapidEnv ->
+        KopierTrygdetidRiver(rapidsConnection, AppBuilder(Miljoevariabler(rapidEnv)).createTrygdetidService())
+    }

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -21,6 +21,7 @@ val sikkerLogg: Logger = sikkerlogger()
 fun main() {
     ApplicationContext().also {
         initRogR(
+            applikasjonsnavn = "utbetaling",
             restModule = {
                 restModule(sikkerLogg, config = HoconApplicationConfig(it.config)) {
                     utbetalingRoutes(it.simuleringOsService, it.behandlingKlient)
@@ -28,7 +29,6 @@ fun main() {
             },
             configFromEnvironment = { configFromEnvironment(it) },
         ) { rc, _ -> rc.settOppRiversOgListener(it) }
-        sikkerLogg.info("Utbetaling logger på sikkerlogg")
     }
 }
 

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -20,7 +20,14 @@ val sikkerLogg: Logger = sikkerlogger()
 
 fun main() {
     ApplicationContext().also {
-        rapidApplication(it)
+        initRogR(
+            restModule = {
+                restModule(sikkerLogg, config = HoconApplicationConfig(it.config)) {
+                    utbetalingRoutes(it.simuleringOsService, it.behandlingKlient)
+                }
+            },
+            configFromEnvironment = { configFromEnvironment(it) },
+        ) { rc, _ -> rc.settOppRiversOgListener(it) }
         sikkerLogg.info("Utbetaling logger på sikkerlogg")
     }
 }
@@ -41,16 +48,6 @@ fun jobs(applicationContext: ApplicationContext): MutableSet<TimerJob> {
     }
     return jobs
 }
-
-fun rapidApplication(applicationContext: ApplicationContext) =
-    initRogR(
-        restModule = {
-            restModule(sikkerLogg, config = HoconApplicationConfig(applicationContext.config)) {
-                utbetalingRoutes(applicationContext.simuleringOsService, applicationContext.behandlingKlient)
-            }
-        },
-        configFromEnvironment = { configFromEnvironment(it) },
-    ) { rc, _ -> rc.settOppRiversOgListener(applicationContext) }
 
 internal fun RapidsConnection.settOppRiversOgListener(applicationContext: ApplicationContext) {
     VedtakMottakRiver(

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -4,7 +4,10 @@ import no.nav.etterlatte.libs.common.TimerJob
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.setReady
+import no.nav.etterlatte.utbetaling.common.OppgavetriggerRiver
 import no.nav.etterlatte.utbetaling.config.ApplicationContext
+import no.nav.etterlatte.utbetaling.iverksetting.KvitteringMottaker
+import no.nav.etterlatte.utbetaling.iverksetting.VedtakMottakRiver
 import no.nav.helse.rapids_rivers.RapidsConnection
 import org.slf4j.Logger
 
@@ -37,9 +40,21 @@ fun jobs(applicationContext: ApplicationContext): MutableSet<TimerJob> {
 fun rapidApplication(applicationContext: ApplicationContext): RapidsConnection =
     applicationContext.rapidsConnection
         .apply {
-            applicationContext.vedtakMottakRiver
-            applicationContext.kvitteringMottaker
-            applicationContext.oppgavetriggerRiver
+            VedtakMottakRiver(
+                rapidsConnection = this,
+                utbetalingService = applicationContext.utbetalingService,
+            )
+            KvitteringMottaker(
+                rapidsConnection = this,
+                utbetalingService = applicationContext.utbetalingService,
+                jmsConnectionFactory = applicationContext.jmsConnectionFactory,
+                queue = applicationContext.properties.mqKvitteringQueue,
+            )
+            OppgavetriggerRiver(
+                rapidsConnection = this,
+                utbetalingService = applicationContext.utbetalingService,
+                grensesnittsavstemmingService = applicationContext.grensesnittsavstemmingService,
+            )
 
             register(
                 object : RapidsConnection.StatusListener {

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
@@ -69,7 +69,7 @@ class ApplicationContext(
             password = properties.serviceUserPassword,
         ),
     // Overridable clients
-    config: Config = ConfigFactory.load(),
+    val config: Config = ConfigFactory.load(),
     httpClient: HttpClient = httpClient(),
     val behandlingKlient: BehandlingKlient = BehandlingKlient(config, httpClient),
     val vedtaksvurderingKlient: VedtaksvurderingKlient = VedtaksvurderingKlient(config, httpClient),
@@ -136,7 +136,7 @@ class ApplicationContext(
         )
     }
 
-    private val simuleringOsService =
+    internal val simuleringOsService =
         SimuleringOsService(
             utbetalingDao,
             vedtaksvurderingKlient,

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
@@ -3,7 +3,6 @@ package no.nav.etterlatte.utbetaling.config
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import io.ktor.client.HttpClient
-import io.ktor.server.config.HoconApplicationConfig
 import no.nav.etterlatte.jobs.next
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.norskKlokke
@@ -13,12 +12,9 @@ import no.nav.etterlatte.libs.database.jdbcUrl
 import no.nav.etterlatte.libs.jobs.LeaderElection
 import no.nav.etterlatte.libs.ktor.httpClient
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
-import no.nav.etterlatte.libs.ktor.restModule
 import no.nav.etterlatte.mq.EtterlatteJmsConnectionFactory
 import no.nav.etterlatte.mq.JmsConnectionFactory
-import no.nav.etterlatte.rapidsandrivers.configFromEnvironment
 import no.nav.etterlatte.rapidsandrivers.getRapidEnv
-import no.nav.etterlatte.sikkerLogg
 import no.nav.etterlatte.utbetaling.BehandlingKlient
 import no.nav.etterlatte.utbetaling.VedtaksvurderingKlient
 import no.nav.etterlatte.utbetaling.avstemming.AvstemmingDao
@@ -48,8 +44,6 @@ import no.nav.etterlatte.utbetaling.simulering.SimuleringDao
 import no.nav.etterlatte.utbetaling.simulering.SimuleringOsKlient
 import no.nav.etterlatte.utbetaling.simulering.SimuleringOsService
 import no.nav.etterlatte.utbetaling.simulering.simuleringObjectMapper
-import no.nav.etterlatte.utbetaling.utbetalingRoutes
-import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helse.rapids_rivers.RapidsConnection
 import java.time.Duration
 import java.time.LocalTime
@@ -192,16 +186,6 @@ class ApplicationContext(
             clock = clock,
             saktype = Saktype.OMSTILLINGSSTOENAD,
         )
-
-    val rapidsConnection =
-        rapidConnection ?: RapidApplication
-            .Builder(
-                RapidApplication.RapidApplicationConfig.fromEnv(env, configFromEnvironment(env)),
-            ).withKtorModule {
-                restModule(sikkerLogg, config = HoconApplicationConfig(config)) {
-                    utbetalingRoutes(simuleringOsService, behandlingKlient)
-                }
-            }.build()
 }
 
 /**

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
@@ -28,7 +28,6 @@ import no.nav.etterlatte.utbetaling.avstemming.KonsistensavstemmingJob
 import no.nav.etterlatte.utbetaling.avstemming.KonsistensavstemmingService
 import no.nav.etterlatte.utbetaling.avstemming.avstemmingsdata.AvstemmingsdataSender
 import no.nav.etterlatte.utbetaling.avstemming.vedtak.Vedtaksverifiserer
-import no.nav.etterlatte.utbetaling.common.OppgavetriggerRiver
 import no.nav.etterlatte.utbetaling.common.april
 import no.nav.etterlatte.utbetaling.common.august
 import no.nav.etterlatte.utbetaling.common.februar
@@ -40,8 +39,6 @@ import no.nav.etterlatte.utbetaling.common.mars
 import no.nav.etterlatte.utbetaling.common.november
 import no.nav.etterlatte.utbetaling.common.oktober
 import no.nav.etterlatte.utbetaling.common.september
-import no.nav.etterlatte.utbetaling.iverksetting.KvitteringMottaker
-import no.nav.etterlatte.utbetaling.iverksetting.VedtakMottakRiver
 import no.nav.etterlatte.utbetaling.iverksetting.oppdrag.OppdragMapper
 import no.nav.etterlatte.utbetaling.iverksetting.oppdrag.OppdragSender
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
@@ -205,30 +202,6 @@ class ApplicationContext(
                     utbetalingRoutes(simuleringOsService, behandlingKlient)
                 }
             }.build()
-
-    val oppgavetriggerRiver by lazy {
-        OppgavetriggerRiver(
-            rapidsConnection = rapidsConnection,
-            utbetalingService = utbetalingService,
-            grensesnittsavstemmingService = grensesnittsavstemmingService,
-        )
-    }
-
-    val kvitteringMottaker by lazy {
-        KvitteringMottaker(
-            rapidsConnection = rapidsConnection,
-            utbetalingService = utbetalingService,
-            jmsConnectionFactory = jmsConnectionFactory,
-            queue = properties.mqKvitteringQueue,
-        )
-    }
-
-    val vedtakMottakRiver by lazy {
-        VedtakMottakRiver(
-            rapidsConnection = rapidsConnection,
-            utbetalingService = utbetalingService,
-        )
-    }
 }
 
 /**

--- a/apps/etterlatte-utbetaling/src/test/kotlin/no/nav/etterlatte/ApplicationIntegrationTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/no/nav/etterlatte/ApplicationIntegrationTest.kt
@@ -74,7 +74,8 @@ class ApplicationIntegrationTest {
             vedtaksvurderingKlient = mockk(),
             simuleringOsKlient = mockk(),
         ).also {
-            rapidApplication(it).start()
+            rapidsConnection.settOppRiversOgListener(it)
+            rapidsConnection.start()
         }
     }
 

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/Application.kt
@@ -12,7 +12,7 @@ import no.nav.etterlatte.vedtaksvurdering.samordning.SamordningMottattRiver
 import rapidsandrivers.initRogR
 
 fun main() {
-    initRogR { rapidsConnection, rapidEnv ->
+    initRogR("vedtaksvurdering-kafka") { rapidsConnection, rapidEnv ->
         val appBuilder = AppBuilder(Miljoevariabler(rapidEnv))
         val vedtakKlient = appBuilder.lagVedtakKlient()
         LoependeYtelserforespoerselRiver(rapidsConnection, vedtakKlient)

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/Application.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte
 
 import no.nav.etterlatte.libs.common.Miljoevariabler
 import no.nav.etterlatte.no.nav.etterlatte.vedtaksvurdering.samordning.TilSamordningRiver
-import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import no.nav.etterlatte.regulering.AppBuilder
 import no.nav.etterlatte.regulering.LoependeYtelserforespoerselRiver
 import no.nav.etterlatte.regulering.OpprettVedtakforespoerselRiver
@@ -10,21 +9,18 @@ import no.nav.etterlatte.vedtaksvurdering.rivers.LagreIverksattVedtakRiver
 import no.nav.etterlatte.vedtaksvurdering.rivers.TidshendelseRiver
 import no.nav.etterlatte.vedtaksvurdering.samordning.AttestertVedtakRiver
 import no.nav.etterlatte.vedtaksvurdering.samordning.SamordningMottattRiver
-import no.nav.helse.rapids_rivers.RapidApplication
+import rapidsandrivers.initRogR
 
 fun main() {
-    val rapidEnv = getRapidEnv()
-    val appBuilder = AppBuilder(Miljoevariabler(rapidEnv))
-    RapidApplication
-        .create(rapidEnv)
-        .also { rapidsConnection ->
-            val vedtakKlient = appBuilder.lagVedtakKlient()
-            LoependeYtelserforespoerselRiver(rapidsConnection, vedtakKlient)
-            OpprettVedtakforespoerselRiver(rapidsConnection, vedtakKlient, appBuilder.lagFeatureToggleService())
-            LagreIverksattVedtakRiver(rapidsConnection, vedtakKlient)
-            AttestertVedtakRiver(rapidsConnection, vedtakKlient)
-            SamordningMottattRiver(rapidsConnection, vedtakKlient)
-            TilSamordningRiver(rapidsConnection, vedtakKlient)
-            TidshendelseRiver(rapidsConnection, vedtakKlient)
-        }.start()
+    initRogR { rapidsConnection, rapidEnv ->
+        val appBuilder = AppBuilder(Miljoevariabler(rapidEnv))
+        val vedtakKlient = appBuilder.lagVedtakKlient()
+        LoependeYtelserforespoerselRiver(rapidsConnection, vedtakKlient)
+        OpprettVedtakforespoerselRiver(rapidsConnection, vedtakKlient, appBuilder.lagFeatureToggleService())
+        LagreIverksattVedtakRiver(rapidsConnection, vedtakKlient)
+        AttestertVedtakRiver(rapidsConnection, vedtakKlient)
+        SamordningMottattRiver(rapidsConnection, vedtakKlient)
+        TilSamordningRiver(rapidsConnection, vedtakKlient)
+        TidshendelseRiver(rapidsConnection, vedtakKlient)
+    }
 }

--- a/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -7,7 +7,7 @@ import no.nav.etterlatte.vilkaarsvurdering.VilkaarsvurderingRiver
 import rapidsandrivers.initRogR
 
 fun main() =
-    initRogR { rapidsConnection, rapidEnv ->
+    initRogR("vilkaarsvurdering-kafka") { rapidsConnection, rapidEnv ->
         val vilkaarsvurderingService = AppBuilder(Miljoevariabler(rapidEnv)).lagVilkaarsvurderingKlient()
         VilkaarsvurderingRiver(rapidsConnection, vilkaarsvurderingService)
         TidshendelseRiver(rapidsConnection, vilkaarsvurderingService)

--- a/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -1,19 +1,14 @@
 package no.nav.etterlatte
 
 import no.nav.etterlatte.libs.common.Miljoevariabler
-import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import no.nav.etterlatte.vilkaarsvurdering.AppBuilder
 import no.nav.etterlatte.vilkaarsvurdering.TidshendelseRiver
 import no.nav.etterlatte.vilkaarsvurdering.VilkaarsvurderingRiver
-import no.nav.helse.rapids_rivers.RapidApplication
+import rapidsandrivers.initRogR
 
-fun main() {
-    val rapidEnv = getRapidEnv()
-    RapidApplication
-        .create(rapidEnv)
-        .also { rapidsConnection ->
-            val vilkaarsvurderingService = AppBuilder(Miljoevariabler(rapidEnv)).lagVilkaarsvurderingKlient()
-            VilkaarsvurderingRiver(rapidsConnection, vilkaarsvurderingService)
-            TidshendelseRiver(rapidsConnection, vilkaarsvurderingService)
-        }.start()
-}
+fun main() =
+    initRogR { rapidsConnection, rapidEnv ->
+        val vilkaarsvurderingService = AppBuilder(Miljoevariabler(rapidEnv)).lagVilkaarsvurderingKlient()
+        VilkaarsvurderingRiver(rapidsConnection, vilkaarsvurderingService)
+        TidshendelseRiver(rapidsConnection, vilkaarsvurderingService)
+    }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
@@ -7,15 +7,16 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 
 fun initRogR(
     restModule: Application.() -> Unit,
+    setReady: () -> Unit,
     settOppRivers: (RapidsConnection) -> Unit,
 ) {
     val rapidEnv = getRapidEnv()
 
-    RapidApplication
-        .Builder(RapidApplication.RapidApplicationConfig.fromEnv(rapidEnv))
-        .withKtorModule(restModule)
-        .build()
-        .also { rapidsConnection ->
-            settOppRivers(rapidsConnection)
-        }.start()
+    val connection =
+        RapidApplication
+            .Builder(RapidApplication.RapidApplicationConfig.fromEnv(rapidEnv))
+            .withKtorModule(restModule)
+            .build()
+            .also { rapidsConnection -> settOppRivers(rapidsConnection) }
+    setReady().also { connection.start() }
 }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
@@ -9,12 +9,18 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 
 fun initRogR(
     restModule: (Application.() -> Unit)? = null,
-    configFromEnvironment: Config = AivenConfig.default,
+    configFromEnvironment: ((Map<String, String>) -> Config) = { AivenConfig.default },
     settOppRivers: (RapidsConnection, rapidEnv: Map<String, String>) -> Unit,
 ) {
     val rapidEnv = getRapidEnv()
 
-    var builder = RapidApplication.Builder(RapidApplication.RapidApplicationConfig.fromEnv(rapidEnv, configFromEnvironment))
+    var builder =
+        RapidApplication.Builder(
+            RapidApplication.RapidApplicationConfig.fromEnv(
+                rapidEnv,
+                configFromEnvironment(rapidEnv),
+            ),
+        )
     if (restModule != null) {
         builder = builder.withKtorModule(restModule)
     }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
@@ -11,7 +11,7 @@ fun initRogR(
     restModule: (Application.() -> Unit)? = null,
     configFromEnvironment: ((Map<String, String>) -> Config) = { AivenConfig.default },
     settOppRivers: (RapidsConnection, rapidEnv: Map<String, String>) -> Unit,
-): RapidsConnection {
+) {
     val rapidEnv = getRapidEnv()
 
     var builder =
@@ -30,5 +30,4 @@ fun initRogR(
             .build()
             .also { rapidsConnection -> settOppRivers(rapidsConnection, rapidEnv) }
     connection.start()
-    return connection
 }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
@@ -2,16 +2,19 @@ package rapidsandrivers
 
 import io.ktor.server.application.Application
 import no.nav.etterlatte.rapidsandrivers.getRapidEnv
+import no.nav.helse.rapids_rivers.AivenConfig
+import no.nav.helse.rapids_rivers.Config
 import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helse.rapids_rivers.RapidsConnection
 
 fun initRogR(
     restModule: (Application.() -> Unit)? = null,
+    configFromEnvironment: Config = AivenConfig.default,
     settOppRivers: (RapidsConnection, rapidEnv: Map<String, String>) -> Unit,
 ) {
     val rapidEnv = getRapidEnv()
 
-    var builder = RapidApplication.Builder(RapidApplication.RapidApplicationConfig.fromEnv(rapidEnv))
+    var builder = RapidApplication.Builder(RapidApplication.RapidApplicationConfig.fromEnv(rapidEnv, configFromEnvironment))
     if (restModule != null) {
         builder = builder.withKtorModule(restModule)
     }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
@@ -1,0 +1,21 @@
+package rapidsandrivers
+
+import io.ktor.server.application.Application
+import no.nav.etterlatte.rapidsandrivers.getRapidEnv
+import no.nav.helse.rapids_rivers.RapidApplication
+import no.nav.helse.rapids_rivers.RapidsConnection
+
+fun initRogR(
+    restModule: Application.() -> Unit,
+    settOppRivers: (RapidsConnection) -> Unit,
+) {
+    val rapidEnv = getRapidEnv()
+
+    RapidApplication
+        .Builder(RapidApplication.RapidApplicationConfig.fromEnv(rapidEnv))
+        .withKtorModule(restModule)
+        .build()
+        .also { rapidsConnection ->
+            settOppRivers(rapidsConnection)
+        }.start()
+}

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
@@ -11,7 +11,7 @@ fun initRogR(
     restModule: (Application.() -> Unit)? = null,
     configFromEnvironment: ((Map<String, String>) -> Config) = { AivenConfig.default },
     settOppRivers: (RapidsConnection, rapidEnv: Map<String, String>) -> Unit,
-) {
+): RapidsConnection {
     val rapidEnv = getRapidEnv()
 
     var builder =
@@ -25,8 +25,10 @@ fun initRogR(
         builder = builder.withKtorModule(restModule)
     }
 
-    builder
-        .build()
-        .also { rapidsConnection -> settOppRivers(rapidsConnection, rapidEnv) }
-        .start()
+    val connection =
+        builder
+            .build()
+            .also { rapidsConnection -> settOppRivers(rapidsConnection, rapidEnv) }
+    connection.start()
+    return connection
 }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
@@ -12,6 +12,7 @@ fun initRogR(
     applikasjonsnavn: String,
     restModule: (Application.() -> Unit)? = null,
     configFromEnvironment: ((Map<String, String>) -> Config) = { AivenConfig.default },
+    setReady: () -> Unit = {},
     settOppRivers: (RapidsConnection, rapidEnv: Map<String, String>) -> Unit,
 ) {
     sikkerLoggOppstartOgAvslutning("etterlatte-$applikasjonsnavn")
@@ -32,5 +33,6 @@ fun initRogR(
         builder
             .build()
             .also { rapidsConnection -> settOppRivers(rapidsConnection, rapidEnv) }
+    setReady()
     connection.start()
 }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
@@ -7,7 +7,7 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 
 fun initRogR(
     restModule: (Application.() -> Unit)? = null,
-    settOppRivers: (RapidsConnection, Map<String, String>) -> Unit,
+    settOppRivers: (RapidsConnection, rapidEnv: Map<String, String>) -> Unit,
 ) {
     val rapidEnv = getRapidEnv()
 

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
@@ -7,20 +7,17 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 
 fun initRogR(
     restModule: (Application.() -> Unit)?,
-    setReady: () -> Unit,
     settOppRivers: (RapidsConnection, Map<String, String>) -> Unit,
 ) {
     val rapidEnv = getRapidEnv()
 
-    var builder =
-        RapidApplication
-            .Builder(RapidApplication.RapidApplicationConfig.fromEnv(rapidEnv))
+    var builder = RapidApplication.Builder(RapidApplication.RapidApplicationConfig.fromEnv(rapidEnv))
     if (restModule != null) {
         builder = builder.withKtorModule(restModule)
     }
-    val connection =
-        builder
-            .build()
-            .also { rapidsConnection -> settOppRivers(rapidsConnection, rapidEnv) }
-    setReady().also { connection.start() }
+
+    builder
+        .build()
+        .also { rapidsConnection -> settOppRivers(rapidsConnection, rapidEnv) }
+        .start()
 }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
@@ -6,17 +6,21 @@ import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helse.rapids_rivers.RapidsConnection
 
 fun initRogR(
-    restModule: Application.() -> Unit,
+    restModule: (Application.() -> Unit)?,
     setReady: () -> Unit,
-    settOppRivers: (RapidsConnection) -> Unit,
+    settOppRivers: (RapidsConnection, Map<String, String>) -> Unit,
 ) {
     val rapidEnv = getRapidEnv()
 
-    val connection =
+    var builder =
         RapidApplication
             .Builder(RapidApplication.RapidApplicationConfig.fromEnv(rapidEnv))
-            .withKtorModule(restModule)
+    if (restModule != null) {
+        builder = builder.withKtorModule(restModule)
+    }
+    val connection =
+        builder
             .build()
-            .also { rapidsConnection -> settOppRivers(rapidsConnection) }
+            .also { rapidsConnection -> settOppRivers(rapidsConnection, rapidEnv) }
     setReady().also { connection.start() }
 }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
@@ -1,6 +1,7 @@
 package rapidsandrivers
 
 import io.ktor.server.application.Application
+import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
 import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import no.nav.helse.rapids_rivers.AivenConfig
 import no.nav.helse.rapids_rivers.Config
@@ -8,10 +9,12 @@ import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helse.rapids_rivers.RapidsConnection
 
 fun initRogR(
+    applikasjonsnavn: String,
     restModule: (Application.() -> Unit)? = null,
     configFromEnvironment: ((Map<String, String>) -> Config) = { AivenConfig.default },
     settOppRivers: (RapidsConnection, rapidEnv: Map<String, String>) -> Unit,
 ) {
+    sikkerLoggOppstartOgAvslutning("etterlatte-$applikasjonsnavn")
     val rapidEnv = getRapidEnv()
 
     var builder =

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
@@ -6,7 +6,7 @@ import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helse.rapids_rivers.RapidsConnection
 
 fun initRogR(
-    restModule: (Application.() -> Unit)?,
+    restModule: (Application.() -> Unit)? = null,
     settOppRivers: (RapidsConnection, Map<String, String>) -> Unit,
 ) {
     val rapidEnv = getRapidEnv()


### PR DESCRIPTION
I dag gjer vi initialisering og oppstart av appane våre på mange forskjellige måtar.

Nokre forskjellar er det, men stort sett ønskjer vi å gjera det samme for kvar applikasjon vi startar opp. Den kognitive lasten vil bli mindre viss vi sørgjer for at vi gjer det likt der det kan og bør vera likt.

Startar i ein ende ved å ta applikasjonane som er basert på rapids and rivers, og får dei over på samme underliggjande init-metode. Med det sikrar vi at ting er likt, og i tillegg får vi innkapsla mykje av r&r-oppsettskoden i r&r-biblioteket vårt, sånn at det ikkje lekkjer ut i resten av kodebasen, kor det i stor grad er teknisk støy.

Har andre idear til oppfølgings-endringar, som kanskje eller kanskje ikkje kjem som PRs, er litt usikker på kor omfattande og knotete det er:
- statuslisteners på r&r-appane
- alltid kalle DataSource.migrate() frå samme plass
- bruke eller ikkje bruke `AppContext`/`ApplicationContext`/`ApplicationBuilder` for konfig, og i så fall vera konsekvent på namn
- vera konsekvent på namnebruk `Application`/`Server`, og kanskje innføre interface eller abstrakt superklasse