### PR TITLE
EY-4676 Støtte endring av mottakertype

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
@@ -95,6 +95,18 @@ fun Route.brevRoute(
                 }
             }
 
+            put("{mottakerId}/hoved") {
+                withSakId(tilgangssjekker, skrivetilgang = true) {
+                    val mottakerId =
+                        call.parameters["mottakerId"]?.let(UUID::fromString)
+                            ?: throw UgyldigForespoerselException("MOTTAKER_ID_MANGLER", "MottakerID mangler")
+
+                    service.settHovedmottaker(brevId, mottakerId, brukerTokenInfo)
+
+                    call.respond(HttpStatusCode.OK)
+                }
+            }
+
             delete("{mottakerId}") {
                 withSakId(tilgangssjekker, skrivetilgang = true) {
                     val mottakerId = UUID.fromString(call.parameters["mottakerId"])

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
@@ -461,7 +461,7 @@ class BrevRepository(
 
     private fun Session.hentMottakere(brevId: BrevID) =
         list(
-            queryOf("SELECT * FROM mottaker WHERE brev_id = ?", brevId),
+            queryOf("SELECT * FROM mottaker WHERE brev_id = ? ORDER BY type", brevId),
             tilMottaker,
         )
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/RedigerMottakerModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/RedigerMottakerModal.tsx
@@ -20,7 +20,7 @@ import { Controller, useForm } from 'react-hook-form'
 import { DocPencilIcon } from '@navikt/aksel-icons'
 import { ControlledRadioGruppe } from '~shared/components/radioGruppe/ControlledRadioGruppe'
 
-enum MottakerType {
+enum JuridiskEnhet {
   PRIVATPERSON = 'PRIVATPERSON',
   BEDRIFT = 'BEDRIFT',
 }
@@ -35,8 +35,8 @@ interface Props {
 
 export function RedigerMottakerModal({ brevId, sakId, mottaker: initialMottaker, lagre, lagreResult }: Props) {
   const [isOpen, setIsOpen] = useState(false)
-  const [mottakerType, setMottakerType] = useState(
-    initialMottaker.orgnummer ? MottakerType.BEDRIFT : MottakerType.PRIVATPERSON
+  const [juridiskEnhet, setJuridiskEnhet] = useState(
+    initialMottaker.orgnummer ? JuridiskEnhet.BEDRIFT : JuridiskEnhet.PRIVATPERSON
   )
 
   const {
@@ -52,9 +52,9 @@ export function RedigerMottakerModal({ brevId, sakId, mottaker: initialMottaker,
   })
 
   useEffect(() => {
-    if (mottakerType == MottakerType.BEDRIFT) setValue('foedselsnummer', undefined)
-    else if (mottakerType == MottakerType.PRIVATPERSON) setValue('orgnummer', undefined)
-  }, [mottakerType])
+    if (juridiskEnhet == JuridiskEnhet.BEDRIFT) setValue('foedselsnummer', undefined)
+    else if (juridiskEnhet == JuridiskEnhet.PRIVATPERSON) setValue('orgnummer', undefined)
+  }, [juridiskEnhet])
 
   const lagreEndringer = (mottaker: Mottaker) => {
     if (!isDirty) {
@@ -87,15 +87,15 @@ export function RedigerMottakerModal({ brevId, sakId, mottaker: initialMottaker,
               </Heading>
 
               <ToggleGroup
-                defaultValue={mottakerType}
-                onChange={(value) => setMottakerType(value as MottakerType)}
+                defaultValue={juridiskEnhet}
+                onChange={(value) => setJuridiskEnhet(value as JuridiskEnhet)}
                 size="small"
               >
-                <ToggleGroup.Item value={MottakerType.PRIVATPERSON}>Privatperson</ToggleGroup.Item>
-                <ToggleGroup.Item value={MottakerType.BEDRIFT}>Bedrift</ToggleGroup.Item>
+                <ToggleGroup.Item value={JuridiskEnhet.PRIVATPERSON}>Privatperson</ToggleGroup.Item>
+                <ToggleGroup.Item value={JuridiskEnhet.BEDRIFT}>Bedrift</ToggleGroup.Item>
               </ToggleGroup>
 
-              {mottakerType == MottakerType.BEDRIFT && (
+              {juridiskEnhet == JuridiskEnhet.BEDRIFT && (
                 <TextField
                   {...register('orgnummer', {
                     required: {
@@ -111,7 +111,7 @@ export function RedigerMottakerModal({ brevId, sakId, mottaker: initialMottaker,
                   error={errors?.orgnummer?.message}
                 />
               )}
-              {mottakerType == MottakerType.PRIVATPERSON && (
+              {juridiskEnhet == JuridiskEnhet.PRIVATPERSON && (
                 <TextField
                   {...register('foedselsnummer.value', {
                     required: {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
@@ -40,6 +40,13 @@ export const oppdaterMottaker = async (props: {
 }): Promise<ApiResponse<void>> =>
   apiClient.put(`/brev/${props.brevId}/mottaker?sakId=${props.sakId}`, { mottaker: props.mottaker })
 
+export const settHovedmottaker = async (props: {
+  brevId: number
+  sakId: number
+  mottakerId: string
+}): Promise<ApiResponse<void>> =>
+  apiClient.put(`/brev/${props.brevId}/mottaker/${props.mottakerId}/hoved?sakId=${props.sakId}`, {})
+
 export const slettMottaker = async (props: {
   brevId: number
   mottakerId: string


### PR DESCRIPTION
Gjør det enkelt å sette kopimottaker som hovedmottaker (og motsatt).

![Screenshot 2024-11-05 at 13 15 45](https://github.com/user-attachments/assets/a3bd625d-3d11-4aea-a64b-ca2c5fb1e049)
