### PR TITLE
Forbedrer info til bruker ved endring av enhet

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/EndreEnhet.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/EndreEnhet.tsx
@@ -58,7 +58,7 @@ export const EndreEnhet = ({ sakId }: { sakId: number }) => {
 
               {!harTilgangPaaNyEnhet && (
                 <Alert variant="warning">
-                  Du har ikke tilgang på enheten vi byttet til, og vil ikke lengre kunne se saken.
+                  Du har ikke lenger tilgang til saken, siden du ikke har tilgang til enheten saken er byttet til.
                 </Alert>
               )}
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/EndreEnhet.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/EndreEnhet.tsx
@@ -1,25 +1,30 @@
 import { Alert, Button, Heading, HStack, Modal, Select, VStack } from '@navikt/ds-react'
 import React, { useState } from 'react'
 import { useApiCall } from '~shared/hooks/useApiCall'
-import { isPending } from '~shared/api/apiUtils'
+import { isFailure, isPending, isSuccess } from '~shared/api/apiUtils'
 import { byttEnhetPaaSak } from '~shared/api/sak'
 import { ENHETER, EnhetFilterKeys, filtrerEnhet } from '~shared/types/Enhet'
 import { PencilIcon } from '@navikt/aksel-icons'
+import { ApiErrorAlert } from '~ErrorBoundary'
+import { useInnloggetSaksbehandler } from '~components/behandling/useInnloggetSaksbehandler'
 
 export const EndreEnhet = ({ sakId }: { sakId: number }) => {
   const [error, setError] = useState<string | null>(null)
   const [open, setOpen] = useState(false)
   const [enhetsFilter, setEnhetsfilter] = useState<EnhetFilterKeys>('VELGENHET')
   const [endreEnhetStatus, endreEnhetKall, resetApiCall] = useApiCall(byttEnhetPaaSak)
+  const [enhetViByttetTil, setEnhetViByttetTil] = useState<string>('')
+  const innloggetSaksbehandler = useInnloggetSaksbehandler()
+
+  const harTilgangPaaNyEnhet = innloggetSaksbehandler.enheter.includes(enhetViByttetTil)
 
   function endreEnhet() {
     if (enhetsFilter === 'VELGENHET') {
       return setError('Du må velge en enhet')
     }
-    endreEnhetKall({ sakId: sakId, enhet: filtrerEnhet(enhetsFilter) }, () => {
-      closeAndReset()
-      setTimeout(() => window.location.reload(), 200)
-    })
+    const enhet = filtrerEnhet(enhetsFilter)
+    setEnhetViByttetTil(enhet)
+    endreEnhetKall({ sakId: sakId, enhet })
   }
 
   const closeAndReset = () => {
@@ -47,33 +52,68 @@ export const EndreEnhet = ({ sakId }: { sakId: number }) => {
         </Modal.Header>
 
         <Modal.Body>
-          <VStack gap="4">
-            <Alert variant="warning">
-              Hvis du endrer til en enhet du selv ikke har tilgang til, vil du ikke kunne flytte saken tilbake
-            </Alert>
+          {isSuccess(endreEnhetStatus) ? (
+            <VStack gap="4">
+              <Alert variant="success">Saken er flyttet til enhet {enhetViByttetTil}.</Alert>
 
-            <Select
-              label="Endre enhet"
-              value={enhetsFilter}
-              onChange={(e) => setEnhetsfilter(e.target.value as EnhetFilterKeys)}
-              error={error}
-            >
-              {Object.entries(ENHETER).map(([status, statusbeskrivelse]) => (
-                <option key={status} value={status}>
-                  {statusbeskrivelse}
-                </option>
-              ))}
-            </Select>
+              {!harTilgangPaaNyEnhet && (
+                <Alert variant="warning">
+                  Du har ikke tilgang på enheten vi byttet til, og vil ikke lengre kunne se saken.
+                </Alert>
+              )}
 
-            <HStack gap="2" justify="end">
-              <Button variant="secondary" onClick={closeAndReset}>
-                Avbryt
-              </Button>
-              <Button loading={isPending(endreEnhetStatus)} onClick={endreEnhet}>
-                Endre
-              </Button>
-            </HStack>
-          </VStack>
+              <HStack gap="2" justify="end">
+                <Button variant={harTilgangPaaNyEnhet ? 'secondary' : 'primary'} as="a" href="/">
+                  Gå til oppgavelisten
+                </Button>
+                {harTilgangPaaNyEnhet && (
+                  <Button variant="primary" onClick={() => window.location.reload()}>
+                    Last saken på nytt
+                  </Button>
+                )}
+              </HStack>
+            </VStack>
+          ) : (
+            <VStack gap="4">
+              <Alert variant="warning">
+                Hvis du endrer til en enhet du selv ikke har tilgang til, vil du ikke kunne flytte saken tilbake
+              </Alert>
+
+              {isFailure(endreEnhetStatus) && (
+                <ApiErrorAlert>
+                  Kunne ikke endre sakens enhet til {enhetsFilter}, på grunn av feil: {endreEnhetStatus.error.detail}
+                </ApiErrorAlert>
+              )}
+
+              <Select
+                label="Endre enhet"
+                value={enhetsFilter}
+                onChange={(e) => setEnhetsfilter(e.target.value as EnhetFilterKeys)}
+                error={error}
+              >
+                {Object.entries(ENHETER).map(([status, statusbeskrivelse]) => (
+                  <option key={status} value={status}>
+                    {statusbeskrivelse}
+                  </option>
+                ))}
+              </Select>
+
+              {enhetsFilter !== 'VELGENHET' && !innloggetSaksbehandler.enheter.includes(filtrerEnhet(enhetsFilter)) && (
+                <Alert variant="warning">
+                  Du har ikke tilgang til enhet {enhetsFilter}, og vil ikke kunne se saken etter flytting.
+                </Alert>
+              )}
+
+              <HStack gap="2" justify="end">
+                <Button variant="secondary" onClick={closeAndReset}>
+                  Avbryt
+                </Button>
+                <Button loading={isPending(endreEnhetStatus)} onClick={endreEnhet}>
+                  Endre
+                </Button>
+              </HStack>
+            </VStack>
+          )}
         </Modal.Body>
       </Modal>
     </div>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Enhet.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Enhet.ts
@@ -11,6 +11,6 @@ export const ENHETER = {
 
 export type EnhetFilterKeys = keyof typeof ENHETER
 
-export function filtrerEnhet(enhetsFilter: EnhetFilterKeys): String {
+export function filtrerEnhet(enhetsFilter: EnhetFilterKeys): string {
   return enhetsFilter.substring(1)
 }


### PR DESCRIPTION
Informerer bruker i forkant at de ikke har tilgang til enheten de endrer til, og forbedrer navigeringen i etterkant

Hvis bruker ikke har tilgang til enhet, før de endrer enhet:
![Screenshot 2024-10-09 at 09 40 42](https://github.com/user-attachments/assets/4c6653f9-020b-4326-97c4-1c8d3a674b1f)

Hvis bruker ikke har tilgang til enhet, etter de endret:
![Screenshot 2024-10-09 at 09 41 49](https://github.com/user-attachments/assets/82565849-9e12-4dd3-9cc4-b4098ba563ea)

Hvis bruker *har* tilgang til enhet, etter de endret:
![Screenshot 2024-10-09 at 09 44 54](https://github.com/user-attachments/assets/8339c226-f3f2-44c3-82df-f2c78932c41a)
