### PR TITLE
EY-4513: Legger på flere varianter for verifikasjon av utbetaling

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningKlassifikasjonskodeJobService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningKlassifikasjonskodeJobService.kt
@@ -23,6 +23,7 @@ import no.nav.etterlatte.rapidsandrivers.HENDELSE_DATA_KEY
 import no.nav.etterlatte.rapidsandrivers.OmregningData
 import no.nav.etterlatte.rapidsandrivers.OmregningHendelseType
 import no.nav.etterlatte.rapidsandrivers.SAK_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.UtbetalingVerifikasjon
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -72,7 +73,7 @@ class OmregningKlassifikasjonskodeJobService(
                             sakId = sakId,
                             revurderingaarsak = Revurderingaarsak.OMREGNING,
                             fradato = foersteVirkningstidspunktForSak,
-                            // verifiserUtbetalingUendret = true, fjernes for å få gjennom saker som har forventet etterbetaling
+                            utbetalingVerifikasjon = UtbetalingVerifikasjon.SIMULERING,
                         )
 
                     logger.info("Publiserer omregningshendelse for sak $sakId på kafka")

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/omregning/OmregningKlassifikasjonskodeJobServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/omregning/OmregningKlassifikasjonskodeJobServiceTest.kt
@@ -24,6 +24,7 @@ import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.rapidsandrivers.HENDELSE_DATA_KEY
 import no.nav.etterlatte.rapidsandrivers.OmregningData
+import no.nav.etterlatte.rapidsandrivers.UtbetalingVerifikasjon
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -97,7 +98,7 @@ internal class OmregningKlassifikasjonskodeJobServiceTest {
                 sakId shouldBe SAK_ID
                 kjoering shouldBe OmregningKlassifikasjonskodeJobService.kjoering
                 revurderingaarsak shouldBe Revurderingaarsak.OMREGNING
-                verifiserUtbetalingUendret shouldBe false
+                utbetalingVerifikasjon shouldBe UtbetalingVerifikasjon.SIMULERING
                 hentFraDato() shouldBe LocalDate.of(2023, Month.NOVEMBER, 1)
             }
         }

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiver.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiver.kt
@@ -11,6 +11,7 @@ import no.nav.etterlatte.rapidsandrivers.ListenerMedLoggingOgFeilhaandtering
 import no.nav.etterlatte.rapidsandrivers.OmregningDataPacket
 import no.nav.etterlatte.rapidsandrivers.OmregningHendelseType
 import no.nav.etterlatte.rapidsandrivers.ReguleringEvents
+import no.nav.etterlatte.rapidsandrivers.UtbetalingVerifikasjon
 import no.nav.etterlatte.rapidsandrivers.omregningData
 import no.nav.etterlatte.vedtaksvurdering.RapidUtsender
 import no.nav.etterlatte.vedtaksvurdering.VedtakOgRapid
