### PR TITLE
EY-4777 Fikser hendelser for endret fnr

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/SamsvarMellomKildeOgGrunnlag.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/SamsvarMellomKildeOgGrunnlag.kt
@@ -67,6 +67,8 @@ sealed class SamsvarMellomKildeOgGrunnlag {
 
     @JsonTypeName("FOLKEREGISTERIDENTIFIKATOR")
     data class Folkeregisteridentifikatorsamsvar(
+        val fraPdl: Folkeregisteridentifikator?,
+        val fraGrunnlag: Folkeregisteridentifikator?,
         override val samsvar: Boolean,
     ) : SamsvarMellomKildeOgGrunnlag()
 

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/SamsvarHelper.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/SamsvarHelper.kt
@@ -12,6 +12,7 @@ import no.nav.etterlatte.common.klienter.hentUtland
 import no.nav.etterlatte.common.klienter.hentVergemaal
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
+import no.nav.etterlatte.libs.common.grunnlag.hentFoedselsnummer
 import no.nav.etterlatte.libs.common.pdl.PersonDTO
 import no.nav.etterlatte.libs.common.person.Adresse
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
@@ -81,7 +82,10 @@ internal fun finnSamsvarForHendelse(
         }
 
         GrunnlagsendringsType.FOLKEREGISTERIDENTIFIKATOR -> {
-            SamsvarMellomKildeOgGrunnlag.Folkeregisteridentifikatorsamsvar(false) // TODO("Må finne ut av denne")
+            samsvarFolkeregisterIdent(
+                identPdl = pdlData.foedselsnummer.verdi,
+                identGrunnlag = grunnlag?.soeker?.hentFoedselsnummer()?.verdi,
+            )
         }
 
         GrunnlagsendringsType.BOSTED -> {
@@ -99,6 +103,15 @@ internal fun finnSamsvarForHendelse(
         }
     }
 }
+
+fun samsvarFolkeregisterIdent(
+    identPdl: Folkeregisteridentifikator?,
+    identGrunnlag: Folkeregisteridentifikator?,
+) = SamsvarMellomKildeOgGrunnlag.Folkeregisteridentifikatorsamsvar(
+    fraPdl = identPdl,
+    fraGrunnlag = identGrunnlag,
+    samsvar = identPdl == identGrunnlag,
+)
 
 fun samsvarDoedsdatoer(
     doedsdatoPdl: LocalDate?,

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/SamsvarHelperKtTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/SamsvarHelperKtTest.kt
@@ -7,6 +7,7 @@ import no.nav.etterlatte.libs.common.person.Sivilstand
 import no.nav.etterlatte.libs.common.person.Sivilstatus
 import no.nav.etterlatte.libs.common.person.UtflyttingFraNorge
 import no.nav.etterlatte.libs.common.person.Utland
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -133,5 +134,27 @@ internal class SamsvarHelperKtTest {
 
         val resultat = samsvarSivilstandOMS(sivilstand1, sivilstand2)
         assertFalse(resultat.samsvar)
+    }
+
+    @Test
+    fun `Sjekk samsvar folkeregisterident - endret ident`() {
+        val pdlIdent = KONTANT_FOT
+        val grunnlagIdent = JOVIAL_LAMA
+
+        val resultat = samsvarFolkeregisterIdent(pdlIdent, grunnlagIdent)
+        assertFalse(resultat.samsvar)
+        assertEquals(pdlIdent, resultat.fraPdl)
+        assertEquals(grunnlagIdent, resultat.fraGrunnlag)
+    }
+
+    @Test
+    fun `Sjekk samsvar folkeregisterident - ingen endring`() {
+        val pdlIdent = KONTANT_FOT
+        val grunnlagIdent = KONTANT_FOT
+
+        val resultat = samsvarFolkeregisterIdent(pdlIdent, grunnlagIdent)
+        assertTrue(resultat.samsvar)
+        assertEquals(pdlIdent, resultat.fraPdl)
+        assertEquals(grunnlagIdent, resultat.fraGrunnlag)
     }
 }

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/ParallelleSannheterService.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/ParallelleSannheterService.kt
@@ -249,9 +249,16 @@ class ParallelleSannheterService(
                     )
                     request.foedselsnummer
                 } else {
+                    sikkerLogg.info(
+                        "Fikk identer fra PDL: ${hentPerson.folkeregisteridentifikator.joinToString { it.identifikasjonsnummer }}",
+                    )
+
                     ppsKlient
                         .avklarFolkeregisteridentifikator(hentPerson.folkeregisteridentifikator)
-                        .let { Folkeregisteridentifikator.of(it.identifikasjonsnummer) }
+                        .let {
+                            sikkerLogg.info("Fikk ident fra PPS: ${it.identifikasjonsnummer}")
+                            Folkeregisteridentifikator.of(it.identifikasjonsnummer)
+                        }
                 }
 
             val navn = ppsKlient.avklarNavn(hentPerson.navn)

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/ParallelleSannheterService.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/ParallelleSannheterService.kt
@@ -249,16 +249,9 @@ class ParallelleSannheterService(
                     )
                     request.foedselsnummer
                 } else {
-                    sikkerLogg.info(
-                        "Fikk identer fra PDL: ${hentPerson.folkeregisteridentifikator.joinToString { it.identifikasjonsnummer }}",
-                    )
-
                     ppsKlient
                         .avklarFolkeregisteridentifikator(hentPerson.folkeregisteridentifikator)
-                        .let {
-                            sikkerLogg.info("Fikk ident fra PPS: ${it.identifikasjonsnummer}")
-                            Folkeregisteridentifikator.of(it.identifikasjonsnummer)
-                        }
+                        .let { Folkeregisteridentifikator.of(it.identifikasjonsnummer) }
                 }
 
             val navn = ppsKlient.avklarNavn(hentPerson.navn)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/hendelser/HendelseBeskrivelse.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/hendelser/HendelseBeskrivelse.tsx
