### PR TITLE
EY-3627 Gjøre mottaker(e) på brev til liste

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageService.kt
@@ -606,7 +606,7 @@ class KlageServiceImpl(
             klage = klage,
             ekstradataInnstilling =
                 EkstradataInnstilling(
-                    mottakerInnstilling = brevMottakerTilKlageMottaker(ferdigstillResultat.oversendelsesbrev.mottaker),
+                    mottakerInnstilling = brevMottakerTilKlageMottaker(ferdigstillResultat.oversendelsesbrev.mottakere.single()),
                     // TODO: Håndter verge
                     vergeEllerFullmektig = null,
                     journalpostInnstillingsbrev = ferdigstillResultat.notatTilKa.journalpostId,

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/klage/KlageServiceImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/klage/KlageServiceImplTest.kt
@@ -619,17 +619,20 @@ internal class KlageServiceImplTest : BehandlingIntegrationTest() {
         Brev(
             id = brevId,
             status = BrevStatus.OPPRETTET,
-            mottaker =
-                Mottaker(
-                    navn = "Mottaker mottakersen",
-                    foedselsnummer = MottakerFoedselsnummer("19448310410"),
-                    orgnummer = null,
-                    adresse =
-                        Adresse(
-                            adresseType = "",
-                            landkode = "",
-                            land = "",
-                        ),
+            mottakere =
+                listOf(
+                    Mottaker(
+                        UUID.randomUUID(),
+                        navn = "Mottaker mottakersen",
+                        foedselsnummer = MottakerFoedselsnummer("19448310410"),
+                        orgnummer = null,
+                        adresse =
+                            Adresse(
+                                adresseType = "",
+                                landkode = "",
+                                land = "",
+                            ),
+                    ),
                 ),
             journalpostId = null,
             bestillingId = null,

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingServiceIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/tilbakekreving/TilbakekrevingServiceIntegrationTest.kt
@@ -562,17 +562,20 @@ internal class TilbakekrevingServiceIntegrationTest : BehandlingIntegrationTest(
         Brev(
             id = brevId,
             status = no.nav.etterlatte.brev.model.Status.OPPRETTET,
-            mottaker =
-                Mottaker(
-                    navn = "Mottaker mottakersen",
-                    foedselsnummer = MottakerFoedselsnummer("19448310410"),
-                    orgnummer = null,
-                    adresse =
-                        Adresse(
-                            adresseType = "",
-                            landkode = "",
-                            land = "",
-                        ),
+            mottakere =
+                listOf(
+                    Mottaker(
+                        UUID.randomUUID(),
+                        navn = "Mottaker mottakersen",
+                        foedselsnummer = MottakerFoedselsnummer("19448310410"),
+                        orgnummer = null,
+                        adresse =
+                            Adresse(
+                                adresseType = "",
+                                landkode = "",
+                                land = "",
+                            ),
+                    ),
                 ),
             journalpostId = null,
             bestillingId = null,

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
@@ -401,17 +401,20 @@ class BrevApiKlientTest : BrevApiKlient {
         Brev(
             id = brevId,
             status = Status.OPPRETTET,
-            mottaker =
-                Mottaker(
-                    navn = "Mottaker mottakersen",
-                    foedselsnummer = MottakerFoedselsnummer("19448310410"),
-                    orgnummer = null,
-                    adresse =
-                        Adresse(
-                            adresseType = "",
-                            landkode = "",
-                            land = "",
-                        ),
+            mottakere =
+                listOf(
+                    Mottaker(
+                        UUID.randomUUID(),
+                        navn = "Mottaker mottakersen",
+                        foedselsnummer = MottakerFoedselsnummer("19448310410"),
+                        orgnummer = null,
+                        adresse =
+                            Adresse(
+                                adresseType = "",
+                                landkode = "",
+                                land = "",
+                            ),
+                    ),
                 ),
             journalpostId = null,
             bestillingId = null,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
@@ -77,9 +77,9 @@ fun Route.brevRoute(
             withSakId(tilgangssjekker, skrivetilgang = true) {
                 val body = call.receive<OppdaterMottakerRequest>()
 
-                val mottaker = service.oppdaterMottaker(brevId, body.mottaker)
+                service.oppdaterMottaker(brevId, body.mottaker)
 
-                call.respond(mottaker)
+                call.respond(HttpStatusCode.OK)
             }
         }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -139,13 +139,13 @@ class BrevService(
     }
 
     fun oppdaterMottaker(
-        id: BrevID,
+        brevId: BrevID,
         mottaker: Mottaker,
     ): Int {
-        sjekkOmBrevKanEndres(id)
+        sjekkOmBrevKanEndres(brevId)
         return db
-            .oppdaterMottaker(id, mottaker)
-            .also { logger.info("Mottaker på brev (id=$id) oppdatert") }
+            .oppdaterMottaker(brevId, mottaker)
+            .also { logger.info("Mottaker på brev (id=$brevId) oppdatert") }
     }
 
     fun oppdaterTittel(
@@ -187,9 +187,9 @@ class BrevService(
     ) {
         val brev = sjekkOmBrevKanEndres(id)
 
-        if (brev.mottaker.erGyldig().isNotEmpty()) {
-            sikkerlogger.error("Ugyldig mottaker: ${brev.mottaker.toJson()}")
-            throw UgyldigMottakerKanIkkeFerdigstilles(brev.id, brev.sakId, brev.mottaker.erGyldig())
+        if (brev.mottakere.any { it.erGyldig().isNotEmpty() }) {
+            sikkerlogger.error("Ugyldig mottaker: ${brev.mottakere.toJson()}")
+            throw UgyldigMottakerKanIkkeFerdigstilles(brev.id, brev.sakId, brev.mottakere.flatMap { it.erGyldig() })
         } else if (brev.prosessType == BrevProsessType.OPPLASTET_PDF) {
             db.settBrevFerdigstilt(id)
         } else {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -152,6 +152,7 @@ class Brevoppretter(
 
     private fun tomMottaker() =
         Mottaker(
+            UUID.randomUUID(),
             navn = "Ukjent",
             foedselsnummer = null,
             orgnummer = null,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/JournalfoerBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/JournalfoerBrevService.kt
@@ -32,7 +32,7 @@ class JournalfoerBrevService(
     private val dokarkivService: DokarkivService,
     private val service: VedtaksbrevService,
 ) {
-    val logger = LoggerFactory.getLogger(this::class.java)
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     suspend fun journalfoer(
         id: BrevID,
@@ -110,8 +110,12 @@ class JournalfoerBrevService(
         val innhold = requireNotNull(db.hentBrevInnhold(brev.id))
         val pdf = requireNotNull(db.hentPdf(brev.id))
 
+        /*
+         * TODO:
+         *   Her må det skilles på hoved- og kopimottaker!
+         */
         val avsenderMottaker =
-            with(brev.mottaker) {
+            with(brev.mottakere.single()) {
                 AvsenderMottaker(
                     id = foedselsnummer?.value ?: orgnummer,
                     idType =

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/distribusjon/Brevdistribuerer.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/distribusjon/Brevdistribuerer.kt
@@ -31,20 +31,25 @@ class Brevdistribuerer(
                     "JournalpostID mangler på brev (id=${brev.id}, status=${brev.status})"
                 }
 
-        val mottaker =
-            requireNotNull(brev.mottaker) {
-                "Mottaker må være satt for å kunne distribuere brevet (id: $brevId)"
-            }
+        check(brev.mottakere.isNotEmpty()) {
+            "Det må finnes minst 1 mottaker for å kunne distribuere brevet (id: $brevId)"
+        }
 
-        return distribusjonService
-            .distribuerJournalpost(
-                brevId = brev.id,
-                journalpostId = journalpostId,
-                type = distribusjonsType,
-                tidspunkt = DistribusjonsTidspunktType.KJERNETID,
-                adresse = mottaker.adresse,
-                tvingSentralPrint = mottaker.tvingSentralPrint,
-            ).also { logger.info("Distribuerte brev $brevId") }
+        /*
+         * TODO:
+         *  Må håndtere flere [BestillingsID] når det blir mulig å legge til flere mottakere.
+         */
+        return with(brev.mottakere.single()) {
+            distribusjonService
+                .distribuerJournalpost(
+                    brevId = brev.id,
+                    journalpostId = journalpostId,
+                    type = distribusjonsType,
+                    tidspunkt = DistribusjonsTidspunktType.KJERNETID,
+                    adresse = adresse,
+                    tvingSentralPrint = tvingSentralPrint,
+                ).also { logger.info("Distribuerte brev $brevId") }
+        }
     }
 }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -16,6 +16,7 @@ fun mottakerFraAdresse(
     fnr: Folkeregisteridentifikator,
     regoppslag: RegoppslagResponseDTO,
 ) = Mottaker(
+    id = UUID.randomUUID(),
     navn = regoppslag.navn,
     foedselsnummer = MottakerFoedselsnummer(fnr.value),
     adresse =
@@ -34,6 +35,7 @@ fun mottakerFraAdresse(
 
 fun tomMottaker(fnr: Folkeregisteridentifikator) =
     Mottaker(
+        id = UUID.randomUUID(),
         navn = "N/A",
         foedselsnummer = MottakerFoedselsnummer(fnr.value),
         adresse =
@@ -57,7 +59,7 @@ fun opprettBrevFra(
     soekerFnr = opprettNyttBrev.soekerFnr,
     status = opprettNyttBrev.status,
     statusEndret = opprettNyttBrev.opprettet,
-    mottaker = opprettNyttBrev.mottaker,
+    mottakere = listOf(opprettNyttBrev.mottaker),
     opprettet = opprettNyttBrev.opprettet,
     brevtype = opprettNyttBrev.brevtype,
     brevkoder = opprettNyttBrev.brevkoder,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
@@ -252,6 +252,7 @@ class OversendelseBrevServiceImpl(
 
     private fun tomMottaker() =
         Mottaker(
+            id = UUID.randomUUID(),
             navn = "Ukjent",
             foedselsnummer = null,
             orgnummer = null,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/pdf/PDFGenerator.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/pdf/PDFGenerator.kt
@@ -46,9 +46,9 @@ class PDFGenerator(
         brevDataMapping: suspend (BrevDataFerdigstillingRequest) -> BrevDataFerdigstilling,
     ): Pdf {
         val brev = sjekkOmBrevKanEndres(id)
-        if (brev.mottaker.erGyldig().isNotEmpty()) {
-            sikkerlogger.error("Ugyldig mottaker: ${brev.mottaker.toJson()}")
-            throw UgyldigMottakerKanIkkeFerdigstilles(brev.id, brev.sakId, brev.mottaker.erGyldig())
+        if (brev.mottakere.any { it.erGyldig().isNotEmpty() }) {
+            sikkerlogger.error("Ugyldig mottaker(e): ${brev.mottakere.toJson()}")
+            throw UgyldigMottakerKanIkkeFerdigstilles(brev.id, brev.sakId, brev.mottakere.flatMap { it.erGyldig() })
         }
 
         val pdf =

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevService.kt
@@ -128,9 +128,9 @@ class VedtaksbrevService(
             return
         } else if (!brev.kanEndres()) {
             throw UgyldigStatusKanIkkeFerdigstilles(brev.id, brev.status)
-        } else if (brev.mottaker.erGyldig().isNotEmpty()) {
-            sikkerlogger.error("Ugyldig mottaker: ${brev.mottaker.toJson()}")
-            throw UgyldigMottakerKanIkkeFerdigstilles(brev.id, brev.sakId, brev.mottaker.erGyldig())
+        } else if (brev.mottakere.any { it.erGyldig().isNotEmpty() }) {
+            sikkerlogger.error("Ugyldig mottaker(e): ${brev.mottakere.toJson()}")
+            throw UgyldigMottakerKanIkkeFerdigstilles(brev.id, brev.sakId, brev.mottakere.flatMap { it.erGyldig() })
         }
 
         val (saksbehandlerIdent, vedtakStatus) =

--- a/apps/etterlatte-brev-api/src/main/resources/db/migration/V25__flere_mottakere.sql
+++ b/apps/etterlatte-brev-api/src/main/resources/db/migration/V25__flere_mottakere.sql
@@ -1,0 +1,10 @@
+ALTER TABLE mottaker
+    DROP CONSTRAINT mottaker_pkey;
+
+ALTER TABLE mottaker
+    ADD COLUMN id UUID PRIMARY KEY DEFAULT (gen_random_uuid());
+
+-- Nytt felt for type mottaker (HOVED eller KOPI)
+ALTER TABLE mottaker ADD COLUMN type TEXT;
+UPDATE mottaker SET type = 'HOVED';
+ALTER TABLE mottaker ALTER COLUMN type SET NOT NULL;

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.util.UUID
 import kotlin.random.Random
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -136,6 +137,7 @@ internal class BrevRouteTest {
     fun deserialiser() {
         val mottaker =
             """{
+            "id": "d762e98d-514d-4bb5-a6b5-a3fbf4d65887",
             "navn": "Peder Ås",
             "foedselsnummer": {
                 "value": "25478323363"
@@ -255,18 +257,21 @@ internal class BrevRouteTest {
             status = Status.OPPRETTET,
             statusEndret = Tidspunkt.now(),
             opprettet = Tidspunkt.now(),
-            mottaker =
-                Mottaker(
-                    "Stor Snerk",
-                    STOR_SNERK,
-                    null,
-                    Adresse(
-                        adresseType = "NORSKPOSTADRESSE",
-                        "Testgaten 13",
-                        "1234",
-                        "OSLO",
-                        land = "Norge",
-                        landkode = "NOR",
+            mottakere =
+                listOf(
+                    Mottaker(
+                        id = UUID.randomUUID(),
+                        "Stor Snerk",
+                        STOR_SNERK,
+                        null,
+                        Adresse(
+                            adresseType = "NORSKPOSTADRESSE",
+                            "Testgaten 13",
+                            "1234",
+                            "OSLO",
+                            land = "Norge",
+                            landkode = "NOR",
+                        ),
                     ),
                 ),
             brevtype = Brevtype.INFORMASJON,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
@@ -323,14 +323,15 @@ internal class BrevServiceTest {
         status = status,
         statusEndret = Tidspunkt.now(),
         opprettet = opprettet,
-        mottaker = opprettMottaker(),
+        mottakere = listOf(opprettMottaker()),
         brevtype = Brevtype.INFORMASJON,
         brevkoder = Brevkoder.TOMT_INFORMASJONSBREV,
     )
 
     private fun opprettMottaker() =
         Mottaker(
-            "Stor Snerk",
+            id = UUID.randomUUID(),
+            navn = "Stor Snerk",
             foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
             orgnummer = null,
             adresse =

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevdistribuererTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevdistribuererTest.kt
@@ -53,7 +53,7 @@ class BrevdistribuererTest {
                 journalpostId,
                 DistribusjonsType.ANNET,
                 DistribusjonsTidspunktType.KJERNETID,
-                brev.mottakere.first().adresse,
+                brev.mottakere.single().adresse,
                 false,
             )
         }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevdistribuererTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevdistribuererTest.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import java.util.UUID
 import kotlin.random.Random
 
 class BrevdistribuererTest {
@@ -52,7 +53,7 @@ class BrevdistribuererTest {
                 journalpostId,
                 DistribusjonsType.ANNET,
                 DistribusjonsTidspunktType.KJERNETID,
-                brev.mottaker.adresse,
+                brev.mottakere.first().adresse,
                 false,
             )
         }
@@ -109,14 +110,15 @@ class BrevdistribuererTest {
         status = status,
         statusEndret = Tidspunkt.now(),
         opprettet = Tidspunkt.now(),
-        mottaker = opprettMottaker(),
+        mottakere = listOf(opprettMottaker()),
         brevtype = Brevtype.MANUELT,
         brevkoder = Brevkoder.TOMT_INFORMASJONSBREV,
     )
 
     private fun opprettMottaker() =
         Mottaker(
-            "Stor Snerk",
+            id = UUID.randomUUID(),
+            navn = "Stor Snerk",
             foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
             orgnummer = null,
             adresse =

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
@@ -157,7 +157,7 @@ class JournalfoerBrevServiceTest {
                 Status.JOURNALFOERT,
                 Tidspunkt.now(),
                 Tidspunkt.now(),
-                mottaker = mockk(),
+                mottakere = mockk(),
                 brevtype = Brevtype.MANUELT,
                 brevkoder = Brevkoder.TOMT_INFORMASJONSBREV,
             )
@@ -193,7 +193,7 @@ class JournalfoerBrevServiceTest {
                 status = Status.FERDIGSTILT,
                 statusEndret = Tidspunkt.now(),
                 opprettet = Tidspunkt.now(),
-                mottaker = opprettMottaker(forventetBrevMottakerFnr),
+                mottakere = listOf(opprettMottaker(forventetBrevMottakerFnr)),
                 brevtype = Brevtype.INFORMASJON,
                 brevkoder = Brevkoder.TOMT_INFORMASJONSBREV,
             )
@@ -276,7 +276,7 @@ class JournalfoerBrevServiceTest {
                 status = Status.FERDIGSTILT,
                 statusEndret = Tidspunkt.now(),
                 opprettet = Tidspunkt.now(),
-                mottaker = opprettMottaker(forventetBrevMottakerFnr),
+                mottakere = listOf(opprettMottaker(forventetBrevMottakerFnr)),
                 brevtype = Brevtype.MANUELT,
                 brevkoder = Brevkoder.TOMT_INFORMASJONSBREV,
             )
@@ -347,14 +347,15 @@ class JournalfoerBrevServiceTest {
             status = status,
             statusEndret = Tidspunkt.now(),
             opprettet = Tidspunkt.now(),
-            mottaker = opprettMottaker(SOEKER_FOEDSELSNUMMER.value),
+            mottakere = listOf(opprettMottaker(SOEKER_FOEDSELSNUMMER.value)),
             brevtype = Brevtype.INFORMASJON,
             brevkoder = Brevkoder.TOMT_INFORMASJONSBREV,
         )
 
     private fun opprettMottaker(fnr: String) =
         Mottaker(
-            "Stor Snerk",
+            id = UUID.randomUUID(),
+            navn = "Stor Snerk",
             foedselsnummer = MottakerFoedselsnummer(fnr),
             orgnummer = null,
             adresse =

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/OversendelsesbrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/OversendelsesbrevRouteTest.kt
@@ -115,11 +115,21 @@ internal class OversendelsesbrevRouteTest {
             Status.OPPRETTET,
             Tidspunkt.now(),
             Tidspunkt.now(),
-            Mottaker(
-                "Stor Snerk",
-                STOR_SNERK,
-                null,
-                Adresse(adresseType = "NORSKPOSTADRESSE", "Testgaten 13", "1234", "OSLO", land = "Norge", landkode = "NOR"),
+            listOf(
+                Mottaker(
+                    UUID.randomUUID(),
+                    "Stor Snerk",
+                    STOR_SNERK,
+                    null,
+                    Adresse(
+                        adresseType = "NORSKPOSTADRESSE",
+                        "Testgaten 13",
+                        "1234",
+                        "OSLO",
+                        land = "Norge",
+                        landkode = "NOR",
+                    ),
+                ),
             ),
             brevtype = Brevtype.OVERSENDELSE_KLAGE,
             brevkoder = Brevkoder.TOMT_INFORMASJONSBREV,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevRouteTest.kt
@@ -249,11 +249,14 @@ internal class VedtaksbrevRouteTest {
             Status.OPPRETTET,
             Tidspunkt.now(),
             Tidspunkt.now(),
-            Mottaker(
-                "Stor Snerk",
-                STOR_SNERK,
-                null,
-                Adresse(adresseType = "NORSKPOSTADRESSE", "Testgaten 13", "1234", "OSLO", land = "Norge", landkode = "NOR"),
+            listOf(
+                Mottaker(
+                    UUID.randomUUID(),
+                    "Stor Snerk",
+                    STOR_SNERK,
+                    null,
+                    Adresse(adresseType = "NORSKPOSTADRESSE", "Testgaten 13", "1234", "OSLO", land = "Norge", landkode = "NOR"),
+                ),
             ),
             brevtype = Brevtype.INFORMASJON,
             brevkoder = Brevkoder.TOMT_INFORMASJONSBREV,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -740,7 +740,7 @@ internal class VedtaksbrevServiceTest {
         status = status,
         Tidspunkt.now(),
         Tidspunkt.now(),
-        mottaker = opprettMottaker(),
+        mottakere = listOf(opprettMottaker()),
         brevtype = Brevtype.VEDTAK,
         brevkoder = Brevkoder.TOMT_INFORMASJONSBREV,
     )
@@ -783,7 +783,8 @@ internal class VedtaksbrevServiceTest {
 
     private fun opprettMottaker() =
         Mottaker(
-            "Rød Blanding",
+            id = UUID.randomUUID(),
+            navn = "Rød Blanding",
             foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
             orgnummer = null,
             adresse =

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/BehandlingTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/BehandlingTest.kt
@@ -214,7 +214,7 @@ internal class BehandlingTest {
 
         coEvery {
             adresseService.hentMottakerAdresse(any<SakType>(), vergesFnr.value)
-        } returns Mottaker("Viggo Verge", null, null, mockk())
+        } returns Mottaker(UUID.randomUUID(), "Viggo Verge", null, null, mockk())
 
         val grunnlagService = GrunnlagService(mockk(), adresseService)
         val vergeBarnepensjon = runBlocking { grunnlagService.hentVergeForSak(SakType.BARNEPENSJON, null, grunnlag) }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/GrunnlagmapperTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/GrunnlagmapperTest.kt
@@ -119,6 +119,7 @@ class GrunnlagmapperTest {
         navn: String,
         fnr: String,
     ) = Mottaker(
+        UUID.randomUUID(),
         navn,
         MottakerFoedselsnummer(fnr),
         "orgnr",

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/db/BrevRepositoryIntegrationTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/db/BrevRepositoryIntegrationTest.kt
@@ -95,7 +95,7 @@ internal class BrevRepositoryIntegrationTest(
         val hentetBrev = db.hentBrev(nyttBrev.id)
         assertEquals(nyttBrev.id, hentetBrev.id)
         assertEquals(behandlingId, hentetBrev.behandlingId)
-        assertEquals(hentetBrev.mottakere.first(), ulagretBrev.mottaker)
+        assertEquals(hentetBrev.mottakere.single(), ulagretBrev.mottaker)
     }
 
     @Test

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/db/BrevRepositoryIntegrationTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/db/BrevRepositoryIntegrationTest.kt
@@ -86,7 +86,8 @@ internal class BrevRepositoryIntegrationTest(
 
         assertEquals(emptyList<Brev>(), db.hentBrevForBehandling(behandlingId, Brevtype.VEDTAK))
 
-        val nyttBrev = db.opprettBrev(ulagretBrev(behandlingId = behandlingId))
+        val ulagretBrev = ulagretBrev(behandlingId = behandlingId)
+        val nyttBrev = db.opprettBrev(ulagretBrev)
 
         val brevTilBehandling = db.hentBrevForBehandling(behandlingId, Brevtype.VEDTAK).first()
         assertEquals(nyttBrev.status, brevTilBehandling.status)
@@ -94,7 +95,7 @@ internal class BrevRepositoryIntegrationTest(
         val hentetBrev = db.hentBrev(nyttBrev.id)
         assertEquals(nyttBrev.id, hentetBrev.id)
         assertEquals(behandlingId, hentetBrev.behandlingId)
-        assertEquals(hentetBrev.mottaker, opprettMottaker())
+        assertEquals(hentetBrev.mottakere.first(), ulagretBrev.mottaker)
     }
 
     @Test
@@ -478,6 +479,7 @@ internal class BrevRepositoryIntegrationTest(
 
     private fun opprettMottaker() =
         Mottaker(
+            id = UUID.randomUUID(),
             navn = "Test Testesen",
             foedselsnummer = STOR_SNERK,
             adresse =

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/BrevModelTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/BrevModelTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldNotBe
 import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import org.junit.jupiter.api.Test
+import java.util.UUID
 
 internal class BrevModelTest {
     @Test
@@ -54,6 +55,7 @@ internal class BrevModelTest {
         landkode: String = "NO",
         land: String = "Norge",
     ) = Mottaker(
+        UUID.randomUUID(),
         navn,
         foedselsnummer,
         orgnummer,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/KlageMottakerRequestTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/KlageMottakerRequestTest.kt
@@ -8,6 +8,7 @@ import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.util.UUID
 
 internal class KlageMottakerRequestTest {
     @Nested
@@ -76,16 +77,24 @@ internal class KlageMottakerRequestTest {
 
         @Test
         fun `Sjekk gyldighet av mottaker fungerer - felles uavhengig av land`() {
-            val manglerNavn = Mottaker("", adresse = mockk())
+            val manglerNavn = Mottaker(UUID.randomUUID(), "", adresse = mockk())
 
             manglerNavn.erGyldig() shouldNotBe emptyList<String>()
 
-            val manglerFnrOgOrgnr = Mottaker("Navn Navnesen", foedselsnummer = null, orgnummer = null, adresse = mockk())
+            val manglerFnrOgOrgnr =
+                Mottaker(
+                    UUID.randomUUID(),
+                    "Navn Navnesen",
+                    foedselsnummer = null,
+                    orgnummer = null,
+                    adresse = mockk(),
+                )
 
             manglerFnrOgOrgnr.erGyldig() shouldNotBe emptyList<String>()
 
             val manglerLand =
                 Mottaker(
+                    UUID.randomUUID(),
                     "Navn",
                     foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
                     adresse = Adresse("type", postnummer = "1234", poststed = "", landkode = "NO", land = ""),
@@ -95,6 +104,7 @@ internal class KlageMottakerRequestTest {
 
             val manglerLandkode =
                 Mottaker(
+                    UUID.randomUUID(),
                     "Navn",
                     foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
                     adresse = Adresse("type", postnummer = "1234", poststed = "", landkode = "", land = "Norge"),
@@ -107,6 +117,7 @@ internal class KlageMottakerRequestTest {
         fun `Sjekk gyldighet av mottaker fungerer - NORSKPOSTADRESSE`() {
             val manglerPoststed =
                 Mottaker(
+                    UUID.randomUUID(),
                     "Navn",
                     foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
                     adresse = Adresse("NORSKPOSTADRESSE", postnummer = "1234", poststed = "", landkode = "NO", land = "Norge"),
@@ -116,6 +127,7 @@ internal class KlageMottakerRequestTest {
 
             val manglerPostnummer =
                 Mottaker(
+                    UUID.randomUUID(),
                     "Navn",
                     foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
                     adresse = Adresse("NORSKPOSTADRESSE", postnummer = "", poststed = "Oslo", landkode = "NO", land = "Norge"),
@@ -128,6 +140,7 @@ internal class KlageMottakerRequestTest {
         fun `Sjekk gyldighet av mottaker fungerer - UTENLANDSKPOSTADRESSE`() {
             val manglerAdresselinje =
                 Mottaker(
+                    UUID.randomUUID(),
                     "Navn",
                     foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
                     adresse =

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevServiceImplTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevServiceImplTest.kt
@@ -149,6 +149,7 @@ class OversendelseBrevServiceImplTest(
 
     private fun opprettMottaker() =
         Mottaker(
+            UUID.randomUUID(),
             "Rød Blanding",
             foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
             orgnummer = null,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
@@ -66,6 +66,7 @@ class VarselbrevTest(
             mockk<AdresseService>().also {
                 coEvery { it.hentMottakerAdresse(any(), any()) } returns
                     Mottaker(
+                        id = UUID.fromString("d762e98d-514d-4bb5-a6b5-a3fbf4d65887"),
                         navn = "Navn Navnesen",
                         foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
                         orgnummer = null,

--- a/apps/etterlatte-brev-kafka/src/test/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiverTest.kt
+++ b/apps/etterlatte-brev-kafka/src/test/kotlin/no/nav/etterlatte/rivers/JournalfoerVedtaksbrevRiverTest.kt
@@ -59,7 +59,7 @@ internal class JournalfoerVedtaksbrevRiverTest {
     @Test
     fun `Gyldig melding skal sende journalpost til distribusjon`() {
         val brevId: Long = 1
-        val brev1 =
+        val brev =
             Brev(
                 brevId,
                 randomSakId(),
@@ -71,12 +71,10 @@ internal class JournalfoerVedtaksbrevRiverTest {
                 Status.FERDIGSTILT,
                 Tidspunkt.now(),
                 Tidspunkt.now(),
-                mottaker = mockk(),
+                mottakere = mockk(),
                 brevtype = Brevtype.VEDTAK,
                 brevkoder = Brevkoder.BP_INNVILGELSE,
             )
-        val brev =
-            brev1
         val response = OpprettJournalpostResponse("1234", true, emptyList())
 
         coEvery { brevApiKlient.journalfoerVedtaksbrev(any()) } returns

--- a/apps/etterlatte-brev-kafka/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
+++ b/apps/etterlatte-brev-kafka/src/test/kotlin/no/nav/etterlatte/rivers/OpprettJournalfoerOgDistribuerTest.kt
@@ -75,7 +75,10 @@ internal class OpprettJournalfoerOgDistribuer {
         )
 
         val distribuermelding = testRapid.hentMelding(0)
-        Assertions.assertEquals(BrevHendelseType.JOURNALFOERT.lagEventnameForType(), distribuermelding.somMap()[EVENT_NAME_KEY])
+        Assertions.assertEquals(
+            BrevHendelseType.JOURNALFOERT.lagEventnameForType(),
+            distribuermelding.somMap()[EVENT_NAME_KEY],
+        )
         testRapid.sendTestMessage(distribuermelding)
 
         val distribuert = testRapid.hentMelding(1).somMap()
@@ -94,12 +97,15 @@ internal class OpprettJournalfoerOgDistribuer {
             status = Status.FERDIGSTILT,
             Tidspunkt.now(),
             Tidspunkt.now(),
-            mottaker =
-                Mottaker(
-                    "Langsom Hest",
-                    mockk(),
-                    null,
-                    Adresse(adresseType = "privat", landkode = "NO", land = "Norge"),
+            mottakere =
+                listOf(
+                    Mottaker(
+                        UUID.randomUUID(),
+                        "Langsom Hest",
+                        mockk(),
+                        null,
+                        Adresse(adresseType = "privat", landkode = "NO", land = "Norge"),
+                    ),
                 ),
             brevtype = Brevtype.INFORMASJON,
             brevkoder = Brevkoder.TOMT_INFORMASJONSBREV,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Varselbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Varselbrev.tsx
@@ -131,7 +131,17 @@ export const Varselbrev = (props: { behandling: IDetaljertBehandling }) => {
                   kanRedigeres={redigerbar}
                 />
                 <br />
-                <BrevMottaker brev={varselbrev} kanRedigeres={redigerbar} />
+
+                {varselbrev.mottakere.map((mottaker) => (
+                  <BrevMottaker
+                    key={mottaker.id}
+                    brevId={varselbrev.id}
+                    behandlingId={behandlingId}
+                    sakId={sakId}
+                    mottaker={mottaker}
+                    kanRedigeres={redigerbar}
+                  />
+                ))}
               </>
             )}
           </Box>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Vedtaksbrev.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Alert, Heading, Box, VStack, HStack } from '@navikt/ds-react'
 import { BehandlingHandlingKnapper } from '../handlinger/BehandlingHandlingKnapper'
 import { hentVedtaksbrev, opprettVedtaksbrev } from '~shared/api/brev'
@@ -193,7 +193,16 @@ export const Vedtaksbrev = (props: { behandling: IDetaljertBehandling }) => {
                 />
                 <BrevSpraak brev={vedtaksbrev} kanRedigeres={redigerbar} />
 
-                <BrevMottaker brev={vedtaksbrev} kanRedigeres={redigerbar} />
+                {vedtaksbrev.mottakere.map((mottaker) => (
+                  <BrevMottaker
+                    key={mottaker.id}
+                    brevId={vedtaksbrev.id}
+                    behandlingId={behandlingId}
+                    sakId={sakId}
+                    mottaker={mottaker}
+                    kanRedigeres={redigerbar}
+                  />
+                ))}
               </>
             )}
           </VStack>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/brev/KlageBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/brev/KlageBrev.tsx
@@ -1,6 +1,6 @@
 import { useKlage } from '~components/klage/useKlage'
 import { useNavigate } from 'react-router-dom'
-import { BodyShort, Box, Button, Heading, HStack } from '@navikt/ds-react'
+import { BodyShort, Box, Button, Heading, HStack, VStack } from '@navikt/ds-react'
 import React, { useEffect, useState } from 'react'
 import Spinner from '~shared/Spinner'
 import { erKlageRedigerbar, Klage } from '~shared/types/Klage'
@@ -12,7 +12,7 @@ import { hentBrev } from '~shared/api/brev'
 import styled from 'styled-components'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { JaNei } from '~shared/types/ISvar'
-import { isSuccess, mapApiResult } from '~shared/api/apiUtils'
+import { mapApiResult, mapSuccess } from '~shared/api/apiUtils'
 import BrevTittel from '~components/person/brev/tittel/BrevTittel'
 import { forrigeSteg } from '~components/klage/stegmeny/KlageStegmeny'
 import { BrevMottaker } from '~components/person/brev/mottaker/BrevMottaker'
@@ -64,18 +64,22 @@ export function KlageBrev() {
                 ? 'Oversendelsesbrev til klager'
                 : 'Avvisningsbrev til klager'}
             </BodyShort>
-            {isSuccess(hentetBrev) && (
-              <>
-                <BrevTittel
-                  brevId={hentetBrev.data.id}
-                  sakId={hentetBrev.data.sakId}
-                  tittel={hentetBrev.data.tittel}
-                  kanRedigeres={redigerbar}
-                />
-                <br />
-                <BrevMottaker brev={hentetBrev.data} kanRedigeres={redigerbar} />
-              </>
-            )}
+            {mapSuccess(hentetBrev, (brev) => (
+              <VStack gap="4">
+                <BrevTittel brevId={brev.id} sakId={brev.sakId} tittel={brev.tittel} kanRedigeres={redigerbar} />
+
+                {brev.mottakere.map((mottaker) => (
+                  <BrevMottaker
+                    key={mottaker.id}
+                    brevId={brev.id}
+                    behandlingId={brev.behandlingId}
+                    sakId={brev.sakId}
+                    mottaker={mottaker}
+                    kanRedigeres={redigerbar}
+                  />
+                ))}
+              </VStack>
+            ))}
           </Box>
         </Sidebar>
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/BrevOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/BrevOversikt.tsx
@@ -1,7 +1,7 @@
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { hentBrevForSak } from '~shared/api/brev'
 import { useEffect } from 'react'
-import { Box, Button, HStack, Table } from '@navikt/ds-react'
+import { BodyShort, Box, Button, HStack, Table } from '@navikt/ds-react'
 import { BrevStatus, formaterBrevtype, IBrev, Mottaker } from '~shared/types/Brev'
 import { DocPencilIcon, ExternalLinkIcon } from '@navikt/aksel-icons'
 import Spinner from '~shared/Spinner'
@@ -91,8 +91,7 @@ export default function BrevOversikt({ sakResult }: { sakResult: Result<SakMedBe
                 <Table.HeaderCell>Status</Table.HeaderCell>
                 <Table.HeaderCell>Distribuert</Table.HeaderCell>
                 <Table.HeaderCell>Type</Table.HeaderCell>
-                <Table.HeaderCell>Navn</Table.HeaderCell>
-                <Table.HeaderCell>Adresse</Table.HeaderCell>
+                <Table.HeaderCell>Mottaker</Table.HeaderCell>
                 <Table.HeaderCell></Table.HeaderCell>
               </Table.Row>
             </Table.Header>
@@ -112,10 +111,17 @@ export default function BrevOversikt({ sakResult }: { sakResult: Result<SakMedBe
                     {b.status === BrevStatus.DISTRIBUERT ? formaterDatoMedKlokkeslett(b.statusEndret) : '-'}
                   </Table.DataCell>
                   <Table.DataCell>{formaterBrevtype(b.brevtype)}</Table.DataCell>
-                  <Table.DataCell>{b.mottaker.navn}</Table.DataCell>
-                  <Table.DataCell>{mapAdresse(b.mottaker)}</Table.DataCell>
                   <Table.DataCell>
-                    <HStack gap="4" justify="end">
+                    {b.mottakere.map((mottaker) => (
+                      <BodyShort key={mottaker.id}>
+                        {mottaker.navn}
+                        <br />
+                        {mapAdresse(mottaker)}
+                      </BodyShort>
+                    ))}
+                  </Table.DataCell>
+                  <Table.DataCell>
+                    <HStack gap="4" justify="end" align="center">
                       <SlettBrev brev={b} />
                       <BrevUtgaar brev={b} />
                       {handlingKnapp(b)}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrev.tsx
@@ -2,7 +2,7 @@ import RedigerbartBrev from '~components/behandling/brev/RedigerbartBrev'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { useParams } from 'react-router-dom'
 import { hentBrev } from '~shared/api/brev'
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Column, GridContainer } from '~shared/styled'
 import { StatusBar } from '~shared/statusbar/Statusbar'
 import NavigerTilbakeMeny from '~components/person/NavigerTilbakeMeny'
@@ -67,7 +67,16 @@ export default function NyttBrev() {
                 <BrevSpraak brev={brev} kanRedigeres={kanRedigeres} />
               </div>
               <div style={{ margin: '1rem' }}>
-                <BrevMottaker brev={brev} kanRedigeres={kanRedigeres} />
+                {brev.mottakere.map((mottaker) => (
+                  <BrevMottaker
+                    key={mottaker.id}
+                    brevId={brev.id}
+                    behandlingId={brev.behandlingId}
+                    sakId={brev.sakId}
+                    mottaker={mottaker}
+                    kanRedigeres={kanRedigeres}
+                  />
+                ))}
               </div>
             </Column>
             <Column>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottaker.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottaker.tsx
@@ -1,4 +1,4 @@
-import { AdresseType, IBrev } from '~shared/types/Brev'
+import { AdresseType, Mottaker } from '~shared/types/Brev'
 import { Alert, BodyShort, Box, Heading, HStack, Loader, Tag, VStack } from '@navikt/ds-react'
 import React, { useEffect, useState } from 'react'
 import { useApiCall } from '~shared/hooks/useApiCall'
@@ -10,32 +10,39 @@ import { mapResult } from '~shared/api/apiUtils'
 import Spinner from '~shared/Spinner'
 import { DigitalKontaktinformasjon, hentKontaktinformasjonKRR } from '~shared/api/krr'
 
-export function BrevMottaker({ brev, kanRedigeres }: { brev: IBrev; kanRedigeres: boolean }) {
-  const [brevState, setBrevState] = useState<IBrev>(brev)
+interface MottakerProps {
+  brevId: number
+  behandlingId?: string
+  sakId: number
+  mottaker: Mottaker
+  kanRedigeres: boolean
+}
 
-  const mottaker = brevState!.mottaker
+export function BrevMottaker({ brevId, behandlingId, sakId, mottaker: initialMottaker, kanRedigeres }: MottakerProps) {
+  const [mottaker, setMottaker] = useState(initialMottaker)
+
   const adresse = mottaker?.adresse
 
   const [soeker, getSoekerFraGrunnlag] = useApiCall(getGrunnlagsAvOpplysningstype)
   const [kontaktinfoResult, hentKontaktinfo] = useApiCall(hentKontaktinformasjonKRR)
 
   useEffect(() => {
-    if (!brev.behandlingId) {
+    if (!behandlingId) {
       return
     }
 
     getSoekerFraGrunnlag({
-      sakId: brev.sakId,
-      behandlingId: brev.behandlingId,
+      sakId: sakId,
+      behandlingId: behandlingId,
       opplysningstype: 'SOEKER_PDL_V1',
     })
-  }, [brev])
+  }, [])
 
   useEffect(() => {
-    if (brev.mottaker.foedselsnummer?.value) {
-      hentKontaktinfo(brev.mottaker.foedselsnummer.value)
+    if (mottaker.foedselsnummer?.value) {
+      hentKontaktinfo(mottaker.foedselsnummer.value)
     }
-  }, [brev.mottaker.foedselsnummer?.value])
+  }, [mottaker.foedselsnummer?.value])
 
   return (
     <Box padding="4" borderWidth="1" borderRadius="small">
@@ -68,7 +75,11 @@ export function BrevMottaker({ brev, kanRedigeres }: { brev: IBrev; kanRedigeres
             </Tag>
           )}
         </Heading>
-        <div>{kanRedigeres && <BrevMottakerModal brev={brevState} setBrev={setBrevState} />}</div>
+        <div>
+          {kanRedigeres && (
+            <BrevMottakerModal brevId={brevId} sakId={sakId} mottaker={mottaker} setMottaker={setMottaker} />
+          )}
+        </div>
       </HStack>
 
       <VStack gap="2">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottakerModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottakerModal.tsx
@@ -1,6 +1,6 @@
 import { Button, Heading, HGrid, HStack, Modal, Radio, Select, TextField, ToggleGroup, VStack } from '@navikt/ds-react'
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react'
-import { AdresseType, IBrev, Mottaker } from '~shared/types/Brev'
+import { AdresseType, Mottaker } from '~shared/types/Brev'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { oppdaterMottaker } from '~shared/api/brev'
 import { isPending } from '~shared/api/apiUtils'
@@ -15,18 +15,18 @@ enum MottakerType {
 }
 
 interface Props {
-  brev: IBrev
-  setBrev: Dispatch<SetStateAction<IBrev>>
+  brevId: number
+  sakId: number
+  mottaker: Mottaker
+  setMottaker: Dispatch<SetStateAction<Mottaker>>
 }
 
-export function BrevMottakerModal({ brev, setBrev }: Props) {
-  const { id: brevId, sakId, mottaker: initialMottaker } = brev
-
+export function BrevMottakerModal({ brevId, sakId, mottaker: initialMottaker, setMottaker }: Props) {
   const [mottakerStatus, apiOppdaterMottaker] = useApiCall(oppdaterMottaker)
 
   const [isOpen, setIsOpen] = useState(false)
   const [mottakerType, setMottakerType] = useState(
-    brev.mottaker.orgnummer ? MottakerType.BEDRIFT : MottakerType.PRIVATPERSON
+    initialMottaker.orgnummer ? MottakerType.BEDRIFT : MottakerType.PRIVATPERSON
   )
 
   const {
@@ -52,8 +52,8 @@ export function BrevMottakerModal({ brev, setBrev }: Props) {
       return
     }
 
-    apiOppdaterMottaker({ brevId, sakId, mottaker: mottaker }, () => {
-      setBrev({ ...brev, mottaker })
+    apiOppdaterMottaker({ brevId, sakId, mottaker }, () => {
+      setMottaker(mottaker)
       setIsOpen(false)
     })
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/brev/TilbakekrevingBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/brev/TilbakekrevingBrev.tsx
@@ -72,7 +72,16 @@ export function TilbakekrevingBrev({
                 <br />
                 <BrevSpraak brev={vedtaksbrev} kanRedigeres={redigerbar} />
                 <br />
-                <BrevMottaker brev={vedtaksbrev} kanRedigeres={redigerbar} />
+                {vedtaksbrev.mottakere.map((mottaker) => (
+                  <BrevMottaker
+                    key={mottaker.id}
+                    brevId={vedtaksbrev.id}
+                    behandlingId={vedtaksbrev.behandlingId}
+                    sakId={vedtaksbrev.sakId}
+                    mottaker={mottaker}
+                    kanRedigeres={redigerbar}
+                  />
+                ))}
               </>
             )}
           </Box>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Brev.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Brev.ts
@@ -8,7 +8,7 @@ export interface IBrev {
   soekerFnr: string
   status: BrevStatus
   statusEndret: string
-  mottaker: Mottaker
+  mottakere: Mottaker[]
   opprettet: string
   brevtype: Brevtype
   journalpostId?: string
@@ -16,6 +16,7 @@ export interface IBrev {
 }
 
 export interface Mottaker {
+  id: string
   navn: string
   foedselsnummer?: {
     value: string
@@ -23,6 +24,7 @@ export interface Mottaker {
   orgnummer?: string
   adresse: Adresse
   tvingSentralPrint: boolean
+  kopimottaker: boolean
 }
 
 export interface Adresse {

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/Brev.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/Brev.kt
@@ -62,11 +62,16 @@ data class Adresse(
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Mottaker(
+    val id: UUID,
     val navn: String,
     val foedselsnummer: MottakerFoedselsnummer? = null,
     val orgnummer: String? = null,
     val adresse: Adresse,
     val tvingSentralPrint: Boolean = false,
+    val type: MottakerType = MottakerType.HOVED,
+    // TODO: flytte disse fra brev- til mottakernivå
+    //  val journalpostId: String
+    //  val bestillingId: BestillingID
 ) {
     fun erGyldig(): List<String> =
         if (navn.isBlank()) {
@@ -77,6 +82,8 @@ data class Mottaker(
             adresse.erGyldig()
         }
 }
+
+enum class MottakerType { HOVED, KOPI }
 
 data class Brev(
     val id: BrevID,
@@ -89,7 +96,7 @@ data class Brev(
     val status: Status,
     val statusEndret: Tidspunkt,
     val opprettet: Tidspunkt,
-    val mottaker: Mottaker,
+    val mottakere: List<Mottaker>,
     val brevtype: Brevtype,
     val brevkoder: Brevkoder?,
     val journalpostId: String? = null,


### PR DESCRIPTION
For å redusere risiko for feil, deler jeg opp saken i mindre biter. 

Denne PR-en vil derfor kun endre datastrukturen slik at vi støtter flere mottakere. Det er p.t. ikke mulig å legge til flere, men det kommer fortløpende. 