### PR TITLE
FAGSYSTEM-343711: Sender med varseltype til brev for tilbakekreving

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingValidering.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingValidering.kt
@@ -6,7 +6,6 @@ import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingBehandling
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingBeloepBeholdSvar
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingHjemmel
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingPeriode
-import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingVarsel
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingVilkaar
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingVurdering
 import java.time.format.DateTimeFormatter
@@ -24,9 +23,7 @@ private fun TilbakekrevingVurdering.valider(): List<String> {
 
     if (aarsak == null) manglendeFelter.add("Årsak")
     if (forhaandsvarsel == null) manglendeFelter.add("Forhåndsvarsel")
-
-    validerForhaandsvarsel(manglendeFelter)
-
+    if (forhaandsvarselDato == null) manglendeFelter.add("Forhåndsvarsel dato / Vedtaksdato")
     if (beskrivelse.isNullOrBlank()) manglendeFelter.add("Beskrivelse")
     if (doedsbosak == null) manglendeFelter.add("Dødsbosak")
     if (foraarsaketAv.isNullOrBlank()) manglendeFelter.add("Forårsaket av")
@@ -38,12 +35,6 @@ private fun TilbakekrevingVurdering.valider(): List<String> {
     validerVilkaarsresultat(manglendeFelter)
 
     return manglendeFelter
-}
-
-private fun TilbakekrevingVurdering.validerForhaandsvarsel(manglendeFelter: MutableList<String>) {
-    if (forhaandsvarsel in listOf(TilbakekrevingVarsel.EGET_BREV, TilbakekrevingVarsel.MED_I_ENDRINGSBREV)) {
-        if (forhaandsvarselDato == null) manglendeFelter.add("Forhåndsvarsel dato")
-    }
 }
 
 private fun TilbakekrevingVurdering.validerVilkaarsresultat(manglendeFelter: MutableList<String>) {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/tilbakekreving/TilbakekrevingBrevData.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/tilbakekreving/TilbakekrevingBrevData.kt
@@ -8,6 +8,7 @@ import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselExceptio
 import no.nav.etterlatte.libs.common.tilbakekreving.JaNei
 import no.nav.etterlatte.libs.common.tilbakekreving.Tilbakekreving
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingResultat
+import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingVarsel
 import no.nav.pensjon.brevbaker.api.model.Kroner
 import java.time.LocalDate
 
@@ -17,7 +18,7 @@ data class TilbakekrevingBrevDTO(
     val bosattUtland: Boolean,
     val brukerNavn: String,
     val doedsbo: Boolean,
-    val varselVedlagt: Boolean,
+    val varsel: TilbakekrevingVarsel,
     val datoVarselEllerVedtak: LocalDate,
     val datoTilsvarBruker: LocalDate?,
     val tilbakekreving: TilbakekrevingData,
@@ -42,7 +43,7 @@ data class TilbakekrevingBrevDTO(
                 bosattUtland = utlandstilknytningType == UtlandstilknytningType.BOSATT_UTLAND,
                 brukerNavn = soekerNavn,
                 doedsbo = tilbakekreving.vurdering?.doedsbosak == JaNei.JA,
-                varselVedlagt = tilbakekreving.vurdering?.forhaandsvarsel != null,
+                varsel = tilbakekreving.vurdering?.forhaandsvarsel ?: throw TilbakeKrevingManglerVarsel(),
                 datoVarselEllerVedtak =
                     tilbakekreving.vurdering?.forhaandsvarselDato ?: throw TilbakeKrevingManglerForhaandsvarselDatoException(),
                 datoTilsvarBruker = tilbakekreving.vurdering?.tilsvar?.dato,
@@ -142,4 +143,10 @@ class TilbakeKrevingManglerForhaandsvarselDatoException :
     UgyldigForespoerselException(
         code = "TILBAKEKREVING_MANGLER_VURDERING_FORHÅNDSVARSELSDATO",
         detail = "Kan ikke generere pdf uten vurdering forhaandsvarselDato av tilbakekreving",
+    )
+
+class TilbakeKrevingManglerVarsel :
+    UgyldigForespoerselException(
+        code = "TILBAKEKREVING_MANGLER_VURDERING_VARSEL",
+        detail = "Kan ikke generere pdf uten at varsel er satt under vurdering",
     )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingSkjema.tsx
@@ -106,15 +106,6 @@ export function TilbakekrevingVurderingSkjema({
   const beloepIBehold = () =>
     watch().beloepBehold ? watch().beloepBehold?.behold == TilbakekrevingBeloepBeholdSvar.BELOEP_I_BEHOLD : false
 
-  const skalHaForhaandsvarsel = () =>
-    watch().forhaandsvarsel
-      ? [
-          TilbakekrevingVarsel.MED_I_ENDRINGSBREV,
-          TilbakekrevingVarsel.EGET_BREV,
-          TilbakekrevingVarsel.AAPENBART_UNOEDVENDIG, // saksbehandler setter vedtaksdato i disse tilfellene
-        ].includes(watch().forhaandsvarsel!)
-      : false
-
   const rettsligGrunnlagForVilkaarOppfyltEllerDelvisOppfylt = () =>
     watch().rettsligGrunnlag
       ? [
@@ -154,15 +145,14 @@ export function TilbakekrevingVurderingSkjema({
             }
           />
 
-          {skalHaForhaandsvarsel() && (
-            <ControlledDatoVelger
-              name="forhaandsvarselDato"
-              label="Forhåndsvarsel dato / vedtaksdato"
-              control={control}
-              readOnly={!redigerbar}
-              shouldUnregister={true}
-            />
-          )}
+          <ControlledDatoVelger
+            name="forhaandsvarselDato"
+            label="Forhåndsvarseldato / vedtaksdato"
+            description="Angi forhåndsvarseldato, eller vedtaksdato dersom forhåndsvarsel ikke ble sendt ut."
+            control={control}
+            readOnly={!redigerbar}
+            shouldUnregister={true}
+          />
 
           <Textarea
             {...register('beskrivelse')}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/vurdering/TilbakekrevingVurderingSkjema.tsx
@@ -108,7 +108,11 @@ export function TilbakekrevingVurderingSkjema({
 
   const skalHaForhaandsvarsel = () =>
     watch().forhaandsvarsel
-      ? [TilbakekrevingVarsel.MED_I_ENDRINGSBREV, TilbakekrevingVarsel.EGET_BREV].includes(watch().forhaandsvarsel!)
+      ? [
+          TilbakekrevingVarsel.MED_I_ENDRINGSBREV,
+          TilbakekrevingVarsel.EGET_BREV,
+          TilbakekrevingVarsel.AAPENBART_UNOEDVENDIG, // saksbehandler setter vedtaksdato i disse tilfellene
+        ].includes(watch().forhaandsvarsel!)
       : false
 
   const rettsligGrunnlagForVilkaarOppfyltEllerDelvisOppfylt = () =>
@@ -153,7 +157,7 @@ export function TilbakekrevingVurderingSkjema({
           {skalHaForhaandsvarsel() && (
             <ControlledDatoVelger
               name="forhaandsvarselDato"
-              label="Forhåndsvarsel dato"
+              label="Forhåndsvarsel dato / vedtaksdato"
               control={control}
               readOnly={!redigerbar}
               shouldUnregister={true}


### PR DESCRIPTION
Må kunne sende over vedtaksdato når det er angitt at varsel var åpenbart unødvendig. Dette fordi vi har gamle saker hvor det ikke ble sendt med forhåndsvarsel i brev. 