### PR TITLE
Legger til manglende klassekode for bidragsforskudd

### DIFF
--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/iverksetting/utbetaling/Utbetaling.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/iverksetting/utbetaling/Utbetaling.kt
@@ -164,6 +164,7 @@ enum class OppdragKlassifikasjonskode(
     FRISSKAT("FRISSKAT"), // Frivillig skattetrekk
     BPSKSKAT("BPSKSKAT"), // Skattetrekk barnepensjon
     AVRGINTE("AVRGINTE"), // Avregning etteroppgjør
+    BIINNBETINTE("BIINNBETINTE"), // Innbetalt bidragsforskudd, trekk
     ;
 
     override fun toString(): String = oppdragVerdi
@@ -189,6 +190,7 @@ enum class OppdragKlassifikasjonskode(
                 "FRISSKAT" -> FRISSKAT
                 "BPSKSKAT" -> BPSKSKAT
                 "AVRGINTE" -> AVRGINTE
+                "BIINNBETINTE" -> BIINNBETINTE
                 else -> throw IllegalArgumentException("$string er ikke en støttet OppdragKlassifikasjonskode!")
             }
     }


### PR DESCRIPTION
Ser også på å gjøre en endring for å splitte bruken av klassifikasjonskode for utbetaling og simulering da disse stadig er tilbakevendende. Vi har ikke så stort behov for typing ved simulering slik det er lagt inn i koden nå.