### PR TITLE
EY-4478: Fjerner kontrollsjekk av samtidig dødsfall for utsendelse mellom 18 og 20 år

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktAvdoedService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktAvdoedService.kt
@@ -3,12 +3,16 @@ package no.nav.etterlatte.grunnlagsendring.doedshendelse.kontrollpunkt
 import no.nav.etterlatte.libs.common.pdl.PersonDTO
 
 internal class DoedshendelseKontrollpunktAvdoedService {
-    fun identifiser(avdoed: PersonDTO): List<DoedshendelseKontrollpunkt> =
-        listOfNotNull(
-            kontrollerDoedsdato(avdoed),
-            kontrollerDNummer(avdoed),
-            kontrollerUtvandring(avdoed),
-        )
+    fun identifiser(
+        avdoed: PersonDTO,
+        kontrollerDNummer: Boolean = true,
+    ): List<DoedshendelseKontrollpunkt> {
+        val kontrollpunkter = mutableListOf<DoedshendelseKontrollpunkt>()
+        kontrollerDoedsdato(avdoed)?.let { kontrollpunkter.add(it) }
+        if (kontrollerDNummer) kontrollerDNummer(avdoed)?.let { kontrollpunkter.add(it) }
+        kontrollerUtvandring(avdoed)?.let { kontrollpunkter.add(it) }
+        return kontrollpunkter
+    }
 
     private fun kontrollerDoedsdato(avdoed: PersonDTO): DoedshendelseKontrollpunkt? =
         when (avdoed.doedsdato) {

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktBarnService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktBarnService.kt
@@ -17,11 +17,15 @@ internal class DoedshendelseKontrollpunktBarnService(
         avdoed: PersonDTO,
         sak: Sak?,
         barn: PersonDTO,
-    ): List<DoedshendelseKontrollpunkt> =
-        listOfNotNull(
-            kontrollerBarnOgHarBP(sak),
-            kontrollerSamtidigDoedsfall(avdoed, hendelse, barn),
-        )
+        kontrollerSamtidigDoedsfall: Boolean = true,
+    ): List<DoedshendelseKontrollpunkt> {
+        val kontrollpunkt = mutableListOf<DoedshendelseKontrollpunkt>()
+        kontrollerBarnOgHarBP(sak)?.let { kontrollpunkt.add(it) }
+        if (kontrollerSamtidigDoedsfall) {
+            kontrollerSamtidigDoedsfall(avdoed, hendelse, barn)?.let { kontrollpunkt.add(it) }
+        }
+        return kontrollpunkt
+    }
 
     private fun kontrollerBarnOgHarBP(sak: Sak?): DoedshendelseKontrollpunkt.BarnHarBarnepensjon? {
         if (sak == null) {

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/mellomAttenOgTjueVedReformtidspunkt/BehandleDoedshendelseKontrollpunktService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/mellomAttenOgTjueVedReformtidspunkt/BehandleDoedshendelseKontrollpunktService.kt
@@ -29,7 +29,7 @@ class BehandleDoedshendelseKontrollpunktService(
         return if (avdoed.doedsdato == null) {
             listOf(DoedshendelseKontrollpunkt.AvdoedLeverIPDL)
         } else {
-            val barnKontrollpunkter = kontrollpunktBarnService.identifiser(hendelse, avdoed, sak, barn)
+            val barnKontrollpunkter = kontrollpunktBarnService.identifiser(hendelse, avdoed, sak, barn, false)
             val avdoedKontrollpunkter = kontrollpunktAvdoedService.identifiser(avdoed)
             val fellesKontrollpunkter = fellesKontrollpunkter(barn)
 

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/mellomAttenOgTjueVedReformtidspunkt/BehandleDoedshendelseKontrollpunktService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/mellomAttenOgTjueVedReformtidspunkt/BehandleDoedshendelseKontrollpunktService.kt
@@ -30,7 +30,7 @@ class BehandleDoedshendelseKontrollpunktService(
             listOf(DoedshendelseKontrollpunkt.AvdoedLeverIPDL)
         } else {
             val barnKontrollpunkter = kontrollpunktBarnService.identifiser(hendelse, avdoed, sak, barn, false)
-            val avdoedKontrollpunkter = kontrollpunktAvdoedService.identifiser(avdoed)
+            val avdoedKontrollpunkter = kontrollpunktAvdoedService.identifiser(avdoed, false)
             val fellesKontrollpunkter = fellesKontrollpunkter(barn)
 
             barnKontrollpunkter + avdoedKontrollpunkter + fellesKontrollpunkter


### PR DESCRIPTION
Dette er ikke nødvendig for denne jobben siden dette hendte bakover i tid og personene er over 18 år.