### PR TITLE
FAGSYSTEM-357977: Ruller tilbake satus i vedtak som feilet i videre flyt

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/resources/db/migration/V34__oppdater_vedtak_i_feil_tilstand.sql
+++ b/apps/etterlatte-vedtaksvurdering/src/main/resources/db/migration/V34__oppdater_vedtak_i_feil_tilstand.sql
@@ -1,0 +1,2 @@
+-- Ruller tilbake vedtak som ble fattet, hvor resten av flyten i behandling feilet
+UPDATE vedtak SET vedtakstatus = 'OPPRETTET', datofattet = null, fattetvedtakenhet = null WHERE id = 36500;


### PR DESCRIPTION
Gjør det mulig å fatte vedtaket på nytt og fortsette med attestering.