### PR TITLE
Tilpasse Avkorting for Aldersovergang

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -172,8 +172,16 @@ data class Avkorting(
                                 periode = Periode(fom = nyttGrunnlag.fom, tom = opphoerFom?.minusMonths(1)),
                                 aarsinntekt = nyttGrunnlag.aarsinntekt,
                                 fratrekkInnAar = nyttGrunnlag.fratrekkInnAar,
+                                fratrekkUtAar = 0,
                                 inntektUtland = nyttGrunnlag.inntektUtland,
                                 fratrekkInnAarUtland = nyttGrunnlag.fratrekkInnAarUtland,
+                                fratrekkUtAarUtlang = 0,
+                                innvilgaMaaneder =
+                                    (aarsoppgjoer.fom!!.monthValue - 1).let { antallMaanederFoerFom ->
+                                        // TODO trekk ut og unittest!!!
+                                        val antallMaanederEtterVirk = opphoerFom?.monthValue?.let { it - 1 } ?: 0
+                                        12 - antallMaanederFoerFom - antallMaanederEtterVirk
+                                    },
                                 spesifikasjon = nyttGrunnlag.spesifikasjon,
                                 kilde = Grunnlagsopplysning.Saksbehandler(bruker.ident(), Tidspunkt.now()),
                             ),
@@ -384,7 +392,7 @@ data class Avkorting(
         return funnet ?: Aarsoppgjoer(
             id = UUID.randomUUID(),
             aar = fom.year,
-            forventaInnvilgaMaaneder = 12 - fom.monthValue + 1,
+            forventaInnvilgaMaaneder = 12 - fom.monthValue + 1, // TODO fjern?...
         )
     }
 
@@ -404,8 +412,11 @@ data class AvkortingGrunnlag(
     val periode: Periode,
     val aarsinntekt: Int,
     val fratrekkInnAar: Int,
+    val fratrekkUtAar: Int? = null,
     val inntektUtland: Int,
     val fratrekkInnAarUtland: Int,
+    val fratrekkUtAarUtlang: Int? = null,
+    val innvilgaMaaneder: Int? = null,
     val spesifikasjon: String,
     val kilde: Grunnlagsopplysning.Saksbehandler,
 )
