### PR TITLE
For parallelle sannheter er det for tidleg å hente ut body-en som Jso…

### DIFF
--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/ParallelleSannheterKlient.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/ParallelleSannheterKlient.kt
@@ -125,10 +125,10 @@ class ParallelleSannheterKlient(
                             .post("$apiUrl/api/${avklaring.feltnavn}") {
                                 accept(Json)
                                 setBody(TextContent(nodeWithFieldName.toJson(), Json))
-                            }.body<JsonNode>()
+                            }
                     }.let {
                         when (it) {
-                            is RetryResult.Success -> it.content
+                            is RetryResult.Success -> it.content.body<JsonNode>()
                             is RetryResult.Failure -> throw it.samlaExceptions()
                         }
                     }


### PR DESCRIPTION
…nNode før vi har sjekka på resultatet - viss det er feil, feks ein 501, så får vi ikkje ein JsonNode-respons. Ventar derfor med uthentinga til vi har suksess.

Løyser ikkje problemet vi har no, men gir betre feilmeldingar