### PR TITLE
Gi alle tilgang til spesifikke routes

### DIFF
--- a/apps/etterlatte-testdata/.nais/dev.yaml
+++ b/apps/etterlatte-testdata/.nais/dev.yaml
@@ -36,12 +36,12 @@ spec:
   azure:
     application:
       enabled: true
+      allowAllUsers: true
       tenant: nav.no
       claims:
         groups:
-          - id: 650684ff-8107-4ae4-98fc-e18b5cf3188b # etterlatte
-          - id: 1a424f32-16a4-4b97-9d77-3e9e781a887e # (DG) NAV Team Etterlatte
-          - id: 20e720b3-4be7-42ec-aff4-af613f25361b # po-pensjon
+          # AD-gruppe for utviklere på Team Etterlatte (etterlatte@nav.no)
+          - id: 650684ff-8107-4ae4-98fc-e18b5cf3188b
     sidecar:
       enabled: true
       autoLogin: true

--- a/apps/etterlatte-testdata/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/Application.kt
@@ -91,6 +91,7 @@ interface TestDataFeature {
     val beskrivelse: String
     val path: String
     val routes: Route.() -> Unit
+    val kunEtterlatte: Boolean
 }
 
 val dollyService =

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/Auth.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/Auth.kt
@@ -1,0 +1,33 @@
+package no.nav.etterlatte.no.nav.etterlatte.testdata
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.util.pipeline.PipelineContext
+import no.nav.etterlatte.libs.ktor.token.Saksbehandler
+import no.nav.etterlatte.libs.ktor.token.Systembruker
+import no.nav.etterlatte.libs.ktor.token.brukerTokenInfo
+
+object ADGruppe {
+    const val ETTERLATTE = "650684ff-8107-4ae4-98fc-e18b5cf3188b"
+}
+
+suspend inline fun PipelineContext<*, ApplicationCall>.kunEtterlatteUtvikling(onSuccess: () -> Unit) {
+    val rollerEllerAdGrupper =
+        when (brukerTokenInfo) {
+            is Saksbehandler -> (call.brukerTokenInfo as Saksbehandler).groups
+            is Systembruker -> (call.brukerTokenInfo as Systembruker).roller
+        }
+    if (rollerEllerAdGrupper.any { it == ADGruppe.ETTERLATTE }) {
+        onSuccess()
+    } else {
+        call.respond(HttpStatusCode.Unauthorized, "Mangler etterlatte-rolle")
+    }
+}
+
+fun PipelineContext<*, ApplicationCall>.harGyldigAdGruppe(): Boolean =
+    when (brukerTokenInfo) {
+        is Saksbehandler -> (brukerTokenInfo as Saksbehandler).groups
+        is Systembruker -> (brukerTokenInfo as Systembruker).roller
+    }.any { it == ADGruppe.ETTERLATTE }

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/OpprettOgBehandle.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/OpprettOgBehandle.kt
@@ -31,6 +31,8 @@ class OpprettOgBehandle(
         get() = "Opprett og behandle søknad(er)"
     override val path: String
         get() = "opprett-og-behandle"
+    override val kunEtterlatte: Boolean
+        get() = true
 
     override val routes: Route.() -> Unit
         get() = {

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/dolly/DollyFeature.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/dolly/DollyFeature.kt
@@ -29,6 +29,8 @@ class DollyFeature(
         get() = "Opprett søknad automatisk via Dolly"
     override val path: String
         get() = "dolly"
+    override val kunEtterlatte: Boolean
+        get() = true
 
     override val routes: Route.() -> Unit
         get() = {

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/egendefinert/EgendefinertMeldingFeature.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/egendefinert/EgendefinertMeldingFeature.kt
@@ -1,8 +1,6 @@
 package no.nav.etterlatte.testdata.features.egendefinert
 
 import com.fasterxml.jackson.module.kotlin.treeToValue
-import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
 import io.ktor.server.mustache.MustacheContent
 import io.ktor.server.request.receiveParameters
@@ -11,13 +9,11 @@ import io.ktor.server.response.respondRedirect
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
-import io.ktor.util.pipeline.PipelineContext
 import no.nav.etterlatte.TestDataFeature
 import no.nav.etterlatte.libs.common.objectMapper
-import no.nav.etterlatte.libs.ktor.token.Saksbehandler
-import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.etterlatte.libs.ktor.token.brukerTokenInfo
 import no.nav.etterlatte.logger
+import no.nav.etterlatte.no.nav.etterlatte.testdata.kunEtterlatteUtvikling
 import no.nav.etterlatte.producer
 import no.nav.etterlatte.rapidsandrivers.HENDELSE_DATA_KEY
 import no.nav.etterlatte.rapidsandrivers.OmregningData
@@ -28,6 +24,8 @@ object EgendefinertMeldingFeature : TestDataFeature {
         get() = "Post egendefinert melding"
     override val path: String
         get() = "egendefinert"
+    override val kunEtterlatte: Boolean
+        get() = true
     override val routes: Route.() -> Unit
         get() = {
             get {
@@ -106,17 +104,4 @@ object EgendefinertMeldingFeature : TestDataFeature {
                 }
             }
         }
-
-    private suspend inline fun PipelineContext<*, ApplicationCall>.kunEtterlatteUtvikling(onSuccess: () -> Unit) {
-        val rollerEllerAdGrupper =
-            when (brukerTokenInfo) {
-                is Saksbehandler -> (call.brukerTokenInfo as Saksbehandler).groups
-                is Systembruker -> (call.brukerTokenInfo as Systembruker).roller
-            }
-        if (rollerEllerAdGrupper.any { it == "650684ff-8107-4ae4-98fc-e18b5cf3188b" }) {
-            onSuccess()
-        } else {
-            call.respond(HttpStatusCode.Unauthorized, "Mangler etterlatte-rolle")
-        }
-    }
 }

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/index/IndexFeature.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/index/IndexFeature.kt
@@ -8,12 +8,15 @@ import io.ktor.server.routing.get
 import no.nav.etterlatte.TestDataFeature
 import no.nav.etterlatte.features
 import no.nav.etterlatte.libs.ktor.token.brukerTokenInfo
+import no.nav.etterlatte.no.nav.etterlatte.testdata.harGyldigAdGruppe
 
 object IndexFeature : TestDataFeature {
     override val beskrivelse: String
         get() = ""
     override val path: String
         get() = "/"
+    override val kunEtterlatte: Boolean
+        get() = false
     override val routes: Route.() -> Unit
         get() = {
             get {
@@ -23,12 +26,20 @@ object IndexFeature : TestDataFeature {
                         mapOf(
                             "navIdent" to (brukerTokenInfo.ident()),
                             "features" to
-                                features.filter { it != IndexFeature }.map {
-                                    mapOf(
-                                        "path" to it.path,
-                                        "beskrivelse" to it.beskrivelse,
-                                    )
-                                },
+                                features
+                                    .filter { it != IndexFeature }
+                                    .filter {
+                                        if (it.kunEtterlatte) {
+                                            harGyldigAdGruppe()
+                                        } else {
+                                            true
+                                        }
+                                    }.map {
+                                        mapOf(
+                                            "path" to it.path,
+                                            "beskrivelse" to it.beskrivelse,
+                                        )
+                                    },
                         ),
                     ),
                 )

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/soeknad/OpprettSoeknad.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/soeknad/OpprettSoeknad.kt
@@ -25,6 +25,8 @@ object OpprettSoeknadFeature : TestDataFeature {
         get() = "Opprett søknad manuelt"
     override val path: String
         get() = "soeknad"
+    override val kunEtterlatte: Boolean
+        get() = false
     override val routes: Route.() -> Unit
         get() = {
             get {

--- a/apps/etterlatte-testdata/src/main/resources/templates/_fragments/header.hbs
+++ b/apps/etterlatte-testdata/src/main/resources/templates/_fragments/header.hbs
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>Post melding til Kafka</title>
+    <title>Etterlatte Testdata</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="/static/bootstrap.min.css" rel="stylesheet">

--- a/apps/etterlatte-testdata/src/main/resources/templates/index.hbs
+++ b/apps/etterlatte-testdata/src/main/resources/templates/index.hbs
@@ -2,7 +2,7 @@
 
 <div class="row mb-5 justify-content-center text-center">
     <div class="col mb-3">
-        <h1>Post meldinger til Kafka</h1>
+        <h1>Etterlatte Testdata</h1>
     </div>
 
     <div class="w-100"></div>


### PR DESCRIPTION
Bruker `allowAllUsers: true` for å gi alle tilgang, deretter en primitiv sjekk for å se om bruker har AD-gruppen til etterlatte utvikling. 

Gjør at brukere kun får se de routes som er ment for alle på index-siden. De kan fremdeles lete seg frem til de andre sidene og få de opp, men det er ikke noe stort problem. Endringen er bare for å unngå forvirring med _hva_ de skal bruke på sidene våre. 

Testet OK med Frida som ikke har forventet ad-gruppe. 