### PR TITLE
standardisere brevutfall objekt

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoDao.kt
@@ -3,7 +3,7 @@ package no.nav.etterlatte.behandling.behandlinginfo
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.utland.SluttbehandlingUtlandBehandlinginfo
 import no.nav.etterlatte.common.ConnectionAutoclosing
-import no.nav.etterlatte.libs.common.behandling.Brevutfall
+import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.feilhaandtering.krev
 import no.nav.etterlatte.libs.common.objectMapper
@@ -72,7 +72,7 @@ class BehandlingInfoDao(
             }
         }
 
-    fun lagreBrevutfall(brevutfall: Brevutfall): Brevutfall =
+    fun lagreBrevutfall(brevutfall: BrevutfallDto): BrevutfallDto =
         connectionAutoclosing.hentConnection { connection ->
             with(connection) {
                 prepareStatement(
@@ -91,13 +91,13 @@ class BehandlingInfoDao(
                             "Kunne ikke lagreBrevutfall behandling for ${brevutfall.behandlingId}"
                         }
                     }.let {
-                        hentBrevutfall(brevutfall.behandlingId)
+                        hentBrevutfall(brevutfall.behandlingId!!)
                             ?: throw InternfeilException("Feilet under lagring av brevutfall")
                     }
             }
         }
 
