### PR TITLE
EY-4778: Tillater midlertidig lagring av skjema uten at resultat og skyld er satt

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderSkjema.tsx
@@ -189,7 +189,7 @@ export function TilbakekrevingVurderingPerioderSkjema({
                     <Table.DataCell key="skyld">
                       <Select
                         {...register(`values.${index}.ytelse.skyld`, {
-                          setValueAs: (value) => (value === '' ? null : value),
+                          setValueAs: (value) => (!!value ? value : null),
                         })}
                         label="Skyld"
                         hideLabel={true}
@@ -205,7 +205,7 @@ export function TilbakekrevingVurderingPerioderSkjema({
                     <Table.DataCell key="resultat">
                       <Select
                         {...register(`values.${index}.ytelse.resultat`, {
-                          setValueAs: (value) => (value === '' ? null : value),
+                          setValueAs: (value) => (!!value ? value : null),
                         })}
                         label="Resultat"
                         hideLabel={true}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderSkjema.tsx
@@ -187,7 +187,13 @@ export function TilbakekrevingVurderingPerioderSkjema({
                       />
                     </Table.DataCell>
                     <Table.DataCell key="skyld">
-                      <Select {...register(`values.${index}.ytelse.skyld`)} label="Skyld" hideLabel={true}>
+                      <Select
+                        {...register(`values.${index}.ytelse.skyld`, {
+                          setValueAs: (value) => (value === '' ? null : value),
+                        })}
+                        label="Skyld"
+                        hideLabel={true}
+                      >
                         <option value="">Velg..</option>
                         {Object.values(TilbakekrevingSkyld).map((skyld) => (
                           <option key={skyld} value={skyld}>
@@ -199,15 +205,10 @@ export function TilbakekrevingVurderingPerioderSkjema({
                     <Table.DataCell key="resultat">
                       <Select
                         {...register(`values.${index}.ytelse.resultat`, {
-                          validate: (value) => {
-                            return value
-                              ? Object.values(TilbakekrevingResultat).includes(value) || `Feil type: ${value}`
-                              : 'Må velge verdi'
-                          },
+                          setValueAs: (value) => (value === '' ? null : value),
                         })}
                         label="Resultat"
                         hideLabel={true}
-                        error={errors.values && errors.values[index]?.ytelse?.resultat?.message}
                       >
                         <option value="">Velg..</option>
                         {Object.values(TilbakekrevingResultat).map((resultat) => (


### PR DESCRIPTION
Valideringen som var lagt inn gjorde at det ikke var mulig å lagre et halvferdig skjema. Dette skal være mulig for tilbakekreving da det kan være mange perioder og det kan ta litt tid før man får ferdigstillt alle periodene.