### PR TITLE
Sette status til ny på oppgaver når man endrer enhet på sak og oppgaver

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -437,6 +437,7 @@ class OppgaveService(
     ) {
         val oppgaverForSak = oppgaveDao.hentOppgaverForSak(sakId)
         oppgaverForSak.forEach {
+            oppgaveDao.endreStatusPaaOppgave(it.id, Status.NY)
             oppgaveDao.endreEnhetPaaOppgave(it.id, enhetsID)
         }
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
@@ -262,6 +262,16 @@ internal class OppgaveDaoTest(
     }
 
     @Test
+    fun `kan endre enhet på oppgave`() {
+        val sakAalesund = sakDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
+        val oppgaveNy = lagNyOppgave(sakAalesund)
+        oppgaveDao.opprettOppgave(oppgaveNy)
+        oppgaveDao.endreEnhetPaaOppgave(oppgaveNy.id, Enheter.PORSGRUNN.enhetNr)
+        val hentetOppgave = oppgaveDao.hentOppgave(oppgaveNy.id)
+        assertEquals(Enheter.PORSGRUNN.enhetNr, hentetOppgave?.enhet)
+    }
+
+    @Test
     fun `Skal ikke kunne hente adressebeskyttede oppgaver fra vanlig hentoppgaver`() {
         val sakAalesund = sakDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
         val oppgaveNy = lagNyOppgave(sakAalesund)

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -801,6 +801,41 @@ internal class OppgaveServiceTest(
     }
 
     @Test
+    fun `Skal endre status til ny ved endring av enhet`() {
+        val opprettetSak = sakDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
+        oppgaveService.opprettOppgave(
+            referanse = UUID.randomUUID().toString(),
+            sakId = opprettetSak.id,
+            kilde = OppgaveKilde.BEHANDLING,
+            type = OppgaveType.FOERSTEGANGSBEHANDLING,
+            merknad = null,
+        )
+
+        val saksbehandlerMedRoller = generateSaksbehandlerMedRoller(AzureGroup.SAKSBEHANDLER)
+        every { saksbehandler.enheter() } returns listOf(Enheter.AALESUND.enhetNr, Enheter.STEINKJER.enhetNr)
+        every { saksbehandler.saksbehandlerMedRoller } returns saksbehandlerMedRoller
+
+        val oppgaverUtenEndring = oppgaveService.finnOppgaverForBruker(saksbehandler, Status.entries.map { it.name })
+        assertEquals(1, oppgaverUtenEndring.size)
+        assertEquals(Enheter.AALESUND.enhetNr, oppgaverUtenEndring[0].enhet)
+        oppgaveService.tildelSaksbehandler(oppgaverUtenEndring[0].id, saksbehandlerMedRoller.saksbehandler.ident())
+        oppgaveService.endrePaaVent(PaaVent(oppgaverUtenEndring[0].id, merknad = "test", paavent = true, aarsak = PaaVentAarsak.ANNET))
+        oppgaveService.oppdaterEnhetForRelaterteOppgaver(
+            listOf(
+                SakMedEnhet(
+                    oppgaverUtenEndring[0].sakId,
+                    Enheter.STEINKJER.enhetNr,
+                ),
+            ),
+        )
+        val oppgaverMedEndring = oppgaveService.finnOppgaverForBruker(saksbehandler, Status.entries.map { it.name })
+
+        assertEquals(1, oppgaverMedEndring.size)
+        assertEquals(Enheter.STEINKJER.enhetNr, oppgaverMedEndring[0].enhet)
+        assertEquals(Status.NY, oppgaverMedEndring[0].status)
+    }
+
+    @Test
     fun `Skal kun få saker som  er strengt fotrolig tilbake hvis saksbehandler har rolle strengt fortrolig`() {
         val opprettetSak = sakDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
         oppgaveService.opprettOppgave(


### PR DESCRIPTION
Ref FAGSYSTEM-343341: sette status til Ny ved enhetsendring, så ny enhet kan prioritere innkommende saker korrekt