### PR TITLE
La saksbehandler legge til, endre og slette aktivitet fra sak

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktRoute.kt
@@ -87,7 +87,7 @@ internal fun Route.aktivitetspliktRoutes(
 
                     val aktiviteter =
                         inTransaction {
-                            aktivitetspliktService.upsertAktivitet(behandlingId, aktivitet, brukerTokenInfo)
+                            aktivitetspliktService.upsertAktivitet(aktivitet, brukerTokenInfo, behandlingId)
                             aktivitetspliktService.hentAktiviteter(behandlingId)
                         }
                     call.respond(aktiviteter)
@@ -101,7 +101,7 @@ internal fun Route.aktivitetspliktRoutes(
 
                         val aktiviteter =
                             inTransaction {
-                                aktivitetspliktService.slettAktivitet(behandlingId, aktivitetId, brukerTokenInfo)
+                                aktivitetspliktService.slettAktivitet(aktivitetId, brukerTokenInfo, behandlingId)
                                 aktivitetspliktService.hentAktiviteter(behandlingId)
                             }
 
@@ -126,6 +126,35 @@ internal fun Route.aktivitetspliktRoutes(
                             }
                         }
                     call.respond(dto)
+                }
+            }
+            post {
+                kunSkrivetilgang {
+                    logger.info("Oppretter eller oppdaterer aktivitet for sakId=$sakId")
+                    val aktivitet = call.receive<LagreAktivitetspliktAktivitet>()
+
+                    val aktiviteter =
+                        inTransaction {
+                            aktivitetspliktService.upsertAktivitet(aktivitet, brukerTokenInfo, sakId = sakId)
+                            aktivitetspliktService.hentAktiviteter(sakId = sakId)
+                        }
+                    call.respond(aktiviteter)
+                }
+            }
+
+            route("/{$AKTIVITET_ID_CALL_PARAMETER}") {
+                delete {
+                    kunSkrivetilgang {
+                        logger.info("Sletter aktivitet $aktivitetId for sakId $sakId")
+
+                        val aktiviteter =
+                            inTransaction {
+                                aktivitetspliktService.slettAktivitet(aktivitetId, brukerTokenInfo, sakId = sakId)
+                                aktivitetspliktService.hentAktiviteter(sakId = sakId)
+                            }
+
+                        call.respond(aktiviteter)
+                    }
                 }
             }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktService.kt
