### PR TITLE
EY-4794: Revurdering etter opphør gir riktig grunnlag for trygdetid og beregning

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingService.kt
@@ -265,7 +265,7 @@ class AvkortingService(
         val forrigeBehandlingId =
             alleVedtak
                 .filter {
-                    it.vedtakType != VedtakType.OPPHOER
+                    it.vedtakType != VedtakType.OPPHOER // Opphør har ikke avkorting
                 }.maxBy {
                     it.datoAttestert ?: throw InternfeilException("Iverksatt vedtak mangler dato attestert")
                 }.behandlingId

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
@@ -239,12 +239,13 @@ class BeregningsGrunnlagService(
         val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
         return if (behandling.behandlingType == BehandlingType.REVURDERING) {
             val sisteIverksatteBehandling =
-                behandlingKlient.hentSisteIverksatteBehandling(
-                    behandling.sak,
-                    brukerTokenInfo,
-                )
+                vedtaksvurderingKlient
+                    .hentIverksatteVedtak(behandling.sak, brukerTokenInfo)
+                    .sortedByDescending { it.datoFattet }
+                    .first { it.vedtakType != VedtakType.OPPHOER } // Opphør har ikke beregningsgrunnlag
+
             beregningsGrunnlagRepository
-                .finnBeregningsGrunnlag(sisteIverksatteBehandling.id)
+                .finnBeregningsGrunnlag(sisteIverksatteBehandling.behandlingId)
                 ?.also {
                     logger.info(
                         "Ga ut forrige beregningsgrunnlag for $behandlingId, funnet i " +

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutesTest.kt
@@ -36,13 +36,14 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.SakType
-import no.nav.etterlatte.libs.common.behandling.SisteIverksatteBehandling
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.beregning.BeregningsMetode
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.SoeskenMedIBeregning
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.vedtak.VedtakSammendragDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.HELSOESKEN_FOEDSELSNUMMER
 import no.nav.security.mock.oauth2.MockOAuth2Server
@@ -52,6 +53,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.time.LocalDate
+import java.util.UUID
 import java.util.UUID.randomUUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -164,8 +166,8 @@ internal class BeregningsGrunnlagRoutesTest {
                 tidligereFamiliepleier = null,
             )
         coEvery {
-            behandlingKlient.hentSisteIverksatteBehandling(sakId, any())
-        } returns SisteIverksatteBehandling(idForrigeIverksatt)
+            vedtaksvurderingKlient.hentIverksatteVedtak(sakId, any())
+        } returns listOf(mockVedtak(idForrigeIverksatt, VedtakType.INNVILGELSE))
         every { repository.finnBeregningsGrunnlag(idRevurdering) } returns null
         every { repository.finnBeregningsGrunnlag(idForrigeIverksatt) } returns
             BeregningsGrunnlag(
@@ -196,7 +198,7 @@ internal class BeregningsGrunnlagRoutesTest {
         }
 
         coVerify(exactly = 1) {
-            behandlingKlient.hentSisteIverksatteBehandling(sakId, any())
+            vedtaksvurderingKlient.hentIverksatteVedtak(sakId, any())
         }
         verify(exactly = 1) {
             repository.lagreBeregningsGrunnlag(any())
@@ -799,6 +801,11 @@ internal class BeregningsGrunnlagRoutesTest {
                 }
         }
     }
+
+    private fun mockVedtak(
+        behandlingId: UUID,
+        type: VedtakType,
+    ) = VedtakSammendragDto(randomUUID().toString(), behandlingId, type, null, null, null, null, null, null)
 
     private val token: String by lazy { mockOAuth2Server.issueSaksbehandlerToken() }
 

--- a/apps/etterlatte-trygdetid/.nais/dev.yaml
+++ b/apps/etterlatte-trygdetid/.nais/dev.yaml
@@ -76,6 +76,10 @@ spec:
       value: http://etterlatte-grunnlag
     - name: ETTERLATTE_GRUNNLAG_CLIENT_ID
       value: dev-gcp.etterlatte.etterlatte-grunnlag
+    - name: ETTERLATTE_VEDTAKSVURDERING_CLIENT_ID
+      value: dev-gcp.etterlatte.etterlatte-vedtaksvurdering
+    - name: ETTERLATTE_VEDTAKSVURDERING_URL
+      value: http://etterlatte-vedtaksvurdering
     - name: PEN_URL
       value: https://pensjon-pen-q2.dev-fss-pub.nais.io/pen
     - name: PEN_CLIENT_ID
@@ -99,6 +103,7 @@ spec:
       rules:
         - application: etterlatte-behandling
         - application: etterlatte-grunnlag
+        - application: etterlatte-vedtaksvurdering
       external:
         - host: etterlatte-unleash-api.nav.cloud.nais.io
         - host: pensjon-pen-q2.dev-fss-pub.nais.io

--- a/apps/etterlatte-trygdetid/.nais/prod.yaml
+++ b/apps/etterlatte-trygdetid/.nais/prod.yaml
@@ -85,6 +85,10 @@ spec:
       value: http://etterlatte-grunnlag
     - name: ETTERLATTE_GRUNNLAG_CLIENT_ID
       value: prod-gcp.etterlatte.etterlatte-grunnlag
+    - name: ETTERLATTE_VEDTAKSVURDERING_CLIENT_ID
+      value: prod-gcp.etterlatte.etterlatte-vedtaksvurdering
+    - name: ETTERLATTE_VEDTAKSVURDERING_URL
+      value: http://etterlatte-vedtaksvurdering
     - name: PEN_URL
       value: https://pensjon-pen.prod-fss-pub.nais.io/pen
     - name: PEN_CLIENT_ID
@@ -103,6 +107,7 @@ spec:
       rules:
         - application: etterlatte-behandling
         - application: etterlatte-grunnlag
+        - application: etterlatte-vedtaksvurdering
       external:
         - host: etterlatte-unleash-api.nav.cloud.nais.io
         - host: pensjon-pen.prod-fss-pub.nais.io

--- a/apps/etterlatte-trygdetid/build.gradle.kts
+++ b/apps/etterlatte-trygdetid/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(project(":libs:etterlatte-database"))
     implementation(project(":libs:etterlatte-trygdetid-model"))
     implementation(project(":libs:etterlatte-funksjonsbrytere"))
+    implementation(project(":libs:etterlatte-vedtaksvurdering-model"))
 
     implementation(libs.database.kotliquery)
     implementation(libs.navfelles.tokenclientcore)

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/config/ApplicationContext.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/config/ApplicationContext.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.trygdetid.avtale.AvtaleService
 import no.nav.etterlatte.trygdetid.klienter.BehandlingKlient
 import no.nav.etterlatte.trygdetid.klienter.GrunnlagKlient
 import no.nav.etterlatte.trygdetid.klienter.PesysKlientImpl
+import no.nav.etterlatte.trygdetid.klienter.VedtaksvurderingKlientImpl
 
 class ApplicationContext {
     val config: Config = ConfigFactory.load()
@@ -30,6 +31,7 @@ class ApplicationContext {
     private val avtaleRepository = AvtaleRepository(dataSource)
 
     val behandlingKlient = BehandlingKlient(config, httpClient())
+    val vedtaksvurderingKlient = VedtaksvurderingKlientImpl(config, httpClient())
     val avtaleService = AvtaleService(avtaleRepository)
 
     val featureToggleService = FeatureToggleService.initialiser(featureToggleProperties(config))
@@ -42,6 +44,7 @@ class ApplicationContext {
             beregnTrygdetidService = TrygdetidBeregningService,
             pesysKlient = PesysKlientImpl(config, httpClient()),
             avtaleService = avtaleService,
+            vedtaksvurderingKlient = vedtaksvurderingKlient,
         )
 }
 

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/VedtaksvurderingKlient.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/VedtaksvurderingKlient.kt
@@ -1,0 +1,71 @@
+package no.nav.etterlatte.trygdetid.klienter
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.github.michaelbull.result.mapBoth
+import com.typesafe.config.Config
+import io.ktor.client.HttpClient
+import no.nav.etterlatte.libs.common.RetryResult
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.retry
+import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.common.vedtak.VedtakSammendragDto
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.AzureAdClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import org.slf4j.LoggerFactory
+
+interface VedtaksvurderingKlient {
+    suspend fun hentIverksatteVedtak(
+        sakId: SakId,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<VedtakSammendragDto>
+}
+
+class VedtaksvurderingKlientException(
+    override val message: String,
+    override val cause: Throwable,
+) : Exception(message, cause)
+
+class VedtaksvurderingKlientImpl(
+    config: Config,
+    httpClient: HttpClient,
+) : VedtaksvurderingKlient {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val azureAdClient = AzureAdClient(config)
+    private val downstreamResourceClient = DownstreamResourceClient(azureAdClient, httpClient)
+
+    private val clientId = config.getString("vedtaksvurdering.client.id")
+    private val resourceUrl = config.getString("vedtaksvurdering.resource.url")
+
+    override suspend fun hentIverksatteVedtak(
+        sakId: SakId,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<VedtakSammendragDto> {
+        logger.info("Henter iverksatte vedtak for sak=$sakId")
+        return retry<List<VedtakSammendragDto>> {
+            downstreamResourceClient
+                .get(
+                    resource =
+                        Resource(
+                            clientId = clientId,
+                            url = "$resourceUrl/api/vedtak/sak/${sakId.sakId}/iverksatte",
+                        ),
+                    brukerTokenInfo = brukerTokenInfo,
+                ).mapBoth(
+                    success = { resource -> objectMapper.readValue(resource.response.toString()) },
+                    failure = { throwableErrorMessage -> throw throwableErrorMessage },
+                )
+        }.let {
+            when (it) {
+                is RetryResult.Success -> it.content
+                is RetryResult.Failure -> {
+                    throw VedtaksvurderingKlientException(
+                        "Klarte ikke hente iverksatte vedtak for sak=$sakId",
+                        it.samlaExceptions(),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/apps/etterlatte-trygdetid/src/main/resources/application.conf
+++ b/apps/etterlatte-trygdetid/src/main/resources/application.conf
@@ -18,6 +18,9 @@ behandling.resource.url = ${?ETTERLATTE_BEHANDLING_URL}
 grunnlag.client.id = ${?ETTERLATTE_GRUNNLAG_CLIENT_ID}
 grunnlag.resource.url = ${?ETTERLATTE_GRUNNLAG_URL}
 
+vedtaksvurdering.client.id = ${?ETTERLATTE_VEDTAKSVURDERING_CLIENT_ID}
+vedtaksvurdering.resource.url = ${?ETTERLATTE_VEDTAKSVURDERING_URL}
+
 funksjonsbrytere.unleash.applicationName = ${?NAIS_APP_NAME}
 funksjonsbrytere.unleash.host = ${?UNLEASH_SERVER_API_URL}
 funksjonsbrytere.unleash.token = ${?UNLEASH_SERVER_API_TOKEN}

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceIntegrationTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceIntegrationTest.kt
@@ -32,6 +32,7 @@ import no.nav.etterlatte.trygdetid.avtale.AvtaleService
 import no.nav.etterlatte.trygdetid.klienter.BehandlingKlient
 import no.nav.etterlatte.trygdetid.klienter.GrunnlagKlient
 import no.nav.etterlatte.trygdetid.klienter.PesysKlient
+import no.nav.etterlatte.trygdetid.klienter.VedtaksvurderingKlient
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -62,6 +63,7 @@ internal class TrygdetidServiceIntegrationTest(
 
     private val behandlingKlient = mockk<BehandlingKlient>()
     private val avtaleService = mockk<AvtaleService>()
+    private val vedtaksvurderingKlient = mockk<VedtaksvurderingKlient>()
 
     @BeforeAll
     fun beforeAll() {
@@ -75,6 +77,7 @@ internal class TrygdetidServiceIntegrationTest(
                 TrygdetidBeregningService,
                 mockk<PesysKlient>(),
                 avtaleService,
+                vedtaksvurderingKlient,
             )
     }
 

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
@@ -256,13 +256,8 @@ internal class TrygdetidServiceTest {
 
         val forrigebehandlingId = randomUUID()
         val forrigeTrygdetid = trygdetid(behandlingId, sakId)
-        val vedtakSammendrag: VedtakSammendragDto =
-            mockk {
-                every { this@mockk.behandlingId } returns forrigebehandlingId
-                every { vedtakType } returns VedtakType.ENDRING
-            }
-
         val oppdatertTrygdetidCaptured = slot<Trygdetid>()
+        val vedtakSammendrag = mockVedtak(forrigebehandlingId, VedtakType.ENDRING)
 
         every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
@@ -270,7 +265,10 @@ internal class TrygdetidServiceTest {
             SisteIverksatteBehandling(
                 forrigebehandlingId,
             )
-        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(any(), any()) } returns listOf(vedtakSammendrag)
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(any(), any()) } returns
+            listOf(
+                vedtakSammendrag,
+            )
         every { repository.hentTrygdetiderForBehandling(forrigebehandlingId) } returns listOf(forrigeTrygdetid)
         every { repository.opprettTrygdetid(capture(oppdatertTrygdetidCaptured)) } returns forrigeTrygdetid
         coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
@@ -331,11 +329,7 @@ internal class TrygdetidServiceTest {
             }
         val grunnlagUtenAvdoede = grunnlagUtenAvdoede()
         val forrigebehandlingId = forrigeTrygdetid.behandlingId
-        val vedtakSammendrag: VedtakSammendragDto =
-            mockk {
-                every { this@mockk.behandlingId } returns forrigebehandlingId
-                every { vedtakType } returns VedtakType.ENDRING
-            }
+        val vedtakSammendrag = mockVedtak(forrigebehandlingId, VedtakType.ENDRING)
 
         val oppdatertTrygdetidCaptured = slot<Trygdetid>()
         every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
@@ -500,11 +494,7 @@ internal class TrygdetidServiceTest {
                 .hentFoedselsnummer()!!
                 .verdi
         val trygdetid = trygdetid(behandlingId, sakId, ident = forventetIdent.value)
-        val vedtakSammendrag: VedtakSammendragDto =
-            mockk {
-                every { this@mockk.behandlingId } returns forrigeBehandlingId
-                every { vedtakType } returns VedtakType.ENDRING
-            }
+        val vedtakSammendrag = mockVedtak(forrigeBehandlingId, VedtakType.ENDRING)
 
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
         every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
@@ -573,11 +563,7 @@ internal class TrygdetidServiceTest {
             }
         val forrigeBehandlingId = randomUUID()
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
-        val vedtakSammendrag: VedtakSammendragDto =
-            mockk {
-                every { this@mockk.behandlingId } returns forrigeBehandlingId
-                every { vedtakType } returns VedtakType.ENDRING
-            }
+        val vedtakSammendrag = mockVedtak(forrigeBehandlingId, VedtakType.ENDRING)
 
         every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
@@ -634,11 +620,7 @@ internal class TrygdetidServiceTest {
                 .hentFoedselsnummer()!!
                 .verdi
         val trygdetid = trygdetid(behandlingId, sakId, ident = forventetIdent.value)
-        val vedtakSammendrag: VedtakSammendragDto =
-            mockk {
-                every { this@mockk.behandlingId } returns forrigeBehandlingId
-                every { vedtakType } returns VedtakType.ENDRING
-            }
+        val vedtakSammendrag = mockVedtak(forrigeBehandlingId, VedtakType.ENDRING)
 
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
         every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
@@ -2046,4 +2028,9 @@ internal class TrygdetidServiceTest {
             ).hentOpplysningsgrunnlag()
         return grunnlag
     }
+
+    private fun mockVedtak(
+        behandlingId: UUID,
+        type: VedtakType,
+    ) = VedtakSammendragDto(randomUUID().toString(), behandlingId, type, null, null, null, null, null, null)
 }

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
@@ -43,6 +43,8 @@ import no.nav.etterlatte.libs.common.trygdetid.DetaljertBeregnetTrygdetidResulta
 import no.nav.etterlatte.libs.common.trygdetid.FaktiskTrygdetid
 import no.nav.etterlatte.libs.common.trygdetid.UKJENT_AVDOED
 import no.nav.etterlatte.libs.common.trygdetid.land.LandNormalisert
+import no.nav.etterlatte.libs.common.vedtak.VedtakSammendragDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED2_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
@@ -53,6 +55,7 @@ import no.nav.etterlatte.trygdetid.klienter.BehandlingKlient
 import no.nav.etterlatte.trygdetid.klienter.GrunnlagKlient
 import no.nav.etterlatte.trygdetid.klienter.PesysKlient
 import no.nav.etterlatte.trygdetid.klienter.TrygdetidsgrunnlagUfoeretrygdOgAlderspensjon
+import no.nav.etterlatte.trygdetid.klienter.VedtaksvurderingKlient
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -72,6 +75,7 @@ internal class TrygdetidServiceTest {
     private val beregningService: TrygdetidBeregningService = spyk(TrygdetidBeregningService)
     private val avtaleService = mockk<AvtaleService>()
     private val pesysklient = mockk<PesysKlient>()
+    private val vedtaksvurderingKlient = mockk<VedtaksvurderingKlient>()
     private val service: TrygdetidService =
         TrygdetidServiceImpl(
             repository,
@@ -80,6 +84,7 @@ internal class TrygdetidServiceTest {
             beregningService,
             pesysklient,
             avtaleService,
+            vedtaksvurderingKlient,
         )
 
     @BeforeEach
@@ -251,6 +256,11 @@ internal class TrygdetidServiceTest {
 
         val forrigebehandlingId = randomUUID()
         val forrigeTrygdetid = trygdetid(behandlingId, sakId)
+        val vedtakSammendrag: VedtakSammendragDto =
+            mockk {
+                every { this@mockk.behandlingId } returns forrigebehandlingId
+                every { vedtakType } returns VedtakType.ENDRING
+            }
 
         val oppdatertTrygdetidCaptured = slot<Trygdetid>()
 
@@ -260,6 +270,7 @@ internal class TrygdetidServiceTest {
             SisteIverksatteBehandling(
                 forrigebehandlingId,
             )
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(any(), any()) } returns listOf(vedtakSammendrag)
         every { repository.hentTrygdetiderForBehandling(forrigebehandlingId) } returns listOf(forrigeTrygdetid)
         every { repository.opprettTrygdetid(capture(oppdatertTrygdetidCaptured)) } returns forrigeTrygdetid
         coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
@@ -273,7 +284,7 @@ internal class TrygdetidServiceTest {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
             repository.hentTrygdetiderForBehandling(behandlingId)
             behandlingKlient.hentBehandling(behandlingId, saksbehandler)
-            behandlingKlient.hentSisteIverksatteBehandling(sakId, saksbehandler)
+            vedtaksvurderingKlient.hentIverksatteVedtak(sakId, saksbehandler)
             repository.hentTrygdetiderForBehandling(forrigebehandlingId)
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
 
@@ -295,6 +306,8 @@ internal class TrygdetidServiceTest {
             behandling.sak
             behandling.id
             behandling.revurderingsaarsak
+            vedtakSammendrag.behandlingId
+            vedtakSammendrag.vedtakType
         }
     }
 
@@ -318,16 +331,18 @@ internal class TrygdetidServiceTest {
             }
         val grunnlagUtenAvdoede = grunnlagUtenAvdoede()
         val forrigebehandlingId = forrigeTrygdetid.behandlingId
+        val vedtakSammendrag: VedtakSammendragDto =
+            mockk {
+                every { this@mockk.behandlingId } returns forrigebehandlingId
+                every { vedtakType } returns VedtakType.ENDRING
+            }
 
         val oppdatertTrygdetidCaptured = slot<Trygdetid>()
         every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
         every { repository.hentTrygdetiderForBehandling(forrigebehandlingId) } returns listOf(forrigeTrygdetid)
         every { repository.hentTrygdetidMedId(forrigebehandlingId, any()) } returns forrigeTrygdetid
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
-            SisteIverksatteBehandling(
-                forrigebehandlingId,
-            )
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(any(), any()) } returns listOf(vedtakSammendrag)
         every { repository.hentTrygdetiderForBehandling(forrigebehandlingId) } returns listOf(forrigeTrygdetid)
         every { repository.opprettTrygdetid(capture(oppdatertTrygdetidCaptured)) } returns forrigeTrygdetid
         coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
@@ -345,7 +360,7 @@ internal class TrygdetidServiceTest {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
             repository.hentTrygdetiderForBehandling(behandlingId)
             behandlingKlient.hentBehandling(behandlingId, saksbehandler)
-            behandlingKlient.hentSisteIverksatteBehandling(sakId, saksbehandler)
+            vedtaksvurderingKlient.hentIverksatteVedtak(sakId, saksbehandler)
             repository.hentTrygdetiderForBehandling(forrigebehandlingId)
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
 
@@ -364,6 +379,8 @@ internal class TrygdetidServiceTest {
             behandling.sak
             behandling.behandlingType
             behandling.revurderingsaarsak
+            vedtakSammendrag.behandlingId
+            vedtakSammendrag.vedtakType
         }
     }
 
@@ -483,14 +500,16 @@ internal class TrygdetidServiceTest {
                 .hentFoedselsnummer()!!
                 .verdi
         val trygdetid = trygdetid(behandlingId, sakId, ident = forventetIdent.value)
+        val vedtakSammendrag: VedtakSammendragDto =
+            mockk {
+                every { this@mockk.behandlingId } returns forrigeBehandlingId
+                every { vedtakType } returns VedtakType.ENDRING
+            }
 
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
         every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
-            SisteIverksatteBehandling(
-                forrigeBehandlingId,
-            )
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(any(), any()) } returns listOf(vedtakSammendrag)
         every { repository.hentTrygdetiderForBehandling(forrigeBehandlingId) } returns emptyList()
         every { repository.hentTrygdetidMedId(any(), any()) } returns trygdetid
         every { repository.opprettTrygdetid(any()) } returns trygdetid
@@ -512,7 +531,7 @@ internal class TrygdetidServiceTest {
             grunnlagKlient.hentGrunnlag(behandlingId, saksbehandler)
             behandlingKlient.hentBehandling(behandlingId, saksbehandler)
             repository.hentTrygdetiderForBehandling(behandlingId)
-            behandlingKlient.hentSisteIverksatteBehandling(sakId, saksbehandler)
+            vedtaksvurderingKlient.hentIverksatteVedtak(sakId, saksbehandler)
             repository.hentTrygdetiderForBehandling(forrigeBehandlingId)
             repository.hentTrygdetidMedId(any(), any())
             repository.opprettTrygdetid(
@@ -535,6 +554,8 @@ internal class TrygdetidServiceTest {
             behandling.id
             behandling.sak
             behandling.behandlingType
+            vedtakSammendrag.behandlingId
+            vedtakSammendrag.vedtakType
         }
     }
 
@@ -552,13 +573,15 @@ internal class TrygdetidServiceTest {
             }
         val forrigeBehandlingId = randomUUID()
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
+        val vedtakSammendrag: VedtakSammendragDto =
+            mockk {
+                every { this@mockk.behandlingId } returns forrigeBehandlingId
+                every { vedtakType } returns VedtakType.ENDRING
+            }
 
         every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
-        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
-            SisteIverksatteBehandling(
-                forrigeBehandlingId,
-            )
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(any(), any()) } returns listOf(vedtakSammendrag)
         every { repository.hentTrygdetiderForBehandling(forrigeBehandlingId) } returns emptyList()
         every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
@@ -573,7 +596,7 @@ internal class TrygdetidServiceTest {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
             repository.hentTrygdetiderForBehandling(behandlingId)
             behandlingKlient.hentBehandling(behandlingId, saksbehandler)
-            behandlingKlient.hentSisteIverksatteBehandling(sakId, saksbehandler)
+            vedtaksvurderingKlient.hentIverksatteVedtak(sakId, saksbehandler)
             repository.hentTrygdetiderForBehandling(forrigeBehandlingId)
         }
         coVerify {
@@ -585,6 +608,8 @@ internal class TrygdetidServiceTest {
             behandling.id
             behandling.sak
             behandling.behandlingType
+            vedtakSammendrag.behandlingId
+            vedtakSammendrag.vedtakType
         }
     }
 
@@ -609,6 +634,11 @@ internal class TrygdetidServiceTest {
                 .hentFoedselsnummer()!!
                 .verdi
         val trygdetid = trygdetid(behandlingId, sakId, ident = forventetIdent.value)
+        val vedtakSammendrag: VedtakSammendragDto =
+            mockk {
+                every { this@mockk.behandlingId } returns forrigeBehandlingId
+                every { vedtakType } returns VedtakType.ENDRING
+            }
 
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
         every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
@@ -617,6 +647,7 @@ internal class TrygdetidServiceTest {
             SisteIverksatteBehandling(
                 forrigeBehandlingId,
             )
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(any(), any()) } returns listOf(vedtakSammendrag)
         coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
         every { repository.hentTrygdetiderForBehandling(forrigeBehandlingId) } returns emptyList()
         every { repository.opprettTrygdetid(any()) } returns trygdetid
@@ -638,7 +669,7 @@ internal class TrygdetidServiceTest {
         coVerify(exactly = 1) {
             grunnlagKlient.hentGrunnlag(behandlingId, saksbehandler)
             repository.hentTrygdetiderForBehandling(behandlingId)
-            behandlingKlient.hentSisteIverksatteBehandling(sakId, saksbehandler)
+            vedtaksvurderingKlient.hentIverksatteVedtak(sakId, saksbehandler)
             repository.hentTrygdetiderForBehandling(forrigeBehandlingId)
             behandlingKlient.hentBehandling(behandlingId, saksbehandler)
             repository.hentTrygdetidMedId(any(), any())
@@ -663,6 +694,8 @@ internal class TrygdetidServiceTest {
             behandling.id
             behandling.sak
             behandling.behandlingType
+            vedtakSammendrag.behandlingId
+            vedtakSammendrag.vedtakType
         }
     }
 

--- a/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
@@ -106,6 +106,7 @@ spec:
         - application: etterlatte-api    # tar over for samordning-vedtak
         - application: etterlatte-vedtaksvurdering-kafka
         - application: etterlatte-utbetaling
+        - application: etterlatte-trygdetid
         - application: azure-token-generator # https://docs.nais.io/auth/entra-id/how-to/generate/?h=token+azure
           namespace: aura
           cluster: dev-gcp

--- a/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/prod.yaml
@@ -116,6 +116,7 @@ spec:
         - application: etterlatte-api    # tar over for samordning-vedtak
         - application: etterlatte-vedtaksvurdering-kafka
         - application: etterlatte-utbetaling
+        - application: etterlatte-trygdetid
     outbound:
       rules:
         - application: etterlatte-beregning


### PR DESCRIPTION
Siden vi ikke kopierer med behandlingsgrunnlag (trygdetidsgrunnlag, beregningsgrunnlag, avkortingsgrunnlag) i opphør, er vi avhengig av å hente denne informasjonen fra siste vedtak som ikke er opphør. Dette var gjort riktig i avkorting, mens denne PR'en også gjør det på tilsvarende måte i beregningsgrunnlag og trygdetid. 