### PR TITLE
Liten forenkling av Spinner-komponentet

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/Behandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/Behandling.tsx
@@ -59,7 +59,7 @@ export const Behandling = () => {
 
   return mapAllApiResult(
     fetchBehandlingStatus,
-    <Spinner label="Henter behandling ..." visible />,
+    <Spinner label="Henter behandling ..." />,
     null,
     () => <ApiErrorAlert>Kunne ikke hente behandling</ApiErrorAlert>,
     () => {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
@@ -41,7 +41,7 @@ export const StegMeny = (props: { behandling: IBehandlingReducer }) => {
     <>
       {mapApiResult(
         fetchVilkaarsvurderingStatus,
-        <Spinner label="Laster stegmeny" visible />,
+        <Spinner label="Laster stegmeny" />,
         () => (
           <ApiErrorAlert>Kunne ikke laste stegmeny</ApiErrorAlert>
         ),

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
@@ -104,9 +104,9 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
               Dette er en vurdering som ble gjort før juni 2024
             </Detail>
 
-            <Spinner visible={isPending(hentet)} label="Henter data" />
-
-            {!isPending(hentet) && (
+            {isPending(hentet) ? (
+              <Spinner label="Henter data" />
+            ) : (
               <>
                 <BodyLong>{aktivitetOppfolging.aktivitet}</BodyLong>
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/AktivitetspliktTidslinje.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/AktivitetspliktTidslinje.tsx
@@ -95,7 +95,7 @@ export const AktivitetspliktTidslinje = (props: { behandling: IDetaljertBehandli
                       </i>
                     </p>
                     {isPending(slettet) ? (
-                      <Spinner visible={true} variant="neutral" label="Sletter" margin="1em" />
+                      <Spinner variant="neutral" label="Sletter" margin="1em" />
                     ) : (
                       <>
                         <SlettEndreWrapper onClick={() => fjernAktivitet(aktivitet.id)}>Slett</SlettEndreWrapper>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/oversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/oppsummering/oversikt.tsx
@@ -97,7 +97,7 @@ export const Oversikt = ({
             <>
               {mapApiResult(
                 res,
-                <Spinner visible={true} label="Henter saksbehandler" />,
+                <Spinner label="Henter saksbehandler" />,
                 () => (
                   <ApiErrorAlert>Kunne ikke hente saksbehandlende saksbehandler</ApiErrorAlert>
                 ),

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
@@ -60,7 +60,7 @@ export const Avkorting = ({
     <Box paddingBlock="8 0">
       <VStack gap="8">
         {mapResult(avkortingStatus, {
-          pending: <Spinner visible label="Henter avkorting" />,
+          pending: <Spinner label="Henter avkorting" />,
           error: <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>,
           success: () => (
             <AvkortingInntekt

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
@@ -118,7 +118,7 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
         <>
           {mapApiResult(
             beregning,
-            <Spinner visible label="Henter beregning" />,
+            <Spinner label="Henter beregning" />,
             () => (
               <ApiErrorAlert>Kunne ikke hente beregning</ApiErrorAlert>
             ),

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/SimulerUtbetaling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/SimulerUtbetaling.tsx
@@ -54,7 +54,7 @@ export const SimulerUtbetaling = (props: { behandling: IBehandlingReducer }) => 
 
         {behandlingStatusFerdigEllerVedtakFattet() &&
           mapResult(lagretSimuleringStatus, {
-            pending: <Spinner visible={true} label="Henter lagret simulering..." />,
+            pending: <Spinner label="Henter lagret simulering..." />,
             success: (lagretSimulering) =>
               lagretSimulering ? (
                 <SimuleringBeregning data={lagretSimulering} />
@@ -65,7 +65,7 @@ export const SimulerUtbetaling = (props: { behandling: IBehandlingReducer }) => 
           })}
 
         {mapResult(simuleringStatus, {
-          pending: <Spinner visible={true} label="Simulerer..." />,
+          pending: <Spinner label="Simulerer..." />,
           success: (simuleringrespons) =>
             simuleringrespons ? (
               <SimuleringBeregning data={simuleringrespons} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
@@ -136,11 +136,11 @@ const BeregningsgrunnlagBarnepensjon = () => {
     <>
       <>
         {mapResult(hentBeregningsgrunnlagResult, {
-          pending: <Spinner visible label="Henter beregningsgrunnlag..." />,
+          pending: <Spinner label="Henter beregningsgrunnlag..." />,
           error: (error) => <ApiErrorAlert>{error.detail || 'Kunne ikke hente beregningsgrunnlag'}</ApiErrorAlert>,
           success: () =>
             mapResult(hentTrygdetiderResult, {
-              pending: <Spinner visible label="Henter trygdetider..." />,
+              pending: <Spinner label="Henter trygdetider..." />,
               error: (error) => <ApiErrorAlert>{error.detail || 'Kunne ikke hente trygdetider'}</ApiErrorAlert>,
               success: (trygdetider) => (
                 <>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
@@ -98,7 +98,7 @@ const BeregningsgrunnlagOmstillingsstoenad = (props: { behandling: IBehandlingRe
     <>
       <>
         {mapResult(beregningsgrunnlagOMSResult, {
-          pending: <Spinner visible label="Henter beregningsgrunnlag..." />,
+          pending: <Spinner label="Henter beregningsgrunnlag..." />,
           error: (error) => <ApiErrorAlert>{error.detail || 'Kunne ikke hente beregningsgrunnlag'}</ApiErrorAlert>,
           success: (beregningsgrunnlag) => (
             <>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/institusjonsopphold/InstitusjonsoppholdHendelser.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/institusjonsopphold/InstitusjonsoppholdHendelser.tsx
@@ -34,7 +34,7 @@ export const InstitusjonsoppholdHendelser = ({ sakId, sakType }: { sakId: number
         {sakType === SakType.BARNEPENSJON && <InstitusjonsoppholdBeregningsgrunnlagReadMoreBP />}
         {sakType === SakType.OMSTILLINGSSTOENAD && <InstitusjonsoppholdBeregningsgrunnlagReadMoreOMS />}
         {mapResult(institusjonsHendelserResult, {
-          pending: <Spinner visible label="Henter hendelser for institusjonsopphold..." />,
+          pending: <Spinner label="Henter hendelser for institusjonsopphold..." />,
           error: (error) => <ApiErrorAlert>{error.detail || 'Kunne ikke hente hendelser'}</ApiErrorAlert>,
           success: (hendelser) => (
             <Table size="small">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/OverstyrBeregningGrunnlag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/OverstyrBeregningGrunnlag.tsx
@@ -70,7 +70,7 @@ const OverstyrBeregningGrunnlag = (props: {
         </HStack>
         <VStack gap="4" maxWidth="70rem">
           {mapResult(overstyrBeregningGrunnlagResult, {
-            pending: <Spinner visible label="Henter overstyrt beregning grunnlag..." />,
+            pending: <Spinner label="Henter overstyrt beregning grunnlag..." />,
             error: (error) => <ApiErrorAlert>{error.detail || 'Kunne ikke hente grunnlag'}</ApiErrorAlert>,
             success: () => (
               <>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/ForhaandsvisningBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/ForhaandsvisningBrev.tsx
@@ -32,7 +32,7 @@ export default function ForhaandsvisningBrev({ brev }: { brev: IBrev }) {
 
   return (
     <Container>
-      {isPendingOrInitial(pdf) && <Spinner visible={true} label="Klargjør forhåndsvisning av PDF ..." />}
+      {isPendingOrInitial(pdf) && <Spinner label="Klargjør forhåndsvisning av PDF ..." />}
       {isSuccess(pdf) && !!fileURL && <PdfViewer src={fileURL} />}
       {isFailureHandler({
         apiResult: pdf,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
@@ -122,7 +122,7 @@ export default function RedigerbartBrev({ brev, kanRedigeres, lukkAdvarselBehand
 
         <Tabs.Panel value={ManueltBrevFane.REDIGER}>
           {(isPendingOrInitial(hentManuellPayloadStatus) || isPending(tilbakestillManuellPayloadStatus)) && (
-            <Spinner visible label="Henter brevinnhold ..." />
+            <Spinner label="Henter brevinnhold ..." />
           )}
           {isSuccess(hentManuellPayloadStatus) && isSuccessOrInitial(tilbakestillManuellPayloadStatus) && (
             <>
@@ -148,7 +148,7 @@ export default function RedigerbartBrev({ brev, kanRedigeres, lukkAdvarselBehand
 
         <Tabs.Panel value={ManueltBrevFane.REDIGER_VEDLEGG}>
           {isPendingOrInitial(hentManuellPayloadStatus) ||
-            (isPending(tilbakestillManuellPayloadStatus) && <Spinner visible label="Henter brevinnhold ..." />)}
+            (isPending(tilbakestillManuellPayloadStatus) && <Spinner label="Henter brevinnhold ..." />)}
           {isSuccess(hentManuellPayloadStatus) && isSuccessOrInitial(tilbakestillManuellPayloadStatus) && (
             <>
               <Accordion indent={false}>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Varselbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Varselbrev.tsx
@@ -100,9 +100,9 @@ export const Varselbrev = (props: { behandling: IDetaljertBehandling }) => {
   }, [behandlingId, sakId])
 
   if (isPendingOrInitial(hentBrevStatus)) {
-    return <Spinner visible label="Henter brev ..." />
+    return <Spinner label="Henter brev ..." />
   } else if (isPending(opprettBrevStatus)) {
-    return <Spinner visible label="Ingen brev funnet. Oppretter brev ..." />
+    return <Spinner label="Ingen brev funnet. Oppretter brev ..." />
   }
 
   return (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
@@ -130,9 +130,9 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
   }, [behandlingId])
 
   if (isPendingOrInitial(hentBrevStatus)) {
-    return <Spinner visible label="Henter brev ..." />
+    return <Spinner label="Henter brev ..." />
   } else if (isPending(opprettBrevStatus)) {
-    return <Spinner visible label="Ingen brev funnet. Oppretter brev ..." />
+    return <Spinner label="Ingen brev funnet. Oppretter brev ..." />
   }
 
   const kanSendeTilAttestering = (): boolean => {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/Brevutfall.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/Brevutfall.tsx
@@ -121,7 +121,7 @@ export const Brevutfall = (props: { behandling: IBehandlingReducer; resetBrevutf
 
       <MapApiResult
         result={hentBrevutfallOgEtterbetalingResult}
-        mapInitialOrPending={<Spinner visible={true} label="Henter brevutfall .." />}
+        mapInitialOrPending={<Spinner label="Henter brevutfall .." />}
         mapError={(apiError) => <Alert variant="error">{apiError.detail}</Alert>}
         mapSuccess={() =>
           visSkjema ? (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/GrunnlagForVirkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/GrunnlagForVirkningstidspunkt.tsx
@@ -40,7 +40,7 @@ const FoersteVirkGrunnlag = () => {
 
   return mapApiResult(
     foersteVirk,
-    <Spinner visible={true} label="Henter første virkningstidspunkt" />,
+    <Spinner label="Henter første virkningstidspunkt" />,
     () => <ApiErrorAlert>Kunne ikke hente første virkningstidspunkt</ApiErrorAlert>,
     (foersteVirk) => (
       <>
@@ -85,7 +85,7 @@ const AdopsjonGrunnlag = () => {
 
   return mapApiResult(
     foreldreansvar,
-    <Spinner visible={true} label="Henter historikk for foreldreansvar" />,
+    <Spinner label="Henter historikk for foreldreansvar" />,
     () => <ApiErrorAlert>Kunne ikke hente foreldreansvar</ApiErrorAlert>,
     (foreldreansvar) => (
       <div>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/sluttbehandlingUtland/SluttbehandlingUtland.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/sluttbehandlingUtland/SluttbehandlingUtland.tsx
@@ -111,7 +111,7 @@ export default function SluttbehandlingUtland({
         </Heading>
         {mapAllApiResult(
           kravpakkeStatus,
-          <Spinner visible={true} label="Henter kravpakke" />,
+          <Spinner label="Henter kravpakke" />,
           null,
           () => (
             <ApiErrorAlert>Klarte ikke å hente kravpakke for sluttbehandling</ApiErrorAlert>
@@ -158,7 +158,9 @@ export default function SluttbehandlingUtland({
         Mottatt krav fra utland
       </Heading>
       <BodyShort>Fyll inn hvilke SED som er mottatt i RINA pr land.</BodyShort>
-      {isPending(hentAlleLandRequest) && <Spinner visible={true} label="Henter land" />}
+
+      <Spinner label="Henter land" visible={isPending(hentAlleLandRequest)} />
+
       {isSuccess(hentAlleLandRequest) && alleLandKodeverk && (
         <SEDLandMedDokumenter
           redigerbar={redigerbar}
@@ -200,7 +202,7 @@ export default function SluttbehandlingUtland({
       {visHistorikk &&
         mapAllApiResult(
           hentRevurderingerForSakMedAarsakStatus,
-          <Spinner visible={true} label="Henter historikk" />,
+          <Spinner label="Henter historikk" />,
           null,
           () => <ApiErrorAlert>Klarte ikke å hente historikken</ApiErrorAlert>,
           (revurderingsinfoliste) => (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sanksjon/Sanksjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sanksjon/Sanksjon.tsx
@@ -153,7 +153,7 @@ export const Sanksjon = ({ behandling }: { behandling: IBehandlingReducer }) => 
     <TableBox>
       {mapApiResult(
         hentSanksjonStatus,
-        <Spinner visible label="Henter sanksjoner" />,
+        <Spinner label="Henter sanksjoner" />,
         () => (
           <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>
         ),

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
@@ -118,7 +118,7 @@ export const BehandlingSidemeny = ({ behandling }: { behandling: IBehandlingRedu
             <>
               {mapApiResult(
                 fetchVedtakStatus,
-                <Spinner label="Henter vedtaksdetaljer" visible />,
+                <Spinner label="Henter vedtaksdetaljer" />,
                 () => (
                   <ApiErrorAlert>Kunne ikke hente vedtak</ApiErrorAlert>
                 ),
@@ -145,7 +145,9 @@ export const BehandlingSidemeny = ({ behandling }: { behandling: IBehandlingRedu
         apiResult: oppgaveResult,
         errorMessage: 'Kunne ikke hente saksbehandler gjeldende oppgave. Husk å tildele oppgaven.',
       })}
-      {isPending(oppgaveResult) && <Spinner visible={true} label="Henter saksbehandler for oppgave" />}
+
+      <Spinner label="Henter saksbehandler for oppgave" visible={isPending(oppgaveResult)} />
+
       <Tabs value={fane} iconPosition="top" onChange={(val) => dispatch(visFane(val as BehandlingFane))}>
         <Tabs.List>
           <Tabs.Tab value={BehandlingFane.DOKUMENTER} label="Dokumenter" icon={<FileTextIcon title="dokumenter" />} />
@@ -169,7 +171,9 @@ export const BehandlingSidemeny = ({ behandling }: { behandling: IBehandlingRedu
         {erFoerstegangsbehandling && (
           <Tabs.Panel value={BehandlingFane.SJEKKLISTE}>
             <Sjekkliste behandling={behandling} />
-            {isPending(hentSjekklisteResult) && <Spinner label="Henter sjekkliste ..." visible />}
+
+            <Spinner label="Henter sjekkliste ..." visible={isPending(hentSjekklisteResult)} />
+
             {!erFerdigBehandlet(behandling.status) &&
               isFailureHandler({
                 apiResult: hentSjekklisteResult,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/bosattUtland/BosattUtland.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/bosattUtland/BosattUtland.tsx
@@ -101,7 +101,9 @@ export const BosattUtland = ({
         apiResult: hentAlleLandRequest,
         errorMessage: 'Vi klarte ikke å hente landlisten, den er påkrevd for å kunne fylle inn SED data',
       })}
-      {isPending(hentAlleLandRequest) && <Spinner visible={true} label="Henter land" />}
+
+      <Spinner visible={isPending(hentAlleLandRequest)} label="Henter land" />
+
       {alleLandKodeverk && (
         <>
           <MottatteSeder

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/bosattUtland/SkalViseBosattUtland.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/bosattUtland/SkalViseBosattUtland.tsx
@@ -34,7 +34,8 @@ const HentBosattutland = ({ behandling, redigerbar }: { behandling: IDetaljertBe
         <EessiPensjonLenke sakId={behandling.sakId} behandlingId={behandling.id} sakType={behandling.sakType} />
       </Heading>
 
-      {isPending(hentBosattUtlandStatus) && <Spinner visible={true} label="Henter bosatt utland info" />}
+      <Spinner visible={isPending(hentBosattUtlandStatus)} label="Henter bosatt utland info" />
+
       {isFailureWithCode(hentBosattUtlandStatus, 404) && (
         <BosattUtland behandlingId={behandling.id} bosattutland={null} redigerbar={redigerbar} />
       )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/Familieforhold.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/Familieforhold.tsx
@@ -50,7 +50,7 @@ export const Familieforhold = ({ behandling, personopplysninger, redigerbar }: P
 export const visLandInfoFraKodeverkEllerDefault = (landListeResult: Result<ILand[]>, statsborgerskap?: string) => {
   return mapApiResult(
     landListeResult,
-    <Spinner label="Henter landliste" visible={true} />,
+    <Spinner label="Henter landliste" />,
     () => <>{statsborgerskap ?? 'Ukjent'}</>,
     (landListe) => <>{statsborgerskap ? finnLandSomTekst(statsborgerskap, landListe) : 'Ukjent'}</>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/SamsvarPersongalleri.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/SamsvarPersongalleri.tsx
@@ -201,7 +201,7 @@ export function SamsvarPersongalleri(props: { landListeResult: Result<ILand[]> }
 
   return mapApiResult(
     samsvarPersongalleri,
-    <Spinner label="Henter samsvar persongalleri" visible />,
+    <Spinner label="Henter samsvar persongalleri" />,
     (error) => <ApiErrorAlert>Kunne ikke hente samsvar persongalleri: {error.detail}</ApiErrorAlert>,
     (samsvarPersongalleri) => (
       <VisSamsvarPersongalleri

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/viderefoere-opphoer/ViderefoereOpphoerVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/viderefoere-opphoer/ViderefoereOpphoerVurdering.tsx
@@ -219,7 +219,7 @@ export const ViderefoereOpphoerVurdering = ({
         </MonthPicker>
         {mapResult(vilkaartyperResult, {
           initial: <ApiWarningAlert>Du må sette virkningstidspunkt først</ApiWarningAlert>,
-          pending: <Spinner label="Laster vilkårstyper" visible />,
+          pending: <Spinner label="Laster vilkårstyper" />,
           error: () => <ApiErrorAlert>Kunne ikke laste vilkårstyper</ApiErrorAlert>,
           success: (typer) => (
             <UNSAFE_Combobox

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/EnkelPersonTrygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/EnkelPersonTrygdetid.tsx
@@ -128,8 +128,10 @@ export const EnkelPersonTrygdetid = (props: Props) => {
             overstyrTrygdetidPoengaar={overstyrTrygdetidPoengaar}
             virkningstidspunktEtterNyRegelDato={virkningstidspunktEtterNyRegelDato}
           />
-          {isPending(overstyrTrygdetidRequest) && <Spinner visible={true} label="Oppdatere poengår" />}
-          {isPending(oppdaterYrkesskadeRequest) && <Spinner visible={true} label="Oppdater yrkesskade" />}
+
+          <Spinner label="Oppdatere poengår" visible={isPending(overstyrTrygdetidRequest)} />
+          <Spinner label="Oppdater yrkesskade" visible={isPending(oppdaterYrkesskadeRequest)} />
+
           {isFailureHandler({
             apiResult: overstyrTrygdetidRequest,
             errorMessage: 'En feil har oppstått ved lagring av norsk poengår',

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
@@ -196,10 +196,8 @@ export const Trygdetid = ({ redigerbar, behandling, vedtaksresultat, virkningsti
           </>
         )}
 
-        {(isPending(hentTrygdetidRequest) || isPending(hentAlleLandRequest)) && (
-          <Spinner visible={true} label="Henter trygdetid" />
-        )}
-        {isPending(opprettTrygdetidRequest) && <Spinner visible={true} label="Oppretter trygdetid" />}
+        <Spinner label="Henter trygdetid" visible={isPending(hentTrygdetidRequest) || isPending(hentAlleLandRequest)} />
+        <Spinner label="Oppretter trygdetid" visible={isPending(opprettTrygdetidRequest)} />
 
         {isFailureHandler({
           apiResult: hentTrygdetidRequest,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlagListe.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidGrunnlagListe.tsx
@@ -223,7 +223,7 @@ const PeriodeRow = ({
           </Table.DataCell>
           <Table.DataCell>
             {isPending(slettTrygdetidStatus) ? (
-              <Spinner visible={true} variant="neutral" label="Sletter" margin="1em" />
+              <Spinner variant="neutral" label="Sletter" margin="1em" />
             ) : (
               <RedigerWrapper onClick={() => slettGrunnlag(trygdetidGrunnlag.id)}>Slett</RedigerWrapper>
             )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/avtaler/TrygdeAvtale.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/avtaler/TrygdeAvtale.tsx
@@ -419,7 +419,7 @@ export const TrygdeAvtale = ({ redigerbar }: Props) => {
           )}
         {(isPending(hentAlleTrygdetidAvtalerRequest) ||
           isPending(hentAlleTrygdetidAvtalerKriterierRequest) ||
-          isPending(hentTrygdeavtaleRequest)) && <Spinner visible={true} label="Henter trgydeavtaler" />}
+          isPending(hentTrygdeavtaleRequest)) && <Spinner label="Henter trygdeavtaler" />}
 
         {isFailureHandler({
           apiResult: hentAlleTrygdetidAvtalerRequest,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
@@ -148,9 +148,11 @@ export const Vilkaarsvurdering = (props: { behandling: IBehandlingReducer }) => 
           />
         </>
       )}
-      {isPending(vilkaarsvurderingStatus) && <Spinner visible={true} label="Henter vilkårsvurdering" />}
-      {isPending(opprettNyVilkaarsvurderingStatus) && <Spinner visible={true} label="Oppretter vilkårsvurdering" />}
-      {isPending(slettVilkaarsvurderingStatus) && <Spinner visible={true} label="Sletter vilkårsvurdering" />}
+
+      <Spinner visible={isPending(vilkaarsvurderingStatus)} label="Henter vilkårsvurdering" />
+      <Spinner visible={isPending(opprettNyVilkaarsvurderingStatus)} label="Oppretter vilkårsvurdering" />
+      <Spinner visible={isPending(slettVilkaarsvurderingStatus)} label="Sletter vilkårsvurdering" />
+
       {isFailure(vilkaarsvurderingStatus) && isInitial(opprettNyVilkaarsvurderingStatus) && (
         <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>
       )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/generellbehandling/GenerellBehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/generellbehandling/GenerellBehandling.tsx
@@ -35,7 +35,7 @@ const GenerellBehandling = () => {
 
   return mapApiResult(
     fetchGenerellbehandlingStatus,
-    <Spinner visible={true} label="Henter generell behandling" />,
+    <Spinner label="Henter generell behandling" />,
     (error) => <ApiErrorAlert>{error.detail || 'Kunne ikke hente generell behandling'}</ApiErrorAlert>,
     (generellBehandling) => {
       switch (generellBehandling.type) {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/generellbehandling/GenerellbehandlingSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/generellbehandling/GenerellbehandlingSidemeny.tsx
@@ -54,7 +54,7 @@ export const GenerellbehandlingSidemeny = (props: {
           apiResult: oppgaveResult,
           errorMessage: 'Vi fant ingen saksbehandler for den tilknyttede oppgaven. Husk å tildele oppgaven.',
         })}
-        {isPending(oppgaveResult) && <Spinner visible={true} label="Henter saksbehandler or oppgave" />}
+        <Spinner visible={isPending(oppgaveResult)} label="Henter saksbehandler or oppgave" />
         {oppgave?.saksbehandler ? (
           <Alert variant={oppgaveErTildeltInnloggetBruker ? 'success' : 'info'} style={{ marginBottom: '2rem' }}>
             <BodyShort>{`Oppgaven for kravpakken er tildelt ${

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/generellbehandling/KravpakkeUtlandBehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/generellbehandling/KravpakkeUtlandBehandling.tsx
@@ -196,9 +196,8 @@ const KravpakkeUtlandBehandling = (props: {
                     apiResult: avdoedeStatus,
                     errorMessage: 'Klarte ikke å hente informasjon om avdøed',
                   })}
-                  {isPendingOrInitial(avdoedeStatus) && (
-                    <Spinner visible={true} label="Henter opplysninger om avdøde" />
-                  )}
+
+                  <Spinner visible={isPendingOrInitial(avdoedeStatus)} label="Henter opplysninger om avdøde" />
                 </div>
               ) : (
                 <Alert variant="warning">
@@ -208,7 +207,7 @@ const KravpakkeUtlandBehandling = (props: {
               )}
               {mapApiResult(
                 hentAlleLandRequest,
-                <Spinner visible={true} label="Laster landliste" />,
+                <Spinner label="Laster landliste" />,
                 () => (
                   <ApiErrorAlert>Vi klarte ikke å hente landlisten</ApiErrorAlert>
                 ),
@@ -467,7 +466,9 @@ const KravpakkeUtlandBehandling = (props: {
                 Behandlingen er oppdatert
               </Alert>
             )}
-            {isPendingOrInitial(gjeldendeSakStatus) && <Spinner visible={true} label="Henter opplysninger om sak" />}
+
+            <Spinner visible={isPendingOrInitial(gjeldendeSakStatus)} label="Henter opplysninger om sak" />
+
             {isFailureHandler({
               errorMessage: 'Vi klarte ikke å hente gjeldende sak',
               apiResult: gjeldendeSakStatus,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/Klagebehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/Klagebehandling.tsx
@@ -62,7 +62,8 @@ export function Klagebehandling() {
     <>
       <StatusBarPersonHenter ident={klage?.sak.ident} />
       <KlageStegmeny />
-      {isPending(fetchKlageStatus) && <Spinner visible label="Henter klagebehandling" />}
+
+      <Spinner visible={isPending(fetchKlageStatus)} label="Henter klagebehandling" />
 
       {klage !== null && viHarLastetRiktigKlage && (
         <GridContainer>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/brev/KlageBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/brev/KlageBrev.tsx
@@ -45,7 +45,7 @@ export function KlageBrev() {
   }, [brevId, sakId])
 
   if (!klage) {
-    return <Spinner visible label="Henter klage" />
+    return <Spinner label="Henter klage" />
   }
 
   const redigerbar = erKlageRedigerbar(klage)
@@ -81,7 +81,7 @@ export function KlageBrev() {
         {mapApiResult(
           hentetBrev,
           <SpinnerContainer>
-            <Spinner visible label="Henter brevet" />
+            <Spinner label="Henter brevet" />
           </SpinnerContainer>,
           () => (
             <ApiErrorAlert>Kunne ikke hente brevet. Prøv å laste siden på nytt</ApiErrorAlert>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/formkrav/KlageFormkravRedigering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/formkrav/KlageFormkravRedigering.tsx
@@ -130,7 +130,7 @@ export function KlageFormkravRedigering() {
   }
 
   if (isPendingOrInitial(vedtakISak)) {
-    return <Spinner visible label={`Laster fattede vedtak på saken med sakId=${klage?.sak.id}`} />
+    return <Spinner label={`Laster fattede vedtak på saken med sakId=${klage?.sak.id}`} />
   }
 
   if (isFailure(vedtakISak)) {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/oppsummering/KlageOppsummering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/oppsummering/KlageOppsummering.tsx
@@ -41,7 +41,7 @@ export function KlageOppsummering({ kanRedigere }: { kanRedigere: boolean }) {
   }, [klage?.id])
 
   if (!klage) {
-    return <Spinner visible label="Henter klage" />
+    return <Spinner label="Henter klage" />
   }
 
   const { utfall, sak } = klage

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/sidemeny/KlageSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/sidemeny/KlageSidemeny.tsx
@@ -86,7 +86,7 @@ export function KlageSidemeny() {
         <>
           {mapApiResult(
             fetchVedtakStatus,
-            <Spinner label="Henter vedtaksdetaljer" visible />,
+            <Spinner label="Henter vedtaksdetaljer" />,
             () => (
               <ApiErrorAlert>Kunne ikke hente vedtak</ApiErrorAlert>
             ),

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/KlageVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/KlageVurdering.tsx
@@ -19,7 +19,7 @@ export function KlageVurdering({ kanRedigere }: { kanRedigere: boolean }) {
   const navigate = useNavigate()
 
   if (!klage) {
-    return <Spinner visible label="Henter klage" />
+    return <Spinner label="Henter klage" />
   }
 
   if (kanRedigere && skalAvvises(klage)) {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/KlageVurderingFelles.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/KlageVurderingFelles.tsx
@@ -96,7 +96,7 @@ export function VisInnstilling(props: { innstilling: InnstillingTilKabal; sakId:
       <Modal width="medium" ref={oversendelseRef} header={{ heading: 'Innstillingsbrev' }}>
         <Modal.Body>
           {mapResult(oversendelseBrev, {
-            pending: <Spinner visible label="Laster brevet" />,
+            pending: <Spinner label="Laster brevet" />,
             success: (hentetBrev) => <ForhaandsvisningBrev brev={hentetBrev} />,
             error: <ApiErrorAlert>Kunne ikke hente brevet, prøv å laste siden på nytt.</ApiErrorAlert>,
           })}
@@ -106,7 +106,7 @@ export function VisInnstilling(props: { innstilling: InnstillingTilKabal; sakId:
       <Modal width="medium" ref={blankettRef} header={{ heading: 'Blankett til KA' }}>
         <Modal.Body>
           {mapResult(forhaandsvisningBlankett, {
-            pending: <Spinner visible label="Henter pdf" />,
+            pending: <Spinner label="Henter pdf" />,
             success: () => (blankettFileUrl ? <PdfViewer src={`${blankettFileUrl}#toolbar=0`} /> : null),
             error: <ApiErrorAlert>Kunne ikke forhåndsvise blanketten. Prøv å laste siden på nytt</ApiErrorAlert>,
           })}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/GosysOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/GosysOppgaveliste.tsx
@@ -109,7 +109,7 @@ export const GosysOppgaveliste = ({ saksbehandlereIEnhet }: Props) => {
       />
 
       {mapResult(gosysOppgaverResult, {
-        pending: <Spinner label="Henter Gosys-oppgaver" visible />,
+        pending: <Spinner label="Henter Gosys-oppgaver" />,
         error: (error) => <ApiErrorAlert>{error.detail || 'Kunne ikke hente Gosys-oppgaver'}</ApiErrorAlert>,
         success: () => (
           <GosysOppgaver

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/MinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/MinOppgaveliste.tsx
@@ -128,7 +128,7 @@ export const MinOppgaveliste = ({ saksbehandlereIEnhet }: Props) => {
         />
       ) : (
         mapResult(minOppgavelisteOppgaverResult, {
-          pending: <Spinner visible={true} label="Henter dine oppgaver" />,
+          pending: <Spinner label="Henter dine oppgaver" />,
           error: (error) => <ApiErrorAlert>{error.detail || 'Kunne ikke hente dine oppgaver'}</ApiErrorAlert>,
         })
       )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/Oppgavelista.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/Oppgavelista.tsx
@@ -122,7 +122,7 @@ export const Oppgavelista = ({ saksbehandlereIEnhet }: Props) => {
         />
       ) : (
         mapResult(oppgavelistaOppgaverResult, {
-          pending: <Spinner visible={true} label="Henter oppgaver" />,
+          pending: <Spinner label="Henter oppgaver" />,
           error: (error) => <ApiErrorAlert>{error.detail || 'Kunne ikke hente oppgaver'}</ApiErrorAlert>,
         })
       )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/gosys/FerdigstillGosysOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/gosys/FerdigstillGosysOppgave.tsx
@@ -29,7 +29,7 @@ export const FerdigstillGosysOppgave = ({
     error: (error) => (
       <Alert variant="error">{error.detail || 'Ukjent feil oppsto ved ferdigstilling av oppgave'}</Alert>
     ),
-    pending: <Spinner visible label="Ferdigstiller oppgaven..." />,
+    pending: <Spinner label="Ferdigstiller oppgaven..." />,
     initial: (
       <>
         <Alert variant="info">Er du sikker på at du vil ferdigstille oppgaven?</Alert>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/OmgjoerVedtakModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/OmgjoerVedtakModal.tsx
@@ -84,7 +84,7 @@ export function OmgjoerVedtakModal({ oppgave }: { oppgave: OppgaveDTO }) {
         <Modal.Body>
           {mapApiResult(
             klageResult,
-            <Spinner label="Henter klage" visible />,
+            <Spinner label="Henter klage" />,
             (error) => (
               <ApiErrorAlert>{error.detail}</ApiErrorAlert>
             ),

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/OpprettRevurderingModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/OpprettRevurderingModal.tsx
@@ -81,7 +81,7 @@ export const OpprettRevurderingModal = ({ sakId, sakType, begrunnelse, hendelseI
         </Modal.Header>
         <Modal.Body>
           {mapResult(muligeRevurderingAarsakerResult, {
-            pending: <Spinner visible label="Henter revurderingsårsaker..." />,
+            pending: <Spinner label="Henter revurderingsårsaker..." />,
             success: (muligeRevurderingAarsaker) =>
               !!muligeRevurderingAarsaker?.length ? (
                 <VStack gap="4">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
@@ -93,7 +93,7 @@ export const Person = () => {
 
       {mapAllApiResult(
         personNavnResult,
-        <Spinner visible label="Laster personinfo ..." />,
+        <Spinner label="Laster personinfo ..." />,
         null,
         (error) => (
           <Box padding="8">{handleError(error)}</Box>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningSak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/SamordningSak.tsx
@@ -29,7 +29,7 @@ export const SamordningSak = ({ fnr, sakResult }: { fnr: string; sakResult: Resu
         success: (data) => (
           <SamordningTabell fnr={fnr} sakId={sakId!} samordningsdata={data} refresh={() => hent(sakId!)} />
         ),
-        pending: <Spinner visible={true} label="Henter samordningsdata" />,
+        pending: <Spinner label="Henter samordningsdata" />,
         error: () => <ApiErrorAlert>Kunne ikke hente samordningsdata</ApiErrorAlert>,
       })}
     </Box>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/VedtakKoloner.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/VedtakKoloner.tsx
@@ -26,7 +26,7 @@ export const VedtakKolonner = (props: { behandlingId: string }) => {
       {mapApiResult(
         vedtak,
         <Table.DataCell colSpan={2}>
-          <Spinner visible label="" margin="0" />
+          <Spinner label="" margin="0" />
         </Table.DataCell>,
         (apierror) => (
           <Table.DataCell colSpan={2}>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/BrevOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/BrevOversikt.tsx
@@ -92,7 +92,7 @@ export default function BrevOversikt({ sakResult }: { sakResult: Result<SakMedBe
     <Box padding="8">
       {mapApiResult(
         brevListe,
-        <Spinner visible label="Henter brev for sak ..." />,
+        <Spinner label="Henter brev for sak ..." />,
         () => (
           <ApiErrorAlert>Feil ved henting av brev...</ApiErrorAlert>
         ),

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrev.tsx
@@ -52,7 +52,7 @@ export default function NyttBrev() {
 
       {mapApiResult(
         brevStatus,
-        <Spinner label="Henter brev ..." visible />,
+        <Spinner label="Henter brev ..." />,
         () => (
           <ApiErrorAlert>Feil oppsto ved henting av brev</ApiErrorAlert>
         ),

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrevHandlingerPanel.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrevHandlingerPanel.tsx
@@ -83,7 +83,7 @@ export default function NyttBrevHandlingerPanel({ brev, setKanRedigeres, callbac
       >
         {mapAllApiResult(
           ferdigstillStatus,
-          <Spinner label="Forsøker å ferdigstille brevet ..." visible />,
+          <Spinner label="Forsøker å ferdigstille brevet ..." />,
           null,
           (error) => (
             <Alert variant="error">{error.detail}</Alert>
@@ -95,7 +95,7 @@ export default function NyttBrevHandlingerPanel({ brev, setKanRedigeres, callbac
 
         {mapAllApiResult(
           journalfoerStatus,
-          <Spinner label="Journalfører brevet i dokarkiv ..." visible />,
+          <Spinner label="Journalfører brevet i dokarkiv ..." />,
           null,
           (error) => (
             <Alert variant="error">{error.detail}</Alert>
@@ -107,7 +107,7 @@ export default function NyttBrevHandlingerPanel({ brev, setKanRedigeres, callbac
 
         {mapAllApiResult(
           distribuerStatus,
-          <Spinner label="Sender brev til distribusjon ..." visible />,
+          <Spinner label="Sender brev til distribusjon ..." />,
           null,
           (error) => (
             <Alert variant="error">{error.detail}</Alert>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottaker.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottaker.tsx
@@ -36,7 +36,7 @@ export function BrevMottaker({ brev, kanRedigeres }: { brev: IBrev; kanRedigeres
             Sjekk om bruker har verge
           </Alert>
         ),
-        pending: <Spinner visible label="Henter eventuelle verger" margin="0" />,
+        pending: <Spinner label="Henter eventuelle verger" margin="0" />,
         error: (error) => (
           <ApiErrorAlert>
             {error.detail || 'Feil oppsto ved henting av eventuelle verger. Prøv igjen senere'}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentModal.tsx
@@ -89,7 +89,7 @@ export default function DokumentModal({ journalpost }: { journalpost: Journalpos
         <Modal.Body>
           {mapApiResult(
             pdfStatus,
-            <Spinner visible label="Laster inn PDF" />,
+            <Spinner label="Laster inn PDF" />,
             (error) => (
               <ApiErrorAlert>{error.detail || 'Feil oppsto ved visning av dokument'}</ApiErrorAlert>
             ),

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/Dokumentliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/Dokumentliste.tsx
@@ -51,7 +51,7 @@ export const Dokumentliste = ({ fnr, sakResult }: { fnr: string; sakResult: Resu
               dokumenter,
               <Table.Row>
                 <Table.DataCell colSpan={100}>
-                  <Spinner margin="0" visible label="Henter dokumenter" />
+                  <Spinner margin="0" label="Henter dokumenter" />
                 </Table.DataCell>
               </Table.Row>,
               () => (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentlisteLiten.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentlisteLiten.tsx
@@ -33,7 +33,7 @@ export const DokumentlisteLiten = ({ fnr }: { fnr: string }) => {
 
       {mapApiResult(
         status,
-        <Spinner label="Henter dokumenter" visible />,
+        <Spinner label="Henter dokumenter" />,
         (error) => (
           <ApiErrorAlert>{error.detail || 'Det har oppstått en feil ved henting av dokumenter'}</ApiErrorAlert>
         ),

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/OppgaveFraJournalpostModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/OppgaveFraJournalpostModal.tsx
@@ -101,7 +101,7 @@ export const OppgaveFraJournalpostModal = ({
 
         <Modal.Body>
           {mapResult(gosysResult, {
-            pending: <Spinner label="Sjekker om det finnes Gosys-oppgaver tilknyttet journalposten" visible />,
+            pending: <Spinner label="Sjekker om det finnes Gosys-oppgaver tilknyttet journalposten" />,
             error: (error) => (
               <ApiErrorAlert>{error.detail || 'Feil oppsto ved henting av oppgaver fra Gosys'}</ApiErrorAlert>
             ),
@@ -152,7 +152,7 @@ export const OppgaveFraJournalpostModal = ({
           })}
 
           {mapResult(hentOppgaverStatus, {
-            pending: <Spinner visible label="Sjekker om det allerede finnes en oppgave" />,
+            pending: <Spinner label="Sjekker om det allerede finnes en oppgave" />,
             success: () =>
               kanOppretteOppgave ? (
                 isSuccess(sakStatus) ? (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/UtsendingsinfoModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/UtsendingsinfoModal.tsx
@@ -31,7 +31,7 @@ export const UtsendingsinfoModal = ({ journalpost }: { journalpost: Journalpost 
         <Modal.Body>
           {mapApiResult(
             status,
-            <Spinner visible label="Henter utsendingsinfo" />,
+            <Spinner label="Henter utsendingsinfo" />,
             (error) => (
               <ApiErrorAlert>{error.detail || 'Feil ved henting av utsendingsinfo'}</ApiErrorAlert>
             ),

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/KnyttTilAnnenBruker.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/KnyttTilAnnenBruker.tsx
@@ -108,7 +108,7 @@ export const KnyttTilAnnentBruker = ({
         </Button>
       </HStack>
     ),
-    pending: <Spinner visible label="Henter sak..." />,
+    pending: <Spinner label="Henter sak..." />,
     success: (annenSak) => (
       <>
         {isSuccess(sakStatus) && <SakOverfoeringDetailjer fra={sakStatus.data.sak} til={annenSak} />}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/KnyttTilAnnenSak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/KnyttTilAnnenSak.tsx
@@ -187,7 +187,7 @@ export const KnyttTilAnnenSak = ({
             </Button>
           </HStack>
         ),
-        pending: <Spinner visible label="Henter sak..." />,
+        pending: <Spinner label="Henter sak..." />,
         success: (annenSak) => (
           <>
             {isSuccess(sakStatus) && <SakOverfoeringDetailjer fra={sakStatus.data.sak} til={annenSak} />}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/OpprettJournalfoeringsoppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/OpprettJournalfoeringsoppgave.tsx
@@ -44,7 +44,7 @@ export const OpprettJournalfoeringsoppgave = ({
     return <Alert variant="warning">Kan ikke opprette oppgave for feilregistrert journalpost</Alert>
 
   return mapResult(sakStatus, {
-    pending: <Spinner label="Henter sak" visible />,
+    pending: <Spinner label="Henter sak" />,
     error: (error) => <ApiErrorAlert>{error.detail || 'Feil ved henting av sak for bruker'}</ApiErrorAlert>,
     success: (sakMedBehandlinger) => (
       <>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/hendelser/Hendelser.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/hendelser/Hendelser.tsx
@@ -72,7 +72,7 @@ export const Hendelser = ({ sakResult, fnr }: { sakResult: Result<SakMedBehandli
         </ToggleGroup>
 
         {mapResult(hendelserResult, {
-          pending: <Spinner visible label="Henter hendelser..." />,
+          pending: <Spinner label="Henter hendelser..." />,
           error: (error) => <ApiErrorAlert>{error.detail || 'Kunne ikke hente hendelser'}</ApiErrorAlert>,
           success: ({ hendelser }) => (
             <>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/BehandleJournalfoeringOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/BehandleJournalfoeringOppgave.tsx
@@ -75,9 +75,9 @@ export default function BehandleJournalfoeringOppgave() {
   }, [oppgaveId])
 
   if (isPendingOrInitial(oppgaveStatus)) {
-    return <Spinner visible label="Henter oppgavedetaljer..." />
+    return <Spinner label="Henter oppgavedetaljer..." />
   } else if (isPending(sakStatus)) {
-    return <Spinner visible label="Henter sak..." />
+    return <Spinner label="Henter sak..." />
   }
 
   return (
@@ -91,7 +91,7 @@ export default function BehandleJournalfoeringOppgave() {
         <Column>
           <Box padding="8">
             {!sakMedBehandlinger || isPendingOrInitial(journalpostStatus) ? (
-              <Spinner visible label="Laster journalpost" />
+              <Spinner label="Laster journalpost" />
             ) : isSuccess(journalpostStatus) && kanEndreJournalpost(journalpostStatus.data) ? (
               <OppdaterJournalpost
                 initialJournalpost={journalpostStatus.data}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/VelgJournalpost.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/VelgJournalpost.tsx
@@ -39,7 +39,7 @@ export default function VelgJournalpost({ journalpostStatus }: { journalpostStat
   return (
     <JournalpostContainer>
       {mapResult(journalpostStatus, {
-        pending: <Spinner label="Henter journalpost for bruker" visible />,
+        pending: <Spinner label="Henter journalpost for bruker" />,
         error: (error) => (
           <ApiErrorAlert>
             {error.detail || 'Feil ved henting av journalpost. Kan ikke fortsette behandlingen.'}
@@ -53,7 +53,7 @@ export default function VelgJournalpost({ journalpostStatus }: { journalpostStat
 
             {mapApiResult(
               dokument,
-              <Spinner label="Klargjør forhåndsvisning av PDF" visible />,
+              <Spinner label="Klargjør forhåndsvisning av PDF" />,
               (error) => (
                 <ApiErrorAlert>{error.detail || 'Feil ved henting av PDF'}</ApiErrorAlert>
               ),

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/EndreBruker.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/EndreBruker.tsx
@@ -97,7 +97,7 @@ export const EndreBruker = ({
               />
 
               {mapResult(personResult, {
-                pending: <Spinner visible label="Søker etter person..." />,
+                pending: <Spinner label="Søker etter person..." />,
                 success: (person) => (
                   <>
                     <Alert variant="info" size="small">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/EndreTema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/EndreTema.tsx
@@ -32,7 +32,7 @@ export const EndreTema = ({
 
   return mapApiResult(
     temaStatus,
-    <Spinner label="Henter tilgjengelige temakoder ..." visible />,
+    <Spinner label="Henter tilgjengelige temakoder ..." />,
     () => <ApiErrorAlert>Feil ved henting av temakoder</ApiErrorAlert>,
     (koder) => (
       <FormWrapper $column={true}>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/modal/PersonSoekModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/modal/PersonSoekModal.tsx
@@ -81,7 +81,7 @@ export const PersonSoekModal = ({ velgPerson }: { velgPerson: (bruker: SoekPerso
             <ControlledDatoVelger name="foedselsdato" label="Fødselsdato" control={control} />
 
             {mapResult(personSoekResult, {
-              pending: <Spinner visible={true} label="Søker etter personer" />,
+              pending: <Spinner label="Søker etter personer" />,
               success: (personer) => {
                 return (
                   <Table className="table" zebraStripes>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/notat/ForhaandsvisningNotat.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/notat/ForhaandsvisningNotat.tsx
@@ -26,7 +26,7 @@ export default function ForhaandsvisningNotat({ id }: { id: number }) {
   }, [id])
 
   return mapResult(pdfStatus, {
-    pending: <Spinner label="Klargjør forhåndsvisning av PDF ..." visible />,
+    pending: <Spinner label="Klargjør forhåndsvisning av PDF ..." />,
     error: (error) => <ApiErrorAlert>{error.detail || 'Ukjent feil oppsto'}</ApiErrorAlert>,
     success: () => !!fileURL && <PdfViewer src={fileURL} />,
   })

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/notat/NotatOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/notat/NotatOversikt.tsx
@@ -41,7 +41,7 @@ export default function NotatOversikt({ sakResult }: { sakResult: Result<SakMedB
   return (
     <Box padding="8">
       {mapResult(notatStatus, {
-        pending: <Spinner visible label="Henter notater for sak ..." />,
+        pending: <Spinner label="Henter notater for sak ..." />,
         error: () => <ApiErrorAlert>Feil ved henting av notater...</ApiErrorAlert>,
         success: () => (
           <Table>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/notat/NotatRedigeringModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/notat/NotatRedigeringModal.tsx
@@ -90,7 +90,7 @@ export const NotatRedigeringModal = ({ notat }: RedigerbartNotatProps) => {
                   <Heading size="xsmall">Rediger notat</Heading>
 
                   {mapResult(hentPayloadStatus, {
-                    pending: <Spinner label="Henter notat ..." visible />,
+                    pending: <Spinner label="Henter notat ..." />,
                     success: () => (
                       <SlateEditor value={content} onChange={(value) => setContent(value)} readonly={false} />
                     ),

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/personopplysninger/Personopplysninger.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/personopplysninger/Personopplysninger.tsx
@@ -54,7 +54,7 @@ export const Personopplysninger = ({
             {!!sak ? (
               <>
                 {mapResult(familieOpplysningerResult, {
-                  pending: <Spinner visible={true} label="Henter opplysninger" />,
+                  pending: <Spinner label="Henter opplysninger" />,
                   error: (error) => <ApiErrorAlert>{error.detail || 'Kunne ikke hente opplysninger'}</ApiErrorAlert>,
                   success: ({ soeker, avdoede, gjenlevende }) => (
                     <>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/Behandlingsliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/Behandlingsliste.tsx
@@ -120,7 +120,9 @@ export const Behandlingsliste = ({ sakOgBehandlinger }: { sakOgBehandlinger: Sak
           Ingen behandlinger på sak
         </Alert>
       )}
-      {isPending(generellbehandlingStatus) && <Spinner visible={true} label="Henter generelle behandlinger" />}
+
+      <Spinner visible={isPending(generellbehandlingStatus)} label="Henter generelle behandlinger" />
+
       {isFailureHandler({
         apiResult: generellbehandlingStatus,
         errorMessage: 'Vi klarte ikke å hente generelle behandligner',

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/KlageListe.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/KlageListe.tsx
@@ -104,7 +104,7 @@ export function KlageListe(props: { sakId: number }) {
 
   return mapApiResult(
     klager,
-    <Spinner visible label="Henter klager i saken" />,
+    <Spinner label="Henter klager i saken" />,
     () => <ApiErrorAlert>Kunne ikke hente klager</ApiErrorAlert>,
     (klageliste) => {
       klageliste.sort((a, b) => (new Date(a.opprettet) < new Date(b.opprettet) ? 1 : -1))

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/SakOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/SakOversikt.tsx
@@ -41,7 +41,7 @@ export const SakOversikt = ({ sakResult, fnr }: { sakResult: Result<SakMedBehand
   return (
     <>
       {mapResult(sakResult, {
-        pending: <Spinner visible label="Henter sak og behandlinger" />,
+        pending: <Spinner label="Henter sak og behandlinger" />,
         error: (error) => <SakIkkeFunnet error={error} fnr={fnr} />,
         success: ({ sak, behandlinger }) => (
           <HStack gap="4" wrap={false}>
@@ -62,7 +62,7 @@ export const SakOversikt = ({ sakResult, fnr }: { sakResult: Result<SakMedBehand
                   <ToggleGroup.Item value={OppgaveValg.FERDIGSTILTE}>Ferdigstilte</ToggleGroup.Item>
                 </ToggleGroup>
                 {mapResult(oppgaverResult, {
-                  pending: <Spinner visible label="Henter oppgaver for sak..." />,
+                  pending: <Spinner label="Henter oppgaver for sak..." />,
                   error: (error) => <ApiErrorAlert>{error.detail}</ApiErrorAlert>,
                   success: (oppgaver) => <ForenkletOppgaverTable oppgaver={oppgaver} oppgaveValg={oppgaveValg} />,
                 })}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/TilbakekrevingListe.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/TilbakekrevingListe.tsx
@@ -76,7 +76,7 @@ export function TilbakekrevingListe(props: { sakId: number }) {
   return (
     <MapApiResult
       result={tilbakekrevinger}
-      mapInitialOrPending={<Spinner visible label="Henter tilbakekrevinger til saken" />}
+      mapInitialOrPending={<Spinner label="Henter tilbakekrevinger til saken" />}
       mapError={() => <ApiErrorAlert>Kunne ikke hente tilbakekrevinger</ApiErrorAlert>}
       mapSuccess={(tilbakekrevinger) => <TilbakekrevingTabell tilbakekrevinger={tilbakekrevinger} />}
     />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/brev/TilbakekrevingBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/brev/TilbakekrevingBrev.tsx
@@ -40,10 +40,10 @@ export function TilbakekrevingBrev({
   }, [behandling])
 
   if (isPending(hentBrevStatus)) {
-    return <Spinner visible label="Henter brev ..." />
+    return <Spinner label="Henter brev ..." />
   }
   if (isPending(opprettBrevStatus)) {
-    return <Spinner visible label="Ingen brev funnet. Oppretter brev ..." />
+    return <Spinner label="Ingen brev funnet. Oppretter brev ..." />
   }
 
   if (isFailure(hentBrevStatus)) {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/oppsummering/TilbakekrevingOppsummering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/oppsummering/TilbakekrevingOppsummering.tsx
@@ -120,7 +120,7 @@ export function TilbakekrevingOppsummering({
         </div>
 
         {mapResult(validerTilbakekrevingStatus, {
-          pending: <Spinner label="Sjekker om tilbakekreving er fylt ut" visible={true} />,
+          pending: <Spinner label="Sjekker om tilbakekreving er fylt ut" />,
           error: (error) => <TilbakekrevingValideringsfeil error={error} />,
         })}
       </Box>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/sidemeny/TilbakekrevingSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/sidemeny/TilbakekrevingSidemeny.tsx
@@ -69,7 +69,7 @@ export function TilbakekrevingSidemeny() {
           <Label size="small">Saksbehandler</Label>
           {mapApiResult(
             oppgaveResult,
-            <Spinner visible={true} label="Henter oppgave" />,
+            <Spinner label="Henter oppgave" />,
             () => (
               <ApiErrorAlert>Kunne ikke hente saksbehandler fra oppgave</ApiErrorAlert>
             ),
@@ -95,7 +95,7 @@ export function TilbakekrevingSidemeny() {
         <>
           {mapApiResult(
             fetchVedtakStatus,
-            <Spinner label="Henter vedtaksdetaljer" visible />,
+            <Spinner label="Henter vedtaksdetaljer" />,
             () => (
               <ApiErrorAlert>Kunne ikke hente vedtak</ApiErrorAlert>
             ),

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/vurderingsboks/VurderingsboksWrapper.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/vurderingsboks/VurderingsboksWrapper.tsx
@@ -78,11 +78,7 @@ export const VurderingsboksWrapper = (props: Props) => {
                     })
                   }}
                 >
-                  {lagrer ? (
-                    <Spinner visible label="" margin="0" variant="interaction" />
-                  ) : (
-                    <TrashIcon aria-hidden="true" />
-                  )}
+                  {lagrer ? <Spinner label="" margin="0" variant="interaction" /> : <TrashIcon aria-hidden="true" />}
                   <span className="text"> Slett</span>
                 </RedigerWrapper>
               )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/Spinner.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/Spinner.tsx
@@ -1,24 +1,19 @@
-import { BodyLong, Loader } from '@navikt/ds-react'
+import { BodyLong, Loader, LoaderProps } from '@navikt/ds-react'
 import styled from 'styled-components'
 
-interface Props {
-  visible: boolean
+interface Props extends Omit<LoaderProps, 'title'> {
+  visible?: boolean // default: true
   label: string
   margin?: string
-  variant?: 'neutral' | 'interaction' | 'inverted'
 }
 
-const Spinner = ({ visible, label, margin = '3em', variant }: Props) => {
-  if (!visible) return null
+const Spinner = ({ visible, label, margin = '3em', ...rest }: Props) => {
+  if (visible === false) return null
 
   return (
     <SpinnerWrap $margin={margin}>
-      <div className="spinner-overlay">
-        <div className="spinner-content">
-          <Loader variant={variant} />
-          {label && <BodyLong spacing>{label}</BodyLong>}
-        </div>
-      </div>
+      <Loader {...rest} title={label} />
+      {label && <BodyLong spacing>{label}</BodyLong>}
     </SpinnerWrap>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/Spinner.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/Spinner.tsx
@@ -1,4 +1,4 @@
-import { BodyLong, Loader, LoaderProps } from '@navikt/ds-react'
+import { BodyLong, HStack, Loader, LoaderProps } from '@navikt/ds-react'
 import styled from 'styled-components'
 
 interface Props extends Omit<LoaderProps, 'title'> {
@@ -12,17 +12,16 @@ const Spinner = ({ visible, label, margin = '3em', ...rest }: Props) => {
 
   return (
     <SpinnerWrap $margin={margin}>
-      <Loader {...rest} title={label} />
-      {label && <BodyLong spacing>{label}</BodyLong>}
+      <HStack gap="4" align="center" justify="center">
+        <Loader {...rest} title={label} />
+        {label && <BodyLong>{label}</BodyLong>}
+      </HStack>
     </SpinnerWrap>
   )
 }
 
 const SpinnerWrap = styled.div<{ $margin: string }>`
-  display: flex;
-  justify-content: center;
   margin: ${(props) => props.$margin};
-  text-align: center;
 `
 
 export default Spinner

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/header/ReleaseAlerts.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/header/ReleaseAlerts.tsx
@@ -57,7 +57,7 @@ export const ReleaseAlerts = () => {
       <DropdownMenu>
         {mapApiResult(
           status,
-          <Spinner visible label="Henter siste utgivelser" />,
+          <Spinner label="Henter siste utgivelser" />,
           () => (
             <ApiErrorAlert>Kunne ikke hente siste utgivelser</ApiErrorAlert>
           ),

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/header/Search.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/header/Search.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { BodyShort, Loader, Search as SearchField } from '@navikt/ds-react'
+import { BodyShort, Search as SearchField } from '@navikt/ds-react'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ABlue500, AGray900, ANavRed } from '@navikt/ds-tokens/dist/tokens'
@@ -9,6 +9,7 @@ import { fnrErGyldig } from '~utils/fnr'
 import { hentSak } from '~shared/api/behandling'
 
 import { isPending, mapFailure } from '~shared/api/apiUtils'
+import Spinner from '~shared/Spinner'
 
 export const Search = () => {
   const navigate = useNavigate()
@@ -58,10 +59,7 @@ export const Search = () => {
 
       {isPending(funnetSak) && (
         <Dropdown>
-          <SpinnerContent>
-            <Loader />
-            <span>Søker...</span>
-          </SpinnerContent>
+          <Spinner label="Søker..." />
         </Dropdown>
       )}
 
@@ -128,10 +126,4 @@ const SearchResult = styled.div`
   .sak {
     color: gray;
   }
-`
-
-const SpinnerContent = styled.div`
-  display: flex;
-  gap: 0.5em;
-  margin: 1em;
 `


### PR DESCRIPTION
Spinner vil nå være synlig med mindre `visible=false`. 
Arver også props fra Aksel sin `Loader` slik at det kan forwardes. 