### PR TITLE
EY-4877 fjerne unødvendige felter for etterbetaling utfall i brev

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/BrevutfallSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/BrevutfallSkjema.tsx
@@ -187,31 +187,11 @@ export const BrevutfallSkjema = ({
                   validate={validerTom}
                   required
                 />
-                {behandling.sakType == SakType.BARNEPENSJON && (
-                  <>
-                    <ControlledRadioGruppe
-                      name="frivilligSkattetrekk"
-                      control={control}
-                      errorVedTomInput="Du må velge om bruker har meldt inn frivillig skattetrekk utover 17%"
-                      legend={<HStack gap="2">Har bruker meldt inn frivillig skattetrekk utover 17%?</HStack>}
-                      radios={
-                        <>
-                          <Radio size="small" value={ISvar.JA}>
-                            Ja
-                          </Radio>
-                          <Radio size="small" value={ISvar.NEI}>
-                            Nei
-                          </Radio>
-                        </>
-                      }
-                    />
-                  </>
-                )}
               </HStack>
             )}
 
-            {watch('harEtterbetaling') == ISvar.NEI && behandling.sakType == SakType.BARNEPENSJON && (
-              <HStack gap="4">
+            {behandling.sakType == SakType.BARNEPENSJON && (
+              <VStack gap="4">
                 <ControlledRadioGruppe
                   name="frivilligSkattetrekk"
                   control={control}
@@ -228,7 +208,7 @@ export const BrevutfallSkjema = ({
                     </>
                   }
                 />
-              </HStack>
+              </VStack>
             )}
           </VStack>
         )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/BrevutfallSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/BrevutfallSkjema.tsx
@@ -65,19 +65,12 @@ export const BrevutfallSkjema = ({
           : brevutfallOgEtterbetaling.etterbetaling
             ? ISvar.JA
             : ISvar.NEI,
-      kravIEtterbetaling:
-        brevutfallOgEtterbetaling.etterbetaling?.inneholderKrav === undefined
-          ? undefined
-          : brevutfallOgEtterbetaling.etterbetaling?.inneholderKrav
-            ? ISvar.JA
-            : ISvar.NEI,
       frivilligSkattetrekk:
         brevutfallOgEtterbetaling.brevutfall?.frivilligSkattetrekk === undefined
           ? undefined
           : brevutfallOgEtterbetaling.brevutfall?.frivilligSkattetrekk
             ? ISvar.JA
             : ISvar.NEI,
-      etterbetalingPeriodeValg: brevutfallOgEtterbetaling.etterbetaling?.etterbetalingPeriodeValg,
       datoFom: brevutfallOgEtterbetaling.etterbetaling?.datoFom
         ? new Date(brevutfallOgEtterbetaling.etterbetaling?.datoFom)
         : undefined,
@@ -197,42 +190,10 @@ export const BrevutfallSkjema = ({
                 {behandling.sakType == SakType.BARNEPENSJON && (
                   <>
                     <ControlledRadioGruppe
-                      name="kravIEtterbetaling"
-                      control={control}
-                      errorVedTomInput="Du må velge om det er krav i etterbetalingen"
-                      legend={<HStack gap="2">Er det krav i etterbetalingen?</HStack>}
-                      radios={
-                        <>
-                          <Radio size="small" value={ISvar.JA}>
-                            Ja
-                          </Radio>
-                          <Radio size="small" value={ISvar.NEI}>
-                            Nei
-                          </Radio>
-                        </>
-                      }
-                    />
-                    <ControlledRadioGruppe
-                      name="etterbetalingPeriodeValg"
-                      control={control}
-                      errorVedTomInput="Velg hvor lang etterbetalingsperiode det er"
-                      legend={<HStack gap="2">Hvor mange måneder etterbetales det for?</HStack>}
-                      radios={
-                        <>
-                          <Radio size="small" value={EtterbetalingPeriodeValg.UNDER_3_MND}>
-                            Etterbetaling 1 - 2 måneder
-                          </Radio>
-                          <Radio size="small" value={EtterbetalingPeriodeValg.FRA_3_MND}>
-                            Etterbetaling fra 3 måneder
-                          </Radio>
-                        </>
-                      }
-                    />
-                    <ControlledRadioGruppe
                       name="frivilligSkattetrekk"
                       control={control}
-                      errorVedTomInput="Du må velge om bruker har meldt inn frivillig skattetrekk"
-                      legend={<HStack gap="2">Har bruker meldt inn frivillig skattetrekk?</HStack>}
+                      errorVedTomInput="Du må velge om bruker har meldt inn frivillig skattetrekk utover 17%"
+                      legend={<HStack gap="2">Har bruker meldt inn frivillig skattetrekk utover 17%?</HStack>}
                       radios={
                         <>
                           <Radio size="small" value={ISvar.JA}>
@@ -254,8 +215,8 @@ export const BrevutfallSkjema = ({
                 <ControlledRadioGruppe
                   name="frivilligSkattetrekk"
                   control={control}
-                  errorVedTomInput="Du må velge om bruker har meldt inn frivillig skattetrekk"
-                  legend={<HStack gap="2">Har bruker meldt inn frivillig skattetrekk?</HStack>}
+                  errorVedTomInput="Du må velge om bruker har meldt inn frivillig skattetrekk utover 17%"
+                  legend={<HStack gap="2">Har bruker meldt inn frivillig skattetrekk utover 17%?</HStack>}
                   radios={
                     <>
                       <Radio size="small" value={ISvar.JA}>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/BrevutfallVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/BrevutfallVisning.tsx
@@ -48,33 +48,36 @@ export const BrevutfallVisning = (props: {
   return (
     <VStack gap="8">
       {!behandlingErOpphoer && (
-        <VStack gap="2">
+        <>
           <VStack gap="2">
-            <Label>Skal det etterbetales?</Label>
-            <BodyShort>{brevutfallOgEtterbetaling.etterbetaling ? 'Ja' : 'Nei'}</BodyShort>
+            <VStack gap="2">
+              <Label>Skal det etterbetales?</Label>
+              <BodyShort>{brevutfallOgEtterbetaling.etterbetaling ? 'Ja' : 'Nei'}</BodyShort>
+            </VStack>
+            {brevutfallOgEtterbetaling.etterbetaling && (
+              <>
+                <HStack gap="8">
+                  <VStack gap="2">
+                    <Label>Fra og med</Label>
+                    <BodyShort>{formaterMaanedDato(brevutfallOgEtterbetaling.etterbetaling.datoFom!!)}</BodyShort>
+                  </VStack>
+                  <VStack gap="2">
+                    <Label>Til og med</Label>
+                    <BodyShort>{formaterMaanedDato(brevutfallOgEtterbetaling.etterbetaling.datoTom!!)}</BodyShort>
+                  </VStack>
+                </HStack>
+              </>
+            )}
           </VStack>
-          {brevutfallOgEtterbetaling.etterbetaling && (
-            <>
-              <HStack gap="8">
-                <VStack gap="2">
-                  <Label>Fra og med</Label>
-                  <BodyShort>{formaterMaanedDato(brevutfallOgEtterbetaling.etterbetaling.datoFom!!)}</BodyShort>
-                </VStack>
-                <VStack gap="2">
-                  <Label>Til og med</Label>
-                  <BodyShort>{formaterMaanedDato(brevutfallOgEtterbetaling.etterbetaling.datoTom!!)}</BodyShort>
-                </VStack>
-              </HStack>
-            </>
-          )}
           {sakType === SakType.BARNEPENSJON && hasValue(brevutfallOgEtterbetaling.brevutfall?.frivilligSkattetrekk) && (
             <VStack gap="2">
               <Label>Har bruker meldt inn frivillig skattetrekk utover 17%?</Label>
               <BodyShort>{brevutfallOgEtterbetaling.brevutfall.frivilligSkattetrekk ? 'Ja' : 'Nei'}</BodyShort>
             </VStack>
           )}
-        </VStack>
+        </>
       )}
+
       {sakType === SakType.BARNEPENSJON && (
         <VStack gap="2">
           <Label>Gjelder brevet under eller over 18 år?</Label>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/BrevutfallVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/BrevutfallVisning.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import {
   Aldersgruppe,
   BrevutfallOgEtterbetaling,
-  EtterbetalingPeriodeValg,
   FeilutbetalingValg,
 } from '~components/behandling/brevutfall/Brevutfall'
 import { SakType } from '~shared/types/sak'
@@ -32,17 +31,6 @@ export function feilutbetalingToString(feilutbetaling?: FeilutbetalingValg | nul
       return 'Ja, men motregnes mot annen ytelse fra NAV, så avventer varsel om feilutbetaling til ev. tilbakekrevingssak'
     case FeilutbetalingValg.JA_INGEN_TK:
       return 'Ja, men ikke grunnlag for tilbakekreving pga under 4 rettsgebyr, eller annen grunn (se notat)'
-    default:
-      return 'Ikke satt'
-  }
-}
-
-function etterbetalingPeriodeValgToString(etterbetalingPeriodeValg?: EtterbetalingPeriodeValg | null) {
-  switch (etterbetalingPeriodeValg) {
-    case EtterbetalingPeriodeValg.UNDER_3_MND:
-      return 'Under 3 måneder'
-    case EtterbetalingPeriodeValg.FRA_3_MND:
-      return 'Fra 3 måneder'
     default:
       return 'Ikke satt'
   }
@@ -77,31 +65,11 @@ export const BrevutfallVisning = (props: {
                   <BodyShort>{formaterMaanedDato(brevutfallOgEtterbetaling.etterbetaling.datoTom!!)}</BodyShort>
                 </VStack>
               </HStack>
-              {sakType === SakType.BARNEPENSJON && (
-                <>
-                  {hasValue(brevutfallOgEtterbetaling.etterbetaling?.inneholderKrav) && (
-                    <VStack gap="2">
-                      <Label>Er det krav i etterbetalingen?</Label>
-                      <BodyShort>{brevutfallOgEtterbetaling.etterbetaling?.inneholderKrav ? 'Ja' : 'Nei'}</BodyShort>
-                    </VStack>
-                  )}
-                  {hasValue(brevutfallOgEtterbetaling.etterbetaling?.etterbetalingPeriodeValg) && (
-                    <VStack gap="2">
-                      <Label>Hvor mange måneder etterbetales det for?</Label>
-                      <BodyShort>
-                        {etterbetalingPeriodeValgToString(
-                          brevutfallOgEtterbetaling.etterbetaling?.etterbetalingPeriodeValg
-                        )}
-                      </BodyShort>
-                    </VStack>
-                  )}
-                </>
-              )}
             </>
           )}
           {sakType === SakType.BARNEPENSJON && hasValue(brevutfallOgEtterbetaling.brevutfall?.frivilligSkattetrekk) && (
             <VStack gap="2">
-              <Label>Har bruker meldt inn frivillig skattetrekk?</Label>
+              <Label>Har bruker meldt inn frivillig skattetrekk utover 17%?</Label>
               <BodyShort>{brevutfallOgEtterbetaling.brevutfall.frivilligSkattetrekk ? 'Ja' : 'Nei'}</BodyShort>
             </VStack>
           )}


### PR DESCRIPTION
Fjerne felter for etterbetaling som skal fases ut. 

Forbedret også visningen for frivilligSkattetrekk - denne skal vises uavhengig av etterbetaling. Og løsningen i dag var duplisering av kode.