### PR TITLE
EY-4359: Endrer status til TRYGDETID_OPPDATERT ved endringer av beregningsgrunnlag

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
@@ -49,7 +49,7 @@ class BeregningsGrunnlagService(
         brukerTokenInfo: BrukerTokenInfo,
     ): BeregningsGrunnlag? =
         when {
-            behandlingKlient.kanBeregnes(behandlingId, brukerTokenInfo, false) -> {
+            behandlingKlient.statusTrygdetidOppdatert(behandlingId, brukerTokenInfo, false) -> {
                 val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
                 if (behandling.sakType == SakType.BARNEPENSJON) {
                     validerSoeskenMedIBeregning(behandlingId, beregningsGrunnlag, brukerTokenInfo)
@@ -113,6 +113,7 @@ class BeregningsGrunnlagService(
                         ),
                     )
 
+                behandlingKlient.statusTrygdetidOppdatert(behandlingId, brukerTokenInfo, commit = true)
                 beregningsGrunnlagRepository.finnBeregningsGrunnlag(behandlingId)
             }
 

--- a/apps/etterlatte-beregning/src/main/kotlin/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/klienter/BehandlingKlient.kt
@@ -5,6 +5,7 @@ import com.github.michaelbull.result.mapBoth
 import com.typesafe.config.Config
 import io.ktor.client.HttpClient
 import no.nav.etterlatte.libs.common.RetryResult
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.FoersteVirkDto
 import no.nav.etterlatte.libs.common.behandling.SisteIverksatteBehandling
@@ -39,6 +40,12 @@ interface BehandlingKlient : BehandlingTilgangsSjekk {
     ): SisteIverksatteBehandling
 
     suspend fun kanBeregnes(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+        commit: Boolean,
+    ): Boolean
+
+    suspend fun statusTrygdetidOppdatert(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         commit: Boolean,
@@ -181,6 +188,32 @@ class BehandlingKlientImpl(
             success = { true },
             failure = {
                 logger.info("Behandling med id $behandlingId kan ikke beregnes, commit=$commit")
+                false
+            },
+        )
+    }
+
+    override suspend fun statusTrygdetidOppdatert(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+        commit: Boolean,
+    ): Boolean {
+        logger.info("Sjekker om behandling med behandlingId=$behandlingId kan sette status ${BehandlingStatus.TRYGDETID_OPPDATERT}")
+        val resource = Resource(clientId = clientId, url = "$resourceUrl/behandlinger/$behandlingId/oppdaterTrygdetid")
+
+        val response =
+            when (commit) {
+                false -> downstreamResourceClient.get(resource, brukerTokenInfo)
+                true -> downstreamResourceClient.post(resource, brukerTokenInfo, "{}")
+            }
+
+        return response.mapBoth(
+            success = { true },
+            failure = {
+                logger.info(
+                    "Behandling med behandlingId=$behandlingId kan ikke settes " +
+                        "status ${BehandlingStatus.TRYGDETID_OPPDATERT}, commit=$commit",
+                )
                 false
             },
         )

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
@@ -269,7 +269,7 @@ internal class BeregningsGrunnlagRoutesTest {
     @Test
     fun `skal opprettere`() {
         coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
-        coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
         every { repository.finnBeregningsGrunnlag(any()) } returns mockk(relaxed = true)
         every { repository.lagreBeregningsGrunnlag(any()) } returns true
         val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
@@ -328,7 +328,7 @@ internal class BeregningsGrunnlagRoutesTest {
     @Test
     fun `skal returnere conflict fra opprettelse `() {
         coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
-        coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
         every { repository.finnBeregningsGrunnlag(any()) } returns null
         every { repository.lagreBeregningsGrunnlag(any()) } returns false
         val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
@@ -78,7 +78,7 @@ internal class BeregningsGrunnlagServiceTest {
                         ),
                 ),
             )
-        coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns
             mockk {
                 coEvery { sakType } returns SakType.BARNEPENSJON
@@ -112,7 +112,7 @@ internal class BeregningsGrunnlagServiceTest {
                         ),
                 ),
             )
-        coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns
             mockk {
                 coEvery { sakType } returns SakType.BARNEPENSJON
@@ -159,7 +159,7 @@ internal class BeregningsGrunnlagServiceTest {
         val behandling = mockBehandling(SakType.BARNEPENSJON, randomUUID())
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
         every { beregningsGrunnlagRepository.finnBeregningsGrunnlag(any()) } returns null
         every { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(any()) } returns true
         val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
@@ -220,7 +220,7 @@ internal class BeregningsGrunnlagServiceTest {
             )
 
         coEvery { behandlingKlient.hentBehandling(foerstegangsbehandling.id, any()) } returns foerstegangsbehandling
-        coEvery { behandlingKlient.kanBeregnes(revurdering.id, any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(revurdering.id, any(), any()) } returns true
         coEvery {
             vedtaksvurderingKlient.hentIverksatteVedtak(sakId, any())
         } returns listOf(mockVedtak(foerstegangsbehandling.id, VedtakType.INNVILGELSE))
@@ -294,7 +294,7 @@ internal class BeregningsGrunnlagServiceTest {
             )
 
         coEvery { behandlingKlient.hentBehandling(foerstegangsbehandling.id, any()) } returns foerstegangsbehandling
-        coEvery { behandlingKlient.kanBeregnes(revurdering.id, any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(revurdering.id, any(), any()) } returns true
         coEvery {
             vedtaksvurderingKlient.hentIverksatteVedtak(sakId, any())
         } returns listOf(mockVedtak(foerstegangsbehandling.id, VedtakType.INNVILGELSE))
@@ -336,7 +336,7 @@ internal class BeregningsGrunnlagServiceTest {
         val behandlingsId = randomUUID()
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
         every { beregningsGrunnlagRepository.finnBeregningsGrunnlag(omregningsId) } returns null
         every { beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(any()) } returns emptyList()
         every {
@@ -371,7 +371,7 @@ internal class BeregningsGrunnlagServiceTest {
         val overstyrBeregningGrunnlagDao = mockk<OverstyrBeregningGrunnlagDao>()
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
         every { beregningsGrunnlagRepository.finnBeregningsGrunnlag(omregningsId) } returns null
         every {
             beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(
@@ -409,7 +409,7 @@ internal class BeregningsGrunnlagServiceTest {
         val behandlingsId = randomUUID()
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
         every { beregningsGrunnlagRepository.finnBeregningsGrunnlag(behandlingsId) } returns null
         val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns hentOpplysningsgrunnlag
@@ -430,7 +430,7 @@ internal class BeregningsGrunnlagServiceTest {
         val omregningsId = randomUUID()
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
         every { beregningsGrunnlagRepository.finnBeregningsGrunnlag(any()) } returns
             BeregningsGrunnlag(
                 behandlingId = behandlingsId,
@@ -456,7 +456,7 @@ internal class BeregningsGrunnlagServiceTest {
         val slot = slot<BeregningsGrunnlag>()
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
         every { beregningsGrunnlagRepository.finnBeregningsGrunnlag(any()) } returns null
         every { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(capture(slot)) } returns true
         val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
@@ -487,7 +487,7 @@ internal class BeregningsGrunnlagServiceTest {
         val slot = slot<BeregningsGrunnlag>()
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
         every { beregningsGrunnlagRepository.finnBeregningsGrunnlag(any()) } returns null
         every { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(capture(slot)) } returns true
         val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
@@ -531,7 +531,7 @@ internal class BeregningsGrunnlagServiceTest {
         val slot = slot<BeregningsGrunnlag>()
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
         every { beregningsGrunnlagRepository.finnBeregningsGrunnlag(any()) } returns null
         every { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(capture(slot)) } returns true
         val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BarnepensjonSammendrag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BarnepensjonSammendrag.tsx
@@ -103,7 +103,7 @@ export const BarnepensjonSammendrag = ({ beregning }: Props) => {
                 {beregningsperiode.soeskenFlokk &&
                   isBefore(beregningsperiode.datoTOM, new Date(2024, 0, 1)) &&
                   `${beregningsperiode.soeskenFlokk.length + 1} barn`}{' '}
-                {beregningsperiode.institusjonsopphold && ' institusjonsopphold'}
+                {beregningsperiode.institusjonsopphold && ' Institusjonsopphold'}
               </Table.DataCell>
               <Table.DataCell>{beregningsperiode.utbetaltBeloep} kr</Table.DataCell>
             </Table.ExpandableRow>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/OmstillingsstoenadSammendrag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/OmstillingsstoenadSammendrag.tsx
@@ -49,7 +49,7 @@ export const OmstillingsstoenadSammendrag = ({ beregning }: Props) => {
                 )}
               </Table.DataCell>
               <Table.DataCell>{NOK(beregningsperiode.grunnbelop)}</Table.DataCell>
-              <Table.DataCell>{beregningsperiode.institusjonsopphold && 'institusjonsopphold'}</Table.DataCell>
+              <Table.DataCell>{beregningsperiode.institusjonsopphold && 'Institusjonsopphold'}</Table.DataCell>
               <Table.DataCell>
                 {NOK(beregningsperiode.utbetaltBeloep)}{' '}
                 <ToolTip title="Få mer informasjon om beregningsgrunnlaget">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
@@ -108,7 +108,10 @@ const BeregningsgrunnlagBarnepensjon = () => {
         behandlingId: behandling.id,
         grunnlag: grunnlag,
       },
-      (result) => dispatch(oppdaterBeregningsGrunnlag(result))
+      (result) => {
+        dispatch(oppdaterBeregningsGrunnlag(result))
+        dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.TRYGDETID_OPPDATERT))
+      }
     )
   }
 
@@ -123,7 +126,10 @@ const BeregningsgrunnlagBarnepensjon = () => {
         behandlingId: behandling.id,
         grunnlag: grunnlag,
       },
-      (result) => dispatch(oppdaterBeregningsGrunnlag(result))
+      (result) => {
+        dispatch(oppdaterBeregningsGrunnlag(result))
+        dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.TRYGDETID_OPPDATERT))
+      }
     )
   }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
@@ -80,6 +80,7 @@ const BeregningsgrunnlagOmstillingsstoenad = () => {
       },
       (result) => {
         dispatch(oppdaterBeregningsGrunnlag(result))
+        dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.TRYGDETID_OPPDATERT))
         setVisManglendeBeregningsgrunnlag(false)
       }
     )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/flereAvdoede/BeregningsMetodeRadForAvdoed.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/flereAvdoede/BeregningsMetodeRadForAvdoed.tsx
@@ -17,7 +17,11 @@ import { FloppydiskIcon, PencilIcon, TrashIcon, XMarkIcon } from '@navikt/aksel-
 import { isPending } from '~shared/api/apiUtils'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { lagreBeregningsGrunnlag } from '~shared/api/beregning'
-import { IBehandlingReducer, oppdaterBeregningsGrunnlag } from '~store/reducers/BehandlingReducer'
+import {
+  IBehandlingReducer,
+  oppdaterBehandlingsstatus,
+  oppdaterBeregningsGrunnlag,
+} from '~store/reducers/BehandlingReducer'
 import { useAppDispatch } from '~store/Store'
 import { formaterEnumTilLesbarString } from '~utils/formatering/formatering'
 import { formaterNavn } from '~shared/types/Person'
@@ -26,6 +30,7 @@ import { ITrygdetid } from '~shared/api/trygdetid'
 import { useForm } from 'react-hook-form'
 import { ControlledRadioGruppe } from '~shared/components/radioGruppe/ControlledRadioGruppe'
 import { ControlledMaanedVelger } from '~shared/components/maanedVelger/ControlledMaanedVelger'
+import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
 
 interface Props {
   behandling: IBehandlingReducer
@@ -85,6 +90,7 @@ export const BeregningsMetodeRadForAvdoed = ({ behandling, trygdetid, redigerbar
       },
       (result) => {
         dispatch(oppdaterBeregningsGrunnlag(result))
+        dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.TRYGDETID_OPPDATERT))
         setRedigerModus(false)
         !!onSuccess && onSuccess(result)
       }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/institusjonsopphold/InstitusjonsoppholdBeregningsgrunnlagSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/institusjonsopphold/InstitusjonsoppholdBeregningsgrunnlagSkjema.tsx
@@ -17,7 +17,7 @@ import { validerStringNumber } from '~components/person/journalfoeringsoppgave/n
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { lagreBeregningsGrunnlag } from '~shared/api/beregning'
 import { SakType } from '~shared/types/sak'
-import { oppdaterBeregningsGrunnlag } from '~store/reducers/BehandlingReducer'
+import { oppdaterBehandlingsstatus, oppdaterBeregningsGrunnlag } from '~store/reducers/BehandlingReducer'
 import { useAppDispatch } from '~store/Store'
 import { isPending } from '~shared/api/apiUtils'
 import {
@@ -27,6 +27,7 @@ import {
 } from '~components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/utils'
 import { useBehandling } from '~components/behandling/useBehandling'
 import { ApiErrorAlert } from '~ErrorBoundary'
+import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
 
 interface Props {
   sakType: SakType
@@ -102,6 +103,7 @@ export const InstitusjonsoppholdBeregningsgrunnlagSkjema = ({
       },
       (result) => {
         dispatch(oppdaterBeregningsGrunnlag(result))
+        dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.TRYGDETID_OPPDATERT))
         paaLagre()
       }
     )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/institusjonsopphold/InstitusjonsoppholdBeregningsgrunnlagTable.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/institusjonsopphold/InstitusjonsoppholdBeregningsgrunnlagTable.tsx
@@ -16,8 +16,13 @@ import { SakType } from '~shared/types/sak'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { lagreBeregningsGrunnlag } from '~shared/api/beregning'
 import { isPending } from '~shared/api/apiUtils'
-import { IBehandlingReducer, oppdaterBeregningsGrunnlag } from '~store/reducers/BehandlingReducer'
+import {
+  IBehandlingReducer,
+  oppdaterBehandlingsstatus,
+  oppdaterBeregningsGrunnlag,
+} from '~store/reducers/BehandlingReducer'
 import { useAppDispatch } from '~store/Store'
+import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
 
 interface PeriodeRedigeringModus {
   redigerPeriode: boolean
@@ -67,6 +72,7 @@ export const InstitusjonsoppholdBeregningsgrunnlagTable = ({
         },
         (result) => {
           dispatch(oppdaterBeregningsGrunnlag(result))
+          dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.TRYGDETID_OPPDATERT))
         }
       )
     }


### PR DESCRIPTION
Når beregningsgrunnlag oppdateres, settes status til forrige status for behandlingen som er TRYGDETID_OPPDATERT. Dette for å unngå at det er mulig å gjøre endringer i beregningsgrunnlag, for så å gå til beregning via stegviseren uten å kjøre beregning på nytt.

Denne erstatter https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/5701 pga langt branchnavn.