### PR TITLE
Enable auto-merge for patch PR fra Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
 version: 2
+
 updates:
   # ==============
   # KOTLIN BACKEND
   # ==============
-
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
@@ -54,11 +54,13 @@ updates:
         patterns:
           - "io.micrometer*"
 
+    automerged-updates:
+      - match:
+          update-type: "patch"
 
   # =============
   # FRONTEND
   # =============
-
   - package-ecosystem: "npm"
     directories:
       - "/apps/etterlatte-saksbehandling-ui/client"
@@ -116,10 +118,13 @@ updates:
           - "unleash-client"
           - "license-checker-rseidelsohn"
 
+    automerged-updates:
+      - match:
+          update-type: "patch"
+
   # =============
   # FRONTEND ROOT
   # =============
-
   - package-ecosystem: "npm"
     directory: "/apps/etterlatte-saksbehandling-ui/"
     schedule:
@@ -135,23 +140,22 @@ updates:
           - "lint-staged"
           - "@typescript-eslint/*"
 
+    automerged-updates:
+      - match:
+          update-type: "patch"
+
   # ==============
   # GITHUB ACTIONS
   # ==============
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
       day: "sunday"
 
-
-
-
   # ==============
   # Docker
   # ==============
-
   - package-ecosystem: "docker"
     directories:
       - /docker


### PR DESCRIPTION
Legge til auto-merge av Dependabot PR for patch

```
Patch Versions:

    Dependabot will automatically update to the latest available patch version within the current minor version range.
    
    For example, if your current version is 1.2.3, Dependabot will update to the latest patch version like 1.2.4 but won’t upgrade to 1.3.0.
```

Tenker vi starter der, så kan vi evnt. se videre på auto-merge av minor versjoner etterpå