### PR TITLE
Refaktorer avkorting

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingRoutes.kt
@@ -35,6 +35,7 @@ import no.nav.etterlatte.libs.common.behandling.TidligereFamiliepleierRequest
 import no.nav.etterlatte.libs.common.behandling.Utlandstilknytning
 import no.nav.etterlatte.libs.common.feilhaandtering.GenerellIkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
+import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.gyldigSoeknad.GyldighetsResultat
@@ -96,6 +97,15 @@ internal fun Route.behandlingRoutes(
             val detaljertBehandlingDTO =
                 behandlingService.hentDetaljertBehandlingMedTilbehoer(behandlingId, brukerTokenInfo)
             call.respond(detaljertBehandlingDTO)
+        }
+
+        get("status") {
+            val status =
+                inTransaction {
+                    behandlingService.hentBehandling(behandlingId)?.status
+                        ?: throw InternfeilException("Fant ikke behandling id=$behandlingId")
+                }
+            call.respond(status)
         }
 
         post("/gyldigfremsatt") {

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -48,7 +48,7 @@ fun Route.avkorting(
             withBehandlingId(behandlingKlient) {
                 val behandling = behandlingKlient.hentBehandling(it, brukerTokenInfo)
                 val skalHaInntektNesteAar = avkortingService.skalHaInntektInnevaerendeOgNesteAar(behandling)
-                call.respond(AvkortingSkalHaToInntektDTO(skalHaInntektNesteAar))
+                call.respond(AvkortingSkalHaInntektNesteAarDTO(skalHaInntektNesteAar))
             }
         }
 
@@ -129,7 +129,7 @@ fun Route.avkorting(
     }
 }
 
-data class AvkortingSkalHaToInntektDTO(
+data class AvkortingSkalHaInntektNesteAarDTO(
     val skalHaToInntekter: Boolean,
 )
 

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -44,6 +44,14 @@ fun Route.avkorting(
             }
         }
 
+        get("skalHaInntektNesteAar") {
+            withBehandlingId(behandlingKlient) {
+                val behandling = behandlingKlient.hentBehandling(it, brukerTokenInfo)
+                val skalHaInntektNesteAar = avkortingService.skalHaInntektInnevaerendeOgNesteAar(behandling)
+                call.respond(AvkortingSkalHaToInntektDTO(skalHaInntektNesteAar))
+            }
+        }
+
         get("ferdig") {
             withBehandlingId(behandlingKlient) {
                 logger.info("Henter ferdig avkorting med behandlingId=$it")
@@ -120,6 +128,10 @@ fun Route.avkorting(
         }
     }
 }
+
+data class AvkortingSkalHaToInntektDTO(
+    val skalHaToInntekter: Boolean,
+)
 
 fun AvkortingGrunnlag.toDto() =
     AvkortingGrunnlagDto(

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -218,6 +218,9 @@ class AvkortingService(
         }
     }
 
