### PR TITLE
Støtte åpning av journalpost i ny fane

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentModal.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { mapApiResult } from '~shared/api/apiUtils'
 import { ApiErrorAlert } from '~ErrorBoundary'
-import { EyeIcon } from '@navikt/aksel-icons'
+import { ChevronDownIcon, EyeIcon } from '@navikt/aksel-icons'
 
 export default function DokumentModal({ journalpost }: { journalpost: Journalpost }) {
   const { tittel, journalpostId, dokumenter } = journalpost
@@ -36,8 +36,8 @@ export default function DokumentModal({ journalpost }: { journalpost: Journalpos
     <>
       {dokumenter.length > 1 ? (
         <Dropdown>
-          <Button icon={<EyeIcon />} size="small" as={Dropdown.Toggle}>
-            Åpne
+          <Button icon={<ChevronDownIcon />} size="small" as={Dropdown.Toggle}>
+            Vis
           </Button>
           <DropdownMenu>
             <Dropdown.Menu.GroupedList>
@@ -71,7 +71,7 @@ export default function DokumentModal({ journalpost }: { journalpost: Journalpos
           onClick={() => open(dokumenter[0].dokumentInfoId)}
           disabled={!dokumenter[0].dokumentvarianter[0]?.saksbehandlerHarTilgang}
         >
-          Åpne
+          Vis
         </Button>
       ) : (
         <Alert variant="warning" size="small">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentRad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/DokumentRad.tsx
@@ -2,7 +2,7 @@ import { Journalpost, Journalposttype, Journalstatus } from '~shared/types/Journ
 import { Result } from '~shared/api/apiUtils'
 import { SakMedBehandlinger } from '~components/person/typer'
 import React, { useState } from 'react'
-import { HStack, Table } from '@navikt/ds-react'
+import { Alert, Box, Button, Dropdown, HStack, Link, Table } from '@navikt/ds-react'
 import { JournalpostInnhold } from '~components/person/journalfoeringsoppgave/journalpost/JournalpostInnhold'
 import { formaterJournalpostStatus, formaterJournalpostType } from '~utils/formatering/formatering'
 import { formaterDato } from '~utils/formatering/dato'
@@ -12,6 +12,7 @@ import DokumentModal from '~components/person/dokumenter/DokumentModal'
 import { HaandterAvvikModal } from './avvik/HaandterAvvikModal'
 import { GosysTemaTag } from '~shared/tags/GosysTemaTag'
 import { GosysTema } from '~shared/types/Gosys'
+import { ChevronDownIcon, ExternalLinkIcon } from '@navikt/aksel-icons'
 
 export const DokumentRad = ({
   dokument,
@@ -56,6 +57,58 @@ export const DokumentRad = ({
           )}
 
           <HaandterAvvikModal journalpost={dokument} sakStatus={sakStatus} />
+
+          {dokument.dokumenter.length > 1 ? (
+            <Dropdown>
+              <Button icon={<ChevronDownIcon />} size="small" as={Dropdown.Toggle} variant="secondary">
+                Åpne
+              </Button>
+              <Dropdown.Menu>
+                <Dropdown.Menu.GroupedList>
+                  <Dropdown.Menu.GroupedList.Heading>Velg dokument</Dropdown.Menu.GroupedList.Heading>
+                  <Dropdown.Menu.Divider />
+                  {dokument.dokumenter.map((dok, index) => (
+                    <HStack key={index} gap="4">
+                      <Dropdown.Menu.GroupedList.Item
+                        key={dok.dokumentInfoId}
+                        disabled={!dok.dokumentvarianter[0]?.saksbehandlerHarTilgang}
+                      >
+                        <Link
+                          href={`/api/dokumenter/${dokument.journalpostId}/${dok.dokumentInfoId}`}
+                          target="_blank"
+                          rel="noreferrer noopener"
+                        >
+                          {dok.tittel}
+                          <ExternalLinkIcon aria-hidden title={dokument.tittel} />
+                        </Link>
+                      </Dropdown.Menu.GroupedList.Item>
+
+                      {!dok.dokumentvarianter[0]?.saksbehandlerHarTilgang && (
+                        <Box padding="4">
+                          <Alert variant="warning" size="small">
+                            Ikke Tilgang
+                          </Alert>
+                        </Box>
+                      )}
+                    </HStack>
+                  ))}
+                </Dropdown.Menu.GroupedList>
+              </Dropdown.Menu>
+            </Dropdown>
+          ) : (
+            <Button
+              as="a"
+              href={`/api/dokumenter/${dokument.journalpostId}/${dokument.dokumenter[0].dokumentInfoId}`}
+              target="_blank"
+              rel="noreferrer noopener"
+              size="small"
+              variant="secondary"
+              icon={<ExternalLinkIcon />}
+              title={dokument.dokumenter[0].tittel || dokument.tittel}
+            >
+              Åpne
+            </Button>
+          )}
 
           <DokumentModal journalpost={dokument} />
         </HStack>


### PR DESCRIPTION
Har fått ønske fra flere saksbehandlere om å støtte åpning av journalpost i ny fane på **dokumentoversikten**. 
I sidemenyen på f.eks. en behandling åpnes alle dokumenter alltid i ny fane. På dokumentoversikten på personsiden åpnes de alltid i modal. Dette gjør det tungvint for dem siden de da ofte jobber med dokumentet side-om-side ved en behandling. 

Har derfor kjapt lagt til støtte for å åpne i ny fane. Skiller nå på `Vis` og `Åpne` journalpost. 

### Ny knapp
![Screenshot 2024-10-31 at 10 18 45](https://github.com/user-attachments/assets/3291939c-412a-414f-8dc0-600156073958)

### Hvis flere dokumenter
![Screenshot 2024-10-31 at 10 18 49](https://github.com/user-attachments/assets/779edcdd-2b10-4cb2-9fa2-171426206d9a)