### PR TITLE
Nytt forsøk på å logge requestobjekt ved deserialiseringsfeil

### DIFF
--- a/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
@@ -5,7 +5,7 @@ import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.log
 import io.ktor.server.plugins.NotFoundException
 import io.ktor.server.plugins.statuspages.StatusPagesConfig
-import io.ktor.server.request.receiveText
+import io.ktor.server.request.receive
 import io.ktor.server.request.uri
 import io.ktor.server.response.respond
 import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
@@ -173,10 +173,11 @@ class StatusPagesKonfigurasjon(
     private suspend fun hentRequestobjekt(call: ApplicationCall): String {
         val requestobjekt =
             try {
-                call.receiveText()
+                call.receive<String>()
             } catch (e: Exception) {
                 "Kunne ikke hente requestobjektet"
             }
+        sikkerLogg.debug("Henta requestobjekt på totalt ${requestobjekt.length} tegn")
         return requestobjekt
     }
 }


### PR DESCRIPTION
Ser i loggane at vi får "En feil har oppstått ved deserialisering. Requestobjektet var ", så da har vi ikkje fått objektet. Prøver å bytte over frå receiveText til receive<String>, for å sjå om det gjer nokon forskjell. Legg også på logging av antal teikn i requestobjektet, for å utelukke at det er escapinga som kåler det til