### PR TITLE
No sett vi readiness litt for tidleg, så vi kan heller vente litt

### DIFF
--- a/libs/etterlatte-ktor/src/main/kotlin/initialisering/EmbeddedServerConfig.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/initialisering/EmbeddedServerConfig.kt
@@ -63,6 +63,7 @@ private fun settOppEmbeddedServer(
                     environment.monitor.subscribe(ServerReady) {
                         val scheduledJobs = cronjobs.map { it.schedule() }
                         addShutdownHook(scheduledJobs)
+                        setReady(true)
                     }
                     environment.monitor.subscribe(ApplicationStopPreparing) {
                         setReady(false)
@@ -73,6 +74,5 @@ private fun settOppEmbeddedServer(
     )
 
 fun CIOApplicationEngine.run() {
-    setReady(true)
     start(true)
 }


### PR DESCRIPTION
Frå lokalt (Running er der vi sett true i dag, Setting ready er den nye):
![image](https://github.com/user-attachments/assets/3d8d3ac9-9eb8-4d71-a2c5-fa3c73b55d71)
