### PR TITLE
EY-3570 Støtte paginering på journalposter

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/DokumentRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/DokumentRoute.kt
@@ -105,5 +105,6 @@ data class HentDokumenterRequest(
     val journalstatuser: List<Journalstatus> = emptyList(),
     val journalposttyper: List<Journalposttype> = emptyList(),
     val tema: List<String> = emptyList(),
-    val foerste: Int = 50,
+    val foerste: Int = 10,
+    val etter: String? = null,
 )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/Model.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/Model.kt
@@ -35,6 +35,32 @@ data class DokumentoversiktBruker(
 
 data class Journalposter(
     val journalposter: List<Journalpost>,
+    val sideInfo: SideInfo,
+)
+
+/*
+* Metadata for å paginere mellom journalposter.
+*
+* Verdt å merke seg at denne gir utrolig forvirrende og lite intuitive verdier.
+* Eks. totaltAntall er ikke totalen du har filtrert på, men totalen som er registrert på bruker.
+*
+* Pagineringen vil også oppføre seg merkelig siden den også teller med de som er filtrert ut.
+* Eks. du søker på tema EYO, foerste=10 (antallet du henter). Du kan da få totaltAntall=30
+* i retur, hvorav 10 av de har tema PEN.
+* Det kan da se slik ut i bolker på 10:
+*   [9 EYO, 1 PEN], [5 EYO, 5 PEN], [6 EYO, 4 PEN]
+* I tilfellet over vil da første side kun inneholde 9 journalposter, selv om du har bedt om 10 stk.
+* Neste side vil så ha 5 journalposter, og siste side vil ha 6... ikke det minste forvirrende.
+*/
+data class SideInfo(
+    // 	Når man paginerer forover, pekeren for å fortsette.
+    val sluttpeker: String,
+    // 	True/False verdi for om neste side eksisterer, når man paginerer forover.
+    val finnesNesteSide: Boolean,
+    // 	Antall journalposter på denne siden.
+    val antall: Int,
+    // 	Totalt antall journalposter på alle sider.
+    val totaltAntall: Int,
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -75,6 +101,7 @@ data class DokumentOversiktBrukerVariables(
     val journalposttyper: List<Journalposttype>,
     val journalstatuser: List<Journalstatus>,
     val foerste: Int,
+    val etter: String? = null,
 ) : GraphqlVariables
 
 data class JournalpostVariables(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/dokument/SafService.kt
@@ -27,7 +27,7 @@ class SafService(
     suspend fun hentDokumenter(
         request: HentDokumenterRequest,
         bruker: BrukerTokenInfo,
-    ): List<Journalpost> {
+    ): Journalposter {
         logger.info("Henter journalposter for ident=${request.foedselsnummer}")
 
         val graphqlVariables =
@@ -37,12 +37,16 @@ class SafService(
                 journalposttyper = request.journalposttyper,
                 journalstatuser = request.journalstatuser,
                 foerste = request.foerste,
+                etter = request.etter,
             )
 
         val response = safKlient.hentDokumenter(graphqlVariables, bruker)
 
         return if (response.errors.isNullOrEmpty()) {
-            response.data?.dokumentoversiktBruker?.journalposter ?: emptyList()
+            response.data?.dokumentoversiktBruker ?: throw IkkeFunnetException(
+                code = "INGEN_JOURNALPOSTER_FUNNET",
+                detail = "Fant ingen journalposter på brukeren",
+            )
         } else {
             throw konverterTilForespoerselException(response.errors)
         }

--- a/apps/etterlatte-brev-api/src/main/resources/graphql/dokumentoversiktBruker.graphql
+++ b/apps/etterlatte-brev-api/src/main/resources/graphql/dokumentoversiktBruker.graphql
@@ -4,13 +4,15 @@ query(
     $journalstatuser: [Journalstatus!],
     $journalposttyper: [Journalposttype!],
     $foerste: Int!,
+    $etter: String,
 ) {
     dokumentoversiktBruker(
         brukerId: $brukerId,
         tema: $tema,
         journalstatuser: $journalstatuser,
         journalposttyper: $journalposttyper,
-        foerste: $foerste
+        foerste: $foerste,
+        etter: $etter
     ) {
         journalposter {
             journalpostId
@@ -42,6 +44,12 @@ query(
             }
             kanal
             datoOpprettet
+        }
+        sideInfo {
+            sluttpeker
+            finnesNesteSide
+            antall
+            totaltAntall
         }
     }
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentFilter.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentFilter.tsx
@@ -33,6 +33,8 @@ export interface DokumentFilter {
   tema: Tema[]
   type: Journalposttype[]
   status: Journalstatus[]
+  foerste?: number
+  etter?: string
 }
 
 export const DokumentFilter = ({

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/Dokumentliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/Dokumentliste.tsx
@@ -1,14 +1,15 @@
-import { Box, Detail, Heading, Table, VStack } from '@navikt/ds-react'
+import { Box, Button, Detail, Heading, HStack, Table, VStack } from '@navikt/ds-react'
 import Spinner from '~shared/Spinner'
-import { Tema } from '~shared/types/Journalpost'
+import { Journalpost, SideInfo, Tema } from '~shared/types/Journalpost'
 import { ApiErrorAlert } from '~ErrorBoundary'
-import { mapApiResult, Result } from '~shared/api/apiUtils'
+import { isPending, mapResult, Result } from '~shared/api/apiUtils'
 import React, { useEffect, useState } from 'react'
 import { hentDokumenter } from '~shared/api/dokument'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { DokumentFilter } from '~components/person/dokumenter/DokumentFilter'
 import { SakMedBehandlinger } from '~components/person/typer'
 import { DokumentRad } from './DokumentRad'
+import { ArrowDownIcon } from '@navikt/aksel-icons'
 
 export const Dokumentliste = ({ fnr, sakResult }: { fnr: string; sakResult: Result<SakMedBehandlinger> }) => {
   const [filter, setFilter] = useState<DokumentFilter>({
@@ -16,12 +17,31 @@ export const Dokumentliste = ({ fnr, sakResult }: { fnr: string; sakResult: Resu
     type: [],
     status: [],
   })
+
+  const [journalposter, setJournalposter] = useState<Journalpost[]>([])
+  const [sideInfo, setSideInfo] = useState<SideInfo>()
+
   const [dokumenter, hentDokumenterForBruker] = useApiCall(hentDokumenter)
 
-  useEffect(
-    () => void hentDokumenterForBruker({ fnr, temaer: filter.tema, typer: filter.type, statuser: filter.status }),
-    [fnr, filter]
-  )
+  useEffect(() => void hent(), [fnr, filter])
+
+  const hent = (etter?: string) =>
+    void hentDokumenterForBruker(
+      {
+        fnr,
+        temaer: filter.tema,
+        typer: filter.type,
+        statuser: filter.status,
+        foerste: 50,
+        etter,
+      },
+      (response) => {
+        if (etter) setJournalposter([...journalposter, ...response.journalposter])
+        else setJournalposter(response.journalposter)
+
+        setSideInfo(response.sideInfo)
+      }
+    )
 
   return (
     <Box padding="8">
@@ -47,39 +67,51 @@ export const Dokumentliste = ({ fnr, sakResult }: { fnr: string; sakResult: Resu
           </Table.Header>
 
           <Table.Body>
-            {mapApiResult(
-              dokumenter,
+            {mapResult(dokumenter, {
+              error: (error) => (
+                <Table.Row>
+                  <Table.DataCell colSpan={100}>
+                    <ApiErrorAlert>
+                      {error.detail || 'Det har oppstått en feil ved henting av dokumenter'}
+                    </ApiErrorAlert>
+                  </Table.DataCell>
+                </Table.Row>
+              ),
+            })}
+
+            {!isPending(dokumenter) && !journalposter.length ? (
+              <Table.Row shadeOnHover={false}>
+                <Table.DataCell colSpan={100}>
+                  <Detail>
+                    <i>Ingen dokumenter funnet</i>
+                  </Detail>
+                </Table.DataCell>
+              </Table.Row>
+            ) : (
+              <>
+                {journalposter.map((dokument) => (
+                  <DokumentRad key={dokument.journalpostId} dokument={dokument} sakStatus={sakResult} />
+                ))}
+              </>
+            )}
+
+            {isPending(dokumenter) && (
               <Table.Row>
                 <Table.DataCell colSpan={100}>
                   <Spinner margin="0" label="Henter dokumenter" />
                 </Table.DataCell>
-              </Table.Row>,
-              () => (
-                <Table.Row>
-                  <Table.DataCell colSpan={100}>
-                    <ApiErrorAlert>Det har oppstått en feil ved henting av dokumenter</ApiErrorAlert>
-                  </Table.DataCell>
-                </Table.Row>
-              ),
-              (dokumentListe) =>
-                !dokumentListe.length ? (
-                  <Table.Row shadeOnHover={false}>
-                    <Table.DataCell colSpan={100}>
-                      <Detail>
-                        <i>Ingen dokumenter funnet</i>
-                      </Detail>
-                    </Table.DataCell>
-                  </Table.Row>
-                ) : (
-                  <>
-                    {dokumentListe.map((dokument) => (
-                      <DokumentRad key={dokument.journalpostId} dokument={dokument} sakStatus={sakResult} />
-                    ))}
-                  </>
-                )
+              </Table.Row>
             )}
           </Table.Body>
         </Table>
+
+        <HStack justify="center" marginBlock="4">
+          {sideInfo?.finnesNesteSide && (
+            <Button variant="secondary" onClick={() => hent(sideInfo?.sluttpeker)} icon={<ArrowDownIcon />}>
+              Last flere
+            </Button>
+          )}
+        </HStack>
       </VStack>
     </Box>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentlisteLiten.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentlisteLiten.tsx
@@ -1,29 +1,41 @@
-import { Alert, BodyShort, Detail, Heading, HStack, Link } from '@navikt/ds-react'
+import { Alert, BodyShort, Box, Button, Detail, Heading, HStack, Link } from '@navikt/ds-react'
 import Spinner from '~shared/Spinner'
-import { ExternalLinkIcon } from '@navikt/aksel-icons'
-import { Journalstatus } from '~shared/types/Journalpost'
-import { mapApiResult } from '~shared/api/apiUtils'
+import { ArrowDownIcon, ExternalLinkIcon } from '@navikt/aksel-icons'
+import { Journalpost, Journalstatus, SideInfo } from '~shared/types/Journalpost'
+import { mapResult } from '~shared/api/apiUtils'
 import { SidebarPanel } from '~shared/components/Sidebar'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { hentDokumenter } from '~shared/api/dokument'
-import { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { ApiErrorAlert } from '~ErrorBoundary'
+import { filter } from 'lodash'
 import { DokumentInfoDetail } from '~components/person/dokumenter/DokumentInfoDetail'
 import { PersonButtonLink } from '~components/person/lenker/PersonButtonLink'
 import { PersonOversiktFane } from '~components/person/Person'
 
 export const DokumentlisteLiten = ({ fnr }: { fnr: string }) => {
+  const [journalposter, setJournalposter] = useState<Journalpost[]>([])
+  const [sideInfo, setSideInfo] = useState<SideInfo>()
+
   const [status, hentDokumenterForBruker] = useApiCall(hentDokumenter)
 
-  useEffect(
-    () =>
-      void hentDokumenterForBruker({
+  useEffect(() => void hent(), [fnr, filter])
+
+  const hent = (etter?: string) =>
+    void hentDokumenterForBruker(
+      {
         fnr,
         statuser: [Journalstatus.FERDIGSTILT, Journalstatus.JOURNALFOERT, Journalstatus.EKSPEDERT],
         foerste: 10,
-      }),
-    [fnr]
-  )
+        etter,
+      },
+      (response) => {
+        if (etter) setJournalposter([...journalposter, ...response.journalposter])
+        else setJournalposter(response.journalposter)
+
+        setSideInfo(response.sideInfo)
+      }
+    )
 
   return (
     <SidebarPanel $border>
@@ -31,64 +43,66 @@ export const DokumentlisteLiten = ({ fnr }: { fnr: string }) => {
         Dokumenter
       </Heading>
 
-      {mapApiResult(
-        status,
-        <Spinner label="Henter dokumenter" />,
-        (error) => (
+      {journalposter?.map((journalpost) => (
+        <div key={journalpost.journalpostId}>
+          {journalpost.dokumenter.map((dokumentInfo) => (
+            <BodyShort key={dokumentInfo.dokumentInfoId} as="div" size="small" spacing>
+              {dokumentInfo.dokumentvarianter[0]?.saksbehandlerHarTilgang ? (
+                <Link
+                  href={`/api/dokumenter/${journalpost.journalpostId}/${dokumentInfo.dokumentInfoId}`}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  {dokumentInfo.tittel}
+                  <ExternalLinkIcon aria-hidden title={journalpost.tittel} />
+                </Link>
+              ) : (
+                <>
+                  {dokumentInfo.tittel}
+                  <Alert variant="warning" size="small" inline>
+                    Mangler tilgang
+                  </Alert>
+                </>
+              )}
+
+              <DokumentInfoDetail dokument={journalpost} />
+            </BodyShort>
+          ))}
+        </div>
+      )) || (
+        <Detail style={{ textAlign: 'center' }}>
+          <i>Ingen dokumenter ble funnet</i>
+        </Detail>
+      )}
+
+      {sideInfo?.finnesNesteSide && (
+        <Button variant="secondary" size="small" onClick={() => hent(sideInfo?.sluttpeker)} icon={<ArrowDownIcon />}>
+          Last flere
+        </Button>
+      )}
+
+      {mapResult(status, {
+        pending: <Spinner label="Henter dokumenter" />,
+        error: (error) => (
           <ApiErrorAlert>{error.detail || 'Det har oppstått en feil ved henting av dokumenter'}</ApiErrorAlert>
         ),
-        (journalposter) => (
-          <>
-            {journalposter.map((journalpost) => (
-              <div key={journalpost.journalpostId}>
-                {journalpost.dokumenter.map((dokumentInfo) => (
-                  <BodyShort key={dokumentInfo.dokumentInfoId} as="div" size="small" spacing>
-                    {dokumentInfo.dokumentvarianter[0]?.saksbehandlerHarTilgang ? (
-                      <Link
-                        href={`/api/dokumenter/${journalpost.journalpostId}/${dokumentInfo.dokumentInfoId}`}
-                        target="_blank"
-                        rel="noreferrer noopener"
-                      >
-                        {dokumentInfo.tittel}
-                        <ExternalLinkIcon aria-hidden title={journalpost.tittel} />
-                      </Link>
-                    ) : (
-                      <>
-                        {dokumentInfo.tittel}
-                        <Alert variant="warning" size="small" inline>
-                          Mangler tilgang
-                        </Alert>
-                      </>
-                    )}
+      })}
 
-                    <DokumentInfoDetail dokument={journalpost} />
-                  </BodyShort>
-                ))}
-              </div>
-            )) || (
-              <Detail style={{ textAlign: 'center' }}>
-                <i>Ingen dokumenter ble funnet</i>
-              </Detail>
-            )}
-
-            <hr />
-
-            <HStack justify="end">
-              <PersonButtonLink
-                fnr={fnr}
-                fane={PersonOversiktFane.DOKUMENTER}
-                variant="tertiary"
-                size="small"
-                target="_blank"
-                rel="noreferrer noopener"
-                icon={<ExternalLinkIcon />}
-              >
-                Gå til dokumentoversikten
-              </PersonButtonLink>
-            </HStack>
-          </>
-        )
-      )}
+      <Box borderColor="border-subtle" borderWidth="1 0 0 0" paddingBlock="4 0" marginBlock="4 0">
+        <HStack justify="end">
+          <PersonButtonLink
+            fnr={fnr}
+            fane={PersonOversiktFane.DOKUMENTER}
+            variant="tertiary"
+            size="small"
+            target="_blank"
+            rel="noreferrer noopener"
+            icon={<ExternalLinkIcon />}
+          >
+            Gå til dokumentoversikten
+          </PersonButtonLink>
+        </HStack>
+      </Box>
     </SidebarPanel>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/dokument.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/dokument.ts
@@ -1,5 +1,6 @@
 import {
   Journalpost,
+  Journalposter,
   JournalpostUtsendingsinfo,
   KnyttTilAnnenSakRequest,
   KnyttTilAnnenSakResponse,
@@ -12,14 +13,16 @@ export const hentDokumenter = async (args: {
   temaer?: string[]
   statuser?: string[]
   typer?: string[]
-  foerste?: number
-}): Promise<ApiResponse<Journalpost[]>> =>
+  foerste: number
+  etter?: string
+}): Promise<ApiResponse<Journalposter>> =>
   apiClient.post(`/dokumenter`, {
     foedselsnummer: args.fnr,
     tema: args.temaer,
     journalstatuser: args.statuser,
     journalposttyper: args.typer,
     foerste: args.foerste,
+    etter: args.etter,
   })
 
 export const feilregistrerSakstilknytning = async (journalpostId: string): Promise<ApiResponse<any>> =>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/components/Sidebar.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/components/Sidebar.tsx
@@ -48,7 +48,6 @@ export const SidebarPanel = styled.div<{ $border?: boolean }>`
 const CollapsibleSidebar = styled.div<{ $collapsed: boolean }>`
   background: var(--a-white);
   border-left: 1px solid var(--a-border-subtle);
-  max-height: fit-content;
   min-width: ${(props) => (props.$collapsed ? '50px' : '20%')};
 `
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Journalpost.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Journalpost.ts
@@ -1,3 +1,8 @@
+export interface Journalposter {
+  journalposter: Journalpost[]
+  sideInfo: SideInfo
+}
+
 export interface Journalpost {
   journalpostId: string
   tittel: string
@@ -11,6 +16,13 @@ export interface Journalpost {
   sak?: JournalpostSak
   datoOpprettet: string
   utsendingsinfo?: object
+}
+
+export interface SideInfo {
+  sluttpeker: string
+  finnesNesteSide: boolean
+  antall: number
+  totaltAntall: number
 }
 
 export interface JournalpostUtsendingsinfo {


### PR DESCRIPTION
### Ny knapp på dokumentvisning i sidemeny:

<img width="610" alt="Screenshot 2024-10-04 at 14 24 38" src="https://github.com/user-attachments/assets/d5b01845-61c7-49ee-b439-eb6ce3574f2f">

### Ny knapp på dokumentoversikt: 

OBS: Dokumentoversikten laster 50 journalposter av gangen, så denne vil på de fleste saker være skjult i dev/prod. Satt 10 lokalt for å illustrere hvordan det blir.

<img width="2298" alt="Screenshot 2024-10-04 at 14 53 21" src="https://github.com/user-attachments/assets/3e4c6b04-79bf-46f0-9aab-a2eb4220b7c5">
