### PR TITLE
EY-4733 varsel dersom søkt ident, eller ident i behandling er historisk

### DIFF
--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
@@ -27,6 +27,7 @@ data class PdlAdressebeskyttelseRequest(
 data class PdlVariables(
     val ident: String,
     val bostedsadresse: Boolean = false,
+    val folkeregisteridentHistorikk: Boolean = false,
     val bostedsadresseHistorikk: Boolean = false,
     val deltBostedsadresse: Boolean = false,
     val oppholdsadresse: Boolean = false,

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlOboKlient.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlOboKlient.kt
@@ -45,7 +45,7 @@ class PdlOboKlient(
         val request =
             PdlGraphqlRequest(
                 query = getQuery("/pdl/hentPersonNavnFoedsel.graphql"),
-                variables = PdlVariables(ident),
+                variables = PdlVariables(ident, folkeregisteridentHistorikk = true),
             )
 
         return retry<PdlPersonNavnFoedselResponse>(times = 3) {

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/personweb/PersonWebService.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/personweb/PersonWebService.kt
@@ -60,7 +60,6 @@ class PersonWebService(
             } else {
                 PersonMapper.mapPersonNavnFoedsel(
                     ppsKlient = ppsKlient,
-                    ident = ident,
                     hentPerson = it.data.hentPerson,
                 )
             }

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/personweb/dto/PersonNavnFoedselsaar.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/personweb/dto/PersonNavnFoedselsaar.kt
@@ -10,6 +10,7 @@ data class PersonNavnFoedselsaar(
     val mellomnavn: String? = null,
     val etternavn: String,
     val foedselsnummer: Folkeregisteridentifikator,
+    val historiskeFoedselsnummer: List<Folkeregisteridentifikator>,
     val foedselsaar: Int,
     val foedselsdato: LocalDate? = null,
     val doedsdato: LocalDate? = null,

--- a/apps/etterlatte-pdltjenester/src/main/resources/pdl/hentPersonNavnFoedsel.graphql
+++ b/apps/etterlatte-pdltjenester/src/main/resources/pdl/hentPersonNavnFoedsel.graphql
@@ -22,9 +22,10 @@ fragment metadata on Metadata {
 
 query(
     $ident: ID!,
+    $folkeregisteridentHistorikk: Boolean!,
 ) {
     hentPerson(ident: $ident) {
-        folkeregisteridentifikator(historikk: false) {
+        folkeregisteridentifikator(historikk: $folkeregisteridentHistorikk) {
             identifikasjonsnummer
             status
             type

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/statusbar/Statusbar.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/statusbar/Statusbar.tsx
@@ -51,6 +51,11 @@ export const StatusBar = ({ ident }: { ident: string | null | undefined }) => {
 
             <BodyShort>|</BodyShort>
             <KopierbarVerdi value={person.foedselsnummer} />
+            {ident !== person.foedselsnummer && person.historiskeFoedselsnummer.includes(ident!!) && (
+              <Alert variant="warning" size="small">
+                Bruker har historisk ident {ident}
+              </Alert>
+            )}
 
             <VergemaalTag vergemaal={person.vergemaal} />
           </HStack>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Person.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Person.ts
@@ -62,6 +62,7 @@ export interface IPdlPersonNavnFoedsel {
   mellomnavn?: string
   etternavn: string
   foedselsnummer: string
+  historiskeFoedselsnummer: string[]
   foedselsaar: number
   foedselsdato: Date | undefined
   doedsdato: Date | undefined


### PR DESCRIPTION
Viser en enkel advarsel i tilfeller hvor det er diff mellom gjeldende ident fra PDL og det vi har gjort oppslaget med. 

![Screenshot 2024-11-12 at 12 43 10](https://github.com/user-attachments/assets/67533cc3-89dd-48ca-aaff-2e105db5ab30)
