### PR TITLE
EY-4377 Har litt ekstra håndtering for aktivitetspliktDto-sending

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktRoute.kt
@@ -155,6 +155,19 @@ internal fun Route.aktivitetspliktRoutes(aktivitetspliktService: Aktivitetsplikt
             }
         }
 
+        route("statistikk/{$BEHANDLINGID_CALL_PARAMETER}") {
+            get {
+                kunSystembruker {
+                    logger.info("Henter aktivitetspliktDto for statistikk")
+                    val dto =
+                        inTransaction {
+                            runBlocking { aktivitetspliktService.hentAktivitetspliktDto(sakId, brukerTokenInfo, behandlingId) }
+                        }
+                    call.respond(dto)
+                }
+            }
+        }
+
         route("vurdering") {
             get {
                 kunSaksbehandler {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktService.kt
@@ -82,7 +82,12 @@ class AktivitetspliktService(
         bruker: BrukerTokenInfo,
         behandlingId: UUID?,
     ): AktivitetspliktDto {
-        val faktiskBehandlingId = behandlingId ?: behandlingService.hentSisteIverksatte(sakId)!!.id
+        val faktiskBehandlingId =
+            behandlingId ?: behandlingService.hentSisteIverksatte(sakId)?.id ?: throw InternfeilException(
+                "Kunne ikke hente ut aktivitetspliktDto for sakId=$sakId, siden vi ikke mottok behandlingId " +
+                    "aktivitetspliktvurderingen er knyttet til, og det ligger heller ingen iverksatte " +
+                    "behandlinger i saken.",
+            )
 
         val grunnlag = grunnlagKlient.hentGrunnlagForBehandling(faktiskBehandlingId, bruker)
         val avdoedDoedsdato =

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/clients/BehandlingKlient.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/clients/BehandlingKlient.kt
@@ -3,9 +3,11 @@ package no.nav.etterlatte.statistikk.clients
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
+import no.nav.etterlatte.libs.common.aktivitetsplikt.AktivitetspliktDto
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.StatistikkBehandling
 import no.nav.etterlatte.libs.common.behandling.Utlandstilknytning
+import no.nav.etterlatte.libs.common.sak.SakId
 import java.util.UUID
 
 interface BehandlingKlient {
@@ -14,6 +16,11 @@ interface BehandlingKlient {
     suspend fun hentStatistikkBehandling(behandlingId: UUID): StatistikkBehandling
 
     suspend fun hentUtlandstilknytning(behandlingId: UUID): Utlandstilknytning?
+
+    suspend fun hentAktivitetspliktDto(
+        sakId: SakId,
+        behandlingId: UUID,
+    ): AktivitetspliktDto
 }
 
 class BehandlingKlientImpl(
@@ -33,6 +40,18 @@ class BehandlingKlientImpl(
 
     override suspend fun hentUtlandstilknytning(behandlingId: UUID): Utlandstilknytning? =
         hentStatistikkBehandling(behandlingId).utlandstilknytning
+
+    override suspend fun hentAktivitetspliktDto(
+        sakId: SakId,
+        behandlingId: UUID,
+    ): AktivitetspliktDto =
+        try {
+            behandlingHttpClient
+                .get("$behandlingUrl/sak/$sakId/aktivitetsplikt/statistikk/$behandlingId")
+                .body()
+        } catch (e: Exception) {
+            throw KunneIkkeHenteFraBehandling("Kunne ikke hente aktivitetspliktDto for sak $sakId fra Behandling", e)
+        }
 }
 
 class KunneIkkeHenteFraBehandling(

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/clients/BehandlingKlient.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/clients/BehandlingKlient.kt
@@ -47,7 +47,7 @@ class BehandlingKlientImpl(
     ): AktivitetspliktDto =
         try {
             behandlingHttpClient
-                .get("$behandlingUrl/sak/$sakId/aktivitetsplikt/statistikk/$behandlingId")
+                .get("$behandlingUrl/api/sak/$sakId/aktivitetsplikt/statistikk/$behandlingId")
                 .body()
         } catch (e: Exception) {
             throw KunneIkkeHenteFraBehandling("Kunne ikke hente aktivitetspliktDto for sak $sakId fra Behandling", e)


### PR DESCRIPTION
Hvis det ikke ligger inne noen avdød i persongalleriet vil oppdateringen av aktivitetsplikt til statistikk feile (behind the scenes). Hvis dette skal være et vedtak, og vurderingene som blir gjort av saksbehandler på aktivitet ikke gjøres etter at persongalleriet er korrigert, så vil ikke aktivitetspliktdataene sendes på nytt.

Dette løses ved at statistikk henter dto for alle OMS-vedtak, og dermed sikrer at vi har riktig informasjon om oppfyllelsen av aktivitetsplikt også når det glipper.

Feil før en sak er vedtatt er litt mer chill på logging, siden det uansett skal fikses i statistikk der det logges feil hvis vi ikke finner riktig dødsdato på innvilgede saker.