### PR TITLE
EY-4317 Vise brukers valg i KRR til saksbehandler

### DIFF
--- a/apps/etterlatte-behandling/.run/etterlatte-behandling.dev-gcp.run.xml
+++ b/apps/etterlatte-behandling/.run/etterlatte-behandling.dev-gcp.run.xml
@@ -48,7 +48,7 @@
       <env name="ETTERLATTE_VILKAARSVURDERING_URL" value="https://etterlatte-vilkaarsvurdering.intern.dev.nav.no" />
       <env name="PEN_CLIENT_ID" value="ddd52335-cfe8-4ee9-9e68-416a5ab26efa" />
       <env name="PEN_URL" value="https://pensjon-pen-q2.dev-fss-pub.nais.io/pen/springapi" />
-      <env name="KRR_ENDPOINT_URL" value="http://digdir-krr-proxy.team-rocket" />
+      <env name="KRR_ENDPOINT_URL" value="https://digdir-krr-proxy.intern.dev.nav.no" />
       <env name="KRR_SCOPE" value="api://dev-gcp.team-rocket.digdir-krr-proxy/.default" />
       <env name="AXSYS_URL" value="https://axsys.dev-fss-pub.nais.io" />
       <env name="AXSYS_SCOPE" value="api://dev-fss.org.axsys/.default" />

--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -36,6 +36,7 @@ import no.nav.etterlatte.grunnlagsendring.grunnlagsendringshendelseRoute
 import no.nav.etterlatte.institusjonsopphold.InstitusjonsoppholdService
 import no.nav.etterlatte.institusjonsopphold.institusjonsoppholdRoute
 import no.nav.etterlatte.kodeverk.kodeverk
+import no.nav.etterlatte.krr.krrRoute
 import no.nav.etterlatte.libs.common.TimerJob
 import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
@@ -214,6 +215,7 @@ private fun Route.settOppRoutes(applicationContext: ApplicationContext) {
 
     tilgangRoutes(applicationContext.tilgangService)
     kodeverk(applicationContext.kodeverkService)
+    krrRoute(applicationContext.tilgangService, applicationContext.krrKlient)
 }
 
 private fun Route.settOppTilganger(

--- a/apps/etterlatte-behandling/src/main/kotlin/krr/KrrResponse.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/krr/KrrResponse.kt
@@ -4,7 +4,7 @@ data class DigitalKontaktinformasjon(
     val personident: String,
     val aktiv: Boolean,
     val kanVarsles: Boolean?,
-    val reservert: Boolean?,
+    val reservert: Boolean?, // Om man er reservert mot kommunikasjon på nett
     val spraak: String?,
     val epostadresse: String?,
     val mobiltelefonnummer: String?,

--- a/apps/etterlatte-behandling/src/main/kotlin/krr/KrrRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/krr/KrrRoute.kt
@@ -1,0 +1,31 @@
+package no.nav.etterlatte.krr
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import no.nav.etterlatte.person.krr.KrrKlient
+import no.nav.etterlatte.sak.TilgangService
+import no.nav.etterlatte.tilgangsstyring.withFoedselsnummerInternal
+
+/**
+ * Endepunkter for KRR (Kontakt- og Reservasjonsregisteret)
+ * Brukes av frontend for å vise sb hvilke preferanser brukeren har, slik at de kan få en indikasjon på hvordan
+ * vi kommuniserer med brukeren
+ **/
+fun Route.krrRoute(
+    tilgangService: TilgangService,
+    klient: KrrKlient,
+) {
+    route("/api/krr") {
+        post {
+            withFoedselsnummerInternal(tilgangService) { fnr ->
+                val response = klient.hentDigitalKontaktinformasjon(fnr.value)
+
+                call.respond(response ?: HttpStatusCode.NoContent)
+            }
+        }
+    }
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottaker.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottaker.tsx
@@ -59,7 +59,7 @@ export function BrevMottaker({ brev, kanRedigeres }: { brev: IBrev; kanRedigeres
           ),
       })}
 
-      <HStack gap="4" justify="space-between">
+      <HStack gap="2" justify="space-between">
         <Heading spacing level="2" size="medium">
           Mottaker{' '}
           {mottaker.adresse.adresseType === AdresseType.UTENLANDSKPOSTADRESSE && (
@@ -71,7 +71,7 @@ export function BrevMottaker({ brev, kanRedigeres }: { brev: IBrev; kanRedigeres
         <div>{kanRedigeres && <BrevMottakerModal brev={brevState} setBrev={setBrevState} />}</div>
       </HStack>
 
-      <VStack gap="4">
+      <VStack gap="2">
         <Info
           wide
           label="Navn"
@@ -155,10 +155,10 @@ export function BrevMottaker({ brev, kanRedigeres }: { brev: IBrev; kanRedigeres
             </Heading>
 
             {res ? (
-              <>
+              <VStack gap="2">
                 <Info label="Kan varsles" tekst={res.kanVarsles ? 'Ja' : 'Nei'} />
                 <Info label="Reservert mot digital kommunikasjon" tekst={res.reservert ? 'Ja' : 'Nei'} />
-              </>
+              </VStack>
             ) : (
               'Ikke registrert i KRR'
             )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/krr.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/krr.ts
@@ -1,0 +1,21 @@
+import { apiClient, ApiResponse } from '~shared/api/apiClient'
+
+export interface DigitalKontaktinformasjon {
+  personident: string
+  aktiv: boolean
+  kanVarsles?: boolean
+  reservert?: boolean
+  spraak?: string
+  epostadresse?: string
+  mobiltelefonnummer?: string
+  sikkerDigitalPostkasse?: SikkerDigitalPostkasse
+}
+
+interface SikkerDigitalPostkasse {
+  adresse: string
+  leverandoerAdresse: string
+  leverandoerSertifikat: string
+}
+
+export const hentKontaktinformasjonKRR = async (fnr: string): Promise<ApiResponse<DigitalKontaktinformasjon>> =>
+  apiClient.post(`/krr`, { foedselsnummer: fnr })

--- a/apps/etterlatte-saksbehandling-ui/server/src/index.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/index.ts
@@ -84,6 +84,7 @@ app.use(
     '/api/sjekkliste',
     '/api/bosattutland',
     '/api/kodeverk',
+    '/api/krr',
   ],
   tokenMiddleware(ApiConfig.behandling.scope),
   proxy(ApiConfig.behandling.url)


### PR DESCRIPTION
Viser nå brukers valg i KRR i mottakerpanelet på brevsiden. Dette gjør det enklere for saksbehandler å vite om brevet sendes digitalt eller ei, og om de er nødt til å tvinge sentral print…

![Screenshot 2024-08-22 at 10 40 03](https://github.com/user-attachments/assets/4f6cae71-0c42-4722-9387-2b282d70e4e7)
