### PR TITLE
Endre skjema i vilkårsvurdering før migrering av database

### DIFF
--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/DelvilkaarRepository.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/DelvilkaarRepository.kt
@@ -34,7 +34,7 @@ class DelvilkaarRepository {
     ) {
         queryOf(
             statement = """
-            UPDATE delvilkaar
+            UPDATE vilkaarsvurdering.delvilkaar
             SET resultat = :resultat
             WHERE vilkaar_id = :vilkaar_id AND vilkaar_type = :vilkaar_type
         """,
@@ -52,7 +52,7 @@ class DelvilkaarRepository {
         tx: TransactionalSession,
     ) = queryOf(
         statement = """
-            UPDATE delvilkaar
+            UPDATE vilkaarsvurdering.delvilkaar
             SET resultat = null
             WHERE vilkaar_id = :vilkaar_id AND hovedvilkaar != true and resultat is not null
         """,
@@ -69,7 +69,7 @@ class DelvilkaarRepository {
     ) {
         queryOf(
             statement = """
-            UPDATE delvilkaar
+            UPDATE vilkaarsvurdering.delvilkaar
             SET resultat = :resultat
             WHERE vilkaar_id = :vilkaar_id AND hovedvilkaar != true
         """,
@@ -99,7 +99,7 @@ class DelvilkaarRepository {
         tx: TransactionalSession,
     ) = queryOf(
         statement = """
-            INSERT INTO delvilkaar(vilkaar_id, vilkaar_type, hovedvilkaar, tittel, beskrivelse, spoersmaal, paragraf, 
+            INSERT INTO vilkaarsvurdering.delvilkaar(vilkaar_id, vilkaar_type, hovedvilkaar, tittel, beskrivelse, spoersmaal, paragraf, 
                 ledd, bokstav, lenke, resultat) 
             VALUES(:vilkaar_id, :vilkaar_type, :hovedvilkaar, :tittel, :beskrivelse, :spoersmaal, :paragraf, :ledd, 
                 :bokstav, :lenke, :resultat)
@@ -132,7 +132,7 @@ class DelvilkaarRepository {
     ) {
         queryOf(
             """
-            UPDATE delvilkaar
+            UPDATE vilkaarsvurdering.delvilkaar
             SET resultat = ${utfall?.name?.let { "'$it'" }}
             WHERE vilkaar_id = :vilkaar_id
         """,

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRepository.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRepository.kt
@@ -354,21 +354,21 @@ class VilkaarsvurderingRepository(
 
     private object Queries {
         const val LAGRE_VILKAARSVURDERING = """
-            INSERT INTO vilkaarsvurdering(id, behandling_id, virkningstidspunkt, grunnlag_versjon) 
+            INSERT INTO vilkaarsvurdering.vilkaarsvurdering(id, behandling_id, virkningstidspunkt, grunnlag_versjon) 
             VALUES(:id, :behandling_id, :virkningstidspunkt, :grunnlag_versjon)
         """
 
         const val LAGRE_VILKAARSVURDERING_KILDE = """
-            INSERT INTO vilkaarsvurdering_kilde(vilkaarsvurdering_id, kopiert_fra_vilkaarsvurdering_id) VALUES(:id, :kopiert_fra)
+            INSERT INTO vilkaarsvurdering.vilkaarsvurdering_kilde(vilkaarsvurdering_id, kopiert_fra_vilkaarsvurdering_id) VALUES(:id, :kopiert_fra)
         """
 
         const val LAGRE_VILKAAR = """
-            INSERT INTO vilkaar(id, vilkaarsvurdering_id, resultat_kommentar, resultat_tidspunkt, resultat_saksbehandler) 
+            INSERT INTO vilkaarsvurdering.vilkaar(id, vilkaarsvurdering_id, resultat_kommentar, resultat_tidspunkt, resultat_saksbehandler) 
             VALUES(:id, :vilkaarsvurdering_id, :resultat_kommentar, :resultat_tidspunkt, :resultat_saksbehandler) 
         """
 
         const val LAGRE_VILKAARSVURDERING_RESULTAT = """
-            UPDATE vilkaarsvurdering
+            UPDATE vilkaarsvurdering.vilkaarsvurdering
             SET virkningstidspunkt = :virkningstidspunkt, 
                 resultat_utfall = :resultat_utfall, 
                 resultat_kommentar = :resultat_kommentar, 
@@ -378,7 +378,7 @@ class VilkaarsvurderingRepository(
         """
 
         const val LAGRE_VILKAAR_RESULTAT = """
-            UPDATE vilkaar
+            UPDATE vilkaarsvurdering.vilkaar
             SET resultat_kommentar = :resultat_kommentar, resultat_tidspunkt = :resultat_tidspunkt, 
                 resultat_saksbehandler = :resultat_saksbehandler   
             WHERE id = :id
@@ -387,11 +387,11 @@ class VilkaarsvurderingRepository(
         const val HENT_VILKAARSVURDERING = """
             SELECT id, behandling_id, virkningstidspunkt, grunnlag_versjon, resultat_utfall, 
                 resultat_kommentar, resultat_tidspunkt, resultat_saksbehandler 
-            FROM vilkaarsvurdering WHERE behandling_id = :behandling_id
+            FROM vilkaarsvurdering.vilkaarsvurdering WHERE behandling_id = :behandling_id
         """
 
         const val HENT_MIGRERT_YRKESSKADE = """
-            SELECT sak_id FROM migrert_yrkesskade WHERE sak_id = :sak_id
+            SELECT sak_id FROM vilkaarsvurdering.migrert_yrkesskade WHERE sak_id = :sak_id
         """
 
         const val HENT_VILKAAR = """
@@ -410,35 +410,35 @@ class VilkaarsvurderingRepository(
                    dv.bokstav,
                    dv.lenke,
                    dv.resultat
-            FROM vilkaar v
+            FROM vilkaarsvurdering.vilkaar v
               JOIN delvilkaar dv on dv.vilkaar_id = v.id
             WHERE v.vilkaarsvurdering_id = :vilkaarsvurdering_id
         """
 
         const val SLETT_VILKAARSVURDERING_RESULTAT = """
-            UPDATE vilkaarsvurdering
+            UPDATE vilkaarsvurdering.vilkaarsvurdering
             SET resultat_utfall = null, resultat_kommentar = null, resultat_tidspunkt = null, 
                 resultat_saksbehandler = null 
             WHERE id = :id
         """
 
         const val SLETT_VILKAAR_RESULTAT = """
-            UPDATE vilkaar
+            UPDATE vilkaarsvurdering.vilkaar
             SET resultat_kommentar = null, resultat_tidspunkt = null, resultat_saksbehandler = null   
             WHERE id = :id
         """
         const val SLETT_VILKAARSVURDERING_KILDE = """
-            DELETE FROM vilkaarsvurdering_kilde
+            DELETE FROM vilkaarsvurdering.vilkaarsvurdering_kilde
             WHERE vilkaarsvurdering_id = :vilkaarsvurdering_id
         """
 
         const val SLETT_VILKAARSVURDERING = """
-            DELETE FROM vilkaarsvurdering
+            DELETE FROM vilkaarsvurdering.vilkaarsvurdering
             WHERE id = :id
         """
 
         const val OPPDATER_GRUNNLAGSVERSJON = """
-            UPDATE vilkaarsvurdering
+            UPDATE vilkaarsvurdering.vilkaarsvurdering
             SET grunnlag_versjon = :grunnlag_versjon 
             WHERE id = :id
         """

--- a/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V25__endre_schema.sql
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V25__endre_schema.sql
@@ -1,4 +1,4 @@
-
+CREATE SCHEMA vilkaarsvurdering;
 
 ALTER TABLE vilkaarsvurdering
     SET SCHEMA vilkaarsvurdering;

--- a/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V25__endre_schema.sql
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V25__endre_schema.sql
@@ -14,5 +14,3 @@ ALTER TABLE vilkaar
 
 ALTER TABLE vilkaarsvurdering_kilde
     SET SCHEMA vilkaarsvurdering;
-
-SET search_path TO vilkaarsvurdering, public;

--- a/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V25__endre_schema.sql
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V25__endre_schema.sql
@@ -1,0 +1,16 @@
+CREATE SCHEMA vilkaarsvurdering;
+
+ALTER TABLE public.vilkaarsvurdering
+    SET SCHEMA vilkaarsvurdering;
+
+ALTER TABLE public.delvilkaar
+    SET SCHEMA vilkaarsvurdering;
+
+ALTER TABLE public.migrert_yrkesskade
+    SET SCHEMA vilkaarsvurdering;
+
+ALTER TABLE public.vilkaar
+    SET SCHEMA vilkaarsvurdering;
+
+ALTER TABLE public.vilkaarsvurdering_kilde
+    SET SCHEMA vilkaarsvurdering;

--- a/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V25__endre_schema.sql
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V25__endre_schema.sql
@@ -14,3 +14,6 @@ ALTER TABLE public.vilkaar
 
 ALTER TABLE public.vilkaarsvurdering_kilde
     SET SCHEMA vilkaarsvurdering;
+
+ALTER TABLE public.flyway_schema_history
+    SET SCHEMA vilkaarsvurdering;

--- a/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V25__endre_schema.sql
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V25__endre_schema.sql
@@ -1,19 +1,18 @@
-CREATE SCHEMA vilkaarsvurdering;
 
-ALTER TABLE public.vilkaarsvurdering
+
+ALTER TABLE vilkaarsvurdering
     SET SCHEMA vilkaarsvurdering;
 
-ALTER TABLE public.delvilkaar
+ALTER TABLE delvilkaar
     SET SCHEMA vilkaarsvurdering;
 
-ALTER TABLE public.migrert_yrkesskade
+ALTER TABLE migrert_yrkesskade
     SET SCHEMA vilkaarsvurdering;
 
-ALTER TABLE public.vilkaar
+ALTER TABLE vilkaar
     SET SCHEMA vilkaarsvurdering;
 
-ALTER TABLE public.vilkaarsvurdering_kilde
+ALTER TABLE vilkaarsvurdering_kilde
     SET SCHEMA vilkaarsvurdering;
 
-ALTER TABLE public.flyway_schema_history
-    SET SCHEMA vilkaarsvurdering;
+SET search_path TO vilkaarsvurdering, public;


### PR DESCRIPTION
Endrer skjema til å matche det som er definert i https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/5723
slik at vi kan overføre data i gcp buckets uten større problemer med flyway scriptene som er definert i vilkårsvurdering sin tabell.