### PR TITLE
FAGSYSTEM-351287: Legger til støtte for revurderingsårsak Ny søknad

### DIFF
--- a/libs/saksbehandling-common/src/main/kotlin/behandling/Revurderingaarsak.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/behandling/Revurderingaarsak.kt
@@ -106,7 +106,7 @@ enum class Revurderingaarsak(
     fun gyldigForSakType(sakType: SakType): Boolean = gyldigFor.any { it == sakType }
 
     fun erStoettaRevurdering(sakType: SakType): Boolean {
-        val erIkkeStoetta = listOf(NY_SOEKNAD, AARLIG_INNTEKTSJUSTERING)
+        val erIkkeStoetta = listOf(AARLIG_INNTEKTSJUSTERING)
         return kanBrukesIMiljo() && gyldigForSakType(sakType) && !erIkkeStoetta.contains(this)
     }
 }


### PR DESCRIPTION
Noen behandlinger hvor det har blitt sendt inn ny søknad har blitt avbrutt. Det er behov for å opprette disse med revurderingsårsak `Ny søknad` slik at saksbehandler kan gi avslag. Dette er eneste revurderingsårsak som lar saksbehandler gi avslag og ikke opphør. 