### PR TITLE
Ta oppgaver av vent-jobben endret i noen tilfeller til ugyldig status

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
@@ -25,7 +25,6 @@ import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.etterlatte.oppgave.OppgaveService
-import no.nav.etterlatte.oppgave.PaaVent
 import no.nav.etterlatte.vedtaksvurdering.VedtakHendelse
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
@@ -302,7 +301,11 @@ class BehandlingStatusServiceImpl(
     private fun haandterFeilutbetaling(behandling: Behandling) {
         val brevutfall = behandlingInfoDao.hentBrevutfall(behandling.id)
         if (brevutfall?.feilutbetaling?.valg in
-            listOf(FeilutbetalingValg.JA_VARSEL, FeilutbetalingValg.JA_INGEN_TK, FeilutbetalingValg.JA_INGEN_VARSEL_MOTREGNES)
+            listOf(
+                FeilutbetalingValg.JA_VARSEL,
+                FeilutbetalingValg.JA_INGEN_TK,
+                FeilutbetalingValg.JA_INGEN_VARSEL_MOTREGNES,
+            )
         ) {
             logger.info("Oppretter oppgave av type ${OppgaveType.TILBAKEKREVING} for behandling ${behandling.id}")
 
@@ -315,12 +318,10 @@ class BehandlingStatusServiceImpl(
             if (oppgaveFraBehandlingMedFeilutbetaling != null) {
                 logger.info("Det finnes allerede en oppgave under behandling på tilbakekreving for sak ${behandling.sak.id}")
                 oppgaveService.endrePaaVent(
-                    PaaVent(
-                        oppgaveId = oppgaveFraBehandlingMedFeilutbetaling.id,
-                        aarsak = PaaVentAarsak.KRAVGRUNNLAG_SPERRET,
-                        merknad = "Venter på oppdatert kravgrunnlag",
-                        paavent = true,
-                    ),
+                    oppgaveId = oppgaveFraBehandlingMedFeilutbetaling.id,
+                    aarsak = PaaVentAarsak.KRAVGRUNNLAG_SPERRET,
+                    merknad = "Venter på oppdatert kravgrunnlag",
+                    paavent = true,
                 )
             } else {
                 oppgaveService.opprettOppgave(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
@@ -27,7 +27,6 @@ import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingVurdering
 import no.nav.etterlatte.libs.common.vedtak.TilbakekrevingVedtakLagretDto
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.oppgave.OppgaveService
-import no.nav.etterlatte.oppgave.PaaVent
 import no.nav.etterlatte.sak.SakLesDao
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -129,7 +128,7 @@ class TilbakekrevingService(
 
             val merknad = if (paaVent) "Kravgrunnlag er sperret" else "Sperre på kravgrunnlag opphevet"
             val aarsak = if (paaVent) PaaVentAarsak.KRAVGRUNNLAG_SPERRET else null
-            oppgaveService.endrePaaVent(PaaVent(oppgaveId = oppgave.id, merknad = merknad, paavent = paaVent, aarsak = aarsak))
+            oppgaveService.endrePaaVent(oppgaveId = oppgave.id, merknad = merknad, paavent = paaVent, aarsak = aarsak)
         }
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDao.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.oppgave
 import no.nav.etterlatte.behandling.hendelse.getUUID
 import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.Enhetsnummer
+import no.nav.etterlatte.libs.common.behandling.PaaVentAarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
 import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
@@ -83,7 +84,9 @@ interface OppgaveDao {
     )
 
     fun oppdaterPaaVent(
-        paavent: PaaVent,
+        oppgaveId: UUID,
+        merknad: String,
+        aarsak: PaaVentAarsak?,
         oppgaveStatus: Status,
     )
 
@@ -536,7 +539,9 @@ class OppgaveDaoImpl(
     }
 
     override fun oppdaterPaaVent(
-        paavent: PaaVent,
+        oppgaveId: UUID,
+        merknad: String,
+        aarsak: PaaVentAarsak?,
         oppgaveStatus: Status,
     ) {
         connectionAutoclosing.hentConnection {
@@ -549,10 +554,10 @@ class OppgaveDaoImpl(
                         where id = ?::UUID
                         """.trimIndent(),
                     )
-                statement.setString(1, paavent.merknad)
+                statement.setString(1, merknad)
                 statement.setString(2, oppgaveStatus.name)
-                statement.setString(3, paavent.aarsak?.name)
-                statement.setObject(4, paavent.oppgaveId)
+                statement.setString(3, aarsak?.name)
+                statement.setObject(4, oppgaveId)
 
                 statement.executeUpdate()
             }

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDaoMedEndringssporing.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDaoMedEndringssporing.kt
@@ -5,6 +5,7 @@ import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.behandling.objectMapper
 import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.Enhetsnummer
+import no.nav.etterlatte.libs.common.behandling.PaaVentAarsak
 import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
 import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
@@ -197,11 +198,13 @@ class OppgaveDaoMedEndringssporingImpl(
     }
 
     override fun oppdaterPaaVent(
-        paavent: PaaVent,
+        oppgaveId: UUID,
+        merknad: String,
+        aarsak: PaaVentAarsak?,
         oppgaveStatus: Status,
     ) {
-        lagreEndringerPaaOppgave(paavent.oppgaveId) {
-            oppgaveDao.oppdaterPaaVent(paavent, oppgaveStatus)
+        lagreEndringerPaaOppgave(oppgaveId) {
+            oppgaveDao.oppdaterPaaVent(oppgaveId, merknad, aarsak, oppgaveStatus)
         }
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveRoutes.kt
@@ -194,10 +194,10 @@ internal fun Route.oppgaveRoutes(service: OppgaveService) {
 
             post("sett-paa-vent") {
                 kunSkrivetilgang {
-                    val settPaaVentRequest = call.receive<EndrePaaVentRequest>()
+                    val req = call.receive<EndrePaaVentRequest>()
                     val oppgave =
                         inTransaction {
-                            service.endrePaaVent(settPaaVentRequest.toDomain(oppgaveId))
+                            service.endrePaaVent(oppgaveId, req.paaVent, req.merknad, req.aarsak)
                         }
                     call.respond(oppgave)
                 }

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -12,6 +12,7 @@ import no.nav.etterlatte.behandling.hendelse.HendelseDao
 import no.nav.etterlatte.grunnlagsendring.SakMedEnhet
 import no.nav.etterlatte.libs.common.Enhetsnummer
 import no.nav.etterlatte.libs.common.behandling.BehandlingHendelseType
+import no.nav.etterlatte.libs.common.behandling.PaaVentAarsak
 import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
@@ -167,15 +168,27 @@ class OppgaveService(
         oppgaveDao.oppdaterReferanseOgMerknad(oppgaveId, referanse, merknad)
     }
 
-    fun endrePaaVent(paavent: PaaVent): OppgaveIntern {
-        val oppgave = hentOppgave(paavent.oppgaveId)
-        if (paavent.paavent && oppgave.status == Status.PAA_VENT) return oppgave
-        if (!paavent.paavent && oppgave.status != Status.PAA_VENT) return oppgave
+    fun endrePaaVent(
+        oppgaveId: UUID,
+        paavent: Boolean,
+        merknad: String,
+        aarsak: PaaVentAarsak?,
+    ): OppgaveIntern {
+        val oppgave = hentOppgave(oppgaveId)
+        if (paavent && oppgave.status == Status.PAA_VENT) return oppgave
+        if (!paavent && oppgave.status != Status.PAA_VENT) return oppgave
+
+        if (paavent && aarsak == null) {
+            throw UgyldigForespoerselException(
+                "MANGLER_AARSAK_PAA_VENT",
+                "Kan ikke sette en oppgave på vent uten en årsak.",
+            )
+        }
 
         sikreAktivOppgaveOgTildeltSaksbehandler(oppgave) {
-            val nyStatus = if (paavent.paavent) Status.PAA_VENT else hentForrigeStatus(paavent.oppgaveId)
+            val nyStatus = if (paavent) Status.PAA_VENT else hentForrigeStatus(oppgaveId)
 
-            oppgaveDao.oppdaterPaaVent(paavent, nyStatus)
+            oppgaveDao.oppdaterPaaVent(oppgaveId, merknad, aarsak, nyStatus)
 
             when (oppgave.type) {
                 OppgaveType.FOERSTEGANGSBEHANDLING,
@@ -187,7 +200,7 @@ class OppgaveService(
                         hendelser.sendMeldingForHendelsePaaVent(
                             UUID.fromString(oppgave.referanse),
                             BehandlingHendelseType.PAA_VENT,
-                            paavent.aarsak!!,
+                            aarsak!!,
                         )
                     } else {
                         hendelser.sendMeldingForHendelseAvVent(
@@ -201,7 +214,7 @@ class OppgaveService(
             }
         }
 
-        return hentOppgave(paavent.oppgaveId)
+        return hentOppgave(oppgaveId)
     }
 
     private fun sikreAktivOppgaveOgTildeltSaksbehandler(
@@ -639,6 +652,7 @@ class OppgaveService(
                         OppgaveType.AKTIVITETSPLIKT_INFORMASJON_VARIG_UNNTAK,
                         ->
                             true
+
                         OppgaveType.KLAGE,
                         OppgaveType.KRAVPAKKE_UTLAND,
                         OppgaveType.MANGLER_SOEKNAD,

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V166__rydde_oppgaver_som_ikke_har_status_attestering.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V166__rydde_oppgaver_som_ikke_har_status_attestering.sql
@@ -1,0 +1,19 @@
+-- Siden ta av vent-jobben kan ha satt en attesteringsoppgave som var på vent tilbake til under behandling
+-- er det ~10 oppgaver som har fått feil status i basen (etter manuell patching av to av de)
+--
+-- Tok en kontroll av de 6 oppgavene som var på vent som hadde behandling til attestering, og
+-- ingen av de vil få feil status når de tas av vent (verifisert ved å kontrollere oppgaveendringer
+-- og dobbeltsjekke at siste status før på vent er attestering
+--
+-- spørring for å sjekke i opppgaveendringer:
+-- select id, oppgaveid, oppgavefoer::jsonb ->> 'status', oppgaveetter::jsonb ->> 'status', tidspunkt
+-- from oppgaveendringer
+-- where oppgaveid in <AKTUELLE_OPPGAVER>
+-- order by oppgaveid, tidspunkt;
+update oppgave
+set status = 'ATTESTERING'
+where id in (SELECT o.id
+             FROM oppgave o
+                      left outer join behandling b on o.referanse = b.id::text
+             where b.status = 'FATTET_VEDTAK'
+               and o.status = 'UNDER_BEHANDLING');

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingStatusServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingStatusServiceTest.kt
@@ -42,7 +42,6 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.nyKontekstMedBruker
 import no.nav.etterlatte.oppgave.OppgaveService
-import no.nav.etterlatte.oppgave.PaaVent
 import no.nav.etterlatte.revurdering
 import no.nav.etterlatte.vedtaksvurdering.VedtakHendelse
 import org.junit.jupiter.api.AfterEach
@@ -394,7 +393,7 @@ internal class BehandlingStatusServiceTest {
         every { behandlingService.hentBehandling(behandlingId) } returns behandling
         every { behandlingInfoDao.hentBrevutfall(behandlingId) } returns brevutfall(behandlingId, feilutbetalingValg)
         every { oppgaveService.hentOppgaverForSak(sakId, OppgaveType.TILBAKEKREVING) } returns listOf(oppgave(oppgaveId, sakId))
-        every { oppgaveService.endrePaaVent(any()) } returns oppgave(oppgaveId, sakId, Status.PAA_VENT)
+        every { oppgaveService.endrePaaVent(any(), any(), any(), any()) } returns oppgave(oppgaveId, sakId, Status.PAA_VENT)
         every { grunnlagsendringshendelseService.settHendelseTilHistorisk(behandlingId) } just runs
 
         inTransaction {
@@ -407,7 +406,7 @@ internal class BehandlingStatusServiceTest {
             behandlingService.registrerVedtakHendelse(behandlingId, iverksettVedtak, HendelseType.IVERKSATT)
             behandlingInfoDao.hentBrevutfall(behandlingId)
             oppgaveService.hentOppgaverForSak(sakId, OppgaveType.TILBAKEKREVING)
-            oppgaveService.endrePaaVent(PaaVent(oppgaveId, PaaVentAarsak.KRAVGRUNNLAG_SPERRET, "Venter på oppdatert kravgrunnlag", true))
+            oppgaveService.endrePaaVent(oppgaveId, true, "Venter på oppdatert kravgrunnlag", PaaVentAarsak.KRAVGRUNNLAG_SPERRET)
             grunnlagsendringshendelseService.settHendelseTilHistorisk(behandlingId)
         }
     }


### PR DESCRIPTION
Endrer på måten jobben setter status på. Tok også en endring på selve service-signaturen siden det var stress å mocke feltene forståelig i testen av ta av vent-jobben.


Det kommer et ryddescript som skal fikse opp i oppgavene som har mismatch med attestering og under behandling.