### PR TITLE
EY-4235 Gjør det mulig å legge til manglende søsken

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BarnepensjonSammendrag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BarnepensjonSammendrag.tsx
@@ -38,13 +38,15 @@ const BenyttetTrygdetid = ({
 
 export const BarnepensjonSammendrag = ({ beregning }: Props) => {
   const personopplysninger = usePersonopplysninger()
-  const avdoede = personopplysninger?.avdoede.find((po) => po)
 
   const beregningsperioder = [...beregning.beregningsperioder].sort((a, b) =>
     compareDesc(new Date(a.datoFOM), new Date(b.datoFOM))
   )
   const soeker = personopplysninger?.soeker?.opplysning
-  const soesken = (avdoede && hentLevendeSoeskenFraAvdoedeForSoeker(avdoede, soeker?.foedselsnummer as string)) ?? []
+  const soesken =
+    (personopplysninger &&
+      hentLevendeSoeskenFraAvdoedeForSoeker(personopplysninger.avdoede, soeker?.foedselsnummer as string)) ??
+    []
 
   return (
     <TableWrapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
@@ -53,7 +53,6 @@ const BeregningsgrunnlagBarnepensjon = (props: { behandling: IBehandlingReducer 
   const { behandling } = props
   const { next } = useBehandlingRoutes()
   const personopplysninger = usePersonopplysninger()
-  const avdoede = personopplysninger?.avdoede.find((po) => po)
   const innloggetSaksbehandler = useInnloggetSaksbehandler()
 
   const redigerbar = behandlingErRedigerbar(
@@ -115,10 +114,10 @@ const BeregningsgrunnlagBarnepensjon = (props: { behandling: IBehandlingReducer 
   }
 
   const soesken =
-    (avdoede &&
+    (personopplysninger &&
       hentLevendeSoeskenFraAvdoedeForSoeker(
-        avdoede,
-        personopplysninger?.soeker?.opplysning.foedselsnummer as string
+        personopplysninger.avdoede,
+        personopplysninger.soeker?.opplysning.foedselsnummer as string
       )) ??
     []
   const skalViseSoeskenjustering = soesken.length > 0 && !behandlingGjelderBarnepensjonPaaNyttRegelverk(behandling)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/Soeskenjustering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/Soeskenjustering.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { IBehandlingReducer } from '~store/reducers/BehandlingReducer'
 import { useFieldArray, useForm } from 'react-hook-form'
-import { Box, Button, ErrorSummary, Heading, HStack } from '@navikt/ds-react'
+import { Alert, BodyShort, Box, Button, ErrorSummary, Heading, HStack, VStack } from '@navikt/ds-react'
 import styled from 'styled-components'
 import { hentLevendeSoeskenFraAvdoedeForSoeker, IPdlPerson } from '~shared/types/Person'
 import { addMonths } from 'date-fns'
@@ -12,6 +12,7 @@ import {
   feilIKomplettePerioderOverIntervall,
   mapListeFraDto,
   PeriodisertBeregningsgrunnlag,
+  PeriodisertBeregningsgrunnlagDto,
 } from '~components/behandling/beregningsgrunnlag/PeriodisertBeregningsgrunnlag'
 import { behandlingErRedigerbar } from '~components/behandling/felles/utils'
 import SoeskenjusteringPeriode from '~components/behandling/beregningsgrunnlag/soeskenjustering/SoeskenjusteringPeriode'
@@ -44,24 +45,37 @@ const nySoeskengrunnlagPeriode = (soesken: IPdlPerson[], fom?: string) => ({
   })),
 })
 
+function manglendeSoeskenIEksisterendeSoeskenjustering(
+  soesken: IPdlPerson[],
+  soeskenjusteringDto?: PeriodisertBeregningsgrunnlagDto<SoeskenMedIBeregning[]>[]
+): PeriodisertBeregningsgrunnlagDto<SoeskenMedIBeregning[]>[] {
+  const perioderMedMangler = (soeskenjusteringDto ?? []).filter((periode) =>
+    periode.data.every(
+      (soeskenIBeregning) => !soesken.some((soesken) => soeskenIBeregning.foedselsnummer === soesken.foedselsnummer)
+    )
+  )
+  return perioderMedMangler
+}
+
 const Soeskenjustering = (props: SoeskenjusteringProps) => {
   const { behandling, onSubmit, setSoeskenJusteringManglerIkke } = props
   const personopplysninger = usePersonopplysninger()
+  const [visFeil, setVisFeil] = useState(false)
+  const [skjulManglendeSoesken, setSkjulManglendeSoesken] = useState(false)
   if (!personopplysninger) {
     return null
   }
-  const [visFeil, setVisFeil] = useState(false)
 
-  const avdoede = usePersonopplysninger()?.avdoede.find((po) => po)
-  const soesken =
-    (avdoede &&
-      hentLevendeSoeskenFraAvdoedeForSoeker(
-        avdoede,
-        personopplysninger.soeker?.opplysning?.foedselsnummer as string
-      )) ??
-    []
+  const soesken = hentLevendeSoeskenFraAvdoedeForSoeker(
+    personopplysninger.avdoede,
+    personopplysninger.soeker?.opplysning.foedselsnummer
+  )
 
-  const { handleSubmit, control, watch } = useForm<{
+  const manglendeSoesken = useMemo(() => {
+    return manglendeSoeskenIEksisterendeSoeskenjustering(soesken, behandling.beregningsGrunnlag?.soeskenMedIBeregning)
+  }, [behandling.beregningsGrunnlag?.soeskenMedIBeregning, personopplysninger.avdoede])
+
+  const { handleSubmit, control, watch, reset } = useForm<{
     soeskenMedIBeregning: PeriodisertBeregningsgrunnlag<SoeskenKanskjeMedIBeregning[]>[]
   }>({
     defaultValues: {
@@ -93,6 +107,32 @@ const Soeskenjustering = (props: SoeskenjusteringProps) => {
     ),
   ]
 
+  function oppdaterSoeskenTilJustering() {
+    setSkjulManglendeSoesken(true)
+    if (manglendeSoesken.length === 0) {
+      return
+    }
+    const allePerioder = mapListeFraDto(behandling.beregningsGrunnlag!!.soeskenMedIBeregning)
+    const oppdatertePerioder = allePerioder.map((periode) => {
+      const manglendeSoeskenForPeriode = soesken.filter((soesken) =>
+        periode.data.every((sib) => sib.foedselsnummer !== soesken.foedselsnummer)
+      )
+      return {
+        ...periode,
+        data: [
+          ...periode.data,
+          ...manglendeSoeskenForPeriode.map(
+            (soesken): SoeskenMedIBeregning => ({
+              foedselsnummer: soesken.foedselsnummer,
+              skalBrukes: false,
+            })
+          ),
+        ],
+      }
+    })
+    reset({ soeskenMedIBeregning: oppdatertePerioder })
+  }
+
   const fnrTilSoesken: Record<string, IPdlPerson> = soesken.reduce(
     (acc, next) => ({
       ...acc,
@@ -123,9 +163,28 @@ const Soeskenjustering = (props: SoeskenjusteringProps) => {
           Søskenjustering
         </Heading>
       </Box>
+      {manglendeSoesken.length > 0 && !skjulManglendeSoesken && (
+        <div style={{ maxWidth: '40rem' }}>
+          <Alert variant="warning">
+            <VStack gap="4">
+              <BodyShort>
+                Den lagrede søskenjusteringen har ikke med alle avdødes barn. For å få riktig søskenjustering må de
+                manglende søskene legges til periodene.
+              </BodyShort>
+              <BodyShort>
+                <Button onClick={oppdaterSoeskenTilJustering}>Oppdater søsken</Button>
+              </BodyShort>
+            </VStack>
+          </Alert>
+        </div>
+      )}
+
       <FamilieforholdWrapper>
         {personopplysninger.soeker && (
-          <Barn person={personopplysninger.soeker?.opplysning} doedsdato={avdoede?.opplysning.doedsdato} />
+          <Barn
+            person={personopplysninger.soeker?.opplysning}
+            doedsdato={personopplysninger.soeker?.opplysning.doedsdato}
+          />
         )}
       </FamilieforholdWrapper>
       <Box paddingBlock="4 0" borderWidth="1 0 0 0" borderColor="border-subtle">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/Soeskenjustering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/Soeskenjustering.tsx
@@ -108,10 +108,10 @@ const Soeskenjustering = (props: SoeskenjusteringProps) => {
   ]
 
   function oppdaterSoeskenTilJustering() {
-    setSkjulManglendeSoesken(true)
     if (manglendeSoesken.length === 0) {
       return
     }
+    setSkjulManglendeSoesken(true)
     const allePerioder = mapListeFraDto(behandling.beregningsGrunnlag!!.soeskenMedIBeregning)
     const oppdatertePerioder = allePerioder.map((periode) => {
       const manglendeSoeskenForPeriode = soesken.filter((soesken) =>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Person.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Person.ts
@@ -9,9 +9,10 @@ export interface Familieforhold {
   gjenlevende: Personopplysning[]
 }
 
-export const hentLevendeSoeskenFraAvdoedeForSoeker = (avdoede: Personopplysning, soekerFnr: string) => {
-  const soeskenliste = (avdoede?.opplysning.avdoedesBarn ?? []).filter((person) => person.foedselsnummer !== soekerFnr)
-  return soeskenliste.filter((soesken) => soesken.doedsdato === null)
+export const hentLevendeSoeskenFraAvdoedeForSoeker = (avdoede: Personopplysning[], soekerFnr?: string) => {
+  const alleAvdoedesBarn = avdoede.flatMap((avdoed) => avdoed.opplysning.avdoedesBarn ?? [])
+  const levendeSoesken = alleAvdoedesBarn.filter((barn) => barn.foedselsnummer !== soekerFnr && !barn.doedsdato)
+  return levendeSoesken
 }
 
 export const hentLevendeSoeskenFraAvdoedeForSoekerGrunnlag = (avdoede: Personopplysning[], soekerFnr: string) => {


### PR DESCRIPTION
Hvis det ligger lagret en søskenjustering som ikke har med alle søsken i periodene for justering, vises det nå et varsel til saksbehandler, og de har mulighet til å legge til de manglende søskenene.

Løser porten-sak FAGSYSTEM-339480

Her er en revurdering av en sak som opprinnelig ikke hadde noen søsken, men et nytt barn til avdøde ble lagt til etter innvilgelse:
![Screenshot 2024-07-30 at 13 48 16](https://github.com/user-attachments/assets/6e8aeb87-b06b-4aa8-a072-60f9905f1fce)


etter trykk på knappen for å oppdatere søsken:
![Screenshot 2024-07-30 at 13 48 22](https://github.com/user-attachments/assets/1862077b-2957-40bf-8086-d9efcca44939)
