### PR TITLE
EY-4809 Nytt format på maskinporten scope + delegation source for altinn

### DIFF
--- a/apps/etterlatte-api/.nais/dev-api.yaml
+++ b/apps/etterlatte-api/.nais/dev-api.yaml
@@ -46,6 +46,8 @@ spec:
         - name: "vedtaksinformasjon.read"
           enabled: true
           product: "etterlatteytelser"
+          separator: "/"
+          delegationSource: "altinn"
           allowedIntegrations:
             - maskinporten
           atMaxAge: 120

--- a/apps/etterlatte-api/.nais/prod-api.yaml
+++ b/apps/etterlatte-api/.nais/prod-api.yaml
@@ -44,8 +44,10 @@ spec:
     scopes:
       exposes:
         - name: "vedtaksinformasjon.read"
+          delegationSource: "altinn"
           enabled: true
           product: "etterlatteytelser"
+          separator: "/"
           allowedIntegrations:
             - maskinporten
           atMaxAge: 60

--- a/apps/etterlatte-api/README.md
+++ b/apps/etterlatte-api/README.md
@@ -11,9 +11,12 @@ Omstillingsstønad er en samordningspliktig ytelse. Applikasjonen tilbyr tjenest
 
 
 ## Autentisering
+#### Maskinporten
+Nytt scope for etterlatte-api med Maskinporten _nav:etterlatteytelser/vedtaksinformasjon.read_
 
-Tjenesten krever token utstedt av Maskinporten med scope _nav:etterlatteytelser:vedtaksinformasjon.read_
+etterlatte-samordning-vedtak(gammel og skal saneres) krever token utstedt av Maskinporten med scope _nav:etterlatteytelser:vedtaksinformasjon.read_
 
+#### Azure & Tokenx
 For interne må det legges inn i yaml filene slik som beskrevet her https://docs.nais.io/auth/entra-id/
 
 ### Autorisasjon

--- a/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRoute.kt
+++ b/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/SamordningVedtakRoute.kt
@@ -28,7 +28,7 @@ fun Route.samordningVedtakRoute(
 ) {
     route("api/vedtak") {
         install(MaskinportenScopeAuthorizationPlugin) {
-            scopes = setOf("nav:etterlatteytelser:vedtaksinformasjon.read")
+            scopes = setOf("nav:etterlatteytelser:vedtaksinformasjon.read", "nav:etterlatteytelser/vedtaksinformasjon.read")
         }
 
         get("{vedtakId}") {


### PR DESCRIPTION
Vi må støtte delegering av auth via maskinporten mot altinn som styrer ut mot TP leverandører managere som feks Aksio, de har p.t. ikke tilgang og trenger dette.