### PR TITLE
Send inn systembruker for grunnlag ved opprett behandling/revurderinger

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/GrunnlagServiceImpl.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/GrunnlagServiceImpl.kt
@@ -11,6 +11,7 @@ import no.nav.etterlatte.libs.common.grunnlag.OppdaterGrunnlagRequest
 import no.nav.etterlatte.libs.common.grunnlag.Opplysningsbehov
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import java.util.UUID
 
 interface GrunnlagService {
@@ -22,6 +23,7 @@ interface GrunnlagService {
     suspend fun leggInnNyttGrunnlag(
         behandling: Behandling,
         persongalleri: Persongalleri,
+        brukerTokenInfo: BrukerTokenInfo? = null,
     )
 
     suspend fun oppdaterGrunnlag(
@@ -33,6 +35,7 @@ interface GrunnlagService {
     suspend fun leggTilNyeOpplysninger(
         behandlingId: UUID,
         opplysninger: NyeSaksopplysninger,
+        brukerTokenInfo: BrukerTokenInfo? = null,
     )
 
     suspend fun leggTilNyeOpplysningerBareSak(
@@ -43,6 +46,7 @@ interface GrunnlagService {
     suspend fun laasTilGrunnlagIBehandling(
         revurdering: Revurdering,
         forrigeBehandling: UUID,
+        brukerTokenInfo: BrukerTokenInfo? = null,
     )
 
     suspend fun hentPersongalleri(behandlingId: UUID): Persongalleri
@@ -64,9 +68,10 @@ class GrunnlagServiceImpl(
     override suspend fun leggInnNyttGrunnlag(
         behandling: Behandling,
         persongalleri: Persongalleri,
+        brukerTokenInfo: BrukerTokenInfo?,
     ) {
         val grunnlagsbehov = grunnlagsbehov(behandling, persongalleri)
-        grunnlagKlient.leggInnNyttGrunnlag(behandling.id, grunnlagsbehov)
+        grunnlagKlient.leggInnNyttGrunnlag(behandling.id, grunnlagsbehov, brukerTokenInfo)
     }
 
     override suspend fun oppdaterGrunnlag(
@@ -83,7 +88,8 @@ class GrunnlagServiceImpl(
     override suspend fun leggTilNyeOpplysninger(
         behandlingId: UUID,
         opplysninger: NyeSaksopplysninger,
-    ) = grunnlagKlient.lagreNyeSaksopplysninger(behandlingId, opplysninger)
+        brukerTokenInfo: BrukerTokenInfo?,
+    ) = grunnlagKlient.lagreNyeSaksopplysninger(behandlingId, opplysninger, brukerTokenInfo)
 
     override suspend fun leggTilNyeOpplysningerBareSak(
         sakId: SakId,
@@ -99,6 +105,7 @@ class GrunnlagServiceImpl(
     override suspend fun laasTilGrunnlagIBehandling(
         revurdering: Revurdering,
         forrigeBehandling: UUID,
+        brukerTokenInfo: BrukerTokenInfo?,
     ) = grunnlagKlient.laasTilGrunnlagIBehandling(revurdering.id, forrigeBehandling)
 
     override suspend fun hentAlleSakerForPerson(fnr: String) = grunnlagKlient.hentPersonSakOgRolle(fnr)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/GrunnlagKlient.kt
@@ -307,7 +307,7 @@ class GrunnlagKlientImpl(
     override suspend fun lagreNyeSaksopplysninger(
         behandlingId: UUID,
         saksopplysninger: NyeSaksopplysninger,
-        brukerTokenInfo: BrukerTokenInfo,
+        brukerTokenInfo: BrukerTokenInfo?,
     ) {
         downstreamResourceClient
             .post(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/GrunnlagKlient.kt
@@ -62,6 +62,7 @@ interface GrunnlagKlient : Pingable {
     suspend fun leggInnNyttGrunnlag(
         behandlingId: UUID,
         opplysningsbehov: Opplysningsbehov,
+        brukerTokenInfo: BrukerTokenInfo? = null,
     )
 
     suspend fun oppdaterGrunnlag(
@@ -74,6 +75,7 @@ interface GrunnlagKlient : Pingable {
     suspend fun lagreNyeSaksopplysninger(
         behandlingId: UUID,
         saksopplysninger: NyeSaksopplysninger,
+        brukerTokenInfo: BrukerTokenInfo? = null,
     )
 
     suspend fun lagreNyeSaksopplysningerBareSak(
@@ -228,6 +230,7 @@ class GrunnlagKlientImpl(
     override suspend fun leggInnNyttGrunnlag(
         behandlingId: UUID,
         opplysningsbehov: Opplysningsbehov,
+        brukerTokenInfo: BrukerTokenInfo?,
     ) {
         downstreamResourceClient
             .post(
@@ -237,7 +240,7 @@ class GrunnlagKlientImpl(
                         url = "$resourceApiUrl/grunnlag/behandling/$behandlingId/opprett-grunnlag",
                     ),
                 postBody = opplysningsbehov.toJson(),
-                brukerTokenInfo = Kontekst.get().brukerTokenInfo!!,
+                brukerTokenInfo = brukerTokenInfo ?: Kontekst.get().brukerTokenInfo!!,
             ).mapBoth(
                 success = { _ -> },
                 failure = { errorResponse -> throw errorResponse },
@@ -304,6 +307,7 @@ class GrunnlagKlientImpl(
     override suspend fun lagreNyeSaksopplysninger(
         behandlingId: UUID,
         saksopplysninger: NyeSaksopplysninger,
+        brukerTokenInfo: BrukerTokenInfo,
     ) {
         downstreamResourceClient
             .post(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingRoutes.kt
@@ -55,7 +55,7 @@ internal fun Route.revurderingRoutes(
                 kunSaksbehandlerMedSkrivetilgang { saksbehandler ->
                     logger.info("Oppretter ny revurdering på sak $sakId")
                     medBody<OpprettRevurderingRequest> { opprettRevurderingRequest ->
-
+                        // TODO: er feil i denne flyten da vi ikke kan gjøre tilgangssjekk for grunnlag da behandlingen ikke finnes enda
                         val revurdering =
                             inTransaction {
                                 manuellRevurderingService.opprettManuellRevurderingWrapper(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -30,6 +30,7 @@ import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.ktor.token.HardkodaSystembruker
 import no.nav.etterlatte.oppgave.OppgaveService
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
@@ -208,9 +209,10 @@ class RevurderingService(
                                         "Har en regulering som ikke sender med behandlingId for sist iverksatt. " +
                                             "Da kan vi ikke legge inn riktig grunnlag. regulering id=${it.id}"
                                     },
+                                    HardkodaSystembruker.opprettGrunnlag,
                                 )
                             }
-                        else -> runBlocking { grunnlagService.leggInnNyttGrunnlag(it, persongalleri) }
+                        else -> runBlocking { grunnlagService.leggInnNyttGrunnlag(it, persongalleri, HardkodaSystembruker.opprettGrunnlag) }
                     }
                 },
                 sendMeldingForHendelse = {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilgang/TilgangRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilgang/TilgangRoutes.kt
@@ -25,7 +25,7 @@ import no.nav.etterlatte.tilgangsstyring.sjekkSkrivetilgang
 const val SKRIVETILGANG_CALL_QUERYPARAMETER = "skrivetilgang"
 inline val PipelineContext<*, ApplicationCall>.berOmSkrivetilgang: Boolean
     get() =
-        call.request.queryParameters[SKRIVETILGANG_CALL_QUERYPARAMETER]?.let { it.toBoolean() } ?: throw NullPointerException(
+        call.request.queryParameters[SKRIVETILGANG_CALL_QUERYPARAMETER]?.toBoolean() ?: throw NullPointerException(
             "Skrivetilgangparameter er ikke i query params",
         )
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
@@ -244,7 +244,7 @@ class BehandlingFactoryTest {
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
         }
-        coVerify(exactly = 1) { grunnlagService.leggInnNyttGrunnlag(any(), any()) }
+        coVerify(exactly = 1) { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) }
     }
 
     @Test
@@ -301,7 +301,7 @@ class BehandlingFactoryTest {
                 any(),
             )
         } returns Unit
-        coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any()) } returns Unit
+        coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) } returns Unit
         every {
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
         } returns mockOppgave
@@ -330,7 +330,7 @@ class BehandlingFactoryTest {
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
         }
-        coVerify { grunnlagService.leggInnNyttGrunnlag(any(), any()) }
+        coVerify { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) }
     }
 
     @Test
@@ -390,7 +390,7 @@ class BehandlingFactoryTest {
                 any(),
             )
         } returns Unit
-        coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any()) } returns Unit
+        coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) } returns Unit
         every {
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
         } returns mockOppgave
@@ -438,7 +438,7 @@ class BehandlingFactoryTest {
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
         }
-        coVerify { grunnlagService.leggInnNyttGrunnlag(any(), any()) }
+        coVerify { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) }
         verify {
             behandlingDaoMock.lagreStatus(any(), BehandlingStatus.AVBRUTT, any())
             oppgaveService.avbrytAapneOppgaverMedReferanse(nyfoerstegangsbehandling!!.id.toString())
@@ -546,7 +546,7 @@ class BehandlingFactoryTest {
         val opprettBehandlingSlot = slot<OpprettBehandling>()
         every { behandlingDaoMock.opprettBehandling(capture(opprettBehandlingSlot)) } just runs
         coEvery { grunnlagService.hentPersongalleri(avslaattFoerstegangsbehandling.id) } returns Persongalleri(sak.ident)
-        coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any()) } just runs
+        coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) } just runs
         every { oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any(), any(), any()) } returns
             OppgaveIntern(
                 id = UUID.randomUUID(),
@@ -588,7 +588,7 @@ class BehandlingFactoryTest {
         coVerify {
             vilkaarsvurderingService.kopierVilkaarsvurdering(any(), any(), any())
             grunnlagService.hentPersongalleri(avslaattFoerstegangsbehandling.id)
-            grunnlagService.leggInnNyttGrunnlag(any(), any())
+            grunnlagService.leggInnNyttGrunnlag(any(), any(), any())
         }
     }
 
@@ -612,7 +612,7 @@ class BehandlingFactoryTest {
         val opprettBehandlingSlot = slot<OpprettBehandling>()
         every { behandlingDaoMock.opprettBehandling(capture(opprettBehandlingSlot)) } just runs
         coEvery { grunnlagService.hentPersongalleri(avslaattFoerstegangsbehandling.id) } returns Persongalleri(sak.ident)
-        coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any()) } just runs
+        coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) } just runs
         every { oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any(), any(), any()) } returns
             OppgaveIntern(
                 id = UUID.randomUUID(),
@@ -651,7 +651,7 @@ class BehandlingFactoryTest {
         }
         coVerify {
             grunnlagService.hentPersongalleri(avslaattFoerstegangsbehandling.id)
-            grunnlagService.leggInnNyttGrunnlag(any(), any())
+            grunnlagService.leggInnNyttGrunnlag(any(), any(), any())
         }
     }
 
@@ -712,7 +712,7 @@ class BehandlingFactoryTest {
                 any(),
             )
         } returns Unit
-        coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any()) } returns Unit
+        coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) } returns Unit
         every {
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
         } returns mockOppgave
