### PR TITLE
Ikke kaste feil hvis sakid eller -system mangler

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/Journalpost.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokarkiv/Journalpost.kt
@@ -131,22 +131,7 @@ data class JournalpostSak(
     val fagsakId: String? = null,
     val tema: String? = null,
     val fagsaksystem: String? = null,
-) {
-    init {
-        if (sakstype == Sakstype.FAGSAK) {
-            check(!fagsakId.isNullOrBlank()) {
-                val error = "fagsakId må være satt når sakstype=${Sakstype.FAGSAK}"
-                logger.error(error)
-                error
-            }
-            check(!fagsaksystem.isNullOrBlank()) {
-                val error = "fagsaksystem må være satt når sakstype=${Sakstype.FAGSAK}"
-                logger.error(error)
-                error
-            }
-        }
-    }
-}
+)
 
 enum class Sakstype {
     FAGSAK,


### PR DESCRIPTION
Viser seg at det er helt lovlig å lagre journalpost _uten_ disse verdiene. Fjerner derfor sperren slik at vi ikke får feil i loggene i tilfeller hvor saksbehandler forsøker å hente journalposter av typen FAGSAK hvor id eller system mangler. 