### PR TITLE
EY-4777 Fikser hendelser for endret folkeregisterident

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
@@ -146,10 +146,7 @@ class GrunnlagsendringshendelseService(
 
     fun opprettFolkeregisteridentifikatorhendelse(hendelse: Folkeregisteridentifikatorhendelse): List<Grunnlagsendringshendelse> =
         inTransaction {
-            opprettHendelseAvTypeForPerson(
-                hendelse.fnr,
-                GrunnlagsendringsType.FOLKEREGISTERIDENTIFIKATOR,
-            )
+            opprettHendelseForEndretFolkeregisterident(hendelse)
         }
 
     fun opprettInstitusjonsOppholdhendelse(oppholdsHendelse: InstitusjonsoppholdHendelseBeriket): List<Grunnlagsendringshendelse> =
@@ -210,7 +207,11 @@ class GrunnlagsendringshendelseService(
         }
 
         if (sakIder.isNotEmpty() &&
-            gradering in listOf(AdressebeskyttelseGradering.STRENGT_FORTROLIG, AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND)
+            gradering in
+            listOf(
+                AdressebeskyttelseGradering.STRENGT_FORTROLIG,
+                AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND,
+            )
         ) {
             logger.error("Vi har en eller flere saker som er beskyttet med gradering ($gradering), se sikkerLogg.")
         }
@@ -360,6 +361,24 @@ class GrunnlagsendringshendelseService(
             }.map { it.first }
     }
 
+    private fun opprettHendelseForEndretFolkeregisterident(hendelse: Folkeregisteridentifikatorhendelse): List<Grunnlagsendringshendelse> {
+        val tidspunktForMottakAvHendelse = now().toLocalDatetimeUTC()
+
+        return runBlocking { sakService.finnSaker(hendelse.fnr) }
+            .map { sak ->
+                Grunnlagsendringshendelse(
+                    id = UUID.randomUUID(),
+                    sakId = sak.id,
+                    type = GrunnlagsendringsType.FOLKEREGISTERIDENTIFIKATOR,
+                    opprettet = tidspunktForMottakAvHendelse,
+                    hendelseGjelderRolle = Saksrolle.SOEKER,
+                    gjelderPerson = sak.ident,
+                ).also {
+                    verifiserOgHaandterHendelse(it, sak)
+                }
+            }
+    }
+
     private fun opprettHendelseAvTypeForSak(
         sakId: SakId,
         grunnlagendringType: GrunnlagsendringsType,
@@ -440,7 +459,10 @@ class GrunnlagsendringshendelseService(
                     "Hendelsen vises derfor til saksbehandler.",
             )
             grunnlagsendringshendelseDao.opprettGrunnlagsendringshendelse(
-                hendelse.copy(samsvarMellomKildeOgGrunnlag = samsvarMellomKildeOgGrunnlag, status = GrunnlagsendringStatus.SJEKKET_AV_JOBB),
+                hendelse.copy(
+                    samsvarMellomKildeOgGrunnlag = samsvarMellomKildeOgGrunnlag,
+                    status = GrunnlagsendringStatus.SJEKKET_AV_JOBB,
+                ),
             )
             opprettOppgave(hendelse)
         }
@@ -464,7 +486,10 @@ class GrunnlagsendringshendelseService(
     ) {
         logger.info("Forkaster grunnlagsendringshendelse med id ${hendelse.id}.")
         grunnlagsendringshendelseDao.opprettGrunnlagsendringshendelse(
-            hendelse.copy(samsvarMellomKildeOgGrunnlag = samsvarMellomKildeOgGrunnlag, status = GrunnlagsendringStatus.FORKASTET),
+            hendelse.copy(
+                samsvarMellomKildeOgGrunnlag = samsvarMellomKildeOgGrunnlag,
+                status = GrunnlagsendringStatus.FORKASTET,
+            ),
         )
     }
 


### PR DESCRIPTION
Forenkler hendelser tilknyttet endret folkeregisteridentifikator. 

Dagens løsning medfører at **søker** får hendelser hvor det ser ut som andre familiemedlemmer har fått endret identifikator. 

Nå vil _kun_ sak(er) tilknyttet bruker med endret ident motta hendelser. 

Avklart med fag at endret ident ikke skal påvirke eventuelle ytelser som familiemedlemmer mottaker. 
Dersom et familiemedlem må gjennomføre en revurdering, vil det komme en advarsel i familiebildet, slik at saksbehandler kan korrigere. 

### Før
<img width="1125" alt="Screenshot 2024-11-21 at 08 43 40" src="https://github.com/user-attachments/assets/c43c2ee0-2db5-47a2-8b7a-2f42a98375b1">


### Etter
<img width="1031" alt="Screenshot 2024-11-21 at 13 44 06" src="https://github.com/user-attachments/assets/d279ef78-7094-40a9-895c-de661733577f">

