### PR TITLE
Setter norsk tidssone ved konvertering av XMLGregorianCalendar til localdate

### DIFF
--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/klienter/TilbakekrevingskomponentenKlient.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/klienter/TilbakekrevingskomponentenKlient.kt
@@ -25,6 +25,7 @@ import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.tilbakekreving.TilbakekrevingHendelseRepository
 import no.nav.etterlatte.tilbakekreving.TilbakekrevingHendelseType
 import no.nav.etterlatte.tilbakekreving.kravgrunnlag.KravgrunnlagMapper
+import no.nav.etterlatte.tilbakekreving.kravgrunnlag.toLocalDate
 import no.nav.okonomi.tilbakekrevingservice.KravgrunnlagHentDetaljRequest
 import no.nav.okonomi.tilbakekrevingservice.KravgrunnlagHentDetaljResponse
 import no.nav.okonomi.tilbakekrevingservice.TilbakekrevingsvedtakRequest
@@ -77,7 +78,7 @@ class TilbakekrevingskomponentenKlient(
 
         hendelseRepository.lagreTilbakekrevingHendelse(
             sakId = vedtak.sakId,
-            payload = response.toJson(),
+            payload = tilbakekrevingObjectMapper.writeValueAsString(response),
             type = TilbakekrevingHendelseType.TILBAKEKREVINGSVEDTAK_KVITTERING,
         )
 
@@ -114,7 +115,7 @@ class TilbakekrevingskomponentenKlient(
 
         hendelseRepository.lagreTilbakekrevingHendelse(
             sakId = sakId,
-            payload = response.toJson(),
+            payload = tilbakekrevingObjectMapper.writeValueAsString(response),
             type = TilbakekrevingHendelseType.KRAVGRUNNLAG_FORESPOERSEL_KVITTERING,
         )
 
@@ -288,8 +289,6 @@ private class CustomXMLGregorianCalendarModule : SimpleModule() {
                     if (value != null) {
                         gen?.writeString(
                             value
-                                .toGregorianCalendar()
-                                .toZonedDateTime()
                                 .toLocalDate()
                                 .toString(),
                         )

--- a/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagMapper.kt
+++ b/apps/etterlatte-tilbakekreving/src/main/kotlin/tilbakekreving/kravgrunnlag/KravgrunnlagMapper.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.tilbakekreving.kravgrunnlag
 
 import no.nav.etterlatte.libs.common.UUID30
+import no.nav.etterlatte.libs.common.tidspunkt.norskTidssone
 import no.nav.etterlatte.libs.common.tilbakekreving.Grunnlagsbeloep
 import no.nav.etterlatte.libs.common.tilbakekreving.KlasseKode
 import no.nav.etterlatte.libs.common.tilbakekreving.KlasseType
@@ -47,6 +48,7 @@ object KravgrunnlagMapper {
 
     private fun toGrunnlagsperiode(periode: DetaljertKravgrunnlagPeriodeDto) =
         KravgrunnlagPeriode(
+            // toLocalDate justerer først til norsk tidssone før tidspunktet fjernes helt
             Periode(
                 fraOgMed = YearMonth.from(periode.periode.fom.toLocalDate()),
                 tilOgMed = YearMonth.from(periode.periode.tom.toLocalDate()),
@@ -73,4 +75,9 @@ object KravgrunnlagMapper {
         )
 }
 
-fun XMLGregorianCalendar.toLocalDate(): LocalDate = this.toGregorianCalendar().toZonedDateTime().toLocalDate()
+fun XMLGregorianCalendar.toLocalDate(): LocalDate =
+    this
+        .toGregorianCalendar()
+        .toZonedDateTime()
+        .withZoneSameInstant(norskTidssone)
+        .toLocalDate()

--- a/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/klienter/TilbakekrevingskomponentenKlientTest.kt
+++ b/apps/etterlatte-tilbakekreving/src/test/kotlin/tilbakekreving/klienter/TilbakekrevingskomponentenKlientTest.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.tilbakekreving.klienter
 
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -26,6 +27,8 @@ import no.nav.okonomi.tilbakekrevingservice.TilbakekrevingsvedtakResponse
 import no.nav.tilbakekreving.typer.v1.MmelDto
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.Month
+import java.time.YearMonth
 
 internal class TilbakekrevingskomponentenKlientTest {
     private val hendelseRepository = mockk<TilbakekrevingHendelseRepository>(relaxed = true)
@@ -105,6 +108,11 @@ internal class TilbakekrevingskomponentenKlientTest {
         val kravgrunnlagResponse = tilbakekrevingskomponentenKlient.hentKravgrunnlag(sakId, 123L)
 
         kravgrunnlagResponse shouldNotBe null
+
+        kravgrunnlagResponse.perioder.first().periode.let {
+            it.fraOgMed shouldBe YearMonth.of(2022, Month.APRIL)
+            it.tilOgMed shouldBe YearMonth.of(2022, Month.APRIL)
+        }
 
         verify {
             hendelseRepository.lagreTilbakekrevingHendelse(


### PR DESCRIPTION
Fjerner tidspunkter fra XMLGregorianCalendar ved å først konverte til norsk tidssone slik at datoene blir riktig, så fjerne tidspunktet slik at det kun er dato som gjenstår.

Skulle gjerne hatt bedre måter å gjøre dette på fordi det blir litt rotete, men ser ingen åpenbar enklere vei rundt problemet. 