### PR TITLE
FAGSYSTEM-358643: Tilgjengeliggjør overstyring av trygdetid for noen saksbehandlere

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/EnkelPersonTrygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/EnkelPersonTrygdetid.tsx
@@ -17,6 +17,8 @@ import { VStack } from '@navikt/ds-react'
 import { skalViseTrygdeavtale } from '~components/behandling/trygdetid/utils'
 import { AvdoedesTrygdetidReadMore } from '~components/behandling/trygdetid/components/AvdoedesTrygdetidReadMore'
 import { ILand } from '~utils/kodeverk'
+import { OpprettManueltOverstyrtTrygdetid } from '~components/behandling/trygdetid/OpprettManueltOverstyrtTrygdetid'
+import { FeatureToggle, useFeaturetoggle } from '~useUnleash'
 
 interface Props {
   redigerbar: boolean
@@ -33,6 +35,7 @@ export const EnkelPersonTrygdetid = (props: Props) => {
   const [trygdetid, setTrygdetid] = useState<ITrygdetid | undefined>()
   const [overstyrTrygdetidRequest, requestOverstyrTrygdetid] = useApiCall(overstyrTrygdetid)
   const [oppdaterYrkesskadeRequest, requestOppdaterYrkesskade] = useApiCall(setTrygdetidYrkesskade)
+  const overstyrTrygdetidFeature = useFeaturetoggle(FeatureToggle.overstyr_trygdetid_knapp)
 
   useEffect(() => {
     if (props.trygdetid) {
@@ -94,6 +97,10 @@ export const EnkelPersonTrygdetid = (props: Props) => {
     <>
       {trygdetid && (
         <VStack gap="12" maxWidth="69rem">
+          {overstyrTrygdetidFeature && (
+            <OpprettManueltOverstyrtTrygdetid behandlingId={behandling.id} redigerbar={redigerbar} />
+          )}
+
           <VStack gap="4">
             {!skalViseTrygdeavtale(behandling) && <AvdoedesTrygdetidReadMore />}
             <Grunnlagopplysninger trygdetid={trygdetid} onOppdatert={oppdaterTrygdetid} redigerbar={redigerbar} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/OpprettManueltOverstyrtTrygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/OpprettManueltOverstyrtTrygdetid.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { Alert, Box, Button, Heading, VStack } from '@navikt/ds-react'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { opprettTrygdetidOverstyrtMigrering } from '~shared/api/trygdetid'
+import { isPending, mapResult } from '~shared/api/apiUtils'
+import Spinner from '~shared/Spinner'
+import { ApiErrorAlert } from '~ErrorBoundary'
+
+export const OpprettManueltOverstyrtTrygdetid = ({
+  behandlingId,
+  redigerbar,
+}: {
+  behandlingId: string
+  redigerbar: boolean
+}) => {
+  const [opprettOverstyrtTrygdetidStatus, opprettOverstyrtTrygdetid] = useApiCall(opprettTrygdetidOverstyrtMigrering)
+
+  const overstyrTrygdetid = () => {
+    opprettOverstyrtTrygdetid({ behandlingId: behandlingId, overskriv: true }, () => window.location.reload())
+  }
+
+  return (
+    <>
+      {redigerbar && (
+        <>
+          <Heading size="small" level="3">
+            Endre til behandlingen til manuelt overstyrt trygdetid
+          </Heading>
+          <Box maxWidth="40rem">
+            <VStack gap="5">
+              <Alert variant="warning">
+                OBS! Dette vil overstyre trygdetiden i behandlingen. Tidligere trygdetidsperioder blir slettet og
+                saksbehandler må sette ny trygdetid manuelt.
+              </Alert>
+              <Box maxWidth="20rem">
+                <Button
+                  variant="danger"
+                  size="small"
+                  onClick={overstyrTrygdetid}
+                  loading={isPending(opprettOverstyrtTrygdetidStatus)}
+                >
+                  Opprett overstyrt trygdetid
+                </Button>
+              </Box>
+            </VStack>
+          </Box>
+          {mapResult(opprettOverstyrtTrygdetidStatus, {
+            pending: <Spinner label="Overstyrer trygdetid" />,
+            error: () => <ApiErrorAlert>En feil har oppstått ved overstyring av trygdetid</ApiErrorAlert>,
+          })}
+        </>
+      )}
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/useUnleash.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/useUnleash.ts
@@ -12,6 +12,7 @@ export const enum FeatureToggle {
   aktivitetsplikt_ny_vurdering = 'aktivitetsplikt.ny-vurdering',
   validere_aarsintnekt_neste_aar = 'validere_aarsintnekt_neste_aar',
   overstyr_beregning_knapp = 'overstyr-beregning-knapp',
+  overstyr_trygdetid_knapp = 'overstyr-trygdetid-knapp',
   notater = 'notater',
   kun_en_registrert_juridisk_forelder = 'kun-en-registrert-juridisk-forelder',
   kopier_trygdetidsgrunnlag = 'kopier-trygdetidsgrunnlag',
@@ -38,6 +39,10 @@ const validere_aarsintnekt_neste_aar: Toggle = {
 }
 const overstyr_beregning_knapp: Toggle = {
   togglename: FeatureToggle.overstyr_beregning_knapp,
+  enabled: false,
+}
+const overstyr_trygdetid_knapp: Toggle = {
+  togglename: FeatureToggle.overstyr_trygdetid_knapp,
   enabled: false,
 }
 const notater: Toggle = { togglename: FeatureToggle.notater, enabled: false }
@@ -83,6 +88,7 @@ export const unleashStartState: Record<string, Toggle> = {
   [FeatureToggle.pensjon_etterlatte_kan_opprette_vedtak_avvist_klage]:
     pensjon_etterlatte_kan_opprette_vedtak_avvist_klage,
   [FeatureToggle.overstyr_beregning_knapp]: overstyr_beregning_knapp,
+  [FeatureToggle.overstyr_trygdetid_knapp]: overstyr_trygdetid_knapp,
   [FeatureToggle.pensjon_etterlatte_oppdater_ident_paa_sak]: pensjon_etterlatte_oppdater_ident_paa_sak,
 }
 


### PR DESCRIPTION
I den aktuelle fagsystemsaken, er det brukt nordisk konvensjon. Dette betyr at saksbehandler må overstyre trygdetiden fordi fremtidig trygdetid skal reduseres. 

Tidligere har det vært mulig å gjøre denne overstyringen når en behandling opprettes. Denne endringen legger på mulighet for å gjøre denne overstyringen i selve trygdetidssteget for saksbehandlere som er lagt til i feature-toggle (Blir vel kun M & L inntil videre).