### PR TITLE
EY-4877 sende med etterbetaling til pensjonsbrev bp revurdering redigerbart utfall

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
@@ -110,6 +110,7 @@ data class BarnepensjonRevurderingRedigerbartUtfall(
     val brukerUnder18Aar: Boolean,
     val bosattUtland: Boolean,
     val frivilligSkattetrekk: Boolean,
+    val etterbetaling: BarnepensjonEtterbetaling?,
 ) : BrevDataRedigerbar {
     companion object {
         fun fra(
@@ -129,6 +130,7 @@ data class BarnepensjonRevurderingRedigerbartUtfall(
                 brukerUnder18Aar = requireNotNull(brevutfall.aldersgruppe) == Aldersgruppe.UNDER_18,
                 bosattUtland = utlandstilknytning == UtlandstilknytningType.BOSATT_UTLAND,
                 frivilligSkattetrekk = frivilligSkattetrekk,
+                etterbetaling = etterbetaling?.let { dto -> Etterbetaling.fraBarnepensjonDTO(dto) },
             )
         }
     }


### PR DESCRIPTION
Avsnitt om etterbetaling mangler noe tekst pga etterbatling objektet er null. Enkleste løsning å sende med. Kan heller se på å bruke erEtterbetaling på sikt. 