### PR TITLE
EY-4729 - Åpner for opprettelse av avvist klage-brev ved formkrav ikke oppfylt

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksbehandling/VedtaksbehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksbehandling/VedtaksbehandlingDao.kt
@@ -56,7 +56,12 @@ private data class Vedtaksbehandling(
             when (type) {
                 BehandlingType.BEHANDLING -> BehandlingStatus.valueOf(status).kanEndres()
                 BehandlingType.TILBAKEKREVING -> TilbakekrevingStatus.valueOf(status).kanEndres()
-                BehandlingType.KLAGE -> KlageStatus.kanEndres(KlageStatus.valueOf(status))
+                BehandlingType.KLAGE -> {
+                    val klageStatus = KlageStatus.valueOf(status)
+                    // I konteksten av vedtak så er klager også mulig å endre når formkravene ikke er oppfylt,
+                    // siden det er da man oppretter vedtak om avvist klage
+                    KlageStatus.kanEndres(klageStatus) || klageStatus == KlageStatus.FORMKRAV_IKKE_OPPFYLT
+                }
             }
         logger.info(
             "Fikk henvendelse om vedtak til behandling $id av type $type var redigerbar. " +

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksbehandling/VedtaksbehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksbehandling/VedtaksbehandlingDao.kt
@@ -5,8 +5,12 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.KlageStatus
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingStatus
 import no.nav.etterlatte.libs.database.single
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.sql.ResultSet
 import java.util.UUID
+
+private val logger: Logger = LoggerFactory.getLogger("Vedtaksbehandling")
 
 class VedtaksbehandlingDao(
     private val connectionAutoclosing: ConnectionAutoclosing,
@@ -47,12 +51,19 @@ private data class Vedtaksbehandling(
     val type: BehandlingType,
     val status: String,
 ) {
-    fun erRedigerbar(): Boolean =
-        when (type) {
-            BehandlingType.BEHANDLING -> BehandlingStatus.valueOf(status).kanEndres()
-            BehandlingType.TILBAKEKREVING -> TilbakekrevingStatus.valueOf(status).kanEndres()
-            BehandlingType.KLAGE -> KlageStatus.kanEndres(KlageStatus.valueOf(status))
-        }
+    fun erRedigerbar(): Boolean {
+        val redigerbar =
+            when (type) {
+                BehandlingType.BEHANDLING -> BehandlingStatus.valueOf(status).kanEndres()
+                BehandlingType.TILBAKEKREVING -> TilbakekrevingStatus.valueOf(status).kanEndres()
+                BehandlingType.KLAGE -> KlageStatus.kanEndres(KlageStatus.valueOf(status))
+            }
+        logger.info(
+            "Fikk henvendelse om vedtak til behandling $id av type $type var redigerbar. " +
+                "Svarte $redigerbar fordi statusen var $status",
+        )
+        return redigerbar
+    }
 }
 
 private enum class BehandlingType {


### PR DESCRIPTION
På grunn av at sjekken ikke tar høyde for tilstanden "formkrav ikke oppfylt" gir den feil svar tilbake på om vedtaket i klagen kan endres.

Legger også på litt logging for vedtaksbehandling-resultatet, så det er mulig å se i loggen hvorfor noe er svart ut slik det er svart ut