### PR TITLE
Sjekker om uuid er gyldig før hendelse for statistikk opprettes fra oppgave

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
@@ -76,7 +76,7 @@ class TilbakekrevingService(
 
             val oppgaveFraBehandlingMedFeilutbetaling =
                 oppgaveService
-                    .hentOppgaverForReferanse(kravgrunnlag.sakId.value.toString())
+                    .hentOppgaverForSak(sak.id)
                     .filter { it.type == OppgaveType.TILBAKEKREVING }
                     .filter { !it.erAvsluttet() }
                     .maxByOrNull { it.opprettet }

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -198,17 +198,23 @@ class OppgaveService(
                 OppgaveType.TILBAKEKREVING,
                 OppgaveType.KLAGE,
                 -> {
-                    if (nyStatus == Status.PAA_VENT) {
-                        hendelser.sendMeldingForHendelsePaaVent(
-                            UUID.fromString(oppgave.referanse),
-                            BehandlingHendelseType.PAA_VENT,
-                            aarsak!!,
-                        )
-                    } else {
-                        hendelser.sendMeldingForHendelseAvVent(
-                            UUID.fromString(oppgave.referanse),
-                            BehandlingHendelseType.AV_VENT,
-                        )
+                    // Oppgaver for tilbakekreving har referanse som er sakId og ikke behandlingId (uuid) inntil
+                    // kravgrunnlag mottas og tilbakekrevingsbehandlingen opprettes. Disse er derfor ikke relevante her
+                    // før dette inntreffer og vi kan få en gyldig uuid fra behandlingen.
+                    val behandlingId = safeUUIDFromString(oppgave.referanse)
+                    if (behandlingId != null) {
+                        if (nyStatus == Status.PAA_VENT) {
+                            hendelser.sendMeldingForHendelsePaaVent(
+                                UUID.fromString(oppgave.referanse),
+                                BehandlingHendelseType.PAA_VENT,
+                                aarsak!!,
+                            )
+                        } else {
+                            hendelser.sendMeldingForHendelseAvVent(
+                                UUID.fromString(oppgave.referanse),
+                                BehandlingHendelseType.AV_VENT,
+                            )
+                        }
                     }
                 }
 
@@ -693,6 +699,13 @@ class OppgaveService(
             }
         }
     }
+
+    private fun safeUUIDFromString(value: String): UUID? =
+        try {
+            UUID.fromString(value)
+        } catch (e: Exception) {
+            null
+        }
 }
 
 class BrukerManglerAttestantRolleException(


### PR DESCRIPTION
Det oppstod en feil ved at det ble forsøkt sendt en hendelse til statistikk når det ikke ennå er opprettet en tilbakekrevingsbehandling. Dette gir ikke mening før kravgrunnlaget er mottatt og behandlingen er opprettet. Gjør derfor en sjekk om referansen er en UUID for å unngå at det feiler.

Fikser også en annen potensiell bug ved at det hentes ut tilbakekrevingsoppgaver basert på referanse, hvor det i stedet kan hentes basert på sakId som er et eget felt på oppgave.

Ref:
https://logs.adeo.no/app/discover#/?_g=(time:(from:now-24h%2Fh,to:now))&_a=(columns:!(level,message,envclass,application,pod),dataSource:(dataViewId:'96e648c0-980a-11e9-830a-e17bbd64b4db',type:dataView),filters:!(),hideChart:!f,interval:auto,query:(language:lucene,query:'x_correlation_id:8005b448-3afc-4ca5-b00e-7b2c05bd1740'),sort:!(!('@timestamp',desc)))