### PR TITLE
Redusere ant. gosysoppgaver som hentes fra 1000 til 500

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveKlient.kt
@@ -131,7 +131,7 @@ class GosysOppgaveKlientImpl(
             val filters =
                 "statuskategori=AAPEN"
                     .plus(temaFilter)
-                    .plus("&limit=1000")
+                    .plus("&limit=500")
                     .plus(enhetsnr?.let { "&tildeltEnhetsnr=$it" } ?: "")
                     .plus(saksbehandler?.let { "&tilordnetRessurs=$it" } ?: "")
                     .plus(harTildeling?.let { "&tildeltRessurs=$it" } ?: "")


### PR DESCRIPTION
Vi får ofte feil fra Gosys når det hentes oppgaver med tema `PEN`. Det finnes helt vanvittig mange oppgaver på dette temaet, så prøver derfor å redusere antall oppgaver vi henter i et forsøk på å redusere antall feil. 

Ideelt sett burde vi skrevet om Gosys-oppgavetabellen til å bruke Oppgave API-et sin paginering, men det krever en del mer innsats. 