@@ -799,7 +799,7 @@ class BehandlingFactoryTest {
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any(), any(), any())
         }
-        coVerify { grunnlagService.leggInnNyttGrunnlag(any(), any()) }
+        coVerify { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) }
         verify(exactly = 2) {
             sakServiceMock.finnSak(any())
             behandlingDaoMock.hentBehandling(any())
@@ -867,7 +867,7 @@ class BehandlingFactoryTest {
                 any(),
             )
         } returns Unit
-        coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any()) } returns Unit
+        coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) } returns Unit
         every {
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
         } returns mockOppgave
@@ -955,7 +955,7 @@ class BehandlingFactoryTest {
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
             oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
         }
-        coVerify { grunnlagService.leggInnNyttGrunnlag(any(), any()) }
+        coVerify { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) }
         verify(exactly = 2) {
             sakServiceMock.finnSak(any())
             behandlingDaoMock.hentBehandling(any())
@@ -1054,8 +1054,8 @@ class BehandlingFactoryTest {
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
         }
         coVerify {
-            grunnlagService.leggInnNyttGrunnlag(any(), any())
-            grunnlagService.leggTilNyeOpplysninger(any(), any())
+            grunnlagService.leggInnNyttGrunnlag(any(), any(), any())
+            grunnlagService.leggTilNyeOpplysninger(any(), any(), any())
         }
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/ManuellRevurderingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/ManuellRevurderingServiceTest.kt
@@ -151,7 +151,7 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
 
         coVerify {
             grunnlagService.hentPersongalleri(any())
-            grunnlagService.leggInnNyttGrunnlag(revurdering, any())
+            grunnlagService.leggInnNyttGrunnlag(revurdering, any(), any())
         }
         verify {
             oppgaveService.opprettOppgave(
@@ -276,7 +276,7 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
             }
             coVerify {
                 grunnlagService.hentPersongalleri(any())
-                grunnlagService.leggInnNyttGrunnlag(any(), any())
+                grunnlagService.leggInnNyttGrunnlag(any(), any(), any())
             }
             confirmVerified(hendelser, grunnlagService, oppgaveService)
         }
@@ -378,8 +378,8 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
             assertEquals(revurdering.id, grunnlaghendelse?.behandlingId)
             coVerify {
                 grunnlagService.hentPersongalleri(any())
-                grunnlagService.leggInnNyttGrunnlag(behandling as Behandling, any())
-                grunnlagService.laasTilGrunnlagIBehandling(revurdering, behandling.id)
+                grunnlagService.leggInnNyttGrunnlag(behandling as Behandling, any(), any())
+                grunnlagService.laasTilGrunnlagIBehandling(revurdering, behandling.id, any())
             }
             verify {
                 oppgaveService.hentOppgaverForSak(sak.id)
@@ -473,7 +473,7 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
             }
 
         coVerify {
-            grunnlagService.leggInnNyttGrunnlag(revurdering, any())
+            grunnlagService.leggInnNyttGrunnlag(revurdering, any(), any())
             grunnlagService.hentPersongalleri(any())
         }
         verify {

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
@@ -149,6 +149,7 @@ class GrunnlagKlientTest : GrunnlagKlient {
     override suspend fun leggInnNyttGrunnlag(
         behandlingId: UUID,
         opplysningsbehov: Opplysningsbehov,
+        brukerTokenInfo: BrukerTokenInfo?,
     ) {
         // NO-OP
     }
@@ -163,6 +164,7 @@ class GrunnlagKlientTest : GrunnlagKlient {
     override suspend fun lagreNyeSaksopplysninger(
         behandlingId: UUID,
         saksopplysninger: NyeSaksopplysninger,
+        brukerTokenInfo: BrukerTokenInfo?,
     ) {
         // NO-OP
     }

--- a/libs/etterlatte-ktor/src/main/kotlin/token/BrukerTokenInfo.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/token/BrukerTokenInfo.kt
@@ -74,11 +74,13 @@ data class HardkodaSystembruker private constructor(
         val doedshendelse = HardkodaSystembruker(Systembrukere.DOEDSHENDELSE)
         val testdata = HardkodaSystembruker(Systembrukere.TESTDATA)
         val oppgave = HardkodaSystembruker(Systembrukere.OPPGAVE)
+        val opprettGrunnlag = HardkodaSystembruker(Systembrukere.OPPRETT_GRUNNLAG) // skal bort på sikt
     }
 
     enum class Systembrukere(
         val appName: String,
     ) {
+        OPPRETT_GRUNNLAG("opprettgrunnlag"),
         RIVER("river"),
         DOEDSHENDELSE("doedshendelse"),
         TESTDATA("testdata"),


### PR DESCRIPTION
Tidligere brukte man bare systembruker mot grunnlag i opprett behandling e.l. noe som ikke var intensjonen. Setter på det for now siden det er låst inni inTransaction slik at man får opprettet behandlinger og revurderinger