-    fun hentBrevutfall(behandlingId: UUID): Brevutfall? =
+    fun hentBrevutfall(behandlingId: UUID): BrevutfallDto? =
         connectionAutoclosing.hentConnection {
             with(it) {
                 prepareStatement(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoRoutes.kt
@@ -9,8 +9,6 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.behandling.utland.SluttbehandlingUtlandBehandlinginfoRequest
 import no.nav.etterlatte.inTransaction
-import no.nav.etterlatte.libs.common.behandling.Brevutfall
-import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
 import no.nav.etterlatte.libs.common.behandling.BrevutfallOgEtterbetalingDto
 import no.nav.etterlatte.libs.common.behandling.EtterbetalingDto
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
@@ -31,7 +29,7 @@ internal fun Route.behandlingInfoRoutes(service: BehandlingInfoService) {
         route("/brevutfall") {
             post {
                 kunSkrivetilgang {
-                    medBody<BrevutfallOgEtterbetalingDto> { dto ->
+                    medBody<BrevutfallOgEtterbetalingDto> { brevutfallDto ->
                         val brevutfallOgEtterbetaling =
                             inTransaction {
                                 logger.info("Lagrer brevutfall og etterbetaling for behandling $behandlingId")
@@ -39,16 +37,16 @@ internal fun Route.behandlingInfoRoutes(service: BehandlingInfoService) {
                                     service.lagreBrevutfallOgEtterbetaling(
                                         behandlingId,
                                         brukerTokenInfo,
-                                        dto.opphoer ?: throw OpphoerIkkeSatt(behandlingId),
-                                        dto.toBrevutfall(behandlingId, brukerTokenInfo),
-                                        dto.toEtterbetaling(behandlingId, brukerTokenInfo),
+                                        brevutfallDto.opphoer ?: throw OpphoerIkkeSatt(behandlingId),
+                                        brevutfallDto.brevutfall!!,
+                                        brevutfallDto.toEtterbetaling(behandlingId, brukerTokenInfo),
                                     )
 
                                 BrevutfallOgEtterbetalingDto(
                                     behandlingId,
-                                    dto.opphoer,
+                                    brevutfallDto.opphoer,
                                     etterbetalingLagret?.toDto(),
-                                    brevutfallLagret.toDto(),
+                                    brevutfallLagret,
                                 )
                             }
                         call.respond(brevutfallOgEtterbetaling)
@@ -64,7 +62,7 @@ internal fun Route.behandlingInfoRoutes(service: BehandlingInfoService) {
                     }
                 when (brevutfall) {
                     null -> call.respond(HttpStatusCode.NoContent)
-                    else -> call.respond(brevutfall.toDto())
+                    else -> call.respond(brevutfall)
                 }
             }
         }
@@ -101,7 +99,7 @@ internal fun Route.behandlingInfoRoutes(service: BehandlingInfoService) {
                         BrevutfallOgEtterbetalingDto(
                             behandlingId = behandlingId,
                             etterbetaling = etterbetaling?.toDto(),
-                            brevutfall = brevutfall.toDto(),
+                            brevutfall = brevutfall,
                         )
                     } else {
                         null
@@ -123,18 +121,6 @@ internal fun Route.behandlingInfoRoutes(service: BehandlingInfoService) {
     }
 }
 
-private fun BrevutfallOgEtterbetalingDto.toBrevutfall(
-    behandlingId: UUID,
-    bruker: BrukerTokenInfo,
-): Brevutfall =
-    Brevutfall(
-        behandlingId = behandlingId,
-        aldersgruppe = brevutfall?.aldersgruppe,
-        feilutbetaling = brevutfall?.feilutbetaling,
-        frivilligSkattetrekk = brevutfall?.frivilligSkattetrekk,
-        kilde = Grunnlagsopplysning.Saksbehandler.create(bruker.ident()),
-    )
-
 private fun BrevutfallOgEtterbetalingDto.toEtterbetaling(
     behandlingId: UUID,
     bruker: BrukerTokenInfo,
@@ -154,15 +140,6 @@ private fun BrevutfallOgEtterbetalingDto.toEtterbetaling(
         null
     }
 }
-
-private fun Brevutfall.toDto() =
-    BrevutfallDto(
-        behandlingId = behandlingId,
-        aldersgruppe = aldersgruppe,
-        feilutbetaling = feilutbetaling,
-        frivilligSkattetrekk = frivilligSkattetrekk,
-        kilde = kilde,
-    )
 
 private fun Etterbetaling.toDto() =
     EtterbetalingDto(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoService.kt
@@ -6,7 +6,7 @@ import no.nav.etterlatte.behandling.domain.Behandling
 import no.nav.etterlatte.behandling.utland.SluttbehandlingUtlandBehandlinginfo
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
-import no.nav.etterlatte.libs.common.behandling.Brevutfall
+import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -26,9 +26,9 @@ class BehandlingInfoService(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         opphoer: Boolean,
-        brevutfall: Brevutfall,
+        brevutfallDto: BrevutfallDto,
         etterbetaling: Etterbetaling?,
-    ): Pair<Brevutfall, Etterbetaling?> {
+    ): Pair<BrevutfallDto, Etterbetaling?> {
         val behandling =
             behandlingService.hentBehandling(behandlingId)
                 ?: throw GenerellIkkeFunnetException()
@@ -42,7 +42,7 @@ class BehandlingInfoService(
             sjekkBehandlingKanEndres(behandling, opphoer)
         }
 
-        val lagretBrevutfall = lagreBrevutfall(behandling, brevutfall)
+        val lagretBrevutfall = lagreBrevutfall(behandling, brevutfallDto)
         val lagretEtterbetaling = lagreEtterbetaling(behandling, etterbetaling)
 
         oppdaterBehandlingStatus(behandling, opphoer, brukerTokenInfo)
@@ -64,14 +64,14 @@ class BehandlingInfoService(
 
     private fun lagreBrevutfall(
         behandling: Behandling,
-        brevutfall: Brevutfall,
-    ): Brevutfall {
-        sjekkAldersgruppeSattVedBarnepensjon(behandling, brevutfall)
-        sjekkFeilutbetalingErSatt(behandling, brevutfall)
-        return behandlingInfoDao.lagreBrevutfall(brevutfall)
+        brevutfallDto: BrevutfallDto,
+    ): BrevutfallDto {
+        sjekkAldersgruppeSattVedBarnepensjon(behandling, brevutfallDto)
+        sjekkFeilutbetalingErSatt(behandling, brevutfallDto)
+        return behandlingInfoDao.lagreBrevutfall(brevutfallDto)
     }
 
-    fun hentBrevutfall(behandlingId: UUID): Brevutfall? = behandlingInfoDao.hentBrevutfall(behandlingId)
+    fun hentBrevutfall(behandlingId: UUID): BrevutfallDto? = behandlingInfoDao.hentBrevutfall(behandlingId)
 
     fun lagreEtterbetaling(
         behandling: Behandling,
@@ -152,19 +152,19 @@ class BehandlingInfoService(
 
     private fun sjekkAldersgruppeSattVedBarnepensjon(
         behandling: Behandling,
-        brevutfall: Brevutfall,
+        brevutfallDto: BrevutfallDto,
     ) {
-        if (behandling.sak.sakType == SakType.BARNEPENSJON && brevutfall.aldersgruppe == null) {
+        if (behandling.sak.sakType == SakType.BARNEPENSJON && brevutfallDto.aldersgruppe == null) {
             throw BrevutfallException.AldergruppeIkkeSatt()
         }
     }
 
     private fun sjekkFeilutbetalingErSatt(
         behandling: Behandling,
-        brevutfall: Brevutfall,
+        brevutfallDto: BrevutfallDto,
     ) {
         if (behandling.type == BehandlingType.REVURDERING &&
-            brevutfall.feilutbetaling == null
+            brevutfallDto.feilutbetaling == null
         ) {
             throw BrevutfallException.FeilutbetalingIkkeSatt()
         }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingStatusServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingStatusServiceTest.kt
@@ -18,7 +18,7 @@ import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BoddEllerArbeidetUtlandet
-import no.nav.etterlatte.libs.common.behandling.Brevutfall
+import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
 import no.nav.etterlatte.libs.common.behandling.Feilutbetaling
 import no.nav.etterlatte.libs.common.behandling.FeilutbetalingValg
 import no.nav.etterlatte.libs.common.behandling.JaNei
@@ -159,7 +159,7 @@ internal class BehandlingStatusServiceTest {
         val iverksettVedtak = VedtakHendelse(1L, Tidspunkt.now(), "sbl")
 
         every { behandlingService.hentBehandling(behandlingId) } returns behandling
-        every { behandlingInfoDao.hentBrevutfall(behandlingId) } returns brevutfall(behandlingId)
+        every { behandlingInfoDao.hentBrevutfall(behandlingId) } returns brevutfallDto(behandlingId)
 
         inTransaction {
             sut.settIverksattVedtak(behandlingId, iverksettVedtak)
@@ -216,7 +216,7 @@ internal class BehandlingStatusServiceTest {
         val iverksattVedtak = VedtakHendelse(1L, Tidspunkt.now(), saksbehandler)
 
         every { behandlingService.hentBehandling(behandlingId) } returns behandling
-        every { behandlingInfoDao.hentBrevutfall(behandlingId) } returns brevutfall(behandlingId)
+        every { behandlingInfoDao.hentBrevutfall(behandlingId) } returns brevutfallDto(behandlingId)
 
         val generellBehandlingUtland =
             GenerellBehandling.opprettUtland(
@@ -343,7 +343,7 @@ internal class BehandlingStatusServiceTest {
         val iverksettVedtak = VedtakHendelse(1L, Tidspunkt.now(), "sbl")
 
         every { behandlingService.hentBehandling(behandlingId) } returns behandling
-        every { behandlingInfoDao.hentBrevutfall(behandlingId) } returns brevutfall(behandlingId, feilutbetalingValg)
+        every { behandlingInfoDao.hentBrevutfall(behandlingId) } returns brevutfallDto(behandlingId, feilutbetalingValg)
         every { oppgaveService.hentOppgaverForSak(sakId, any()) } returns
             listOf(
                 oppgave(UUID.randomUUID(), sakId, Status.FERDIGSTILT),
@@ -391,7 +391,7 @@ internal class BehandlingStatusServiceTest {
         val iverksettVedtak = VedtakHendelse(1L, Tidspunkt.now(), "sbl")
 
         every { behandlingService.hentBehandling(behandlingId) } returns behandling
-        every { behandlingInfoDao.hentBrevutfall(behandlingId) } returns brevutfall(behandlingId, feilutbetalingValg)
+        every { behandlingInfoDao.hentBrevutfall(behandlingId) } returns brevutfallDto(behandlingId, feilutbetalingValg)
         every { oppgaveService.hentOppgaverForSak(sakId, OppgaveType.TILBAKEKREVING) } returns listOf(oppgave(oppgaveId, sakId))
         every { oppgaveService.endrePaaVent(any(), any(), any(), any()) } returns oppgave(oppgaveId, sakId, Status.PAA_VENT)
         every { grunnlagsendringshendelseService.settHendelseTilHistorisk(behandlingId) } just runs
@@ -432,10 +432,10 @@ internal class BehandlingStatusServiceTest {
         frist = Tidspunkt.now(),
     )
 
-    private fun brevutfall(
+    private fun brevutfallDto(
         behandlingId: UUID,
         feilutbetalingValg: FeilutbetalingValg = FeilutbetalingValg.NEI,
-    ) = Brevutfall(
+    ) = BrevutfallDto(
         behandlingId = behandlingId,
         aldersgruppe = null,
         feilutbetaling = Feilutbetaling(feilutbetalingValg, "kommentar"),

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoDaoTest.kt
@@ -17,7 +17,7 @@ import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.Aldersgruppe
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
-import no.nav.etterlatte.libs.common.behandling.Brevutfall
+import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
 import no.nav.etterlatte.libs.common.behandling.EtterbetalingPeriodeValg
 import no.nav.etterlatte.libs.common.behandling.Feilutbetaling
 import no.nav.etterlatte.libs.common.behandling.FeilutbetalingValg
@@ -110,7 +110,7 @@ internal class BehandlingInfoDaoTest(
 
     @Test
     fun `skal lagre brevutfall`() {
-        val brevutfall = brevutfall(behandlingId)
+        val brevutfall = brevutfallDto(behandlingId)
 
         val lagretBrevutfall = dao.lagreBrevutfall(brevutfall)
 
@@ -121,32 +121,32 @@ internal class BehandlingInfoDaoTest(
 
     @Test
     fun `skal hente brevutfall`() {
-        val brevutfall = brevutfall(behandlingId)
-        dao.hentBrevutfall(brevutfall.behandlingId) shouldBe null
+        val brevutfall = brevutfallDto(behandlingId)
+        dao.hentBrevutfall(brevutfall.behandlingId!!) shouldBe null
         dao.lagreBrevutfall(brevutfall)
-        val lagretBrevutfall = dao.hentBrevutfall(brevutfall.behandlingId)
+        val lagretBrevutfall = dao.hentBrevutfall(brevutfall.behandlingId!!)
 
         lagretBrevutfall shouldNotBe null
     }
 
     @Test
     fun `skal hente brevutfall men etterbetaling lå der, skal allikevel gå bra`() {
-        val brevutfall = brevutfall(behandlingId)
-        dao.hentBrevutfall(brevutfall.behandlingId) shouldBe null
+        val brevutfall = brevutfallDto(behandlingId)
+        dao.hentBrevutfall(brevutfall.behandlingId!!) shouldBe null
         val etterbetaling = etterbetaling(behandlingId)
         dao.lagreEtterbetaling(etterbetaling)
         // Tryna her tidligere fordi etterbetaling gjorde at next i singleOrNull ga true og block ble kjørt. Den tryna da på this.getString("brevutfall").let var uten spørsmålstegn
-        dao.hentBrevutfall(brevutfall.behandlingId)
+        dao.hentBrevutfall(brevutfall.behandlingId!!)
 
         dao.lagreBrevutfall(brevutfall)
-        val lagretBrevutfall = dao.hentBrevutfall(brevutfall.behandlingId)
+        val lagretBrevutfall = dao.hentBrevutfall(brevutfall.behandlingId!!)
 
         lagretBrevutfall shouldBe brevutfall
     }
 
     @Test
     fun `skal oppdatere brevutfall`() {
-        val brevutfall = brevutfall(behandlingId)
+        val brevutfall = brevutfallDto(behandlingId)
 
         val lagretBrevutfall = dao.lagreBrevutfall(brevutfall)
 
@@ -197,8 +197,8 @@ internal class BehandlingInfoDaoTest(
         dao.hentEtterbetaling(etterbetaling.behandlingId) shouldBe null
     }
 
-    private fun brevutfall(behandlingId: UUID) =
-        Brevutfall(
+    private fun brevutfallDto(behandlingId: UUID) =
+        BrevutfallDto(
             behandlingId = behandlingId,
             aldersgruppe = Aldersgruppe.UNDER_18,
             feilutbetaling = Feilutbetaling(FeilutbetalingValg.NEI, null),

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoRoutesTest.kt
@@ -23,7 +23,6 @@ import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
 import no.nav.etterlatte.libs.common.behandling.Aldersgruppe
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
-import no.nav.etterlatte.libs.common.behandling.Brevutfall
 import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
 import no.nav.etterlatte.libs.common.behandling.BrevutfallOgEtterbetalingDto
 import no.nav.etterlatte.libs.common.behandling.EtterbetalingDto
@@ -90,7 +89,7 @@ internal class BehandlingInfoRoutesTest {
         val dto = brevutfallOgEtterbetalingDto(behandlingId)
 
         every { behandlingService.hentBehandling(any()) } returns behandling(behandlingId)
-        every { behandlingInfoDao.lagreBrevutfall(any()) } returns brevutfall(behandlingId)
+        every { behandlingInfoDao.lagreBrevutfall(any()) } returns brevutfallDto(behandlingId)
         every { behandlingInfoDao.lagreEtterbetaling(any()) } returns etterbetaling(behandlingId)
         every { behandlingsstatusService.settBeregnet(any(), any(), any()) } returns Unit
 
@@ -128,7 +127,7 @@ internal class BehandlingInfoRoutesTest {
         val dto = brevutfallOgEtterbetalingDto(behandlingId)
 
         every { behandlingService.hentBehandling(any()) } returns behandling(behandlingId)
-        every { behandlingInfoDao.hentBrevutfall(any()) } returns brevutfall(behandlingId)
+        every { behandlingInfoDao.hentBrevutfall(any()) } returns brevutfallDto(behandlingId)
         every { behandlingInfoDao.hentEtterbetaling(any()) } returns etterbetaling(behandlingId)
 
         testApplication {
@@ -197,8 +196,8 @@ internal class BehandlingInfoRoutesTest {
                 )
         }
 
-    private fun brevutfall(behandlingId: UUID) =
-        Brevutfall(
+    private fun brevutfallDto(behandlingId: UUID) =
+        BrevutfallDto(
             behandlingId = behandlingId,
             aldersgruppe = Aldersgruppe.UNDER_18,
             feilutbetaling = Feilutbetaling(FeilutbetalingValg.NEI, null),

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoServiceTest.kt
@@ -10,7 +10,7 @@ import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.behandling.Aldersgruppe
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
-import no.nav.etterlatte.libs.common.behandling.Brevutfall
+import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
 import no.nav.etterlatte.libs.common.behandling.EtterbetalingPeriodeValg
 import no.nav.etterlatte.libs.common.behandling.Feilutbetaling
 import no.nav.etterlatte.libs.common.behandling.FeilutbetalingValg
@@ -38,7 +38,7 @@ internal class BehandlingInfoServiceTest {
     @Test
     fun `Skal oppdatere behandlingsstatus hvis endret barnepensjon`() {
         val behandlingId = randomUUID()
-        val brevutfall = brevutfall(behandlingId)
+        val brevutfall = brevutfallDto(behandlingId)
         val etterbetaling = etterbetaling(behandlingId = behandlingId)
         every { behandlingService.hentBehandling(any()) } returns behandling(behandlingId)
         every { behandlingInfoDao.lagreBrevutfall(any()) } returns mockk()
@@ -49,7 +49,7 @@ internal class BehandlingInfoServiceTest {
             behandlingId = behandlingId,
             brukerTokenInfo = bruker,
             opphoer = false,
-            brevutfall = brevutfall,
+            brevutfallDto = brevutfall,
             etterbetaling = etterbetaling,
         )
 
@@ -63,7 +63,7 @@ internal class BehandlingInfoServiceTest {
     @Test
     fun `Etterbetaling skal oppdatere behandlingsstatus hvis endret omstillingstoenad`() {
         val behandlingId = randomUUID()
-        val brevutfall = brevutfall(behandlingId)
+        val brevutfall = brevutfallDto(behandlingId)
         val etterbetaling = etterbetaling(behandlingId = behandlingId)
 
         every { behandlingService.hentBehandling(any()) } returns
@@ -81,7 +81,7 @@ internal class BehandlingInfoServiceTest {
             behandlingId = behandlingId,
             brukerTokenInfo = bruker,
             opphoer = false,
-            brevutfall = brevutfall,
+            brevutfallDto = brevutfall,
             etterbetaling = etterbetaling,
         )
 
@@ -107,7 +107,7 @@ internal class BehandlingInfoServiceTest {
                 behandlingId = behandlingId,
                 brukerTokenInfo = bruker,
                 opphoer = false,
-                brevutfall = brevutfall(behandlingId),
+                brevutfallDto = brevutfallDto(behandlingId),
                 etterbetaling = null,
             )
         }
@@ -133,7 +133,7 @@ internal class BehandlingInfoServiceTest {
                 behandlingId = behandlingId,
                 brukerTokenInfo = bruker,
                 opphoer = false,
-                brevutfall = brevutfall(behandlingId).copy(feilutbetaling = null),
+                brevutfallDto = brevutfallDto(behandlingId).copy(feilutbetaling = null),
                 etterbetaling = etterbetaling(behandlingId = behandlingId),
             )
         }
@@ -188,7 +188,7 @@ internal class BehandlingInfoServiceTest {
             behandlingId = behandlingId,
             brukerTokenInfo = bruker,
             opphoer = true,
-            brevutfall = brevutfall(behandlingId).copy(aldersgruppe = null),
+            brevutfallDto = brevutfallDto(behandlingId).copy(aldersgruppe = null),
             etterbetaling = null,
         )
 
@@ -218,7 +218,7 @@ internal class BehandlingInfoServiceTest {
             behandlingId = behandlingId,
             brukerTokenInfo = bruker,
             opphoer = true,
-            brevutfall = brevutfall(behandlingId).copy(),
+            brevutfallDto = brevutfallDto(behandlingId).copy(),
             etterbetaling = null,
         )
 
@@ -252,8 +252,8 @@ internal class BehandlingInfoServiceTest {
                 )
         }
 
-    private fun brevutfall(behandlingId: UUID) =
-        Brevutfall(
+    private fun brevutfallDto(behandlingId: UUID) =
+        BrevutfallDto(
             behandlingId = behandlingId,
             aldersgruppe = Aldersgruppe.UNDER_18,
             feilutbetaling = Feilutbetaling(FeilutbetalingValg.NEI, null),

--- a/libs/saksbehandling-common/src/main/kotlin/behandling/Brevutfall.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/behandling/Brevutfall.kt
@@ -1,16 +1,5 @@
 package no.nav.etterlatte.libs.common.behandling
 
-import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
-import java.util.UUID
-
-data class Brevutfall(
-    val behandlingId: UUID,
-    val aldersgruppe: Aldersgruppe?,
-    val feilutbetaling: Feilutbetaling?,
-    val frivilligSkattetrekk: Boolean?,
-    val kilde: Grunnlagsopplysning.Kilde,
-)
-
 enum class Aldersgruppe {
     OVER_18,
     UNDER_18,


### PR DESCRIPTION
I dag har vi to objekter som er like. Faser ut det som er minst brukt slik at vi kun trenger å bruke ett