### PR TITLE
EY-4330 Notat i behandling

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NotatRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NotatRepository.kt
@@ -39,14 +39,14 @@ class NotatRepository(
             )
         }
 
-    fun hentForReferanse(referanse: String): Notat? =
+    fun hentForReferanse(referanse: String): List<Notat> =
         using(sessionOf(ds)) {
             it.run(
                 queryOf(
                     "SELECT id, sak_id, journalpost_id, tittel, opprettet, referanse FROM notat WHERE referanse = ?",
                     referanse,
                 ).map(tilNotat)
-                    .asSingle,
+                    .asList,
             )
         }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NotatRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NotatRoute.kt
@@ -97,6 +97,15 @@ fun Route.notatRoute(
             }
         }
 
+        route("/referanse/{referanse}") {
+            get {
+                val referanse = checkNotNull(call.parameters["referanse"])
+
+                val notater = nyNotatService.hentForReferanse(referanse)
+                call.respond(notater)
+            }
+        }
+
         route("/sak/{$SAKID_CALL_PARAMETER}") {
             get {
                 withSakId(tilgangsSjekk, skrivetilgang = true) { sakId ->
@@ -107,11 +116,13 @@ fun Route.notatRoute(
 
             post {
                 withSakId(tilgangsSjekk, skrivetilgang = true) { sakId ->
+                    val referanse = call.request.queryParameters["referanse"]
                     val mal = NotatMal.valueOf(call.request.queryParameters["mal"]!!)
 
                     val notat =
                         nyNotatService.opprett(
                             sakId = sakId,
+                            referanse = referanse,
                             mal = mal,
                             bruker = brukerTokenInfo,
                         )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NyNotatService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NyNotatService.kt
@@ -44,6 +44,12 @@ class NyNotatService(
         return notatRepository.hentForSak(sakId)
     }
 
+    fun hentForReferanse(referanse: String): List<Notat> {
+        logger.info("Henter notat for referanse $referanse")
+
+        return notatRepository.hentForReferanse(referanse)
+    }
+
     fun hentPayload(id: NotatID): Slate = notatRepository.hentPayload(id)
 
     fun oppdaterPayload(
@@ -80,15 +86,19 @@ class NyNotatService(
         sakId: Long,
         mal: NotatMal,
         tittel: String = "Mangler tittel",
+        referanse: String? = null,
         params: NotatParametre? = null,
         bruker: BrukerTokenInfo,
     ): Notat {
         val sak = behandlingService.hentSak(sakId, bruker)
 
+        logger.info("Oppretter notat for sak $sakId og referanse '$referanse'")
+
         val id =
             notatRepository.opprett(
                 NyttNotat(
                     sakId = sak.id,
+                    referanse = referanse,
                     tittel = tittel,
                     payload =
                         when (mal) {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
@@ -32,6 +32,7 @@ import { DokumentlisteLiten } from '~components/person/dokumenter/DokumentlisteL
 import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
 import { useOppgaveUnderBehandling } from '~shared/hooks/useOppgaveUnderBehandling'
 import { OppgaveEndring } from './OppgaveEndring'
+import { NotatPanel } from '~components/behandling/sidemeny/NotatPanel'
 
 const finnUtNasjonalitet = (behandling: IBehandlingReducer): UtlandstilknytningType | null => {
   if (behandling.utlandstilknytning?.type) {
@@ -162,7 +163,12 @@ export const BehandlingSidemeny = ({ behandling }: { behandling: IBehandlingRedu
         </Tabs.List>
 
         <Tabs.Panel value={BehandlingFane.DOKUMENTER}>
-          {soeker?.foedselsnummer && <DokumentlisteLiten fnr={soeker.foedselsnummer} />}
+          {soeker?.foedselsnummer && (
+            <>
+              <NotatPanel sakId={behandling.sakId} behandlingId={behandling.id} fnr={soeker?.foedselsnummer} />
+              <DokumentlisteLiten fnr={soeker.foedselsnummer} />
+            </>
+          )}
         </Tabs.Panel>
         <Tabs.Panel value={BehandlingFane.HISTORIKK}>
           <OppgaveEndring oppgaveResult={oppgaveResult} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
@@ -33,6 +33,7 @@ import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
 import { useOppgaveUnderBehandling } from '~shared/hooks/useOppgaveUnderBehandling'
 import { OppgaveEndring } from './OppgaveEndring'
 import { NotatPanel } from '~components/behandling/sidemeny/NotatPanel'
+import { useFeatureEnabledMedDefault } from '~shared/hooks/useFeatureToggle'
 
 const finnUtNasjonalitet = (behandling: IBehandlingReducer): UtlandstilknytningType | null => {
   if (behandling.utlandstilknytning?.type) {
@@ -69,6 +70,7 @@ export const BehandlingSidemeny = ({ behandling }: { behandling: IBehandlingRedu
   const [beslutning, setBeslutning] = useState<IBeslutning>()
   const fane = useSelectorBehandlingSidemenyFane()
 
+  const skalViseNotater = useFeatureEnabledMedDefault('notater', false)
   const [oppgaveResult] = useOppgaveUnderBehandling({ referanse: behandling.id })
 
   const behandlingsinfo = mapTilBehandlingInfo(behandling, vedtak)
@@ -165,7 +167,9 @@ export const BehandlingSidemeny = ({ behandling }: { behandling: IBehandlingRedu
         <Tabs.Panel value={BehandlingFane.DOKUMENTER}>
           {soeker?.foedselsnummer && (
             <>
-              <NotatPanel sakId={behandling.sakId} behandlingId={behandling.id} fnr={soeker?.foedselsnummer} />
+              {skalViseNotater && (
+                <NotatPanel sakId={behandling.sakId} behandlingId={behandling.id} fnr={soeker?.foedselsnummer} />
+              )}
               <DokumentlisteLiten fnr={soeker.foedselsnummer} />
             </>
           )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/NotatPanel.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/NotatPanel.tsx
@@ -1,0 +1,90 @@
+import { NotatRedigeringModal } from '~components/person/notat/NotatRedigeringModal'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { hentNotaterForReferanse, NotatMal, opprettNotatForSak } from '~shared/api/notat'
+import { useEffect } from 'react'
+import { isInitial, isPending, mapResult } from '~shared/api/apiUtils'
+import { Alert, BodyShort, Button, Detail, Heading, HStack, VStack } from '@navikt/ds-react'
+import { SidebarPanel } from '~shared/components/Sidebar'
+import styled from 'styled-components'
+import { NotatVisningModal } from '~components/person/notat/NotatVisningModal'
+import { PersonButtonLink } from '~components/person/lenker/PersonButtonLink'
+import { PersonOversiktFane } from '~components/person/Person'
+import { ExternalLinkIcon } from '@navikt/aksel-icons'
+
+export const NotatPanel = ({ sakId, behandlingId, fnr }: { sakId: number; behandlingId: string; fnr: string }) => {
+  const [notatResult, hentNotater] = useApiCall(hentNotaterForReferanse)
+  const [nyttNotatResult, opprettNotat] = useApiCall(opprettNotatForSak)
+
+  useEffect(() => {
+    if (isInitial(notatResult)) {
+      hentNotater(behandlingId)
+    }
+  }, [behandlingId])
+
+  const opprettNyttNotat = () => {
+    opprettNotat({ sakId, referanse: behandlingId, mal: NotatMal.TOM_MAL }, () => {
+      hentNotater(behandlingId)
+    })
+  }
+
+  return mapResult(notatResult, {
+    success: (notater) => (
+      <SidebarPanel $border>
+        <Heading size="small" spacing>
+          Notater
+        </Heading>
+
+        <VStack gap="2">
+          {notater.map(
+            (notat) =>
+              !notat.journalpostId && (
+                <HStack gap="2" justify="space-between" wrap={false} key={`notat-${notat.id}`}>
+                  <TextOverflow size="small">{notat.tittel}</TextOverflow>
+
+                  {!notat.journalpostId ? (
+                    <NotatRedigeringModal notat={notat} minifyRedigerKnapp />
+                  ) : (
+                    <NotatVisningModal notat={notat} />
+                  )}
+                </HStack>
+              )
+          )}
+
+          {!notater.length && <Detail spacing>Ingen notater funnet</Detail>}
+        </VStack>
+
+        <hr />
+
+        <HStack justify="space-between">
+          <Button onClick={opprettNyttNotat} loading={isPending(nyttNotatResult)} size="small" variant="secondary">
+            Opprett nytt notat
+          </Button>
+
+          <PersonButtonLink
+            fnr={fnr}
+            fane={PersonOversiktFane.NOTATER}
+            variant="tertiary"
+            size="small"
+            target="_blank"
+            rel="noreferrer noopener"
+            icon={<ExternalLinkIcon />}
+          >
+            Gå til notatoversikten
+          </PersonButtonLink>
+        </HStack>
+      </SidebarPanel>
+    ),
+    error: (err) => (
+      <Alert variant="error" size="small">
+        {err.detail}
+      </Alert>
+    ),
+  })
+}
+
+const TextOverflow = styled(BodyShort)`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 300px;
+`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentInfoDetail.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentInfoDetail.tsx
@@ -10,10 +10,11 @@ export const DokumentInfoDetail = ({ dokument }: { dokument: Journalpost }) => {
         {
           [Journalposttype.I]: 'Avsender: ',
           [Journalposttype.U]: 'Mottaker: ',
-          [Journalposttype.N]: 'Notat',
+          [Journalposttype.N]: 'Notat ',
         }[dokument.journalposttype]
       }
-      {dokument.avsenderMottaker.navn || 'Ukjent'} ({formaterDato(dokument.datoOpprettet)})
+      {dokument.journalposttype !== Journalposttype.N && (dokument.avsenderMottaker.navn || 'Ukjent')} (
+      {formaterDato(dokument.datoOpprettet)})
     </Detail>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/notat/NotatRedigeringModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/notat/NotatRedigeringModal.tsx
@@ -19,9 +19,10 @@ export enum NotatRedigeringFane {
 
 interface RedigerbartNotatProps {
   notat: Notat
+  minifyRedigerKnapp?: boolean
 }
 
-export const NotatRedigeringModal = ({ notat }: RedigerbartNotatProps) => {
+export const NotatRedigeringModal = ({ notat, minifyRedigerKnapp }: RedigerbartNotatProps) => {
   const [fane, setFane] = useState<string>(NotatRedigeringFane.REDIGER)
 
   const [isOpen, setIsOpen] = useState(false)
@@ -59,7 +60,7 @@ export const NotatRedigeringModal = ({ notat }: RedigerbartNotatProps) => {
   return (
     <>
       <Button variant="secondary" onClick={open} size="small" icon={<PencilIcon />}>
-        Rediger
+        {!minifyRedigerKnapp && 'Rediger'}
       </Button>
 
       <DokumentVisningModal open={isOpen} onClose={() => setIsOpen(false)} aria-labelledby="modal-heading">

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/notat.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/notat.ts
@@ -12,12 +12,25 @@ export enum NotatMal {
   TOM_MAL = 'TOM_MAL',
 }
 
-export function opprettNotatForSak(args: { sakId: number; mal: string }): Promise<ApiResponse<Notat>> {
-  return apiClient.post(`/notat/sak/${args.sakId}?mal=${args.mal}`, {})
+export function opprettNotatForSak(args: {
+  sakId: number
+  referanse?: string
+  mal: string
+}): Promise<ApiResponse<Notat>> {
+  const params = new URLSearchParams({
+    mal: args.mal,
+  })
+  if (args.referanse) params.append('referanse', args.referanse)
+
+  return apiClient.post(`/notat/sak/${args.sakId}?${params}`, {})
 }
 
 export function hentNotaterForSak(sakId: number): Promise<ApiResponse<Notat[]>> {
   return apiClient.get(`/notat/sak/${sakId}`)
+}
+
+export function hentNotaterForReferanse(referanse: string): Promise<ApiResponse<Notat[]>> {
+  return apiClient.get(`/notat/referanse/${referanse}`)
 }
 
 export function slettNotat(id: number): Promise<ApiResponse<Notat>> {


### PR DESCRIPTION
Notat opprettes med referanse til behandlingen, men henter alle som er tilknyttet saken. Mulig det blir filtrert litt på sikt. Avventer eventuelle tilbakemeldinger fra saksbehandlere.

Notater vil vises under "Dokumenter"-fanen på en behandling. Journalførte notater vil kun bli vist som journalpost. 

![Screenshot 2024-08-23 at 15 54 39](https://github.com/user-attachments/assets/cbfecf12-5fad-44fc-a0ed-34ad04e44990)

![Screenshot 2024-08-23 at 16 13 30](https://github.com/user-attachments/assets/aef1b31f-f349-46c3-b531-3566d21f3d31)
