### PR TITLE
La bruker gå videre hvis de har varig unntak

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/Aktivitetsplikt.tsx
@@ -46,6 +46,7 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
   const avdoedesDoedsdato = avdoede?.opplysning?.doedsdato
   const [aktivitetOppfolging, setAktivitetOppfolging] = useState<AktivitetspliktOppfolging>()
   const [manglerAktivitetspliktVurdering, setManglerAktivitetspliktVurdering] = useState<boolean | undefined>(undefined)
+  const [visFeilmelding, setVisFeilmelding] = useState<boolean>(false)
 
   const [hentetAktivitetspliktOppfoelgingStatus, hentAktivitetspliktOppfoelging] =
     useApiCall(hentAktivitetspliktOppfolging)
@@ -60,12 +61,18 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
 
   const erFerdigUtfylt = () => {
     if (manglerAktivitetspliktVurdering === undefined || manglerAktivitetspliktVurdering) {
-      setManglerAktivitetspliktVurdering(true)
+      setVisFeilmelding(true)
       return
     }
 
     next()
   }
+
+  useEffect(() => {
+    if (!manglerAktivitetspliktVurdering) {
+      setVisFeilmelding(false)
+    }
+  }, [manglerAktivitetspliktVurdering])
 
   return (
     <>
@@ -125,7 +132,7 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
 
         <AktivitetspliktVurdering
           behandling={behandling}
-          resetManglerAktivitetspliktVurdering={() => setManglerAktivitetspliktVurdering(false)}
+          setManglerAktivitetspliktVurdering={setManglerAktivitetspliktVurdering}
           doedsdato={avdoedesDoedsdato!!}
         />
 
@@ -193,7 +200,7 @@ export const Aktivitetsplikt = (props: { behandling: IDetaljertBehandling }) => 
           </Button>
         </TekstWrapper>
 
-        {manglerAktivitetspliktVurdering && (
+        {visFeilmelding && (
           <Alert style={{ maxWidth: '16em' }} variant="error">
             Du må fylle ut vurdering om aktivitetsplikt
           </Alert>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/AktivitetspliktVurdering.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/aktivitetsplikt/AktivitetspliktVurdering.tsx
@@ -40,11 +40,11 @@ const harVarigUnntak = (vurdering: IAktivitetspliktVurderingNyDto): boolean => {
 
 export const AktivitetspliktVurdering = ({
   behandling,
-  resetManglerAktivitetspliktVurdering,
+  setManglerAktivitetspliktVurdering,
   doedsdato,
 }: {
   behandling: IDetaljertBehandling
-  resetManglerAktivitetspliktVurdering: () => void
+  setManglerAktivitetspliktVurdering: (manglerVurdering: boolean) => void
   doedsdato: Date
 }) => {
   const [vurdering, setVurdering] = useState<IAktivitetspliktVurderingNyDto>()
@@ -75,7 +75,6 @@ export const AktivitetspliktVurdering = ({
             if (vurderingHarInnhold(result)) {
               setManglerVurdering(false)
               setHarAktivitetsplikt(JaNei.JA)
-              resetManglerAktivitetspliktVurdering()
             } else {
               setManglerVurdering(true)
             }
@@ -97,6 +96,10 @@ export const AktivitetspliktVurdering = ({
     }
   }, [updated])
 
+  useEffect(() => {
+    setManglerAktivitetspliktVurdering(manglerVurdering)
+  }, [manglerVurdering])
+
   const lagreVarigUnntak = () => {
     if (harAktivitetsplikt == JaNei.NEI) {
       lagreUnntakVarig(
@@ -113,6 +116,7 @@ export const AktivitetspliktVurdering = ({
         },
         (data) => {
           dispatch(setVurderingBehandling(data))
+          setManglerVurdering(false)
         }
       )
     } else {


### PR DESCRIPTION
Fikser logikken som gjør at saksbehandler kan gå videre hvis de har valgt varig unntak for bruker. Dette gjør også at hvis saksbehandler sletter en vurdering, så må de fylle inn aktivitetsplikt for å kunne gå videre.