### PR TITLE
EY-4685: Avslag tidligere familiepleier

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
@@ -169,8 +169,6 @@ class BrevDataMapperFerdigstillingVedtak(
 
                 OMS_AVSLAG ->
                     omstillingsstoenadAvslag(
-                        behandlingId!!,
-                        bruker,
                         innholdMedVedlegg.innhold(),
                         utlandstilknytningType,
                     )
@@ -446,17 +444,12 @@ class BrevDataMapperFerdigstillingVedtak(
     }
 
     private suspend fun omstillingsstoenadAvslag(
-        behandlingId: UUID,
-        bruker: BrukerTokenInfo,
         innhold: List<Slate.Element>,
         utlandstilknytningType: UtlandstilknytningType?,
     ) = coroutineScope {
-        val tidligereFamiliepleier = async { behandlingService.hentTidligereFamiliepleier(behandlingId, bruker) }
-
         OmstillingsstoenadAvslag.fra(
             innhold,
             utlandstilknytningType,
-            tidligereFamiliepleier.await(),
         )
     }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
@@ -189,7 +189,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
     ): BrevDataRedigerbar =
         coroutineScope {
             val behandling = behandlingService.hentBehandling(behandlingId, brukerTokenInfo)
-            OmstillingsstoenadAvslagRedigerbartUtfall.fra(avdoede, behandling.erSluttbehandling)
+            OmstillingsstoenadAvslagRedigerbartUtfall.fra(avdoede, behandling.erSluttbehandling, behandling.tidligereFamiliepleier)
         }
 
     private suspend fun barnepensjonInnvilgelse(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadAvslag.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadAvslag.kt
@@ -10,18 +10,15 @@ import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
 data class OmstillingsstoenadAvslag(
     override val innhold: List<Slate.Element>,
     val bosattUtland: Boolean,
-    val tidligereFamiliepleier: Boolean,
 ) : BrevDataFerdigstilling {
     companion object {
         fun fra(
             innhold: List<Slate.Element>,
             utlandstilknytningType: UtlandstilknytningType?,
-            tidligereFamiliepleier: TidligereFamiliepleier?,
         ): OmstillingsstoenadAvslag =
             OmstillingsstoenadAvslag(
                 bosattUtland = utlandstilknytningType == UtlandstilknytningType.BOSATT_UTLAND,
                 innhold = innhold,
-                tidligereFamiliepleier = tidligereFamiliepleier?.svar ?: false,
             )
     }
 }
@@ -29,16 +26,19 @@ data class OmstillingsstoenadAvslag(
 data class OmstillingsstoenadAvslagRedigerbartUtfall(
     val avdoedNavn: String,
     val erSluttbehandling: Boolean,
+    val tidligereFamiliepleier: Boolean,
 ) : BrevDataRedigerbar {
     companion object {
         fun fra(
             avdoede: List<Avdoed>,
             erSluttbehandling: Boolean,
+            tidligereFamiliepleier: TidligereFamiliepleier?,
         ) = OmstillingsstoenadAvslagRedigerbartUtfall(
             avdoedNavn =
                 avdoede.firstOrNull()?.navn
                     ?: "<Klarte ikke å finne navn automatisk, du må sette inn her>",
             erSluttbehandling = erSluttbehandling,
+            tidligereFamiliepleier = tidligereFamiliepleier?.svar ?: false,
         )
     }
 }


### PR DESCRIPTION
Tidligere familiepleier ble sendt til hoveddel når det skulle blitt sendt til redigerbart utfall