### PR TITLE
Konsolidere routesjekking i stegmeny og behandlingroutes

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/Behandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/Behandling.tsx
@@ -4,7 +4,7 @@ import { hentBehandling } from '~shared/api/behandling'
 import { GridContainer, MainContent } from '~shared/styled'
 import { IBehandlingReducer, resetBehandling, setBehandling } from '~store/reducers/BehandlingReducer'
 import { StatusBar } from '~shared/statusbar/Statusbar'
-import { useBehandlingRoutes } from './BehandlingRoutes'
+import { BehandlingRouteContext, useBehandlingRoutes } from './BehandlingRoutes'
 import { StegMeny } from './StegMeny/stegmeny'
 import { useAppDispatch } from '~store/Store'
 import { useApiCall } from '~shared/hooks/useApiCall'
@@ -25,7 +25,7 @@ export const Behandling = () => {
   const behandlingFraRedux = useBehandling()
   const dispatch = useAppDispatch()
   const { behandlingId: behandlingIdFraURL } = useParams()
-  const { behandlingRoutes } = useBehandlingRoutes()
+  const routedata = useBehandlingRoutes()
   const [fetchBehandlingStatus, fetchBehandling] = useApiCall(hentBehandling)
   const [, fetchPersonopplysninger] = useApiCall(hentPersonopplysningerForBehandling)
   const soeker = usePersonopplysninger()?.soeker?.opplysning
@@ -65,7 +65,7 @@ export const Behandling = () => {
       if (behandlingFraRedux) {
         const behandling = behandlingFraRedux as IBehandlingReducer
         return (
-          <>
+          <BehandlingRouteContext.Provider value={routedata}>
             <StickyToppMeny>
               <StatusBar ident={soeker?.foedselsnummer} />
               <StegMeny behandling={behandling} />
@@ -73,15 +73,15 @@ export const Behandling = () => {
             <GridContainer>
               <MainContent>
                 <Routes>
-                  {behandlingRoutes.map((route) => (
+                  {routedata.behandlingRoutes.map((route) => (
                     <Route key={route.path} path={route.path} element={route.element(behandling)} />
                   ))}
-                  <Route path="*" element={<Navigate to={behandlingRoutes[0].path} replace />} />
+                  <Route path="*" element={<Navigate to={routedata.behandlingRoutes[0].path} replace />} />
                 </Routes>
               </MainContent>
               <BehandlingSidemeny behandling={behandling} />
             </GridContainer>
-          </>
+          </BehandlingRouteContext.Provider>
         )
       }
       return null

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/Behandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/Behandling.tsx
@@ -74,7 +74,7 @@ export const Behandling = () => {
               <MainContent>
                 <Routes>
                   {behandlingRoutes.map((route) => (
-                    <Route key={route.path} path={route.path} element={route.element} />
+                    <Route key={route.path} path={route.path} element={route.element(behandling)} />
                   ))}
                   <Route path="*" element={<Navigate to={behandlingRoutes[0].path} replace />} />
                 </Routes>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
@@ -106,23 +106,6 @@ const behandlingroutes: Record<string, BehandlingRouteType> = {
   },
 }
 
-function useRouteNavigation() {
-  const match = useMatch('/behandling/:behandlingId/:section')
-  const [currentRoute, setCurrentRoute] = useState<string | undefined>(match?.params?.section)
-  const navigate = useNavigate()
-
-  useEffect(() => {
-    setCurrentRoute(match?.params?.section)
-  }, [match])
-
-  const goto = (path: BehandlingRouteTypesPath) => {
-    setCurrentRoute(path)
-    navigate(`/behandling/${match?.params?.behandlingId}/${path}`)
-  }
-
-  return { currentRoute, goto }
-}
-
 export const useBehandlingRoutes = () => {
   const { currentRoute, goto } = useRouteNavigation()
   const behandling = useBehandling()
@@ -182,6 +165,23 @@ export const useBehandlingRoutes = () => {
   }
 }
 
+function useRouteNavigation() {
+  const match = useMatch('/behandling/:behandlingId/:section')
+  const [currentRoute, setCurrentRoute] = useState<string | undefined>(match?.params?.section)
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    setCurrentRoute(match?.params?.section)
+  }, [match])
+
+  const goto = (path: BehandlingRouteTypesPath) => {
+    setCurrentRoute(path)
+    navigate(`/behandling/${match?.params?.behandlingId}/${path}`)
+  }
+
+  return { currentRoute, goto }
+}
+
 const hentAktuelleRoutes = (behandling: IBehandlingReducer | null, personopplysninger: Personopplysninger | null) => {
   if (!behandling) return []
 
@@ -197,7 +197,7 @@ const hentAktuelleRoutes = (behandling: IBehandlingReducer | null, personopplysn
   }
 }
 
-export function foerstegangsbehandlingRoutes(
+function foerstegangsbehandlingRoutes(
   behandling: IBehandlingReducer,
   personopplysninger: Personopplysninger | null,
   lagVarselbrev: boolean
@@ -231,7 +231,7 @@ export function foerstegangsbehandlingRoutes(
   )
 }
 
-export function revurderingRoutes(behandling: IBehandlingReducer, lagVarselbrev: boolean): Array<BehandlingRouteType> {
+function revurderingRoutes(behandling: IBehandlingReducer, lagVarselbrev: boolean): Array<BehandlingRouteType> {
   const opphoer = behandling.vilkaarsvurdering?.resultat?.utfall == VilkaarsvurderingResultat.IKKE_OPPFYLT
 
   const defaultRoutes: Array<BehandlingRouteType> = opphoer

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { createContext, useEffect, useState } from 'react'
 import { useMatch, useNavigate } from 'react-router'
 import { Beregne } from './beregne/Beregne'
 import { Vilkaarsvurdering } from './vilkaarsvurdering/Vilkaarsvurdering'
@@ -164,6 +164,32 @@ export const useBehandlingRoutes = () => {
     currentRouteErGyldig: currentRouteErGyldig,
   }
 }
+
+type DefaultBehandlingRoutecontextType = {
+  next: () => void
+  back: () => void
+  lastPage: boolean
+  firstPage: boolean
+  behandlingRoutes: BehandlingRouteType[]
+  currentRoute: string | undefined
+  goto: (path: BehandlingRouteTypesPath) => void
+  routeErGyldig: (route: string | undefined) => boolean
+  currentRouteErGyldig: () => boolean
+}
+
+const DefaultBehandlingRoutecontext: DefaultBehandlingRoutecontextType = {
+  next: () => {},
+  back: () => {},
+  lastPage: false,
+  firstPage: true,
+  behandlingRoutes: new Array<BehandlingRouteType>(),
+  currentRoute: undefined,
+  goto: () => {},
+  routeErGyldig: () => false,
+  currentRouteErGyldig: () => false,
+}
+
+export const BehandlingRouteContext = createContext<DefaultBehandlingRoutecontextType>(DefaultBehandlingRoutecontext)
 
 function useRouteNavigation() {
   const match = useMatch('/behandling/:behandlingId/:section')

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
@@ -188,7 +188,7 @@ const hentAktuelleRoutes = (behandling: IBehandlingReducer | null, personopplysn
   const lagVarselbrev =
     behandling?.kilde === Vedtaksloesning.GJENOPPRETTA ||
     behandling?.revurderingsaarsak === Revurderingaarsak.AKTIVITETSPLIKT
-  //denne
+
   switch (behandling.behandlingType) {
     case IBehandlingsType.FØRSTEGANGSBEHANDLING:
       return foerstegangsbehandlingRoutes(behandling, personopplysninger, lagVarselbrev)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
@@ -105,7 +105,7 @@ const behandlingroutes: Record<string, BehandlingRouteType> = {
     kreverBehandlingsstatus: () => IBehandlingStatus.AVKORTET,
   },
 }
-
+// skal kun brukes av Behandling som laster behandling, å newe opp denne kan få utilsiktede konsekvenser andre steder
 export const useBehandlingRoutes = () => {
   const { currentRoute, goto } = useRouteNavigation()
   const behandling = useBehandling()

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
@@ -159,14 +159,14 @@ export const useBehandlingRoutes = () => {
   const next = () => {
     const index = aktuelleRoutes.findIndex((item) => item.path === currentRoute)
     const nextPath = aktuelleRoutes[index + 1].path
-    goto(nextPath as BehandlingRouteTypesPath)
+    goto(nextPath)
   }
 
   const back = () => {
     const index = aktuelleRoutes.findIndex((item) => item.path === currentRoute)
     const previousPath = aktuelleRoutes[index - 1].path
 
-    goto(previousPath as BehandlingRouteTypesPath)
+    goto(previousPath)
   }
 
   return {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/BehandlingRoutes.tsx
@@ -106,7 +106,7 @@ const behandlingroutes: Record<string, BehandlingRouteType> = {
   },
 }
 // skal kun brukes av Behandling som laster behandling, å newe opp denne kan få utilsiktede konsekvenser andre steder
-export const useBehandlingRoutes = () => {
+export const useBehandlingRoutes = (): DefaultBehandlingRouteContextType => {
   const { currentRoute, goto } = useRouteNavigation()
   const behandling = useBehandling()
   const personopplysninger = usePersonopplysninger()
@@ -165,7 +165,7 @@ export const useBehandlingRoutes = () => {
   }
 }
 
-type DefaultBehandlingRoutecontextType = {
+type DefaultBehandlingRouteContextType = {
   next: () => void
   back: () => void
   lastPage: boolean
@@ -177,7 +177,7 @@ type DefaultBehandlingRoutecontextType = {
   currentRouteErGyldig: () => boolean
 }
 
-const DefaultBehandlingRoutecontext: DefaultBehandlingRoutecontextType = {
+const DefaultBehandlingRoutecontext: DefaultBehandlingRouteContextType = {
   next: () => {},
   back: () => {},
   lastPage: false,
@@ -189,7 +189,7 @@ const DefaultBehandlingRoutecontext: DefaultBehandlingRoutecontextType = {
   currentRouteErGyldig: () => false,
 }
 
-export const BehandlingRouteContext = createContext<DefaultBehandlingRoutecontextType>(DefaultBehandlingRoutecontext)
+export const BehandlingRouteContext = createContext<DefaultBehandlingRouteContextType>(DefaultBehandlingRoutecontext)
 
 function useRouteNavigation() {
   const match = useMatch('/behandling/:behandlingId/:section')

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/NavLenke.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/NavLenke.tsx
@@ -1,11 +1,11 @@
 import { ChevronRightIcon } from '@navikt/aksel-icons'
 import { IBehandlingReducer } from '~store/reducers/BehandlingReducer'
-import { BehandlingRouteTypes, useBehandlingRoutes } from '~components/behandling/BehandlingRoutes'
+import { BehandlingRouteType, useBehandlingRoutes } from '~components/behandling/BehandlingRoutes'
 import { Label, Link } from '@navikt/ds-react'
 import { DisabledLabel } from '~components/behandling/StegMeny/stegmeny'
 
 export const NavLenke = (props: {
-  pathInfo: BehandlingRouteTypes
+  pathInfo: BehandlingRouteType
   behandling: IBehandlingReducer
   separator: boolean
 }) => {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/NavLenke.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/NavLenke.tsx
@@ -1,7 +1,6 @@
 import { ChevronRightIcon } from '@navikt/aksel-icons'
-import { hentGyldigeNavigeringsStatuser } from '~components/behandling/felles/utils'
 import { IBehandlingReducer } from '~store/reducers/BehandlingReducer'
-import { BehandlingRouteTypes } from '~components/behandling/BehandlingRoutes'
+import { BehandlingRouteTypes, useBehandlingRoutes } from '~components/behandling/BehandlingRoutes'
 import { Label, Link } from '@navikt/ds-react'
 import { DisabledLabel } from '~components/behandling/StegMeny/stegmeny'
 
@@ -10,17 +9,13 @@ export const NavLenke = (props: {
   behandling: IBehandlingReducer
   separator: boolean
 }) => {
-  const { pathInfo, separator } = props
-  const { status } = props.behandling
+  const { routeErGyldig } = useBehandlingRoutes()
 
-  const routeErDisabled =
-    pathInfo.kreverBehandlingsstatus &&
-    !hentGyldigeNavigeringsStatuser(status).includes(pathInfo.kreverBehandlingsstatus(props.behandling))
+  const { pathInfo, separator } = props
+
   return (
     <>
-      {routeErDisabled ? (
-        <DisabledLabel>{pathInfo.description}</DisabledLabel>
-      ) : (
+      {routeErGyldig(pathInfo.path) ? (
         <>
           {location.pathname.split('/')[3] === pathInfo.path ? (
             <Label>{pathInfo.description}</Label>
@@ -32,6 +27,8 @@ export const NavLenke = (props: {
             </Label>
           )}
         </>
+      ) : (
+        <DisabledLabel>{pathInfo.description}</DisabledLabel>
       )}
       {separator && <ChevronRightIcon aria-hidden />}
     </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/NavLenke.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/NavLenke.tsx
@@ -1,15 +1,16 @@
 import { ChevronRightIcon } from '@navikt/aksel-icons'
 import { IBehandlingReducer } from '~store/reducers/BehandlingReducer'
-import { BehandlingRouteType, useBehandlingRoutes } from '~components/behandling/BehandlingRoutes'
+import { BehandlingRouteContext, BehandlingRouteType } from '~components/behandling/BehandlingRoutes'
 import { Label, Link } from '@navikt/ds-react'
 import { DisabledLabel } from '~components/behandling/StegMeny/stegmeny'
+import { useContext } from 'react'
 
 export const NavLenke = (props: {
   pathInfo: BehandlingRouteType
   behandling: IBehandlingReducer
   separator: boolean
 }) => {
-  const { routeErGyldig } = useBehandlingRoutes()
+  const { routeErGyldig } = useContext(BehandlingRouteContext)
 
   const { pathInfo, separator } = props
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
@@ -1,10 +1,10 @@
 import styled from 'styled-components'
 import { NavLenke } from '~components/behandling/StegMeny/NavLenke'
 import { IBehandlingReducer, updateVilkaarsvurdering } from '~store/reducers/BehandlingReducer'
-import { BehandlingRouteType, useBehandlingRoutes } from '~components/behandling/BehandlingRoutes'
+import { BehandlingRouteContext, BehandlingRouteType } from '~components/behandling/BehandlingRoutes'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { hentVilkaarsvurdering } from '~shared/api/vilkaarsvurdering'
-import React, { useEffect } from 'react'
+import React, { useContext, useEffect } from 'react'
 import { useAppDispatch } from '~store/Store'
 import { mapApiResult } from '~shared/api/apiUtils'
 import Spinner from '~shared/Spinner'
@@ -15,7 +15,7 @@ export const StegMeny = (props: { behandling: IBehandlingReducer }) => {
   const dispatch = useAppDispatch()
   const behandling = props.behandling
   const { id } = behandling
-  const { behandlingRoutes } = useBehandlingRoutes()
+  const { behandlingRoutes } = useContext(BehandlingRouteContext)
 
   const [fetchVilkaarsvurderingStatus, fetchVilkaarsvurdering] = useApiCall(hentVilkaarsvurdering)
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 import { NavLenke } from '~components/behandling/StegMeny/NavLenke'
 import { IBehandlingReducer, updateVilkaarsvurdering } from '~store/reducers/BehandlingReducer'
-import { BehandlingRouteTypes, useBehandlingRoutes } from '~components/behandling/BehandlingRoutes'
+import { BehandlingRouteType, useBehandlingRoutes } from '~components/behandling/BehandlingRoutes'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { hentVilkaarsvurdering } from '~shared/api/vilkaarsvurdering'
 import React, { useEffect } from 'react'
@@ -19,7 +19,7 @@ export const StegMeny = (props: { behandling: IBehandlingReducer }) => {
 
   const [fetchVilkaarsvurderingStatus, fetchVilkaarsvurdering] = useApiCall(hentVilkaarsvurdering)
 
-  const erSisteRoute = (index: number, list: BehandlingRouteTypes[]) => index != list.length - 1
+  const erSisteRoute = (index: number, list: BehandlingRouteType[]) => index != list.length - 1
 
   // Trenger vilkårsvurdering for å kunne vise riktig routes etter at vv i en behandling er utført
   useEffect(() => {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/StegMeny/stegmeny.tsx
@@ -1,38 +1,23 @@
 import styled from 'styled-components'
-import { IBehandlingsType, Vedtaksloesning } from '~shared/types/IDetaljertBehandling'
 import { NavLenke } from '~components/behandling/StegMeny/NavLenke'
 import { IBehandlingReducer, updateVilkaarsvurdering } from '~store/reducers/BehandlingReducer'
-import {
-  BehandlingRouteTypes,
-  revurderingRoutes,
-  foerstegangsbehandlingRoutes,
-} from '~components/behandling/BehandlingRoutes'
+import { BehandlingRouteTypes, useBehandlingRoutes } from '~components/behandling/BehandlingRoutes'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { hentVilkaarsvurdering } from '~shared/api/vilkaarsvurdering'
 import React, { useEffect } from 'react'
 import { useAppDispatch } from '~store/Store'
 import { mapApiResult } from '~shared/api/apiUtils'
-import { usePersonopplysninger } from '~components/person/usePersonopplysninger'
 import Spinner from '~shared/Spinner'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { Box, HStack, Label } from '@navikt/ds-react'
-import { Revurderingaarsak } from '~shared/types/Revurderingaarsak'
 
 export const StegMeny = (props: { behandling: IBehandlingReducer }) => {
   const dispatch = useAppDispatch()
   const behandling = props.behandling
-  const { id, behandlingType } = behandling
-  const personopplysninger = usePersonopplysninger()
+  const { id } = behandling
+  const { behandlingRoutes } = useBehandlingRoutes()
 
   const [fetchVilkaarsvurderingStatus, fetchVilkaarsvurdering] = useApiCall(hentVilkaarsvurdering)
-
-  const lagVarselbrev =
-    behandling.kilde === Vedtaksloesning.GJENOPPRETTA ||
-    behandling.revurderingsaarsak == Revurderingaarsak.AKTIVITETSPLIKT
-  const routes =
-    behandlingType === IBehandlingsType.FØRSTEGANGSBEHANDLING
-      ? foerstegangsbehandlingRoutes(behandling, personopplysninger, lagVarselbrev)
-      : revurderingRoutes(behandling, lagVarselbrev)
 
   const erSisteRoute = (index: number, list: BehandlingRouteTypes[]) => index != list.length - 1
 
@@ -54,12 +39,12 @@ export const StegMeny = (props: { behandling: IBehandlingReducer }) => {
         () => (
           <StegMenyBox>
             <HStack gap="6" align="center">
-              {routes.map((pathInfo, index) => (
+              {behandlingRoutes.map((pathInfo, index) => (
                 <NavLenke
                   key={pathInfo.path}
                   pathInfo={pathInfo}
                   behandling={props.behandling}
-                  separator={erSisteRoute(index, routes)}
+                  separator={erSisteRoute(index, behandlingRoutes)}
                 />
               ))}
             </HStack>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
@@ -5,7 +5,7 @@ import { ExternalLinkIcon } from '@navikt/aksel-icons'
 import { BehandlingHandlingKnapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
 import { ConfigContext } from '~clientConfig'
 import { IBehandlingsType, IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
-import { useBehandlingRoutes } from '~components/behandling/BehandlingRoutes'
+import { BehandlingRouteContext } from '~components/behandling/BehandlingRoutes'
 import { handlinger } from '~components/behandling/handlinger/typer'
 import { usePersonopplysninger, usePersonopplysningerOmsAvdoede } from '~components/person/usePersonopplysninger'
 import { AktivitetspliktTidslinje } from '~components/behandling/aktivitetsplikt/AktivitetspliktTidslinje'
@@ -31,7 +31,8 @@ const isValidDateOfDeath = (date?: Date) => {
 
 export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => {
   const { behandling } = props
-  const { next } = useBehandlingRoutes()
+  const { next } = useContext(BehandlingRouteContext)
+
   const innloggetSaksbehandler = useInnloggetSaksbehandler()
 
   const redigerbar = behandlingErRedigerbar(

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/attestering/attesteringEllerUnderkjenning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/attestering/attesteringEllerUnderkjenning.tsx
@@ -1,8 +1,8 @@
-import { useBehandlingRoutes } from '~components/behandling/BehandlingRoutes'
+import { BehandlingRouteContext } from '~components/behandling/BehandlingRoutes'
 import { IBeslutning } from '../types'
 import { Beslutningsvalg } from './beslutningsvalg'
 import { Alert, BodyShort, VStack } from '@navikt/ds-react'
-import { useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { SidebarPanel } from '~shared/components/Sidebar'
 import { VedtakSammendrag } from '~components/vedtak/typer'
 import { useSelectorOppgaveUnderBehandling } from '~store/selectors/useSelectorOppgaveUnderBehandling'
@@ -17,8 +17,7 @@ type Props = {
 }
 
 export const AttesteringEllerUnderkjenning = ({ setBeslutning, beslutning, vedtak, erFattet }: Props) => {
-  const { lastPage } = useBehandlingRoutes()
-
+  const { lastPage } = useContext(BehandlingRouteContext)
   const oppgave = useSelectorOppgaveUnderBehandling()
   const innloggetSaksbehandler = useInnloggetSaksbehandler()
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
@@ -2,8 +2,8 @@ import { behandlingErRedigerbar } from '../felles/utils'
 import { formaterDato } from '~utils/formatering/dato'
 import { useVedtaksResultat } from '../useVedtaksResultat'
 import { useAppDispatch, useAppSelector } from '~store/Store'
-import { useBehandlingRoutes } from '../BehandlingRoutes'
-import React, { useEffect, useState } from 'react'
+import { BehandlingRouteContext } from '../BehandlingRoutes'
+import React, { useContext, useEffect, useState } from 'react'
 import { hentBeregning } from '~shared/api/beregning'
 import { IBehandlingReducer, oppdaterBehandlingsstatus, oppdaterBeregning } from '~store/reducers/BehandlingReducer'
 import Spinner from '~shared/Spinner'
@@ -33,7 +33,7 @@ import { useFeatureEnabledMedDefault } from '~shared/hooks/useFeatureToggle'
 
 export const Beregne = (props: { behandling: IBehandlingReducer }) => {
   const { behandling } = props
-  const { next } = useBehandlingRoutes()
+  const { next } = useContext(BehandlingRouteContext)
   const dispatch = useAppDispatch()
   const [beregning, hentBeregningRequest] = useApiCall(hentBeregning)
   const [vedtakStatus, oppdaterVedtakRequest] = useApiCall(upsertVedtak)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagBarnepensjon.tsx
@@ -1,6 +1,6 @@
 import { Box, Button } from '@navikt/ds-react'
 import { BehandlingHandlingKnapper } from '../handlinger/BehandlingHandlingKnapper'
-import { useBehandlingRoutes } from '../BehandlingRoutes'
+import { BehandlingRouteContext } from '../BehandlingRoutes'
 import { behandlingErRedigerbar } from '../felles/utils'
 import { NesteOgTilbake } from '../handlinger/NesteOgTilbake'
 import { useAppDispatch } from '~store/Store'
@@ -18,7 +18,7 @@ import {
   mapListeTilDto,
   periodisertBeregningsgrunnlagTilDto,
 } from '~components/behandling/beregningsgrunnlag/PeriodisertBeregningsgrunnlag'
-import React, { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import Soeskenjustering, {
   Soeskengrunnlag,
 } from '~components/behandling/beregningsgrunnlag/soeskenjustering/Soeskenjustering'
@@ -47,7 +47,7 @@ import { mapNavn } from '~components/behandling/beregningsgrunnlag/Beregningsgru
 import { AnnenForelderVurdering } from '~shared/types/grunnlag'
 
 const BeregningsgrunnlagBarnepensjon = () => {
-  const { next } = useBehandlingRoutes()
+  const { next } = useContext(BehandlingRouteContext)
   const personopplysninger = usePersonopplysninger()
   const innloggetSaksbehandler = useInnloggetSaksbehandler()
   const behandling = useBehandling()

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
@@ -1,6 +1,6 @@
 import { Box, Button } from '@navikt/ds-react'
 import { BehandlingHandlingKnapper } from '../handlinger/BehandlingHandlingKnapper'
-import { useBehandlingRoutes } from '../BehandlingRoutes'
+import { BehandlingRouteContext } from '../BehandlingRoutes'
 import { behandlingErRedigerbar } from '../felles/utils'
 import { NesteOgTilbake } from '../handlinger/NesteOgTilbake'
 import { useAppDispatch } from '~store/Store'
@@ -12,7 +12,7 @@ import {
   oppdaterBeregningsGrunnlag,
 } from '~store/reducers/BehandlingReducer'
 import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
-import React, { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import {
   Beregning,
   BeregningsMetodeBeregningsgrunnlagForm,
@@ -37,7 +37,7 @@ import { formaterNavn } from '~shared/types/Person'
 const BeregningsgrunnlagOmstillingsstoenad = () => {
   const behandling = useBehandling()
   const personopplysninger = usePersonopplysninger()
-  const { next } = useBehandlingRoutes()
+  const { next } = useContext(BehandlingRouteContext)
   const dispatch = useAppDispatch()
   const innloggetSaksbehandler = useInnloggetSaksbehandler()
   const [visManglendeBeregningsgrunnlag, setVisManglendeBeregningsgrunnlag] = useState(false)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/OverstyrBeregningGrunnlag.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/OverstyrBeregningGrunnlag.tsx
@@ -1,7 +1,7 @@
 import { Beregning, OverstyrBeregning } from '~shared/types/Beregning'
 import { Box, Button, Heading, HStack, VStack } from '@navikt/ds-react'
 import { behandlingErRedigerbar } from '../../felles/utils'
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react'
+import React, { Dispatch, SetStateAction, useContext, useEffect, useState } from 'react'
 import { CalculatorIcon, PlusIcon } from '@navikt/aksel-icons'
 import {
   IBehandlingReducer,
@@ -14,7 +14,7 @@ import { useAppDispatch } from '~store/Store'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { NesteOgTilbake } from '../../handlinger/NesteOgTilbake'
 import { BehandlingHandlingKnapper } from '../../handlinger/BehandlingHandlingKnapper'
-import { useBehandlingRoutes } from '../../BehandlingRoutes'
+import { BehandlingRouteContext } from '../../BehandlingRoutes'
 import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
 import { isPending, mapResult } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
@@ -43,7 +43,7 @@ const OverstyrBeregningGrunnlag = (props: {
   const [overstyrBeregningGrunnlagResult, overstyrBeregningGrunnlagRequest] = useApiCall(hentOverstyrBeregningGrunnlag)
   const [opprettEllerEndreBeregningResult, opprettEllerEndreBeregningRequest] = useApiCall(opprettEllerEndreBeregning)
 
-  const { next } = useBehandlingRoutes()
+  const { next } = useContext(BehandlingRouteContext)
   const dispatch = useAppDispatch()
 
   const onSubmit = () => {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Varselbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Varselbrev.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { Alert, BodyShort, Box, Button, Heading } from '@navikt/ds-react'
 import { BehandlingHandlingKnapper } from '../handlinger/BehandlingHandlingKnapper'
 import { hentVarselbrev, opprettVarselbrev } from '~shared/api/brev'
@@ -18,7 +18,7 @@ import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { BrevMottaker } from '~components/person/brev/mottaker/BrevMottaker'
 import BrevTittel from '~components/person/brev/tittel/BrevTittel'
 import { NesteOgTilbake } from '~components/behandling/handlinger/NesteOgTilbake'
-import { useBehandlingRoutes } from '~components/behandling/BehandlingRoutes'
+import { BehandlingRouteContext } from '~components/behandling/BehandlingRoutes'
 import NyttBrevHandlingerPanel from '~components/person/brev/NyttBrevHandlingerPanel'
 import { hentOppgaveForReferanseUnderBehandling, settOppgavePaaVentApi } from '~shared/api/oppgaver'
 import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
@@ -37,7 +37,7 @@ export const Varselbrev = (props: { behandling: IDetaljertBehandling }) => {
   )
 
   const [varselbrev, setVarselbrev] = useState<IBrev>()
-  const { next, currentRouteErGyldig } = useBehandlingRoutes()
+  const { next, currentRouteErGyldig } = useContext(BehandlingRouteContext)
   if (!currentRouteErGyldig()) {
     throw Error(
       `Varselbrev er ugyldig for denne behandlingen med ${props.behandling.status} id: ${props.behandling.id} mangler kanskje vilkårsvurdering? `

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Varselbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Varselbrev.tsx
@@ -37,8 +37,8 @@ export const Varselbrev = (props: { behandling: IDetaljertBehandling }) => {
   )
 
   const [varselbrev, setVarselbrev] = useState<IBrev>()
-  const { next, routeErGyldig } = useBehandlingRoutes()
-  if (!routeErGyldig()) {
+  const { next, currentRouteErGyldig } = useBehandlingRoutes()
+  if (!currentRouteErGyldig()) {
     throw Error(
       `Varselbrev er ugyldig for denne behandlingen med ${props.behandling.status} id: ${props.behandling.id} mangler kanskje vilkårsvurdering? `
     )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/NesteOgTilbake.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/NesteOgTilbake.tsx
@@ -1,10 +1,11 @@
 import { Button, HStack, VStack } from '@navikt/ds-react'
-import { useBehandlingRoutes } from '../BehandlingRoutes'
+import { BehandlingRouteContext } from '../BehandlingRoutes'
 import AvbrytBehandling from './AvbrytBehandling'
 import { handlinger } from './typer'
+import { useContext } from 'react'
 
 export const NesteOgTilbake = () => {
-  const { next, back, lastPage, firstPage } = useBehandlingRoutes()
+  const { next, back, lastPage, firstPage } = useContext(BehandlingRouteContext)
 
   return (
     <VStack gap="4">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/Start.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/Start.tsx
@@ -1,9 +1,10 @@
 import { Button } from '@navikt/ds-react'
-import { useBehandlingRoutes } from '../BehandlingRoutes'
+import { BehandlingRouteContext } from '../BehandlingRoutes'
 import { handlinger } from './typer'
+import { useContext } from 'react'
 
 export const Start = ({ disabled }: { disabled?: boolean }) => {
-  const { next } = useBehandlingRoutes()
+  const { next } = useContext(BehandlingRouteContext)
 
   return (
     <Button variant="primary" onClick={next} disabled={disabled}>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/Tilbake.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/handlinger/Tilbake.tsx
@@ -1,9 +1,10 @@
 import { Button } from '@navikt/ds-react'
-import { useBehandlingRoutes } from '../BehandlingRoutes'
+import { BehandlingRouteContext } from '../BehandlingRoutes'
 import { handlinger } from './typer'
+import { useContext } from 'react'
 
 export const Tilbake = () => {
-  const { back, firstPage } = useBehandlingRoutes()
+  const { back, firstPage } = useContext(BehandlingRouteContext)
 
   return (
     <>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidVisning.tsx
@@ -5,9 +5,9 @@ import { useVedtaksResultat } from '~components/behandling/useVedtaksResultat'
 import { BehandlingHandlingKnapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
 import { NesteOgTilbake } from '~components/behandling/handlinger/NesteOgTilbake'
 import { behandlingErRedigerbar } from '~components/behandling/felles/utils'
-import { useBehandlingRoutes } from '~components/behandling/BehandlingRoutes'
+import { BehandlingRouteContext } from '~components/behandling/BehandlingRoutes'
 import { useApiCall } from '~shared/hooks/useApiCall'
-import React from 'react'
+import React, { useContext } from 'react'
 import { Trygdetid } from '~components/behandling/trygdetid/Trygdetid'
 import { oppdaterStatus } from '~shared/api/trygdetid'
 import { IBehandlingReducer, oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'
@@ -29,7 +29,7 @@ const TrygdetidVisning = (props: { behandling: IBehandlingReducer }) => {
     behandling.sakEnhetId,
     innloggetSaksbehandler.skriveEnheter
   )
-  const { next } = useBehandlingRoutes()
+  const { next } = useContext(BehandlingRouteContext)
 
   const vedtaksresultat = useVedtaksResultat()
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/VilkaarsvurderingKnapper.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/VilkaarsvurderingKnapper.tsx
@@ -9,7 +9,6 @@ import { useAppDispatch } from '~store/Store'
 import { oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'
 import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
 import { BehandlingHandlingKnapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
-
 import { isPending } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { useBehandling } from '~components/behandling/useBehandling'

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/VilkaarsvurderingKnapper.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/vilkaarsvurdering/VilkaarsvurderingKnapper.tsx
@@ -1,6 +1,6 @@
 import { handlinger } from '../handlinger/typer'
 import { Button } from '@navikt/ds-react'
-import { useBehandlingRoutes } from '../BehandlingRoutes'
+import { BehandlingRouteContext } from '../BehandlingRoutes'
 import { useVedtaksResultat } from '../useVedtaksResultat'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { upsertVedtak } from '~shared/api/vedtaksvurdering'
@@ -14,9 +14,10 @@ import { isPending } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { useBehandling } from '~components/behandling/useBehandling'
 import { usePersonopplysninger } from '~components/person/usePersonopplysninger'
+import { useContext } from 'react'
 
 export const VilkaarsvurderingKnapper = (props: { behandlingId: string }) => {
-  const { next, goto } = useBehandlingRoutes()
+  const { next, goto } = useContext(BehandlingRouteContext)
   const dispatch = useAppDispatch()
   const { behandlingId } = props
   const vedtaksresultat = useVedtaksResultat()


### PR DESCRIPTION
1. Per i dag sjekker vi om routes er gyldige på 2 forskjellige steder og måter, samler de to og skriver om slik at vi kun har en route liste med egenskaper vi trenger kontra 2 og x antall forskjellige måter å sjonglere disse på.

2.  https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/6052/commits/455371c593a1ab30b674a07beba765b6cf0478fd
Tar for seg at vi sender behandlingroute data og funksjoner nedover i en context i stedet for å newe opp overalt da det kan få utilsiktede konsekvenser...