### PR TITLE
Logger tilfeller der vi har verge uten ident til feil

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/grunnlag/GrunnlagService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/grunnlag/GrunnlagService.kt
@@ -76,15 +76,25 @@ class GrunnlagService(
                 grunnlag.soeker.hentFoedselsnummer()?.verdi,
             )
         return if (verger.size == 1) {
-            val vergeFnr = verger.first().vergeEllerFullmektig.motpartsPersonident!!
-            val vergenavn =
-                adresseService
-                    .hentMottakerAdresse(sakType, vergeFnr.value)
-                    .navn
-            Vergemaal(
-                vergenavn,
-                vergeFnr,
-            )
+            val vergeFnr = verger.first().vergeEllerFullmektig.motpartsPersonident
+            if (vergeFnr == null) {
+                logger.error(
+                    "Vi genererer et brev til en person som har verge uten ident. Det er verdt å følge " +
+                        "opp saken ekstra, for å sikre at det ikke blir noe feil her (koble på fag). saken har " +
+                        "id=${grunnlag.metadata.sakId}. Denne loggmeldingen kan nok fjernes etter at løpet her" +
+                        " er kvalitetssikret.",
+                )
+                UkjentVergemaal()
+            } else {
+                val vergenavn =
+                    adresseService
+                        .hentMottakerAdresse(sakType, vergeFnr.value)
+                        .navn
+                Vergemaal(
+                    vergenavn,
+                    vergeFnr,
+                )
+            }
         } else if (verger.size > 1) {
             logger.info(
                 "Fant flere verger for bruker med fnr ${grunnlag.soeker.hentFoedselsnummer()?.verdi} i " +


### PR DESCRIPTION
Avklarer de også som "UkjentVergemaal". Loggen vår er mest for å fange opp at dette skjer, slik at vi kan se om vi trenger noe ekstra håndtering på dette tilfellet.