### PR TITLE
Mangler Kontekst i AktivitetspliktUnntakDaoTest slik at den er avhengig av rekkefølge for å fullføre

### DIFF
--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/aktivitetsplikt/vurdering/AktivitetspliktUnntakDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/aktivitetsplikt/vurdering/AktivitetspliktUnntakDaoTest.kt
@@ -2,9 +2,11 @@ package no.nav.etterlatte.behandling.aktivitetsplikt.vurdering
 
 import io.kotest.assertions.asClue
 import io.kotest.matchers.shouldBe
+import io.mockk.every
 import io.mockk.mockk
 import no.nav.etterlatte.ConnectionAutoclosingTest
 import no.nav.etterlatte.DatabaseExtension
+import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
 import no.nav.etterlatte.behandling.BehandlingDao
 import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktDaoTest.Companion.kilde
 import no.nav.etterlatte.behandling.aktivitetsplikt.vurdering.AktivitetspliktUnntakType.GRADERT_UFOERETRYGD
@@ -24,11 +26,13 @@ import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.oppgave.Status
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.nyKontekstMedBruker
 import no.nav.etterlatte.oppgave.OppgaveDaoImpl
 import no.nav.etterlatte.oppgave.lagNyOppgave
 import no.nav.etterlatte.opprettBehandling
 import no.nav.etterlatte.sak.SakSkrivDao
 import no.nav.etterlatte.sak.SakendringerDao
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -50,6 +54,12 @@ class AktivitetspliktUnntakDaoTest(
             RevurderingDao(ConnectionAutoclosingTest(ds)),
             (ConnectionAutoclosingTest(ds)),
         )
+    private val user = mockk<SaksbehandlerMedEnheterOgRoller>().also { every { it.name() } returns this::class.java.simpleName }
+
+    @BeforeEach
+    fun setup() {
+        nyKontekstMedBruker(user)
+    }
 
     @Test
     fun `skal lagre ned og hente opp et nytt unntak for oppgave`() {


### PR DESCRIPTION
Ser ut til at testene er gyldig ca annenhver gang, sikkert avhengig av om kontekst finnes allerede