### PR TITLE
Ikke gjør oppslag mot Pesys for å sjekke behandlingsstatus

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/common/klienter/PesysKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/common/klienter/PesysKlient.kt
@@ -19,12 +19,6 @@ interface PesysKlient {
         fnr: String,
         bruker: BrukerTokenInfo,
     ): List<SakSammendragResponse>
-
-    suspend fun erTilstoetendeBehandlet(
-        fnr: String,
-        doedsdato: LocalDate,
-        bruker: BrukerTokenInfo,
-    ): Boolean
 }
 
 class PesysKlientImpl(
@@ -50,28 +44,6 @@ class PesysKlientImpl(
                     Resource(
                         clientId = clientId,
                         url = "$resourceUrl/sak/sammendragWonderful",
-                        additionalHeaders = mapOf("fnr" to fnr),
-                    ),
-                brukerTokenInfo = bruker,
-            ).mapBoth(
-                success = { resource -> objectMapper.readValue(resource.response.toString()) },
-                failure = { errorResponse -> throw errorResponse },
-            )
-    }
-
-    override suspend fun erTilstoetendeBehandlet(
-        fnr: String,
-        doedsdato: LocalDate,
-        bruker: BrukerTokenInfo,
-    ): Boolean {
-        logger.info("Sjekker om tilstøtende er behandlet i Pesys for ${fnr.maskerFnr()}")
-
-        return downstreamResourceClient
-            .get(
-                resource =
-                    Resource(
-                        clientId = clientId,
-                        url = "$resourceUrl/sak/tilstotendeBehandlet?dodsdato=$doedsdato",
                         additionalHeaders = mapOf("fnr" to fnr),
                     ),
                 brukerTokenInfo = bruker,

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktServiceTest.kt
@@ -81,20 +81,6 @@ class DoedshendelseKontrollpunktServiceTest {
     fun oppsett() {
         coEvery { pesysKlient.hentSaker(doedshendelseInternalBP.beroertFnr, bruker) } returns emptyList()
         coEvery { pesysKlient.hentSaker(doedshendelseInternalOMS.beroertFnr, bruker) } returns emptyList()
-        coEvery {
-            pesysKlient.erTilstoetendeBehandlet(
-                doedshendelseInternalOMS.beroertFnr,
-                any(),
-                bruker,
-            )
-        } returns false
-        coEvery {
-            pesysKlient.erTilstoetendeBehandlet(
-                doedshendelseInternalBP.beroertFnr,
-                any(),
-                bruker,
-            )
-        } returns false
 
         every { behandlingService.hentSisteIverksatte(any()) } returns null
         every {
@@ -401,20 +387,6 @@ class DoedshendelseKontrollpunktServiceTest {
             )
 
         kontrollpunkter shouldContainExactly listOf(DoedshendelseKontrollpunkt.GjenlevendeManglerAdresse)
-    }
-
-    @Test
-    fun `Skal opprette kontrollpunkt hvis saken er behandlet i Pesys`() {
-        coEvery {
-            pesysKlient.erTilstoetendeBehandlet(
-                doedshendelseInternalBP.beroertFnr,
-                any(),
-                bruker,
-            )
-        } returns true
-
-        kontrollpunktService.identifiserKontrollerpunkter(doedshendelseInternalBP, bruker) shouldBe
-            listOf(DoedshendelseKontrollpunkt.TilstoetendeBehandletIPesys)
     }
 
     @Test

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
@@ -405,12 +405,6 @@ class PesysKlientTest : PesysKlient {
         fnr: String,
         bruker: BrukerTokenInfo,
     ): List<SakSammendragResponse> = emptyList()
-
-    override suspend fun erTilstoetendeBehandlet(
-        fnr: String,
-        doedsdato: LocalDate,
-        bruker: BrukerTokenInfo,
-    ): Boolean = false
 }
 
 class KrrklientTest : KrrKlient {


### PR DESCRIPTION
Pesys behandler ikke lengre dødsmeldinger for OMS eller BP, vi kan fjerne oppslag mot Pesys for å se om sak har blitt behandlet der.

EY-4324