### PR TITLE
Miniendringer i ui

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/vurdering/unntak/LagreUnntakForm.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/vurdering/unntak/LagreUnntakForm.tsx
@@ -38,25 +38,27 @@ export const LagreUnntakForm = ({
   return (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit(sendInn)}>
-        <UnntakAktivitetsplikt vurderingType={vurderingType} erVarigUnntak={erVarigUnntak} />
-        <HStack gap="4">
-          {!!onAvbryt && (
-            <Button variant="secondary" onClick={onAvbryt}>
-              Avbryt
+        <VStack gap="4">
+          <UnntakAktivitetsplikt vurderingType={vurderingType} erVarigUnntak={erVarigUnntak} />
+          <HStack gap="4">
+            {!!onAvbryt && (
+              <Button variant="secondary" onClick={onAvbryt}>
+                Avbryt
+              </Button>
+            )}
+            <Button
+              variant="primary"
+              type="submit"
+              icon={<FloppydiskIcon aria-hidden />}
+              loading={isPending(lagreUnntakStatus)}
+            >
+              Lagre
             </Button>
+          </HStack>
+          {isFailure(lagreUnntakStatus) && (
+            <ApiErrorAlert>Kunne ikke lagre unntak: {lagreUnntakStatus.error.detail}</ApiErrorAlert>
           )}
-          <Button
-            variant="primary"
-            type="submit"
-            icon={<FloppydiskIcon aria-hidden />}
-            loading={isPending(lagreUnntakStatus)}
-          >
-            Lagre
-          </Button>
-        </HStack>
-        {isFailure(lagreUnntakStatus) && (
-          <ApiErrorAlert>Kunne ikke lagre unntak: {lagreUnntakStatus.error.detail}</ApiErrorAlert>
-        )}
+        </VStack>
       </form>
     </FormProvider>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/header/HeaderBanner.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/header/HeaderBanner.tsx
@@ -13,11 +13,11 @@ export const HeaderBanner = () => {
     <InternalHeader data-theme="light">
       <InternalHeader.Title href="/">
         <HStack gap="4">
-          <div>
-            {erDesember && (
+          {erDesember && (
+            <div>
               <img src="/Christmas_tree_02.png" alt="juletre" style={{ height: '1.5rem', width: '1.5rem' }} />
-            )}
-          </div>
+            </div>
+          )}
           Gjenny
           {erDesember && (
             <img


### PR DESCRIPTION
Det manglet mellomrom mellom avbryt/lagre og tekstfeltet over
![Skjermbilde 2025-01-27 kl  12 35 08](https://github.com/user-attachments/assets/3fc219a5-f222-4123-866f-59567cb9ac60)

Diven til juletreet var fortsatt tilstede selv om julen er over. Spacing rundt Gjenny er nå riktig igjen.
![Skjermbilde 2025-01-27 kl  12 37 15](https://github.com/user-attachments/assets/75c2e4a0-45db-4427-86a9-0213082abd9b)
