### PR TITLE
Bedre feilmelding ved manglende brevutfall

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
@@ -301,7 +301,7 @@ class BrevDataMapperFerdigstillingVedtak(
             requireNotNull(trygdetid.await()) { "Mangler trygdetid" },
             requireNotNull(grunnbeloep.await()) { "Mangler grunnbeloep" },
             utlandstilknytningType,
-            brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
+            brevutfall.await() ?: throw ManglerBrevutfall(behandlingId),
             revurderingaarsak,
             erForeldreloes,
             avdoede,
@@ -345,7 +345,7 @@ class BrevDataMapperFerdigstillingVedtak(
                 requireNotNull(trygdetid.await()) { "Mangler trygdetid" },
                 requireNotNull(grunnbeloep.await()) { "Mangler grunnbeloep" },
                 utlandstilknytningType,
-                brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
+                brevutfall.await() ?: throw ManglerBrevutfall(behandlingId),
                 loependeIPesys,
                 avdoede,
                 erGjenoppretting = systemkilde == Vedtaksloesning.GJENOPPRETTA,
@@ -360,7 +360,7 @@ class BrevDataMapperFerdigstillingVedtak(
                 requireNotNull(trygdetid.await()) { "Mangler trygdetid" },
                 requireNotNull(grunnbeloep.await()) { "Mangler grunnbeløp" },
                 utlandstilknytningType,
-                brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
+                brevutfall.await() ?: throw ManglerBrevutfall(behandlingId),
                 erGjenoppretting = systemkilde == Vedtaksloesning.GJENOPPRETTA,
                 erMigrertYrkesskade = erMigrertYrkesskade.await(),
             )
@@ -391,7 +391,7 @@ class BrevDataMapperFerdigstillingVedtak(
         BarnepensjonOpphoer.fra(
             innholdMedVedlegg,
             utlandstilknytningType,
-            brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
+            brevutfall.await() ?: throw ManglerBrevutfall(behandlingId),
             virkningsdato,
         )
     }
@@ -481,7 +481,7 @@ class BrevDataMapperFerdigstillingVedtak(
             forrigeAvkortingsinfo.await(),
             etterbetaling.await(),
             requireNotNull(trygdetid.await()) { "Mangler trygdetid" }.single(),
-            brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
+            brevutfall.await() ?: throw ManglerBrevutfall(behandlingId),
             revurderingaarsak,
             avdoede
                 .single()
@@ -502,7 +502,7 @@ class BrevDataMapperFerdigstillingVedtak(
 
         OmstillingsstoenadOpphoer.fra(
             innholdMedVedlegg,
-            brevutfall.await() ?: throw BrevutfallMangler(behandlingId!!),
+            brevutfall.await() ?: throw ManglerBrevutfall(behandlingId),
             virkningsdato,
             utlandstilknytningType,
         )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
@@ -301,7 +301,7 @@ class BrevDataMapperFerdigstillingVedtak(
             requireNotNull(trygdetid.await()) { "Mangler trygdetid" },
             requireNotNull(grunnbeloep.await()) { "Mangler grunnbeloep" },
             utlandstilknytningType,
-            requireNotNull(brevutfall.await()) { "Mangler brevutfall" },
+            brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
             revurderingaarsak,
             erForeldreloes,
             avdoede,
@@ -345,7 +345,7 @@ class BrevDataMapperFerdigstillingVedtak(
                 requireNotNull(trygdetid.await()) { "Mangler trygdetid" },
                 requireNotNull(grunnbeloep.await()) { "Mangler grunnbeloep" },
                 utlandstilknytningType,
-                requireNotNull(brevutfall.await()) { "Mangler brevutfall" },
+                brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
                 loependeIPesys,
                 avdoede,
                 erGjenoppretting = systemkilde == Vedtaksloesning.GJENOPPRETTA,
@@ -360,7 +360,7 @@ class BrevDataMapperFerdigstillingVedtak(
                 requireNotNull(trygdetid.await()) { "Mangler trygdetid" },
                 requireNotNull(grunnbeloep.await()) { "Mangler grunnbeløp" },
                 utlandstilknytningType,
-                requireNotNull(brevutfall.await()) { "Mangler brevutfall" },
+                brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
                 erGjenoppretting = systemkilde == Vedtaksloesning.GJENOPPRETTA,
                 erMigrertYrkesskade = erMigrertYrkesskade.await(),
             )
@@ -391,7 +391,7 @@ class BrevDataMapperFerdigstillingVedtak(
         BarnepensjonOpphoer.fra(
             innholdMedVedlegg,
             utlandstilknytningType,
-            requireNotNull(brevutfall.await()) { "Mangler brevutfall" },
+            brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
             virkningsdato,
         )
     }
@@ -481,7 +481,7 @@ class BrevDataMapperFerdigstillingVedtak(
             forrigeAvkortingsinfo.await(),
             etterbetaling.await(),
             requireNotNull(trygdetid.await()) { "Mangler trygdetid" }.single(),
-            requireNotNull(brevutfall.await()) { "Mangler brevutfall" },
+            brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
             revurderingaarsak,
             avdoede
                 .single()
@@ -502,7 +502,7 @@ class BrevDataMapperFerdigstillingVedtak(
 
         OmstillingsstoenadOpphoer.fra(
             innholdMedVedlegg,
-            requireNotNull(brevutfall.await()) { "Mangler brevutfall" },
+            brevutfall.await() ?: throw BrevutfallMangler(behandlingId!!),
             virkningsdato,
             utlandstilknytningType,
         )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
@@ -20,7 +20,6 @@ import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.Klage
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
-import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.person.ForelderVerge
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
@@ -225,7 +224,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
         val brevutfall = async { behandlingService.hentBrevutfall(behandlingId, bruker) }
 
         BarnepensjonOpphoerRedigerbarUtfall.fra(
-            brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
+            brevutfall.await() ?: throw ManglerBrevutfall(behandlingId),
         )
     }
 
@@ -250,7 +249,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
         BarnepensjonRevurderingRedigerbartUtfall.fra(
             etterbetaling.await(),
             utbetalingsinfo.await(),
-            brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
+            brevutfall.await() ?: throw ManglerBrevutfall(behandlingId),
         )
     }
 
@@ -314,7 +313,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
         OmstillingsstoenadRevurderingRedigerbartUtfall.fra(
             requireNotNull(avkortingsinfo.await()),
             etterbetaling.await(),
-            brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
+            brevutfall.await() ?: throw ManglerBrevutfall(behandlingId),
         )
     }
 
@@ -325,14 +324,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
         val brevutfall = async { behandlingService.hentBrevutfall(behandlingId, bruker) }
 
         OmstillingsstoenadOpphoerRedigerbartUtfall.fra(
-            brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
+            brevutfall.await() ?: throw ManglerBrevutfall(behandlingId),
         )
     }
 }
-
-class BrevutfallMangler(
-    behandlingId: UUID,
-) : UgyldigForespoerselException(
-        code = "BREVUTFALL_MANGLER",
-        detail = "Brevutfall må være satt for behandling $behandlingId",
-    )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
@@ -20,6 +20,7 @@ import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.Klage
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.person.ForelderVerge
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
@@ -224,7 +225,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
         val brevutfall = async { behandlingService.hentBrevutfall(behandlingId, bruker) }
 
         BarnepensjonOpphoerRedigerbarUtfall.fra(
-            requireNotNull(brevutfall.await()),
+            brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
         )
     }
 
@@ -249,7 +250,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
         BarnepensjonRevurderingRedigerbartUtfall.fra(
             etterbetaling.await(),
             utbetalingsinfo.await(),
-            requireNotNull(brevutfall.await()),
+            brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
         )
     }
 
@@ -313,7 +314,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
         OmstillingsstoenadRevurderingRedigerbartUtfall.fra(
             requireNotNull(avkortingsinfo.await()),
             etterbetaling.await(),
-            requireNotNull(brevutfall.await()),
+            brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
         )
     }
 
