### PR TITLE
Skrur på konfigurasjonscachen i Gradle

### DIFF
--- a/.github/workflows/.build-and-deploy.yaml
+++ b/.github/workflows/.build-and-deploy.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Validate licenses
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew checkLicense
+        run: ./gradlew checkLicense --no-configuration-cache
   salsa:
     name: Generate SBOM, attest and sign image
     runs-on: ubuntu-latest

--- a/.github/workflows/.lib-test.yaml
+++ b/.github/workflows/.lib-test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Validate licenses
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew checkLicense
+        run: ./gradlew checkLicense --no-configuration-cache
       - name: Gradle test and build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/.test.yaml
+++ b/.github/workflows/.test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Validate licenses
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew checkLicense
+        run: ./gradlew checkLicense --no-configuration-cache
       - name: Gradle test and build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/buildSrc/src/main/kotlin/etterlatte.common.gradle.kts
+++ b/buildSrc/src/main/kotlin/etterlatte.common.gradle.kts
@@ -1,3 +1,4 @@
+
 import org.gradle.accessors.dm.LibrariesForLibs
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
@@ -41,10 +42,15 @@ tasks {
                 }
         }
 
+        val configuration =
+            configurations.runtimeClasspath.get().map {
+                it.toPath().toFile()
+            }
+        val buildDirectory = layout.buildDirectory
         doLast {
-            configurations.runtimeClasspath.get().forEach {
+            configuration.forEach {
                 val file =
-                    layout.buildDirectory
+                    buildDirectory
                         .file("libs/${it.name}")
                         .get()
                         .asFile

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.configuration-cache=true

--- a/libs/etterlatte-regler/build.gradle.kts
+++ b/libs/etterlatte-regler/build.gradle.kts
@@ -33,14 +33,13 @@ sourceSets {
 }
 
 tasks.register("generateVersionProperties") {
-    doLast {
-        val propertiesFile = file("${generatedVersionDir.get()}/version.properties")
-        propertiesFile.parentFile.mkdirs()
-        val properties = Properties()
-        properties.setProperty("version", "$version")
-        val out = FileOutputStream(propertiesFile)
-        properties.store(out, null)
-    }
+    val get = generatedVersionDir.get()
+    val propertiesFile = file("$get/version.properties")
+    propertiesFile.parentFile.mkdirs()
+    val properties = Properties()
+    properties.setProperty("version", "$version")
+    val out = FileOutputStream(propertiesFile)
+    properties.store(out, null)
 }
 
 tasks.named("processResources") {


### PR DESCRIPTION
Skrur på Gradle configuration cache

Ifølgje dokumentasjonen (https://docs.gradle.org/current/userguide/configuration_cache.html) skal Gradle configuration cache gjera at bygg skal gå raskare, ved å gjenbruke konfig frå cache, omtrent tilsvarande som korleis caching elles funkar i Gradle.

Det er ikkje alle plugins som er støtta, men det ser ut som dei fleste viktige er det, så tenkjer vi kan teste det ut.