### PR TITLE
Kan fatte vedtak ved status TRYGDETID_OPPDATERT ved avslag i revurdering

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ManuellRevurdering.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ManuellRevurdering.kt
@@ -144,6 +144,7 @@ data class ManuellRevurdering(
                 BehandlingStatus.BEREGNET,
                 BehandlingStatus.AVKORTET,
                 BehandlingStatus.RETURNERT,
+                BehandlingStatus.TRYGDETID_OPPDATERT,
             ),
             BehandlingStatus.FATTET_VEDTAK,
         ) {


### PR DESCRIPTION
Ved utlandsopphold vil saksbehandler også ha mulighet til å legge til trygdetid ved avslag.