### PR TITLE
Hotfix: Sikre at enhetsnummer toString kun gir value

### DIFF
--- a/libs/saksbehandling-common/src/main/kotlin/Enhetsnummer.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/Enhetsnummer.kt
@@ -19,4 +19,6 @@ data class Enhetsnummer(
 
         fun nullable(enhetNr: String? = null) = enhetNr.takeUnless { it.isNullOrBlank() }?.let { Enhetsnummer(it) }
     }
+
+    override fun toString(): String = enhetNr
 }


### PR DESCRIPTION
Fikser feil i henting av gosys-oppgaver. 

`GosysOppgaveKlient` lager filter slik: 
```
.plus(enhetsnr?.let { "&tildeltEnhetsnr=$it" } ?: "")
```

Søket har mao. ikke gitt noen resultater (0 oppgaver) siden vi typesikret `Enhetsnummer`.
Setter derfor `Enhetsnummer` sin `.toString` til å _alltid_ være value for å redusere sannsynligheten for slike tullefeil. 