### PR TITLE
Minske error-logging når noe faktisk ikke er error

### DIFF
--- a/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -2,7 +2,7 @@ package no.nav.etterlatte
 
 import io.ktor.server.application.install
 import no.nav.etterlatte.libs.common.Miljoevariabler
-import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
+import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstart
 import no.nav.etterlatte.libs.ktor.initialisering.initEmbeddedServer
 import no.nav.etterlatte.libs.ktor.initialisering.run
 import no.nav.etterlatte.samordning.sak.behandlingSakRoutes
@@ -19,7 +19,7 @@ class Server(
     applicationContext: ApplicationContext,
 ) {
     init {
-        sikkerLoggOppstartOgAvslutning("etterlatte-api")
+        sikkerLoggOppstart("etterlatte-api")
     }
 
     private val engine =

--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -38,7 +38,7 @@ import no.nav.etterlatte.institusjonsopphold.institusjonsoppholdRoute
 import no.nav.etterlatte.kodeverk.kodeverk
 import no.nav.etterlatte.krr.krrRoute
 import no.nav.etterlatte.libs.common.TimerJob
-import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
+import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstart
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.initialisering.initEmbeddedServer
@@ -67,7 +67,7 @@ private class Server(
     private val context: ApplicationContext,
 ) {
     init {
-        sikkerLoggOppstartOgAvslutning("etterlatte-behandling")
+        sikkerLoggOppstart("etterlatte-behandling")
     }
 
     private val engine =

--- a/apps/etterlatte-beregning/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/Application.kt
@@ -5,7 +5,7 @@ import no.nav.etterlatte.beregning.beregning
 import no.nav.etterlatte.beregning.grunnlag.beregningsGrunnlag
 import no.nav.etterlatte.config.ApplicationContext
 import no.nav.etterlatte.grunnbeloep.grunnbeloep
-import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
+import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstart
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.initialisering.initEmbeddedServer
 import no.nav.etterlatte.libs.ktor.initialisering.run
@@ -20,7 +20,7 @@ class Server(
     private val context: ApplicationContext,
 ) {
     init {
-        sikkerLoggOppstartOgAvslutning("etterlatte-beregning")
+        sikkerLoggOppstart("etterlatte-beregning")
     }
 
     private val engine =

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -6,7 +6,7 @@ import no.nav.etterlatte.brev.notat.notatRoute
 import no.nav.etterlatte.brev.oversendelsebrev.oversendelseBrevRoute
 import no.nav.etterlatte.brev.varselbrev.varselbrevRoute
 import no.nav.etterlatte.brev.vedtaksbrev.vedtaksbrevRoute
-import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
+import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstart
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.initialisering.initEmbeddedServer
 import no.nav.etterlatte.libs.ktor.initialisering.run
@@ -19,7 +19,7 @@ private class Server(
     val context: ApplicationContext,
 ) {
     init {
-        sikkerLoggOppstartOgAvslutning("etterlatte-brev-api") // TODO: naisappame?
+        sikkerLoggOppstart("etterlatte-brev-api") // TODO: naisappame?
     }
 
     val engine =

--- a/apps/etterlatte-egne-ansatte-lytter/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-egne-ansatte-lytter/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -10,7 +10,7 @@ import no.nav.etterlatte.kafka.KafkaEnvironment
 import no.nav.etterlatte.kafka.startLytting
 import no.nav.etterlatte.libs.common.EnvEnum
 import no.nav.etterlatte.libs.common.Miljoevariabler
-import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
+import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstart
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 import no.nav.etterlatte.libs.ktor.initialisering.initEmbeddedServerUtenRest
 import no.nav.etterlatte.libs.ktor.initialisering.run
@@ -25,7 +25,7 @@ class Server {
     private val engine = initEmbeddedServerUtenRest(httpPort = 8080, applicationConfig = defaultConfig)
 
     init {
-        sikkerLoggOppstartOgAvslutning("etterlatte-egne-ansatte-lytter")
+        sikkerLoggOppstart("etterlatte-egne-ansatte-lytter")
     }
 
     fun run() {

--- a/apps/etterlatte-klage/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-klage/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -4,7 +4,7 @@ import io.ktor.server.application.Application
 import no.nav.etterlatte.kafka.startLytting
 import no.nav.etterlatte.klage.ApplicationContext
 import no.nav.etterlatte.klage.kabalOvesendelseRoute
-import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
+import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstart
 import no.nav.etterlatte.libs.ktor.initialisering.initEmbeddedServer
 import no.nav.etterlatte.libs.ktor.initialisering.run
 import org.slf4j.LoggerFactory
@@ -17,7 +17,7 @@ class Server(
     private val context: ApplicationContext,
 ) {
     init {
-        sikkerLoggOppstartOgAvslutning("etterlatte-klage")
+        sikkerLoggOppstart("etterlatte-klage")
     }
 
     private val engine =

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/Application.kt
@@ -3,7 +3,7 @@ package no.nav.etterlatte
 import io.ktor.server.routing.route
 import no.nav.etterlatte.config.ApplicationContext
 import no.nav.etterlatte.libs.common.Miljoevariabler
-import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
+import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstart
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.ktor.initialisering.initEmbeddedServer
 import no.nav.etterlatte.libs.ktor.initialisering.run
@@ -23,7 +23,7 @@ class Server(
     applicationContext: ApplicationContext,
 ) {
     init {
-        sikkerLoggOppstartOgAvslutning("etterlatte-pdltjenester")
+        sikkerLoggOppstart("etterlatte-pdltjenester")
     }
 
     private val engine =

--- a/apps/etterlatte-statistikk/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/Application.kt
@@ -1,11 +1,11 @@
 package no.nav.etterlatte
 
-import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
+import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstart
 import no.nav.etterlatte.statistikk.config.ApplicationContext
 
 fun main() =
     with(ApplicationContext()) {
         maanedligStatistikkJob.schedule().also { addShutdownHook(it) }
         initRapidsConnection()
-        sikkerLoggOppstartOgAvslutning("etterlatte-statistikk")
+        sikkerLoggOppstart("etterlatte-statistikk")
     }

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/Application.kt
@@ -4,7 +4,7 @@ import com.typesafe.config.ConfigFactory
 import io.ktor.server.application.log
 import io.ktor.server.routing.application
 import no.nav.etterlatte.libs.common.appIsInGCP
-import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
+import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstart
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.initialisering.initEmbeddedServer
 import no.nav.etterlatte.libs.ktor.initialisering.run
@@ -22,7 +22,7 @@ class Server(
     val devMode = context.properties.devMode
 
     init {
-        sikkerLoggOppstartOgAvslutning("etterlatte-tilbakekreving")
+        sikkerLoggOppstart("etterlatte-tilbakekreving")
     }
 
     private val engine =

--- a/apps/etterlatte-trygdetid/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/Application.kt
@@ -1,6 +1,6 @@
 package no.nav.etterlatte
 
-import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
+import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstart
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.initialisering.initEmbeddedServer
 import no.nav.etterlatte.libs.ktor.initialisering.run
@@ -16,7 +16,7 @@ class Server(
     private val context: ApplicationContext,
 ) {
     init {
-        sikkerLoggOppstartOgAvslutning("etterlatte-trygdetid")
+        sikkerLoggOppstart("etterlatte-trygdetid")
     }
 
     private val engine =

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/Application.kt
@@ -1,6 +1,6 @@
 package no.nav.etterlatte
 
-import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
+import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstart
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.initialisering.initEmbeddedServer
 import no.nav.etterlatte.libs.ktor.initialisering.run
@@ -19,7 +19,7 @@ class Server(
     private val context: ApplicationContext,
 ) {
     init {
-        sikkerLoggOppstartOgAvslutning("etterlatte-vedtakdsvurdering")
+        sikkerLoggOppstart("etterlatte-vedtakdsvurdering")
     }
 
     private val engine =

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/config/ApplicationContext.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/config/ApplicationContext.kt
@@ -15,7 +15,7 @@ import no.nav.etterlatte.libs.common.EnvEnum
 import no.nav.etterlatte.libs.common.Miljoevariabler
 import no.nav.etterlatte.libs.common.OpeningHours
 import no.nav.etterlatte.libs.common.appIsInGCP
-import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
+import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstart
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.jobs.LeaderElection
 import no.nav.etterlatte.libs.ktor.AppConfig.ELECTOR_PATH
@@ -47,7 +47,7 @@ import java.util.UUID
 
 class ApplicationContext {
     init {
-        sikkerLoggOppstartOgAvslutning("etterlatte-vedtaksvurdering")
+        sikkerLoggOppstart("etterlatte-vedtaksvurdering")
     }
 
     val env = Miljoevariabler.systemEnv()

--- a/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-vilkaarsvurdering/src/main/kotlin/Application.kt
@@ -1,6 +1,6 @@
 package no.nav.etterlatte
 
-import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
+import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstart
 import no.nav.etterlatte.libs.database.migrate
 import no.nav.etterlatte.libs.ktor.initialisering.initEmbeddedServer
 import no.nav.etterlatte.libs.ktor.initialisering.run
@@ -15,7 +15,7 @@ class Server(
     private val context: ApplicationContext,
 ) {
     init {
-        sikkerLoggOppstartOgAvslutning("etterlatte-vilkaarsvurdering")
+        sikkerLoggOppstart("etterlatte-vilkaarsvurdering")
     }
 
     private val engine =

--- a/libs/etterlatte-ktor/src/main/kotlin/HealthRoute.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/HealthRoute.kt
@@ -6,6 +6,7 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
+import no.nav.etterlatte.libs.ktor.initialisering.isReady
 
 fun Route.healthApi() {
     route("health") {

--- a/libs/etterlatte-ktor/src/main/kotlin/initialisering/EmbeddedServerConfig.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/initialisering/EmbeddedServerConfig.kt
@@ -19,7 +19,6 @@ import no.nav.etterlatte.libs.ktor.healthApi
 import no.nav.etterlatte.libs.ktor.ktor.shutdownPolicyEmbeddedServer
 import no.nav.etterlatte.libs.ktor.metricsRoute
 import no.nav.etterlatte.libs.ktor.restModule
-import no.nav.etterlatte.libs.ktor.setReady
 
 fun initEmbeddedServer(
     httpPort: Int,

--- a/libs/etterlatte-ktor/src/main/kotlin/initialisering/ReadinessProbe.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/initialisering/ReadinessProbe.kt
@@ -1,10 +1,20 @@
-package no.nav.etterlatte.libs.ktor
+package no.nav.etterlatte.libs.ktor.initialisering
 
 import io.ktor.http.HttpStatusCode
+import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
 import java.util.concurrent.atomic.AtomicBoolean
 
 private var ready = AtomicBoolean(false)
 
 fun setReady(value: Boolean = true) = ready.set(value)
 
-fun isReady() = if (ready.get()) HttpStatusCode.OK else HttpStatusCode.ServiceUnavailable
+fun isReady() =
+    if (ready.get()) {
+        HttpStatusCode.OK
+    } else {
+        throw ForespoerselException(
+            status = HttpStatusCode.ServiceUnavailable.value,
+            "SERVICE_UNAVAILABLE",
+            "Service not yet ready",
+        )
+    }

--- a/libs/etterlatte-ktor/src/test/kotlin/RestModuleTest.kt
+++ b/libs/etterlatte-ktor/src/test/kotlin/RestModuleTest.kt
@@ -31,6 +31,7 @@ import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.toJson
+import no.nav.etterlatte.libs.ktor.initialisering.setReady
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.BehandlingTilgangsSjekk
 import no.nav.etterlatte.libs.ktor.route.FoedselsnummerDTO

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/InitRogR.kt
@@ -2,7 +2,7 @@ package rapidsandrivers
 
 import io.ktor.server.application.Application
 import no.nav.etterlatte.libs.common.Miljoevariabler
-import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstartOgAvslutning
+import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstart
 import no.nav.etterlatte.rapidsandrivers.getRapidEnv
 import no.nav.helse.rapids_rivers.AivenConfig
 import no.nav.helse.rapids_rivers.Config
@@ -15,7 +15,7 @@ fun initRogR(
     configFromEnvironment: (Miljoevariabler) -> Config = { AivenConfig.default },
     settOppRivers: (RapidsConnection, rapidEnv: Miljoevariabler) -> Unit,
 ) {
-    sikkerLoggOppstartOgAvslutning("etterlatte-$applikasjonsnavn")
+    sikkerLoggOppstart("etterlatte-$applikasjonsnavn")
 
     val rapidEnv = getRapidEnv()
 

--- a/libs/saksbehandling-common/src/main/kotlin/ShutdownHook.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/ShutdownHook.kt
@@ -19,6 +19,10 @@ fun addShutdownHook(vararg timer: Timer) {
             },
         )
     } catch (e: IllegalStateException) {
-        logger.warn("App er på vei ned allerede, kan ikke legge til shutdownhooks", e)
+        try {
+            logger.warn("App er på vei ned allerede, kan ikke legge til shutdownhooks", e)
+        } catch (e: Exception) {
+            // Ignorer at vi  ikke får logget på grunn av shutdown, da er det ikke noe å gjøre uansett
+        }
     }
 }

--- a/libs/saksbehandling-common/src/main/kotlin/logging/LogUtils.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/logging/LogUtils.kt
@@ -50,14 +50,9 @@ private fun generateCorrelationId() = UUID.randomUUID().toString()
 
 fun getCorrelationId(): String = MDC.get(CORRELATION_ID) ?: generateCorrelationId()
 
-fun sikkerLoggOppstartOgAvslutning(applikasjonsnavn: String) {
+fun sikkerLoggOppstart(applikasjonsnavn: String) {
     val sikkerLogg = sikkerlogger()
     sikkerLogg.info("SikkerLogg: $applikasjonsnavn oppstart")
-    Runtime.getRuntime().addShutdownHook(
-        Thread {
-            sikkerLogg.debug("SikkerLogg: $applikasjonsnavn avslutter")
-        },
-    )
 }
 
 fun sikkerlogger(): Logger = LoggerFactory.getLogger("sikkerLogg")


### PR DESCRIPTION
Endringen i isReady-endepunktene våre bør fjerne `Et endepunkt returnerte 503 Service Unavailable. Maskerer som 500: ` fra error-logging, ved at vi heller håndterer det som en standard ForespoerselException med status = 503. Tenker å teste deploy på denne i dev for å sjekke at vi ikke brekker noe når vi returnerer en faktisk response-body med 503'en når vi ikke er klar, men kan i utgangspunktet ikke se at det er et problem.

Tar også å fjerner shutdown-logging for sikkerlogg, da den i alle fall et tilfelle ser ut til å ha forårsaket en "Uncaught exception in thread main: Shutdown in progress"-feil. Vi trenger ikke at sikkerlogg logger at appen går ned uansett, det er en ganske sporbar greie i vanlige logger, og hvis den kan forårsake spammy logging ved enkelte deploys er det mer bry enn det er verdt uansett.