### PR TITLE
EY-4505: Fjerner tabell brukt ved opprettelse av dødshendelser for personer mellom 18 og 20

### DIFF
--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V168__fjerner_tabell_mellom_atten_og_tjue_ved_reformtidspunkt.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V168__fjerner_tabell_mellom_atten_og_tjue_ved_reformtidspunkt.sql
@@ -1,0 +1,2 @@
+-- Fjerner tabell brukt under utsending av brev for personer mellom 18 og 20 år på reformtidspunkt
+DROP TABLE mellom_atten_og_tjue_ved_reformtidspunkt;


### PR DESCRIPTION
Tabellen ble brukt midlertidig ved opprettelse av dødshendelser som trigget brev til personer mellom 18 og 20 på reformtidspunkt. Dataene er nå tilgjengelig i `doedshendelse`-tabellen, og vi har ikke lenger behov for å ha denne tabellen liggende.