### PR TITLE
Ikke hente ugyldige arkivtemaer

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/kodeverk/KodeverkKlientImpl.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/kodeverk/KodeverkKlientImpl.kt
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory
 interface KodeverkKlient {
     suspend fun hent(
         kodeverkNavn: KodeverkNavn,
+        ekskluderUgyldige: Boolean,
         brukerTokenInfo: BrukerTokenInfo,
     ): KodeverkResponse
 }
@@ -34,6 +35,7 @@ class KodeverkKlientImpl(
 
     override suspend fun hent(
         kodeverkNavn: KodeverkNavn,
+        ekskluderUgyldige: Boolean,
         brukerTokenInfo: BrukerTokenInfo,
     ): KodeverkResponse =
         try {
@@ -43,7 +45,7 @@ class KodeverkKlientImpl(
                     resource =
                         Resource(
                             clientId = clientId,
-                            url = "$url/$kodeverkNavn/koder/betydninger?ekskluderUgyldige=false&spraak=nb",
+                            url = "$url/$kodeverkNavn/koder/betydninger?ekskluderUgyldige=$ekskluderUgyldige&spraak=nb",
                             additionalHeaders = mapOf(Headers.NAV_CONSUMER_ID to applicationName),
                         ),
                     brukerTokenInfo = brukerTokenInfo,

--- a/apps/etterlatte-behandling/src/main/kotlin/kodeverk/KodeverkService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/kodeverk/KodeverkService.kt
@@ -24,7 +24,7 @@ class KodeverkService(
         val landkoder =
             cache.getIfPresent(CacheKey.LANDKODER)
                 ?: klient
-                    .hent(KodeverkNavn.LANDKODER, brukerTokenInfo)
+                    .hent(KodeverkNavn.LANDKODER, false, brukerTokenInfo)
                     .also { cache.put(CacheKey.LANDKODER, it) }
 
         return mapLandkoder(landkoder)
@@ -34,7 +34,7 @@ class KodeverkService(
         val landkoder =
             cache.getIfPresent(CacheKey.LANDKODER_ISO2)
                 ?: klient
-                    .hent(KodeverkNavn.LANDKODERISO2, brukerTokenInfo)
+                    .hent(KodeverkNavn.LANDKODERISO2, false, brukerTokenInfo)
                     .also { cache.put(CacheKey.LANDKODER_ISO2, it) }
 
         return mapLandkoder(landkoder)
@@ -44,7 +44,7 @@ class KodeverkService(
         val arkivtemaer =
             cacheArkivtemaer.getIfPresent(CacheKey.ARKIVTEMAER)
                 ?: klient
-                    .hent(KodeverkNavn.ARKIVTEMAER, brukerTokenInfo)
+                    .hent(KodeverkNavn.ARKIVTEMAER, true, brukerTokenInfo)
                     .also { cacheArkivtemaer.put(CacheKey.ARKIVTEMAER, it) }
 
         return arkivtemaer.betydninger.map { (tema, betydninger) ->

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
@@ -611,6 +611,7 @@ class AxsysKlientTest : AxsysKlient {
 class KodeverkKlientTest : KodeverkKlient {
     override suspend fun hent(
         kodeverkNavn: KodeverkNavn,
+        ekskluderUgyldige: Boolean,
         brukerTokenInfo: BrukerTokenInfo,
     ): KodeverkResponse {
         val betydning =

--- a/apps/etterlatte-behandling/src/test/kotlin/kodeverk/KodeverkServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/kodeverk/KodeverkServiceTest.kt
@@ -19,26 +19,26 @@ internal class KodeverkServiceTest {
 
     @Test
     fun `Hent alle landkoder`() {
-        coEvery { mockKlient.hent(LANDKODER, saksbehandler) } returns opprettLandkoderResponse()
+        coEvery { mockKlient.hent(LANDKODER, false, saksbehandler) } returns opprettLandkoderResponse()
 
         runBlocking {
             val land = service.hentAlleLand(saksbehandler)
 
             assertEquals(5, land.size)
-            coVerify(exactly = 1) { mockKlient.hent(LANDKODER, saksbehandler) }
+            coVerify(exactly = 1) { mockKlient.hent(LANDKODER, false, saksbehandler) }
         }
     }
 
     @Test
     fun `Cache for landkode fungerer`() {
-        coEvery { mockKlient.hent(LANDKODER, saksbehandler) } returns opprettLandkoderResponse()
+        coEvery { mockKlient.hent(LANDKODER, false, saksbehandler) } returns opprettLandkoderResponse()
 
         runBlocking {
             val land = service.hentAlleLand(saksbehandler)
             assertEquals(5, land.size)
         }
 
-        coVerify(exactly = 1) { mockKlient.hent(LANDKODER, saksbehandler) }
+        coVerify(exactly = 1) { mockKlient.hent(LANDKODER, false, saksbehandler) }
     }
 
     @Test
@@ -57,7 +57,7 @@ internal class KodeverkServiceTest {
                 ),
             )
 
-        coEvery { mockKlient.hent(LANDKODER, saksbehandler) } returns KodeverkResponse(testdatasandwich)
+        coEvery { mockKlient.hent(LANDKODER, false, saksbehandler) } returns KodeverkResponse(testdatasandwich)
 
         runBlocking {
             val alleLand = service.hentAlleLand(saksbehandler)


### PR DESCRIPTION
Sikre at vi ikke henter ugyldige arkivtemaer. På den måten unngår vi unødvendige feil mot dokarkiv fordi saksbehandler velger feil tema (eks. OKO=Økonomi).

Eks:
https://logs.adeo.no/app/discover#/?_g=(time:(from:'2024-12-18T07:34:58.308Z',to:'2024-12-18T07:49:58.308Z'))&_a=(columns:!(level,message,envclass,application,pod),dataSource:(dataViewId:'96e648c0-980a-11e9-830a-e17bbd64b4db',type:dataView),filters:!(),interval:auto,query:(language:lucene,query:'namespace:etterlatte%20AND%20envclass:p%20AND%20level:Error'),sort:!(!('@timestamp',desc)))
