### PR TITLE
EY-4160: Viser årsak ved avbrutt tilbakekreving

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingRoutes.kt
@@ -114,9 +114,11 @@ internal fun Route.tilbakekrevingRoutes(service: TilbakekrevingService) {
 
         put("/avbryt") {
             kunSystembruker {
-                val sakId = requireNotNull(call.parameters["sakId"]).toLong()
-                service.avbrytTilbakekreving(sakId)
-                call.respond(HttpStatusCode.OK)
+                medBody<AvbrytRequest> {
+                    val sakId = requireNotNull(call.parameters["sakId"]).toLong()
+                    service.avbrytTilbakekreving(sakId, it.merknad)
+                    call.respond(HttpStatusCode.OK)
+                }
             }
         }
     }
@@ -124,6 +126,10 @@ internal fun Route.tilbakekrevingRoutes(service: TilbakekrevingService) {
 
 data class OppgaveStatusRequest(
     val paaVent: Boolean,
+)
+
+data class AvbrytRequest(
+    val merknad: String,
 )
 
 data class TilbakekrevingSendeBrevRequest(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
@@ -132,7 +132,10 @@ class TilbakekrevingService(
         }
     }
 
-    fun avbrytTilbakekreving(sakId: Long): TilbakekrevingBehandling =
+    fun avbrytTilbakekreving(
+        sakId: Long,
+        merknad: String,
+    ): TilbakekrevingBehandling =
         inTransaction {
             logger.info("Avbryter tilbakekreving for sakId=$sakId")
 
@@ -147,7 +150,7 @@ class TilbakekrevingService(
                     ),
                 )
 
-            oppgaveService.avbrytAapneOppgaverMedReferanse(tilbakekreving.id.toString())
+            oppgaveService.avbrytAapneOppgaverMedReferanse(tilbakekreving.id.toString(), merknad)
 
             tilbakekrevingHendelse(tilbakekreving, TilbakekrevingHendelseType.AVBRUTT)
 

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -575,14 +575,25 @@ class OppgaveService(
      * Skal kun brukes til:
      *  - automatisk avbrudd når vi får erstattende førstegangsbehandling i saken
      *  - journalposter som avbrytes/annuleres
+     *  - automatisk avbrudd når kravgrunnlag i tilbakekreving er nullet ut
+     *  - automatisk avbrudd når kravgrunnlag i tilbakekreving er endret
      */
-    fun avbrytAapneOppgaverMedReferanse(referanse: String) {
+    fun avbrytAapneOppgaverMedReferanse(
+        referanse: String,
+        merknad: String? = null,
+    ) {
         logger.info("Avbryter åpne oppgaver med referanse=$referanse")
 
         oppgaveDao
             .hentOppgaverForReferanse(referanse)
             .filterNot(OppgaveIntern::erAvsluttet)
-            .forEach { oppgaveDao.endreStatusPaaOppgave(it.id, Status.AVBRUTT) }
+            .forEach {
+                if (merknad != null) {
+                    oppgaveDao.oppdaterStatusOgMerknad(it.id, merknad, Status.AVBRUTT)
+                } else {
+                    oppgaveDao.endreStatusPaaOppgave(it.id, Status.AVBRUTT)
+                }
+            }
     }
 
     fun hentFristGaarUt(request: VentefristGaarUtRequest): List<VentefristGaarUt> =

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingRoutesIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingRoutesIntegrationTest.kt
@@ -276,11 +276,13 @@ class TilbakekrevingRoutesIntegrationTest : BehandlingIntegrationTest() {
             client.putAndAssertOk(
                 "/tilbakekreving/${tilbakekreving.sak.id}/avbryt",
                 systemBruker,
+                AvbrytRequest("merknad"),
             )
 
             inTransaction {
                 val oppgave = oppgaveService.hentOppgaverForReferanse(tilbakekreving.id.toString()).first()
                 oppgave.status shouldBe Status.AVBRUTT
+                oppgave.merknad shouldBe "merknad"
             }
 
             val avbruttTilbakekreving = tilbakekrevingService.hentTilbakekreving(tilbakekreving.id)

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingServiceIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingServiceIntegrationTest.kt
@@ -256,7 +256,7 @@ internal class TilbakekrevingServiceIntegrationTest : BehandlingIntegrationTest(
         service.validerVurderingOgPerioder(tilbakekreving.id, saksbehandler)
 
         // Avbryter tilbakekreving
-        val avbruttTilbakekreving = runBlocking { service.avbrytTilbakekreving(sak.id) }
+        val avbruttTilbakekreving = runBlocking { service.avbrytTilbakekreving(sak.id, "merknad") }
         val sisteLagretHendelse = inTransaction { hendelseDao.hentHendelserISak(sak.id).maxBy { it.opprettet } }
         val avbruttOppgave = inTransaction { oppgaveService.hentOppgave(oppgave.id) }
 

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/klienter/BehandlingKlient.kt
@@ -50,11 +50,15 @@ class BehandlingKlient(
         }
     }
 
-    suspend fun avbrytTilbakekreving(sakId: SakId) {
+    suspend fun avbrytTilbakekreving(
+        sakId: SakId,
+        merknad: String,
+    ) {
         logger.info("Avbryter tilbakekreving i sak ${sakId.value}")
         try {
             httpClient.put("$url/tilbakekreving/${sakId.value}/avbryt") {
                 contentType(ContentType.Application.Json)
+                setBody(AvbrytRequest(merknad))
             }
         } catch (e: Exception) {
             throw Exception("Klarte ikke å avbryte tilbakekreving for sak $sakId", e)
@@ -64,4 +68,8 @@ class BehandlingKlient(
 
 data class OppgaveStatusRequest(
     val paaVent: Boolean,
+)
+
+data class AvbrytRequest(
+    val merknad: String,
 )

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagService.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagService.kt
@@ -97,7 +97,7 @@ class KravgrunnlagService(
                     "Kravgrunnlag ${kravgrunnlag.kravgrunnlagId.value} er endret i sak ${kravgrunnlag.sakId.value}" +
                         " avbryter eksisterende tilbakekreving og oppretter ny",
                 )
-                behandlingKlient.avbrytTilbakekreving(kravgrunnlag.sakId)
+                behandlingKlient.avbrytTilbakekreving(kravgrunnlag.sakId, "Avbrutt fordi kravgrunnlag er endret")
                 behandlingKlient.opprettTilbakekreving(kravgrunnlag.sakId, kravgrunnlag)
             }
         }
@@ -109,7 +109,7 @@ class KravgrunnlagService(
                 "Kravgrunnlag for sak ${kravOgVedtakstatus.sakId.value} har blitt nullet ut og er ikke lenger aktuelt - " +
                     "avbryter tilbakekreving",
             )
-            behandlingKlient.avbrytTilbakekreving(kravOgVedtakstatus.sakId)
+            behandlingKlient.avbrytTilbakekreving(kravOgVedtakstatus.sakId, "Avbrutt fordi det ikke lenger foreligger en feilutbetaling")
         }
     }
 }

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagServiceTest.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagServiceTest.kt
@@ -60,13 +60,13 @@ class KravgrunnlagServiceTest {
     fun `skal avbryte gjeldende tilbakekreving og opprette ny naar kravgrunnlag har status ENDR og perioder`() {
         val kravgrunnlag = kravgrunnlag(status = KravgrunnlagStatus.ENDR)
 
-        coEvery { behandlingKlient.avbrytTilbakekreving(any()) } just runs
+        coEvery { behandlingKlient.avbrytTilbakekreving(any(), any()) } just runs
         coEvery { behandlingKlient.opprettTilbakekreving(any(), any()) } just runs
 
         kravgrunnlagService.haandterKravgrunnlag(kravgrunnlag)
 
         coVerify(exactly = 1) {
-            behandlingKlient.avbrytTilbakekreving(kravgrunnlag.sakId)
+            behandlingKlient.avbrytTilbakekreving(kravgrunnlag.sakId, any())
             behandlingKlient.opprettTilbakekreving(kravgrunnlag.sakId, kravgrunnlag)
         }
     }
@@ -84,12 +84,12 @@ class KravgrunnlagServiceTest {
     fun `skal avbryte tilbakekreving naar kravOgVedtakstatus har status AVSL`() {
         val kravOgVedtakstatus = kravOgVedtakStatus(status = KravgrunnlagStatus.AVSL)
 
-        coEvery { behandlingKlient.avbrytTilbakekreving(any()) } just runs
+        coEvery { behandlingKlient.avbrytTilbakekreving(any(), any()) } just runs
 
         kravgrunnlagService.haandterKravOgVedtakStatus(kravOgVedtakstatus)
 
         coVerify(exactly = 1) {
-            behandlingKlient.avbrytTilbakekreving(kravOgVedtakstatus.sakId)
+            behandlingKlient.avbrytTilbakekreving(kravOgVedtakstatus.sakId, any())
         }
     }
 


### PR DESCRIPTION
Hvis et kravgrunnlag for eksempel blir avsluttet fordi det er motregnet mot uføretrygd, blir tilbakekrevingen som er opprettet avbrutt. Denne endringen legger på en merknad i oppgaven, slik at det blir tydeligere hvorfor dette skjedde. 

Tilsvarende vil det også legges på en merknad dersom en tilbakekreving blir avbrutt fordi det har kommet endringer på kravgrunnlaget.