### PR TITLE
EY-4704: Forbedrer visning av hendelsesoppgave

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/hendelser/HendelseBeskrivelse.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/hendelser/HendelseBeskrivelse.tsx
@@ -6,6 +6,7 @@ import {
   formaterRolle,
   grunnlagsendringsBeskrivelse,
   grunnlagsendringsKilde,
+  ufoeretrygdVedtakstypeBeskrivelse,
 } from '~components/person/hendelser/utils'
 import {
   AdresseSamsvar,
@@ -17,11 +18,12 @@ import {
   InstitusjonsoppholdSamsvar,
   Sivilstand,
   SivilstandSamsvar,
+  UfoereHendelse,
   UtlandSamsvar,
   VergemaalEllerFremtidsfullmakt,
   VergemaalEllerFremtidsfullmaktForholdSamsvar,
 } from '~components/person/typer'
-import { formaterKanskjeStringDatoMedFallback, formaterDato } from '~utils/formatering/dato'
+import { formaterDato, formaterKanskjeStringDatoMedFallback } from '~utils/formatering/dato'
 import styled from 'styled-components'
 import { BodyShort, Label, VStack } from '@navikt/ds-react'
 import { Adressevisning } from '~components/behandling/felles/Adressevisning'
@@ -188,6 +190,22 @@ const VisSivilstand = ({ samsvar }: { samsvar: SivilstandSamsvar }) => {
   )
 }
 
+const Ufoeretrygd = (props: { hendelse: UfoereHendelse }) => {
+  const hendelse = props.hendelse
+  return (
+    <>
+      <div>
+        <Label>Vedtakstype</Label>
+        <KortTekst>{ufoeretrygdVedtakstypeBeskrivelse[hendelse.vedtaksType]}</KortTekst>
+      </div>
+      <div>
+        <Label>Virkningstidspunkt</Label>
+        <KortTekst>{formaterDato(hendelse.virkningsdato)}</KortTekst>
+      </div>
+    </>
+  )
+}
+
 const Institusjonsopphold = (props: { samsvar: InstitusjonsoppholdSamsvar }) => {
   const { samsvar } = props
   return (
@@ -336,6 +354,14 @@ export const HendelseBeskrivelse = ({
         <VStack gap="4">
           <HendelseDetaljer sakType={sakType} hendelse={hendelse} />
           <Institusjonsopphold samsvar={hendelse.samsvarMellomKildeOgGrunnlag} />
+          <HendelseKommentar kommentar={hendelse.kommentar} />
+        </VStack>
+      )
+    case 'UFOERETRYGD':
+      return (
+        <VStack gap="4">
+          <HendelseDetaljer sakType={sakType} hendelse={hendelse} />
+          <Ufoeretrygd hendelse={hendelse.samsvarMellomKildeOgGrunnlag.hendelse} />
           <HendelseKommentar kommentar={hendelse.kommentar} />
         </VStack>
       )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/hendelser/utils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/hendelser/utils.ts
@@ -4,6 +4,7 @@ import {
   GrunnlagsendringsType,
   IBehandlingsammendrag,
   Saksrolle,
+  UfoeretrygdVedtakstype,
 } from '~components/person/typer'
 import { formaterKanskjeStringDatoMedFallback } from '~utils/formatering/dato'
 import React from 'react'
@@ -38,7 +39,7 @@ export const grunnlagsendringsBeskrivelse: Record<GrunnlagendringshendelseSamsva
   INSTITUSJONSOPPHOLD: 'institusjonsopphold',
   ADRESSE: 'fått ny geografisk tilknytning men saken kunne ikke flyttes på grunn av åpen behandling',
   FOLKEREGISTERIDENTIFIKATOR: 'endring av folkeregisteridentifikator',
-  UFOERETRYGD: 'uføretrygd',
+  UFOERETRYGD: 'et nytt vedtak om uføretrygd',
 }
 
 export const grunnlagsendringsKilde = (type: GrunnlagendringshendelseSamsvarType): string => {
@@ -99,6 +100,12 @@ export const formaterRolle = (sakType: SakType, rolle: Saksrolle) => {
     case 'UKJENT':
       return 'Ukjent person i saken'
   }
+}
+
+export const ufoeretrygdVedtakstypeBeskrivelse: Record<UfoeretrygdVedtakstype, string> = {
+  INNV: 'Innvilgelse',
+  ENDR: 'Endring',
+  OPPH: 'Opphør',
 }
 
 export const formaterLandList = (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/typer.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/typer.tsx
@@ -152,6 +152,14 @@ export interface UfoeretrygdSamsvar {
 
 export interface UfoereHendelse {
   personIdent: string
+  virkningsdato: string
+  vedtaksType: UfoeretrygdVedtakstype
+}
+
+export enum UfoeretrygdVedtakstype {
+  INNV = 'INNV',
+  OPPH = 'OPPH',
+  ENDR = 'ENDR',
 }
 
 interface InstitusjonsoppholdHendelseBeriket {


### PR DESCRIPTION
Får inn litt info om hendelsen når saksbehandler viser den.

![Screenshot 2024-11-19 at 09 43 53](https://github.com/user-attachments/assets/b2b1eca7-2696-4b5f-b606-dd25f3a26671)
