### PR TITLE
EY-4669 Fjern alle requires med internfeilexception check

### DIFF
--- a/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/Tjenestepensjon.kt
+++ b/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/Tjenestepensjon.kt
@@ -4,12 +4,13 @@ import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 
 data class Tjenestepensjonnummer(
     val value: String,
 ) {
     init {
-        require(value == value.replace(Regex("[^0-9]"), ""))
+        checkInternFeil(value == value.replace(Regex("[^0-9]"), "")) { "Feil innhold i Tjenestepensjonnummer" }
     }
 }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingDao.kt
@@ -24,6 +24,7 @@ import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.TidligereFamiliepleier
 import no.nav.etterlatte.libs.common.behandling.Utlandstilknytning
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.gyldigSoeknad.GyldighetsResultat
 import no.nav.etterlatte.libs.common.sak.BehandlingOgSak
@@ -261,7 +262,9 @@ class BehandlingDao(
                     stmt.setString(18, opphoerFraOgMed?.let { fom -> objectMapper.writeValueAsString(fom) })
                     stmt.setJsonb(19, tidligereFamiliepleier)
                 }
-                require(stmt.executeUpdate() == 1)
+                checkInternFeil(stmt.executeUpdate() == 1) {
+                    "Kunne ikke opprette behandling for ${behandling.id}"
+                }
             }
         }
 
@@ -281,7 +284,9 @@ class BehandlingDao(
             stmt.setObject(1, objectMapper.writeValueAsString(gyldighetsproeving))
             stmt.setTidspunkt(2, Tidspunkt.now().toLocalDatetimeUTC().toTidspunkt())
             stmt.setObject(3, behandlingId)
-            require(stmt.executeUpdate() == 1)
+            checkInternFeil(stmt.executeUpdate() == 1) {
+                "Kunne ikke lagreGyldighetsproeving behandling for $behandlingId"
+            }
         }
     }
 
@@ -300,7 +305,9 @@ class BehandlingDao(
             stmt.setString(1, status.name)
             stmt.setTidspunkt(2, sistEndret.toTidspunkt())
             stmt.setObject(3, behandlingId)
-            require(stmt.executeUpdate() == 1)
+            checkInternFeil(stmt.executeUpdate() == 1) {
+                "Kunne ikke lagreStatus behandling for $behandlingId"
+            }
         }
     }
 
@@ -313,7 +320,9 @@ class BehandlingDao(
 
             stmt.setString(1, objectMapper.writeValueAsString(boddEllerArbeidetUtlandet))
             stmt.setObject(2, behandlingId)
-            require(stmt.executeUpdate() == 1)
+            checkInternFeil(stmt.executeUpdate() == 1) {
+                "Kunne ikke lagreBoddEllerArbeidetUtlandet behandling for $behandlingId"
+            }
         }
     }
 
@@ -325,7 +334,9 @@ class BehandlingDao(
             val statement = prepareStatement("UPDATE behandling set utlandstilknytning = ? where id = ?")
             statement.setJsonb(1, utlandstilknytning)
             statement.setObject(2, behandlingId)
-            require(statement.executeUpdate() == 1)
+            checkInternFeil(statement.executeUpdate() == 1) {
+                "Kunne ikke lagreUtlandstilknytning behandling for $behandlingId"
+            }
         }
     }
 
@@ -337,7 +348,9 @@ class BehandlingDao(
             val statement = prepareStatement("UPDATE behandling set tidligere_familiepleier = ? where id = ?")
             statement.setJsonb(1, tidligereFamiliepleier)
             statement.setObject(2, behandlingId)
-            require(statement.executeUpdate() == 1)
+            checkInternFeil(statement.executeUpdate() == 1) {
+                "Kunne ikke lagreTidligereFamiliepleier behandling for $behandlingId"
+            }
         }
     }
 
@@ -446,7 +459,9 @@ class BehandlingDao(
             val statement = prepareStatement("UPDATE behandling set sende_brev = ? where id = ?")
             statement.setBoolean(1, skalSendeBrev)
             statement.setObject(2, behandlingId)
-            require(statement.executeUpdate() == 1)
+            checkInternFeil(statement.executeUpdate() == 1) {
+                "Kunne ikke send brev behandling for $behandlingId"
+            }
         }
     }
 
@@ -503,4 +518,5 @@ private fun ResultSet.toTidligereFamiliepleier(): TidligereFamiliepleier? =
 val objectMapper: ObjectMapper =
     jacksonObjectMapper().registerModule(JavaTimeModule()).disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
