### PR TITLE
Fjerne SB før flytting, så vi ikke beholder SB når status blir NY

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -417,8 +417,8 @@ class OppgaveService(
 
     fun oppdaterEnhetForRelaterteOppgaver(sakerMedNyEnhet: List<SakMedEnhet>) {
         sakerMedNyEnhet.forEach {
-            endreEnhetForOppgaverTilknyttetSak(it.id, it.enhet)
             fjernSaksbehandlerFraOppgaveVedFlytt(it.id)
+            endreEnhetForOppgaverTilknyttetSak(it.id, it.enhet)
         }
     }
 


### PR DESCRIPTION
Fjerner SB før flytt, da status 'ny' ikke fører til fjerning av SB