### PR TITLE
Viss omregning feilar, bør vi logge det som error, ikkje info

### DIFF
--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/Application.kt
@@ -4,8 +4,8 @@ import no.nav.etterlatte.inntektsjustering.InntektsjusteringVarselOmVedtakRiver
 import no.nav.etterlatte.inntektsjustering.OppdaterInntektsjusteringBrevDistribuert
 import no.nav.etterlatte.migrering.AvbrytBehandlingHvisMigreringFeilaRiver
 import no.nav.etterlatte.regulering.FinnSakerTilReguleringRiver
+import no.nav.etterlatte.regulering.OmregningFeiletRiver
 import no.nav.etterlatte.regulering.OmregningsHendelserBehandlingRiver
-import no.nav.etterlatte.regulering.ReguleringFeiletRiver
 import no.nav.etterlatte.regulering.ReguleringsforespoerselRiver
 import no.nav.etterlatte.regulering.VedtakAttestertRiver
 import no.nav.etterlatte.regulering.YtelseIkkeLoependeRiver
@@ -28,7 +28,7 @@ private fun settOppRivers(
     OmregningsHendelserBehandlingRiver(rapidsConnection, behandlingservice)
     FinnSakerTilReguleringRiver(rapidsConnection, behandlingservice)
     ReguleringsforespoerselRiver(rapidsConnection, behandlingservice, featureToggleService)
-    ReguleringFeiletRiver(rapidsConnection, behandlingservice)
+    OmregningFeiletRiver(rapidsConnection, behandlingservice)
     VedtakAttestertRiver(rapidsConnection, behandlingservice)
     AvbrytBehandlingHvisMigreringFeilaRiver(rapidsConnection, behandlingservice)
     YtelseIkkeLoependeRiver(rapidsConnection, behandlingservice)

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/OmregningFeiletRiver.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/OmregningFeiletRiver.kt
@@ -15,7 +15,7 @@ import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
 import org.slf4j.LoggerFactory
 
-internal class ReguleringFeiletRiver(
+internal class OmregningFeiletRiver(
     rapidsConnection: RapidsConnection,
     private val behandlingService: BehandlingService,
 ) : ListenerMedLogging() {
@@ -33,7 +33,7 @@ internal class ReguleringFeiletRiver(
         packet: JsonMessage,
         context: MessageContext,
     ) {
-        logger.info("Regulering har feilet for sak ${packet.sakId}")
+        logger.error("Omregning har feilet for sak ${packet.sakId}")
         behandlingService.lagreKjoering(
             kjoering = packet.kjoering,
             sakId = packet.sakId,

--- a/apps/etterlatte-oppdater-behandling/src/test/kotlin/regulering/OmregningFeiletRiverTest.kt
+++ b/apps/etterlatte-oppdater-behandling/src/test/kotlin/regulering/OmregningFeiletRiverTest.kt
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
-internal class ReguleringFeiletRiverTest {
+internal class OmregningFeiletRiverTest {
     private val foersteMai2023 = LocalDate.of(2023, 5, 1)
 
     private fun genererReguleringMelding() =
@@ -42,7 +42,7 @@ internal class ReguleringFeiletRiverTest {
         val melding = genererReguleringMelding()
         val behandlingService = mockk<BehandlingService>(relaxed = true)
         every { behandlingService.lagreKjoering(capture(sakId), capture(status), capture(kjoering)) } returns Unit
-        val inspector = TestRapid().apply { ReguleringFeiletRiver(this, behandlingService) }
+        val inspector = TestRapid().apply { OmregningFeiletRiver(this, behandlingService) }
 
         inspector.sendTestMessage(melding.toJson())
         val sendteMeldinger = inspector.inspektør.size


### PR DESCRIPTION
 Det er ikkje forventa, skal i prinsippet ikkje skje, og når det skjer bør vi som oftast følgje det opp.

Døper med det samme om klassa, for denne bør vera lik for alle typar omregningar