### PR TITLE
Sikre at statusbar ALLTID har sanntidsdata fra PDL

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/Behandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/Behandling.tsx
@@ -2,8 +2,8 @@ import { useEffect } from 'react'
 import { Navigate, Route, Routes, useParams } from 'react-router-dom'
 import { hentBehandling } from '~shared/api/behandling'
 import { GridContainer, MainContent } from '~shared/styled'
-import { setBehandling, resetBehandling, IBehandlingReducer } from '~store/reducers/BehandlingReducer'
-import { PdlPersonStatusBar } from '~shared/statusbar/Statusbar'
+import { IBehandlingReducer, resetBehandling, setBehandling } from '~store/reducers/BehandlingReducer'
+import { StatusBar } from '~shared/statusbar/Statusbar'
 import { useBehandlingRoutes } from './BehandlingRoutes'
 import { StegMeny } from './StegMeny/stegmeny'
 import { useAppDispatch } from '~store/Store'
@@ -14,11 +14,10 @@ import { BehandlingSidemeny } from '~components/behandling/sidemeny/BehandlingSi
 import Spinner from '~shared/Spinner'
 import { hentPersonopplysningerForBehandling } from '~shared/api/grunnlag'
 import { resetPersonopplysninger, setPersonopplysninger } from '~store/reducers/PersonopplysningerReducer'
-import { usePersonopplysninger } from '~components/person/usePersonopplysninger'
 import { mapAllApiResult } from '~shared/api/apiUtils'
 import { useSidetittel } from '~shared/hooks/useSidetittel'
 import { StickyToppMeny } from '~shared/StickyToppMeny'
-import { IPdlPerson, IPdlPersonNavnFoedsel } from '~shared/types/Person'
+import { usePersonopplysninger } from '~components/person/usePersonopplysninger'
 
 export const Behandling = () => {
   useSidetittel('Behandling')
@@ -68,7 +67,7 @@ export const Behandling = () => {
         return (
           <>
             <StickyToppMeny>
-              {soeker && <PdlPersonStatusBar person={personTilPersonNavnFoedselsAar(soeker)} />}
+              <StatusBar ident={soeker?.foedselsnummer} />
               <StegMeny behandling={behandling} />
             </StickyToppMeny>
             <GridContainer>
@@ -88,17 +87,4 @@ export const Behandling = () => {
       return null
     }
   )
-}
-
-const personTilPersonNavnFoedselsAar = (person: IPdlPerson): IPdlPersonNavnFoedsel => {
-  return {
-    foedselsnummer: person.foedselsnummer,
-    fornavn: person.fornavn,
-    mellomnavn: person.mellomnavn,
-    etternavn: person.etternavn,
-    foedselsaar: person.foedselsaar,
-    foedselsdato: person.foedselsdato,
-    doedsdato: person.doedsdato,
-    vergemaal: person.vergemaalEllerFremtidsfullmakt?.[0],
-  }
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/generellbehandling/GenerellBehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/generellbehandling/GenerellBehandling.tsx
@@ -8,7 +8,7 @@ import KravpakkeUtlandBehandling from '~components/generellbehandling/KravpakkeU
 import { KravpakkeUtland } from '~shared/types/Generellbehandling'
 import { Alert } from '@navikt/ds-react'
 import { Generellbehandling } from '~shared/types/Generellbehandling'
-import { StatusBarPersonHenter } from '~shared/statusbar/Statusbar'
+import { StatusBar } from '~shared/statusbar/Statusbar'
 import { hentSak } from '~shared/api/sak'
 import { isSuccess, mapApiResult } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
@@ -46,7 +46,7 @@ const GenerellBehandling = () => {
                 apiResult: hentSakStatus,
                 errorMessage: 'Vi klarte ikke å hente sak og derfor vil navn baren være borte',
               })}
-              {isSuccess(hentSakStatus) && <StatusBarPersonHenter ident={hentSakStatus.data.ident} />}
+              {isSuccess(hentSakStatus) && <StatusBar ident={hentSakStatus.data.ident} />}
               <KravpakkeUtlandBehandling
                 utlandsBehandling={generellBehandling as Generellbehandling & { innhold: KravpakkeUtland | null }}
               />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/Klagebehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/Klagebehandling.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react'
 import { useAppDispatch } from '~store/Store'
 import { addKlage, resetKlage } from '~store/reducers/KlageReducer'
 import { useApiCall } from '~shared/hooks/useApiCall'
