### PR TITLE
Håndtere manglende tilgang bedre

### DIFF
--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlFeilLogger.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlFeilLogger.kt
@@ -1,5 +1,7 @@
 package no.nav.etterlatte.pdl
 
+import io.ktor.http.HttpStatusCode
+import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
 import no.nav.etterlatte.sikkerLogg
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -16,6 +18,19 @@ fun loggDelvisReturnerteData(
     req: Any,
 ) {
     if (result.data != null) {
+        val unauthorized = result.errors?.firstOrNull { it.extensions?.code == "unauthorized" }
+
+        if (unauthorized != null) {
+            // TODO: Denne burde være warn, men settes til error midlertidig siden jeg er nysgjerrig på hvorfor
+            //  [result.data] IKKE er null i dette tilfellet... logger det til sikkerlogg og bruker error som påminnelse
+            logger.error(
+                "Saksbehandler forsøkte å se person de ikke har tilgang til. Se data i sikkerlogg. " +
+                    "Feilmelding fra PDL: \n${unauthorized.extensions?.details?.cause}",
+            )
+            sikkerLogg.error("Saksbehandler mangler tilgang, men fikk allikevel data i resultatsettet: ${result.data}")
+            throw ManglerTilgangTilPerson()
+        }
+
         result.errors?.joinToString(",")?.let { feil ->
             val stackTrace = Exception()
             logger.error(
@@ -28,3 +43,10 @@ fun loggDelvisReturnerteData(
         }
     }
 }
+
+class ManglerTilgangTilPerson :
+    ForespoerselException(
+        status = HttpStatusCode.Unauthorized.value,
+        code = "MANGLER_TILGANG_TIL_PERSON",
+        detail = "Mangler tilgang til person",
+    )


### PR DESCRIPTION
Henger sammen med: https://logs.adeo.no/app/r/s/eOvfU

Vil på sikt redusere unødvenige prodvarsler, men logges som `error` en liten stund til for å se data-objektet. 

Min teori er at sjekken på `result.data` er en smule misvisende, da det ikke er `data` som er null, men query-objektet. I dette tilfellet objektet under, dvs. `hentPerson`

Forventet respons i prod: 
```
"result": {
   "data": {
       "hentPerson": null       // eller tilsvarende 
   },
  "errors": [ ... liste med feil ... ]
}
```
