### PR TITLE
Unngå dobbeldefinisjon av moduler fra ktor rest module

### DIFF
--- a/apps/etterlatte-api/build.gradle.kts
+++ b/apps/etterlatte-api/build.gradle.kts
@@ -9,13 +9,6 @@ dependencies {
     implementation(project(":libs:etterlatte-vedtaksvurdering-model"))
     implementation(project(":libs:etterlatte-sporingslogg"))
 
-    implementation(libs.ktor2.servercio)
-
-    implementation(libs.navfelles.tokenvalidationktor2) {
-        exclude("io.ktor", "ktor-server")
-    }
-    implementation(libs.ktor2.server) // For å kompensere for exclude-en over
-
     testImplementation(libs.ktor2.clientcontentnegotiation)
     testImplementation(libs.ktor2.jackson)
     testImplementation(libs.ktor2.clientmock)

--- a/apps/etterlatte-behandling/build.gradle.kts
+++ b/apps/etterlatte-behandling/build.gradle.kts
@@ -27,7 +27,6 @@ dependencies {
     implementation(libs.navfelles.tokenvalidationktor2) {
         exclude("io.ktor", "ktor-server")
     }
-    implementation(libs.ktor2.server) // For å kompensere for exclude-en over
 
     implementation(libs.database.kotliquery)
 

--- a/apps/etterlatte-beregning/build.gradle.kts
+++ b/apps/etterlatte-beregning/build.gradle.kts
@@ -17,8 +17,6 @@ dependencies {
     implementation(project(":libs:etterlatte-vedtaksvurdering-model"))
 
     implementation(libs.database.kotliquery)
-
-    implementation(libs.ktor2.servercio)
     implementation(libs.navfelles.tokenclientcore)
 
     testImplementation(libs.test.kotest.assertionscore)

--- a/apps/etterlatte-brev-api/build.gradle.kts
+++ b/apps/etterlatte-brev-api/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     implementation(project(":libs:etterlatte-migrering-model"))
     implementation(project(":libs:etterlatte-brev-model"))
     implementation(project(":libs:etterlatte-oppgave-model"))
-    implementation(libs.ktor2.server)
     implementation(libs.ktor2.clientcore)
 
     implementation(libs.etterlatte.common)
@@ -26,10 +25,6 @@ dependencies {
     implementation("no.nav.pensjon.brevbaker:brevbaker-api-model-common:1.4.0")
 
     implementation(libs.database.kotliquery)
-
-    implementation(libs.ktor2.clientcontentnegotiation)
-    implementation(libs.ktor2.jackson)
-    implementation(libs.ktor2.clientauth)
     implementation(libs.cache.caffeine)
 
     testImplementation(libs.test.kotest.assertionscore)

--- a/apps/etterlatte-gyldig-soeknad/build.gradle.kts
+++ b/apps/etterlatte-gyldig-soeknad/build.gradle.kts
@@ -11,9 +11,6 @@ dependencies {
     implementation(project(":libs:etterlatte-ktor"))
     implementation(project(":libs:rapidsandrivers-extras"))
 
-    implementation(libs.ktor2.jackson)
-    implementation(libs.ktor2.clientauth)
-
     testImplementation(libs.ktor2.clientmock)
     testImplementation(libs.ktor2.servertests)
     testImplementation(libs.test.kotest.assertionscore)

--- a/apps/etterlatte-hendelser-joark/build.gradle.kts
+++ b/apps/etterlatte-hendelser-joark/build.gradle.kts
@@ -14,8 +14,6 @@ dependencies {
     implementation(project(":libs:etterlatte-kafka"))
     implementation(project(":libs:etterlatte-oppgave-model"))
 
-    implementation(libs.ktor2.servercio)
-
     implementation(libs.kafka.avro) {
         exclude("org.apache.commons", "commons-compress")
     }

--- a/apps/etterlatte-hendelser-pdl/build.gradle.kts
+++ b/apps/etterlatte-hendelser-pdl/build.gradle.kts
@@ -12,8 +12,6 @@ dependencies {
     implementation(project(":libs:etterlatte-kafka"))
     implementation(project(":libs:etterlatte-pdl-model"))
 
-    implementation(libs.ktor2.servercio)
-
     implementation(libs.kafka.avro) {
         exclude("org.apache.commons", "commons-compress")
     }

--- a/apps/etterlatte-hendelser-samordning/build.gradle.kts
+++ b/apps/etterlatte-hendelser-samordning/build.gradle.kts
@@ -8,10 +8,6 @@ dependencies {
     implementation(project(":libs:etterlatte-kafka"))
     implementation(project(":libs:etterlatte-vedtaksvurdering-model"))
 
-    implementation(libs.ktor2.servercio)
-    implementation(libs.ktor2.servercorejvm)
-    implementation(libs.ktor2.auth)
-
     implementation(libs.kafka.clients)
     implementation(libs.kafka.avro) {
         exclude("org.apache.commons", "commons-compress")

--- a/apps/etterlatte-pdltjenester/build.gradle.kts
+++ b/apps/etterlatte-pdltjenester/build.gradle.kts
@@ -9,9 +9,6 @@ dependencies {
     implementation(project(":libs:etterlatte-pdl-model"))
     implementation(project(":libs:etterlatte-funksjonsbrytere"))
 
-    implementation(libs.ktor2.servercio)
-    implementation(libs.navfelles.tokenclientcore)
-
     testImplementation(libs.ktor2.clientcontentnegotiation)
     testImplementation(libs.ktor2.jackson)
     testImplementation(libs.ktor2.clientmock)

--- a/apps/etterlatte-trygdetid/build.gradle.kts
+++ b/apps/etterlatte-trygdetid/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
     implementation(project(":libs:etterlatte-trygdetid-model"))
     implementation(project(":libs:etterlatte-funksjonsbrytere"))
 
-    implementation(libs.ktor2.servercio)
     implementation(libs.database.kotliquery)
     implementation(libs.navfelles.tokenclientcore)
 

--- a/apps/etterlatte-vedtaksvurdering-kafka/build.gradle.kts
+++ b/apps/etterlatte-vedtaksvurdering-kafka/build.gradle.kts
@@ -3,7 +3,9 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":libs:etterlatte-ktor"))
+    implementation(project(":libs:etterlatte-ktor")) {
+        exclude("io.ktor:ktor-server-cio", "io.ktor:ktor-server-metrics-micrometer")
+    }
     implementation(project(":libs:saksbehandling-common"))
     implementation(project(":libs:etterlatte-behandling-model"))
     implementation(project(":libs:etterlatte-utbetaling-model"))

--- a/apps/etterlatte-vilkaarsvurdering-kafka/build.gradle.kts
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/build.gradle.kts
@@ -3,7 +3,9 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":libs:etterlatte-ktor"))
+    implementation(project(":libs:etterlatte-ktor")) {
+        exclude("io.ktor:ktor-server-cio", "io.ktor:ktor-server-metrics-micrometer")
+    }
     implementation(project(":libs:saksbehandling-common"))
     implementation(project(":libs:etterlatte-vilkaarsvurdering-model"))
     implementation(project(":libs:etterlatte-migrering-model"))

--- a/apps/etterlatte-vilkaarsvurdering/build.gradle.kts
+++ b/apps/etterlatte-vilkaarsvurdering/build.gradle.kts
@@ -11,9 +11,6 @@ dependencies {
     implementation(project(":libs:etterlatte-vilkaarsvurdering-model"))
     implementation(project(":libs:etterlatte-funksjonsbrytere"))
 
-    implementation(libs.ktor2.servercio)
-    implementation(libs.navfelles.tokenclientcore)
-
     implementation(libs.database.kotliquery)
 
     testImplementation(libs.ktor2.servertests)

--- a/libs/etterlatte-ktor/build.gradle.kts
+++ b/libs/etterlatte-ktor/build.gradle.kts
@@ -11,30 +11,35 @@ dependencies {
         exclude("io.ktor", "ktor-server-auth")
         exclude("io.ktor", "ktor-server-resources")
     }
-    implementation(libs.ktor2.servercorejvm)
     implementation(libs.ktor2.webjars)
-    implementation(libs.ktor2.auth)
     implementation(libs.ktor2.serverresources)
     // Fram hit: ktor-avhengnadar for å dekkje det vi ekskluderer frå openapi-importen
 
     implementation(project(":libs:saksbehandling-common"))
+    api(libs.ktor2.auth)
+    api(libs.ktor2.servercorejvm)
     api(libs.ktor2.servercio)
-    implementation(libs.ktor2.jackson)
+    api(libs.ktor2.server)
+    api(libs.ktor2.clientcontentnegotiation)
+    api(libs.ktor2.jackson)
+    api(libs.ktor2.okhttp)
+    api(libs.ktor2.clientauth)
+    api(libs.ktor2.clientloggingjvm)
+
+    api(libs.navfelles.tokenclientcore)
+
     implementation(libs.ktor2.calllogging)
     implementation(libs.ktor2.callid)
     implementation(libs.ktor2.statuspages)
     implementation(libs.ktor2.servercontentnegotiation)
-    implementation(libs.ktor2.okhttp)
-    implementation(libs.ktor2.clientcontentnegotiation)
+
     implementation(libs.ktor2.metricsmicrometer)
     implementation(libs.ktor2.doublereceive)
-    implementation(libs.navfelles.tokenvalidationktor2) {
+
+    api(libs.navfelles.tokenvalidationktor2) {
         exclude("io.ktor", "ktor-server")
     }
-    implementation(libs.ktor2.server)
-    implementation(libs.ktor2.clientauth)
-    api(libs.ktor2.clientloggingjvm)
-    implementation(libs.navfelles.tokenclientcore)
+
     api(libs.kotlin.result)
 
     implementation(libs.logging.logstashlogbackencoder) {


### PR DESCRIPTION
Gå over til å eksponere implementation i libs ktor som `api` ikke implementation og fjerne fra apper som bruker libben.

Går gjennom flere i neste iterasjon, blir brått så mye å teste :D 