### PR TITLE
Bedre feilmelding hvis fnr er ugyldig/null

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/Person.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom'
 import { StatusBar } from '~shared/statusbar/Statusbar'
 import { SakOversikt } from './sakOgBehandling/SakOversikt'
 import { useApiCall } from '~shared/hooks/useApiCall'
-import { Tabs } from '@navikt/ds-react'
+import { Link, Tabs } from '@navikt/ds-react'
 import { fnrHarGyldigFormat } from '~utils/fnr'
 import NavigerTilbakeMeny from '~components/person/NavigerTilbakeMeny'
 import {
@@ -45,7 +45,7 @@ export const Person = () => {
   useSidetittel('Personoversikt')
 
   const [search, setSearch] = useSearchParams()
-  const { fnr } = usePersonLocationState(search.get('key'))
+  const fnr = usePersonLocationState(search.get('key'))?.fnr
 
   const [sakResult, sakFetch] = useApiCall(hentSakMedBehandlnger)
   const [fane, setFane] = useState(search.get('fane') || PersonOversiktFane.SAKER)
@@ -63,7 +63,16 @@ export const Person = () => {
     }
   }, [fnr])
 
-  if (!fnrHarGyldigFormat(fnr)) {
+  if (!fnr) {
+    return (
+      <ApiErrorAlert>
+        Fant ikke fødselsnummer. Dette kan komme av at URL-en ble kopiert fra en annen fane eller nettleser, eller har
+        blitt endret manuelt.
+        <br />
+        <Link href="/">Gå til forsiden</Link>
+      </ApiErrorAlert>
+    )
+  } else if (!fnrHarGyldigFormat(fnr)) {
     return <ApiErrorAlert>Fødselsnummeret {fnr} har et ugyldig format (ikke 11 siffer)</ApiErrorAlert>
   }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/lenker/usePersonLocationState.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/lenker/usePersonLocationState.tsx
@@ -23,9 +23,9 @@ interface PersonLocationState {
  * Hack for å støtte åpning av personsiden i ny fane.
  * FNR lagres med en nøkkel (UUID) i localStorage og hentes opp igjen når [Person.tsx] lastes.
  **/
-export const usePersonLocationState = (key: string | null): PersonLocationState => {
+export const usePersonLocationState = (key: string | null): PersonLocationState | null => {
   const location = useLocation()
-  const [state, setState] = useState<PersonLocationState>(location.state || hentPersonLocationState(key))
+  const [state, setState] = useState<PersonLocationState | null>(location.state || hentPersonLocationState(key))
 
   useEffect(() => {
     if (key) localStorage.removeItem(key)


### PR DESCRIPTION
Skjer bare i tilfeller hvor saksbehandlere sender hverandre URL-en, kopierer til ny fane, eller modifiserer manuelt. 
Lager derfor bare en superenkelt fiks på det. 

![Screenshot 2024-12-19 at 10 06 30](https://github.com/user-attachments/assets/bba9d073-67c1-4059-b8f6-01eff6562d22)
