### PR TITLE
EY-4287: Konfigurerer opp configuration cache for Gradle

### DIFF
--- a/.github/workflows/.build-and-deploy.yaml
+++ b/.github/workflows/.build-and-deploy.yaml
@@ -32,7 +32,6 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-encryption-key: ${{ secrets.gradlekey }}
-          cache-read-only: false
           dependency-graph: generate-and-submit
       - name: Gradle test and build
         env:

--- a/.github/workflows/.build-and-deploy.yaml
+++ b/.github/workflows/.build-and-deploy.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 10
     permissions:
-      contents: read
+      contents: write
       id-token: write
     outputs:
       image: ${{ steps.docker-build-push.outputs.image }}

--- a/.github/workflows/.build-and-deploy.yaml
+++ b/.github/workflows/.build-and-deploy.yaml
@@ -33,6 +33,7 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.gradlekey }}
           cache-read-only: false
+          dependency-graph: generate-and-submit
       - name: Gradle test and build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/.build-and-deploy.yaml
+++ b/.github/workflows/.build-and-deploy.yaml
@@ -29,7 +29,10 @@ jobs:
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.gradlekey }}
+          cache-read-only: false
       - name: Gradle test and build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/app-etterlatte-behandling.yaml
+++ b/.github/workflows/app-etterlatte-behandling.yaml
@@ -52,7 +52,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-beregning-kafka.yaml
+++ b/.github/workflows/app-etterlatte-beregning-kafka.yaml
@@ -36,7 +36,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-beregning.yaml
+++ b/.github/workflows/app-etterlatte-beregning.yaml
@@ -44,7 +44,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-brev-api.yaml
+++ b/.github/workflows/app-etterlatte-brev-api.yaml
@@ -50,7 +50,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-egne-ansatte-lytter.yaml
+++ b/.github/workflows/app-etterlatte-egne-ansatte-lytter.yaml
@@ -30,7 +30,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-grunnlag.yaml
+++ b/.github/workflows/app-etterlatte-grunnlag.yaml
@@ -40,7 +40,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-gyldig-soeknad.yaml
+++ b/.github/workflows/app-etterlatte-gyldig-soeknad.yaml
@@ -30,7 +30,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-hendelser-joark.yaml
+++ b/.github/workflows/app-etterlatte-hendelser-joark.yaml
@@ -34,7 +34,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-hendelser-pdl.yaml
+++ b/.github/workflows/app-etterlatte-hendelser-pdl.yaml
@@ -34,7 +34,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-hendelser-samordning.yaml
+++ b/.github/workflows/app-etterlatte-hendelser-samordning.yaml
@@ -32,7 +32,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-institusjonsopphold.yaml
+++ b/.github/workflows/app-etterlatte-institusjonsopphold.yaml
@@ -30,7 +30,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-klage.yaml
+++ b/.github/workflows/app-etterlatte-klage.yaml
@@ -32,7 +32,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-migrering.yaml
+++ b/.github/workflows/app-etterlatte-migrering.yaml
@@ -44,7 +44,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-oppdater-behandling.yaml
+++ b/.github/workflows/app-etterlatte-oppdater-behandling.yaml
@@ -40,7 +40,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-opplysninger-fra-soeknad.yaml
+++ b/.github/workflows/app-etterlatte-opplysninger-fra-soeknad.yaml
@@ -28,7 +28,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-pdltjenester.yaml
+++ b/.github/workflows/app-etterlatte-pdltjenester.yaml
@@ -34,7 +34,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-samordning-vedtak.yaml
+++ b/.github/workflows/app-etterlatte-samordning-vedtak.yaml
@@ -37,7 +37,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -57,7 +57,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     timeout-minutes: 10
     steps:
@@ -74,7 +74,7 @@ jobs:
     needs: [deploy-api-dev, build]
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     timeout-minutes: 10
     steps:

--- a/.github/workflows/app-etterlatte-statistikk.yaml
+++ b/.github/workflows/app-etterlatte-statistikk.yaml
@@ -38,7 +38,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-testdata-behandler.yaml
+++ b/.github/workflows/app-etterlatte-testdata-behandler.yaml
@@ -19,7 +19,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-testdata.yaml
+++ b/.github/workflows/app-etterlatte-testdata.yaml
@@ -19,7 +19,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-tidshendelser.yaml
+++ b/.github/workflows/app-etterlatte-tidshendelser.yaml
@@ -38,7 +38,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-tilbakekreving.yaml
+++ b/.github/workflows/app-etterlatte-tilbakekreving.yaml
@@ -34,7 +34,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-trygdetid-kafka.yaml
+++ b/.github/workflows/app-etterlatte-trygdetid-kafka.yaml
@@ -34,7 +34,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-trygdetid.yaml
+++ b/.github/workflows/app-etterlatte-trygdetid.yaml
@@ -36,7 +36,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-utbetaling.yaml
+++ b/.github/workflows/app-etterlatte-utbetaling.yaml
@@ -40,7 +40,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-vedtaksvurdering-kafka.yaml
+++ b/.github/workflows/app-etterlatte-vedtaksvurdering-kafka.yaml
@@ -42,7 +42,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-vedtaksvurdering.yaml
+++ b/.github/workflows/app-etterlatte-vedtaksvurdering.yaml
@@ -44,7 +44,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-vilkaarsvurdering-kafka.yaml
+++ b/.github/workflows/app-etterlatte-vilkaarsvurdering-kafka.yaml
@@ -32,7 +32,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/app-etterlatte-vilkaarsvurdering.yaml
+++ b/.github/workflows/app-etterlatte-vilkaarsvurdering.yaml
@@ -36,7 +36,7 @@ on:
       - gradle/libs.versions.toml
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
Innførte Gradle configuration cache i https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/5494, men oppdagar at han ikkje funkar utan at vi har sett _encryption-key_-variabelen i byggejobben, så definerer opp den.


https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#optimizing-cache-effectiveness

Inspirert av [løysinga frå dagpenger](https://github.com/navikt/dp-behandling/blob/main/.github/workflows/deploy.yaml).