### PR TITLE
EY-4738 Fjerner siste rest av check/require

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageService.kt
@@ -33,6 +33,7 @@ import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.klage.AarsakTilAvbrytelse
 import no.nav.etterlatte.libs.common.klage.KlageHendelseType
@@ -482,7 +483,7 @@ class KlageServiceImpl(
 
         sjekkAtSaksbehandlerHarOppgaven(klageId, saksbehandler, "attestere vedtak")
 
-        checkNotNull(klage.utfall as? KlageUtfallMedData.Avvist) {
+        krevIkkeNull(klage.utfall as? KlageUtfallMedData.Avvist) {
             "Vi har en klage som kunne attesteres, men har feil utfall lagret. Id: $klageId"
         }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -27,6 +27,7 @@ import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
@@ -216,7 +217,7 @@ class RevurderingService(
                         } else {
                             grunnlagService.laasTilGrunnlagIBehandling(
                                 it,
-                                checkNotNull(forrigeBehandling.id) {
+                                krevIkkeNull(forrigeBehandling.id) {
                                     "Har en automatisk behandling som ikke sender med behandlingId for sist iverksatt. " +
                                         "Da kan vi ikke legge inn riktig grunnlag. Automatisk behandling id=${it.id}"
                                 },

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -359,7 +359,7 @@ class OppgaveService(
         merknad: String? = null,
     ): OppgaveIntern {
         val oppgave =
-            checkNotNull(oppgaveDao.hentOppgave(id)) {
+            krevIkkeNull(oppgaveDao.hentOppgave(id)) {
                 "Oppgave med id=$id finnes ikke – avbryter ferdigstilling av oppgaven"
             }
         ferdigstillOppgave(oppgave, saksbehandler, merknad)
@@ -530,7 +530,7 @@ class OppgaveService(
                     .hentOppgaverForReferanse(referanse)
                     .singleOrNull { !it.erAvsluttet() }
 
-            checkNotNull(oppgaveUnderbehandling) {
+            krevIkkeNull(oppgaveUnderbehandling) {
                 "Fant ingen oppgave under behandling med referanse=$referanse"
             }
 

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregningRepository.kt
@@ -12,6 +12,7 @@ import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
 import no.nav.etterlatte.libs.common.beregning.Beregningstype
 import no.nav.etterlatte.libs.common.beregning.OverstyrtBeregningKategori
 import no.nav.etterlatte.libs.common.feilhaandtering.krev
+import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.Metadata
 import no.nav.etterlatte.libs.common.objectMapper
@@ -101,8 +102,8 @@ class BeregningRepository(
         if (overstyrBeregning.status == OverstyrBeregningStatus.IKKE_AKTIV) {
             return null
         }
-        return checkNotNull(hentOverstyrBeregning(overstyrBeregning.sakId)) {
-            "Vi opprettet en overstyrt beregning på sakId=${overstyrBeregning.sakId} akkurat nå men den finnes ikke >:("
+        return krevIkkeNull(hentOverstyrBeregning(overstyrBeregning.sakId)) {
+            "Vi opprettet en overstyrt beregning på sakId=${overstyrBeregning.sakId} akkurat nå men den finnes ikke"
         }
     }
 

--- a/apps/etterlatte-beregning/src/main/kotlin/sanksjon/SanksjonService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/sanksjon/SanksjonService.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
 import java.time.YearMonth
@@ -189,7 +190,7 @@ class SanksjonService(
         }
 
         val virkningstidspunkt =
-            checkNotNull(behandling.virkningstidspunkt) {
+            krevIkkeNull(behandling.virkningstidspunkt) {
                 "Behandling (id=$behandlingId) man prøver å slette sanksjon (id=$sanksjonId) i har ikke virkningstidspunkt"
             }.dato
         if (sanksjonSomSkalSlettes.fom < virkningstidspunkt) {

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationContext.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationContext.kt
@@ -68,6 +68,7 @@ import no.nav.etterlatte.brev.virusskanning.ClamAvClient
 import no.nav.etterlatte.brev.virusskanning.VirusScanService
 import no.nav.etterlatte.libs.common.EnvEnum
 import no.nav.etterlatte.libs.common.Miljoevariabler
+import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.database.DataSourceBuilder
 import no.nav.etterlatte.libs.ktor.AzureEnums.AZURE_APP_OUTBOUND_SCOPE
@@ -237,7 +238,11 @@ internal class ApplicationContext {
                 it.install(Auth) {
                     clientCredential {
                         config =
-                            env.append(AZURE_APP_OUTBOUND_SCOPE) { requireNotNull(it.get(scope)) }
+                            env.append(AZURE_APP_OUTBOUND_SCOPE) { variabler ->
+                                krevIkkeNull(variabler[scope]) {
+                                    "Mangler outbound scope"
+                                }
+                            }
                     }
                 }
                 it.install(HttpTimeout)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/distribusjon/DistribusjonService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/distribusjon/DistribusjonService.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.brev.distribusjon
 
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.brev.model.Mottaker
+import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.Fagsaksystem
 import no.nav.etterlatte.brev.distribusjon.Adresse as DistAdresse
@@ -27,7 +28,10 @@ internal class DistribusjonServiceImpl(
         runBlocking {
             val request =
                 DistribuerJournalpostRequest(
-                    journalpostId = checkNotNull(mottaker.journalpostId) { "JournalpostID mangler på mottaker=${mottaker.id}" },
+                    journalpostId =
+                        krevIkkeNull(mottaker.journalpostId) {
+                            "JournalpostID mangler på mottaker=${mottaker.id}"
+                        },
                     bestillendeFagsystem = Fagsaksystem.EY.navn,
                     distribusjonstype = type,
                     adresse =

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/beregning/BeregningService.kt
@@ -124,7 +124,7 @@ class BeregningService(
         vedtakType: VedtakType,
         brukerTokenInfo: BrukerTokenInfo,
     ): Avkortingsinfo =
-        checkNotNull(
+        krevIkkeNull(
             finnAvkortingsinfoNullable(
                 behandlingId,
                 sakType,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonBeregning.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonBeregning.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.brev.model.erYrkesskade
 import no.nav.etterlatte.brev.model.fromDto
 import no.nav.etterlatte.grunnbeloep.Grunnbeloep
 import no.nav.etterlatte.libs.common.beregning.BeregningsMetode
+import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.common.trygdetid.TrygdetidDto
 import no.nav.etterlatte.libs.common.trygdetid.UKJENT_AVDOED
 import no.nav.etterlatte.sikkerLogg
@@ -130,18 +131,18 @@ fun finnForskjelligTrygdetid(
 
     // Hvis vi har anvendt forskjellige trygdetider over beregningen må vi ha forskjeller i avdøde
     val forskjelligAvdoedPeriode =
-        checkNotNull(finnEventuellForskjelligAvdoedPeriode(avdoede, utbetalingsinfo)) {
+        krevIkkeNull(finnEventuellForskjelligAvdoedPeriode(avdoede, utbetalingsinfo)) {
             "Vi har anvendt forskjellige trygdetider, men vi har ikke forskjellige perioder for hvilke" +
                 "avdøde vi har brukt i beregningen. Dette bør ikke være mulig. " +
                 "BehandlingId=$behandlingId"
         }
 
     val trygdetidForFoersteAvdoed =
-        checkNotNull(trygdetid.find { it.ident == forskjelligAvdoedPeriode.foersteAvdoed.fnr.value }) {
+        krevIkkeNull(trygdetid.find { it.ident == forskjelligAvdoedPeriode.foersteAvdoed.fnr.value }) {
             "Fant ikke trygdetiden som er brukt i første beregningsperiode i behandlingId=$behandlingId"
         }
     val trygdetidBruktSenere =
-        checkNotNull(trygdetid.find { it.ident == sisteBeregningsperiode.trygdetidForIdent }) {
+        krevIkkeNull(trygdetid.find { it.ident == sisteBeregningsperiode.trygdetidForIdent }) {
             "Fant ikke trygdetiden som er brukt i siste beregningsperiode i behandlingId=$behandlingId"
         }
 

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NotatRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NotatRepository.kt
@@ -8,6 +8,7 @@ import kotliquery.using
 import no.nav.etterlatte.brev.Slate
 import no.nav.etterlatte.brev.model.OpprettJournalpostResponse
 import no.nav.etterlatte.libs.common.deserialize
+import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toTimestamp
@@ -146,7 +147,7 @@ class NotatRepository(
                     ).asUpdateAndReturnGeneratedKey,
                 )
 
-            checkNotNull(id) { "Kunne ikke lagre notat i databasen!" }
+            krevIkkeNull(id) { "Kunne ikke lagre notat i databasen!" }
 
             tx.lagreHendelse(id, notat.toJson(), bruker)
 
@@ -168,7 +169,7 @@ class NotatRepository(
                     ),
                 ).asUpdate,
             ).also { oppdatert ->
-                checkNotNull(oppdatert == 1) { "Kunne ikke lagre tittel! for id $id" }
+                krevIkkeNull(oppdatert == 1) { "Kunne ikke lagre tittel! for id $id" }
             }
 
         tx.lagreHendelse(id, tittel.toJson(), bruker)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NotatRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/notat/NotatRoute.kt
@@ -102,7 +102,10 @@ fun Route.notatRoute(
 
         route("/referanse/{referanse}") {
             get {
-                val referanse = checkNotNull(call.parameters["referanse"])
+                val referanse =
+                    krevIkkeNull(call.parameters["referanse"]) {
+                        "Kan ikke hente notat uten referanse"
+                    }
 
                 val notater = nyNotatService.hentForReferanse(referanse)
                 call.respond(notater)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/oversendelsebrev/OversendelseBrevService.kt
@@ -198,7 +198,10 @@ class OversendelseBrevServiceImpl(
                     "siden det har feil brevtype",
             )
         }
-        val behandlingId = checkNotNull(brev.behandlingId)
+        val behandlingId =
+            krevIkkeNull(brev.behandlingId) {
+                "Brev ${brev.id} mangler behandlingId"
+            }
 
         val klage =
             runBlocking {
@@ -271,7 +274,7 @@ data class OversendelseBrevFerdigstillingData(
                 sakType = request.sakType,
                 klageDato = klage.innkommendeDokument?.mottattDato ?: klage.opprettet.toLocalDate(),
                 vedtakDato =
-                    checkNotNull(
+                    krevIkkeNull(
                         klage.formkrav
                             ?.formkrav
                             ?.vedtaketKlagenGjelder

--- a/apps/etterlatte-gyldig-soeknad/src/main/kotlin/no/nav/etterlatte/gyldigsoeknad/PersongalleriMapper.kt
+++ b/apps/etterlatte-gyldig-soeknad/src/main/kotlin/no/nav/etterlatte/gyldigsoeknad/PersongalleriMapper.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.gyldigsoeknad
 
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
+import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.common.innsendtsoeknad.barnepensjon.Barnepensjon
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.InnsendtSoeknad
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.PersonType
@@ -43,7 +44,7 @@ object PersongalleriMapper {
         logger.info("Hent persongalleri fra søknad")
 
         val soekerFnr =
-            checkNotNull(
+            krevIkkeNull(
                 soeknad.soeker.foedselsnummer
                     ?.svar
                     ?.value,

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/egendefinert/EgendefinertMeldingFeature.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/egendefinert/EgendefinertMeldingFeature.kt
@@ -10,6 +10,7 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import no.nav.etterlatte.TestDataFeature
+import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.ktor.token.brukerTokenInfo
 import no.nav.etterlatte.logger
@@ -46,14 +47,14 @@ object EgendefinertMeldingFeature : TestDataFeature {
                 kunEtterlatteUtvikling {
                     try {
                         val navIdent =
-                            requireNotNull(brukerTokenInfo.ident()) {
+                            krevIkkeNull(brukerTokenInfo.ident()) {
                                 "Nav ident mangler. Du må være innlogget for å sende søknad."
                             }
 
                         val params = call.receiveParameters()
-                        val key = requireNotNull(params["key"])
-                        val hendelseType = requireNotNull(params["hendelseType"])
-                        val json = requireNotNull(params["json"])
+                        val key = krevIkkeNull(params["key"]) { "Parameter key mangler" }
+                        val hendelseType = krevIkkeNull(params["hendelseType"]) { "Parameter hendelseType mangler" }
+                        val json = krevIkkeNull(params["json"]) { "Parameter json mangler" }
 
                         if (hendelseType == "omregning") {
                             val jsonNode = objectMapper.readTree(json)

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -328,7 +328,7 @@ class TrygdetidServiceImpl(
             avdoede
                 .map { avdoed ->
                     val fnr =
-                        requireNotNull(avdoed.hentFoedselsnummer()?.verdi?.value) {
+                        krevIkkeNull(avdoed.hentFoedselsnummer()?.verdi?.value) {
                             "Kunne ikke hente identifikator for avdød til trygdetid i " +
                                 "behandlingen med id=$behandlingId"
                         }
@@ -375,7 +375,7 @@ class TrygdetidServiceImpl(
         return avdoede
             .map { avdoed ->
                 val fnr =
-                    requireNotNull(avdoed.hentFoedselsnummer()?.verdi?.value) {
+                    krevIkkeNull(avdoed.hentFoedselsnummer()?.verdi?.value) {
                         "Kunne ikke hente identifikator for avdød til trygdetid i " +
                             "behandlingen med id=$behandlingId"
                     }

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/AppBuilder.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/AppBuilder.kt
@@ -12,6 +12,7 @@ import no.nav.etterlatte.funksjonsbrytere.FeatureToggleProperties
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.libs.common.EnvEnum
 import no.nav.etterlatte.libs.common.Miljoevariabler
+import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.ktor.AzureEnums.AZURE_APP_CLIENT_ID
 import no.nav.etterlatte.libs.ktor.AzureEnums.AZURE_APP_JWK
 import no.nav.etterlatte.libs.ktor.AzureEnums.AZURE_APP_WELL_KNOWN_URL
@@ -26,9 +27,9 @@ import no.nav.etterlatte.regulering.VedtakKafkaKey.ETTERLATTE_VEDTAK_URL
 class AppBuilder(
     props: Miljoevariabler,
 ) {
-    private val vedtakUrl = requireNotNull(props[ETTERLATTE_VEDTAK_URL]) { "Mangler vedtak url " }
-    private val utbetalingUrl = requireNotNull(props[ETTERLATTE_UTBETALING_URL]) { "Mangler utbetaling url " }
-    private val brevUrl = requireNotNull(props[ETTERLATTE_BREV_API_URL]) { "Mangler brev-api url " }
+    private val vedtakUrl = krevIkkeNull(props[ETTERLATTE_VEDTAK_URL]) { "Mangler vedtak url " }
+    private val utbetalingUrl = krevIkkeNull(props[ETTERLATTE_UTBETALING_URL]) { "Mangler utbetaling url " }
+    private val brevUrl = krevIkkeNull(props[ETTERLATTE_BREV_API_URL]) { "Mangler brev-api url " }
     private val env = Miljoevariabler.systemEnv()
 
     fun lagVedtakKlient(): VedtakServiceImpl = VedtakServiceImpl(vedtakHttpKlient, vedtakUrl)

--- a/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/AppBuilder.kt
+++ b/apps/etterlatte-vilkaarsvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/AppBuilder.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.vilkaarsvurdering
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
+import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 import no.nav.etterlatte.vilkaarsvurdering.services.VilkaarsvurderingServiceImpl
 
@@ -14,7 +15,10 @@ class AppBuilder {
             azureAppWellKnownUrl = config.getString("azure.app.well.known.url"),
             azureAppScope = config.getString("behandling.azure.scope"),
         )
-    private val vilkaarsvurderingUrl = requireNotNull(config.getString("behandling.resource.url"))
+    private val vilkaarsvurderingUrl =
+        krevIkkeNull(config.getString("behandling.resource.url")) {
+            "Mangler url for vilkårsvurdering"
+        }
 
     fun lagVilkaarsvurderingKlient(): VilkaarsvurderingServiceImpl =
         VilkaarsvurderingServiceImpl(vilkaarsvurderingHttpKlient, vilkaarsvurderingUrl)

--- a/libs/etterlatte-kafka/src/main/kotlin/kafka/JsonMessage.kt
+++ b/libs/etterlatte-kafka/src/main/kotlin/kafka/JsonMessage.kt
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.nav.etterlatte.libs.common.Miljoevariabler
 import no.nav.etterlatte.libs.common.NaisKey
 import no.nav.etterlatte.libs.common.NaisKey.NAIS_APP_NAME
+import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import java.net.InetAddress
@@ -103,7 +104,7 @@ open class JsonMessage(
     }
 
     operator fun get(key: String): JsonNode =
-        requireNotNull(recognizedKeys[key]) {
+        krevIkkeNull(recognizedKeys[key]) {
             "$key is unknown; keys must be declared as required, forbidden, or interesting"
         }
 

--- a/libs/saksbehandling-common/src/testFixtures/kotlin/etterlatte/pdl/PersonTestData.kt
+++ b/libs/saksbehandling-common/src/testFixtures/kotlin/etterlatte/pdl/PersonTestData.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.libs.testdata.pdl
 
 import com.fasterxml.jackson.databind.JsonNode
+import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.common.grunnlag.Opplysning
 import no.nav.etterlatte.libs.common.grunnlag.hentAdressebeskyttelse
 import no.nav.etterlatte.libs.common.grunnlag.hentAvdoedesbarn
@@ -27,7 +28,7 @@ fun personTestData(opplysningsmap: Map<Opplysningstype, Opplysning<JsonNode>>): 
         fornavn = opplysningsmap.hentNavn()?.verdi?.fornavn ?: "TEST",
         etternavn = opplysningsmap.hentNavn()?.verdi?.etternavn ?: "PERSON",
         foedselsnummer =
-            requireNotNull(opplysningsmap.hentFoedselsnummer()) {
+            krevIkkeNull(opplysningsmap.hentFoedselsnummer()) {
                 "Mangler opplysning fødselsnummer for en testperson"
             }.verdi,
         foedselsdato = opplysningsmap.hentFoedselsdato()?.verdi,


### PR DESCRIPTION
Bruker `krevIkkeNull` for å sikre at vi får error i loggene, tilsvarende hva `checkNotNull` har gjort til nå. 
Så kan vi filtrere ut det som bare er støy fortløpende. 