### PR TITLE
EY-4264: Ikkje importer ktor-avhengnadar transitivt frå andre

### DIFF
--- a/apps/etterlatte-behandling/build.gradle.kts
+++ b/apps/etterlatte-behandling/build.gradle.kts
@@ -23,7 +23,10 @@ dependencies {
     implementation(project(":libs:etterlatte-vilkaarsvurdering-model"))
 
     implementation(libs.cache.caffeine)
-    implementation(libs.navfelles.tokenvalidationktor2)
+    implementation(libs.navfelles.tokenvalidationktor2) {
+        exclude("io.ktor", "ktor-server")
+    }
+    implementation(libs.ktor2.servercore) // For å kompensere for exclude-en over
 
     testImplementation(libs.ktor2.clientcontentnegotiation)
     testImplementation(libs.ktor2.clientmock)

--- a/apps/etterlatte-behandling/build.gradle.kts
+++ b/apps/etterlatte-behandling/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     implementation(libs.navfelles.tokenvalidationktor2) {
         exclude("io.ktor", "ktor-server")
     }
-    implementation(libs.ktor2.servercore) // For å kompensere for exclude-en over
+    implementation(libs.ktor2.server) // For å kompensere for exclude-en over
 
     testImplementation(libs.ktor2.clientcontentnegotiation)
     testImplementation(libs.ktor2.clientmock)

--- a/apps/etterlatte-samordning-vedtak/build.gradle.kts
+++ b/apps/etterlatte-samordning-vedtak/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     implementation(libs.navfelles.tokenvalidationktor2) {
         exclude("io.ktor", "ktor-server")
     }
-    implementation(libs.ktor2.servercore) // For å kompensere for exclude-en over
+    implementation(libs.ktor2.server) // For å kompensere for exclude-en over
 
     testImplementation(libs.ktor2.clientcontentnegotiation)
     testImplementation(libs.ktor2.jackson)

--- a/apps/etterlatte-samordning-vedtak/build.gradle.kts
+++ b/apps/etterlatte-samordning-vedtak/build.gradle.kts
@@ -11,7 +11,10 @@ dependencies {
 
     implementation(libs.ktor2.servercio)
 
-    implementation(libs.navfelles.tokenvalidationktor2)
+    implementation(libs.navfelles.tokenvalidationktor2) {
+        exclude("io.ktor", "ktor-server")
+    }
+    implementation(libs.ktor2.servercore) // For å kompensere for exclude-en over
 
     testImplementation(libs.ktor2.clientcontentnegotiation)
     testImplementation(libs.ktor2.jackson)

--- a/apps/etterlatte-testdata/build.gradle.kts
+++ b/apps/etterlatte-testdata/build.gradle.kts
@@ -18,7 +18,10 @@ dependencies {
     implementation(libs.navfelles.tokenvalidationktor2) {
         exclude("io.ktor", "ktor-server")
     }
-    implementation(libs.ktor2.servercore) // For å kompensere for exclude-en over
+    implementation(libs.ktor2.servercore)
+    implementation(libs.ktor2.auth)
+    implementation(libs.ktor2.calllogging)
+    implementation(libs.ktor2.statuspages) // For å kompensere for exclude-en over
 
     testImplementation(libs.test.kotest.assertionscore)
 }

--- a/apps/etterlatte-testdata/build.gradle.kts
+++ b/apps/etterlatte-testdata/build.gradle.kts
@@ -15,7 +15,10 @@ dependencies {
     implementation(libs.cache.caffeine)
     implementation(libs.etterlatte.common)
 
-    implementation(libs.navfelles.tokenvalidationktor2)
+    implementation(libs.navfelles.tokenvalidationktor2) {
+        exclude("io.ktor", "ktor-server")
+    }
+    implementation(libs.ktor2.servercore) // For å kompensere for exclude-en over
 
     testImplementation(libs.test.kotest.assertionscore)
 }

--- a/apps/etterlatte-testdata/build.gradle.kts
+++ b/apps/etterlatte-testdata/build.gradle.kts
@@ -18,10 +18,7 @@ dependencies {
     implementation(libs.navfelles.tokenvalidationktor2) {
         exclude("io.ktor", "ktor-server")
     }
-    implementation(libs.ktor2.servercore)
-    implementation(libs.ktor2.auth)
-    implementation(libs.ktor2.calllogging)
-    implementation(libs.ktor2.statuspages) // For å kompensere for exclude-en over
+    implementation(libs.ktor2.server)
 
     testImplementation(libs.test.kotest.assertionscore)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,9 @@ ktor2-statuspages = { module = "io.ktor:ktor-server-status-pages", version.ref =
 ktor2-metricsmicrometer = { module = "io.ktor:ktor-server-metrics-micrometer", version.ref = "ktor2-version" }
 ktor2-mustache = { module = "io.ktor:ktor-server-mustache", version.ref = "ktor2-version" }
 ktor2-clientmock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor2-version" }
+ktor2-serverresources = { module = "io.ktor:ktor-server-resources", version.ref = "ktor2-version" }
 ktor2-servertests = { module = "io.ktor:ktor-server-tests", version.ref = "ktor2-version" }
+ktor2-webjars = { module = "io.ktor:ktor-server-webjars", version.ref = "ktor2-version" }
 
 etterlatte-common = { module = "pensjon-etterlatte-libs:common", version = "2024.07.23-11.12.ae810566ac12"}
 teamdokumenthandtering-avroschemas = { module = "no.nav.teamdokumenthandtering:teamdokumenthandtering-avro-schemas", version = "08c0b2d2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ ktor2-clientjackson = { module = "io.ktor:ktor-client-jackson", version.ref = "k
 ktor2-clientlogging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor2-version" }
 ktor2-clientciojvm = { module = "io.ktor:ktor-client-cio-jvm", version.ref = "ktor2-version" }
 ktor2-servercore = { module = "io.ktor:ktor-server-core", version.ref = "ktor2-version" }
+ktor2-servercorejvm = { module = "io.ktor:ktor-server-core-jvm", version.ref = "ktor2-version" }
 ktor2-doublereceive = { module = "io.ktor:ktor-server-double-receive", version.ref = "ktor2-version" }
 ktor2-servercio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor2-version" }
 ktor2-auth = { module = "io.ktor:ktor-server-auth", version.ref = "ktor2-version" }
@@ -55,6 +56,7 @@ ktor2-statuspages = { module = "io.ktor:ktor-server-status-pages", version.ref =
 ktor2-metricsmicrometer = { module = "io.ktor:ktor-server-metrics-micrometer", version.ref = "ktor2-version" }
 ktor2-mustache = { module = "io.ktor:ktor-server-mustache", version.ref = "ktor2-version" }
 ktor2-clientmock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor2-version" }
+ktor2-server = { module = "io.ktor:ktor-server", version.ref = "ktor2-version" }
 ktor2-serverresources = { module = "io.ktor:ktor-server-resources", version.ref = "ktor2-version" }
 ktor2-servertests = { module = "io.ktor:ktor-server-tests", version.ref = "ktor2-version" }
 ktor2-webjars = { module = "io.ktor:ktor-server-webjars", version.ref = "ktor2-version" }

--- a/libs/etterlatte-ktor/build.gradle.kts
+++ b/libs/etterlatte-ktor/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation(libs.ktor2.metricsmicrometer)
     implementation(libs.ktor2.doublereceive)
     implementation(libs.navfelles.tokenvalidationktor2) {
-        exclude("io.ktor")
+        exclude("io.ktor", "ktor-server")
     }
     implementation(libs.ktor2.clientauth)
     api(libs.ktor2.clientloggingjvm)

--- a/libs/etterlatte-ktor/build.gradle.kts
+++ b/libs/etterlatte-ktor/build.gradle.kts
@@ -5,12 +5,20 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":libs:saksbehandling-common"))
-    implementation(libs.openapi)
-
+    implementation(libs.openapi) {
+        exclude("io.ktor", "ktor-server-core-jvm")
+        exclude("io.ktor", "ktor-server-webjars")
+        exclude("io.ktor", "ktor-server-auth")
+        exclude("io.ktor", "ktor-server-resources")
+    }
     implementation(libs.ktor2.servercore)
-    implementation(libs.ktor2.servercio)
+    implementation(libs.ktor2.webjars)
     implementation(libs.ktor2.auth)
+    implementation(libs.ktor2.serverresources)
+    // Fram hit: ktor-avhengnadar for å dekkje det vi ekskluderer frå openapi-importen
+
+    implementation(project(":libs:saksbehandling-common"))
+    implementation(libs.ktor2.servercio)
     implementation(libs.ktor2.jackson)
     implementation(libs.ktor2.calllogging)
     implementation(libs.ktor2.callid)

--- a/libs/etterlatte-ktor/build.gradle.kts
+++ b/libs/etterlatte-ktor/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
         exclude("io.ktor", "ktor-server-auth")
         exclude("io.ktor", "ktor-server-resources")
     }
-    implementation(libs.ktor2.servercore)
+    implementation(libs.ktor2.servercorejvm)
     implementation(libs.ktor2.webjars)
     implementation(libs.ktor2.auth)
     implementation(libs.ktor2.serverresources)
@@ -31,6 +31,7 @@ dependencies {
     implementation(libs.navfelles.tokenvalidationktor2) {
         exclude("io.ktor", "ktor-server")
     }
+    implementation(libs.ktor2.server)
     implementation(libs.ktor2.clientauth)
     api(libs.ktor2.clientloggingjvm)
     implementation(libs.navfelles.tokenclientcore)

--- a/libs/rapidsandrivers-extras/build.gradle.kts
+++ b/libs/rapidsandrivers-extras/build.gradle.kts
@@ -4,7 +4,13 @@ plugins {
 
 dependencies {
     api(libs.bundles.jackson)
-    api(libs.navfelles.rapidandriversktor2)
+    api(libs.navfelles.rapidandriversktor2) {
+        exclude("io.ktor", "ktor-server-cio")
+        exclude("io.ktor", "ktor-server-metrics-micrometer")
+    }
+    api(libs.ktor2.servercio)
+    api(libs.ktor2.metricsmicrometer)
+    // Desse to over er spesifisert som api i r&r sjølv, så vi må ha dei med her for å ikkje få feil i runtime
 
     implementation(project(":libs:saksbehandling-common"))
 


### PR DESCRIPTION
EY-4264: Ekskluderer ktor-avhengnadane vi får inn transitivt gjennom openapi, rapids&rivers og token-biblioteket. Kjens mykje tryggare å sjølv deklarere desse og spesifisere rett versjon.

Er eit lite dilemma her om vi skal ekskludere alt under io.ktor her, men det ber jo også med seg ein risiko for at vi plutseleg manglar ein avhengnad i runtime viss desse biblioteka endrar kva dei er avhengige av, så da kjens det greiare å spesifisere opp eksplisitt.

Er litt usikker på forholdet mellom ktor-server og ktor-server-core, samt mellom ktor-server-core og ktor-server-core-jvm, så må teste litt før eventuell merge.