### PR TITLE
Fiks brev i crashloop prod

### DIFF
--- a/apps/etterlatte-brev-api/src/main/resources/db/prod/V23__oppdater_hendelse_ferdigstill.sql
+++ b/apps/etterlatte-brev-api/src/main/resources/db/prod/V23__oppdater_hendelse_ferdigstill.sql
@@ -1,0 +1,1 @@
+insert into hendelse (brev_id, status_id, payload) values (24379, 'FERDIGSTILT', '{}');


### PR DESCRIPTION
Siden brev-kafka var nede så ble en behandling attestert før underkjent hendelsen ble kjørt som førte til at brev hendelsen fikk status oppdatert