### PR TITLE
Bumpe til 1GB minne for db i dev

### DIFF
--- a/apps/etterlatte-beregning/.nais/dev.yaml
+++ b/apps/etterlatte-beregning/.nais/dev.yaml
@@ -60,7 +60,7 @@ spec:
     sqlInstances:
       - type: POSTGRES_14
         name: etterlatte-beregning
-        tier: db-f1-micro
+        tier: db-g1-small
         databases:
           - name: beregning
             envVarPrefix: DB

--- a/apps/etterlatte-brev-api/.nais/dev.yaml
+++ b/apps/etterlatte-brev-api/.nais/dev.yaml
@@ -34,7 +34,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14
-        tier: db-f1-micro
+        tier: db-g1-small
         databases:
           - name: etterlatte-brev
             envVarPrefix: DB

--- a/apps/etterlatte-grunnlag/.nais/dev.yaml
+++ b/apps/etterlatte-grunnlag/.nais/dev.yaml
@@ -14,7 +14,7 @@ spec:
     sqlInstances:
       - type: POSTGRES_14
         name: etterlatte-grunnlag
-        tier: db-f1-micro
+        tier: db-g1-small
         databases:
           - name: grunnlag
             envVarPrefix: DB

--- a/apps/etterlatte-statistikk/.nais/dev.yaml
+++ b/apps/etterlatte-statistikk/.nais/dev.yaml
@@ -12,7 +12,7 @@ spec:
     sqlInstances:
       - type: POSTGRES_14
         name: etterlatte-statistikk
-        tier: db-f1-micro
+        tier: db-g1-small
         databases:
           - name: statistikk
             envVarPrefix: DB

--- a/apps/etterlatte-tidshendelser/.nais/dev.yaml
+++ b/apps/etterlatte-tidshendelser/.nais/dev.yaml
@@ -12,7 +12,7 @@ spec:
     sqlInstances:
       - type: POSTGRES_14
         name: etterlatte-tidshendelser
-        tier: db-f1-micro
+        tier: db-g1-small
         databases:
           - name: tidshendelser
             envVarPrefix: DB

--- a/apps/etterlatte-trygdetid/.nais/dev.yaml
+++ b/apps/etterlatte-trygdetid/.nais/dev.yaml
@@ -33,7 +33,7 @@ spec:
     sqlInstances:
       - type: POSTGRES_14
         name: etterlatte-trygdetid
-        tier: db-f1-micro
+        tier: db-g1-small
         databases:
           - name: trygdetid
             envVarPrefix: DB

--- a/apps/etterlatte-utbetaling/.nais/dev.yaml
+++ b/apps/etterlatte-utbetaling/.nais/dev.yaml
@@ -36,7 +36,7 @@ spec:
     sqlInstances:
       - type: POSTGRES_14
         name: etterlatte-utbetaling
-        tier: db-f1-micro
+        tier: db-g1-small
         databases:
           - name: utbetaling
             envVarPrefix: DB

--- a/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
@@ -16,7 +16,7 @@ spec:
     sqlInstances:
       - type: POSTGRES_14
         name: etterlatte-vedtaksvurdering
-        tier: db-f1-micro
+        tier: db-g1-small
         databases:
           - name: vedtaksvurdering
             envVarPrefix: DB

--- a/apps/etterlatte-vilkaarsvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vilkaarsvurdering/.nais/dev.yaml
@@ -33,7 +33,7 @@ spec:
     sqlInstances:
       - type: POSTGRES_14
         name: etterlatte-vilkaarsvurdering
-        tier: db-f1-micro
+        tier: db-g1-small
         databases:
           - name: vilkaarsvurdering
             envVarPrefix: DB


### PR DESCRIPTION
GCP sier `Underprovisioned resource` for disse instansene fordi de bruker for mer minne enn sqlinstansen vi spesifisierer.