### PR TITLE
Fjerner (med brev) for ANNEN revurderingsårsak

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/behandlingsslistemappere.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/behandlingsslistemappere.ts
@@ -44,7 +44,7 @@ export function mapAarsak(aarsak: BehandlingOgRevurderingsAarsakerType) {
     case Revurderingaarsak.UT_AV_FENGSEL:
       return 'Ut av fengsel'
     case Revurderingaarsak.ANNEN:
-      return 'Annen (med brev)'
+      return 'Annen'
     case Revurderingaarsak.ANNEN_UTEN_BREV:
       return 'Annen (uten brev)'
     case Revurderingaarsak.RETT_UTEN_TIDSBEGRENSNING:


### PR DESCRIPTION
Stemmer ikke alltid at ANNEN er med brev. Dette er noe vi hadde tidligere når dette var to ulike årsaker.