### PR TITLE
EY-4808: Bruk angitt flyttedato for innflytting

### DIFF
--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagHelperKtTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/GrunnlagHelperKtTest.kt
@@ -147,7 +147,10 @@ internal class GrunnlagHelperKtTest {
     fun `skal hente utland`() {
         val utland =
             Utland(
-                innflyttingTilNorge = listOf(InnflyttingTilNorge("Danmark", LocalDate.of(2007, 4, 1))),
+                innflyttingTilNorge =
+                    listOf(
+                        InnflyttingTilNorge("Danmark", LocalDate.of(2007, 4, 1), LocalDate.of(2013, 7, 9), LocalDate.of(2013, 7, 9)),
+                    ),
                 utflyttingFraNorge =
                     listOf(
                         UtflyttingFraNorge("Sverige", LocalDate.of(2005, 7, 8)),

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/SamsvarHelperKtTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/SamsvarHelperKtTest.kt
@@ -66,7 +66,10 @@ internal class SamsvarHelperKtTest {
     fun `samsvarUtflytting med samsvar`() {
         val utland =
             Utland(
-                innflyttingTilNorge = listOf(InnflyttingTilNorge("Tyskland", LocalDate.of(2013, 7, 9))),
+                innflyttingTilNorge =
+                    listOf(
+                        InnflyttingTilNorge("Tyskland", LocalDate.of(2013, 7, 9), LocalDate.of(2013, 7, 9), LocalDate.of(2013, 7, 9)),
+                    ),
                 utflyttingFraNorge = listOf(UtflyttingFraNorge("Tyskland", LocalDate.of(2022, 1, 1))),
             )
         val utflyttingPdl = utland
@@ -79,7 +82,10 @@ internal class SamsvarHelperKtTest {
     fun `samsvarUtflytting uten samsvar`() {
         val utflyttingPdl =
             Utland(
-                innflyttingTilNorge = listOf(InnflyttingTilNorge("Tyskland", LocalDate.of(2013, 7, 9))),
+                innflyttingTilNorge =
+                    listOf(
+                        InnflyttingTilNorge("Tyskland", LocalDate.of(2013, 7, 9), LocalDate.of(2013, 7, 9), LocalDate.of(2013, 7, 9)),
+                    ),
                 utflyttingFraNorge = listOf(UtflyttingFraNorge("Tyskland", LocalDate.of(2022, 1, 1))),
             )
         val utflyttingGrunnlag =

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
@@ -236,6 +236,7 @@ data class PdlFoedested(
 
 data class PdlFolkeregistermetadata(
     val gyldighetstidspunkt: LocalDateTime? = null,
+    val ajourholdstidspunkt: LocalDateTime? = null,
     val opphoerstidspunkt: LocalDateTime? = null,
 )
 
@@ -305,6 +306,7 @@ data class PdlUtflyttingFraNorge(
 )
 
 data class PdlBostedsadresse(
+    val angittFlyttedato: LocalDateTime? = null,
     val coAdressenavn: String?,
     val gyldigFraOgMed: LocalDateTime? = null,
     val gyldigTilOgMed: LocalDateTime? = null,

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlModell.kt
@@ -306,7 +306,7 @@ data class PdlUtflyttingFraNorge(
 )
 
 data class PdlBostedsadresse(
-    val angittFlyttedato: LocalDateTime? = null,
+    val angittFlyttedato: LocalDate? = null,
     val coAdressenavn: String?,
     val gyldigFraOgMed: LocalDateTime? = null,
     val gyldigTilOgMed: LocalDateTime? = null,

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/UtlandMapper.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/UtlandMapper.kt
@@ -26,25 +26,25 @@ object UtlandMapper {
         innflytting: PdlInnflyttingTilNorge?,
         bostedsadresse: List<PdlBostedsadresse>?,
     ): InnflyttingTilNorge {
-        val gyldighetstidspunkt: LocalDate? = innflytting?.folkeregistermetadata?.gyldighetstidspunkt?.toLocalDate()
-        val ajourholdstidspunkt: LocalDate? = innflytting?.folkeregistermetadata?.ajourholdstidspunkt?.toLocalDate()
+        val gyldighetsdato: LocalDate? = innflytting?.folkeregistermetadata?.gyldighetstidspunkt?.toLocalDate()
+        val ajourholdsdato: LocalDate? = innflytting?.folkeregistermetadata?.ajourholdstidspunkt?.toLocalDate()
 
         val innvandretDato =
-            if (gyldighetstidspunkt != null) {
+            if (gyldighetsdato != null) {
                 val angittFlyttedato =
                     bostedsadresse
                         ?.filter {
                             it.gyldigFraOgMed != null
-                        }?.find { it.gyldigFraOgMed?.toLocalDate() == gyldighetstidspunkt }
+                        }?.find { it.gyldigFraOgMed?.toLocalDate() == gyldighetsdato }
                         ?.angittFlyttedato
 
                 if (angittFlyttedato != null) {
                     angittFlyttedato
                 } else {
-                    finnForsteDatoEtterInnflytting(gyldighetstidspunkt, bostedsadresse)
+                    finnForsteDatoEtterInnflytting(gyldighetsdato, bostedsadresse)
                 }
-            } else if (ajourholdstidspunkt != null) {
-                finnForsteDatoEtterInnflytting(ajourholdstidspunkt, bostedsadresse)
+            } else if (ajourholdsdato != null) {
+                finnForsteDatoEtterInnflytting(ajourholdsdato, bostedsadresse)
             } else {
                 null
             }
@@ -52,8 +52,8 @@ object UtlandMapper {
         return InnflyttingTilNorge(
             fraflyttingsland = innflytting?.fraflyttingsland,
             dato = innvandretDato,
-            gyldighetstidspunkt = gyldighetstidspunkt,
-            ajourholdstidspunkt = ajourholdstidspunkt,
+            gyldighetsdato = gyldighetsdato,
+            ajourholdsdato = ajourholdsdato,
         )
     }
 

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/UtlandMapper.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/UtlandMapper.kt
@@ -29,6 +29,7 @@ object UtlandMapper {
         val gyldighetsdato: LocalDate? = innflytting.folkeregistermetadata?.gyldighetstidspunkt?.toLocalDate()
         val ajourholdsdato: LocalDate? = innflytting.folkeregistermetadata?.ajourholdstidspunkt?.toLocalDate()
 
+        // Logikk for å finne innvandretDato er hentet fra Pesys
         val innvandretDato =
             if (gyldighetsdato != null) {
                 val angittFlyttedato =

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/UtlandMapper.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/UtlandMapper.kt
@@ -3,15 +3,17 @@ package no.nav.etterlatte.pdl.mapper
 import no.nav.etterlatte.libs.common.person.InnflyttingTilNorge
 import no.nav.etterlatte.libs.common.person.UtflyttingFraNorge
 import no.nav.etterlatte.libs.common.person.Utland
+import no.nav.etterlatte.pdl.PdlBostedsadresse
 import no.nav.etterlatte.pdl.PdlHentPerson
 import no.nav.etterlatte.pdl.PdlInnflyttingTilNorge
 import no.nav.etterlatte.pdl.PdlUtflyttingFraNorge
+import java.time.LocalDate
 
 object UtlandMapper {
     fun mapUtland(hentPerson: PdlHentPerson): Utland =
         Utland(
             utflyttingFraNorge = hentPerson.utflyttingFraNorge?.map { (mapUtflytting(it)) },
-            innflyttingTilNorge = hentPerson.innflyttingTilNorge?.map { (mapInnflytting(it)) },
+            innflyttingTilNorge = hentPerson.innflyttingTilNorge?.map { (mapInnflytting(it, hentPerson.bostedsadresse)) },
         )
 
     private fun mapUtflytting(utflytting: PdlUtflyttingFraNorge): UtflyttingFraNorge =
@@ -20,11 +22,64 @@ object UtlandMapper {
             dato = utflytting.utflyttingsdato,
         )
 
-    private fun mapInnflytting(innflytting: PdlInnflyttingTilNorge): InnflyttingTilNorge =
-        InnflyttingTilNorge(
-            fraflyttingsland = innflytting.fraflyttingsland,
-            // TODO her må vi heller sjekke mot gyldighetsdato på bostedsadresse
-            // TODO skal ikke være tostring her
-            dato = innflytting.folkeregistermetadata?.gyldighetstidspunkt?.toLocalDate(),
+    private fun mapInnflytting(
+        innflytting: PdlInnflyttingTilNorge?,
+        bostedsadresse: List<PdlBostedsadresse>?,
+    ): InnflyttingTilNorge {
+        val gyldighetstidspunkt: LocalDate? = innflytting?.folkeregistermetadata?.gyldighetstidspunkt?.toLocalDate()
+        val ajourholdstidspunkt: LocalDate? = innflytting?.folkeregistermetadata?.ajourholdstidspunkt?.toLocalDate()
+
+        val innvandretDato =
+            if (gyldighetstidspunkt != null) {
+                val angittFlyttedato =
+                    bostedsadresse
+                        ?.filter {
+                            it.gyldigFraOgMed != null
+                        }?.find { it.gyldigFraOgMed?.toLocalDate() == gyldighetstidspunkt }
+                        ?.angittFlyttedato
+
+                if (angittFlyttedato != null) {
+                    angittFlyttedato.toLocalDate()
+                } else {
+                    finnForsteDatoEtterInnflytting(gyldighetstidspunkt, bostedsadresse)
+                }
+            } else if (ajourholdstidspunkt != null) {
+                finnForsteDatoEtterInnflytting(ajourholdstidspunkt, bostedsadresse)
+            } else {
+                null
+            }
+
+        return InnflyttingTilNorge(
+            fraflyttingsland = innflytting?.fraflyttingsland,
+            dato = innvandretDato,
+            gyldighetstidspunkt = gyldighetstidspunkt,
+            ajourholdstidspunkt = ajourholdstidspunkt,
         )
+    }
+
+    private fun finnForsteDatoEtterInnflytting(
+        systemoppgitt: LocalDate,
+        bostedstidspunkt: List<PdlBostedsadresse>?,
+    ): LocalDate {
+        if (bostedstidspunkt.isNullOrEmpty()) {
+            return systemoppgitt
+        }
+
+        return bostedstidspunkt
+            .sortedBy { it.angittFlyttedato }
+            .mapNotNull { hentDatoForBostedadresse(it) }
+            .firstOrNull { it.isAfter(systemoppgitt) || it.isEqual(systemoppgitt) } ?: systemoppgitt
+    }
+
+    private fun hentDatoForBostedadresse(bostedstidspunkt: PdlBostedsadresse): LocalDate? {
+        if (bostedstidspunkt.angittFlyttedato != null) {
+            return bostedstidspunkt.angittFlyttedato.toLocalDate()
+        }
+
+        if (bostedstidspunkt.gyldigFraOgMed != null) {
+            return bostedstidspunkt.gyldigFraOgMed.toLocalDate()
+        }
+
+        return null
+    }
 }

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/UtlandMapper.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/UtlandMapper.kt
@@ -59,25 +59,25 @@ object UtlandMapper {
 
     private fun finnForsteDatoEtterInnflytting(
         systemoppgitt: LocalDate,
-        bostedstidspunkt: List<PdlBostedsadresse>?,
+        bostedsadresse: List<PdlBostedsadresse>?,
     ): LocalDate {
-        if (bostedstidspunkt.isNullOrEmpty()) {
+        if (bostedsadresse.isNullOrEmpty()) {
             return systemoppgitt
         }
 
-        return bostedstidspunkt
+        return bostedsadresse
             .sortedBy { it.angittFlyttedato }
             .mapNotNull { hentDatoForBostedadresse(it) }
             .firstOrNull { it.isAfter(systemoppgitt) || it.isEqual(systemoppgitt) } ?: systemoppgitt
     }
 
-    private fun hentDatoForBostedadresse(bostedstidspunkt: PdlBostedsadresse): LocalDate? {
-        if (bostedstidspunkt.angittFlyttedato != null) {
-            return bostedstidspunkt.angittFlyttedato
+    private fun hentDatoForBostedadresse(bostedsadresse: PdlBostedsadresse): LocalDate? {
+        if (bostedsadresse.angittFlyttedato != null) {
+            return bostedsadresse.angittFlyttedato
         }
 
-        if (bostedstidspunkt.gyldigFraOgMed != null) {
-            return bostedstidspunkt.gyldigFraOgMed.toLocalDate()
+        if (bostedsadresse.gyldigFraOgMed != null) {
+            return bostedsadresse.gyldigFraOgMed.toLocalDate()
         }
 
         return null

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/UtlandMapper.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/UtlandMapper.kt
@@ -23,11 +23,11 @@ object UtlandMapper {
         )
 
     private fun mapInnflytting(
-        innflytting: PdlInnflyttingTilNorge?,
+        innflytting: PdlInnflyttingTilNorge,
         bostedsadresse: List<PdlBostedsadresse>?,
     ): InnflyttingTilNorge {
-        val gyldighetsdato: LocalDate? = innflytting?.folkeregistermetadata?.gyldighetstidspunkt?.toLocalDate()
-        val ajourholdsdato: LocalDate? = innflytting?.folkeregistermetadata?.ajourholdstidspunkt?.toLocalDate()
+        val gyldighetsdato: LocalDate? = innflytting.folkeregistermetadata?.gyldighetstidspunkt?.toLocalDate()
+        val ajourholdsdato: LocalDate? = innflytting.folkeregistermetadata?.ajourholdstidspunkt?.toLocalDate()
 
         val innvandretDato =
             if (gyldighetsdato != null) {
@@ -50,7 +50,7 @@ object UtlandMapper {
             }
 
         return InnflyttingTilNorge(
-            fraflyttingsland = innflytting?.fraflyttingsland,
+            fraflyttingsland = innflytting.fraflyttingsland,
             dato = innvandretDato,
             gyldighetsdato = gyldighetsdato,
             ajourholdsdato = ajourholdsdato,

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/UtlandMapper.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/UtlandMapper.kt
@@ -39,7 +39,7 @@ object UtlandMapper {
                         ?.angittFlyttedato
 
                 if (angittFlyttedato != null) {
-                    angittFlyttedato.toLocalDate()
+                    angittFlyttedato
                 } else {
                     finnForsteDatoEtterInnflytting(gyldighetstidspunkt, bostedsadresse)
                 }
@@ -73,7 +73,7 @@ object UtlandMapper {
 
     private fun hentDatoForBostedadresse(bostedstidspunkt: PdlBostedsadresse): LocalDate? {
         if (bostedstidspunkt.angittFlyttedato != null) {
-            return bostedstidspunkt.angittFlyttedato.toLocalDate()
+            return bostedstidspunkt.angittFlyttedato
         }
 
         if (bostedstidspunkt.gyldigFraOgMed != null) {

--- a/apps/etterlatte-pdltjenester/src/main/resources/pdl/hentPerson.graphql
+++ b/apps/etterlatte-pdltjenester/src/main/resources/pdl/hentPerson.graphql
@@ -172,6 +172,7 @@ query(
             }
         }
         bostedsadresse(historikk: $bostedsadresseHistorikk) @include(if: $bostedsadresse) {
+            angittFlyttedato
             coAdressenavn
             vegadresse {...vegadresseDetails}
             utenlandskAdresse {...utenlandskAdresseDetails}

--- a/apps/etterlatte-pdltjenester/src/main/resources/pdl/hentPersonBolk.graphql
+++ b/apps/etterlatte-pdltjenester/src/main/resources/pdl/hentPersonBolk.graphql
@@ -156,6 +156,7 @@ query(
                 }
             }
             bostedsadresse(historikk: $bostedsadresseHistorikk) @include(if: $bostedsadresse) {
+                angittFlyttedato
                 coAdressenavn
                 vegadresse {...vegadresseDetails}
                 utenlandskAdresse {...utenlandskAdresseDetails}

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/pdl/mapper/UtlandMapperTest.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/pdl/mapper/UtlandMapperTest.kt
@@ -54,7 +54,7 @@ internal class UtlandMapperTest {
                 every { bostedsadresse } returns
                     listOf(
                         mockk {
-                            every { angittFlyttedato } returns LocalDateTime.parse("2021-07-01T00:00:00")
+                            every { angittFlyttedato } returns LocalDate.parse("2021-07-01")
                             every { gyldigFraOgMed } returns LocalDateTime.parse("2021-07-01T00:00:00")
                         },
                     )

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/pdl/mapper/UtlandMapperTest.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/pdl/mapper/UtlandMapperTest.kt
@@ -85,4 +85,115 @@ internal class UtlandMapperTest {
                 .toString(),
         )
     }
+
+    @Test
+    fun `skal mappe dato til angittFlyttedato hvis angittFlyttedato er etter gyldighetstidspunkt`() {
+        val hentPerson =
+            mockk<PdlHentPerson> {
+                every { innflyttingTilNorge } returns
+                    listOf(
+                        mockk {
+                            every { fraflyttingsland } returns "FRA"
+                            every { folkeregistermetadata } returns
+                                mockk {
+                                    every { gyldighetstidspunkt } returns LocalDateTime.parse("2021-06-01T00:00:00")
+                                    every { ajourholdstidspunkt } returns LocalDateTime.parse("2021-08-01T00:00:00")
+                                }
+                        },
+                    )
+                every { utflyttingFraNorge } returns null
+                every { bostedsadresse } returns
+                    listOf(
+                        mockk {
+                            every { angittFlyttedato } returns LocalDate.parse("2021-07-01")
+                            every { gyldigFraOgMed } returns LocalDateTime.parse("2021-07-01T00:00:00")
+                        },
+                    )
+            }
+
+        val utland = UtlandMapper.mapUtland(hentPerson)
+
+        assertEquals("FRA", utland.innflyttingTilNorge?.first()?.fraflyttingsland)
+        assertEquals(
+            "2021-07-01",
+            utland.innflyttingTilNorge
+                ?.first()
+                ?.dato
+                .toString(),
+        )
+    }
+
+    @Test
+    fun `skal mappe dato til gyldighetstidspunkt hvis angittFlyttedato er før gyldighetstidspunkt`() {
+        val hentPerson =
+            mockk<PdlHentPerson> {
+                every { innflyttingTilNorge } returns
+                    listOf(
+                        mockk {
+                            every { fraflyttingsland } returns "FRA"
+                            every { folkeregistermetadata } returns
+                                mockk {
+                                    every { gyldighetstidspunkt } returns LocalDateTime.parse("2021-08-01T00:00:00")
+                                    every { ajourholdstidspunkt } returns LocalDateTime.parse("2021-09-01T00:00:00")
+                                }
+                        },
+                    )
+                every { utflyttingFraNorge } returns null
+                every { bostedsadresse } returns
+                    listOf(
+                        mockk {
+                            every { angittFlyttedato } returns LocalDate.parse("2021-07-01")
+                            every { gyldigFraOgMed } returns LocalDateTime.parse("2021-07-01T00:00:00")
+                        },
+                    )
+            }
+
+        val utland = UtlandMapper.mapUtland(hentPerson)
+
+        assertEquals("FRA", utland.innflyttingTilNorge?.first()?.fraflyttingsland)
+        assertEquals(
+            "2021-08-01",
+            utland.innflyttingTilNorge
+                ?.first()
+                ?.dato
+                .toString(),
+        )
+    }
+
+    @Test
+    fun `skal mappe dato til ajourholdstidspunkt hvis gyldighetstidspunkt er null`() {
+        val hentPerson =
+            mockk<PdlHentPerson> {
+                every { innflyttingTilNorge } returns
+                    listOf(
+                        mockk {
+                            every { fraflyttingsland } returns "FRA"
+                            every { folkeregistermetadata } returns
+                                mockk {
+                                    every { gyldighetstidspunkt } returns null
+                                    every { ajourholdstidspunkt } returns LocalDateTime.parse("2021-09-01T00:00:00")
+                                }
+                        },
+                    )
+                every { utflyttingFraNorge } returns null
+                every { bostedsadresse } returns
+                    listOf(
+                        mockk {
+                            every { angittFlyttedato } returns null
+                            every { gyldigFraOgMed } returns LocalDateTime.parse("2021-07-01T00:00:00")
+                        },
+                    )
+            }
+
+        val utland = UtlandMapper.mapUtland(hentPerson)
+
+        assertEquals("FRA", utland.innflyttingTilNorge?.first()?.fraflyttingsland)
+        assertEquals(
+            "2021-09-01",
+            utland.innflyttingTilNorge
+                ?.first()
+                ?.dato
+                .toString(),
+        )
+    }
 }

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/pdl/mapper/UtlandMapperTest.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/pdl/mapper/UtlandMapperTest.kt
@@ -74,14 +74,14 @@ internal class UtlandMapperTest {
             "2021-07-01",
             utland.innflyttingTilNorge
                 ?.first()
-                ?.gyldighetstidspunkt
+                ?.gyldighetsdato
                 .toString(),
         )
         assertEquals(
             "2021-07-01",
             utland.innflyttingTilNorge
                 ?.first()
-                ?.ajourholdstidspunkt
+                ?.ajourholdsdato
                 .toString(),
         )
     }

--- a/apps/etterlatte-pdltjenester/src/test/kotlin/pdl/mapper/UtlandMapperTest.kt
+++ b/apps/etterlatte-pdltjenester/src/test/kotlin/pdl/mapper/UtlandMapperTest.kt
@@ -46,10 +46,18 @@ internal class UtlandMapperTest {
                             every { folkeregistermetadata } returns
                                 mockk {
                                     every { gyldighetstidspunkt } returns LocalDateTime.parse("2021-07-01T00:00:00")
+                                    every { ajourholdstidspunkt } returns LocalDateTime.parse("2021-07-01T00:00:00")
                                 }
                         },
                     )
                 every { utflyttingFraNorge } returns null
+                every { bostedsadresse } returns
+                    listOf(
+                        mockk {
+                            every { angittFlyttedato } returns LocalDateTime.parse("2021-07-01T00:00:00")
+                            every { gyldigFraOgMed } returns LocalDateTime.parse("2021-07-01T00:00:00")
+                        },
+                    )
             }
 
         val utland = UtlandMapper.mapUtland(hentPerson)
@@ -60,6 +68,20 @@ internal class UtlandMapperTest {
             utland.innflyttingTilNorge
                 ?.first()
                 ?.dato
+                .toString(),
+        )
+        assertEquals(
+            "2021-07-01",
+            utland.innflyttingTilNorge
+                ?.first()
+                ?.gyldighetstidspunkt
+                .toString(),
+        )
+        assertEquals(
+            "2021-07-01",
+            utland.innflyttingTilNorge
+                ?.first()
+                ?.ajourholdstidspunkt
                 .toString(),
         )
     }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/personopplysninger/Innflytting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/personopplysninger/Innflytting.tsx
@@ -1,14 +1,11 @@
 import React, { ReactNode } from 'react'
 import { Personopplysning } from '~components/person/personopplysninger/Personopplysning'
 import { AirplaneIcon } from '@navikt/aksel-icons'
-import { Heading, Table } from '@navikt/ds-react'
+import { Heading, ReadMore, Table, VStack } from '@navikt/ds-react'
 import { finnLandSomTekst } from '~components/person/personopplysninger/utils'
 import { ILand } from '~utils/kodeverk'
-
-interface InnflyttingDTO {
-  fraflyttingsland?: string
-  dato?: string
-}
+import { formaterDatoMedFallback } from '~utils/formatering/dato'
+import { InnflyttingDTO } from '~shared/types/Person'
 
 export const Innflytting = ({
   innflytting,
@@ -19,11 +16,27 @@ export const Innflytting = ({
 }): ReactNode => {
   return (
     <Personopplysning heading="Innflytting" icon={<AirplaneIcon />}>
+      <VStack gap="4">
+        <ReadMore header="Gyldighetsdato">
+          Gyldighetsdato kommer fra folkeregisteret og har ikke nødvendigvis sammenheng med når innflytting faktisk
+          skjedde.
+          <br />
+          <br />
+          Dersom man skal finne ut om sen preson regnes som innflyttet i hendhold til folkeregisterlover, så kan man se
+          på om personen har en norsk bostedsadresse med angitt flyttedato.
+        </ReadMore>
+        <ReadMore header="Ajourholdsdato">
+          Datoen opplysningen ble opprettet i Folkeregisteret. Feltet mangler på en del opplysninger migrert fra gammelt
+          registert.
+        </ReadMore>
+      </VStack>
       <Table>
         <Table.Header>
           <Table.Row>
             <Table.ColumnHeader scope="col">Innflyttet fra</Table.ColumnHeader>
-            <Table.ColumnHeader scope="col">Innflyttet år</Table.ColumnHeader>
+            <Table.ColumnHeader scope="col">Dato</Table.ColumnHeader>
+            <Table.ColumnHeader scope="col">Gyldighetsdato</Table.ColumnHeader>
+            <Table.ColumnHeader scope="col">Ajourholdsdato</Table.ColumnHeader>
           </Table.Row>
         </Table.Header>
         <Table.Body>
@@ -34,7 +47,9 @@ export const Innflytting = ({
                   <Table.DataCell>
                     {!!flytting.fraflyttingsland && finnLandSomTekst(flytting.fraflyttingsland, landListe)}
                   </Table.DataCell>
-                  <Table.DataCell>{!!flytting.dato && new Date(flytting.dato).getFullYear()}</Table.DataCell>
+                  <Table.DataCell>{formaterDatoMedFallback(flytting.dato)}</Table.DataCell>
+                  <Table.DataCell>{formaterDatoMedFallback(flytting.gyldighetstidspunkt)}</Table.DataCell>
+                  <Table.DataCell>{formaterDatoMedFallback(flytting.ajourholdstidspunkt)}</Table.DataCell>
                 </Table.Row>
               ))}
             </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/personopplysninger/Innflytting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/personopplysninger/Innflytting.tsx
@@ -22,8 +22,8 @@ export const Innflytting = ({
           skjedde.
           <br />
           <br />
-          Dersom man skal finne ut om en person regnes som innflyttet i henhold til folkeregisterlover, så kan man se
-          på om personen har en norsk bostedsadresse med angitt flyttedato.
+          Dersom man skal finne ut om en person regnes som innflyttet i henhold til folkeregisterlover, så kan man se på
+          om personen har en norsk bostedsadresse med angitt flyttedato.
         </ReadMore>
         <ReadMore header="Ajourholdsdato">
           Datoen opplysningen ble opprettet i Folkeregisteret. Feltet mangler på en del opplysninger migrert fra gammelt
@@ -48,8 +48,8 @@ export const Innflytting = ({
                     {!!flytting.fraflyttingsland && finnLandSomTekst(flytting.fraflyttingsland, landListe)}
                   </Table.DataCell>
                   <Table.DataCell>{formaterDatoMedFallback(flytting.dato)}</Table.DataCell>
-                  <Table.DataCell>{formaterDatoMedFallback(flytting.gyldighetstidspunkt)}</Table.DataCell>
-                  <Table.DataCell>{formaterDatoMedFallback(flytting.ajourholdstidspunkt)}</Table.DataCell>
+                  <Table.DataCell>{formaterDatoMedFallback(flytting.gyldighetsdato)}</Table.DataCell>
+                  <Table.DataCell>{formaterDatoMedFallback(flytting.ajourholdsdato)}</Table.DataCell>
                 </Table.Row>
               ))}
             </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/personopplysninger/Innflytting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/personopplysninger/Innflytting.tsx
@@ -22,7 +22,7 @@ export const Innflytting = ({
           skjedde.
           <br />
           <br />
-          Dersom man skal finne ut om sen preson regnes som innflyttet i hendhold til folkeregisterlover, så kan man se
+          Dersom man skal finne ut om en person regnes som innflyttet i henhold til folkeregisterlover, så kan man se
           på om personen har en norsk bostedsadresse med angitt flyttedato.
         </ReadMore>
         <ReadMore header="Ajourholdsdato">

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Person.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Person.ts
@@ -80,8 +80,8 @@ export interface Utland {
 export interface InnflyttingDTO {
   fraflyttingsland?: string
   dato?: string
-  gyldighetstidspunkt?: string
-  ajourholdstidspunkt?: string
+  gyldighetsdato?: string
+  ajourholdsdato?: string
 }
 
 export interface Statsborgerskap {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Person.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Person.ts
@@ -74,10 +74,14 @@ export interface Utland {
     tilflyttingsland?: string
     dato?: string
   }[]
-  innflyttingTilNorge?: {
-    fraflyttingsland?: string
-    dato?: string
-  }[]
+  innflyttingTilNorge?: InnflyttingDTO[]
+}
+
+export interface InnflyttingDTO {
+  fraflyttingsland?: string
+  dato?: string
+  gyldighetstidspunkt?: string
+  ajourholdstidspunkt?: string
 }
 
 export interface Statsborgerskap {

--- a/libs/saksbehandling-common/src/main/kotlin/person/Person.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/person/Person.kt
@@ -114,8 +114,8 @@ data class Utland(
 data class InnflyttingTilNorge(
     val fraflyttingsland: String?,
     val dato: LocalDate?,
-    val gyldighetstidspunkt: LocalDate?,
-    val ajourholdstidspunkt: LocalDate?,
+    val gyldighetsdato: LocalDate?,
+    val ajourholdsdato: LocalDate?,
 )
 
 data class UtflyttingFraNorge(

--- a/libs/saksbehandling-common/src/main/kotlin/person/Person.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/person/Person.kt
@@ -114,6 +114,8 @@ data class Utland(
 data class InnflyttingTilNorge(
     val fraflyttingsland: String?,
     val dato: LocalDate?,
+    val gyldighetstidspunkt: LocalDate?,
+    val ajourholdstidspunkt: LocalDate?,
 )
 
 data class UtflyttingFraNorge(


### PR DESCRIPTION
Legger også til gyldighetsdato og ajourholdsdato som brukes i pesys i dag.
Ta gjerne en ekstra titt på Utlandsmapper da mye er lånt fra pesys for at dato skal være lik i begge systemer.

![Skjermbilde 2024-12-04 kl  10 34 42](https://github.com/user-attachments/assets/384abcd2-8bca-4f66-83f8-cff9653d2fed)

![Skjermbilde 2024-12-04 kl  10 34 50](https://github.com/user-attachments/assets/32e9e155-bd15-401a-9ef5-0d880a33fe2a)
