### PR TITLE
Opprydding i opprettelse av oppgave (forarbeid EY-4597)

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
@@ -230,7 +230,7 @@ class BehandlingFactory(
                 )
             }
             val oppgave =
-                oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(
+                opprettOppgaveForFoerstegangsbehandling(
                     referanse = behandling.id.toString(),
                     sakId = request.sak.id,
                     oppgaveKilde =
@@ -320,7 +320,7 @@ class BehandlingFactory(
                 }
 
                 val oppgave =
-                    oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(
+                    opprettOppgaveForFoerstegangsbehandling(
                         referanse = nyFoerstegangsbehandling.id.toString(),
                         sakId = nyFoerstegangsbehandling.sak.id,
                         oppgaveKilde = OppgaveKilde.BEHANDLING,
@@ -357,6 +357,23 @@ class BehandlingFactory(
             BehandlingHendelseType.OPPRETTET,
         )
         return behandlingerForOmgjoering.nyFoerstegangsbehandling
+    }
+
+    private fun opprettOppgaveForFoerstegangsbehandling(
+        referanse: String,
+        sakId: SakId,
+        oppgaveKilde: OppgaveKilde = OppgaveKilde.BEHANDLING,
+        merknad: String? = null,
+    ): OppgaveIntern {
+        oppgaveService.avbrytAapneOppgaverMedReferanse(referanse)
+
+        return oppgaveService.opprettOppgave(
+            referanse = referanse,
+            sakId = sakId,
+            kilde = oppgaveKilde,
+            type = OppgaveType.FOERSTEGANGSBEHANDLING,
+            merknad = merknad,
+        )
     }
 
     private fun kopierFoerstegangsbehandlingOversikt(

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -557,27 +557,6 @@ class OppgaveService(
                 }
             }
 
-    fun opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(
-        referanse: String,
-        sakId: SakId,
-        oppgaveKilde: OppgaveKilde = OppgaveKilde.BEHANDLING,
-        merknad: String? = null,
-    ): OppgaveIntern {
-        val oppgaverForBehandling = oppgaveDao.hentOppgaverForReferanse(referanse)
-        val oppgaverSomKanLukkes = oppgaverForBehandling.filter { !it.erAvsluttet() }
-        oppgaverSomKanLukkes.forEach {
-            oppgaveDao.endreStatusPaaOppgave(it.id, Status.AVBRUTT)
-        }
-
-        return opprettOppgave(
-            referanse = referanse,
-            sakId = sakId,
-            kilde = oppgaveKilde,
-            type = OppgaveType.FOERSTEGANGSBEHANDLING,
-            merknad = merknad,
-        )
-    }
-
     fun opprettOppgaveBulk(
         referanse: String,
         sakIds: List<SakId>,

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
@@ -8,6 +8,7 @@ import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.just
+import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
@@ -133,6 +134,7 @@ class BehandlingFactoryTest {
     fun before() {
         every { user.name() } returns "User"
         every { user.enheter() } returns listOf(Enheter.defaultEnhet.enhetNr)
+        justRun { oppgaveService.avbrytAapneOppgaverMedReferanse(any()) }
 
         nyKontekstMedBruker(user)
     }
@@ -210,7 +212,7 @@ class BehandlingFactoryTest {
         } returns Unit
         coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any()) } returns Unit
         every {
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
         } returns mockOppgave
 
         val resultat =
@@ -241,8 +243,8 @@ class BehandlingFactoryTest {
                 any(),
                 BehandlingHendelseType.OPPRETTET,
             )
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
         }
         coVerify(exactly = 1) { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) }
     }
@@ -303,7 +305,7 @@ class BehandlingFactoryTest {
         } returns Unit
         coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) } returns Unit
         every {
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
         } returns mockOppgave
 
         val foerstegangsbehandling =
@@ -326,8 +328,8 @@ class BehandlingFactoryTest {
             hendelseDaoMock.behandlingOpprettet(any())
             behandlingDaoMock.hentBehandlingerForSak(any())
             behandlingHendelserKafkaProducerMock.sendMeldingForHendelseStatisitkk(any(), any())
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
         }
         coVerify { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) }
     }
