### PR TITLE
EY-4562 Sjekker alle identer på person ved henting av sak

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
@@ -18,6 +18,7 @@ import no.nav.etterlatte.libs.common.behandling.Flyktning
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
+import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.NyeSaksopplysninger
@@ -160,8 +161,13 @@ class SakServiceImpl(
     ) = finnSakerForPerson(ident, sakType).let {
         if (it.isEmpty()) {
             null
-        } else {
+        } else if (it.size == 1) {
             it.single()
+        } else {
+            throw InternfeilException(
+                "Personen har flere saker (${it.joinToString()} av type $sakType. " +
+                    "Dette må meldes i Porten for manuell kontroll og opprydding.",
+            )
         }
     }
 
@@ -188,7 +194,13 @@ class SakServiceImpl(
     private fun finnSakerForPerson(
         ident: String,
         sakType: SakType? = null,
-    ) = lesDao.finnSaker(ident, sakType)
+    ): List<Sak> =
+        runBlocking {
+            pdltjenesterKlient
+                .hentPdlFolkeregisterIdenter(ident)
+                .identifikatorer
+                .flatMap { lesDao.finnSaker(it.folkeregisterident.value, sakType) }
+        }
 
     override fun markerSakerMedSkjerming(
         sakIder: List<SakId>,

--- a/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattRouteTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattRouteTest.kt
@@ -33,7 +33,7 @@ import no.nav.etterlatte.libs.common.skjermet.EgenAnsattSkjermet
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.ktor.route.FoedselsnummerDTO
-import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
+import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import no.nav.etterlatte.module
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
@@ -59,7 +59,7 @@ class EgenAnsattRouteTest : BehandlingIntegrationTest() {
 
     @Test
     fun `Skal kunne sette på skjerming og få satt ny enhet`() {
-        val fnr = AVDOED_FOEDSELSNUMMER.value
+        val fnr = SOEKER_FOEDSELSNUMMER.value
 
         testApplication {
             val client =
@@ -161,7 +161,7 @@ class EgenAnsattRouteTest : BehandlingIntegrationTest() {
 
     @Test
     fun `Skal ikke sette skjerming hvis adressebeskyttet, og da beholde 2103 som enhet`() {
-        val fnr = AVDOED_FOEDSELSNUMMER.value
+        val fnr = SOEKER_FOEDSELSNUMMER.value
 
         testApplication {
             val client =

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
@@ -59,6 +59,7 @@ import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 import no.nav.etterlatte.libs.common.person.GeografiskTilknytning
 import no.nav.etterlatte.libs.common.person.HentAdressebeskyttelseRequest
 import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
+import no.nav.etterlatte.libs.common.person.PdlFolkeregisterIdentListe
 import no.nav.etterlatte.libs.common.person.PdlIdentifikator
 import no.nav.etterlatte.libs.common.person.Person
 import no.nav.etterlatte.libs.common.person.PersonRolle
@@ -79,6 +80,7 @@ import no.nav.etterlatte.libs.ktor.route.SakTilgangsSjekk
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
+import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import no.nav.etterlatte.oppgaveGosys.EndreStatusRequest
 import no.nav.etterlatte.oppgaveGosys.GosysApiOppgave
 import no.nav.etterlatte.oppgaveGosys.GosysOppgaveKlient
@@ -641,6 +643,11 @@ class PdltjenesterKlientTest : PdlTjenesterKlient {
     override suspend fun hentPdlIdentifikator(ident: String): PdlIdentifikator? {
         TODO("Not yet implemented")
     }
+
+    override suspend fun hentPdlFolkeregisterIdenter(ident: String): PdlFolkeregisterIdentListe =
+        PdlFolkeregisterIdentListe(
+            listOf(PdlIdentifikator.FolkeregisterIdent(SOEKER_FOEDSELSNUMMER)),
+        )
 
     override suspend fun hentAdressebeskyttelseForPerson(
         hentAdressebeskyttelseRequest: HentAdressebeskyttelseRequest,


### PR DESCRIPTION
- Henter alle identer tilknyttet person i PDL
- Henter så alle saker tilknyttet alle identer. 
- Hvis det finnes flere saker av samme type, kastes `InternfeilException`

Dette sikrer at det ikke opprettes flere saker på samme person, selv om ident er ulik. 