### PR TITLE
fjerne attributt som ikke lenger er i bruk

### DIFF
--- a/apps/etterlatte-behandling/docker-compose.yml
+++ b/apps/etterlatte-behandling/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   postgres:
     restart: always

--- a/apps/etterlatte-beregning/docker-compose.yml
+++ b/apps/etterlatte-beregning/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   postgres:
     restart: always

--- a/apps/etterlatte-brev-api/docker-compose.yml
+++ b/apps/etterlatte-brev-api/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   postgres:
     container_name: etterlatte-brev

--- a/apps/etterlatte-grunnlag/docker-compose.yml
+++ b/apps/etterlatte-grunnlag/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   postgres:
     restart: always

--- a/apps/etterlatte-hendelser-samordning/docker-compose.yml
+++ b/apps/etterlatte-hendelser-samordning/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   postgres:
     restart: always

--- a/apps/etterlatte-migrering/docker-compose.yml
+++ b/apps/etterlatte-migrering/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
  postgres:
     restart: always

--- a/apps/etterlatte-testdata/docker-compose.yml
+++ b/apps/etterlatte-testdata/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   kafka:
     image: 'bitnami/kafka:latest'

--- a/apps/etterlatte-tidshendelser/docker-compose.yml
+++ b/apps/etterlatte-tidshendelser/docker-compose.yml
@@ -1,7 +1,4 @@
-version: "3"
-
 services:
-
   postgres:
     restart: always
     container_name: etterlatte-tidshendelser

--- a/apps/etterlatte-tilbakekreving/docker-compose.yml
+++ b/apps/etterlatte-tilbakekreving/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   postgres:
     image: postgres

--- a/apps/etterlatte-trygdetid/docker-compose.yml
+++ b/apps/etterlatte-trygdetid/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   postgres:
     restart: always

--- a/apps/etterlatte-utbetaling/docker-compose.yml
+++ b/apps/etterlatte-utbetaling/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   postgres:
     image: postgres

--- a/apps/etterlatte-vedtaksvurdering/docker-compose.yml
+++ b/apps/etterlatte-vedtaksvurdering/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   postgres:
     restart: always


### PR DESCRIPTION
Får advarsel hver gang vi kjører docker compose lokalt

```
 the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```