### PR TITLE
Går over frå å bruke URL til å bruke outbound for brevbaker, som jo også køyrer på gcp

### DIFF
--- a/apps/etterlatte-brev-api/.nais/dev.yaml
+++ b/apps/etterlatte-brev-api/.nais/dev.yaml
@@ -69,7 +69,7 @@ spec:
     min: 2
   env:
     - name: BREVBAKER_URL
-      value: https://pensjon-brevbaker.intern.dev.nav.no
+      value: http://pensjon-brevbaker
     - name: BREVBAKER_SCOPE
       value: api://dev-gcp.pensjonsbrev.pensjon-brevbaker/.default
     - name: PDFGEN_URL

--- a/apps/etterlatte-brev-api/.nais/dev.yaml
+++ b/apps/etterlatte-brev-api/.nais/dev.yaml
@@ -69,7 +69,7 @@ spec:
     min: 2
   env:
     - name: BREVBAKER_URL
-      value: http://pensjon-brevbaker
+      value: http://pensjon-brevbaker.pensjonsbrev
     - name: BREVBAKER_SCOPE
       value: api://dev-gcp.pensjonsbrev.pensjon-brevbaker/.default
     - name: PDFGEN_URL

--- a/apps/etterlatte-brev-api/.nais/dev.yaml
+++ b/apps/etterlatte-brev-api/.nais/dev.yaml
@@ -140,6 +140,8 @@ spec:
         - application: ey-pdfgen
         - application: clamav
           namespace: nais-system
+        - application: pensjon-brevbaker
+          namespace: pensjonsbrev
       external:
         - host: norg2.dev-fss-pub.nais.io
         - host: saf-q2.dev-fss-pub.nais.io
@@ -148,7 +150,6 @@ spec:
         - host: dokdistfordeling.dev-fss-pub.nais.io
         - host: dokdistkanal.dev-fss-pub.nais.io
         - host: data.brreg.no
-        - host: pensjon-brevbaker.intern.dev.nav.no
         - host: etterlatte-unleash-api.nav.cloud.nais.io
     inbound:
       rules:

--- a/apps/etterlatte-brev-api/.nais/prod.yaml
+++ b/apps/etterlatte-brev-api/.nais/prod.yaml
@@ -78,7 +78,7 @@ spec:
     min: 2
   env:
     - name: BREVBAKER_URL
-      value: https://pensjon-brevbaker.intern.nav.no
+      value: http://pensjon-brevbaker
     - name: BREVBAKER_SCOPE
       value: api://prod-gcp.pensjonsbrev.pensjon-brevbaker/.default
     - name: PDFGEN_URL

--- a/apps/etterlatte-brev-api/.nais/prod.yaml
+++ b/apps/etterlatte-brev-api/.nais/prod.yaml
@@ -149,6 +149,8 @@ spec:
         - application: ey-pdfgen
         - application: clamav
           namespace: nais-system
+        - application: pensjon-brevbaker
+          namespace: pensjonsbrev
       external:
         - host: norg2.prod-fss-pub.nais.io
         - host: saf.prod-fss-pub.nais.io
@@ -157,7 +159,6 @@ spec:
         - host: dokdistfordeling.prod-fss-pub.nais.io
         - host: dokdistkanal.prod-fss-pub.nais.io
         - host: data.brreg.no
-        - host: pensjon-brevbaker.intern.nav.no
         - host: etterlatte-unleash-api.nav.cloud.nais.io
     inbound:
       rules:

--- a/apps/etterlatte-brev-api/.nais/prod.yaml
+++ b/apps/etterlatte-brev-api/.nais/prod.yaml
@@ -78,7 +78,7 @@ spec:
     min: 2
   env:
     - name: BREVBAKER_URL
-      value: http://pensjon-brevbaker
+      value: http://pensjon-brevbaker.pensjonsbrev
     - name: BREVBAKER_SCOPE
       value: api://prod-gcp.pensjonsbrev.pensjon-brevbaker/.default
     - name: PDFGEN_URL


### PR DESCRIPTION
Vi får åtvaring i nais-konsollet vårt om at "Traffic from [etterlatte-brev-api](https://console.nav.cloud.nais.io/team/etterlatte/prod-gcp/app/etterlatte-brev-api) in namespace etterlatte (prod-gcp) is allowed by access policy, but [etterlatte-brev-api](https://console.nav.cloud.nais.io/team/etterlatte/prod-gcp/app/etterlatte-brev-api) does not have an outbound rule for pensjon-brevbaker." (og tilsvarande for dev)

Trur ikkje det er nokon grunn til at dokker bør kalle oss via ingress heller enn service discovery, men bør jo sjølvsagt teste i dev før eventuell merge.