### PR TITLE
Oppdater videreført opphør må sjekke for konflikt på behandlingsid. I…

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
@@ -304,7 +304,7 @@ class BehandlingDao(
                         "INSERT INTO viderefoert_opphoer " +
                             "(skalViderefoere, dato, kilde, begrunnelse, kravdato, behandling_id, vilkaar) " +
                             "VALUES (?, ?, ?, ?, ?, ?, ?)" +
-                            "ON CONFLICT (id) DO UPDATE SET " +
+                            "ON CONFLICT (behandling_id) DO UPDATE SET " +
                             "dato=excluded.dato, " +
                             "kilde=excluded.kilde, " +
                             "begrunnelse=excluded.begrunnelse, " +


### PR DESCRIPTION
… praksis er det denne vi bruker som input-parameter, så konfliktar kjem på denne heller enn på id-en for sjølve videreført opphør-objektet, som vi i praksis ikkje bruker sånn