### PR TITLE
gitignore .kotlin-mappe som blir generert ved feil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 .gradle/
 .idea/
+.kotlin/
 
 build/
 dist/


### PR DESCRIPTION
Dersom man får kotlin-relaterte feil i IntelliJ vil det bli generert opp en mappe med errorlogg tilknyttet feilen. Legger til ignore for å unngå at det havner i kodebasen. 