### PR TITLE
EY-4640 hotfix for saker som står fast TIL_SAMORDNING

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.vedtaksvurdering
 
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.libs.common.Regelverk
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
@@ -49,6 +50,9 @@ class VedtakBehandlingService(
     private val behandlingKlient: BehandlingKlient,
     private val samordningsKlient: SamordningsKlient,
     private val trygdetidKlient: TrygdetidKlient,
+
+    // Denne må confes opp også med miljøvariabler (se behandling)
+    private val featureToggleService: FeatureToggleService
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -408,7 +412,15 @@ class VedtakBehandlingService(
         repository.lagreManuellBehandlingSamordningsmelding(samordningmelding, brukerTokenInfo)
 
         try {
-            samordningsKlient.oppdaterSamordningsmelding(samordningmelding, brukerTokenInfo)
+            val svarFins = samordningsKlient.oppdaterSamordningsmelding(samordningmelding, brukerTokenInfo)
+            // bare sett samordnet hvis svar fins?
+            if (svarFins) {
+                if (featureToggleService.isEnabled()) {
+                    // hent ut behandlingId
+                    samordne(samordningmelding.)
+                }
+            }
+
         } catch (e: Exception) {
             repository.slettManuellBehandlingSamordningsmelding(samordningmelding.samId)
             throw e

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
@@ -413,6 +413,7 @@ class VedtakBehandlingService(
             if (meldingFinnes) { // TODO bør vi ha ytterlige sjekker før vi samordner?
                 val vedtak = repository.hentVedtakTilSamordning(sakId)
                 if (vedtak != null) {
+                    logger.info("Manuelt samordner")
                     samordne(vedtak.behandlingId, brukerTokenInfo)
                 }
             }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.vedtaksvurdering
 
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
-import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.libs.common.Regelverk
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
@@ -50,9 +49,6 @@ class VedtakBehandlingService(
     private val behandlingKlient: BehandlingKlient,
     private val samordningsKlient: SamordningsKlient,
     private val trygdetidKlient: TrygdetidKlient,
-
-    // Denne må confes opp også med miljøvariabler (se behandling)
-    private val featureToggleService: FeatureToggleService
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -408,19 +404,18 @@ class VedtakBehandlingService(
     suspend fun oppdaterSamordningsmelding(
         samordningmelding: OppdaterSamordningsmelding,
         brukerTokenInfo: BrukerTokenInfo,
+        sakId: SakId,
     ) {
         repository.lagreManuellBehandlingSamordningsmelding(samordningmelding, brukerTokenInfo)
 
         try {
-            val svarFins = samordningsKlient.oppdaterSamordningsmelding(samordningmelding, brukerTokenInfo)
-            // bare sett samordnet hvis svar fins?
-            if (svarFins) {
-                if (featureToggleService.isEnabled()) {
-                    // hent ut behandlingId
-                    samordne(samordningmelding.)
+            val meldingFinnes = samordningsKlient.oppdaterSamordningsmelding(samordningmelding, brukerTokenInfo)
+            if (meldingFinnes) { // TODO bør vi ha ytterlige sjekker før vi samordner?
+                val vedtak = repository.hentVedtakTilSamordning(sakId)
+                if (vedtak != null) {
+                    samordne(vedtak.behandlingId, brukerTokenInfo)
                 }
             }
-
         } catch (e: Exception) {
             repository.slettManuellBehandlingSamordningsmelding(samordningmelding.samId)
             throw e

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
@@ -413,7 +413,7 @@ class VedtakBehandlingService(
             if (meldingFinnes) { // TODO bør vi ha ytterlige sjekker før vi samordner?
                 val vedtak = repository.hentVedtakTilSamordning(sakId)
                 if (vedtak != null) {
-                    logger.info("Manuelt samordner")
+                    logger.info("Manuelt samordner pga ALLEREDE_REGISTRERT_ELLER_UTENFOR_FRIST, sakId=$sakId, vedtakId=${vedtak.id}")
                     samordne(vedtak.behandlingId, brukerTokenInfo)
                 }
             }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
@@ -49,6 +49,31 @@ class VedtaksvurderingRepository(
             this.block(it)
         }
 
+    fun hentVedtakTilSamordning(
+        sakId: SakId,
+        tx: TransactionalSession? = null,
+    ): Vedtak? =
+        tx.session {
+            hent(
+                queryString = """
+            SELECT sakid, behandlingId, saksbehandlerId, beregningsresultat, avkorting, vilkaarsresultat, id, fnr, 
+                datoFattet, datoattestert, attestant, datoVirkFom, vedtakstatus, saktype, behandlingtype, 
+                attestertVedtakEnhet, fattetVedtakEnhet, type, revurderingsaarsak, revurderinginfo, opphoer_fom,
+                tilbakekreving, klage 
+            FROM vedtak 
+            WHERE sakid = :sakId
+            AND vedtakstatus = :vedtakStatus
+            """,
+                params =
+                    mapOf(
+                        "sakId" to sakId,
+                        "vedtakStatus" to VedtakStatus.TIL_SAMORDNING,
+                    ),
+            ) {
+                it.toVedtak(emptyList())
+            }
+        }
+
     fun opprettVedtak(
         opprettVedtak: OpprettVedtak,
         tx: TransactionalSession? = null,

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
@@ -63,6 +63,8 @@ class VedtaksvurderingRepository(
             FROM vedtak 
             WHERE sakid = :sakId
             AND vedtakstatus = :vedtakStatus
+            ORDER BY datoattestert DESC
+            LIMIT 1
             """,
                 params =
                     mapOf(

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -62,7 +62,7 @@ fun Route.vedtaksvurderingRoute(
             withSakId(behandlingKlient) { sakId ->
                 val oppdatering = requireNotNull(call.receive<OppdaterSamordningsmelding>())
                 logger.info("Oppdaterer samordningsmelding=${oppdatering.samId}, sak=$sakId")
-                vedtakBehandlingService.oppdaterSamordningsmelding(oppdatering, brukerTokenInfo).run {
+                vedtakBehandlingService.oppdaterSamordningsmelding(oppdatering, brukerTokenInfo, sakId).run {
                     rapidService.sendGenerellHendelse(
                         VedtakKafkaHendelseHendelseType.SAMORDNING_MANUELT_BEHANDLET,
                         mapOf(

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/klienter/SamordningsKlient.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/klienter/SamordningsKlient.kt
@@ -111,6 +111,8 @@ class SamordningsKlientImpl(
         samordningmelding: OppdaterSamordningsmelding,
         brukerTokenInfo: BrukerTokenInfo,
     ): Boolean {
+        val meldingFinnes = HttpStatusCode.Conflict
+
         try {
             val response =
                 httpClient.post("$resourceUrl/api/refusjonskrav") {
@@ -122,17 +124,16 @@ class SamordningsKlientImpl(
                     expectSuccess = false
                 }
 
-            when {
-                response.status == HttpStatusCode.Conflict -> return true
-                !response.status.isSuccess() -> {
-                    throw ResponseException(
-                        response,
-                        "Oppdatere samordningsmelding feilet [samId=${samordningmelding.samId}]",
-                    )
-                }
+            if (response.status == meldingFinnes) return true
+
+            if (!response.status.isSuccess()) {
+                throw ResponseException(
+                    response,
+                    "Oppdatere samordningsmelding feilet [samId=${samordningmelding.samId}]",
+                )
             }
         } catch (e: ResponseException) {
-            if (e.response.status == HttpStatusCode.Conflict) {
+            if (e.response.status == meldingFinnes) {
                 return true
             }
             throw e


### PR DESCRIPTION
Saker som ikke for overstyre samordning pga følgende melding

```
Text: "{"message":"Message with id = 25758215 has already been answered or time limit is exceeded.","exceptionType":"ALLEREDE_REGISTRERT_ELLER_UTENFOR_FRIST"}" 
```

De står derfor fast med status TIL_SAMORDNING og får ikke utbetaling 