### PR TITLE
FAGSYSTEM-344020  rette feil når forrigeGrunnlag er null pga overstyrt beregnet

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
@@ -182,7 +182,7 @@ class BeregningsGrunnlagService(
                 forrigeIverksatteBehandlingId,
             )
 
-        // hvis forrigeGrunnlag er null, kan årsaken være at tidligere behandling er manuelt overstyrt
+        // hvis forrigeGrunnlag er null, kan aarsaken være at tidligere behandling er manuelt overstyrt
         if (forrigeGrunnlag == null) {
             val overstyrtBeregningsGrunnlag =
                 beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(
@@ -193,7 +193,7 @@ class BeregningsGrunnlagService(
                 // kan vi returnere True ettersom vi ikke har noe å sammenligne med
                 return true
             } else {
-                // i tilfelle hvor tidligere behandling ikke er overstyrt
+                // i tilfelle hvor tidligere behandling ikke er overstyrt beregnet
                 throw ManglerForrigeGrunnlag()
             }
         }

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
@@ -259,7 +259,7 @@ internal class BeregningsGrunnlagServiceTest {
     }
 
     @Test
-    fun `skal ikke tillate endringer i beregningsgrunnlaget hvis forrige beregningsgrunnlag mangler`() {
+    fun `skal ikke tillate endringer i beregningsgrunnlaget hvis forrigeGrunnlag mangler`() {
         val sakId = 1337L
         val foerstegangsbehandling = mockBehandling(type = SakType.BARNEPENSJON, uuid = randomUUID(), sakId = sakId)
 
@@ -317,7 +317,7 @@ internal class BeregningsGrunnlagServiceTest {
     }
 
     @Test
-    fun `skal tillate endringer i beregningsgrunnlaget hvis forrige beregningsgrunnlag mangler pga overstyrt beregning`() {
+    fun `skal tillate endringer i beregningsgrunnlaget hvis forrigeGrunnlag mangler pga overstyrt beregning`() {
         val sakId = 1337L
         val foerstegangsbehandling = mockBehandling(type = SakType.BARNEPENSJON, uuid = randomUUID(), sakId = sakId)
 
@@ -369,7 +369,7 @@ internal class BeregningsGrunnlagServiceTest {
                         ),
                     brukerTokenInfo = mockk(relaxed = true),
                 )
-            assertTrue(lagret)
+            assertNotNull(lagret)
         }
 
         coVerify(exactly = 1) { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(any()) }

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
@@ -259,6 +259,123 @@ internal class BeregningsGrunnlagServiceTest {
     }
 
     @Test
+    fun `skal ikke tillate endringer i beregningsgrunnlaget hvis forrige beregningsgrunnlag mangler`() {
+        val sakId = 1337L
+        val foerstegangsbehandling = mockBehandling(type = SakType.BARNEPENSJON, uuid = randomUUID(), sakId = sakId)
+
+        val revurdering =
+            mockBehandling(
+                type = SakType.BARNEPENSJON,
+                uuid = randomUUID(),
+                behandlingstype = BehandlingType.REVURDERING,
+                sakId = sakId,
+            )
+
+        val grunnlagEndring =
+            beregningsgrunnlag(
+                behandlingId = revurdering.id,
+                soeskenMedIBeregning = emptyList(),
+            )
+
+        coEvery { behandlingKlient.hentBehandling(foerstegangsbehandling.id, any()) } returns foerstegangsbehandling
+        coEvery { behandlingKlient.kanBeregnes(revurdering.id, any(), any()) } returns true
+        coEvery {
+            vedtaksvurderingKlient.hentIverksatteVedtak(sakId, any())
+        } returns listOf(mockVedtak(foerstegangsbehandling.id, VedtakType.INNVILGELSE))
+        coEvery { behandlingKlient.hentBehandling(revurdering.id, any()) } returns revurdering
+
+        every {
+            beregningsGrunnlagRepository.finnBeregningsGrunnlag(foerstegangsbehandling.id)
+        } returns null
+
+        every {
+            beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(foerstegangsbehandling.id)
+        } returns emptyList()
+
+        every {
+            beregningsGrunnlagRepository.finnBeregningsGrunnlag(revurdering.id)
+        } returns grunnlagEndring
+
+        val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns hentOpplysningsgrunnlag
+
+        runBlocking {
+            assertThrows<ManglerForrigeGrunnlag> {
+                beregningsGrunnlagService.lagreBeregningsGrunnlag(
+                    behandlingId = revurdering.id,
+                    beregningsGrunnlag =
+                        LagreBeregningsGrunnlag(
+                            soeskenMedIBeregning = emptyList(),
+                            institusjonsopphold = emptyList(),
+                        ),
+                    brukerTokenInfo = mockk(relaxed = true),
+                )
+            }
+        }
+
+        coVerify(exactly = 0) { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(any()) }
+    }
+
+    @Test
+    fun `skal tillate endringer i beregningsgrunnlaget hvis forrige beregningsgrunnlag mangler pga overstyrt beregning`() {
+        val sakId = 1337L
+        val foerstegangsbehandling = mockBehandling(type = SakType.BARNEPENSJON, uuid = randomUUID(), sakId = sakId)
+
+        val revurdering =
+            mockBehandling(
+                type = SakType.BARNEPENSJON,
+                uuid = randomUUID(),
+                behandlingstype = BehandlingType.REVURDERING,
+                sakId = sakId,
+            )
+
+        val grunnlagEndring =
+            beregningsgrunnlag(
+                behandlingId = revurdering.id,
+                soeskenMedIBeregning = emptyList(),
+            )
+
+        coEvery { behandlingKlient.hentBehandling(foerstegangsbehandling.id, any()) } returns foerstegangsbehandling
+        coEvery { behandlingKlient.kanBeregnes(revurdering.id, any(), any()) } returns true
+        coEvery {
+            vedtaksvurderingKlient.hentIverksatteVedtak(sakId, any())
+        } returns listOf(mockVedtak(foerstegangsbehandling.id, VedtakType.INNVILGELSE))
+        coEvery { behandlingKlient.hentBehandling(revurdering.id, any()) } returns revurdering
+
+        every {
+            beregningsGrunnlagRepository.finnBeregningsGrunnlag(foerstegangsbehandling.id)
+        } returns null
+
+        every {
+            beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(foerstegangsbehandling.id)
+        } returns listOf(mockk<OverstyrBeregningGrunnlagDao>())
+
+        every {
+            beregningsGrunnlagRepository.finnBeregningsGrunnlag(revurdering.id)
+        } returns grunnlagEndring
+
+        every { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(any()) } returns true
+        val hentOpplysningsgrunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns hentOpplysningsgrunnlag
+
+        runBlocking {
+            val lagret =
+                beregningsGrunnlagService.lagreBeregningsGrunnlag(
+                    behandlingId = revurdering.id,
+                    beregningsGrunnlag =
+                        LagreBeregningsGrunnlag(
+                            soeskenMedIBeregning = emptyList(),
+                            institusjonsopphold = emptyList(),
+                        ),
+                    brukerTokenInfo = mockk(relaxed = true),
+                )
+            assertTrue(lagret)
+        }
+
+        coVerify(exactly = 1) { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(any()) }
+    }
+
+    @Test
     fun `skal tillate endringer i beregningsgrunnlaget etter virk på revurdering`() {
         val sakId = 1337L
         val foerstegangsbehandling = mockBehandling(type = SakType.BARNEPENSJON, uuid = randomUUID(), sakId = sakId)


### PR DESCRIPTION
Se fagsak: https://jira.adeo.no/browse/FAGSYSTEM-344020?filter=-1

I det tilfelle hvor forrigeGrunnlag er null (pga overstyrt beregning) er det heller ingen avvik, vi kan derfor returnere at det ikke er avvik på soeskenjustering, institusjonsopphold ettersom vi ikke har noe å sammenligne med