@@ -324,7 +325,14 @@ class BrevDataMapperRedigerbartUtfallVedtak(
         val brevutfall = async { behandlingService.hentBrevutfall(behandlingId, bruker) }
 
         OmstillingsstoenadOpphoerRedigerbartUtfall.fra(
-            requireNotNull(brevutfall.await()),
+            brevutfall.await() ?: throw BrevutfallMangler(behandlingId),
         )
     }
 }
+
+class BrevutfallMangler(
+    behandlingId: UUID,
+) : UgyldigForespoerselException(
+        code = "BREVUTFALL_MANGLER",
+        detail = "Brevutfall må være satt for behandling $behandlingId",
+    )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/EtterlatteBrev.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/EtterlatteBrev.kt
@@ -243,6 +243,16 @@ class ManglerFrivilligSkattetrekk(
     behandlingId: UUID?,
 ) : UgyldigForespoerselException(
         code = "BEHANDLING_MANGLER_FRIVILLIG_SKATTETREKK",
-        detail = "Behandling mangler informasjon om frivillig skattetrekk, som er påkrevd for barnepensjon. Du kan legge til dette i Valg av utfall i brev.",
+        detail =
+            "Behandling mangler informasjon om frivillig skattetrekk, som er påkrevd for barnepensjon. " +
+                "Du kan legge til dette i Valg av utfall i brev.",
+        meta = mapOf("behandlingId" to behandlingId.toString()),
+    )
+
+class ManglerBrevutfall(
+    behandlingId: UUID?,
+) : UgyldigForespoerselException(
+        code = "BEHANDLING_MANGLER_BREVUTFALL",
+        detail = "Behandling mangler brevutfall, som er påkrevd. Legg til dette ved å lagre Valg av utfall i brev.",
         meta = mapOf("behandlingId" to behandlingId.toString()),
     )


### PR DESCRIPTION
Vi får en del feil med `Required value was null.` pga manglende brevutfall. Endrer til `UgyldigForespoerselException` slik at dette ikke kommer opp i loggene våre. Så lenge bruker får en beskrivende melding her, vet de hva som må gjøres.