### PR TITLE
FAGSYSTEM-363686 Hindre brev aksjoner på brev i aktivitetspliktflyten

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -36,6 +36,7 @@ import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.util.UUID
+import kotlin.collections.contains
 
 class BrevService(
     private val db: BrevRepository,
@@ -372,11 +373,22 @@ class BrevService(
             brevDataMapping = { ManueltBrevMedTittelData(it.innholdMedVedlegg.innhold(), it.tittel) },
         )
 
+    /*NB må kun brukes av route endepunktet for ferdigstilling med mindre sjekken mot brevkoder under flyttes et annet sted som ikke påvirker den flyten.
+    der brukes i dag routen ferdigstill-journalfoer-og-distribuer som kaller rett på lagrePdfOgFerdigstillBrev
+     */
     suspend fun ferdigstill(
         id: BrevID,
         bruker: BrukerTokenInfo,
     ) {
         val brev = sjekkOmBrevKanEndres(id)
+        if (listOf(
+                Brevkoder.OMSTILLINGSSTOENAD_AKTIVITETSPLIKT_INFORMASJON_10MND_INNHOLD,
+                Brevkoder.OMSTILLINGSSTOENAD_AKTIVITETSPLIKT_INFORMASJON_6MND_INNHOLD,
+            ).contains(brev.brevkoder)
+        ) {
+            throw BrevKanIkkeEndres(brev)
+            // se https://jira.adeo.no/browse/FAGSYSTEM-363686?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258aXNzdWU%3D
+        }
 
         if (brev.mottakere.size !in 1..2) {
             logger.error("Brev ${brev.id} har ${brev.mottakere.size} mottakere. Dette skal ikke være mulig...")

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -386,7 +386,7 @@ class BrevService(
                 Brevkoder.OMSTILLINGSSTOENAD_AKTIVITETSPLIKT_INFORMASJON_6MND_INNHOLD,
             ).contains(brev.brevkoder)
         ) {
-            throw BrevKanIkkeEndres(brev)
+            throw BrevKanIkkeEndres(brev, "brevkoden er feil, er ${brev.brevkoder}")
             // se https://jira.adeo.no/browse/FAGSYSTEM-363686?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258aXNzdWU%3D
         }
 
@@ -487,9 +487,10 @@ class BrevService(
 
 class BrevKanIkkeEndres(
     brev: Brev,
+    msg: String? = "",
 ) : UgyldigForespoerselException(
         code = "BREV_KAN_IKKE_ENDRES",
-        detail = "Brevet kan ikke endres siden det har status ${brev.status.name.lowercase()}",
+        detail = "Brevet kan ikke endres siden det har status ${brev.status.name.lowercase()} $msg",
         meta =
             mapOf(
                 "brevId" to brev.id,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -490,7 +490,7 @@ class BrevKanIkkeEndres(
     msg: String? = "",
 ) : UgyldigForespoerselException(
         code = "BREV_KAN_IKKE_ENDRES",
-        detail = "Brevet kan ikke endres siden det har status ${brev.status.name.lowercase()} $msg",
+        detail = "Brevet kan ikke endres siden det har status ${brev.status.name.lowercase()}, $msg",
         meta =
             mapOf(
                 "brevId" to brev.id,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/BrevOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/BrevOversikt.tsx
@@ -24,10 +24,16 @@ const mapAdresse = (mottaker: Mottaker) => {
   return `${adresselinje}, ${postlinje}`
 }
 
-const kanEndres = (status: BrevStatus) => status !== BrevStatus.DISTRIBUERT
+const kanEndres = (brev: IBrev) => brev.status !== BrevStatus.DISTRIBUERT && gyldigbrevkode(brev.brevkoder)
+
+export const gyldigbrevkode = (brevkoder: string): boolean =>
+  ![
+    'OMSTILLINGSSTOENAD_AKTIVITETSPLIKT_INFORMASJON_10MND_INNHOLD',
+    'OMSTILLINGSSTOENAD_AKTIVITETSPLIKT_INFORMASJON_6MND_INNHOLD',
+  ].includes(brevkoder)
 
 const handlingKnapp = (brev: IBrev) => {
-  if (kanEndres(brev.status)) {
+  if (kanEndres(brev)) {
     const href = brev.behandlingId
       ? `/behandling/${brev.behandlingId}/brev`
       : `/person/sak/${brev.sakId}/brev/${brev.id}`

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrevHandlingerPanel.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrevHandlingerPanel.tsx
@@ -23,7 +23,7 @@ export default function NyttBrevHandlingerPanel({ brev, setKanRedigeres, callbac
   const [ferdigstillStatus, apiFerdigstillBrev] = useApiCall(ferdigstillBrev)
   const [journalfoerStatus, apiJournalfoerBrev] = useApiCall(journalfoerBrev)
   const [distribuerStatus, apiDistribuerBrev] = useApiCall(distribuerBrev)
-
+  //TODO: ferdigstill, journalfoer og distribuer burde gjøres i samme kall
   const ferdigstill = () => {
     setFeilmeldingBekreft(undefined)
     if (erAktivitetspliktVarsel && !bekreftetInfobrev) {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/handlinger/SlettBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/handlinger/SlettBrev.tsx
@@ -6,9 +6,14 @@ import { TrashIcon } from '@navikt/aksel-icons'
 import { isPending } from '~shared/api/apiUtils'
 import { BrevStatus, IBrev } from '~shared/types/Brev'
 import { ClickEvent, trackClick } from '~utils/amplitude'
+import { gyldigbrevkode } from '~components/person/brev/BrevOversikt'
 
 const kanSlettes = (brev: IBrev) => {
-  return !brev.behandlingId && [BrevStatus.OPPRETTET, BrevStatus.OPPDATERT].includes(brev.status)
+  return (
+    !brev.behandlingId &&
+    [BrevStatus.OPPRETTET, BrevStatus.OPPDATERT].includes(brev.status) &&
+    gyldigbrevkode(brev.brevkoder)
+  )
 }
 
 /**

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Brev.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Brev.ts
@@ -11,6 +11,7 @@ export interface IBrev {
   mottakere: Mottaker[]
   opprettet: string
   brevtype: Brevtype
+  brevkoder: string
 }
 
 export interface Mottaker {


### PR DESCRIPTION
Det blir feil i aktivitetspliktsoppfølgingen om sb redigerer eller sletter brevet fra dens behandling, hotfix som fjerner muligheten i frontend.