### PR TITLE
EY-4972 - Fjerne ubrukt endepunkt fra etterlatte-api

### DIFF
--- a/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/behandling/sak/BehandlingSakRoutes.kt
+++ b/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/behandling/sak/BehandlingSakRoutes.kt
@@ -40,18 +40,6 @@ fun Route.behandlingSakRoutes(
     }
 
     route("api/sak") {
-        route("oms/har_sak") {
-            install(AuthorizationPlugin) {
-                accessPolicyRolesEllerAdGrupper = setOf("les-oms-sak")
-            }
-            post {
-                val foedselsnummer = call.receive<FoedselsnummerDTO>()
-                val saker = behandlingService.hentSakforPerson(foedselsnummer)
-
-                call.respond(HarOMSSakIGjenny(saker.isNotEmpty()))
-            }
-        }
-
         route("oms/har-loepende-sak") {
             install(AuthorizationPlugin) {
                 accessPolicyRolesEllerAdGrupper = setOf("les-oms-sak")


### PR DESCRIPTION
Nytt endepunkt for å sjekke om bruker har løpende saker brukes istedenfor, derfor kan dette fjernes