### PR TITLE
EY-4555: Fjerner komma i liste ved konvertering til Slate

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BlockTilSlateKonverterer.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BlockTilSlateKonverterer.kt
@@ -96,7 +96,7 @@ object BlockTilSlateKonverterer {
                 listOf(
                     Slate.InnerElement(
                         type = Slate.ElementType.PARAGRAPH,
-                        text = it.content.joinToString { i -> i.text },
+                        text = it.content.joinToString("") { i -> i.text },
                     ),
                 ),
         )


### PR DESCRIPTION
Hadde en litt irriterende bug som legger inn komma når flere objekter i en liste slås sammen

![Screenshot 2024-10-24 at 15 10 51](https://github.com/user-attachments/assets/864767f2-fb7d-496f-89ba-5db390d7bb00)
