### PR TITLE
FAGSYSTEM-335584 Støtte setting av virk FØR første iverksatte virk

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -162,10 +162,9 @@ internal fun Route.behandlingRoutes(
 
         post("/virkningstidspunkt") {
             kunSkrivetilgang {
-                logger.debug("Prøver å fastsette virkningstidspunkt")
                 val body = call.receive<VirkningstidspunktRequest>()
-                logger.debug("Tok imot virkningstidspunktrequest")
-                logger.debug("Virkningstidspunktrequest hadde dato {}", body.dato)
+                val overstyr = call.request.queryParameters["overstyr"].toBoolean()
+                logger.debug("Virkningstidspunkt forsøkes satt til {} (overstyr={})", body.dato, overstyr)
 
                 val erGyldigVirkningstidspunkt =
                     inTransaction {
@@ -174,6 +173,7 @@ internal fun Route.behandlingRoutes(
                                 behandlingId,
                                 brukerTokenInfo,
                                 body,
+                                overstyr,
                             )
                         }
                     }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
@@ -33,8 +33,11 @@ import no.nav.etterlatte.libs.common.behandling.NyBehandlingRequest
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
+import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.toNorskTid
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.GJENLEVENDE_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.INNSENDER_FOEDSELSNUMMER
@@ -48,6 +51,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.time.LocalDateTime
+import java.time.YearMonth
 import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -185,6 +189,12 @@ internal class BehandlingRoutesTest {
         val bodyVirkningstidspunkt = Tidspunkt.parse("2017-02-01T00:00:00Z")
         val bodyBegrunnelse = "begrunnelse"
 
+        mockBehandlingService(bodyVirkningstidspunkt, bodyBegrunnelse)
+
+        coEvery {
+            behandlingService.erGyldigVirkningstidspunkt(any(), any(), any(), any())
+        } returns true
+
         withTestApplication { client ->
             val response =
                 client.post("/api/behandling/$behandlingId/virkningstidspunkt") {
@@ -214,6 +224,36 @@ internal class BehandlingRoutesTest {
 
             assertEquals(200, response.status.value)
             verify(exactly = 1) { behandlingService.avbrytBehandling(behandlingId, any()) }
+        }
+    }
+
+    @Test
+    fun `Gir bad request hvis virkningstidspunkt ikke er gyldig`() {
+        val bodyVirkningstidspunkt = Tidspunkt.parse("2017-02-01T00:00:00Z")
+        val bodyBegrunnelse = "begrunnelse"
+
+        mockBehandlingService(bodyVirkningstidspunkt, bodyBegrunnelse)
+
+        coEvery {
+            behandlingService.erGyldigVirkningstidspunkt(any(), any(), any(), any())
+        } returns false
+
+        withTestApplication { client ->
+            val response =
+                client.post("/api/behandling/$behandlingId/virkningstidspunkt") {
+                    header(HttpHeaders.Authorization, "Bearer $saksbehandlertoken")
+                    contentType(ContentType.Application.Json)
+                    setBody(
+                        """
+                        {
+                        "dato":"$bodyVirkningstidspunkt",
+                        "begrunnelse":"$bodyBegrunnelse"
+                        }
+                        """.trimIndent(),
+                    )
+                }
+
+            assertEquals(400, response.status.value)
         }
     }
 
@@ -258,6 +298,33 @@ internal class BehandlingRoutesTest {
                 }
             block(client)
         }
+    }
+
+    private fun mockBehandlingService(
+        bodyVirkningstidspunkt: Tidspunkt,
+        bodyBegrunnelse: String,
+    ) {
+        val parsetVirkningstidspunkt =
+            YearMonth.from(
+                bodyVirkningstidspunkt.toNorskTid().let {
+                    YearMonth.of(it.year, it.month)
+                },
+            )
+        val virkningstidspunkt =
+            Virkningstidspunkt(
+                parsetVirkningstidspunkt,
+                Grunnlagsopplysning.Saksbehandler.create(NAV_IDENT),
+                bodyBegrunnelse,
+            )
+        coEvery {
+            behandlingService.oppdaterVirkningstidspunkt(
+                behandlingId,
+                parsetVirkningstidspunkt,
+                any(),
+                bodyBegrunnelse,
+                any(),
+            )
+        } returns virkningstidspunkt
     }
 
     private val saksbehandlertoken: String by lazy { mockOAuth2Server.issueSaksbehandlerToken(navIdent = NAV_IDENT) }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingServiceImplTest.kt
@@ -596,15 +596,14 @@ internal class BehandlingServiceImplTest {
     @ParameterizedTest
     @EnumSource(SakType::class, names = ["OMSTILLINGSSTOENAD", "BARNEPENSJON"], mode = EnumSource.Mode.INCLUDE)
     fun `skal gi ugyldig virkningstidspunkt for revurdering hvis virkningstidspunkt er foer foerste virk`(sakType: SakType) {
-        val gyldigVirkningstidspunkt =
+        shouldThrow<VirkFoerIverksattVirk> {
             sjekkOmVirkningstidspunktErGyldig(
                 sakType = sakType,
                 behandlingType = BehandlingType.REVURDERING,
                 virkningstidspunkt = Tidspunkt.parse("2023-12-01T00:00:00Z"),
                 foersteVirk = YearMonth.of(2024, Month.JANUARY),
             )
-
-        gyldigVirkningstidspunkt shouldBe false
+        }
     }
 
     @ParameterizedTest
@@ -683,7 +682,7 @@ internal class BehandlingServiceImplTest {
         val request = VirkningstidspunktRequest(virkningstidspunkt.toString(), begrunnelse, kravdato?.toLocalDate())
 
         return runBlocking {
-            behandlingService.erGyldigVirkningstidspunkt(BEHANDLINGS_ID, TOKEN, request)
+            behandlingService.erGyldigVirkningstidspunkt(BEHANDLINGS_ID, TOKEN, request, false)
         }
     }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/GrunnlagForVirkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/GrunnlagForVirkningstidspunkt.tsx
@@ -1,13 +1,13 @@
 import { Revurderingaarsak } from '~shared/types/Revurderingaarsak'
 import { useBehandling } from '~components/behandling/useBehandling'
 import { Info } from '~components/behandling/soeknadsoversikt/Info'
-import { formaterKanskjeStringDato, formaterDato } from '~utils/formatering/dato'
+import { formaterDato, formaterKanskjeStringDato } from '~utils/formatering/dato'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { useEffect } from 'react'
 import Spinner from '~shared/Spinner'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { hentFoersteVirk } from '~shared/api/behandling'
-import { Box, Label, VStack } from '@navikt/ds-react'
+import { Alert, Box, Label, VStack } from '@navikt/ds-react'
 import { formaterNavn, IPdlPerson } from '~shared/types/Person'
 import { getHistoriskForeldreansvar } from '~shared/api/grunnlag'
 import { usePersonopplysninger } from '~components/person/usePersonopplysninger'
@@ -15,7 +15,7 @@ import { usePersonopplysninger } from '~components/person/usePersonopplysninger'
 import { mapApiResult } from '~shared/api/apiUtils'
 import { SakType } from '~shared/types/sak'
 import { formaterGrunnlagKilde } from '~components/behandling/soeknadsoversikt/utils'
-import { addYears } from 'date-fns'
+import { addYears, isBefore } from 'date-fns'
 
 const SoekerDoedsdatoGrunnlag = () => {
   const soeker = usePersonopplysninger()?.soeker?.opplysning
@@ -43,7 +43,16 @@ const FoersteVirkGrunnlag = () => {
     <Spinner visible={true} label="Henter første virkningstidspunkt" />,
     () => <ApiErrorAlert>Kunne ikke hente første virkningstidspunkt</ApiErrorAlert>,
     (foersteVirk) => (
-      <Info tekst={formaterDato(foersteVirk.foersteIverksatteVirkISak)} label="Første virkningstidspunkt i sak" />
+      <>
+        <Info tekst={formaterDato(foersteVirk.foersteIverksatteVirkISak)} label="Første virkningstidspunkt i sak" />
+
+        {behandling?.virkningstidspunkt &&
+          isBefore(new Date(behandling.virkningstidspunkt.dato), new Date(foersteVirk.foersteIverksatteVirkISak)) && (
+            <Alert variant="warning">
+              <strong>OBS:</strong> Nytt virkningstidspunkt er <i>før</i> første virkningstidspunkt i sak!
+            </Alert>
+          )}
+      </>
     )
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
@@ -45,8 +45,9 @@ export const fastsettVirkningstidspunkt = async (args: {
   dato: Date
   begrunnelse: string
   kravdato: Date | null
+  overstyr: boolean
 }): Promise<ApiResponse<Virkningstidspunkt>> => {
-  return apiClient.post(`/behandling/${args.id}/virkningstidspunkt`, {
+  return apiClient.post(`/behandling/${args.id}/virkningstidspunkt?overstyr=${args.overstyr}`, {
     dato: args.dato,
     begrunnelse: args.begrunnelse,
     kravdato: args.kravdato ? format(args.kravdato, DatoFormat.AAR_MAANED_DAG) : null,


### PR DESCRIPTION
I enkelte revurderinger kan det være aktuelt å sette virkningstidspunkt til et tidspunkt som er _før_ det opprinnelige virkningstidspunktet de satt på førstegangsbehandlingen som er iverksatt. 

Endringen her kaster feilmelding og gir saksbehandler mulighet til å overstyre med ny virk, selv om den er "ugyldig". 

![Screenshot 2024-08-12 at 16 02 49](https://github.com/user-attachments/assets/0168feee-afe0-49dd-aa93-6a189ed82a43)

Liten advarsel når nytt virk er før første virk:
![Screenshot 2024-08-12 at 16 26 42](https://github.com/user-attachments/assets/39dc8387-3823-404f-b2fe-78ee463a9720)