@@ -170,47 +170,65 @@ class AktivitetspliktService(
         )
 
     fun upsertAktivitet(
-        behandlingId: UUID,
         aktivitet: LagreAktivitetspliktAktivitet,
         brukerTokenInfo: BrukerTokenInfo,
+        behandlingId: UUID? = null,
+        sakId: Long? = null,
     ) {
-        val behandling =
-            requireNotNull(behandlingService.hentBehandling(behandlingId)) { "Fant ikke behandling $behandlingId" }
-
-        if (!behandling.status.kanEndres()) {
-            throw BehandlingKanIkkeEndres()
-        }
-
-        if (aktivitet.sakId != behandling.sak.id) {
-            throw SakidTilhoererIkkeBehandlingException()
-        }
-
         if (aktivitet.tom != null && aktivitet.tom < aktivitet.fom) {
             throw TomErFoerFomException()
         }
-
         val kilde = Grunnlagsopplysning.Saksbehandler.create(brukerTokenInfo.ident())
-        if (aktivitet.id != null) {
-            aktivitetspliktDao.oppdaterAktivitet(behandlingId, aktivitet, kilde)
+
+        if (behandlingId != null) {
+            val behandling =
+                requireNotNull(behandlingService.hentBehandling(behandlingId)) { "Fant ikke behandling $behandlingId" }
+            if (!behandling.status.kanEndres()) {
+                throw BehandlingKanIkkeEndres()
+            }
+            if (aktivitet.sakId != behandling.sak.id) {
+                throw SakidTilhoererIkkeBehandlingException()
+            }
+            if (aktivitet.id != null) {
+                aktivitetspliktDao.oppdaterAktivitet(behandlingId, aktivitet, kilde)
+            } else {
+                aktivitetspliktDao.opprettAktivitet(behandlingId, aktivitet, kilde)
+            }
+            runBlocking { sendDtoTilStatistikk(aktivitet.sakId, brukerTokenInfo, behandlingId) }
+        } else if (sakId != null) {
+            if (aktivitet.sakId != sakId) {
+                throw SakidTilhoererIkkeBehandlingException()
+            }
+
+            if (aktivitet.id != null) {
+                aktivitetspliktDao.oppdaterAktivitetForSak(sakId, aktivitet, kilde)
+            } else {
+                aktivitetspliktDao.opprettAktivitetForSak(sakId, aktivitet, kilde)
+            }
         } else {
-            aktivitetspliktDao.opprettAktivitet(behandlingId, aktivitet, kilde)
+            throw ManglerSakEllerBehandlingIdException()
         }
-        runBlocking { sendDtoTilStatistikk(aktivitet.sakId, brukerTokenInfo, behandlingId) }
     }
 
     fun slettAktivitet(
-        behandlingId: UUID,
         aktivitetId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
+        behandlingId: UUID? = null,
+        sakId: Long? = null,
     ) {
-        val behandling =
-            requireNotNull(behandlingService.hentBehandling(behandlingId)) { "Fant ikke behandling $behandlingId" }
-
-        if (!behandling.status.kanEndres()) {
-            throw BehandlingKanIkkeEndres()
+        if (behandlingId != null) {
+            val behandling =
+                requireNotNull(behandlingService.hentBehandling(behandlingId)) { "Fant ikke behandling $behandlingId" }
+            if (!behandling.status.kanEndres()) {
+                throw BehandlingKanIkkeEndres()
+            }
+            aktivitetspliktDao.slettAktivitet(aktivitetId, behandlingId)
+            runBlocking { sendDtoTilStatistikk(behandling.sak.id, brukerTokenInfo, behandlingId) }
+        } else if (sakId != null) {
+            aktivitetspliktDao.slettAktivitetForSak(aktivitetId, sakId)
+        } else {
+            throw ManglerSakEllerBehandlingIdException()
         }
-        aktivitetspliktDao.slettAktivitet(aktivitetId, behandlingId)
-        runBlocking { sendDtoTilStatistikk(behandling.sak.id, brukerTokenInfo, behandlingId) }
     }
 
     fun opprettAktivitetsgradForOppgave(

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/aktivitetsplikt/AktivitetspliktDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/aktivitetsplikt/AktivitetspliktDaoTest.kt
@@ -47,7 +47,6 @@ class AktivitetspliktDaoTest(
         val hentAktiviteter = dao.hentAktiviteterForBehandling(behandlingId)
         hentAktiviteter.first().asClue { aktivitet ->
             aktivitet.sakId shouldBe nyAktivitet.sakId
-            aktivitet.behandlingId shouldBe behandlingId
             aktivitet.type shouldBe nyAktivitet.type
             aktivitet.fom shouldBe nyAktivitet.fom
             aktivitet.tom shouldBe nyAktivitet.tom
@@ -84,7 +83,6 @@ class AktivitetspliktDaoTest(
             aktiviteter.first().asClue { oppdatertAktivitet ->
                 oppdatertAktivitet.id shouldBe gammelAktivitet.id
                 oppdatertAktivitet.sakId shouldBe gammelAktivitet.sakId
-                oppdatertAktivitet.behandlingId shouldBe gammelAktivitet.behandlingId
                 oppdatertAktivitet.type shouldBe oppdaterAktivitet.type
                 oppdatertAktivitet.fom shouldBe oppdaterAktivitet.fom
                 oppdatertAktivitet.tom shouldBe oppdaterAktivitet.tom
@@ -162,7 +160,6 @@ class AktivitetspliktDaoTest(
                 it shouldHaveSize 3
                 it.forEach { aktivitet ->
                     aktivitet.sakId shouldBe nyAktivitet.sakId
-                    aktivitet.behandlingId shouldBe nyBehandling
                     aktivitet.type shouldBe nyAktivitet.type
                     aktivitet.fom shouldBe nyAktivitet.fom
                     aktivitet.tom shouldBe nyAktivitet.tom

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/aktivitetsplikt/AktivitetspliktServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/aktivitetsplikt/AktivitetspliktServiceTest.kt
@@ -109,7 +109,7 @@ class AktivitetspliktServiceTest {
         fun `Skal opprette en aktivitet`() {
             every { aktivitetspliktDao.opprettAktivitet(behandling.id, aktivitet, any()) } returns 1
 
-            service.upsertAktivitet(behandling.id, aktivitet, brukerTokenInfo)
+            service.upsertAktivitet(aktivitet, brukerTokenInfo, behandling.id)
 
             coVerify { aktivitetspliktDao.opprettAktivitet(behandling.id, aktivitet, any()) }
             coVerify(exactly = 0) { aktivitetspliktDao.oppdaterAktivitet(any(), any(), any()) }
@@ -120,7 +120,7 @@ class AktivitetspliktServiceTest {
             val aktivitet = aktivitet.copy(id = UUID.randomUUID())
             every { aktivitetspliktDao.oppdaterAktivitet(behandling.id, aktivitet, any()) } returns 1
 
-            service.upsertAktivitet(behandling.id, aktivitet, brukerTokenInfo)
+            service.upsertAktivitet(aktivitet, brukerTokenInfo, behandling.id)
 
             coVerify { aktivitetspliktDao.oppdaterAktivitet(behandling.id, aktivitet, any()) }
             coVerify(exactly = 0) { aktivitetspliktDao.opprettAktivitet(any(), any(), any()) }
@@ -131,7 +131,7 @@ class AktivitetspliktServiceTest {
             val aktivitet = aktivitet.copy(sakId = 2)
 
             assertThrows<SakidTilhoererIkkeBehandlingException> {
-                service.upsertAktivitet(behandling.id, aktivitet, brukerTokenInfo)
+                service.upsertAktivitet(aktivitet, brukerTokenInfo, behandling.id)
             }
         }
 
@@ -140,7 +140,7 @@ class AktivitetspliktServiceTest {
             val aktivitet = aktivitet.copy(tom = LocalDate.now().minusYears(1))
 
             assertThrows<TomErFoerFomException> {
-                service.upsertAktivitet(behandling.id, aktivitet, brukerTokenInfo)
+                service.upsertAktivitet(aktivitet, brukerTokenInfo, behandling.id)
             }
         }
 
@@ -153,7 +153,7 @@ class AktivitetspliktServiceTest {
             every { behandlingService.hentBehandling(behandling.id) } returns behandling
 
             assertThrows<BehandlingKanIkkeEndres> {
-                service.upsertAktivitet(behandling.id, aktivitet, brukerTokenInfo)
+                service.upsertAktivitet(aktivitet, brukerTokenInfo, behandling.id)
             }
         }
     }
@@ -170,7 +170,7 @@ class AktivitetspliktServiceTest {
                     every { status } returns BehandlingStatus.VILKAARSVURDERT
                 }
 
-            service.slettAktivitet(behandling.id, aktivitetId, brukerTokenInfo)
+            service.slettAktivitet(aktivitetId, brukerTokenInfo, behandling.id)
 
             coVerify { aktivitetspliktDao.slettAktivitet(aktivitetId, behandling.id) }
         }
@@ -183,7 +183,7 @@ class AktivitetspliktServiceTest {
                 }
 
             assertThrows<BehandlingKanIkkeEndres> {
-                service.slettAktivitet(behandling.id, aktivitetId, brukerTokenInfo)
+                service.slettAktivitet(aktivitetId, brukerTokenInfo, behandling.id)
             }
         }
     }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/AktivitetspliktTidslinje.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/AktivitetspliktTidslinje.tsx
@@ -1,6 +1,11 @@
 import { Buildings2Icon, HatSchoolIcon, PencilIcon, PersonIcon, RulerIcon } from '@navikt/aksel-icons'
 import { Alert, HStack, Timeline, ToggleGroup, VStack } from '@navikt/ds-react'
-import { hentAktiviteterForBehandling, hentAktiviteterForSak, slettAktivitet } from '~shared/api/aktivitetsplikt'
+import {
+  hentAktiviteterForBehandling,
+  hentAktiviteterForSak,
+  slettAktivitet,
+  slettAktivitetForSak,
+} from '~shared/api/aktivitetsplikt'
 import { formaterDato, formaterDatoMedTidspunkt } from '~utils/formatering/dato'
 import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 import { addMonths, addYears } from 'date-fns'
@@ -22,6 +27,7 @@ export const AktivitetspliktTidslinje = (props: {
   const [hentet, hent] = useApiCall(hentAktiviteterForBehandling)
   const [hentetForSak, hentForSak] = useApiCall(hentAktiviteterForSak)
   const [slettet, slett] = useApiCall(slettAktivitet)
+  const [slettetForSak, slettForSak] = useApiCall(slettAktivitetForSak)
   const seksMndEtterDoedsfall = addMonths(doedsdato, 6)
   const tolvMndEtterDoedsfall = addMonths(doedsdato, 12)
 
@@ -50,6 +56,10 @@ export const AktivitetspliktTidslinje = (props: {
   const fjernAktivitet = (aktivitetId: string) => {
     if (behandling) {
       slett({ behandlingId: behandling.id, aktivitetId: aktivitetId }, (aktiviteter) => {
+        oppdaterAktiviteter(aktiviteter)
+      })
+    } else if (sakId) {
+      slettForSak({ sakId: sakId, aktivitetId: aktivitetId }, (aktiviteter) => {
         oppdaterAktiviteter(aktiviteter)
       })
     }
@@ -107,7 +117,7 @@ export const AktivitetspliktTidslinje = (props: {
                         {aktivitet.endret.ident}
                       </i>
                     </p>
-                    {isPending(slettet) ? (
+                    {isPending(slettet) || isPending(slettetForSak) ? (
                       <Spinner variant="neutral" label="Sletter" margin="1em" />
                     ) : (
                       <>
@@ -126,15 +136,14 @@ export const AktivitetspliktTidslinje = (props: {
         </Timeline>
       )}
 
-      <HStack align="center" justify={behandling ? 'space-between' : 'end'}>
-        {behandling && (
-          <NyAktivitet
-            key={rediger?.id}
-            behandling={behandling}
-            oppdaterAktiviteter={oppdaterAktiviteter}
-            redigerAktivitet={rediger}
-          />
-        )}
+      <HStack align="center" justify="space-between">
+        <NyAktivitet
+          key={rediger?.id}
+          behandling={behandling}
+          oppdaterAktiviteter={oppdaterAktiviteter}
+          redigerAktivitet={rediger}
+          sakId={sakId}
+        />
 
         {aktiviteter.length > 0 && (
           <ToggleGroup

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
@@ -112,7 +112,7 @@ export const Person = () => {
                 icon={<PersonIcon />}
               />
               <Tabs.Tab value={PersonOversiktFane.HENDELSER} label="Hendelser" icon={<BellIcon />} />
-              {isOmstillingsstoenad(sakResult) && skalViseAktivitet && (
+              {isOmstillingsstoenad(sakResult) && !skalViseAktivitet && (
                 <Tabs.Tab value={PersonOversiktFane.AKTIVITET} label="Aktivitet" icon={<BriefcaseClockIcon />} />
               )}
               <Tabs.Tab value={PersonOversiktFane.DOKUMENTER} label="Dokumentoversikt" icon={<FileTextIcon />} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
@@ -112,7 +112,7 @@ export const Person = () => {
                 icon={<PersonIcon />}
               />
               <Tabs.Tab value={PersonOversiktFane.HENDELSER} label="Hendelser" icon={<BellIcon />} />
-              {isOmstillingsstoenad(sakResult) && !skalViseAktivitet && (
+              {isOmstillingsstoenad(sakResult) && skalViseAktivitet && (
                 <Tabs.Tab value={PersonOversiktFane.AKTIVITET} label="Aktivitet" icon={<BriefcaseClockIcon />} />
               )}
               <Tabs.Tab value={PersonOversiktFane.DOKUMENTER} label="Dokumentoversikt" icon={<FileTextIcon />} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/aktivitetsplikt.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/aktivitetsplikt.ts
@@ -42,6 +42,18 @@ export const slettAktivitet = async (args: {
 export const hentAktiviteterForSak = async (args: { sakId: number }): Promise<ApiResponse<IAktivitet[]>> =>
   apiClient.get(`/sak/${args.sakId}/aktivitetsplikt/aktivitet`)
 
+export const opprettAktivitetForSak = async (args: {
+  sakId: number
+  request: IOpprettAktivitet
+}): Promise<ApiResponse<IAktivitet[]>> =>
+  apiClient.post(`/sak/${args.sakId}/aktivitetsplikt/aktivitet`, { ...args.request })
+
+export const slettAktivitetForSak = async (args: {
+  sakId: number
+  aktivitetId: string
+}): Promise<ApiResponse<IAktivitet[]>> =>
+  apiClient.delete(`/sak/${args.sakId}/aktivitetsplikt/aktivitet/${args.aktivitetId}`)
+
 export const hentAktivitspliktVurderingForSak = async (args: {
   sakId: number
 }): Promise<ApiResponse<IAktivitetspliktVurderingNy>> => apiClient.get(`/sak/${args.sakId}/aktivitetsplikt/vurdering`)


### PR DESCRIPTION
Har nå lagt til muligheten for å legge til, endre og slette aktivitet fra sak. 
Alt er lagt parallelt med måten man gjør det med behandling, men siden man nå kan slette og endre ting som tidligere er lagt på behandling så burde man kanskje skrive om den delen til å basere seg på sakId og ikke behandling?