### PR TITLE
FAGSYSTEM-348427 Sikre at GyldighetsResultat er initiert

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
@@ -128,7 +128,7 @@ class BehandlingFactory(
                                 oppgaveService.ferdigstillOppgave(it.id, brukerTokenInfo)
                             }
                     }
-                } ?: throw IllegalStateException("Kunne ikke opprette behandling")
+                }
             }.also { it.sendMeldingForHendelse() }
                 .behandling
 
@@ -284,19 +284,27 @@ class BehandlingFactory(
                 val foerstegangsbehandlingViOmgjoerer =
                     foerstegangsbehandlinger.maxBy { it.behandlingOpprettet }
                 val nyFoerstegangsbehandling =
-                    checkNotNull(
-                        opprettFoerstegangsbehandling(
-                            behandlingerUnderBehandling = emptyList(),
-                            sak = sak,
-                            mottattDato = foerstegangsbehandlingViOmgjoerer.mottattDato().toString(),
-                            kilde = Vedtaksloesning.GJENNY,
-                            prosessType = Prosesstype.MANUELL,
-                        ),
-                    ) {
-                        "Behandlingen vi akkurat opprettet fins ikke :("
-                    }
+                    opprettFoerstegangsbehandling(
+                        behandlingerUnderBehandling = emptyList(),
+                        sak = sak,
+                        mottattDato = foerstegangsbehandlingViOmgjoerer.mottattDato().toString(),
+                        kilde = Vedtaksloesning.GJENNY,
+                        prosessType = Prosesstype.MANUELL,
+                    )
 
-                kopierFoerstegangsbehandlingOversikt(skalKopiere, sisteAvslaatteBehandling, nyFoerstegangsbehandling.id)
+                if (skalKopiere && sisteAvslaatteBehandling != null) {
+                    kopierFoerstegangsbehandlingOversikt(sisteAvslaatteBehandling, nyFoerstegangsbehandling.id)
+                } else {
+                    val nyGyldighetsproeving =
+                        GyldighetsResultat(
+                            VurderingsResultat.KAN_IKKE_VURDERE_PGA_MANGLENDE_OPPLYSNING,
+                            emptyList(),
+                            Tidspunkt.now().toLocalDatetimeUTC(),
+                        )
+
+                    behandlingDao.lagreGyldighetsproeving(nyFoerstegangsbehandling.id, nyGyldighetsproeving)
+                }
+
                 val oppgave =
                     oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(
                         referanse = nyFoerstegangsbehandling.id.toString(),
@@ -339,30 +347,27 @@ class BehandlingFactory(
     }
 
     private fun kopierFoerstegangsbehandlingOversikt(
-        skalKopiere: Boolean,
-        sisteAvslaatteBehandling: Behandling?,
+        sisteAvslaatteBehandling: Behandling,
         nyFoerstegangsbehandlingId: UUID,
     ) {
-        if (skalKopiere && sisteAvslaatteBehandling != null) {
-            sisteAvslaatteBehandling.kommerBarnetTilgode?.let {
-                kommerBarnetTilGodeService.lagreKommerBarnetTilgode(it.copy(behandlingId = nyFoerstegangsbehandlingId))
-            }
-            sisteAvslaatteBehandling.virkningstidspunkt?.let {
-                behandlingDao.lagreNyttVirkningstidspunkt(
-                    nyFoerstegangsbehandlingId,
-                    it,
-                )
-            }
-            sisteAvslaatteBehandling.utlandstilknytning?.let {
-                behandlingDao.lagreUtlandstilknytning(
-                    nyFoerstegangsbehandlingId,
-                    it,
-                )
-            }
-            sisteAvslaatteBehandling
-                .gyldighetsproeving()
-                ?.let { behandlingDao.lagreGyldighetsproeving(nyFoerstegangsbehandlingId, it) }
+        sisteAvslaatteBehandling.kommerBarnetTilgode?.let {
+            kommerBarnetTilGodeService.lagreKommerBarnetTilgode(it.copy(behandlingId = nyFoerstegangsbehandlingId))
         }
+        sisteAvslaatteBehandling.virkningstidspunkt?.let {
+            behandlingDao.lagreNyttVirkningstidspunkt(
+                nyFoerstegangsbehandlingId,
+                it,
+            )
+        }
+        sisteAvslaatteBehandling.utlandstilknytning?.let {
+            behandlingDao.lagreUtlandstilknytning(
+                nyFoerstegangsbehandlingId,
+                it,
+            )
+        }
+        sisteAvslaatteBehandling
+            .gyldighetsproeving()
+            ?.let { behandlingDao.lagreGyldighetsproeving(nyFoerstegangsbehandlingId, it) }
     }
 
     internal fun hentDataForOpprettBehandling(sakId: SakId): DataHentetForOpprettBehandling {

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
@@ -684,6 +684,7 @@ class BehandlingFactoryTest {
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any(), any(), any())
             hendelseDaoMock.behandlingOpprettet(any())
             behandlingHendelserKafkaProducerMock.sendMeldingForHendelseStatisitkk(any(), any())
+            behandlingDaoMock.lagreGyldighetsproeving(opprettetBehandling.id, any())
         }
         coVerify {
             grunnlagService.hentPersongalleri(avslaattFoerstegangsbehandling.id)


### PR DESCRIPTION
Dersom saksbehandler ikke velger å kopiere forrige behandling blir ikke gyldighetsresultat tatt med videre. Det blir som en følge av dette `null` og gjør at behandlingen stopper opp. 

https://jira.adeo.no/browse/FAGSYSTEM-348427
