### PR TITLE
Fikser resetting av skjema ved fjerning av aldersovergang

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -9,7 +9,7 @@ import { enhetErSkrivbar } from '~components/behandling/felles/utils'
 import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
 import { lastDayOfMonth } from 'date-fns'
 import { AvkortingInntektForm } from '~components/behandling/avkorting/AvkortingInntektForm'
-import { IAvkortingGrunnlagFrontend } from '~shared/types/IAvkorting'
+import { IAvkortingGrunnlagFrontend, SystemOverstyrtInnvilgaMaanederAarsak } from '~shared/types/IAvkorting'
 import { ArrowCirclepathIcon, HeadCloudIcon, PencilIcon } from '@navikt/aksel-icons'
 import { usePersonopplysninger } from '~components/person/usePersonopplysninger'
 import {
@@ -139,11 +139,14 @@ export const AvkortingInntekt = ({
                       <Table.DataCell>
                         <HStack gap="4" align="center">
                           <BodyShort>{avkortingGrunnlag.innvilgaMaaneder}</BodyShort>
-                          {fyller67 && !avkortingGrunnlag.overstyrtInnvilgaMaaneder && (
-                            <Tooltip content="Fyller 67 år">
-                              <HeadCloudIcon aria-hidden fontSize="1.5rem" />
-                            </Tooltip>
-                          )}
+                          {fyller67 &&
+                            (!avkortingGrunnlag.overstyrtInnvilgaMaaneder ||
+                              avkortingGrunnlag.overstyrtInnvilgaMaaneder.aarsak ===
+                                SystemOverstyrtInnvilgaMaanederAarsak.BLIR_67) && (
+                              <Tooltip content="Fyller 67 år">
+                                <HeadCloudIcon aria-hidden fontSize="1.5rem" />
+                              </Tooltip>
+                            )}
                           {!!avkortingGrunnlag.overstyrtInnvilgaMaaneder && (
                             <Tooltip content="Antall innvilga måneder er overstyrt">
                               <ArrowCirclepathIcon aria-hidden fontSize="1.5rem" />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntektForm.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntektForm.tsx
@@ -104,6 +104,7 @@ export const AvkortingInntektForm = ({
     handleSubmit,
     formState: { errors },
     watch,
+    setValue,
     getValues,
   } = methods
 
@@ -131,7 +132,7 @@ export const AvkortingInntektForm = ({
   const [skalOverstyreMaaneder, setSkalOverstyreMaaneder] = useState(!!getValues('overstyrtInnvilgaMaaneder'))
   const toggleOverstyrtInnvilgaMaaneder = () => {
     if (skalOverstyreMaaneder) {
-      reset({ overstyrtInnvilgaMaaneder: undefined })
+      setValue('overstyrtInnvilgaMaaneder', undefined)
     }
     setSkalOverstyreMaaneder(!skalOverstyreMaaneder)
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/OverstyrInnvilgaMaaneder.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/OverstyrInnvilgaMaaneder.tsx
@@ -45,7 +45,8 @@ export default function OverstyrInnvilgaMaander() {
               <option value="">Velg årsak</option>
               {watch('overstyrtInnvilgaMaaneder.aarsak') === SystemOverstyrtInnvilgaMaanederAarsak.BLIR_67 && (
                 <option value={SystemOverstyrtInnvilgaMaanederAarsak.BLIR_67} disabled={true}>
-                  Blir 67 år
+                  {hentLesbarTekstForInnvilgaMaanederType(SystemOverstyrtInnvilgaMaanederAarsak.BLIR_67)} (satt av
+                  Gjenny)
                 </option>
               )}
               {Object.values(OverstyrtInnvilgaMaanederAarsak).map((type) => (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/OverstyrInnvilgaMaaneder.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/OverstyrInnvilgaMaaneder.tsx
@@ -4,12 +4,14 @@ import { useFormContext } from 'react-hook-form'
 import {
   hentLesbarTekstForInnvilgaMaanederType,
   IAvkortingGrunnlagLagre,
-  OverstyrtInnvilaMaanederAarsak,
+  OverstyrtInnvilgaMaanederAarsak,
+  SystemOverstyrtInnvilgaMaanederAarsak,
 } from '~shared/types/IAvkorting'
 
 export default function OverstyrInnvilgaMaander() {
   const {
     register,
+    watch,
     formState: { errors },
   } = useFormContext<IAvkortingGrunnlagLagre>()
 
@@ -41,9 +43,14 @@ export default function OverstyrInnvilgaMaander() {
               error={errors?.overstyrtInnvilgaMaaneder?.aarsak?.message}
             >
               <option value="">Velg årsak</option>
-              {Object.values(OverstyrtInnvilaMaanederAarsak).map((type) => (
+              {watch('overstyrtInnvilgaMaaneder.aarsak') === SystemOverstyrtInnvilgaMaanederAarsak.BLIR_67 && (
+                <option value={SystemOverstyrtInnvilgaMaanederAarsak.BLIR_67} disabled={true}>
+                  Blir 67 år
+                </option>
+              )}
+              {Object.values(OverstyrtInnvilgaMaanederAarsak).map((type) => (
                 <option key={type} value={type}>
-                  {hentLesbarTekstForInnvilgaMaanederType(type as OverstyrtInnvilaMaanederAarsak)}
+                  {hentLesbarTekstForInnvilgaMaanederType(type as OverstyrtInnvilgaMaanederAarsak)}
                 </option>
               ))}
             </Select>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
@@ -42,21 +42,29 @@ export interface IAvkortingGrunnlagLagre {
 
 export interface IOverstyrtInnvilgaMaaneder {
   antall: number
-  aarsak: OverstyrtInnvilaMaanederAarsak
+  aarsak: OverstyrtInnvilgaMaanederAarsak | SystemOverstyrtInnvilgaMaanederAarsak
   begrunnelse: string
 }
 
-export enum OverstyrtInnvilaMaanederAarsak {
+export enum OverstyrtInnvilgaMaanederAarsak {
   TAR_UT_PENSJON_TIDLIG = 'TAR_UT_PENSJON_TIDLIG',
   ANNEN = 'ANNEN',
 }
 
-export function hentLesbarTekstForInnvilgaMaanederType(type: OverstyrtInnvilaMaanederAarsak) {
+export enum SystemOverstyrtInnvilgaMaanederAarsak {
+  BLIR_67 = 'BLIR_67',
+}
+
+export function hentLesbarTekstForInnvilgaMaanederType(
+  type: OverstyrtInnvilgaMaanederAarsak | SystemOverstyrtInnvilgaMaanederAarsak
+) {
   switch (type) {
-    case OverstyrtInnvilaMaanederAarsak.TAR_UT_PENSJON_TIDLIG:
+    case OverstyrtInnvilgaMaanederAarsak.TAR_UT_PENSJON_TIDLIG:
       return 'Tar ut pensjon tidlig'
-    case OverstyrtInnvilaMaanederAarsak.ANNEN:
+    case OverstyrtInnvilgaMaanederAarsak.ANNEN:
       return 'Annen'
+    case SystemOverstyrtInnvilgaMaanederAarsak.BLIR_67:
+      return 'Blir 67'
   }
 }
 


### PR DESCRIPTION
Viser også 67 år som en begrunnelse hvis det er satt av systemet (som ikke kan velges manuelt av saksbehandler)