### PR TITLE
EY-4349: Try-catch rundt onPacket i r&r, så vi får logga ut feilmeldi…

### DIFF
--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/ListenerMedLogging.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/ListenerMedLogging.kt
@@ -25,7 +25,13 @@ abstract class ListenerMedLogging : River.PacketListener {
         packet: JsonMessage,
         context: MessageContext,
     ) = withLogContext(packet.correlationId) {
-        haandterPakke(packet, context)
+        try {
+            haandterPakke(packet, context)
+        } catch (e: Exception) {
+            logger.warn("Fikk feil under handtering av melding. Se sikkerlogg for hele meldinga", e)
+            sikkerlogg.warn("Fikk feil under handtering av melding. Meldinga var ${packet.toJson()}", e)
+            throw e
+        }
     }
 
     override fun onError(


### PR DESCRIPTION
…ngar ordentleg utan at vi også må logge altfor mykje, som elles skjer i onSevere, der exceptionen elles hamnar