### PR TITLE
EY-4430: Begrenser valgbare virkningstidspunkt til å være etter det første dødsfallet. Før ble det brukt et vilkårlig dødsfall.

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/barnepensjon/FamilieforholdBarnepensjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/barnepensjon/FamilieforholdBarnepensjon.tsx
@@ -23,6 +23,7 @@ export const FamilieforholdBarnepensjon = ({
   landListeResult,
   behandlingId,
 }: PropsFamilieforhold) => {
+  const enJuridiskForelderEnabled = useFeatureEnabledMedDefault('kun-en-registrert-juridisk-forelder', false)
   if (personopplysninger == null || personopplysninger.soeker == null) {
     return <ErrorMessage>Familieforhold kan ikke hentes ut</ErrorMessage>
   }
@@ -30,7 +31,6 @@ export const FamilieforholdBarnepensjon = ({
   const alleGjenlevende = personopplysninger.gjenlevende
   const alleAvdoede = personopplysninger.avdoede
   const familieforhold: Familieforhold = { avdoede: alleAvdoede, gjenlevende: alleGjenlevende, soeker: soeker }
-  const enJuridiskForelderEnabled = useFeatureEnabledMedDefault('kun-en-registrert-juridisk-forelder', false)
 
   return (
     <>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -68,18 +68,11 @@ const Virkningstidspunkt = (props: {
     // Denne siste fallbacken er altså tenkt for disse sakene
   }
 
-  function foersteDoedsdato() {
+  function foersteDoedsdato(): Date | undefined {
     const avdoede = usePersonopplysninger()?.avdoede
-    const foersteAvdoede =
-      avdoede &&
-      avdoede.reduce((prev, current) =>
-        current.opplysning.doedsdato && prev.opplysning.doedsdato
-          ? current.opplysning.doedsdato < prev.opplysning.doedsdato
-            ? current
-            : prev
-          : prev
-      )
-    return foersteAvdoede?.opplysning.doedsdato
+    return avdoede
+      ?.map((it) => it.opplysning.doedsdato)
+      .reduce((prev, current) => (prev && current && current < prev ? current : prev))
   }
 
   const { monthpickerProps, inputProps } = useMonthpicker({

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -71,8 +71,8 @@ const Virkningstidspunkt = (props: {
   function foersteDoedsdato(): Date | undefined {
     const avdoede = usePersonopplysninger()?.avdoede
     return avdoede
-      ?.map((it) => it.opplysning.doedsdato)
-      .reduce((prev, current) => (prev && current && current < prev ? current : prev))
+      ?.map((it) => it.opplysning.doedsdato!!)
+      .reduce((accumulator, current) => (current < accumulator ? current : accumulator))
   }
 
   const { monthpickerProps, inputProps } = useMonthpicker({

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -42,7 +42,7 @@ const Virkningstidspunkt = (props: {
   erBosattUtland: boolean
 }) => {
   const { behandling, erBosattUtland } = props
-  const avdoede = usePersonopplysninger()?.avdoede.find((po) => po)
+
   const dispatch = useAppDispatch()
   const [fastsettVirkStatus, fastsettVirkningstidspunktRequest, resetToInitial] = useApiCall(fastsettVirkningstidspunkt)
 
@@ -68,12 +68,22 @@ const Virkningstidspunkt = (props: {
     // Denne siste fallbacken er altså tenkt for disse sakene
   }
 
+  function foersteDoedsdato() {
+    const avdoede = usePersonopplysninger()?.avdoede
+    const foersteAvdoede =
+      avdoede &&
+      avdoede.reduce((prev, current) =>
+        current.opplysning.doedsdato && prev.opplysning.doedsdato
+          ? current.opplysning.doedsdato < prev.opplysning.doedsdato
+            ? current
+            : prev
+          : prev
+      )
+    return foersteAvdoede?.opplysning.doedsdato
+  }
+
   const { monthpickerProps, inputProps } = useMonthpicker({
-    fromDate: hentMinimumsVirkningstidspunkt(
-      avdoede?.opplysning?.doedsdato,
-      getSoeknadMottattDato(),
-      behandling.sakType
-    ),
+    fromDate: hentMinimumsVirkningstidspunkt(foersteDoedsdato(), getSoeknadMottattDato(), behandling.sakType),
     toDate: addMonths(new Date(), 4),
     onMonthChange: (date: Date) => setVirkningstidspunkt(date),
     inputFormat: 'dd.MM.yyyy',


### PR DESCRIPTION
Hvis det var to avdøde, så ville virk bli begrenset til en av dødsdatoene. Sørger nå for at det er den tidligste avdøde som brukes.