### PR TITLE
Vise feilmelding hvis lagring av beregningsgrunnlag feiler

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
@@ -21,7 +21,7 @@ import {
 } from '~shared/types/Beregning'
 import Spinner from '~shared/Spinner'
 import { handlinger } from '~components/behandling/handlinger/typer'
-import { isPending, mapResult } from '~shared/api/apiUtils'
+import { isPending, mapFailure, mapResult } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
 import { BeregningsMetodeBrukt } from '~components/behandling/beregningsgrunnlag/beregningsMetode/BeregningsMetodeBrukt'
@@ -112,6 +112,11 @@ const BeregningsgrunnlagOmstillingsstoenad = () => {
                 oppdaterBeregningsgrunnlag={oppdaterBeregningsMetode}
                 lagreBeregningsGrunnlagResult={lagreBeregningsGrunnlagResult}
               />
+
+              {mapFailure(lagreBeregningsGrunnlagResult, (error) => (
+                <ApiErrorAlert>{error.detail}</ApiErrorAlert>
+              ))}
+
               <Box maxWidth="70rem">
                 <InstitusjonsoppholdHendelser sakId={behandling.sakId} />
               </Box>


### PR DESCRIPTION
P.t. får ikke saksbehandler beskjed dersom lagring av metode feiler. Så det ser ut som de lagrer ok, mens det i realiteten bare feiler. 