### PR TITLE
Kall til Exception fungerer ikke

### DIFF
--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlFeilLogger.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlFeilLogger.kt
@@ -28,7 +28,8 @@ fun loggDelvisReturnerteData(
         }
 
         result.errors?.joinToString(",")?.let { feil ->
-            val stackTrace = Exception()
+
+            val stackTrace = Stacktrace("Stacktrace")
             logger.error(
                 "Fikk data fra PDL, men også feil / mangler. Dette kan gjøre at saksbehandler får et " +
                     "ukomplett bilde av dataene i PDL, uten at vi indikerer dette." +
@@ -39,6 +40,10 @@ fun loggDelvisReturnerteData(
         }
     }
 }
+
+class Stacktrace(
+    message: String,
+) : Exception(message)
 
 class ManglerTilgangTilPerson :
     ForespoerselException(

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlFeilLogger.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlFeilLogger.kt
@@ -28,22 +28,15 @@ fun loggDelvisReturnerteData(
         }
 
         result.errors?.joinToString(",")?.let { feil ->
-
-            val stackTrace = Stacktrace("Stacktrace")
             logger.error(
                 "Fikk data fra PDL, men også feil / mangler. Dette kan gjøre at saksbehandler får et " +
                     "ukomplett bilde av dataene i PDL, uten at vi indikerer dette." +
                     " Se sikkerlogg for feilmelding",
-                stackTrace,
             )
-            sikkerLogg.error("PDL feil $feil \n\n Request: $req", stackTrace)
+            sikkerLogg.error("PDL feil $feil \n\n Request: $req")
         }
     }
 }
-
-class Stacktrace(
-    message: String,
-) : Exception(message)
 
 class ManglerTilgangTilPerson :
     ForespoerselException(


### PR DESCRIPTION
```
java.lang.Exception: null
	at no.nav.etterlatte.pdl.PdlFeilLoggerKt.loggDelvisReturnerteData(PdlFeilLogger.kt:31)
	at no.nav.etterlatte.pdl.PdlKlient.hentPerson(PdlKlient.kt:49)
	at no.nav.etterlatte.pdl.PdlKlient$hentPerson$1.invokeSuspend(PdlKlient.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.RunnableWrapper.lambda$stopPropagation$0(RunnableWrapper.java:16)
	at io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.RunnableWrapper.lambda$stopPropagation$0(RunnableWrapper.java:16)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:115)
	at io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.RunnableWrapper.lambda$stopPropagation$0(RunnableWrapper.java:16)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:100)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:793)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:697)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:684)

```