@@ -414,6 +425,7 @@ data class Aarsoppgjoer(
     val id: UUID,
     val aar: Int,
     val forventaInnvilgaMaaneder: Int,
+    val fom: YearMonth? = null,
     val ytelseFoerAvkorting: List<YtelseFoerAvkorting> = emptyList(),
     val inntektsavkorting: List<Inntektsavkorting> = emptyList(),
     val avkortetYtelseAar: List<AvkortetYtelse> = emptyList(),

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -666,7 +666,6 @@ fun finnAntallInnvilgaMaanederForAar(
     aarsoppgjoerFom: YearMonth,
     opphoerFom: YearMonth?,
 ): Int {
-    val antallMaanederFoerFom = aarsoppgjoerFom.monthValue - 1
-    val antallMaanederEtterVirk = opphoerFom?.monthValue?.let { it - 1 } ?: 0
-    return 12 - antallMaanederFoerFom - antallMaanederEtterVirk
+    val tom = opphoerFom?.monthValue?.let { it - 1 } ?: 12
+    return tom - (aarsoppgjoerFom.monthValue - 1)
 }

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -212,7 +212,7 @@ data class Avkorting(
                     aarsoppgjoer.inntektsavkorting.map { inntektsavkorting ->
                         val periode =
                             Periode(
-                                fom = aarsoppgjoer.foersteInnvilgedeMaaned(),
+                                fom = aarsoppgjoer.fom,
                                 tom = inntektsavkorting.grunnlag.periode.tom,
                             )
 
@@ -308,7 +308,7 @@ data class Avkorting(
                     0 -> null
                     else ->
                         AvkortingRegelkjoring.beregnRestanse(
-                            aarsoppgjoer.foersteInnvilgedeMaaned(),
+                            aarsoppgjoer.fom,
                             inntektsavkorting,
                             avkortetYtelseMedAllForventetInntekt,
                             kjenteSanksjonerForInntektsavkorting,
@@ -334,7 +334,7 @@ data class Avkorting(
         if (senesteSanksjonFom != null && senesteSanksjonFom >= senesteInntektsjusteringFom) {
             val restanse =
                 AvkortingRegelkjoring.beregnRestanse(
-                    aarsoppgjoer.foersteInnvilgedeMaaned(),
+                    aarsoppgjoer.fom,
                     reberegnetInntektsavkorting.last(),
                     avkortetYtelseMedAllForventetInntekt,
                     sorterteSanksjonerInnenforAarsoppgjoer,
@@ -456,8 +456,6 @@ data class Aarsoppgjoer(
             }
         }
     }
-
-    fun foersteInnvilgedeMaaned(): YearMonth = fom!! // TODO
 
     /**
      * Gir kun de sanksjonene som har en periode som overlapper med dette årsoppgjøret.

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
@@ -33,7 +33,6 @@ object AvkortingRegelkjoring {
     fun beregnInntektsavkorting(
         periode: Periode,
         avkortingGrunnlag: AvkortingGrunnlag,
-        innvilgaMaaneder: Int,
     ): List<Avkortingsperiode> {
         logger.info("Beregner inntektsavkorting")
 
@@ -56,7 +55,7 @@ object AvkortingRegelkjoring {
                                             fratrekkInnAar = Beregningstall(it.fratrekkInnAar),
                                             inntektUtland = Beregningstall(it.inntektUtland),
                                             fratrekkInnAarUtland = Beregningstall(it.fratrekkInnAarUtland),
-                                            relevanteMaaneder = Beregningstall(innvilgaMaaneder),
+                                            relevanteMaaneder = Beregningstall(it.innvilgaMaaneder!!),
                                             it.id,
                                         ),
                                     kilde = it.kilde,

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
@@ -55,7 +55,7 @@ object AvkortingRegelkjoring {
                                             fratrekkInnAar = Beregningstall(it.fratrekkInnAar),
                                             inntektUtland = Beregningstall(it.inntektUtland),
                                             fratrekkInnAarUtland = Beregningstall(it.fratrekkInnAarUtland),
-                                            relevanteMaaneder = Beregningstall(it.innvilgaMaaneder!!),
+                                            relevanteMaaneder = Beregningstall(it.innvilgaMaaneder),
                                             it.id,
                                         ),
                                     kilde = it.kilde,

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
@@ -32,7 +32,7 @@ class AvkortingRepository(
                                 Aarsoppgjoer(
                                     id = row.uuid("id"),
                                     aar = row.int("aar"),
-                                    forventaInnvilgaMaaneder = row.string("innvilga_maaneder").toInt(),
+                                    fom = YearMonth.now(), // TODO
                                 )
                             }.asList,
                     )
@@ -227,7 +227,7 @@ class AvkortingRepository(
                 "behandling_id" to behandlingId,
                 "sak_id" to sakId,
                 "aar" to aarsoppgjoer.aar,
-                "innvilga_maaneder" to aarsoppgjoer.forventaInnvilgaMaaneder,
+                "innvilga_maaneder" to 0, // TODO
             ),
     ).let { query -> tx.run(query.asUpdate) }
 
@@ -241,10 +241,10 @@ class AvkortingRepository(
             """
             INSERT INTO avkortingsgrunnlag(
                 id, behandling_id, fom, tom, aarsinntekt, fratrekk_inn_ut, inntekt_utland, fratrekk_inn_aar_utland,
-                spesifikasjon, kilde, aarsoppgjoer_id
+                spesifikasjon, kilde, aarsoppgjoer_id, relevante_maaneder
             ) VALUES (
                 :id, :behandlingId, :fom, :tom, :aarsinntekt, :fratrekkInnAar, :inntektUtland, :fratrekkInnAarUtland,
-                :spesifikasjon, :kilde, :aarsoppgjoerId
+                :spesifikasjon, :kilde, :aarsoppgjoerId, :relevanteMaaneder
             )
             """.trimIndent(),
         paramMap =
@@ -258,6 +258,7 @@ class AvkortingRepository(
                 "fratrekkInnAar" to avkortingsgrunnlag.fratrekkInnAar,
                 "inntektUtland" to avkortingsgrunnlag.inntektUtland,
                 "fratrekkInnAarUtland" to avkortingsgrunnlag.fratrekkInnAarUtland,
+                "relevanteMaaneder" to avkortingsgrunnlag.innvilgaMaaneder,
                 "spesifikasjon" to avkortingsgrunnlag.spesifikasjon,
                 "kilde" to avkortingsgrunnlag.kilde.toJson(),
             ),
@@ -403,6 +404,7 @@ class AvkortingRepository(
             fratrekkInnAar = int("fratrekk_inn_ut"),
             inntektUtland = int("inntekt_utland"),
             fratrekkInnAarUtland = int("fratrekk_inn_aar_utland"),
+            innvilgaMaaneder = int("relevante_maaneder"),
             spesifikasjon = string("spesifikasjon"),
             kilde = string("kilde").let { objectMapper.readValue(it) },
         )

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
@@ -32,7 +32,7 @@ class AvkortingRepository(
                                 Aarsoppgjoer(
                                     id = row.uuid("id"),
                                     aar = row.int("aar"),
-                                    fom = YearMonth.now(), // TODO
+                                    fom = row.sqlDate("fom").let { YearMonth.from(it.toLocalDate()) },
                                 )
                             }.asList,
                     )
@@ -216,9 +216,9 @@ class AvkortingRepository(
         statement =
             """
             INSERT INTO avkorting_aarsoppgjoer(
-            	id, behandling_id, sak_id, aar, innvilga_maaneder
+            	id, behandling_id, sak_id, aar, fom
             ) VALUES (
-            	:id, :behandling_id, :sak_id, :aar, :innvilga_maaneder
+            	:id, :behandling_id, :sak_id, :aar, :fom
             )
             """.trimIndent(),
         paramMap =
@@ -227,7 +227,7 @@ class AvkortingRepository(
                 "behandling_id" to behandlingId,
                 "sak_id" to sakId,
                 "aar" to aarsoppgjoer.aar,
-                "innvilga_maaneder" to 0, // TODO
+                "fom" to aarsoppgjoer.fom.atDay(1),
             ),
     ).let { query -> tx.run(query.asUpdate) }
 

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -86,7 +86,7 @@ fun AvkortingGrunnlag.toDto() =
         fratrekkInnAar = fratrekkInnAar,
         inntektUtland = inntektUtland,
         fratrekkInnAarUtland = fratrekkInnAarUtland,
-        relevanteMaanederInnAar = innvilgaMaaneder!!,
+        relevanteMaanederInnAar = innvilgaMaaneder,
         spesifikasjon = spesifikasjon,
         kilde = AvkortingGrunnlagKildeDto(kilde.tidspunkt.toString(), kilde.ident),
     )

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -77,7 +77,7 @@ fun Route.avkorting(
     }
 }
 
-fun AvkortingGrunnlag.toDto(forventaInnvilgaMaaneder: Int) =
+fun AvkortingGrunnlag.toDto() =
     AvkortingGrunnlagDto(
         id = id,
         fom = periode.fom,
@@ -86,7 +86,7 @@ fun AvkortingGrunnlag.toDto(forventaInnvilgaMaaneder: Int) =
         fratrekkInnAar = fratrekkInnAar,
         inntektUtland = inntektUtland,
         fratrekkInnAarUtland = fratrekkInnAarUtland,
-        relevanteMaanederInnAar = forventaInnvilgaMaaneder,
+        relevanteMaanederInnAar = innvilgaMaaneder!!,
         spesifikasjon = spesifikasjon,
         kilde = AvkortingGrunnlagKildeDto(kilde.tidspunkt.toString(), kilde.ident),
     )

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -18,6 +18,7 @@ import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.sanksjon.SanksjonService
 import org.slf4j.LoggerFactory
+import java.time.YearMonth
 import java.util.UUID
 
 enum class AvkortingToggles(
@@ -111,13 +112,16 @@ class AvkortingService(
         val beregning = beregningService.hentBeregningNonnull(behandlingId)
         val sanksjoner = sanksjonService.hentSanksjon(behandlingId) ?: emptyList()
 
+        val forutsettAldersovergang: YearMonth? = YearMonth.now() // TODO kalle en tjeneste som kan si om det er AO?
+        val opphoerFom = forutsettAldersovergang ?: behandling.opphoerFraOgMed
+
         val beregnetAvkorting =
             avkorting.beregnAvkortingMedNyttGrunnlag(
                 lagreGrunnlag,
                 brukerTokenInfo,
                 beregning,
                 sanksjoner,
-                behandling.opphoerFraOgMed,
+                opphoerFom,
             )
 
         avkortingRepository.lagreAvkorting(behandlingId, behandling.sak, beregnetAvkorting)

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -93,7 +93,7 @@ class AvkortingService(
         val avkorting =
             avkortingRepository.hentAvkorting(behandlingId)
                 ?: throw AvkortingFinnesIkkeException(behandlingId)
-        return avkorting.toDto(behandling.virkningstidspunkt().dato, null)
+        return avkorting.toDto(behandling.virkningstidspunkt().dato)
     }
 
     suspend fun beregnAvkortingMedNyttGrunnlag(

--- a/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
@@ -128,6 +128,7 @@ class ApplicationContext {
             avkortingRepository = avkortingRepository,
             beregningService = beregningService,
             sanksjonService = sanksjonService,
+            grunnlagKlient = grunnlagKlient,
             featureToggleService = featureToggleService,
         )
     val ytelseMedGrunnlagService =

--- a/apps/etterlatte-beregning/src/main/kotlin/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/klienter/GrunnlagKlient.kt
@@ -93,7 +93,7 @@ class GrunnlagKlientImpl(
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$resourceUrl/api/grunnlag/aldersovergang/$sakId/${sakType.name}",
+                            url = "$resourceUrl/api/grunnlag/aldersovergang/sak/$sakId/${sakType.name}",
                         ),
                     brukerTokenInfo = brukerTokenInfo,
                 ).mapBoth(

--- a/apps/etterlatte-beregning/src/main/kotlin/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/klienter/GrunnlagKlient.kt
@@ -5,14 +5,17 @@ import com.github.michaelbull.result.mapBoth
 import com.typesafe.config.Config
 import io.ktor.client.HttpClient
 import no.nav.etterlatte.libs.common.RetryResult
+import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.retry
+import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.AzureAdClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
+import java.time.YearMonth
 import java.util.UUID
 
 interface GrunnlagKlient {
@@ -20,6 +23,12 @@ interface GrunnlagKlient {
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): Grunnlag
+
+    suspend fun aldersovergangMaaned(
+        sakId: SakId,
+        sakType: SakType,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): YearMonth
 }
 
 class GrunnlagKlientException(
@@ -64,6 +73,39 @@ class GrunnlagKlientImpl(
                 is RetryResult.Failure -> {
                     throw GrunnlagKlientException(
                         "Klarte ikke hente grunnlag for behandling med id=$behandlingId",
+                        it.samlaExceptions(),
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun aldersovergangMaaned(
+        sakId: SakId,
+        sakType: SakType,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): YearMonth {
+        logger.info("Henter måned for aldersovergang for sak=$sakId saktype=${sakType.name}")
+
+        return retry<YearMonth> {
+            downstreamResourceClient
+                .get(
+                    resource =
+                        Resource(
+                            clientId = clientId,
+                            url = "$resourceUrl/api/grunnlag/aldersovergang/$sakId/${sakType.name}",
+                        ),
+                    brukerTokenInfo = brukerTokenInfo,
+                ).mapBoth(
+                    success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },
+                    failure = { throwableErrorMessage -> throw throwableErrorMessage },
+                )
+        }.let {
+            when (it) {
+                is RetryResult.Success -> it.content
+                is RetryResult.Failure -> {
+                    throw GrunnlagKlientException(
+                        "Klarte ikke hente måned for aldersovergang for sak=$sakId saktype=${sakType.name}",
                         it.samlaExceptions(),
                     )
                 }

--- a/apps/etterlatte-beregning/src/main/resources/db/migration/V52__innvilga_maander_til_grunnlag_og_fom_aarsopgjoer.sql
+++ b/apps/etterlatte-beregning/src/main/resources/db/migration/V52__innvilga_maander_til_grunnlag_og_fom_aarsopgjoer.sql
@@ -1,0 +1,22 @@
+-- Antall innvilga måneder kan ikke være på årsoppgjør nivå da det må tas høyde for uforutsigbare oppphør underveis i året
+ALTER TABLE avkorting_aarsoppgjoer
+    ALTER COLUMN innvilga_maaneder DROP NOT NULL;
+
+-- For å enkelt vite når første fom for alle perioder er
+ALTER TABLE avkorting_aarsoppgjoer
+    ADD COLUMN fom DATE;
+
+-- Finner første fom ved å finne antall IKKE innvilga måneder og plusse fra januer
+UPDATE avkorting_aarsoppgjoer
+SET fom = (date('2024-01-01') + ((12 - subquery.innvilga_maaneder::int8)::text || ' month')::interval)::date
+FROM (SELECT innvilga_maaneder FROM avkorting_aarsoppgjoer) subquery;
+
+ALTER TABLE avkorting_aarsoppgjoer
+    ALTER COLUMN fom SET NOT NULL;
+
+-- Flytter innvilga måneder fra årsoppgjør til grunnlag
+-- Dette kjøres i første år til OMS så det er ingen perioder hvor antall innvilga varierer enda
+UPDATE avkortingsgrunnlag
+SET relevante_maaneder = aarsoppgjoer.innvilga_maaneder
+FROM (SELECT * FROM avkorting_aarsoppgjoer) aarsoppgjoer
+WHERE avkortingsgrunnlag.aarsoppgjoer_id = aarsoppgjoer.id;

--- a/apps/etterlatte-beregning/src/main/resources/db/migration/V52__innvilga_maander_til_grunnlag_og_fom_aarsopgjoer.sql
+++ b/apps/etterlatte-beregning/src/main/resources/db/migration/V52__innvilga_maander_til_grunnlag_og_fom_aarsopgjoer.sql
@@ -9,7 +9,8 @@ ALTER TABLE avkorting_aarsoppgjoer
 -- Finner første fom ved å finne antall IKKE innvilga måneder og plusse fra januer
 UPDATE avkorting_aarsoppgjoer
 SET fom = (date('2024-01-01') + ((12 - subquery.innvilga_maaneder::int8)::text || ' month')::interval)::date
-FROM (SELECT innvilga_maaneder FROM avkorting_aarsoppgjoer) subquery;
+FROM (SELECT id, innvilga_maaneder FROM avkorting_aarsoppgjoer) subquery
+WHERE avkorting_aarsoppgjoer.id = subquery.id;
 
 ALTER TABLE avkorting_aarsoppgjoer
     ALTER COLUMN fom SET NOT NULL;

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -128,6 +128,7 @@ fun avkortinggrunnlag(
     aarsinntekt: Int = 100000,
     fratrekkInnAar: Int = 10000,
     fratrekkInnAarUtland: Int = 0,
+    innvilgaMaaneder: Int = 12,
     periode: Periode = Periode(fom = YearMonth.of(2024, 1), tom = null),
     kilde: Grunnlagsopplysning.Saksbehandler = Grunnlagsopplysning.Saksbehandler.create("Z123456"),
 ) = AvkortingGrunnlag(
@@ -137,6 +138,7 @@ fun avkortinggrunnlag(
     fratrekkInnAar = fratrekkInnAar,
     inntektUtland = 0,
     fratrekkInnAarUtland = fratrekkInnAarUtland,
+    innvilgaMaaneder = innvilgaMaaneder,
     spesifikasjon = "Spesifikasjon",
     kilde = kilde,
 )
@@ -180,14 +182,14 @@ fun inntektAvkortingGrunnlag(
 
 fun aarsoppgjoer(
     aar: Int = 2024,
-    forventaInnvilgaMaaneder: Int = 12,
+    fom: YearMonth = YearMonth.of(aar, 1),
     ytelseFoerAvkorting: List<YtelseFoerAvkorting> = emptyList(),
     inntektsavkorting: List<Inntektsavkorting> = emptyList(),
     avkortetYtelseAar: List<AvkortetYtelse> = emptyList(),
 ) = Aarsoppgjoer(
     id = UUID.randomUUID(),
     aar = aar,
-    forventaInnvilgaMaaneder = forventaInnvilgaMaaneder,
+    fom = fom,
     ytelseFoerAvkorting = ytelseFoerAvkorting,
     inntektsavkorting = inntektsavkorting,
     avkortetYtelseAar = avkortetYtelseAar,

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRegelkjoringTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRegelkjoringTest.kt
@@ -26,7 +26,6 @@ class AvkortingRegelkjoringTest {
             AvkortingRegelkjoring.beregnInntektsavkorting(
                 Periode(fom = virkningstidspunkt.dato, tom = null),
                 avkortingGrunnlag,
-                12,
             )
 
         with(avkortingsperioder[0]) {

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingRepositoryTest.kt
@@ -124,11 +124,21 @@ internal class AvkortingRepositoryTest(
         aar: Int,
         forventaInnvilgaMaaneder: Int = 12,
     ): Aarsoppgjoer {
-        val inntektEn = avkortinggrunnlag(periode = Periode(fom = YearMonth.of(aar, 1), tom = YearMonth.of(aar, 3)))
+        val inntektEn =
+            avkortinggrunnlag(
+                innvilgaMaaneder = forventaInnvilgaMaaneder,
+                periode = Periode(fom = YearMonth.of(aar, 1), tom = YearMonth.of(aar, 3)),
+            )
         val inntektsavkortingEn =
             Inntektsavkorting(
                 grunnlag = inntektEn,
-                avkortingsperioder = listOf(avkortingsperiode(inntektsgrunnlag = inntektEn.id, fom = YearMonth.of(aar, 1))),
+                avkortingsperioder =
+                    listOf(
+                        avkortingsperiode(
+                            inntektsgrunnlag = inntektEn.id,
+                            fom = YearMonth.of(aar, 1),
+                        ),
+                    ),
                 avkortetYtelseForventetInntekt =
                     listOf(
                         avkortetYtelse(
@@ -139,11 +149,21 @@ internal class AvkortingRepositoryTest(
                     ),
             )
 
-        val inntektTo = avkortinggrunnlag(periode = Periode(fom = YearMonth.of(aar, 4), tom = null))
+        val inntektTo =
+            avkortinggrunnlag(
+                innvilgaMaaneder = forventaInnvilgaMaaneder,
+                periode = Periode(fom = YearMonth.of(aar, 4), tom = null),
+            )
         val inntektsavkortingTo =
             Inntektsavkorting(
                 grunnlag = inntektTo,
-                avkortingsperioder = listOf(avkortingsperiode(inntektsgrunnlag = inntektTo.id, fom = YearMonth.of(aar, 4))),
+                avkortingsperioder =
+                    listOf(
+                        avkortingsperiode(
+                            inntektsgrunnlag = inntektTo.id,
+                            fom = YearMonth.of(aar, 4),
+                        ),
+                    ),
                 avkortetYtelseForventetInntekt =
                     listOf(
                         avkortetYtelse(
@@ -157,8 +177,17 @@ internal class AvkortingRepositoryTest(
         return Aarsoppgjoer(
             id = UUID.randomUUID(),
             aar = aar,
-            forventaInnvilgaMaaneder = forventaInnvilgaMaaneder,
-            ytelseFoerAvkorting = listOf(ytelseFoerAvkorting(periode = Periode(fom = YearMonth.of(aar, 1), tom = null))),
+            fom = YearMonth.of(aar, 12),
+            ytelseFoerAvkorting =
+                listOf(
+                    ytelseFoerAvkorting(
+                        periode =
+                            Periode(
+                                fom = YearMonth.of(aar, 1),
+                                tom = null,
+                            ),
+                    ),
+                ),
             inntektsavkorting =
                 listOf(
                     inntektsavkortingEn,

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -17,8 +17,10 @@ import no.nav.etterlatte.beregning.regler.behandling
 import no.nav.etterlatte.beregning.regler.bruker
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.klienter.BehandlingKlient
+import no.nav.etterlatte.klienter.GrunnlagKlient
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.SisteIverksatteBehandling
 import no.nav.etterlatte.libs.common.beregning.AvkortingFrontend
 import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagLagreDto
@@ -37,6 +39,7 @@ internal class AvkortingServiceTest {
     private val avkortingRepository: AvkortingRepository = mockk()
     private val beregningService: BeregningService = mockk()
     private val sanksjonService: SanksjonService = mockk()
+    private val grunnlagKlient: GrunnlagKlient = mockk()
     private val featureToggleService: FeatureToggleService =
         mockk(relaxed = true) {
             every { isEnabled(AvkortingToggles.VALIDERE_AARSINNTEKT_NESTE_AAR, any(), any()) } returns false
@@ -47,6 +50,7 @@ internal class AvkortingServiceTest {
             avkortingRepository,
             beregningService,
             sanksjonService,
+            grunnlagKlient,
             featureToggleService,
         )
 
@@ -345,6 +349,8 @@ internal class AvkortingServiceTest {
             every { AvkortingValider.validerInntekt(any(), any(), any()) } returns Unit
             every { beregningService.hentBeregningNonnull(any()) } returns beregning
             every { sanksjonService.hentSanksjon(behandlingId) } returns null
+            coEvery { grunnlagKlient.aldersovergangMaaned(any(), any(), any()) } returns YearMonth.of(1900, 1)
+            every { endretGrunnlag.fom } returns YearMonth.of(2024, 1)
             every {
                 eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(any(), any(), any(), any(), any())
             } returns beregnetAvkorting
@@ -366,6 +372,8 @@ internal class AvkortingServiceTest {
                 AvkortingValider.validerInntekt(endretGrunnlag, eksisterendeAvkorting, true)
                 beregningService.hentBeregningNonnull(behandlingId)
                 sanksjonService.hentSanksjon(behandlingId)
+                grunnlagKlient.aldersovergangMaaned(behandling.sak, SakType.OMSTILLINGSSTOENAD, bruker)
+                endretGrunnlag.fom
                 eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(
                     endretGrunnlag,
                     bruker,
@@ -403,6 +411,8 @@ internal class AvkortingServiceTest {
             every { AvkortingValider.validerInntekt(any(), any(), any()) } returns Unit
             every { beregningService.hentBeregningNonnull(any()) } returns beregning
             every { sanksjonService.hentSanksjon(revurderingId) } returns null
+            coEvery { grunnlagKlient.aldersovergangMaaned(any(), any(), any()) } returns YearMonth.of(1900, 1)
+            every { endretGrunnlag.fom } returns YearMonth.of(2024, 1)
             every {
                 eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(any(), any(), any(), any(), any())
             } returns beregnetAvkorting
@@ -429,6 +439,8 @@ internal class AvkortingServiceTest {
                 AvkortingValider.validerInntekt(endretGrunnlag, eksisterendeAvkorting, false)
                 beregningService.hentBeregningNonnull(revurderingId)
                 sanksjonService.hentSanksjon(revurderingId)
+                grunnlagKlient.aldersovergangMaaned(sakId, SakType.OMSTILLINGSSTOENAD, bruker)
+                endretGrunnlag.fom
                 eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(
                     endretGrunnlag,
                     bruker,
@@ -485,6 +497,8 @@ internal class AvkortingServiceTest {
             every { AvkortingValider.validerInntekt(any(), any(), any()) } returns Unit
             every { beregningService.hentBeregningNonnull(any()) } returns beregning
             every { sanksjonService.hentSanksjon(behandlingId) } returns null
+            coEvery { grunnlagKlient.aldersovergangMaaned(any(), any(), any()) } returns YearMonth.of(1900, 1)
+            every { endretGrunnlag.fom } returns YearMonth.of(2024, 1)
             every {
                 eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(any(), any(), any(), any(), any())
             } returns beregnetAvkorting
@@ -515,6 +529,8 @@ internal class AvkortingServiceTest {
                 AvkortingValider.validerInntekt(endretGrunnlag, eksisterendeAvkorting, true)
                 beregningService.hentBeregningNonnull(behandlingId)
                 sanksjonService.hentSanksjon(behandlingId)
+                grunnlagKlient.aldersovergangMaaned(behandling.sak, SakType.OMSTILLINGSSTOENAD, bruker)
+                endretGrunnlag.fom
                 eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(
                     endretGrunnlag,
                     bruker,
@@ -552,6 +568,8 @@ internal class AvkortingServiceTest {
             every { AvkortingValider.validerInntekt(any(), any(), any()) } returns Unit
             every { beregningService.hentBeregningNonnull(any()) } returns beregning
             every { sanksjonService.hentSanksjon(behandlingId) } returns null
+            coEvery { grunnlagKlient.aldersovergangMaaned(any(), any(), any()) } returns YearMonth.of(1900, 1)
+            every { endretGrunnlag.fom } returns YearMonth.of(2024, 1)
             every {
                 eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(any(), any(), any(), any(), any())
             } returns beregnetAvkorting
@@ -582,6 +600,8 @@ internal class AvkortingServiceTest {
                 AvkortingValider.validerInntekt(endretGrunnlag, eksisterendeAvkorting, true)
                 beregningService.hentBeregningNonnull(behandlingId)
                 sanksjonService.hentSanksjon(behandlingId)
+                grunnlagKlient.aldersovergangMaaned(behandling.sak, SakType.OMSTILLINGSSTOENAD, bruker)
+                endretGrunnlag.fom
                 eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(
                     endretGrunnlag,
                     bruker,
@@ -599,6 +619,68 @@ internal class AvkortingServiceTest {
             }
             coVerify(exactly = 0) {
                 behandlingKlient.avkort(behandlingId, bruker, true)
+            }
+        }
+
+        @Test
+        fun `Skal beregne og lagre avkorting me opphør grunnet aldersovergang`() {
+            val behandlingId = UUID.randomUUID()
+            val sakId = randomSakId()
+            val behandling =
+                behandling(
+                    id = behandlingId,
+                    sak = sakId,
+                    behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, 1)),
+                )
+
+            val foedselsdato67aar = YearMonth.of(2024, 6)
+
+            every { avkortingRepository.hentAvkorting(any()) } returns eksisterendeAvkorting andThen lagretAvkorting
+            coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+            mockkObject(AvkortingValider)
+            every { AvkortingValider.validerInntekt(any(), any(), any()) } returns Unit
+            every { beregningService.hentBeregningNonnull(any()) } returns beregning
+            every { sanksjonService.hentSanksjon(behandlingId) } returns null
+            coEvery { grunnlagKlient.aldersovergangMaaned(any(), any(), any()) } returns foedselsdato67aar
+            every { endretGrunnlag.fom } returns YearMonth.of(2024, 1)
+            every {
+                eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(any(), any(), any(), any(), any())
+            } returns beregnetAvkorting
+            every { avkortingRepository.lagreAvkorting(any(), any(), any()) } returns Unit
+            coEvery { behandlingKlient.avkort(any(), any(), any()) } returns true
+            every { lagretAvkorting.toFrontend(any(), any(), any()) } returns avkortingFrontend
+
+            runBlocking {
+                service.beregnAvkortingMedNyttGrunnlag(
+                    behandlingId,
+                    bruker,
+                    endretGrunnlag,
+                ) shouldBe avkortingFrontend
+            }
+
+            coVerify(exactly = 1) {
+                behandlingKlient.avkort(behandlingId, bruker, false)
+                behandlingKlient.hentBehandling(behandlingId, bruker)
+                AvkortingValider.validerInntekt(endretGrunnlag, eksisterendeAvkorting, true)
+                beregningService.hentBeregningNonnull(behandlingId)
+                sanksjonService.hentSanksjon(behandlingId)
+                grunnlagKlient.aldersovergangMaaned(behandling.sak, SakType.OMSTILLINGSSTOENAD, bruker)
+                endretGrunnlag.fom
+                eksisterendeAvkorting.beregnAvkortingMedNyttGrunnlag(
+                    endretGrunnlag,
+                    bruker,
+                    beregning,
+                    any(),
+                    foedselsdato67aar,
+                )
+                avkortingRepository.lagreAvkorting(behandlingId, sakId, beregnetAvkorting)
+                lagretAvkorting.toFrontend(YearMonth.of(2024, 1), null, BehandlingStatus.BEREGNET)
+                featureToggleService.isEnabled(AvkortingToggles.VALIDERE_AARSINNTEKT_NESTE_AAR, false)
+                behandlingKlient.avkort(behandlingId, bruker, true)
+            }
+            coVerify(exactly = 2) {
+                avkortingRepository.hentAvkorting(behandlingId)
             }
         }
     }

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -34,7 +34,7 @@ internal class AvkortingTest {
                         Aarsoppgjoer(
                             id = UUID.randomUUID(),
                             aar = 2024,
-                            forventaInnvilgaMaaneder = 10,
+                            fom = YearMonth.of(2024, Month.MARCH),
                             inntektsavkorting =
                                 listOf(
                                     Inntektsavkorting(
@@ -84,7 +84,7 @@ internal class AvkortingTest {
                         Aarsoppgjoer(
                             id = UUID.randomUUID(),
                             aar = 2025,
-                            forventaInnvilgaMaaneder = 12,
+                            fom = YearMonth.of(2025, Month.JANUARY),
                             inntektsavkorting =
                                 listOf(
                                     Inntektsavkorting(
@@ -122,17 +122,17 @@ internal class AvkortingTest {
                     avkorting.aarsoppgjoer[0]
                         .inntektsavkorting[0]
                         .grunnlag
-                        .toDto(10)
+                        .toDto()
                 it.avkortingGrunnlag[1] shouldBe
                     avkorting.aarsoppgjoer[0]
                         .inntektsavkorting[1]
                         .grunnlag
-                        .toDto(10)
+                        .toDto()
                 it.avkortingGrunnlag[2] shouldBe
                     avkorting.aarsoppgjoer[1]
                         .inntektsavkorting[0]
                         .grunnlag
-                        .toDto(12)
+                        .toDto()
             }
         }
 
@@ -227,6 +227,7 @@ internal class AvkortingTest {
     inner class AvkortingTilFrontend {
         val inntektFraMars24 =
             avkortinggrunnlag(
+                innvilgaMaaneder = 10,
                 periode =
                     Periode(
                         fom = YearMonth.of(2024, Month.MARCH),
@@ -236,6 +237,7 @@ internal class AvkortingTest {
             )
         val inntektFraAug24 =
             avkortinggrunnlag(
+                innvilgaMaaneder = 10,
                 periode =
                     Periode(
                         fom = YearMonth.of(2024, Month.AUGUST),
@@ -245,6 +247,7 @@ internal class AvkortingTest {
             )
         val inntektFraJan25 =
             avkortinggrunnlag(
+                innvilgaMaaneder = 12,
                 periode =
                     Periode(
                         fom = YearMonth.of(2025, Month.JANUARY),
@@ -259,7 +262,7 @@ internal class AvkortingTest {
                         Aarsoppgjoer(
                             id = UUID.randomUUID(),
                             aar = 2024,
-                            forventaInnvilgaMaaneder = 10,
+                            fom = YearMonth.of(2024, Month.MARCH),
                             inntektsavkorting =
                                 listOf(
                                     Inntektsavkorting(grunnlag = inntektFraMars24),
@@ -289,7 +292,7 @@ internal class AvkortingTest {
                         Aarsoppgjoer(
                             id = UUID.randomUUID(),
                             aar = 2025,
-                            forventaInnvilgaMaaneder = 12,
+                            fom = YearMonth.of(2025, Month.JANUARY),
                             inntektsavkorting =
                                 listOf(
                                     Inntektsavkorting(
@@ -494,7 +497,7 @@ internal class AvkortingTest {
                         Aarsoppgjoer(
                             id = UUID.randomUUID(),
                             aar = 2024,
-                            forventaInnvilgaMaaneder = 6,
+                            fom = YearMonth.of(2024, 1),
                             ytelseFoerAvkorting =
                                 listOf(
                                     YtelseFoerAvkorting(
@@ -586,7 +589,7 @@ internal class AvkortingTest {
                 opprettaAvkorting.aarsoppgjoer.single().shouldBeEqualToIgnoringFields(
                     aarsoppgjoer(
                         aar = 2024,
-                        forventaInnvilgaMaaneder = 10,
+                        fom = YearMonth.of(2024, 3),
                     ),
                     Aarsoppgjoer::id,
                     Aarsoppgjoer::inntektsavkorting,
@@ -731,7 +734,7 @@ internal class AvkortingTest {
                     shouldBeEqualToIgnoringFields(
                         aarsoppgjoer(
                             aar = 2025,
-                            forventaInnvilgaMaaneder = 12,
+                            fom = YearMonth.of(2025, 1),
                         ),
                         Aarsoppgjoer::inntektsavkorting,
                         Aarsoppgjoer::id,
@@ -758,8 +761,8 @@ internal class AvkortingTest {
             assertThrows<InternfeilException> {
                 Avkorting(
                     listOf(
-                        Aarsoppgjoer(aar = 2025, id = UUID.randomUUID(), forventaInnvilgaMaaneder = 12),
-                        Aarsoppgjoer(aar = 2024, id = UUID.randomUUID(), forventaInnvilgaMaaneder = 12),
+                        Aarsoppgjoer(aar = 2025, id = UUID.randomUUID(), fom = YearMonth.of(2025, 1)),
+                        Aarsoppgjoer(aar = 2024, id = UUID.randomUUID(), fom = YearMonth.of(2024, 1)),
                     ),
                 )
             }
@@ -779,7 +782,7 @@ internal class AvkortingTest {
                             ytelseFoerAvkorting = ytelseFoerAvkorting,
                             aar = 2024,
                             id = UUID.randomUUID(),
-                            forventaInnvilgaMaaneder = 12,
+                            fom = YearMonth.of(2024, 1),
                         ),
                     ),
                 )
@@ -816,7 +819,7 @@ internal class AvkortingTest {
                             inntektsavkorting = inntektsavkorting,
                             aar = 2024,
                             id = UUID.randomUUID(),
-                            forventaInnvilgaMaaneder = 12,
+                            fom = YearMonth.of(2024, 1),
                         ),
                     ),
                 )
@@ -837,7 +840,7 @@ internal class AvkortingTest {
                             avkortetYtelseAar = avkortetYtelseAar,
                             aar = 2024,
                             id = UUID.randomUUID(),
-                            forventaInnvilgaMaaneder = 12,
+                            fom = YearMonth.of(2024, 1),
                         ),
                     ),
                 )
@@ -873,5 +876,12 @@ internal class AvkortingTest {
                 )
             }
         }
+    }
+
+    @Test
+    fun `utledning av innvilga måneder`() {
+        val aarsoppgjoerFom = YearMonth.of(2024, 3)
+        val opphoerFom = YearMonth.of(2024, 7)
+        finnAntallInnvilgaMaanederForAar(aarsoppgjoerFom, opphoerFom) shouldBe 4
     }
 }

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -881,6 +881,12 @@ internal class AvkortingTest {
     @Test
     fun `utledning av innvilga måneder`() {
         val aarsoppgjoerFom = YearMonth.of(2024, 3)
+        finnAntallInnvilgaMaanederForAar(aarsoppgjoerFom, null) shouldBe 10
+    }
+
+    @Test
+    fun `utledning av innvilga måneder med opphør`() {
+        val aarsoppgjoerFom = YearMonth.of(2024, 3)
         val opphoerFom = YearMonth.of(2024, 7)
         finnAntallInnvilgaMaanederForAar(aarsoppgjoerFom, opphoerFom) shouldBe 4
     }

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingValiderTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingValiderTest.kt
@@ -25,12 +25,14 @@ class AvkortingValiderTest {
                 aarsoppgjoer =
                     listOf(
                         aarsoppgjoer(
-                            forventaInnvilgaMaaneder = 11,
                             aar = 2024,
                             inntektsavkorting =
                                 listOf(
                                     Inntektsavkorting(
-                                        avkortinggrunnlag(periode = Periode(fom = YearMonth.of(2024, 2), tom = null)),
+                                        avkortinggrunnlag(
+                                            innvilgaMaaneder = 11,
+                                            periode = Periode(fom = YearMonth.of(2024, 2), tom = null),
+                                        ),
                                     ),
                                 ),
                         ),
@@ -58,15 +60,20 @@ class AvkortingValiderTest {
                 aarsoppgjoer =
                     listOf(
                         aarsoppgjoer(
-                            forventaInnvilgaMaaneder = 12,
                             aar = 2024,
                             inntektsavkorting =
                                 listOf(
                                     Inntektsavkorting(
-                                        avkortinggrunnlag(periode = Periode(fom = YearMonth.of(2024, 1), tom = null)),
+                                        avkortinggrunnlag(
+                                            innvilgaMaaneder = 11,
+                                            periode = Periode(fom = YearMonth.of(2024, 1), tom = null),
+                                        ),
                                     ),
                                     Inntektsavkorting(
-                                        avkortinggrunnlag(periode = Periode(fom = YearMonth.of(2024, 2), tom = null)),
+                                        avkortinggrunnlag(
+                                            innvilgaMaaneder = 11,
+                                            periode = Periode(fom = YearMonth.of(2024, 2), tom = null),
+                                        ),
                                     ),
                                 ),
                         ),
@@ -130,12 +137,12 @@ class AvkortingValiderTest {
                     aarsoppgjoer =
                         listOf(
                             aarsoppgjoer(
-                                forventaInnvilgaMaaneder = 12,
                                 aar = 2024,
                                 inntektsavkorting =
                                     listOf(
                                         Inntektsavkorting(
                                             avkortinggrunnlag(
+                                                innvilgaMaaneder = 12,
                                                 periode = Periode(fom = YearMonth.of(2024, 1), tom = null),
                                                 fratrekkInnAar = 100000,
                                                 fratrekkInnAarUtland = 50000,
@@ -182,7 +189,6 @@ class AvkortingValiderTest {
                     aarsoppgjoer =
                         listOf(
                             aarsoppgjoer(
-                                forventaInnvilgaMaaneder = 12,
                                 aar = 2025,
                                 inntektsavkorting = listOf(),
                             ),

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingMedToInntektsTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingMedToInntektsTest.kt
@@ -27,7 +27,7 @@ class BeregnAvkortingMedToInntektsTest {
             size shouldBe 1
             get(0).shouldBeEqualToIgnoringFields(
                 avkortetYtelse(
-                    periode = Periode(fom = YearMonth.of(2024, Month.JULY), tom = null),
+                    periode = Periode(fom = YearMonth.of(2024, Month.JULY), tom = YearMonth.of(2024, Month.DECEMBER)),
                     ytelseEtterAvkorting = 7758,
                     ytelseEtterAvkortingFoerRestanse = 7758,
                     restanse = null,

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingTest.kt
@@ -1679,8 +1679,8 @@ class BeregnAvkortingTest {
     }
 
     @Test
-    fun `Revurdering enda en inntektsendring nytt år`() {
-        val avkorting = `Revurdering enda en ny inntekt nytt år`()
+    fun `Revurdering inntektsendring nytt år med opphør`() {
+        val avkorting = `Revurdering ny inntekt nytt år med opphør`()
         with(avkorting.aarsoppgjoer[0].avkortetYtelseAar) {
             size shouldBe 6
             get(0).asClue {
@@ -1884,11 +1884,11 @@ class BeregnAvkortingTest {
                         periode =
                             Periode(
                                 fom = YearMonth.of(2026, Month.JANUARY),
-                                tom = null,
+                                tom = YearMonth.of(2026, Month.JUNE),
                             ),
-                        ytelseEtterAvkorting = 2879,
-                        ytelseEtterAvkortingFoerRestanse = 2879,
-                        avkortingsbeloep = 17362,
+                        ytelseEtterAvkorting = 2917,
+                        ytelseEtterAvkortingFoerRestanse = 2917,
+                        avkortingsbeloep = 17324,
                         ytelseFoerAvkorting = 20241,
                         inntektsgrunnlag = null,
                     ),
@@ -2261,15 +2261,16 @@ class BeregnAvkortingTest {
                 sanksjoner = emptyList(),
             )
 
-    private fun `Revurdering enda en ny inntekt nytt år`() =
+    private fun `Revurdering ny inntekt nytt år med opphør`() =
         `Revurdering med virk tilbake i tidligere år`()
             .kopierAvkorting()
             .beregnAvkortingMedNyttGrunnlag(
                 nyttGrunnlag =
                     avkortinggrunnlagLagre(
                         id = UUID.randomUUID(),
-                        aarsinntekt = 525000,
+                        aarsinntekt = 262500,
                         fratrekkInnAar = 0,
+                        // TODO Legge til fratrekk ut år når det kommer
                         fom = YearMonth.of(2026, Month.JANUARY),
                     ),
                 bruker = bruker,
@@ -2284,6 +2285,6 @@ class BeregnAvkortingTest {
                             ),
                     ),
                 sanksjoner = emptyList(),
-                opphoerFom = null,
+                opphoerFom = YearMonth.of(2026, Month.JULY),
             )
 }

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingTest.kt
@@ -1426,7 +1426,11 @@ class BeregnAvkortingTest {
                 it.shouldBeEqualToIgnoringFields(
                     avkortetYtelse(
                         type = AvkortetYtelseType.AARSOPPGJOER,
-                        periode = Periode(fom = YearMonth.of(2024, Month.SEPTEMBER), tom = null),
+                        periode =
+                            Periode(
+                                fom = YearMonth.of(2024, Month.SEPTEMBER),
+                                tom = YearMonth.of(2024, Month.DECEMBER),
+                            ),
                         ytelseEtterAvkorting = 3005,
                         ytelseEtterAvkortingFoerRestanse = 7692,
                         avkortingsbeloep = 14549,
@@ -1624,7 +1628,7 @@ class BeregnAvkortingTest {
                         periode =
                             Periode(
                                 fom = YearMonth.of(2024, Month.NOVEMBER),
-                                tom = null,
+                                tom = YearMonth.of(2024, Month.DECEMBER),
                             ),
                         ytelseEtterAvkorting = 1005,
                         ytelseEtterAvkortingFoerRestanse = 5692,
@@ -1823,7 +1827,7 @@ class BeregnAvkortingTest {
                         periode =
                             Periode(
                                 fom = YearMonth.of(2024, Month.NOVEMBER),
-                                tom = null,
+                                tom = YearMonth.of(2024, Month.DECEMBER),
                             ),
                         ytelseEtterAvkorting = 1005,
                         ytelseEtterAvkortingFoerRestanse = 5692,
@@ -1858,7 +1862,7 @@ class BeregnAvkortingTest {
                         periode =
                             Periode(
                                 fom = YearMonth.of(2025, Month.JANUARY),
-                                tom = null,
+                                tom = YearMonth.of(2025, Month.DECEMBER),
                             ),
                         ytelseEtterAvkorting = 3817,
                         ytelseEtterAvkortingFoerRestanse = 3817,
@@ -1902,6 +1906,8 @@ class BeregnAvkortingTest {
             }
         }
     }
+
+    // TODO Revurdering opphør midt i et år
 
     private fun `Avkorting foerstegangsbehandling`() =
         Avkorting()

--- a/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/Application.kt
@@ -70,7 +70,7 @@ class ApplicationBuilder {
                         sakGrunnlagRoute(grunnlagService, behandlingKlient)
                         behandlingGrunnlagRoute(grunnlagService, behandlingKlient)
                         personRoute(grunnlagService, behandlingKlient)
-                        aldersovergangRoutes(aldersovergangService)
+                        aldersovergangRoutes(behandlingKlient, aldersovergangService)
                     }
                 }
             },

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangDao.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangDao.kt
@@ -92,12 +92,11 @@ class AldersovergangDao(
         }
     }
 
-    fun hentAlder(
+    fun hentFoedselsdato(
         sakId: SakId,
         opplysningType: Opplysningstype,
-        paaDato: LocalDate,
         tx: TransactionalSession? = null,
-    ): Alder? {
+    ): LocalDate? {
         val sql =
             """
             select distinct TO_DATE(g.opplysning, '\"YYYY-MM-DD\"') as foedselsdato
@@ -115,7 +114,7 @@ class AldersovergangDao(
             """.trimIndent()
         return tx.session {
             hent(sql, mapOf("sak_id" to sakId, "opplysningType" to opplysningType.name)) {
-                it.localDate("foedselsdato").until(paaDato).years
+                it.localDate("foedselsdato")
             }
         }
     }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangRoutes.kt
@@ -1,10 +1,13 @@
 package no.nav.etterlatte.grunnlag.aldersovergang
 
+import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import java.time.YearMonth
 
 fun Route.aldersovergangRoutes(aldersovergangService: AldersovergangService) {
@@ -12,6 +15,21 @@ fun Route.aldersovergangRoutes(aldersovergangService: AldersovergangService) {
         get("{yearMonth}") {
             val yearMonth = call.parameters["yearMonth"].toString().let { YearMonth.parse(it) }
             call.respond(aldersovergangService.hentSoekereFoedtIEnGittMaaned(yearMonth))
+        }
+        get("sak/{sakId}/{sakType}") {
+            val sakId =
+                call.parameters["sakId"]?.toLong() ?: throw UgyldigForespoerselException(
+                    "MANGLER_SAKID",
+                    "Mangler sakId",
+                )
+            val sakType =
+                call.parameters["sakType"]?.let { SakType.valueOf(it) }
+                    ?: throw UgyldigForespoerselException("MANGLER_SAKTYPE", "Mangler sakType")
+
+            when (val maaned = aldersovergangService.aldersovergangMaaned(sakId, sakType)) {
+                null -> call.respond(HttpStatusCode.NoContent)
+                else -> call.respond(maaned)
+            }
         }
     }
 

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangRoutes.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangRoutes.kt
@@ -6,29 +6,32 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
+import no.nav.etterlatte.grunnlag.klienter.BehandlingKlient
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.ktor.route.sakId
+import no.nav.etterlatte.libs.ktor.route.withSakId
 import java.time.YearMonth
 
-fun Route.aldersovergangRoutes(aldersovergangService: AldersovergangService) {
+fun Route.aldersovergangRoutes(
+    behandlingKlient: BehandlingKlient,
+    aldersovergangService: AldersovergangService,
+) {
     route("/aldersovergang") {
         get("{yearMonth}") {
             val yearMonth = call.parameters["yearMonth"].toString().let { YearMonth.parse(it) }
             call.respond(aldersovergangService.hentSoekereFoedtIEnGittMaaned(yearMonth))
         }
         get("sak/{sakId}/{sakType}") {
-            val sakId =
-                call.parameters["sakId"]?.toLong() ?: throw UgyldigForespoerselException(
-                    "MANGLER_SAKID",
-                    "Mangler sakId",
-                )
-            val sakType =
-                call.parameters["sakType"]?.let { SakType.valueOf(it) }
-                    ?: throw UgyldigForespoerselException("MANGLER_SAKTYPE", "Mangler sakType")
+            withSakId(behandlingKlient) {
+                val sakType =
+                    call.parameters["sakType"]?.let { SakType.valueOf(it) }
+                        ?: throw UgyldigForespoerselException("MANGLER_SAKTYPE", "Mangler sakType")
 
-            when (val maaned = aldersovergangService.aldersovergangMaaned(sakId, sakType)) {
-                null -> call.respond(HttpStatusCode.NoContent)
-                else -> call.respond(maaned)
+                when (val maaned = aldersovergangService.aldersovergangMaaned(sakId, sakType)) {
+                    null -> call.respond(HttpStatusCode.NoContent)
+                    else -> call.respond(maaned)
+                }
             }
         }
     }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangService.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangService.kt
@@ -17,7 +17,8 @@ class AldersovergangService(
         val foedselsdato = dao.hentFoedselsdato(sakId, Opplysningstype.SOEKER_PDL_V1)
         return when (sakType) {
             SakType.BARNEPENSJON -> TODO()
-            SakType.OMSTILLINGSSTOENAD -> foedselsdato?.let { YearMonth.from(it.plusYears(67)) }
+            // Mottaker av Omstillingstønad opphører måned etter fylt 67 (§ 22-12 sjette ledd)
+            SakType.OMSTILLINGSSTOENAD -> foedselsdato?.let { YearMonth.from(it.plusYears(67).plusMonths(1)) }
         }
     }
 

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangService.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangService.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.grunnlag.aldersovergang
 
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.sak.SakId
@@ -16,7 +17,10 @@ class AldersovergangService(
     ): YearMonth? {
         val foedselsdato = dao.hentFoedselsdato(sakId, Opplysningstype.SOEKER_PDL_V1)
         return when (sakType) {
-            SakType.BARNEPENSJON -> TODO()
+            SakType.BARNEPENSJON -> throw UgyldigForespoerselException(
+                "SAKTYPE_IKKE_STØTTET",
+                "Uthenting av måned for opphør grunnet aldersovergang støttes ikke for barnepensjon",
+            )
             // Mottaker av Omstillingstønad opphører måned etter fylt 67 (§ 22-12 sjette ledd)
             SakType.OMSTILLINGSSTOENAD -> foedselsdato?.let { YearMonth.from(it.plusYears(67).plusMonths(1)) }
         }

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangService.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/aldersovergang/AldersovergangService.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.grunnlag.aldersovergang
 
+import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.sak.SakId
@@ -9,6 +10,17 @@ import java.time.YearMonth
 class AldersovergangService(
     private val dao: AldersovergangDao,
 ) {
+    fun aldersovergangMaaned(
+        sakId: SakId,
+        sakType: SakType,
+    ): YearMonth? {
+        val foedselsdato = dao.hentFoedselsdato(sakId, Opplysningstype.SOEKER_PDL_V1)
+        return when (sakType) {
+            SakType.BARNEPENSJON -> TODO()
+            SakType.OMSTILLINGSSTOENAD -> foedselsdato?.let { YearMonth.from(it.plusYears(67)) }
+        }
+    }
+
     fun hentSoekereFoedtIEnGittMaaned(maaned: YearMonth) = dao.hentSoekereFoedtIEnGittMaaned(maaned)
 
     fun hentSakerHvorDoedsfallForekomIGittMaaned(behandlingsmaaned: YearMonth) =
@@ -20,7 +32,7 @@ class AldersovergangService(
         paaDato: LocalDate,
     ): Alder? =
         when (rolle) {
-            PersonRolle.BARN -> dao.hentAlder(sakId, Opplysningstype.SOEKER_PDL_V1, paaDato)
+            PersonRolle.BARN -> dao.hentFoedselsdato(sakId, Opplysningstype.SOEKER_PDL_V1)?.until(paaDato)?.years
             else -> throw NotImplementedError("Ikke støtta å finne alder per nå for rolle $rolle")
         }
 }

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/aldersovergang/AldersovergangServiceTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/aldersovergang/AldersovergangServiceTest.kt
@@ -38,9 +38,9 @@ class AldersovergangServiceTest(
     }
 
     @Test
-    fun `Mottaker av omstillingstoenad henter måned fyller 67 år`() {
+    fun `Mottaker av omstillingstoenad henter måned etter fyller 67 år`() {
         lagSakMedSoekerFoedtPaaGittDato(LocalDate.of(2000, 6, 15))
-        service.aldersovergangMaaned(1L, SakType.OMSTILLINGSSTOENAD) shouldBe YearMonth.of(2067, 6)
+        service.aldersovergangMaaned(1L, SakType.OMSTILLINGSSTOENAD) shouldBe YearMonth.of(2067, 7)
     }
 
     private fun lagSakMedSoekerFoedtPaaGittDato(foedselsdato: LocalDate) {

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/aldersovergang/AldersovergangServiceTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/aldersovergang/AldersovergangServiceTest.kt
@@ -1,10 +1,12 @@
 package grunnlag.aldersovergang
 
+import io.kotest.matchers.shouldBe
 import no.nav.etterlatte.behandling.sakId1
 import no.nav.etterlatte.grunnlag.GrunnlagDbExtension
 import no.nav.etterlatte.grunnlag.aldersovergang.AldersovergangDao
 import no.nav.etterlatte.grunnlag.aldersovergang.AldersovergangService
 import no.nav.etterlatte.insert
+import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -12,6 +14,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDate
+import java.time.YearMonth
 import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -32,6 +35,12 @@ class AldersovergangServiceTest(
     fun `foedt for 20 aar siden i morgen er 19`() {
         lagSakMedSoekerFoedtPaaGittDato(LocalDate.now().minusYears(20).plusDays(1))
         assertEquals(19, service.hentAlder(sakId1, PersonRolle.BARN, LocalDate.now()))
+    }
+
+    @Test
+    fun `Mottaker av omstillingstoenad henter måned fyller 67 år`() {
+        lagSakMedSoekerFoedtPaaGittDato(LocalDate.of(2000, 6, 15))
+        service.aldersovergangMaaned(1L, SakType.OMSTILLINGSSTOENAD) shouldBe YearMonth.of(2067, 6)
     }
 
     private fun lagSakMedSoekerFoedtPaaGittDato(foedselsdato: LocalDate) {

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/aldersovergang/AldersovergangTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/aldersovergang/AldersovergangTest.kt
@@ -64,7 +64,12 @@ class AldersovergangTest(
         opplysningDao.leggTilOpplysning(sakId, Opplysningstype.FOEDSELSDATO, TextNode("2018-01-01"), fnrInnenfor)
         opplysningDao.leggTilOpplysning(sakId, Opplysningstype.FOEDSELSDATO, TextNode("2020-01-01"), fnrInnenfor)
         opplysningDao.leggTilOpplysning(sakId, Opplysningstype.SOEKER_PDL_V1, TextNode("hei, hallo"), fnrInnenfor)
-        opplysningDao.leggTilOpplysning(sakId, Opplysningstype.FOEDSELSDATO, TextNode("1987-04-20"), AVDOED_FOEDSELSNUMMER)
+        opplysningDao.leggTilOpplysning(
+            sakId,
+            Opplysningstype.FOEDSELSDATO,
+            TextNode("1987-04-20"),
+            AVDOED_FOEDSELSNUMMER,
+        )
 
         val sakIdUtenfor = randomSakId()
         val fnrUtenfor = HELSOESKEN_FOEDSELSNUMMER
@@ -149,6 +154,6 @@ class AldersovergangTest(
 
     private fun ApplicationTestBuilder.createHttpClient(service: AldersovergangService): HttpClient =
         runServer(mockOAuth2Server, "api/grunnlag") {
-            aldersovergangRoutes(service)
+            aldersovergangRoutes(mockk(), service)
         }
 }


### PR DESCRIPTION
- Antall innvilga måneder flyttes tilbake til avkortingsgrunnlag
- nytt felt 'fom' på årsoppgjør for å enkelt kunne vite første fom i året - til nå blitt utledet av aarsoppgjoer.innvilga_maaneder
- Setter oppørFom til avkorting basert på måned bruker har aldersovergang ved å hente info fra Grunnlag