### PR TITLE
Fikser problem med beregning av etterbetaling ved opphør

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakEtterbetaling.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakEtterbetaling.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.vedtaksvurdering
 import no.nav.etterlatte.libs.common.tidspunkt.norskKlokke
 import no.nav.etterlatte.libs.common.vedtak.Periode
 import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
+import java.math.BigDecimal
 import java.time.Clock
 import java.time.Month
 import java.time.YearMonth
@@ -45,7 +46,9 @@ internal fun Vedtak.erVedtakMedEtterbetaling(
     }
 }
 
-internal fun Utbetalingsperiode.beloepErMindreEnn(that: Utbetalingsperiode) = this.beloep?.compareTo(that.beloep) == -1
+internal fun Utbetalingsperiode.beloepErMindreEnn(that: Utbetalingsperiode) = this.beloep?.compareTo(that.beloep.toNonNullBeloep()) == -1
+
+private fun BigDecimal?.toNonNullBeloep(): BigDecimal = this ?: BigDecimal.valueOf(0)
 
 internal fun Utbetalingsperiode.overlapper(other: Utbetalingsperiode): Boolean = periode.overlapper(other.periode)
 


### PR DESCRIPTION
Når det gjøres et vedtak som er opphør, så vil beløp være `null` og dette feiler ved beregning av etterbetaling. 

Tenker kanskje denne sjekken uansett burde byttes ut med simulering, men nå må vi få det opp å gå i prod.