### PR TITLE
Flytter kall til tilbakekreving før hendelser opprettes for å lettere kunne rulle tilbake

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingService.kt
@@ -420,6 +420,13 @@ class TilbakekrevingService(
                     tilbakekreving.copy(status = TilbakekrevingStatus.ATTESTERT),
                 )
 
+            runBlocking {
+                tilbakekrevingKlient.sendTilbakekrevingsvedtak(
+                    saksbehandler,
+                    tilbakekrevingVedtak(tilbakekreving, vedtak),
+                )
+            }
+
             tilbakekrevingHendelse(tilbakekreving, TilbakekrevingHendelseType.ATTESTERT, vedtak.id, saksbehandler, kommentar)
 
             oppgaveService.ferdigStillOppgaveUnderBehandling(
@@ -432,13 +439,6 @@ class TilbakekrevingService(
                 statistikkTilbakekreving = tilbakekrevingForStatistikk(tilbakekreving),
                 type = TilbakekrevingHendelseType.ATTESTERT,
             )
-
-            runBlocking {
-                tilbakekrevingKlient.sendTilbakekrevingsvedtak(
-                    saksbehandler,
-                    tilbakekrevingVedtak(tilbakekreving, vedtak),
-                )
-            }
 
             oppdatertTilbakekreving
         }


### PR DESCRIPTION
Dette gjør at vi ikke allerede har sendt flere hendelser på kafka (statistikk etc) dersom vedtaket mot tilbakekreving feiler.

Dette er en midlertidig fiks før vi flytter tilbakekrevingskallet over i vedtak for å sikre at man ikke får et attestert vedtak, men feilende vedtak mot tilbakekrevingskomponenten i etterkant.