### PR TITLE
Svelg redeploy exceptions

### DIFF
--- a/libs/etterlatte-ktor/src/main/kotlin/initialisering/EmbeddedServerConfig.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/initialisering/EmbeddedServerConfig.kt
@@ -19,6 +19,9 @@ import no.nav.etterlatte.libs.ktor.healthApi
 import no.nav.etterlatte.libs.ktor.ktor.shutdownPolicyEmbeddedServer
 import no.nav.etterlatte.libs.ktor.metricsRoute
 import no.nav.etterlatte.libs.ktor.restModule
+import no.nav.etterlatte.logger
+import org.slf4j.LoggerFactory
+import kotlin.coroutines.cancellation.CancellationException
 
 fun initEmbeddedServer(
     httpPort: Int,
@@ -73,6 +76,12 @@ private fun settOppEmbeddedServer(
             },
     )
 
+val logger = LoggerFactory.getLogger("CIOApplicationEngine")
+
 fun CIOApplicationEngine.run() {
-    start(true)
+    try {
+        start(true)
+    } catch (e: CancellationException) {
+        logger.warn("Appen redeployes mens den kjører opp e.l.", e)
+    }
 }


### PR DESCRIPTION
Hindrer disse fra å komme i error logger. Se tilsvarende eksempel https://kotlinlang.org/docs/cancellation-and-timeouts.html#timeout

https://logs.adeo.no/app/discover#/?_g=(time:(from:'2024-10-17T07:04:26.575Z',to:'2024-10-17T07:19:26.575Z'))&_a=(columns:!(level,message,envclass,application,pod),dataSource:(dataViewId:'96e648c0-980a-11e9-830a-e17bbd64b4db',type:dataView),filters:!(),hideChart:!f,interval:auto,query:(language:lucene,query:'namespace:etterlatte%20AND%20envclass:p%20AND%20level:Error'),sort:!(!('@timestamp',desc)))