+// TODO: fjerne denne bruke, blir veldig dårlig feilmelding
 fun PreparedStatement.updateSuccessful() = require(this.executeUpdate() == 1)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
@@ -44,6 +44,7 @@ import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.NyeSaksopplysninger
 import no.nav.etterlatte.libs.common.grunnlag.lagOpplysning
@@ -617,10 +618,10 @@ internal class BehandlingServiceImpl(
     ) {
         inTransaction {
             val behandling = behandlingDao.hentBehandling(behandlingId)
-            require(behandling != null) {
+            checkInternFeil(behandling != null) {
                 "Behandling finnes ikke $behandlingId"
             }
-            when (behandling.type) {
+            when (behandling!!.type) {
                 BehandlingType.FØRSTEGANGSBEHANDLING -> throw KanIkkeEndreSendeBrevForFoerstegangsbehandling()
                 BehandlingType.REVURDERING -> {
                     behandlingDao.lagreSendeBrev(behandlingId, skalSendeBrev)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/aktivitetsplikt/AktivitetspliktService.kt
@@ -31,6 +31,7 @@ import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.tilVirkningstidspunkt
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.hentDoedsdato
 import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
@@ -290,7 +291,7 @@ class AktivitetspliktService(
         if (aktivitetsgrad.id != null) {
             aktivitetspliktAktivitetsgradDao.oppdaterAktivitetsgrad(aktivitetsgrad, kilde, behandlingId)
         } else {
-            require(
+            checkInternFeil(
                 aktivitetspliktAktivitetsgradDao.hentAktivitetsgradForBehandling(behandlingId).isEmpty(),
             ) { "Aktivitetsgrad finnes allerede for behandling $behandlingId" }
             val unntak = aktivitetspliktUnntakDao.hentUnntakForBehandling(behandlingId)
@@ -385,7 +386,7 @@ class AktivitetspliktService(
         if (unntak.id != null) {
             aktivitetspliktUnntakDao.oppdaterUnntak(unntak, kilde, behandlingId)
         } else {
-            require(
+            checkInternFeil(
                 aktivitetspliktUnntakDao.hentUnntakForBehandling(behandlingId).isEmpty(),
             ) { "Unntak finnes allerede for behandling $behandlingId" }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoDao.kt
@@ -5,6 +5,7 @@ import no.nav.etterlatte.behandling.utland.SluttbehandlingUtlandBehandlinginfo
 import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.behandling.Brevutfall
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.database.setJsonb
 import no.nav.etterlatte.libs.database.singleOrNull
@@ -85,8 +86,11 @@ class BehandlingInfoDao(
                     setObject(1, brevutfall.behandlingId)
                     setJsonb(2, brevutfall)
                 }.run { executeUpdate() }
-                    .also { require(it == 1) }
-                    .let {
+                    .also {
+                        checkInternFeil(it == 1) {
+                            "Kunne ikke lagreBrevutfall behandling for ${brevutfall.behandlingId}"
+                        }
+                    }.let {
                         hentBrevutfall(brevutfall.behandlingId)
                             ?: throw InternfeilException("Feilet under lagring av brevutfall")
                     }
@@ -125,8 +129,11 @@ class BehandlingInfoDao(
                     setObject(1, etterbetaling.behandlingId)
                     setJsonb(2, etterbetaling)
                 }.run { executeUpdate() }
-                    .also { require(it == 1) }
-                    .let {
+                    .also {
+                        checkInternFeil(it == 1) {
+                            "Kunne ikke lagreBrevutfall behandling for ${etterbetaling.behandlingId}"
+                        }
+                    }.let {
                         hentEtterbetaling(etterbetaling.behandlingId)
                             ?: throw InternfeilException("Feilet under lagring av etterbetaling")
                     }
@@ -145,7 +152,11 @@ class BehandlingInfoDao(
                     setJsonb(1, null)
                     setObject(2, behandlingId)
                 }.run { executeUpdate() }
-                    .also { require(it == 1) }
+                    .also {
+                        checkInternFeil(it == 1) {
+                            "Kunne ikke slettEtterbetaling behandling for $behandlingId"
+                        }
+                    }
             }
         }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/bosattutland/BosattUtlandDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/bosattutland/BosattUtlandDao.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.hendelse.getUUID
 import no.nav.etterlatte.behandling.objectMapper
 import no.nav.etterlatte.common.ConnectionAutoclosing
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.database.setJsonb
 import no.nav.etterlatte.libs.database.singleOrNull
 import java.sql.ResultSet
@@ -29,7 +30,7 @@ class BosattUtlandDao(
                 statement.setObject(2, bosattUtland.rinanummer)
                 statement.setJsonb(3, bosattUtland.mottatteSeder)
                 statement.setJsonb(4, bosattUtland.sendteSeder)
-                require(statement.executeUpdate() == 1)
+                checkInternFeil(statement.executeUpdate() == 1) { "Kunne ikke lagre utland for behandlingId: ${bosattUtland.behandlingId}" }
             }
         }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/omregning/OmregningDao.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.behandling.omregning
 
 import no.nav.etterlatte.common.ConnectionAutoclosing
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.sak.KjoeringRequest
 import no.nav.etterlatte.libs.common.sak.KjoeringStatus
 import no.nav.etterlatte.libs.common.sak.LagreKjoeringRequest
@@ -69,7 +70,11 @@ class OmregningDao(
                 statement.setString(4, request.begrunnelse)
                 statement.setString(5, request.corrId)
                 statement.setString(6, request.feilendeSteg)
-                statement.executeUpdate().also { require(it == 1) }
+                statement.executeUpdate().also {
+                    checkInternFeil(it > 0) {
+                        "Kunne ikke oppdaterKjoering for id sakid ${request.sakId}"
+                    }
+                }
             }
         }
     }
@@ -97,7 +102,11 @@ class OmregningDao(
                 statement.setBigDecimal(9, request.avkortingFoer)
                 statement.setBigDecimal(10, request.avkortingEtter)
                 statement.setBigDecimal(11, request.vedtakBeloep)
-                statement.executeUpdate().also { require(it == 1) }
+                statement.executeUpdate().also {
+                    checkInternFeil(it > 0) {
+                        "Kunne ikke lagreKjoering for id sakid ${request.sakId}"
+                    }
+                }
             }
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingDao.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.hendelse.getUUID
 import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.Enhetsnummer
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.sak.SakId
@@ -197,7 +198,11 @@ class TilbakekrevingDao(
             statement.setJsonb(6, vurdering)
         }
         statement.setBoolean(7, tilbakekrevingBehandling.sendeBrev)
-        statement.executeUpdate().also { require(it == 1) }
+        statement.executeUpdate().also {
+            checkInternFeil(it == 1) {
+                "Kunne ikke lagre tilbaekreving behandling for sakid ${tilbakekrevingBehandling.sak.id}"
+            }
+        }
     }
 
     private fun deleteTilbakekrevingsperioder(
@@ -212,7 +217,11 @@ class TilbakekrevingDao(
                 """.trimIndent(),
             )
         statement.setObject(1, tilbakekrevingId)
-        statement.executeUpdate().also { require(it > 0) }
+        statement.executeUpdate().also {
+            checkInternFeil(it > 0) {
+                "Kunne ikke deleteTilbakekrevingsperioder behandling for id $tilbakekrevingId"
+            }
+        }
     }
 
     private fun insertTilbakekrevingsperioder(

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakSkrivDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakSkrivDao.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.sak
 import no.nav.etterlatte.grunnlagsendring.SakMedEnhet
 import no.nav.etterlatte.libs.common.Enhetsnummer
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.sak.SakId
@@ -38,7 +39,9 @@ class SakSkrivDao(
                     logger.info(
                         "Oppdaterer adressebeskyttelse med: $adressebeskyttelseGradering for sak med id: $sakId, antall oppdatert er $it",
                     )
-                    require(it == 1)
+                    checkInternFeil(it > 0) {
+                        "Kunne ikke oppdaterAdresseBeskyttelse for id sakid $sakId"
+                    }
                 }
             }
         }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/aktivitetsplikt/AktivitetspliktServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/aktivitetsplikt/AktivitetspliktServiceTest.kt
@@ -40,6 +40,7 @@ import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.tilVirkningstidspunkt
+import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
 import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
@@ -457,7 +458,7 @@ class AktivitetspliktServiceTest {
                     every { status } returns BehandlingStatus.VILKAARSVURDERT
                 }
 
-            assertThrows<IllegalArgumentException> {
+            assertThrows<InternfeilException> {
                 service.upsertUnntakForBehandling(unntak, behandlingId, sakId, brukerTokenInfo)
             }
         }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingDaoTest.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.behandling.generellbehandling
 import no.nav.etterlatte.ConnectionAutoclosingTest
 import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.behandling.sakId1
+import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.generellbehandling.DokumentMedSendtDato
 import no.nav.etterlatte.libs.common.generellbehandling.GenerellBehandling
 import no.nav.etterlatte.libs.common.generellbehandling.Innhold
@@ -48,7 +49,7 @@ internal class GenerellBehandlingDaoTest(
 
     @Test
     fun `Assert skal catche at man oppretter med feil type`() {
-        assertThrows<IllegalArgumentException> {
+        assertThrows<InternfeilException> {
             GenerellBehandling(
                 UUID.randomUUID(),
                 sakId1,

--- a/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/beregningkafka/BeregningService.kt
+++ b/apps/etterlatte-beregning-kafka/src/main/kotlin/no/nav/etterlatte/beregningkafka/BeregningService.kt
@@ -13,6 +13,7 @@ import io.ktor.http.isSuccess
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.grunnbeloep.Grunnbeloep
 import no.nav.etterlatte.libs.common.beregning.AarligInntektsjusteringAvkortingRequest
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import java.util.UUID
 
 class BeregningService(
@@ -86,6 +87,6 @@ class BeregningService(
     suspend fun hentGrunnbeloep(): Grunnbeloep =
         beregningApp
             .get("$url/api/beregning/grunnbeloep")
-            .also { require(it.status.isSuccess()) }
+            .also { checkInternFeil(it.status.isSuccess()) { "Kunne ikke hente grunnbeloep" } }
             .body<Grunnbeloep>()
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NotatRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NotatRepository.kt
@@ -168,7 +168,7 @@ class NotatRepository(
                     ),
                 ).asUpdate,
             ).also { oppdatert ->
-                require(oppdatert == 1)
+                checkNotNull(oppdatert == 1) { "Kunne ikke lagre tittel! for id $id" }
             }
 
         tx.lagreHendelse(id, tittel.toJson(), bruker)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevService.kt
@@ -21,6 +21,7 @@ import no.nav.etterlatte.brev.varselbrev.BrevDataMapperRedigerbartUtfallVarsel
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.toJson
@@ -60,7 +61,7 @@ class VedtaksbrevService(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): Brev {
-        require(db.hentBrevForBehandling(behandlingId, Brevtype.VEDTAK).firstOrNull() == null) {
+        checkInternFeil(db.hentBrevForBehandling(behandlingId, Brevtype.VEDTAK).firstOrNull() == null) {
             "Vedtaksbrev finnes allerede på behandling (id=$behandlingId) og kan ikke opprettes på nytt"
         }
 

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -65,6 +65,7 @@ import no.nav.etterlatte.libs.common.behandling.FeilutbetalingValg
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.beregning.BeregningsMetode
+import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
@@ -365,7 +366,7 @@ internal class VedtaksbrevServiceTest {
                     ),
                 )
 
-            assertThrows<IllegalArgumentException> {
+            assertThrows<InternfeilException> {
                 runBlocking {
                     vedtaksbrevService.opprettVedtaksbrev(
                         SAK_ID,

--- a/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/OpplysningDao.kt
+++ b/apps/etterlatte-grunnlag/src/main/kotlin/grunnlag/OpplysningDao.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.grunnlag
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.objectMapper
@@ -233,7 +234,9 @@ class OpplysningDao(
                 setLong(3, hendelsenummer)
                 setBoolean(4, false)
             }.executeUpdate()
-            .also { require(it > 0) }
+            .also {
+                checkInternFeil(it > 0) { "Kunne ikke oppdaterVersjonForBehandling for behandlingid $behandlingId sakid: $sakId" }
+            }
     }
 
     fun laasGrunnlagVersjonForBehandling(behandlingId: UUID) =

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/domain/SoeknadStatistikk.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/domain/SoeknadStatistikk.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.statistikk.domain
 
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 
 data class SoeknadStatistikk(
     val soeknadId: Long,
@@ -14,7 +15,7 @@ data class SoeknadStatistikk(
                 true -> kriterierForIngenBehandling.isEmpty()
                 false -> kriterierForIngenBehandling.isNotEmpty()
             }
-        require(erKonsekvent) {
+        checkInternFeil(erKonsekvent) {
             "En søknad skal enten være gyldig for behandling med ingen kriterier for ingen behandling, " +
                 "eller den er ikke gyldig for behandling på grunn av en eller flere kriterier "
         }

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingHendelseRepository.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/TilbakekrevingHendelseRepository.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.tilbakekreving
 import kotliquery.queryOf
 import kotliquery.sessionOf
 import kotliquery.using
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toTimestamp
@@ -70,7 +71,7 @@ class TilbakekrevingHendelseRepository(
                     ),
             ).let { query ->
                 session.update(query).also {
-                    require(it == 1) {
+                    checkInternFeil(it == 1) {
                         "Feil under lagring av hendelse for sak $sakId"
                     }
                 }
@@ -129,7 +130,7 @@ class TilbakekrevingHendelseRepository(
                     ),
             ).let { query ->
                 session.update(query).also {
-                    require(it == 1) {
+                    checkInternFeil(it == 1) {
                         "Feil under oppdatering av hendelse for sak $sakId"
                     }
                 }

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -10,6 +10,7 @@ import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.feilhaandtering.GenerellIkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsdata
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.hentDoedsdato
@@ -882,7 +883,7 @@ class TrygdetidServiceImpl(
         val trygdetiderKilde = trygdetidRepository.hentTrygdetiderForBehandling(kildeBehandlingId)
         val trygdetiderMaal = trygdetidRepository.hentTrygdetiderForBehandling(behandlingId)
 
-        require(trygdetiderMaal.map { it.ident }.sorted() == trygdetiderKilde.map { it.ident }.sorted()) {
+        checkInternFeil(trygdetiderMaal.map { it.ident }.sorted() == trygdetiderKilde.map { it.ident }.sorted()) {
             "Trygdetidene gjelder forskjellige avdøde"
         }
 

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/avstemming/AvstemmingDao.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/avstemming/AvstemmingDao.kt
@@ -5,6 +5,7 @@ import kotliquery.param
 import kotliquery.queryOf
 import kotliquery.sessionOf
 import kotliquery.using
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toTimestamp
 import no.nav.etterlatte.libs.common.toJson
@@ -39,7 +40,7 @@ class AvstemmingDao(
                 session.run(
                     it.asUpdate,
                 )
-            }.also { require(it == 1) { "Kunne ikke opprette avstemming" } }
+            }.also { checkInternFeil(it == 1) { "Kunne ikke opprette avstemming" } }
         }
 
     fun hentDatoOpprettetForSisteKonsistensavstemming(saktype: Saktype): Tidspunkt? =
@@ -87,7 +88,9 @@ class AvstemmingDao(
                         "avstemmingtype" to Avstemmingtype.GRENSESNITTAVSTEMMING.name.param(),
                         "saktype" to grensesnittavstemming.saktype.name.param(),
                     ),
-            ).let { session.run(it.asUpdate) }.also { require(it == 1) { "Kunne ikke opprette avstemming" } }
+            ).let { session.run(it.asUpdate) }.also {
+                checkInternFeil(it == 1) { "Kunne ikke opprette avstemming" }
+            }
         }
 
     fun hentSisteGrensesnittavstemming(saktype: Saktype): Grensesnittavstemming? =

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/avstemming/Grensesnittavstemming.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/avstemming/Grensesnittavstemming.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.utbetaling.avstemming
 
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.utbetaling.iverksetting.utbetaling.Saktype
 import java.nio.ByteBuffer
@@ -24,7 +25,7 @@ data class Avstemmingsperiode(
     val til: Tidspunkt,
 ) {
     init {
-        require(fraOgMed.isBefore(til)) { "fraOgMed-tidspunkt maa vaere foer til-tidspunkt" }
+        checkInternFeil(fraOgMed.isBefore(til)) { "fraOgMed-tidspunkt maa vaere foer til-tidspunkt" }
     }
 }
 

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/iverksetting/utbetaling/UtbetalingDao.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/iverksetting/utbetaling/UtbetalingDao.kt
@@ -8,6 +8,7 @@ import kotliquery.queryOf
 import kotliquery.sessionOf
 import kotliquery.using
 import no.nav.etterlatte.libs.common.Enhetsnummer
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
@@ -342,7 +343,11 @@ class UtbetalingDao(
                         "vedtakId" to oppdragMedKvittering.vedtakId().param(),
                     ),
             ).let { tx.run(it.asUpdate) }
-                .also { require(it == 1) { "Kunne ikke oppdatere kvittering i utbetaling" } }
+                .also {
+                    checkInternFeil(it == 1) {
+                        "Kunne ikke oppdatere kvittering i utbetaling"
+                    }
+                }
 
             opprettUtbetalingshendelse(
                 Utbetalingshendelse(

--- a/apps/etterlatte-utbetaling/src/test/kotlin/no/nav/etterlatte/utbetaling/avstemming/GrensesnittavstemmingServiceTest.kt
+++ b/apps/etterlatte-utbetaling/src/test/kotlin/no/nav/etterlatte/utbetaling/avstemming/GrensesnittavstemmingServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.utbetaling.avstemming
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.utcKlokke
 import no.nav.etterlatte.utbetaling.avstemming.avstemmingsdata.AvstemmingsdataSender
@@ -93,7 +94,7 @@ internal class GrensesnittavstemmingServiceTest {
                 saktype = Saktype.BARNEPENSJON,
             )
 
-        assertThrows<IllegalArgumentException> {
+        assertThrows<InternfeilException> {
             grensesnittavstemmingService.hentNestePeriode(Saktype.BARNEPENSJON)
         }
     }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
@@ -12,6 +12,7 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.beregning.AvkortetYtelseDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingDto
 import no.nav.etterlatte.libs.common.deserialize
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.sak.SakId
@@ -406,7 +407,7 @@ class VedtaksvurderingRepository(
                         "behandlingId" to behandlingId,
                     ),
                 loggtekst = "Fatter vedtak for behandling $behandlingId",
-            ).also { require(it == 1) }
+            ).also { checkInternFeil(it == 1) { "Vedtak ble ikke oppdatert etter fatting behandlingid: $behandlingId" } }
                 .let { hentVedtakNonNull(behandlingId, this) }
         }
 
@@ -432,7 +433,7 @@ class VedtaksvurderingRepository(
                     ),
                 loggtekst = "Attesterer vedtak $behandlingId",
             ).also {
-                require(it == 1)
+                checkInternFeil(it == 1) { "Vedtak ble ikke oppdatert etter attestering behandlingid: $behandlingId" }
             }
 
             opprett(
@@ -463,7 +464,9 @@ class VedtaksvurderingRepository(
             """,
                 params = mapOf("vedtakstatus" to VedtakStatus.RETURNERT.name, "behandlingId" to behandlingId),
                 loggtekst = "Underkjenner vedtak for behandling $behandlingId",
-            ).also { require(it == 1) }
+            ).also {
+                checkInternFeil(it == 1) { "Vedtak ble ikke oppdatert etter underkjenning behandlingid: $behandlingId" }
+            }
             return@session hentVedtakNonNull(behandlingId, this)
         }
 
@@ -476,7 +479,9 @@ class VedtaksvurderingRepository(
                 query = "UPDATE vedtak SET vedtakstatus = :vedtakstatus WHERE behandlingId = :behandlingId",
                 params = mapOf("vedtakstatus" to VedtakStatus.TIL_SAMORDNING.name, "behandlingId" to behandlingId),
                 loggtekst = "Lagrer til_samordning vedtak",
-            ).also { require(it == 1) }
+            ).also {
+                checkInternFeil(it == 1) { "Vedtak ble ikke oppdatert etter satt til samordning behandlingid: $behandlingId" }
+            }
             return@session hentVedtakNonNull(behandlingId, this)
         }
 
@@ -489,7 +494,9 @@ class VedtaksvurderingRepository(
                 query = "UPDATE vedtak SET vedtakstatus = :vedtakstatus WHERE behandlingId = :behandlingId",
                 params = mapOf("vedtakstatus" to VedtakStatus.SAMORDNET.name, "behandlingId" to behandlingId),
                 loggtekst = "Lagrer samordnet vedtak",
-            ).also { require(it == 1) }
+            ).also {
+                checkInternFeil(it == 1) { "Vedtak ble ikke oppdatert etter samordnet behandlingid: $behandlingId" }
+            }
             return@session hentVedtakNonNull(behandlingId, this)
         }
 
@@ -502,7 +509,9 @@ class VedtaksvurderingRepository(
                 query = "UPDATE vedtak SET vedtakstatus = :vedtakstatus WHERE behandlingId = :behandlingId",
                 params = mapOf("vedtakstatus" to VedtakStatus.IVERKSATT.name, "behandlingId" to behandlingId),
                 loggtekst = "Lagrer iverksatt vedtak",
-            ).also { require(it == 1) }
+            ).also {
+                checkInternFeil(it == 1) { "Vedtak ble ikke oppdatert etter iverksatt behandlingid: $behandlingId" }
+            }
             return@session hentVedtakNonNull(behandlingId, this)
         }
 
@@ -607,7 +616,9 @@ class VedtaksvurderingRepository(
                         "behandlingId" to behandlingId,
                     ),
                 loggtekst = "Returnerer vedtak $behandlingId",
-            ).also { require(it == 1) }
+            ).also {
+                checkInternFeil(it == 1) { "Vedtak ble ikke oppdatert returnert/tilbakestilt behandlingid: $behandlingId" }
+            }
             return@session hentVedtakNonNull(behandlingId, this)
         }
     }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxRepository.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/outbox/OutboxRepository.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.vedtaksvurdering.outbox
 
 import kotliquery.Row
 import kotliquery.queryOf
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.database.transaction
 import java.util.UUID
 import javax.sql.DataSource
