### PR TITLE
Forbedre feilmeld til sb ved manglende tilgang til enhet (403)

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
@@ -18,6 +18,7 @@ import io.ktor.util.pipeline.PipelinePhase
 import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
 import no.nav.etterlatte.SystemUser
+import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.ktor.route.CallParamAuthId
@@ -224,7 +225,7 @@ private fun PipelineContext<*, ApplicationCall>.finnSkriveTilgangForId(sakId: Sa
     }
 }
 
-suspend inline fun PipelineContext<*, ApplicationCall>.kunSkrivetilgang(
+inline fun PipelineContext<*, ApplicationCall>.kunSkrivetilgang(
     sakId: SakId? = null,
     enhetNr: String? = null,
     onSuccess: () -> Unit,
@@ -235,9 +236,15 @@ suspend inline fun PipelineContext<*, ApplicationCall>.kunSkrivetilgang(
             application.log.debug("Har skrivetilgang, fortsetter")
             onSuccess()
         }
+
         false -> {
             application.log.debug("Mangler skrivetilgang, avviser forespørselen")
-            call.respond(HttpStatusCode.Forbidden)
+
+            throw ForespoerselException(
+                status = HttpStatusCode.Forbidden.value,
+                code = "MANGLER_SKRIVETILGANG",
+                detail = "Mangler skrivetilgang til enhet $enhetNr",
+            )
         }
     }
 }


### PR DESCRIPTION
Dersom sb ikke har tilgang til enhet får de en sykt vag feilmelding, noe som medfører at vi får masse spørsmål om hvorfor noe ikke fungerer. Ved å endre feilmeldingen de får vil det (forhåpentligvis) spare oss for unødvendig debugging. 

Ser slik ut i prod p.t. 

![Screenshot 2024-09-12 at 10 46 48](https://github.com/user-attachments/assets/5905f1c2-9884-41fc-8ce7-cfce8e9c1066)
