### PR TITLE
Fjerner workaround for å fjerne opphørFom i revurdering da dette kan gjøres direkte nå

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
@@ -51,7 +51,6 @@ class VedtakBehandlingService(
     private val behandlingKlient: BehandlingKlient,
     private val samordningsKlient: SamordningsKlient,
     private val trygdetidKlient: TrygdetidKlient,
-    private val rapidService: VedtaksvurderingRapidService,
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
@@ -566,13 +566,9 @@ class VedtakBehandlingService(
         VedtakType.AVSLAG -> behandling.opphoerFraOgMed
         else -> {
             if (virkningstidspunkt == behandling.opphoerFraOgMed) {
-                // TODO Det burde være en løsning for å kunne fjerne et opphør uten en revurdering med samme virk som opphøret?
-                null
+                throw VirkningstidspunktOgOpphoerFomPaaSammeDatoException()
             } else if (behandling.opphoerFraOgMed != null && virkningstidspunkt > behandling.opphoerFraOgMed) {
-                throw UgyldigForespoerselException(
-                    code = "VIRKNINGSTIDSPUNKT_ETTER_OPPHOER",
-                    detail = "Virkningstidspunkt kan ikke være senere enn opphør fra og med",
-                )
+                throw VirkningstidspunktEtterOpphoerException()
             } else {
                 behandling.opphoerFraOgMed
             }
@@ -781,4 +777,16 @@ class ManglerAvkortetYtelse :
         code = "VEDTAKSVURDERING_MANGLER_AVKORTET_YTELSE",
         detail =
             "Det må legges til inntektsavkorting selv om mottaker ikke har inntekt. Legg inn \"0\" kr i alle felter.",
+    )
+
+class VirkningstidspunktEtterOpphoerException :
+    UgyldigForespoerselException(
+        code = "VIRKNINGSTIDSPUNKT_ETTER_OPPHOER",
+        detail = "Virkningstidspunkt kan ikke være senere enn opphør fra og med",
+    )
+
+class VirkningstidspunktOgOpphoerFomPaaSammeDatoException :
+    UgyldigForespoerselException(
+        code = "VIRKNINGSTIDSPUNKT_OG_OPPHOER_FRA_OG_MED_PAA_SAMME_DATO",
+        detail = "Virkningstidspunkt og opphør fra og med kan ikke være på samme dato",
     )

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/config/ApplicationContext.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/config/ApplicationContext.kt
@@ -83,7 +83,6 @@ class ApplicationContext {
             behandlingKlient = behandlingKlient,
             samordningsKlient = samKlient,
             trygdetidKlient = trygdetidKlient,
-            rapidService = vedtaksvurderingRapidService,
         )
 
     val vedtakTilbakekrevingService =

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingServiceTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingServiceTest.kt
@@ -99,7 +99,6 @@ internal class VedtakBehandlingServiceTest(
                 behandlingKlient = behandlingKlientMock,
                 samordningsKlient = samordningsKlientMock,
                 trygdetidKlient = trygdetidKlientMock,
-                rapidService = mockk(),
             )
     }
 


### PR DESCRIPTION
Tidligere måtte man revurdere fra opphør-tidspunkt for å fjerne et opphør (med litt usynlig logikk i vedtaksvurdering). 

Nå som revurderinger kopierer med opphør fra og med, kan man i revurderingen velge om opphøret skal fjernes direkte i revurderingsoversikten. Vedtaksvurdering trenger ikke da å gjøre noe logikk her annet enn å sjekke konsistens.