### PR TITLE
FAGSYSTEM-347262 Sikre at JsonNode for pdfgen er korrekt

### DIFF
--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/notat/NyNotatServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/notat/NyNotatServiceTest.kt
@@ -22,6 +22,7 @@ import no.nav.etterlatte.brev.pdfgen.SlatePDFMal
 import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.sak.Sak
+import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -146,6 +147,7 @@ internal class NyNotatServiceTest(
                 )
             }
         val payload = SlatePDFMal(nyNotatService.hentPayload(nyttNotat.id))
+        assertTrue(payload.toJsonNode().has("slate"), "OBS! Payload må ha feltet [Slate] for at PDFGEN skal virke.")
 
         runBlocking { nyNotatService.journalfoer(nyttNotat.id, saksbehandler) }
 


### PR DESCRIPTION
Burde på sikt lage et bedre system for å ha 1-1 på dataobjektet som leses av pdfgen. 