### PR TITLE
Endrer log-level for ulik versjon av grunnlag til warn

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/grunnlag/GrunnlagVersjonValidering.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/grunnlag/GrunnlagVersjonValidering.kt
@@ -39,7 +39,7 @@ object GrunnlagVersjonValidering {
         if (vilkaarsvurdering?.grunnlagVersjon == null || beregningOgAvkorting == null) {
             logger.info("Vilkaar og/eller beregning er null – fortsetter ...")
         } else if (vilkaarsvurdering.grunnlagVersjon != beregningOgAvkorting.beregning.grunnlagMetadata.versjon) {
-            logger.error(
+            logger.warn(
                 "Ulik versjon av grunnlag i vilkaarsvurdering (versjon=${vilkaarsvurdering.grunnlagVersjon})" +
                     " og beregning (versjon=${beregningOgAvkorting.beregning.grunnlagMetadata.versjon}) ",
             )


### PR DESCRIPTION
Her får bruker en god feilmelding som sier hva som må fikses. Tenker det holder med warn i loggene våre her. 

Brukers feilmelding:  `Ulik versjon av grunnlag brukt i vilkårsvurdering og beregning. Gå tilbake til søknadsoversikten og trykk oppdater grunnlag, deretter må totalvurderingen i vilkårsvurderingen gjøres på nytt.`