### PR TITLE
opprydding i diverse smårusk

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
@@ -186,8 +186,8 @@ class BehandlingStatusServiceImpl(
         registrerVedtakHendelse(behandling.id, vedtak.vedtakHendelse, HendelseType.FATTET)
 
         val merknadBehandling =
-            when (val bruker = brukerTokenInfo) {
-                is Saksbehandler -> "Behandlet av ${bruker.ident}"
+            when (brukerTokenInfo) {
+                is Saksbehandler -> "Behandlet av ${brukerTokenInfo.ident}"
                 is Systembruker -> "Behandlet av systemet"
             }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingsstatusRoutes.kt
@@ -9,6 +9,7 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
+import io.ktor.util.pipeline.PipelineContext
 import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
 import no.nav.etterlatte.libs.common.sak.SakslisteDTO
@@ -25,7 +26,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         get("/opprett") {
             // TODO: kan slettes
             // Kalles kun av vilkårsvurdering når total-vurdering slettes
-            haandterStatusEndring(call) {
+            haandterStatusEndring {
                 inTransaction {
                     behandlingsstatusService.settOpprettet(behandlingId, brukerTokenInfo)
                 }
@@ -35,7 +36,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
             // TODO: kan slettes
             // Kalles kun av vilkårsvurdering når total-vurdering slettes
             kunSkrivetilgang {
-                haandterStatusEndring(call) {
+                haandterStatusEndring {
                     inTransaction {
                         behandlingsstatusService.settOpprettet(behandlingId, brukerTokenInfo, false)
                     }
@@ -44,7 +45,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         }
 
         get("/vilkaarsvurder") {
-            haandterStatusEndring(call) {
+            haandterStatusEndring {
                 inTransaction {
                     behandlingsstatusService.settVilkaarsvurdert(behandlingId, brukerTokenInfo)
                 }
@@ -52,7 +53,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         }
         post("/vilkaarsvurder") {
             kunSkrivetilgang {
-                haandterStatusEndring(call) {
+                haandterStatusEndring {
                     inTransaction {
                         behandlingsstatusService.settVilkaarsvurdert(behandlingId, brukerTokenInfo, false)
                     }
@@ -61,7 +62,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         }
 
         get("/oppdaterTrygdetid") {
-            haandterStatusEndring(call) {
+            haandterStatusEndring {
                 inTransaction {
                     behandlingsstatusService.settTrygdetidOppdatert(behandlingId, brukerTokenInfo)
                 }
@@ -69,7 +70,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         }
         post("/oppdaterTrygdetid") {
             kunSkrivetilgang {
-                haandterStatusEndring(call) {
+                haandterStatusEndring {
                     inTransaction {
                         behandlingsstatusService.settTrygdetidOppdatert(behandlingId, brukerTokenInfo, false)
                     }
@@ -78,7 +79,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         }
 
         get("/beregn") {
-            haandterStatusEndring(call) {
+            haandterStatusEndring {
                 inTransaction {
                     behandlingsstatusService.settBeregnet(behandlingId, brukerTokenInfo)
                 }
@@ -87,7 +88,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
 
         post("/beregn") {
             kunSkrivetilgang {
-                haandterStatusEndring(call) {
+                haandterStatusEndring {
                     inTransaction {
                         behandlingsstatusService.settBeregnet(behandlingId, brukerTokenInfo, false)
                     }
@@ -96,7 +97,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         }
 
         get("/avkort") {
-            haandterStatusEndring(call) {
+            haandterStatusEndring {
                 inTransaction {
                     behandlingsstatusService.settAvkortet(behandlingId, brukerTokenInfo)
                 }
@@ -105,7 +106,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
 
         post("/avkort") {
             kunSkrivetilgang {
-                haandterStatusEndring(call) {
+                haandterStatusEndring {
                     inTransaction {
                         behandlingsstatusService.settAvkortet(behandlingId, brukerTokenInfo, false)
                     }
@@ -114,14 +115,14 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         }
 
         get("/fatteVedtak") {
-            haandterStatusEndring(call) {
+            haandterStatusEndring {
                 inTransaction {
                     behandlingsstatusService.sjekkOmKanFatteVedtak(behandlingId)
                 }
             }
         }
         get("/returner") {
-            haandterStatusEndring(call) {
+            haandterStatusEndring {
                 inTransaction {
                     behandlingsstatusService.sjekkOmKanReturnereVedtak(behandlingId)
                 }
@@ -130,7 +131,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
 
         get("/attester") {
             kunAttestant {
-                haandterStatusEndring(call) {
+                haandterStatusEndring {
                     inTransaction {
                         behandlingsstatusService.sjekkOmKanAttestere(behandlingId)
                     }
@@ -141,7 +142,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         post("/tilsamordning") {
             kunSkrivetilgang {
                 val vedtakHendelse = call.receive<VedtakHendelse>()
-                haandterStatusEndring(call) {
+                haandterStatusEndring {
                     inTransaction {
                         behandlingsstatusService.settTilSamordnetVedtak(behandlingId, vedtakHendelse)
                     }
@@ -152,7 +153,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         post("/samordnet") {
             kunSkrivetilgang {
                 val vedtakHendelse = call.receive<VedtakHendelse>()
-                haandterStatusEndring(call) {
+                haandterStatusEndring {
                     inTransaction {
                         behandlingsstatusService.settSamordnetVedtak(behandlingId, vedtakHendelse)
                     }
@@ -163,7 +164,7 @@ internal fun Route.behandlingsstatusRoutes(behandlingsstatusService: BehandlingS
         post("/iverksett") {
             kunSkrivetilgang {
                 val vedtakHendelse = call.receive<VedtakHendelse>()
-                haandterStatusEndring(call) {
+                haandterStatusEndring {
                     inTransaction {
                         behandlingsstatusService.settIverksattVedtak(behandlingId, vedtakHendelse)
                     }
@@ -188,10 +189,7 @@ data class OperasjonGyldig(
     val gyldig: Boolean,
 )
 
-private suspend fun haandterStatusEndring(
-    call: ApplicationCall,
-    proevStatusEndring: () -> Unit,
-) {
+private suspend fun PipelineContext<Unit, ApplicationCall>.haandterStatusEndring(proevStatusEndring: () -> Unit) {
     runCatching(proevStatusEndring)
         .fold(
             onSuccess = { call.respond(HttpStatusCode.OK, OperasjonGyldig(true)) },

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringsHendelseFilter.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringsHendelseFilter.kt
@@ -24,7 +24,7 @@ class GrunnlagsendringsHendelseFilter(
         sakId: SakId,
         grunnlagendringType: GrunnlagsendringsType,
     ): Boolean {
-        if (!ikkeRelevanteHendelserForOpphoertSak(grunnlagendringType)) {
+        if (!erHendelseRelevant(grunnlagendringType)) {
             logger.info("Grunnlagsendring av type $grunnlagendringType i sak $sakId er ikke relevant")
             return false
         }
@@ -54,17 +54,20 @@ class GrunnlagsendringsHendelseFilter(
         }
     }
 
-    private fun ikkeRelevanteHendelserForOpphoertSak(grunnlagendringType: GrunnlagsendringsType) =
+    private fun erHendelseRelevant(grunnlagendringType: GrunnlagsendringsType) =
         when (grunnlagendringType) {
-            GrunnlagsendringsType.DOEDSFALL -> true
-            GrunnlagsendringsType.UTFLYTTING -> true
-            GrunnlagsendringsType.FORELDER_BARN_RELASJON -> true
-            GrunnlagsendringsType.VERGEMAAL_ELLER_FREMTIDSFULLMAKT -> true
-            GrunnlagsendringsType.SIVILSTAND -> true
-            GrunnlagsendringsType.GRUNNBELOEP -> false
-            GrunnlagsendringsType.INSTITUSJONSOPPHOLD -> false
-            GrunnlagsendringsType.BOSTED -> true
-            GrunnlagsendringsType.FOLKEREGISTERIDENTIFIKATOR -> true
-            GrunnlagsendringsType.UFOERETRYGD -> true
+            GrunnlagsendringsType.DOEDSFALL,
+            GrunnlagsendringsType.UTFLYTTING,
+            GrunnlagsendringsType.FORELDER_BARN_RELASJON,
+            GrunnlagsendringsType.VERGEMAAL_ELLER_FREMTIDSFULLMAKT,
+            GrunnlagsendringsType.SIVILSTAND,
+            GrunnlagsendringsType.BOSTED,
+            GrunnlagsendringsType.FOLKEREGISTERIDENTIFIKATOR,
+            GrunnlagsendringsType.UFOERETRYGD,
+            -> true
+
+            GrunnlagsendringsType.INSTITUSJONSOPPHOLD,
+            GrunnlagsendringsType.GRUNNBELOEP,
+            -> false
         }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseService.kt
@@ -210,7 +210,11 @@ class GrunnlagsendringshendelseService(
         }
 
         if (sakIder.isNotEmpty() &&
-            gradering in listOf(AdressebeskyttelseGradering.STRENGT_FORTROLIG, AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND)
+            gradering in
+            listOf(
+                AdressebeskyttelseGradering.STRENGT_FORTROLIG,
+                AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND,
+            )
         ) {
             logger.error("Vi har en eller flere saker som er beskyttet med gradering ($gradering), se sikkerLogg.")
         }
@@ -401,14 +405,15 @@ class GrunnlagsendringshendelseService(
         try {
             val samsvarMellomPdlOgGrunnlag =
                 finnSamsvarForHendelse(grunnlagsendringshendelse, pdlData, grunnlag, personRolle, sak.sakType)
-            val erDuplikat =
-                erDuplikatHendelse(
-                    sak.id,
-                    grunnlagsendringshendelse,
-                    samsvarMellomPdlOgGrunnlag,
-                )
 
             if (!samsvarMellomPdlOgGrunnlag.samsvar) {
+                val erDuplikat =
+                    erDuplikatHendelse(
+                        sak.id,
+                        grunnlagsendringshendelse,
+                        samsvarMellomPdlOgGrunnlag,
+                    )
+
                 if (erDuplikat) {
                     forkastHendelse(grunnlagsendringshendelse, samsvarMellomPdlOgGrunnlag)
                 } else {
@@ -440,7 +445,10 @@ class GrunnlagsendringshendelseService(
                     "Hendelsen vises derfor til saksbehandler.",
             )
             grunnlagsendringshendelseDao.opprettGrunnlagsendringshendelse(
-                hendelse.copy(samsvarMellomKildeOgGrunnlag = samsvarMellomKildeOgGrunnlag, status = GrunnlagsendringStatus.SJEKKET_AV_JOBB),
+                hendelse.copy(
+                    samsvarMellomKildeOgGrunnlag = samsvarMellomKildeOgGrunnlag,
+                    status = GrunnlagsendringStatus.SJEKKET_AV_JOBB,
+                ),
             )
             opprettOppgave(hendelse)
         }
@@ -464,7 +472,10 @@ class GrunnlagsendringshendelseService(
     ) {
         logger.info("Forkaster grunnlagsendringshendelse med id ${hendelse.id}.")
         grunnlagsendringshendelseDao.opprettGrunnlagsendringshendelse(
-            hendelse.copy(samsvarMellomKildeOgGrunnlag = samsvarMellomKildeOgGrunnlag, status = GrunnlagsendringStatus.FORKASTET),
+            hendelse.copy(
+                samsvarMellomKildeOgGrunnlag = samsvarMellomKildeOgGrunnlag,
+                status = GrunnlagsendringStatus.FORKASTET,
+            ),
         )
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringsHendelseFilterTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagsendringsHendelseFilterTest.kt
@@ -31,7 +31,7 @@ import org.junit.jupiter.params.provider.EnumSource
 import java.time.LocalDate
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class GrunnlagsendringsHendelseFilterTest {
+internal class GrunnlagsendringsHendelseFilterTest {
     private val vedtakklient = mockk<VedtakKlient>()
     private val behandlingService = mockk<BehandlingService>()
     private lateinit var service: GrunnlagsendringsHendelseFilter


### PR DESCRIPTION
Gjør funksjonsnavn i hendelsesfilteret litt mer forståelig: 
`ikkeRelevanteHendelserForOpphoertSak` til `erHendelseRelevant`

Og ikke gjøre duplikatsjekk på hendelse med mindre det faktisk er nødvendig. 

Pluss litt smått. 