### PR TITLE
EY-4513: Gjør verifikasjon av omregning kun ved regulering

### DIFF
--- a/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/beregningkafka/BeregningService.kt
+++ b/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/beregningkafka/BeregningService.kt
@@ -43,7 +43,7 @@ class BeregningService(
             beregningApp.put("$url/api/beregning/beregningsgrunnlag/$omregningsId/overstyr/regulering")
         }
 
-    fun regulerAvkorting(
+    fun omregnAvkorting(
         behandlingId: UUID,
         forrigeBehandlingId: UUID,
     ): HttpResponse =

--- a/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/beregningkafka/OmregningHendelserBeregningRiver.kt
+++ b/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/beregningkafka/OmregningHendelserBeregningRiver.kt
@@ -64,7 +64,9 @@ internal class OmregningHendelserBeregningRiver(
         runBlocking {
             val beregning = beregn(sakType, behandlingId, behandlingViOmregnerFra)
             packet[BEREGNING_KEY] = beregning.beregning
-            sendMedInformasjonTilKontrollsjekking(beregning, packet)
+
+            // TODO denne burde flyttes ut av direkte omregning
+            // sendMedInformasjonTilKontrollsjekking(beregning, packet)
         }
         packet.setEventNameForHendelseType(OmregningHendelseType.BEREGNA)
         context.publish(packet.toJson())
@@ -76,18 +78,19 @@ internal class OmregningHendelserBeregningRiver(
         behandlingId: UUID,
         behandlingViOmregnerFra: UUID,
     ): BeregningOgAvkorting {
-        val g = beregningService.hentGrunnbeloep()
         beregningService.opprettBeregningsgrunnlagFraForrigeBehandling(behandlingId, behandlingViOmregnerFra)
         beregningService.tilpassOverstyrtBeregningsgrunnlagForRegulering(behandlingId)
         val beregning = beregningService.beregn(behandlingId).body<BeregningDTO>()
         val forrigeBeregning = beregningService.hentBeregning(behandlingViOmregnerFra).body<BeregningDTO>()
 
-        verifiserToleransegrenser(ny = beregning, gammel = forrigeBeregning, g = g, behandlingId = behandlingId)
+        // TODO denne burde flyttes ut av omregning
+        // val g = beregningService.hentGrunnbeloep()
+        // verifiserToleransegrenser(ny = beregning, gammel = forrigeBeregning, g = g, behandlingId = behandlingId)
 
         return if (sakType == SakType.OMSTILLINGSSTOENAD) {
             val avkorting =
                 beregningService
-                    .regulerAvkorting(behandlingId, behandlingViOmregnerFra)
+                    .omregnAvkorting(behandlingId, behandlingViOmregnerFra)
                     .body<AvkortingDto>()
             val forrigeAvkorting =
                 beregningService

--- a/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/beregningkafka/OmregningHendelserBeregningRiver.kt
+++ b/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/beregningkafka/OmregningHendelserBeregningRiver.kt
@@ -4,6 +4,7 @@ import io.ktor.client.call.body
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.grunnbeloep.Grunnbeloep
+import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.beregning.AvkortetYtelseDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingDto
@@ -62,11 +63,13 @@ internal class OmregningHendelserBeregningRiver(
         val behandlingViOmregnerFra = omregningData.hentForrigeBehandlingid()
         val sakType = omregningData.hentSakType()
         runBlocking {
-            val beregning = beregn(sakType, behandlingId, behandlingViOmregnerFra)
+            val beregning = beregn(sakType, omregningData.revurderingaarsak, behandlingId, behandlingViOmregnerFra)
             packet[BEREGNING_KEY] = beregning.beregning
 
-            // TODO denne burde flyttes ut av direkte omregning
-            // sendMedInformasjonTilKontrollsjekking(beregning, packet)
+            // TODO bør vi ha slike ting her?
+            if (omregningData.revurderingaarsak == Revurderingaarsak.REGULERING) {
+                sendMedInformasjonTilKontrollsjekking(beregning, packet)
+            }
         }
         packet.setEventNameForHendelseType(OmregningHendelseType.BEREGNA)
         context.publish(packet.toJson())
@@ -75,6 +78,7 @@ internal class OmregningHendelserBeregningRiver(
 
     internal suspend fun beregn(
         sakType: SakType,
+        revurderingaarsak: Revurderingaarsak,
         behandlingId: UUID,
         behandlingViOmregnerFra: UUID,
     ): BeregningOgAvkorting {
@@ -83,9 +87,11 @@ internal class OmregningHendelserBeregningRiver(
         val beregning = beregningService.beregn(behandlingId).body<BeregningDTO>()
         val forrigeBeregning = beregningService.hentBeregning(behandlingViOmregnerFra).body<BeregningDTO>()
 
-        // TODO denne burde flyttes ut av omregning
-        // val g = beregningService.hentGrunnbeloep()
-        // verifiserToleransegrenser(ny = beregning, gammel = forrigeBeregning, g = g, behandlingId = behandlingId)
+        if (revurderingaarsak == Revurderingaarsak.REGULERING) {
+            // TODO denne burde flyttes ut av omregning
+            val g = beregningService.hentGrunnbeloep()
+            verifiserToleransegrenser(ny = beregning, gammel = forrigeBeregning, g = g, behandlingId = behandlingId)
+        }
 
         return if (sakType == SakType.OMSTILLINGSSTOENAD) {
             val avkorting =

--- a/apps/etterlatte-beregning-kafka/src/test/kotlin/no/nav/etterlatte/beregningkafka/OmregningHendelserBeregningRiverTest.kt
+++ b/apps/etterlatte-beregning-kafka/src/test/kotlin/no/nav/etterlatte/beregningkafka/OmregningHendelserBeregningRiverTest.kt
@@ -10,6 +10,7 @@ import io.mockk.runs
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.randomSakId
 import no.nav.etterlatte.grunnbeloep.Grunnbeloep
+import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.beregning.BeregningDTO
 import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
@@ -54,6 +55,7 @@ class OmregningHendelserBeregningRiverTest {
         runBlocking {
             river.beregn(
                 SakType.BARNEPENSJON,
+                revurderingaarsak = Revurderingaarsak.REGULERING,
                 behandlingId = nyBehandling,
                 behandlingViOmregnerFra = gammelBehandling,
             )
@@ -88,6 +90,7 @@ class OmregningHendelserBeregningRiverTest {
             assertThrows<MindreEnnForrigeBehandling> {
                 river.beregn(
                     SakType.BARNEPENSJON,
+                    revurderingaarsak = Revurderingaarsak.REGULERING,
                     behandlingId = nyBehandling,
                     behandlingViOmregnerFra = gammelBehandling,
                 )
@@ -124,6 +127,7 @@ class OmregningHendelserBeregningRiverTest {
         runBlocking {
             river.beregn(
                 SakType.BARNEPENSJON,
+                revurderingaarsak = Revurderingaarsak.REGULERING,
                 behandlingId = nyBehandling,
                 behandlingViOmregnerFra = gammelBehandling,
             )
@@ -158,6 +162,7 @@ class OmregningHendelserBeregningRiverTest {
             assertThrows<ForStorOekning> {
                 river.beregn(
                     SakType.BARNEPENSJON,
+                    revurderingaarsak = Revurderingaarsak.REGULERING,
                     behandlingId = nyBehandling,
                     behandlingViOmregnerFra = gammelBehandling,
                 )
@@ -193,6 +198,7 @@ class OmregningHendelserBeregningRiverTest {
             val resultat =
                 river.beregn(
                     SakType.BARNEPENSJON,
+                    revurderingaarsak = Revurderingaarsak.REGULERING,
                     behandlingId = nyBehandling,
                     behandlingViOmregnerFra = gammelBehandling,
                 )

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -60,7 +60,7 @@ fun Route.avkorting(
 
         post("/med/{forrigeBehandlingId}") {
             withBehandlingId(behandlingKlient, skrivetilgang = true) {
-                logger.info("Regulere avkorting for behandlingId=$it")
+                logger.info("Kopierer avkorting for behandlingId=$it")
                 val forrigeBehandlingId = call.uuid("forrigeBehandlingId")
                 val avkorting = avkortingService.kopierAvkorting(it, forrigeBehandlingId, brukerTokenInfo)
                 call.respond(avkorting.toDto())

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -151,7 +151,7 @@ class AvkortingService(
     fun slettAvkorting(behandlingId: UUID) = avkortingRepository.slettForBehandling(behandlingId)
 
     /*
-     * Brukes ved automatisk regulering
+     * Brukes ved omregning
      */
     suspend fun kopierAvkorting(
         behandlingId: UUID,

--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/VedtakAttestertRiver.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/regulering/VedtakAttestertRiver.kt
@@ -7,7 +7,6 @@ import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseHendelseType
 import no.nav.etterlatte.rapidsandrivers.Kontekst
 import no.nav.etterlatte.rapidsandrivers.ListenerMedLoggingOgFeilhaandtering
 import no.nav.etterlatte.rapidsandrivers.OmregningDataPacket
-import no.nav.etterlatte.rapidsandrivers.RapidEvents.KJOERING
 import no.nav.etterlatte.rapidsandrivers.ReguleringEvents.AVKORTING_ETTER
 import no.nav.etterlatte.rapidsandrivers.ReguleringEvents.AVKORTING_FOER
 import no.nav.etterlatte.rapidsandrivers.ReguleringEvents.BEREGNING_BELOEP_ETTER
@@ -16,9 +15,7 @@ import no.nav.etterlatte.rapidsandrivers.ReguleringEvents.BEREGNING_BRUKT_OMREGN
 import no.nav.etterlatte.rapidsandrivers.ReguleringEvents.BEREGNING_G_ETTER
 import no.nav.etterlatte.rapidsandrivers.ReguleringEvents.BEREGNING_G_FOER
 import no.nav.etterlatte.rapidsandrivers.ReguleringEvents.VEDTAK_BELOEP
-import no.nav.etterlatte.rapidsandrivers.kjoering
 import no.nav.etterlatte.rapidsandrivers.omregningData
-import no.nav.etterlatte.rapidsandrivers.sakId
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
@@ -36,11 +33,11 @@ internal class VedtakAttestertRiver(
             validate { it.requireKey(OmregningDataPacket.KEY) }
             validate { it.requireKey(OmregningDataPacket.SAK_ID) }
             validate { it.requireKey(OmregningDataPacket.KJOERING) }
-            validate { it.requireKey(BEREGNING_BELOEP_FOER) }
-            validate { it.requireKey(BEREGNING_BELOEP_ETTER) }
-            validate { it.requireKey(BEREGNING_G_FOER) }
-            validate { it.requireKey(BEREGNING_G_ETTER) }
-            validate { it.requireKey(BEREGNING_BRUKT_OMREGNINGSFAKTOR) }
+            validate { it.interestedIn(BEREGNING_BELOEP_FOER) }
+            validate { it.interestedIn(BEREGNING_BELOEP_ETTER) }
+            validate { it.interestedIn(BEREGNING_G_FOER) }
+            validate { it.interestedIn(BEREGNING_G_ETTER) }
+            validate { it.interestedIn(BEREGNING_BRUKT_OMREGNINGSFAKTOR) }
             validate { it.interestedIn(AVKORTING_FOER) }
             validate { it.interestedIn(AVKORTING_ETTER) }
             validate { it.requireKey(VEDTAK_BELOEP) }
@@ -65,8 +62,8 @@ internal class VedtakAttestertRiver(
                 beregningGFoer = bigDecimal(packet, BEREGNING_G_FOER),
                 beregningGEtter = bigDecimal(packet, BEREGNING_G_ETTER),
                 beregningBruktOmregningsfaktor = bigDecimal(packet, BEREGNING_BRUKT_OMREGNINGSFAKTOR),
-                avkortingFoer = packet[AVKORTING_FOER].asText().takeIf { it.isNotEmpty() }?.let { BigDecimal(it) },
-                avkortingEtter = packet[AVKORTING_ETTER].asText().takeIf { it.isNotEmpty() }?.let { BigDecimal(it) },
+                avkortingFoer = bigDecimal(packet, AVKORTING_FOER),
+                avkortingEtter = bigDecimal(packet, AVKORTING_ETTER),
                 vedtakBeloep = bigDecimal(packet, VEDTAK_BELOEP),
             )
         behandlingService.lagreFullfoertKjoering(request)
@@ -76,5 +73,5 @@ internal class VedtakAttestertRiver(
     private fun bigDecimal(
         packet: JsonMessage,
         noekkel: String,
-    ) = BigDecimal(packet[noekkel].asText())
+    ): BigDecimal? = packet[noekkel].asText().takeIf { it.isNotEmpty() }?.let { BigDecimal(it) }
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/behandlingsslistemappere.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/behandlingsslistemappere.ts
@@ -11,6 +11,8 @@ export function mapAarsak(aarsak: BehandlingOgRevurderingsAarsakerType) {
       return 'Revurdering'
     case Revurderingaarsak.REGULERING:
       return 'Regulering'
+    case Revurderingaarsak.OMREGNING:
+      return 'Omregning'
     case Revurderingaarsak.ANSVARLIGE_FORELDRE:
       return 'Ansvarlige foreldre'
     case Revurderingaarsak.SOESKENJUSTERING:

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/sak/KjoeringRequest.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/sak/KjoeringRequest.kt
@@ -12,14 +12,14 @@ data class LagreKjoeringRequest(
     val kjoering: String,
     val status: KjoeringStatus,
     val sakId: SakId,
-    val beregningBeloepFoer: BigDecimal,
-    val beregningBeloepEtter: BigDecimal,
-    val beregningGFoer: BigDecimal,
-    val beregningGEtter: BigDecimal,
-    val beregningBruktOmregningsfaktor: BigDecimal,
+    val beregningBeloepFoer: BigDecimal?,
+    val beregningBeloepEtter: BigDecimal?,
+    val beregningGFoer: BigDecimal?,
+    val beregningGEtter: BigDecimal?,
+    val beregningBruktOmregningsfaktor: BigDecimal?,
     val avkortingFoer: BigDecimal?,
     val avkortingEtter: BigDecimal?,
-    val vedtakBeloep: BigDecimal,
+    val vedtakBeloep: BigDecimal?,
 )
 
 enum class KjoeringStatus {


### PR DESCRIPTION
Pr nå så er verifikasjonen med toleransegrenser og forrige / gjeldende beregning veldig tilpasset regulering som kun må forholde seg til en periode (for og etter ny G). Ved omregning feks fra 1. virk, vil det potensielt bli en lang tidslinje med mange perioder og det gir ikke samme mening å verifisere beløp her på en gitt dato. 

I denne PR'en gjøres det endringer slik at det kun er regulering som gjør verifikasjonene som er lagt inn. Videre er det tenkt å se på muligheten for å verifisere omregning med feks simulering. 
