### PR TITLE
Er mer eksplisitt på at vi ikke får generert brev

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadRevurdering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadRevurdering.kt
@@ -18,6 +18,7 @@ import no.nav.etterlatte.brev.model.toFeilutbetalingType
 import no.nav.etterlatte.brev.model.vedleggHvisFeilutbetaling
 import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
+import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.trygdetid.TrygdetidDto
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.Utfall
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarType
@@ -37,6 +38,15 @@ data class OmstillingsstoenadRevurdering(
     val omsRettUtenTidsbegrensning: Boolean,
     val feilutbetaling: FeilutbetalingType,
 ) : BrevDataFerdigstilling {
+    init {
+        if (erOmgjoering && datoVedtakOmgjoering == null) {
+            throw InternfeilException(
+                "Kunne ikke lage revurderingsbrevet for omstillingsstønad siden vi ikke" +
+                    " fikk dato vedtak for omgjøring, i en revurdering som er omgjøring.",
+            )
+        }
+    }
+
     companion object {
         fun fra(
             innholdMedVedlegg: InnholdMedVedlegg,


### PR DESCRIPTION
Hvis vi har satt `erOmgjoering` som true, og `datoVedtakOmgjoering` som null vil tittelen på revurderingsbrevet bli "Vi har" uten noe mer. Kaster en feil i stedet for å lage feil brev