### PR TITLE
EY-4684 Lagre saksbehandler ident på hendelse i brev

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
@@ -87,7 +87,7 @@ fun Route.brevRoute(
             put {
                 withSakId(tilgangssjekker, skrivetilgang = true) {
                     val body = call.receive<OppdaterMottakerRequest>()
-                    service.oppdaterMottaker(brevId, body.mottaker)
+                    service.oppdaterMottaker(brevId, body.mottaker, brukerTokenInfo)
 
                     call.respond(HttpStatusCode.OK)
                 }
@@ -97,7 +97,7 @@ fun Route.brevRoute(
                 withSakId(tilgangssjekker, skrivetilgang = true) {
                     val mottakerId = UUID.fromString(call.parameters["mottakerId"])
 
-                    service.slettMottaker(brevId, mottakerId)
+                    service.slettMottaker(brevId, mottakerId, brukerTokenInfo)
 
                     call.respond(HttpStatusCode.OK)
                 }
@@ -108,7 +108,7 @@ fun Route.brevRoute(
             withSakId(tilgangssjekker, skrivetilgang = true) {
                 val request = call.receive<OppdaterTittelRequest>()
 
-                service.oppdaterTittel(brevId, request.tittel)
+                service.oppdaterTittel(brevId, request.tittel, brukerTokenInfo)
 
                 call.respond(HttpStatusCode.OK)
             }
@@ -118,7 +118,7 @@ fun Route.brevRoute(
             withSakId(tilgangssjekker, skrivetilgang = true) {
                 val request = call.receive<OppdaterSpraakRequest>()
 
-                service.oppdaterSpraak(brevId, request.spraak)
+                service.oppdaterSpraak(brevId, request.spraak, brukerTokenInfo)
 
                 call.respond(HttpStatusCode.OK)
             }
@@ -136,8 +136,8 @@ fun Route.brevRoute(
                     val brevId = brevId
                     val body = call.receive<OppdaterPayloadRequest>()
 
-                    service.lagreBrevPayload(brevId, body.payload)
-                    body.payload_vedlegg?.let { service.lagreBrevPayloadVedlegg(brevId, it) }
+                    service.lagreBrevPayload(brevId, body.payload, brukerTokenInfo)
+                    body.payload_vedlegg?.let { service.lagreBrevPayloadVedlegg(brevId, it, brukerTokenInfo) }
                     call.respond(HttpStatusCode.OK)
                 }
             }
@@ -173,7 +173,8 @@ fun Route.brevRoute(
                 val bestillingsIder =
                     distribuerer.distribuer(
                         brevId,
-                        distribusjonsType = distribusjonsType,
+                        distribusjonsType,
+                        brukerTokenInfo,
                     )
 
                 call.respond(BestillingsIdDto(bestillingsIder))
@@ -272,7 +273,7 @@ fun Route.brevRoute(
         post("pdf") {
             withSakId(tilgangssjekker, skrivetilgang = true) { sakId ->
                 try {
-                    val brev = pdfService.lagreOpplastaPDF(sakId, call.receiveMultipart().readAllParts())
+                    val brev = pdfService.lagreOpplastaPDF(sakId, call.receiveMultipart().readAllParts(), brukerTokenInfo)
                     brev.onSuccess {
                         call.respond(brev)
                     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -55,7 +55,7 @@ class Brevoppretter(
                     brevkoder = brevkode,
                 )
 
-            return Pair(db.opprettBrev(nyttBrev), enhet)
+            return Pair(db.opprettBrev(nyttBrev, bruker), enhet)
         }
     }
 
@@ -88,7 +88,7 @@ class Brevoppretter(
                     brevtype = brevkode.brevtype,
                     brevkoder = brevkode,
                 )
-            return Pair(db.opprettBrev(nyttBrev), enhet)
+            return Pair(db.opprettBrev(nyttBrev, bruker), enhet)
         }
 
     suspend fun hentNyttInnhold(
@@ -113,16 +113,16 @@ class Brevoppretter(
             ),
         ) {
             if (innhold.payload != null) {
-                db.oppdaterPayload(brevId, innhold.payload)
+                db.oppdaterPayload(brevId, innhold.payload, bruker)
             }
 
             if (innholdVedlegg != null) {
-                db.oppdaterPayloadVedlegg(brevId, innholdVedlegg)
+                db.oppdaterPayloadVedlegg(brevId, innholdVedlegg, bruker)
             }
 
             if (opprinneligBrevkoder != brevkode) {
                 db.oppdaterBrevkoder(brevId, brevkode)
-                db.oppdaterTittel(brevId, innhold.tittel)
+                db.oppdaterTittel(brevId, innhold.tittel, bruker)
             }
 
             return BrevService.BrevPayload(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/JournalfoerBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/JournalfoerBrevService.kt
@@ -93,7 +93,7 @@ class JournalfoerBrevService(
 
         return brev.mottakere
             .map { mottaker -> journalfoerPaaMottaker(brev.id, brev.soekerFnr, mottaker, sak, bruker) }
-            .also { db.settBrevJournalfoert(brev.id, it) }
+            .also { db.settBrevJournalfoert(brev.id, it, bruker) }
     }
 
     private suspend fun journalfoerPaaMottaker(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
@@ -105,6 +105,7 @@ class BrevRepository(
     fun oppdaterPayload(
         id: BrevID,
         payload: Slate,
+        bruker: BrukerTokenInfo,
     ) = ds.transaction { tx ->
         tx
             .run(
@@ -119,13 +120,14 @@ class BrevRepository(
             ).also { require(it == 1) }
 
         tx
-            .lagreHendelse(id, Status.OPPDATERT, payload.toJson())
+            .lagreHendelse(id, Status.OPPDATERT, payload.toJson(), bruker)
             .also { require(it == 1) }
     }
 
     fun oppdaterPayloadVedlegg(
         id: BrevID,
         payload: List<BrevInnholdVedlegg>,
+        bruker: BrukerTokenInfo,
     ) = ds.transaction { tx ->
         tx
             .run(
@@ -140,7 +142,7 @@ class BrevRepository(
             ).also { require(it == 1) }
 
         tx
-            .lagreHendelse(id, Status.OPPDATERT, payload.toJson())
+            .lagreHendelse(id, Status.OPPDATERT, payload.toJson(), bruker)
             .also { require(it == 1) }
     }
 
@@ -185,6 +187,7 @@ class BrevRepository(
     fun oppdaterMottaker(
         id: BrevID,
         mottaker: Mottaker,
+        bruker: BrukerTokenInfo,
     ) = ds.transaction { tx ->
         tx
             .run(
@@ -211,26 +214,28 @@ class BrevRepository(
             ).also { require(it == 1) }
 
         tx
-            .lagreHendelse(id, Status.OPPDATERT, mottaker.toJson())
+            .lagreHendelse(id, Status.OPPDATERT, mottaker.toJson(), bruker)
             .also { require(it == 1) }
     }
 
     fun slettMottaker(
         brevId: BrevID,
         mottakerId: UUID,
+        bruker: BrukerTokenInfo,
     ) = ds.transaction { tx ->
         tx
             .run(queryOf("DELETE FROM mottaker WHERE id = ? AND brev_id = ?", mottakerId, brevId).asUpdate)
             .also { require(it == 1) }
 
         tx
-            .lagreHendelse(brevId, Status.OPPDATERT, "mottaker med id=$mottakerId fjernet fra brevet ")
+            .lagreHendelse(brevId, Status.OPPDATERT, "mottaker med id=$mottakerId fjernet fra brevet ", bruker)
             .also { require(it == 1) }
     }
 
     fun oppdaterTittel(
         id: BrevID,
         tittel: String,
+        bruker: BrukerTokenInfo,
     ) = ds.transaction { tx ->
         tx
             .run(
@@ -244,13 +249,14 @@ class BrevRepository(
             ).also { require(it == 1) }
 
         tx
-            .lagreHendelse(id, Status.OPPDATERT, tittel.toJson())
+            .lagreHendelse(id, Status.OPPDATERT, tittel.toJson(), bruker)
             .also { require(it == 1) }
     }
 
     fun oppdaterSpraak(
         id: BrevID,
         spraak: Spraak,
+        bruker: BrukerTokenInfo,
     ) = ds.transaction { tx ->
         tx
             .run(
@@ -264,13 +270,14 @@ class BrevRepository(
             ).also { require(it == 1) }
 
         tx
-            .lagreHendelse(id, Status.OPPDATERT, spraak.toJson())
+            .lagreHendelse(id, Status.OPPDATERT, spraak.toJson(), bruker)
             .also { require(it == 1) }
     }
 
     fun lagrePdfOgFerdigstillBrev(
         id: BrevID,
         pdf: Pdf,
+        bruker: BrukerTokenInfo,
     ) {
         ds.transaction { tx ->
             tx
@@ -284,7 +291,7 @@ class BrevRepository(
                     ).asUpdate,
                 ).also { oppdatert -> require(oppdatert == 1) }
 
-            tx.lagreHendelse(id, Status.FERDIGSTILT)
+            tx.lagreHendelse(id, Status.FERDIGSTILT, bruker = bruker)
         }
     }
 
@@ -306,9 +313,12 @@ class BrevRepository(
         }
     }
 
-    fun settBrevFerdigstilt(id: BrevID) {
+    fun settBrevFerdigstilt(
+        id: BrevID,
+        bruker: BrukerTokenInfo,
+    ) {
         using(sessionOf(ds)) {
-            it.lagreHendelse(id, Status.FERDIGSTILT)
+            it.lagreHendelse(id, Status.FERDIGSTILT, bruker = bruker)
         }
     }
 
@@ -318,11 +328,14 @@ class BrevRepository(
         bruker: BrukerTokenInfo,
     ) {
         using(sessionOf(ds)) {
-            it.lagreHendelse(id, Status.UTGAATT, "${bruker.ident()}: $kommentar".toJson())
+            it.lagreHendelse(id, Status.UTGAATT, "${bruker.ident()}: $kommentar".toJson(), bruker)
         }
     }
 
-    fun opprettBrev(ulagretBrev: OpprettNyttBrev): Brev =
+    fun opprettBrev(
+        ulagretBrev: OpprettNyttBrev,
+        bruker: BrukerTokenInfo,
+    ): Brev =
         ds.transaction(true) { tx ->
             val id =
                 tx.run(
@@ -380,7 +393,7 @@ class BrevRepository(
                 ).also { opprettet -> require(opprettet == 1) }
 
             tx
-                .lagreHendelse(id, Status.OPPRETTET, ulagretBrev.opprettet)
+                .lagreHendelse(id, Status.OPPRETTET, ulagretBrev.opprettet, bruker = bruker)
                 .also { oppdatert -> require(oppdatert == 1) }
 
             opprettBrevFra(id, ulagretBrev)
@@ -403,9 +416,10 @@ class BrevRepository(
     fun settBrevJournalfoert(
         brevId: BrevID,
         journalpostResponse: List<OpprettJournalpostResponse>,
+        bruker: BrukerTokenInfo,
     ): Boolean =
         using(sessionOf(ds)) {
-            it.lagreHendelse(brevId, Status.JOURNALFOERT, journalpostResponse.toJson()) > 0
+            it.lagreHendelse(brevId, Status.JOURNALFOERT, journalpostResponse.toJson(), bruker) > 0
         }
 
     fun lagreBestillingId(
@@ -425,8 +439,9 @@ class BrevRepository(
     fun settBrevDistribuert(
         brevId: BrevID,
         distResponse: List<DistribuerJournalpostResponse>,
+        bruker: BrukerTokenInfo,
     ) = using(sessionOf(ds)) {
-        it.lagreHendelse(brevId, Status.DISTRIBUERT, distResponse.toJson())
+        it.lagreHendelse(brevId, Status.DISTRIBUERT, distResponse.toJson(), bruker)
     }
 
     fun settBrevSlettet(
@@ -434,14 +449,15 @@ class BrevRepository(
         bruker: BrukerTokenInfo,
     ): Boolean =
         ds.transaction { tx ->
-            tx.lagreHendelse(brevId, Status.SLETTET, bruker.ident()) > 0
+            tx.lagreHendelse(brevId, Status.SLETTET, bruker.ident(), bruker) > 0
         }
 
     private fun Session.lagreHendelse(
         brevId: BrevID,
         status: Status,
         payload: String = "{}",
-    ) = lagreHendelse(brevId, status, Tidspunkt.now(), payload)
+        bruker: BrukerTokenInfo,
+    ) = lagreHendelse(brevId, status, Tidspunkt.now(), payload, bruker)
 
     private fun Session.hentMottakere(brevId: BrevID) =
         list(
@@ -454,6 +470,7 @@ class BrevRepository(
         status: Status,
         opprettet: Tidspunkt = Tidspunkt.now(),
         payload: String = "{}",
+        bruker: BrukerTokenInfo,
     ) = run(
         queryOf(
             OPPRETT_HENDELSE_QUERY,
@@ -462,6 +479,7 @@ class BrevRepository(
                 "status_id" to status.name,
                 "payload" to payload,
                 "opprettet" to opprettet.toTimestamp(),
+                "saksbehandler" to bruker.ident(),
             ),
         ).asUpdate,
     )
@@ -664,8 +682,8 @@ class BrevRepository(
         """
 
         const val OPPRETT_HENDELSE_QUERY = """
-            INSERT INTO hendelse (brev_id, status_id, payload, opprettet) 
-            VALUES (:brev_id, :status_id, :payload, :opprettet)
+            INSERT INTO hendelse (brev_id, status_id, payload, opprettet, saksbehandler) 
+            VALUES (:brev_id, :status_id, :payload, :opprettet, :saksbehandler)
         """
     }
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/distribusjon/Brevdistribuerer.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/distribusjon/Brevdistribuerer.kt
@@ -5,6 +5,7 @@ import no.nav.etterlatte.brev.model.BrevID
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Status
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
@@ -17,6 +18,7 @@ class Brevdistribuerer(
     fun distribuer(
         brevId: BrevID,
         distribusjonsType: DistribusjonsType = DistribusjonsType.ANNET,
+        bruker: BrukerTokenInfo,
     ): List<BestillingsID> {
         logger.info("Starter distribuering av brev $brevId.")
 
@@ -33,7 +35,7 @@ class Brevdistribuerer(
         return brev.mottakere
             .filter { it.bestillingId.isNullOrBlank() }
             .map { mottaker -> sendTilMottaker(brevId, mottaker, distribusjonsType) }
-            .also { db.settBrevDistribuert(brevId, it) }
+            .also { db.settBrevDistribuert(brevId, it, bruker) }
             .map { it.bestillingsId }
     }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
@@ -111,6 +111,7 @@ class OversendelseBrevServiceImpl(
                     brevtype = Brevtype.OVERSENDELSE_KLAGE,
                     brevkoder = Brevkoder.OVERSENDELSE_KLAGE,
                 ),
+                brukerTokenInfo,
             )
         return brev
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/pdf/PDFGenerator.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/pdf/PDFGenerator.kt
@@ -62,7 +62,7 @@ class PDFGenerator(
                 brevKodeMapping,
                 brevDataMapping,
             )
-        db.lagrePdfOgFerdigstillBrev(id, pdf)
+        db.lagrePdfOgFerdigstillBrev(id, pdf, bruker)
         return pdf
     }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/pdf/PDFService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/pdf/PDFService.kt
@@ -20,6 +20,7 @@ import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
 
 class PDFService(
@@ -31,6 +32,7 @@ class PDFService(
     suspend fun lagreOpplastaPDF(
         sakId: SakId,
         multiPart: List<PartData>,
+        bruker: BrukerTokenInfo,
     ): Result<Brev> {
         val request =
             multiPart
@@ -56,7 +58,7 @@ class PDFService(
             return Result.failure(IllegalArgumentException("Virussjekken feila for ${request.innhold.tittel}"))
         }
 
-        return Result.success(lagrePdf(sakId, fil, request.innhold, request.sak))
+        return Result.success(lagrePdf(sakId, fil, request.innhold, request.sak, bruker))
     }
 
     private fun lagrePdf(
@@ -64,6 +66,7 @@ class PDFService(
         fil: ByteArray,
         innhold: BrevInnhold,
         sak: Sak,
+        bruker: BrukerTokenInfo,
     ): Brev {
         val brev =
             db.opprettBrev(
@@ -79,6 +82,7 @@ class PDFService(
                     brevtype = Brevtype.OPPLASTET_PDF,
                     brevkoder = Brevkoder.OPPLASTET_PDF,
                 ),
+                bruker,
             )
 
         db.lagrePdf(brev.id, Pdf(fil))

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevService.kt
@@ -154,7 +154,7 @@ class VedtaksbrevService(
             if (db.hentPdf(brev.id) == null) {
                 throw BrevManglerPDF(brev.id)
             } else {
-                db.settBrevFerdigstilt(brev.id)
+                db.settBrevFerdigstilt(brev.id, brukerTokenInfo)
             }
         } else {
             throw SaksbehandlerOgAttestantSammePerson(saksbehandlerIdent, brukerTokenInfo.ident())

--- a/apps/etterlatte-brev-api/src/main/resources/db/migration/V27__lagre_bruker_paa_hendelse.sql
+++ b/apps/etterlatte-brev-api/src/main/resources/db/migration/V27__lagre_bruker_paa_hendelse.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hendelse ADD COLUMN saksbehandler TEXT;

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
@@ -37,6 +37,7 @@ import no.nav.etterlatte.brev.pdf.PDFService
 import no.nav.etterlatte.ktor.runServer
 import no.nav.etterlatte.ktor.startRandomPort
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
+import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -182,8 +183,8 @@ internal class BrevRouteTest {
     @Test
     fun `Endepunkt for lagring av manuelt brev`() {
         val brevId = Random.nextLong()
-        coEvery { brevService.lagreBrevPayload(any(), any()) } returns 1
-        coEvery { brevService.lagreBrevPayloadVedlegg(any(), any()) } returns 1
+        coEvery { brevService.lagreBrevPayload(any(), any(), any()) } returns 1
+        coEvery { brevService.lagreBrevPayloadVedlegg(any(), any(), any()) } returns 1
         coEvery { tilgangssjekker.harTilgangTilSak(any(), any(), any()) } returns true
 
         testApplication {
@@ -201,7 +202,7 @@ internal class BrevRouteTest {
         }
 
         coVerify(exactly = 1) {
-            brevService.lagreBrevPayload(brevId, any())
+            brevService.lagreBrevPayload(brevId, any(), any())
             tilgangssjekker.harTilgangTilSak(any(), any(), any())
         }
     }
@@ -243,7 +244,8 @@ internal class BrevRouteTest {
         }
     }
 
-    val accessToken: String by lazy { mockOAuth2Server.issueSaksbehandlerToken() }
+    private val saksbehandler = simpleSaksbehandler("Z123456")
+    private val accessToken: String by lazy { mockOAuth2Server.issueSaksbehandlerToken(navIdent = saksbehandler.ident()) }
 
     private fun opprettBrev(id: BrevID) =
         Brev(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
@@ -176,11 +176,11 @@ internal class BrevServiceTest {
             every { db.hentBrev(any()) } returns brev
 
             val tittel = "En oppdatert tittel"
-            brevService.oppdaterTittel(brev.id, tittel)
+            brevService.oppdaterTittel(brev.id, tittel, bruker)
 
             verify {
                 db.hentBrev(brev.id)
-                db.oppdaterTittel(brev.id, tittel)
+                db.oppdaterTittel(brev.id, tittel, bruker)
             }
         }
 
@@ -192,7 +192,7 @@ internal class BrevServiceTest {
             every { db.hentBrev(any()) } returns brev
 
             assertThrows<BrevKanIkkeEndres> {
-                brevService.oppdaterTittel(brev.id, "Ny tittel skal feile")
+                brevService.oppdaterTittel(brev.id, "Ny tittel skal feile", bruker)
             }
 
             verify {
@@ -336,11 +336,11 @@ internal class BrevServiceTest {
                         ),
                 )
 
-            brevService.oppdaterMottaker(brev.id, nyMottaker)
+            brevService.oppdaterMottaker(brev.id, nyMottaker, bruker)
 
             verify {
                 db.hentBrev(brev.id)
-                db.oppdaterMottaker(brev.id, nyMottaker)
+                db.oppdaterMottaker(brev.id, nyMottaker, bruker)
             }
         }
 
@@ -352,7 +352,7 @@ internal class BrevServiceTest {
             every { db.hentBrev(any()) } returns brev
 
             assertThrows<BrevKanIkkeEndres> {
-                brevService.oppdaterMottaker(brev.id, tomMottaker())
+                brevService.oppdaterMottaker(brev.id, tomMottaker(), bruker)
             }
 
             verify {
@@ -373,11 +373,11 @@ internal class BrevServiceTest {
 
             every { db.hentBrev(any()) } returns brev
 
-            brevService.slettMottaker(brev.id, kopimottaker.id)
+            brevService.slettMottaker(brev.id, kopimottaker.id, bruker)
 
             verify {
                 db.hentBrev(brev.id)
-                db.slettMottaker(brev.id, kopimottaker.id)
+                db.slettMottaker(brev.id, kopimottaker.id, bruker)
             }
         }
 
@@ -389,7 +389,7 @@ internal class BrevServiceTest {
 
             every { db.hentBrev(any()) } returns brev
 
-            assertThrows<KanIkkeSletteHovedmottaker> { brevService.slettMottaker(brev.id, mottaker.id) }
+            assertThrows<KanIkkeSletteHovedmottaker> { brevService.slettMottaker(brev.id, mottaker.id, bruker) }
 
             verify {
                 db.hentBrev(brev.id)
@@ -404,7 +404,7 @@ internal class BrevServiceTest {
             every { db.hentBrev(any()) } returns brev
 
             assertThrows<BrevKanIkkeEndres> {
-                brevService.slettMottaker(brev.id, mockk())
+                brevService.slettMottaker(brev.id, mockk(), bruker)
             }
 
             verify {

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/JournalfoerBrevServiceTest.kt
@@ -84,7 +84,7 @@ internal class JournalfoerBrevServiceTest {
         coEvery { behandlingService.hentSak(any(), any()) } returns sak
         coEvery { dokarkivService.journalfoer(any(), any()) } returns journalpostResponse
         every { db.hentBrev(any()) } returns brev
-        every { db.settBrevJournalfoert(any(), any()) } returns true
+        every { db.settBrevJournalfoert(any(), any(), any()) } returns true
 
         val faktiskJournalpostId =
             runBlocking {
@@ -98,7 +98,7 @@ internal class JournalfoerBrevServiceTest {
             db.hentBrevInnhold(brev.id)
             db.hentPdf(brev.id)
             db.lagreJournalpostId(brev.mottakere.single().id, journalpostResponse)
-            db.settBrevJournalfoert(brev.id, listOf(journalpostResponse))
+            db.settBrevJournalfoert(brev.id, listOf(journalpostResponse), bruker)
         }
         coVerify {
             behandlingService.hentSak(sak.id, bruker)
@@ -125,7 +125,7 @@ internal class JournalfoerBrevServiceTest {
         coEvery { dokarkivService.journalfoer(any(), any()) } returns response1 andThen response2
 
         every { db.hentBrev(any()) } returns brev
-        every { db.settBrevJournalfoert(any(), any()) } returns true
+        every { db.settBrevJournalfoert(any(), any(), any()) } returns true
 
         val faktiskResponse =
             runBlocking {
@@ -142,7 +142,7 @@ internal class JournalfoerBrevServiceTest {
             db.lagreJournalpostId(brev.mottakere[0].id, response1)
             db.lagreJournalpostId(brev.mottakere[1].id, response2)
 
-            db.settBrevJournalfoert(brev.id, listOf(response1, response2))
+            db.settBrevJournalfoert(brev.id, listOf(response1, response2), bruker)
         }
         coVerify {
             behandlingService.hentSak(sak.id, bruker)
@@ -227,6 +227,7 @@ internal class JournalfoerBrevServiceTest {
     fun `Journalfoeringsrequest for vedtaksbrev mappes korrekt`(type: SakType) {
         val behandlingId = UUID.randomUUID()
         val forventetBrevMottakerFnr = SOEKER_FOEDSELSNUMMER.value
+        val systembruker = systembruker()
 
         val sak = Sak(forventetBrevMottakerFnr, type, randomSakId(), Enheter.defaultEnhet.enhetNr)
 
@@ -270,13 +271,13 @@ internal class JournalfoerBrevServiceTest {
             )
         coEvery { dokarkivService.journalfoer(any(), any()) } returns journalpostResponse
 
-        runBlocking { service.journalfoerVedtaksbrev(vedtak, systembruker()) }
+        runBlocking { service.journalfoerVedtaksbrev(vedtak, systembruker) }
 
         verify(exactly = 1) {
             db.hentBrevInnhold(forventetBrev.id)
             db.hentPdf(forventetBrev.id)
             db.lagreJournalpostId(forventetBrev.mottakere.single().id, journalpostResponse)
-            db.settBrevJournalfoert(forventetBrev.id, listOf(journalpostResponse))
+            db.settBrevJournalfoert(forventetBrev.id, listOf(journalpostResponse), systembruker)
         }
 
         val requestSlot = slot<JournalpostRequest>()
@@ -352,7 +353,7 @@ internal class JournalfoerBrevServiceTest {
             db.hentPdf(forventetBrev.id)
             db.hentBrev(forventetBrev.id)
             db.lagreJournalpostId(forventetBrev.mottakere.single().id, journalpostResponse)
-            db.settBrevJournalfoert(forventetBrev.id, listOf(journalpostResponse))
+            db.settBrevJournalfoert(forventetBrev.id, listOf(journalpostResponse), bruker)
         }
 
         val requestSlot = slot<JournalpostRequest>()

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -275,7 +275,7 @@ internal class VedtaksbrevServiceTest {
             }
 
             verify {
-                db.opprettBrev(capture(brevSlot))
+                db.opprettBrev(capture(brevSlot), ATTESTANT)
                 brevbaker wasNot Called
                 dokarkivService wasNot Called
             }
@@ -343,7 +343,7 @@ internal class VedtaksbrevServiceTest {
             }
 
             verify {
-                db.opprettBrev(capture(brevSlot))
+                db.opprettBrev(capture(brevSlot), ATTESTANT)
                 dokarkivService wasNot Called
             }
 
@@ -441,7 +441,7 @@ internal class VedtaksbrevServiceTest {
 
             verify {
                 db.hentBrevForBehandling(brev.behandlingId!!, Brevtype.VEDTAK)
-                db.settBrevFerdigstilt(brev.id)
+                db.settBrevFerdigstilt(brev.id, ATTESTANT)
                 db.hentPdf(brev.id)
             }
 
@@ -472,7 +472,7 @@ internal class VedtaksbrevServiceTest {
                 db.hentBrevForBehandling(brev.behandlingId!!, Brevtype.VEDTAK)
                 db.hentPdf(brev.id)
             }
-            verify(exactly = 0) { db.settBrevFerdigstilt(any()) }
+            verify(exactly = 0) { db.settBrevFerdigstilt(any(), ATTESTANT) }
 
             coVerify {
                 vedtaksvurderingService.hentVedtakSaksbehandlerOgStatus(brev.behandlingId!!, any())
@@ -649,8 +649,8 @@ internal class VedtaksbrevServiceTest {
                 )
 
             runBlocking {
-                db.oppdaterPayload(brev.id, tomPayload)
-                db.oppdaterPayloadVedlegg(brev.id, listOf(vedleggPayload(tomPayload)))
+                db.oppdaterPayload(brev.id, tomPayload, SAKSBEHANDLER)
+                db.oppdaterPayloadVedlegg(brev.id, listOf(vedleggPayload(tomPayload)), SAKSBEHANDLER)
             }
 
             val nyttInnhold =
@@ -674,13 +674,13 @@ internal class VedtaksbrevServiceTest {
 
             verify {
                 db.hentBrevInnhold(brev.id)
-                db.oppdaterPayload(brev.id, opphoerPayload)
-                db.oppdaterPayload(brev.id, tomPayload)
-                db.oppdaterPayloadVedlegg(brev.id, listOf(vedleggPayload(opprettVedleggPayload())))
-                db.oppdaterPayloadVedlegg(brev.id, listOf(vedleggPayload(tomPayload)))
+                db.oppdaterPayload(brev.id, opphoerPayload, SAKSBEHANDLER)
+                db.oppdaterPayload(brev.id, tomPayload, SAKSBEHANDLER)
+                db.oppdaterPayloadVedlegg(brev.id, listOf(vedleggPayload(opprettVedleggPayload())), SAKSBEHANDLER)
+                db.oppdaterPayloadVedlegg(brev.id, listOf(vedleggPayload(tomPayload)), SAKSBEHANDLER)
                 db.hentBrevkoder(brev.id)
                 db.oppdaterBrevkoder(brev.id, Brevkoder.OMS_OPPHOER)
-                db.oppdaterTittel(brev.id, Brevkoder.OMS_OPPHOER.tittel)
+                db.oppdaterTittel(brev.id, Brevkoder.OMS_OPPHOER.tittel, SAKSBEHANDLER)
             }
 
             coVerify {


### PR DESCRIPTION
Gjør det mulig å se _hvem_ som har gjort endringer i brev. Oppdateringer, ferdigstilling, journalføring, osv. 