### PR TITLE
EY-4305: Simuleringsklienten var satt opp til å kaste exception ved f…

### DIFF
--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
@@ -76,6 +76,7 @@ class ApplicationContext(
                 azureAppJwk = config.getString("azure.app.jwk"),
                 azureAppWellKnownUrl = config.getString("azure.app.well.known.url"),
                 azureAppScope = config.getString("etterlatteproxy.scope"),
+                forventSuksess = false,
             ),
             objectMapper = simuleringObjectMapper(),
         ),

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/simulering/SimuleringOsKlient.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/simulering/SimuleringOsKlient.kt
@@ -11,12 +11,14 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
 import no.nav.etterlatte.libs.common.logging.getCorrelationId
+import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.system.os.tjenester.simulerfpservice.simulerfpserviceservicetypes.SimulerBeregningRequest
@@ -38,6 +40,7 @@ class SimuleringOsKlient(
     private val objectMapper: ObjectMapper,
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
+    private val sikkerlogg = sikkerlogger()
 
     private val url = config.getString("etterlatteproxy.url")
 
@@ -54,9 +57,10 @@ class SimuleringOsKlient(
                 )
             }
         if (!response.status.isSuccess()) {
+            sikkerlogg.error("Simulering mot oppdrag feilet med status ${response.status}: ${response.bodyAsText()}")
             throw SimuleringOsKlientException(
                 response.status,
-                "Simulering mot Oppdrag feilet",
+                "Simulering mot Oppdrag feilet. Se hele feilen i sikkerlogg",
             )
         } else {
             return response.body<String>().let {

--- a/libs/etterlatte-ktor/src/main/kotlin/HttpClient.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/HttpClient.kt
@@ -25,6 +25,7 @@ fun httpClientClientCredentials(
     azureAppJwk: String,
     azureAppWellKnownUrl: String,
     azureAppScope: String,
+    forventSuksess: Boolean = true,
     ekstraJacksoninnstillinger: ((o: ObjectMapper) -> Unit) = { },
 ) = httpClient(
     ekstraJacksoninnstillinger = ekstraJacksoninnstillinger,
@@ -43,7 +44,7 @@ fun httpClientClientCredentials(
             }
         }
     },
-    forventSuksess = true,
+    forventSuksess = forventSuksess,
 )
 
 fun httpClient(


### PR DESCRIPTION
…eil-responskodar, så da kom vi aldri til den forventa feilhandteringa. Justerer det, og loggar samtidig full respons-tekst ved feil til sikkerlogg