### PR TITLE
Legger til gjenværende saker som mangler samordningsmeldinger

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
@@ -462,18 +462,18 @@ class VedtakBehandlingService(
             listOf(
                 "6e960200-ac0a-4341-8e00-cf4300588d65", // iverksatt
                 "e893f467-4870-4d5c-a37a-9b63059206e3", // iverksatt
-                "b3cd19f6-4801-46b7-b711-b0270c754165",
-                "32728cab-773e-4506-9df7-de721434ea06",
-                "71224dbc-c2bd-4bb6-83f6-3616c74b67d1",
-                "9451ea21-6fa5-40ef-8921-8357810bbdc7",
-                "6aea67f4-d361-4ebb-823e-1a4013f7d03e",
-                "aa0e9fc0-168a-4722-8f76-e8cc56c8771c",
-                "d134905f-e6ac-4a5e-b0df-86267c55a72d",
-                "989d4930-5752-4b07-84e9-d747f912708c",
-                "b66404a7-1d28-400d-b70b-a29abec13472",
-                "03a17bf9-28f6-4630-99c8-b3828162e26f",
-                "ef84c8c4-c37d-4273-9531-9783a85790ab",
-                "6f9e8895-f725-4323-b1f2-da094bad1118",
+                "b3cd19f6-4801-46b7-b711-b0270c754165", // iverksatt
+                "32728cab-773e-4506-9df7-de721434ea06", // sak 16490
+                "71224dbc-c2bd-4bb6-83f6-3616c74b67d1", // sak 16794
+                "9451ea21-6fa5-40ef-8921-8357810bbdc7", // sak 16946
+                //"6aea67f4-d361-4ebb-823e-1a4013f7d03e",
+                //"aa0e9fc0-168a-4722-8f76-e8cc56c8771c",
+                //"d134905f-e6ac-4a5e-b0df-86267c55a72d",
+                //"989d4930-5752-4b07-84e9-d747f912708c",
+                "b66404a7-1d28-400d-b70b-a29abec13472", // sak 18360
+                //"03a17bf9-28f6-4630-99c8-b3828162e26f",
+                //"ef84c8c4-c37d-4273-9531-9783a85790ab",
+                "6f9e8895-f725-4323-b1f2-da094bad1118", // sak 19069
             )
         return behandlingerSomErStuck.find { it == behandlingId.toString() } != null
     }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
@@ -463,6 +463,17 @@ class VedtakBehandlingService(
                 "6e960200-ac0a-4341-8e00-cf4300588d65", // iverksatt
                 "e893f467-4870-4d5c-a37a-9b63059206e3", // iverksatt
                 "b3cd19f6-4801-46b7-b711-b0270c754165",
+                "32728cab-773e-4506-9df7-de721434ea06",
+                "71224dbc-c2bd-4bb6-83f6-3616c74b67d1",
+                "9451ea21-6fa5-40ef-8921-8357810bbdc7",
+                "6aea67f4-d361-4ebb-823e-1a4013f7d03e",
+                "aa0e9fc0-168a-4722-8f76-e8cc56c8771c",
+                "d134905f-e6ac-4a5e-b0df-86267c55a72d",
+                "989d4930-5752-4b07-84e9-d747f912708c",
+                "b66404a7-1d28-400d-b70b-a29abec13472",
+                "03a17bf9-28f6-4630-99c8-b3828162e26f",
+                "ef84c8c4-c37d-4273-9531-9783a85790ab",
+                "6f9e8895-f725-4323-b1f2-da094bad1118",
             )
         return behandlingerSomErStuck.find { it == behandlingId.toString() } != null
     }


### PR DESCRIPTION
Verifisert opp mot uttrekk fra SAM om at disse skulle ha blitt sendt melding på, og kan kjøres til utbetaling