### PR TITLE
EY-4625: Endrer rekkefølge på avsnitt revurdering BP

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperRedigerbartUtfallVedtak.kt
@@ -143,7 +143,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
                             brukerTokenInfo,
                             behandlingId,
                             virkningstidspunkt,
-                            sakType,
+                            utlandstilknytningType,
                         )
                     VedtakType.OPPHOER -> barnepensjonOpphoer(brukerTokenInfo, behandlingId)
                     VedtakType.AVSLAG -> barnepensjonAvslag(avdoede, brukerTokenInfo, behandlingId)
@@ -254,7 +254,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
         bruker: BrukerTokenInfo,
         behandlingId: UUID,
         virkningstidspunkt: YearMonth?,
-        sakType: SakType,
+        utlandstilknytningType: UtlandstilknytningType?,
     ) = coroutineScope {
         val etterbetaling = async { behandlingService.hentEtterbetaling(behandlingId, bruker) }
         val brevutfall = async { behandlingService.hentBrevutfall(behandlingId, bruker) }
@@ -271,6 +271,7 @@ class BrevDataMapperRedigerbartUtfallVedtak(
             etterbetaling.await(),
             utbetalingsinfo.await(),
             brevutfall.await() ?: throw ManglerBrevutfall(behandlingId),
+            utlandstilknytningType,
         )
     }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
@@ -108,18 +108,28 @@ data class BarnepensjonRevurderingRedigerbartUtfall(
     val harUtbetaling: Boolean,
     val feilutbetaling: FeilutbetalingType,
     val brukerUnder18Aar: Boolean,
+    val bosattUtland: Boolean,
+    val frivilligSkattetrekk: Boolean,
 ) : BrevDataRedigerbar {
     companion object {
         fun fra(
             etterbetaling: EtterbetalingDTO?,
             utbetalingsinfo: Utbetalingsinfo,
             brevutfall: BrevutfallDto,
-        ): BarnepensjonRevurderingRedigerbartUtfall =
-            BarnepensjonRevurderingRedigerbartUtfall(
+            utlandstilknytning: UtlandstilknytningType?,
+        ): BarnepensjonRevurderingRedigerbartUtfall {
+            val frivilligSkattetrekk =
+                brevutfall.frivilligSkattetrekk ?: etterbetaling?.frivilligSkattetrekk
+                    ?: throw ManglerFrivilligSkattetrekk(brevutfall.behandlingId)
+
+            return BarnepensjonRevurderingRedigerbartUtfall(
                 erEtterbetaling = etterbetaling != null,
                 harUtbetaling = utbetalingsinfo.beregningsperioder.any { it.utbetaltBeloep.value > 0 },
                 feilutbetaling = toFeilutbetalingType(requireNotNull(brevutfall.feilutbetaling?.valg)),
                 brukerUnder18Aar = requireNotNull(brevutfall.aldersgruppe) == Aldersgruppe.UNDER_18,
+                bosattUtland = utlandstilknytning == UtlandstilknytningType.BOSATT_UTLAND,
+                frivilligSkattetrekk = frivilligSkattetrekk,
             )
+        }
     }
 }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -319,6 +319,7 @@ internal class VedtaksbrevServiceTest {
                 mockk<BrevutfallDto> {
                     every { feilutbetaling?.valg } returns FeilutbetalingValg.JA_VARSEL
                     every { aldersgruppe } returns Aldersgruppe.UNDER_18
+                    every { frivilligSkattetrekk } returns true
                 }
 
             runBlocking {


### PR DESCRIPTION
Utbetalingsavsnittet blir redigerbart så flere parametere må sendes til brevbakeren for dette. Endringer i pensjonsbrev her: https://github.com/navikt/pensjonsbrev/pull/1047
