### PR TITLE
EY-4499 Splitt opp opprettelse av brev fra OpprettJournalfoerOgDistri…

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevParametre.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevParametre.kt
@@ -20,7 +20,7 @@ import java.time.LocalDate
 sealed class BrevParametre {
     abstract val brevkode: Brevkoder
 
-    abstract fun brevDataMapping(req: BrevDataRedigerbarRequest): BrevDataRedigerbar
+    abstract fun brevDataMapping(): BrevDataRedigerbar
 
     @JsonTypeName("OMSTILLINGSSTOENAD_AKTIVITETSPLIKT_INFORMASJON_4MND")
     data class AktivitetspliktInformasjon4Mnd(
@@ -30,7 +30,7 @@ sealed class BrevParametre {
         val nasjonalEllerUtland: NasjonalEllerUtland,
         override val brevkode: Brevkoder = Brevkoder.OMSTILLINGSSTOENAD_AKTIVITETSPLIKT_INFORMASJON_4MND_INNHOLD,
     ) : BrevParametre() {
-        override fun brevDataMapping(req: BrevDataRedigerbarRequest): BrevDataRedigerbar =
+        override fun brevDataMapping(): BrevDataRedigerbar =
             AktivitetspliktInformasjon4MndBrevdata(aktivitetsgrad, utbetaling, redusertEtterInntekt, nasjonalEllerUtland)
     }
 
@@ -40,7 +40,7 @@ sealed class BrevParametre {
         val nasjonalEllerUtland: NasjonalEllerUtland,
         override val brevkode: Brevkoder = Brevkoder.OMSTILLINGSSTOENAD_AKTIVITETSPLIKT_INFORMASJON_6MND_INNHOLD,
     ) : BrevParametre() {
-        override fun brevDataMapping(req: BrevDataRedigerbarRequest): BrevDataRedigerbar =
+        override fun brevDataMapping(): BrevDataRedigerbar =
             AktivitetspliktInformasjon6MndBrevdata(redusertEtterInntekt, nasjonalEllerUtland)
     }
 
@@ -50,7 +50,7 @@ sealed class BrevParametre {
         val borINorgeEllerIkkeAvtaleland: Boolean,
         override val brevkode: Brevkoder = Brevkoder.OMSTILLINGSSTOENAD_INFORMASJON_MOTTATT_SOEKNAD,
     ) : BrevParametre() {
-        override fun brevDataMapping(req: BrevDataRedigerbarRequest): BrevDataRedigerbar =
+        override fun brevDataMapping(): BrevDataRedigerbar =
             OmstillingsstoenadInformasjonMottattSoeknad(
                 mottattDato = mottattDato,
                 borINorgeEllerIkkeAvtaleland = borINorgeEllerIkkeAvtaleland,
@@ -62,8 +62,7 @@ sealed class BrevParametre {
         val borIUtlandet: Boolean,
         override val brevkode: Brevkoder = Brevkoder.OMSTILLINGSSTOENAD_INFORMASJON_INNHENTING_AV_OPPLYSNINGER,
     ) : BrevParametre() {
-        override fun brevDataMapping(req: BrevDataRedigerbarRequest): BrevDataRedigerbar =
-            OmstillingsstoenadInnhentingAvOpplysninger(borIUtlandet = borIUtlandet)
+        override fun brevDataMapping(): BrevDataRedigerbar = OmstillingsstoenadInnhentingAvOpplysninger(borIUtlandet = borIUtlandet)
     }
 
     @JsonTypeName("OMSTILLINGSSTOENAD_INFORMASJON_DOEDSFALL_INNHOLD")
@@ -72,7 +71,7 @@ sealed class BrevParametre {
         val avdoedNavn: String,
         override val brevkode: Brevkoder = Brevkoder.OMS_INFORMASJON_DOEDSFALL,
     ) : BrevParametre() {
-        override fun brevDataMapping(req: BrevDataRedigerbarRequest): BrevDataRedigerbar =
+        override fun brevDataMapping(): BrevDataRedigerbar =
             OmstillingsstoenadInformasjonDoedsfall(
                 avdoedNavn = avdoedNavn,
                 borIutland = bosattUtland,
@@ -86,7 +85,7 @@ sealed class BrevParametre {
         val erOver18Aar: Boolean,
         override val brevkode: Brevkoder = Brevkoder.BP_INFORMASJON_DOEDSFALL,
     ) : BrevParametre() {
-        override fun brevDataMapping(req: BrevDataRedigerbarRequest): BrevDataRedigerbar =
+        override fun brevDataMapping(): BrevDataRedigerbar =
             BarnepensjonInformasjonDoedsfall(
                 avdoedNavn = avdoedNavn,
                 borIutland = bosattUtland,
@@ -102,7 +101,7 @@ sealed class BrevParametre {
         val bosattUtland: Boolean,
         override val brevkode: Brevkoder = Brevkoder.BARNEPENSJON_INFORMASJON_MOTTATT_SOEKNAD,
     ) : BrevParametre() {
-        override fun brevDataMapping(req: BrevDataRedigerbarRequest): BrevDataRedigerbar =
+        override fun brevDataMapping(): BrevDataRedigerbar =
             BarnepensjonInformasjonMottattSoeknad(
                 mottattDato = mottattDato,
                 borINorgeEllerIkkeAvtaleland = borINorgeEllerIkkeAvtaleland,
@@ -117,7 +116,7 @@ sealed class BrevParametre {
         val borIUtlandet: Boolean,
         override val brevkode: Brevkoder = Brevkoder.BARNEPENSJON_INFORMASJON_INNHENTING_AV_OPPLYSNINGER,
     ) : BrevParametre() {
-        override fun brevDataMapping(req: BrevDataRedigerbarRequest): BrevDataRedigerbar =
+        override fun brevDataMapping(): BrevDataRedigerbar =
             BarnepensjonInnhentingAvOpplysninger(
                 erOver18aar = erOver18aar,
                 borIUtlandet = borIUtlandet,
@@ -128,6 +127,6 @@ sealed class BrevParametre {
     class TomtBrev : BrevParametre() {
         override val brevkode: Brevkoder = Brevkoder.TOMT_INFORMASJONSBREV
 
-        override fun brevDataMapping(req: BrevDataRedigerbarRequest): BrevDataRedigerbar = ManueltBrevData()
+        override fun brevDataMapping(): BrevDataRedigerbar = ManueltBrevData()
     }
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
@@ -174,7 +174,8 @@ fun Route.brevRoute(
                         sakId,
                         brukerTokenInfo,
                         Brevkoder.TOMT_INFORMASJONSBREV,
-                    ) { ManueltBrevData() }
+                        ManueltBrevData(),
+                    )
                 }.let { (brev, varighet) ->
                     logger.info("Oppretting av brev tok ${varighet.toString(DurationUnit.SECONDS, 2)}")
                     call.respond(HttpStatusCode.Created, brev)
@@ -188,12 +189,14 @@ fun Route.brevRoute(
                 val brevParametre = call.receive<BrevParametre>()
                 val sak = behandlingService.hentSak(sakId, brukerTokenInfo)
                 grunnlagService.oppdaterGrunnlagForSak(sak, brukerTokenInfo)
+                val data = brevParametre.brevDataMapping()
                 measureTimedValue {
                     service.opprettNyttManueltBrev(
                         sakId,
                         brukerTokenInfo,
                         brevParametre.brevkode,
-                    ) { redigerbarTekstRequest -> brevParametre.brevDataMapping(redigerbarTekstRequest) }
+                        data,
+                    )
                 }.let { (brev, varighet) ->
                     logger.info("Oppretting av brev tok ${varighet.toString(DurationUnit.SECONDS, 2)}")
                     call.respond(HttpStatusCode.Created, brev)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
@@ -189,13 +189,12 @@ fun Route.brevRoute(
                 val brevParametre = call.receive<BrevParametre>()
                 val sak = behandlingService.hentSak(sakId, brukerTokenInfo)
                 grunnlagService.oppdaterGrunnlagForSak(sak, brukerTokenInfo)
-                val data = brevParametre.brevDataMapping()
                 measureTimedValue {
                     service.opprettNyttManueltBrev(
                         sakId,
                         brukerTokenInfo,
                         brevParametre.brevkode,
-                        data,
+                        brevParametre.brevDataMapping(),
                     )
                 }.let { (brev, varighet) ->
                     logger.info("Oppretting av brev tok ${varighet.toString(DurationUnit.SECONDS, 2)}")

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -37,16 +37,17 @@ class BrevService(
         sakId: SakId,
         bruker: BrukerTokenInfo,
         brevkode: Brevkoder,
-        brevDataMapping: suspend (BrevDataRedigerbarRequest) -> BrevDataRedigerbar,
+        brevData: BrevDataRedigerbar,
     ): Brev =
         brevoppretter
-            .opprettBrev(
+            .opprettBrevSomHarInnhold(
                 sakId = sakId,
                 behandlingId = null,
                 bruker = bruker,
-                brevKodeMapping = { brevkode },
+                brevKode = brevkode,
+                brevData = brevData,
                 brevtype = brevkode.brevtype,
-                brevDataMapping = brevDataMapping,
+                validerMottaker = false,
             ).first
 
     data class BrevPayload(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -47,7 +47,6 @@ class BrevService(
                 brevKode = brevkode,
                 brevData = brevData,
                 brevtype = brevkode.brevtype,
-                validerMottaker = false,
             ).first
 
     data class BrevPayload(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -46,7 +46,6 @@ class BrevService(
                 bruker = bruker,
                 brevKode = brevkode,
                 brevData = brevData,
-                brevtype = brevkode.brevtype,
             ).first
 
     data class BrevPayload(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -33,7 +33,6 @@ class Brevoppretter(
         brevKode: Brevkoder,
         brevtype: Brevtype,
         brevData: BrevDataRedigerbar,
-        validerMottaker: Boolean = true,
     ): Pair<Brev, Enhetsnummer> {
         with(
             innholdTilRedigerbartBrevHenter.hentInnDataForBrevMedData(
@@ -57,14 +56,7 @@ class Brevoppretter(
                     brevtype = brevtype,
                     brevkoder = brevkode,
                 )
-            if (validerMottaker && nyttBrev.mottaker.erGyldig().isNotEmpty()) {
-                sikkerLogg.error("Ugyldig mottaker: ${nyttBrev.mottaker.toJson()}")
-                throw UgyldigMottakerKanIkkeFerdigstilles(
-                    id = null,
-                    sakId = nyttBrev.sakId,
-                    nyttBrev.mottaker.erGyldig(),
-                )
-            }
+
             return Pair(db.opprettBrev(nyttBrev), enhet)
         }
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -31,7 +31,6 @@ class Brevoppretter(
         behandlingId: UUID?,
         bruker: BrukerTokenInfo,
         brevKode: Brevkoder,
-        brevtype: Brevtype,
         brevData: BrevDataRedigerbar,
     ): Pair<Brev, Enhetsnummer> {
         with(
@@ -53,7 +52,7 @@ class Brevoppretter(
                     opprettet = Tidspunkt.now(),
                     innhold = innhold,
                     innholdVedlegg = innholdVedlegg,
-                    brevtype = brevtype,
+                    brevtype = brevKode.brevtype,
                     brevkoder = brevkode,
                 )
 
@@ -66,7 +65,6 @@ class Brevoppretter(
         behandlingId: UUID?,
         bruker: BrukerTokenInfo,
         brevKodeMapping: (b: BrevkodeRequest) -> Brevkoder,
-        brevtype: Brevtype,
         brevDataMapping: suspend (BrevDataRedigerbarRequest) -> BrevDataRedigerbar,
     ): Pair<Brev, Enhetsnummer> =
         with(
@@ -88,7 +86,7 @@ class Brevoppretter(
                     opprettet = Tidspunkt.now(),
                     innhold = innhold,
                     innholdVedlegg = innholdVedlegg,
-                    brevtype = brevtype,
+                    brevtype = brevkode.brevtype,
                     brevkoder = brevkode,
                 )
             return Pair(db.opprettBrev(nyttBrev), enhet)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/InnholdTilRedigerbartBrevHenter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/InnholdTilRedigerbartBrevHenter.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.brev
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import no.nav.etterlatte.brev.adresse.AdresseService
+import no.nav.etterlatte.brev.behandling.GenerellBrevData
 import no.nav.etterlatte.brev.behandling.PersonerISak
 import no.nav.etterlatte.brev.behandling.erForeldreloes
 import no.nav.etterlatte.brev.behandling.loependeIPesys
@@ -10,6 +11,7 @@ import no.nav.etterlatte.brev.behandling.opprettAvsenderRequest
 import no.nav.etterlatte.brev.brevbaker.BrevbakerRequest
 import no.nav.etterlatte.brev.brevbaker.BrevbakerService
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
+import no.nav.etterlatte.brev.model.BrevData
 import no.nav.etterlatte.brev.model.BrevDataRedigerbar
 import no.nav.etterlatte.brev.model.BrevInnhold
 import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
@@ -37,7 +39,63 @@ class InnholdTilRedigerbartBrevHenter(
     ): OpprettBrevRequest {
         val generellBrevData =
             retryOgPakkUt { brevdataFacade.hentGenerellBrevData(sakId, behandlingId, null, bruker) }
-        return coroutineScope {
+        return opprettBrevRequest(generellBrevData, brevKode, brevData, bruker)
+    }
+
+    internal suspend fun hentInnData(
+        sakId: SakId,
+        behandlingId: UUID?,
+        bruker: BrukerTokenInfo,
+        brevKodeMapping: (b: BrevkodeRequest) -> Brevkoder,
+        brevDataMapping: suspend (BrevDataRedigerbarRequest) -> BrevDataRedigerbar,
+        overstyrSpraak: Spraak? = null,
+    ): OpprettBrevRequest {
+        val generellBrevData =
+            retryOgPakkUt { brevdataFacade.hentGenerellBrevData(sakId, behandlingId, overstyrSpraak, bruker) }
+
+        val brevkodeRequest =
+            BrevkodeRequest(
+                loependeIPesys(
+                    systemkilde = generellBrevData.systemkilde,
+                    behandlingId = generellBrevData.behandlingId,
+                    revurderingsaarsak = generellBrevData.revurderingsaarsak,
+                ),
+                erForeldreloes(generellBrevData.personerISak.soeker, generellBrevData.personerISak.avdoede),
+                generellBrevData.sak.sakType,
+                generellBrevData.forenkletVedtak?.type,
+            )
+
+        val kode = brevKodeMapping(brevkodeRequest)
+        val brevDataRedigerbarRequest =
+            BrevDataRedigerbarRequest(
+                brukerTokenInfo = bruker,
+                soekerOgEventuellVerge = generellBrevData.personerISak.soekerOgEventuellVerge(),
+                sakType = generellBrevData.sak.sakType,
+                forenkletVedtak = generellBrevData.forenkletVedtak,
+                utlandstilknytningType = generellBrevData.utlandstilknytning?.type,
+                revurderingsaarsak = generellBrevData.revurderingsaarsak,
+                behandlingId = behandlingId,
+                erForeldreloes = erForeldreloes(generellBrevData.personerISak.soeker, generellBrevData.personerISak.avdoede),
+                loependeIPesys =
+                    loependeIPesys(
+                        generellBrevData.systemkilde,
+                        generellBrevData.behandlingId,
+                        generellBrevData.revurderingsaarsak,
+                    ),
+                systemkilde = generellBrevData.systemkilde,
+                avdoede = generellBrevData.personerISak.avdoede,
+            )
+        val brevData: BrevDataRedigerbar = brevDataMapping(brevDataRedigerbarRequest)
+        return opprettBrevRequest(generellBrevData, kode, brevData, bruker)
+    }
+
+    private suspend fun opprettBrevRequest(
+        generellBrevData: GenerellBrevData,
+        brevKode: Brevkoder,
+        brevData: BrevData,
+        bruker: BrukerTokenInfo,
+    ): OpprettBrevRequest =
+        coroutineScope {
             val innhold =
                 async {
                     brevbaker.hentRedigerbarTekstFraBrevbakeren(
@@ -49,7 +107,7 @@ class InnholdTilRedigerbartBrevHenter(
                                     opprettAvsenderRequest(bruker, generellBrevData.forenkletVedtak, generellBrevData.sak.enhet),
                                 ),
                             soekerOgEventuellVerge = generellBrevData.personerISak.soekerOgEventuellVerge(),
-                            sakId = sakId,
+                            sakId = generellBrevData.sak.id,
                             spraak = generellBrevData.spraak,
                             sakType = generellBrevData.sak.sakType,
                         ),
@@ -83,100 +141,6 @@ class InnholdTilRedigerbartBrevHenter(
                 brevkode = brevKode,
             )
         }
-    }
-
-    internal suspend fun hentInnData(
-        sakId: SakId,
-        behandlingId: UUID?,
-        bruker: BrukerTokenInfo,
-        brevKodeMapping: (b: BrevkodeRequest) -> Brevkoder,
-        brevDataMapping: suspend (BrevDataRedigerbarRequest) -> BrevDataRedigerbar,
-        overstyrSpraak: Spraak? = null,
-    ): OpprettBrevRequest {
-        val generellBrevData =
-            retryOgPakkUt { brevdataFacade.hentGenerellBrevData(sakId, behandlingId, overstyrSpraak, bruker) }
-
-        val brevkodeRequest =
-            BrevkodeRequest(
-                loependeIPesys(
-                    systemkilde = generellBrevData.systemkilde,
-                    behandlingId = generellBrevData.behandlingId,
-                    revurderingsaarsak = generellBrevData.revurderingsaarsak,
-                ),
-                erForeldreloes(generellBrevData.personerISak.soeker, generellBrevData.personerISak.avdoede),
-                generellBrevData.sak.sakType,
-                generellBrevData.forenkletVedtak?.type,
-            )
-
-        val kode = brevKodeMapping(brevkodeRequest)
-        return coroutineScope {
-            val brevDataRedigerbarRequest =
-                BrevDataRedigerbarRequest(
-                    brukerTokenInfo = bruker,
-                    soekerOgEventuellVerge = generellBrevData.personerISak.soekerOgEventuellVerge(),
-                    sakType = generellBrevData.sak.sakType,
-                    forenkletVedtak = generellBrevData.forenkletVedtak,
-                    utlandstilknytningType = generellBrevData.utlandstilknytning?.type,
-                    revurderingsaarsak = generellBrevData.revurderingsaarsak,
-                    behandlingId = behandlingId,
-                    erForeldreloes = erForeldreloes(generellBrevData.personerISak.soeker, generellBrevData.personerISak.avdoede),
-                    loependeIPesys =
-                        loependeIPesys(
-                            generellBrevData.systemkilde,
-                            generellBrevData.behandlingId,
-                            generellBrevData.revurderingsaarsak,
-                        ),
-                    systemkilde = generellBrevData.systemkilde,
-                    avdoede = generellBrevData.personerISak.avdoede,
-                )
-            val brevData: BrevDataRedigerbar = brevDataMapping(brevDataRedigerbarRequest)
-
-            val innhold =
-                async {
-                    brevbaker.hentRedigerbarTekstFraBrevbakeren(
-                        BrevbakerRequest.fra(
-                            brevKode = kode.redigering,
-                            brevData = brevData,
-                            avsender =
-                                adresseService.hentAvsender(
-                                    opprettAvsenderRequest(bruker, generellBrevData.forenkletVedtak, generellBrevData.sak.enhet),
-                                ),
-                            soekerOgEventuellVerge = generellBrevData.personerISak.soekerOgEventuellVerge(),
-                            sakId = sakId,
-                            spraak = generellBrevData.spraak,
-                            sakType = generellBrevData.sak.sakType,
-                        ),
-                    )
-                }
-
-            val innholdVedlegg =
-                async {
-                    redigerbartVedleggHenter.hentInitiellPayloadVedlegg(
-                        bruker,
-                        kode.brevtype,
-                        generellBrevData.sak.sakType,
-                        generellBrevData.forenkletVedtak?.type,
-                        generellBrevData.behandlingId,
-                        generellBrevData.revurderingsaarsak,
-                        generellBrevData.personerISak.soekerOgEventuellVerge(),
-                        generellBrevData.sak.id,
-                        generellBrevData.forenkletVedtak,
-                        generellBrevData.sak.enhet,
-                        generellBrevData.spraak,
-                    )
-                }
-
-            OpprettBrevRequest(
-                soekerFnr = generellBrevData.personerISak.soeker.fnr.value,
-                sakType = generellBrevData.sak.sakType,
-                enhet = generellBrevData.sak.enhet,
-                personerISak = generellBrevData.personerISak,
-                innhold = BrevInnhold(kode.tittel, generellBrevData.spraak, innhold.await()),
-                innholdVedlegg = innholdVedlegg.await(),
-                brevkode = kode,
-            )
-        }
-    }
 }
 
 internal data class OpprettBrevRequest(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/InnholdTilRedigerbartBrevHenter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/InnholdTilRedigerbartBrevHenter.kt
@@ -37,13 +37,12 @@ class InnholdTilRedigerbartBrevHenter(
     ): OpprettBrevRequest {
         val generellBrevData =
             retryOgPakkUt { brevdataFacade.hentGenerellBrevData(sakId, behandlingId, null, bruker) }
-        val kode = brevKode
         return coroutineScope {
             val innhold =
                 async {
                     brevbaker.hentRedigerbarTekstFraBrevbakeren(
                         BrevbakerRequest.fra(
-                            brevKode = kode.redigering,
+                            brevKode = brevKode.redigering,
                             brevData = brevData,
                             avsender =
                                 adresseService.hentAvsender(
@@ -61,7 +60,7 @@ class InnholdTilRedigerbartBrevHenter(
                 async {
                     redigerbartVedleggHenter.hentInitiellPayloadVedlegg(
                         bruker,
-                        kode.brevtype,
+                        brevKode.brevtype,
                         generellBrevData.sak.sakType,
                         generellBrevData.forenkletVedtak?.type,
                         generellBrevData.behandlingId,
@@ -79,9 +78,9 @@ class InnholdTilRedigerbartBrevHenter(
                 sakType = generellBrevData.sak.sakType,
                 enhet = generellBrevData.sak.enhet,
                 personerISak = generellBrevData.personerISak,
-                innhold = BrevInnhold(kode.tittel, generellBrevData.spraak, innhold.await()),
+                innhold = BrevInnhold(brevKode.tittel, generellBrevData.spraak, innhold.await()),
                 innholdVedlegg = innholdVedlegg.await(),
-                brevkode = kode,
+                brevkode = brevKode,
             )
         }
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
@@ -155,8 +155,3 @@ class PDFGenerator(
         return brev
     }
 }
-
-class PdfOgForenkletVedtak(
-    val pdf: Pdf,
-    val forenkletVedtak: ForenkletVedtak? = null,
-)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/PDFGenerator.kt
@@ -23,7 +23,6 @@ import no.nav.etterlatte.libs.common.Enhetsnummer
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.common.retryOgPakkUt
 import no.nav.etterlatte.libs.common.toJson
-import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
 
@@ -42,7 +41,6 @@ class PDFGenerator(
         avsenderRequest: (BrukerTokenInfo, ForenkletVedtak?, Enhetsnummer) -> AvsenderRequest,
         brevKodeMapping: (BrevkodeRequest) -> Brevkoder,
         brevDataMapping: suspend (BrevDataFerdigstillingRequest) -> BrevDataFerdigstilling,
-        lagrePdfHvisVedtakFattet: (VedtakStatus?, String?, Brev, Pdf) -> Unit = { _, _, _, _ -> run {} },
     ): Pdf {
         val brev = sjekkOmBrevKanEndres(id)
         if (brev.mottaker.erGyldig().isNotEmpty()) {
@@ -57,7 +55,6 @@ class PDFGenerator(
                 avsenderRequest,
                 brevKodeMapping,
                 brevDataMapping,
-                lagrePdfHvisVedtakFattet,
             )
         db.lagrePdfOgFerdigstillBrev(id, pdf)
         return pdf
@@ -69,13 +66,12 @@ class PDFGenerator(
         avsenderRequest: (BrukerTokenInfo, ForenkletVedtak?, Enhetsnummer) -> AvsenderRequest,
         brevKodeMapping: (BrevkodeRequest) -> Brevkoder,
         brevDataMapping: suspend (BrevDataFerdigstillingRequest) -> BrevDataFerdigstilling,
-        lagrePdfHvisVedtakFattet: (VedtakStatus?, String?, Brev, Pdf) -> Unit = { _, _, _, _ -> run {} },
     ): Pdf {
         val brev = db.hentBrev(id)
 
         if (!brev.kanEndres()) {
             logger.info("Brev har status ${brev.status} - returnerer lagret innhold")
-            return requireNotNull(db.hentPdf(brev.id)) { "Fant ikke brev med id ${brev.id}" }
+            return requireNotNull(db.hentPdf(brev.id)) { "Fant ikke pdf for brev med id=${brev.id}" }
         } else if (brev.prosessType == BrevProsessType.OPPLASTET_PDF) {
             logger.info("Brev er en opplastet PDF – returnerer lagret innhold")
             return requireNotNull(db.hentPdf(brev.id)) { "Fant ikke pdf for brev med id=${brev.id}" }
@@ -139,14 +135,6 @@ class PDFGenerator(
 
         return brevbakerService
             .genererPdf(brev.id, brevRequest)
-            .also {
-                lagrePdfHvisVedtakFattet(
-                    generellBrevData.forenkletVedtak?.status,
-                    generellBrevData.forenkletVedtak?.saksbehandlerIdent,
-                    brev,
-                    it,
-                )
-            }
     }
 
     private fun hentLagretInnhold(brev: Brev) =
@@ -167,3 +155,8 @@ class PDFGenerator(
         return brev
     }
 }
+
+class PdfOgForenkletVedtak(
+    val pdf: Pdf,
+    val forenkletVedtak: ForenkletVedtak? = null,
+)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/ForenkletVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/behandling/ForenkletVedtak.kt
@@ -9,8 +9,6 @@ import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import java.time.LocalDate
 import java.time.YearMonth
 
-fun VedtakType?.somTittel() = this?.name?.lowercase()?.replace("_", " ")
-
 data class ForenkletVedtak(
     val id: Long,
     val status: VedtakStatus,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
@@ -221,18 +221,15 @@ class OversendelseBrevServiceImpl(
                 behandlingService.hentKlage(klageId = behandlingId, brukerTokenInfo)
             }
 
-        val pdf =
-            runBlocking {
-                // TODO: se på disse
-                pdfGenerator.ferdigstillOgGenererPDF(
-                    id = brev.id,
-                    bruker = brukerTokenInfo,
-                    avsenderRequest = { bruker, _, enhet -> AvsenderRequest(bruker.ident(), enhet) },
-                    brevKodeMapping = { Brevkoder.OVERSENDELSE_KLAGE },
-                    brevDataMapping = { req -> OversendelseBrevFerdigstillingData.fra(req, klage) },
-                )
-            }
-        return pdf
+        return runBlocking {
+            pdfGenerator.ferdigstillOgGenererPDF(
+                id = brev.id,
+                bruker = brukerTokenInfo,
+                avsenderRequest = { bruker, _, enhet -> AvsenderRequest(bruker.ident(), enhet) },
+                brevKodeMapping = { Brevkoder.OVERSENDELSE_KLAGE },
+                brevDataMapping = { req -> OversendelseBrevFerdigstillingData.fra(req, klage) },
+            )
+        }
     }
 
     override suspend fun slettOversendelseBrev(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
@@ -223,6 +223,7 @@ class OversendelseBrevServiceImpl(
 
         val pdf =
             runBlocking {
+                // TODO: se på disse
                 pdfGenerator.ferdigstillOgGenererPDF(
                     id = brev.id,
                     bruker = brukerTokenInfo,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevRoute.kt
@@ -63,7 +63,7 @@ internal fun Route.varselbrevRoute(
                 logger.info("Genererer PDF for varselbrev (id=$brevId)")
 
                 measureTimedValue {
-                    service.genererPdf(brevId, brukerTokenInfo).bytes
+                    service.genererPdfFerdigstilling(brevId, brukerTokenInfo).bytes
                 }.let { (pdf, varighet) ->
                     logger.info("Generering av pdf tok ${varighet.toString(DurationUnit.SECONDS, 2)}")
                     call.respond(pdf)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
@@ -35,21 +35,23 @@ internal class VarselbrevService(
     ): Brev {
         val sakType = behandlingService.hentSak(sakId, brukerTokenInfo).sakType
         val brevkode = hentBrevkode(sakType, behandlingId, brukerTokenInfo)
+        val behandling = behandlingService.hentBehandling(behandlingId, brukerTokenInfo)
 
+        val brevdata =
+            BrevDataMapperRedigerbartUtfallVarsel.hentBrevDataRedigerbar(
+                sakType,
+                brukerTokenInfo,
+                behandling.utlandstilknytning?.type,
+                behandling.revurderingsaarsak,
+            )
         return brevoppretter
-            .opprettBrev(
+            .opprettBrevSomHarInnhold(
                 sakId = sakId,
                 behandlingId = behandlingId,
                 bruker = brukerTokenInfo,
-                brevKodeMapping = { brevkode },
-            ) {
-                BrevDataMapperRedigerbartUtfallVarsel.hentBrevDataRedigerbar(
-                    sakType,
-                    brukerTokenInfo,
-                    it.utlandstilknytningType,
-                    it.revurderingsaarsak,
-                )
-            }.first
+                brevKode = brevkode,
+                brevData = brevdata,
+            ).first
     }
 
     private suspend fun hentBrevkode(
@@ -87,7 +89,7 @@ internal class VarselbrevService(
         brevDataMapping = { brevDataMapperFerdigstillVarsel.hentBrevDataFerdigstilling(it) },
     )
 
-    suspend fun genererPdf(
+    suspend fun genererPdfFerdigstilling(
         brevId: Long,
         bruker: BrukerTokenInfo,
         avsenderRequest: (BrukerTokenInfo, ForenkletVedtak?, Enhetsnummer) -> AvsenderRequest =

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
@@ -85,6 +85,7 @@ internal class VarselbrevService(
             val brev = db.hentBrev(brevId)
             runBlocking { hentBrevkode(it.sakType, brev.behandlingId, bruker) }
         },
+        // TODO: endre bruken her?
         brevDataMapping = { brevDataMapperFerdigstillVarsel.hentBrevDataFerdigstilling(it) },
     )
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
@@ -42,7 +42,6 @@ internal class VarselbrevService(
                 behandlingId = behandlingId,
                 bruker = brukerTokenInfo,
                 brevKodeMapping = { brevkode },
-                brevtype = Brevtype.VARSEL,
             ) {
                 BrevDataMapperRedigerbartUtfallVarsel.hentBrevDataRedigerbar(
                     sakType,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
@@ -84,7 +84,6 @@ internal class VarselbrevService(
             val brev = db.hentBrev(brevId)
             runBlocking { hentBrevkode(it.sakType, brev.behandlingId, bruker) }
         },
-        // TODO: endre bruken her?
         brevDataMapping = { brevDataMapperFerdigstillVarsel.hentBrevDataFerdigstilling(it) },
     )
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevService.kt
@@ -78,7 +78,6 @@ class VedtaksbrevService(
                 behandlingId = behandlingId,
                 bruker = brukerTokenInfo,
                 brevKodeMapping = { brevKodeMappingVedtak.brevKode(it) },
-                brevtype = Brevtype.VEDTAK,
                 brevDataMapping = { brevDataMapperRedigerbartUtfallVedtak.brevData(it) },
             ).first
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevService.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.brev.vedtaksbrev
 
 import com.fasterxml.jackson.databind.JsonNode
+import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.brev.BrevService
 import no.nav.etterlatte.brev.Brevkoder
 import no.nav.etterlatte.brev.Brevoppretter
@@ -82,26 +83,35 @@ class VedtaksbrevService(
             ).first
     }
 
-    suspend fun genererPdf(
+    fun genererPdf(
         id: BrevID,
         bruker: BrukerTokenInfo,
-    ): Pdf =
-        pdfGenerator.genererPdf(
-            id = id,
-            bruker = bruker,
-            avsenderRequest = { brukerToken, vedtak, enhet -> opprettAvsenderRequest(brukerToken, vedtak, enhet) },
-            brevKodeMapping = { brevKodeMappingVedtak.brevKode(it) },
-            brevDataMapping = { brevDataMapperFerdigstilling.brevDataFerdigstilling(it) },
-        ) { vedtakStatus, saksbehandler, brev, pdf ->
-            brev.brevkoder?.let { db.oppdaterBrevkoder(brev.id, it) }
-            lagrePdfHvisVedtakFattet(
-                brev.id,
-                pdf,
-                bruker,
-                vedtakStatus!!,
-                saksbehandler!!,
-            )
-        }
+    ): Pdf {
+        val pdf =
+            runBlocking {
+                pdfGenerator.genererPdf(
+                    id = id,
+                    bruker = bruker,
+                    avsenderRequest = { brukerToken, vedtak, enhet -> opprettAvsenderRequest(brukerToken, vedtak, enhet) },
+                    brevKodeMapping = { brevKodeMappingVedtak.brevKode(it) },
+                    brevDataMapping = { brevDataMapperFerdigstilling.brevDataFerdigstilling(it) },
+                )
+            }
+
+        val brev = db.hentBrev(id)
+        val vedtakDeferred = brev.behandlingId?.let { runBlocking { vedtaksvurderingService.hentVedtak(it, bruker) } }
+        val saksbehandlerident: String = vedtakDeferred?.vedtakFattet?.ansvarligSaksbehandler ?: bruker.ident()
+        brev.brevkoder?.let { db.oppdaterBrevkoder(brev.id, it) }
+        lagrePdfHvisVedtakFattet(
+            brev.id,
+            pdf,
+            bruker,
+            vedtakDeferred?.status!!,
+            saksbehandlerident,
+        )
+
+        return pdf
+    }
 
     suspend fun ferdigstillVedtaksbrev(
         behandlingId: UUID,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
@@ -145,7 +145,6 @@ class OpprettJournalfoerOgDistribuerRiver(
                         behandlingId = null,
                         bruker = brukerTokenInfo,
                         brevKode = brevKode,
-                        brevtype = brevKode.brevtype,
                         brevData = brevdata,
                     )
                 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
@@ -110,13 +110,7 @@ class OpprettJournalfoerOgDistribuerRiver(
         val (brev, enhetsnummer) =
             try {
                 retryOgPakkUt {
-                    brevoppretter.opprettBrev(
-                        sakId = sakId,
-                        behandlingId = null,
-                        bruker = brukerTokenInfo,
-                        brevKodeMapping = { brevKode },
-                        brevtype = brevKode.brevtype,
-                    ) {
+                    val brevdata =
                         when (brevKode) {
                             Brevkoder.BP_INFORMASJON_DOEDSFALL -> {
                                 val borIutland = packet.hentVerdiEllerKastFeil(BOR_I_UTLAND_KEY).toBoolean()
@@ -146,7 +140,14 @@ class OpprettJournalfoerOgDistribuerRiver(
 
                             else -> ManueltBrevData()
                         }
-                    }
+                    brevoppretter.opprettBrevSomHarInnhold(
+                        sakId = sakId,
+                        behandlingId = null,
+                        bruker = brukerTokenInfo,
+                        brevKode = brevKode,
+                        brevtype = brevKode.brevtype,
+                        brevData = brevdata,
+                    )
                 }
             } catch (e: Exception) {
                 val feilMelding = "Fikk feil ved opprettelse av brev for sak $sakId for brevkode: $brevKode"

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -544,12 +544,19 @@ internal class VedtaksbrevServiceTest {
             coEvery { adresseService.hentAvsender(any()) } returns opprettAvsender()
             coEvery { brevbakerService.genererPdf(any(), any()) } returns opprettBrevbakerResponse()
             coEvery { brevDataMapperFerdigstilling.brevDataFerdigstilling(any()) } returns ManueltBrevDataTest()
+            coEvery { vedtaksvurderingService.hentVedtak(any(), any()) } returns
+                mockk<VedtakDto> {
+                    every { status } returns VedtakStatus.FATTET_VEDTAK
+                    every { vedtakFattet } returns VedtakFattet("ident", Enheter.PORSGRUNN.enhetNr, Tidspunkt.now())
+                }
 
             runBlocking {
                 vedtaksbrevService.genererPdf(brev.id, bruker = SAKSBEHANDLER)
             }
 
             verify {
+                db.oppdaterBrevkoder(any(), any())
+                db.lagrePdf(any(), any())
                 db.hentBrev(brev.id)
                 db.oppdaterBrevkoder(brev.id, Brevkoder.TOMT_INFORMASJONSBREV)
             }
@@ -572,12 +579,19 @@ internal class VedtaksbrevServiceTest {
             coEvery { adresseService.hentAvsender(any()) } returns opprettAvsender()
             coEvery { brevbakerService.genererPdf(any(), any()) } returns opprettBrevbakerResponse()
             coEvery { brevDataMapperFerdigstilling.brevDataFerdigstilling(any()) } returns ManueltBrevDataTest()
+            coEvery { vedtaksvurderingService.hentVedtak(any(), any()) } returns
+                mockk<VedtakDto> {
+                    every { status } returns VedtakStatus.FATTET_VEDTAK
+                    every { vedtakFattet } returns VedtakFattet("ident", Enheter.PORSGRUNN.enhetNr, Tidspunkt.now())
+                }
 
             runBlocking {
                 vedtaksbrevService.genererPdf(brev.id, bruker = ATTESTANT)
             }
 
             verify {
+                db.oppdaterBrevkoder(any(), any())
+                db.lagrePdf(any(), any())
                 db.hentBrev(brev.id)
                 db.lagrePdf(brev.id, any())
                 db.oppdaterBrevkoder(brev.id, Brevkoder.TOMT_INFORMASJONSBREV)
@@ -601,12 +615,19 @@ internal class VedtaksbrevServiceTest {
             coEvery { adresseService.hentAvsender(any()) } returns opprettAvsender()
             coEvery { brevbakerService.genererPdf(any(), any()) } returns opprettBrevbakerResponse()
             coEvery { brevDataMapperFerdigstilling.brevDataFerdigstilling(any()) } returns ManueltBrevDataTest()
+            coEvery { vedtaksvurderingService.hentVedtak(any(), any()) } returns
+                mockk<VedtakDto> {
+                    every { status } returns VedtakStatus.FATTET_VEDTAK
+                    every { vedtakFattet } returns VedtakFattet("ident", Enheter.PORSGRUNN.enhetNr, Tidspunkt.now())
+                }
 
             runBlocking {
                 vedtaksbrevService.genererPdf(brev.id, bruker = SAKSBEHANDLER)
             }
 
             verify {
+                db.oppdaterBrevkoder(any(), any())
+                db.lagrePdf(any(), any())
                 db.hentBrev(brev.id)
                 db.oppdaterBrevkoder(brev.id, Brevkoder.TOMT_INFORMASJONSBREV)
             }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
@@ -28,10 +28,16 @@ import no.nav.etterlatte.brev.model.tomMottaker
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.ktor.token.systembruker
 import no.nav.etterlatte.libs.common.Vedtaksloesning
+import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
+import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.behandling.Utlandstilknytning
+import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.person.AdresseType
 import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.sak.Sak
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import no.nav.pensjon.brevbaker.api.model.Telefonnummer
@@ -128,7 +134,20 @@ class VarselbrevTest(
                     )
                 } returns listOf()
             }
-        val behandlingService = mockk<BehandlingService>().also { coEvery { it.hentSak(sak.id, any()) } returns sak }
+        val behandlingService =
+            mockk<BehandlingService>().also {
+                coEvery { it.hentSak(sak.id, any()) } returns sak
+                coEvery { it.hentBehandling(any(), any()) } returns
+                    mockk<DetaljertBehandling> {
+                        every { utlandstilknytning } returns
+                            Utlandstilknytning(
+                                UtlandstilknytningType.NASJONAL,
+                                Grunnlagsopplysning.Saksbehandler(ident = "Z123", tidspunkt = Tidspunkt.now()),
+                                "begrunnelse",
+                            )
+                        every { revurderingsaarsak } returns Revurderingaarsak.AKTIVITETSPLIKT
+                    }
+            }
 
         val innholdTilRedigerbartBrevHenter =
             InnholdTilRedigerbartBrevHenter(brevdataFacade, brevbaker, adresseService, redigerbartVedleggHenter)

--- a/libs/saksbehandling-common/src/main/kotlin/behandling/Utlandstilknytning.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/behandling/Utlandstilknytning.kt
@@ -6,9 +6,7 @@ data class Utlandstilknytning(
     val type: UtlandstilknytningType,
     val kilde: Grunnlagsopplysning.Kilde,
     val begrunnelse: String,
-) {
-    fun erBosattUtland() = this.type == UtlandstilknytningType.BOSATT_UTLAND
-}
+)
 
 enum class UtlandstilknytningType {
     NASJONAL,


### PR DESCRIPTION
…buerRiver

* Så vi unngår unødvendig brevDataMapping

commit 2 går på å gjøre en oppsplitting for det samme med manuelt brev opprettelse.

Videre vei er å gjøre litt av det samme for varselbrev og andre steder i brevkoden der det er hensiktsmessig.

Den store kua blir å flippe vedtaksbrev som må gjøres i mindre deler tenker jeg.