### PR TITLE
EY-4580 Markere brev som utgått

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
@@ -158,6 +158,16 @@ fun Route.brevRoute(
             }
         }
 
+        post("utgaar") {
+            withSakId(tilgangssjekker, skrivetilgang = true) {
+                val request = call.receive<BrevUtgaarRequest>()
+
+                service.markerSomUtgaatt(brevId, request.kommentar, brukerTokenInfo)
+
+                call.respond(HttpStatusCode.OK)
+            }
+        }
+
         delete {
             withSakId(tilgangssjekker, skrivetilgang = true) {
                 call.respond(service.slett(brevId, brukerTokenInfo))
@@ -263,6 +273,10 @@ data class OppdaterPayloadRequest(
 
 data class OppdaterMottakerRequest(
     val mottaker: Mottaker,
+)
+
+data class BrevUtgaarRequest(
+    val kommentar: String,
 )
 
 data class OppdaterTittelRequest(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
@@ -263,6 +263,16 @@ class BrevRepository(
         }
     }
 
+    fun settBrevUtgaatt(
+        id: BrevID,
+        kommentar: String,
+        bruker: BrukerTokenInfo,
+    ) {
+        using(sessionOf(ds)) {
+            it.lagreHendelse(id, Status.UTGAATT, "${bruker.ident()}: $kommentar".toJson())
+        }
+    }
+
     fun opprettBrev(ulagretBrev: OpprettNyttBrev): Brev =
         ds.transaction(true) { tx ->
             val id =

--- a/apps/etterlatte-brev-api/src/main/resources/db/migration/V24__status_utgaatt.sql
+++ b/apps/etterlatte-brev-api/src/main/resources/db/migration/V24__status_utgaatt.sql
@@ -1,0 +1,1 @@
+INSERT INTO status (id) VALUES ('UTGAATT');

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/BrevStatusTag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/BrevStatusTag.tsx
@@ -15,6 +15,8 @@ const mapBrevStatus = (status: BrevStatus) => {
       return 'Distribuert'
     case BrevStatus.SLETTET:
       return 'Slettet'
+    case BrevStatus.UTGAATT:
+      return 'Utgått'
   }
 }
 
@@ -29,7 +31,8 @@ const tagColors = (status: BrevStatus) => {
     case BrevStatus.DISTRIBUERT:
       return 'success'
     case BrevStatus.SLETTET:
-      return 'neutral'
+    case BrevStatus.UTGAATT:
+      return 'warning'
   }
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/handlinger/BrevUtgaar.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/handlinger/BrevUtgaar.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { Alert, BodyShort, Button, HStack, Modal, Textarea, VStack } from '@navikt/ds-react'
+import { ArrowUndoIcon } from '@navikt/aksel-icons'
+import { isPending, mapResult } from '~shared/api/apiUtils'
+import { BrevStatus, IBrev } from '~shared/types/Brev'
+import { differenceInWeeks } from 'date-fns'
+import { markerBrevSomUtgaar } from '~shared/api/brev'
+import { ApiErrorAlert } from '~ErrorBoundary'
+
+const EN_UKE = 1
+
+/**
+ * Sjekker om brevet er ferdigstilt eller journalført og over 1 uke gammelt.
+ * Dette er som oftest et tegn på at noe har gått galt i flyten
+ **/
+const kanMarkereSomUtgaar = (brev: IBrev) =>
+  [BrevStatus.FERDIGSTILT, BrevStatus.JOURNALFOERT].includes(brev.status) &&
+  differenceInWeeks(new Date(), brev.statusEndret) >= EN_UKE
+
+/**
+ * Handling som kan brukes i tilfeller hvor et brev ikke lenger er relevant/aktuelt.
+ **/
+export const BrevUtgaar = ({ brev }: { brev: IBrev }) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [kommentar, setKommentar] = useState<string>()
+  const [brevUtgaarResult, apiBrevUtgaar] = useApiCall(markerBrevSomUtgaar)
+
+  if (!kanMarkereSomUtgaar(brev)) {
+    return null
+  }
+
+  const utgaar = () => {
+    if (!kommentar) return
+
+    apiBrevUtgaar({ brevId: brev.id, sakId: brev.sakId, kommentar }, () => window.location.reload())
+  }
+
+  return (
+    <>
+      <Button variant="danger" icon={<ArrowUndoIcon />} onClick={() => setIsOpen(true)} title="Marker som utgår" />
+
+      <Modal open={isOpen} onClose={() => setIsOpen(false)} aria-label="Slett brev" header={{ heading: 'Brev utgår' }}>
+        <Modal.Body>
+          <VStack gap="4">
+            <BodyShort spacing>
+              Brevet er mer enn {EN_UKE} uke gammelt og ikke distribuert. Vurder om brevet skal utgå.
+            </BodyShort>
+
+            <BodyShort spacing>
+              Vær obs på at markering av brev med status <strong>UTGÅR</strong> ikke kan angres!
+            </BodyShort>
+
+            {brev.status === BrevStatus.JOURNALFOERT && (
+              <Alert variant="warning">
+                OBS: Brevet har status journalført. Hvis journalposten skal avbrytes/utgå må det gjøres manuelt via
+                dokumentoversikten.
+              </Alert>
+            )}
+
+            <Textarea
+              label="Kommentar"
+              name="Kommentar"
+              description="Skriv hvorfor brevet utgår eller annen relevant informasjon"
+              value={kommentar || ''}
+              onChange={(e) => setKommentar(e.target.value)}
+            />
+
+            {mapResult(brevUtgaarResult, {
+              error: (error) => <ApiErrorAlert>{error.detail}</ApiErrorAlert>,
+              success: () => <Alert variant="success">Brev markert som utgått. Laster siden på nytt...</Alert>,
+            })}
+
+            <HStack gap="4" justify="center">
+              <Button variant="secondary" onClick={() => setIsOpen(false)} disabled={isPending(brevUtgaarResult)}>
+                Nei, avbryt
+              </Button>
+              <Button variant="danger" onClick={utgaar} loading={isPending(brevUtgaarResult)} disabled={!kommentar}>
+                Ja, brevet utgår
+              </Button>
+            </HStack>
+          </VStack>
+        </Modal.Body>
+      </Modal>
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/handlinger/SlettBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/handlinger/SlettBrev.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { slettBrev } from '~shared/api/brev'
+import { BodyShort, Button, HStack, Modal } from '@navikt/ds-react'
+import { TrashIcon } from '@navikt/aksel-icons'
+import { isPending } from '~shared/api/apiUtils'
+import { BrevStatus, IBrev } from '~shared/types/Brev'
+
+const kanSlettes = (brev: IBrev) => {
+  return !brev.behandlingId && [BrevStatus.OPPRETTET, BrevStatus.OPPDATERT].includes(brev.status)
+}
+
+/**
+ * Gjør det mulig å slette brev som er nye eller under arbeid.
+ * Skal ikke være mulig å slette vedtaksbrev eller brev som passert status ferdigstilt.
+ **/
+export const SlettBrev = ({ brev }: { brev: IBrev }) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [slettBrevStatus, apiSlettBrev] = useApiCall(slettBrev)
+
+  if (!kanSlettes(brev)) {
+    return null
+  }
+
+  const slett = () => {
+    apiSlettBrev({ brevId: brev.id, sakId: brev.sakId }, () => {
+      window.location.reload()
+    })
+  }
+
+  return (
+    <>
+      <Button variant="danger" icon={<TrashIcon />} onClick={() => setIsOpen(true)} title="Slett brev" />
+
+      <Modal open={isOpen} onClose={() => setIsOpen(false)} aria-label="Slett brev">
+        <Modal.Body>
+          <BodyShort spacing>Er du sikker på at du vil slette brevet? Handlingen kan ikke angres.</BodyShort>
+
+          <HStack gap="4" justify="center">
+            <Button variant="secondary" onClick={() => setIsOpen(false)} disabled={isPending(slettBrevStatus)}>
+              Nei, avbryt
+            </Button>
+            <Button variant="danger" onClick={slett} loading={isPending(slettBrevStatus)}>
+              Ja, slett
+            </Button>
+          </HStack>
+        </Modal.Body>
+      </Modal>
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
@@ -121,3 +121,10 @@ export const journalfoerBrev = async (props: { brevId: number; sakId: number }):
 
 export const distribuerBrev = async (props: { brevId: number; sakId: number }): Promise<ApiResponse<any>> =>
   apiClient.post(`/brev/${props.brevId}/distribuer?sakId=${props.sakId}`, {})
+
+export const markerBrevSomUtgaar = async (props: {
+  brevId: number
+  sakId: number
+  kommentar: string
+}): Promise<ApiResponse<any>> =>
+  apiClient.post(`/brev/${props.brevId}/utgaar?sakId=${props.sakId}`, { kommentar: props.kommentar })

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Brev.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Brev.ts
@@ -48,6 +48,7 @@ export enum BrevStatus {
   JOURNALFOERT = 'JOURNALFOERT',
   DISTRIBUERT = 'DISTRIBUERT',
   SLETTET = 'SLETTET',
+  UTGAATT = 'UTGAATT',
 }
 
 export enum BrevProsessType {

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/Brev.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/Brev.kt
@@ -20,6 +20,7 @@ enum class Status {
     JOURNALFOERT,
     DISTRIBUERT,
     SLETTET,
+    UTGAATT,
     ;
 
     fun ikkeFerdigstilt(): Boolean = this in listOf(OPPRETTET, OPPDATERT)


### PR DESCRIPTION
Grunnet historiske problemer med brevløsningen har vi en del brev som er i limbo... Mange av disse brevene er såpass gamle at det ikke lenger er aktuelt å sende de. Brev som har status **FERDIGSTILT** eller **JOURNALFOERT**, og er mer enn 1 uke gammelt vil være mulig å markere som **UTGÅTT**. Dette gjør det mulig for saksbehandler å få gamle brev som har feilet ut av ordinær saksbehandlingsflyt. 

<img width="1542" alt="Screenshot 2024-10-14 at 14 22 34" src="https://github.com/user-attachments/assets/900f4a9b-1ec7-4402-84b7-d5e010191de1">

<img width="990" alt="Screenshot 2024-10-14 at 14 22 39" src="https://github.com/user-attachments/assets/9ea4ef8d-48a7-4bff-8050-5c712016c2a8">

<img width="1546" alt="Screenshot 2024-10-14 at 14 23 17" src="https://github.com/user-attachments/assets/cb123cd9-0bd2-483b-bc69-420e13720288">