### PR TITLE
Fjerne mer ubrukt kode fra rivers (EY-4942)

### DIFF
--- a/apps/etterlatte-gyldig-soeknad/src/main/kotlin/no/nav/etterlatte/gyldigsoeknad/NySoeknadRiver.kt
+++ b/apps/etterlatte-gyldig-soeknad/src/main/kotlin/no/nav/etterlatte/gyldigsoeknad/NySoeknadRiver.kt
@@ -47,7 +47,6 @@ internal class NySoeknadRiver(
             validate { it.requireKey(SoeknadInnsendt.lagretSoeknadIdKey) }
             validate { it.requireKey(SoeknadInnsendt.hendelseGyldigTilKey) }
             validate { it.requireKey(SoeknadInnsendt.fnrSoekerKey) }
-            validate { it.rejectKey(SoeknadInnsendt.adressebeskyttelseKey) }
             validate { it.rejectKey(SoeknadInnsendt.dokarkivReturKey) }
             validate { it.rejectKey(GyldigSoeknadVurdert.sakIdKey) }
             validate { it.rejectKey(FordelerFordelt.soeknadFordeltKey) }

--- a/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/no/nav/etterlatte/opplysningerfrasoknad/StartUthentingFraSoeknadRiver.kt
+++ b/apps/etterlatte-opplysninger-fra-soeknad/src/main/kotlin/no/nav/etterlatte/opplysningerfrasoknad/StartUthentingFraSoeknadRiver.kt
@@ -4,7 +4,6 @@ import no.nav.etterlatte.libs.common.event.GyldigSoeknadVurdert
 import no.nav.etterlatte.libs.common.event.SoeknadInnsendtHendelseType
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.SoeknadType
 import no.nav.etterlatte.libs.common.rapidsandrivers.CORRELATION_ID_KEY
-import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
 import no.nav.etterlatte.libs.common.rapidsandrivers.lagParMedEventNameKey
 import no.nav.etterlatte.opplysningerfrasoknad.opplysningsuthenter.Opplysningsuthenter
 import no.nav.etterlatte.rapidsandrivers.BEHANDLING_ID_KEY
@@ -27,13 +26,7 @@ internal class StartUthentingFraSoeknadRiver(
     private val rapid = rapidsConnection
 
     init {
-        initialiserRiverUtenEventName(rapidsConnection) {
-            validate {
-                it.demandAny(
-                    EVENT_NAME_KEY,
-                    SoeknadInnsendtHendelseType.entries.map { it.lagEventnameForType() },
-                )
-            }
+        initialiserRiver(rapidsConnection, SoeknadInnsendtHendelseType.EVENT_NAME_BEHANDLINGBEHOV) {
             validate { it.requireKey(GyldigSoeknadVurdert.skjemaInfoKey) }
             validate { it.requireKey(GyldigSoeknadVurdert.sakIdKey) }
             validate { it.requireKey(GyldigSoeknadVurdert.behandlingIdKey) }

--- a/apps/etterlatte-opplysninger-fra-soeknad/src/test/resources/melding.json
+++ b/apps/etterlatte-opplysninger-fra-soeknad/src/test/resources/melding.json
@@ -1,5 +1,5 @@
 {
-  "@event_name": "soeknad_innsendt",
+  "@event_name": "trenger_behandling",
   "behandlingId": "f525f2f7-e246-43d7-b61a-5f0757472916",
   "sakId": 1,
   "@skjema_info": {

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/soeknad/SoeknadMapper.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/soeknad/SoeknadMapper.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.testdata.features.soeknad
 
+import no.nav.etterlatte.libs.common.event.SoeknadInnsendt
 import no.nav.etterlatte.libs.common.event.SoeknadInnsendtHendelseType
 import no.nav.etterlatte.libs.common.innsendtsoeknad.ArbeidOgUtdanningOMS
 import no.nav.etterlatte.libs.common.innsendtsoeknad.ForholdTilAvdoedeOMS
@@ -49,16 +50,16 @@ object SoeknadMapper {
                 JsonMessage.newMessage(
                     mutableMapOf(
                         SoeknadInnsendtHendelseType.EVENT_NAME_BEHANDLINGBEHOV.lagParMedEventNameKey(),
-                        "@skjema_info" to
+                        SoeknadInnsendt.skjemaInfoKey to
                             opprettOmstillingsstoenadSoeknad(
                                 soekerFnr = soekerFnr,
                                 avdoedFnr = avdoedFnr,
                                 barn = barn,
                             ).toObjectNode(),
-                        "@lagret_soeknad_id" to "TEST-${UUID.randomUUID()}",
-                        "@template" to "soeknad",
-                        "@fnr_soeker" to soekerFnr,
-                        "@hendelse_gyldig_til" to OffsetDateTime.now().plusMinutes(60L),
+                        SoeknadInnsendt.lagretSoeknadIdKey to "TEST-${UUID.randomUUID()}",
+                        SoeknadInnsendt.templateKey to "soeknad",
+                        SoeknadInnsendt.fnrSoekerKey to soekerFnr,
+                        SoeknadInnsendt.hendelseGyldigTilKey to OffsetDateTime.now().plusMinutes(60L),
                         Behandlingssteg.KEY to behandlingssteg.name,
                     ),
                 )
@@ -69,17 +70,17 @@ object SoeknadMapper {
                 JsonMessage.newMessage(
                     mutableMapOf(
                         SoeknadInnsendtHendelseType.EVENT_NAME_BEHANDLINGBEHOV.lagParMedEventNameKey(),
-                        "@skjema_info" to
+                        SoeknadInnsendt.skjemaInfoKey to
                             opprettBarnepensjonSoeknad(
                                 gjenlevendeFnr = gjenlevendeFnr,
                                 avdoedFnr = avdoedFnr,
                                 barnFnr = soekerFnr,
                                 soesken = barn.filter { it != soeker },
                             ).toObjectNode(),
-                        "@lagret_soeknad_id" to "TEST-${UUID.randomUUID()}",
-                        "@template" to "soeknad",
-                        "@fnr_soeker" to barn.first(),
-                        "@hendelse_gyldig_til" to OffsetDateTime.now().plusMinutes(60L),
+                        SoeknadInnsendt.lagretSoeknadIdKey to "TEST-${UUID.randomUUID()}",
+                        SoeknadInnsendt.templateKey to "soeknad",
+                        SoeknadInnsendt.fnrSoekerKey to barn.first(),
+                        SoeknadInnsendt.hendelseGyldigTilKey to OffsetDateTime.now().plusMinutes(60L),
                         Behandlingssteg.KEY to behandlingssteg.name,
                     ),
                 )

--- a/libs/saksbehandling-common/src/main/kotlin/event/SoeknadInnsendt.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/event/SoeknadInnsendt.kt
@@ -6,7 +6,6 @@ interface ISoeknadInnsendt {
     val templateKey get() = "@template"
     val lagretSoeknadIdKey get() = "@lagret_soeknad_id"
     val hendelseGyldigTilKey get() = "@hendelse_gyldig_til"
-    val adressebeskyttelseKey get() = "@adressebeskyttelse"
     val fnrSoekerKey get() = "@fnr_soeker"
     val dokarkivReturKey get() = "@dokarkivRetur"
 }


### PR DESCRIPTION
- `GrunnlagHendelseRiver` har kun aktivt eventname. Bruker det direkte. 
- Fjerner `@adressebeskyttelse` siden det ikke lenger er i bruk
- Bruke constants for nøkler