### PR TITLE
EY-4677 Opprette alle mottakere automatisk

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -1,27 +1,17 @@
 package no.nav.etterlatte.brev
 
 import no.nav.etterlatte.brev.adresse.AdresseService
-import no.nav.etterlatte.brev.behandling.PersonerISak
 import no.nav.etterlatte.brev.db.BrevRepository
-import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevID
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.BrevkodeRequest
-import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.OpprettNyttBrev
 import no.nav.etterlatte.brev.model.Spraak
-import no.nav.etterlatte.brev.model.VERGENAVN_FOR_MOTTAKER
 import no.nav.etterlatte.libs.common.Enhetsnummer
-import no.nav.etterlatte.libs.common.behandling.SakType
-import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
-import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
-import no.nav.etterlatte.libs.common.person.UkjentVergemaal
-import no.nav.etterlatte.libs.common.person.Vergemaal
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
-import org.slf4j.LoggerFactory
 import java.util.UUID
 
 class Brevoppretter(
@@ -29,8 +19,6 @@ class Brevoppretter(
     private val db: BrevRepository,
     private val innholdTilRedigerbartBrevHenter: InnholdTilRedigerbartBrevHenter,
 ) {
-    private val logger = LoggerFactory.getLogger(this::class.java)
-
     suspend fun oppdaterBrevInnhold(
         sakId: SakId,
         brevID: BrevID,
@@ -87,7 +75,7 @@ class Brevoppretter(
                     behandlingId = behandlingId,
                     prosessType = BrevProsessType.REDIGERBAR,
                     soekerFnr = soekerFnr,
-                    mottaker = finnMottaker(sakType, personerISak),
+                    mottakere = adresseService.hentMottakere(sakType, personerISak),
                     opprettet = Tidspunkt.now(),
                     innhold = innhold,
                     innholdVedlegg = innholdVedlegg,
@@ -121,7 +109,7 @@ class Brevoppretter(
                     behandlingId = behandlingId,
                     prosessType = BrevProsessType.REDIGERBAR,
                     soekerFnr = soekerFnr,
-                    mottaker = finnMottaker(sakType, personerISak),
+                    mottakere = adresseService.hentMottakere(sakType, personerISak),
                     opprettet = Tidspunkt.now(),
                     innhold = innhold,
                     innholdVedlegg = innholdVedlegg,
@@ -171,37 +159,4 @@ class Brevoppretter(
             )
         }
     }
-
-    private suspend fun finnMottaker(
-        sakType: SakType,
-        personerISak: PersonerISak,
-    ): Mottaker =
-        with(personerISak) {
-            when (verge) {
-                is Vergemaal -> {
-                    logger.warn("Er verge, kan ikke ferdigstille uten å legge til adresse manuelt.")
-                    tomVergeMottaker().copy(foedselsnummer = MottakerFoedselsnummer(verge.foedselsnummer.value))
-                }
-                is UkjentVergemaal -> {
-                    logger.warn("Er verge, kan ikke ferdigstille uten å legge til adresse manuelt.")
-                    tomVergeMottaker()
-                }
-
-                else ->
-                    adresseService.hentMottakerAdresse(
-                        sakType,
-                        innsender?.fnr?.value?.takeIf { Folkeregisteridentifikator.isValid(it) }
-                            ?: soeker.fnr.value,
-                    )
-            }
-        }
-
-    private fun tomVergeMottaker(): Mottaker =
-        Mottaker(
-            UUID.randomUUID(),
-            navn = VERGENAVN_FOR_MOTTAKER,
-            foedselsnummer = null,
-            orgnummer = null,
-            adresse = Adresse(adresseType = "", landkode = "", land = ""),
-        )
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/AdresseService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/adresse/AdresseService.kt
@@ -4,15 +4,23 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import no.nav.etterlatte.brev.AvsenderRequest
 import no.nav.etterlatte.brev.adresse.saksbehandler.SaksbehandlerKlient
+import no.nav.etterlatte.brev.behandling.PersonerISak
+import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Mottaker
+import no.nav.etterlatte.brev.model.MottakerType
+import no.nav.etterlatte.brev.model.VERGENAVN_FOR_MOTTAKER
 import no.nav.etterlatte.brev.model.mottakerFraAdresse
 import no.nav.etterlatte.brev.model.tomMottaker
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
+import no.nav.etterlatte.libs.common.person.UkjentVergemaal
+import no.nav.etterlatte.libs.common.person.Vergemaal
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
 import no.nav.pensjon.brevbaker.api.model.Telefonnummer
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 class AdresseService(
     private val norg2Klient: Norg2Klient,
@@ -21,20 +29,38 @@ class AdresseService(
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    suspend fun hentMottakerAdresse(
+    suspend fun hentMottakere(
         sakType: SakType,
-        ident: String,
-    ): Mottaker {
-        val regoppslag = regoppslagKlient.hentMottakerAdresse(sakType, ident)
+        personerISak: PersonerISak,
+    ): List<Mottaker> =
+        with(personerISak) {
+            val soekerAdresse = hentMottakerAdresse(sakType, soeker.fnr.value, MottakerType.HOVED)
 
-        val fnr = Folkeregisteridentifikator.of(ident)
+            val vergeAdresse: Mottaker? =
+                when (verge) {
+                    is Vergemaal -> {
+                        logger.warn("Er verge, kan ikke ferdigstille uten å legge til adresse manuelt.")
+                        tomVergeMottaker(MottakerFoedselsnummer(verge.foedselsnummer.value))
+                    }
 
-        return if (regoppslag == null) {
-            tomMottaker(fnr)
-        } else {
-            mottakerFraAdresse(fnr, regoppslag)
+                    is UkjentVergemaal -> {
+                        logger.warn("Verge med ukjent vergemål, kan ikke ferdigstille uten å legge til adresse manuelt.")
+                        tomVergeMottaker()
+                    }
+
+                    else ->
+                        if (
+                            Folkeregisteridentifikator.isValid(innsender?.fnr?.value) &&
+                            innsender!!.fnr.value != soeker.fnr.value
+                        ) {
+                            hentMottakerAdresse(sakType, innsender.fnr.value, MottakerType.KOPI)
+                        } else {
+                            null
+                        }
+                }
+
+            listOfNotNull(soekerAdresse, vergeAdresse)
         }
-    }
 
     suspend fun hentAvsender(
         request: AvsenderRequest,
@@ -57,6 +83,28 @@ class AdresseService(
 
             mapTilAvsender(saksbehandlerEnhet.await(), saksbehandlerNavn.await(), attestantNavn.await())
         }
+
+    @Deprecated(message = "Midlertidig løsning for å støtte gammel flyt. Burde hente navn fra Grunnlag eller PDL")
+    suspend fun hentNavn(
+        sakType: SakType,
+        ident: String,
+    ): String = hentMottakerAdresse(sakType, ident, MottakerType.KOPI).navn
+
+    private suspend fun hentMottakerAdresse(
+        sakType: SakType,
+        ident: String,
+        type: MottakerType,
+    ): Mottaker {
+        val regoppslag = regoppslagKlient.hentMottakerAdresse(sakType, ident)
+
+        val fnr = Folkeregisteridentifikator.of(ident)
+
+        return if (regoppslag == null) {
+            tomMottaker(fnr, type)
+        } else {
+            mottakerFraAdresse(fnr, regoppslag, type)
+        }
+    }
 
     private suspend fun hentSaksbehandlerNavn(
         ident: String,
@@ -82,4 +130,14 @@ class AdresseService(
             attestant = attestantNavn,
         )
     }
+
+    private fun tomVergeMottaker(fnr: MottakerFoedselsnummer? = null): Mottaker =
+        Mottaker(
+            UUID.randomUUID(),
+            navn = VERGENAVN_FOR_MOTTAKER,
+            foedselsnummer = fnr,
+            orgnummer = null,
+            adresse = Adresse(adresseType = "", landkode = "", land = ""),
+            type = MottakerType.KOPI,
+        )
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/grunnlag/GrunnlagService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/grunnlag/GrunnlagService.kt
@@ -76,10 +76,9 @@ class GrunnlagService(
                 )
                 UkjentVergemaal()
             } else {
-                val vergenavn =
-                    adresseService
-                        .hentMottakerAdresse(sakType, vergeFnr.value)
-                        .navn
+                // TODO: Hente navn direkte fra Grunnlag eller PDL
+                val vergenavn = adresseService.hentNavn(sakType, vergeFnr.value)
+
                 Vergemaal(
                     vergenavn,
                     vergeFnr,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -15,6 +15,7 @@ import java.util.UUID
 fun mottakerFraAdresse(
     fnr: Folkeregisteridentifikator,
     regoppslag: RegoppslagResponseDTO,
+    type: MottakerType,
 ) = Mottaker(
     id = UUID.randomUUID(),
     navn = regoppslag.navn,
@@ -31,11 +32,12 @@ fun mottakerFraAdresse(
             land = regoppslag.adresse.land,
         ),
     tvingSentralPrint = false,
+    type = type,
 )
 
 fun tomMottaker(
     fnr: Folkeregisteridentifikator? = null,
-    type: MottakerType = MottakerType.HOVED,
+    type: MottakerType,
 ) = Mottaker(
     id = UUID.randomUUID(),
     navn = "N/A",
@@ -62,7 +64,7 @@ fun opprettBrevFra(
     soekerFnr = opprettNyttBrev.soekerFnr,
     status = opprettNyttBrev.status,
     statusEndret = opprettNyttBrev.opprettet,
-    mottakere = listOf(opprettNyttBrev.mottaker),
+    mottakere = opprettNyttBrev.mottakere,
     opprettet = opprettNyttBrev.opprettet,
     brevtype = opprettNyttBrev.brevtype,
     brevkoder = opprettNyttBrev.brevkoder,
@@ -96,7 +98,7 @@ data class OpprettNyttBrev(
     val behandlingId: UUID?,
     val soekerFnr: String,
     val prosessType: BrevProsessType,
-    val mottaker: Mottaker,
+    val mottakere: List<Mottaker>,
     val opprettet: Tidspunkt,
     val innhold: BrevInnhold,
     val innholdVedlegg: List<BrevInnholdVedlegg>?,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/pdf/PDFService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/pdf/PDFService.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.brev.db.BrevRepository
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevInnhold
 import no.nav.etterlatte.brev.model.BrevProsessType
+import no.nav.etterlatte.brev.model.MottakerType
 import no.nav.etterlatte.brev.model.OpprettNyttBrev
 import no.nav.etterlatte.brev.model.Pdf
 import no.nav.etterlatte.brev.model.tomMottaker
@@ -75,7 +76,7 @@ class PDFService(
                     behandlingId = null,
                     soekerFnr = sak.ident,
                     prosessType = BrevProsessType.OPPLASTET_PDF,
-                    mottaker = tomMottaker(Folkeregisteridentifikator.of(sak.ident)),
+                    mottakere = listOf(tomMottaker(Folkeregisteridentifikator.of(sak.ident), MottakerType.HOVED)),
                     opprettet = Tidspunkt.now(),
                     innhold = innhold,
                     innholdVedlegg = null,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
@@ -353,7 +353,7 @@ internal class BrevServiceTest {
             every { db.hentBrev(any()) } returns brev
 
             assertThrows<BrevKanIkkeEndres> {
-                brevService.oppdaterMottaker(brev.id, tomMottaker(), bruker)
+                brevService.oppdaterMottaker(brev.id, tomMottaker(type = MottakerType.HOVED), bruker)
             }
 
             verify {

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.brev
 
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.mockk.Called
 import io.mockk.clearAllMocks
@@ -242,7 +243,7 @@ internal class VedtaksbrevServiceTest {
             every { db.hentBrevForBehandling(BEHANDLING_ID, Brevtype.VEDTAK) } returns emptyList()
             coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any(), any()) } returns behandling
             coEvery { adresseService.hentAvsender(any(), any()) } returns opprettAvsender()
-            coEvery { adresseService.hentMottakerAdresse(any(), any()) } returns mottaker
+            coEvery { adresseService.hentMottakere(any(), any()) } returns listOf(mottaker)
             coEvery { brevbakerService.hentRedigerbarTekstFraBrevbakeren(any()) } returns Slate(emptyList())
             coEvery { behandlingService.hentVedtaksbehandlingKanRedigeres(any(), any()) } returns true
             coEvery { behandlingService.hentEtterbetaling(any(), any()) } returns null
@@ -298,11 +299,7 @@ internal class VedtaksbrevServiceTest {
             coVerify {
                 db.hentBrevForBehandling(BEHANDLING_ID, Brevtype.VEDTAK)
                 brevdataFacade.hentGenerellBrevData(sakId, BEHANDLING_ID, null, any())
-                adresseService.hentMottakerAdresse(
-                    sakType,
-                    behandling.personerISak.innsender!!
-                        .fnr.value,
-                )
+                adresseService.hentMottakere(sakType, behandling.personerISak)
                 adresseService.hentAvsender(any(), any())
             }
 
@@ -317,7 +314,7 @@ internal class VedtaksbrevServiceTest {
             brev.sakId shouldBe sakId
             brev.behandlingId shouldBe behandling.behandlingId
             brev.soekerFnr shouldBe behandling.personerISak.soeker.fnr.value
-            brev.mottaker shouldBe mottaker
+            brev.mottakere shouldContain mottaker
             brev.prosessType shouldBe forventetProsessType
         }
 
@@ -342,7 +339,7 @@ internal class VedtaksbrevServiceTest {
             coEvery { brevbakerService.hentRedigerbarTekstFraBrevbakeren(any()) } returns opprettLetterMarkup()
             every { db.hentBrevForBehandling(behandling.behandlingId!!, Brevtype.VEDTAK) } returns emptyList()
             coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any(), any()) } returns behandling
-            coEvery { adresseService.hentMottakerAdresse(sakType, any()) } returns mottaker
+            coEvery { adresseService.hentMottakere(sakType, any()) } returns listOf(mottaker)
             coEvery { adresseService.hentAvsender(any(), any()) } returns opprettAvsender()
             coEvery { beregningService.finnUtbetalingsinfo(any(), any(), any()) } returns utbetalingsinfo
             coEvery { behandlingService.hentEtterbetaling(any(), any()) } returns null
@@ -367,11 +364,7 @@ internal class VedtaksbrevServiceTest {
             coVerify {
                 db.hentBrevForBehandling(BEHANDLING_ID, Brevtype.VEDTAK)
                 brevdataFacade.hentGenerellBrevData(sakId, BEHANDLING_ID, null, any())
-                adresseService.hentMottakerAdresse(
-                    sakType,
-                    behandling.personerISak.innsender!!
-                        .fnr.value,
-                )
+                adresseService.hentMottakere(sakType, behandling.personerISak)
                 adresseService.hentAvsender(any(), any())
                 brevbakerService.hentRedigerbarTekstFraBrevbakeren(any())
             }
@@ -385,7 +378,7 @@ internal class VedtaksbrevServiceTest {
             brev.sakId shouldBe sakId
             brev.behandlingId shouldBe behandling.behandlingId
             brev.soekerFnr shouldBe behandling.personerISak.soeker.fnr.value
-            brev.mottaker shouldBe mottaker
+            brev.mottakere shouldContain mottaker
             brev.prosessType shouldBe forventetProsessType
         }
 
@@ -431,7 +424,7 @@ internal class VedtaksbrevServiceTest {
 
             every { db.hentBrevForBehandling(behandling.behandlingId!!, Brevtype.VEDTAK) } returns listOf()
             coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any(), any()) } returns behandling
-            coEvery { adresseService.hentMottakerAdresse(any(), any()) } returns mottaker
+            coEvery { adresseService.hentMottakere(any(), any()) } returns listOf(mottaker)
 
             coEvery { behandlingService.hentVedtaksbehandlingKanRedigeres(any(), any()) } returns false
 
@@ -787,7 +780,7 @@ internal class VedtaksbrevServiceTest {
         systemkilde: Vedtaksloesning = Vedtaksloesning.GJENNY,
         revurderingsaarsak: Revurderingaarsak? = null,
     ): GenerellBrevData {
-        val soeker = "12345612345"
+        val soeker = SOEKER_FOEDSELSNUMMER.value
         return GenerellBrevData(
             sak = Sak(soeker, sakType, SAK_ID, Enheter.PORSGRUNN.enhetNr),
             personerISak =

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/adresse/AdresseServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/adresse/AdresseServiceTest.kt
@@ -10,12 +10,26 @@ import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.randomSakId
 import no.nav.etterlatte.brev.AvsenderRequest
 import no.nav.etterlatte.brev.adresse.saksbehandler.SaksbehandlerKlient
+import no.nav.etterlatte.brev.behandling.Avdoed
+import no.nav.etterlatte.brev.behandling.Innsender
+import no.nav.etterlatte.brev.behandling.PersonerISak
+import no.nav.etterlatte.brev.behandling.Soeker
+import no.nav.etterlatte.brev.model.MottakerType
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.person.Vergemaal
 import no.nav.etterlatte.libs.common.sak.Sak
+import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
+import no.nav.etterlatte.libs.testdata.grunnlag.INNSENDER_FOEDSELSNUMMER
+import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
+import no.nav.etterlatte.libs.testdata.grunnlag.VERGE_FOEDSELSNUMMER
+import no.nav.pensjon.brevbaker.api.model.Foedselsnummer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.time.LocalDate
 
 internal class AdresseServiceTest {
     private val norg2Mock = mockk<Norg2Klient>()
@@ -88,6 +102,117 @@ internal class AdresseServiceTest {
             saksbehandlerKlient.hentSaksbehandlerNavn(zIdent, any())
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(SakType::class)
+    fun `Skal IKKE sende kopi hvis innsender og søker er samme person, uten verge`(sakType: SakType) {
+        val personerISak =
+            PersonerISak(
+                innsender = Innsender(Foedselsnummer(SOEKER_FOEDSELSNUMMER.value)),
+                soeker = Soeker("RETRO", null, "TELEFONKIOSK", Foedselsnummer(SOEKER_FOEDSELSNUMMER.value)),
+                avdoede = listOf(Avdoed(Foedselsnummer(AVDOED_FOEDSELSNUMMER.value), "RIKTIG BOK", LocalDate.now())),
+                verge = null,
+            )
+
+        coEvery { regoppslagMock.hentMottakerAdresse(any(), any()) } returns opprettRegoppslagResponse()
+
+        val mottakere =
+            runBlocking {
+                adresseService.hentMottakere(sakType, personerISak)
+            }
+
+        mottakere.size shouldBe 1
+
+        val mottaker = mottakere.single()
+        mottaker.type shouldBe MottakerType.HOVED
+        mottaker.foedselsnummer!!.value shouldBe personerISak.soeker.fnr.value
+
+        coVerify(exactly = 1) {
+            regoppslagMock.hentMottakerAdresse(sakType, personerISak.soeker.fnr.value)
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(SakType::class)
+    fun `Skal sende kopi til innsender hvis verge mangler`(sakType: SakType) {
+        val personerISak =
+            PersonerISak(
+                innsender = Innsender(Foedselsnummer(INNSENDER_FOEDSELSNUMMER.value)),
+                soeker = Soeker("LITEN", null, "FLASKE", Foedselsnummer(SOEKER_FOEDSELSNUMMER.value)),
+                avdoede = listOf(Avdoed(Foedselsnummer(AVDOED_FOEDSELSNUMMER.value), "RIKTIG BOK", LocalDate.now())),
+                verge = null,
+            )
+
+        coEvery { regoppslagMock.hentMottakerAdresse(any(), any()) } returns opprettRegoppslagResponse()
+
+        val mottakere =
+            runBlocking {
+                adresseService.hentMottakere(sakType, personerISak)
+            }
+
+        mottakere.size shouldBe 2
+
+        val innsender = mottakere.single { it.foedselsnummer!!.value == personerISak.innsender!!.fnr.value }
+        innsender.type shouldBe MottakerType.KOPI
+
+        val soeker = mottakere.single { it.foedselsnummer!!.value == personerISak.soeker.fnr.value }
+        soeker.type shouldBe MottakerType.HOVED
+
+        coVerify(exactly = 1) {
+            regoppslagMock.hentMottakerAdresse(sakType, personerISak.soeker.fnr.value)
+            regoppslagMock.hentMottakerAdresse(sakType, personerISak.innsender!!.fnr.value)
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(SakType::class)
+    fun `Skal sende kopi til verge hvis verge finnes`(sakType: SakType) {
+        val personerISak =
+            PersonerISak(
+                innsender = Innsender(Foedselsnummer(INNSENDER_FOEDSELSNUMMER.value)),
+                soeker = Soeker("LITEN", null, "FLASKE", Foedselsnummer(SOEKER_FOEDSELSNUMMER.value)),
+                avdoede = listOf(Avdoed(Foedselsnummer(AVDOED_FOEDSELSNUMMER.value), "RIKTIG BOK", LocalDate.now())),
+                verge = Vergemaal("Verg Vergesen", VERGE_FOEDSELSNUMMER),
+            )
+
+        coEvery { regoppslagMock.hentMottakerAdresse(any(), any()) } returns opprettRegoppslagResponse()
+
+        val mottakere =
+            runBlocking {
+                adresseService.hentMottakere(sakType, personerISak)
+            }
+
+        mottakere.size shouldBe 2
+
+        val verge =
+            mottakere.single { it.foedselsnummer!!.value == (personerISak.verge as Vergemaal).foedselsnummer.value }
+        verge.type shouldBe MottakerType.KOPI
+
+        val soeker = mottakere.single { it.foedselsnummer!!.value == personerISak.soeker.fnr.value }
+        soeker.type shouldBe MottakerType.HOVED
+
+        coVerify(exactly = 1) {
+            regoppslagMock.hentMottakerAdresse(sakType, personerISak.soeker.fnr.value)
+            // Skal ikke hente mottaker adresse for verge
+        }
+    }
+
+    private fun opprettRegoppslagResponse() =
+        RegoppslagResponseDTO(
+            "Test Testesen",
+            adresse =
+                RegoppslagResponseDTO.Adresse(
+                    type = RegoppslagResponseDTO.AdresseType.NORSKPOSTADRESSE,
+                    adresseKilde = RegoppslagResponseDTO.AdresseKilde.BOSTEDSADRESSE,
+                    adresselinje1 = "Testveien 13A",
+                    adresselinje2 = null,
+                    adresselinje3 = null,
+                    postnummer = "0123",
+                    poststed = "Teststed",
+                    landkode = "NO",
+                    land = "NORGE",
+                ),
+        )
 
     private fun opprettEnhet() =
         Norg2Enhet(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/BehandlingTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/BehandlingTest.kt
@@ -6,7 +6,6 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.brev.adresse.AdresseService
 import no.nav.etterlatte.brev.hentinformasjon.grunnlag.GrunnlagService
-import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.behandling.Aldersgruppe
 import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
@@ -212,9 +211,7 @@ internal class BehandlingTest {
                 metadata = mockk(),
             )
 
-        coEvery {
-            adresseService.hentMottakerAdresse(any<SakType>(), vergesFnr.value)
-        } returns Mottaker(UUID.randomUUID(), "Viggo Verge", null, null, mockk())
+        coEvery { adresseService.hentNavn(any<SakType>(), vergesFnr.value) } returns "Viggo Verge"
 
         val grunnlagService = GrunnlagService(mockk(), adresseService)
         val vergeBarnepensjon = runBlocking { grunnlagService.hentVergeForSak(SakType.BARNEPENSJON, null, grunnlag) }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/GrunnlagmapperTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/behandling/GrunnlagmapperTest.kt
@@ -7,14 +7,12 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.brev.adresse.AdresseService
 import no.nav.etterlatte.brev.hentinformasjon.grunnlag.GrunnlagService
-import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.Opplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.FOEDSELSNUMMER
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype.SOEKER_PDL_V1
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
-import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.person.UkjentVergemaal
 import no.nav.etterlatte.libs.common.person.VergeEllerFullmektig
 import no.nav.etterlatte.libs.common.person.Vergemaal
@@ -53,9 +51,7 @@ class GrunnlagmapperTest {
                 opplysningsmapSakOverrides = emptyMap(),
             ).hentOpplysningsgrunnlag()
 
-        coEvery {
-            adresseService.hentMottakerAdresse(any(), pdlVergeOekonomiskFnr)
-        } returns lagretVergeAdresse("Vera Verge", pdlVergeOekonomiskFnr)
+        coEvery { adresseService.hentNavn(any(), pdlVergeOekonomiskFnr) } returns "Vera Verge"
         val grunnlagService = GrunnlagService(mockk(), adresseService)
         val verge = runBlocking { grunnlagService.hentVergeForSak(SakType.BARNEPENSJON, null, opplysningsgrunnlag)!! }
 
@@ -81,9 +77,7 @@ class GrunnlagmapperTest {
                 opplysningsmapSakOverrides = emptyMap(),
             ).hentOpplysningsgrunnlag()
 
-        coEvery {
-            adresseService.hentMottakerAdresse(any(), pdlVergeOekonomiskFnr)
-        } returns lagretVergeAdresse("Vera Verge", pdlVergeOekonomiskFnr)
+        coEvery { adresseService.hentNavn(any(), pdlVergeOekonomiskFnr) } returns "Vera Verge"
 
         val grunnlagService = GrunnlagService(mockk(), adresseService)
         val verge =
@@ -113,17 +107,6 @@ class GrunnlagmapperTest {
             omfang,
             false,
         ),
-    )
-
-    private fun lagretVergeAdresse(
-        navn: String,
-        fnr: String,
-    ) = Mottaker(
-        UUID.randomUUID(),
-        navn,
-        MottakerFoedselsnummer(fnr),
-        "orgnr",
-        mockk(),
     )
 
     private fun opprettOpplysning(jsonNode: JsonNode) =

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/db/BrevRepositoryIntegrationTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/db/BrevRepositoryIntegrationTest.kt
@@ -97,7 +97,7 @@ internal class BrevRepositoryIntegrationTest(
         val hentetBrev = db.hentBrev(nyttBrev.id)
         assertEquals(nyttBrev.id, hentetBrev.id)
         assertEquals(behandlingId, hentetBrev.behandlingId)
-        assertEquals(hentetBrev.mottakere.single(), ulagretBrev.mottaker)
+        assertEquals(hentetBrev.mottakere, ulagretBrev.mottakere)
     }
 
     @Test
@@ -509,7 +509,7 @@ internal class BrevRepositoryIntegrationTest(
         behandlingId = behandlingId,
         prosessType = BrevProsessType.AUTOMATISK,
         soekerFnr = "00000012345",
-        mottaker = opprettMottaker(),
+        mottakere = listOf(opprettMottaker()),
         opprettet = Tidspunkt.now(),
         innhold = innhold ?: BrevInnhold("tittel", Spraak.NB),
         innholdVedlegg = innhold_vedlegg,

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/KlageMottakerRequestTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/KlageMottakerRequestTest.kt
@@ -32,7 +32,7 @@ internal class KlageMottakerRequestTest {
                         ),
                 )
 
-            val mottaker = mottakerFraAdresse(SOEKER_FOEDSELSNUMMER, regoppslagResponseDTO)
+            val mottaker = mottakerFraAdresse(SOEKER_FOEDSELSNUMMER, regoppslagResponseDTO, MottakerType.HOVED)
 
             mottaker.navn shouldBe regoppslagResponseDTO.navn
             mottaker.adresse.adresselinje1 shouldBe "Testveien 13A"
@@ -63,7 +63,7 @@ internal class KlageMottakerRequestTest {
                         ),
                 )
 
-            val mottaker = mottakerFraAdresse(SOEKER_FOEDSELSNUMMER, regoppslagResponseDTO)
+            val mottaker = mottakerFraAdresse(SOEKER_FOEDSELSNUMMER, regoppslagResponseDTO, MottakerType.HOVED)
 
             mottaker.navn shouldBe regoppslagResponseDTO.navn
             mottaker.adresse.adresselinje1 shouldBe "c/o STOR SNERK"

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevServiceImplTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevServiceImplTest.kt
@@ -73,7 +73,7 @@ class OversendelseBrevServiceImplTest(
     fun setUp() {
         coEvery { behandlingService.hentKlage(any(), any()) } returns klage()
         coEvery { brevdataFacade.hentGenerellBrevData(any(), any(), any(), any()) } returns brevData()
-        coEvery { adresseService.hentMottakerAdresse(any(), any()) } returns opprettMottaker()
+        coEvery { adresseService.hentMottakere(any(), any()) } returns listOf(opprettMottaker())
         coEvery { behandlingService.hentVedtaksbehandlingKanRedigeres(any(), any()) } returns true
     }
 

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/varselbrev/VarselbrevTest.kt
@@ -23,7 +23,6 @@ import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.Spraak
-import no.nav.etterlatte.brev.model.tomMottaker
 import no.nav.etterlatte.brev.pdf.PDFGenerator
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.ktor.token.systembruker
@@ -64,22 +63,23 @@ class VarselbrevTest(
     fun start() {
         val adresseService =
             mockk<AdresseService>().also {
-                coEvery { it.hentMottakerAdresse(any(), any()) } returns
-                    Mottaker(
-                        id = UUID.fromString("d762e98d-514d-4bb5-a6b5-a3fbf4d65887"),
-                        navn = "Navn Navnesen",
-                        foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
-                        orgnummer = null,
-                        adresse =
-                            Adresse(
-                                adresseType = AdresseType.VEGADRESSE.name,
-                                adresselinje1 = "Adresse1",
-                                landkode = "NO",
-                                land = "Norge",
-                            ),
+                coEvery { it.hentMottakere(any(), any()) } returns
+                    listOf(
+                        Mottaker(
+                            id = UUID.fromString("d762e98d-514d-4bb5-a6b5-a3fbf4d65887"),
+                            navn = "Navn Navnesen",
+                            foedselsnummer = MottakerFoedselsnummer(SOEKER_FOEDSELSNUMMER.value),
+                            orgnummer = null,
+                            adresse =
+                                Adresse(
+                                    adresseType = AdresseType.VEGADRESSE.name,
+                                    adresselinje1 = "Adresse1",
+                                    landkode = "NO",
+                                    land = "Norge",
+                                ),
+                        ),
                     )
 
-                tomMottaker(SOEKER_FOEDSELSNUMMER)
                 coEvery { it.hentAvsender(any(), any()) } returns
                     Avsender(
                         kontor = "",

--- a/apps/etterlatte-saksbehandling-ui/docker-compose.yml
+++ b/apps/etterlatte-saksbehandling-ui/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       PSAK_URL: https://pensjon-psak-q2.dev.adeo.no/psak
       APP_VERSION: 1
       # Lokale URL-er skal kommenteres ut når de ikke er i bruk
-      BREV_API_URL: http://host.docker.internal:8084
+#      BREV_API_URL: http://host.docker.internal:8084
 #      BEHANDLING_API_URL: http://host.docker.internal:8090
 #      PDLTJENESTER_API_URL: http://host.docker.internal:8091
 #      GRUNNLAG_API_URL: http://host.docker.internal:8092

--- a/apps/etterlatte-saksbehandling-ui/docker-compose.yml
+++ b/apps/etterlatte-saksbehandling-ui/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       PSAK_URL: https://pensjon-psak-q2.dev.adeo.no/psak
       APP_VERSION: 1
       # Lokale URL-er skal kommenteres ut når de ikke er i bruk
-#      BREV_API_URL: http://host.docker.internal:8084
+      BREV_API_URL: http://host.docker.internal:8084
 #      BEHANDLING_API_URL: http://host.docker.internal:8090
 #      PDLTJENESTER_API_URL: http://host.docker.internal:8091
 #      GRUNNLAG_API_URL: http://host.docker.internal:8092


### PR DESCRIPTION
Oppretter flere mottakere ved opprettelse av brev. 
Gjøres i tilfeller hvor det finnes verge, eller søker og innsender er to ulike personer. 
Vil også gjøre enhetstesting enklere.