@@ -57,12 +58,18 @@ internal class OpprettVedtakforespoerselRiver(
             if (featureToggleService.isEnabled(ReguleringFeatureToggle.SkalStoppeEtterFattetVedtak, false)) {
                 vedtak.opprettVedtakOgFatt(sakId, behandlingId)
             } else {
-                if (omregningData.verifiserUtbetalingUendret) {
-                    vedtak.opprettVedtakOgFatt(sakId, behandlingId)
-                    verifiserUendretUtbetaling(behandlingId)
-                    vedtak.attesterVedtak(sakId, behandlingId)
-                } else {
-                    vedtak.opprettVedtakFattOgAttester(sakId, behandlingId)
+                when (omregningData.utbetalingVerifikasjon) {
+                    UtbetalingVerifikasjon.INGEN -> vedtak.opprettVedtakFattOgAttester(sakId, behandlingId)
+                    UtbetalingVerifikasjon.SIMULERING -> {
+                        vedtak.opprettVedtakOgFatt(sakId, behandlingId)
+                        verifiserUendretUtbetaling(behandlingId, skalAvbryte = false)
+                        vedtak.attesterVedtak(sakId, behandlingId)
+                    }
+                    UtbetalingVerifikasjon.SIMULERING_AVBRYT_ETTERBETALING_ELLER_TILBAKEKREVING -> {
+                        vedtak.opprettVedtakOgFatt(sakId, behandlingId)
+                        verifiserUendretUtbetaling(behandlingId, skalAvbryte = true)
+                        vedtak.attesterVedtak(sakId, behandlingId)
+                    }
                 }
             }
 
@@ -71,17 +78,39 @@ internal class OpprettVedtakforespoerselRiver(
         RapidUtsender.sendUt(respons, packet, context)
     }
 
-    private fun verifiserUendretUtbetaling(behandlingId: UUID) {
+    private fun verifiserUendretUtbetaling(
+        behandlingId: UUID,
+        skalAvbryte: Boolean,
+    ) {
         val simulertBeregning = utbetalingKlient.simuler(behandlingId)
+
         val etterbetalingSum = simulertBeregning.etterbetaling.sumOf { it.beloep }
+        val etterbetaling = etterbetalingSum.compareTo(BigDecimal.ZERO) != 0
+
         val tilbakekrevingSum = simulertBeregning.tilbakekreving.sumOf { it.beloep }
-        if (etterbetalingSum.compareTo(BigDecimal.ZERO) != 0) {
-            throw Exception("Omregningen fører til etterbetaling på $etterbetalingSum kr, avbryter behandlingen")
+        val tilbakekreving = tilbakekrevingSum.compareTo(BigDecimal.ZERO) != 0
+
+        if (etterbetaling) {
+            val msg = "Omregningen fører til etterbetaling på $etterbetalingSum kr, avbryter behandlingen"
+            if (skalAvbryte) {
+                throw Exception(msg)
+            } else {
+                logger.info(msg)
+            }
         }
-        if (tilbakekrevingSum.compareTo(BigDecimal.ZERO) != 0) {
-            throw Exception("Omregningen fører til tilbakekreving på $tilbakekrevingSum, avbryter behandlingen")
+
+        if (tilbakekreving) {
+            val msg = "Omregningen fører til tilbakekreving på $tilbakekrevingSum, avbryter behandlingen"
+            if (skalAvbryte) {
+                throw Exception(msg)
+            } else {
+                logger.info(msg)
+            }
         }
-        logger.info("Omregningen førte ikke til tilbakekreving eller etterbetaling")
+
+        if (!etterbetaling && !tilbakekreving) {
+            logger.info("Omregningen førte ikke til tilbakekreving eller etterbetaling")
+        }
     }
 
     private fun hentBeloep(

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiverTest.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiverTest.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.rapidsandrivers.EventNames
 import no.nav.etterlatte.rapidsandrivers.HENDELSE_DATA_KEY
 import no.nav.etterlatte.rapidsandrivers.OmregningData
 import no.nav.etterlatte.rapidsandrivers.OmregningHendelseType
+import no.nav.etterlatte.rapidsandrivers.UtbetalingVerifikasjon
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import org.junit.jupiter.api.Test
@@ -30,7 +31,7 @@ internal class OpprettVedtakforespoerselRiverTest {
     private fun genererOpprettVedtakforespoersel(
         behandlingId: UUID,
         revurderingaarsak: Revurderingaarsak = Revurderingaarsak.REGULERING,
-        verifiserUtbetaling: Boolean = false,
+        utbetalingVerifikasjon: UtbetalingVerifikasjon = UtbetalingVerifikasjon.INGEN,
     ) = JsonMessage.newMessage(
         mapOf(
             OmregningHendelseType.BEREGNA.lagParMedEventNameKey(),
@@ -41,7 +42,7 @@ internal class OpprettVedtakforespoerselRiverTest {
                     fradato = foersteMai2023,
                     revurderingaarsak = revurderingaarsak,
                     behandlingId = behandlingId,
-                    verifiserUtbetalingUendret = verifiserUtbetaling,
+                    utbetalingVerifikasjon = utbetalingVerifikasjon,
                 ).toPacket(),
         ),
     )
@@ -118,7 +119,12 @@ internal class OpprettVedtakforespoerselRiverTest {
     @Test
     fun `skal opprette vedtak, simulere og attestere ved uendret utbetaling`() {
         val behandlingId = UUID.randomUUID()
-        val melding = genererOpprettVedtakforespoersel(behandlingId, Revurderingaarsak.OMREGNING, true)
+        val melding =
+            genererOpprettVedtakforespoersel(
+                behandlingId,
+                Revurderingaarsak.OMREGNING,
+                UtbetalingVerifikasjon.SIMULERING_AVBRYT_ETTERBETALING_ELLER_TILBAKEKREVING,
+            )
         val vedtakServiceMock = mockk<VedtakService>(relaxed = true)
         val utbetalingKlientMock =
             mockk<UtbetalingKlient> {
@@ -156,7 +162,12 @@ internal class OpprettVedtakforespoerselRiverTest {
     @Test
     fun `skal opprette vedtak, simulere og feile fordi det finnes etterbetaling`() {
         val behandlingId = UUID.randomUUID()
-        val melding = genererOpprettVedtakforespoersel(behandlingId, Revurderingaarsak.OMREGNING, true)
+        val melding =
+            genererOpprettVedtakforespoersel(
+                behandlingId,
+                Revurderingaarsak.OMREGNING,
+                UtbetalingVerifikasjon.SIMULERING_AVBRYT_ETTERBETALING_ELLER_TILBAKEKREVING,
+            )
         val vedtakServiceMock = mockk<VedtakService>(relaxed = true)
         val utbetalingKlientMock =
             mockk<UtbetalingKlient> {
@@ -189,7 +200,12 @@ internal class OpprettVedtakforespoerselRiverTest {
     @Test
     fun `skal opprette vedtak, simulere og feile fordi det finnes tilbakekreving`() {
         val behandlingId = UUID.randomUUID()
-        val melding = genererOpprettVedtakforespoersel(behandlingId, Revurderingaarsak.OMREGNING, true)
+        val melding =
+            genererOpprettVedtakforespoersel(
+                behandlingId,
+                Revurderingaarsak.OMREGNING,
+                UtbetalingVerifikasjon.SIMULERING_AVBRYT_ETTERBETALING_ELLER_TILBAKEKREVING,
+            )
         val vedtakServiceMock = mockk<VedtakService>(relaxed = true)
         val utbetalingKlientMock =
             mockk<UtbetalingKlient> {

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/OmregningHendelseType.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/OmregningHendelseType.kt
@@ -40,6 +40,12 @@ enum class OmregningHendelseType : EventnameHendelseType {
     override fun lagEventnameForType(): String = "OMREGNING:${this.name}"
 }
 
+enum class UtbetalingVerifikasjon {
+    INGEN,
+    SIMULERING,
+    SIMULERING_AVBRYT_ETTERBETALING_ELLER_TILBAKEKREVING,
+}
+
 /*
 * Verdier til omregninghendelse vil tilføres underveis i omregningsløpet og flere felter er derfor nødt ti å være mutable.
 * Derimot er det ønskelig at feltene er immutable og non null etter de blir satt.
@@ -55,7 +61,7 @@ data class OmregningData(
     private var sakType: SakType? = null,
     private var behandlingId: UUID? = null,
     private var forrigeBehandlingId: UUID? = null,
-    val verifiserUtbetalingUendret: Boolean = false,
+    val utbetalingVerifikasjon: UtbetalingVerifikasjon = UtbetalingVerifikasjon.INGEN,
 ) {
     fun toPacket() =
         OmregningDataPacket(
@@ -66,7 +72,7 @@ data class OmregningData(
             sakType,
             behandlingId,
             forrigeBehandlingId,
-            verifiserUtbetalingUendret,
+            utbetalingVerifikasjon,
         )
 
     fun hentFraDato(): LocalDate = fradato ?: throw OmregningshendelseHarFeilTilstand(OmregningData::fradato.name)
@@ -114,7 +120,7 @@ data class OmregningDataPacket(
     val sakType: SakType?,
     val behandlingId: UUID?,
     val forrigeBehandlingId: UUID?,
-    val verifiserUtbetalingUendret: Boolean,
+    val utbetalingVerifikasjon: UtbetalingVerifikasjon,
 ) {
     companion object KEYS {
         val KEY = HENDELSE_DATA_KEY


### PR DESCRIPTION
Endrer fra boolean for verifikasjon av utbetaling slik at man nå kan velge:
- INGEN
- SIMULERING
- SIMULERING_AVBRYT_ETTERBETALING_ELLER_TILBAKEKREVING

Dette vil også være enklere å utvide senere ved behov.