### PR TITLE
Ordentleg logging av exceptions i r&r-listeners

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
@@ -103,7 +103,7 @@ class OpprettJournalfoerOgDistribuerRiver(
                 }
             } catch (e: Exception) {
                 val feilMelding = "Fikk feil ved opprettelse av brev for sak $sakId for brevkode: $brevKode"
-                logger.error(feilMelding)
+                logger.error(feilMelding, e)
                 throw OpprettJournalfoerOgDistribuerRiverException(
                     feilMelding,
                     e,

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/ListenerMedLogging.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/ListenerMedLogging.kt
@@ -36,6 +36,14 @@ abstract class ListenerMedLogging : River.PacketListener {
         super.onError(problems, context)
     }
 
+    override fun onSevere(
+        error: MessageProblems.MessageException,
+        context: MessageContext,
+    ) {
+        sikkerlogg.error("Klarte ikke å håndtere meldinga i ${context.rapidName()} fordi ${error.problems.toExtendedReport()}", error)
+        super.onSevere(error, context)
+    }
+
     protected fun initialiserRiver(
         rapidsConnection: RapidsConnection,
         hendelsestype: EventnameHendelseType,

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/ListenerMedLoggingOgFeilhaandtering.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/ListenerMedLoggingOgFeilhaandtering.kt
@@ -45,6 +45,14 @@ abstract class ListenerMedLoggingOgFeilhaandtering : River.PacketListener {
         super.onError(problems, context)
     }
 
+    override fun onSevere(
+        error: MessageProblems.MessageException,
+        context: MessageContext,
+    ) {
+        sikkerlogg.error("Klarte ikke å håndtere meldinga i ${context.rapidName()} fordi ${error.problems.toExtendedReport()}", error)
+        super.onSevere(error, context)
+    }
+
     protected fun initialiserRiver(
         rapidsConnection: RapidsConnection,
         hendelsestype: EventnameHendelseType,


### PR DESCRIPTION
I dag svelgjer vi unna exceptions som skjer her (dvs det hamnar i onSevere, som er ein noop-metode). Med denne loggar vi det ordentleg.