### PR TITLE
Fikser feilhåndtering ved uthenting av obo-token

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/server/src/middleware/getOboToken.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/middleware/getOboToken.ts
@@ -12,14 +12,22 @@ interface OboResponse {
 export const tokenMiddleware = (scope: string) => async (req: Request, res: Response, next: NextFunction) => {
   const bearerToken = req.headers?.authorization?.split(' ')[1]
 
-  if (!bearerToken) return next(new Error('Ikke autentisert'))
+  if (!bearerToken) {
+    const msg = 'Kunne ikke hente obo-token på grunn av manglende bearerToken'
+    logger.error(msg)
+    return res.status(401).send(msg)
+  }
 
   getOboToken(bearerToken, scope)
     .then((token) => {
       res.locals.token = token
       return next()
     })
-    .catch((error) => next(error))
+    .catch((error) => {
+      const msg = 'Kunne ikke hente obo-token'
+      logger.error(msg, error)
+      return res.status(401).send(msg)
+    })
 }
 
 export const getOboToken = async (bearerToken: string, scope: string): Promise<string> => {
@@ -31,36 +39,32 @@ export const getOboToken = async (bearerToken: string, scope: string): Promise<s
     return tokenFromCache
   }
 
-  try {
-    const body: Record<string, string> = {
-      client_id: AdConfig.clientId,
-      client_secret: AdConfig.clientSecret,
-      scope,
-      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
-      assertion: bearerToken,
-      requested_token_use: 'on_behalf_of',
-    }
-
-    const response = await fetch(AdConfig.tokenEndpoint, {
-      method: 'post',
-      body: Object.keys(body)
-        .map((key) => encodeURIComponent(key) + '=' + encodeURIComponent(body[key]))
-        .join('&'),
-      headers: {
-        'content-type': 'application/x-www-form-urlencoded',
-      },
-    })
-    if (response.status >= 400) {
-      throw new Error('Token-kall feilet')
-    }
-
-    const json = (await response.json()) as OboResponse
-
-    setTokenInCache(cacheKey, json.access_token, json.expires_in)
-
-    return json.access_token
-  } catch (e) {
-    logger.info('Feil ved henting av obo-token: ', e)
-    throw new Error('Det skjedde en feil ved henting av obo-token')
+  const body: Record<string, string> = {
+    client_id: AdConfig.clientId,
+    client_secret: AdConfig.clientSecret,
+    scope,
+    grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+    assertion: bearerToken,
+    requested_token_use: 'on_behalf_of',
   }
+
+  const response = await fetch(AdConfig.tokenEndpoint, {
+    method: 'post',
+    body: Object.keys(body)
+      .map((key) => encodeURIComponent(key) + '=' + encodeURIComponent(body[key]))
+      .join('&'),
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+    },
+  })
+  if (response.status >= 400) {
+    const body = await response.text()
+    throw new Error(`getOboToken feilet (status=${response.status} body=${body})`)
+  }
+
+  const json = (await response.json()) as OboResponse
+
+  setTokenInCache(cacheKey, json.access_token, json.expires_in)
+
+  return json.access_token
 }


### PR DESCRIPTION
Basert på et par feil som oppstod i prod forrige uke, så endres feilhåndteringen slik at feil catches og logges fremfor å sende feil videre til default error-handler. Dette gjør at stacktrace blir riktig logget i stedet for å bli splittet over mange logg-entries.