### PR TITLE
OMS-mottaker må hentes som gjenlevende

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/common/klienter/PdlTjenesterKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/common/klienter/PdlTjenesterKlient.kt
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory
 import java.time.LocalDate
 
 interface PdlTjenesterKlient : Pingable {
-    fun hentPdlModellFlereSaktyper(
+    fun hentPdlModellForSaktype(
         foedselsnummer: String,
         rolle: PersonRolle,
         saktype: SakType,
@@ -112,7 +112,7 @@ class PdlTjenesterKlientImpl(
         return response
     }
 
-    override fun hentPdlModellFlereSaktyper(
+    override fun hentPdlModellForSaktype(
         foedselsnummer: String,
         rolle: PersonRolle,
         saktype: SakType,

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
@@ -366,7 +366,7 @@ class GrunnlagsendringshendelseService(
     ) {
         val personRolle = grunnlagsendringshendelse.hendelseGjelderRolle.toPersonrolle(sak.sakType)
         val pdlData =
-            pdltjenesterKlient.hentPdlModellFlereSaktyper(
+            pdltjenesterKlient.hentPdlModellForSaktype(
                 grunnlagsendringshendelse.gjelderPerson,
                 personRolle,
                 sak.sakType,

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
@@ -204,7 +204,7 @@ class DoedshendelseJobService(
 
     private fun hentAnnenForelder(doedshendelse: DoedshendelseInternal): String? =
         pdlTjenesterKlient
-            .hentPdlModellFlereSaktyper(
+            .hentPdlModellForSaktype(
                 foedselsnummer = doedshendelse.beroertFnr,
                 rolle = PersonRolle.BARN,
                 saktype = SakType.BARNEPENSJON,
@@ -238,7 +238,7 @@ class DoedshendelseJobService(
 
     private fun sjekkUnder18aar(doedshendelse: DoedshendelseInternal): Boolean {
         val person =
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 foedselsnummer = doedshendelse.beroertFnr,
                 rolle = PersonRolle.BARN,
                 saktype = SakType.BARNEPENSJON,
@@ -250,14 +250,14 @@ class DoedshendelseJobService(
         val beroertPersonDto =
             when (doedshendelse.sakTypeForEpsEllerBarn()) {
                 SakType.BARNEPENSJON -> {
-                    pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+                    pdlTjenesterKlient.hentPdlModellForSaktype(
                         foedselsnummer = doedshendelse.beroertFnr,
                         rolle = PersonRolle.BARN,
                         saktype = SakType.BARNEPENSJON,
                     )
                 }
                 SakType.OMSTILLINGSSTOENAD -> {
-                    pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+                    pdlTjenesterKlient.hentPdlModellForSaktype(
                         foedselsnummer = doedshendelse.beroertFnr,
                         rolle = PersonRolle.GJENLEVENDE,
                         saktype = SakType.OMSTILLINGSSTOENAD,

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseService.kt
@@ -193,7 +193,7 @@ class DoedshendelseService(
             ?.map {
                 val annenForelder =
                     runBlocking {
-                        pdlTjenesterKlient.hentPdlModellFlereSaktyper(it, PersonRolle.TILKNYTTET_BARN, SakType.OMSTILLINGSSTOENAD)
+                        pdlTjenesterKlient.hentPdlModellForSaktype(it, PersonRolle.TILKNYTTET_BARN, SakType.OMSTILLINGSSTOENAD)
                     }
                 AvdoedOgAnnenForelderMedFellesbarn(avdoed, annenForelder)
             }?.filter { erSamboere(it) }

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktBarnService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktBarnService.kt
@@ -55,7 +55,7 @@ internal class DoedshendelseKontrollpunktBarnService(
                 DoedshendelseKontrollpunkt.AnnenForelderIkkeFunnet
             } else {
                 pdlTjenesterKlient
-                    .hentPdlModellFlereSaktyper(
+                    .hentPdlModellForSaktype(
                         foedselsnummer = annenForelderFnr,
                         rolle = PersonRolle.GJENLEVENDE,
                         saktype = SakType.BARNEPENSJON,

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktService.kt
@@ -103,8 +103,8 @@ class DoedshendelseKontrollpunktService(
     ): Triple<Sak?, PersonDTO, PersonDTO> {
         val sakType = hendelse.sakTypeForEpsEllerBarn()
         val sak = sakService.finnSak(hendelse.beroertFnr, sakType)
-        val avdoed = pdlTjenesterKlient.hentPdlModellFlereSaktyper(hendelse.avdoedFnr, PersonRolle.AVDOED, sakType)
-        val gjenlevende = pdlTjenesterKlient.hentPdlModellFlereSaktyper(hendelse.beroertFnr, beroert, hendelse.sakTypeForEpsEllerBarn())
+        val avdoed = pdlTjenesterKlient.hentPdlModellForSaktype(hendelse.avdoedFnr, PersonRolle.AVDOED, sakType)
+        val gjenlevende = pdlTjenesterKlient.hentPdlModellForSaktype(hendelse.beroertFnr, beroert, hendelse.sakTypeForEpsEllerBarn())
 
         return Triple(sak, avdoed, gjenlevende)
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/inntektsjustering/AarligInntektsjusteringJobbService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/inntektsjustering/AarligInntektsjusteringJobbService.kt
@@ -184,11 +184,6 @@ class AarligInntektsjusteringJobbService(
                 return@inTransaction
             }
 
-            if (opplysningerGjenny.opplysning.vergemaalEllerFremtidsfullmakt?.isNotEmpty() == true) {
-                nyBehandlingOgOppdaterKjoering(sakId, loependeFom, forrigeBehandling, kjoering, VERGEMAAL)
-                return@inTransaction
-            }
-
             oppdaterKjoering(kjoering, KjoeringStatus.KLAR_FOR_OMREGNING, sakId)
             publiserKlarForOmregning(sakId, loependeFom, kjoering)
         } catch (e: Exception) {

--- a/apps/etterlatte-behandling/src/main/kotlin/inntektsjustering/AarligInntektsjusteringJobbService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/inntektsjustering/AarligInntektsjusteringJobbService.kt
@@ -163,17 +163,22 @@ class AarligInntektsjusteringJobbService(
 
             val opplysningerGjenny = hentOpplysningerGjenny(sak, forrigeBehandling.id)
 
+            val opplysningerPdl = hentPdlPersonopplysning(sak)
+
+            if (!opplysningerPdl.vergemaalEllerFremtidsfullmakt.isNullOrEmpty()) {
+                nyBehandlingOgOppdaterKjoering(sakId, loependeFom, forrigeBehandling, kjoering, VERGEMAAL)
+                return@inTransaction
+            }
             val opplysningerErUendretIPdl =
-                hentPdlPersonopplysning(sak).let { opplysningerPdl ->
-                    with(opplysningerGjenny.opplysning) {
-                        fornavn == opplysningerPdl.fornavn.verdi &&
-                            mellomnavn == opplysningerPdl.mellomnavn?.verdi &&
-                            etternavn == opplysningerPdl.etternavn.verdi &&
-                            foedselsdato == opplysningerPdl.foedselsdato?.verdi &&
-                            doedsdato == opplysningerPdl.doedsdato?.verdi &&
-                            vergemaalEllerFremtidsfullmakt == opplysningerPdl.vergemaalEllerFremtidsfullmakt?.map { it.verdi }
-                    }
+                with(opplysningerGjenny.opplysning) {
+                    fornavn == opplysningerPdl.fornavn.verdi &&
+                        mellomnavn == opplysningerPdl.mellomnavn?.verdi &&
+                        etternavn == opplysningerPdl.etternavn.verdi &&
+                        foedselsdato == opplysningerPdl.foedselsdato?.verdi &&
+                        doedsdato == opplysningerPdl.doedsdato?.verdi &&
+                        vergemaalEllerFremtidsfullmakt == opplysningerPdl.vergemaalEllerFremtidsfullmakt?.map { it.verdi }
                 }
+
             if (!opplysningerErUendretIPdl) {
                 nyBehandlingOgOppdaterKjoering(sakId, loependeFom, forrigeBehandling, kjoering, UTDATERTE_PERSONO_INFO)
                 return@inTransaction
@@ -358,7 +363,7 @@ class AarligInntektsjusteringJobbService(
             ?: throw InternfeilException("Fant ikke iverksatt behandling sak=$sakId")
 
     private fun hentPdlPersonopplysning(sak: Sak) =
-        pdlTjenesterKlient.hentPdlModellFlereSaktyper(sak.ident, PersonRolle.INNSENDER, SakType.OMSTILLINGSSTOENAD)
+        pdlTjenesterKlient.hentPdlModellForSaktype(sak.ident, PersonRolle.GJENLEVENDE, SakType.OMSTILLINGSSTOENAD)
 
     private fun hentPdlPersonident(sak: Sak) =
         runBlocking {

--- a/apps/etterlatte-behandling/src/test/kotlin/common/klienter/PdlTjenesterKlientTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/common/klienter/PdlTjenesterKlientTest.kt
@@ -37,7 +37,7 @@ internal class PdlTjenesterKlientTest {
         val pdlService = PdlTjenesterKlientImpl(config, klient)
         val fnr = KONTANT_FOT
         val rolle = PersonRolle.BARN
-        val resultat = pdlService.hentPdlModellFlereSaktyper(fnr.value, rolle, SakType.BARNEPENSJON)
+        val resultat = pdlService.hentPdlModellForSaktype(fnr.value, rolle, SakType.BARNEPENSJON)
         Assertions.assertEquals("Ola", resultat.fornavn.verdi)
         Assertions.assertEquals("Mellom", resultat.mellomnavn?.verdi)
         Assertions.assertEquals("Nordmann", resultat.etternavn.verdi)
@@ -49,7 +49,7 @@ internal class PdlTjenesterKlientTest {
         val pdlService = PdlTjenesterKlientImpl(config, klient)
         val fnr = KONTANT_FOT
         val rolle = PersonRolle.BARN
-        val resultat = pdlService.hentPdlModellFlereSaktyper(fnr.value, rolle, SakType.BARNEPENSJON).hentDoedsdato()
+        val resultat = pdlService.hentPdlModellForSaktype(fnr.value, rolle, SakType.BARNEPENSJON).hentDoedsdato()
         Assertions.assertEquals(mockPerson().doedsdato?.verdi, resultat)
     }
 
@@ -61,7 +61,7 @@ internal class PdlTjenesterKlientTest {
         val pdlService = PdlTjenesterKlientImpl(config, klient)
         val fnr = KONTANT_FOT
         val rolle = PersonRolle.BARN
-        val resultat = pdlService.hentPdlModellFlereSaktyper(fnr.value, rolle, SakType.BARNEPENSJON).hentAnsvarligeForeldre()
+        val resultat = pdlService.hentPdlModellForSaktype(fnr.value, rolle, SakType.BARNEPENSJON).hentAnsvarligeForeldre()
         Assertions.assertEquals(familierelasjon.ansvarligeForeldre, resultat)
     }
 
@@ -73,7 +73,7 @@ internal class PdlTjenesterKlientTest {
         val pdlService = PdlTjenesterKlientImpl(config, klient)
         val fnr = KONTANT_FOT
         val rolle = PersonRolle.BARN
-        val resultat = pdlService.hentPdlModellFlereSaktyper(fnr.value, rolle, SakType.BARNEPENSJON).hentBarn()
+        val resultat = pdlService.hentPdlModellForSaktype(fnr.value, rolle, SakType.BARNEPENSJON).hentBarn()
         Assertions.assertEquals(familierelasjon.barn, resultat)
     }
 
@@ -104,7 +104,7 @@ internal class PdlTjenesterKlientTest {
         val pdlService = PdlTjenesterKlientImpl(config, klient)
         val fnr = KONTANT_FOT
         val rolle = PersonRolle.BARN
-        val resultat = pdlService.hentPdlModellFlereSaktyper(fnr.value, rolle, SakType.BARNEPENSJON).hentUtland()
+        val resultat = pdlService.hentPdlModellForSaktype(fnr.value, rolle, SakType.BARNEPENSJON).hentUtland()
         Assertions.assertEquals(utland, resultat)
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringshendelseServiceTest.kt
@@ -346,7 +346,7 @@ internal class GrunnlagsendringshendelseServiceTest {
             grunnlagshendelsesDao.opprettGrunnlagsendringshendelse(capture(opprettGrunnlagsendringshendelse))
         } returns grunnlagsendringshendelse
 
-        every { pdlService.hentPdlModellFlereSaktyper(any(), any(), SakType.BARNEPENSJON) } returns mockPerson()
+        every { pdlService.hentPdlModellForSaktype(any(), any(), SakType.BARNEPENSJON) } returns mockPerson()
         val opprettedeHendelser =
             grunnlagsendringshendelseService.opprettHendelseAvTypeForPerson(fnr, GrunnlagsendringsType.DOEDSFALL)
         assertEquals(6, opprettedeHendelser.size)
@@ -373,7 +373,7 @@ internal class GrunnlagsendringshendelseServiceTest {
         every {
             sakService.finnSak(sakId)
         } returns sak
-        every { pdlService.hentPdlModellFlereSaktyper(soekerFnr, any(), sak.sakType) } returns
+        every { pdlService.hentPdlModellForSaktype(soekerFnr, any(), sak.sakType) } returns
             mockPerson()
         coEvery { grunnlagKlient.hentGrunnlag(any()) } returns Grunnlag.empty()
         every {
@@ -427,7 +427,7 @@ internal class GrunnlagsendringshendelseServiceTest {
         every {
             sakService.finnSak(sakId)
         } returns sak
-        every { pdlService.hentPdlModellFlereSaktyper(soekerFnr, any(), sak.sakType) } returns
+        every { pdlService.hentPdlModellForSaktype(soekerFnr, any(), sak.sakType) } returns
             mockPerson()
         coEvery { grunnlagKlient.hentGrunnlag(any()) } returns Grunnlag.empty()
         every {
@@ -487,7 +487,7 @@ internal class GrunnlagsendringshendelseServiceTest {
             sakService.finnSak(sakId)
         } returns Sak(soekerFnr, SakType.OMSTILLINGSSTOENAD, sakId, Enheter.defaultEnhet.enhetNr)
 
-        every { pdlService.hentPdlModellFlereSaktyper(soekerFnr, any(), SakType.OMSTILLINGSSTOENAD) } returns
+        every { pdlService.hentPdlModellForSaktype(soekerFnr, any(), SakType.OMSTILLINGSSTOENAD) } returns
             mockPerson()
         coEvery { grunnlagKlient.hentGrunnlag(any()) } returns Grunnlag.empty()
         every {
@@ -527,7 +527,7 @@ internal class GrunnlagsendringshendelseServiceTest {
                 postnr = "2040",
                 adresseLinje1 = "Furukollveien 189",
             )
-        every { pdlService.hentPdlModellFlereSaktyper(gjenlevendeFnr, any(), SakType.BARNEPENSJON) } returns
+        every { pdlService.hentPdlModellForSaktype(gjenlevendeFnr, any(), SakType.BARNEPENSJON) } returns
             mockPerson()
                 .copy(bostedsadresse = listOf(OpplysningDTO(bostedAdresse, "adresse")))
         coEvery { grunnlagKlient.hentGrunnlag(any()) } returns Grunnlag.empty()
@@ -653,7 +653,7 @@ internal class GrunnlagsendringshendelseServiceTest {
 
         coVerify(exactly = 1) { grunnlagKlient.hentAlleSakIder(adressebeskyttelse.fnr) }
 
-        every { pdlService.hentPdlModellFlereSaktyper(any(), any(), SakType.BARNEPENSJON) } returns mockPerson()
+        every { pdlService.hentPdlModellForSaktype(any(), any(), SakType.BARNEPENSJON) } returns mockPerson()
 
         sakIder.forEach {
             verify(exactly = 1) {
@@ -701,7 +701,7 @@ internal class GrunnlagsendringshendelseServiceTest {
         coVerify(exactly = 1) { grunnlagKlient.hentAlleSakIder(adressebeskyttelse.fnr) }
         verify(exactly = 2) { sakService.finnSak(any()) }
 
-        every { pdlService.hentPdlModellFlereSaktyper(any(), any(), SakType.BARNEPENSJON) } returns mockPerson()
+        every { pdlService.hentPdlModellForSaktype(any(), any(), SakType.BARNEPENSJON) } returns mockPerson()
 
         verify(exactly = 0) {
             sakService.oppdaterAdressebeskyttelse(
@@ -796,7 +796,7 @@ internal class GrunnlagsendringshendelseServiceTest {
         every {
             oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
         } returns mockOppgave
-        every { pdlService.hentPdlModellFlereSaktyper(any(), any(), SakType.BARNEPENSJON) } returns mockPerson()
+        every { pdlService.hentPdlModellForSaktype(any(), any(), SakType.BARNEPENSJON) } returns mockPerson()
         every { behandlingService.hentBehandlingerForSak(any()) } returns emptyList()
 
         coEvery { grunnlagKlient.hentGrunnlag(sakId) } returns Grunnlag.empty()

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobServiceTest.kt
@@ -73,7 +73,7 @@ class DoedshendelseJobServiceTest {
 
     private val pdlTjenesterKlient =
         mockk<PdlTjenesterKlient> {
-            every { hentPdlModellFlereSaktyper(any(), any(), SakType.BARNEPENSJON) } returns mockPerson()
+            every { hentPdlModellForSaktype(any(), any(), SakType.BARNEPENSJON) } returns mockPerson()
         }
 
     private val krrKlient =

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseServiceTest.kt
@@ -123,7 +123,7 @@ internal class DoedshendelseServiceTest {
         } returns avdoed.copy(avdoedesBarn = listOf(fellesbarn, fellesbarn), bostedsadresse = bostedsadresse)
 
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 annenForelder.value,
                 PersonRolle.TILKNYTTET_BARN,
                 SakType.OMSTILLINGSSTOENAD,
@@ -220,7 +220,7 @@ internal class DoedshendelseServiceTest {
             )
 
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 annenForelder.value,
                 PersonRolle.TILKNYTTET_BARN,
                 SakType.OMSTILLINGSSTOENAD,
@@ -328,7 +328,7 @@ internal class DoedshendelseServiceTest {
             )
 
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 annenForelder.value,
                 PersonRolle.TILKNYTTET_BARN,
                 SakType.OMSTILLINGSSTOENAD,

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktBarnServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktBarnServiceTest.kt
@@ -35,14 +35,14 @@ class DoedshendelseKontrollpunktBarnServiceTest {
     @Test
     fun `Skal opprette kontrollpunkt ved samtidig doedsfall`() {
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 foedselsnummer = KONTANT_FOT.value,
                 rolle = PersonRolle.AVDOED,
                 saktype = SakType.BARNEPENSJON,
             )
         } returns avdoed
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 foedselsnummer = JOVIAL_LAMA.value,
                 rolle = PersonRolle.GJENLEVENDE,
                 saktype = SakType.BARNEPENSJON,
@@ -57,14 +57,14 @@ class DoedshendelseKontrollpunktBarnServiceTest {
     @Test
     fun `Skal opprette kontrollpunkt dersom vi ikke finner den andre forelderen`() {
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 foedselsnummer = KONTANT_FOT.value,
                 rolle = PersonRolle.AVDOED,
                 saktype = SakType.BARNEPENSJON,
             )
         } returns avdoed
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 foedselsnummer = JOVIAL_LAMA.value,
                 rolle = PersonRolle.GJENLEVENDE,
                 saktype = SakType.BARNEPENSJON,
@@ -91,14 +91,14 @@ class DoedshendelseKontrollpunktBarnServiceTest {
     @Test
     fun `Skal opprette kontrollpunkt ved iverksatt vedtak`() {
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 foedselsnummer = KONTANT_FOT.value,
                 rolle = PersonRolle.AVDOED,
                 saktype = SakType.BARNEPENSJON,
             )
         } returns avdoed
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 foedselsnummer = JOVIAL_LAMA.value,
                 rolle = PersonRolle.GJENLEVENDE,
                 saktype = SakType.BARNEPENSJON,
@@ -115,14 +115,14 @@ class DoedshendelseKontrollpunktBarnServiceTest {
     @Test
     fun `Skal ikke opprette kontrollpunkt ved dersom det kun eksisterer en sak`() {
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 foedselsnummer = KONTANT_FOT.value,
                 rolle = PersonRolle.AVDOED,
                 saktype = SakType.BARNEPENSJON,
             )
         } returns avdoed
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 foedselsnummer = JOVIAL_LAMA.value,
                 rolle = PersonRolle.GJENLEVENDE,
                 saktype = SakType.BARNEPENSJON,

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktServiceTest.kt
@@ -85,7 +85,7 @@ class DoedshendelseKontrollpunktServiceTest {
 
         every { behandlingService.hentSisteIverksatte(any()) } returns null
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 foedselsnummer = doedshendelseInternalBP.avdoedFnr,
                 rolle = PersonRolle.AVDOED,
                 saktype = any(),
@@ -96,7 +96,7 @@ class DoedshendelseKontrollpunktServiceTest {
                 doedsdato = OpplysningDTO(doedshendelseInternalBP.avdoedDoedsdato, null),
             )
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 foedselsnummer = doedshendelseInternalBP.beroertFnr,
                 rolle = PersonRolle.BARN,
                 saktype = SakType.BARNEPENSJON,
@@ -115,7 +115,7 @@ class DoedshendelseKontrollpunktServiceTest {
                     ),
             )
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 foedselsnummer = JOVIAL_LAMA.value,
                 rolle = PersonRolle.GJENLEVENDE,
                 saktype = SakType.BARNEPENSJON,
@@ -156,7 +156,7 @@ class DoedshendelseKontrollpunktServiceTest {
             )
         } returns foerstegangsbehandling(sakId = sak.id, status = BehandlingStatus.IVERKSATT)
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 foedselsnummer = doedshendelseInternalBP.avdoedFnr,
                 rolle = PersonRolle.AVDOED,
                 saktype = any(),
@@ -194,7 +194,7 @@ class DoedshendelseKontrollpunktServiceTest {
         } returns listOf(sak)
         every { behandlingService.hentSisteIverksatte(sak.id) } returns null
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 foedselsnummer = doedshendelseInternalBP.avdoedFnr,
                 rolle = PersonRolle.AVDOED,
                 saktype = any(),
@@ -231,7 +231,7 @@ class DoedshendelseKontrollpunktServiceTest {
         } returns emptyList()
 
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 foedselsnummer = doedshendelseInternalBP.avdoedFnr,
                 rolle = PersonRolle.AVDOED,
                 saktype = any(),
@@ -274,7 +274,7 @@ class DoedshendelseKontrollpunktServiceTest {
             )
         } returns foerstegangsbehandling(sakId = sakIdd, status = BehandlingStatus.IVERKSATT)
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 foedselsnummer = doedshendelseInternalAvdoed.avdoedFnr,
                 rolle = PersonRolle.AVDOED,
                 saktype = any(),
@@ -360,7 +360,7 @@ class DoedshendelseKontrollpunktServiceTest {
     @Test
     fun `Skal gi kontrollpunkt dersom gjenlevende ikke har aktiv adresse`() {
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 foedselsnummer = doedshendelseInternalBP.beroertFnr,
                 rolle = PersonRolle.BARN,
                 saktype = SakType.BARNEPENSJON,

--- a/apps/etterlatte-behandling/src/test/kotlin/inntektsjustering/AarligInntektsjusteringJobbServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/inntektsjustering/AarligInntektsjusteringJobbServiceTest.kt
@@ -172,19 +172,6 @@ class AarligInntektsjusteringJobbServiceTest {
             personPdl.copy(etternavn = OpplysningDTO("endret etternavn", "")),
             personPdl.copy(foedselsdato = OpplysningDTO(LocalDate.of(1990, 2, 25), "")),
             personPdl.copy(doedsdato = OpplysningDTO(LocalDate.of(1990, 2, 25), "")),
-            personPdl.copy(
-                vergemaalEllerFremtidsfullmakt =
-                    listOf(
-                        OpplysningDTO(
-                            VergemaalEllerFremtidsfullmakt(
-                                embete = null,
-                                type = null,
-                                vergeEllerFullmektig = VergeEllerFullmektig(null, null, null, null, null),
-                            ),
-                            "",
-                        ),
-                    ),
-            ),
         )
 
     @Test

--- a/apps/etterlatte-behandling/src/test/kotlin/inntektsjustering/AarligInntektsjusteringJobbServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/inntektsjustering/AarligInntektsjusteringJobbServiceTest.kt
@@ -112,7 +112,7 @@ class AarligInntektsjusteringJobbServiceTest {
                 Folkeregisteridentifikator.of(fnrGyldigSak),
             )
         coEvery {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 any(),
                 any(),
                 SakType.OMSTILLINGSSTOENAD,
@@ -506,7 +506,7 @@ class AarligInntektsjusteringJobbServiceTest {
             )
 
         coEvery {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 any(),
                 any(),
                 SakType.OMSTILLINGSSTOENAD,
@@ -561,7 +561,7 @@ class AarligInntektsjusteringJobbServiceTest {
             }
 
         coEvery {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellForSaktype(
                 any(),
                 any(),
                 SakType.OMSTILLINGSSTOENAD,

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
@@ -614,7 +614,7 @@ class KodeverkKlientTest : KodeverkKlient {
 }
 
 class PdltjenesterKlientTest : PdlTjenesterKlient {
-    override fun hentPdlModellFlereSaktyper(
+    override fun hentPdlModellForSaktype(
         foedselsnummer: String,
         rolle: PersonRolle,
         saktype: SakType,


### PR DESCRIPTION
Renamer også funksjonen i PdlKlient til noe mer sensible for henting med kun en saktype