### PR TITLE
Går tilbake til å bruke vår eigen readiness-mekanisme for appane som …

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/klienter/GrunnlagKlient.kt
@@ -179,7 +179,7 @@ class GrunnlagKlientImpl(
 
     override suspend fun ping(konsument: String?): PingResult =
         client.ping(
-            pingUrl = url.plus("/isready"),
+            pingUrl = url.plus("/health/isready"),
             logger = logger,
             serviceName = serviceName,
             beskrivelse = beskrivelse,

--- a/apps/etterlatte-brev-api/.nais/dev.yaml
+++ b/apps/etterlatte-brev-api/.nais/dev.yaml
@@ -14,10 +14,10 @@ spec:
     - "https://etterlatte-brev-api.intern.dev.nav.no"
   liveness:
     initialDelay: 5
-    path: /isalive
+    path: /health/isalive
   readiness:
     initialDelay: 5
-    path: /isready
+    path: /health/isready
   prometheus:
     enabled: true
     path: /metrics

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationBuilder.kt
@@ -85,6 +85,7 @@ import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 import no.nav.etterlatte.libs.ktor.ktor.clientCredential
 import no.nav.etterlatte.libs.ktor.restModule
 import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
+import no.nav.etterlatte.libs.ktor.setReady
 import no.nav.etterlatte.rapidsandrivers.configFromEnvironment
 import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import no.nav.etterlatte.rivers.DistribuerBrevRiver
@@ -267,6 +268,7 @@ class ApplicationBuilder {
                 }
             },
             configFromEnvironment = { configFromEnvironment(it) },
+            setReady = { setReady() },
         ) { rapidsConnection, _ ->
             val brevgenerering =
                 StartInformasjonsbrevgenereringRiver(

--- a/apps/etterlatte-grunnlag/.nais/dev.yaml
+++ b/apps/etterlatte-grunnlag/.nais/dev.yaml
@@ -22,10 +22,10 @@ spec:
             value: "100"
   liveness:
     initialDelay: 5
-    path: /isalive
+    path: /health/isalive
   readiness:
     initialDelay: 5
-    path: /isready
+    path: /health/isready
   prometheus:
     enabled: true
     path: /metrics

--- a/apps/etterlatte-grunnlag/.nais/prod.yaml
+++ b/apps/etterlatte-grunnlag/.nais/prod.yaml
@@ -32,10 +32,10 @@ spec:
             value: "100"
   liveness:
     initialDelay: 5
-    path: /isalive
+    path: /health/isalive
   readiness:
     initialDelay: 5
-    path: /isready
+    path: /health/isready
   prometheus:
     enabled: true
     path: /metrics

--- a/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
@@ -26,6 +26,7 @@ import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.httpClient
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 import no.nav.etterlatte.libs.ktor.restModule
+import no.nav.etterlatte.libs.ktor.setReady
 import no.nav.etterlatte.rapidsandrivers.configFromEnvironment
 import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import org.slf4j.Logger
@@ -75,6 +76,7 @@ class ApplicationBuilder {
                 }
             },
             configFromEnvironment = { configFromEnvironment(it) },
+            setReady = { setReady() },
         ) { rapidsConnection, _ ->
             GrunnlagsversjoneringRiver(rapidsConnection, grunnlagService)
             GrunnlagHendelserRiver(rapidsConnection, grunnlagService)

--- a/apps/etterlatte-utbetaling/.nais/dev.yaml
+++ b/apps/etterlatte-utbetaling/.nais/dev.yaml
@@ -12,10 +12,10 @@ spec:
     - "https://etterlatte-utbetaling.intern.dev.nav.no"
   liveness:
     initialDelay: 5
-    path: /isalive
+    path: /health/isalive
   readiness:
     initialDelay: 5
-    path: /isready
+    path: /health/isready
   prometheus:
     enabled: true
     path: /metrics

--- a/apps/etterlatte-utbetaling/.nais/prod.yaml
+++ b/apps/etterlatte-utbetaling/.nais/prod.yaml
@@ -10,10 +10,10 @@ spec:
   port: 8080
   liveness:
     initialDelay: 5
-    path: /isalive
+    path: /health/isalive
   readiness:
     initialDelay: 5
-    path: /isready
+    path: /health/isready
   prometheus:
     enabled: true
     path: /metrics

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -5,6 +5,7 @@ import no.nav.etterlatte.libs.common.TimerJob
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.restModule
+import no.nav.etterlatte.libs.ktor.setReady
 import no.nav.etterlatte.rapidsandrivers.configFromEnvironment
 import no.nav.etterlatte.utbetaling.common.OppgavetriggerRiver
 import no.nav.etterlatte.utbetaling.config.ApplicationContext
@@ -27,6 +28,7 @@ fun main() {
                 }
             },
             configFromEnvironment = { configFromEnvironment(it) },
+            setReady = { setReady() },
         ) { rc, _ -> rc.settOppRiversOgListener(it) }
     }
 }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
@@ -13,6 +13,7 @@ fun initRogR(
     applikasjonsnavn: String,
     restModule: (Application.() -> Unit)? = null,
     configFromEnvironment: (Miljoevariabler) -> Config = { AivenConfig.default },
+    setReady: () -> Unit = {},
     settOppRivers: (RapidsConnection, rapidEnv: Miljoevariabler) -> Unit,
 ) {
     sikkerLoggOppstartOgAvslutning("etterlatte-$applikasjonsnavn")
@@ -33,5 +34,6 @@ fun initRogR(
         builder
             .build()
             .also { rapidsConnection -> settOppRivers(rapidsConnection, rapidEnv) }
+    setReady()
     connection.start()
 }


### PR DESCRIPTION
…blir kalt frå frontend.

Rapids and rivers-biblioteket eksponerer ut readiness på /isready, og for å kunne få logikken frå sjølvtesten vår i frontend til å oppføre seg ordentleg, bør alle backend-apps eksponere isready på samme sti. Det gjer dei ikkje no, men resten av dei r&r-baserte appane blir ikkje kalt direkte frå frontend, så da går det bra (for no). Vi bør gjera dette opplegget litt meir robust etter kvart