@@ -56,7 +56,12 @@ const FolkeregisterSamsvarVisning = ({ samsvar }: { samsvar: Folkeregisteridenti
   return (
     <GrunnlagSammenligningWrapper>
       <div>
-        <Label>{samsvar.samsvar ? 'Er samsvar' : 'Er ikke samsvar'}</Label>
+        <Label>Ny folkeregisteridentifikator (PDL)</Label>
+        <KortTekst size="small">{samsvar.fraPdl}</KortTekst>
+      </div>
+      <div>
+        <Label>Eksisterende folkeregisteridentifikator (grunnlag)</Label>
+        <KortTekst size="small">{samsvar.fraGrunnlag}</KortTekst>
       </div>
     </GrunnlagSammenligningWrapper>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/typer.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/typer.tsx
@@ -60,6 +60,8 @@ export enum GrunnlagsendringsType {
 export interface Folkeregisteridentifikatorsamsvar {
   type: 'FOLKEREGISTERIDENTIFIKATOR'
   samsvar: boolean
+  fraPdl?: string
+  fraGrunnlag?: string
 }
 
 export interface DoedsdatoSamsvar {


### PR DESCRIPTION
Nytt forsøk. Samme PR som sist, men nå med tester og et par ekstra sjekker. 

Forenkler hendelser tilknyttet endret folkeregisteridentifikator. 

Dagens løsning medfører at **søker** får hendelser hvor det ser ut som andre familiemedlemmer har fått endret identifikator. 

Nå vil _kun_ sak(er) tilknyttet bruker med endret ident motta hendelser. 

Avklart med fag at endret ident ikke skal påvirke eventuelle ytelser som familiemedlemmer mottaker. 
Dersom et familiemedlem må gjennomføre en revurdering, vil det komme en advarsel i familiebildet, slik at saksbehandler kan korrigere. 

### Før
<img width="1125" alt="Screenshot 2024-11-21 at 08 43 40" src="https://github.com/user-attachments/assets/c43c2ee0-2db5-47a2-8b7a-2f42a98375b1">


### Etter
<img width="1143" alt="Screenshot 2024-11-21 at 19 57 34" src="https://github.com/user-attachments/assets/65866d9c-dac1-4bd8-987b-4e3b0b376a2d">

