### PR TITLE
Legger på canonical name til klassen som feilen har

### DIFF
--- a/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/feilhaandtering/StatusPagesKonfigurasjon.kt
@@ -15,7 +15,6 @@ import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilLoggerException
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
-import no.nav.etterlatte.libs.common.feilhaandtering.UkjentInternfeilException
 import no.nav.etterlatte.libs.common.isProd
 import no.nav.etterlatte.libs.ktor.erDeserialiseringsException
 import no.nav.etterlatte.libs.ktor.feilhaandtering.EscapeUtils.escape
@@ -53,7 +52,7 @@ class StatusPagesKonfigurasjon(
                 }
 
                 else -> {
-                    val mappetFeil = UkjentInternfeilException("En feil har skjedd.", cause)
+                    val mappetFeil = UkjentInternfeilException("En feil har skjedd: ${cause::class.java.canonicalName}", cause)
                     call.application.log.loggInternfeilException(mappetFeil, call)
                     call.respond(mappetFeil)
                 }
@@ -191,3 +190,8 @@ class StatusPagesKonfigurasjon(
         return requestobjekt
     }
 }
+
+private class UkjentInternfeilException(
+    override val detail: String,
+    override val cause: Throwable,
+) : InternfeilException(detail, cause)

--- a/libs/saksbehandling-common/src/main/kotlin/feilhaandtering/InternfeilException.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/feilhaandtering/InternfeilException.kt
@@ -19,8 +19,3 @@ open class InternfeilException(
             meta = null,
         )
 }
-
-class UkjentInternfeilException(
-    override val detail: String,
-    override val cause: Throwable,
-) : InternfeilException(detail, cause)


### PR DESCRIPTION
Hvis feilen selv ikke setter message så får vi i alle fall feilklassen i loggene. Gjør også UkjentInternfeilException umulig å bruke utenfor StatusPagesKonfigurasjon.