### PR TITLE
EY-4892: Kunne endre fra overstyrt til vanlig trygdetid

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/Trygdetid.tsx
@@ -93,7 +93,7 @@ export const Trygdetid = ({ redigerbar, behandling, vedtaksresultat, virkningsti
         if (behandlingErIverksatt(behandling.status)) {
           setHarPilotTrygdetid(true)
         } else if (redigerbar) {
-          requestOpprettTrygdetid(behandling.id, (trygdetider: ITrygdetid[]) => {
+          requestOpprettTrygdetid({ behandlingId: behandling.id, overskriv: false }, (trygdetider: ITrygdetid[]) => {
             oppdaterTrygdetider(trygdetider)
           })
         } else if (vedtaksresultat === 'avslag') {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidManueltOverstyrt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidManueltOverstyrt.tsx
@@ -5,7 +5,7 @@ import {
   IDetaljertBeregnetTrygdetid,
   ITrygdetid,
   oppdaterTrygdetidOverstyrtMigrering,
-  opprettTrygdetidOverstyrtMigrering,
+  opprettTrygdetider,
 } from '~shared/api/trygdetid'
 import { isPending, mapResult } from '~shared/api/apiUtils'
 import { usePersonopplysninger } from '~components/person/usePersonopplysninger'
@@ -44,7 +44,7 @@ export const TrygdetidManueltOverstyrt = ({
   const [prorataNevner, setNevner] = useState<number | undefined>(beregnetTrygdetid.resultat.prorataBroek?.nevner)
 
   const [oppdaterStatus, oppdaterTrygdetidRequest] = useApiCall(oppdaterTrygdetidOverstyrtMigrering)
-  const [opprettStatus, opprettOverstyrtTrygdetid] = useApiCall(opprettTrygdetidOverstyrtMigrering)
+  const [opprettStatus, opprettTrygdetid] = useApiCall(opprettTrygdetider)
 
   const lagre = () => {
     oppdaterTrygdetidRequest(
@@ -65,8 +65,8 @@ export const TrygdetidManueltOverstyrt = ({
     )
   }
 
-  const overskrivOverstyrtTrygdetid = () => {
-    opprettOverstyrtTrygdetid({ behandlingId: behandling!!.id, overskriv: true }, () => window.location.reload())
+  const opprettNyTrygdetid = () => {
+    opprettTrygdetid({ behandlingId: behandling!!.id, overskriv: true }, () => window.location.reload())
   }
 
   if (!behandling) return <ApiErrorAlert>Fant ikke behandling</ApiErrorAlert>
@@ -88,19 +88,15 @@ export const TrygdetidManueltOverstyrt = ({
         <>
           {ident == 'UKJENT_AVDOED' && (
             <Box maxWidth="40rem">
-              <VStack gap="1">
+              <VStack gap="3">
                 <Alert variant="warning">
-                  OBS! Trygdetiden er koblet til ukjent avdød. Hvis avdød i saken faktisk er kjent bør du annullere
-                  behandlingen og lage en ny behandling med riktig avdød i familieoversikten.
+                  Trygdetiden er koblet til en ukjent avdød. Hvis avdøde i saken er kjent, og familieoversikten er
+                  oppdatert, bør trygdetid opprettes på nytt. Dette for å unngå å bruke manuelt overstyrt trygdetid der
+                  dette ikke er nødvendig.
                 </Alert>
                 <Box maxWidth="20rem">
-                  <Button
-                    variant="danger"
-                    size="small"
-                    onClick={overskrivOverstyrtTrygdetid}
-                    loading={isPending(opprettStatus)}
-                  >
-                    Opprett overstyrt trygdetid på nytt
+                  <Button variant="danger" size="small" onClick={opprettNyTrygdetid} loading={isPending(opprettStatus)}>
+                    Opprett ny trygdetid
                   </Button>
                 </Box>
               </VStack>
@@ -145,15 +141,19 @@ export const TrygdetidManueltOverstyrt = ({
               </HStack>
             )}
 
-            <Button
-              variant="secondary"
-              size="small"
-              onClick={lagre}
-              loading={isPending(oppdaterStatus)}
-              disabled={anvendtTrygdetid == null || (skalHaProrata && (prorataNevner == null || prorataTeller == null))}
-            >
+            <Box width="20rem">
+              <Button
+                variant="primary"
+                size="small"
+                onClick={lagre}
+                loading={isPending(oppdaterStatus)}
+                disabled={
+                  anvendtTrygdetid == null || (skalHaProrata && (prorataNevner == null || prorataTeller == null))
+                }
+              >
                 Lagre overstyrt trygdetid
-            </Button>
+              </Button>
+            </Box>
           </VStack>
           {mapResult(oppdaterStatus, {
             pending: <Spinner label="Lagrer trygdetid" />,

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
@@ -4,8 +4,11 @@ import { JaNei } from '~shared/types/ISvar'
 export const hentTrygdetider = async (behandlingId: string): Promise<ApiResponse<ITrygdetid[]>> =>
   apiClient.get<ITrygdetid[]>(`/trygdetid_v2/${behandlingId}`)
 
-export const opprettTrygdetider = async (behandlingId: string): Promise<ApiResponse<ITrygdetid[]>> =>
-  apiClient.post(`/trygdetid_v2/${behandlingId}`, {})
+export const opprettTrygdetider = async (args: {
+  behandlingId: string
+  overskriv?: boolean
+}): Promise<ApiResponse<ITrygdetid[]>> =>
+  apiClient.post(`/trygdetid_v2/${args.behandlingId}?overskriv=${args.overskriv}`, {})
 
 export const hentOgLeggInnTrygdetidsGrunnlagForUfoeretrygdOgAlderspensjon = async (
   behandlingId: string

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/trygdetid.ts
@@ -6,7 +6,7 @@ export const hentTrygdetider = async (behandlingId: string): Promise<ApiResponse
 
 export const opprettTrygdetider = async (args: {
   behandlingId: string
-  overskriv?: boolean
+  overskriv: boolean
 }): Promise<ApiResponse<ITrygdetid[]>> =>
   apiClient.post(`/trygdetid_v2/${args.behandlingId}?overskriv=${args.overskriv}`, {})
 

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
@@ -87,7 +87,9 @@ fun Route.trygdetid(
             post {
                 withBehandlingId(behandlingKlient, skrivetilgang = true) {
                     logger.info("Oppretter trygdetid(er) for behandling $behandlingId")
-                    trygdetidService.opprettTrygdetiderForBehandling(behandlingId, brukerTokenInfo)
+                    val overskriv = call.request.queryParameters["overskriv"]?.toBoolean() ?: false
+
+                    trygdetidService.opprettTrygdetiderForBehandling(behandlingId, brukerTokenInfo, overskriv)
                     call.respond(
                         trygdetidService
                             .hentTrygdetiderIBehandling(behandlingId, brukerTokenInfo)

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -62,6 +62,7 @@ interface TrygdetidService {
     suspend fun opprettTrygdetiderForBehandling(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
+        overskriv: Boolean = false,
     ): List<Trygdetid>
 
     suspend fun harTrygdetidsgrunnlagIPesysForApOgUfoere(
@@ -204,12 +205,23 @@ class TrygdetidServiceImpl(
     override suspend fun opprettTrygdetiderForBehandling(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
+        overskriv: Boolean,
     ) = kanOppdatereTrygdetid(
         behandlingId,
         brukerTokenInfo,
     ) {
         val avdoede = grunnlagKlient.hentGrunnlag(behandlingId, brukerTokenInfo).hentAvdoede()
-        val eksisterendeTrygdetider = trygdetidRepository.hentTrygdetiderForBehandling(behandlingId)
+        val eksisterendeTrygdetider =
+            trygdetidRepository.hentTrygdetiderForBehandling(behandlingId).let { trygdetider ->
+                if (overskriv) {
+                    trygdetider
+                        .forEach { trygdetid -> trygdetidRepository.slettTrygdetid(trygdetid.id) }
+                        .let { emptyList() }
+                } else {
+                    trygdetider
+                }
+            }
+
         if (eksisterendeTrygdetider.isNotEmpty() && avdoede.size == eksisterendeTrygdetider.size) {
             throw TrygdetidAlleredeOpprettetException()
         }

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -216,7 +216,7 @@ class TrygdetidServiceImpl(
                 if (overskriv) {
                     trygdetider
                         .forEach { trygdetid -> trygdetidRepository.slettTrygdetid(trygdetid.id) }
-                        .let { emptyList() }
+                    emptyList()
                 } else {
                     trygdetider
                 }


### PR DESCRIPTION
I noen tilfeller så har saksbehandler opprettet trygdetid med ukjent avdød (altså overstyrt trygdetid). Men ønsker senere å endre til vanlig trygdetid etter å ha oppdatert grunnlaget. Denne endringen gjør det mulig å gjøre dette ved å tilby en knapp for å opprette trygdetid på nytt. Denne vil overskrive eksisterende.

![Screenshot 2025-01-02 at 14 25 38](https://github.com/user-attachments/assets/ef0b2438-9609-4e2d-bca9-8188f63ce95e)

Se også porten-sak: https://jira.adeo.no/browse/FAGSYSTEM-362610?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258aXNzdWU%3D
