### PR TITLE
Sjekk om soeker mangler trygdetid hvis det er tidligere familiepleier

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
@@ -79,8 +79,9 @@ export const Trygdetid = ({ redigerbar, behandling, vedtaksresultat, virkningsti
   }
 
   const tidligereFamiliepleier =
-    behandling.tidligereFamiliepleier?.svar &&
-    behandling.vilkaarsvurdering?.resultat?.utfall == VilkaarsvurderingResultat.OPPFYLT
+    (behandling.tidligereFamiliepleier?.svar &&
+      behandling.vilkaarsvurdering?.resultat?.utfall == VilkaarsvurderingResultat.OPPFYLT) ??
+    false
 
   const oppdaterTrygdetider = (trygdetid: ITrygdetid[]) => {
     setTrygdetider(trygdetid)
@@ -92,7 +93,7 @@ export const Trygdetid = ({ redigerbar, behandling, vedtaksresultat, virkningsti
       if (
         trygdetider === null ||
         trygdetider.length == 0 ||
-        manglerTrygdetid(trygdetider, !!tidligereFamiliepleier, personopplysninger?.avdoede, personopplysninger?.soeker)
+        manglerTrygdetid(trygdetider, tidligereFamiliepleier, personopplysninger?.avdoede, personopplysninger?.soeker)
       ) {
         if (tidligereFamiliepleier) {
           opprettOverstyrtTrygdetidReq({ behandlingId: behandling.id, overskriv: true }, () =>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
@@ -35,10 +35,17 @@ interface Props {
   virkningstidspunktEtterNyRegelDato: boolean
 }
 
-const manglerTrygdetid = (trygdetider: ITrygdetid[], avdoede?: Personopplysning[]): boolean => {
-  const avdoedIdenter = (avdoede || []).map((avdoed) => avdoed.opplysning.foedselsnummer)
+const manglerTrygdetid = (
+  trygdetider: ITrygdetid[],
+  tidligereFamiliepleier: boolean,
+  avdoede?: Personopplysning[],
+  soeker?: Personopplysning
+): boolean => {
   const trygdetidIdenter = trygdetider.map((trygdetid) => trygdetid.ident)
 
+  if (tidligereFamiliepleier) return soeker ? !trygdetidIdenter.includes(soeker.opplysning.foedselsnummer) : true
+
+  const avdoedIdenter = (avdoede || []).map((avdoed) => avdoed.opplysning.foedselsnummer)
   return !avdoedIdenter.every((ident) => trygdetidIdenter.includes(ident))
 }
 
@@ -85,7 +92,7 @@ export const Trygdetid = ({ redigerbar, behandling, vedtaksresultat, virkningsti
       if (
         trygdetider === null ||
         trygdetider.length == 0 ||
-        manglerTrygdetid(trygdetider, personopplysninger?.avdoede)
+        manglerTrygdetid(trygdetider, !!tidligereFamiliepleier, personopplysninger?.avdoede, personopplysninger?.soeker)
       ) {
         if (tidligereFamiliepleier) {
           opprettOverstyrtTrygdetidReq({ behandlingId: behandling.id, overskriv: true }, () =>


### PR DESCRIPTION
Trygdetid går i loop hvis man har en avdød på en tidligere familiepleier sak. 