### PR TITLE
EY-4155 Sender aktivitetspliktDto til statistikk

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -90,6 +90,7 @@ private fun timerJobs(context: ApplicationContext): List<TimerJob> =
         context.doedsmeldingerReminderJob,
         context.saksbehandlerJob,
         context.oppgaveFristGaarUtJobb,
+        context.resendAktivitetspliktJob,
     )
 
 @Deprecated("Denne blir brukt i veldig mange testar. Bør rydde opp, men tar det etter denne endringa er inne")

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktService.kt
@@ -32,6 +32,7 @@ import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.route.logger
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.etterlatte.oppgave.OppgaveService
 import java.time.LocalDate
 import java.time.YearMonth
@@ -431,6 +432,11 @@ class AktivitetspliktService(
         } else {
             logger.warn("Fant ikke oppgave for revurdering av aktivitetsplikt for sak ${revurdering.sak.id}")
         }
+    }
+
+    suspend fun sendMeldingOmAktivitetForSak(sakId: Long) {
+        val behandlingId = behandlingService.hentBehandlingerForSak(sakId).maxBy { it.sistEndret }.id
+        sendDtoTilStatistikk(sakId, Systembruker.automatiskJobb, behandlingId)
     }
 }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/OppdaterAktivitetspliktRepo.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/OppdaterAktivitetspliktRepo.kt
