### PR TITLE
Viser ikke omgjør-knapp hvis det ikke er noe å omgjøre

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/hendelser/utils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/hendelser/utils.ts
@@ -152,10 +152,12 @@ export const omgjoeringAvslagKanOpprettes = (
   enheter: Array<string>
 ): Boolean => {
   return (
+    behandlinger.length > 0 &&
     behandlinger.every(
       (behandling) =>
         behandling.behandlingType != IBehandlingsType.FØRSTEGANGSBEHANDLING ||
         [IBehandlingStatus.AVSLAG, IBehandlingStatus.AVBRUTT].includes(behandling.status)
-    ) && enhetErSkrivbar(enhet, enheter)
+    ) &&
+    enhetErSkrivbar(enhet, enheter)
   )
 }


### PR DESCRIPTION
fjerner denne:

![Screenshot 2024-08-05 at 14 55 41](https://github.com/user-attachments/assets/7355e66e-4bda-48b3-9b6f-a1456d81b9e2)

siden det er uansett ikke noe å omgjøre