### PR TITLE
EY-4473 Støtte behandling av oppgavetype tilleggsinformasjon

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/components/HandlingerForOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/components/HandlingerForOppgave.tsx
@@ -12,6 +12,7 @@ import { PersonButtonLink } from '~components/person/lenker/PersonButtonLink'
 import { PersonOversiktFane } from '~components/person/Person'
 import { AktivitetspliktInfo6MndVarigUnntakModal } from '~components/oppgavebenk/oppgaveModal/AktivitetspliktInfo6MndVarigUnntakModal'
 import { BrevOppgaveModal } from '~components/oppgavebenk/oppgaveModal/BrevOppgaveModal'
+import { TilleggsinformasjonOppgaveModal } from '~components/oppgavebenk/oppgaveModal/TilleggsinformasjonOppgaveModal'
 
 export const HandlingerForOppgave = ({
   oppgave,
@@ -114,6 +115,12 @@ export const HandlingerForOppgave = ({
           <Button size="small" href={`/oppgave/${oppgave.id}`} as="a">
             Gå til oppgave
           </Button>
+        )
+      )
+    case Oppgavetype.TILLEGGSINFORMASJON:
+      return (
+        erInnloggetSaksbehandlerOppgave && (
+          <TilleggsinformasjonOppgaveModal oppgave={oppgave} oppdaterStatus={oppdaterStatus} />
         )
       )
     case Oppgavetype.OMGJOERING:

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/TilleggsinformasjonOppgaveModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/TilleggsinformasjonOppgaveModal.tsx
@@ -1,0 +1,133 @@
+import { Alert, BodyShort, Button, HGrid, HStack, Modal, Textarea, VStack } from '@navikt/ds-react'
+import React, { useEffect, useState } from 'react'
+import { DokumentVisningModal, PdfVisning } from '~shared/brev/pdf-visning'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { hentDokumentPDF, hentJournalpost } from '~shared/api/dokument'
+import { erOppgaveRedigerbar, OppgaveDTO, Oppgavestatus } from '~shared/types/oppgave'
+import { isPending } from '~shared/api/apiUtils'
+import { ferdigstillOppgaveMedMerknad } from '~shared/api/oppgaver'
+import { useForm } from 'react-hook-form'
+import { useInnloggetSaksbehandler } from '~components/behandling/useInnloggetSaksbehandler'
+import Spinner from '~shared/Spinner'
+import { EyeIcon } from '@navikt/aksel-icons'
+
+export const TilleggsinformasjonOppgaveModal = ({
+  oppgave,
+  oppdaterStatus,
+}: {
+  oppgave: OppgaveDTO
+  oppdaterStatus: (oppgaveId: string, status: Oppgavestatus) => void
+}) => {
+  const innloggetSaksbehandler = useInnloggetSaksbehandler()
+
+  const [isOpen, setIsOpen] = useState(false)
+  const [fileURL, setFileURL] = useState<string>()
+
+  const [journalpostResult, apiHentJournalpost] = useApiCall(hentJournalpost)
+  const [pdfResult, apiHentDokumentPDF] = useApiCall(hentDokumentPDF)
+  const [ferdigstillOppgaveStatus, avsluttOppgave] = useApiCall(ferdigstillOppgaveMedMerknad)
+
+  const {
+    formState: { errors },
+    handleSubmit,
+    register,
+  } = useForm<{ kommentar: string }>({ defaultValues: { kommentar: '' } })
+
+  useEffect(() => {
+    if (isOpen) {
+      apiHentJournalpost(oppgave.referanse!, (journalpost) => {
+        apiHentDokumentPDF(
+          {
+            journalpostId: journalpost.journalpostId,
+            dokumentInfoId: journalpost.dokumenter[0].dokumentInfoId,
+          },
+          (bytes) => {
+            const blob = new Blob([bytes], { type: 'application/pdf' })
+
+            setFileURL(URL.createObjectURL(blob))
+          }
+        )
+      })
+    }
+  }, [isOpen])
+
+  const avslutt = ({ kommentar }: { kommentar: string }) => {
+    const merknad = `${oppgave.merknad}. Kommentar: ${kommentar}`
+
+    avsluttOppgave({ id: oppgave.id, merknad }, () => {
+      oppdaterStatus(oppgave.id, Oppgavestatus.FERDIGSTILT)
+      setIsOpen(false)
+    })
+  }
+
+  const erTildeltSaksbehandler = innloggetSaksbehandler.ident === oppgave.saksbehandler?.ident
+  const kanRedigeres = erOppgaveRedigerbar(oppgave.status)
+
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)} size="small" icon={<EyeIcon />}>
+        Se oppgave
+      </Button>
+
+      <DokumentVisningModal
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
+        aria-label="Tilleggsinformasjon"
+        header={{ heading: 'Vurder tilleggsinformasjon' }}
+      >
+        <Modal.Body>
+          <HGrid gap="6" columns={{ md: 'auto 400px' }}>
+            {isPending(journalpostResult) || isPending(pdfResult) ? (
+              <Spinner label="Henter journalført søknad..." />
+            ) : (
+              <PdfVisning fileUrl={fileURL} />
+            )}
+
+            <VStack gap="4" justify="end">
+              <Alert variant="warning">{oppgave.merknad}</Alert>
+
+              {kanRedigeres &&
+                (erTildeltSaksbehandler ? (
+                  <Textarea
+                    {...register('kommentar', {
+                      required: {
+                        value: true,
+                        message: 'Du må legge til en kommentar',
+                      },
+                      minLength: {
+                        value: 10,
+                        message: 'Kommentaren må bestå av minst 10 tegn',
+                      },
+                    })}
+                    label="Kommentar"
+                    error={errors.kommentar?.message}
+                  />
+                ) : (
+                  <BodyShort>Du må tildele deg oppgaven for å endre den.</BodyShort>
+                ))}
+            </VStack>
+          </HGrid>
+        </Modal.Body>
+
+        <Modal.Footer>
+          <HStack gap="4" justify="end">
+            <Button variant="secondary" onClick={() => setIsOpen(false)} disabled={isPending(ferdigstillOppgaveStatus)}>
+              Lukk
+            </Button>
+
+            {kanRedigeres && erTildeltSaksbehandler && (
+              <Button
+                variant="danger"
+                onClick={handleSubmit(avslutt)}
+                loading={isPending(ferdigstillOppgaveStatus)}
+                disabled={!fileURL}
+              >
+                Avslutt oppgave
+              </Button>
+            )}
+          </HStack>
+        </Modal.Footer>
+      </DokumentVisningModal>
+    </>
+  )
+}


### PR DESCRIPTION
Gjør det mulig for saksbehandler å behandle oppgaver av type **tilleggsinformasjon** (bruker sender søknad mens behandling av forrige søknad pågår). 

![Screenshot 2024-09-27 at 12 58 21](https://github.com/user-attachments/assets/0361443a-0fad-4cd0-8f85-a4a8847c5394)
