### PR TITLE
EY-4241: Loggar requestobjektet som tekst ved feilande deserialisering

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ ktor2-clientjackson = { module = "io.ktor:ktor-client-jackson", version.ref = "k
 ktor2-clientlogging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor2-version" }
 ktor2-clientciojvm = { module = "io.ktor:ktor-client-cio-jvm", version.ref = "ktor2-version" }
 ktor2-servercore = { module = "io.ktor:ktor-server-core", version.ref = "ktor2-version" }
+ktor2-doublereceive = { module = "io.ktor:ktor-server-double-receive", version.ref = "ktor2-version" }
 ktor2-servercio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor2-version" }
 ktor2-auth = { module = "io.ktor:ktor-server-auth", version.ref = "ktor2-version" }
 ktor2-authjwt = { module = "io.ktor:ktor-server-auth-jwt", version.ref = "ktor2-version" }

--- a/libs/etterlatte-ktor/build.gradle.kts
+++ b/libs/etterlatte-ktor/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(libs.ktor2.okhttp)
     implementation(libs.ktor2.clientcontentnegotiation)
     implementation(libs.ktor2.metricsmicrometer)
+    implementation(libs.ktor2.doublereceive)
     implementation(libs.navfelles.tokenvalidationktor2)
     api(libs.ktor2.clientauth)
     api(libs.ktor2.clientloggingjvm)

--- a/libs/etterlatte-ktor/src/main/kotlin/RestModule.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/RestModule.kt
@@ -17,6 +17,7 @@ import io.ktor.server.plugins.callid.callIdMdc
 import io.ktor.server.plugins.callloging.CallLogging
 import io.ktor.server.plugins.callloging.processingTimeMillis
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.doublereceive.DoubleReceive
 import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.request.header
 import io.ktor.server.request.httpMethod
@@ -54,6 +55,8 @@ fun Application.restModule(
     install(ContentNegotiation) {
         register(ContentType.Application.Json, JacksonConverter(objectMapper))
     }
+
+    install(DoubleReceive)
 
     install(IgnoreTrailingSlash)
 

--- a/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/EscapeUtils.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/EscapeUtils.kt
@@ -1,0 +1,22 @@
+package no.nav.etterlatte.libs.ktor.feilhaandtering
+
+// Forenkla versjon av io.micrometer.core.instrument.util. StringEscapeUtils
+
+object EscapeUtils {
+    fun escape(str: String?) =
+        str
+            ?.map {
+                replacements.getOrDefault(it, it).toString()
+            }?.joinToString("") ?: ""
+
+    private val replacements: Map<Char, String> =
+        mapOf(
+            '"' to "\\\"",
+            '\\' to "\\\\",
+            '\t' to "\\t",
+            '\b' to "\\b",
+            '\n' to "\\n",
+            '\r' to "\\r",
+            '\u000c' to "\\f", // \f, som er 13 i ascii-tabellen. Form feed, ikkje noko vi skal ha i praksis
+        )
+}

--- a/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
@@ -5,6 +5,7 @@ import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.log
 import io.ktor.server.plugins.NotFoundException
 import io.ktor.server.plugins.statuspages.StatusPagesConfig
+import io.ktor.server.request.receiveText
 import io.ktor.server.request.uri
 import io.ktor.server.response.respond
 import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
@@ -29,12 +30,12 @@ class StatusPagesKonfigurasjon(
         exception<Throwable> { call, cause ->
             when (cause) {
                 is ForespoerselException -> {
-                    call.application.log.loggForespoerselException(cause)
+                    call.application.log.loggForespoerselException(cause, call)
                     call.respond(cause)
                 }
 
                 is InternfeilException -> {
-                    call.application.log.loggInternfeilException(cause)
+                    call.application.log.loggInternfeilException(cause, call)
                     call.respond(cause)
                 }
 
@@ -45,13 +46,13 @@ class StatusPagesKonfigurasjon(
                             detail = cause.message ?: "Fant ikke ressursen",
                             cause = cause,
                         )
-                    call.application.log.loggForespoerselException(wrapped)
+                    call.application.log.loggForespoerselException(wrapped, call)
                     call.respond(wrapped)
                 }
 
                 else -> {
                     val mappetFeil = InternfeilException("En feil har skjedd.", cause)
-                    call.application.log.loggInternfeilException(mappetFeil)
+                    call.application.log.loggInternfeilException(mappetFeil, call)
                     call.respond(mappetFeil)
                 }
             }
@@ -118,9 +119,12 @@ class StatusPagesKonfigurasjon(
         }
     }
 
-    private fun Logger.loggInternfeilException(internfeil: InternfeilException) {
+    private suspend fun Logger.loggInternfeilException(
+        internfeil: InternfeilException,
+        call: ApplicationCall,
+    ) {
         if (internfeil.erDeserialiseringsException() && isProd()) {
-            sikkerLogg.error("En feil har oppstått ved deserialisering", internfeil)
+            sikkerLogg.error("En feil har oppstått ved deserialisering. Requestobjektet var ${hentRequestobjekt(call)}", internfeil)
             this.error(
                 "En feil har oppstått ved deserialisering. Se sikkerlogg for mer detaljer.",
             )
@@ -132,9 +136,12 @@ class StatusPagesKonfigurasjon(
         }
     }
 
-    private fun Logger.loggForespoerselException(internfeil: ForespoerselException) {
+    private suspend fun Logger.loggForespoerselException(
+        internfeil: ForespoerselException,
+        call: ApplicationCall,
+    ) {
         if (internfeil.erDeserialiseringsException() && isProd()) {
-            sikkerLogg.info("En feil har oppstått ved deserialisering", internfeil)
+            sikkerLogg.info("En feil har oppstått ved deserialisering. Requestobjektet var ${hentRequestobjekt(call)}", internfeil)
             this.info(
                 "En feil har oppstått ved deserialisering i et endepunkt. Se sikkerlogg for mer detaljer. " +
                     "Feilen fikk status ${internfeil.status} til frontend.",
@@ -156,5 +163,15 @@ class StatusPagesKonfigurasjon(
             HttpStatusCode.InternalServerError,
             feil.somJsonRespons(),
         )
+    }
+
+    private suspend fun hentRequestobjekt(call: ApplicationCall): String {
+        val requestobjekt =
+            try {
+                call.receiveText()
+            } catch (e: Exception) {
+                "Kunne ikke hente requestobjektet"
+            }
+        return requestobjekt
     }
 }

--- a/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
@@ -17,6 +17,7 @@ import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilLoggerException
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.isProd
 import no.nav.etterlatte.libs.ktor.erDeserialiseringsException
+import no.nav.etterlatte.libs.ktor.feilhaandtering.EscapeUtils.escape
 import no.nav.etterlatte.libs.ktor.route.routeLogger
 import org.slf4j.Logger
 
@@ -124,7 +125,11 @@ class StatusPagesKonfigurasjon(
         call: ApplicationCall,
     ) {
         if (internfeil.erDeserialiseringsException() && isProd()) {
-            sikkerLogg.error("En feil har oppstått ved deserialisering. Requestobjektet var ${hentRequestobjekt(call)}", internfeil)
+            sikkerLogg.error(
+                "En feil har oppstått ved deserialisering. Requestobjektet var {}",
+                escape(hentRequestobjekt(call)),
+                internfeil,
+            )
             this.error(
                 "En feil har oppstått ved deserialisering. Se sikkerlogg for mer detaljer.",
             )
@@ -141,7 +146,7 @@ class StatusPagesKonfigurasjon(
         call: ApplicationCall,
     ) {
         if (internfeil.erDeserialiseringsException() && isProd()) {
-            sikkerLogg.info("En feil har oppstått ved deserialisering. Requestobjektet var ${hentRequestobjekt(call)}", internfeil)
+            sikkerLogg.info("En feil har oppstått ved deserialisering. Requestobjektet var {}", escape(hentRequestobjekt(call)), internfeil)
             this.info(
                 "En feil har oppstått ved deserialisering i et endepunkt. Se sikkerlogg for mer detaljer. " +
                     "Feilen fikk status ${internfeil.status} til frontend.",

--- a/libs/etterlatte-ktor/src/test/kotlin/no/nav/etterlatte/feilhaandtering/EscapeUtilsTest.kt
+++ b/libs/etterlatte-ktor/src/test/kotlin/no/nav/etterlatte/feilhaandtering/EscapeUtilsTest.kt
@@ -1,0 +1,21 @@
+package no.nav.etterlatte.libs.ktor.feilhaandtering
+
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.ktor.feilhaandtering.EscapeUtils.escape
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class EscapeUtilsTest {
+    @Test
+    fun `escaping fungerer`() {
+        assertEquals("", escape(""))
+        assertEquals("a", escape("a"))
+        assertEquals(" a b ", escape(" a b "))
+        val str = escape(objectMapper.writeValueAsString(EnkelKlasse("hemmelig")))
+        assertEquals("{\\\"ident\\\":\\\"hemmelig\\\"}", str)
+    }
+}
+
+private data class EnkelKlasse(
+    val ident: String,
+)


### PR DESCRIPTION
Viss vi får feil under deserialisering, er det veldig greitt å veta kva request-objektet som feila var. Loggar derfor det ut i rein tekst til sikkerlogg.

For å få til det må vi konfigurere opp ktor til å la oss køyre receive på requesten fleire gongar, så innfører double receive-pluginen til ktor for å opne for det.

Dette er jo ein trade-off, å innføre ein ny plugin kun for dette, samtidig gjer det feilsøkinga såpass mykje enklare i desse høva at eg tenkjer at det er verdt det.