### PR TITLE
EY-4268: Trigger for å lytte på oppdateringar av sak-tabellen

### DIFF
--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V152__sistEndretAv.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V152__sistEndretAv.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sak ADD COLUMN sistEndretAv TEXT;

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V152__trigger_lytte_sakendringer.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V152__trigger_lytte_sakendringer.sql
@@ -1,0 +1,43 @@
+-- Basert på https://www.cybertec-postgresql.com/en/tracking-changes-in-postgresql/
+CREATE SCHEMA logging;
+
+CREATE TABLE logging.t_history
+(
+    id         serial,
+    timestamp  timestamp DEFAULT now(),
+    schemaname text,
+    tabname    text,
+    operation  text,
+    who        text      DEFAULT current_user,
+    new_val    jsonb,
+    old_val    jsonb
+);
+
+CREATE FUNCTION logging.change_trigger() RETURNS trigger AS
+$$
+BEGIN
+    IF TG_OP = 'INSERT'
+    THEN
+        INSERT INTO logging.t_history (tabname, schemaname, operation, new_val)
+        VALUES (TG_RELNAME, TG_TABLE_SCHEMA, TG_OP, row_to_json(NEW));
+        RETURN NEW;
+    ELSIF TG_OP = 'UPDATE'
+    THEN
+        INSERT INTO logging.t_history (tabname, schemaname, operation, new_val, old_val)
+        VALUES (TG_RELNAME, TG_TABLE_SCHEMA, TG_OP,
+                row_to_json(NEW), row_to_json(OLD));
+        RETURN NEW;
+    ELSIF TG_OP = 'DELETE'
+    THEN
+        INSERT INTO logging.t_history (tabname, schemaname, operation, old_val)
+        VALUES (TG_RELNAME, TG_TABLE_SCHEMA, TG_OP, row_to_json(OLD));
+        RETURN OLD;
+    END IF;
+END;
+$$ LANGUAGE 'plpgsql' SECURITY DEFINER;
+
+CREATE TRIGGER audit_sak
+    AFTER INSERT OR UPDATE OR DELETE
+    ON sak
+    FOR EACH ROW
+EXECUTE PROCEDURE logging.change_trigger();

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V153__trigger_lytte_sakendringer.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V153__trigger_lytte_sakendringer.sql
@@ -8,7 +8,7 @@ CREATE TABLE logging.t_history
     schemaname text,
     tabname    text,
     operation  text,
-    who        text      DEFAULT current_user,
+    who        text,
     new_val    jsonb,
     old_val    jsonb
 );
@@ -18,19 +18,20 @@ $$
 BEGIN
     IF TG_OP = 'INSERT'
     THEN
-        INSERT INTO logging.t_history (tabname, schemaname, operation, new_val)
-        VALUES (TG_RELNAME, TG_TABLE_SCHEMA, TG_OP, row_to_json(NEW));
+        INSERT INTO logging.t_history (tabname, schemaname, operation, new_val, who)
+        VALUES (TG_RELNAME, TG_TABLE_SCHEMA, TG_OP, row_to_json(NEW), NEW.sistEndretAv);
         RETURN NEW;
     ELSIF TG_OP = 'UPDATE'
     THEN
-        INSERT INTO logging.t_history (tabname, schemaname, operation, new_val, old_val)
+        INSERT INTO logging.t_history (tabname, schemaname, operation, new_val, old_val, who)
         VALUES (TG_RELNAME, TG_TABLE_SCHEMA, TG_OP,
-                row_to_json(NEW), row_to_json(OLD));
+                row_to_json(NEW), row_to_json(OLD), NEW.sistEndretAv);
         RETURN NEW;
     ELSIF TG_OP = 'DELETE'
     THEN
-        INSERT INTO logging.t_history (tabname, schemaname, operation, old_val)
-        VALUES (TG_RELNAME, TG_TABLE_SCHEMA, TG_OP, row_to_json(OLD));
+        -- TODO: who her er ikkje heilt opplagt
+        INSERT INTO logging.t_history (tabname, schemaname, operation, old_val, who)
+        VALUES (TG_RELNAME, TG_TABLE_SCHEMA, TG_OP, row_to_json(OLD), current_user);
         RETURN OLD;
     END IF;
 END;


### PR DESCRIPTION
Generisk, databasebasert variant. Sikrar at vi  får med alle endringar.

Ikkje like eksplisitt synleg som å løyse det i kode, men kan spare oss for mykje kompleksitet.

Alternativ programmatisk (ikkje heilt ferdig) løysing: https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/5582