### PR TITLE
EY-4889 rydde opp 'Utfall i brev' - etterbetaling, brevutfall 

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoRoutes.kt
@@ -131,7 +131,6 @@ private fun BrevutfallOgEtterbetalingDto.toEtterbetaling(
             behandlingId = behandlingId,
             datoFom = etterbetalingCopy.datoFom,
             datoTom = etterbetalingCopy.datoTom,
-            frivilligSkattetrekk = etterbetalingCopy.frivilligSkattetrekk,
             kilde = Grunnlagsopplysning.Saksbehandler.create(bruker.ident()),
         )
     } else {
@@ -145,7 +144,6 @@ private fun Etterbetaling.toDto() =
         datoFom = fom.atDay(1),
         datoTom = tom.atEndOfMonth(),
         kilde = kilde,
-        frivilligSkattetrekk = frivilligSkattetrekk,
     )
 
 class OpphoerIkkeSatt(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/BehandlingInfoRoutes.kt
@@ -131,9 +131,7 @@ private fun BrevutfallOgEtterbetalingDto.toEtterbetaling(
             behandlingId = behandlingId,
             datoFom = etterbetalingCopy.datoFom,
             datoTom = etterbetalingCopy.datoTom,
-            inneholderKrav = etterbetalingCopy.inneholderKrav,
             frivilligSkattetrekk = etterbetalingCopy.frivilligSkattetrekk,
-            etterbetalingPeriodeValg = etterbetalingCopy.etterbetalingPeriodeValg,
             kilde = Grunnlagsopplysning.Saksbehandler.create(bruker.ident()),
         )
     } else {
@@ -147,9 +145,7 @@ private fun Etterbetaling.toDto() =
         datoFom = fom.atDay(1),
         datoTom = tom.atEndOfMonth(),
         kilde = kilde,
-        inneholderKrav = inneholderKrav,
         frivilligSkattetrekk = frivilligSkattetrekk,
-        etterbetalingPeriodeValg = etterbetalingPeriodeValg,
     )
 
 class OpphoerIkkeSatt(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/Etterbetaling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/Etterbetaling.kt
@@ -10,7 +10,6 @@ data class Etterbetaling(
     val behandlingId: UUID,
     val fom: YearMonth,
     val tom: YearMonth,
-    val frivilligSkattetrekk: Boolean?,
     val kilde: Grunnlagsopplysning.Saksbehandler,
 ) {
     init {
@@ -27,7 +26,6 @@ data class Etterbetaling(
             behandlingId: UUID,
             datoFom: LocalDate?,
             datoTom: LocalDate?,
-            frivilligSkattetrekk: Boolean?,
             kilde: Grunnlagsopplysning.Saksbehandler,
         ): Etterbetaling {
             if (datoFom == null || datoTom == null) {
@@ -37,7 +35,6 @@ data class Etterbetaling(
                 behandlingId = behandlingId,
                 fom = YearMonth.from(datoFom),
                 tom = YearMonth.from(datoTom),
-                frivilligSkattetrekk = frivilligSkattetrekk,
                 kilde = kilde,
             )
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/Etterbetaling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/behandlinginfo/Etterbetaling.kt
@@ -1,6 +1,5 @@
 package no.nav.etterlatte.behandling.behandlinginfo
 
-import no.nav.etterlatte.libs.common.behandling.EtterbetalingPeriodeValg
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import java.time.LocalDate
@@ -11,9 +10,7 @@ data class Etterbetaling(
     val behandlingId: UUID,
     val fom: YearMonth,
     val tom: YearMonth,
-    val inneholderKrav: Boolean?,
     val frivilligSkattetrekk: Boolean?,
-    val etterbetalingPeriodeValg: EtterbetalingPeriodeValg?,
     val kilde: Grunnlagsopplysning.Saksbehandler,
 ) {
     init {
@@ -30,9 +27,7 @@ data class Etterbetaling(
             behandlingId: UUID,
             datoFom: LocalDate?,
             datoTom: LocalDate?,
-            inneholderKrav: Boolean?,
             frivilligSkattetrekk: Boolean?,
-            etterbetalingPeriodeValg: EtterbetalingPeriodeValg?,
             kilde: Grunnlagsopplysning.Saksbehandler,
         ): Etterbetaling {
             if (datoFom == null || datoTom == null) {
@@ -42,9 +37,7 @@ data class Etterbetaling(
                 behandlingId = behandlingId,
                 fom = YearMonth.from(datoFom),
                 tom = YearMonth.from(datoTom),
-                inneholderKrav = inneholderKrav,
                 frivilligSkattetrekk = frivilligSkattetrekk,
-                etterbetalingPeriodeValg = etterbetalingPeriodeValg,
                 kilde = kilde,
             )
         }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoDaoTest.kt
@@ -210,7 +210,6 @@ internal class BehandlingInfoDaoTest(
             behandlingId = behandlingId,
             fom = YearMonth.of(2023, 11),
             tom = YearMonth.of(2023, 12),
-            frivilligSkattetrekk = true,
             kilde = Grunnlagsopplysning.Saksbehandler("Z1234567", Tidspunkt.now()),
         )
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoDaoTest.kt
@@ -18,7 +18,6 @@ import no.nav.etterlatte.libs.common.behandling.Aldersgruppe
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
-import no.nav.etterlatte.libs.common.behandling.EtterbetalingPeriodeValg
 import no.nav.etterlatte.libs.common.behandling.Feilutbetaling
 import no.nav.etterlatte.libs.common.behandling.FeilutbetalingValg
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -211,9 +210,7 @@ internal class BehandlingInfoDaoTest(
             behandlingId = behandlingId,
             fom = YearMonth.of(2023, 11),
             tom = YearMonth.of(2023, 12),
-            inneholderKrav = true,
             frivilligSkattetrekk = true,
-            etterbetalingPeriodeValg = EtterbetalingPeriodeValg.UNDER_3_MND,
             kilde = Grunnlagsopplysning.Saksbehandler("Z1234567", Tidspunkt.now()),
         )
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoRoutesTest.kt
@@ -113,7 +113,6 @@ internal class BehandlingInfoRoutesTest {
 
             opprettetBrevutfallOgEtterbetaling.etterbetaling?.datoFom shouldBe dto.etterbetaling?.datoFom
             opprettetBrevutfallOgEtterbetaling.etterbetaling?.datoTom shouldBe dto.etterbetaling?.datoTom
-            opprettetBrevutfallOgEtterbetaling.etterbetaling?.frivilligSkattetrekk shouldBe dto.etterbetaling?.frivilligSkattetrekk
             opprettetBrevutfallOgEtterbetaling.etterbetaling?.kilde shouldNotBe null
         }
     }
@@ -169,7 +168,6 @@ internal class BehandlingInfoRoutesTest {
 
             etterbetaling.datoFom shouldBe dto.etterbetaling?.datoFom
             etterbetaling.datoTom shouldBe dto.etterbetaling?.datoTom
-            etterbetaling.frivilligSkattetrekk shouldBe dto.etterbetaling?.frivilligSkattetrekk
         }
     }
 
@@ -206,7 +204,6 @@ internal class BehandlingInfoRoutesTest {
             fom = YearMonth.of(2023, 1),
             tom = YearMonth.of(2023, 2),
             kilde = Grunnlagsopplysning.Saksbehandler.create("Saksbehandler01"),
-            frivilligSkattetrekk = true,
         )
 
     private fun brevutfallOgEtterbetalingDto(behandlingId: UUID = UUID.randomUUID()) =
@@ -226,7 +223,6 @@ internal class BehandlingInfoRoutesTest {
                     behandlingId = behandlingId,
                     datoFom = LocalDate.of(2023, 1, 1),
                     datoTom = LocalDate.of(2023, 2, 28),
-                    frivilligSkattetrekk = true,
                     kilde = null,
                 ),
         )

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoRoutesTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoRoutesTest.kt
@@ -26,7 +26,6 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
 import no.nav.etterlatte.libs.common.behandling.BrevutfallOgEtterbetalingDto
 import no.nav.etterlatte.libs.common.behandling.EtterbetalingDto
-import no.nav.etterlatte.libs.common.behandling.EtterbetalingPeriodeValg
 import no.nav.etterlatte.libs.common.behandling.Feilutbetaling
 import no.nav.etterlatte.libs.common.behandling.FeilutbetalingValg
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -114,8 +113,6 @@ internal class BehandlingInfoRoutesTest {
 
             opprettetBrevutfallOgEtterbetaling.etterbetaling?.datoFom shouldBe dto.etterbetaling?.datoFom
             opprettetBrevutfallOgEtterbetaling.etterbetaling?.datoTom shouldBe dto.etterbetaling?.datoTom
-            opprettetBrevutfallOgEtterbetaling.etterbetaling?.inneholderKrav shouldBe dto.etterbetaling?.inneholderKrav
-            opprettetBrevutfallOgEtterbetaling.etterbetaling?.etterbetalingPeriodeValg shouldBe dto.etterbetaling?.etterbetalingPeriodeValg
             opprettetBrevutfallOgEtterbetaling.etterbetaling?.frivilligSkattetrekk shouldBe dto.etterbetaling?.frivilligSkattetrekk
             opprettetBrevutfallOgEtterbetaling.etterbetaling?.kilde shouldNotBe null
         }
@@ -172,8 +169,6 @@ internal class BehandlingInfoRoutesTest {
 
             etterbetaling.datoFom shouldBe dto.etterbetaling?.datoFom
             etterbetaling.datoTom shouldBe dto.etterbetaling?.datoTom
-            etterbetaling.inneholderKrav shouldBe dto.etterbetaling?.inneholderKrav
-            etterbetaling.etterbetalingPeriodeValg shouldBe dto.etterbetaling?.etterbetalingPeriodeValg
             etterbetaling.frivilligSkattetrekk shouldBe dto.etterbetaling?.frivilligSkattetrekk
         }
     }
@@ -210,10 +205,8 @@ internal class BehandlingInfoRoutesTest {
             behandlingId = behandlingId,
             fom = YearMonth.of(2023, 1),
             tom = YearMonth.of(2023, 2),
-            inneholderKrav = true,
             kilde = Grunnlagsopplysning.Saksbehandler.create("Saksbehandler01"),
             frivilligSkattetrekk = true,
-            etterbetalingPeriodeValg = EtterbetalingPeriodeValg.UNDER_3_MND,
         )
 
     private fun brevutfallOgEtterbetalingDto(behandlingId: UUID = UUID.randomUUID()) =
@@ -233,9 +226,7 @@ internal class BehandlingInfoRoutesTest {
                     behandlingId = behandlingId,
                     datoFom = LocalDate.of(2023, 1, 1),
                     datoTom = LocalDate.of(2023, 2, 28),
-                    inneholderKrav = true,
                     frivilligSkattetrekk = true,
-                    etterbetalingPeriodeValg = EtterbetalingPeriodeValg.UNDER_3_MND,
                     kilde = null,
                 ),
         )

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoServiceTest.kt
@@ -268,7 +268,6 @@ internal class BehandlingInfoServiceTest {
         behandlingId = behandlingId,
         fom = fom,
         tom = tom,
-        frivilligSkattetrekk = true,
         kilde = Grunnlagsopplysning.Saksbehandler.create("Saksbehandler01"),
     )
 }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/behandlinginfo/BehandlingInfoServiceTest.kt
@@ -11,7 +11,6 @@ import no.nav.etterlatte.libs.common.behandling.Aldersgruppe
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
-import no.nav.etterlatte.libs.common.behandling.EtterbetalingPeriodeValg
 import no.nav.etterlatte.libs.common.behandling.Feilutbetaling
 import no.nav.etterlatte.libs.common.behandling.FeilutbetalingValg
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
@@ -269,9 +268,7 @@ internal class BehandlingInfoServiceTest {
         behandlingId = behandlingId,
         fom = fom,
         tom = tom,
-        inneholderKrav = true,
         frivilligSkattetrekk = true,
-        etterbetalingPeriodeValg = EtterbetalingPeriodeValg.UNDER_3_MND,
         kilde = Grunnlagsopplysning.Saksbehandler.create("Saksbehandler01"),
     )
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevDataMapperFerdigstillingVedtak.kt
@@ -241,6 +241,7 @@ class BrevDataMapperFerdigstillingVedtak(
         val trygdetid = async { trygdetidService.hentTrygdetid(behandlingId, bruker) }
         val grunnbeloep = async { beregningService.hentGrunnbeloep(bruker) }
         val etterbetaling = async { behandlingService.hentEtterbetaling(behandlingId, bruker) }
+        val brevutfall = async { behandlingService.hentBrevutfall(behandlingId, bruker) }
 
         if (erForeldreloes) {
             barnepensjonInnvilgelse(
@@ -265,6 +266,7 @@ class BrevDataMapperFerdigstillingVedtak(
                 grunnbeloep = grunnbeloep.await(),
                 utlandstilknytning = utlandstilknytningType,
                 avdoede = avdoede,
+                brevutfall = brevutfall.await(),
             )
         }
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -4,7 +4,6 @@ import no.nav.etterlatte.brev.Brevkoder
 import no.nav.etterlatte.brev.Brevtype
 import no.nav.etterlatte.brev.Slate
 import no.nav.etterlatte.brev.adresse.RegoppslagResponseDTO
-import no.nav.etterlatte.libs.common.behandling.EtterbetalingPeriodeValg
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.MottakerFoedselsnummer
 import no.nav.etterlatte.libs.common.sak.SakId
@@ -111,7 +110,5 @@ data class OpprettNyttBrev(
 data class EtterbetalingDTO(
     val datoFom: LocalDate,
     val datoTom: LocalDate,
-    val inneholderKrav: Boolean?,
     val frivilligSkattetrekk: Boolean?,
-    val etterbetalingPeriodeValg: EtterbetalingPeriodeValg?,
 )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -110,5 +110,4 @@ data class OpprettNyttBrev(
 data class EtterbetalingDTO(
     val datoFom: LocalDate,
     val datoTom: LocalDate,
-    val frivilligSkattetrekk: Boolean?,
 )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/Etterbetaling.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/Etterbetaling.kt
@@ -3,11 +3,6 @@ package no.nav.etterlatte.brev.model
 import java.time.LocalDate
 
 object Etterbetaling {
-    fun fraBarnepensjonDTO(dto: EtterbetalingDTO) =
-        BarnepensjonEtterbetaling(
-            frivilligSkattetrekk = dto.frivilligSkattetrekk,
-        )
-
     fun fraOmstillingsstoenadBeregningsperioder(
         dto: EtterbetalingDTO,
         perioder: List<OmstillingsstoenadBeregningsperiode>,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/Etterbetaling.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/Etterbetaling.kt
@@ -5,9 +5,7 @@ import java.time.LocalDate
 object Etterbetaling {
     fun fraBarnepensjonDTO(dto: EtterbetalingDTO) =
         BarnepensjonEtterbetaling(
-            inneholderKrav = dto.inneholderKrav,
             frivilligSkattetrekk = dto.frivilligSkattetrekk,
-            etterbetalingPeriodeValg = dto.etterbetalingPeriodeValg,
         )
 
     fun fraOmstillingsstoenadBeregningsperioder(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/EtterlatteBrev.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/EtterlatteBrev.kt
@@ -7,7 +7,6 @@ import no.nav.etterlatte.brev.behandling.Avdoed
 import no.nav.etterlatte.brev.behandling.Beregningsperiode
 import no.nav.etterlatte.brev.hentinformasjon.beregning.UgyldigBeregningsMetode
 import no.nav.etterlatte.libs.common.IntBroek
-import no.nav.etterlatte.libs.common.behandling.EtterbetalingPeriodeValg
 import no.nav.etterlatte.libs.common.beregning.BeregningsMetode
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.trygdetid.BeregnetTrygdetidGrunnlagDto
@@ -18,9 +17,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 data class BarnepensjonEtterbetaling(
-    val inneholderKrav: Boolean?,
     val frivilligSkattetrekk: Boolean?,
-    val etterbetalingPeriodeValg: EtterbetalingPeriodeValg?,
 )
 
 data class OmstillingsstoenadEtterbetaling(

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
@@ -7,8 +7,6 @@ import no.nav.etterlatte.brev.behandling.Avdoed
 import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
 import no.nav.etterlatte.brev.model.BarnepensjonBeregning
 import no.nav.etterlatte.brev.model.BarnepensjonBeregningsperiode
-import no.nav.etterlatte.brev.model.BarnepensjonEtterbetaling
-import no.nav.etterlatte.brev.model.Etterbetaling
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
 import no.nav.etterlatte.brev.model.ManglerFrivilligSkattetrekk
@@ -25,7 +23,6 @@ import java.time.LocalDate
 data class BarnepensjonInnvilgelse(
     override val innhold: List<Slate.Element>,
     val beregning: BarnepensjonBeregning,
-    val etterbetaling: BarnepensjonEtterbetaling?,
     val frivilligSkattetrekk: Boolean,
     val brukerUnder18Aar: Boolean,
     val bosattUtland: Boolean,
@@ -34,6 +31,7 @@ data class BarnepensjonInnvilgelse(
     val harUtbetaling: Boolean,
     val erMigrertYrkesskade: Boolean,
     val erSluttbehandling: Boolean,
+    val erEtterbetaling: Boolean,
 ) : BrevDataFerdigstilling {
     companion object {
         val tidspunktNyttRegelverk: LocalDate = LocalDate.of(2024, 1, 1)
@@ -64,7 +62,6 @@ data class BarnepensjonInnvilgelse(
                 brukerUnder18Aar = brevutfall.aldersgruppe == Aldersgruppe.UNDER_18,
                 erGjenoppretting = erGjenoppretting,
                 erMigrertYrkesskade = erMigrertYrkesskade,
-                etterbetaling = etterbetaling?.let { dto -> Etterbetaling.fraBarnepensjonDTO(dto) },
                 frivilligSkattetrekk = frivilligSkattetrekk,
                 harUtbetaling = beregningsperioder.any { it.utbetaltBeloep.value > 0 },
                 kunNyttRegelverk =
@@ -72,6 +69,7 @@ data class BarnepensjonInnvilgelse(
                         it.datoFOM.isAfter(tidspunktNyttRegelverk) || it.datoFOM.isEqual(tidspunktNyttRegelverk)
                     },
                 erSluttbehandling = erSluttbehandling,
+                erEtterbetaling = etterbetaling != null,
             )
         }
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelse.kt
@@ -9,7 +9,6 @@ import no.nav.etterlatte.brev.model.BarnepensjonBeregning
 import no.nav.etterlatte.brev.model.BarnepensjonBeregningsperiode
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
-import no.nav.etterlatte.brev.model.ManglerFrivilligSkattetrekk
 import no.nav.etterlatte.grunnbeloep.Grunnbeloep
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.Aldersgruppe
@@ -50,9 +49,6 @@ data class BarnepensjonInnvilgelse(
             erSluttbehandling: Boolean,
         ): BarnepensjonInnvilgelse {
             val beregningsperioder = barnepensjonBeregningsperioder(utbetalingsinfo)
-            val frivilligSkattetrekk =
-                brevutfall.frivilligSkattetrekk ?: etterbetaling?.frivilligSkattetrekk
-                    ?: throw ManglerFrivilligSkattetrekk(brevutfall.behandlingId)
 
             return BarnepensjonInnvilgelse(
                 innhold = innhold.innhold(),
@@ -62,7 +58,7 @@ data class BarnepensjonInnvilgelse(
                 brukerUnder18Aar = brevutfall.aldersgruppe == Aldersgruppe.UNDER_18,
                 erGjenoppretting = erGjenoppretting,
                 erMigrertYrkesskade = erMigrertYrkesskade,
-                frivilligSkattetrekk = frivilligSkattetrekk,
+                frivilligSkattetrekk = brevutfall.frivilligSkattetrekk ?: false,
                 harUtbetaling = beregningsperioder.any { it.utbetaltBeloep.value > 0 },
                 kunNyttRegelverk =
                     utbetalingsinfo.beregningsperioder.all {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelseForeldreloes.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelseForeldreloes.kt
@@ -9,7 +9,6 @@ import no.nav.etterlatte.brev.model.BarnepensjonBeregning
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
 import no.nav.etterlatte.brev.model.ForskjelligAvdoedPeriode
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
-import no.nav.etterlatte.brev.model.ManglerFrivilligSkattetrekk
 import no.nav.etterlatte.grunnbeloep.Grunnbeloep
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.Aldersgruppe
@@ -53,9 +52,6 @@ data class BarnepensjonInnvilgelseForeldreloes(
         ): BarnepensjonInnvilgelseForeldreloes {
             val beregningsperioder =
                 barnepensjonBeregningsperioder(utbetalingsinfo)
-            val frivilligSkattetrekk =
-                brevutfall.frivilligSkattetrekk ?: etterbetaling?.frivilligSkattetrekk
-                    ?: throw ManglerFrivilligSkattetrekk(brevutfall.behandlingId)
 
             return BarnepensjonInnvilgelseForeldreloes(
                 innhold = innhold.innhold(),
@@ -73,7 +69,7 @@ data class BarnepensjonInnvilgelseForeldreloes(
                 brukerUnder18Aar = brevutfall.aldersgruppe == Aldersgruppe.UNDER_18,
                 erGjenoppretting = erGjenoppretting,
                 erMigrertYrkesskade = erMigrertYrkesskade,
-                frivilligSkattetrekk = frivilligSkattetrekk,
+                frivilligSkattetrekk = brevutfall.frivilligSkattetrekk ?: false,
                 harUtbetaling = utbetalingsinfo.beregningsperioder.any { it.utbetaltBeloep.value > 0 },
                 kunNyttRegelverk =
                     utbetalingsinfo.beregningsperioder.all {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelseForeldreloes.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgelseForeldreloes.kt
@@ -6,8 +6,6 @@ import no.nav.etterlatte.brev.Slate
 import no.nav.etterlatte.brev.behandling.Avdoed
 import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
 import no.nav.etterlatte.brev.model.BarnepensjonBeregning
-import no.nav.etterlatte.brev.model.BarnepensjonEtterbetaling
-import no.nav.etterlatte.brev.model.Etterbetaling
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
 import no.nav.etterlatte.brev.model.ForskjelligAvdoedPeriode
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
@@ -25,7 +23,6 @@ import java.time.LocalDate
 data class BarnepensjonInnvilgelseForeldreloes(
     override val innhold: List<Slate.Element>,
     val beregning: BarnepensjonBeregning,
-    val etterbetaling: BarnepensjonEtterbetaling?,
     val brukerUnder18Aar: Boolean,
     val frivilligSkattetrekk: Boolean,
     val bosattUtland: Boolean,
@@ -35,6 +32,7 @@ data class BarnepensjonInnvilgelseForeldreloes(
     val vedtattIPesys: Boolean,
     val erMigrertYrkesskade: Boolean,
     val erSluttbehandling: Boolean,
+    val erEtterbetaling: Boolean,
 ) : BrevDataFerdigstilling {
     companion object {
         val tidspunktNyttRegelverk: LocalDate = LocalDate.of(2024, 1, 1)
@@ -75,7 +73,6 @@ data class BarnepensjonInnvilgelseForeldreloes(
                 brukerUnder18Aar = brevutfall.aldersgruppe == Aldersgruppe.UNDER_18,
                 erGjenoppretting = erGjenoppretting,
                 erMigrertYrkesskade = erMigrertYrkesskade,
-                etterbetaling = etterbetaling?.let { dto -> Etterbetaling.fraBarnepensjonDTO(dto) },
                 frivilligSkattetrekk = frivilligSkattetrekk,
                 harUtbetaling = utbetalingsinfo.beregningsperioder.any { it.utbetaltBeloep.value > 0 },
                 kunNyttRegelverk =
@@ -84,6 +81,7 @@ data class BarnepensjonInnvilgelseForeldreloes(
                     },
                 vedtattIPesys = vedtattIPesys,
                 erSluttbehandling = erSluttbehandling,
+                erEtterbetaling = etterbetaling != null,
             )
         }
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOmregnetNyttRegelverk.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOmregnetNyttRegelverk.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.brev.model.BarnepensjonBeregning
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
 import no.nav.etterlatte.grunnbeloep.Grunnbeloep
+import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
 import no.nav.etterlatte.libs.common.trygdetid.TrygdetidDto
 import no.nav.pensjon.brevbaker.api.model.Kroner
@@ -74,6 +75,7 @@ data class BarnepensjonOmregnetNyttRegelverk(
             etterbetaling: EtterbetalingDTO?,
             utlandstilknytning: UtlandstilknytningType?,
             avdoede: List<Avdoed>,
+            brevutfall: BrevutfallDto?,
         ): BarnepensjonOmregnetNyttRegelverk {
             val erUnder18AarNonNull =
                 requireNotNull(erUnder18Aar) {
@@ -94,7 +96,7 @@ data class BarnepensjonOmregnetNyttRegelverk(
                         beregningsperioder,
                         trygdetid,
                     ),
-                frivilligSkattetrekk = etterbetaling?.frivilligSkattetrekk ?: false,
+                frivilligSkattetrekk = brevutfall?.frivilligSkattetrekk ?: false,
                 erBosattUtlandet =
                     (
                         requireNotNull(utlandstilknytning)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOmregnetNyttRegelverk.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOmregnetNyttRegelverk.kt
@@ -6,8 +6,6 @@ import no.nav.etterlatte.brev.Slate
 import no.nav.etterlatte.brev.behandling.Avdoed
 import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
 import no.nav.etterlatte.brev.model.BarnepensjonBeregning
-import no.nav.etterlatte.brev.model.BarnepensjonEtterbetaling
-import no.nav.etterlatte.brev.model.Etterbetaling
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
 import no.nav.etterlatte.grunnbeloep.Grunnbeloep
@@ -61,10 +59,10 @@ data class BarnepensjonOmregnetNyttRegelverkRedigerbartUtfall(
 data class BarnepensjonOmregnetNyttRegelverk(
     override val innhold: List<Slate.Element>,
     val beregning: BarnepensjonBeregning,
-    val etterbetaling: BarnepensjonEtterbetaling?,
     val frivilligSkattetrekk: Boolean?,
     val erUnder18Aar: Boolean,
     val erBosattUtlandet: Boolean,
+    val erEtterbetaling: Boolean,
 ) : BrevDataFerdigstilling {
     companion object {
         fun fra(
@@ -96,12 +94,12 @@ data class BarnepensjonOmregnetNyttRegelverk(
                         beregningsperioder,
                         trygdetid,
                     ),
-                etterbetaling = etterbetaling?.let { dto -> Etterbetaling.fraBarnepensjonDTO(dto) },
                 frivilligSkattetrekk = etterbetaling?.frivilligSkattetrekk ?: false,
                 erBosattUtlandet =
                     (
                         requireNotNull(utlandstilknytning)
                     ) == UtlandstilknytningType.BOSATT_UTLAND,
+                erEtterbetaling = etterbetaling != null,
             )
         }
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
@@ -6,9 +6,7 @@ import no.nav.etterlatte.brev.Slate
 import no.nav.etterlatte.brev.behandling.Avdoed
 import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
 import no.nav.etterlatte.brev.model.BarnepensjonBeregning
-import no.nav.etterlatte.brev.model.BarnepensjonEtterbetaling
 import no.nav.etterlatte.brev.model.BrevVedleggKey
-import no.nav.etterlatte.brev.model.Etterbetaling
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
 import no.nav.etterlatte.brev.model.FeilutbetalingType
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
@@ -30,7 +28,7 @@ data class BarnepensjonRevurdering(
     val erOmgjoering: Boolean,
     val datoVedtakOmgjoering: LocalDate?,
     val beregning: BarnepensjonBeregning,
-    val etterbetaling: BarnepensjonEtterbetaling?,
+    val etterbetaling: EtterbetalingDTO?,
     val frivilligSkattetrekk: Boolean,
     val brukerUnder18Aar: Boolean,
     val bosattUtland: Boolean,
@@ -58,9 +56,6 @@ data class BarnepensjonRevurdering(
         ): BarnepensjonRevurdering {
             val beregningsperioder = barnepensjonBeregningsperioder(utbetalingsinfo)
             val feilutbetaling = toFeilutbetalingType(requireNotNull(brevutfall.feilutbetaling?.valg))
-            val frivilligSkattetrekk =
-                brevutfall.frivilligSkattetrekk ?: etterbetaling?.frivilligSkattetrekk
-                    ?: throw ManglerFrivilligSkattetrekk(brevutfall.behandlingId)
 
             return BarnepensjonRevurdering(
                 innhold = innhold.innhold(),
@@ -80,9 +75,9 @@ data class BarnepensjonRevurdering(
                 erEndret = forrigeUtbetalingsinfo == null || forrigeUtbetalingsinfo.beloep != utbetalingsinfo.beloep,
                 erMigrertYrkesskade = erMigrertYrkesskade,
                 erOmgjoering = revurderingaarsak == Revurderingaarsak.OMGJOERING_ETTER_KLAGE,
-                etterbetaling = etterbetaling?.let { dto -> Etterbetaling.fraBarnepensjonDTO(dto) },
+                etterbetaling = etterbetaling,
                 feilutbetaling = feilutbetaling,
-                frivilligSkattetrekk = frivilligSkattetrekk,
+                frivilligSkattetrekk = brevutfall.frivilligSkattetrekk ?: false,
                 harFlereUtbetalingsperioder = utbetalingsinfo.beregningsperioder.size > 1,
                 harUtbetaling = beregningsperioder.any { it.utbetaltBeloep.value > 0 },
                 innholdForhaandsvarsel =
@@ -119,8 +114,7 @@ data class BarnepensjonRevurderingRedigerbartUtfall(
             utlandstilknytning: UtlandstilknytningType?,
         ): BarnepensjonRevurderingRedigerbartUtfall {
             val frivilligSkattetrekk =
-                brevutfall.frivilligSkattetrekk ?: etterbetaling?.frivilligSkattetrekk
-                    ?: throw ManglerFrivilligSkattetrekk(brevutfall.behandlingId)
+                brevutfall.frivilligSkattetrekk ?: throw ManglerFrivilligSkattetrekk(brevutfall.behandlingId)
 
             return BarnepensjonRevurderingRedigerbartUtfall(
                 erEtterbetaling = etterbetaling != null,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
@@ -110,7 +110,6 @@ data class BarnepensjonRevurderingRedigerbartUtfall(
     val brukerUnder18Aar: Boolean,
     val bosattUtland: Boolean,
     val frivilligSkattetrekk: Boolean,
-    val etterbetaling: BarnepensjonEtterbetaling?,
 ) : BrevDataRedigerbar {
     companion object {
         fun fra(
@@ -130,7 +129,6 @@ data class BarnepensjonRevurderingRedigerbartUtfall(
                 brukerUnder18Aar = requireNotNull(brevutfall.aldersgruppe) == Aldersgruppe.UNDER_18,
                 bosattUtland = utlandstilknytning == UtlandstilknytningType.BOSATT_UTLAND,
                 frivilligSkattetrekk = frivilligSkattetrekk,
-                etterbetaling = etterbetaling?.let { dto -> Etterbetaling.fraBarnepensjonDTO(dto) },
             )
         }
     }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
@@ -37,6 +37,7 @@ data class BarnepensjonRevurdering(
     val harUtbetaling: Boolean,
     val feilutbetaling: FeilutbetalingType,
     val erMigrertYrkesskade: Boolean,
+    val erEtterbetaling: Boolean,
 ) : BrevDataFerdigstilling {
     companion object {
         fun fra(
@@ -93,6 +94,7 @@ data class BarnepensjonRevurdering(
                                 BarnepensjonInnvilgelse.tidspunktNyttRegelverk,
                             )
                     },
+                erEtterbetaling = etterbetaling != null,
             )
         }
     }

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgetDTOTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgetDTOTest.kt
@@ -13,7 +13,6 @@ import no.nav.etterlatte.brev.model.InnholdMedVedlegg
 import no.nav.etterlatte.grunnbeloep.Grunnbeloep
 import no.nav.etterlatte.libs.common.behandling.Aldersgruppe
 import no.nav.etterlatte.libs.common.behandling.BrevutfallDto
-import no.nav.etterlatte.libs.common.behandling.EtterbetalingPeriodeValg
 import no.nav.etterlatte.libs.common.behandling.Feilutbetaling
 import no.nav.etterlatte.libs.common.behandling.FeilutbetalingValg
 import no.nav.etterlatte.libs.common.beregning.BeregningsMetode
@@ -58,9 +57,7 @@ internal class BarnepensjonInnvilgetDTOTest {
                     EtterbetalingDTO(
                         datoFom = LocalDate.of(2022, Month.JANUARY, 1),
                         datoTom = LocalDate.of(2022, Month.MARCH, 31),
-                        inneholderKrav = true,
                         frivilligSkattetrekk = true,
-                        etterbetalingPeriodeValg = EtterbetalingPeriodeValg.FRA_3_MND,
                     ),
                 trygdetid =
                     listOf(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgetDTOTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgetDTOTest.kt
@@ -57,7 +57,6 @@ internal class BarnepensjonInnvilgetDTOTest {
                     EtterbetalingDTO(
                         datoFom = LocalDate.of(2022, Month.JANUARY, 1),
                         datoTom = LocalDate.of(2022, Month.MARCH, 31),
-                        frivilligSkattetrekk = true,
                     ),
                 trygdetid =
                     listOf(

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/Brevutfall.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/Brevutfall.tsx
@@ -30,11 +30,6 @@ export interface Brevutfall {
   frivilligSkattetrekk?: boolean | null
 }
 
-export enum EtterbetalingPeriodeValg {
-  UNDER_3_MND = 'UNDER_3_MND',
-  FRA_3_MND = 'FRA_3_MND',
-}
-
 export enum Aldersgruppe {
   OVER_18 = 'OVER_18',
   UNDER_18 = 'UNDER_18',
@@ -56,9 +51,6 @@ export enum FeilutbetalingValg {
 export interface Etterbetaling {
   datoFom?: string | null
   datoTom?: string | null
-  inneholderKrav: boolean | null
-  frivilligSkattetrekk?: boolean | null
-  etterbetalingPeriodeValg: EtterbetalingPeriodeValg | null
 }
 
 const initialBrevutfallOgEtterbetaling = (saktype: SakType, behandlingId: string) => {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/BrevutfallSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/BrevutfallSkjema.tsx
@@ -8,7 +8,6 @@ import { isFailure, isPending } from '~shared/api/apiUtils'
 import {
   Aldersgruppe,
   BrevutfallOgEtterbetaling,
-  EtterbetalingPeriodeValg,
   FeilutbetalingValg,
 } from '~components/behandling/brevutfall/Brevutfall'
 import { add, formatISO, lastDayOfMonth, startOfDay } from 'date-fns'
@@ -27,9 +26,7 @@ interface BrevutfallSkjemaData {
   harEtterbetaling: ISvar | null
   datoFom?: Date | null
   datoTom?: Date | null
-  kravIEtterbetaling: ISvar | null
   frivilligSkattetrekk: ISvar | null
-  etterbetalingPeriodeValg: EtterbetalingPeriodeValg | null
   aldersgruppe?: Aldersgruppe | null
   feilutbetalingValg?: FeilutbetalingValg | null
   feilutbetalingKommentar: string | null
@@ -102,8 +99,6 @@ export const BrevutfallSkjema = ({
           ? {
               datoFom: formatISO(data.datoFom!, { representation: 'date' }),
               datoTom: formatISO(data.datoTom!, { representation: 'date' }),
-              inneholderKrav: data.kravIEtterbetaling === ISvar.JA,
-              etterbetalingPeriodeValg: data.etterbetalingPeriodeValg,
             }
           : null,
     }

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/EtterbetalingDto.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/EtterbetalingDto.kt
@@ -8,6 +8,5 @@ data class EtterbetalingDto(
     val behandlingId: UUID?,
     val datoFom: LocalDate?,
     val datoTom: LocalDate?,
-    val frivilligSkattetrekk: Boolean?,
     val kilde: Grunnlagsopplysning.Kilde?,
 )

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/EtterbetalingDto.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/EtterbetalingDto.kt
@@ -8,13 +8,6 @@ data class EtterbetalingDto(
     val behandlingId: UUID?,
     val datoFom: LocalDate?,
     val datoTom: LocalDate?,
-    val inneholderKrav: Boolean?,
     val frivilligSkattetrekk: Boolean?,
-    val etterbetalingPeriodeValg: EtterbetalingPeriodeValg?,
     val kilde: Grunnlagsopplysning.Kilde?,
 )
-
-enum class EtterbetalingPeriodeValg {
-    UNDER_3_MND,
-    FRA_3_MND,
-}


### PR DESCRIPTION
Ettersom `kravIEtterbetaling` og `etterbetalingPerioderValgt` ikke lengre er i bruk tar vi en opprydding i etterbetaling for barnepensjon

- `frivilligSkattetrekk` har i en periode blitt dobbeltlagret (`brevutfall` og `etterbetalingDto`), vi fjerner den fra `etterbetalingDto` ettersom `frivilligSkattetrekk` kan oppstå uten etterbetaling
- `datoTom` og `datoFom` i `etterbetalingDto` er faktisk ikke i bruk, endrer fra `etterbetaling` til `erEtterbetaling`, ikke utenkelig at `datoTom` og `datoFom` fases ut på sikt?

!! Det er og diskutert at historisk visning av valg i brevutfall ikke er relevant da dette uansett kommer frem i det genererte brevet 

Denne henger sammen med endringer i pensjonsbrev https://github.com/navikt/pensjonsbrev/pull/1148