### PR TITLE
fikse advarsel fra husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 cd ./apps/etterlatte-saksbehandling-ui
 yarn lint-staged --cwd ./client
 yarn lint-staged --cwd ./server


### PR DESCRIPTION
Fjerner denne advarselen:


```
husky - DEPRECATED

Please remove the following two lines from .husky/pre-commit:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.
```