### PR TITLE
FAGSYSTEM-352841: Bruker sortert trygdetidsgrunnlag ved normalisering og poengår

### DIFF
--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/Trygdetid.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/Trygdetid.kt
@@ -139,39 +139,42 @@ data class TrygdetidPeriode(
     fun overlapperMed(other: TrygdetidPeriode): Boolean = this.fra.isBefore(other.til) && other.fra.isBefore(this.til)
 }
 
-fun List<TrygdetidGrunnlag>.normaliser() =
-    this.sortedBy { it.periode.fra }.mapIndexed { idx, trygdetidGrunnlag ->
-        var fra = trygdetidGrunnlag.periode.fra
-        var til = trygdetidGrunnlag.periode.til
+fun List<TrygdetidGrunnlag>.normaliser(): List<TrygdetidGrunnlag> {
+    val sortertTrygdetidGrunnlag = this.sortedBy { it.periode.fra }
+    return sortertTrygdetidGrunnlag
+        .mapIndexed { idx, trygdetidGrunnlag ->
+            var fra = trygdetidGrunnlag.periode.fra
+            var til = trygdetidGrunnlag.periode.til
 
-        if (trygdetidGrunnlag.poengInnAar) {
-            fra = fra.with(MonthDay.of(1, 1))
-        }
-
-        if (trygdetidGrunnlag.poengUtAar) {
-            til = til.with(MonthDay.of(12, 31))
-        }
-
-        // Håndtere at den forrige var et ut år - og at dette hadde en fra i samme år
-        if (idx > 0) {
-            val prev = this[idx - 1]
-
-            if (prev.poengUtAar && prev.periode.til.year == fra.year) {
-                fra = LocalDate.of(prev.periode.til.year + 1, 1, 1)
+            if (trygdetidGrunnlag.poengInnAar) {
+                fra = fra.with(MonthDay.of(1, 1))
             }
-        }
 
-        // Håndtere at den neste var et inn år - og at dette hadde en til i samme år
-        if (idx < this.size - 2) {
-            val next = this[idx + 1]
-
-            if (next.poengInnAar && next.periode.til.year == fra.year) {
-                til = LocalDate.of(next.periode.til.year - 1, 12, 31)
+            if (trygdetidGrunnlag.poengUtAar) {
+                til = til.with(MonthDay.of(12, 31))
             }
-        }
 
-        trygdetidGrunnlag.copy(periode = TrygdetidPeriode(fra = fra, til = til.plusDays(1)))
-    }
+            // Håndtere at den forrige var et ut år - og at dette hadde en fra i samme år
+            if (idx > 0) {
+                val prev = sortertTrygdetidGrunnlag[idx - 1]
+
+                if (prev.poengUtAar && prev.periode.til.year == fra.year) {
+                    fra = LocalDate.of(prev.periode.til.year + 1, 1, 1)
+                }
+            }
+
+            // Håndtere at den neste var et inn år - og at dette hadde en til i samme år
+            if (idx < sortertTrygdetidGrunnlag.size - 2) {
+                val next = sortertTrygdetidGrunnlag[idx + 1]
+
+                if (next.poengInnAar && next.periode.til.year == fra.year) {
+                    til = LocalDate.of(next.periode.til.year - 1, 12, 31)
+                }
+            }
+
+            trygdetidGrunnlag.copy(periode = TrygdetidPeriode(fra = fra, til = til.plusDays(1)))
+        }
+}
 
 class OverlappendePeriodeException(
     message: String,

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidTest.kt
@@ -165,4 +165,42 @@ internal class TrygdetidTest {
 
         oppdatert.trygdetidGrunnlag.size shouldBe 4
     }
+
+    @Test
+    fun `Skal kunne legge til grunnlag i vilkaarlig rekkefoelge ogsaa hvor det er poengaar som trigger endring av periode`() {
+        val usortertTrygdetid =
+            trygdetid(
+                trygdetidGrunnlag =
+                    listOf(
+                        trygdetidGrunnlag(
+                            periode = TrygdetidPeriode(LocalDate.of(2020, 7, 1), LocalDate.of(2020, 9, 1)),
+                            trygdetidType = TrygdetidType.FAKTISK,
+                        ),
+                        trygdetidGrunnlag(
+                            periode = TrygdetidPeriode(LocalDate.of(2022, 5, 1), LocalDate.of(2022, 8, 31)),
+                            trygdetidType = TrygdetidType.FAKTISK,
+                        ),
+                        trygdetidGrunnlag(
+                            periode = TrygdetidPeriode(LocalDate.of(2019, 2, 1), LocalDate.of(2019, 11, 30)),
+                            poengInnAar = true,
+                            trygdetidType = TrygdetidType.FAKTISK,
+                        ),
+                        trygdetidGrunnlag(
+                            periode = TrygdetidPeriode(LocalDate.of(2019, 12, 1), LocalDate.of(2020, 3, 28)),
+                            trygdetidType = TrygdetidType.FAKTISK,
+                        ),
+                    ),
+            )
+
+        val oppdatert =
+            usortertTrygdetid.leggTilEllerOppdaterTrygdetidGrunnlag(
+                trygdetidGrunnlag(
+                    periode = TrygdetidPeriode(LocalDate.of(2021, 5, 29), LocalDate.of(2021, 7, 27)),
+                    poengInnAar = true,
+                    trygdetidType = TrygdetidType.FAKTISK,
+                ),
+            )
+
+        oppdatert.trygdetidGrunnlag.size shouldBe 5
+    }
 }


### PR DESCRIPTION
I koden så vil trygdetidsgrunnlagene sorteres, men siden elementer aksesseres direkte med `this` lenger nede i funksjonen, så vil ikke dette være den samme listen som er sortert. Dette fører til at saksbehandler får feil som nevnt i https://jira.adeo.no/browse/FAGSYSTEM-352841. 