### PR TITLE
FAGSYSTEM-340116: Kjøre avstemming for 3. og 4. januar på nytt

### DIFF
--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/avstemming/GrensesnittsavstemmingJob.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/avstemming/GrensesnittsavstemmingJob.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.utbetaling.avstemming
 import no.nav.etterlatte.jobs.LoggerInfo
 import no.nav.etterlatte.jobs.fixedRateCancellableTimer
 import no.nav.etterlatte.libs.common.TimerJob
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.jobs.LeaderElection
 import no.nav.etterlatte.sikkerLogg
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
@@ -50,7 +51,37 @@ class GrensesnittsavstemmingJob(
         fun run() {
             log.info("Starter $jobbNavn")
             if (leaderElection.isLeader()) {
-                grensesnittsavstemmingService.startGrensesnittsavstemming(saktype)
+                /**
+                 * Periode kan spesifiseres her dersom man ønsker å gjøre avstemming for en gitt dato.
+                 * Dette kan være kjekt dersom avstemming feiler eller man av andre grunner har behov
+                 * for å kjøre avstemming på nytt.
+                 *
+                 * Eksempel:
+                 *
+                 * periode =
+                 *   Avstemmingsperiode(
+                 *     fraOgMed = Tidspunkt.parse("2024-01-02T23:00:00.00Z"),
+                 *     til = Tidspunkt.parse("2024-01-03T23:00:00.00Z"),
+                 *   )
+                 */
+
+                listOf(
+                    Avstemmingsperiode(
+                        fraOgMed = Tidspunkt.parse("2024-01-02T23:00:00.00Z"),
+                        til = Tidspunkt.parse("2024-01-03T23:00:00.00Z"),
+                    ),
+                    Avstemmingsperiode(
+                        fraOgMed = Tidspunkt.parse("2024-01-03T23:00:00.00Z"),
+                        til = Tidspunkt.parse("2024-01-04T23:00:00.00Z"),
+                    ),
+                ).forEach {
+                    // TODO skal fjernes når avstemming er kjørt
+                    grensesnittsavstemmingService.startGrensesnittsavstemming(
+                        saktype = saktype,
+                        periode = it,
+                    )
+                }
+                // grensesnittsavstemmingService.startGrensesnittsavstemming(saktype)
             }
         }
     }

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
@@ -144,7 +144,8 @@ class ApplicationContext(
         GrensesnittsavstemmingJob(
             grensesnittsavstemmingService = grensesnittsavstemmingService,
             leaderElection = leaderElection,
-            starttidspunkt = Tidspunkt.now(norskKlokke()).next(LocalTime.of(3, 0, 0)),
+            starttidspunkt = Tidspunkt.now(norskKlokke()).next(LocalTime.of(14, 0, 0)), // TODO fjern denne når avstemming er kjørt
+            // starttidspunkt = Tidspunkt.now(norskKlokke()).next(LocalTime.of(3, 0, 0)),
             periode = Duration.of(1, ChronoUnit.DAYS),
             saktype = Saktype.BARNEPENSJON,
         )
@@ -152,7 +153,8 @@ class ApplicationContext(
         GrensesnittsavstemmingJob(
             grensesnittsavstemmingService = grensesnittsavstemmingService,
             leaderElection = leaderElection,
-            starttidspunkt = Tidspunkt.now(norskKlokke()).next(LocalTime.of(3, 0, 0)),
+            starttidspunkt = Tidspunkt.now(norskKlokke()).next(LocalTime.of(14, 5, 0)), // TODO fjern denne når avstemming er kjørt
+            // starttidspunkt = Tidspunkt.now(norskKlokke()).next(LocalTime.of(3, 0, 0)),
             periode = Duration.of(1, ChronoUnit.DAYS),
             saktype = Saktype.OMSTILLINGSSTOENAD,
         )

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
@@ -144,7 +144,7 @@ class ApplicationContext(
         GrensesnittsavstemmingJob(
             grensesnittsavstemmingService = grensesnittsavstemmingService,
             leaderElection = leaderElection,
-            starttidspunkt = Tidspunkt.now(norskKlokke()).next(LocalTime.of(14, 0, 0)), // TODO fjern denne når avstemming er kjørt
+            starttidspunkt = Tidspunkt.now(norskKlokke()).next(LocalTime.of(14, 30, 0)), // TODO fjern denne når avstemming er kjørt
             // starttidspunkt = Tidspunkt.now(norskKlokke()).next(LocalTime.of(3, 0, 0)),
             periode = Duration.of(1, ChronoUnit.DAYS),
             saktype = Saktype.BARNEPENSJON,
@@ -153,7 +153,7 @@ class ApplicationContext(
         GrensesnittsavstemmingJob(
             grensesnittsavstemmingService = grensesnittsavstemmingService,
             leaderElection = leaderElection,
-            starttidspunkt = Tidspunkt.now(norskKlokke()).next(LocalTime.of(14, 5, 0)), // TODO fjern denne når avstemming er kjørt
+            starttidspunkt = Tidspunkt.now(norskKlokke()).next(LocalTime.of(14, 35, 0)), // TODO fjern denne når avstemming er kjørt
             // starttidspunkt = Tidspunkt.now(norskKlokke()).next(LocalTime.of(3, 0, 0)),
             periode = Duration.of(1, ChronoUnit.DAYS),
             saktype = Saktype.OMSTILLINGSSTOENAD,

--- a/apps/etterlatte-utbetaling/src/test/kotlin/no/nav/etterlatte/utbetaling/avstemming/GrensesnittsavstemmingsJobTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/no/nav/etterlatte/utbetaling/avstemming/GrensesnittsavstemmingsJobTest.kt
@@ -60,10 +60,10 @@ internal class GrensesnittsavstemmingsJobTest {
         grensesnittavstemming.run()
         omsGrensesnittavstemming.run()
 
-        verify(exactly = 1) {
+        verify(exactly = 2) {
             grensesnittavstemmingService.startGrensesnittsavstemming(saktype = Saktype.BARNEPENSJON, any())
         }
-        verify(exactly = 1) {
+        verify(exactly = 2) {
             grensesnittavstemmingService.startGrensesnittsavstemming(saktype = Saktype.OMSTILLINGSSTOENAD, any())
         }
         assertTrue(leaderElection.isLeader())


### PR DESCRIPTION
Kjører grensesnittavstemming for 3. og 4. januar på nytt etter forspørsel fra økonomi. Både for BP og OMS. Disse dagene hadde blit kjørt sammen av en eller annen grunn (sannsynligvis fordi utbetaling var nede i tidsrommet jobben skulle kjørt i første gang). 

Endringene her fjernes så fort kjøringen er gjort.