### PR TITLE
Forenkle feil til saksbehandler på vilkårsvurdering

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutes.kt
@@ -30,7 +30,6 @@ import no.nav.etterlatte.libs.ktor.token.brukerTokenInfo
 import no.nav.etterlatte.libs.vilkaarsvurdering.VurdertVilkaarsvurderingResultatDto
 import no.nav.etterlatte.vilkaarsvurdering.service.BehandlingstilstandException
 import no.nav.etterlatte.vilkaarsvurdering.service.VilkaarsvurderingService
-import no.nav.etterlatte.vilkaarsvurdering.service.VilkaarsvurderingTilstandException
 import no.nav.etterlatte.vilkaarsvurdering.service.VirkningstidspunktIkkeSattException
 import java.util.UUID
 
@@ -175,15 +174,6 @@ fun Route.vilkaarsvurdering(vilkaarsvurderingService: VilkaarsvurderingService) 
                     e,
                 )
                 call.respond(HttpStatusCode.PreconditionFailed, "Statussjekk for behandling feilet")
-            } catch (e: VilkaarsvurderingTilstandException) {
-                logger.error(e.message)
-                call.respond(
-                    HttpStatusCode.PreconditionFailed,
-                    "Kan ikke endre vurdering av vilkår på en vilkårsvurdering som har et resultat.",
-                )
-            } catch (e: Exception) {
-                logger.error(e.message)
-                call.respond(HttpStatusCode.InternalServerError)
             }
         }
 
@@ -212,12 +202,6 @@ fun Route.vilkaarsvurdering(vilkaarsvurderingService: VilkaarsvurderingService) 
                         e,
                     )
                     call.respond(HttpStatusCode.PreconditionFailed, "Statussjekk for behandling feilet")
-                } catch (e: VilkaarsvurderingTilstandException) {
-                    logger.error(e.message)
-                    call.respond(
-                        HttpStatusCode.PreconditionFailed,
-                        "Kan ikke slette vurdering av vilkår på en vilkårsvurdering som har et resultat.",
-                    )
                 }
             }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/vilkaarsvurdering/service/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/vilkaarsvurdering/service/VilkaarsvurderingService.kt
@@ -106,8 +106,8 @@ class VilkaarsvurderingService(
             val vilkaarsvurdering = vilkaarsvurderingRepositoryWrapper.hent(behandlingId)
             if (vilkaarsvurdering?.resultat != null) {
                 throw VilkaarsvurderingTilstandException(
-                    "Kan ikke endre et vilkår (${vurdertVilkaar.vilkaarId}) på en vilkårsvurdering som har et resultat. " +
-                        "Vilkårsvurderingid: ${vilkaarsvurdering.id} Behandlingid: ${vilkaarsvurdering.behandlingId}",
+                    "Kan ikke endre et vilkår (${vurdertVilkaar.vilkaarId}) på en vilkårsvurdering som har et resultat. ",
+                    vilkaarsvurdering,
                 )
             }
             vilkaarsvurderingRepositoryWrapper.oppdaterVurderingPaaVilkaar(behandlingId, vurdertVilkaar)
@@ -122,8 +122,8 @@ class VilkaarsvurderingService(
             val vilkaarsvurdering = vilkaarsvurderingRepositoryWrapper.hent(behandlingId)
             if (vilkaarsvurdering?.resultat != null) {
                 throw VilkaarsvurderingTilstandException(
-                    "Kan ikke slette et vilkår ($vilkaarId) på en vilkårsvurdering som har et resultat. " +
-                        "Vilkårsvurderingid: ${vilkaarsvurdering.id} Behandlingid: ${vilkaarsvurdering.behandlingId}",
+                    "Kan ikke slette et vilkår ($vilkaarId) på en vilkårsvurdering som har et resultat. ",
+                    vilkaarsvurdering,
                 )
             }
 
@@ -428,8 +428,17 @@ class BehandlingstilstandException(
 ) : IllegalStateException(message, e)
 
 class VilkaarsvurderingTilstandException(
-    message: String,
-) : IllegalStateException(message)
+    detail: String,
+    vilkaarvurdering: Vilkaarsvurdering,
+) : UgyldigForespoerselException(
+        code = "UGYLDIG_TILSTAND_VILKAARSVURDERING",
+        detail = detail,
+        meta =
+            mapOf(
+                "vilkaarvurderingId" to vilkaarvurdering.id,
+                "behandlingId" to vilkaarvurdering.behandlingId,
+            ),
+    )
 
 class VilkaarsvurderingIkkeFunnet :
     IkkeFunnetException(

--- a/apps/etterlatte-behandling/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingRoutesTest.kt
@@ -553,13 +553,13 @@ internal class VilkaarsvurderingRoutesTest(
                     setBody(vurdertVilkaarDto.toJson())
                     header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     header(HttpHeaders.Authorization, "Bearer $token")
-                }.let { assertEquals(HttpStatusCode.PreconditionFailed, it.status) }
+                }.let { assertEquals(HttpStatusCode.BadRequest, it.status) }
             client
                 .delete("/api/vilkaarsvurdering/$behandlingId/${vurdertVilkaarDto.vilkaarId}") {
                     setBody(vurdertVilkaarDto.toJson())
                     header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     header(HttpHeaders.Authorization, "Bearer $token")
-                }.let { assertEquals(HttpStatusCode.PreconditionFailed, it.status) }
+                }.let { assertEquals(HttpStatusCode.BadRequest, it.status) }
         }
     }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/Vilkaarsvurdering.tsx
@@ -21,7 +21,7 @@ import {
   vilkaarsvurderingErPaaNyttRegelverk,
 } from '~components/behandling/vilkaarsvurdering/utils'
 
-import { isFailure, isInitial, isPending } from '~shared/api/apiUtils'
+import { isFailure, isInitial, isPending, mapFailure } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
 
@@ -156,15 +156,15 @@ export const Vilkaarsvurdering = (props: { behandling: IBehandlingReducer }) => 
       {isFailure(vilkaarsvurderingStatus) && isInitial(opprettNyVilkaarsvurderingStatus) && (
         <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>
       )}
-      {isFailure(opprettNyVilkaarsvurderingStatus) && (
+      {mapFailure(opprettNyVilkaarsvurderingStatus, (error) => (
         <ApiErrorAlert>
-          {opprettNyVilkaarsvurderingStatus.error.status === 412
+          {error.status === 412
             ? behandling.status === IBehandlingStatus.AVBRUTT
               ? 'Behandlingen er avbrutt, vilkårsvurderingen finnes ikke.'
               : 'Virkningstidspunkt og kommer søker tilgode må avklares før vilkårsvurdering kan starte'
-            : 'En feil har oppstått'}
+            : error.detail}
         </ApiErrorAlert>
-      )}
+      ))}
     </>
   )
 }


### PR DESCRIPTION
Bruker `UgyldigForespoerselException` i stedet for `IllegalStateException` som forenkler feilhåndteringen og melding til saksbehandler. 