### PR TITLE
EY-4010: Legger til brevutfallvalg for feilutbetaling ved motregning mot annen ytelse

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
@@ -301,7 +301,9 @@ class BehandlingStatusServiceImpl(
 
     private fun haandterFeilutbetaling(behandling: Behandling) {
         val brevutfall = behandlingInfoDao.hentBrevutfall(behandling.id)
-        if (brevutfall?.feilutbetaling?.valg in listOf(FeilutbetalingValg.JA_VARSEL, FeilutbetalingValg.JA_INGEN_TK)) {
+        if (brevutfall?.feilutbetaling?.valg in
+            listOf(FeilutbetalingValg.JA_VARSEL, FeilutbetalingValg.JA_INGEN_TK, FeilutbetalingValg.JA_INGEN_VARSEL_MOTREGNES)
+        ) {
             logger.info("Oppretter oppgave av type ${OppgaveType.TILBAKEKREVING} for behandling ${behandling.id}")
 
             val oppgaveFraBehandlingMedFeilutbetaling =

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/FeilutbetalingUtils.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/FeilutbetalingUtils.kt
@@ -6,6 +6,7 @@ fun toFeilutbetalingType(feilutbetalingValg: FeilutbetalingValg) =
     when (feilutbetalingValg) {
         FeilutbetalingValg.NEI -> FeilutbetalingType.INGEN_FEILUTBETALING
         FeilutbetalingValg.JA_INGEN_TK -> FeilutbetalingType.FEILUTBETALING_UTEN_VARSEL
+        FeilutbetalingValg.JA_INGEN_VARSEL_MOTREGNES -> FeilutbetalingType.FEILUTBETALING_UTEN_VARSEL
         FeilutbetalingValg.JA_VARSEL -> FeilutbetalingType.FEILUTBETALING_MED_VARSEL
     }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/Brevutfall.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/Brevutfall.tsx
@@ -46,6 +46,7 @@ export interface Feilutbetaling {
 export enum FeilutbetalingValg {
   NEI = 'NEI',
   JA_VARSEL = 'JA_VARSEL',
+  JA_INGEN_VARSEL_MOTREGNES = 'JA_INGEN_VARSEL_MOTREGNES',
   JA_INGEN_TK = 'JA_INGEN_TK',
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/BrevutfallVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/BrevutfallVisning.tsx
@@ -27,6 +27,8 @@ export function feilutbetalingToString(feilutbetaling?: FeilutbetalingValg | nul
       return 'Nei'
     case FeilutbetalingValg.JA_VARSEL:
       return 'Ja, det skal sendes varsel'
+    case FeilutbetalingValg.JA_INGEN_VARSEL_MOTREGNES:
+      return 'Ja, men motregnes mot annen ytelse fra NAV, så avventer varsel om feilutbetaling til ev. tilbakekrevingssak'
     case FeilutbetalingValg.JA_INGEN_TK:
       return 'Ja, men under 4 rettsgebyr, så ingen tilbakekreving'
     default:

--- a/libs/saksbehandling-common/src/main/kotlin/behandling/Brevutfall.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/behandling/Brevutfall.kt
@@ -23,6 +23,7 @@ data class Feilutbetaling(
 enum class FeilutbetalingValg {
     NEI,
     JA_VARSEL,
+    JA_INGEN_VARSEL_MOTREGNES,
     JA_INGEN_TK,
 }
 


### PR DESCRIPTION
Legger til ekstra valg for brevutfall og feilutbetaling hvor saksbehandler kan velge at det ikke legges ved vedlegg ved feilutbetaling fordi kravet vil bli nullet ut eller endres som følge av motregning mot annen ytelse.