### PR TITLE
Feature/rydde opp i innsender for persongalleri

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
@@ -107,22 +107,11 @@ class BehandlingFactory(
             }
         }
 
-        val persongalleri =
-            with(request) {
-                if (kilde?.foerstOpprettaIPesys() == true) {
-                    persongalleri.copy(innsender = kilde!!.name)
-                } else if (persongalleri.innsender == null) {
-                    persongalleri.copy(innsender = brukerTokenInfo.ident())
-                } else {
-                    persongalleri
-                }
-            }
-
         val behandling =
             inTransaction {
                 opprettBehandling(
                     sak.id,
-                    persongalleri,
+                    request.persongalleri,
                     request.mottattDato,
                     request.kilde ?: Vedtaksloesning.GJENNY,
                     request = hentDataForOpprettBehandling(sak.id),
@@ -239,7 +228,7 @@ class BehandlingFactory(
                 grunnlagService.leggInnNyttGrunnlag(
                     behandling,
                     persongalleri,
-                    HardkodaSystembruker.opprettGrunnlag,
+                    brukerTokenInfo,
                 )
             }
 
@@ -355,7 +344,7 @@ class BehandlingFactory(
             grunnlagService.leggInnNyttGrunnlag(
                 behandlingerForOmgjoering.nyFoerstegangsbehandling,
                 persongalleri,
-                HardkodaSystembruker.opprettGrunnlag,
+                brukerTokenInfo = saksbehandler,
             )
         }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/RevurderingService.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.behandling.revurdering
 
 import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.behandling.BehandlingDao
 import no.nav.etterlatte.behandling.BehandlingHendelserKafkaProducer
 import no.nav.etterlatte.behandling.GrunnlagService
@@ -213,7 +214,7 @@ class RevurderingService(
                             grunnlagService.leggInnNyttGrunnlag(
                                 it,
                                 persongalleri,
-                                HardkodaSystembruker.opprettGrunnlag,
+                                Kontekst.get().brukerTokenInfo ?: HardkodaSystembruker.opprettGrunnlag, // Yolo
                             )
                         } else {
                             grunnlagService.laasTilGrunnlagIBehandling(

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
@@ -18,7 +18,6 @@ import no.nav.etterlatte.grunnlagsendring.doedshendelse.kontrollpunkt.Doedshende
 import no.nav.etterlatte.grunnlagsendring.doedshendelse.kontrollpunkt.finnOppgaveId
 import no.nav.etterlatte.grunnlagsendring.doedshendelse.kontrollpunkt.finnSak
 import no.nav.etterlatte.inTransaction
-import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.Saksrolle
@@ -181,18 +180,17 @@ class DoedshendelseJobService(
                 SakType.BARNEPENSJON -> hentAnnenForelder(doedshendelse)
                 SakType.OMSTILLINGSSTOENAD -> null
             }
-        val galleri =
+        val persongalleri =
             Persongalleri(
                 soeker = doedshendelse.beroertFnr,
                 avdoed = listOf(doedshendelse.avdoedFnr),
                 gjenlevende = listOfNotNull(gjenlevende),
-                innsender = Vedtaksloesning.GJENNY.name,
             )
 
         runBlocking {
             grunnlagService.leggInnNyttGrunnlagSak(
                 sak = opprettetSak,
-                galleri,
+                persongalleri,
                 HardkodaSystembruker.doedshendelse,
             )
         }

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/BehandlingGrunnlagRoutesKtTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/BehandlingGrunnlagRoutesKtTest.kt
@@ -256,7 +256,8 @@ internal class BehandlingGrunnlagRoutesKtTest {
         val sakId = randomSakId()
         val behandlingId = UUID.randomUUID()
         val persongalleri = GrunnlagTestData().hentPersonGalleri()
-        val opplysningsbehov = Opplysningsbehov(sakId, SakType.BARNEPENSJON, persongalleri)
+        val opplysningsbehov =
+            Opplysningsbehov(sakId, SakType.BARNEPENSJON, persongalleri, Grunnlagsopplysning.Saksbehandler.create("ident"))
 
         coEvery { grunnlagService.opprettGrunnlag(any(), any()) } just Runs
 

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagHenterTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagHenterTest.kt
@@ -15,7 +15,6 @@ import no.nav.etterlatte.libs.common.grunnlag.Opplysningsbehov
 import no.nav.etterlatte.libs.common.pdl.OpplysningDTO
 import no.nav.etterlatte.libs.common.person.Person
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
-import no.nav.etterlatte.libs.testdata.grunnlag.kilde
 import org.junit.jupiter.api.Test
 
 class GrunnlagHenterTest {

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagHenterTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagHenterTest.kt
@@ -10,10 +10,12 @@ import no.nav.etterlatte.behandling.sakId1
 import no.nav.etterlatte.grunnlag.klienter.PdlTjenesterKlientImpl
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.Opplysningsbehov
 import no.nav.etterlatte.libs.common.pdl.OpplysningDTO
 import no.nav.etterlatte.libs.common.person.Person
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
+import no.nav.etterlatte.libs.testdata.grunnlag.kilde
 import org.junit.jupiter.api.Test
 
 class GrunnlagHenterTest {
@@ -63,6 +65,7 @@ class GrunnlagHenterTest {
                             grunnlagTestData.avdoede.map { it.foedselsnummer.value },
                             listOf(grunnlagTestData.gjenlevende.foedselsnummer.value),
                         ),
+                        kilde = Grunnlagsopplysning.Saksbehandler.create("ident"),
                     ),
                 )
             }

--- a/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagServiceTest.kt
+++ b/apps/etterlatte-grunnlag/src/test/kotlin/grunnlag/GrunnlagServiceTest.kt
@@ -242,7 +242,7 @@ internal class GrunnlagServiceTest {
             every { opplysningDaoMock.finnHendelserIGrunnlag(sakId) } returns emptyList()
             every { opplysningDaoMock.leggOpplysningTilGrunnlag(any(), any(), any()) } returns sakId.sakId
 
-            val opplysningsbehov = Opplysningsbehov(sakId, SakType.BARNEPENSJON, galleri)
+            val opplysningsbehov = Opplysningsbehov(sakId, SakType.BARNEPENSJON, galleri, kilde)
 
             runBlocking { grunnlagService.opprettEllerOppdaterGrunnlagForSak(sakId, opplysningsbehov) }
 

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/grunnlag/Opplysningsbehov.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/grunnlag/Opplysningsbehov.kt
@@ -8,5 +8,5 @@ data class Opplysningsbehov(
     val sakId: SakId,
     val sakType: SakType,
     val persongalleri: Persongalleri,
-    val kilde: Grunnlagsopplysning.Kilde? = null,
+    val kilde: Grunnlagsopplysning.Kilde,
 )

--- a/libs/saksbehandling-common/src/main/kotlin/behandling/Persongalleri.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/behandling/Persongalleri.kt
@@ -7,6 +7,7 @@ import java.time.LocalDate
 /*
     innsender: Denne brukes til å indikere system eller saksbehandler ident(manuelt opprettet behandling) i tillegg til faktisk innsender(innbygger)
  */
+// TODO: gjøre om alle strings her til Folkeregister identifikator
 data class Persongalleri(
     val soeker: String,
     val innsender: String? = null,


### PR DESCRIPTION
Innsender er en del av persongalleriert og vi ønsker at innsender skal være en gyldig identifikator derfor bør alle fnr strings i persongalleriet være av typen folkeregisteridentifikator i stedet for STRING, det har blitt lagt inn mye ræl der blanet annet systemnavn og saksbehandler som aldri ble brukt til noenting ellers i systemet.
Denne opplysningen ligger lagret som kilde på opplysningstypen.

Merk at enkelte persongallerier i grunnlag har innsender satt til "PESYS"
men dette er kun de med kilde = "PESYS"/"SAKSBEHANDLER"
så med sjekker i grunnlag på om innsender er folkereg ellers sette `innsender = null` .
Man da egentlig sette innsender i alle med oppslysningstype `PERSONGALLERI_V1`med `innsender=PESYS/saksbehandler` til `null`.

Kilden ser da feks slik ut for de med pesys/saksbehandler
`{"tidspunkt":"2023-11-22T14:03:55.311652Z","type":"pesys"}`
` {"ident":"SAKSBEHANDLERIDENT","tidspunkt":"2022-04-24T09:03:01.493157Z","type":"saksbehandler"}`