### PR TITLE
EY-4824 vise hjelpetekst ved spesifikke vedlegg

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
@@ -166,7 +166,7 @@ export default function RedigerbartBrev({
                       <Accordion.Header>{brevVedlegg.tittel}</Accordion.Header>
 
                       <Accordion.Content>
-                        <VStack gap="4" padding="4 0">
+                        <VStack gap="4" paddingBlock="4" paddingInline="0">
                           {getInfoboksForVedlegg(brevVedlegg.tittel)}
                           <SlateEditor
                             value={brevVedlegg.payload}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
@@ -215,7 +215,7 @@ const getInfoboksForVedlegg = (tittel: string) => {
     {
       brevtittel: 'Utfall ved beregning av omstillingsstønad',
       infotekst:
-        'SKRIV INN HVILKEN INNTEKT SOM ER LAGT TIL GRUNN. HER KAN DU OGSÅ LEGGE INN OM INSTITUSJONSOPPHOLD E.L. OM DET SKULLE VÆRE AKTUELT.',
+        'Skriv inn hvilken inntekt som er lagt til grunn. Her kan du også legge inn om institusjonsopphold e.l. dersom det skulle være aktuelt.',
     },
   ]
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
@@ -213,12 +213,12 @@ const Container = styled.div`
 const getInfoboksForVedlegg = (tittel: string) => {
   const vedleggInfo = [
     {
-      tittel: 'Utfall ved beregning av omstillingsstønad',
+      brevtittel: 'Utfall ved beregning av omstillingsstønad',
       infotekst:
         'SKRIV INN HVILKEN INNTEKT SOM ER LAGT TIL GRUNN. HER KAN DU OGSÅ LEGGE INN OM INSTITUSJONSOPPHOLD E.L. OM DET SKULLE VÆRE AKTUELT.',
     },
   ]
 
-  const skalViseInfoboks = vedleggInfo.find((info) => info.tittel === tittel)
+  const skalViseInfoboks = vedleggInfo.find((info) => info.brevtittel === tittel)
   return skalViseInfoboks ? <Alert variant="info">{skalViseInfoboks.infotekst}</Alert> : null
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
@@ -1,4 +1,4 @@
-import { Accordion, Tabs, Alert, VStack } from '@navikt/ds-react'
+import { Accordion, Tabs, VStack } from '@navikt/ds-react'
 import SlateEditor from '~components/behandling/brev/SlateEditor'
 import React, { useEffect, useState } from 'react'
 import { FilePdfIcon, PencilIcon } from '@navikt/aksel-icons'
@@ -12,6 +12,7 @@ import { isPending, isPendingOrInitial, isSuccess, isSuccessOrInitial } from '~s
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { TilbakestillOgLagreRad } from '~components/behandling/brev/TilbakestillOgLagreRad'
 import { formaterTidspunktTimeMinutterSekunder } from '~utils/formatering/dato'
+import VedleggInfo from '~components/vedlegg/VedleggInfo'
 
 enum ManueltBrevFane {
   REDIGER = 'REDIGER',
@@ -167,7 +168,7 @@ export default function RedigerbartBrev({
 
                       <Accordion.Content>
                         <VStack gap="4" paddingBlock="4" paddingInline="0">
-                          {getInfoboksForVedlegg(brevVedlegg.tittel)}
+                          <VedleggInfo vedleggTittel={brevVedlegg.tittel} />
                           <SlateEditor
                             value={brevVedlegg.payload}
                             onChange={onChangeVedlegg}
@@ -209,16 +210,3 @@ export default function RedigerbartBrev({
 const Container = styled.div`
   width: 100%;
 `
-
-const getInfoboksForVedlegg = (tittel: string) => {
-  const vedleggInfo = [
-    {
-      brevtittel: 'Utfall ved beregning av omstillingsstønad',
-      infotekst:
-        'Skriv inn hvilken inntekt som er lagt til grunn. Her kan du også legge inn om institusjonsopphold e.l. dersom det skulle være aktuelt.',
-    },
-  ]
-
-  const skalViseInfoboks = vedleggInfo.find((info) => info.brevtittel === tittel)
-  return skalViseInfoboks ? <Alert variant="info">{skalViseInfoboks.infotekst}</Alert> : null
-}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
@@ -1,4 +1,4 @@
-import { Accordion, Tabs } from '@navikt/ds-react'
+import { Accordion, Tabs, Alert, VStack } from '@navikt/ds-react'
 import SlateEditor from '~components/behandling/brev/SlateEditor'
 import React, { useEffect, useState } from 'react'
 import { FilePdfIcon, PencilIcon } from '@navikt/aksel-icons'
@@ -164,13 +164,17 @@ export default function RedigerbartBrev({
                   vedlegg.map((brevVedlegg) => (
                     <Accordion.Item key={brevVedlegg.key}>
                       <Accordion.Header>{brevVedlegg.tittel}</Accordion.Header>
+
                       <Accordion.Content>
-                        <SlateEditor
-                          value={brevVedlegg.payload}
-                          onChange={onChangeVedlegg}
-                          readonly={!kanRedigeres}
-                          editKey={brevVedlegg.key}
-                        />
+                        <VStack gap="4">
+                          {getInfoboksForVedlegg(brevVedlegg.tittel)}
+                          <SlateEditor
+                            value={brevVedlegg.payload}
+                            onChange={onChangeVedlegg}
+                            readonly={!kanRedigeres}
+                            editKey={brevVedlegg.key}
+                          />
+                        </VStack>
                       </Accordion.Content>
                     </Accordion.Item>
                   ))}
@@ -205,3 +209,16 @@ export default function RedigerbartBrev({
 const Container = styled.div`
   width: 100%;
 `
+
+const getInfoboksForVedlegg = (tittel: string) => {
+  const vedleggInfo = [
+    {
+      tittel: 'Utfall ved beregning av omstillingsstønad',
+      infotekst:
+        'SKRIV INN HVILKEN INNTEKT SOM ER LAGT TIL GRUNN. HER KAN DU OGSÅ LEGGE INN OM INSTITUSJONSOPPHOLD E.L. OM DET SKULLE VÆRE AKTUELT.',
+    },
+  ]
+
+  const skalViseInfoboks = vedleggInfo.find((info) => info.tittel === tittel)
+  return skalViseInfoboks ? <Alert variant="info">{skalViseInfoboks.infotekst}</Alert> : null
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
@@ -166,7 +166,7 @@ export default function RedigerbartBrev({
                       <Accordion.Header>{brevVedlegg.tittel}</Accordion.Header>
 
                       <Accordion.Content>
-                        <VStack gap="4">
+                        <VStack gap="4" padding="4 0">
                           {getInfoboksForVedlegg(brevVedlegg.tittel)}
                           <SlateEditor
                             value={brevVedlegg.payload}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/vedlegg/VedleggInfo.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/vedlegg/VedleggInfo.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { Alert } from '@navikt/ds-react'
+
+const VedleggInfo = (props: { vedleggTittel: string }) => {
+  const { vedleggTittel } = props
+
+  const vedleggInfo = [
+    {
+      tittel: 'Utfall ved beregning av omstillingsstønad',
+      infotekst:
+        'Skriv inn hvilken inntekt som er lagt til grunn. Her kan du også legge inn om institusjonsopphold e.l. dersom det skulle være aktuelt.',
+    },
+  ]
+
+  const skalViseInfoboks = vedleggInfo.find((info) => info.tittel === vedleggTittel)
+
+  return skalViseInfoboks ? <Alert variant="info">{skalViseInfoboks.infotekst}</Alert> : null
+}
+
+export default VedleggInfo


### PR DESCRIPTION
Ikke alltid lett å huske på å fjerne hjelpetekst fra brev, legger derfor til infoboks

![image](https://github.com/user-attachments/assets/d33a8537-733b-4c60-8a01-84865f263f90)


- En hjelpetekst dukker opp i fanen for vedlegget hvis det er definert. 


Henger sammen med endring i pensjonsbrev https://github.com/navikt/pensjonsbrev/pull/1225