### PR TITLE
Køyrer kun lisenssjekken ved deploy, og verifiserer at denne er ok før deploy til prod

### DIFF
--- a/.github/workflows/.build-and-deploy.yaml
+++ b/.github/workflows/.build-and-deploy.yaml
@@ -114,7 +114,7 @@ jobs:
   deploy-to-prod-gcp:
     name: prod-gcp
     if: ${{ github.ref == 'refs/heads/main' || github.event.inputs.deploy-prod == 'true' }}
-    needs: [build-and-publish, deploy-to-dev-gcp]
+    needs: [build-and-publish, license-check, deploy-to-dev-gcp]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/.lib-test.yaml
+++ b/.github/workflows/.lib-test.yaml
@@ -18,10 +18,6 @@ jobs:
           java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-      - name: Validate licenses
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew checkLicense --no-configuration-cache
       - name: Gradle test and build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/.test.yaml
+++ b/.github/workflows/.test.yaml
@@ -18,10 +18,6 @@ jobs:
           java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-      - name: Validate licenses
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew checkLicense --no-configuration-cache
       - name: Gradle test and build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Det sparer ein del tid under bygg, og eg trur det skal vera godt nok for alt vi kan komme borti av problematikk. Sjølvsagt ei avveging, men tida vi sparer for kvart PR-bygg trur eg er verdt det