### PR TITLE
EY-4583 Egen behandlingsflyt vurdering aktivitet

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/App.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/App.tsx
@@ -25,6 +25,7 @@ import { isSuccess } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { setDefaultOptions } from 'date-fns'
 import GenerellOppgave from '~components/generelloppgave/GenerellOppgave'
+import { VurderAktivitetspliktOppgave } from '~components/aktivitetsplikt/VurderAktivitetspliktOppgave'
 
 function App() {
   const innloggetbrukerHentet = useHentInnloggetSaksbehandler()
@@ -61,6 +62,7 @@ function App() {
                   <Route path="/klage/:klageId/*" element={<Klagebehandling />} />
                   <Route path="/tilbakekreving/:tilbakekrevingId/*" element={<Tilbakekrevingsbehandling />} />
                   <Route path="/generellbehandling/:generellbehandlingId" element={<GenerellBehandling />} />
+                  <Route path="/aktivitet-vurdering/:oppgaveId/*" element={<VurderAktivitetspliktOppgave />}></Route>
                   <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>
               </ErrorBoundary>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/OppgaveVurderingRoute.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/OppgaveVurderingRoute.tsx
@@ -1,0 +1,49 @@
+import { OppgaveDTO } from '~shared/types/oppgave'
+import { StatusBar } from '~shared/statusbar/Statusbar'
+import { GridContainer, MainContent } from '~shared/styled'
+import { Navigate, Route, Routes } from 'react-router-dom'
+import React, { createContext, useContext } from 'react'
+import { AktivitetspliktSidemeny } from '~components/aktivitetsplikt/sidemeny/AktivitetspliktSidemeny'
+import {
+  AktivitetspliktSteg,
+  AktivitetspliktStegmeny,
+} from '~components/aktivitetsplikt/stegmeny/AktivitetspliktStegmeny'
+import { VurderAktivitet } from '~components/aktivitetsplikt/vurdering/VurderAktivitet'
+import { VurderingInfoBrev } from '~components/aktivitetsplikt/brev/VurderingInfoBrev'
+
+const AktivitetspliktOppgaveContext = createContext<OppgaveDTO>({} as OppgaveDTO)
+
+export function OppgaveVurderingRoute(props: { oppgave: OppgaveDTO }) {
+  const { oppgave } = props
+  return (
+    <AktivitetspliktOppgaveContext.Provider value={oppgave}>
+      <StatusBar ident={oppgave.fnr} />
+      <AktivitetspliktStegmeny />
+
+      <GridContainer>
+        <MainContent>
+          <Routes>
+            <Route path={AktivitetspliktSteg.VURDERING} element={<VurderAktivitet />} />
+            <Route path={AktivitetspliktSteg.BREV} element={<VurderingInfoBrev />} />
+            <Route path="*" element={<Navigate to={AktivitetspliktSteg.VURDERING} replace />} />
+          </Routes>
+        </MainContent>
+        <AktivitetspliktSidemeny />
+      </GridContainer>
+    </AktivitetspliktOppgaveContext.Provider>
+  )
+}
+
+export const useOppgaveForVurdering = (): OppgaveDTO => {
+  try {
+    const oppgave = useContext(AktivitetspliktOppgaveContext)
+    if (!oppgave) {
+      throw new Error('Oppgave er ikke definert')
+    }
+    return oppgave
+  } catch (e) {
+    const msg = 'Kan ikke bruke useOppgaveForVurdering utenfor OppgaveVurderingRoute-treet'
+    console.error(msg)
+    throw new Error(msg, { cause: e })
+  }
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/VurderAktivitetspliktOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/VurderAktivitetspliktOppgave.tsx
@@ -1,0 +1,38 @@
+import { useSidetittel } from '~shared/hooks/useSidetittel'
+import { useMatch } from 'react-router-dom'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { hentOppgave } from '~shared/api/oppgaver'
+import React, { useEffect } from 'react'
+import { isSuccess, mapResult } from '~shared/api/apiUtils'
+import Spinner from '~shared/Spinner'
+import { ApiErrorAlert } from '~ErrorBoundary'
+import { OppgaveVurderingRoute } from '~components/aktivitetsplikt/OppgaveVurderingRoute'
+import { Link } from '@navikt/ds-react'
+
+export function VurderAktivitetspliktOppgave() {
+  useSidetittel('Vurder aktivitetsplikt')
+  const match = useMatch('/aktivitet-vurdering/:oppgaveId/*')
+  const oppgaveId = match?.params.oppgaveId
+
+  const [oppgave, fetchOppgave] = useApiCall(hentOppgave)
+
+  useEffect(() => {
+    if (!oppgaveId || (isSuccess(oppgave) && oppgave.data.id === oppgaveId)) {
+      return
+    }
+    fetchOppgave(oppgaveId)
+  }, [oppgaveId, oppgave])
+
+  return mapResult(oppgave, {
+    initial: (
+      <ApiErrorAlert>
+        OppgaveId mangler. Prøv å gå inn på oppgaven på nytt fra <Link href="/">oppgavelisten.</Link>
+      </ApiErrorAlert>
+    ),
+    pending: <Spinner visible label="Henter oppgave for vurdering" />,
+    success: (oppgave) => <OppgaveVurderingRoute oppgave={oppgave} />,
+    error: (e) => (
+      <ApiErrorAlert>{e.detail || 'Kunne ikke hente oppgave for vurderingen av aktivitetsplikt'}</ApiErrorAlert>
+    ),
+  })
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/brev/VurderingInfoBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/brev/VurderingInfoBrev.tsx
@@ -1,0 +1,9 @@
+import { Box, Heading } from '@navikt/ds-react'
+
+export function VurderingInfoBrev() {
+  return (
+    <Box paddingInline="16" paddingBlock="16">
+      <Heading size="large">Vurdering infobrev her</Heading>
+    </Box>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/sidemeny/AktivitetspliktSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/sidemeny/AktivitetspliktSidemeny.tsx
@@ -1,0 +1,30 @@
+import { useOppgaveForVurdering } from '~components/aktivitetsplikt/OppgaveVurderingRoute'
+import { Sidebar, SidebarPanel } from '~shared/components/Sidebar'
+import { BodyShort, Heading, Label, VStack } from '@navikt/ds-react'
+import { formaterOppgaveStatus } from '~utils/formatering/formatering'
+import { SakTypeTag } from '~shared/tags/SakTypeTag'
+import { DokumentlisteLiten } from '~components/person/dokumenter/DokumentlisteLiten'
+
+export function AktivitetspliktSidemeny() {
+  const oppgave = useOppgaveForVurdering()
+  return (
+    <Sidebar>
+      <SidebarPanel $border>
+        <Heading size="small">Vurdering av aktivitet</Heading>
+        <Heading size="xsmall">{formaterOppgaveStatus(oppgave.status)}</Heading>
+
+        <VStack gap="2">
+          <div>
+            <SakTypeTag sakType={oppgave.sakType} />
+          </div>
+          <div>
+            <Label>Saksbehandler</Label>
+            <BodyShort>{oppgave.saksbehandler?.navn ?? '-'}</BodyShort>
+          </div>
+        </VStack>
+      </SidebarPanel>
+
+      {oppgave.fnr && <DokumentlisteLiten fnr={oppgave.fnr} />}
+    </Sidebar>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/stegmeny/AktivitetspliktNavLenke.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/stegmeny/AktivitetspliktNavLenke.tsx
@@ -1,0 +1,39 @@
+import { DisabledLabel } from '~components/behandling/StegMeny/stegmeny'
+import { Label } from '@navikt/ds-react'
+import { ChevronRightIcon } from '@navikt/aksel-icons'
+import React from 'react'
+import { AktivitetspliktSteg } from '~components/aktivitetsplikt/stegmeny/AktivitetspliktStegmeny'
+import { NavLink, useMatch } from 'react-router-dom'
+
+interface Props {
+  path: AktivitetspliktSteg
+  description: string
+  enabled: boolean
+  erSisteRoute?: boolean
+}
+
+export function AktivitetNavLenke({ path, description, enabled, erSisteRoute }: Props) {
+  const match = useMatch('/aktivitet-vurdering/:oppgaveId/:steg')
+  const currentPath = match?.params?.steg
+
+  return (
+    <>
+      {!enabled ? (
+        <DisabledLabel>{description}</DisabledLabel>
+      ) : (
+        <>
+          {currentPath === path ? (
+            <Label>{description}</Label>
+          ) : (
+            <Label>
+              <NavLink to={path} style={{ textDecoration: 'none' }}>
+                {description}
+              </NavLink>
+            </Label>
+          )}
+        </>
+      )}
+      {!erSisteRoute && <ChevronRightIcon aria-hidden />}
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/stegmeny/AktivitetspliktStegmeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/stegmeny/AktivitetspliktStegmeny.tsx
@@ -1,0 +1,22 @@
+import { StegMenyBox } from '~components/behandling/StegMeny/stegmeny'
+import { HStack } from '@navikt/ds-react'
+import React from 'react'
+import { AktivitetNavLenke } from '~components/aktivitetsplikt/stegmeny/AktivitetspliktNavLenke'
+
+export enum AktivitetspliktSteg {
+  VURDERING = 'vurdering',
+  BREV = 'brev',
+}
+
+export function AktivitetspliktStegmeny() {
+  const skalBrevVises = true // TODO: logikk for om man skal sende brev
+
+  return (
+    <StegMenyBox>
+      <HStack gap="6" align="center">
+        <AktivitetNavLenke path={AktivitetspliktSteg.VURDERING} description="Oppfølging av aktivitet" enabled={true} />
+        <AktivitetNavLenke path={AktivitetspliktSteg.BREV} description="Brev" enabled={skalBrevVises} erSisteRoute />
+      </HStack>
+    </StegMenyBox>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/vurdering/VurderAktivitet.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/vurdering/VurderAktivitet.tsx
@@ -1,0 +1,15 @@
+import { Box, Heading } from '@navikt/ds-react'
+import React from 'react'
+
+export function VurderAktivitet() {
+  return (
+    <>
+      <Box paddingInline="16" paddingBlock="16 4">
+        <Heading level="1" size="large">
+          Oppfølging av aktivitet
+        </Heading>
+      </Box>
+      <Box paddingBlock="16"></Box>
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/components/HandlingerForOppgave.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/components/HandlingerForOppgave.tsx
@@ -4,7 +4,6 @@ import { OmgjoerVedtakModal } from '~components/oppgavebenk/oppgaveModal/Omgjoer
 import React from 'react'
 import { OppgaveDTO, OppgaveKilde, Oppgavestatus, Oppgavetype } from '~shared/types/oppgave'
 import { useInnloggetSaksbehandler } from '~components/behandling/useInnloggetSaksbehandler'
-import { AktivitetspliktInfoModal } from '~components/oppgavebenk/oppgaveModal/AktivitetspliktInfoModal'
 import { OpprettRevurderingModal } from '~components/person/OpprettRevurderingModal'
 import { AktivitetspliktRevurderingModal } from '~components/oppgavebenk/oppgaveModal/AktivitetspliktRevurderingModal'
 import { GeneriskOppgaveModal } from '~components/oppgavebenk/oppgaveModal/GeneriskOppgaveModal'
@@ -13,6 +12,10 @@ import { PersonOversiktFane } from '~components/person/Person'
 import { AktivitetspliktInfo6MndVarigUnntakModal } from '~components/oppgavebenk/oppgaveModal/AktivitetspliktInfo6MndVarigUnntakModal'
 import { BrevOppgaveModal } from '~components/oppgavebenk/oppgaveModal/BrevOppgaveModal'
 import { TilleggsinformasjonOppgaveModal } from '~components/oppgavebenk/oppgaveModal/TilleggsinformasjonOppgaveModal'
+import { useFeatureEnabledMedDefault } from '~shared/hooks/useFeatureToggle'
+import { AktivitetspliktInfoModal } from '~components/oppgavebenk/oppgaveModal/AktivitetspliktInfoModal'
+
+export const FEATURE_NY_SIDE_VURDERING_AKTIVITETSPLIKT = 'aktivitetsplikt.ny-vurdering'
 
 export const HandlingerForOppgave = ({
   oppgave,
@@ -25,6 +28,10 @@ export const HandlingerForOppgave = ({
 
   const { id, type, kilde, fnr, saksbehandler, referanse } = oppgave
   const erInnloggetSaksbehandlerOppgave = saksbehandler?.ident === innloggetsaksbehandler.ident
+  const brukNyVurderingssideAktivitetsplikt = useFeatureEnabledMedDefault(
+    FEATURE_NY_SIDE_VURDERING_AKTIVITETSPLIKT,
+    false
+  )
 
   if (kilde === OppgaveKilde.GENERELL_BEHANDLING) {
     switch (type) {
@@ -135,9 +142,14 @@ export const HandlingerForOppgave = ({
       )
     case Oppgavetype.AKTIVITETSPLIKT:
       return (
-        erInnloggetSaksbehandlerOppgave && (
+        erInnloggetSaksbehandlerOppgave &&
+        (brukNyVurderingssideAktivitetsplikt ? (
+          <Button size="small" as="a" href={`/aktivitet-vurdering/${id}/`}>
+            Gå til vurdering
+          </Button>
+        ) : (
           <AktivitetspliktInfoModal oppgave={oppgave} oppdaterStatus={oppdaterStatus} />
-        )
+        ))
       )
     case Oppgavetype.AKTIVITETSPLIKT_REVURDERING:
       return (

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/aktivitetsplikt.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/aktivitetsplikt.ts
@@ -64,6 +64,12 @@ export const hentAktivitspliktVurderingForOppgave = async (args: {
 }): Promise<ApiResponse<IAktivitetspliktVurdering>> =>
   apiClient.get(`/sak/${args.sakId}/oppgave/${args.oppgaveId}/aktivitetsplikt/vurdering`)
 
+export const hentAktivitspliktVurderingForOppgaveNy = async (args: {
+  sakId: number
+  oppgaveId: string
+}): Promise<ApiResponse<IAktivitetspliktVurderingNy>> =>
+  apiClient.get(`/sak/${args.sakId}/oppgave/${args.oppgaveId}/aktivitetsplikt/vurdering/ny`)
+
 export const opprettAktivitspliktAktivitetsgrad = async (args: {
   sakId: number
   oppgaveId: string


### PR DESCRIPTION
Denne siden skal ta over for modalen der vurderingen gjøres i dag, og skal også ta med de nye vurderingene som gjøres for 12 mnd-kravet

Denne endringen bygger opp skjelettet og har en feature-toggle (`aktivitetsplikt.ny-vurdering`) for om den brukes.