### PR TITLE
EY-4537 Fikse bug + opprydding i hendelsesbildet

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/hendelser/ArkiverHendelseModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/hendelser/ArkiverHendelseModal.tsx
@@ -62,7 +62,7 @@ export const ArkiverHendelseModal = ({ hendelse }: { hendelse: Grunnlagsendrings
                 I noen tilfeller krever ikke ny informasjon eller hendelser noen revurdering. Beskriv hvorfor en
                 revurdering ikke er nødvendig.
               </BodyShort>
-              <Textarea label="Begrunnelse" value={kommentar} onChange={(e) => setKommentar(e.target.value)} />
+              <Textarea label="Kommentar" value={kommentar} onChange={(e) => setKommentar(e.target.value)} />
 
               {isFailureHandler({
                 apiResult: arkiverHendelseResult,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/hendelser/NyHendelseExpandableRow.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/hendelser/NyHendelseExpandableRow.tsx
@@ -1,12 +1,16 @@
 import React, { ReactNode } from 'react'
-import { Grunnlagsendringshendelse, IBehandlingsammendrag } from '~components/person/typer'
+import { Grunnlagsendringshendelse, GrunnlagsendringStatus, IBehandlingsammendrag } from '~components/person/typer'
 import { ISakMedUtlandstilknytning } from '~shared/types/sak'
 import { Revurderingaarsak } from '~shared/types/Revurderingaarsak'
 import { Alert, HStack, Link, Table, VStack } from '@navikt/ds-react'
 import { HendelseBeskrivelse } from '~components/person/hendelser/HendelseBeskrivelse'
-import { grunnlagsendringsTittel, stoetterRevurderingAvHendelse } from '~components/person/hendelser/utils'
+import {
+  grunnlagsendringsTittel,
+  harAapenRevurdering,
+  revurderingKanOpprettes,
+  stoetterRevurderingAvHendelse,
+} from '~components/person/hendelser/utils'
 import { formaterDato } from '~utils/formatering/dato'
-import { harAapenRevurdering, revurderingKanOpprettes } from '~components/person/hendelser/utils'
 import { useInnloggetSaksbehandler } from '~components/behandling/useInnloggetSaksbehandler'
 import { ArkiverHendelseModal } from '~components/person/hendelser/ArkiverHendelseModal'
 import { useSearchParams } from 'react-router-dom'
@@ -24,15 +28,18 @@ export const NyHendelseExpandableRow = ({ hendelse, sak, behandlinger, revurderi
 
   const [search] = useSearchParams()
 
+  const erValgtHendelse = search.get('referanse') === hendelse.id
+
   return (
     <Table.ExpandableRow
-      defaultOpen={search.get('referanse') === hendelse.id}
+      defaultOpen={erValgtHendelse}
+      selected={erValgtHendelse}
       expandOnRowClick
       content={
         <VStack gap="4">
           <HendelseBeskrivelse sakType={sak.sakType} hendelse={hendelse} />
 
-          {hendelse.status === 'TATT_MED_I_BEHANDLING' ? (
+          {hendelse.status === GrunnlagsendringStatus.TATT_MED_I_BEHANDLING ? (
             <Alert variant="info" inline>
               Denne hendelsen har en revurdering knyttet til seg.{' '}
               <Link href={`/behandling/${hendelse.behandlingId}/revurderingsoversikt`}>Gå til revurdering</Link>
@@ -52,7 +59,7 @@ export const NyHendelseExpandableRow = ({ hendelse, sak, behandlinger, revurderi
           <HStack gap="4">
             <ArkiverHendelseModal hendelse={hendelse} />
 
-            {hendelse.status !== 'TATT_MED_I_BEHANDLING' &&
+            {hendelse.status !== GrunnlagsendringStatus.TATT_MED_I_BEHANDLING &&
               stoetterRevurderingAvHendelse(hendelse, revurderinger) &&
               revurderingKanOpprettes(behandlinger, sak.enhet, innloggetSaksbehandler.enheter) && (
                 <OpprettRevurderingModal sakId={sak.id} sakType={sak.sakType} hendelseId={hendelse.id} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/typer.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/typer.tsx
@@ -56,19 +56,6 @@ export enum GrunnlagsendringsType {
   ADRESSE = 'ADRESSE',
 }
 
-export const GRUNNLAGSENDRING_STATUS = [
-  'VENTER_PAA_JOBB',
-  'SJEKKET_AV_JOBB',
-  'TATT_MED_I_BEHANDLING',
-  'VURDERT_SOM_IKKE_RELEVANT',
-  'FORKASTET',
-  'HISTORISK',
-] as const
-
-export const STATUS_IRRELEVANT: GrunnlagsendringStatus = 'VURDERT_SOM_IKKE_RELEVANT'
-export const TATT_MED_I_BEHANDLING: GrunnlagsendringStatus = 'TATT_MED_I_BEHANDLING'
-export const HISTORISK_REVURDERING: GrunnlagsendringStatus = 'HISTORISK'
-
 export interface DoedsdatoSamsvar {
   type: 'DOEDSDATO'
   samsvar: boolean
@@ -171,7 +158,14 @@ export type SamsvarMellomKildeOgGrunnlag =
   | InstitusjonsoppholdSamsvar
   | AdresseSamsvar
 
-export type GrunnlagsendringStatus = (typeof GRUNNLAGSENDRING_STATUS)[number]
+export enum GrunnlagsendringStatus {
+  VENTER_PAA_JOBB = 'VENTER_PAA_JOBB',
+  SJEKKET_AV_JOBB = 'SJEKKET_AV_JOBB',
+  TATT_MED_I_BEHANDLING = 'TATT_MED_I_BEHANDLING',
+  VURDERT_SOM_IKKE_RELEVANT = 'VURDERT_SOM_IKKE_RELEVANT',
+  FORKASTET = 'FORKASTET',
+  HISTORISK = 'HISTORISK',
+}
 
 const SAKSROLLER = ['SOEKER', 'INNSENDER', 'SOESKEN', 'AVDOED', 'GJENLEVENDE', 'UKJENT'] as const
 


### PR DESCRIPTION
- Fikse bug som gjorde at hendelser ikke lastet når man ble lenket direkte til siden.
- Endre fra "Begrunnelse" til "Kommentar" for at det skal være likt på tvers av alle oppgaver i løsningen. 
- Fikse filtrering på arkiverte hendelser (den viste tidligere de aktive også).
- Opprydding i type. Endret til enum. 
- Bruke `selected` på tabellraden for å tydeliggjøre hvilken som er valgt (ved redirect).
