### PR TITLE
EY-4932 Fiksinger klage

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/sidemeny/KlageSidemeny.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/sidemeny/KlageSidemeny.tsx
@@ -1,5 +1,5 @@
 import { useKlage, useKlageRedigerbar } from '~components/klage/useKlage'
-import { Detail, Heading, HStack, Label, VStack } from '@navikt/ds-react'
+import { BodyShort, Box, Detail, Heading, HStack, Label, VStack } from '@navikt/ds-react'
 import { Sidebar, SidebarPanel } from '~shared/components/Sidebar'
 import { KlageStatus, teksterKabalstatus, teksterKlagestatus } from '~shared/types/Klage'
 import { formaterDato } from '~utils/formatering/dato'
@@ -20,6 +20,7 @@ import { useOppgaveUnderBehandling } from '~shared/hooks/useOppgaveUnderBehandli
 import { useInnloggetSaksbehandler } from '~components/behandling/useInnloggetSaksbehandler'
 import { SakTypeTag } from '~shared/tags/SakTypeTag'
 import { RedigerMottattDato } from '~components/klage/sidemeny/RedigerMottattDato'
+import { Info } from '~components/behandling/soeknadsoversikt/Info'
 
 export function KlageSidemeny() {
   const klage = useKlage()
@@ -51,23 +52,17 @@ export function KlageSidemeny() {
   return (
     <Sidebar>
       <SidebarPanel $border>
-        <Heading size="small">Klage</Heading>
-        <Heading size="xsmall" spacing>
-          {teksterKlagestatus[klage.status]}
-        </Heading>
-
-        {klage.kabalStatus && (
-          <>
-            <Heading size="small">Status Kabal</Heading>
-            <Heading size="xsmall">{teksterKabalstatus[klage.kabalStatus]}</Heading>
-          </>
-        )}
-
+        <HStack width="100%">
+          <Heading size="small">Klage</Heading>
+        </HStack>
         <VStack gap="2">
-          <div>
-            <SakTypeTag sakType={klage.sak.sakType} />
-          </div>
+          <BodyShort>{teksterKlagestatus[klage.status]}</BodyShort>
 
+          {klage.kabalStatus && <Info label="Status Kabal" tekst={teksterKabalstatus[klage.kabalStatus]} />}
+
+          <Box>
+            <SakTypeTag sakType={klage.sak.sakType}></SakTypeTag>
+          </Box>
           <HStack gap="4">
             <div>
               <Label size="small">Klager</Label>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/InitiellVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/InitiellVurdering.tsx
@@ -129,11 +129,11 @@ export const InitiellVurdering = (props: { klage: Klage }) => {
         {klage.initieltUtfall?.utfallMedBegrunnelse?.utfall === Utfall.STADFESTE_VEDTAK && !klage.utfall && (
           <Alert variant="info">
             <Heading level="2" size="small">
-              Du må sende brev til klager
+              Informer om saksbehandlingstid
             </Heading>
             <BodyLong spacing>
-              Siden vurderingen er satt til {teksterKlageutfall[Utfall.STADFESTE_VEDTAK]} må du opprette et manuelt
-              kvitteringsbrev til klager for å opplyse om saksbehandlingstid.
+              Siden vurderingen er satt til &quot;{teksterKlageutfall[Utfall.STADFESTE_VEDTAK].toLowerCase()}&quot; må
+              du manuelt informere klager om saksbehandlingstid hvis den går ut over 4 uker.
             </BodyLong>
             <ButtonNavigerTilBrev klage={klage} />
           </Alert>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/InitiellVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/InitiellVurdering.tsx
@@ -79,7 +79,7 @@ export const InitiellVurdering = (props: { klage: Klage }) => {
       <>
         {redigeres ? (
           <form onSubmit={handleSubmit(lagreInitieltUtfall)}>
-            <VStack gap="4" width="30rem">
+            <VStack gap="4" width="41.5rem">
               <ControlledRadioGruppe
                 name="utfall"
                 control={control}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/KlageVurderingFelles.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/KlageVurderingFelles.tsx
@@ -9,14 +9,14 @@ import React, { useRef, useState } from 'react'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { hentBrev } from '~shared/api/brev'
 import { isFailure, isInitial, mapResult } from '~shared/api/apiUtils'
-import { Alert, BodyShort, Button, Heading, Modal } from '@navikt/ds-react'
+import { Alert, BodyShort, Box, Button, Heading, HStack, Modal, VStack } from '@navikt/ds-react'
 import Spinner from '~shared/Spinner'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import ForhaandsvisningBrev, { PdfViewer } from '~components/behandling/brev/ForhaandsvisningBrev'
 import styled from 'styled-components'
 import { useKlage } from '~components/klage/useKlage'
 import { forhaandsvisBlankettKa } from '~shared/api/klage'
-import { EnvelopeClosedIcon } from '@navikt/aksel-icons'
+import { EnvelopeClosedIcon, EyeIcon } from '@navikt/aksel-icons'
 import { PersonButtonLink } from '~components/person/lenker/PersonButtonLink'
 import { PersonOversiktFane } from '~components/person/Person'
 import { TekstMedMellomrom } from '~shared/TekstMedMellomrom'
@@ -60,59 +60,64 @@ export function VisInnstilling(props: { innstilling: InnstillingTilKabal; sakId:
 
   return (
     <Maksbredde>
-      <Heading size="small" level="3">
-        Innstilling til KA
-      </Heading>
-      <BodyShort spacing>
-        Vedtak opprettholdes med følgende hovedhjemmel: <strong>{TEKSTER_LOVHJEMLER[innstilling.lovhjemmel]}.</strong>
-      </BodyShort>
-      <Heading size="xsmall" level="4">
-        Innstillingstekst:
-      </Heading>
-      <TekstMedMellomrom spacing>{innstilling.innstillingTekst}</TekstMedMellomrom>
-      <Heading size="xsmall" level="4">
-        Intern kommentar:
-      </Heading>
-      <TekstMedMellomrom spacing>{innstilling.internKommentar || 'Ikke registrert'}</TekstMedMellomrom>
+      <VStack gap="6">
+        <Box>
+          <Heading size="small" level="3">
+            Innstilling til KA
+          </Heading>
+          <BodyShort>
+            Vedtak opprettholdes med følgende hovedhjemmel:{' '}
+            <strong>{TEKSTER_LOVHJEMLER[innstilling.lovhjemmel]}.</strong>
+          </BodyShort>
+        </Box>
+        <Box>
+          <Heading size="xsmall" level="4">
+            Innstillingstekst:
+          </Heading>
+          <TekstMedMellomrom>{innstilling.innstillingTekst}</TekstMedMellomrom>
+        </Box>
+        <Box>
+          <Heading size="xsmall" level="4">
+            Intern kommentar:
+          </Heading>
+          <TekstMedMellomrom>{innstilling.internKommentar || 'Ikke registrert'}</TekstMedMellomrom>
+        </Box>
+        <HStack gap="2">
+          <Button icon={<EyeIcon />} size="small" variant="secondary" onClick={visOversendelseModal}>
+            Oversendelsesbrev til klager
+          </Button>
+          <Button icon={<EyeIcon />} size="small" variant="secondary" onClick={visBlankettModal}>
+            Innstillingsbrev til KA
+          </Button>
+        </HStack>
 
-      <BodyShort spacing>
-        <Button size="small" variant="primary" onClick={visOversendelseModal}>
-          Se innstillingsbrevet
-        </Button>
-      </BodyShort>
+        {kanRedigere && (
+          <Alert variant="info">
+            Når klagen ferdigstilles vil oversendelsesbrevet bli sendt til klager, og klagen blir videresendt for
+            behandling i klageinstans.
+          </Alert>
+        )}
 
-      <BodyShort spacing>
-        <Button size="small" variant="primary" onClick={visBlankettModal}>
-          Se blankett til KA
-        </Button>
-      </BodyShort>
+        <Modal width="medium" ref={oversendelseRef} header={{ heading: 'Oversendelsesbrev til klager' }}>
+          <Modal.Body>
+            {mapResult(oversendelseBrev, {
+              pending: <Spinner label="Laster brevet" />,
+              success: (hentetBrev) => <ForhaandsvisningBrev brev={hentetBrev} />,
+              error: <ApiErrorAlert>Kunne ikke hente brevet, prøv å laste siden på nytt.</ApiErrorAlert>,
+            })}
+          </Modal.Body>
+        </Modal>
 
-      {kanRedigere && (
-        <Alert variant="info">
-          Når klagen ferdigstilles vil innstillingsbrevet bli sendt til mottaker, og klagen blir videresendt for
-          behandling av KA.
-        </Alert>
-      )}
-
-      <Modal width="medium" ref={oversendelseRef} header={{ heading: 'Innstillingsbrev' }}>
-        <Modal.Body>
-          {mapResult(oversendelseBrev, {
-            pending: <Spinner label="Laster brevet" />,
-            success: (hentetBrev) => <ForhaandsvisningBrev brev={hentetBrev} />,
-            error: <ApiErrorAlert>Kunne ikke hente brevet, prøv å laste siden på nytt.</ApiErrorAlert>,
-          })}
-        </Modal.Body>
-      </Modal>
-
-      <Modal width="medium" ref={blankettRef} header={{ heading: 'Blankett til KA' }}>
-        <Modal.Body>
-          {mapResult(forhaandsvisningBlankett, {
-            pending: <Spinner label="Henter pdf" />,
-            success: () => (blankettFileUrl ? <PdfViewer src={`${blankettFileUrl}#toolbar=0`} /> : null),
-            error: <ApiErrorAlert>Kunne ikke forhåndsvise blanketten. Prøv å laste siden på nytt</ApiErrorAlert>,
-          })}
-        </Modal.Body>
-      </Modal>
+        <Modal width="medium" ref={blankettRef} header={{ heading: 'Innstillingsbrev til KA' }}>
+          <Modal.Body>
+            {mapResult(forhaandsvisningBlankett, {
+              pending: <Spinner label="Henter pdf" />,
+              success: () => (blankettFileUrl ? <PdfViewer src={`${blankettFileUrl}#toolbar=0`} /> : null),
+              error: <ApiErrorAlert>Kunne ikke forhåndsvise blanketten. Prøv å laste siden på nytt</ApiErrorAlert>,
+            })}
+          </Modal.Body>
+        </Modal>
+      </VStack>
     </Maksbredde>
   )
 }
@@ -122,20 +127,25 @@ export function VisOmgjoering(props: { omgjoering: Omgjoering; kanRedigere: bool
 
   return (
     <Maksbredde>
-      <Heading size="small" level="3">
-        Omgjøring
-      </Heading>
-      <BodyShort spacing as="div">
-        Vedtaket omgjøres på grunn av <strong>{TEKSTER_AARSAK_OMGJOERING[omgjoering.grunnForOmgjoering]}.</strong>
-      </BodyShort>
-      <BodyShort>
-        <strong>Begrunnelse:</strong>
-      </BodyShort>
-      <TekstMedMellomrom spacing>{omgjoering.begrunnelse}</TekstMedMellomrom>
-
-      {kanRedigere && (
-        <Alert variant="info">Når klagen ferdigstilles vil det opprettes en oppgave for omgjøring av vedtaket.</Alert>
-      )}
+      <VStack gap="6">
+        <Box>
+          <Heading size="small" level="3">
+            Omgjøring
+          </Heading>
+          <BodyShort>
+            Vedtaket omgjøres på grunn av <strong>{TEKSTER_AARSAK_OMGJOERING[omgjoering.grunnForOmgjoering]}.</strong>
+          </BodyShort>
+        </Box>
+        <Box>
+          <Heading size="xsmall" level="4">
+            Begrunnelse:
+          </Heading>
+          <TekstMedMellomrom>{omgjoering.begrunnelse}</TekstMedMellomrom>
+        </Box>
+        {kanRedigere && (
+          <Alert variant="info">Når klagen ferdigstilles vil det opprettes en oppgave for omgjøring av vedtaket.</Alert>
+        )}
+      </VStack>
     </Maksbredde>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/components/KlageInnstilling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/components/KlageInnstilling.tsx
@@ -4,7 +4,7 @@ import { FormdataVurdering } from '~components/klage/vurdering/EndeligVurdering'
 import { useKlage } from '~components/klage/useKlage'
 import { SakType } from '~shared/types/sak'
 import { LOVHJEMLER_BP, LOVHJEMLER_OMS, TEKSTER_LOVHJEMLER } from '~shared/types/Klage'
-import { ErrorMessage, Heading, Select, Textarea, VStack } from '@navikt/ds-react'
+import { Box, ErrorMessage, Heading, Select, Textarea, VStack } from '@navikt/ds-react'
 
 export const KlageInnstilling = ({
   register,
@@ -17,28 +17,30 @@ export const KlageInnstilling = ({
   const aktuelleHjemler = klage?.sak.sakType === SakType.BARNEPENSJON ? LOVHJEMLER_BP : LOVHJEMLER_OMS
 
   return (
-    <VStack gap="4" width="30rem">
+    <VStack gap="4" width="41.5rem">
       <Heading level="3" size="medium">
         Innstilling til KA
       </Heading>
 
-      <Select
-        {...register('innstilling.lovhjemmel', {
-          required: true,
-        })}
-        label="Hjemmel"
-        description="Velg hvilken hjemmel klagen knytter seg til"
-      >
-        <option value="">Velg hjemmel</option>
-        {aktuelleHjemler.map((hjemmel) => (
-          <option key={hjemmel} value={hjemmel}>
-            {TEKSTER_LOVHJEMLER[hjemmel]}
-          </option>
-        ))}
-      </Select>
-      {errors.innstilling?.lovhjemmel && (
-        <ErrorMessage>Du må angi hjemmelen klagen hovedsakelig knytter seg til.</ErrorMessage>
-      )}
+      <Box width="fit-content">
+        <Select
+          {...register('innstilling.lovhjemmel', {
+            required: true,
+          })}
+          label="Hjemmel"
+          description="Velg hvilken hjemmel klagen knytter seg til"
+        >
+          <option value="">Velg hjemmel</option>
+          {aktuelleHjemler.map((hjemmel) => (
+            <option key={hjemmel} value={hjemmel}>
+              {TEKSTER_LOVHJEMLER[hjemmel]}
+            </option>
+          ))}
+        </Select>
+        {errors.innstilling?.lovhjemmel && (
+          <ErrorMessage>Du må angi hjemmelen klagen hovedsakelig knytter seg til.</ErrorMessage>
+        )}
+      </Box>
 
       <Textarea
         {...register('innstilling.innstillingTekst', {
@@ -54,7 +56,7 @@ export const KlageInnstilling = ({
 
       <Textarea
         {...register('innstilling.internKommentar')}
-        label="Intern kommentar til KA"
+        label="Intern kommentar til KA (valgfri)"
         description="Kommentaren blir ikke synlig for bruker"
       />
     </VStack>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/components/KlageOmgjoering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/klage/vurdering/components/KlageOmgjoering.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { FieldErrors, UseFormRegister } from 'react-hook-form'
 import { FormdataVurdering } from '~components/klage/vurdering/EndeligVurdering'
-import { Heading, Select, Textarea, VStack } from '@navikt/ds-react'
+import { Box, Heading, Select, Textarea, VStack } from '@navikt/ds-react'
 import { AARSAKER_OMGJOERING, TEKSTER_AARSAK_OMGJOERING } from '~shared/types/Klage'
 
 export const KlageOmgjoering = ({
@@ -12,28 +12,30 @@ export const KlageOmgjoering = ({
   errors: FieldErrors<FormdataVurdering>
 }) => {
   return (
-    <VStack gap="4" width="30rem">
+    <VStack gap="4" width="41.5rem">
       <Heading level="3" size="medium">
         Omgjøring
       </Heading>
 
-      <Select
-        label="Hvorfor skal saken omgjøres?"
-        error={errors.omgjoering?.grunnForOmgjoering?.message}
-        {...register('omgjoering.grunnForOmgjoering', {
-          required: {
-            value: true,
-            message: 'Du må velge en årsak for omgjøringen.',
-          },
-        })}
-      >
-        <option value="">Velg grunn</option>
-        {AARSAKER_OMGJOERING.map((aarsak) => (
-          <option key={aarsak} value={aarsak}>
-            {TEKSTER_AARSAK_OMGJOERING[aarsak]}
-          </option>
-        ))}
-      </Select>
+      <Box maxWidth="fit-content">
+        <Select
+          label="Hvorfor skal saken omgjøres?"
+          error={errors.omgjoering?.grunnForOmgjoering?.message}
+          {...register('omgjoering.grunnForOmgjoering', {
+            required: {
+              value: true,
+              message: 'Du må velge en årsak for omgjøringen.',
+            },
+          })}
+        >
+          <option value="">Velg grunn</option>
+          {AARSAKER_OMGJOERING.map((aarsak) => (
+            <option key={aarsak} value={aarsak}>
+              {TEKSTER_AARSAK_OMGJOERING[aarsak]}
+            </option>
+          ))}
+        </Select>
+      </Box>
 
       <Textarea
         label="Begrunnelse"

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrevModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/NyttBrevModal.tsx
@@ -88,18 +88,18 @@ const SoeknadMottattDato = ({ control }: { control: Control<FilledFormData, any>
 const VedtakDato = ({ control }: { control: Control<FilledFormData, any> }) => (
   <ControlledDatoVelger
     name="datoForVedtak"
-    label="Når ble vedtaken gjort"
+    label="Når ble vedtaket gjort?"
     control={control}
-    errorVedTomInput="Du må velge når vedtaksdatoen er"
+    errorVedTomInput="Du må velge dato for vedtaket"
   />
 )
 
 const KlageMotattDato = ({ control }: { control: Control<FilledFormData, any> }) => (
   <ControlledDatoVelger
     name="datoMottatKlage"
-    label="Når ble søknaden mottatt?"
+    label="Når ble klagen mottatt?"
     control={control}
-    errorVedTomInput="Du må velge når søknaden ble mottatt"
+    errorVedTomInput="Du må velge når klagen ble mottatt"
   />
 )
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/oppretteklage/OppsummeringKlagebehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/oppretteklage/OppsummeringKlagebehandling.tsx
@@ -1,6 +1,6 @@
 import { useJournalfoeringOppgave } from '~components/person/journalfoeringsoppgave/useJournalfoeringOppgave'
 import { Navigate, useNavigate } from 'react-router-dom'
-import { Alert, Button, Heading, HStack, Tag, VStack } from '@navikt/ds-react'
+import { Button, Heading, HStack, Tag, VStack } from '@navikt/ds-react'
 import { FormWrapper } from '~components/person/journalfoeringsoppgave/BehandleJournalfoeringOppgave'
 import { Info } from '~components/behandling/soeknadsoversikt/Info'
 import AvbrytBehandleJournalfoeringOppgave from '~components/person/journalfoeringsoppgave/AvbrytBehandleJournalfoeringOppgave'
@@ -45,12 +45,6 @@ export default function OppsummeringKlagebehandling() {
 
       <VStack gap="4">
         <Info label="Klage framsatt dato" tekst={formaterDato(mottattDato)} />
-
-        <Alert variant="warning">
-          {/* TODO: støtte for at vi bare sender ut et strukturert kvitteringsbrev når klagen opprettes */}
-          Etter at klagebehandlingen er opprettet må du sende ut et kvitteringsbrev til den som har sendt inn klagen
-          manuelt.
-        </Alert>
       </VStack>
       <div>
         <HStack gap="4" justify="center">


### PR DESCRIPTION
Diverse enkle småfikser og justeringer i klage-frontend

* Når ble vedtaken mottatt - skriveleif
* Gul alert, ta bort ved første steg (fra journalføringsflyt)
* I blå alert: Legg til kanskje - Du må kanskje sende brev til klager / eller presisere teksten 
* ønske om mellomlagring/ha lagreknapp
* Tekstboksene for smale 
* Se innstillingsbrevet og se blankett til KA, ha øye ikon/forhåndsvis 
* Intern kommentar, ha mer luft og større overskrift, nå flyter de sammen.
* Endre fra blankett, til "se innstillingsbrev til KA" 
* I høyresiden, bold headings begge steder, ser rart ut. Gjør brødtekst til regular.
* I alert skift fra av ka til "i klageinntans)