### PR TITLE
Låse klage + bedre feilmelding ved ulik bruker på oppg. og journalpost

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/handling/StartOppgavebehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/handling/StartOppgavebehandling.tsx
@@ -75,7 +75,11 @@ export default function StartOppgavebehandling() {
       )}
 
       {isSuccess(personResult) && !tilhoererBruker && (
-        <Alert variant="error">Journalposten tilhører ikke bruker som oppgaven er tilknyttet</Alert>
+        <Alert variant="warning">
+          Journalposten og oppgaven tilhører nå to ulike brukere. Hvis du skal opprette ny behandling eller klage på
+          bruker tilknyttet journalposten, må du opprette ny journalføringsoppgave. Dette kan du gjøre fra
+          dokumentoversikten til brukeren.
+        </Alert>
       )}
 
       <RadioGroup
@@ -93,7 +97,11 @@ export default function StartOppgavebehandling() {
         >
           Opprett behandling
         </Radio>
-        <Radio value={OppgaveHandling.NY_KLAGE} description="Opprett ny klagebehandling" disabled={!journalpost}>
+        <Radio
+          value={OppgaveHandling.NY_KLAGE}
+          description="Opprett ny klagebehandling"
+          disabled={!journalpost || !tilhoererBruker}
+        >
           Opprett klagebehandling
         </Radio>
         <Radio


### PR DESCRIPTION
Siden ny behandling eller klage opprettes med utgangspunkt i brukeren tilknyttet oppgaven må vi forhindre at saksbehandler oppretter på feil person. 

Funksjonalitet for overføring til annen bruker er bak feature toggle, men skal åpnes så snart denne endringen er ute. 


<img width="812" alt="Screenshot 2024-08-15 at 09 19 48" src="https://github.com/user-attachments/assets/48c30125-eb54-43fc-a938-570db2640d4b">
