### PR TITLE
Vis advarsel om at dødsdato ikke er registrert ved setting av virk

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   BodyShort,
   ConfirmationPanel,
   ErrorMessage,
@@ -202,6 +203,10 @@ const Virkningstidspunkt = (props: {
               <Heading level="3" size="small">
                 Hva er virkningstidspunkt for behandlingen?
               </Heading>
+
+              {!foersteDoedsdato() && (
+                <Alert variant="warning">Det er anbefalt å registrere dødsdato før du setter virkningstidspunkt.</Alert>
+              )}
 
               {erBosattUtland && (
                 <DatoVelger


### PR DESCRIPTION
Forslag til advarsel hvis saksbehandler prøver å sette virk uten at det er registrert dødsdato. 
Tar gjerne tips til forbedring av tekst.
![Skjermbilde 2025-01-23 kl  12 06 40](https://github.com/user-attachments/assets/2b87adb7-cf13-45df-8f25-507a2dddaf35)
