### PR TITLE
FAGSYSTEM-346194 Slette duplikatoppgaver for SOEKNAD_MANGLER

### DIFF
--- a/apps/etterlatte-behandling/src/main/resources/db/prod/V160__slette_duplikate_mangler_soeknad_oppgaver.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/prod/V160__slette_duplikate_mangler_soeknad_oppgaver.sql
@@ -1,0 +1,77 @@
+-- Duplikater for sakid 17991
+DELETE
+FROM oppgave
+WHERE id IN (
+             '65e43f94-4e03-4aef-a3c7-226092b8994e',
+             'c1d3d61c-3c55-4b24-b6a4-74a9c7ed2dc2',
+             'fb1be24f-8ad5-4940-9967-ee73279924bd',
+             '15f84b2e-2d1e-4682-a680-c59fabdb910d',
+             '719ce459-b212-4f59-80db-764bef0b659b',
+             '71e5d26e-c25e-408d-a9d6-cc0d986437c3',
+             '16b44c86-30fe-4ed0-882c-62e21974e8ad'
+    );
+
+-- Duplikater for sakid 18195
+DELETE
+FROM oppgave
+WHERE id IN (
+             'f54acef3-42ef-4ef6-b203-67cfcb24fb5a',
+             'cbbbd76b-0571-4e13-aebf-da51fa01891f',
+             '5d5d0d96-1bf7-481f-b77a-f0c4ca32fdb9',
+             'f6ce5012-8c60-4204-abf0-ccb2de57f092',
+             '5f7371b1-f525-4f8b-a78f-665de8bffade',
+             '326e0b8b-94ef-4c37-a3e5-6a896253504d',
+             'a4c4c47c-606b-4209-84b7-f43cdb2ba8ba'
+    );
+
+-- Duplikater for sakid 18211
+DELETE
+FROM oppgave
+WHERE id IN (
+             '5342be98-a72b-453a-8a39-63aa663d250a',
+             'd5629634-249f-4ae9-92f1-9f644ed1e57e',
+             'b6df27c0-506a-41af-8694-b3993601ac22',
+             '7a2e0b75-c5c1-4c21-90ee-b71bcd8a6685',
+             '5d0944be-8dd8-4717-97e7-d609d8583bc2',
+             'a009b898-1d9c-46d2-b6bc-486703811814',
+             '00ad22fc-7772-4e98-b27a-ad6e1a7a6384'
+    );
+
+-- Duplikater for sakid 18222
+DELETE
+FROM oppgave
+WHERE id IN (
+             '881ce6c6-8ae0-49ec-9305-60cbe62c7f81',
+             '5f5fed59-f942-4818-b0c6-4ddcfe0ab7e6',
+             'c69b3c88-9408-4938-a02b-ea603f7da6a4',
+             '360c1e7c-862b-40d5-b724-e62dce26e83a',
+             'd8765869-11c4-4b5b-80f9-c08408ed2632',
+             '2dc03519-6752-4af2-aff2-31294257b167',
+             '09eaea88-056c-4493-96a0-86d923ae602f'
+    );
+
+-- Duplikater for sakid 18257
+DELETE
+FROM oppgave
+WHERE id IN (
+             '9497c69c-e968-4c72-be31-bf502a561ae6',
+             '20fc2cd6-cadb-4479-bfe6-cbe955ea9c11',
+             'fd2d456c-9086-406e-94b5-a92b93b4dbf6'
+    );
+
+-- Duplikater for sakid 18265
+DELETE
+FROM oppgave
+WHERE id IN (
+             '924da17f-0bd1-4877-972b-f49944000a0f',
+             '6f52545e-cc95-49c7-b24b-9eae70e66237',
+             '4e1ab585-5648-4ac3-80db-a306f3b5e664'
+    );
+
+
+-- Duplikater for sakid 18268
+DELETE
+FROM oppgave
+WHERE id IN (
+    '6e1cb573-d035-403e-9963-110d829f9328'
+    );


### PR DESCRIPTION
Det finnes 42 oppgaver for `SOEKNAD_MANGLER`, hvorav 35 av de er duplikater som ikke skulle vært opprettet. 
Dette fjerner de som er feilaktig opprettet. 