### PR TITLE
Gir ikke mening å sette referanse når opprettelse av behandling feilet

### DIFF
--- a/apps/etterlatte-oppdater-behandling/src/main/kotlin/TidshendelseService.kt
+++ b/apps/etterlatte-oppdater-behandling/src/main/kotlin/TidshendelseService.kt
@@ -38,7 +38,7 @@ class TidshendelseService(
                 }
             } catch (e: Exception) {
                 logger.error("Kunne ikke opprette omregning [sak=${hendelse.sakId}]", e)
-                return opprettOppgave(hendelse)
+                return opprettOppgaveOpphoerYtelse(hendelse)
                     .let { oppgaveId -> TidshendelseResult.OpprettetOppgave(oppgaveId) }
             }
         } else {
@@ -88,12 +88,12 @@ class TidshendelseService(
             oppgavefrist = hendelse.behandlingsmaaned.atEndOfMonth(),
         )
 
-    private fun opprettOppgave(hendelse: TidshendelsePacket): UUID {
+    private fun opprettOppgaveOpphoerYtelse(hendelse: TidshendelsePacket): UUID {
         val oppgaveId =
             behandlingService.opprettOppgave(
                 hendelse.sakId,
                 oppgaveTypeFor(hendelse.jobbtype),
-                referanse = hendelse.behandlingId?.toString(),
+                referanse = null, // Settes til null da opprettelse av behandling feilet. Har da ingen gyldig referanse.
                 merknad = hendelse.jobbtype.beskrivelse,
                 frist = Tidspunkt.ofNorskTidssone(hendelse.behandlingsmaaned.atEndOfMonth(), LocalTime.NOON),
             )


### PR DESCRIPTION
Referansen som ble brukt for å opprette disse oppgavene pekte på forrige iverksatte behandling. Dette gav ingen mening da denne behandlingen allerede er lukket. Behandlingen oppgaven egentlig omhandler har blitt avbrutt.