### PR TITLE
FAGSYSTEM-360636: Ikke lov å legge til trygdetid > 40 år

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
@@ -329,6 +329,13 @@ class BeregningsGrunnlagService(
             beregningsGrunnlagRepository.lagreOverstyrBeregningGrunnlagForBehandling(
                 behandlingId,
                 data.perioder.map {
+                    val gyldigTrygdetid = it.data.trygdetid in 0..40
+                    if (!gyldigTrygdetid) {
+                        throw OverstyrtBeregningUgyldigTrygdetid(behandlingId)
+                    }
+
+                    // TODO her burde det sikkert være mer validering av hva saksbehandler kan sende inn
+
                     OverstyrBeregningGrunnlagDao(
                         id = UUID.randomUUID(),
                         behandlingId = behandlingId,
@@ -414,6 +421,14 @@ class BeregningsGrunnlagService(
         }
     }
 }
+
+class OverstyrtBeregningUgyldigTrygdetid(
+    behandlingId: UUID,
+) : UgyldigForespoerselException(
+        code = "OVERSTYRT_BEREGNING_UGYLDIG_TRYGDETID",
+        detail = "Anvendt trygdetid må være mellom 0 og 40 år",
+        meta = mapOf("behandlingId" to behandlingId),
+    )
 
 class OverstyrtBeregningFeilBehandlingStatusException(
     behandlingId: UUID,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/OverstyrBeregningsgrunnlagExpandableRowContent.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/OverstyrBeregningsgrunnlagExpandableRowContent.tsx
@@ -11,7 +11,7 @@ export const OverstyrBeregningsgrunnlagExpandableRowContent = ({
   return (
     <HStack gap="8">
       <div>
-        <Label>Anvendt trygdetid</Label>
+        <Label>Anvendt trygdetid (år)</Label>
         <BodyShort>{overtyrBeregningsgrunnlagPeriode.data.trygdetid}</BodyShort>
       </div>
       <div>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/OverstyrBeregningsgrunnlagPeriodeSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/overstyrGrunnlagsBeregning/OverstyrBeregningsgrunnlagPeriodeSkjema.tsx
@@ -149,9 +149,10 @@ export const OverstyrBeregningsgrunnlagPeriodeSkjema = ({
               valueAsNumber: true,
               required: { value: true, message: 'Må settes' },
               min: { value: 0, message: 'Kan ikke være negativ' },
+              max: { value: 40, message: 'Kan ikke være mer enn 40 år' },
               validate: validerStringNumber,
             })}
-            label="Anvendt trygdetid"
+            label="Anvendt trygdetid (år)"
             error={errors.data?.trygdetid?.message}
           />
           <TextField


### PR DESCRIPTION
Det var lagt inn 480 år trygdetid i overstyrt beregning. Dette brukes ikke til noe direkte i beregningen.

Legger inn en sperre mot flere år enn 40 også i overstyrt beregning. 