### PR TITLE
Innfører eit hjelpe-lag for JDBC-kalla våre

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
@@ -12,7 +12,6 @@ import no.nav.etterlatte.behandling.domain.Revurdering
 import no.nav.etterlatte.behandling.hendelse.getUUID
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeDao
 import no.nav.etterlatte.behandling.revurdering.RevurderingDao
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
@@ -36,6 +35,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarType
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.setJsonb
 import no.nav.etterlatte.libs.database.singleOrNull
 import no.nav.etterlatte.libs.database.toList

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
@@ -17,6 +17,7 @@ import no.nav.etterlatte.libs.database.SQLObject
 import no.nav.etterlatte.libs.database.SQLString
 import no.nav.etterlatte.libs.database.oppdater
 import no.nav.etterlatte.libs.database.opprett
+import no.nav.etterlatte.libs.database.slett
 import no.nav.etterlatte.libs.database.toList
 import java.sql.Date
 import java.sql.ResultSet
@@ -194,7 +195,7 @@ class AktivitetspliktDao(
     fun slettAktivitet(
         aktivitetId: UUID,
         behandlingId: UUID,
-    ) = connectionAutoclosing.oppdater(
+    ) = connectionAutoclosing.slett(
         """DELETE FROM aktivitetsplikt_aktivitet WHERE id = ? AND behandling_id = ?""",
         listOf(SQLObject(aktivitetId), SQLObject(behandlingId)),
     )
@@ -202,7 +203,7 @@ class AktivitetspliktDao(
     fun slettAktivitetForSak(
         aktivitetId: UUID,
         sakId: SakId,
-    ) = connectionAutoclosing.oppdater(
+    ) = connectionAutoclosing.slett(
         "DELETE FROM aktivitetsplikt_aktivitet WHERE id = ? AND sak_id = ?",
         listOf(SQLObject(aktivitetId), SQLObject(sakId)),
     )

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
@@ -11,8 +11,10 @@ import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.getTidspunkt
 import no.nav.etterlatte.libs.database.ConnectionAutoclosing
-import no.nav.etterlatte.libs.database.Parametertype
-import no.nav.etterlatte.libs.database.SQLParameter
+import no.nav.etterlatte.libs.database.SQLDate
+import no.nav.etterlatte.libs.database.SQLLong
+import no.nav.etterlatte.libs.database.SQLObject
+import no.nav.etterlatte.libs.database.SQLString
 import no.nav.etterlatte.libs.database.oppdater
 import no.nav.etterlatte.libs.database.opprett
 import no.nav.etterlatte.libs.database.toList
@@ -65,9 +67,9 @@ class AktivitetspliktDao(
             |VALUES (?, ?, ?)
                     """,
         listOf(
-            SQLParameter(Parametertype.OBJECT, behandlingId),
-            SQLParameter(Parametertype.STRING, nyOppfolging.aktivitet),
-            SQLParameter(Parametertype.STRING, navIdent),
+            SQLObject(behandlingId),
+            SQLString(nyOppfolging.aktivitet),
+            SQLString(navIdent),
         ),
     )
 
@@ -115,15 +117,15 @@ class AktivitetspliktDao(
                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
         listOf(
-            SQLParameter(Parametertype.OBJECT, UUID.randomUUID()),
-            SQLParameter(Parametertype.LONG, aktivitet.sakId),
-            SQLParameter(Parametertype.OBJECT, behandlingId),
-            SQLParameter(Parametertype.STRING, aktivitet.type.name),
-            SQLParameter(Parametertype.DATE, Date.valueOf(aktivitet.fom)),
-            SQLParameter(Parametertype.DATE, aktivitet.tom?.let { tom -> Date.valueOf(tom) }),
-            SQLParameter(Parametertype.STRING, kilde.toJson()),
-            SQLParameter(Parametertype.STRING, kilde.toJson()),
-            SQLParameter(Parametertype.STRING, aktivitet.beskrivelse),
+            SQLObject(UUID.randomUUID()),
+            SQLLong(aktivitet.sakId),
+            SQLObject(behandlingId),
+            SQLString(aktivitet.type.name),
+            SQLDate(Date.valueOf(aktivitet.fom)),
+            SQLDate(aktivitet.tom?.let { tom -> Date.valueOf(tom) }),
+            SQLString(kilde.toJson()),
+            SQLString(kilde.toJson()),
+            SQLString(aktivitet.beskrivelse),
         ),
     )
 
@@ -164,13 +166,13 @@ class AktivitetspliktDao(
                         WHERE id = ? AND behandling_id = ?
                     """,
         listOf(
-            SQLParameter(Parametertype.STRING, aktivitet.type.name),
-            SQLParameter(Parametertype.DATE, Date.valueOf(aktivitet.fom)),
-            SQLParameter(Parametertype.DATE, aktivitet.tom?.let { tom -> Date.valueOf(tom) }),
-            SQLParameter(Parametertype.STRING, kilde.toJson()),
-            SQLParameter(Parametertype.STRING, aktivitet.beskrivelse),
-            SQLParameter(Parametertype.OBJECT, requireNotNull(aktivitet.id)),
-            SQLParameter(Parametertype.OBJECT, behandlingId),
+            SQLString(aktivitet.type.name),
+            SQLDate(Date.valueOf(aktivitet.fom)),
+            SQLDate(aktivitet.tom?.let { tom -> Date.valueOf(tom) }),
+            SQLString(kilde.toJson()),
+            SQLString(aktivitet.beskrivelse),
+            SQLObject(requireNotNull(aktivitet.id)),
+            SQLObject(behandlingId),
         ),
     )
 
@@ -184,13 +186,13 @@ class AktivitetspliktDao(
                         WHERE id = ? AND sak_id = ?""",
         params =
             listOf(
-                SQLParameter(Parametertype.STRING, aktivitet.type.name),
-                SQLParameter(Parametertype.DATE, Date.valueOf(aktivitet.fom)),
-                SQLParameter(Parametertype.DATE, aktivitet.tom?.let { tom -> Date.valueOf(tom) }),
-                SQLParameter(Parametertype.STRING, kilde.toJson()),
-                SQLParameter(Parametertype.STRING, aktivitet.beskrivelse),
-                SQLParameter(Parametertype.OBJECT, requireNotNull(aktivitet.id)),
-                SQLParameter(Parametertype.OBJECT, sakId),
+                SQLString(aktivitet.type.name),
+                SQLDate(Date.valueOf(aktivitet.fom)),
+                SQLDate(aktivitet.tom?.let { tom -> Date.valueOf(tom) }),
+                SQLString(kilde.toJson()),
+                SQLString(aktivitet.beskrivelse),
+                SQLObject(requireNotNull(aktivitet.id)),
+                SQLObject(sakId),
             ),
     )
 
@@ -199,7 +201,7 @@ class AktivitetspliktDao(
         behandlingId: UUID,
     ) = connectionAutoclosing.oppdater(
         """DELETE FROM aktivitetsplikt_aktivitet WHERE id = ? AND behandling_id = ?""",
-        listOf(SQLParameter(Parametertype.OBJECT, aktivitetId), SQLParameter(Parametertype.OBJECT, behandlingId)),
+        listOf(SQLObject(aktivitetId), SQLObject(behandlingId)),
     )
 
     fun slettAktivitetForSak(
@@ -207,7 +209,7 @@ class AktivitetspliktDao(
         sakId: SakId,
     ) = connectionAutoclosing.oppdater(
         "DELETE FROM aktivitetsplikt_aktivitet WHERE id = ? AND sak_id = ?",
-        listOf(SQLParameter(Parametertype.OBJECT, aktivitetId), SQLParameter(Parametertype.OBJECT, sakId)),
+        listOf(SQLObject(aktivitetId), SQLObject(sakId)),
     )
 
     fun kopierAktiviteter(
@@ -218,7 +220,7 @@ class AktivitetspliktDao(
                         INSERT INTO aktivitetsplikt_aktivitet (id, sak_id, behandling_id, aktivitet_type, fom, tom, opprettet, endret, beskrivelse)
                         (SELECT gen_random_uuid(), sak_id, ?, aktivitet_type, fom, tom, opprettet, endret, beskrivelse FROM aktivitetsplikt_aktivitet WHERE behandling_id = ?)
                     """,
-        listOf(SQLParameter(Parametertype.OBJECT, nyBehandlingId), SQLParameter(Parametertype.OBJECT, forrigeBehandlingId)),
+        listOf(SQLObject(nyBehandlingId), SQLObject(forrigeBehandlingId)),
     )
 
     private fun ResultSet.toAktivitet() =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
@@ -19,7 +19,6 @@ import no.nav.etterlatte.libs.database.hent
 import no.nav.etterlatte.libs.database.oppdater
 import no.nav.etterlatte.libs.database.opprett
 import no.nav.etterlatte.libs.database.slett
-import no.nav.etterlatte.libs.database.toList
 import java.sql.Date
 import java.sql.ResultSet
 import java.time.LocalDate
@@ -43,7 +42,7 @@ class AktivitetspliktDao(
                 |LIMIT 1
                         """,
                 listOf(SQLObject(behandlingId)),
-            ).toList {
+            ) {
                 AktivitetspliktOppfolging(
                     behandlingId = getUUID("behandling_id"),
                     aktivitet = getString("aktivitet"),
@@ -77,7 +76,7 @@ class AktivitetspliktDao(
                         WHERE behandling_id = ?
                         """,
                 listOf(SQLObject(behandlingId)),
-            ).toList { toAktivitet() }
+            ) { toAktivitet() }
 
     fun hentAktiviteterForSak(sakId: SakId): List<AktivitetspliktAktivitet> =
         connectionAutoclosing
@@ -88,7 +87,7 @@ class AktivitetspliktDao(
                         WHERE sak_id = ?
                         """,
                 listOf(SQLObject(sakId)),
-            ).toList { toAktivitet() }
+            ) { toAktivitet() }
 
     fun opprettAktivitet(
         behandlingId: UUID,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
@@ -43,7 +43,7 @@ class AktivitetspliktDao(
                 |ORDER BY id DESC
                 |LIMIT 1
                         """,
-                listOf(SQLObject(behandlingId)),
+                mapOf(1 to SQLObject(behandlingId)),
                 modus = Uthentingsmodus.FIRST_OR_NULL,
             ) {
                 AktivitetspliktOppfolging(
@@ -63,10 +63,10 @@ class AktivitetspliktDao(
             |INSERT INTO aktivitetsplikt_oppfolging(behandling_id, aktivitet, opprettet_av) 
             |VALUES (?, ?, ?)
                     """,
-        listOf(
-            SQLObject(behandlingId),
-            SQLString(nyOppfolging.aktivitet),
-            SQLString(navIdent),
+        mapOf(
+            1 to SQLObject(behandlingId),
+            2 to SQLString(nyOppfolging.aktivitet),
+            3 to SQLString(navIdent),
         ),
     )
 
@@ -78,7 +78,7 @@ class AktivitetspliktDao(
                         FROM aktivitetsplikt_aktivitet
                         WHERE behandling_id = ?
                         """,
-                listOf(SQLObject(behandlingId)),
+                mapOf(1 to SQLObject(behandlingId)),
             ) { toAktivitet() }
 
     fun hentAktiviteterForSak(sakId: SakId): List<AktivitetspliktAktivitet> =
@@ -89,7 +89,7 @@ class AktivitetspliktDao(
                         FROM aktivitetsplikt_aktivitet
                         WHERE sak_id = ?
                         """,
-                listOf(SQLObject(sakId)),
+                mapOf(1 to SQLObject(sakId)),
             ) { toAktivitet() }
 
     fun opprettAktivitet(
@@ -101,16 +101,16 @@ class AktivitetspliktDao(
                         INSERT INTO aktivitetsplikt_aktivitet(id, sak_id, behandling_id, aktivitet_type, fom, tom, opprettet, endret, beskrivelse) 
                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
-        listOf(
-            SQLObject(UUID.randomUUID()),
-            SQLLong(aktivitet.sakId),
-            SQLObject(behandlingId),
-            SQLString(aktivitet.type.name),
-            SQLDate(Date.valueOf(aktivitet.fom)),
-            SQLDate(aktivitet.tom?.let { tom -> Date.valueOf(tom) }),
-            SQLString(kilde.toJson()),
-            SQLString(kilde.toJson()),
-            SQLString(aktivitet.beskrivelse),
+        mapOf(
+            1 to SQLObject(UUID.randomUUID()),
+            2 to SQLLong(aktivitet.sakId),
+            3 to SQLObject(behandlingId),
+            4 to SQLString(aktivitet.type.name),
+            5 to SQLDate(Date.valueOf(aktivitet.fom)),
+            6 to SQLDate(aktivitet.tom?.let { tom -> Date.valueOf(tom) }),
+            7 to SQLString(kilde.toJson()),
+            8 to SQLString(kilde.toJson()),
+            9 to SQLString(aktivitet.beskrivelse),
         ),
     )
 
@@ -123,15 +123,15 @@ class AktivitetspliktDao(
                         INSERT INTO aktivitetsplikt_aktivitet(id, sak_id, aktivitet_type, fom, tom, opprettet, endret, beskrivelse) 
                         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                     """,
-        listOf(
-            SQLObject(UUID.randomUUID()),
-            SQLLong(sakId),
-            SQLString(aktivitet.type.name),
-            SQLDate(Date.valueOf(aktivitet.fom)),
-            SQLDate(aktivitet.tom?.let { tom -> Date.valueOf(tom) }),
-            SQLString(kilde.toJson()),
-            SQLString(kilde.toJson()),
-            SQLString(aktivitet.beskrivelse),
+        mapOf(
+            1 to SQLObject(UUID.randomUUID()),
+            2 to SQLLong(sakId),
+            3 to SQLString(aktivitet.type.name),
+            4 to SQLDate(Date.valueOf(aktivitet.fom)),
+            5 to SQLDate(aktivitet.tom?.let { tom -> Date.valueOf(tom) }),
+            6 to SQLString(kilde.toJson()),
+            7 to SQLString(kilde.toJson()),
+            8 to SQLString(aktivitet.beskrivelse),
         ),
     )
 
@@ -145,14 +145,14 @@ class AktivitetspliktDao(
                         SET aktivitet_type = ?, fom = ?, tom = ?, endret = ?, beskrivelse = ?
                         WHERE id = ? AND behandling_id = ?
                     """,
-        listOf(
-            SQLString(aktivitet.type.name),
-            SQLDate(Date.valueOf(aktivitet.fom)),
-            SQLDate(aktivitet.tom?.let { tom -> Date.valueOf(tom) }),
-            SQLString(kilde.toJson()),
-            SQLString(aktivitet.beskrivelse),
-            SQLObject(requireNotNull(aktivitet.id)),
-            SQLObject(behandlingId),
+        mapOf(
+            1 to SQLString(aktivitet.type.name),
+            2 to SQLDate(Date.valueOf(aktivitet.fom)),
+            3 to SQLDate(aktivitet.tom?.let { tom -> Date.valueOf(tom) }),
+            4 to SQLString(kilde.toJson()),
+            5 to SQLString(aktivitet.beskrivelse),
+            6 to SQLObject(requireNotNull(aktivitet.id)),
+            7 to SQLObject(behandlingId),
         ),
     )
 
@@ -165,14 +165,14 @@ class AktivitetspliktDao(
                         SET aktivitet_type = ?, fom = ?, tom = ?, endret = ?, beskrivelse = ?
                         WHERE id = ? AND sak_id = ?""",
         params =
-            listOf(
-                SQLString(aktivitet.type.name),
-                SQLDate(Date.valueOf(aktivitet.fom)),
-                SQLDate(aktivitet.tom?.let { tom -> Date.valueOf(tom) }),
-                SQLString(kilde.toJson()),
-                SQLString(aktivitet.beskrivelse),
-                SQLObject(requireNotNull(aktivitet.id)),
-                SQLObject(sakId),
+            mapOf(
+                1 to SQLString(aktivitet.type.name),
+                2 to SQLDate(Date.valueOf(aktivitet.fom)),
+                3 to SQLDate(aktivitet.tom?.let { tom -> Date.valueOf(tom) }),
+                4 to SQLString(kilde.toJson()),
+                5 to SQLString(aktivitet.beskrivelse),
+                6 to SQLObject(requireNotNull(aktivitet.id)),
+                7 to SQLObject(sakId),
             ),
     )
 
@@ -181,7 +181,7 @@ class AktivitetspliktDao(
         behandlingId: UUID,
     ) = connectionAutoclosing.slett(
         """DELETE FROM aktivitetsplikt_aktivitet WHERE id = ? AND behandling_id = ?""",
-        listOf(SQLObject(aktivitetId), SQLObject(behandlingId)),
+        mapOf(1 to SQLObject(aktivitetId), 2 to SQLObject(behandlingId)),
     )
 
     fun slettAktivitetForSak(
@@ -189,7 +189,7 @@ class AktivitetspliktDao(
         sakId: SakId,
     ) = connectionAutoclosing.slett(
         "DELETE FROM aktivitetsplikt_aktivitet WHERE id = ? AND sak_id = ?",
-        listOf(SQLObject(aktivitetId), SQLObject(sakId)),
+        mapOf(1 to SQLObject(aktivitetId), 2 to SQLObject(sakId)),
     )
 
     fun kopierAktiviteter(
@@ -200,7 +200,7 @@ class AktivitetspliktDao(
                         INSERT INTO aktivitetsplikt_aktivitet (id, sak_id, behandling_id, aktivitet_type, fom, tom, opprettet, endret, beskrivelse)
                         (SELECT gen_random_uuid(), sak_id, ?, aktivitet_type, fom, tom, opprettet, endret, beskrivelse FROM aktivitetsplikt_aktivitet WHERE behandling_id = ?)
                     """,
-        listOf(SQLObject(nyBehandlingId), SQLObject(forrigeBehandlingId)),
+        mapOf(1 to SQLObject(nyBehandlingId), 2 to SQLObject(forrigeBehandlingId)),
     )
 
     private fun ResultSet.toAktivitet() =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
@@ -133,27 +133,22 @@ class AktivitetspliktDao(
         sakId: SakId,
         aktivitet: LagreAktivitetspliktAktivitet,
         kilde: Grunnlagsopplysning.Kilde,
-    ) = connectionAutoclosing.hentConnection {
-        with(it) {
-            val stmt =
-                prepareStatement(
-                    """
+    ) = connectionAutoclosing.opprett(
+        """
                         INSERT INTO aktivitetsplikt_aktivitet(id, sak_id, aktivitet_type, fom, tom, opprettet, endret, beskrivelse) 
                         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                    """.trimMargin(),
-                )
-            stmt.setObject(1, UUID.randomUUID())
-            stmt.setLong(2, sakId)
-            stmt.setString(3, aktivitet.type.name)
-            stmt.setDate(4, Date.valueOf(aktivitet.fom))
-            stmt.setDate(5, aktivitet.tom?.let { tom -> Date.valueOf(tom) })
-            stmt.setString(6, kilde.toJson())
-            stmt.setString(7, kilde.toJson())
-            stmt.setString(8, aktivitet.beskrivelse)
-
-            stmt.executeUpdate()
-        }
-    }
+                    """,
+        listOf(
+            SQLObject(UUID.randomUUID()),
+            SQLLong(sakId),
+            SQLString(aktivitet.type.name),
+            SQLDate(Date.valueOf(aktivitet.fom)),
+            SQLDate(aktivitet.tom?.let { tom -> Date.valueOf(tom) }),
+            SQLString(kilde.toJson()),
+            SQLString(kilde.toJson()),
+            SQLString(aktivitet.beskrivelse),
+        ),
+    )
 
     fun oppdaterAktivitet(
         behandlingId: UUID,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
@@ -3,7 +3,6 @@ package no.nav.etterlatte.behandling.aktivitetsplikt
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.hendelse.getUUID
 import no.nav.etterlatte.behandling.objectMapper
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.aktivitetsplikt.AktivitetDto
 import no.nav.etterlatte.libs.common.aktivitetsplikt.AktivitetType
 import no.nav.etterlatte.libs.common.behandling.AktivitetspliktOppfolging
@@ -11,6 +10,7 @@ import no.nav.etterlatte.libs.common.behandling.OpprettAktivitetspliktOppfolging
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.getTidspunkt
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.toList
 import java.sql.Date
 import java.sql.ResultSet

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
@@ -198,13 +198,13 @@ class AktivitetspliktDao(
                         WHERE id = ? AND sak_id = ?""",
         params =
             listOf(
-                SQLParameter(1, Parametertype.STRING, aktivitet.type.name),
-                SQLParameter(2, Parametertype.DATE, Date.valueOf(aktivitet.fom)),
-                SQLParameter(3, Parametertype.DATE, aktivitet.tom?.let { tom -> Date.valueOf(tom) }),
-                SQLParameter(4, Parametertype.STRING, kilde.toJson()),
-                SQLParameter(5, Parametertype.STRING, aktivitet.beskrivelse),
-                SQLParameter(6, Parametertype.OBJECT, requireNotNull(aktivitet.id)),
-                SQLParameter(7, Parametertype.OBJECT, sakId),
+                SQLParameter(Parametertype.STRING, aktivitet.type.name),
+                SQLParameter(Parametertype.DATE, Date.valueOf(aktivitet.fom)),
+                SQLParameter(Parametertype.DATE, aktivitet.tom?.let { tom -> Date.valueOf(tom) }),
+                SQLParameter(Parametertype.STRING, kilde.toJson()),
+                SQLParameter(Parametertype.STRING, aktivitet.beskrivelse),
+                SQLParameter(Parametertype.OBJECT, requireNotNull(aktivitet.id)),
+                SQLParameter(Parametertype.OBJECT, sakId),
             ),
     )
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.libs.database.SQLLong
 import no.nav.etterlatte.libs.database.SQLObject
 import no.nav.etterlatte.libs.database.SQLString
 import no.nav.etterlatte.libs.database.hent
+import no.nav.etterlatte.libs.database.hentListe
 import no.nav.etterlatte.libs.database.oppdater
 import no.nav.etterlatte.libs.database.opprett
 import no.nav.etterlatte.libs.database.slett
@@ -42,6 +43,7 @@ class AktivitetspliktDao(
                 |LIMIT 1
                         """,
                 listOf(SQLObject(behandlingId)),
+                single = false,
             ) {
                 AktivitetspliktOppfolging(
                     behandlingId = getUUID("behandling_id"),
@@ -49,7 +51,7 @@ class AktivitetspliktDao(
                     opprettet = getTidspunkt("opprettet"),
                     opprettetAv = getString("opprettet_av"),
                 )
-            }.firstOrNull()
+            }
 
     fun lagre(
         behandlingId: UUID,
@@ -69,7 +71,7 @@ class AktivitetspliktDao(
 
     fun hentAktiviteterForBehandling(behandlingId: UUID): List<AktivitetspliktAktivitet> =
         connectionAutoclosing
-            .hent(
+            .hentListe(
                 """
                         SELECT id, sak_id, behandling_id, aktivitet_type, fom, tom, opprettet, endret, beskrivelse
                         FROM aktivitetsplikt_aktivitet
@@ -80,7 +82,7 @@ class AktivitetspliktDao(
 
     fun hentAktiviteterForSak(sakId: SakId): List<AktivitetspliktAktivitet> =
         connectionAutoclosing
-            .hent(
+            .hentListe(
                 """
                         SELECT id, sak_id, behandling_id, aktivitet_type, fom, tom, opprettet, endret, beskrivelse
                         FROM aktivitetsplikt_aktivitet

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktDao.kt
@@ -15,6 +15,7 @@ import no.nav.etterlatte.libs.database.SQLDate
 import no.nav.etterlatte.libs.database.SQLLong
 import no.nav.etterlatte.libs.database.SQLObject
 import no.nav.etterlatte.libs.database.SQLString
+import no.nav.etterlatte.libs.database.Uthentingsmodus
 import no.nav.etterlatte.libs.database.hent
 import no.nav.etterlatte.libs.database.hentListe
 import no.nav.etterlatte.libs.database.oppdater
@@ -43,7 +44,7 @@ class AktivitetspliktDao(
                 |LIMIT 1
                         """,
                 listOf(SQLObject(behandlingId)),
-                single = false,
+                modus = Uthentingsmodus.FIRST_OR_NULL,
             ) {
                 AktivitetspliktOppfolging(
                     behandlingId = getUUID("behandling_id"),

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/vurdering/AktivitetspliktAktivitetsgradDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/vurdering/AktivitetspliktAktivitetsgradDao.kt
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktVurderingOpprettetDato
 import no.nav.etterlatte.behandling.hendelse.getUUID
 import no.nav.etterlatte.behandling.objectMapper
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.aktivitetsplikt.AktivitetspliktAktivitetsgradDto
 import no.nav.etterlatte.libs.common.aktivitetsplikt.VurdertAktivitetsgrad
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.singleOrNull
 import no.nav.etterlatte.libs.database.toList
 import java.sql.Date

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/vurdering/AktivitetspliktUnntakDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/vurdering/AktivitetspliktUnntakDao.kt
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktVurderingOpprettetDato
 import no.nav.etterlatte.behandling.hendelse.getUUID
 import no.nav.etterlatte.behandling.objectMapper
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.aktivitetsplikt.UnntakFraAktivitetDto
 import no.nav.etterlatte.libs.common.aktivitetsplikt.UnntakFraAktivitetsplikt
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.singleOrNull
 import no.nav.etterlatte.libs.database.toList
 import java.sql.Date

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoDao.kt
@@ -1,10 +1,10 @@
 package no.nav.etterlatte.behandling.behandlinginfo
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.behandling.Brevutfall
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.setJsonb
 import no.nav.etterlatte.libs.database.singleOrNull
 import java.sql.ResultSet

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoDao.kt
@@ -46,7 +46,7 @@ class BehandlingInfoDao(
                 listOf(SQLObject(behandlingId)),
             ) {
                 toBrevutfall()
-            }.singleOrNull()
+            }
 
     fun lagreEtterbetaling(etterbetaling: Etterbetaling): Etterbetaling =
         connectionAutoclosing
@@ -85,7 +85,7 @@ class BehandlingInfoDao(
                 listOf(SQLObject(behandlingId)),
             ) {
                 toEtterbetaling()
-            }.singleOrNull()
+            }
 
     private fun ResultSet.toBrevutfall(): Brevutfall = this.getString("brevutfall").let { objectMapper.readValue(it) }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoDao.kt
@@ -5,6 +5,7 @@ import no.nav.etterlatte.libs.common.behandling.Brevutfall
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.database.ConnectionAutoclosing
+import no.nav.etterlatte.libs.database.ForventaResultat
 import no.nav.etterlatte.libs.database.SQLJsonb
 import no.nav.etterlatte.libs.database.SQLObject
 import no.nav.etterlatte.libs.database.hent
@@ -29,7 +30,7 @@ class BehandlingInfoDao(
                     SQLObject(brevutfall.behandlingId),
                     SQLJsonb(brevutfall),
                 ),
-                { require(it == 1) },
+                ForventaResultat.RADER,
             ).let {
                 hentBrevutfall(brevutfall.behandlingId)
                     ?: throw InternfeilException("Feilet under lagring av brevutfall")
@@ -58,7 +59,7 @@ class BehandlingInfoDao(
                     UPDATE SET etterbetaling = excluded.etterbetaling
                     """,
                 listOf(SQLObject(etterbetaling.behandlingId), SQLJsonb(etterbetaling)),
-                { require(it == 1) },
+                ForventaResultat.RADER,
             ).let {
                 hentEtterbetaling(etterbetaling.behandlingId)
                     ?: throw InternfeilException("Feilet under lagring av etterbetaling")
@@ -71,7 +72,7 @@ class BehandlingInfoDao(
                     WHERE behandling_id = ?
                     """,
             listOf(SQLJsonb(null), SQLObject(behandlingId)),
-            { require(it == 1) },
+            ForventaResultat.RADER,
         )
 
     fun hentEtterbetaling(behandlingId: UUID): Etterbetaling? =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoDao.kt
@@ -29,6 +29,7 @@ class BehandlingInfoDao(
                     SQLObject(brevutfall.behandlingId),
                     SQLJsonb(brevutfall),
                 ),
+                { require(it == 1) },
             ).let {
                 hentBrevutfall(brevutfall.behandlingId)
                     ?: throw InternfeilException("Feilet under lagring av brevutfall")
@@ -57,6 +58,7 @@ class BehandlingInfoDao(
                     UPDATE SET etterbetaling = excluded.etterbetaling
                     """,
                 listOf(SQLObject(etterbetaling.behandlingId), SQLJsonb(etterbetaling)),
+                { require(it == 1) },
             ).let {
                 hentEtterbetaling(etterbetaling.behandlingId)
                     ?: throw InternfeilException("Feilet under lagring av etterbetaling")
@@ -69,6 +71,7 @@ class BehandlingInfoDao(
                     WHERE behandling_id = ?
                     """,
             listOf(SQLJsonb(null), SQLObject(behandlingId)),
+            { require(it == 1) },
         )
 
     fun hentEtterbetaling(behandlingId: UUID): Etterbetaling? =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoDao.kt
@@ -26,9 +26,9 @@ class BehandlingInfoDao(
                     ON CONFLICT (behandling_id) DO 
                     UPDATE SET brevutfall = excluded.brevutfall
                     """,
-                listOf(
-                    SQLObject(brevutfall.behandlingId),
-                    SQLJsonb(brevutfall),
+                mapOf(
+                    1 to SQLObject(brevutfall.behandlingId),
+                    2 to SQLJsonb(brevutfall),
                 ),
                 ForventaResultat.RADER,
             ).let {
@@ -44,7 +44,7 @@ class BehandlingInfoDao(
                     FROM behandling_info 
                     WHERE behandling_id = ?::UUID
                     """,
-                listOf(SQLObject(behandlingId)),
+                mapOf(1 to SQLObject(behandlingId)),
             ) {
                 toBrevutfall()
             }
@@ -58,7 +58,7 @@ class BehandlingInfoDao(
                     ON CONFLICT (behandling_id) DO 
                     UPDATE SET etterbetaling = excluded.etterbetaling
                     """,
-                listOf(SQLObject(etterbetaling.behandlingId), SQLJsonb(etterbetaling)),
+                mapOf(1 to SQLObject(etterbetaling.behandlingId), 2 to SQLJsonb(etterbetaling)),
                 ForventaResultat.RADER,
             ).let {
                 hentEtterbetaling(etterbetaling.behandlingId)
@@ -71,7 +71,7 @@ class BehandlingInfoDao(
                     UPDATE behandling_info SET etterbetaling = ?
                     WHERE behandling_id = ?
                     """,
-            listOf(SQLJsonb(null), SQLObject(behandlingId)),
+            mapOf(1 to SQLJsonb(null), 2 to SQLObject(behandlingId)),
             ForventaResultat.RADER,
         )
 
@@ -83,7 +83,7 @@ class BehandlingInfoDao(
                     FROM behandling_info 
                     WHERE behandling_id = ?::UUID AND etterbetaling IS NOT NULL
                     """,
-                listOf(SQLObject(behandlingId)),
+                mapOf(1 to SQLObject(behandlingId)),
             ) {
                 toEtterbetaling()
             }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/bosattutland/BosattUtlandDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/bosattutland/BosattUtlandDao.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.hendelse.getUUID
 import no.nav.etterlatte.behandling.objectMapper
 import no.nav.etterlatte.libs.database.ConnectionAutoclosing
+import no.nav.etterlatte.libs.database.ForventaResultat
 import no.nav.etterlatte.libs.database.SQLJsonb
 import no.nav.etterlatte.libs.database.SQLObject
 import no.nav.etterlatte.libs.database.hent
@@ -29,7 +30,7 @@ class BosattUtlandDao(
                 SQLJsonb(bosattUtland.mottatteSeder),
                 SQLJsonb(bosattUtland.sendteSeder),
             ),
-            { require(it == 1) },
+            ForventaResultat.RADER,
         )
 
     fun hentBosattUtland(behandlingId: UUID): BosattUtland? =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/bosattutland/BosattUtlandDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/bosattutland/BosattUtlandDao.kt
@@ -24,11 +24,11 @@ class BosattUtlandDao(
                             DO UPDATE SET rinanummer = excluded.rinanummer,
                             mottattSeder = excluded.mottattSeder, sendteSeder = excluded.sendteSeder
                         """,
-            listOf(
-                SQLObject(bosattUtland.behandlingId),
-                SQLObject(bosattUtland.rinanummer),
-                SQLJsonb(bosattUtland.mottatteSeder),
-                SQLJsonb(bosattUtland.sendteSeder),
+            mapOf(
+                1 to SQLObject(bosattUtland.behandlingId),
+                2 to SQLObject(bosattUtland.rinanummer),
+                3 to SQLJsonb(bosattUtland.mottatteSeder),
+                4 to SQLJsonb(bosattUtland.sendteSeder),
             ),
             ForventaResultat.RADER,
         )
@@ -37,7 +37,7 @@ class BosattUtlandDao(
         connectionAutoclosing
             .hent(
                 "SELECT behandlingid, rinanummer, mottattSeder, sendteSeder from bosattutland where behandlingid = ?",
-                listOf(SQLObject(behandlingId)),
+                mapOf(1 to SQLObject(behandlingId)),
             ) { toBosattUtland() }
 
     private fun ResultSet.toBosattUtland(): BosattUtland =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/bosattutland/BosattUtlandDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/bosattutland/BosattUtlandDao.kt
@@ -38,7 +38,6 @@ class BosattUtlandDao(
                 "SELECT behandlingid, rinanummer, mottattSeder, sendteSeder from bosattutland where behandlingid = ?",
                 listOf(SQLObject(behandlingId)),
             ) { toBosattUtland() }
-            .singleOrNull()
 
     private fun ResultSet.toBosattUtland(): BosattUtland =
         BosattUtland(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/bosattutland/BosattUtlandDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/bosattutland/BosattUtlandDao.kt
@@ -3,7 +3,7 @@ package no.nav.etterlatte.behandling.bosattutland
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.hendelse.getUUID
 import no.nav.etterlatte.behandling.objectMapper
-import no.nav.etterlatte.common.ConnectionAutoclosing
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.setJsonb
 import no.nav.etterlatte.libs.database.singleOrNull
 import java.sql.ResultSet

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/bosattutland/BosattUtlandDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/bosattutland/BosattUtlandDao.kt
@@ -29,6 +29,7 @@ class BosattUtlandDao(
                 SQLJsonb(bosattUtland.mottatteSeder),
                 SQLJsonb(bosattUtland.sendteSeder),
             ),
+            { require(it == 1) },
         )
 
     fun hentBosattUtland(behandlingId: UUID): BosattUtland? =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/generellbehandling/GenerellBehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/generellbehandling/GenerellBehandlingDao.kt
@@ -13,6 +13,7 @@ import no.nav.etterlatte.libs.database.SQLObject
 import no.nav.etterlatte.libs.database.SQLString
 import no.nav.etterlatte.libs.database.SQLTidspunkt
 import no.nav.etterlatte.libs.database.hent
+import no.nav.etterlatte.libs.database.hentListe
 import no.nav.etterlatte.libs.database.oppdaterOgReturner
 import no.nav.etterlatte.libs.database.opprettOgReturner
 import java.sql.ResultSet
@@ -67,10 +68,9 @@ class GenerellBehandlingDao(
                         """,
                 listOf(SQLObject(id)),
             ) { toGenerellBehandling() }
-            .singleOrNull()
 
     fun hentGenerellBehandlingForSak(sakId: SakId): List<GenerellBehandling> =
-        connectionAutoclosing.hent(
+        connectionAutoclosing.hentListe(
             """
                         SELECT id, innhold, sak_id, opprettet, type, tilknyttet_behandling, status, behandler, attestant, kommentar
                         FROM generellbehandling
@@ -89,7 +89,6 @@ class GenerellBehandlingDao(
                         """,
                 listOf(SQLObject(tilknyttetBehandlingId)),
             ) { toGenerellBehandling() }
-            .singleOrNull()
 
     private fun ResultSet.toGenerellBehandling(): GenerellBehandling =
         GenerellBehandling(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/generellbehandling/GenerellBehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/generellbehandling/GenerellBehandlingDao.kt
@@ -29,14 +29,14 @@ class GenerellBehandlingDao(
                         VALUES(?::UUID, ?, ?, ?, ?, ?, ?)
                         RETURNING id, innhold, sak_id, opprettet, type, tilknyttet_behandling, status, behandler, attestant, kommentar
                         """,
-            listOf(
-                SQLObject(generellBehandling.id),
-                SQLJsonb(generellBehandling.innhold),
-                SQLLong(generellBehandling.sakId),
-                SQLTidspunkt(generellBehandling.opprettet),
-                SQLString(generellBehandling.type.name),
-                SQLObject(generellBehandling.tilknyttetBehandling),
-                SQLString(generellBehandling.status.name),
+            mapOf(
+                1 to SQLObject(generellBehandling.id),
+                2 to SQLJsonb(generellBehandling.innhold),
+                3 to SQLLong(generellBehandling.sakId),
+                4 to SQLTidspunkt(generellBehandling.opprettet),
+                5 to SQLString(generellBehandling.type.name),
+                6 to SQLObject(generellBehandling.tilknyttetBehandling),
+                7 to SQLString(generellBehandling.status.name),
             ),
         ) { toGenerellBehandling() }
 
@@ -48,13 +48,13 @@ class GenerellBehandlingDao(
                         where id = ?
                         RETURNING id, innhold, sak_id, opprettet, type, tilknyttet_behandling, status, behandler, attestant, kommentar
                         """,
-            listOf(
-                SQLJsonb(generellBehandling.innhold),
-                SQLString(generellBehandling.status.name),
-                SQLJsonb(generellBehandling.behandler),
-                SQLJsonb(generellBehandling.attestant),
-                SQLString(generellBehandling.returnertKommenar),
-                SQLObject(generellBehandling.id),
+            mapOf(
+                1 to SQLJsonb(generellBehandling.innhold),
+                2 to SQLString(generellBehandling.status.name),
+                3 to SQLJsonb(generellBehandling.behandler),
+                4 to SQLJsonb(generellBehandling.attestant),
+                5 to SQLString(generellBehandling.returnertKommenar),
+                6 to SQLObject(generellBehandling.id),
             ),
         ) { toGenerellBehandling() }
 
@@ -66,7 +66,7 @@ class GenerellBehandlingDao(
                         FROM generellbehandling
                         WHERE id = ?
                         """,
-                listOf(SQLObject(id)),
+                mapOf(1 to SQLObject(id)),
             ) { toGenerellBehandling() }
 
     fun hentGenerellBehandlingForSak(sakId: SakId): List<GenerellBehandling> =
@@ -76,7 +76,7 @@ class GenerellBehandlingDao(
                         FROM generellbehandling
                         WHERE sak_id = ?
                         """,
-            listOf(SQLLong(sakId)),
+            mapOf(1 to SQLLong(sakId)),
         ) { toGenerellBehandling() }
 
     fun hentBehandlingForTilknyttetBehandling(tilknyttetBehandlingId: UUID): GenerellBehandling? =
@@ -87,7 +87,7 @@ class GenerellBehandlingDao(
                         FROM generellbehandling
                         WHERE tilknyttet_behandling = ?::uuid
                         """,
-                listOf(SQLObject(tilknyttetBehandlingId)),
+                mapOf(1 to SQLObject(tilknyttetBehandlingId)),
             ) { toGenerellBehandling() }
 
     private fun ResultSet.toGenerellBehandling(): GenerellBehandling =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/generellbehandling/GenerellBehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/generellbehandling/GenerellBehandlingDao.kt
@@ -2,12 +2,12 @@ package no.nav.etterlatte.behandling.generellbehandling
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.hendelse.getUUID
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.generellbehandling.GenerellBehandling
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.getTidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.setTidspunkt
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.setJsonb
 import no.nav.etterlatte.libs.database.single
 import no.nav.etterlatte.libs.database.singleOrNull

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/HendelseDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/HendelseDao.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.behandling.hendelse
 
 import no.nav.etterlatte.behandling.domain.Behandling
 import no.nav.etterlatte.behandling.domain.BehandlingOpprettet
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.generellbehandling.GenerellBehandlingHendelseType
 import no.nav.etterlatte.libs.common.klage.KlageHendelseType
@@ -12,6 +11,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.getTidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.getTidspunktOrNull
 import no.nav.etterlatte.libs.common.tidspunkt.setTidspunkt
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingHendelseType
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.toList
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageDao.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.behandling.klage
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.behandling.BehandlingResultat
 import no.nav.etterlatte.libs.common.behandling.KabalStatus
 import no.nav.etterlatte.libs.common.behandling.Kabalrespons
@@ -12,6 +11,7 @@ import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.getTidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.setTidspunkt
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.setJsonb
 import no.nav.etterlatte.libs.database.singleOrNull
 import no.nav.etterlatte.libs.database.toList

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/kommerbarnettilgode/KommerBarnetTilGodeDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/kommerbarnettilgode/KommerBarnetTilGodeDao.kt
@@ -2,9 +2,9 @@ package no.nav.etterlatte.behandling.kommerbarnettilgode
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.objectMapper
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.behandling.JaNei
 import no.nav.etterlatte.libs.common.behandling.KommerBarnetTilgode
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.singleOrNull
 import java.util.UUID
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningDao.kt
@@ -1,8 +1,8 @@
 package no.nav.etterlatte.behandling.omregning
 
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.sak.KjoeringRequest
 import no.nav.etterlatte.libs.common.sak.LagreKjoeringRequest
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 
 class OmregningDao(
     private val connection: ConnectionAutoclosing,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingDao.kt
@@ -5,7 +5,6 @@ import no.nav.etterlatte.behandling.domain.Revurdering
 import no.nav.etterlatte.behandling.hendelse.getUUID
 import no.nav.etterlatte.behandling.objectMapper
 import no.nav.etterlatte.behandling.somLocalDateTimeUTC
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.KommerBarnetTilgode
@@ -13,6 +12,7 @@ import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.sak.Sak
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.setJsonb
 import no.nav.etterlatte.libs.database.singleOrNull
 import java.sql.PreparedStatement

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/sjekkliste/SjekklisteDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/sjekkliste/SjekklisteDao.kt
@@ -2,7 +2,7 @@ package no.nav.etterlatte.behandling.sjekkliste
 
 import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.behandling.hendelse.getUUID
-import no.nav.etterlatte.common.ConnectionAutoclosing
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.toList
 import java.sql.ResultSet
 import java.util.UUID

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingDao.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.behandling.tilbakekreving
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.hendelse.getUUID
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.sak.SakId
@@ -16,6 +15,7 @@ import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingResultat
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingSkyld
 import no.nav.etterlatte.libs.common.tilbakekreving.Tilbakekrevingsbelop
 import no.nav.etterlatte.libs.common.toJsonNode
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.setJsonb
 import no.nav.etterlatte.libs.database.singleOrNull
 import no.nav.etterlatte.libs.database.toList

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksbehandling/VedtaksbehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksbehandling/VedtaksbehandlingDao.kt
@@ -1,9 +1,9 @@
 package no.nav.etterlatte.behandling.vedtaksbehandling
 
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.KlageStatus
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingStatus
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.single
 import java.sql.ResultSet
 import java.util.UUID

--- a/apps/etterlatte-behandling/src/main/kotlin/common/ConnectionAutoclosingImpl.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/common/ConnectionAutoclosingImpl.kt
@@ -2,12 +2,11 @@ package no.nav.etterlatte.common
 
 import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.databaseContext
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import java.sql.Connection
 import javax.sql.DataSource
 
-abstract class ConnectionAutoclosing {
-    abstract fun <T> hentConnection(block: (connection: Connection) -> T): T
-
+abstract class ConnectionAutoclosingBehandling : ConnectionAutoclosing {
     internal fun manglerKontekst() =
         when (Kontekst.get()) {
             null -> true
@@ -17,7 +16,7 @@ abstract class ConnectionAutoclosing {
 
 class ConnectionAutoclosingImpl(
     val dataSource: DataSource,
-) : ConnectionAutoclosing() {
+) : ConnectionAutoclosingBehandling() {
     override fun <T> hentConnection(block: (connection: Connection) -> T): T =
         if (manglerKontekst()) {
             dataSource.connection.use {

--- a/apps/etterlatte-behandling/src/main/kotlin/common/ConnectionAutoclosingImpl.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/common/ConnectionAutoclosingImpl.kt
@@ -8,13 +8,11 @@ import javax.sql.DataSource
 abstract class ConnectionAutoclosing {
     abstract fun <T> hentConnection(block: (connection: Connection) -> T): T
 
-    internal fun manglerKontekst(): Boolean {
-        val kontekst = Kontekst.get()
-        return when (kontekst) {
+    internal fun manglerKontekst() =
+        when (Kontekst.get()) {
             null -> true
             else -> false
         }
-    }
 }
 
 class ConnectionAutoclosingImpl(

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -79,7 +79,6 @@ import no.nav.etterlatte.behandling.tilbakekreving.TilbakekrevingHendelserServic
 import no.nav.etterlatte.behandling.tilbakekreving.TilbakekrevingService
 import no.nav.etterlatte.behandling.vedtaksbehandling.VedtaksbehandlingDao
 import no.nav.etterlatte.behandling.vedtaksbehandling.VedtaksbehandlingService
-import no.nav.etterlatte.common.ConnectionAutoclosingImpl
 import no.nav.etterlatte.common.klienter.PdlTjenesterKlient
 import no.nav.etterlatte.common.klienter.PdlTjenesterKlientImpl
 import no.nav.etterlatte.common.klienter.PesysKlient
@@ -122,6 +121,7 @@ import no.nav.etterlatte.libs.common.appIsInGCP
 import no.nav.etterlatte.libs.common.isProd
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.norskKlokke
+import no.nav.etterlatte.libs.database.ConnectionAutoclosingImpl
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.jobs.LeaderElection
 import no.nav.etterlatte.libs.ktor.AppConfig.ELECTOR_PATH

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -79,6 +79,7 @@ import no.nav.etterlatte.behandling.tilbakekreving.TilbakekrevingHendelserServic
 import no.nav.etterlatte.behandling.tilbakekreving.TilbakekrevingService
 import no.nav.etterlatte.behandling.vedtaksbehandling.VedtaksbehandlingDao
 import no.nav.etterlatte.behandling.vedtaksbehandling.VedtaksbehandlingService
+import no.nav.etterlatte.common.ConnectionAutoclosingImpl
 import no.nav.etterlatte.common.klienter.PdlTjenesterKlient
 import no.nav.etterlatte.common.klienter.PdlTjenesterKlientImpl
 import no.nav.etterlatte.common.klienter.PesysKlient
@@ -121,7 +122,6 @@ import no.nav.etterlatte.libs.common.appIsInGCP
 import no.nav.etterlatte.libs.common.isProd
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.norskKlokke
-import no.nav.etterlatte.libs.database.ConnectionAutoclosingImpl
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.jobs.LeaderElection
 import no.nav.etterlatte.libs.ktor.AppConfig.ELECTOR_PATH

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseDao.kt
@@ -6,13 +6,13 @@ import no.nav.etterlatte.behandling.domain.GrunnlagsendringsType
 import no.nav.etterlatte.behandling.domain.Grunnlagsendringshendelse
 import no.nav.etterlatte.behandling.domain.SamsvarMellomKildeOgGrunnlag
 import no.nav.etterlatte.behandling.objectMapper
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.getTidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.setTidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.setJsonb
 import no.nav.etterlatte.libs.database.singleOrNull
 import no.nav.etterlatte.libs.database.toList

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseDao.kt
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.doedshendelse.DoedshendelseReminder
 import no.nav.etterlatte.behandling.hendelse.setLong
 import no.nav.etterlatte.behandling.objectMapper
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.behandling.DoedshendelseBrevDistribuert
 import no.nav.etterlatte.libs.common.pdlhendelse.Endringstype
 import no.nav.etterlatte.libs.common.tidspunkt.getTidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.setTidspunkt
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.setJsonb
 import no.nav.etterlatte.libs.database.toList
 import no.nav.helse.rapids_rivers.toUUID

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/mellomAttenOgTjueVedReformtidspunkt/OpprettDoedshendelseDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/mellomAttenOgTjueVedReformtidspunkt/OpprettDoedshendelseDao.kt
@@ -1,6 +1,6 @@
 package no.nav.etterlatte.grunnlagsendring.doedshendelse.mellom18og20PaaReformtidspunkt
 
-import no.nav.etterlatte.common.ConnectionAutoclosing
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.toList
 
 enum class OpprettDoedshendelseStatus {

--- a/apps/etterlatte-behandling/src/main/kotlin/institusjonsopphold/InstitusjonsoppholdDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/institusjonsopphold/InstitusjonsoppholdDao.kt
@@ -1,11 +1,11 @@
 package no.nav.etterlatte.institusjonsopphold
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.behandling.JaNei
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.singleOrNull
 import java.util.UUID
 

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDao.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.oppgave
 
 import no.nav.etterlatte.behandling.hendelse.getUUID
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
 import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
@@ -17,6 +16,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.getTidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.getTidspunktOrNull
 import no.nav.etterlatte.libs.common.tidspunkt.setTidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.singleOrNull
 import no.nav.etterlatte.libs.database.toList
 import org.slf4j.LoggerFactory

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDaoMedEndringssporing.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDaoMedEndringssporing.kt
@@ -3,7 +3,6 @@ package no.nav.etterlatte.oppgave
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.behandling.objectMapper
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
 import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
@@ -13,6 +12,7 @@ import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.getTidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.setTidspunkt
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.setJsonb
 import no.nav.etterlatte.libs.database.toList
 import java.sql.ResultSet

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakLesDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakLesDao.kt
@@ -2,12 +2,12 @@ package no.nav.etterlatte.sak
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.objectMapper
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.behandling.Flyktning
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 import no.nav.etterlatte.libs.common.sak.KjoeringStatus
 import no.nav.etterlatte.libs.common.sak.Sak
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.single
 import no.nav.etterlatte.libs.database.singleOrNull
 import no.nav.etterlatte.libs.database.toList

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakendringerDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakendringerDao.kt
@@ -1,11 +1,11 @@
 package no.nav.etterlatte.sak
 
 import no.nav.etterlatte.Kontekst
-import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.setTidspunkt
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.setJsonb
 import java.sql.Connection
 import java.util.UUID

--- a/apps/etterlatte-behandling/src/main/kotlin/saksbehandler/SaksbehandlerInfoDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/saksbehandler/SaksbehandlerInfoDao.kt
@@ -3,7 +3,7 @@ package no.nav.etterlatte.saksbehandler
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.klienter.SaksbehandlerInfo
 import no.nav.etterlatte.behandling.objectMapper
-import no.nav.etterlatte.common.ConnectionAutoclosing
+import no.nav.etterlatte.libs.database.ConnectionAutoclosing
 import no.nav.etterlatte.libs.database.setJsonb
 import no.nav.etterlatte.libs.database.single
 import no.nav.etterlatte.libs.database.singleOrNull

--- a/apps/etterlatte-behandling/src/test/kotlin/DatabaseContextTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/DatabaseContextTest.kt
@@ -1,7 +1,7 @@
 package no.nav.etterlatte
 
 import io.mockk.mockk
-import no.nav.etterlatte.common.ConnectionAutoclosing
+import no.nav.etterlatte.libs.database.ConnectionAutoclosingBehandling
 import no.nav.etterlatte.libs.ktor.token.HardkodaSystembruker
 import java.sql.Connection
 import javax.sql.DataSource
@@ -27,7 +27,7 @@ class DatabaseContextTest(
 
 class ConnectionAutoclosingTest(
     val dataSource: DataSource,
-) : ConnectionAutoclosing() {
+) : ConnectionAutoclosingBehandling() {
     private val context =
         Context(Self(this::class.java.simpleName), DatabaseContextTest(dataSource), mockk(), HardkodaSystembruker.testdata)
 

--- a/apps/etterlatte-behandling/src/test/kotlin/DatabaseContextTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/DatabaseContextTest.kt
@@ -1,7 +1,7 @@
 package no.nav.etterlatte
 
 import io.mockk.mockk
-import no.nav.etterlatte.libs.database.ConnectionAutoclosingBehandling
+import no.nav.etterlatte.common.ConnectionAutoclosingBehandling
 import no.nav.etterlatte.libs.ktor.token.HardkodaSystembruker
 import java.sql.Connection
 import javax.sql.DataSource

--- a/libs/etterlatte-database/src/main/kotlin/ConnectionAutoclosing.kt
+++ b/libs/etterlatte-database/src/main/kotlin/ConnectionAutoclosing.kt
@@ -1,0 +1,7 @@
+package no.nav.etterlatte.libs.database
+
+import java.sql.Connection
+
+interface ConnectionAutoclosing {
+    fun <T> hentConnection(block: (connection: Connection) -> T): T
+}

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -53,16 +53,18 @@ inline fun <reified T : Any> PreparedStatement.setJsonb(
     return this
 }
 
-fun ConnectionAutoclosing.hent(
+fun <T> ConnectionAutoclosing.hent(
     statement: String,
     params: List<SQLParameter>,
-) = hentConnection {
-    with(it) {
-        val stmt = prepareStatement(statement.trimMargin())
-        params.forEachIndexed { index, param -> settParameter(index + 1, param, stmt) }
-        stmt.executeQuery()
+    konverterer: (ResultSet.(Any?) -> T),
+): List<T> =
+    hentConnection {
+        with(it) {
+            val stmt = prepareStatement(statement.trimMargin())
+            params.forEachIndexed { index, param -> settParameter(index + 1, param, stmt) }
+            stmt.executeQuery()
+        }.toList { konverterer(it) }
     }
-}
 
 fun ConnectionAutoclosing.opprett(
     statement: String,

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -53,6 +53,17 @@ inline fun <reified T : Any> PreparedStatement.setJsonb(
     return this
 }
 
+fun ConnectionAutoclosing.hent(
+    statement: String,
+    params: List<SQLParameter>,
+) = hentConnection {
+    with(it) {
+        val stmt = prepareStatement(statement.trimMargin())
+        params.forEachIndexed { index, param -> settParameter(index, param, stmt) }
+        stmt.executeQuery()
+    }
+}
+
 fun ConnectionAutoclosing.opprett(
     statement: String,
     params: List<SQLParameter>,

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -56,13 +56,11 @@ inline fun <reified T : Any> PreparedStatement.setJsonb(
 fun ConnectionAutoclosing.oppdater(
     statement: String,
     params: List<SQLParameter>,
-) {
-    hentConnection {
-        with(it) {
-            val stmt = prepareStatement(statement.trimMargin())
-            params.forEachIndexed { index, param -> settParameter(index, param, stmt) }
-            stmt.executeUpdate()
-        }
+) = hentConnection {
+    with(it) {
+        val stmt = prepareStatement(statement.trimMargin())
+        params.forEachIndexed { index, param -> settParameter(index, param, stmt) }
+        stmt.executeUpdate()
     }
 }
 

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -53,6 +53,17 @@ inline fun <reified T : Any> PreparedStatement.setJsonb(
     return this
 }
 
+fun ConnectionAutoclosing.opprett(
+    statement: String,
+    params: List<SQLParameter>,
+) = hentConnection {
+    with(it) {
+        val stmt = prepareStatement(statement.trimMargin())
+        params.forEachIndexed { index, param -> settParameter(index, param, stmt) }
+        stmt.executeUpdate()
+    }
+}
+
 fun ConnectionAutoclosing.oppdater(
     statement: String,
     params: List<SQLParameter>,

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -100,7 +100,6 @@ fun ConnectionAutoclosing.slett(
 }
 
 abstract class SQLParameter(
-    val type: Parametertype,
     open val verdi: Any?,
 ) {
     abstract fun settParameter(
@@ -111,7 +110,7 @@ abstract class SQLParameter(
 
 data class SQLString(
     override val verdi: String?,
-) : SQLParameter(Parametertype.STRING, verdi) {
+) : SQLParameter(verdi) {
     override fun settParameter(
         index: Int,
         stmt: PreparedStatement,
@@ -120,7 +119,7 @@ data class SQLString(
 
 data class SQLInt(
     override val verdi: Int,
-) : SQLParameter(Parametertype.INT, verdi) {
+) : SQLParameter(verdi) {
     override fun settParameter(
         index: Int,
         stmt: PreparedStatement,
@@ -129,7 +128,7 @@ data class SQLInt(
 
 data class SQLLong(
     override val verdi: Long,
-) : SQLParameter(Parametertype.LONG, verdi) {
+) : SQLParameter(verdi) {
     override fun settParameter(
         index: Int,
         stmt: PreparedStatement,
@@ -138,7 +137,7 @@ data class SQLLong(
 
 data class SQLDate(
     override val verdi: Date?,
-) : SQLParameter(Parametertype.DATE, verdi) {
+) : SQLParameter(verdi) {
     override fun settParameter(
         index: Int,
         stmt: PreparedStatement,
@@ -147,17 +146,9 @@ data class SQLDate(
 
 data class SQLObject(
     override val verdi: Any?,
-) : SQLParameter(Parametertype.OBJECT, verdi) {
+) : SQLParameter(verdi) {
     override fun settParameter(
         index: Int,
         stmt: PreparedStatement,
     ) = stmt.setObject(index, verdi)
-}
-
-enum class Parametertype {
-    STRING,
-    INT,
-    LONG,
-    DATE,
-    OBJECT,
 }

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -59,7 +59,7 @@ fun ConnectionAutoclosing.hent(
 ) = hentConnection {
     with(it) {
         val stmt = prepareStatement(statement.trimMargin())
-        params.forEachIndexed { index, param -> settParameter(index, param, stmt) }
+        params.forEachIndexed { index, param -> settParameter(index + 1, param, stmt) }
         stmt.executeQuery()
     }
 }
@@ -70,7 +70,7 @@ fun ConnectionAutoclosing.opprett(
 ) = hentConnection {
     with(it) {
         val stmt = prepareStatement(statement.trimMargin())
-        params.forEachIndexed { index, param -> settParameter(index, param, stmt) }
+        params.forEachIndexed { index, param -> settParameter(index + 1, param, stmt) }
         stmt.executeUpdate()
     }
 }
@@ -81,7 +81,7 @@ fun ConnectionAutoclosing.oppdater(
 ) = hentConnection {
     with(it) {
         val stmt = prepareStatement(statement.trimMargin())
-        params.forEachIndexed { index, param -> settParameter(index, param, stmt) }
+        params.forEachIndexed { index, param -> settParameter(index + 1, param, stmt) }
         stmt.executeUpdate()
     }
 }
@@ -92,7 +92,7 @@ fun ConnectionAutoclosing.slett(
 ) = hentConnection {
     with(it) {
         val stmt = prepareStatement(statement.trimMargin())
-        params.forEachIndexed { index, param -> settParameter(index, param, stmt) }
+        params.forEachIndexed { index, param -> settParameter(index + 1, param, stmt) }
         stmt.executeUpdate()
     }
 }

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -73,7 +73,7 @@ fun ConnectionAutoclosing.opprett(
     with(it) {
         val stmt = prepareStatement(statement.trimMargin())
         params.forEachIndexed { index, param -> param.settParameter(index + 1, stmt) }
-        stmt.executeUpdate()
+        stmt.executeUpdate().also { require(it == 1) }
     }
 }
 

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -57,86 +57,86 @@ inline fun <reified T : Any> PreparedStatement.setJsonb(
 
 fun <T> ConnectionAutoclosing.hent(
     statement: String,
-    params: List<SQLParameter>,
+    params: Map<Int, SQLParameter>,
     modus: Uthentingsmodus = Uthentingsmodus.SINGLE_OR_NULL,
     konverterer: (ResultSet.(Any?) -> T),
 ): T? =
     hentConnection {
         with(it) {
             val stmt = prepareStatement(statement.trimMargin())
-            params.forEachIndexed { index, param -> param.settParameter(index + 1, stmt) }
+            params.entries.forEach { entry -> entry.value.settParameter(entry.key, stmt) }
             stmt.executeQuery()
         }.let { modus.haandterUthenting(it, konverterer) }
     }
 
 fun <T> ConnectionAutoclosing.hentListe(
     statement: String,
-    params: List<SQLParameter>,
+    params: Map<Int, SQLParameter>,
     konverterer: (ResultSet.(Any?) -> T),
 ): List<T> =
     hentConnection {
         with(it) {
             val stmt = prepareStatement(statement.trimMargin())
-            params.forEachIndexed { index, param -> param.settParameter(index + 1, stmt) }
+            params.entries.forEach { entry -> entry.value.settParameter(entry.key, stmt) }
             stmt.executeQuery()
         }.toList { konverterer(it) }
     }
 
 fun ConnectionAutoclosing.opprett(
     statement: String,
-    params: List<SQLParameter>,
+    params: Map<Int, SQLParameter>,
     forventaResultat: ForventaResultat = ForventaResultat.IKKE_KJENT,
 ) = hentConnection {
     with(it) {
         val stmt = prepareStatement(statement.trimMargin())
-        params.forEachIndexed { index, param -> param.settParameter(index + 1, stmt) }
+        params.entries.forEach { entry -> entry.value.settParameter(entry.key, stmt) }
         stmt.executeUpdate().also { forventaResultat.haandhevKrav(it) }
     }
 }
 
 fun <T> ConnectionAutoclosing.opprettOgReturner(
     statement: String,
-    params: List<SQLParameter>,
+    params: Map<Int, SQLParameter>,
     konverterer: ResultSet.(Any?) -> T,
 ) = hentConnection {
     with(it) {
         val stmt = prepareStatement(statement.trimMargin())
-        params.forEachIndexed { index, param -> param.settParameter(index + 1, stmt) }
+        params.entries.forEach { entry -> entry.value.settParameter(entry.key, stmt) }
         stmt.executeQuery().single { konverterer(it) }
     }
 }
 
 fun ConnectionAutoclosing.oppdater(
     statement: String,
-    params: List<SQLParameter>,
+    params: Map<Int, SQLParameter>,
 ) = hentConnection {
     with(it) {
         val stmt = prepareStatement(statement.trimMargin())
-        params.forEachIndexed { index, param -> param.settParameter(index + 1, stmt) }
+        params.entries.forEach { entry -> entry.value.settParameter(entry.key, stmt) }
         stmt.executeUpdate()
     }
 }
 
 fun <T> ConnectionAutoclosing.oppdaterOgReturner(
     statement: String,
-    params: List<SQLParameter>,
+    params: Map<Int, SQLParameter>,
     konverterer: ResultSet.(Any?) -> T,
 ) = hentConnection {
     with(it) {
         val stmt = prepareStatement(statement.trimMargin())
-        params.forEachIndexed { index, param -> param.settParameter(index + 1, stmt) }
+        params.entries.forEach { entry -> entry.value.settParameter(entry.key, stmt) }
         stmt.executeQuery().single { konverterer(it) }
     }
 }
 
 fun ConnectionAutoclosing.slett(
     statement: String,
-    params: List<SQLParameter>,
+    params: Map<Int, SQLParameter>,
     forventaResultat: ForventaResultat = ForventaResultat.IKKE_KJENT,
 ) = hentConnection {
     with(it) {
         val stmt = prepareStatement(statement.trimMargin())
-        params.forEachIndexed { index, param -> param.settParameter(index + 1, stmt) }
+        params.entries.forEach { entry -> entry.value.settParameter(entry.key, stmt) }
         stmt.executeUpdate().also { forventaResultat.haandhevKrav(it) }
     }
 }

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -71,11 +71,12 @@ fun <T> ConnectionAutoclosing.hent(
 fun ConnectionAutoclosing.opprett(
     statement: String,
     params: List<SQLParameter>,
+    require: (Int) -> Unit = {},
 ) = hentConnection {
     with(it) {
         val stmt = prepareStatement(statement.trimMargin())
         params.forEachIndexed { index, param -> param.settParameter(index + 1, stmt) }
-        stmt.executeUpdate().also { require(it == 1) }
+        stmt.executeUpdate().also { require(it) }
     }
 }
 
@@ -117,11 +118,12 @@ fun <T> ConnectionAutoclosing.oppdaterOgReturner(
 fun ConnectionAutoclosing.slett(
     statement: String,
     params: List<SQLParameter>,
+    require: (Int) -> Unit = {},
 ) = hentConnection {
     with(it) {
         val stmt = prepareStatement(statement.trimMargin())
         params.forEachIndexed { index, param -> param.settParameter(index + 1, stmt) }
-        stmt.executeUpdate()
+        stmt.executeUpdate().also { require(it) }
     }
 }
 

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -105,7 +105,7 @@ abstract class SQLParameter(
     abstract fun settParameter(
         index: Int,
         stmt: PreparedStatement,
-    )
+    ): Any?
 }
 
 data class SQLString(
@@ -151,4 +151,13 @@ data class SQLObject(
         index: Int,
         stmt: PreparedStatement,
     ) = stmt.setObject(index, verdi)
+}
+
+data class SQLJsonb(
+    override val verdi: Any?,
+) : SQLParameter(verdi) {
+    override fun settParameter(
+        index: Int,
+        stmt: PreparedStatement,
+    ) = stmt.setJsonb(index, verdi)
 }

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -87,10 +87,30 @@ private fun settParameter(
     else -> stmt.setObject(index, param.verdi)
 }
 
-data class SQLParameter(
+abstract class SQLParameter(
     val type: Parametertype,
-    val verdi: Any?,
+    open val verdi: Any?,
 )
+
+data class SQLString(
+    override val verdi: String?,
+) : SQLParameter(Parametertype.STRING, verdi)
+
+data class SQLInt(
+    override val verdi: Int,
+) : SQLParameter(Parametertype.INT, verdi)
+
+data class SQLLong(
+    override val verdi: Long,
+) : SQLParameter(Parametertype.LONG, verdi)
+
+data class SQLDate(
+    override val verdi: Date?,
+) : SQLParameter(Parametertype.DATE, verdi)
+
+data class SQLObject(
+    override val verdi: Any?,
+) : SQLParameter(Parametertype.OBJECT, verdi)
 
 enum class Parametertype {
     STRING,

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -53,12 +53,11 @@ inline fun <reified T : Any> PreparedStatement.setJsonb(
     return this
 }
 
-fun oppdater(
+fun ConnectionAutoclosing.oppdater(
     statement: String,
-    params: List<SQLParameter<Any>>,
-    connection: ConnectionAutoclosing,
+    params: List<SQLParameter>,
 ) {
-    connection.hentConnection {
+    hentConnection {
         with(it) {
             val stmt = prepareStatement(statement.trimMargin())
             params.forEach { param -> settParameter(param, stmt) }
@@ -67,21 +66,27 @@ fun oppdater(
     }
 }
 
-private fun <T> settParameter(
-    param: SQLParameter<T>,
+private fun settParameter(
+    param: SQLParameter,
     stmt: PreparedStatement,
-) {
-    when (param.type) {
-        String::class.java -> stmt.setString(param.index, param.verdi as String?)
-        Int::class.java -> stmt.setInt(param.index, param.verdi as Int)
-        Long::class.java -> stmt.setLong(param.index, param.verdi as Long)
-        Date::class.java -> stmt.setDate(param.index, param.verdi as Date?)
-        else -> stmt.setObject(param.index, param.verdi)
-    }
+) = when (param.type) {
+    Parametertype.STRING -> stmt.setString(param.index, param.verdi as String?)
+    Parametertype.INT -> stmt.setInt(param.index, param.verdi as Int)
+    Parametertype.LONG -> stmt.setLong(param.index, param.verdi as Long)
+    Parametertype.DATE -> stmt.setDate(param.index, param.verdi as Date?)
+    else -> stmt.setObject(param.index, param.verdi)
 }
 
-data class SQLParameter<T>(
+data class SQLParameter(
     val index: Int,
-    val type: Class<T>,
-    val verdi: Any,
+    val type: Parametertype,
+    val verdi: Any?,
 )
+
+enum class Parametertype {
+    STRING,
+    INT,
+    LONG,
+    DATE,
+    OBJECT,
+}

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -75,6 +75,17 @@ fun ConnectionAutoclosing.oppdater(
     }
 }
 
+fun ConnectionAutoclosing.slett(
+    statement: String,
+    params: List<SQLParameter>,
+) = hentConnection {
+    with(it) {
+        val stmt = prepareStatement(statement.trimMargin())
+        params.forEachIndexed { index, param -> settParameter(index, param, stmt) }
+        stmt.executeUpdate()
+    }
+}
+
 private fun settParameter(
     index: Int,
     param: SQLParameter,

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -60,25 +60,25 @@ fun ConnectionAutoclosing.oppdater(
     hentConnection {
         with(it) {
             val stmt = prepareStatement(statement.trimMargin())
-            params.forEach { param -> settParameter(param, stmt) }
+            params.forEachIndexed { index, param -> settParameter(index, param, stmt) }
             stmt.executeUpdate()
         }
     }
 }
 
 private fun settParameter(
+    index: Int,
     param: SQLParameter,
     stmt: PreparedStatement,
 ) = when (param.type) {
-    Parametertype.STRING -> stmt.setString(param.index, param.verdi as String?)
-    Parametertype.INT -> stmt.setInt(param.index, param.verdi as Int)
-    Parametertype.LONG -> stmt.setLong(param.index, param.verdi as Long)
-    Parametertype.DATE -> stmt.setDate(param.index, param.verdi as Date?)
-    else -> stmt.setObject(param.index, param.verdi)
+    Parametertype.STRING -> stmt.setString(index, param.verdi as String?)
+    Parametertype.INT -> stmt.setInt(index, param.verdi as Int)
+    Parametertype.LONG -> stmt.setLong(index, param.verdi as Long)
+    Parametertype.DATE -> stmt.setDate(index, param.verdi as Date?)
+    else -> stmt.setObject(index, param.verdi)
 }
 
 data class SQLParameter(
-    val index: Int,
     val type: Parametertype,
     val verdi: Any?,
 )

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -79,6 +79,18 @@ fun ConnectionAutoclosing.opprett(
     }
 }
 
+fun <T> ConnectionAutoclosing.opprettOgReturner(
+    statement: String,
+    params: List<SQLParameter>,
+    konverterer: ResultSet.(Any?) -> T,
+) = hentConnection {
+    with(it) {
+        val stmt = prepareStatement(statement.trimMargin())
+        params.forEachIndexed { index, param -> param.settParameter(index + 1, stmt) }
+        stmt.executeQuery().single { konverterer(it) }
+    }
+}
+
 fun ConnectionAutoclosing.oppdater(
     statement: String,
     params: List<SQLParameter>,
@@ -87,6 +99,18 @@ fun ConnectionAutoclosing.oppdater(
         val stmt = prepareStatement(statement.trimMargin())
         params.forEachIndexed { index, param -> param.settParameter(index + 1, stmt) }
         stmt.executeUpdate()
+    }
+}
+
+fun <T> ConnectionAutoclosing.oppdaterOgReturner(
+    statement: String,
+    params: List<SQLParameter>,
+    konverterer: ResultSet.(Any?) -> T,
+) = hentConnection {
+    with(it) {
+        val stmt = prepareStatement(statement.trimMargin())
+        params.forEachIndexed { index, param -> param.settParameter(index + 1, stmt) }
+        stmt.executeQuery().single { konverterer(it) }
     }
 }
 

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -1,6 +1,8 @@
 package no.nav.etterlatte.libs.database
 
 import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.setTidspunkt
 import org.postgresql.util.PGobject
 import java.sql.Date
 import java.sql.PreparedStatement
@@ -160,4 +162,13 @@ data class SQLJsonb(
         index: Int,
         stmt: PreparedStatement,
     ) = stmt.setJsonb(index, verdi)
+}
+
+data class SQLTidspunkt(
+    override val verdi: Tidspunkt?,
+) : SQLParameter(verdi) {
+    override fun settParameter(
+        index: Int,
+        stmt: PreparedStatement,
+    ) = stmt.setTidspunkt(index, verdi)
 }


### PR DESCRIPTION
Poenget er å skilje tydeleg mellom _dette er koden som handterer spørringane mot databasen_ og _dette er dei funksjonelle spørringane vi vil gjera mot basen_. Ved å skilje ut generiske hjelpemetodar for det som er teknisk nødvendig for å gjera dei relevante SQL-spørringane, kan vi få ganske rein domene-kode der vi treng spørringane.

Her innført for aktivitetsplikt som ein første (litt vilkårleg vald) plass å starte.

Det trengs sikkert nokre iterasjonar her, feks for logging eller for å sjekke at execute-kalla har returnert med rett verdi, men det går an å byggje vidare på.

Ser for meg at vi på sikt 1) tar i bruk dette overalt og 2) faser ut Kotliquery. Når vi skal fase ut Kotliquery, er det lurt å ha eit mønster på plass for _sånn som vi ønskjer at SQL-spørringane våre skal vera_ - og dét prøver eg å lage i denne PR-en.


Endringane i denne PR-en er i `JdbcUtils` og i nokre av dao-ane i behandling, resten er imports