### PR TITLE
EY-4564: Legger til manglende regelverk i overstyrt beregning

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnOverstyrBeregningService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnOverstyrBeregningService.kt
@@ -13,6 +13,7 @@ import no.nav.etterlatte.beregning.regler.overstyr.grunnbeloep
 import no.nav.etterlatte.klienter.GrunnlagKlient
 import no.nav.etterlatte.klienter.VilkaarsvurderingKlient
 import no.nav.etterlatte.libs.common.IntBroek
+import no.nav.etterlatte.libs.common.Regelverk
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -248,6 +249,7 @@ class BeregnOverstyrBeregningService(
                                         .takeIf { broek != null }
                                         ?.toInt(),
                                 broek = broek,
+                                regelverk = Regelverk.fraDato(periodisertResultat.periode.fraDato),
                                 regelResultat = objectMapper.valueToTree(periodisertResultat),
                                 regelVersjon = periodisertResultat.reglerVersjon,
                                 kilde =

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnOverstyrServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnOverstyrServiceTest.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.beregning.regler.bruker
 import no.nav.etterlatte.klienter.GrunnlagKlientImpl
 import no.nav.etterlatte.klienter.VilkaarsvurderingKlient
 import no.nav.etterlatte.libs.common.IntBroek
+import no.nav.etterlatte.libs.common.Regelverk
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.SakType
@@ -124,6 +125,7 @@ internal class BeregnOverstyrServiceTest {
                     samletNorskTrygdetid shouldBe 20
                     samletTeoretiskTrygdetid shouldBe null
                     broek shouldBe null
+                    regelverk shouldBe Regelverk.REGELVERK_TOM_DES_2023
                     regelResultat shouldNotBe null
                     regelVersjon shouldNotBe null
                 }
@@ -206,6 +208,7 @@ internal class BeregnOverstyrServiceTest {
                     samletNorskTrygdetid shouldBe null
                     samletTeoretiskTrygdetid shouldBe 20
                     broek shouldBe IntBroek(10, 20)
+                    regelverk shouldBe Regelverk.REGELVERK_TOM_DES_2023
                     regelResultat shouldNotBe null
                     regelVersjon shouldNotBe null
                 }
@@ -295,6 +298,7 @@ internal class BeregnOverstyrServiceTest {
                     samletNorskTrygdetid shouldBe 20
                     samletTeoretiskTrygdetid shouldBe null
                     broek shouldBe null
+                    regelverk shouldBe Regelverk.REGELVERK_TOM_DES_2023
                     regelResultat shouldNotBe null
                     regelVersjon shouldNotBe null
                 }
@@ -384,6 +388,7 @@ internal class BeregnOverstyrServiceTest {
                     samletNorskTrygdetid shouldBe 0
                     samletTeoretiskTrygdetid shouldBe null
                     broek shouldBe null
+                    regelverk shouldBe Regelverk.REGELVERK_TOM_DES_2023
                     regelResultat shouldNotBe null
                     regelVersjon shouldNotBe null
                 }


### PR DESCRIPTION
Regelverk ble ikke satt i overstyrt beregning. Dette medførte ikke problemer da dette også blir utledet i utbetaling, men ønsker egentlig at utbetaling skal få inn dette parameteret uten å ha noen fallback hvis det er `null`. Fin start å få det riktig ved alle tilfeller fra beregning / vedtak.