### PR TITLE
EY-3940: Legg til sanksjon i ytelse med grunnlag periodisert

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/ytelseMedGrunnlag/YtelseMedGrunnlagService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/ytelseMedGrunnlag/YtelseMedGrunnlagService.kt
@@ -32,7 +32,6 @@ class YtelseMedGrunnlagService(
                     beregning.beregningsperioder
                         .filter { it.datoFOM <= avkortetYtelse.fom }
                         .maxBy { it.datoFOM }
-
                 val grunnlag =
                     avkorting.avkortingGrunnlag
                         .filter { it.fom <= avkortetYtelse.fom }
@@ -53,6 +52,7 @@ class YtelseMedGrunnlagService(
                     grunnbelop = beregningIPeriode.grunnbelop,
                     grunnbelopMnd = beregningIPeriode.grunnbelopMnd,
                     beregningsMetode = beregningIPeriode.beregningsMetode,
+                    sanksjon = avkortetYtelse.sanksjon,
                 )
             }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/Beregning.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/Beregning.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.brev.behandling
 
 import no.nav.etterlatte.libs.common.IntBroek
 import no.nav.etterlatte.libs.common.beregning.BeregningsMetode
+import no.nav.etterlatte.libs.common.beregning.SanksjonertYtelse
 import no.nav.pensjon.brevbaker.api.model.Kroner
 import java.time.LocalDate
 
@@ -32,6 +33,7 @@ data class AvkortetBeregningsperiode(
     val utbetaltBeloep: Kroner,
     val beregningsMetodeAnvendt: BeregningsMetode,
     val beregningsMetodeFraGrunnlag: BeregningsMetode,
+    val sanksjon: SanksjonertYtelse?,
 )
 
 data class Beregningsperiode(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningService.kt
@@ -136,6 +136,7 @@ class BeregningService(
                         beregningsGrunnlag?.beregningsMetode?.beregningsMetode
                             ?: requireNotNull(it.beregningsMetode),
                     // ved manuelt overstyrt beregning har vi ikke grunnlag
+                    sanksjon = it.sanksjon,
                 )
             }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/EtterlatteBrev.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/EtterlatteBrev.kt
@@ -67,6 +67,7 @@ data class OmstillingsstoenadBeregningsperiode(
     val trygdetid: Int,
     val beregningsMetodeAnvendt: BeregningsMetode,
     val beregningsMetodeFraGrunnlag: BeregningsMetode,
+    val sanksjon: Boolean,
 )
 
 data class TrygdetidMedBeregningsmetode(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelse.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelse.kt
@@ -55,6 +55,7 @@ data class OmstillingsstoenadInnvilgelse(
                         trygdetid = it.trygdetid,
                         beregningsMetodeFraGrunnlag = it.beregningsMetodeFraGrunnlag,
                         beregningsMetodeAnvendt = it.beregningsMetodeAnvendt,
+                        sanksjon = it.sanksjon != null,
                     )
                 }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadRevurdering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadRevurdering.kt
@@ -64,6 +64,7 @@ data class OmstillingsstoenadRevurdering(
                         trygdetid = it.trygdetid,
                         beregningsMetodeFraGrunnlag = it.beregningsMetodeFraGrunnlag,
                         beregningsMetodeAnvendt = it.beregningsMetodeAnvendt,
+                        sanksjon = it.sanksjon != null,
                     )
                 }
 

--- a/libs/etterlatte-beregning-model/src/main/kotlin/BeregningDTO.kt
+++ b/libs/etterlatte-beregning-model/src/main/kotlin/BeregningDTO.kt
@@ -108,6 +108,7 @@ data class YtelseMedGrunnlagPeriodisertDto(
     val grunnbelop: Int,
     val grunnbelopMnd: Int,
     val beregningsMetode: BeregningsMetode?,
+    val sanksjon: SanksjonertYtelse?,
 )
 
 enum class OverstyrtBeregningKategori {


### PR DESCRIPTION
Sender nå med hele sanksjonen fra beregning slik at man lettere kan bruke den senere. I brevet er det per dags dato kun nødvendig å vite om det finnes en sanksjon eller ikke. 