@@ -391,7 +393,7 @@ class BehandlingFactoryTest {
         } returns Unit
         coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) } returns Unit
         every {
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
         } returns mockOppgave
         every {
             oppgaveService.avbrytAapneOppgaverMedReferanse(any())
@@ -434,8 +436,8 @@ class BehandlingFactoryTest {
             hendelseDaoMock.behandlingOpprettet(any())
             behandlingDaoMock.hentBehandlingerForSak(any())
             behandlingHendelserKafkaProducerMock.sendMeldingForHendelseStatisitkk(any(), any())
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
         }
         coVerify { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) }
         verify {
@@ -577,12 +579,7 @@ class BehandlingFactoryTest {
         coEvery { grunnlagService.hentPersongalleri(sak.id) } returns Persongalleri(sak.ident)
         coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) } just runs
         every {
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(
-                any(),
-                any(),
-                any(),
-                any(),
-            )
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
         } returns
             OppgaveIntern(
                 id = UUID.randomUUID(),
@@ -624,7 +621,7 @@ class BehandlingFactoryTest {
             behandlingDaoMock.opprettBehandling(any())
             kommerBarnetTilGodeServiceMock.lagreKommerBarnetTilgode(any())
             oppgaveService.tildelSaksbehandler(any(), saksbehandler.ident)
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any(), any(), any())
+            oppgaveService.opprettOppgave(opprettetBehandling.id.toString(), sak.id, any(), any(), any())
             hendelseDaoMock.behandlingOpprettet(any())
             behandlingHendelserKafkaProducerMock.sendMeldingForHendelseStatisitkk(any(), any())
             vilkaarsvurderingService.kopierVilkaarsvurdering(any(), any(), any())
@@ -661,12 +658,7 @@ class BehandlingFactoryTest {
         coEvery { grunnlagService.hentPersongalleri(sak.id) } returns Persongalleri(sak.ident)
         coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) } just runs
         every {
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(
-                any(),
-                any(),
-                any(),
-                any(),
-            )
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
         } returns
             OppgaveIntern(
                 id = UUID.randomUUID(),
@@ -700,7 +692,7 @@ class BehandlingFactoryTest {
             behandlingDaoMock.hentBehandling(any())
             behandlingDaoMock.opprettBehandling(any())
             oppgaveService.tildelSaksbehandler(any(), saksbehandler.ident)
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any(), any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
             hendelseDaoMock.behandlingOpprettet(any())
             behandlingHendelserKafkaProducerMock.sendMeldingForHendelseStatisitkk(any(), any())
             behandlingDaoMock.lagreGyldighetsproeving(opprettetBehandling.id, any())
@@ -770,7 +762,7 @@ class BehandlingFactoryTest {
         } returns Unit
         coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) } returns Unit
         every {
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
         } returns mockOppgave
         every {
             oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
@@ -852,8 +844,13 @@ class BehandlingFactoryTest {
                 ?.behandling
         Assertions.assertTrue(revurderingsBehandling is Revurdering)
         verify {
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any(), any(), any())
+            oppgaveService.opprettOppgave(
+                revurderingsBehandling!!.id.toString(),
+                sakId1,
+                OppgaveKilde.BEHANDLING,
+                OppgaveType.FOERSTEGANGSBEHANDLING,
+                any(),
+            )
         }
         coVerify { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) }
         verify(exactly = 2) {
@@ -925,7 +922,7 @@ class BehandlingFactoryTest {
         } returns Unit
         coEvery { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) } returns Unit
         every {
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
         } returns mockOppgave
         every {
             oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
@@ -1007,7 +1004,7 @@ class BehandlingFactoryTest {
                 .behandling
         Assertions.assertTrue(revurderingsBehandling is Revurdering)
         verify {
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
             oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
         }
         coVerify { grunnlagService.leggInnNyttGrunnlag(any(), any(), any()) }
@@ -1072,7 +1069,7 @@ class BehandlingFactoryTest {
         every { behandlingDaoMock.hentBehandling(capture(behandlingHentes)) } returns opprettetBehandling
         every { behandlingDaoMock.hentBehandlingerForSak(any()) } returns emptyList()
         every {
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
         } returns mockOppgave
 
         coEvery { pdlTjenesterKlientMock.hentAdressebeskyttelseForPerson(any()) } returns AdressebeskyttelseGradering.UGRADERT
@@ -1111,8 +1108,8 @@ class BehandlingFactoryTest {
                 any(),
                 BehandlingHendelseType.OPPRETTET,
             )
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
         }
         coVerify {
             grunnlagService.leggInnNyttGrunnlag(any(), any(), any())

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/generellbehandling/GenerellBehandlingServiceTest.kt
@@ -254,7 +254,13 @@ internal class GenerellBehandlingServiceTest(
         assertNull(opprettBehandling.innhold)
 
         val oppgaveForFoerstegangsBehandling =
-            oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(behandlingId.toString(), sak.id)
+            oppgaveService.opprettOppgave(
+                behandlingId.toString(),
+                sak.id,
+                OppgaveKilde.BEHANDLING,
+                OppgaveType.FOERSTEGANGSBEHANDLING,
+                null,
+            )
         val saksbehandler = "saksbehandler"
         oppgaveService.tildelSaksbehandler(oppgaveForFoerstegangsBehandling.id, saksbehandler)
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/ManuellRevurderingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/ManuellRevurderingServiceTest.kt
@@ -109,7 +109,7 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
                         Vedtaksloesning.GJENNY,
                         factory.hentDataForOpprettBehandling(sak.id),
                     )
-            }?.also { it.sendMeldingForHendelse() }?.behandling
+            }.also { it.sendMeldingForHendelse() }.behandling
 
         return Pair(sak, behandling as Foerstegangsbehandling)
     }
