### PR TITLE
Avkorting inntekt neste år obligatorisk

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
@@ -108,6 +108,7 @@ class ApplicationContext {
             avkortingRepository = avkortingRepository,
             beregningService = beregningService,
             sanksjonService = sanksjonService,
+            featureToggleService = featureToggleService,
         )
     val ytelseMedGrunnlagService =
         YtelseMedGrunnlagService(

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -15,6 +15,7 @@ import no.nav.etterlatte.beregning.BeregningService
 import no.nav.etterlatte.beregning.regler.avkortinggrunnlagLagre
 import no.nav.etterlatte.beregning.regler.behandling
 import no.nav.etterlatte.beregning.regler.bruker
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
@@ -36,12 +37,17 @@ internal class AvkortingServiceTest {
     private val avkortingRepository: AvkortingRepository = mockk()
     private val beregningService: BeregningService = mockk()
     private val sanksjonService: SanksjonService = mockk()
+    private val featureToggleService: FeatureToggleService =
+        mockk(relaxed = true) {
+            every { isEnabled(AvkortingToggles.VALIDERE_AARSINNTEKT_NESTE_AAR, any(), any()) } returns false
+        }
     private val service =
         AvkortingService(
             behandlingKlient,
             avkortingRepository,
             beregningService,
             sanksjonService,
+            featureToggleService,
         )
 
     @BeforeEach
@@ -368,6 +374,7 @@ internal class AvkortingServiceTest {
                 )
                 avkortingRepository.lagreAvkorting(behandlingId, sakId, beregnetAvkorting)
                 lagretAvkorting.toFrontend(YearMonth.of(2024, 1), null, BehandlingStatus.BEREGNET)
+                featureToggleService.isEnabled(AvkortingToggles.VALIDERE_AARSINNTEKT_NESTE_AAR, false)
                 behandlingKlient.avkort(behandlingId, bruker, true)
             }
             coVerify(exactly = 2) {
@@ -456,6 +463,141 @@ internal class AvkortingServiceTest {
 
             coVerify {
                 behandlingKlient.avkort(behandlingId, bruker, false)
+            }
+        }
+
+        @Test
+        fun `Hvis bryter er på skal behandlingstatus oppdateres hvis inntekt for inneværende og neste år er angitt`() {
+            val behandlingId = UUID.randomUUID()
+            val sakId = randomSakId()
+            val behandling =
+                behandling(
+                    id = behandlingId,
+                    sak = sakId,
+                    behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, 1)),
+                )
+
+            every { avkortingRepository.hentAvkorting(any()) } returns eksisterendeAvkorting andThen lagretAvkorting
+            coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+            mockkObject(AvkortingValider)
+            every { AvkortingValider.validerInntekt(any(), any(), any()) } returns Unit
+            every { beregningService.hentBeregningNonnull(any()) } returns beregning
+            every { sanksjonService.hentSanksjon(behandlingId) } returns null
+            every {
+                eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(any(), any(), any(), any(), any())
+            } returns beregnetAvkorting
+            every { avkortingRepository.lagreAvkorting(any(), any(), any()) } returns Unit
+            coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
+            every { lagretAvkorting.toFrontend(any(), any(), any()) } returns avkortingFrontend
+            every { lagretAvkorting.aarsoppgjoer } returns listOf(mockk(), mockk())
+
+            every {
+                featureToggleService.isEnabled(
+                    AvkortingToggles.VALIDERE_AARSINNTEKT_NESTE_AAR,
+                    any(),
+                    any(),
+                )
+            } returns true
+
+            runBlocking {
+                service.beregnAvkortingMedNyttGrunnlag(
+                    behandlingId,
+                    bruker,
+                    endretGrunnlag,
+                ) shouldBe avkortingFrontend
+            }
+
+            coVerify(exactly = 1) {
+                behandlingKlient.avkort(behandlingId, bruker, false)
+                behandlingKlient.hentBehandling(behandlingId, bruker)
+                AvkortingValider.validerInntekt(endretGrunnlag, eksisterendeAvkorting, true)
+                beregningService.hentBeregningNonnull(behandlingId)
+                sanksjonService.hentSanksjon(behandlingId)
+                eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(
+                    endretGrunnlag,
+                    bruker,
+                    beregning,
+                    any(),
+                    any(),
+                )
+                avkortingRepository.lagreAvkorting(behandlingId, sakId, beregnetAvkorting)
+                lagretAvkorting.toFrontend(YearMonth.of(2024, 1), null, BehandlingStatus.BEREGNET)
+                featureToggleService.isEnabled(AvkortingToggles.VALIDERE_AARSINNTEKT_NESTE_AAR, false)
+                lagretAvkorting.aarsoppgjoer
+
+                behandlingKlient.avkort(behandlingId, bruker, true)
+            }
+            coVerify(exactly = 2) {
+                avkortingRepository.hentAvkorting(behandlingId)
+            }
+        }
+
+        @Test
+        fun `Hvis bryter er på skal behandlingstatus ikke oppdateres hvis inntekt for inneværende eller neste år mangler`() {
+            val behandlingId = UUID.randomUUID()
+            val sakId = randomSakId()
+            val behandling =
+                behandling(
+                    id = behandlingId,
+                    sak = sakId,
+                    behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, 1)),
+                )
+
+            every { avkortingRepository.hentAvkorting(any()) } returns eksisterendeAvkorting andThen lagretAvkorting
+            coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+            mockkObject(AvkortingValider)
+            every { AvkortingValider.validerInntekt(any(), any(), any()) } returns Unit
+            every { beregningService.hentBeregningNonnull(any()) } returns beregning
+            every { sanksjonService.hentSanksjon(behandlingId) } returns null
+            every {
+                eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(any(), any(), any(), any(), any())
+            } returns beregnetAvkorting
+            every { avkortingRepository.lagreAvkorting(any(), any(), any()) } returns Unit
+            coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
+            every { lagretAvkorting.toFrontend(any(), any(), any()) } returns avkortingFrontend
+            every { lagretAvkorting.aarsoppgjoer } returns listOf(mockk())
+
+            every {
+                featureToggleService.isEnabled(
+                    AvkortingToggles.VALIDERE_AARSINNTEKT_NESTE_AAR,
+                    any(),
+                    any(),
+                )
+            } returns true
+
+            runBlocking {
+                service.beregnAvkortingMedNyttGrunnlag(
+                    behandlingId,
+                    bruker,
+                    endretGrunnlag,
+                ) shouldBe avkortingFrontend
+            }
+
+            coVerify(exactly = 1) {
+                behandlingKlient.avkort(behandlingId, bruker, false)
+                behandlingKlient.hentBehandling(behandlingId, bruker)
+                AvkortingValider.validerInntekt(endretGrunnlag, eksisterendeAvkorting, true)
+                beregningService.hentBeregningNonnull(behandlingId)
+                sanksjonService.hentSanksjon(behandlingId)
+                eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(
+                    endretGrunnlag,
+                    bruker,
+                    beregning,
+                    any(),
+                    any(),
+                )
+                avkortingRepository.lagreAvkorting(behandlingId, sakId, beregnetAvkorting)
+                lagretAvkorting.toFrontend(YearMonth.of(2024, 1), null, BehandlingStatus.BEREGNET)
+                featureToggleService.isEnabled(AvkortingToggles.VALIDERE_AARSINNTEKT_NESTE_AAR, false)
+                lagretAvkorting.aarsoppgjoer
+            }
+            coVerify(exactly = 2) {
+                avkortingRepository.hentAvkorting(behandlingId)
+            }
+            coVerify(exactly = 0) {
+                behandlingKlient.avkort(behandlingId, bruker, true)
             }
         }
     }

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -155,6 +155,7 @@ internal class AvkortingServiceTest {
                 eksisterendeAvkorting.beregnAvkortingRevurdering(beregning, any())
                 avkortingRepository.lagreAvkorting(behandlingId, sakId, reberegnetAvkorting)
                 behandlingKlient.avkort(behandlingId, bruker, true)
+                featureToggleService.isEnabled(AvkortingToggles.VALIDERE_AARSINNTEKT_NESTE_AAR, false)
                 lagretAvkorting.toFrontend(YearMonth.of(2024, 1), null, BehandlingStatus.BEREGNET)
             }
             coVerify(exactly = 2) {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
@@ -5,14 +5,9 @@ import { AvkortingInntekt } from '~components/behandling/avkorting/AvkortingInnt
 import Spinner from '~shared/Spinner'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { YtelseEtterAvkorting } from '~components/behandling/avkorting/YtelseEtterAvkorting'
-import {
-  IBehandlingReducer,
-  oppdaterAvkorting,
-  oppdaterBehandlingsstatus,
-  resetAvkorting,
-} from '~store/reducers/BehandlingReducer'
+import { IBehandlingReducer, oppdaterAvkorting, resetAvkorting } from '~store/reducers/BehandlingReducer'
 import { useAppDispatch, useAppSelector } from '~store/Store'
-import { IBehandlingStatus, IBehandlingsType, virkningstidspunkt } from '~shared/types/IDetaljertBehandling'
+import { IBehandlingsType, virkningstidspunkt } from '~shared/types/IDetaljertBehandling'
 import { behandlingErRedigerbar } from '~components/behandling/felles/utils'
 import { mapResult } from '~shared/api/apiUtils'
 import { Brevutfall } from '~components/behandling/brevutfall/Brevutfall'
@@ -54,12 +49,6 @@ export const Avkorting = ({
     if (!avkorting) {
       dispatch(resetAvkorting())
       hentAvkortingRequest(behandling.id, (res) => {
-        const ferdigAvkortetOgErUnderBehandling = !skalHaInntektNesteAar
-          ? res && redigerbar
-          : res && res.avkortingGrunnlag.length === 2 && redigerbar
-        if (ferdigAvkortetOgErUnderBehandling) {
-          dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.AVKORTET))
-        }
         dispatch(oppdaterAvkorting(res))
       })
     }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -44,10 +44,17 @@ export const AvkortingInntekt = ({
   }
 
   const knappTekst = () => {
-    if (avkortingGrunnlagFrontend?.fraVirk != null) {
-      return 'Rediger'
+    if (erInnevaerendeAar) {
+      if (avkortingGrunnlagFrontend?.fraVirk != null) {
+        return 'Rediger'
+      }
+      return 'Legg til'
+    } else {
+      if (!!avkortingGrunnlagFrontend?.historikk?.length) {
+        return 'Rediger'
+      }
+      return 'Legg til for neste år'
     }
-    return erInnevaerendeAar ? 'Legg til' : 'Legg til for neste år'
   }
 
   return (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
@@ -29,6 +29,7 @@ import { Brevutfall } from '~components/behandling/brevutfall/Brevutfall'
 import { VilkaarsvurderingResultat } from '~shared/api/vilkaarsvurdering'
 import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
 import { SimulerUtbetaling } from '~components/behandling/beregne/SimulerUtbetaling'
+import { useFeatureEnabledMedDefault } from '~shared/hooks/useFeatureToggle'
 
 export const Beregne = (props: { behandling: IBehandlingReducer }) => {
   const { behandling } = props
@@ -57,6 +58,7 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
 
   const [manglerBrevutfall, setManglerbrevutfall] = useState(false)
   const [manglerAvkorting, setManglerAvkorting] = useState(false)
+  const skalHaInntektNesteAar = useFeatureEnabledMedDefault('validere_aarsintnekt_neste_aar', false)
 
   const erOpphoer = behandling.vilkaarsvurdering?.resultat?.utfall == VilkaarsvurderingResultat.IKKE_OPPFYLT
 
@@ -157,8 +159,9 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
                 )}
                 {manglerAvkorting && (
                   <Alert style={{ maxWidth: '16em' }} variant="error">
-                    Du må legge til inntektsavkorting, også når etterlatte ikke har inntekt. Legg da inn 0 i
-                    inntektsfeltene.
+                    {skalHaInntektNesteAar
+                      ? 'Du må legge til inntektsavkorting for inneværende og neste år, også når etterlatte ikke har inntekt. Legg da inn 0 i inntektsfeltene.'
+                      : 'Du må legge til inntektsavkorting, også når etterlatte ikke har inntekt. Legg da inn 0 i inntektsfeltene.'}
                   </Alert>
                 )}
               </Box>


### PR DESCRIPTION
Saker hvor søknad er sendt inn før vi ber om inntekt neste år i søknadsskjema og som ikke blir innvilga i tide til varselbrev vil mange inntekt neste år uten at bruker vet at det skal oppgis.
Saksbehandler er nødt til å innhente dette manuelt men for å sikre at dette skjer gjør vi utfylling av inntekt neste år obligatorisk.
Siden dette er bare relevant i tiden fra og med varselbrev blir sendt ut ønsker vi å styre valideringen med brytere.