### PR TITLE
Mottaker skal valideres før ferdigstilling, ikke opprettelse

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -46,7 +46,6 @@ class BrevService(
                 bruker = bruker,
                 brevKodeMapping = { brevkode },
                 brevtype = brevkode.brevtype,
-                validerMottaker = false,
                 brevDataMapping = brevDataMapping,
             ).first
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -10,7 +10,6 @@ import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.BrevkodeRequest
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.OpprettNyttBrev
-import no.nav.etterlatte.brev.vedtaksbrev.UgyldigMottakerKanIkkeFerdigstilles
 import no.nav.etterlatte.libs.common.Enhetsnummer
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
@@ -19,9 +18,7 @@ import no.nav.etterlatte.libs.common.person.UkjentVergemaal
 import no.nav.etterlatte.libs.common.person.Vergemaal
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
-import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
-import no.nav.etterlatte.sikkerLogg
 import java.util.UUID
 
 class Brevoppretter(
@@ -35,7 +32,6 @@ class Brevoppretter(
         bruker: BrukerTokenInfo,
         brevKodeMapping: (b: BrevkodeRequest) -> Brevkoder,
         brevtype: Brevtype,
-        validerMottaker: Boolean,
         brevDataMapping: suspend (BrevDataRedigerbarRequest) -> BrevDataRedigerbar,
     ): Pair<Brev, Enhetsnummer> =
         with(
@@ -60,10 +56,6 @@ class Brevoppretter(
                     brevtype = brevtype,
                     brevkoder = brevkode,
                 )
-            if (validerMottaker && nyttBrev.mottaker.erGyldig().isNotEmpty()) {
-                sikkerLogg.error("Ugyldig mottaker: ${nyttBrev.mottaker.toJson()}")
-                throw UgyldigMottakerKanIkkeFerdigstilles(id = null, sakId = nyttBrev.sakId, nyttBrev.mottaker.erGyldig())
-            }
             return Pair(db.opprettBrev(nyttBrev), enhet)
         }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevService.kt
@@ -43,7 +43,6 @@ internal class VarselbrevService(
                 bruker = brukerTokenInfo,
                 brevKodeMapping = { brevkode },
                 brevtype = Brevtype.VARSEL,
-                validerMottaker = false,
             ) {
                 BrevDataMapperRedigerbartUtfallVarsel.hentBrevDataRedigerbar(
                     sakType,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevService.kt
@@ -78,7 +78,6 @@ class VedtaksbrevService(
                 bruker = brukerTokenInfo,
                 brevKodeMapping = { brevKodeMappingVedtak.brevKode(it) },
                 brevtype = Brevtype.VEDTAK,
-                validerMottaker = false,
                 brevDataMapping = { brevDataMapperRedigerbartUtfallVedtak.brevData(it) },
             ).first
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
@@ -181,7 +181,7 @@ class OpprettJournalfoerOgDistribuerRiver(
             )
             return Pair(brevID, true)
         } catch (e: Exception) {
-            logger.error("Feil opp sto under ferdigstill/journalfør/distribuer av brevID=${brev.id}...")
+            logger.error("Feil opp sto under ferdigstill/journalfør/distribuer av brevID=${brev.id}...", e)
             return Pair(brev.id, false)
         }
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerRiver.kt
@@ -116,7 +116,6 @@ class OpprettJournalfoerOgDistribuerRiver(
                         bruker = brukerTokenInfo,
                         brevKodeMapping = { brevKode },
                         brevtype = brevKode.brevtype,
-                        validerMottaker = true,
                     ) {
                         when (brevKode) {
                             Brevkoder.BP_INFORMASJON_DOEDSFALL -> {


### PR DESCRIPTION
Flyten blir feil med denne. Ved å fjerne den sjekkes mottakeren _etter_ at brevet er opprettet, men _før_ det ferdigstilles. 
Hvis det ikke kan ferdigstilles vil det bli opprettet en manuell oppgave til saksbehandler. 