### PR TITLE
Sett dagens dato til startsdato for vurdering av aktivitetsplikt

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/AktivitetspliktVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/AktivitetspliktVurdering.tsx
@@ -259,10 +259,6 @@ export const AktivitetspliktVurdering = ({
                     <Label>Unntaksperiode</Label>
                     <BodyLong>Du trenger ikke legge til en sluttdato hvis den ikke er tilgjengelig</BodyLong>
                   </div>
-                  <HStack gap="4">
-                    <ControlledDatoVelger name="fom" label="Angi startdato" control={control} />
-                    <ControlledDatoVelger name="tom" label="Angi sluttdato" control={control} required={false} />
-                  </HStack>
                 </>
               )}
               {harUnntak === JaNei.NEI && (
@@ -285,6 +281,10 @@ export const AktivitetspliktVurdering = ({
                     <Label>Aktivitetsgradsperiode</Label>
                     <BodyLong>Du trenger ikke legge til en sluttdato hvis den ikke er tilgjengelig</BodyLong>
                   </div>
+                </>
+              )}
+              {harUnntak && (
+                <>
                   <HStack gap="4">
                     <ControlledDatoVelger name="fom" label="Angi startdato" control={control} />
                     <ControlledDatoVelger name="tom" label="Angi sluttdato" control={control} required={false} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/AktivitetspliktInfoModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/AktivitetspliktInfoModal.tsx
@@ -235,15 +235,6 @@ export const AktivitetspliktInfoModal = ({
                             <Label>Unntaksperiode</Label>
                             <BodyLong>Du trenger ikke legge til en sluttdato hvis den ikke er tilgjengelig</BodyLong>
                           </div>
-                          <HStack gap="4">
-                            <ControlledDatoVelger name="fom" label="Angi startdato" control={control} />
-                            <ControlledDatoVelger
-                              name="tom"
-                              label="Angi sluttdato"
-                              control={control}
-                              required={false}
-                            />
-                          </HStack>
                         </>
                       )}
                       {harUnntak === JaNei.NEI && (
@@ -266,6 +257,10 @@ export const AktivitetspliktInfoModal = ({
                             <Label>Aktivitetsgradsperiode</Label>
                             <BodyLong>Du trenger ikke legge til en sluttdato hvis den ikke er tilgjengelig</BodyLong>
                           </div>
+                        </>
+                      )}
+                      {harUnntak && (
+                        <>
                           <HStack gap="4">
                             <ControlledDatoVelger name="fom" label="Angi startdato" control={control} />
                             <ControlledDatoVelger

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Aktivitetsplikt.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Aktivitetsplikt.ts
@@ -136,7 +136,7 @@ export const AktivitetspliktVurderingValuesDefault: AktivitetspliktVurderingValu
   aktivitetsgrad: '',
   unntak: null,
   midlertidigUnntak: '',
-  fom: undefined,
+  fom: new Date(),
   tom: undefined,
   beskrivelse: '',
 }


### PR DESCRIPTION
Fjernet også duplikat av startdato og sluttdato da den vises i begge tilfeller etter at bruker har svart på `harUnntak`.