### PR TITLE
Ha min 2 og max 4 brev-api apper oppe å kjøre brev-api

### DIFF
--- a/apps/etterlatte-brev-api/.nais/dev.yaml
+++ b/apps/etterlatte-brev-api/.nais/dev.yaml
@@ -64,8 +64,8 @@ spec:
       cpu: 20m
       memory: 512Mi
   replicas:
-    max: 1
-    min: 1
+    max: 4
+    min: 2
   env:
     - name: BREVBAKER_URL
       value: https://pensjon-brevbaker.intern.dev.nav.no

--- a/apps/etterlatte-brev-api/.nais/prod.yaml
+++ b/apps/etterlatte-brev-api/.nais/prod.yaml
@@ -73,8 +73,8 @@ spec:
       cpu: 20m
       memory: 512Mi
   replicas:
-    max: 1
-    min: 1
+    max: 4
+    min: 2
   env:
     - name: BREVBAKER_URL
       value: https://pensjon-brevbaker.intern.nav.no


### PR DESCRIPTION
Ser ingen umiddelbar grunn til at brev-api ikke kan ha flere instanser oppe å kjøre nå som den er pure rest app.