### PR TITLE
EY-4499 Fiks sakid problematikk for distribuer brev

### DIFF
--- a/apps/etterlatte-brev-kafka/src/main/kotlin/no/nav/etterlatte/klienter/BrevapiKlient.kt
+++ b/apps/etterlatte-brev-kafka/src/main/kotlin/no/nav/etterlatte/klienter/BrevapiKlient.kt
@@ -57,18 +57,19 @@ class BrevapiKlient(
     internal suspend fun distribuer(
         brevId: BrevID,
         distribusjonsType: DistribusjonsType,
+        sakId: SakId,
         journalpostIdInn: String? = null,
     ): BestillingsIdDto {
         try {
             logger.info("Distribuerer brev med id $brevId")
             return httpClient
                 .post(
-                    "$baseUrl/api/brev/$brevId/distribuer?journalpostIdInn=$journalpostIdInn&distribusjonsType=${distribusjonsType.name}",
+                    "$baseUrl/api/brev/$brevId/distribuer?journalpostIdInn=$journalpostIdInn&distribusjonsType=${distribusjonsType.name}&sakId=$sakId",
                 ) {
                     contentType(ContentType.Application.Json)
                 }.body<BestillingsIdDto>()
         } catch (e: ResponseException) {
-            logger.error("Henting av grunnlag for sak med brevId=$brevId feilet", e)
+            logger.error("Distribuering av brev med brevId=$brevId feilet", e)
 
             throw ForespoerselException(
                 status = e.response.status.value,

--- a/apps/etterlatte-brev-kafka/src/main/kotlin/no/nav/etterlatte/klienter/BrevapiKlient.kt
+++ b/apps/etterlatte-brev-kafka/src/main/kotlin/no/nav/etterlatte/klienter/BrevapiKlient.kt
@@ -74,7 +74,7 @@ class BrevapiKlient(
             throw ForespoerselException(
                 status = e.response.status.value,
                 code = "UKJENT_FEIL_KAN_IKKE_DISTRIBUERE_BREV",
-                detail = "Kunne ikke opprette brev brev med id: $brevId",
+                detail = "Kunne ikke distribuere brev med id: $brevId",
             )
         }
     }

--- a/apps/etterlatte-brev-kafka/src/main/kotlin/no/nav/etterlatte/rivers/DistribuerBrevRiver.kt
+++ b/apps/etterlatte-brev-kafka/src/main/kotlin/no/nav/etterlatte/rivers/DistribuerBrevRiver.kt
@@ -8,7 +8,6 @@ import no.nav.etterlatte.libs.common.brev.BestillingsIdDto
 import no.nav.etterlatte.libs.common.rapidsandrivers.setEventNameForHendelseType
 import no.nav.etterlatte.rapidsandrivers.BREV_ID_KEY
 import no.nav.etterlatte.rapidsandrivers.ListenerMedLogging
-import no.nav.etterlatte.rapidsandrivers.SAK_ID_KEY
 import no.nav.etterlatte.rapidsandrivers.sakId
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
@@ -23,7 +22,7 @@ internal class DistribuerBrevRiver(
 
     init {
         initialiserRiver(rapidsConnection, BrevHendelseType.JOURNALFOERT) {
-            validate { it.requireKey(BREV_ID_KEY, "journalpostId", "distribusjonType", SAK_ID_KEY) }
+            validate { it.requireKey(BREV_ID_KEY, "journalpostId", "distribusjonType") }
             validate { it.requireKey("vedtak.sak.id") }
             validate { it.rejectKey("bestillingsId") }
         }

--- a/apps/etterlatte-brev-kafka/src/main/kotlin/no/nav/etterlatte/rivers/DistribuerBrevRiver.kt
+++ b/apps/etterlatte-brev-kafka/src/main/kotlin/no/nav/etterlatte/rivers/DistribuerBrevRiver.kt
@@ -32,14 +32,7 @@ internal class DistribuerBrevRiver(
         packet: JsonMessage,
         context: MessageContext,
     ) {
-        val sakid = {
-            val vedtakSakId = packet["vedtak.sak.id"].asLong()
-            if (vedtakSakId != 0L) {
-                vedtakSakId
-            } else {
-                packet.sakId
-            }
-        }
+        val sakid = packet["vedtak.sak.id"].asLong()
 
         val bestillingsId =
             runBlocking {
@@ -47,7 +40,7 @@ internal class DistribuerBrevRiver(
                     brevId = packet[BREV_ID_KEY].asLong(),
                     distribusjonsType = packet.distribusjonType(),
                     journalpostIdInn = packet["journalpostId"].asText(),
-                    sakId = sakid(),
+                    sakId = sakid,
                 )
             }
         rapidsConnection.svarSuksess(packet, bestillingsId)

--- a/apps/etterlatte-brev-kafka/src/main/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiver.kt
+++ b/apps/etterlatte-brev-kafka/src/main/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiver.kt
@@ -15,7 +15,6 @@ import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseHendelseType
 import no.nav.etterlatte.rapidsandrivers.BREV_ID_KEY
 import no.nav.etterlatte.rapidsandrivers.ListenerMedLogging
-import no.nav.etterlatte.rapidsandrivers.SAK_ID_KEY
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
@@ -65,7 +64,6 @@ internal class JournalfoerVedtaksbrevRiver(
                     packet,
                     journalfoervedtaksbrevResponse.brevId,
                     journalfoervedtaksbrevResponse.opprettetJournalpost.journalpostId,
-                    vedtak,
                 )
             }
         } catch (e: Exception) {
@@ -80,12 +78,10 @@ internal class JournalfoerVedtaksbrevRiver(
         packet: JsonMessage,
         brevId: BrevID,
         journalpostId: String,
-        vedtakTilJournalfoering: VedtakTilJournalfoering,
     ) {
         logger.info("Brev har blitt distribuert. Svarer tilbake med bekreftelse.")
         packet.setEventNameForHendelseType(BrevHendelseType.JOURNALFOERT)
         packet[BREV_ID_KEY] = brevId
-        packet[SAK_ID_KEY] = vedtakTilJournalfoering.sak.id
         packet["journalpostId"] = journalpostId
         packet["distribusjonType"] =
             DistribusjonsType.VEDTAK.name


### PR DESCRIPTION
bare videresender sakid fra 
```
internal class JournalfoerVedtaksbrevRiver(
    private val rapidsConnection: RapidsConnection,
    private val brevapiKlient: BrevapiKlient,
) : ListenerMedLogging() {
    private val logger = LoggerFactory.getLogger(JournalfoerVedtaksbrevRiver::class.java)

    init {
        initialiserRiver(rapidsConnection, VedtakKafkaHendelseHendelseType.ATTESTERT) {
            validate { it.requireKey("vedtak") }
            validate { it.requireKey("vedtak.id") }
            validate { it.requireKey("vedtak.behandlingId") }
            validate { it.requireKey("vedtak.sak") }
            validate { it.requireKey("vedtak.sak.id") }
```