+    /*
+     OBS! Samme logikk benyttes i frontend (BeregneOMS.tsx skalHaInntektNesteAar ())
+     */
     private fun skalHaInntektInnevaerendeOgNesteAar(behandling: DetaljertBehandling): Boolean {
         if (behandling.behandlingType != BehandlingType.FØRSTEGANGSBEHANDLING) {
             return false

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -19,6 +19,7 @@ import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.sanksjon.SanksjonService
 import org.slf4j.LoggerFactory
+import java.time.Month
 import java.time.YearMonth
 import java.util.UUID
 
@@ -199,10 +200,6 @@ class AvkortingService(
         return lagretAvkorting
     }
 
-    /*
-    I tilfeller der det behøves inntekt for året etter virkningsitdspunkt oppdateres status kun hvis to inntekter er lagt til.
-    Dette gjelder hvis behandling er førstegangsbehandling og nåtid er fra og med oktober i innvilgelesår
-     */
     private suspend fun settBehandlingStatusAvkortet(
         brukerTokenInfo: BrukerTokenInfo,
         behandling: DetaljertBehandling,
@@ -218,9 +215,11 @@ class AvkortingService(
     }
 
     /*
-     OBS! Samme logikk benyttes i frontend (BeregneOMS.tsx skalHaInntektNesteAar ())
+    I tilfeller der det behøves inntekt for året etter virkningsitdspunkt oppdateres status kun hvis to inntekter er lagt til.
+    Dette gjelder hvis behandling er førstegangsbehandling og nåtid er fra og med oktober i innvilgelesår.
+    Da anses det at nytt år er nærme nok til at søker bør kunne oppgi inntekt for nytt år.
      */
-    private fun skalHaInntektInnevaerendeOgNesteAar(behandling: DetaljertBehandling): Boolean {
+    fun skalHaInntektInnevaerendeOgNesteAar(behandling: DetaljertBehandling): Boolean {
         if (behandling.behandlingType != BehandlingType.FØRSTEGANGSBEHANDLING) {
             return false
         }
@@ -241,7 +240,7 @@ class AvkortingService(
             return true
         }
 
-        val virkFraOgMedOktober = virkningstidspunkt.month.value > 9
+        val virkFraOgMedOktober = naa.year == virkningstidspunkt.year && naa.month.value >= Month.OCTOBER.value
         return virkFraOgMedOktober && !erOpphoer
     }
 

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -219,13 +219,15 @@ class AvkortingService(
     Dette gjelder hvis behandling er førstegangsbehandling og nåtid er fra og med oktober i innvilgelesår.
     Da anses det at nytt år er nærme nok til at søker bør kunne oppgi inntekt for nytt år.
      */
-    fun skalHaInntektInnevaerendeOgNesteAar(behandling: DetaljertBehandling): Boolean {
+    fun skalHaInntektInnevaerendeOgNesteAar(
+        behandling: DetaljertBehandling,
+        naa: YearMonth = YearMonth.now(),
+    ): Boolean {
         if (behandling.behandlingType != BehandlingType.FØRSTEGANGSBEHANDLING) {
             return false
         }
 
         val virkningstidspunkt = behandling.virkningstidspunkt().dato
-        val naa = YearMonth.now()
 
         val erOpphoer =
             if (behandling.opphoerFraOgMed == null) {

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -19,7 +19,6 @@ import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.sanksjon.SanksjonService
 import org.slf4j.LoggerFactory
-import java.time.Month
 import java.time.YearMonth
 import java.util.UUID
 
@@ -202,7 +201,7 @@ class AvkortingService(
 
     /*
     I tilfeller der det behøves inntekt for året etter virkningsitdspunkt oppdateres status kun hvis to inntekter er lagt til.
-    Dette gjelder førstegangsbehandlinger med virk fra og med oktober uten oppphør i samme år.
+    Dette gjelder hvis behandling er førstegangsbehandling og nåtid er fra og med oktober i innvilgelesår
      */
     private suspend fun settBehandlingStatusAvkortet(
         brukerTokenInfo: BrukerTokenInfo,
@@ -233,11 +232,8 @@ class AvkortingService(
             if (behandling.opphoerFraOgMed == null) {
                 false
             } else {
-                val opphoerDato = behandling.opphoerFraOgMed!!
-                val opphoerSammeAarSomVirk = opphoerDato.year == virkningstidspunkt.year
-                val januarEtterVirkAar =
-                    opphoerDato.year - 1 == virkningstidspunkt.year && opphoerDato.month == Month.JANUARY
-                opphoerSammeAarSomVirk || januarEtterVirkAar
+                val loependeTom = behandling.opphoerFraOgMed!!.minusMonths(1)
+                loependeTom.year == virkningstidspunkt.year
             }
 
         val virkIFjor = naa.year > virkningstidspunkt.year

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -233,7 +233,7 @@ class AvkortingService(
                 val opphoerDato = behandling.opphoerFraOgMed!!
                 val opphoerSammeAarSomVirk = opphoerDato.year == virkningstidspunkt.year
                 val januarEtterVirkAar =
-                    opphoerDato.year + 1 == virkningstidspunkt.year && opphoerDato.month == Month.JANUARY
+                    opphoerDato.year - 1 == virkningstidspunkt.year && opphoerDato.month == Month.JANUARY
                 opphoerSammeAarSomVirk || januarEtterVirkAar
             }
 

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -224,23 +224,26 @@ class AvkortingService(
         }
 
         val virkningstidspunkt = behandling.virkningstidspunkt().dato
-        val virkFraOgMedOktober = virkningstidspunkt.month.value > 9
-        if (!virkFraOgMedOktober) {
-            return false
-        }
+        val naa = YearMonth.now()
 
-        if (behandling.opphoerFraOgMed == null) {
+        val erOpphoer =
+            if (behandling.opphoerFraOgMed == null) {
+                false
+            } else {
+                val opphoerDato = behandling.opphoerFraOgMed!!
+                val opphoerSammeAarSomVirk = opphoerDato.year == virkningstidspunkt.year
+                val januarEtterVirkAar =
+                    opphoerDato.year + 1 == virkningstidspunkt.year && opphoerDato.month == Month.JANUARY
+                opphoerSammeAarSomVirk || januarEtterVirkAar
+            }
+
+        val virkIFjor = naa.year > virkningstidspunkt.year
+        if (virkIFjor && !erOpphoer) {
             return true
         }
 
-        val opphoerDato = behandling.opphoerFraOgMed!!
-
-        val opphoerSammeAarSomVirk = opphoerDato.year == virkningstidspunkt.year
-        if (opphoerSammeAarSomVirk) {
-            return false
-        }
-        val januarEtterVirkAar = opphoerDato.year + 1 == virkningstidspunkt.year && opphoerDato.month == Month.JANUARY
-        return januarEtterVirkAar
+        val virkFraOgMedOktober = virkningstidspunkt.month.value > 9
+        return virkFraOgMedOktober && !erOpphoer
     }
 
     private fun hentAvkortingNonNull(behandlingId: UUID) =

--- a/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
@@ -119,7 +119,6 @@ class ApplicationContext {
             grunnlagKlient = grunnlagKlient,
             vedtakKlient = vedtaksvurderingKlient,
             avkortingReparerAarsoppgjoeret = avkortingReparerAarsoppgjoeret,
-            featureToggleService = featureToggleService,
         )
     val avkortingTidligAlderspensjonService =
         AvkortingTidligAlderspensjonService(

--- a/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/TestHelper.kt
@@ -331,6 +331,7 @@ fun behandling(
     behandlingType: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
     virkningstidspunkt: Virkningstidspunkt? = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, 1)),
     status: BehandlingStatus = BehandlingStatus.BEREGNET,
+    opphoerFraOgMed: YearMonth? = null,
 ) = DetaljertBehandling(
     id = id,
     sak = sak,
@@ -346,7 +347,7 @@ fun behandling(
     revurderingInfo = null,
     kilde = Vedtaksloesning.GJENNY,
     sendeBrev = true,
-    opphoerFraOgMed = null,
+    opphoerFraOgMed = opphoerFraOgMed,
     relatertBehandlingId = null,
     tidligereFamiliepleier = null,
 )

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.Year
 import java.time.YearMonth
 import java.util.UUID
 
@@ -133,6 +134,7 @@ internal class AvkortingServiceTest {
                     sak = sakId,
                     behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
                     status = BehandlingStatus.BEREGNET,
+                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(Year.now().value, 1)),
                 )
             val eksisterendeAvkorting = mockk<Avkorting>()
             val beregning = mockk<Beregning>()
@@ -160,7 +162,7 @@ internal class AvkortingServiceTest {
                 eksisterendeAvkorting.beregnAvkortingRevurdering(beregning, any())
                 avkortingRepository.lagreAvkorting(behandlingId, sakId, reberegnetAvkorting)
                 behandlingKlient.avkort(behandlingId, bruker, true)
-                lagretAvkorting.toFrontend(YearMonth.of(2024, 1), null, BehandlingStatus.BEREGNET)
+                lagretAvkorting.toFrontend(YearMonth.of(Year.now().value, 1), null, BehandlingStatus.BEREGNET)
             }
             coVerify(exactly = 2) {
                 avkortingRepository.hentAvkorting(behandlingId)
@@ -386,7 +388,13 @@ internal class AvkortingServiceTest {
                     id = behandlingId,
                     sak = sakId,
                     behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, 1)),
+                    virkningstidspunkt =
+                        VirkningstidspunktTestData.virkningstidsunkt(
+                            YearMonth.of(
+                                Year.now().value,
+                                1,
+                            ),
+                        ),
                 )
 
             every { avkortingRepository.hentAvkorting(any()) } returns eksisterendeAvkorting andThen lagretAvkorting
@@ -428,7 +436,7 @@ internal class AvkortingServiceTest {
                     any(),
                 )
                 avkortingRepository.lagreAvkorting(behandlingId, sakId, beregnetAvkorting)
-                lagretAvkorting.toFrontend(YearMonth.of(2024, 1), null, BehandlingStatus.BEREGNET)
+                lagretAvkorting.toFrontend(YearMonth.of(Year.now().value, 1), null, BehandlingStatus.BEREGNET)
                 behandlingKlient.avkort(behandlingId, bruker, true)
             }
             coVerify(exactly = 2) {
@@ -673,7 +681,13 @@ internal class AvkortingServiceTest {
                     id = behandlingId,
                     sak = sakId,
                     behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-                    virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.of(2024, 1)),
+                    virkningstidspunkt =
+                        VirkningstidspunktTestData.virkningstidsunkt(
+                            YearMonth.of(
+                                Year.now().value,
+                                1,
+                            ),
+                        ),
                 )
 
             val foedselsdato67aar = YearMonth.of(2024, 6)
@@ -718,7 +732,7 @@ internal class AvkortingServiceTest {
                     foedselsdato67aar,
                 )
                 avkortingRepository.lagreAvkorting(behandlingId, sakId, beregnetAvkorting)
-                lagretAvkorting.toFrontend(YearMonth.of(2024, 1), null, BehandlingStatus.BEREGNET)
+                lagretAvkorting.toFrontend(YearMonth.of(Year.now().value, 1), null, BehandlingStatus.BEREGNET)
                 behandlingKlient.avkort(behandlingId, bruker, true)
             }
             coVerify(exactly = 2) {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
@@ -5,56 +5,41 @@ import { AvkortingInntekt } from '~components/behandling/avkorting/AvkortingInnt
 import Spinner from '~shared/Spinner'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { YtelseEtterAvkorting } from '~components/behandling/avkorting/YtelseEtterAvkorting'
-import { IBehandlingReducer, oppdaterAvkorting, resetAvkorting } from '~store/reducers/BehandlingReducer'
+import {
+  IBehandlingReducer,
+  oppdaterAvkorting,
+  oppdaterBehandlingsstatus,
+  resetAvkorting,
+} from '~store/reducers/BehandlingReducer'
 import { useAppDispatch, useAppSelector } from '~store/Store'
-import { IBehandlingsType, virkningstidspunkt } from '~shared/types/IDetaljertBehandling'
+import { virkningstidspunkt } from '~shared/types/IDetaljertBehandling'
 import { behandlingErRedigerbar } from '~components/behandling/felles/utils'
 import { mapResult } from '~shared/api/apiUtils'
-import { Brevutfall } from '~components/behandling/brevutfall/Brevutfall'
 import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
 import { Sanksjon } from '~components/behandling/sanksjon/Sanksjon'
 import { Alert, BodyShort, Box, Heading, VStack } from '@navikt/ds-react'
-import { SimulerUtbetaling } from '~components/behandling/beregne/SimulerUtbetaling'
 import { HjemmelLenke } from '~components/behandling/felles/HjemmelLenke'
 import { IAvkorting } from '~shared/types/IAvkorting'
 import { aarFraDatoString } from '~utils/formatering/dato'
 import { FeatureToggle, useFeaturetoggle } from '~useUnleash'
+import { hentBehandlingstatus } from '~shared/api/behandling'
 
 export const Avkorting = ({
   behandling,
-  resetBrevutfallvalidering,
   resetInntektsavkortingValidering,
+  skalHaInntektNesteAar,
 }: {
   behandling: IBehandlingReducer
-  resetBrevutfallvalidering: () => void
   resetInntektsavkortingValidering: () => void
+  skalHaInntektNesteAar: boolean
 }) => {
   const dispatch = useAppDispatch()
   const avkorting = useAppSelector((state) => state.behandlingReducer.behandling?.avkorting) as IAvkorting
   const [avkortingStatus, hentAvkortingRequest] = useApiCall(hentAvkorting)
+  const [, hentBehandlingstatusRequest] = useApiCall(hentBehandlingstatus)
   const innloggetSaksbehandler = useInnloggetSaksbehandler()
 
   const visSanksjon = useFeaturetoggle(FeatureToggle.sanksjon)
-  const inntektNesteAarBryter = useFeaturetoggle(FeatureToggle.validere_aarsintnekt_neste_aar)
-
-  const virkAar = new Date(virkningstidspunkt(behandling).dato).getFullYear()
-
-  const skalHaInntektNesteAar = behandling.behandlingType === IBehandlingsType.FØRSTEGANGSBEHANDLING && virkAar === 2024 // TODO Midlertidig til vi får en bedre løsning på hele avkorting frontend....EY-4632
-  //  && (behandling.viderefoertOpphoer == null || new Date(behandling.viderefoertOpphoer.dato) > new Date('2025-01-01')) TODO Fjerner midlertidig
-
-  const klarForBrevutfall = () => {
-    if (avkorting == undefined) {
-      return false
-    }
-    if (skalHaInntektNesteAar && inntektNesteAarBryter) {
-      if (behandling.viderefoertOpphoer && new Date(behandling.viderefoertOpphoer.dato).getFullYear() === virkAar) {
-        // Trenger ikke to inntekter hvis det er opphør i samme året
-        return true
-      }
-      return avkorting.avkortingGrunnlag.length === 2
-    }
-    return true
-  }
 
   const harInstitusjonsopphold = behandling?.beregning?.beregningsperioder.find((bp) => bp.institusjonsopphold)
 
@@ -67,8 +52,11 @@ export const Avkorting = ({
   useEffect(() => {
     if (!avkorting) {
       dispatch(resetAvkorting())
-      hentAvkortingRequest(behandling.id, (res) => {
-        dispatch(oppdaterAvkorting(res))
+      hentAvkortingRequest(behandling.id, (avkorting) => {
+        hentBehandlingstatusRequest(behandling.id, (status) => {
+          dispatch(oppdaterBehandlingsstatus(status))
+          dispatch(oppdaterAvkorting(avkorting))
+        })
       })
     }
   }, [])
@@ -132,10 +120,6 @@ export const Avkorting = ({
           <Sanksjon behandling={behandling} manglerInntektVirkAar={!avkortingGrunnlagInnevaerendeAar()} />
         )}
         {avkorting && <YtelseEtterAvkorting />}
-        {avkorting && <SimulerUtbetaling behandling={behandling} />}
-        {klarForBrevutfall() && (
-          <Brevutfall behandling={behandling} resetBrevutfallvalidering={resetBrevutfallvalidering} />
-        )}
       </VStack>
     </Box>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
@@ -1,109 +1,20 @@
-import { behandlingErRedigerbar } from '../felles/utils'
 import { formaterDato } from '~utils/formatering/dato'
 import { useVedtaksResultat } from '../useVedtaksResultat'
-import { useAppDispatch, useAppSelector } from '~store/Store'
-import { BehandlingRouteContext } from '../BehandlingRoutes'
-import React, { useContext, useEffect, useState } from 'react'
-import { hentBeregning } from '~shared/api/beregning'
-import { IBehandlingReducer, oppdaterBehandlingsstatus, oppdaterBeregning } from '~store/reducers/BehandlingReducer'
-import Spinner from '~shared/Spinner'
-import { BehandlingHandlingKnapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
-import { Alert, Box, Button, Heading, HStack } from '@navikt/ds-react'
-import { useApiCall } from '~shared/hooks/useApiCall'
-import { IBehandlingStatus, Vedtaksloesning } from '~shared/types/IDetaljertBehandling'
-import { NesteOgTilbake } from '../handlinger/NesteOgTilbake'
-import { SendTilAttesteringModal } from '~components/behandling/handlinger/SendTilAttesteringModal'
-import { Beregningstype } from '~shared/types/Beregning'
-import { BarnepensjonSammendrag } from '~components/behandling/beregne/BarnepensjonSammendrag'
-import { OmstillingsstoenadSammendrag } from '~components/behandling/beregne/OmstillingsstoenadSammendrag'
-import { Avkorting } from '~components/behandling/avkorting/Avkorting'
+import React from 'react'
+import { IBehandlingReducer } from '~store/reducers/BehandlingReducer'
+import { Box, Heading } from '@navikt/ds-react'
 import { SakType } from '~shared/types/sak'
-import { fattVedtak, upsertVedtak } from '~shared/api/vedtaksvurdering'
-import { ApiErrorAlert } from '~ErrorBoundary'
-import { handlinger } from '~components/behandling/handlinger/typer'
 import { Vedtaksresultat } from '~components/behandling/felles/Vedtaksresultat'
-
-import { isPending, mapApiResult } from '~shared/api/apiUtils'
-import { isFailureHandler } from '~shared/api/IsFailureHandler'
-import { Brevutfall } from '~components/behandling/brevutfall/Brevutfall'
-import { VilkaarsvurderingResultat } from '~shared/api/vilkaarsvurdering'
-import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
-import { SimulerUtbetaling } from '~components/behandling/beregne/SimulerUtbetaling'
-import { FeatureToggle, useFeaturetoggle } from '~useUnleash'
+import { BeregneBP } from '~components/behandling/beregne/BeregneBP'
+import { BeregneOMS } from '~components/behandling/beregne/BeregneOMS'
 
 export const Beregne = (props: { behandling: IBehandlingReducer }) => {
   const { behandling } = props
-  const { next } = useContext(BehandlingRouteContext)
-  const dispatch = useAppDispatch()
-  const [beregning, hentBeregningRequest] = useApiCall(hentBeregning)
-  const [vedtakStatus, oppdaterVedtakRequest] = useApiCall(upsertVedtak)
-  const [visAttesteringsmodal, setVisAttesteringsmodal] = useState(false)
   const virkningstidspunkt = behandling.virkningstidspunkt?.dato
     ? formaterDato(behandling.virkningstidspunkt.dato)
     : undefined
-  const innloggetSaksbehandler = useInnloggetSaksbehandler()
 
   const vedtaksresultat = useVedtaksResultat()
-
-  const redigerbar = behandlingErRedigerbar(
-    behandling.status,
-    behandling.sakEnhetId,
-    innloggetSaksbehandler.skriveEnheter
-  )
-  const brevutfallOgEtterbetaling = useAppSelector(
-    (state) => state.behandlingReducer.behandling?.brevutfallOgEtterbetaling
-  )
-
-  const behandlingsstatus = useAppSelector((state) => state.behandlingReducer.behandling?.status)
-
-  const [manglerBrevutfall, setManglerbrevutfall] = useState(false)
-  const [manglerAvkorting, setManglerAvkorting] = useState(false)
-
-  const skalHaInntektNesteAar = useFeaturetoggle(FeatureToggle.validere_aarsintnekt_neste_aar)
-
-  const erOpphoer = behandling.vilkaarsvurdering?.resultat?.utfall == VilkaarsvurderingResultat.IKKE_OPPFYLT
-
-  useEffect(() => {
-    if (!erOpphoer) {
-      hentBeregningRequest(behandling.id, (res) => dispatch(oppdaterBeregning(res)))
-    }
-  }, [])
-
-  const opprettEllerOppdaterVedtak = () => {
-    const erBarnepensjon = behandling.sakType === SakType.BARNEPENSJON
-    const skalSendeBrev = behandling.sendeBrev
-
-    if (!erBarnepensjon && behandlingsstatus == IBehandlingStatus.BEREGNET) {
-      setManglerAvkorting(true)
-      return
-    } else {
-      setManglerAvkorting(false)
-    }
-
-    if (skalSendeBrev && !brevutfallOgEtterbetaling?.brevutfall) {
-      setManglerbrevutfall(true)
-      return
-    }
-    setManglerbrevutfall(false)
-
-    if (behandling.kilde === Vedtaksloesning.GJENOPPRETTA) {
-      oppdaterStatus(erBarnepensjon, skalSendeBrev)
-    } else {
-      oppdaterVedtakRequest(behandling.id, () => {
-        oppdaterStatus(erBarnepensjon, skalSendeBrev)
-      })
-    }
-  }
-
-  const oppdaterStatus = (erBarnepensjon: boolean, skalSendeBrev: boolean) => {
-    const nyStatus = erBarnepensjon ? IBehandlingStatus.BEREGNET : IBehandlingStatus.AVKORTET
-    dispatch(oppdaterBehandlingsstatus(nyStatus))
-    if (skalSendeBrev) {
-      next()
-    } else {
-      setVisAttesteringsmodal(true)
-    }
-  }
 
   return (
     <>
@@ -113,89 +24,14 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
         </Heading>
         <Vedtaksresultat vedtaksresultat={vedtaksresultat} virkningstidspunktFormatert={virkningstidspunkt} />
       </Box>
-      {erOpphoer ? (
-        <Box paddingInline="18" paddingBlock="4">
-          <Brevutfall behandling={behandling} resetBrevutfallvalidering={() => setManglerbrevutfall(false)} />
-        </Box>
-      ) : (
-        <>
-          {mapApiResult(
-            beregning,
-            <Spinner label="Henter beregning" />,
-            () => (
-              <ApiErrorAlert>Kunne ikke hente beregning</ApiErrorAlert>
-            ),
-            (beregning) => (
-              <Box paddingInline="18" paddingBlock="4">
-                {(() => {
-                  switch (beregning.type) {
-                    case Beregningstype.BP:
-                      return (
-                        <>
-                          <BarnepensjonSammendrag beregning={beregning} />
-                          <SimulerUtbetaling behandling={behandling} />
-                          <Brevutfall
-                            behandling={behandling}
-                            resetBrevutfallvalidering={() => setManglerbrevutfall(false)}
-                          />
-                        </>
-                      )
-                    case Beregningstype.OMS:
-                      return (
-                        <>
-                          <OmstillingsstoenadSammendrag beregning={beregning} />
-                          <Avkorting
-                            behandling={behandling}
-                            resetBrevutfallvalidering={() => setManglerbrevutfall(false)}
-                            resetInntektsavkortingValidering={() => setManglerAvkorting(false)}
-                          />
-                        </>
-                      )
-                  }
-                })()}
-                {manglerBrevutfall && (
-                  <Alert style={{ maxWidth: '16em' }} variant="error">
-                    Du må fylle ut utfall i brev
-                  </Alert>
-                )}
-                {manglerAvkorting && (
-                  <Alert style={{ maxWidth: '16em' }} variant="error">
-                    {skalHaInntektNesteAar
-                      ? 'Du må legge til inntektsavkorting for inneværende og neste år, også når etterlatte ikke har inntekt. Legg da inn 0 i inntektsfeltene.'
-                      : 'Du må legge til inntektsavkorting, også når etterlatte ikke har inntekt. Legg da inn 0 i inntektsfeltene.'}
-                  </Alert>
-                )}
-              </Box>
-            )
-          )}
-        </>
-      )}
-
-      {isFailureHandler({
-        apiResult: vedtakStatus,
-        errorMessage: 'Vedtaksoppdatering feilet',
-        wrapperComponent: { component: HStack, props: { justify: 'center' } },
-      })}
-
-      <Box paddingBlock="4 0" borderWidth="1 0 0 0" borderColor="border-subtle">
-        {redigerbar ? (
-          <BehandlingHandlingKnapper>
-            {visAttesteringsmodal ? (
-              <SendTilAttesteringModal
-                behandlingId={behandling.id}
-                fattVedtakApi={fattVedtak}
-                validerKanSendeTilAttestering={() => true}
-              />
-            ) : (
-              <Button loading={isPending(vedtakStatus)} variant="primary" onClick={opprettEllerOppdaterVedtak}>
-                {behandling.sendeBrev ? handlinger.NESTE.navn : handlinger.FATT_VEDTAK.navn}
-              </Button>
-            )}
-          </BehandlingHandlingKnapper>
-        ) : (
-          <NesteOgTilbake />
-        )}
-      </Box>
+      {(() => {
+        switch (behandling.sakType) {
+          case SakType.BARNEPENSJON:
+            return <BeregneBP behandling={behandling} />
+          case SakType.OMSTILLINGSSTOENAD:
+            return <BeregneOMS behandling={behandling} />
+        }
+      })()}
     </>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/Beregne.tsx
@@ -29,7 +29,7 @@ export const Beregne = (props: { behandling: IBehandlingReducer }) => {
           case SakType.BARNEPENSJON:
             return <BeregneBP behandling={behandling} />
           case SakType.OMSTILLINGSSTOENAD:
-            return <BeregneOMS behandling={behandling} />
+            return <BeregneOMS />
         }
       })()}
     </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneBP.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneBP.tsx
@@ -1,0 +1,154 @@
+import { behandlingErRedigerbar } from '../felles/utils'
+import { formaterDato } from '~utils/formatering/dato'
+import { useVedtaksResultat } from '../useVedtaksResultat'
+import { useAppDispatch, useAppSelector } from '~store/Store'
+import { BehandlingRouteContext } from '../BehandlingRoutes'
+import React, { useContext, useEffect, useState } from 'react'
+import { hentBeregning } from '~shared/api/beregning'
+import { IBehandlingReducer, oppdaterBehandlingsstatus, oppdaterBeregning } from '~store/reducers/BehandlingReducer'
+import Spinner from '~shared/Spinner'
+import { BehandlingHandlingKnapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
+import { Alert, Box, Button, Heading, HStack } from '@navikt/ds-react'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { IBehandlingStatus, Vedtaksloesning } from '~shared/types/IDetaljertBehandling'
+import { NesteOgTilbake } from '../handlinger/NesteOgTilbake'
+import { SendTilAttesteringModal } from '~components/behandling/handlinger/SendTilAttesteringModal'
+import { BarnepensjonSammendrag } from '~components/behandling/beregne/BarnepensjonSammendrag'
+import { fattVedtak, upsertVedtak } from '~shared/api/vedtaksvurdering'
+import { ApiErrorAlert } from '~ErrorBoundary'
+import { handlinger } from '~components/behandling/handlinger/typer'
+import { Vedtaksresultat } from '~components/behandling/felles/Vedtaksresultat'
+
+import { isPending, mapApiResult } from '~shared/api/apiUtils'
+import { isFailureHandler } from '~shared/api/IsFailureHandler'
+import { Brevutfall } from '~components/behandling/brevutfall/Brevutfall'
+import { VilkaarsvurderingResultat } from '~shared/api/vilkaarsvurdering'
+import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
+import { SimulerUtbetaling } from '~components/behandling/beregne/SimulerUtbetaling'
+
+export const BeregneBP = (props: { behandling: IBehandlingReducer }) => {
+  const { behandling } = props
+  const { next } = useContext(BehandlingRouteContext)
+  const dispatch = useAppDispatch()
+  const [beregning, hentBeregningRequest] = useApiCall(hentBeregning)
+  const [vedtakStatus, oppdaterVedtakRequest] = useApiCall(upsertVedtak)
+  const [visAttesteringsmodal, setVisAttesteringsmodal] = useState(false)
+  const virkningstidspunkt = behandling.virkningstidspunkt?.dato
+    ? formaterDato(behandling.virkningstidspunkt.dato)
+    : undefined
+  const innloggetSaksbehandler = useInnloggetSaksbehandler()
+
+  const vedtaksresultat = useVedtaksResultat()
+
+  const redigerbar = behandlingErRedigerbar(
+    behandling.status,
+    behandling.sakEnhetId,
+    innloggetSaksbehandler.skriveEnheter
+  )
+  const brevutfallOgEtterbetaling = useAppSelector(
+    (state) => state.behandlingReducer.behandling?.brevutfallOgEtterbetaling
+  )
+
+  const [manglerBrevutfall, setManglerbrevutfall] = useState(false)
+
+  const erOpphoer = behandling.vilkaarsvurdering?.resultat?.utfall == VilkaarsvurderingResultat.IKKE_OPPFYLT
+
+  useEffect(() => {
+    if (!erOpphoer) {
+      hentBeregningRequest(behandling.id, (res) => dispatch(oppdaterBeregning(res)))
+    }
+  }, [])
+
+  const opprettEllerOppdaterVedtak = () => {
+    const skalSendeBrev = behandling.sendeBrev
+
+    if (skalSendeBrev && !brevutfallOgEtterbetaling?.brevutfall) {
+      setManglerbrevutfall(true)
+      return
+    }
+    setManglerbrevutfall(false)
+
+    if (behandling.kilde === Vedtaksloesning.GJENOPPRETTA) {
+      oppdaterStatus(skalSendeBrev)
+    } else {
+      oppdaterVedtakRequest(behandling.id, () => {
+        oppdaterStatus(skalSendeBrev)
+      })
+    }
+  }
+
+  const oppdaterStatus = (skalSendeBrev: boolean) => {
+    dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.BEREGNET))
+    if (skalSendeBrev) {
+      next()
+    } else {
+      setVisAttesteringsmodal(true)
+    }
+  }
+
+  return (
+    <>
+      <Box paddingInline="16" paddingBlock="16 4">
+        <Heading spacing size="large" level="1">
+          Beregning og vedtak
+        </Heading>
+        <Vedtaksresultat vedtaksresultat={vedtaksresultat} virkningstidspunktFormatert={virkningstidspunkt} />
+      </Box>
+      {erOpphoer ? (
+        <Box paddingInline="18" paddingBlock="4">
+          <Brevutfall behandling={behandling} resetBrevutfallvalidering={() => setManglerbrevutfall(false)} />
+        </Box>
+      ) : (
+        <>
+          {mapApiResult(
+            beregning,
+            <Spinner label="Henter beregning" />,
+            () => (
+              <ApiErrorAlert>Kunne ikke hente beregning</ApiErrorAlert>
+            ),
+            (beregning) => (
+              <Box paddingInline="18" paddingBlock="4">
+                <>
+                  <BarnepensjonSammendrag beregning={beregning} />
+                  <SimulerUtbetaling behandling={behandling} />
+                  <Brevutfall behandling={behandling} resetBrevutfallvalidering={() => setManglerbrevutfall(false)} />
+                </>
+                {manglerBrevutfall && (
+                  <Alert style={{ maxWidth: '16em' }} variant="error">
+                    Du må fylle ut utfall i brev
+                  </Alert>
+                )}
+              </Box>
+            )
+          )}
+        </>
+      )}
+
+      {isFailureHandler({
+        apiResult: vedtakStatus,
+        errorMessage: 'Vedtaksoppdatering feilet',
+        wrapperComponent: { component: HStack, props: { justify: 'center' } },
+      })}
+
+      <Box paddingBlock="4 0" borderWidth="1 0 0 0" borderColor="border-subtle">
+        {redigerbar ? (
+          <BehandlingHandlingKnapper>
+            {visAttesteringsmodal ? (
+              <SendTilAttesteringModal
+                behandlingId={behandling.id}
+                fattVedtakApi={fattVedtak}
+                validerKanSendeTilAttestering={() => true}
+              />
+            ) : (
+              <Button loading={isPending(vedtakStatus)} variant="primary" onClick={opprettEllerOppdaterVedtak}>
+                {behandling.sendeBrev ? handlinger.NESTE.navn : handlinger.FATT_VEDTAK.navn}
+              </Button>
+            )}
+          </BehandlingHandlingKnapper>
+        ) : (
+          <NesteOgTilbake />
+        )}
+      </Box>
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneOMS.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneOMS.tsx
@@ -1,0 +1,173 @@
+import { behandlingErRedigerbar } from '../felles/utils'
+import { formaterDato } from '~utils/formatering/dato'
+import { useVedtaksResultat } from '../useVedtaksResultat'
+import { useAppDispatch, useAppSelector } from '~store/Store'
+import { BehandlingRouteContext } from '../BehandlingRoutes'
+import React, { useContext, useEffect, useState } from 'react'
+import { hentBeregning } from '~shared/api/beregning'
+import { IBehandlingReducer, oppdaterBehandlingsstatus, oppdaterBeregning } from '~store/reducers/BehandlingReducer'
+import Spinner from '~shared/Spinner'
+import { BehandlingHandlingKnapper } from '~components/behandling/handlinger/BehandlingHandlingKnapper'
+import { Alert, Box, Button, Heading, HStack } from '@navikt/ds-react'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
+import { NesteOgTilbake } from '../handlinger/NesteOgTilbake'
+import { SendTilAttesteringModal } from '~components/behandling/handlinger/SendTilAttesteringModal'
+import { OmstillingsstoenadSammendrag } from '~components/behandling/beregne/OmstillingsstoenadSammendrag'
+import { Avkorting } from '~components/behandling/avkorting/Avkorting'
+import { fattVedtak, upsertVedtak } from '~shared/api/vedtaksvurdering'
+import { ApiErrorAlert } from '~ErrorBoundary'
+import { handlinger } from '~components/behandling/handlinger/typer'
+import { Vedtaksresultat } from '~components/behandling/felles/Vedtaksresultat'
+
+import { isPending, mapApiResult } from '~shared/api/apiUtils'
+import { isFailureHandler } from '~shared/api/IsFailureHandler'
+import { Brevutfall } from '~components/behandling/brevutfall/Brevutfall'
+import { VilkaarsvurderingResultat } from '~shared/api/vilkaarsvurdering'
+import { useInnloggetSaksbehandler } from '../useInnloggetSaksbehandler'
+import { FeatureToggle, useFeaturetoggle } from '~useUnleash'
+
+export const BeregneOMS = (props: { behandling: IBehandlingReducer }) => {
+  const { behandling } = props
+  const { next } = useContext(BehandlingRouteContext)
+  const dispatch = useAppDispatch()
+  const [beregning, hentBeregningRequest] = useApiCall(hentBeregning)
+  const [vedtakStatus, oppdaterVedtakRequest] = useApiCall(upsertVedtak)
+  const [visAttesteringsmodal, setVisAttesteringsmodal] = useState(false)
+  const virkningstidspunkt = behandling.virkningstidspunkt?.dato
+    ? formaterDato(behandling.virkningstidspunkt.dato)
+    : undefined
+  const innloggetSaksbehandler = useInnloggetSaksbehandler()
+
+  const vedtaksresultat = useVedtaksResultat()
+
+  const redigerbar = behandlingErRedigerbar(
+    behandling.status,
+    behandling.sakEnhetId,
+    innloggetSaksbehandler.skriveEnheter
+  )
+  const brevutfallOgEtterbetaling = useAppSelector(
+    (state) => state.behandlingReducer.behandling?.brevutfallOgEtterbetaling
+  )
+
+  const behandlingsstatus = useAppSelector((state) => state.behandlingReducer.behandling?.status)
+
+  const [manglerBrevutfall, setManglerbrevutfall] = useState(false)
+  const [manglerAvkorting, setManglerAvkorting] = useState(false)
+
+  const skalHaInntektNesteAar = useFeaturetoggle(FeatureToggle.validere_aarsintnekt_neste_aar)
+
+  const erOpphoer = behandling.vilkaarsvurdering?.resultat?.utfall == VilkaarsvurderingResultat.IKKE_OPPFYLT
+
+  useEffect(() => {
+    if (!erOpphoer) {
+      hentBeregningRequest(behandling.id, (res) => dispatch(oppdaterBeregning(res)))
+    }
+  }, [])
+
+  const opprettEllerOppdaterVedtak = () => {
+    const skalSendeBrev = behandling.sendeBrev
+
+    if (behandlingsstatus == IBehandlingStatus.BEREGNET) {
+      setManglerAvkorting(true)
+      return
+    }
+    setManglerAvkorting(false)
+
+    if (skalSendeBrev && !brevutfallOgEtterbetaling?.brevutfall) {
+      setManglerbrevutfall(true)
+      return
+    }
+    setManglerbrevutfall(false)
+
+    // TODO er denne nødvendig?
+    oppdaterVedtakRequest(behandling.id, () => {
+      oppdaterStatus(skalSendeBrev)
+    })
+  }
+
+  const oppdaterStatus = (skalSendeBrev: boolean) => {
+    dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.AVKORTET))
+    if (skalSendeBrev) {
+      next()
+    } else {
+      setVisAttesteringsmodal(true)
+    }
+  }
+
+  return (
+    <>
+      <Box paddingInline="16" paddingBlock="16 4">
+        <Heading spacing size="large" level="1">
+          Beregning og vedtak
+        </Heading>
+        <Vedtaksresultat vedtaksresultat={vedtaksresultat} virkningstidspunktFormatert={virkningstidspunkt} />
+      </Box>
+      {erOpphoer ? (
+        <Box paddingInline="18" paddingBlock="4">
+          <Brevutfall behandling={behandling} resetBrevutfallvalidering={() => setManglerbrevutfall(false)} />
+        </Box>
+      ) : (
+        <>
+          {mapApiResult(
+            beregning,
+            <Spinner label="Henter beregning" />,
+            () => (
+              <ApiErrorAlert>Kunne ikke hente beregning</ApiErrorAlert>
+            ),
+            (beregning) => (
+              <Box paddingInline="18" paddingBlock="4">
+                <>
+                  <OmstillingsstoenadSammendrag beregning={beregning} />
+                  <Avkorting
+                    behandling={behandling}
+                    resetBrevutfallvalidering={() => setManglerbrevutfall(false)} // TODO trekk ut brevutfall hit..
+                    resetInntektsavkortingValidering={() => setManglerAvkorting(false)}
+                  />
+                </>
+                {manglerBrevutfall && (
+                  <Alert style={{ maxWidth: '16em' }} variant="error">
+                    Du må fylle ut utfall i brev
+                  </Alert>
+                )}
+                {manglerAvkorting && (
+                  <Alert style={{ maxWidth: '16em' }} variant="error">
+                    {skalHaInntektNesteAar
+                      ? 'Du må legge til inntektsavkorting for inneværende og neste år, også når etterlatte ikke har inntekt. Legg da inn 0 i inntektsfeltene.'
+                      : 'Du må legge til inntektsavkorting, også når etterlatte ikke har inntekt. Legg da inn 0 i inntektsfeltene.'}
+                  </Alert>
+                )}
+              </Box>
+            )
+          )}
+        </>
+      )}
+
+      {isFailureHandler({
+        apiResult: vedtakStatus,
+        errorMessage: 'Vedtaksoppdatering feilet',
+        wrapperComponent: { component: HStack, props: { justify: 'center' } },
+      })}
+
+      <Box paddingBlock="4 0" borderWidth="1 0 0 0" borderColor="border-subtle">
+        {redigerbar ? (
+          <BehandlingHandlingKnapper>
+            {visAttesteringsmodal ? (
+              <SendTilAttesteringModal
+                behandlingId={behandling.id}
+                fattVedtakApi={fattVedtak}
+                validerKanSendeTilAttestering={() => true}
+              />
+            ) : (
+              <Button loading={isPending(vedtakStatus)} variant="primary" onClick={opprettEllerOppdaterVedtak}>
+                {behandling.sendeBrev ? handlinger.NESTE.navn : handlinger.FATT_VEDTAK.navn}
+              </Button>
+            )}
+          </BehandlingHandlingKnapper>
+        ) : (
+          <NesteOgTilbake />
+        )}
+      </Box>
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneOMS.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneOMS.tsx
@@ -81,7 +81,7 @@ export const BeregneOMS = () => {
       if (opphoerSammeAarSomVirk) {
         erOpphoer = true
       }
-      const januarEtterVirkAar = opphoerDato.getFullYear() + 1 === virk.getFullYear() && opphoerDato.getMonth() === 0
+      const januarEtterVirkAar = opphoerDato.getFullYear() - 1 === virk.getFullYear() && opphoerDato.getMonth() === 0
       if (januarEtterVirkAar) {
         erOpphoer = true
       }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneOMS.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneOMS.tsx
@@ -69,7 +69,7 @@ export const BeregneOMS = () => {
     if (!erOpphoer) {
       hentBeregningRequest(behandling.id, (res) => dispatch(oppdaterBeregning(res)))
       avkortingSkalHaToInntekterRequest(behandling.id, (response) =>
-        setSkalHaInntektNesteAar(response.skalHaToInntekter)
+        setSkalHaInntektNesteAar(response.skalHaInntektNesteAar)
       )
     }
   }, [])

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneOMS.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneOMS.tsx
@@ -71,23 +71,29 @@ export const BeregneOMS = () => {
       return false
     }
     const virk = new Date(virkningstidspunkt(behandling).dato)
+    const naa = new Date()
 
-    const virkOktoberEllerSenere = virk.getMonth() > 8
-    if (!virkOktoberEllerSenere) {
-      return false
+    let erOpphoer = false
+    if (behandling.viderefoertOpphoer != null) {
+      const opphoerDato = new Date(behandling.viderefoertOpphoer.dato)
+
+      const opphoerSammeAarSomVirk = opphoerDato.getFullYear() === virk.getFullYear()
+      if (opphoerSammeAarSomVirk) {
+        erOpphoer = true
+      }
+      const januarEtterVirkAar = opphoerDato.getFullYear() + 1 === virk.getFullYear() && opphoerDato.getMonth() === 0
+      if (januarEtterVirkAar) {
+        erOpphoer = true
+      }
     }
 
-    if (behandling.viderefoertOpphoer == null) {
+    const virkIFjor = naa.getFullYear() > virk.getFullYear()
+    if (virkIFjor && !erOpphoer) {
       return true
     }
-    const opphoerDato = new Date(behandling.viderefoertOpphoer.dato)
 
-    const opphoerSammeAarSomVirk = opphoerDato.getFullYear() === virk.getFullYear()
-    if (opphoerSammeAarSomVirk) {
-      return true
-    }
-    const januarEtterVirkAar = opphoerDato.getFullYear() + 1 === virk.getFullYear() && opphoerDato.getMonth() === 0
-    return januarEtterVirkAar
+    const erOktoberEllerSenere = naa.getFullYear() === virk.getFullYear() && naa.getMonth() > 8
+    return erOktoberEllerSenere && !erOpphoer
   }
 
   const erAvkortet = () =>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneOMS.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneOMS.tsx
@@ -67,16 +67,27 @@ export const BeregneOMS = () => {
   }, [])
 
   const skalHaInntektNesteAar = () => {
+    if (behandling.behandlingType !== IBehandlingsType.FØRSTEGANGSBEHANDLING) {
+      return false
+    }
     const virk = new Date(virkningstidspunkt(behandling).dato)
+
     const virkOktoberEllerSenere = virk.getMonth() > 8
-    const opphoerSammeAarSomVirk =
-      behandling.viderefoertOpphoer != null &&
-      new Date(behandling.viderefoertOpphoer.dato).getFullYear() === virk.getFullYear()
-    return (
-      behandling.behandlingType === IBehandlingsType.FØRSTEGANGSBEHANDLING &&
-      virkOktoberEllerSenere &&
-      !opphoerSammeAarSomVirk
-    )
+    if (!virkOktoberEllerSenere) {
+      return false
+    }
+
+    if (behandling.viderefoertOpphoer == null) {
+      return true
+    }
+    const opphoerDato = new Date(behandling.viderefoertOpphoer.dato)
+
+    const opphoerSammeAarSomVirk = opphoerDato.getFullYear() === virk.getFullYear()
+    if (opphoerSammeAarSomVirk) {
+      return true
+    }
+    const januarEtterVirkAar = opphoerDato.getFullYear() + 1 === virk.getFullYear() && opphoerDato.getMonth() === 0
+    return januarEtterVirkAar
   }
 
   const erAvkortet = () =>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneOMS.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneOMS.tsx
@@ -67,8 +67,8 @@ export const BeregneOMS = () => {
   }, [])
 
   /*
-   OBS! Samme logikk benyttes i bakcend (AvkortingService.kt skalHaInntektInnevaerendeOgNesteAar())
-  */
+             OBS! Samme logikk benyttes i bakcend (AvkortingService.kt skalHaInntektInnevaerendeOgNesteAar())
+            */
   const skalHaInntektNesteAar = () => {
     if (behandling.behandlingType !== IBehandlingsType.FØRSTEGANGSBEHANDLING) {
       return false
@@ -78,14 +78,11 @@ export const BeregneOMS = () => {
 
     let erOpphoer = false
     if (behandling.viderefoertOpphoer != null) {
-      const opphoerDato = new Date(behandling.viderefoertOpphoer.dato)
+      const loependeTom = new Date(behandling.viderefoertOpphoer.dato)
+      loependeTom.setMonth(loependeTom.getMonth() - 1)
 
-      const opphoerSammeAarSomVirk = opphoerDato.getFullYear() === virk.getFullYear()
+      const opphoerSammeAarSomVirk = loependeTom.getFullYear() === virk.getFullYear()
       if (opphoerSammeAarSomVirk) {
-        erOpphoer = true
-      }
-      const januarEtterVirkAar = opphoerDato.getFullYear() - 1 === virk.getFullYear() && opphoerDato.getMonth() === 0
-      if (januarEtterVirkAar) {
         erOpphoer = true
       }
     }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneOMS.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneOMS.tsx
@@ -66,6 +66,9 @@ export const BeregneOMS = () => {
     }
   }, [])
 
+  /*
+   OBS! Samme logikk benyttes i bakcend (AvkortingService.kt skalHaInntektInnevaerendeOgNesteAar())
+  */
   const skalHaInntektNesteAar = () => {
     if (behandling.behandlingType !== IBehandlingsType.FØRSTEGANGSBEHANDLING) {
       return false

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/avkorting.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/avkorting.ts
@@ -1,8 +1,14 @@
 import { apiClient, ApiResponse } from '~shared/api/apiClient'
-import { IAvkorting, IAvkortingGrunnlagLagre } from '~shared/types/IAvkorting'
+import { IAvkorting, IAvkortingGrunnlagLagre, IAvkortingSkalHaToInntekt } from '~shared/types/IAvkorting'
 
 export const hentAvkorting = async (behandlingId: string): Promise<ApiResponse<IAvkorting>> => {
   return apiClient.get(`/beregning/avkorting/${behandlingId}`)
+}
+
+export const avkortingSkalHaToInntekter = async (
+  behandlingId: string
+): Promise<ApiResponse<IAvkortingSkalHaToInntekt>> => {
+  return apiClient.get(`/beregning/avkorting/${behandlingId}/skalHaInntektNesteAar`)
 }
 
 export const lagreAvkortingGrunnlag = async (args: {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/avkorting.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/avkorting.ts
@@ -1,5 +1,5 @@
 import { apiClient, ApiResponse } from '~shared/api/apiClient'
-import { IAvkorting, IAvkortingGrunnlagLagre, IAvkortingSkalHaToInntekt } from '~shared/types/IAvkorting'
+import { IAvkorting, IAvkortingGrunnlagLagre, IAvkortingSkalHaInntektNesteAar } from '~shared/types/IAvkorting'
 
 export const hentAvkorting = async (behandlingId: string): Promise<ApiResponse<IAvkorting>> => {
   return apiClient.get(`/beregning/avkorting/${behandlingId}`)
@@ -7,7 +7,7 @@ export const hentAvkorting = async (behandlingId: string): Promise<ApiResponse<I
 
 export const avkortingSkalHaToInntekter = async (
   behandlingId: string
-): Promise<ApiResponse<IAvkortingSkalHaToInntekt>> => {
+): Promise<ApiResponse<IAvkortingSkalHaInntektNesteAar>> => {
   return apiClient.get(`/beregning/avkorting/${behandlingId}/skalHaInntektNesteAar`)
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/behandling.ts
@@ -1,4 +1,5 @@
 import {
+  IBehandlingStatus,
   IBoddEllerArbeidetUtlandet,
   IDetaljertBehandling,
   IGyldighetResultat,
@@ -36,6 +37,10 @@ export const arkiverGrunnlagshendelse = async (hendelse: Grunnlagsendringshendel
 
 export const hentBehandling = async (id: string): Promise<ApiResponse<IDetaljertBehandling>> => {
   return apiClient.get(`/behandling/${id}`)
+}
+
+export const hentBehandlingstatus = async (id: string): Promise<ApiResponse<IBehandlingStatus>> => {
+  return apiClient.get(`/behandling/${id}/status`)
 }
 
 export const opprettBehandling = async (nyBehandlingRequest: NyBehandlingRequest): Promise<ApiResponse<string>> =>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
@@ -6,8 +6,8 @@ export interface IAvkorting {
   tidligereAvkortetYtelse: IAvkortetYtelse[]
 }
 
-export interface IAvkortingSkalHaToInntekt {
-  skalHaToInntekter: boolean
+export interface IAvkortingSkalHaInntektNesteAar {
+  skalHaInntektNesteAar: boolean
 }
 
 export interface IAvkortingGrunnlagFrontend {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
@@ -6,6 +6,10 @@ export interface IAvkorting {
   tidligereAvkortetYtelse: IAvkortetYtelse[]
 }
 
+export interface IAvkortingSkalHaToInntekt {
+  skalHaToInntekter: boolean
+}
+
 export interface IAvkortingGrunnlagFrontend {
   aar: number
   fraVirk: IAvkortingGrunnlag | null


### PR DESCRIPTION
- Deler Beregne.tsx opp i to egne for BP og OMS (er så mye logikk kun relevant for OMS)
- Sjekk om status avkorting hentes fra backend fordi det ikke er trygt å anta at status vil være avkorting i frontend
- Permanent håndtering av inntekt inntekt to år (ikke toggle eller hardkodet 2024)

Generelt vanskelig å få gode løsninger for disse tingene når beregningssiden er slik som nå. Tre steg på en side (beregning,avkorting og brevutfall) hvor beregning og avkorting har egen status men brevutfall ikke.
Det harmonerer ikke helt med "steg/status"-logikken behandlingsløpet legger opp til.