### PR TITLE
Endre feltnamn responsobjekt frå brevbaker

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerKlient.kt
@@ -71,7 +71,7 @@ class BrevbakerException(
 ) : Exception(msg, cause)
 
 class BrevbakerPdfResponse(
-    val base64pdf: String,
+    val file: String,
     val letterMetadata: LetterMetadata,
 )
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/brevbaker/BrevbakerService.kt
@@ -22,7 +22,7 @@ class BrevbakerService(
 
         return Base64
             .getDecoder()
-            .decode(brevbakerResponse.base64pdf)
+            .decode(brevbakerResponse.file)
             .let { Pdf(it) }
             .also { logger.info("Generert brev (id=$brevID) med størrelse: ${it.bytes.size}") }
     }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -810,7 +810,7 @@ internal class VedtaksbrevServiceTest {
                 LetterMetadata.Distribusjonstype.VEDTAK,
                 LetterMetadata.Brevtype.VEDTAKSBREV,
             ),
-        ).let { Base64.getDecoder().decode(it.base64pdf) }
+        ).let { Base64.getDecoder().decode(it.file) }
             .let { Pdf(it) }
 
     private fun opprettAvsender() =


### PR DESCRIPTION
Frå brevbaker-sida ønskjer vi like responsobjekt for etterlatte og PEN, pga kompleksitet på vår side. Legg til rette for det ved å bruke samme namn i responsobjekta

Obs: Avhengig av https://github.com/navikt/pensjonsbrev/pull/1081