### PR TITLE
EY-3270 Legge tilbake avbryt behandling (delvis)

### DIFF
--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
@@ -439,6 +439,10 @@ class BehandlingFactoryTest {
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
         }
         coVerify { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) }
+        verify {
+            behandlingDaoMock.lagreStatus(any(), BehandlingStatus.AVBRUTT, any())
+            oppgaveService.avbrytAapneOppgaverMedReferanse(nyfoerstegangsbehandling!!.id.toString())
+        }
     }
 
     @Test


### PR DESCRIPTION
Skrur tilbake deler av 44303d3f3cf40011d198ce9191d78b3e188f7a5e 

Siden ny søknad ikke lenger avbryter automatisk kan denne koden forbli inntil vi anser den unødvendig. 