### PR TITLE
Hindre unødige deploys av brev-kafka

### DIFF
--- a/.github/workflows/app-etterlatte-brev-kafka.yaml
+++ b/.github/workflows/app-etterlatte-brev-kafka.yaml
@@ -14,6 +14,14 @@ on:
   push:
     branches:
       - main
+    paths:
+      - apps/etterlatte-brev-kafka/**
+      - "!apps/etterlatte-brev-kafka/.nais/*"
+      - libs/saksbehandling-common/**
+      - libs/etterlatte-behandling-model/**
+      - libs/etterlatte-vedtaksvurdering-model/**
+      - libs/etterlatte-brev-model/**
+      - gradle/libs.versions.toml
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Vi må definere paths både på push main og pull request i yaml-en, elles vil denne appen byggje på kvar einaste push til main