### PR TITLE
Kun randomized port for mockauthservder

### DIFF
--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingRoutesTest.kt
@@ -25,6 +25,7 @@ import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeServi
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.funksjonsbrytere.DummyFeatureToggleService
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.token.issueSystembrukerToken
 import no.nav.etterlatte.libs.common.Vedtaksloesning
@@ -61,11 +62,10 @@ internal class BehandlingRoutesTest {
     private val gyldighetsproevingService = mockk<GyldighetsproevingService>()
     private val kommerBarnetTilGodeService = mockk<KommerBarnetTilGodeService>()
     private val behandlingFactory = mockk<BehandlingFactory>()
-    private val featureToggleService = DummyFeatureToggleService()
 
     @BeforeAll
     fun before() {
-        mockOAuth2Server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterEach

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingsstatusRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingsstatusRoutesTest.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.azureAdSaksbehandlerClaim
 import no.nav.etterlatte.behandling.domain.Behandling
 import no.nav.etterlatte.config.ApplicationContext
 import no.nav.etterlatte.ktor.runServerWithModule
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.module
@@ -31,11 +32,11 @@ import java.util.UUID
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class BehandlingsstatusRoutesTest {
     private val applicationContext: ApplicationContext = mockk(relaxed = true)
-    private val server: MockOAuth2Server = MockOAuth2Server()
+    private val mockOAuth2Server = MockOAuth2Server()
 
     @BeforeAll
     fun before() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
 
         val azureAdGroupIds =
             mapOf(
@@ -54,7 +55,7 @@ internal class BehandlingsstatusRoutesTest {
     @AfterAll
     fun after() {
         applicationContext.close()
-        server.shutdown()
+        mockOAuth2Server.shutdown()
     }
 
     @Test
@@ -65,7 +66,7 @@ internal class BehandlingsstatusRoutesTest {
             }
 
         testApplication {
-            runServerWithModule(server) {
+            runServerWithModule(mockOAuth2Server) {
                 module(applicationContext)
             }
 
@@ -91,7 +92,7 @@ internal class BehandlingsstatusRoutesTest {
             }
 
         testApplication {
-            runServerWithModule(server) {
+            runServerWithModule(mockOAuth2Server) {
                 module(applicationContext)
             }
 
@@ -117,7 +118,7 @@ internal class BehandlingsstatusRoutesTest {
             }
 
         testApplication {
-            runServerWithModule(server) {
+            runServerWithModule(mockOAuth2Server) {
                 module(applicationContext)
             }
 
@@ -145,7 +146,7 @@ internal class BehandlingsstatusRoutesTest {
             }
 
         testApplication {
-            runServerWithModule(server) {
+            runServerWithModule(mockOAuth2Server) {
                 module(applicationContext)
             }
 
@@ -159,10 +160,10 @@ internal class BehandlingsstatusRoutesTest {
         }
     }
 
-    private val tokenSaksbehandler: String by lazy { server.issueSaksbehandlerToken(groups = listOf(azureAdSaksbehandlerClaim)) }
+    private val tokenSaksbehandler: String by lazy { mockOAuth2Server.issueSaksbehandlerToken(groups = listOf(azureAdSaksbehandlerClaim)) }
 
     private val tokenAttestant: String by lazy {
-        server.issueSaksbehandlerToken(navIdent = "Saksbehandler02", groups = listOf(azureAdAttestantClaim))
+        mockOAuth2Server.issueSaksbehandlerToken(navIdent = "Saksbehandler02", groups = listOf(azureAdAttestantClaim))
     }
 
     private companion object {

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseRouteTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseRouteTest.kt
@@ -57,7 +57,7 @@ internal class DoedshendelseRouteTest(
 
     @BeforeAll
     fun before() {
-        mockOAuth2Server.start(1234)
+        mockOAuth2Server.start()
     }
 
     @AfterEach

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseRouteTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseRouteTest.kt
@@ -21,6 +21,7 @@ import no.nav.etterlatte.SystemUser
 import no.nav.etterlatte.attachMockContext
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.token.issueSystembrukerToken
 import no.nav.etterlatte.libs.common.behandling.DoedshendelseBrevDistribuert
@@ -57,7 +58,7 @@ internal class DoedshendelseRouteTest(
 
     @BeforeAll
     fun before() {
-        mockOAuth2Server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterEach

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakRoutesTest.kt
@@ -55,7 +55,7 @@ internal class SakRoutesTest {
 
     @BeforeAll
     fun before() {
-        mockOAuth2Server.start(1234)
+        mockOAuth2Server.start()
     }
 
     @AfterEach

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakRoutesTest.kt
@@ -24,6 +24,7 @@ import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.grunnlagsendring.GrunnlagsendringshendelseService
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakRoutesTest.kt
@@ -55,7 +55,7 @@ internal class SakRoutesTest {
 
     @BeforeAll
     fun before() {
-        mockOAuth2Server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterEach

--- a/apps/etterlatte-behandling/src/test/kotlin/tilgangsstyring/TilgangsstyringTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/tilgangsstyring/TilgangsstyringTest.kt
@@ -21,6 +21,7 @@ import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.lagContext
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER

--- a/apps/etterlatte-behandling/src/test/kotlin/tilgangsstyring/TilgangsstyringTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/tilgangsstyring/TilgangsstyringTest.kt
@@ -66,7 +66,7 @@ class TilgangsstyringTest {
         @BeforeAll
         @JvmStatic
         fun before() {
-            mockOAuth2Server.start()
+            mockOAuth2Server.startRandomPort()
         }
 
         @AfterAll

--- a/apps/etterlatte-behandling/src/test/kotlin/tilgangsstyring/TilgangsstyringTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/tilgangsstyring/TilgangsstyringTest.kt
@@ -66,7 +66,7 @@ class TilgangsstyringTest {
         @BeforeAll
         @JvmStatic
         fun before() {
-            mockOAuth2Server.start(1234)
+            mockOAuth2Server.start()
         }
 
         @AfterAll

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRoutesTest.kt
@@ -16,6 +16,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
@@ -42,7 +43,7 @@ import java.util.UUID.randomUUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class BeregningRoutesTest {
-    private val server = MockOAuth2Server()
+    private val mockOAuth2Server = MockOAuth2Server()
     private val beregningRepository = mockk<BeregningRepository>()
     private val behandlingKlient = mockk<BehandlingKlient>()
     private val beregnBarnepensjonService = mockk<BeregnBarnepensjonService>()
@@ -61,14 +62,14 @@ internal class BeregningRoutesTest {
 
     @BeforeAll
     fun before() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
 
         coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
     }
 
     @AfterAll
     fun after() {
-        server.shutdown()
+        mockOAuth2Server.shutdown()
     }
 
     @Test
@@ -76,7 +77,7 @@ internal class BeregningRoutesTest {
         every { beregningRepository.hent(any()) } returns null
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 beregning(beregningService, behandlingKlient)
             }
 
@@ -102,7 +103,7 @@ internal class BeregningRoutesTest {
         every { beregningRepository.hentOverstyrBeregning(1L) } returns null
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 beregning(beregningService, behandlingKlient)
             }
 
@@ -126,7 +127,7 @@ internal class BeregningRoutesTest {
         coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns false
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 beregning(beregningService, behandlingKlient)
             }
 
@@ -153,7 +154,7 @@ internal class BeregningRoutesTest {
         every { beregningRepository.lagreEllerOppdaterBeregning(any()) } returnsArgument 0
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 beregning(beregningService, behandlingKlient)
             }
 
@@ -191,7 +192,7 @@ internal class BeregningRoutesTest {
             )
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 beregning(beregningService, behandlingKlient)
             }
 
@@ -220,7 +221,7 @@ internal class BeregningRoutesTest {
         every { beregningRepository.hentOverstyrBeregning(1L) } returns null
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 beregning(beregningService, behandlingKlient)
             }
 
@@ -272,5 +273,5 @@ internal class BeregningRoutesTest {
             every { opphoerFraOgMed } returns null
         }
 
-    private val token: String by lazy { server.issueSaksbehandlerToken() }
+    private val token: String by lazy { mockOAuth2Server.issueSaksbehandlerToken() }
 }

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
@@ -23,6 +23,7 @@ import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.klienter.GrunnlagKlient
 import no.nav.etterlatte.klienter.VedtaksvurderingKlient
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.token.issueSystembrukerToken
 import no.nav.etterlatte.libs.common.Vedtaksloesning
@@ -50,7 +51,7 @@ import java.util.UUID.randomUUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class BeregningsGrunnlagRoutesTest {
-    private val server = MockOAuth2Server()
+    private val mockOAuth2Server = MockOAuth2Server()
     private val behandlingKlient = mockk<BehandlingKlient>()
     private val vedtaksvurderingKlient = mockk<VedtaksvurderingKlient>()
     private val repository = mockk<BeregningsGrunnlagRepository>()
@@ -67,12 +68,12 @@ internal class BeregningsGrunnlagRoutesTest {
 
     @BeforeAll
     fun before() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterAll
     fun after() {
-        server.shutdown()
+        mockOAuth2Server.shutdown()
     }
 
     @Test
@@ -100,7 +101,7 @@ internal class BeregningsGrunnlagRoutesTest {
         every { repository.finnBeregningsGrunnlag(any()) } returns null
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 beregningsGrunnlag(service, behandlingKlient)
             }
 
@@ -166,7 +167,7 @@ internal class BeregningsGrunnlagRoutesTest {
             )
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 beregningsGrunnlag(service, behandlingKlient)
             }
 
@@ -202,7 +203,7 @@ internal class BeregningsGrunnlagRoutesTest {
             )
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 beregningsGrunnlag(service, behandlingKlient)
             }
 
@@ -223,7 +224,7 @@ internal class BeregningsGrunnlagRoutesTest {
         coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns false
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 beregningsGrunnlag(service, behandlingKlient)
             }
 
@@ -243,7 +244,7 @@ internal class BeregningsGrunnlagRoutesTest {
 
         testApplication {
             val client =
-                runServer(server) {
+                runServer(mockOAuth2Server) {
                     beregningsGrunnlag(service, behandlingKlient)
                 }
 
@@ -301,7 +302,7 @@ internal class BeregningsGrunnlagRoutesTest {
 
         testApplication {
             val client =
-                runServer(server) {
+                runServer(mockOAuth2Server) {
                     beregningsGrunnlag(service, behandlingKlient)
                 }
 
@@ -359,7 +360,7 @@ internal class BeregningsGrunnlagRoutesTest {
 
         testApplication {
             val client =
-                runServer(server) {
+                runServer(mockOAuth2Server) {
                     beregningsGrunnlag(service, behandlingKlient)
                 }
 
@@ -410,7 +411,7 @@ internal class BeregningsGrunnlagRoutesTest {
         every { repository.lagreBeregningsGrunnlag(any()) } returns true
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 beregningsGrunnlag(service, behandlingKlient)
             }
 
@@ -444,7 +445,7 @@ internal class BeregningsGrunnlagRoutesTest {
         every { repository.lagreBeregningsGrunnlag(any()) } returns true
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 beregningsGrunnlag(service, behandlingKlient)
             }
 
@@ -469,7 +470,7 @@ internal class BeregningsGrunnlagRoutesTest {
         every { repository.lagreBeregningsGrunnlag(any()) } returns true
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 beregningsGrunnlag(service, behandlingKlient)
             }
 
@@ -509,7 +510,7 @@ internal class BeregningsGrunnlagRoutesTest {
         every { repository.lagreBeregningsGrunnlag(any()) } returns true
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 beregningsGrunnlag(service, behandlingKlient)
             }
 
@@ -573,7 +574,7 @@ internal class BeregningsGrunnlagRoutesTest {
 
         testApplication {
             val client =
-                runServer(server) {
+                runServer(mockOAuth2Server) {
                     beregningsGrunnlag(service, behandlingKlient)
                 }
 
@@ -677,7 +678,7 @@ internal class BeregningsGrunnlagRoutesTest {
 
         testApplication {
             val client =
-                runServer(server) {
+                runServer(mockOAuth2Server) {
                     beregningsGrunnlag(service, behandlingKlient)
                 }
 
@@ -768,7 +769,7 @@ internal class BeregningsGrunnlagRoutesTest {
         }
     }
 
-    private val token: String by lazy { server.issueSaksbehandlerToken() }
+    private val token: String by lazy { mockOAuth2Server.issueSaksbehandlerToken() }
 
-    private val systemToken: String by lazy { server.issueSystembrukerToken() }
+    private val systemToken: String by lazy { mockOAuth2Server.issueSystembrukerToken() }
 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
@@ -34,6 +34,7 @@ import no.nav.etterlatte.brev.model.Slate
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
@@ -61,7 +61,7 @@ internal class BrevRouteTest {
 
     @BeforeAll
     fun before() {
-        mockOAuth2Server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterEach

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/OversendelsesbrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/OversendelsesbrevRouteTest.kt
@@ -26,6 +26,7 @@ import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.brev.oversendelsebrev.OversendelseBrevService
 import no.nav.etterlatte.brev.oversendelsebrev.oversendelseBrevRoute
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/OversendelsesbrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/OversendelsesbrevRouteTest.kt
@@ -46,7 +46,7 @@ internal class OversendelsesbrevRouteTest {
 
     @BeforeAll
     fun before() {
-        mockOAuth2Server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterEach

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
@@ -51,7 +51,7 @@ internal class VedtaksbrevRouteTest {
 
     @BeforeAll
     fun before() {
-        mockOAuth2Server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterEach

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
@@ -28,6 +28,7 @@ import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokument/DokumentRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokument/DokumentRouteTest.kt
@@ -32,7 +32,7 @@ internal class DokumentRouteTest {
 
     @BeforeAll
     fun before() {
-        mockOAuth2Server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterEach

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokument/DokumentRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/dokument/DokumentRouteTest.kt
@@ -13,6 +13,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.etterlatte.brev.dokarkiv.DokarkivService
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
 import no.nav.security.mock.oauth2.MockOAuth2Server

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/BehandlingGrunnlagRoutesKtTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/BehandlingGrunnlagRoutesKtTest.kt
@@ -27,6 +27,7 @@ import io.mockk.verify
 import lagGrunnlagsopplysning
 import no.nav.etterlatte.grunnlag.klienter.BehandlingKlient
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.ktor.token.issueSystembrukerToken
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -56,11 +57,11 @@ import kotlin.random.Random
 internal class BehandlingGrunnlagRoutesKtTest {
     private val grunnlagService = mockk<GrunnlagService>()
     private val behandlingKlient = mockk<BehandlingKlient>()
-    private val server = MockOAuth2Server()
+    private val mockOAuth2Server = MockOAuth2Server()
 
     @BeforeAll
     fun before() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterEach
@@ -71,7 +72,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
 
     @AfterAll
     fun after() {
-        server.shutdown()
+        mockOAuth2Server.shutdown()
     }
 
     @Test
@@ -95,7 +96,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
         coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
 
         testApplication {
-            runServer(server, "api/grunnlag") {
+            runServer(mockOAuth2Server, "api/grunnlag") {
                 behandlingGrunnlagRoute(
                     grunnlagService,
                     behandlingKlient,
@@ -106,7 +107,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
                 client.get("api/grunnlag/behandling/$behandlingId") {
                     headers {
                         append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                        append(HttpHeaders.Authorization, "Bearer ${server.issueSaksbehandlerToken()}")
+                        append(HttpHeaders.Authorization, "Bearer ${mockOAuth2Server.issueSaksbehandlerToken()}")
                     }
                 }
 
@@ -130,7 +131,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
                 createHttpClient().get("api/grunnlag/behandling/$behandlingId") {
                     headers {
                         append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                        append(HttpHeaders.Authorization, "Bearer ${server.issueSaksbehandlerToken()}")
+                        append(HttpHeaders.Authorization, "Bearer ${mockOAuth2Server.issueSaksbehandlerToken()}")
                     }
                 }
 
@@ -164,7 +165,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
                 createHttpClient().get("api/grunnlag/behandling/$behandlingId/$type") {
                     headers {
                         append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                        append(HttpHeaders.Authorization, "Bearer ${server.issueSaksbehandlerToken()}")
+                        append(HttpHeaders.Authorization, "Bearer ${mockOAuth2Server.issueSaksbehandlerToken()}")
                     }
                 }
 
@@ -199,7 +200,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
                 ) {
                     headers {
                         append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                        append(HttpHeaders.Authorization, "Bearer ${server.issueSaksbehandlerToken()}")
+                        append(HttpHeaders.Authorization, "Bearer ${mockOAuth2Server.issueSaksbehandlerToken()}")
                     }
                 }
 
@@ -233,7 +234,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
                     contentType(ContentType.Application.Json)
                     setBody(NyeSaksopplysninger(sakId, opplysninger))
                     headers {
-                        append(HttpHeaders.Authorization, "Bearer ${server.issueSaksbehandlerToken()}")
+                        append(HttpHeaders.Authorization, "Bearer ${mockOAuth2Server.issueSaksbehandlerToken()}")
                     }
                 }
 
@@ -265,7 +266,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
                     contentType(ContentType.Application.Json)
                     setBody(opplysningsbehov)
                     headers {
-                        append(HttpHeaders.Authorization, "Bearer ${server.issueSystembrukerToken()}")
+                        append(HttpHeaders.Authorization, "Bearer ${mockOAuth2Server.issueSystembrukerToken()}")
                     }
                 }
 
@@ -298,7 +299,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
                     contentType(ContentType.Application.Json)
                     setBody(request)
                     headers {
-                        append(HttpHeaders.Authorization, "Bearer ${server.issueSystembrukerToken()}")
+                        append(HttpHeaders.Authorization, "Bearer ${mockOAuth2Server.issueSystembrukerToken()}")
                     }
                 }
 
@@ -316,7 +317,7 @@ internal class BehandlingGrunnlagRoutesKtTest {
     }
 
     private fun ApplicationTestBuilder.createHttpClient(): HttpClient =
-        runServer(server, "api/grunnlag") {
+        runServer(mockOAuth2Server, "api/grunnlag") {
             behandlingGrunnlagRoute(grunnlagService, behandlingKlient)
         }
 }

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/PersonRoutesTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/PersonRoutesTest.kt
@@ -20,6 +20,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.etterlatte.grunnlag.klienter.BehandlingKlient
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSystembrukerToken
 import no.nav.etterlatte.libs.common.behandling.PersonMedSakerOgRoller
 import no.nav.etterlatte.libs.common.behandling.SakidOgRolle
@@ -39,11 +40,11 @@ import org.junit.jupiter.api.TestInstance
 internal class PersonRoutesTest {
     private val grunnlagService = mockk<GrunnlagService>()
     private val behandlingKlient = mockk<BehandlingKlient>()
-    private val server = MockOAuth2Server()
+    private val mockOAuth2Server = MockOAuth2Server()
 
     @BeforeAll
     fun before() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterEach
@@ -54,13 +55,13 @@ internal class PersonRoutesTest {
 
     @AfterAll
     fun after() {
-        server.shutdown()
+        mockOAuth2Server.shutdown()
     }
 
     @Test
     fun `returnerer 401 uten gyldig token`() {
         testApplication {
-            runServer(server, "api/grunnlag") {
+            runServer(mockOAuth2Server, "api/grunnlag") {
                 personRoute(grunnlagService, behandlingKlient)
             }
 
@@ -90,7 +91,7 @@ internal class PersonRoutesTest {
                     setBody(FoedselsnummerDTO(SOEKER_FOEDSELSNUMMER.value))
                     headers {
                         append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                        append(HttpHeaders.Authorization, "Bearer ${server.issueSystembrukerToken()}")
+                        append(HttpHeaders.Authorization, "Bearer ${mockOAuth2Server.issueSystembrukerToken()}")
                     }
                 }
 
@@ -114,7 +115,7 @@ internal class PersonRoutesTest {
                     contentType(ContentType.Application.Json)
                     setBody(FoedselsnummerDTO(SOEKER_FOEDSELSNUMMER.value))
                     headers {
-                        append(HttpHeaders.Authorization, "Bearer ${server.issueSystembrukerToken()}")
+                        append(HttpHeaders.Authorization, "Bearer ${mockOAuth2Server.issueSystembrukerToken()}")
                     }
                 }
 
@@ -127,7 +128,7 @@ internal class PersonRoutesTest {
     }
 
     private fun ApplicationTestBuilder.createHttpClient(): HttpClient =
-        runServer(server, "api/grunnlag") {
+        runServer(mockOAuth2Server, "api/grunnlag") {
             personRoute(grunnlagService, behandlingKlient)
         }
 }

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/SakGrunnlagRoutesKtTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/SakGrunnlagRoutesKtTest.kt
@@ -19,6 +19,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.etterlatte.grunnlag.klienter.BehandlingKlient
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.common.serialize
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
@@ -35,11 +36,11 @@ import kotlin.random.Random
 internal class SakGrunnlagRoutesKtTest {
     private val grunnlagService = mockk<GrunnlagService>()
     private val behandlingKlient = mockk<BehandlingKlient>()
-    private val server = MockOAuth2Server()
+    private val mockOAuth2Server = MockOAuth2Server()
 
     @BeforeAll
     fun before() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterEach
@@ -50,7 +51,7 @@ internal class SakGrunnlagRoutesKtTest {
 
     @AfterAll
     fun after() {
-        server.shutdown()
+        mockOAuth2Server.shutdown()
     }
 
     @Test
@@ -78,7 +79,7 @@ internal class SakGrunnlagRoutesKtTest {
                 createHttpClient().get("api/grunnlag/sak/$sakId") {
                     headers {
                         append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                        append(HttpHeaders.Authorization, "Bearer ${server.issueSaksbehandlerToken()}")
+                        append(HttpHeaders.Authorization, "Bearer ${mockOAuth2Server.issueSaksbehandlerToken()}")
                     }
                 }
 
@@ -102,7 +103,7 @@ internal class SakGrunnlagRoutesKtTest {
                 createHttpClient().get("api/grunnlag/sak/$sakId") {
                     headers {
                         append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                        append(HttpHeaders.Authorization, "Bearer ${server.issueSaksbehandlerToken()}")
+                        append(HttpHeaders.Authorization, "Bearer ${mockOAuth2Server.issueSaksbehandlerToken()}")
                     }
                 }
 
@@ -115,5 +116,5 @@ internal class SakGrunnlagRoutesKtTest {
     }
 
     private fun ApplicationTestBuilder.createHttpClient(): HttpClient =
-        runServer(server, "api/grunnlag") { sakGrunnlagRoute(grunnlagService, behandlingKlient) }
+        runServer(mockOAuth2Server, "api/grunnlag") { sakGrunnlagRoute(grunnlagService, behandlingKlient) }
 }

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/aldersovergang/AldersovergangTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/aldersovergang/AldersovergangTest.kt
@@ -14,6 +14,7 @@ import io.mockk.mockk
 import no.nav.etterlatte.grunnlag.GrunnlagDbExtension
 import no.nav.etterlatte.grunnlag.OpplysningDao
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.common.deserialize
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -40,16 +41,16 @@ import javax.sql.DataSource
 class AldersovergangTest(
     private val dataSource: DataSource,
 ) {
-    private val server = MockOAuth2Server()
+    private val mockOAuth2Server = MockOAuth2Server()
 
     @BeforeAll
     fun beforeAll() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterAll
     fun after() {
-        server.shutdown()
+        mockOAuth2Server.shutdown()
     }
 
     @Test
@@ -73,7 +74,7 @@ class AldersovergangTest(
                 createHttpClient(AldersovergangService(AldersovergangDao(dataSource))).get("api/grunnlag/aldersovergang/2020-01") {
                     headers {
                         append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                        append(HttpHeaders.Authorization, "Bearer ${server.issueSaksbehandlerToken()}")
+                        append(HttpHeaders.Authorization, "Bearer ${mockOAuth2Server.issueSaksbehandlerToken()}")
                     }
                 }
 
@@ -121,7 +122,7 @@ class AldersovergangTest(
         this.get(url) {
             headers {
                 append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                append(HttpHeaders.Authorization, "Bearer ${server.issueSaksbehandlerToken()}")
+                append(HttpHeaders.Authorization, "Bearer ${mockOAuth2Server.issueSaksbehandlerToken()}")
             }
         }
 
@@ -144,7 +145,7 @@ class AldersovergangTest(
     )
 
     private fun ApplicationTestBuilder.createHttpClient(service: AldersovergangService): HttpClient =
-        runServer(server, "api/grunnlag") {
+        runServer(mockOAuth2Server, "api/grunnlag") {
             aldersovergangRoutes(service)
         }
 }

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonRouteTest.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/person/PersonRouteTest.kt
@@ -13,6 +13,7 @@ import io.mockk.confirmVerified
 import io.mockk.mockk
 import no.nav.etterlatte.TRIVIELL_MIDTPUNKT
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.person.HentGeografiskTilknytningRequest
@@ -35,17 +36,17 @@ import org.junit.jupiter.api.TestInstance
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PersonRouteTest {
-    private val server = MockOAuth2Server()
+    private val mockOAuth2Server = MockOAuth2Server()
     private val personService: PersonService = mockk()
 
     @BeforeAll
     fun before() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterAll
     fun after() {
-        server.shutdown()
+        mockOAuth2Server.shutdown()
     }
 
     @Test
@@ -60,7 +61,7 @@ class PersonRouteTest {
         coEvery { personService.hentPerson(hentPersonRequest) } returns GrunnlagTestData().soeker
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 personRoute(personService)
             }
 
@@ -89,7 +90,7 @@ class PersonRouteTest {
         coEvery { personService.hentOpplysningsperson(hentPersonRequest) } returns mockPerson()
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 personRoute(personService)
             }
 
@@ -117,7 +118,7 @@ class PersonRouteTest {
             )
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 personRoute(personService)
             }
 
@@ -147,7 +148,7 @@ class PersonRouteTest {
         } returns mockGeografiskTilknytning()
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 personRoute(personService)
             }
 
@@ -178,7 +179,7 @@ class PersonRouteTest {
         } throws PdlForesporselFeilet("Noe feilet")
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 personRoute(personService)
             }
 
@@ -207,7 +208,7 @@ class PersonRouteTest {
             )
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 personRoute(personService)
             }
 
@@ -224,7 +225,7 @@ class PersonRouteTest {
         }
     }
 
-    private val token: String by lazy { server.issueSaksbehandlerToken() }
+    private val token: String by lazy { mockOAuth2Server.issueSaksbehandlerToken() }
 
     private companion object {
         const val PERSON_ENDEPUNKT = "/person"

--- a/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/sak/BehandlingSakRoutesTest.kt
+++ b/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/sak/BehandlingSakRoutesTest.kt
@@ -45,7 +45,7 @@ class BehandlingSakRoutesTest {
 
     @BeforeAll
     fun before() {
-        mockOAuth2Server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterAll

--- a/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/sak/BehandlingSakRoutesTest.kt
+++ b/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/sak/BehandlingSakRoutesTest.kt
@@ -21,6 +21,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.mockk
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.CLIENT_ID
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.common.objectMapper

--- a/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRouteTest.kt
+++ b/apps/etterlatte-samordning-vedtak/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRouteTest.kt
@@ -17,6 +17,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.mockk
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.ktor.restModule
 import no.nav.etterlatte.libs.ktor.route.routeLogger
@@ -37,21 +38,21 @@ import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SamordningVedtakRouteTest {
-    private val server = MockOAuth2Server()
+    private val mockOAuth2Server = MockOAuth2Server()
     private val samordningVedtakService = mockk<SamordningVedtakService>()
     private lateinit var config: Config
     private lateinit var applicationConfig: HoconApplicationConfig
 
     @BeforeAll
     fun before() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @Nested
     inner class MaskinportenApi {
         @BeforeEach
         fun before() {
-            config = config(server.config.httpServer.port(), Issuer.MASKINPORTEN.issuerName)
+            config = config(mockOAuth2Server.config.httpServer.port(), Issuer.MASKINPORTEN.issuerName)
             applicationConfig = HoconApplicationConfig(config)
         }
 
@@ -186,7 +187,7 @@ class SamordningVedtakRouteTest {
             claims["consumer"] = mapOf("ID" to "0192:0123456789")
             maskinportenScope?.let { claims["scope"] = it }
 
-            return server
+            return mockOAuth2Server
                 .issueToken(
                     issuerId = Issuer.MASKINPORTEN.issuerName,
                     claims = claims,
@@ -201,7 +202,7 @@ class SamordningVedtakRouteTest {
 
         @BeforeEach
         fun before() {
-            config = config(server.config.httpServer.port(), Issuer.AZURE.issuerName)
+            config = config(mockOAuth2Server.config.httpServer.port(), Issuer.AZURE.issuerName)
             applicationConfig = HoconApplicationConfig(config)
         }
 
@@ -284,7 +285,7 @@ class SamordningVedtakRouteTest {
                     ),
                 )
 
-            return server
+            return mockOAuth2Server
                 .issueToken(
                     issuerId = Issuer.AZURE.issuerName,
                     claims = claimSet.allClaims,
@@ -309,7 +310,7 @@ class SamordningVedtakRouteTest {
 
     @AfterAll
     fun after() {
-        server.shutdown()
+        mockOAuth2Server.shutdown()
     }
 }
 

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/TilbakekrevingRoutesTest.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/TilbakekrevingRoutesTest.kt
@@ -16,6 +16,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSystembrukerToken
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.security.mock.oauth2.MockOAuth2Server
@@ -26,17 +27,17 @@ import org.junit.jupiter.api.TestInstance
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class TilbakekrevingRoutesTest {
-    private val server = MockOAuth2Server()
+    private val mockOAuth2Server = MockOAuth2Server()
     private val service = mockk<TilbakekrevingService>()
 
     @BeforeAll
     fun beforeAll() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterAll
     fun afterAll() {
-        server.shutdown()
+        mockOAuth2Server.shutdown()
         confirmVerified(service)
     }
 
@@ -128,12 +129,12 @@ internal class TilbakekrevingRoutesTest {
 
     private fun testApplication(block: suspend ApplicationTestBuilder.() -> Unit) {
         io.ktor.server.testing.testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 tilbakekrevingRoutes(service)
             }
             block(this)
         }
     }
 
-    private val token: String by lazy { server.issueSystembrukerToken() }
+    private val token: String by lazy { mockOAuth2Server.issueSystembrukerToken() }
 }

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidRoutesTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidRoutesTest.kt
@@ -13,6 +13,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.trygdetid.StatusOppdatertDto
@@ -26,19 +27,19 @@ import java.util.UUID.randomUUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class TrygdetidRoutesTest {
-    private val server = MockOAuth2Server()
+    private val mockOAuth2Server = MockOAuth2Server()
     private val behandlingKlient = mockk<BehandlingKlient>()
     private val trygdetidService = mockk<TrygdetidService>()
 
     @BeforeAll
     fun beforeAll() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
         coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
     }
 
     @AfterAll
     fun afterAll() {
-        server.shutdown()
+        mockOAuth2Server.shutdown()
     }
 
     @Test
@@ -86,12 +87,12 @@ internal class TrygdetidRoutesTest {
 
     private fun testApplication(block: suspend ApplicationTestBuilder.() -> Unit) {
         io.ktor.server.testing.testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 trygdetid(trygdetidService, behandlingKlient)
             }
             block(this)
         }
     }
 
-    private val token: String by lazy { server.issueSaksbehandlerToken() }
+    private val token: String by lazy { mockOAuth2Server.issueSaksbehandlerToken() }
 }

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/avtale/AvtaleRoutesTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/avtale/AvtaleRoutesTest.kt
@@ -20,6 +20,7 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.common.trygdetid.avtale.Trygdeavtale
 import no.nav.etterlatte.libs.common.trygdetid.avtale.TrygdetidAvtale
@@ -44,16 +45,16 @@ internal class AvtaleRoutesTest {
 
     private val service = AvtaleService(repository)
 
-    private val server = MockOAuth2Server()
+    private val mockOAuth2Server = MockOAuth2Server()
 
     @BeforeAll
     fun beforeAll() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterAll
     fun afterAll() {
-        server.shutdown()
+        mockOAuth2Server.shutdown()
     }
 
     @BeforeEach
@@ -234,7 +235,7 @@ internal class AvtaleRoutesTest {
     private fun testApplication(block: suspend (client: HttpClient) -> Unit) {
         io.ktor.server.testing.testApplication {
             val client =
-                runServer(server) {
+                runServer(mockOAuth2Server) {
                     avtale(service, behandlingKlient)
                 }
 
@@ -242,5 +243,5 @@ internal class AvtaleRoutesTest {
         }
     }
 
-    private val token: String by lazy { server.issueSaksbehandlerToken() }
+    private val token: String by lazy { mockOAuth2Server.issueSaksbehandlerToken() }
 }

--- a/apps/etterlatte-utbetaling/src/test/kotlin/no/nav/etterlatte/utbetaling/simulering/SimuleringOsRouteTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/no/nav/etterlatte/utbetaling/simulering/SimuleringOsRouteTest.kt
@@ -13,6 +13,7 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.slot
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.toUUID30
@@ -45,7 +46,7 @@ import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SimuleringOsRouteTest {
-    private val server = MockOAuth2Server()
+    private val mockOAuth2Server = MockOAuth2Server()
     private val utbetalingDao: UtbetalingDao = mockk()
     private val vedtaksvurderingKlient: VedtaksvurderingKlient = mockk()
     private val simuleringDao: SimuleringDao = mockk()
@@ -61,7 +62,7 @@ class SimuleringOsRouteTest {
 
     @BeforeAll
     fun before() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterEach
@@ -71,7 +72,7 @@ class SimuleringOsRouteTest {
 
     @AfterAll
     fun after() {
-        server.shutdown()
+        mockOAuth2Server.shutdown()
     }
 
     @Test
@@ -123,7 +124,7 @@ class SimuleringOsRouteTest {
             }
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 utbetalingRoutes(simuleringOsService, behandlingKlient)
             }
 
@@ -176,5 +177,5 @@ class SimuleringOsRouteTest {
         }
     }
 
-    private val token: String by lazy { server.issueSaksbehandlerToken(navIdent = "Z991122") }
+    private val token: String by lazy { mockOAuth2Server.issueSaksbehandlerToken(navIdent = "Z991122") }
 }

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/SamordningsvedtakRouteTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/SamordningsvedtakRouteTest.kt
@@ -12,6 +12,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSystembrukerToken
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -36,12 +37,12 @@ import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SamordningsvedtakRouteTest {
-    private val server = MockOAuth2Server()
+    private val mockOAuth2Server = MockOAuth2Server()
     private val vedtakSamordningService: VedtakSamordningService = mockk()
 
     @BeforeAll
     fun before() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterEach
@@ -51,7 +52,7 @@ class SamordningsvedtakRouteTest {
 
     @AfterAll
     fun after() {
-        server.shutdown()
+        mockOAuth2Server.shutdown()
     }
 
     @Test
@@ -60,7 +61,7 @@ class SamordningsvedtakRouteTest {
             samordningVedtak()
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 samordningSystembrukerVedtakRoute(vedtakSamordningService)
             }
 
@@ -75,7 +76,7 @@ class SamordningsvedtakRouteTest {
         }
     }
 
-    private fun token(roles: List<String>): String = server.issueSystembrukerToken(mittsystem = "pensjon-pen", roles = roles)
+    private fun token(roles: List<String>): String = mockOAuth2Server.issueSystembrukerToken(mittsystem = "pensjon-pen", roles = roles)
 }
 
 private fun samordningVedtak() =

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRouteTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRouteTest.kt
@@ -23,6 +23,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.common.behandling.Klage
 import no.nav.etterlatte.libs.common.behandling.KlageStatus
@@ -59,7 +60,7 @@ import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class VedtaksvurderingRouteTest {
-    private val server = MockOAuth2Server()
+    private val mockOAuth2Server = MockOAuth2Server()
     private val behandlingKlient = mockk<BehandlingKlient>()
     private val vedtaksvurderingService: VedtaksvurderingService = mockk()
     private val vedtakBehandlingService: VedtakBehandlingService = mockk()
@@ -68,7 +69,7 @@ internal class VedtaksvurderingRouteTest {
 
     @BeforeAll
     fun before() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterEach
@@ -85,13 +86,13 @@ internal class VedtaksvurderingRouteTest {
 
     @AfterAll
     fun after() {
-        server.shutdown()
+        mockOAuth2Server.shutdown()
     }
 
     @Test
     fun `skal returnere 401 naar token mangler`() {
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 vedtaksvurderingRoute(
                     vedtaksvurderingService,
                     vedtakBehandlingService,
@@ -114,7 +115,7 @@ internal class VedtaksvurderingRouteTest {
         every { vedtaksvurderingService.hentVedtakMedBehandlingId(any<UUID>()) } throws Exception("ukjent feil")
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 vedtaksvurderingRoute(
                     vedtaksvurderingService,
                     vedtakBehandlingService,
@@ -143,7 +144,7 @@ internal class VedtaksvurderingRouteTest {
         every { vedtaksvurderingService.hentVedtakMedBehandlingId(any<UUID>()) } returns null
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 vedtaksvurderingRoute(
                     vedtaksvurderingService,
                     vedtakBehandlingService,
@@ -173,7 +174,7 @@ internal class VedtaksvurderingRouteTest {
         every { vedtaksvurderingService.hentVedtakMedBehandlingId(any<UUID>()) } returns opprettetVedtak
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 vedtaksvurderingRoute(
                     vedtaksvurderingService,
                     vedtakBehandlingService,
@@ -228,7 +229,7 @@ internal class VedtaksvurderingRouteTest {
         every { vedtaksvurderingService.hentVedtakMedBehandlingId(any<UUID>()) } returns opprettetVedtak
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 vedtaksvurderingRoute(
                     vedtaksvurderingService,
                     vedtakBehandlingService,
@@ -283,7 +284,7 @@ internal class VedtaksvurderingRouteTest {
         every { vedtaksvurderingService.hentVedtakMedBehandlingId(any<UUID>()) } returns opprettetVedtak
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 vedtaksvurderingRoute(
                     vedtaksvurderingService,
                     vedtakBehandlingService,
@@ -332,7 +333,7 @@ internal class VedtaksvurderingRouteTest {
         every { vedtaksvurderingService.hentVedtakMedBehandlingId(any<UUID>()) } returns attestertVedtak
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 vedtaksvurderingRoute(
                     vedtaksvurderingService,
                     vedtakBehandlingService,
@@ -380,7 +381,7 @@ internal class VedtaksvurderingRouteTest {
         coEvery { behandlingKlient.harTilgangTilSak(any(), any(), any()) } returns true
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 vedtaksvurderingRoute(
                     vedtaksvurderingService,
                     vedtakBehandlingService,
@@ -415,7 +416,7 @@ internal class VedtaksvurderingRouteTest {
         coEvery { vedtakBehandlingService.opprettEllerOppdaterVedtak(any(), any()) } returns opprettetVedtak
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 vedtaksvurderingRoute(
                     vedtaksvurderingService,
                     vedtakBehandlingService,
@@ -479,7 +480,7 @@ internal class VedtaksvurderingRouteTest {
         coEvery { rapidService.sendToRapid(any()) } just runs
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 vedtaksvurderingRoute(
                     vedtaksvurderingService,
                     vedtakBehandlingService,
@@ -546,7 +547,7 @@ internal class VedtaksvurderingRouteTest {
         coEvery { rapidService.sendToRapid(any()) } just runs
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 vedtaksvurderingRoute(
                     vedtaksvurderingService,
                     vedtakBehandlingService,
@@ -614,7 +615,7 @@ internal class VedtaksvurderingRouteTest {
         coEvery { rapidService.sendToRapid(any()) } just runs
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 vedtaksvurderingRoute(
                     vedtaksvurderingService,
                     vedtakBehandlingService,
@@ -678,7 +679,7 @@ internal class VedtaksvurderingRouteTest {
         coEvery { vedtakBehandlingService.tilbakestillIkkeIverksatteVedtak(any()) } returns tilbakestiltVedtak
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 vedtaksvurderingRoute(
                     vedtaksvurderingService,
                     vedtakBehandlingService,
@@ -710,7 +711,7 @@ internal class VedtaksvurderingRouteTest {
         every { vedtaksvurderingService.hentVedtakMedBehandlingId(any<UUID>()) } returns vedtakKlage
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 vedtaksvurderingRoute(
                     vedtaksvurderingService,
                     vedtakBehandlingService,
@@ -743,7 +744,7 @@ internal class VedtaksvurderingRouteTest {
         }
     }
 
-    private val token: String by lazy { server.issueSaksbehandlerToken(navIdent = SAKSBEHANDLER_1) }
+    private val token: String by lazy { mockOAuth2Server.issueSaksbehandlerToken(navIdent = SAKSBEHANDLER_1) }
 
     private fun klage(): Klage =
         Klage(

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/migrering/AutomatiskBehandlingRoutesKtTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/migrering/AutomatiskBehandlingRoutesKtTest.kt
@@ -18,6 +18,7 @@ import io.mockk.mockk
 import io.mockk.runs
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.deserialize
@@ -52,7 +53,7 @@ import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class AutomatiskBehandlingRoutesKtTest {
-    private val server = MockOAuth2Server()
+    private val mockOAuth2Server = MockOAuth2Server()
     private val behandlingKlient = mockk<BehandlingKlient>()
     private val vedtakService: VedtakBehandlingService = mockk()
     private val rapidService: VedtaksvurderingRapidService = mockk()
@@ -60,7 +61,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
 
     @BeforeAll
     fun before() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterEach
@@ -76,7 +77,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
 
     @AfterAll
     fun after() {
-        server.shutdown()
+        mockOAuth2Server.shutdown()
     }
 
     @Test
@@ -118,7 +119,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
                 )
             coEvery { rapidService.sendToRapid(any()) } just runs
 
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 automatiskBehandlingRoutes(
                     automatiskBehandlingService,
                     behandlingKlient,
@@ -195,7 +196,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
 
                 coEvery { rapidService.sendToRapid(any()) } just runs
 
-                runServer(server) {
+                runServer(mockOAuth2Server) {
                     automatiskBehandlingRoutes(
                         automatiskBehandlingService,
                         behandlingKlient,
@@ -251,7 +252,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
                     listOf(lagOppgave(behandlingId, Status.ATTESTERING))
                 coEvery { runBlocking { behandlingKlient.tildelSaksbehandler(any(), any()) } } returns true
 
-                runServer(server) {
+                runServer(mockOAuth2Server) {
                     automatiskBehandlingRoutes(
                         automatiskBehandlingService,
                         behandlingKlient,
@@ -308,7 +309,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
                         ),
                     )
 
-                runServer(server) {
+                runServer(mockOAuth2Server) {
                     automatiskBehandlingRoutes(
                         automatiskBehandlingService,
                         behandlingKlient,
@@ -338,7 +339,7 @@ internal class AutomatiskBehandlingRoutesKtTest {
         }
     }
 
-    private val token: String by lazy { server.issueSaksbehandlerToken(navIdent = SAKSBEHANDLER_1) }
+    private val token: String by lazy { mockOAuth2Server.issueSaksbehandlerToken(navIdent = SAKSBEHANDLER_1) }
 
     private fun lagOppgave(
         referanse: UUID,

--- a/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangRoutesTest.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/AldersovergangRoutesTest.kt
@@ -13,6 +13,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSystembrukerToken
 import no.nav.etterlatte.vilkaarsvurdering.klienter.BehandlingKlient
 import no.nav.security.mock.oauth2.MockOAuth2Server
@@ -24,7 +25,7 @@ import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class AldersovergangRoutesTest {
-    private val server = MockOAuth2Server()
+    private val mockOAuth2Server = MockOAuth2Server()
     private val behandlingKlient = mockk<BehandlingKlient>()
     private val aldersovergangService = mockk<AldersovergangService>()
 
@@ -33,20 +34,20 @@ internal class AldersovergangRoutesTest {
 
     @BeforeAll
     fun before() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterAll
     fun after() {
-        server.shutdown()
+        mockOAuth2Server.shutdown()
     }
 
-    private val token: String by lazy { server.issueSystembrukerToken() }
+    private val token: String by lazy { mockOAuth2Server.issueSystembrukerToken() }
 
     @Test
     fun `skal delegere til aldersovergangservice`() {
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 aldersovergang(behandlingKlient, aldersovergangService)
             }
 

--- a/libs/etterlatte-ktor/src/test/kotlin/RestModuleTest.kt
+++ b/libs/etterlatte-ktor/src/test/kotlin/RestModuleTest.kt
@@ -24,6 +24,7 @@ import io.ktor.server.testing.testApplication
 import io.mockk.coEvery
 import io.mockk.mockk
 import no.nav.etterlatte.ktor.runServer
+import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.common.feilhaandtering.ExceptionResponse
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
@@ -55,23 +56,23 @@ class RestModuleTest {
     private val sakTilgangsSjekkMock = mockk<SakTilgangsSjekk>()
     private val personTilgangsSjekkMock = mockk<PersonTilgangsSjekk>()
 
-    private val server = MockOAuth2Server()
-    private val token: String by lazy { server.issueSaksbehandlerToken() }
+    private val mockOAuth2Server = MockOAuth2Server()
+    private val token: String by lazy { mockOAuth2Server.issueSaksbehandlerToken() }
 
     @BeforeAll
     fun beforeAll() {
-        server.start()
+        mockOAuth2Server.startRandomPort()
     }
 
     @AfterAll
     fun afterAll() {
-        server.shutdown()
+        mockOAuth2Server.shutdown()
     }
 
     @Test
     fun `skal sette opp to endepunkter med autentisering`() {
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 route1()
                 route2()
             }
@@ -98,7 +99,7 @@ class RestModuleTest {
         coEvery { personTilgangsSjekkMock.harTilgangTilPerson(any(), any(), any()) } returns true
 
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 tilgangTestRoute()
             }.also { setReady() }
 
@@ -141,7 +142,7 @@ class RestModuleTest {
     @Test
     fun `skal kunne lese og skrive json payload`() {
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 route1()
             }
 
@@ -164,7 +165,7 @@ class RestModuleTest {
     @Test
     fun `skal returnere internal server error og logge dersom noe feiler`() {
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 route1()
             }
 
@@ -180,7 +181,7 @@ class RestModuleTest {
     @Test
     fun `skal svare paa helsesjekk uten autentisering`() {
         testApplication {
-            runServer(server) {
+            runServer(mockOAuth2Server) {
                 route1()
             }.also { setReady() }
 
@@ -221,7 +222,7 @@ class RestModuleTest {
     @Test
     fun `metrics test`() {
         testApplication {
-            runServer(server, withMetrics = true) {
+            runServer(mockOAuth2Server, withMetrics = true) {
                 route1()
             }
 
@@ -238,7 +239,7 @@ class RestModuleTest {
     fun `statuspages håndterer kjente og ukjente exceptions`() {
         testApplication {
             val client =
-                runServer(server) {
+                runServer(mockOAuth2Server) {
                     routesMedForskjelligeFeil()
                 }
 

--- a/libs/etterlatte-ktor/src/testFixtures/kotlin/no/nav/etterlatte/ktor/KtorEnvironmentTestConfigOauth.kt
+++ b/libs/etterlatte-ktor/src/testFixtures/kotlin/no/nav/etterlatte/ktor/KtorEnvironmentTestConfigOauth.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.ktor
 import com.typesafe.config.ConfigFactory
 import io.ktor.server.config.HoconApplicationConfig
 import no.nav.etterlatte.ktor.token.CLIENT_ID
+import no.nav.security.mock.oauth2.MockOAuth2Server
 
 internal fun buildTestApplicationConfigurationForOauth(
     port: Int,
@@ -22,3 +23,5 @@ internal fun buildTestApplicationConfigurationForOauth(
             ),
         ),
     )
+
+fun MockOAuth2Server.startRandomPort() = this.start()


### PR DESCRIPTION
Hindrer feil i testkjøringer / delays ved bruk av samme port. Vi hadde flere som kjørte på port 1234
bedre å bruke start() som gir random port, gjør det tydeligere med extension function og renamer mockAuthServer var lik overalt.