@@ -385,22 +385,17 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
             }
             verify {
                 oppgaveService.hentOppgaverForSak(sak.id)
+                oppgaveService.avbrytAapneOppgaverMedReferanse(behandling!!.id.toString())
                 oppgaveService.hentOppgave(any())
                 hendelser.sendMeldingForHendelseStatisitkk(any(), BehandlingHendelseType.OPPRETTET)
                 oppgaveService.opprettOppgave(
-                    behandling!!.id.toString(),
+                    behandling.id.toString(),
                     sak.id,
                     OppgaveKilde.BEHANDLING,
                     OppgaveType.FOERSTEGANGSBEHANDLING,
                     "2 søsken",
                     null,
                     null,
-                )
-                oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(
-                    behandling!!.id.toString(),
-                    sak.id,
-                    OppgaveKilde.BEHANDLING,
-                    "2 søsken",
                 )
                 oppgaveService.tildelSaksbehandler(any(), saksbehandler.ident)
                 oppgaveService.opprettOppgave(

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -1135,28 +1135,6 @@ internal class OppgaveServiceTest(
     }
 
     @Test
-    fun `skal lukke nye ikke ferdige eller feilregistrerte oppgaver hvis ny søknad kommer inn`() {
-        val opprettetSak = sakSkrivDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
-        val behandlingsref = UUID.randomUUID().toString()
-        val oppgaveSomSkalBliAvbrutt =
-            oppgaveService.opprettOppgave(
-                behandlingsref,
-                opprettetSak.id,
-                OppgaveKilde.BEHANDLING,
-                OppgaveType.FOERSTEGANGSBEHANDLING,
-                null,
-            )
-        oppgaveService.tildelSaksbehandler(oppgaveSomSkalBliAvbrutt.id, "saksbehandler01")
-
-        oppgaveService.opprettFoerstegangsbehandlingsOppgaveForInnsendtSoeknad(behandlingsref, opprettetSak.id)
-
-        val alleOppgaver = oppgaveDao.hentOppgaverForReferanse(behandlingsref)
-        assertEquals(2, alleOppgaver.size)
-        val avbruttOppgave = oppgaveDao.hentOppgave(oppgaveSomSkalBliAvbrutt.id)!!
-        assertEquals(avbruttOppgave.status, Status.AVBRUTT)
-    }
-
-    @Test
     fun `Skal filtrere bort oppgaver med annen enhet`() {
         nyKontekstMedBrukerOgDatabaseContext(saksbehandler, DatabaseContextTest(dataSource))
 


### PR DESCRIPTION
Flytter funksjon for opprettelse av førstegangsbehandling fra `oppgave` til `behandling`. 