### PR TITLE
Forbedre feilmelding ved manglende tilgang

### DIFF
--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregningRoutesTest.kt
@@ -137,7 +137,7 @@ internal class BeregningRoutesTest {
                     header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     header(HttpHeaders.Authorization, "Bearer $token")
                 }.let {
-                    it.status shouldBe HttpStatusCode.NotFound
+                    it.status shouldBe HttpStatusCode.Forbidden
                 }
         }
     }

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
@@ -251,7 +251,7 @@ internal class BeregningsGrunnlagRoutesTest {
                     header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     header(HttpHeaders.Authorization, "Bearer $token")
                 }.let {
-                    it.status shouldBe HttpStatusCode.NotFound
+                    it.status shouldBe HttpStatusCode.Forbidden
                 }
         }
     }
@@ -277,7 +277,7 @@ internal class BeregningsGrunnlagRoutesTest {
                         ),
                     )
                 }.let {
-                    it.status shouldBe HttpStatusCode.NotFound
+                    it.status shouldBe HttpStatusCode.Forbidden
                 }
         }
     }

--- a/libs/etterlatte-ktor/src/main/kotlin/route/RouteUtils.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/route/RouteUtils.kt
@@ -101,7 +101,7 @@ suspend inline fun PipelineContext<*, ApplicationCall>.withBehandlingId(
                 onSuccess(behandlingId)
             } else {
                 logger.info("Har ikke tilgang til behandling")
-                throw GenerellIkkeFunnetException()
+                throw ManglerTilgang(skrivetilgang, "behandling")
             }
         }
 
@@ -131,7 +131,7 @@ suspend inline fun PipelineContext<*, ApplicationCall>.withSakId(
                 onSuccess(sakId)
             } else {
                 logger.info("Har ikke tilgang til sak")
-                throw GenerellIkkeFunnetException()
+                throw ManglerTilgang(skrivetilgang, "sak")
             }
         }
 
@@ -158,7 +158,7 @@ suspend inline fun PipelineContext<*, ApplicationCall>.withFoedselsnummer(
                 onSuccess(foedselsnummer)
             } else {
                 logger.info("Har ikke tilgang til person")
-                throw GenerellIkkeFunnetException()
+                throw ManglerTilgang(skrivetilgang, "person")
             }
         }
 
@@ -234,6 +234,15 @@ class UgyldigDatoFormatException :
     UgyldigForespoerselException(
         code = "UGYLDIG-DATOFORMAT",
         detail = "Forventet format YYYY-MM-DD (ISO-8601)",
+    )
+
+class ManglerTilgang(
+    skrivetilgang: Boolean,
+    type: String,
+) : ForespoerselException(
+        status = HttpStatusCode.Forbidden.value,
+        code = "MANGLER_TILGANG",
+        detail = if (skrivetilgang) "Har ikke skrivetilgang til $type" else "Har ikke lesetilgang til $type",
     )
 
 fun ApplicationCall.dato(param: String) =

--- a/libs/etterlatte-ktor/src/test/kotlin/RestModuleTest.kt
+++ b/libs/etterlatte-ktor/src/test/kotlin/RestModuleTest.kt
@@ -9,6 +9,7 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode.Companion.Forbidden
 import io.ktor.http.HttpStatusCode.Companion.InternalServerError
 import io.ktor.http.HttpStatusCode.Companion.NotFound
 import io.ktor.http.HttpStatusCode.Companion.OK
@@ -126,17 +127,17 @@ class RestModuleTest {
             client
                 .get("/behandling/${UUID.randomUUID()}") {
                     header(HttpHeaders.Authorization, "Bearer $token")
-                }.let { assertEquals(NotFound, it.status) }
+                }.let { assertEquals(Forbidden, it.status) }
             client
                 .get("/sak/1") {
                     header(HttpHeaders.Authorization, "Bearer $token")
-                }.let { assertEquals(NotFound, it.status) }
+                }.let { assertEquals(Forbidden, it.status) }
             client
                 .post("/person") {
                     header(HttpHeaders.Authorization, "Bearer $token")
                     contentType(ContentType.Application.Json)
                     setBody(FoedselsnummerDTO("27458328671").toJson())
-                }.let { assertEquals(NotFound, it.status) }
+                }.let { assertEquals(Forbidden, it.status) }
         }
     }
 


### PR DESCRIPTION
Forslag til forbedring på feil som kastes og feilmelding som vises til saksbehandler. 

P.t. må vi bruke masse tid på å debugge hver gang de ikke har tilgang siden de får en veldig misvisende "404 Ressurs ikke funnet". Dette vil spare både oss og saksbehandler mye tid på sikt..