### PR TITLE
EY-4359: Setter TRYGDETID_OPPDATERT ved endring på overstyrt beregning

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningService.kt
@@ -100,22 +100,30 @@ class BeregningService(
             validerFoersteVirke(behandlingKlient, behandling, brukerTokenInfo)
         }
 
-        return hentOverstyrBeregning(behandling).takeIf { it != null }
-            ?: beregningRepository.opprettOverstyrBeregning(
-                OverstyrBeregning(
-                    behandling.sak,
-                    overstyrBeregning.beskrivelse,
-                    Tidspunkt.now(),
-                    kategori = overstyrBeregning.kategori,
-                ),
-            )
+        if (behandlingKlient.kanSetteStatusTrygdetidOppdatert(behandlingId, brukerTokenInfo)) {
+            return hentOverstyrBeregning(behandling).takeIf { it != null } ?: run {
+                val opprettetOverstyrtBeregning =
+                    beregningRepository.opprettOverstyrBeregning(
+                        OverstyrBeregning(
+                            behandling.sak,
+                            overstyrBeregning.beskrivelse,
+                            Tidspunkt.now(),
+                            kategori = overstyrBeregning.kategori,
+                        ),
+                    )
+                behandlingKlient.statusTrygdetidOppdatert(behandlingId, brukerTokenInfo, commit = true)
+                opprettetOverstyrtBeregning
+            }
+        } else {
+            throw KanIkkeEndreOverstyrtBeregningGrunnetStatus(behandlingId)
+        }
     }
 
     suspend fun deaktiverOverstyrtberegning(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ) {
-        if (behandlingKlient.kanBeregnes(behandlingId, brukerTokenInfo, false)) {
+        if (behandlingKlient.kanSetteStatusTrygdetidOppdatert(behandlingId, brukerTokenInfo)) {
             val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
 
             if (behandling.behandlingType === BehandlingType.REVURDERING) {
@@ -124,8 +132,9 @@ class BeregningService(
 
             beregningRepository.deaktiverOverstyrtBeregning(behandling.sak)
             beregningRepository.slettOverstyrtBeregningsgrunnlag(behandling.id)
+            behandlingKlient.statusTrygdetidOppdatert(behandlingId, brukerTokenInfo, commit = true)
         } else {
-            throw KanIkkeDeaktivereOverstyrtBeregningGrunnetStatus()
+            throw KanIkkeEndreOverstyrtBeregningGrunnetStatus(behandlingId)
         }
     }
 
@@ -156,10 +165,12 @@ class KanIkkeAktivereOverstyrtBeregningGrunnetVirkningsdato :
         detail = "For å legge til eller fjerne overstyre beregning må behandlingen revurderes fra sakens første virkningstidspunkt",
     )
 
-class KanIkkeDeaktivereOverstyrtBeregningGrunnetStatus :
-    UgyldigForespoerselException(
+class KanIkkeEndreOverstyrtBeregningGrunnetStatus(
+    behandlingId: UUID,
+) : UgyldigForespoerselException(
         code = "UGYLDIG_STATUS_BEHANDLING",
         detail = "Behandlingen kan ikke endre overstyrt beregning da den har feil status",
+        meta = mapOf("behandlingId" to behandlingId),
     )
 
 class TrygdetidMangler(

--- a/apps/etterlatte-beregning/src/main/kotlin/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/klienter/BehandlingKlient.kt
@@ -45,6 +45,11 @@ interface BehandlingKlient : BehandlingTilgangsSjekk {
         commit: Boolean,
     ): Boolean
 
+    suspend fun kanSetteStatusTrygdetidOppdatert(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Boolean
+
     suspend fun statusTrygdetidOppdatert(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
@@ -192,6 +197,11 @@ class BehandlingKlientImpl(
             },
         )
     }
+
+    override suspend fun kanSetteStatusTrygdetidOppdatert(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Boolean = statusTrygdetidOppdatert(behandlingId, brukerTokenInfo, false)
 
     override suspend fun statusTrygdetidOppdatert(
         behandlingId: UUID,

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningServiceTest.kt
@@ -232,6 +232,8 @@ internal class BeregningServiceTest {
         val behandling = mockBehandling(SakType.OMSTILLINGSSTOENAD)
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        coEvery { behandlingKlient.kanSetteStatusTrygdetidOppdatert(any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
         every { beregningRepository.hentOverstyrBeregning(any()) } returns null
         every { beregningRepository.opprettOverstyrBeregning(any()) } returnsArgument 0
 
@@ -261,7 +263,8 @@ internal class BeregningServiceTest {
         val behandling = mockBehandling(SakType.OMSTILLINGSSTOENAD)
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.kanBeregnes(any(), any(), any()) } returns true
+        coEvery { behandlingKlient.kanSetteStatusTrygdetidOppdatert(any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
         every { beregningRepository.hentOverstyrBeregning(any()) } returns null
         every { beregningRepository.opprettOverstyrBeregning(any()) } returnsArgument 0
         every { beregningRepository.deaktiverOverstyrtBeregning(any()) } just runs
@@ -296,6 +299,8 @@ internal class BeregningServiceTest {
         val behandling = mockBehandling(SakType.OMSTILLINGSSTOENAD)
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        coEvery { behandlingKlient.kanSetteStatusTrygdetidOppdatert(any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
         every { beregningRepository.hentOverstyrBeregning(any()) } returns
             OverstyrBeregning(
                 behandling.sak,

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
@@ -269,6 +269,7 @@ internal class BeregningsGrunnlagRoutesTest {
     @Test
     fun `skal opprettere`() {
         coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
+        coEvery { behandlingKlient.kanSetteStatusTrygdetidOppdatert(any(), any()) } returns true
         coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
         every { repository.finnBeregningsGrunnlag(any()) } returns mockk(relaxed = true)
         every { repository.lagreBeregningsGrunnlag(any()) } returns true
@@ -328,6 +329,7 @@ internal class BeregningsGrunnlagRoutesTest {
     @Test
     fun `skal returnere conflict fra opprettelse `() {
         coEvery { behandlingKlient.harTilgangTilBehandling(any(), any(), any()) } returns true
+        coEvery { behandlingKlient.kanSetteStatusTrygdetidOppdatert(any(), any()) } returns true
         coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
         every { repository.finnBeregningsGrunnlag(any()) } returns null
         every { repository.lagreBeregningsGrunnlag(any()) } returns false

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
@@ -37,6 +37,7 @@ import no.nav.etterlatte.libs.testdata.grunnlag.HALVSOESKEN_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.HELSOESKEN_FOEDSELSNUMMER
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
@@ -65,6 +66,12 @@ internal class BeregningsGrunnlagServiceTest {
             grunnlagKlient,
         )
 
+    @BeforeEach
+    fun beforeEach() {
+        coEvery { behandlingKlient.kanSetteStatusTrygdetidOppdatert(any(), any()) } returns true
+        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
+    }
+
     @Test
     fun `alle søsken må være avdødes barn hvis ikke kast BPBeregningsgrunnlagBrukerUgydligFnr`() {
         val soeskenMedIBeregning: List<GrunnlagMedPeriode<List<SoeskenMedIBeregning>>> =
@@ -78,7 +85,7 @@ internal class BeregningsGrunnlagServiceTest {
                         ),
                 ),
             )
-        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
+
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns
             mockk {
                 coEvery { sakType } returns SakType.BARNEPENSJON
@@ -112,7 +119,7 @@ internal class BeregningsGrunnlagServiceTest {
                         ),
                 ),
             )
-        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
+
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns
             mockk {
                 coEvery { sakType } returns SakType.BARNEPENSJON
@@ -159,7 +166,7 @@ internal class BeregningsGrunnlagServiceTest {
         val behandling = mockBehandling(SakType.BARNEPENSJON, randomUUID())
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
+
         every { beregningsGrunnlagRepository.finnBeregningsGrunnlag(any()) } returns null
         every { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(any()) } returns true
         val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
@@ -336,7 +343,7 @@ internal class BeregningsGrunnlagServiceTest {
         val behandlingsId = randomUUID()
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
+
         every { beregningsGrunnlagRepository.finnBeregningsGrunnlag(omregningsId) } returns null
         every { beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(any()) } returns emptyList()
         every {
@@ -371,7 +378,7 @@ internal class BeregningsGrunnlagServiceTest {
         val overstyrBeregningGrunnlagDao = mockk<OverstyrBeregningGrunnlagDao>()
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
+
         every { beregningsGrunnlagRepository.finnBeregningsGrunnlag(omregningsId) } returns null
         every {
             beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(
@@ -409,7 +416,7 @@ internal class BeregningsGrunnlagServiceTest {
         val behandlingsId = randomUUID()
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
+
         every { beregningsGrunnlagRepository.finnBeregningsGrunnlag(behandlingsId) } returns null
         val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns hentOpplysningsgrunnlag
@@ -430,7 +437,7 @@ internal class BeregningsGrunnlagServiceTest {
         val omregningsId = randomUUID()
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
+
         every { beregningsGrunnlagRepository.finnBeregningsGrunnlag(any()) } returns
             BeregningsGrunnlag(
                 behandlingId = behandlingsId,
@@ -456,7 +463,7 @@ internal class BeregningsGrunnlagServiceTest {
         val slot = slot<BeregningsGrunnlag>()
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
+
         every { beregningsGrunnlagRepository.finnBeregningsGrunnlag(any()) } returns null
         every { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(capture(slot)) } returns true
         val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
@@ -487,7 +494,7 @@ internal class BeregningsGrunnlagServiceTest {
         val slot = slot<BeregningsGrunnlag>()
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
+
         every { beregningsGrunnlagRepository.finnBeregningsGrunnlag(any()) } returns null
         every { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(capture(slot)) } returns true
         val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
@@ -531,7 +538,7 @@ internal class BeregningsGrunnlagServiceTest {
         val slot = slot<BeregningsGrunnlag>()
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.statusTrygdetidOppdatert(any(), any(), any()) } returns true
+
         every { beregningsGrunnlagRepository.finnBeregningsGrunnlag(any()) } returns null
         every { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(capture(slot)) } returns true
         val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/OverstyrBeregningsgrunnlagPeriodeSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/OverstyrBeregningsgrunnlagPeriodeSkjema.tsx
@@ -13,9 +13,9 @@ import {
   validerStringNumber,
 } from '~components/person/journalfoeringsoppgave/nybehandling/validator'
 import { isPending } from '~shared/api/apiUtils'
-import { oppdaterOverstyrBeregningsGrunnlag } from '~store/reducers/BehandlingReducer'
+import { oppdaterBehandlingsstatus, oppdaterOverstyrBeregningsGrunnlag } from '~store/reducers/BehandlingReducer'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
-import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
+import { IBehandlingStatus, IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 import {
   initialOverstyrBeregningsgrunnlagPeriode,
   konverterTilSisteDagIMaaneden,
@@ -87,6 +87,7 @@ export const OverstyrBeregningsgrunnlagPeriodeSkjema = ({
         },
         (result) => {
           dispatch(oppdaterOverstyrBeregningsGrunnlag(result))
+          dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.TRYGDETID_OPPDATERT))
           paaLagre()
         }
       )
@@ -102,6 +103,7 @@ export const OverstyrBeregningsgrunnlagPeriodeSkjema = ({
         },
         (result) => {
           dispatch(oppdaterOverstyrBeregningsGrunnlag(result))
+          dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.TRYGDETID_OPPDATERT))
           paaLagre()
         }
       )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/OverstyrtBeregningsgrunnlagTable.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/OverstyrtBeregningsgrunnlagTable.tsx
@@ -8,10 +8,10 @@ import { PencilIcon, TrashIcon } from '@navikt/aksel-icons'
 import { formaterDatoMedFallback } from '~utils/formatering/dato'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { lagreOverstyrBeregningGrunnlag } from '~shared/api/beregning'
-import { oppdaterOverstyrBeregningsGrunnlag } from '~store/reducers/BehandlingReducer'
+import { oppdaterBehandlingsstatus, oppdaterOverstyrBeregningsGrunnlag } from '~store/reducers/BehandlingReducer'
 import { isPending } from '~shared/api/apiUtils'
 import { OverstyrBeregningsgrunnlagPeriodeSkjema } from '~components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/OverstyrBeregningsgrunnlagPeriodeSkjema'
-import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
+import { IBehandlingStatus, IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 
 interface PeriodeRedigeringModus {
   redigerPeriode: boolean
@@ -50,7 +50,10 @@ export const OverstyrtBeregningsgrunnlagTable = ({ behandling }: { behandling: I
             perioder: perioderKopi,
           },
         },
-        (result) => dispatch(oppdaterOverstyrBeregningsGrunnlag(result))
+        (result) => {
+          dispatch(oppdaterOverstyrBeregningsGrunnlag(result))
+          dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.TRYGDETID_OPPDATERT))
+        }
       )
     }
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/SkruAvOverstyrtBeregningModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/SkruAvOverstyrtBeregningModal.tsx
@@ -6,6 +6,9 @@ import { useApiCall } from '~shared/hooks/useApiCall'
 import { deaktiverOverstyrtBeregning } from '~shared/api/beregning'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { isPending } from '~shared/api/apiUtils'
+import { useAppDispatch } from '~store/Store'
+import { oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'
+import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
 
 interface Props {
   behandlingId: string
@@ -14,12 +17,14 @@ interface Props {
 
 export const SkruAvOverstyrtBeregningModal = ({ behandlingId, setOverstyrt }: Props) => {
   const [open, setOpen] = useState<boolean>(false)
+  const dispatch = useAppDispatch()
 
   const [deaktiverOverstyrtBeregningResult, deaktiverOverstyrtBeregningRequest] =
     useApiCall(deaktiverOverstyrtBeregning)
 
   const skruAvOverstyrtBeregning = () => {
     deaktiverOverstyrtBeregningRequest(behandlingId, () => {
+      dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.TRYGDETID_OPPDATERT))
       setOpen(false)
       setOverstyrt(undefined)
     })

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/SkruPaaOverstyrtBeregning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/SkruPaaOverstyrtBeregning.tsx
@@ -7,6 +7,9 @@ import { useApiCall } from '~shared/hooks/useApiCall'
 import { opprettOverstyrBeregning } from '~shared/api/beregning'
 import { isPending } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
+import { oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'
+import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
+import { useAppDispatch } from '~store/Store'
 
 export const SkruPaaOverstyrtBeregning = ({
   behandlingId,
@@ -21,6 +24,7 @@ export const SkruPaaOverstyrtBeregning = ({
   const [aarsakError, setAarsakError] = useState<string>('')
 
   const [opprettOverstyrBeregningResult, opprettOverstyrBeregningRequest] = useApiCall(opprettOverstyrBeregning)
+  const dispatch = useAppDispatch()
 
   const overstyrBeregning = () => {
     if (!!aarsak) {
@@ -32,7 +36,10 @@ export const SkruPaaOverstyrtBeregning = ({
           kategori: aarsak,
         },
         (result) => {
-          if (result) setOverstyrt(result)
+          if (result) {
+            setOverstyrt(result)
+            dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.TRYGDETID_OPPDATERT))
+          }
         }
       )
     } else setAarsakError('Du må velge en årsak')


### PR DESCRIPTION
Når overstyrt beregning oppdateres, settes status til forrige status for behandlingen som er TRYGDETID_OPPDATERT. Dette for å unngå at det er mulig å gjøre endringer i overstyrt beregning, for så å gå til beregning via stegviseren uten å kjøre beregning på nytt.