### PR TITLE
Tydliggjøre at revurdering gjelder inntektsjustering

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/inntektsjustering/AarligInntektsjusteringJobbService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/inntektsjustering/AarligInntektsjusteringJobbService.kt
@@ -441,7 +441,7 @@ class AarligInntektsjusteringJobbService(
     }
 
     private fun genererManuellBegrunnelseTekst(aarsakTilManuell: AarligInntektsjusteringAarsakManuell): String =
-        "Kan ikke behandles automatisk. Årsak: ${aarsakTilManuell.name}"
+        "Inntektsjustering kan ikke behandles automatisk. Årsak: ${aarsakTilManuell.name}"
 }
 
 enum class AarligInntektsjusteringAarsakManuell {


### PR DESCRIPTION
Når revurdering er opprettet fra oppgave (Årlig inntektsjustering), så kan det være vanskelig å se at revurdering er knytt til inntektsjustering 

Slik er det i dag:
![image](https://github.com/user-attachments/assets/e8eefaa8-de7a-4354-96fe-fb6ff0b82605)

Endre til dette: 
![image](https://github.com/user-attachments/assets/e7c5f379-f209-45d2-a637-d9562b9d022b)
