### PR TITLE
EY-4499 Grante servicebruker i prod tilgang til migrering

### DIFF
--- a/apps/etterlatte-behandling/src/main/resources/db/prod/V172__grante_servicebruker.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/prod/V172__grante_servicebruker.sql
@@ -1,2 +1,2 @@
-GRANT USAGE on SCHEMA public to "migrering-user@etterlatte-prod-207c.iam";
-GRANT INSERT ON ALL TABLES IN SCHEMA public TO "migrering-user@etterlatte-prod-207c.iam";
+GRANT USAGE on SCHEMA public to "cloudsqliamserviceaccount";
+GRANT INSERT ON ALL TABLES IN SCHEMA public TO "cloudsqliamserviceaccount";

--- a/apps/etterlatte-behandling/src/main/resources/db/prod/V172__grante_servicebruker.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/prod/V172__grante_servicebruker.sql
@@ -1,0 +1,2 @@
+GRANT USAGE on SCHEMA public to "migrering-user@etterlatte-prod-207c.iam";
+GRANT INSERT ON ALL TABLES IN SCHEMA public TO "migrering-user@etterlatte-prod-207c.iam";

--- a/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V31__grante_servicebruker.sql
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V31__grante_servicebruker.sql
@@ -1,0 +1,2 @@
+GRANT USAGE on SCHEMA public to "migrering-user@etterlatte-prod-207c.iam";
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO "migrering-user@etterlatte-prod-207c.iam";

--- a/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V31__grante_servicebruker.sql
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/resources/db/migration/V31__grante_servicebruker.sql
@@ -1,2 +1,2 @@
-GRANT USAGE on SCHEMA public to "migrering-user@etterlatte-prod-207c.iam";
-GRANT SELECT ON ALL TABLES IN SCHEMA public TO "migrering-user@etterlatte-prod-207c.iam";
+GRANT USAGE on SCHEMA public to "cloudsqliamserviceaccount";
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO "cloudsqliamserviceaccount";


### PR DESCRIPTION
vi har manuelt lagt inn for dev for å teste + at dev allerede er migrert.

Obs til later så må vi huske å ta ned podder, ta backup av databaser og være klar til å deploy versjon som bruker vilkårsvurderingsdata i tabellene i etterlatte-behandling.