@@ -30,7 +31,7 @@ class OutboxRepository(
                 """.trimIndent(),
                 id,
             ).let { query -> tx.run(query.asUpdate) }
-                .also { require(it == 1) { "Fant ikke hendelse med id $id og status upublisert" } }
+                .also { checkInternFeil(it == 1) { "Fant ikke hendelse med id $id og status upublisert" } }
         }
     }
 

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Klage.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Klage.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.PDFMal
 import no.nav.etterlatte.libs.common.klage.AarsakTilAvbrytelse
@@ -208,7 +209,7 @@ data class Klage(
                 is KlageUtfallMedData.AvvistMedOmgjoering -> null
             }
         hjemmel?.let {
-            require(it.kanBrukesForSaktype(this.sak.sakType)) {
+            checkInternFeil(it.kanBrukesForSaktype(this.sak.sakType)) {
                 "Hjemmelen $it er ikke gyldig for saktypen ${this.sak.sakType}"
             }
         }

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/generellbehandling/GenerellBehandling.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/generellbehandling/GenerellBehandling.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.libs.common.generellbehandling
 
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.util.UUID
@@ -46,12 +47,12 @@ data class GenerellBehandling(
         if (innhold !== null) {
             when (type) {
                 GenerellBehandlingType.ANNEN ->
-                    require(innhold is Innhold.Annen) {
+                    checkInternFeil(innhold is Innhold.Annen) {
                         "Type $type matcher " +
                             "ikke innhold navn: ${innhold.javaClass.simpleName}"
                     }
                 GenerellBehandlingType.KRAVPAKKE_UTLAND ->
-                    require(innhold is Innhold.KravpakkeUtland) {
+                    checkInternFeil(innhold is Innhold.KravpakkeUtland) {
                         "Type $type matcher ikke innhold navn: ${innhold.javaClass.simpleName}"
                     }
             }

--- a/libs/etterlatte-beregning-model/src/main/kotlin/Prosent.kt
+++ b/libs/etterlatte-beregning-model/src/main/kotlin/Prosent.kt
@@ -1,10 +1,12 @@
 package no.nav.etterlatte.beregning.grunnlag
 
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
+
 data class Prosent(
     val verdi: Int,
 ) {
     init {
-        require(verdi in 0..100)
+        checkInternFeil(verdi in 0..100) { "Ugyldig prosent verdi: $verdi" }
     }
 
     fun minus(verdi: Prosent?) = minus(verdi?.verdi ?: 0)

--- a/libs/etterlatte-beregning-model/src/test/kotlin/ProsentTest.kt
+++ b/libs/etterlatte-beregning-model/src/test/kotlin/ProsentTest.kt
@@ -1,5 +1,6 @@
 
 import no.nav.etterlatte.beregning.grunnlag.Prosent
+import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -17,11 +18,11 @@ class ProsentTest {
 
     @Test
     fun `stoetter ikke negativ prosent`() {
-        assertThrows<IllegalArgumentException> { Prosent(-1) }
+        assertThrows<InternfeilException> { Prosent(-1) }
     }
 
     @Test
     fun `stoetter ikke prosent over 100`() {
-        assertThrows<IllegalArgumentException> { Prosent(101) }
+        assertThrows<InternfeilException> { Prosent(101) }
     }
 }

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/Brevkoder.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/Brevkoder.kt
@@ -1,5 +1,7 @@
 package no.nav.etterlatte.brev
 
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
+
 /*
 Breva våre er teknisk sett to brev som er satt sammen - den redigerbare delen, og delen som ligg fast.
 Saksbehandler kan redigere den redigerbare delen, og ved PDF-generering sender vi den delen over til brevbakeren,
@@ -212,7 +214,7 @@ enum class Brevkoder(
     ;
 
     init {
-        require(redigering != ferdigstilling) {
+        checkInternFeil(redigering != ferdigstilling) {
             "Bruk forskjellige maler for redigering og ferdigstilling. $redigering og $ferdigstilling er like"
         }
     }

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.libs.database
 
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.sak.SakId
 import org.postgresql.util.PGobject
@@ -9,18 +10,18 @@ import java.sql.ResultSet
 fun <T> ResultSet.singleOrNull(block: ResultSet.() -> T): T? =
     if (next()) {
         block().also {
-            require(!next()) { "Skal være unik" }
+            checkInternFeil(!next()) { "Skal være unik" }
         }
     } else {
         null
     }
 
 fun <T> ResultSet.single(block: ResultSet.() -> T): T {
-    require(next()) {
+    checkInternFeil(next()) {
         "Skal ha en verdi"
     }
     return block().also {
-        require(!next()) { "Skal være unik" }
+        checkInternFeil(!next()) { "Skal være unik" }
     }
 }
 

--- a/libs/etterlatte-kafka/src/main/kotlin/kafka/KafkaProdusent.kt
+++ b/libs/etterlatte-kafka/src/main/kotlin/kafka/KafkaProdusent.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.kafka
 
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.StringSerializer
@@ -68,7 +69,7 @@ class TestProdusent<K, V> : KafkaProdusent<K, V> {
         verdi: V,
         headers: Map<String, ByteArray>?,
     ): Pair<Int, Long> {
-        require(!closed)
+        checkInternFeil(!closed) { "Kafka produsent var lukket" }
         return publiserteMeldinger.let {
             it.add(Record(noekkel, verdi, headers))
             Pair(0, (it.size - 1).toLong())

--- a/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/VedtakDto.kt
+++ b/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/VedtakDto.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.RevurderingInfo
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.sak.VedtakSak
@@ -86,7 +87,7 @@ data class Periode(
     val tom: YearMonth?,
 ) {
     init {
-        require(isNull(tom) || fom == tom || fom.isBefore(tom)) {
+        checkInternFeil(isNull(tom) || fom == tom || fom.isBefore(tom)) {
             "Fom må vera før eller lik tom, men fom er $fom og tom er $tom"
         }
     }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/ListenerMedLoggingOgFeilhaandtering.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/ListenerMedLoggingOgFeilhaandtering.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.rapidsandrivers
 
 import no.nav.etterlatte.libs.common.event.EventnameHendelseType
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.common.logging.withLogContext
 import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
@@ -62,7 +63,7 @@ abstract class ListenerMedLoggingOgFeilhaandtering : River.PacketListener {
         block: River.() -> Unit = {},
     ) {
         logger.info("Initialiserer river for ${this.javaClass.simpleName}")
-        require(kontekst() in setOf(Kontekst.MIGRERING, Kontekst.REGULERING, Kontekst.OMREGNING, Kontekst.TEST)) {
+        checkInternFeil(kontekst() in setOf(Kontekst.MIGRERING, Kontekst.REGULERING, Kontekst.OMREGNING, Kontekst.TEST)) {
             "Bruk heller ${ListenerMedLogging::class.simpleName}, denne her svelger feilmeldinger"
         }
         River(rapidsConnection)

--- a/libs/saksbehandling-common/src/main/kotlin/Enhetsnummer.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/Enhetsnummer.kt
@@ -1,12 +1,13 @@
 package no.nav.etterlatte.libs.common
 
 import com.fasterxml.jackson.annotation.JsonValue
+import no.nav.etterlatte.libs.common.feilhaandtering.checkInternFeil
 
 data class Enhetsnummer(
     @JsonValue val enhetNr: String,
 ) {
     init {
-        require(enhetNr.length == 4 && enhetNr.toIntOrNull() != null) {
+        checkInternFeil(enhetNr.length == 4 && enhetNr.toIntOrNull() != null) {
             "Enhetsnummer må være et firesifret tall, men var $enhetNr"
         }
     }

--- a/libs/saksbehandling-common/src/main/kotlin/feilhaandtering/Utils.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/feilhaandtering/Utils.kt
@@ -11,6 +11,7 @@ fun <T : Any> checkNotNullOrThrowException(
     }
 }
 
+// Todo endre til if(value)
 fun checkInternFeil(
     value: Boolean,
     message: () -> String,
@@ -20,6 +21,7 @@ fun checkInternFeil(
     }
 }
 
+// Todo endre til if(value)
 fun checkUgyldigForespoerselException(
     value: Boolean,
     code: String,
@@ -29,3 +31,5 @@ fun checkUgyldigForespoerselException(
         throw UgyldigForespoerselException(code = code, detail = message())
     }
 }
+
+// TODO: må også bytte ut checknotnull og requirenotnull


### PR DESCRIPTION
Tenker at spesialiseringer av feilmeldingene kan komme senere, viktigste er å bli kvitt de standard dårlige feilmeldingene som IllegalArgumentException og IllegalStateException

Har også lagt på beskrivelse mange steder på requires, men ingen tester tester de så ja hvem vet om de er nyttige, foråpentligvis har vi noen tester som sjekker tilstanden om de brukes også,