### PR TITLE
EY-4779: flytter validering attesteringsvalg

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/attestering/attesteringEllerUnderkjenning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/attestering/attestering/attesteringEllerUnderkjenning.tsx
@@ -1,8 +1,7 @@
-import { BehandlingRouteContext } from '~components/behandling/BehandlingRoutes'
 import { IBeslutning } from '../types'
 import { Beslutningsvalg } from './beslutningsvalg'
 import { Alert, BodyShort, VStack } from '@navikt/ds-react'
-import { useContext, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { SidebarPanel } from '~shared/components/Sidebar'
 import { VedtakSammendrag } from '~components/vedtak/typer'
 import { useSelectorOppgaveUnderBehandling } from '~store/selectors/useSelectorOppgaveUnderBehandling'
@@ -14,10 +13,16 @@ type Props = {
   beslutning: IBeslutning | undefined
   vedtak?: VedtakSammendrag
   erFattet: boolean
+  gyldigStegForBeslutning: boolean
 }
 
-export const AttesteringEllerUnderkjenning = ({ setBeslutning, beslutning, vedtak, erFattet }: Props) => {
-  const { lastPage } = useContext(BehandlingRouteContext)
+export const AttesteringEllerUnderkjenning = ({
+  setBeslutning,
+  beslutning,
+  vedtak,
+  erFattet,
+  gyldigStegForBeslutning,
+}: Props) => {
   const oppgave = useSelectorOppgaveUnderBehandling()
   const innloggetSaksbehandler = useInnloggetSaksbehandler()
 
@@ -42,7 +47,7 @@ export const AttesteringEllerUnderkjenning = ({ setBeslutning, beslutning, vedta
             </Alert>
           )}
 
-          {lastPage ? (
+          {gyldigStegForBeslutning ? (
             <Beslutningsvalg
               beslutning={beslutning}
               setBeslutning={setBeslutning}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sidemeny/BehandlingSidemeny.tsx
@@ -1,7 +1,7 @@
 import { Behandlingsoppsummering } from '~components/behandling/attestering/oppsummering/oppsummering'
 import { AttesteringEllerUnderkjenning } from '~components/behandling/attestering/attestering/attesteringEllerUnderkjenning'
 import AnnullerBehandling from '~components/behandling/handlinger/AnnullerBehanding'
-import React, { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { IBeslutning } from '~components/behandling/attestering/types'
 import { BehandlingFane, IBehandlingInfo } from '~components/behandling/sidemeny/IBehandlingInfo'
 import {
@@ -39,6 +39,7 @@ import { useOppgaveUnderBehandling } from '~shared/hooks/useOppgaveUnderBehandli
 import { OppgaveEndring } from './OppgaveEndring'
 import { NotatPanel } from '~components/behandling/sidemeny/NotatPanel'
 import { useFeatureEnabledMedDefault } from '~shared/hooks/useFeatureToggle'
+import { BehandlingRouteContext } from '~components/behandling/BehandlingRoutes'
 
 const finnUtNasjonalitet = (behandling: IBehandlingReducer): UtlandstilknytningType | null => {
   if (behandling.utlandstilknytning?.type) {
@@ -67,6 +68,7 @@ const mapTilBehandlingInfo = (behandling: IBehandlingReducer, vedtak: VedtakSamm
 })
 
 export const BehandlingSidemeny = ({ behandling }: { behandling: IBehandlingReducer }) => {
+  const { lastPage } = useContext(BehandlingRouteContext)
   const soeker = usePersonopplysninger()?.soeker?.opplysning
   const vedtak = useVedtak()
   const dispatch = useAppDispatch()
@@ -141,6 +143,7 @@ export const BehandlingSidemeny = ({ behandling }: { behandling: IBehandlingRedu
                     beslutning={beslutning}
                     vedtak={vedtak}
                     erFattet={behandling.status === IBehandlingStatus.FATTET_VEDTAK}
+                    gyldigStegForBeslutning={lastPage}
                   />
                 )
               )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/sidemeny/KlageSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/sidemeny/KlageSidemeny.tsx
@@ -100,7 +100,7 @@ export function KlageSidemeny() {
                 beslutning={beslutning}
                 vedtak={vedtak}
                 erFattet={klage?.status === KlageStatus.FATTET_VEDTAK}
-                gyldigStegForBeslutning={true}
+                gyldigStegForBeslutning={true} // TODO lage en måte å sjekke at vi er på riktig steg her (https://jira.adeo.no/browse/EY-4780)
               />
             )
           )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/sidemeny/KlageSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/sidemeny/KlageSidemeny.tsx
@@ -100,6 +100,7 @@ export function KlageSidemeny() {
                 beslutning={beslutning}
                 vedtak={vedtak}
                 erFattet={klage?.status === KlageStatus.FATTET_VEDTAK}
+                gyldigStegForBeslutning={true}
               />
             )
           )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/sidemeny/TilbakekrevingSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/sidemeny/TilbakekrevingSidemeny.tsx
@@ -105,6 +105,7 @@ export function TilbakekrevingSidemeny() {
                 beslutning={beslutning}
                 vedtak={vedtak}
                 erFattet={tilbakekreving?.status === TilbakekrevingStatus.FATTET_VEDTAK}
+                gyldigStegForBeslutning={true} // TODO lage en måte å sjekke at vi er på riktig steg her
               />
             )
           )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/sidemeny/TilbakekrevingSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/sidemeny/TilbakekrevingSidemeny.tsx
@@ -105,7 +105,7 @@ export function TilbakekrevingSidemeny() {
                 beslutning={beslutning}
                 vedtak={vedtak}
                 erFattet={tilbakekreving?.status === TilbakekrevingStatus.FATTET_VEDTAK}
-                gyldigStegForBeslutning={true} // TODO lage en måte å sjekke at vi er på riktig steg her
+                gyldigStegForBeslutning={true} // TODO lage en måte å sjekke at vi er på riktig steg her (https://jira.adeo.no/browse/EY-4780)
               />
             )
           )}


### PR DESCRIPTION
Det er pr nå ikke mulig å attestere tilbakekreving- og klagebehandlinger fordi det brukes en property som hentes fra stegmenyen i en vanlig behandling for å sjekke om disse er på siste side i stegmenyen. 

Flytter denne property'en ett nivå opp, slik at dette blir et parameter inn til komponenten `AttesteringEllerUnderkjenning` og setter inntil videre hardkodet til `true` for tilbakekreving og klage. Har laget en oppgave for å sjekke at man er på siste side i disse behandlingene også (https://jira.adeo.no/browse/EY-4780).