### PR TITLE
FAGSYSTEM-358848: Fikser sjekk som har blitt snudd ved omskriving

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapperVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevKodeMapperVedtak.kt
@@ -19,13 +19,13 @@ class VedtakTypeFeilForBrevkode(
     val vedtakType: VedtakType?,
 ) : UgyldigForespoerselException(
         code = "FEIL_VEDTAKTYPE",
-        detail = "Feil vedtakstype $ $vedtakType",
+        detail = "Feil vedtakstype $vedtakType",
     )
 
 class BrevKodeMapperVedtak {
     fun brevKode(request: BrevkodeRequest): Brevkoder {
         if (request.erMigrering && !request.erForeldreloes) {
-            if (listOf(VedtakType.INNVILGELSE, VedtakType.ENDRING).contains(request.vedtakType)) {
+            if (!listOf(VedtakType.INNVILGELSE, VedtakType.ENDRING).contains(request.vedtakType)) {
                 throw VedtakTypeFeilForBrevkode(request.vedtakType)
             }
             return Brevkoder.OMREGNING


### PR DESCRIPTION
Denne sjekken var før omskriving:

`check(listOf(VedtakType.INNVILGELSE, VedtakType.ENDRING).contains(request.vedtakType)) {
                "Vedtaktype må være ${VedtakType.INNVILGELSE.name} eller ${VedtakType.ENDRING.name} var ${request.vedtakType}"
            }
`

Endrer slik at logikken blir riktig her.