### PR TITLE
EY-4294: Fjerner egen reduksjon når et annet valg velges for institusjon

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/institusjonsopphold/InstitusjonsoppholdBeregningsgrunnlagSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/institusjonsopphold/InstitusjonsoppholdBeregningsgrunnlagSkjema.tsx
@@ -184,6 +184,7 @@ export const InstitusjonsoppholdBeregningsgrunnlagSkjema = ({
                 valueAsNumber: true,
                 required: { value: true, message: 'Må settes' },
                 validate: validerStringNumber,
+                shouldUnregister: true,
               })}
               label={
                 <HStack gap="2">


### PR DESCRIPTION
Pr nå så vises egen reduksjon selv om saksbehandler velger noe annet. Dette blir veldig misvisende da det ikke i disse tilfellene brukes i beregningen. 

Grunnen til at det skjer, er fordi feltet blir stuck i skjemaet med mindre man setter på `shouldUnregister: true`. 