-import { StatusBarPersonHenter } from '~shared/statusbar/Statusbar'
+import { StatusBar } from '~shared/statusbar/Statusbar'
 import Spinner from '~shared/Spinner'
 import { GridContainer, MainContent } from '~shared/styled'
 import { hentKlage } from '~shared/api/klage'
@@ -60,7 +60,7 @@ export function Klagebehandling() {
 
   return (
     <>
-      <StatusBarPersonHenter ident={klage?.sak.ident} />
+      <StatusBar ident={klage?.sak.ident} />
       <KlageStegmeny />
 
       <Spinner visible={isPending(fetchKlageStatus)} label="Henter klagebehandling" />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { PdlPersonStatusBar } from '~shared/statusbar/Statusbar'
+import { StatusBar } from '~shared/statusbar/Statusbar'
 import { SakOversikt } from './sakOgBehandling/SakOversikt'
-import Spinner from '~shared/Spinner'
 import { useApiCall } from '~shared/hooks/useApiCall'
-import { Box, Tabs } from '@navikt/ds-react'
+import { Tabs } from '@navikt/ds-react'
 import { fnrHarGyldigFormat } from '~utils/fnr'
 import NavigerTilbakeMeny from '~components/person/NavigerTilbakeMeny'
 import {
@@ -17,12 +16,10 @@ import {
   PersonIcon,
 } from '@navikt/aksel-icons'
 import { ApiErrorAlert } from '~ErrorBoundary'
-import { ApiError } from '~shared/api/apiClient'
 import BrevOversikt from '~components/person/brev/BrevOversikt'
 import { hentSakMedBehandlnger } from '~shared/api/sak'
-import { isSuccess, mapAllApiResult, mapSuccess, Result } from '~shared/api/apiUtils'
+import { isSuccess, Result } from '~shared/api/apiUtils'
 import { Dokumentliste } from '~components/person/dokumenter/Dokumentliste'
-import { hentPersonNavnogFoedsel } from '~shared/api/pdltjenester'
 import { SamordningSak } from '~components/person/SamordningSak'
 import { SakMedBehandlinger } from '~components/person/typer'
 import { SakType } from '~shared/types/sak'
@@ -51,7 +48,6 @@ export const Person = () => {
   const [search, setSearch] = useSearchParams()
   const { fnr } = usePersonLocationState(search.get('key'))
 
-  const [personNavnResult, personNavnFetch] = useApiCall(hentPersonNavnogFoedsel)
   const [sakResult, sakFetch] = useApiCall(hentSakMedBehandlnger)
   const [fane, setFane] = useState(search.get('fane') || PersonOversiktFane.SAKER)
   const skalViseNotater = useFeatureEnabledMedDefault('notater', false)
@@ -65,18 +61,9 @@ export const Person = () => {
 
   useEffect(() => {
     if (fnrHarGyldigFormat(fnr)) {
-      personNavnFetch(fnr!!)
       sakFetch(fnr!!)
     }
   }, [fnr])
-
-  const handleError = (error: ApiError) => {
-    if (error.status === 400) {
-      return <ApiErrorAlert>Ugyldig forespørsel: {error.detail}</ApiErrorAlert>
-    } else {
-      return <ApiErrorAlert>Feil oppsto ved henting av person med fødselsnummer {fnr}</ApiErrorAlert>
-    }
-  }
 
   if (!fnrHarGyldigFormat(fnr)) {
     return <ApiErrorAlert>Fødselsnummeret {fnr} har et ugyldig format (ikke 11 siffer)</ApiErrorAlert>
@@ -88,71 +75,53 @@ export const Person = () => {
 
   return (
     <>
-      {mapSuccess(personNavnResult, (person) => (
-        <PdlPersonStatusBar person={person} />
-      ))}
+      <StatusBar ident={fnr} />
 
       <NavigerTilbakeMeny to="/">Tilbake til oppgavebenken</NavigerTilbakeMeny>
 
-      {mapAllApiResult(
-        personNavnResult,
-        <Spinner label="Laster personinfo ..." />,
-        null,
-        (error) => (
-          <Box padding="8">{handleError(error)}</Box>
-        ),
-        (person) => (
-          <Tabs value={fane} onChange={velgFane}>
-            <Tabs.List>
-              <Tabs.Tab value={PersonOversiktFane.SAKER} label="Sak og behandling" icon={<BulletListIcon />} />
-              <Tabs.Tab
-                value={PersonOversiktFane.PERSONOPPLYSNINGER}
-                label="Personopplysninger"
-                icon={<PersonIcon />}
-              />
-              <Tabs.Tab value={PersonOversiktFane.HENDELSER} label="Hendelser" icon={<BellIcon />} />
-              {isOmstillingsstoenad(sakResult) && (
-                <Tabs.Tab value={PersonOversiktFane.AKTIVITET} label="Aktivitet" icon={<BriefcaseClockIcon />} />
-              )}
-              <Tabs.Tab value={PersonOversiktFane.DOKUMENTER} label="Dokumentoversikt" icon={<FileTextIcon />} />
-              <Tabs.Tab value={PersonOversiktFane.BREV} label="Brev" icon={<EnvelopeClosedIcon />} />
-              {skalViseNotater && (
-                <Tabs.Tab value={PersonOversiktFane.NOTATER} label="Notater" icon={<FileTextIcon />} />
-              )}
-              {isOmstillingsstoenad(sakResult) && (
-                <Tabs.Tab value={PersonOversiktFane.SAMORDNING} label="Samordning" icon={<CogRotationIcon />} />
-              )}
-            </Tabs.List>
+      <Tabs value={fane} onChange={velgFane}>
+        <Tabs.List>
+          <Tabs.Tab value={PersonOversiktFane.SAKER} label="Sak og behandling" icon={<BulletListIcon />} />
+          <Tabs.Tab value={PersonOversiktFane.PERSONOPPLYSNINGER} label="Personopplysninger" icon={<PersonIcon />} />
+          <Tabs.Tab value={PersonOversiktFane.HENDELSER} label="Hendelser" icon={<BellIcon />} />
+          {isOmstillingsstoenad(sakResult) && (
+            <Tabs.Tab value={PersonOversiktFane.AKTIVITET} label="Aktivitet" icon={<BriefcaseClockIcon />} />
+          )}
+          <Tabs.Tab value={PersonOversiktFane.DOKUMENTER} label="Dokumentoversikt" icon={<FileTextIcon />} />
+          <Tabs.Tab value={PersonOversiktFane.BREV} label="Brev" icon={<EnvelopeClosedIcon />} />
+          {skalViseNotater && <Tabs.Tab value={PersonOversiktFane.NOTATER} label="Notater" icon={<FileTextIcon />} />}
+          {isOmstillingsstoenad(sakResult) && (
+            <Tabs.Tab value={PersonOversiktFane.SAMORDNING} label="Samordning" icon={<CogRotationIcon />} />
+          )}
+        </Tabs.List>
 
-            <Tabs.Panel value={PersonOversiktFane.SAKER}>
-              <SakOversikt sakResult={sakResult} fnr={person.foedselsnummer} />
-            </Tabs.Panel>
-            <Tabs.Panel value={PersonOversiktFane.PERSONOPPLYSNINGER}>
-              <Personopplysninger sakResult={sakResult} fnr={person.foedselsnummer} />
-            </Tabs.Panel>
-            <Tabs.Panel value={PersonOversiktFane.HENDELSER}>
-              <Hendelser sakResult={sakResult} fnr={person.foedselsnummer} />
-            </Tabs.Panel>
-            <Tabs.Panel value={PersonOversiktFane.DOKUMENTER}>
-              <Dokumentliste sakResult={sakResult} fnr={person.foedselsnummer} />
-            </Tabs.Panel>
-            <Tabs.Panel value={PersonOversiktFane.BREV}>
-              <BrevOversikt sakResult={sakResult} />
-            </Tabs.Panel>
-            {skalViseNotater && (
-              <Tabs.Panel value={PersonOversiktFane.NOTATER}>
-                <NotatOversikt sakResult={sakResult} />
-              </Tabs.Panel>
-            )}
-            <Tabs.Panel value={PersonOversiktFane.SAMORDNING}>
-              <SamordningSak fnr={person.foedselsnummer} sakResult={sakResult} />
-            </Tabs.Panel>
-            <Tabs.Panel value={PersonOversiktFane.AKTIVITET}>
-              <Aktivitet fnr={person.foedselsnummer} sakResult={sakResult} />
-            </Tabs.Panel>
-          </Tabs>
-        )
-      )}
+        <Tabs.Panel value={PersonOversiktFane.SAKER}>
+          <SakOversikt sakResult={sakResult} fnr={fnr} />
+        </Tabs.Panel>
+        <Tabs.Panel value={PersonOversiktFane.PERSONOPPLYSNINGER}>
+          <Personopplysninger sakResult={sakResult} fnr={fnr} />
+        </Tabs.Panel>
+        <Tabs.Panel value={PersonOversiktFane.HENDELSER}>
+          <Hendelser sakResult={sakResult} fnr={fnr} />
+        </Tabs.Panel>
+        <Tabs.Panel value={PersonOversiktFane.DOKUMENTER}>
+          <Dokumentliste sakResult={sakResult} fnr={fnr} />
+        </Tabs.Panel>
+        <Tabs.Panel value={PersonOversiktFane.BREV}>
+          <BrevOversikt sakResult={sakResult} />
+        </Tabs.Panel>
+        {skalViseNotater && (
+          <Tabs.Panel value={PersonOversiktFane.NOTATER}>
+            <NotatOversikt sakResult={sakResult} />
+          </Tabs.Panel>
+        )}
+        <Tabs.Panel value={PersonOversiktFane.SAMORDNING}>
+          <SamordningSak fnr={fnr} sakResult={sakResult} />
+        </Tabs.Panel>
+        <Tabs.Panel value={PersonOversiktFane.AKTIVITET}>
+          <Aktivitet fnr={fnr} sakResult={sakResult} />
+        </Tabs.Panel>
+      </Tabs>
     </>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrev.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router-dom'
 import { hentBrev } from '~shared/api/brev'
 import { useEffect, useState } from 'react'
 import { Column, GridContainer } from '~shared/styled'
-import { StatusBarPersonHenter } from '~shared/statusbar/Statusbar'
+import { StatusBar } from '~shared/statusbar/Statusbar'
 import NavigerTilbakeMeny from '~components/person/NavigerTilbakeMeny'
 import { BrevProsessType, BrevStatus } from '~shared/types/Brev'
 import ForhaandsvisningBrev from '~components/behandling/brev/ForhaandsvisningBrev'
@@ -44,7 +44,7 @@ export default function NyttBrev() {
     <>
       {mapSuccess(brevStatus, (brev) => (
         <>
-          <StatusBarPersonHenter ident={brev.soekerFnr} />
+          <StatusBar ident={brev.soekerFnr} />
           <NavigerTilbakeMeny to="/person?fane=BREV" state={{ fnr: brev.soekerFnr }}>
             Tilbake til brevoversikt
           </NavigerTilbakeMeny>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/BehandleJournalfoeringOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/BehandleJournalfoeringOppgave.tsx
@@ -31,7 +31,7 @@ import OppsummeringKlagebehandling from '~components/person/journalfoeringsoppga
 import { Sidebar, SidebarPanel } from '~shared/components/Sidebar'
 import { hentJournalpost } from '~shared/api/dokument'
 import { JournalpostInnhold } from './journalpost/JournalpostInnhold'
-import { StatusBarPersonHenter } from '~shared/statusbar/Statusbar'
+import { StatusBar } from '~shared/statusbar/Statusbar'
 import { useSidetittel } from '~shared/hooks/useSidetittel'
 import { Box } from '@navikt/ds-react'
 import { StickyToppMeny } from '~shared/StickyToppMeny'
@@ -83,7 +83,7 @@ export default function BehandleJournalfoeringOppgave() {
   return (
     <>
       <StickyToppMeny>
-        <StatusBarPersonHenter ident={oppgave?.fnr} />
+        <StatusBar ident={oppgave?.fnr} />
         <NavigerTilbakeMeny to="/">Tilbake til oppgavebenken</NavigerTilbakeMeny>
       </StickyToppMeny>
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/Tilbakekrevingsbehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/Tilbakekrevingsbehandling.tsx
@@ -2,7 +2,7 @@ import { Navigate, Route, Routes, useParams } from 'react-router-dom'
 import React, { useEffect, useState } from 'react'
 import { useAppDispatch } from '~store/Store'
 import { useApiCall } from '~shared/hooks/useApiCall'
-import { StatusBarPersonHenter } from '~shared/statusbar/Statusbar'
+import { StatusBar } from '~shared/statusbar/Statusbar'
 import Spinner from '~shared/Spinner'
 import { GridContainer, MainContent } from '~shared/styled'
 import { hentTilbakekreving } from '~shared/api/tilbakekreving'
@@ -56,7 +56,7 @@ export function Tilbakekrevingsbehandling() {
 
   return (
     <>
-      <StatusBarPersonHenter ident={tilbakekreving?.sak.ident} />
+      <StatusBar ident={tilbakekreving?.sak.ident} />
       <TilbakekrevingStegmeny />
       <Spinner visible={isPending(fetchTilbakekrevingStatus)} label="Henter tilbakekrevingsbehandling" />
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/statusbar/Statusbar.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/statusbar/Statusbar.tsx
@@ -3,8 +3,7 @@ import { GenderIcon, GenderList } from '../icons/genderIcon'
 import { IPersonResult } from '~components/person/typer'
 import { BodyShort, Box, HelpText, HStack, Label, Skeleton } from '@navikt/ds-react'
 import { KopierbarVerdi } from '~shared/statusbar/KopierbarVerdi'
-import { IPdlPersonNavnFoedsel } from '~shared/types/Person'
-import { mapApiResult, Result } from '~shared/api/apiUtils'
+import { mapApiResult } from '~shared/api/apiUtils'
 import { useEffect } from 'react'
 import { hentPersonNavnogFoedsel } from '~shared/api/pdltjenester'
 import { useApiCall } from '~shared/hooks/useApiCall'
@@ -14,34 +13,13 @@ import { DoedsdatoTag } from '~shared/tags/DoedsdatoTag'
 import { PersonLink } from '~components/person/lenker/PersonLink'
 import { VergemaalTag } from '~shared/tags/VergemaalTag'
 
-export const PdlPersonStatusBar = ({ person }: { person: IPdlPersonNavnFoedsel }) => (
-  <StatusBar
-    result={{
-      status: 'success',
-      data: {
-        foedselsnummer: person.foedselsnummer,
-        fornavn: person.fornavn,
-        mellomnavn: person.mellomnavn,
-        etternavn: person.etternavn,
-        foedselsaar: person.foedselsaar,
-        foedselsdato: person.foedselsdato,
-        doedsdato: person.doedsdato,
-        vergemaal: person.vergemaal,
-      },
-    }}
-  />
-)
+export const StatusBar = ({ ident }: { ident: string | null | undefined }) => {
+  const [result, hentPerson] = useApiCall(hentPersonNavnogFoedsel)
 
-export const StatusBarPersonHenter = ({ ident }: { ident: string | null | undefined }) => {
-  const [personStatus, hentPerson] = useApiCall(hentPersonNavnogFoedsel)
   useEffect(() => {
     ident && hentPerson(ident)
   }, [ident])
 
-  return <StatusBar result={personStatus} />
-}
-
-export const StatusBar = ({ result }: { result: Result<IPdlPersonNavnFoedsel> }) => {
   const gender = (fnr: string): GenderList => {
     const genderNum = Number(fnr[8])
     if (genderNum % 2 === 0) {
@@ -110,7 +88,7 @@ const Alder = ({
 
 const PersonSkeleton = () => (
   <StatusbarBox>
-    <HStack gap="4">
+    <HStack gap="4" align="center">
       <Skeleton variant="circle" width="30px" height="30px" />
       <Skeleton variant="rounded" width="10rem" height="1rem" />
       <BodyShort>|</BodyShort>


### PR DESCRIPTION
Dagens løsning gjør at det kan være diff i statusbar mellom `Behandling` og de andre sidene som bruker den. 
Et eksempel på noe som kan skje er at bruker dør. Dette vil vises med en tag på _alle_ sider, med unntak av behandling. 

Denne endringen gjør følgende: 

- Sikrer at `StatusBar` viser det samme på _alle_ sider. 
- Fjerner unødvendig kode. 

Avklart OK med fag! 