### PR TITLE
EY-4588: Bruker foreldre i stedet for gjenlevende for å sjekke om personer er søsken

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/Soesken.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/personer/Soesken.tsx
@@ -4,11 +4,16 @@ import React from 'react'
 import { hentAdresserEtterDoedsdato, hentAlderForDato } from '~components/behandling/felles/utils'
 import { Familieforhold, IPdlPerson } from '~shared/types/Person'
 import { BodyShort, HStack, Label, VStack } from '@navikt/ds-react'
+import { Personopplysning } from '~shared/types/grunnlag'
 
 export const Soesken = ({ person, familieforhold }: { person: IPdlPerson; familieforhold: Familieforhold }) => {
   const avdoede = familieforhold.avdoede.find((po) => po)!
-  const gjenlevende = familieforhold.gjenlevende?.find((po) => po)
-  const erHelsoesken = (fnr: string) => gjenlevende?.opplysning.familieRelasjon?.barn?.includes(fnr)
+
+  const erHelsoesken = (soeker: Personopplysning | undefined, soesken: IPdlPerson) => {
+    const foreldreSoeker = new Set(soeker?.opplysning.familieRelasjon?.foreldre ?? [])
+    const foreldreSoesken = new Set(soesken.familieRelasjon?.foreldre ?? [])
+    return foreldreSoeker.difference(foreldreSoesken).size === 0
+  }
 
   return (
     <>
@@ -20,7 +25,7 @@ export const Soesken = ({ person, familieforhold }: { person: IPdlPerson; famili
           </BodyShort>
           <BodyShort>({hentAlderForDato(person.foedselsdato)} år)</BodyShort>
         </HStack>
-        <BodyShort>{erHelsoesken(person.foedselsnummer) ? 'Helsøsken' : 'Halvsøsken'}</BodyShort>
+        <BodyShort>{erHelsoesken(familieforhold.soeker, person) ? 'Helsøsken' : 'Halvsøsken'}</BodyShort>
       </VStack>
       <VStack>
         <Label>Fødselsnummer</Label>


### PR DESCRIPTION
Tidligere sjekk for å finne ut om to personer var hel/halvsøsken fungerte ikke da den kun så på gjenlevende. Denne endringen gjør at dette også blir riktig ved to avdøde / manglende gjenlevende