### PR TITLE
Gi sb feilmelding når PDF ikke er ferdig generert ved ferdigstilling

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/VedtaksbrevService.kt
@@ -118,7 +118,7 @@ class VedtaksbrevService(
             logger.info("Ferdigstiller brev med id=${brev.id}")
 
             if (db.hentPdf(brev.id) == null) {
-                throw IllegalStateException("Kan ikke ferdigstille brev (id=${brev.id}) siden PDF er null!")
+                throw BrevManglerPDF(brev.id)
             } else {
                 db.settBrevFerdigstilt(brev.id)
             }
@@ -243,9 +243,15 @@ class UgyldigMottakerKanIkkeFerdigstilles(
         code = "UGYLDIG_MOTTAKER_BREV",
         detail = "Brevet kan ikke ferdigstilles med ugyldig mottaker og/eller adresse. BrevID: $id",
         meta =
-            mapOf(
-                "id" to id,
-            ),
+            mapOf("id" to id),
+    )
+
+class BrevManglerPDF(
+    id: BrevID,
+) : UgyldigForespoerselException(
+        code = "PDF_MANGLER",
+        detail = "Kan ikke ferdigstille brev siden PDF ikke er ferdig generert og lagret.",
+        meta = mapOf("id" to id),
     )
 
 class SaksbehandlerOgAttestantSammePerson(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -472,7 +472,7 @@ internal class VedtaksbrevServiceTest {
                 )
 
             runBlocking {
-                assertThrows<IllegalStateException> {
+                assertThrows<BrevManglerPDF> {
                     vedtaksbrevService.ferdigstillVedtaksbrev(brev.behandlingId!!, brukerTokenInfo = ATTESTANT)
                 }
             }


### PR DESCRIPTION
Sikrer at saksbehandler får feilmelding i tilfeller hvor PDF-en ikke er ferdig generert og lagret når de forsøker å attestere (ferdigstille). 