### PR TITLE
EY-2476: Rydd bort kommer barnet til gode frå behandlingstabellen.

### DIFF
--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V158__kommer_barnet_til_gode.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V158__kommer_barnet_til_gode.sql
@@ -1,0 +1,1 @@
+ALTER TABLE behandling DROP COLUMN kommer_barnet_tilgode;


### PR DESCRIPTION
I EY-2349 splitta vi alt i fjor sommar denne informasjonen ut i ein eigen tabell. Tanken var heile tida å fjerne kolonna frå behandling, men vi ville gi det nokre veker først for å sjå at alt framleis fungerte. Det gjorde det, så no er det på tide å rydde opp.

I EY-2349 migrerte vi eksisterande data ut i den nye tabellen, så det som ligg i kolonna i behandling er ikkje lenger i bruk eller nyttig