### PR TITLE
Støtter revurdering med tidligere familiepleier

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -21,7 +21,6 @@ import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.RevurderingInfo
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
-import no.nav.etterlatte.libs.common.behandling.TidligereFamiliepleier
 import no.nav.etterlatte.libs.common.behandling.Utlandstilknytning
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
@@ -162,7 +161,6 @@ class RevurderingService(
         frist: Tidspunkt? = null,
         paaGrunnAvOppgave: UUID? = null,
         opphoerFraOgMed: YearMonth? = null,
-        tidligereFamiliepleier: TidligereFamiliepleier? = null,
     ): RevurderingOgOppfoelging =
         OpprettBehandling(
             type = BehandlingType.REVURDERING,
@@ -180,9 +178,14 @@ class RevurderingService(
             relatertBehandlingId = relatertBehandlingId,
             sendeBrev = revurderingAarsak.skalSendeBrev,
             opphoerFraOgMed = opphoerFraOgMed,
-            tidligereFamiliepleier = tidligereFamiliepleier,
+            tidligereFamiliepleier = null,
         ).let { opprettBehandling ->
             behandlingDao.opprettBehandling(opprettBehandling)
+
+            val tidligereFamiliepleier = forrigeBehandling?.let { behandlingDao.hentTidligereFamiliepleier(it) }
+            if (tidligereFamiliepleier != null) {
+                behandlingDao.lagreTidligereFamiliepleier(opprettBehandling.id, tidligereFamiliepleier)
+            }
 
             if (!fritekstAarsak.isNullOrEmpty()) {
                 lagreRevurderingsaarsakFritekst(fritekstAarsak, opprettBehandling.id, saksbehandlerIdent)

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
@@ -1010,6 +1010,7 @@ class BehandlingFactoryTest {
         verify {
             oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
             oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
+            behandlingDaoMock.hentTidligereFamiliepleier(any())
         }
         coVerify { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) }
         verify(exactly = 2) {

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
@@ -994,6 +994,7 @@ class BehandlingFactoryTest {
                 revurderingAarsak = Revurderingaarsak.NY_SOEKNAD,
                 enhet = Enheter.defaultEnhet.enhetNr,
             )
+        every { behandlingDaoMock.hentTidligereFamiliepleier(any()) } returns null
 
         val revurderingsBehandling =
             behandlingFactory

--- a/apps/etterlatte-behandling/src/test/kotlin/inntektsjustering/AarligInntektsjusteringJobbServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/inntektsjustering/AarligInntektsjusteringJobbServiceTest.kt
@@ -153,7 +153,6 @@ class AarligInntektsjusteringJobbServiceTest {
                 any(),
                 any(),
                 any(),
-                any(),
             )
         } returns
             mockk {
@@ -213,7 +212,6 @@ class AarligInntektsjusteringJobbServiceTest {
                 frist = any(),
                 paaGrunnAvOppgave = any(),
                 opphoerFraOgMed = any(),
-                tidligereFamiliepleier = any(),
             )
         }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/Revurderingsoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/revurderingsoversikt/Revurderingsoversikt.tsx
@@ -43,6 +43,7 @@ import { usePersonopplysninger } from '~components/person/usePersonopplysninger'
 import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
 import { RevurderingKravpakke } from '~components/behandling/revurderingsoversikt/RevurderingKravpakke'
 import { ViderefoereOpphoer } from '~components/behandling/soeknadsoversikt/viderefoere-opphoer/ViderefoereOpphoer'
+import { TidligereFamiliepleier } from '~components/behandling/soeknadsoversikt/tidligereFamiliepleier/TidligereFamiliepleier'
 
 const revurderingsaarsakTilTekst = (revurderingsaarsak: Revurderingaarsak): string =>
   tekstRevurderingsaarsak[revurderingsaarsak]
@@ -169,6 +170,9 @@ export const Revurderingsoversikt = (props: { behandling: IDetaljertBehandling }
           {{ info: <GrunnlagForVirkningstidspunkt /> }}
         </Virkningstidspunkt>
 
+        {behandling.sakType == SakType.OMSTILLINGSSTOENAD && (
+          <TidligereFamiliepleier behandling={behandling} redigerbar={redigerbar} />
+        )}
         <ViderefoereOpphoer behandling={behandling} redigerbar={redigerbar} />
       </Box>
       <Box paddingBlock="4 0" borderWidth="1 0 0 0" borderColor="border-subtle">


### PR DESCRIPTION
Tror jeg kanskje i alle fall, dette er en veldig naiv håndtering

(Vi vil gjerne dobbeltsjekke at vi har riktig håndtering for årlig inntektsjusteringsjobb nå når vi tester og dette mangler, men det skal ikke være noen som skal få det årlige inntektsjusteringsbrevet for tidligere familiepleier i årets kjøring. Dette fordi det skal ha vært påkrevd inntekt for neste år i førstegangsbehandling OMS før noen tidligere familiepleier-saker ble innvilget)