### PR TITLE
Legg inn revurderingsårsak omregning i enumen.

### DIFF
--- a/libs/saksbehandling-common/src/main/kotlin/behandling/Revurderingaarsak.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/behandling/Revurderingaarsak.kt
@@ -39,6 +39,7 @@ enum class Revurderingaarsak(
     NY_SOEKNAD(SAKTYPE_BP_OMS, DevOgProd, skalSendeBrev = true),
     SOESKENJUSTERING(SAKTYPE_BP, DevOgProd, skalSendeBrev = true),
     REGULERING(SAKTYPE_BP_OMS, DevOgProd, skalSendeBrev = false),
+    OMREGNING(SAKTYPE_BP_OMS, KunIDev, skalSendeBrev = false), // TODO
     INNTEKTSENDRING(SAKTYPE_OMS, DevOgProd, skalSendeBrev = true),
     INSTITUSJONSOPPHOLD(SAKTYPE_BP_OMS, DevOgProd, skalSendeBrev = true),
     YRKESSKADE(SAKTYPE_BP_OMS, DevOgProd, skalSendeBrev = true),


### PR DESCRIPTION
Denne kjem seinare i arbeid Bjørn (mfl?) held på med, men sia ho allereie er brukt i dev, feilar metrikk-jobben vår ved forsøk på uthenting