### PR TITLE
Håndterer beregninger på gammelt regelverk i utledning av tt-grunnlag

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonBeregning.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonBeregning.kt
@@ -103,7 +103,17 @@ fun finnForskjelligTrygdetid(
     // Vi må sende med forskjellig trygdetid hvis trygdetidsgrunnlaget varierer over perioder
     val foersteBeregningsperiode = utbetalingsinfo.beregningsperioder.minBy { it.datoFOM }
     val sisteBeregningsperiode = utbetalingsinfo.beregningsperioder.maxBy { it.datoFOM }
-    if (foersteBeregningsperiode.avdoedeForeldre?.toSet() == sisteBeregningsperiode.avdoedeForeldre?.toSet()) {
+
+    // For beregninger gjort på gammelt regelverk har vi kun en avdød, og den er ikke fylt inn
+    // i "avdoedeForeldre" siden flere avdøde foreldre-regelen kjører kun på nytt regelverk
+    val avdoedeForeldreFoerstePeriode =
+        if (foersteBeregningsperiode.datoFOM < BarnepensjonInnvilgelse.tidspunktNyttRegelverk) {
+            listOfNotNull(foersteBeregningsperiode.trygdetidForIdent)
+        } else {
+            foersteBeregningsperiode.avdoedeForeldre
+        }
+
+    if (avdoedeForeldreFoerstePeriode?.toSet() == sisteBeregningsperiode.avdoedeForeldre?.toSet()) {
         // Vi har det samme trygdetidsgrunnlaget over alle periodene
         return null
     }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgetDTOTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgetDTOTest.kt
@@ -50,7 +50,8 @@ internal class BarnepensjonInnvilgetDTOTest {
                                 beregningsperiodeFebruar2022(),
                                 beregningsperiodeMarsApril2022(),
                                 beregningsperiodeAprilDesember2022(),
-                                beregningsperiode2023OgUtover(),
+                                beregningsperiodeHele2023(),
+                                beregningsperiode2024OgUtover(),
                             ),
                     ),
                 etterbetaling =
@@ -127,7 +128,8 @@ internal class BarnepensjonInnvilgetDTOTest {
                 beregningsperiodeFebruar2022().toBarnepensjonBeregningsperiode(),
                 beregningsperiodeMarsApril2022().toBarnepensjonBeregningsperiode(),
                 beregningsperiodeAprilDesember2022().toBarnepensjonBeregningsperiode(),
-                beregningsperiode2023OgUtover().toBarnepensjonBeregningsperiode(),
+                beregningsperiodeHele2023().toBarnepensjonBeregningsperiode(),
+                beregningsperiode2024OgUtover().toBarnepensjonBeregningsperiode(),
             ),
             barnepensjonInnvilgelse.beregning.beregningsperioder,
         )
@@ -157,9 +159,15 @@ internal class BarnepensjonInnvilgetDTOTest {
             LocalDate.of(2022, Month.DECEMBER, 31),
         )
 
-    private fun beregningsperiode2023OgUtover() =
+    private fun beregningsperiodeHele2023() =
         beregningsperiode(
             datoFOM = LocalDate.of(2023, Month.JANUARY, 1),
+            datoTOM = LocalDate.of(2023, Month.DECEMBER, 31),
+        )
+
+    private fun beregningsperiode2024OgUtover() =
+        beregningsperiode(
+            datoFOM = LocalDate.of(2024, Month.JANUARY, 1),
             datoTOM = null,
         )
 
@@ -178,6 +186,7 @@ internal class BarnepensjonInnvilgetDTOTest {
         beregningsMetodeAnvendt = BeregningsMetode.NASJONAL,
         beregningsMetodeFraGrunnlag = BeregningsMetode.BEST,
         trygdetidForIdent = "123",
+        avdoedeForeldre = if (datoFOM < BarnepensjonInnvilgelse.tidspunktNyttRegelverk) null else listOf("123"),
     )
 
     private fun lagInnholdMedVedlegg() =


### PR DESCRIPTION
Siden avdoedeForeldre ikke populeres på beregninger på gammelt regelverk må vi benytte trygdetidForIdent for å finne den avdøde på gamle perioder (her garanterer vi at vi har kun en avdød, siden det er kun det vi støtter på gammelt regelverk)