### PR TITLE
Informerer om flere land i prorata i trygdetid

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/EnkelPersonTrygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/EnkelPersonTrygdetid.tsx
@@ -13,7 +13,7 @@ import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { useAppDispatch } from '~store/Store'
 import { oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'
 import { TrygdetidPerioder } from '~components/behandling/trygdetid/trygdetidPerioder/TrygdetidPerioder'
-import { VStack } from '@navikt/ds-react'
+import { Alert, Box, VStack } from '@navikt/ds-react'
 import { skalViseTrygdeavtale } from '~components/behandling/trygdetid/utils'
 import { AvdoedesTrygdetidReadMore } from '~components/behandling/trygdetid/components/AvdoedesTrygdetidReadMore'
 import { ILand } from '~utils/kodeverk'
@@ -26,6 +26,18 @@ interface Props {
   landListe: ILand[]
   fetchTrygdetider: (behandlingId: string) => void
   setTrygdetider: (trygdetider: ITrygdetid[]) => void
+}
+
+function harTrygdetidFlereForskjelligeProrataLand(trygdetid: ITrygdetid): boolean {
+  return (
+    new Set([
+      ...trygdetid.trygdetidGrunnlag
+        .filter(
+          (periode) => !!periode.prorata && periode.type === ITrygdetidGrunnlagType.FAKTISK && periode.bosted !== 'NOR'
+        )
+        .map((periode) => periode.bosted),
+    ]).size > 1
+  )
 }
 
 export const EnkelPersonTrygdetid = (props: Props) => {
@@ -92,6 +104,8 @@ export const EnkelPersonTrygdetid = (props: Props) => {
     )
   }
 
+  const flereLandProrata = !!trygdetid && harTrygdetidFlereForskjelligeProrataLand(trygdetid)
+
   return (
     <>
       {trygdetid && (
@@ -112,6 +126,18 @@ export const EnkelPersonTrygdetid = (props: Props) => {
             behandling={behandling}
             setTrygdetider={setTrygdetider}
           />
+
+          {flereLandProrata && (
+            <Box maxWidth="41.5rem">
+              {redigerbar ? (
+                <Alert variant="warning">
+                  Det er lagt inn flere land i prorata. Dobbeltsjekk at disse landene er med i samme trygdeavtale.
+                </Alert>
+              ) : (
+                <Alert variant="info">Det er lagt inn flere land i prorata.</Alert>
+              )}
+            </Box>
+          )}
 
           <TrygdetidPerioder
             trygdetid={trygdetid}


### PR DESCRIPTION
Viser advarsel til saksbehandler / info til attestant om at et trygdetidgrunnlag har flere forskjellige land med i prorata-beregningen.

Advarsel hvis redigerbar:
<img width="1070" alt="Screenshot 2025-01-22 at 14 05 01" src="https://github.com/user-attachments/assets/b12e933e-8cb2-42f4-8d38-269c553bd595" />

info hvis ikke redigerbar:
<img width="1112" alt="Screenshot 2025-01-22 at 14 05 08" src="https://github.com/user-attachments/assets/fc25b6a2-fbe8-4faf-820a-6e56c1ac5f82" />