@@ -1,0 +1,50 @@
+package no.nav.etterlatte.behandling.aktivitetsplikt
+
+import no.nav.etterlatte.common.ConnectionAutoclosing
+import no.nav.etterlatte.libs.database.toList
+
+class OppdaterAktivitetspliktRepo(
+    private val datasource: ConnectionAutoclosing,
+) {
+    fun hentSakerSomIkkeErSendt(limit: Int): List<Long> =
+        datasource.hentConnection { connection ->
+            val statement =
+                connection.prepareStatement(
+                    """
+                    SELECT sak_id from resend_aktivitetsplikt_statistikk
+                    WHERE status = ? LIMIT ?
+                    """.trimIndent(),
+                )
+
+            statement.setString(1, OppdaterAktivitetspliktStatus.IKKE_SENDT.name)
+            statement.setInt(2, limit)
+            val saker =
+                statement.executeQuery().toList {
+                    getLong("sak_id")
+                }
+            return@hentConnection saker
+        }
+
+    fun oppdaterSakSendt(
+        sakId: Long,
+        status: OppdaterAktivitetspliktStatus,
+    ) {
+        datasource.hentConnection { connection ->
+            val statement =
+                connection.prepareStatement(
+                    """
+                    UPDATE resend_aktivitetsplikt_statistikk SET status = ? WHERE sak_id = ?
+                    """.trimIndent(),
+                )
+            statement.setString(1, status.name)
+            statement.setLong(2, sakId)
+            statement.executeUpdate()
+        }
+    }
+}
+
+enum class OppdaterAktivitetspliktStatus {
+    IKKE_SENDT,
+    SENDT,
+    FEIL_I_SENDING,
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/jobs/SendTilStatistikkJob.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/jobs/SendTilStatistikkJob.kt
@@ -1,0 +1,73 @@
+package no.nav.etterlatte.behandling.jobs
+
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktService
+import no.nav.etterlatte.behandling.aktivitetsplikt.OppdaterAktivitetspliktRepo
+import no.nav.etterlatte.behandling.aktivitetsplikt.OppdaterAktivitetspliktStatus
+import no.nav.etterlatte.inTransaction
+import no.nav.etterlatte.jobs.LoggerInfo
+import no.nav.etterlatte.jobs.fixedRateCancellableTimer
+import no.nav.etterlatte.libs.common.TimerJob
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.util.Timer
+
+class SendTilStatistikkJob(
+    private val aktivitetspliktService: AktivitetspliktService,
+    private val oppdaterAktivitetspliktRepo: OppdaterAktivitetspliktRepo,
+    private val initialDelay: Long,
+    private val erLeader: () -> Boolean,
+    private val interval: Duration,
+) : TimerJob {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val jobbNavn = this::class.simpleName
+
+    override fun schedule(): Timer {
+        logger.info("$jobbNavn er satt til å kjøre med periode=$interval etter $initialDelay ms")
+
+        return fixedRateCancellableTimer(
+            name = jobbNavn,
+            initialDelay = initialDelay,
+            period = interval.toMillis(),
+            loggerInfo = LoggerInfo(logger = logger, loggTilSikkerLogg = false),
+        ) {
+            if (erLeader()) {
+                sendEnBatch()
+            }
+        }
+    }
+
+    private fun sendEnBatch() {
+        val saker =
+            inTransaction {
+                oppdaterAktivitetspliktRepo
+                    .hentSakerSomIkkeErSendt(100)
+            }
+        saker.forEach { sakId ->
+            try {
+                inTransaction {
+                    runBlocking { aktivitetspliktService.sendMeldingOmAktivitetForSak(sakId) }
+                    oppdaterAktivitetspliktRepo.oppdaterSakSendt(sakId, OppdaterAktivitetspliktStatus.SENDT)
+                }
+            } catch (e: Exception) {
+                try {
+                    logger.warn(
+                        "Feil oppstod i sending av aktivitet til statistikk for sak med id=$sakId",
+                        e,
+                    )
+                    inTransaction {
+                        oppdaterAktivitetspliktRepo.oppdaterSakSendt(
+                            sakId,
+                            OppdaterAktivitetspliktStatus.FEIL_I_SENDING,
+                        )
+                    }
+                } catch (inner: Exception) {
+                    logger.warn(
+                        "Kunne ikke oppdatere sak med feil i sending for sakId=$sakId, på grunn av feil",
+                        inner,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -302,7 +302,7 @@ internal class ApplicationContext(
     val omregningDao = OmregningDao(autoClosingDatabase)
     val sakTilgangDao = SakTilgangDao(dataSource)
 
-    val oppdaterAktivietetspliktRepo = OppdaterAktivitetspliktRepo(autoClosingDatabase)
+    val oppdaterAktivitetspliktRepo = OppdaterAktivitetspliktRepo(autoClosingDatabase)
 
     // Klient
     val skjermingKlient = SkjermingKlient(skjermingHttpKlient, env.getValue("SKJERMING_URL"))
@@ -581,7 +581,7 @@ internal class ApplicationContext(
     val resendAktivitetspliktJob: SendTilStatistikkJob by lazy {
         SendTilStatistikkJob(
             aktivitetspliktService = aktivitetspliktService,
-            oppdaterAktivitetspliktRepo = oppdaterAktivietetspliktRepo,
+            oppdaterAktivitetspliktRepo = oppdaterAktivitetspliktRepo,
             initialDelay = Duration.of(3, ChronoUnit.MINUTES).toMillis(),
             erLeader = { leaderElectionKlient.isLeader() },
             interval = Duration.of(5, ChronoUnit.MINUTES),

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -17,6 +17,7 @@ import no.nav.etterlatte.behandling.GyldighetsproevingServiceImpl
 import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktDao
 import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktKopierService
 import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktService
+import no.nav.etterlatte.behandling.aktivitetsplikt.OppdaterAktivitetspliktRepo
 import no.nav.etterlatte.behandling.aktivitetsplikt.vurdering.AktivitetspliktAktivitetsgradDao
 import no.nav.etterlatte.behandling.aktivitetsplikt.vurdering.AktivitetspliktUnntakDao
 import no.nav.etterlatte.behandling.behandlinginfo.BehandlingInfoDao
@@ -32,6 +33,7 @@ import no.nav.etterlatte.behandling.jobs.DoedsmeldingJob
 import no.nav.etterlatte.behandling.jobs.DoedsmeldingReminderJob
 import no.nav.etterlatte.behandling.jobs.OppgaveFristGaarUtJobb
 import no.nav.etterlatte.behandling.jobs.SaksbehandlerJob
+import no.nav.etterlatte.behandling.jobs.SendTilStatistikkJob
 import no.nav.etterlatte.behandling.klage.KlageBrevService
 import no.nav.etterlatte.behandling.klage.KlageDaoImpl
 import no.nav.etterlatte.behandling.klage.KlageHendelserServiceImpl
@@ -299,6 +301,8 @@ internal class ApplicationContext(
     val doedshendelseDao = DoedshendelseDao(autoClosingDatabase)
     val omregningDao = OmregningDao(autoClosingDatabase)
     val sakTilgangDao = SakTilgangDao(dataSource)
+
+    val oppdaterAktivietetspliktRepo = OppdaterAktivitetspliktRepo(autoClosingDatabase)
 
     // Klient
     val skjermingKlient = SkjermingKlient(skjermingHttpKlient, env.getValue("SKJERMING_URL"))
@@ -571,6 +575,16 @@ internal class ApplicationContext(
             oppgaveFristGaarUtJobService = oppgaveFristGaarUtJobService,
             dataSource = dataSource,
             sakTilgangDao = sakTilgangDao,
+        )
+    }
+
+    val resendAktivitetspliktJob: SendTilStatistikkJob by lazy {
+        SendTilStatistikkJob(
+            aktivitetspliktService = aktivitetspliktService,
+            oppdaterAktivitetspliktRepo = oppdaterAktivietetspliktRepo,
+            initialDelay = Duration.of(3, ChronoUnit.MINUTES).toMillis(),
+            erLeader = { leaderElectionKlient.isLeader() },
+            interval = Duration.of(5, ChronoUnit.MINUTES),
         )
     }
 

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V145__resend_aktivitetsplikt_statistikk_tabell.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V145__resend_aktivitetsplikt_statistikk_tabell.sql
@@ -1,0 +1,16 @@
+create table resend_aktivitetsplikt_statistikk
+(
+    sak_id BIGINT PRIMARY KEY,
+    status TEXT
+);
+
+with saker_med_aktivitet as (select distinct sak_id, behandling_id
+                             from aktivitetsplikt_aktivitetsgrad
+                             union
+                             select distinct sak_id, behandling_id
+                             from aktivitetsplikt_unntak)
+insert
+into resend_aktivitetsplikt_statistikk (sak_id, status)
+select sak_id, 'IKKE_SENDT'
+from saker_med_aktivitet
+on conflict do nothing;


### PR DESCRIPTION
for alle saker som har registrert noe i basen, for å dekke de tilfellene der det ikke ble sendt før nå.

Enkel jobb som bare prøver å sende 100 saker i gangen, hvert femte minutt. Tabell og kodeendringer skal fjernes etter at sakene er jobbet igjennom.