### PR TITLE
FAGSYSTEM-357542: Tillatter å overstyre virk etter opphørt sak

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -229,7 +229,8 @@ const Virkningstidspunkt = (props: {
                 fastsettVirkStatus,
                 (error) =>
                   behandling.behandlingType === IBehandlingsType.REVURDERING &&
-                  error.code === 'VIRK_FOER_FOERSTE_IVERKSATT_VIRK' && (
+                  error.code &&
+                  ['VIRK_FOER_FOERSTE_IVERKSATT_VIRK', 'VIRK_KAN_IKKE_VAERE_ETTER_OPPHOER'].includes(error.code) && (
                     <ConfirmationPanel
                       label="Ja, jeg er sikker"
                       checked={overstyr}


### PR DESCRIPTION
Gjør det mulig å overstyre virkningstidspunkt når en sak er opphørt (bruker samme konsept som er brukt tidligere ved overstyring av første virk). 

Grunnen til at det er behov for dette er at vi nå har noen saker hvor det skal innvilges perioder før 2024, deretter blir det opphør pga aldersovergang 18 år (etter gammelt regelverk). Etter en stund blir personen 20 år og har rett på ytelsen igjen. Man ønsker da å revurdere etter et opphør, med et virkningstidspunkt en del senere en opphørstidspunktet. 