### PR TITLE
EY-4615 fix oppretting av ekstra sanksjoner

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
@@ -125,12 +125,16 @@ object AvkortingRegelkjoring {
                         code = "OVERLAPPENDE_SANKSJONER",
                         detail =
                             "Behandlingen har sanksjoner som overlapper med hverandre i perioder. Dobbelt " +
-                                "sanksjon i en måned støttes ikke, og de overlappende sanksjonene må endres / fjernes" +
-                                " for å kunne beregne avkortet ytelse.",
+                                "sanksjon i en måned støttes ikke, og de overlappende sanksjonene må endres / " +
+                                "fjernes for å kunne beregne avkortet ytelse.",
                         cause = e,
                     )
 
-                    else -> throw InternfeilException("", e)
+                    else -> throw InternfeilException(
+                        "Kunne ikke sette opp perioder for sanksjon riktig. " +
+                            "Feilen som oppstod var: ${e.code}",
+                        e,
+                    )
                 }
             }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
@@ -75,7 +75,7 @@ export const Avkorting = ({
       <VStack gap="8">
         {mapResult(avkortingStatus, {
           pending: <Spinner label="Henter avkorting" />,
-          error: <ApiErrorAlert>En feil har oppstått</ApiErrorAlert>,
+          error: (e) => <ApiErrorAlert>En feil har oppstått: {e.detail}</ApiErrorAlert>,
           success: () => (
             <>
               <VStack maxWidth="70rem">


### PR DESCRIPTION
Unngår å kopiere sanksjoner hver gang vi beregner, hvis vi allerede har gjort det.

Gir også bedre feilmeldinger når noe rart har skjedd med sanksjonsgrunnlaget som fører til at man ikke får lastet f.eks. avkorting, slik at saksbehandler kan rydde opp selv, eller det er en feiltype som vi ikke forventer og vi logger ut i prod-loggene.