### PR TITLE
EY-4396 Gir saksbehandler mulighet til å endre klagedato

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageRoutes.kt
@@ -141,6 +141,16 @@ internal fun Route.klageRoutes(
                 }
             }
 
+            put("mottattdato") {
+                kunSaksbehandlerMedSkrivetilgang { saksbehandler ->
+                    medBody<OppdaterMottattDatoRequest> {
+                        inTransaction {
+                            klageService.oppdaterMottattDato(klageId, it.parseMottattDato(), saksbehandler)
+                        }
+                    }
+                }
+            }
+
             post("avbryt") {
                 kunSaksbehandlerMedSkrivetilgang { saksbehandler ->
                     medBody<AvbrytKlageDto> { avbrytKlageDto ->
@@ -200,6 +210,12 @@ internal fun Route.klageRoutes(
             call.respond(klager)
         }
     }
+}
+
+data class OppdaterMottattDatoRequest(
+    val mottattDato: String,
+) {
+    fun parseMottattDato(): LocalDate = Tidspunkt(OffsetDateTime.parse(mottattDato).toInstant()).toNorskLocalDate()
 }
 
 private fun sjekkStoetterUtfallHvisAvvist(

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/sidemeny/KlageSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/sidemeny/KlageSidemeny.tsx
@@ -1,4 +1,4 @@
-import { useKlage } from '~components/klage/useKlage'
+import { useKlage, useKlageRedigerbar } from '~components/klage/useKlage'
 import { Detail, Heading, HStack, Label, VStack } from '@navikt/ds-react'
 import { Sidebar, SidebarPanel } from '~shared/components/Sidebar'
 import { KlageStatus, teksterKabalstatus, teksterKlagestatus } from '~shared/types/Klage'
@@ -19,6 +19,7 @@ import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { useOppgaveUnderBehandling } from '~shared/hooks/useOppgaveUnderBehandling'
 import { useInnloggetSaksbehandler } from '~components/behandling/useInnloggetSaksbehandler'
 import { SakTypeTag } from '~shared/tags/SakTypeTag'
+import { RedigerMottattDato } from '~components/klage/sidemeny/RedigerMottattDato'
 
 export function KlageSidemeny() {
   const klage = useKlage()
@@ -27,6 +28,7 @@ export function KlageSidemeny() {
   const innloggetSaksbehandler = useInnloggetSaksbehandler()
   const [beslutning, setBeslutning] = useState<IBeslutning>()
   const kanAttestere = !!klage && innloggetSaksbehandler.kanAttestere && klage.status === KlageStatus.FATTET_VEDTAK
+  const erRedigerbar = useKlageRedigerbar()
 
   useEffect(() => {
     if (!klage) return
@@ -80,6 +82,8 @@ export function KlageSidemeny() {
               </Detail>
             </div>
           </HStack>
+
+          {erRedigerbar && <RedigerMottattDato />}
         </VStack>
       </SidebarPanel>
       {kanAttestere && (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/sidemeny/RedigerMottattDato.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/sidemeny/RedigerMottattDato.tsx
@@ -1,0 +1,77 @@
+import { useKlage } from '~components/klage/useKlage'
+import { useState } from 'react'
+import { DatoVelger } from '~shared/components/datoVelger/DatoVelger'
+import { Box, Button, VStack } from '@navikt/ds-react'
+import { PencilIcon } from '@navikt/aksel-icons'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { oppdaterMottattDatoForKlage } from '~shared/api/klage'
+import { useDispatch } from 'react-redux'
+import { isFailure, isPending } from '~shared/api/apiUtils'
+import { addKlage } from '~store/reducers/KlageReducer'
+import { ApiErrorAlert } from '~ErrorBoundary'
+
+export function RedigerMottattDato() {
+  const klage = useKlage()
+  const [redigererDato, setRedigererDato] = useState<boolean>(false)
+  const dispatch = useDispatch()
+  const eksisterendeDato = klage?.innkommendeDokument?.mottattDato
+    ? new Date(klage.innkommendeDokument.mottattDato)
+    : undefined
+  const [datoUnderRedigering, setDatoUnderRedigering] = useState<Date | undefined>(eksisterendeDato)
+  const [oppdaterDatoStatus, oppdaterDato] = useApiCall(oppdaterMottattDatoForKlage)
+  const [feilmelding, setFeilmelding] = useState('')
+
+  function oppdaterMottattDato() {
+    setFeilmelding('')
+    if (!klage || isPending(oppdaterDatoStatus)) {
+      return
+    }
+    if (!datoUnderRedigering) {
+      setFeilmelding('Du må velge en ny klagedato.')
+      return
+    }
+    oppdaterDato({ klageId: klage.id, mottattDato: datoUnderRedigering?.toISOString() }, (klage) => {
+      dispatch(addKlage(klage))
+      setRedigererDato(false)
+      setDatoUnderRedigering(undefined)
+    })
+  }
+
+  if (redigererDato) {
+    return (
+      <VStack gap="4">
+        <DatoVelger
+          error={feilmelding}
+          value={datoUnderRedigering}
+          onChange={setDatoUnderRedigering}
+          label="Klagedato"
+          toDate={new Date()}
+        />
+        <Box>
+          <Button size="small" onClick={oppdaterMottattDato} loading={isPending(oppdaterDatoStatus)}>
+            Lagre
+          </Button>
+        </Box>
+        {isFailure(oppdaterDatoStatus) && (
+          <ApiErrorAlert>
+            Kunne ikke oppdatere dato klage mottatt, på grunn av feil: {oppdaterDatoStatus.error.detail}
+          </ApiErrorAlert>
+        )}
+      </VStack>
+    )
+  }
+
+  return (
+    <Box>
+      <Button
+        size="small"
+        icon={<PencilIcon />}
+        iconPosition="left"
+        variant="secondary"
+        onClick={() => setRedigererDato(true)}
+      >
+        Rediger klagedato
+      </Button>
+    </Box>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/klage.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/klage.ts
@@ -44,6 +44,14 @@ export function oppdaterInitieltUtfallForKlage(args: {
   })
 }
 
+export function oppdaterMottattDatoForKlage(args: {
+  klageId: string
+  mottattDato: string
+}): Promise<ApiResponse<Klage>> {
+  const { klageId, mottattDato } = args
+  return apiClient.put(`/klage/${klageId}/mottattdato`, { mottattDato })
+}
+
 export function ferdigstillKlagebehandling(klageId: string): Promise<ApiResponse<Klage>> {
   return apiClient.post(`/klage/${klageId}/ferdigstill`, {})
 }

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/klage/StatistikkKlage.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/klage/StatistikkKlage.kt
@@ -19,6 +19,7 @@ enum class KlageHendelseType : EventnameHendelseType {
     FERDIGSTILT,
     KABAL_HENDELSE,
     AVBRUTT,
+    OPPDATERT_MOTTATT_DATO,
     ;
 
     override fun lagEventnameForType(): String = "KLAGE:${this.name}"


### PR DESCRIPTION
Kun når klagen er redigerbar -- for å kunne selv fikse på feil i registrering etc.

Det logges og registreres en hendelse i databasen når dette gjøres, for å ha sporbarhet på endringen.

![Screenshot 2024-09-10 at 10 31 52](https://github.com/user-attachments/assets/7e6a41ec-bae8-447c-bc1e-149b7223faab)

Etter at "Rediger klagedato" er trykket på

![Screenshot 2024-09-10 at 10 31 59](https://github.com/user-attachments/assets/11cb9326-21f8-4e1f-83bb-638ebb8e9504)
