### PR TITLE
EY-4414: Opphør mangler dersom dette er satt i en revurdering av OMS

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -81,7 +81,7 @@ data class Avkorting(
     /*
      * Skal kun benyttes ved opprettelse av ny avkorting ved revurdering.
      */
-    fun kopierAvkorting(): Avkorting =
+    fun kopierAvkorting(opphoerFom: YearMonth?): Avkorting =
         Avkorting(
             aarsoppgjoer =
                 aarsoppgjoer.map {
@@ -89,7 +89,17 @@ data class Avkorting(
                         id = UUID.randomUUID(),
                         inntektsavkorting =
                             it.inntektsavkorting.map { inntektsavkorting ->
-                                inntektsavkorting.copy(grunnlag = inntektsavkorting.grunnlag.copy(id = UUID.randomUUID()))
+                                inntektsavkorting.copy(
+                                    grunnlag =
+                                        inntektsavkorting.grunnlag.copy(
+                                            id = UUID.randomUUID(),
+                                            periode =
+                                                inntektsavkorting.grunnlag.periode.copy(
+                                                    fom = inntektsavkorting.grunnlag.periode.fom,
+                                                    tom = opphoerFom?.minusMonths(1),
+                                                ),
+                                        ),
+                                )
                             },
                     )
                 },

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -81,7 +81,7 @@ data class Avkorting(
     /*
      * Skal kun benyttes ved opprettelse av ny avkorting ved revurdering.
      */
-    fun kopierAvkorting(opphoerFom: YearMonth?): Avkorting =
+    fun kopierAvkorting(opphoerFom: YearMonth? = null): Avkorting =
         Avkorting(
             aarsoppgjoer =
                 aarsoppgjoer.map {
@@ -96,7 +96,9 @@ data class Avkorting(
                                             periode =
                                                 inntektsavkorting.grunnlag.periode.copy(
                                                     fom = inntektsavkorting.grunnlag.periode.fom,
-                                                    tom = opphoerFom?.minusMonths(1),
+                                                    tom =
+                                                        inntektsavkorting.grunnlag.periode.tom
+                                                            ?: opphoerFom?.minusMonths(1),
                                                 ),
                                         ),
                                 )
@@ -126,7 +128,7 @@ data class Avkorting(
             aarsoppgjoer.inntektsavkorting
                 // Fjerner hvis det finnes fra før for å erstatte/redigere
                 .filter { it.grunnlag.id != nyttGrunnlag.id }
-                .map { it.lukkSisteInntektsperiode(nyttGrunnlag.fom) } +
+                .map { it.lukkSisteInntektsperiode(nyttGrunnlag.fom, opphoerFom) } +
                 listOf(
                     Inntektsavkorting(
                         grunnlag =
@@ -435,22 +437,23 @@ data class Inntektsavkorting(
         }
     }
 
-    fun lukkSisteInntektsperiode(virkningstidspunkt: YearMonth) =
-        when (grunnlag.periode.tom) {
-            null ->
-                copy(
-                    grunnlag =
-                        grunnlag.copy(
-                            periode =
-                                Periode(
-                                    fom = grunnlag.periode.fom,
-                                    tom = virkningstidspunkt.minusMonths(1),
-                                ),
+    fun lukkSisteInntektsperiode(
+        virkningstidspunkt: YearMonth,
+        opphoerFom: YearMonth?,
+    ) = if (grunnlag.periode.tom == null || grunnlag.periode.tom == opphoerFom?.minusMonths(1)) {
+        copy(
+            grunnlag =
+                grunnlag.copy(
+                    periode =
+                        Periode(
+                            fom = grunnlag.periode.fom,
+                            tom = virkningstidspunkt.minusMonths(1),
                         ),
-                )
-
-            else -> this
-        }
+                ),
+        )
+    } else {
+        this
+    }
 }
 
 /**

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -48,7 +48,7 @@ class AvkortingService(
         val forrigeAvkorting = hentAvkortingForrigeBehandling(behandling.sak, brukerTokenInfo)
         return if (eksisterendeAvkorting == null) {
             val nyAvkorting =
-                kopierOgReberegnAvkorting(behandling.id, behandling.sak, forrigeAvkorting, brukerTokenInfo)
+                kopierOgReberegnAvkorting(behandling, behandling.sak, forrigeAvkorting, brukerTokenInfo)
             avkortingMedTillegg(nyAvkorting, behandling, forrigeAvkorting)
         } else if (behandling.status == BehandlingStatus.BEREGNET) {
             val reberegnetAvkorting =
@@ -126,17 +126,18 @@ class AvkortingService(
         logger.info("Kopierer avkorting fra forrige behandling med behandlingId=$forrigeBehandlingId")
         val forrigeAvkorting = hentForrigeAvkorting(forrigeBehandlingId)
         val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
-        return kopierOgReberegnAvkorting(behandling.id, behandling.sak, forrigeAvkorting, brukerTokenInfo)
+        return kopierOgReberegnAvkorting(behandling, behandling.sak, forrigeAvkorting, brukerTokenInfo)
     }
 
     private suspend fun kopierOgReberegnAvkorting(
-        behandlingId: UUID,
+        behandling: DetaljertBehandling,
         sakId: SakId,
         forrigeAvkorting: Avkorting,
         brukerTokenInfo: BrukerTokenInfo,
     ): Avkorting {
-        val kopiertAvkorting = forrigeAvkorting.kopierAvkorting()
-        return reberegnOgLagreAvkorting(behandlingId, sakId, kopiertAvkorting, brukerTokenInfo)
+        val opphoerFraOgMed = behandling.opphoerFraOgMed
+        val kopiertAvkorting = forrigeAvkorting.kopierAvkorting(opphoerFraOgMed)
+        return reberegnOgLagreAvkorting(behandling.id, sakId, kopiertAvkorting, brukerTokenInfo)
     }
 
     private suspend fun reberegnOgLagreAvkorting(


### PR DESCRIPTION
- Legger til opphørsdato i avkortingsgrunnlag som kopieres
- Ved nytt avkortingsgrunnlag, vil eksisterende periode endre tom-dato fra opphørsdato - 1 til virkningstidspunkt - 1