### PR TITLE
EY-4212 RHF og validering i vurdering av trygdeavtale

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/avtaler/TrygdeAvtale.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/avtaler/TrygdeAvtale.tsx
@@ -1,18 +1,5 @@
 import { FloppydiskIcon, HandshakeIcon, PencilIcon, XMarkIcon } from '@navikt/aksel-icons'
-import {
-  Alert,
-  Box,
-  Button,
-  Heading,
-  HelpText,
-  HGrid,
-  HStack,
-  Radio,
-  RadioGroup,
-  Select,
-  Textarea,
-  VStack,
-} from '@navikt/ds-react'
+import { Alert, Box, Button, Heading, HelpText, HGrid, HStack, Radio, Select, Textarea, VStack } from '@navikt/ds-react'
 import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import Spinner from '~shared/Spinner'
@@ -35,6 +22,10 @@ import { HjemmelLenke } from '~components/behandling/felles/HjemmelLenke'
 import { isPending, isSuccess } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { AvdoedesTrygdetidReadMore } from '~components/behandling/trygdetid/components/AvdoedesTrygdetidReadMore'
+import { useForm } from 'react-hook-form'
+import { ControlledRadioGruppe } from '~shared/components/radioGruppe/ControlledRadioGruppe'
+import { useBehandling } from '~components/behandling/useBehandling'
+import { ApiErrorAlert } from '~ErrorBoundary'
 
 interface TrygdetidAvtaleOptionProps {
   defaultBeskrivelse: string
@@ -64,12 +55,10 @@ export const TrygdeAvtale = ({ redigerbar }: Props) => {
   const [hentAlleTrygdetidAvtalerKriterierRequest, fetchTrygdetidAvtaleKriterier] = useApiCall(
     hentAlleTrygdetidAvtaleKriterier
   )
-  const [lagreTrygdeavtaleRequest, lagreTrygdeavtale] = useApiCall(lagreTrygdeavtaleForBehandling)
   const [hentTrygdeavtaleRequest, fetchTrygdeavtale] = useApiCall(hentTrygdeavtaleForBehandling)
   const [avtalerListe, setAvtalerListe] = useState<TrygdetidAvtale[]>()
   const [avtaleKriterierListe, setAvtaleKriterierListe] = useState<TrygdetidAvtaleKriteria[]>()
-  const [trygdeavtale, setTrygdeavtale] = useState<Trygdeavtale>({} as Trygdeavtale)
-  const [valgtAvtale, setValgtAvtale] = useState<TrygdetidAvtale>()
+  const [trygdeavtale, setTrygdeavtale] = useState<Trygdeavtale | undefined>(undefined)
   const [redigering, setRedigering] = useState<Boolean>(true)
 
   useEffect(() => {
@@ -93,51 +82,17 @@ export const TrygdeAvtale = ({ redigerbar }: Props) => {
     }
   }, [])
 
+  const oppdaterTrygdeavtale = (trygdeavtale: Trygdeavtale) => {
+    setRedigering(false)
+    setTrygdeavtale(trygdeavtale)
+  }
+
   const avbryt = () => {
-    if (redigering) {
-      setRedigering(false)
-    }
+    setRedigering(false)
   }
 
   const rediger = () => {
-    if (!redigering) {
-      velgAvtale(trygdeavtale?.avtaleKode)
-      setRedigering(true)
-    }
-  }
-
-  const lagre = () => {
-    if (!behandlingId) throw new Error('Mangler behandlingsid')
-    lagreTrygdeavtale(
-      {
-        behandlingId,
-        avtaleRequest: {
-          avtaleKode: trygdeavtale.avtaleKode,
-          avtaleDatoKode: trygdeavtale.avtaleDatoKode,
-          avtaleKriteriaKode: trygdeavtale.avtaleKriteriaKode,
-          personKrets: trygdeavtale.personKrets,
-          arbInntekt1G: trygdeavtale.arbInntekt1G,
-          arbInntekt1GKommentar: trygdeavtale.arbInntekt1GKommentar,
-          beregArt50: trygdeavtale.beregArt50,
-          beregArt50Kommentar: trygdeavtale.beregArt50Kommentar,
-          nordiskTrygdeAvtale: trygdeavtale.nordiskTrygdeAvtale,
-          nordiskTrygdeAvtaleKommentar: trygdeavtale.nordiskTrygdeAvtaleKommentar,
-          id: trygdeavtale.id,
-        } as TrygdeavtaleRequest,
-      },
-      (respons) => {
-        setTrygdeavtale(respons)
-        setRedigering(false)
-      }
-    )
-  }
-
-  const velgAvtale = (kode?: string) => {
-    if (kode && avtalerListe) {
-      setValgtAvtale(avtalerListe.find((avtale) => avtale.kode === kode))
-    } else {
-      setValgtAvtale(undefined)
-    }
+    setRedigering(true)
   }
 
   const trygdeavtaleOptionSort = (a: TrygdetidAvtaleOptions, b: TrygdetidAvtaleOptions) => {
@@ -158,264 +113,41 @@ export const TrygdeAvtale = ({ redigerbar }: Props) => {
         </HStack>
 
         <AvdoedesTrygdetidReadMore />
-
-        {!redigering && avtalerListe && avtaleKriterierListe && (
-          <>
-            <TrygdeavtaleVisning avtaler={avtalerListe} kriterier={avtaleKriterierListe} trygdeavtale={trygdeavtale} />
-            {redigerbar && (
-              <div>
-                <Button size="small" variant="secondary" onClick={rediger} type="button" icon={<PencilIcon />}>
-                  Rediger avtale
-                </Button>
-              </div>
-            )}
-          </>
-        )}
+        {!redigering &&
+          avtalerListe &&
+          avtaleKriterierListe &&
+          (trygdeavtale ? (
+            <>
+              <TrygdeavtaleVisning
+                avtaler={avtalerListe}
+                kriterier={avtaleKriterierListe}
+                trygdeavtale={trygdeavtale}
+              />
+              {redigerbar && (
+                <div>
+                  <Button size="small" variant="secondary" onClick={rediger} type="button" icon={<PencilIcon />}>
+                    Rediger avtale
+                  </Button>
+                </div>
+              )}
+            </>
+          ) : (
+            <ApiErrorAlert>
+              Kunne ikke vise trygdeavtale. Meld sak i porten hvis dette ikke løser seg selv ved å laste siden på nytt
+            </ApiErrorAlert>
+          ))}
         {isSuccess(hentAlleTrygdetidAvtalerRequest) &&
           isSuccess(hentAlleTrygdetidAvtalerKriterierRequest) &&
           isSuccess(hentTrygdeavtaleRequest) &&
           redigerbar &&
           redigering && (
-            <form>
-              <VStack gap="6">
-                <HStack gap="4">
-                  <Select
-                    label="Avtale"
-                    autoComplete="off"
-                    value={trygdeavtale.avtaleKode}
-                    onChange={(e) => {
-                      if (e.target.value) {
-                        setTrygdeavtale({ ...trygdeavtale, avtaleKode: e.target.value })
-                      }
-                      velgAvtale(e.target.value)
-                    }}
-                  >
-                    <TrygdetidAvtaleOptionsView
-                      defaultBeskrivelse="Velg avtale"
-                      trygdeavtaleOptions={hentAlleTrygdetidAvtalerRequest.data}
-                    />
-                  </Select>
-                  {valgtAvtale && valgtAvtale.datoer.length > 0 && (
-                    <Select
-                      label="Dato"
-                      autoComplete="off"
-                      value={trygdeavtale.avtaleDatoKode}
-                      onChange={(e) => {
-                        setTrygdeavtale({ ...trygdeavtale, avtaleDatoKode: e.target.value })
-                      }}
-                    >
-                      <TrygdetidAvtaleOptionsView
-                        defaultBeskrivelse="Velg avtaledato"
-                        trygdeavtaleOptions={valgtAvtale.datoer}
-                      />
-                    </Select>
-                  )}
-                </HStack>
-
-                <Box width="50%">
-                  <Select
-                    label="Kriterier for å omfattes av avtalen"
-                    autoComplete="off"
-                    value={trygdeavtale.avtaleKriteriaKode}
-                    onChange={(e) => setTrygdeavtale({ ...trygdeavtale, avtaleKriteriaKode: e.target.value })}
-                  >
-                    <TrygdetidAvtaleOptionsView
-                      defaultBeskrivelse="Velg kriterie"
-                      trygdeavtaleOptions={hentAlleTrygdetidAvtalerKriterierRequest.data}
-                    />
-                  </Select>
-                </Box>
-
-                <VStack gap="2">
-                  <Heading size="xsmall">Er avdøde i personkretsen i denne avtalen?</Heading>
-                  <RadioGroup
-                    legend=""
-                    size="small"
-                    onChange={(event) => setTrygdeavtale({ ...trygdeavtale, personKrets: event as JaNei })}
-                    value={trygdeavtale.personKrets || ''}
-                  >
-                    <HStack gap="8">
-                      <Radio value={JaNei.JA}>Ja</Radio>
-                      <Radio value={JaNei.NEI}>Nei</Radio>
-                    </HStack>
-                  </RadioGroup>
-                </VStack>
-
-                <HGrid gap="8 4" columns="60% 40%">
-                  <VStack gap="2">
-                    <HStack gap="2">
-                      <Heading size="xsmall">Er arbeidsinntekt i avtaleland på minst 1 G på dødstidspunktet?</Heading>
-                      <HelpText>
-                        Poengår (år med arbeidsinntekt på mer enn 1 G) i andre EØS-land medregnes som poengår, forutsatt
-                        at det ikke er tjent opp poengår i Norge i året. Hvis «Ja» gir det rett til fremtidige poeng,
-                        eller fremtidig trygdetid, ved en prorata beregning. Hvis «Nei» gir det ikke rett til dette.
-                      </HelpText>
-                    </HStack>
-                    <>
-                      <HjemmelLenke
-                        tittel="Rundskriv til hovednummer 45 kap. 3 punkt 3.3.2"
-                        lenke="https://lovdata.no/pro/rundskriv/r45-00/KAPITTEL_3-3-2-1"
-                      />
-                      <RadioGroup
-                        legend=""
-                        size="small"
-                        className="radioGroup"
-                        onChange={(event) => {
-                          setTrygdeavtale({ ...trygdeavtale, arbInntekt1G: event as JaNei })
-                        }}
-                        value={trygdeavtale.arbInntekt1G || ''}
-                      >
-                        <HStack gap="8">
-                          <Radio value={JaNei.JA}>Ja</Radio>
-                          <Radio value={JaNei.NEI}>Nei</Radio>
-                        </HStack>
-                      </RadioGroup>
-                      {trygdeavtale.arbInntekt1G === JaNei.NEI && (
-                        <Alert variant="info" size="small" inline>
-                          Det gis ikke rett til fremtidig trygdetid fra utland ved en prorata beregning. Hvis det heller
-                          ikke er rett til fremtidig trygdetid etter nasjonale regler, må du ta bort registrert
-                          fremtidig trygdetid.
-                        </Alert>
-                      )}
-                    </>
-                  </VStack>
-                  <Textarea
-                    label="Kommentar"
-                    value={trygdeavtale.arbInntekt1GKommentar}
-                    onChange={(e) => setTrygdeavtale({ ...trygdeavtale, arbInntekt1GKommentar: e.target.value })}
-                    minRows={2}
-                    autoComplete="off"
-                    size="small"
-                  />
-
-                  <VStack gap="2">
-                    <HStack gap="2">
-                      <Heading size="xsmall">Beregning etter artikkel 50 (EØS-forordning 883/2004)?</Heading>
-                      <HelpText>
-                        Denne artikkelen skal anvendes hvis det foreligger pensjonsrett i minst to EØS-land i tillegg
-                        til Norge, og hvis vilkårene for pensjon ikke er oppfylt i alle EØS-landene avdøde har
-                        opptjening i. Det skal gjøres en alternativ prorata-beregning med trygdetid kun for de
-                        EØS-landene der rett til pensjon er oppfylt. Dette er fordi trygdetid fra land der vilkårene
-                        ikke er oppfylte ikke skal medregnes hvis det ikke lønner seg.
-                      </HelpText>
-                    </HStack>
-                    <>
-                      <HjemmelLenke
-                        tittel="EØS-forordning 883/2004 artikkel 50"
-                        lenke="https://lovdata.no/pro/eu/32004r0883/ARTIKKEL_50"
-                      />
-                      <RadioGroup
-                        legend="Beregning etter artikkel 50 (EØS-forordning 883/2004)?"
-                        hideLegend={true}
-                        size="small"
-                        className="radioGroup"
-                        defaultValue={trygdeavtale.beregArt50}
-                        onChange={(event) => {
-                          setTrygdeavtale({ ...trygdeavtale, beregArt50: event as JaNei })
-                        }}
-                        value={trygdeavtale.beregArt50 || ''}
-                      >
-                        <HStack gap="8">
-                          <Radio value={JaNei.JA}>Ja</Radio>
-                          <Radio value={JaNei.NEI}>Nei</Radio>
-                        </HStack>
-                      </RadioGroup>
-                      {trygdeavtale.beregArt50 === JaNei.JA && (
-                        <Alert variant="info" size="small" inline>
-                          Ta en alternativ prorata-beregning. Huk av for «Ikke i prorata» på trygdetidsperioder for
-                          EØS-land som har gitt avslag på ytelse.
-                        </Alert>
-                      )}
-                    </>
-                  </VStack>
-                  <Textarea
-                    label="Kommentar"
-                    value={trygdeavtale.beregArt50Kommentar}
-                    onChange={(e) => setTrygdeavtale({ ...trygdeavtale, beregArt50Kommentar: e.target.value })}
-                    minRows={2}
-                    size="small"
-                    autoComplete="off"
-                  />
-
-                  <VStack gap="2">
-                    <HStack gap="2">
-                      <Heading size="xsmall">Skal artikkel 9 anvendes - fremtidig trygdetid avkortes?</Heading>
-                      <HelpText>
-                        Hvis forutgående medlemskap, og derav vilkår for å beregne framtidig trygdetid, er oppfylt etter
-                        nasjonale regler i Sverige og/eller Island i tillegg til Norge, skal framtidig trygdetid
-                        avkortes. I en prorata-beregnet ytelse, der forutgående medlemskap er oppfylt ved sammenlegging,
-                        er den framtidige trygdetiden allerede avkortet, og artikkelen skal ikke anvendes.
-                      </HelpText>
-                    </HStack>
-                    <>
-                      <HjemmelLenke
-                        tittel="Nordisk konvensjon artikkel 9"
-                        lenke="https://lovdata.no/pro/traktat/2012-06-12-18/ARTIKKEL_9"
-                      />
-                      <RadioGroup
-                        legend="Nordisk trygdeavtale: Skal artikkel 9 anvendes - fremtidig trygdetid avkortes?"
-                        hideLegend={true}
-                        size="small"
-                        className="radioGroup"
-                        onChange={(event) => {
-                          setTrygdeavtale({ ...trygdeavtale, nordiskTrygdeAvtale: event as JaNei })
-                        }}
-                        value={trygdeavtale.nordiskTrygdeAvtale || ''}
-                      >
-                        <HStack gap="8">
-                          <Radio value={JaNei.JA}>Ja</Radio>
-                          <Radio value={JaNei.NEI}>Nei</Radio>
-                        </HStack>
-                      </RadioGroup>
-                      {trygdeavtale.nordiskTrygdeAvtale === JaNei.JA && (
-                        <Alert variant="info" size="small" inline>
-                          Fremtidig trygdetid skal avkortes. Gjenny støtter ikke dette. Du må derfor beregne fremtidig
-                          trygdetid manuelt, og beregning av ytelsen må manuelt overstyres. Formel: Avkortet framtidig
-                          trygdetid = Framtidig trygdetid x norsk faktisk trygdetid/samlet faktisk trygdetid i de
-                          nordiske land som beregner framtidig trygdetid (maks. 40 år).
-                        </Alert>
-                      )}
-                    </>
-                  </VStack>
-                  <Textarea
-                    label="Kommentar"
-                    value={trygdeavtale.nordiskTrygdeAvtaleKommentar}
-                    onChange={(e) =>
-                      setTrygdeavtale({
-                        ...trygdeavtale,
-                        nordiskTrygdeAvtaleKommentar: e.target.value,
-                      })
-                    }
-                    minRows={2}
-                    size="small"
-                    autoComplete="off"
-                  />
-                </HGrid>
-
-                <HStack gap="4">
-                  {trygdeavtale && (
-                    <Button
-                      size="small"
-                      onClick={avbryt}
-                      type="button"
-                      variant="secondary"
-                      icon={<XMarkIcon aria-hidden />}
-                    >
-                      Avbryt
-                    </Button>
-                  )}
-                  <Button
-                    size="small"
-                    loading={isPending(lagreTrygdeavtaleRequest)}
-                    type="button"
-                    onClick={lagre}
-                    icon={<FloppydiskIcon />}
-                  >
-                    Lagre
-                  </Button>
-                </HStack>
-              </VStack>
-            </form>
+            <TrygdeAvtaleRedigering
+              trygdeavtale={trygdeavtale ?? {}}
+              avtaler={avtalerListe ?? []}
+              kriterier={avtaleKriterierListe ?? []}
+              oppdaterAvtale={oppdaterTrygdeavtale}
+              avbryt={avbryt}
+            />
           )}
         {(isPending(hentAlleTrygdetidAvtalerRequest) ||
           isPending(hentAlleTrygdetidAvtalerKriterierRequest) ||
@@ -433,11 +165,287 @@ export const TrygdeAvtale = ({ redigerbar }: Props) => {
           apiResult: hentTrygdeavtaleRequest,
           errorMessage: 'En feil har oppstått ved henting av trygdeavtale for behandlingen',
         })}
+      </VStack>
+    </Box>
+  )
+}
+
+function TrygdeAvtaleRedigering(props: {
+  trygdeavtale: Partial<Trygdeavtale>
+  avtaler: TrygdetidAvtale[]
+  kriterier: TrygdetidAvtaleKriteria[]
+  oppdaterAvtale: (avtale: Trygdeavtale) => void
+  avbryt: () => void
+}) {
+  const { trygdeavtale, avtaler, kriterier, avbryt, oppdaterAvtale } = props
+  const behandling = useBehandling()
+  const [lagreTrygdeavtaleRequest, lagreTrygdeavtale] = useApiCall(lagreTrygdeavtaleForBehandling)
+  const {
+    control,
+    register,
+    watch,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<Partial<Trygdeavtale>>({
+    defaultValues: trygdeavtale,
+  })
+
+  if (!behandling?.id) {
+    return null
+  }
+
+  const lagreOgOppdater = (trygdeavtale: Partial<Trygdeavtale>) => {
+    lagreTrygdeavtale(
+      {
+        behandlingId: behandling.id,
+        avtaleRequest: {
+          avtaleKode: trygdeavtale?.avtaleKode,
+          avtaleDatoKode: trygdeavtale?.avtaleDatoKode,
+          avtaleKriteriaKode: trygdeavtale?.avtaleKriteriaKode,
+          personKrets: trygdeavtale?.personKrets,
+          arbInntekt1G: trygdeavtale?.arbInntekt1G,
+          arbInntekt1GKommentar: trygdeavtale?.arbInntekt1GKommentar,
+          beregArt50: trygdeavtale?.beregArt50,
+          beregArt50Kommentar: trygdeavtale?.beregArt50Kommentar,
+          nordiskTrygdeAvtale: trygdeavtale?.nordiskTrygdeAvtale,
+          nordiskTrygdeAvtaleKommentar: trygdeavtale?.nordiskTrygdeAvtaleKommentar,
+          id: trygdeavtale?.id,
+        } as TrygdeavtaleRequest,
+      },
+      (respons) => {
+        oppdaterAvtale(respons)
+      }
+    )
+  }
+
+  const valgtAvtaleKode = watch('avtaleKode')
+  const valgtAvtale = avtaler.find((avtale) => avtale.kode === valgtAvtaleKode)
+
+  return (
+    <form onSubmit={handleSubmit(lagreOgOppdater)}>
+      <VStack gap="6">
+        <HStack gap="4">
+          <Select
+            {...register('avtaleKode', {
+              required: {
+                value: true,
+                message: 'Du må velge en trygdeavtale',
+              },
+            })}
+            error={errors.avtaleKode?.message}
+            label="Avtale"
+          >
+            <TrygdetidAvtaleOptionsView defaultBeskrivelse="Velg avtale" trygdeavtaleOptions={avtaler} />
+          </Select>
+          {valgtAvtale && valgtAvtale.datoer.length > 0 && (
+            <Select
+              label="Dato"
+              autoComplete="off"
+              {...register('avtaleDatoKode', {
+                required: {
+                  value: true,
+                  message: 'Du må velge datoen for avtalen.',
+                },
+              })}
+              error={errors.avtaleDatoKode?.message}
+            >
+              <TrygdetidAvtaleOptionsView
+                defaultBeskrivelse="Velg avtaledato"
+                trygdeavtaleOptions={valgtAvtale.datoer}
+              />
+            </Select>
+          )}
+        </HStack>
+
+        <Box width="50%">
+          <Select
+            label="Kriterier for å omfattes av avtalen"
+            autoComplete="off"
+            {...register('avtaleKriteriaKode', {
+              required: {
+                value: true,
+                message: 'Du må velge kriterier for å omfattes av avtalen',
+              },
+            })}
+            error={errors.avtaleKriteriaKode?.message}
+          >
+            <TrygdetidAvtaleOptionsView defaultBeskrivelse="Velg kriterie" trygdeavtaleOptions={kriterier} />
+          </Select>
+        </Box>
+
+        <VStack gap="2">
+          <Heading size="xsmall">Er avdøde i personkretsen i denne avtalen?</Heading>
+          <ControlledRadioGruppe
+            control={control}
+            name="personKrets"
+            legend="Er avdøde i personkretsen i denne avtalen?"
+            hideLegend
+            errorVedTomInput="Du må svare ja eller nei."
+            size="small"
+            radios={
+              <>
+                <Radio value={JaNei.JA}>Ja</Radio>
+                <Radio value={JaNei.NEI}>Nei</Radio>
+              </>
+            }
+          />
+        </VStack>
+
+        <HGrid gap="8 4" columns="60% 40%">
+          <VStack gap="2">
+            <HStack gap="2">
+              <Heading size="xsmall">Er arbeidsinntekt i avtaleland på minst 1 G på dødstidspunktet?</Heading>
+              <HelpText>
+                Poengår (år med arbeidsinntekt på mer enn 1 G) i andre EØS-land medregnes som poengår, forutsatt at det
+                ikke er tjent opp poengår i Norge i året. Hvis «Ja» gir det rett til fremtidige poeng, eller fremtidig
+                trygdetid, ved en prorata beregning. Hvis «Nei» gir det ikke rett til dette.
+              </HelpText>
+            </HStack>
+            <>
+              <HjemmelLenke
+                tittel="Rundskriv til hovednummer 45 kap. 3 punkt 3.3.2"
+                lenke="https://lovdata.no/pro/rundskriv/r45-00/KAPITTEL_3-3-2-1"
+              />
+              <ControlledRadioGruppe
+                legend="Er arbeidsinntekt i avtaleland på minst 1 G på dødstidspunktet?"
+                hideLegend
+                errorVedTomInput="Du må svare ja eller nei."
+                control={control}
+                name="arbInntekt1G"
+                size="small"
+                radios={
+                  <>
+                    <Radio value={JaNei.JA}>Ja</Radio>
+                    <Radio value={JaNei.NEI}>Nei</Radio>
+                  </>
+                }
+              />
+              {watch('arbInntekt1G') === JaNei.NEI && (
+                <Alert variant="info" size="small" inline>
+                  Det gis ikke rett til fremtidig trygdetid fra utland ved en prorata beregning. Hvis det heller ikke er
+                  rett til fremtidig trygdetid etter nasjonale regler, må du ta bort registrert fremtidig trygdetid.
+                </Alert>
+              )}
+            </>
+          </VStack>
+          <Box>
+            <Textarea
+              label="Kommentar"
+              {...register('arbInntekt1GKommentar')}
+              minRows={2}
+              autoComplete="off"
+              size="small"
+            />
+          </Box>
+
+          <VStack gap="2">
+            <HStack gap="2">
+              <Heading size="xsmall">Beregning etter artikkel 50 (EØS-forordning 883/2004)?</Heading>
+              <HelpText>
+                Denne artikkelen skal anvendes hvis det foreligger pensjonsrett i minst to EØS-land i tillegg til Norge,
+                og hvis vilkårene for pensjon ikke er oppfylt i alle EØS-landene avdøde har opptjening i. Det skal
+                gjøres en alternativ prorata-beregning med trygdetid kun for de EØS-landene der rett til pensjon er
+                oppfylt. Dette er fordi trygdetid fra land der vilkårene ikke er oppfylte ikke skal medregnes hvis det
+                ikke lønner seg.
+              </HelpText>
+            </HStack>
+            <>
+              <HjemmelLenke
+                tittel="EØS-forordning 883/2004 artikkel 50"
+                lenke="https://lovdata.no/pro/eu/32004r0883/ARTIKKEL_50"
+              />
+              <ControlledRadioGruppe
+                legend="Beregning etter artikkel 50 (EØS-forordning 883/2004)?"
+                hideLegend
+                control={control}
+                errorVedTomInput="Du må svare ja eller nei."
+                name="beregArt50"
+                size="small"
+                radios={
+                  <>
+                    <Radio value={JaNei.JA}>Ja</Radio>
+                    <Radio value={JaNei.NEI}>Nei</Radio>
+                  </>
+                }
+              />
+              {watch('beregArt50') === JaNei.JA && (
+                <Alert variant="info" size="small" inline>
+                  Ta en alternativ prorata-beregning. Huk av for «Ikke i prorata» på trygdetidsperioder for EØS-land som
+                  har gitt avslag på ytelse.
+                </Alert>
+              )}
+            </>
+          </VStack>
+          <Box>
+            <Textarea
+              label="Kommentar"
+              {...register('beregArt50Kommentar')}
+              minRows={2}
+              size="small"
+              autoComplete="off"
+            />
+          </Box>
+
+          <VStack gap="2">
+            <HStack gap="2">
+              <Heading size="xsmall">Skal artikkel 9 anvendes - fremtidig trygdetid avkortes?</Heading>
+              <HelpText>
+                Hvis forutgående medlemskap, og derav vilkår for å beregne framtidig trygdetid, er oppfylt etter
+                nasjonale regler i Sverige og/eller Island i tillegg til Norge, skal framtidig trygdetid avkortes. I en
+                prorata-beregnet ytelse, der forutgående medlemskap er oppfylt ved sammenlegging, er den framtidige
+                trygdetiden allerede avkortet, og artikkelen skal ikke anvendes.
+              </HelpText>
+            </HStack>
+            <>
+              <HjemmelLenke
+                tittel="Nordisk konvensjon artikkel 9"
+                lenke="https://lovdata.no/pro/traktat/2012-06-12-18/ARTIKKEL_9"
+              />
+              <ControlledRadioGruppe
+                legend="Skal artikkel 9 anvendes - fremtidig trygdetid avkortes?"
+                hideLegend
+                control={control}
+                errorVedTomInput="Du må svare ja eller nei."
+                size="small"
+                name="nordiskTrygdeAvtale"
+                radios={
+                  <>
+                    <Radio value={JaNei.JA}>Ja</Radio>
+                    <Radio value={JaNei.NEI}>Nei</Radio>
+                  </>
+                }
+              />
+              {watch('nordiskTrygdeAvtale') === JaNei.JA && (
+                <Alert variant="info" size="small" inline>
+                  Fremtidig trygdetid skal avkortes. Gjenny støtter ikke dette. Du må derfor beregne fremtidig trygdetid
+                  manuelt, og beregning av ytelsen må manuelt overstyres. Formel: Avkortet framtidig trygdetid =
+                  Framtidig trygdetid x norsk faktisk trygdetid/samlet faktisk trygdetid i de nordiske land som beregner
+                  framtidig trygdetid (maks. 40 år).
+                </Alert>
+              )}
+            </>
+          </VStack>
+          <Box>
+            <Textarea label="Kommentar" {...register('nordiskTrygdeAvtaleKommentar')} size="small" autoComplete="off" />
+          </Box>
+        </HGrid>
+
         {isFailureHandler({
           apiResult: lagreTrygdeavtaleRequest,
           errorMessage: 'En feil har oppstått ved lagring av trygdeavtale for behandlingen',
         })}
+
+        <HStack gap="4">
+          {trygdeavtale && (
+            <Button size="small" type="button" variant="secondary" icon={<XMarkIcon aria-hidden />} onClick={avbryt}>
+              Avbryt
+            </Button>
+          )}
+          <Button size="small" loading={isPending(lagreTrygdeavtaleRequest)} type="submit" icon={<FloppydiskIcon />}>
+            Lagre
+          </Button>
+        </HStack>
       </VStack>
-    </Box>
+    </form>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/avtaler/TrygdeavtaleVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/avtaler/TrygdeavtaleVisning.tsx
@@ -1,6 +1,6 @@
-import { BodyShort } from '@navikt/ds-react'
-import styled from 'styled-components'
+import { BodyShort, Box, Label, VStack } from '@navikt/ds-react'
 import { Trygdeavtale, TrygdetidAvtale, TrygdetidAvtaleKriteria } from '~shared/api/trygdetid'
+import { JaNeiRec } from '~shared/types/ISvar'
 
 interface TrygdeavtaleVisningProps {
   trygdeavtale: Trygdeavtale
@@ -14,38 +14,72 @@ export const TrygdeavtaleVisning = ({ trygdeavtale, avtaler, kriterier }: Trygde
   const avtaleKriteria = kriterier.find((kriteria) => trygdeavtale.avtaleKriteriaKode === kriteria.kode)
 
   return (
-    <TrygdeavtaleBody>
-      <BodyShort>
-        {avtale && avtale.beskrivelse}
-        {avtaleDato && <> - {avtaleDato.beskrivelse}</>}
-      </BodyShort>
-      {avtaleKriteria && <BodyShort>{avtaleKriteria.beskrivelse}</BodyShort>}
+    <VStack gap="8">
+      <Box>
+        <Label>Avtale</Label>
+        <BodyShort>
+          {avtale && avtale.beskrivelse}
+          {avtaleDato && <> - {avtaleDato.beskrivelse}</>}
+        </BodyShort>
+      </Box>
+
+      {avtaleKriteria && (
+        <Box>
+          <Label>Avtalekriterier</Label>
+          <BodyShort>{avtaleKriteria.beskrivelse}</BodyShort>
+        </Box>
+      )}
       {trygdeavtale.personKrets && (
-        <BodyShort>Er avdøde i personkretsen i denne avtalen? {trygdeavtale.personKrets}</BodyShort>
+        <Box>
+          <Label>Er avdøde i personkretsen i denne avtalen? </Label>
+          <BodyShort>{JaNeiRec[trygdeavtale.personKrets]}</BodyShort>
+        </Box>
       )}
       {trygdeavtale.arbInntekt1G && (
-        <BodyShort>
-          Er arbeidsinntekt i avtaleland på minst 1 G på dødstidspunktet? {trygdeavtale.arbInntekt1G}
-        </BodyShort>
+        <VStack gap="2">
+          <Box>
+            <Label>Er arbeidsinntekt i avtaleland på minst 1 G på dødstidspunktet?</Label>
+            <BodyShort>{JaNeiRec[trygdeavtale.arbInntekt1G]}</BodyShort>
+          </Box>
+          {trygdeavtale.arbInntekt1GKommentar && (
+            <Box>
+              <Label>Kommentar</Label>
+              <BodyShort>{trygdeavtale.arbInntekt1GKommentar}</BodyShort>
+            </Box>
+          )}
+        </VStack>
       )}
-      {trygdeavtale.arbInntekt1GKommentar && <BodyShort>Kommentar: {trygdeavtale.arbInntekt1GKommentar}</BodyShort>}
       {trygdeavtale.beregArt50 && (
-        <BodyShort>Beregning etter artikkel 50 (EØS-forordning 883/2004)? {trygdeavtale.beregArt50}</BodyShort>
+        <VStack gap="2">
+          <Box>
+            <Label>Beregning etter artikkel 50 (EØS-forordning 883/2004)?</Label>
+            <BodyShort>{JaNeiRec[trygdeavtale.beregArt50]}</BodyShort>
+          </Box>
+
+          {trygdeavtale.beregArt50Kommentar && (
+            <Box>
+              <Label>Kommentar</Label>
+              <BodyShort>{trygdeavtale.beregArt50Kommentar}</BodyShort>
+            </Box>
+          )}
+        </VStack>
       )}
-      {trygdeavtale.beregArt50Kommentar && <BodyShort>Kommentar: {trygdeavtale.beregArt50Kommentar}</BodyShort>}
+
       {trygdeavtale.nordiskTrygdeAvtale && (
-        <BodyShort>
-          Nordisk trygdeavtale: Skal artikkel 9 anvendes - fremtidig trygdetid avkortes?{' '}
-          {trygdeavtale.nordiskTrygdeAvtale}
-        </BodyShort>
+        <VStack gap="2">
+          <Box>
+            <Label>Nordisk trygdeavtale: Skal artikkel 9 anvendes - fremtidig trygdetid avkortes?</Label>
+            <BodyShort>{JaNeiRec[trygdeavtale.nordiskTrygdeAvtale]}</BodyShort>
+          </Box>
+
+          {trygdeavtale.nordiskTrygdeAvtaleKommentar && (
+            <Box>
+              <Label>Kommentar</Label>
+              <BodyShort>{trygdeavtale.nordiskTrygdeAvtaleKommentar}</BodyShort>
+            </Box>
+          )}
+        </VStack>
       )}
-      {trygdeavtale.nordiskTrygdeAvtaleKommentar && (
-        <BodyShort>Kommentar: {trygdeavtale.nordiskTrygdeAvtaleKommentar}</BodyShort>
-      )}
-    </TrygdeavtaleBody>
+    </VStack>
   )
 }
-
-const TrygdeavtaleBody = styled.div`
-  margin-bottom: 2em;
-`


### PR DESCRIPTION
Det ser ut som mer endringer enn det i praksis er, siden skjema-biten er skilt ut i en egen komponent.




Oppgraderer også visningen av vurdert trygdeavtale.

Eksempler på feilmeldinger:
![Screenshot 2024-10-09 at 12 24 29](https://github.com/user-attachments/assets/f7d850ba-e69e-4865-ab5d-46cc2dd9fe47)
![Screenshot 2024-10-09 at 12 24 39](https://github.com/user-attachments/assets/a515d616-af36-4fe1-9a2e-7566a78a5fbe)


Før for visningen av vurdert avtale:
![Screenshot 2024-10-09 at 12 28 36](https://github.com/user-attachments/assets/c4ce553c-c3f7-4089-8a7d-d38ae8ad4b12)

Etter: 
![Screenshot 2024-10-09 at 12 48 15](https://github.com/user-attachments/assets/ba29ef11-cc67-415e-94ea-2d3e95c91dc0)
