### PR TITLE
Ser ut som lisenssjekk-pluginen kan trekkje med seg både commons-comp…

### DIFF
--- a/.github/workflows/.test.yaml
+++ b/.github/workflows/.test.yaml
@@ -18,6 +18,10 @@ jobs:
           java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
+      - name: Validate licenses
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew checkLicense --no-configuration-cache
       - name: Gradle test and build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,16 @@ fun hentAntallKjerner(): Int {
     }
     return Runtime.getRuntime().availableProcessors() / 2
 }
+
+buildscript {
+    configurations.all {
+        resolutionStrategy {
+            force(libs.commons.compress)
+            force("com.squareup.okio:okio-jvm:3.4.0")
+        }
+    }
+}
+
 plugins {
     alias(libs.plugins.license) apply true
     alias(libs.plugins.versions) apply true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -94,7 +94,7 @@ test-testcontainer-jupiter = { module = "org.testcontainers:junit-jupiter", vers
 test-testcontainer-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainer-version" }
 test-testcontainer-kafka = { module = "org.testcontainers:kafka", version.ref = "testcontainer-version" }
 
-commons-compress = { module = "org.apache.commons:commons-compress", version = "1.26.2"}
+commons-compress = { module = "org.apache.commons:commons-compress", version = "1.27.0"}
 unleash-client = { module = "io.getunleash:unleash-client-java", version = "9.2.4" }
 openapi = { module = "io.github.smiley4:ktor-swagger-ui", version = "3.2.0" }
 


### PR DESCRIPTION
…ress og ein okio-avhengnad som er litt sårbar. Denne er jo berre i bruk under byggesteget, så eg trur ikkje risikoen vår er så stor, men kan jo uansett tvinge denne over på samme commons-compress-versjon som vi har elles


Gradle-triks plukka frå https://stackoverflow.com/questions/67874881/force-version-of-dependency-in-gradle-plugin