### PR TITLE
EY-4879: Flytter trigging av hendelse for utsending av brev til behandling for tilbakekreving

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/VedtakKlientImpl.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/VedtakKlientImpl.kt
@@ -15,7 +15,6 @@ import no.nav.etterlatte.libs.common.toObjectNode
 import no.nav.etterlatte.libs.common.vedtak.LoependeYtelseDTO
 import no.nav.etterlatte.libs.common.vedtak.TilbakekrevingFattEllerAttesterVedtakDto
 import no.nav.etterlatte.libs.common.vedtak.TilbakekrevingVedtakDto
-import no.nav.etterlatte.libs.common.vedtak.TilbakekrevingVedtakLagretDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakDto
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.AzureAdClient
 import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
@@ -30,24 +29,24 @@ interface VedtakKlient {
         tilbakekrevingBehandling: TilbakekrevingBehandling,
         brukerTokenInfo: BrukerTokenInfo,
         enhet: Enhetsnummer,
-    ): Long
+    ): VedtakDto
 
     suspend fun fattVedtakTilbakekreving(
         tilbakekrevingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         enhet: Enhetsnummer,
-    ): Long
+    ): VedtakDto
 
     suspend fun attesterVedtakTilbakekreving(
         tilbakekrevingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         enhet: Enhetsnummer,
-    ): TilbakekrevingVedtakLagretDto
+    ): VedtakDto
 
     suspend fun underkjennVedtakTilbakekreving(
         tilbakekrevingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
-    ): Long
+    ): VedtakDto
 
     suspend fun lagreVedtakKlage(
         klage: Klage,
@@ -97,7 +96,7 @@ class VedtakKlientImpl(
         tilbakekrevingBehandling: TilbakekrevingBehandling,
         brukerTokenInfo: BrukerTokenInfo,
         enhet: Enhetsnummer,
-    ): Long {
+    ): VedtakDto {
         try {
             logger.info(
                 "Sender tilbakekreving som det skal lagre vedtak for tilbakekreving=${tilbakekrevingBehandling.id} til vedtak",
@@ -134,7 +133,7 @@ class VedtakKlientImpl(
         tilbakekrevingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         enhet: Enhetsnummer,
-    ): Long {
+    ): VedtakDto {
         try {
             logger.info("Sender tilbakekreving som skal fatte vedtak for tilbakekreving=$tilbakekrevingId til vedtak")
             return downstreamResourceClient
@@ -166,7 +165,7 @@ class VedtakKlientImpl(
         tilbakekrevingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         enhet: Enhetsnummer,
-    ): TilbakekrevingVedtakLagretDto {
+    ): VedtakDto {
         try {
             logger.info("Sender attesteringsinfo for tilbakekreving=$tilbakekrevingId til vedtak")
             return downstreamResourceClient
@@ -197,7 +196,7 @@ class VedtakKlientImpl(
     override suspend fun underkjennVedtakTilbakekreving(
         tilbakekrevingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
-    ): Long {
+    ): VedtakDto {
         try {
             logger.info("Ber om underkjennelse for tilbakekreving=$tilbakekrevingId til vedtak")
             return downstreamResourceClient

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingHendelserService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingHendelserService.kt
@@ -4,18 +4,29 @@ import no.nav.etterlatte.kafka.JsonMessage
 import no.nav.etterlatte.kafka.KafkaProdusent
 import no.nav.etterlatte.libs.common.logging.getCorrelationId
 import no.nav.etterlatte.libs.common.rapidsandrivers.CORRELATION_ID_KEY
+import no.nav.etterlatte.libs.common.rapidsandrivers.SKAL_SENDE_BREV
 import no.nav.etterlatte.libs.common.rapidsandrivers.TEKNISK_TID_KEY
 import no.nav.etterlatte.libs.common.tilbakekreving.StatistikkTilbakekrevingDto
 import no.nav.etterlatte.libs.common.tilbakekreving.TILBAKEKREVING_STATISTIKK_RIVER_KEY
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingHendelseType
+import no.nav.etterlatte.libs.common.toObjectNode
+import no.nav.etterlatte.libs.common.vedtak.VedtakDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseHendelseType
+import no.nav.etterlatte.rapidsandrivers.VEDTAK_KEY
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
+import java.util.UUID
 
 interface TilbakekrevingHendelserService {
     fun sendTilbakekreving(
         statistikkTilbakekreving: StatistikkTilbakekrevingDto,
         type: TilbakekrevingHendelseType,
+    )
+
+    fun sendVedtakForJournalfoeringOgDistribusjonAvBrev(
+        tilbakekrevingId: UUID,
+        vedtak: VedtakDto,
     )
 }
 
@@ -44,7 +55,35 @@ class TilbakekrevingHendelserServiceImpl(
                     ).toJson(),
             ).also { (partition, offset) ->
                 logger.info(
-                    "Posted event ${type.lagEventnameForType()} for TILBAKEKREVING ${statistikkTilbakekreving.id}" +
+                    "Posted event ${type.lagEventnameForType()} for tilbakekreving ${statistikkTilbakekreving.id}" +
+                        " to partiton $partition, offset $offset correlationid: $correlationId",
+                )
+            }
+    }
+
+    override fun sendVedtakForJournalfoeringOgDistribusjonAvBrev(
+        tilbakekrevingId: UUID,
+        vedtak: VedtakDto,
+    ) {
+        val correlationId = getCorrelationId()
+        val type = VedtakKafkaHendelseHendelseType.ATTESTERT.lagEventnameForType()
+
+        rapid
+            .publiser(
+                vedtak.behandlingId.toString(),
+                JsonMessage
+                    .newMessage(
+                        type,
+                        mapOf(
+                            CORRELATION_ID_KEY to getCorrelationId(),
+                            TEKNISK_TID_KEY to LocalDateTime.now(),
+                            VEDTAK_KEY to vedtak.toObjectNode(),
+                            SKAL_SENDE_BREV to true,
+                        ),
+                    ).toJson(),
+            ).also { (partition, offset) ->
+                logger.info(
+                    "Posted event $type for tilbakekreving $tilbakekrevingId" +
                         " to partiton $partition, offset $offset correlationid: $correlationId",
                 )
             }

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
@@ -72,7 +72,6 @@ import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingVedtak
 import no.nav.etterlatte.libs.common.toObjectNode
 import no.nav.etterlatte.libs.common.trygdetid.land.LandNormalisert
 import no.nav.etterlatte.libs.common.vedtak.LoependeYtelseDTO
-import no.nav.etterlatte.libs.common.vedtak.TilbakekrevingVedtakLagretDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakDto
 import no.nav.etterlatte.libs.ktor.PingResult
 import no.nav.etterlatte.libs.ktor.PingResultUp
@@ -257,30 +256,42 @@ class VedtakKlientTest : VedtakKlient {
         tilbakekrevingBehandling: TilbakekrevingBehandling,
         brukerTokenInfo: BrukerTokenInfo,
         enhet: Enhetsnummer,
-    ): Long = 123L
+    ): VedtakDto =
+        mockk<VedtakDto> {
+            every { id } returns 123L
+        }
 
     override suspend fun fattVedtakTilbakekreving(
         tilbakekrevingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         enhet: Enhetsnummer,
-    ): Long = 123L
+    ): VedtakDto =
+        mockk<VedtakDto> {
+            every { id } returns 123L
+        }
 
     override suspend fun attesterVedtakTilbakekreving(
         tilbakekrevingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         enhet: Enhetsnummer,
-    ): TilbakekrevingVedtakLagretDto =
-        TilbakekrevingVedtakLagretDto(
-            id = 123L,
-            fattetAv = "saksbehandler",
-            enhet = Enheter.defaultEnhet.enhetNr,
-            dato = LocalDate.now(),
-        )
+    ): VedtakDto =
+        mockk<VedtakDto> {
+            every { id } returns 123L
+            every { vedtakFattet } returns
+                mockk {
+                    every { ansvarligSaksbehandler } returns "saksbehandler"
+                    every { ansvarligEnhet } returns Enheter.defaultEnhet.enhetNr
+                    every { tidspunkt } returns Tidspunkt.now()
+                }
+        }
 
     override suspend fun underkjennVedtakTilbakekreving(
         tilbakekrevingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
-    ): Long = 123L
+    ): VedtakDto =
+        mockk<VedtakDto> {
+            every { id } returns 123L
+        }
 
     override suspend fun lagreVedtakKlage(
         klage: Klage,

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -310,27 +310,27 @@ fun Route.tilbakekrevingvedtakRoute(
             withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 val dto = call.receive<TilbakekrevingVedtakDto>()
                 logger.info("Oppretter vedtak for tilbakekreving=${dto.tilbakekrevingId}")
-                call.respond(service.opprettEllerOppdaterVedtak(dto))
+                call.respond(service.opprettEllerOppdaterVedtak(dto).toDto())
             }
         }
         post("/fatt-vedtak") {
             withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 val dto = call.receive<TilbakekrevingFattEllerAttesterVedtakDto>()
                 logger.info("Fatter vedtak for tilbakekreving=${dto.tilbakekrevingId}")
-                call.respond(service.fattVedtak(dto, brukerTokenInfo))
+                call.respond(service.fattVedtak(dto, brukerTokenInfo).toDto())
             }
         }
         post("/attester-vedtak") {
             withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 val dto = call.receive<TilbakekrevingFattEllerAttesterVedtakDto>()
                 logger.info("Attesterer vedtak for tilbakekreving=${dto.tilbakekrevingId}")
-                call.respond(service.attesterVedtak(dto, brukerTokenInfo))
+                call.respond(service.attesterVedtak(dto, brukerTokenInfo).toDto())
             }
         }
         post("/underkjenn-vedtak") {
             withBehandlingId(behandlingKlient, skrivetilgang = true) {
                 logger.info("Underkjenner vedtak for tilbakekreving=$behandlingId")
-                call.respond(service.underkjennVedtak(behandlingId))
+                call.respond(service.underkjennVedtak(behandlingId).toDto())
             }
         }
     }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/config/ApplicationContext.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/config/ApplicationContext.kt
@@ -89,8 +89,6 @@ class ApplicationContext {
     val vedtakTilbakekrevingService =
         VedtakTilbakekrevingService(
             repository = VedtaksvurderingRepository(dataSource),
-            rapidService = vedtaksvurderingRapidService,
-            behandlingKlient = behandlingKlient,
         )
     val vedtakKlageService =
         VedtakKlageService(

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakTilbakekrevingServiceTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakTilbakekrevingServiceTest.kt
@@ -1,9 +1,8 @@
 package no.nav.etterlatte.vedtaksvurdering
 
 import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
-import io.kotest.matchers.maps.shouldContain
 import io.kotest.matchers.shouldBe
-import io.mockk.coEvery
+import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -12,18 +11,14 @@ import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
-import no.nav.etterlatte.libs.common.rapidsandrivers.SKAL_SENDE_BREV
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vedtak.Attestasjon
 import no.nav.etterlatte.libs.common.vedtak.TilbakekrevingFattEllerAttesterVedtakDto
 import no.nav.etterlatte.libs.common.vedtak.TilbakekrevingVedtakDto
-import no.nav.etterlatte.libs.common.vedtak.TilbakekrevingVedtakLagretDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakFattet
-import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseHendelseType
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
-import no.nav.etterlatte.vedtaksvurdering.klienter.BehandlingKlient
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.temporal.ChronoUnit
@@ -31,9 +26,7 @@ import java.util.UUID
 
 class VedtakTilbakekrevingServiceTest {
     private val repo = mockk<VedtaksvurderingRepository>()
-    private val rapid = mockk<VedtaksvurderingRapidService>()
-    private val behandlingKlient = mockk<BehandlingKlient>()
-    private val service = VedtakTilbakekrevingService(repo, rapid, behandlingKlient)
+    private val service = VedtakTilbakekrevingService(repo)
 
     @Test
     fun `opprettEllerOppdaterVedtak oppretter hvis ikke finnes fra foer`() {
@@ -49,7 +42,9 @@ class VedtakTilbakekrevingServiceTest {
         every { repo.hentVedtak(dto.tilbakekrevingId) } returns null
         every { repo.opprettVedtak(any()) } returns vedtak()
 
-        service.opprettEllerOppdaterVedtak(dto) shouldBe 1L
+        val vedtak = service.opprettEllerOppdaterVedtak(dto)
+
+        vedtak shouldNotBe null
 
         verify { repo.hentVedtak(dto.tilbakekrevingId) }
         verify {
@@ -82,7 +77,7 @@ class VedtakTilbakekrevingServiceTest {
         every { repo.hentVedtak(dto.tilbakekrevingId) } returns eksisterende
         every { repo.oppdaterVedtak(any()) } returns eksisterende
 
-        service.opprettEllerOppdaterVedtak(dto) shouldBe 1L
+        service.opprettEllerOppdaterVedtak(dto).id shouldBe 1L
 
         verify { repo.hentVedtak(dto.tilbakekrevingId) }
         verify {
@@ -124,7 +119,9 @@ class VedtakTilbakekrevingServiceTest {
         every { repo.hentVedtak(dto.tilbakekrevingId) } returns vedtak()
         every { repo.fattVedtak(any(), any()) } returns vedtak()
 
-        service.fattVedtak(dto, saksbehandler) shouldBe 1L
+        val vedtak = service.fattVedtak(dto, saksbehandler)
+
+        vedtak shouldNotBe null
 
         verify { repo.hentVedtak(dto.tilbakekrevingId) }
         verify {
@@ -172,11 +169,6 @@ class VedtakTilbakekrevingServiceTest {
                     ),
             )
 
-        coEvery { behandlingKlient.hentTilbakekrevingBehandling(attesterDto.tilbakekrevingId, any()) } returns
-            mockk {
-                every { sendeBrev } returns true
-            }
-
         val attestertVedtak =
             vedtakTilbakekreving(
                 behandlingId = attesterDto.tilbakekrevingId,
@@ -193,21 +185,20 @@ class VedtakTilbakekrevingServiceTest {
                         tidspunkt = Tidspunkt.now(),
                     ),
             )
-        every { repo.inTransaction<TilbakekrevingVedtakLagretDto>(any()) } answers
+        every { repo.inTransaction<Vedtak>(any()) } answers
             {
-                val block = firstArg<VedtaksvurderingRepository.(TransactionalSession) -> TilbakekrevingVedtakLagretDto>()
+                val block = firstArg<VedtaksvurderingRepository.(TransactionalSession) -> Vedtak>()
                 repo.block(mockk())
             }
         every { repo.attesterVedtak(any(), any(), any()) } returns attestertVedtak
-        every { rapid.sendToRapid(any()) } returns Unit
 
-        val vedtakDto = service.attesterVedtak(attesterDto, saksbehandler)
+        val vedtak = service.attesterVedtak(attesterDto, saksbehandler)
 
-        with(vedtakDto) {
+        with(vedtak) {
             id shouldBe 1L
-            fattetAv shouldBe "saksbehandler"
-            enhet shouldBe Enheter.STEINKJER.enhetNr
-            dato shouldBe attestertVedtak.vedtakFattet!!.tidspunkt.toLocalDate()
+            vedtakFattet?.ansvarligSaksbehandler shouldBe "saksbehandler"
+            vedtakFattet?.ansvarligEnhet shouldBe Enheter.STEINKJER.enhetNr
+            vedtakFattet?.tidspunkt?.toLocalDate() shouldBe attestertVedtak.vedtakFattet!!.tidspunkt.toLocalDate()
         }
         verify { repo.hentVedtak(attesterDto.tilbakekrevingId) }
         verify {
@@ -218,21 +209,6 @@ class VedtakTilbakekrevingServiceTest {
                     it.attesterendeEnhet shouldBe attesterDto.enhet
                 },
                 any(),
-            )
-        }
-        verify {
-            val returDto = attestertVedtak.toDto()
-            rapid.sendToRapid(
-                withArg {
-                    it.vedtak shouldBe returDto
-                    with(it.rapidInfo1) {
-                        vedtakhendelse shouldBe VedtakKafkaHendelseHendelseType.ATTESTERT
-                        vedtak shouldBe returDto
-                        behandlingId shouldBe attesterDto.tilbakekrevingId
-                        extraParams.size shouldBe 1
-                        extraParams shouldContain Pair(SKAL_SENDE_BREV, true)
-                    }
-                },
             )
         }
     }
@@ -282,7 +258,9 @@ class VedtakTilbakekrevingServiceTest {
         every { repo.hentVedtak(tilbakekrevingId) } returns vedtak(status = VedtakStatus.FATTET_VEDTAK)
         every { repo.underkjennVedtak(tilbakekrevingId) } returns vedtak()
 
-        service.underkjennVedtak(tilbakekrevingId) shouldBe 1L
+        val vedtak = service.underkjennVedtak(tilbakekrevingId)
+
+        vedtak shouldNotBe null
 
         verify { repo.hentVedtak(tilbakekrevingId) }
         verify { repo.underkjennVedtak(tilbakekrevingId) }

--- a/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/IkkeStandardiserteKeys.kt
+++ b/libs/rapidsandrivers-extras/src/main/kotlin/rapidsandrivers/IkkeStandardiserteKeys.kt
@@ -27,6 +27,7 @@ const val DRYRUN = "dry_run"
 const val BOR_I_UTLAND_KEY = "bor_i_utland"
 const val ER_OVER_18_AAR = "er_over_18_aar"
 const val KONTEKST_KEY = "kontekst"
+const val VEDTAK_KEY = "vedtak"
 
 var JsonMessage.sakId: SakId
     get() = SakId(this[SAK_ID_KEY].asLong())


### PR DESCRIPTION
Utsending av vedtaksbrev for tilbakekreving ble gjort fra vedtaksvurdering tidligere. Dette skjedde før vi gjorde endelig kall mot tilbakekrevingskomponenten. Problemet her, er at sistnevnte kall kan feile (som vi har erfart), og da er brevet allerede på vei ut. 

Flytter nå trigging av hendelsen som journalfører og sender ut brevet til behandling, slik at vi kan sende vedtaket til tilbakekrevingskomponenten først, se at dette går fint for så å sende ut brevet. 