### PR TITLE
EY-4680 Sjekker konsistens med forrige overstyrt grunnlag

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnOverstyrBeregningService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/BeregnOverstyrBeregningService.kt
@@ -56,8 +56,14 @@ class BeregnOverstyrBeregningService(
 
         val beregningsGrunnlag =
             krevIkkeNull(
-                beregningsGrunnlagService.hentOverstyrBeregningGrunnlag(behandling.id),
+                beregningsGrunnlagService.hentOverstyrBeregningGrunnlag(behandling.id, brukerTokenInfo),
             ) { "Behandling ${behandling.id} mangler overstyr beregningsgrunnlag" }
+
+        beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(
+            behandling.id,
+            virkningstidspunkt,
+            brukerTokenInfo,
+        )
 
         val beregningsType =
             when (behandling.sakType) {

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagRoutes.kt
@@ -79,6 +79,7 @@ fun Route.beregningsGrunnlag(
                             beregningsGrunnlagService
                                 .hentOverstyrBeregningGrunnlag(
                                     behandlingId,
+                                    brukerTokenInfo,
                                 ).perioder,
                     )
 

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
@@ -331,7 +331,7 @@ class BeregningsGrunnlagService(
                     kilde = overstyrtePerioderForrigeBehandling.firstOrNull()?.kilde ?: automatiskSaksbehandler,
                 ).also {
                     // Lagre ned det grunnlaget vi gir ut fra forrige iverksatte også på behandlingen vi er i
-                    if (overstyrtePerioderForrigeBehandling.isEmpty()) {
+                    if (overstyrtePerioderForrigeBehandling.isNotEmpty()) {
                         beregningsGrunnlagRepository.lagreOverstyrBeregningGrunnlagForBehandling(
                             behandlingId,
                             overstyrtePerioderForrigeBehandling,

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
@@ -324,6 +324,10 @@ class BeregningsGrunnlagService(
             // Det kan hende behandlingen er en revurdering, og da må vi finne forrige grunnlag for saken
             val forrigeIverksatte = forrigeIverksatteBehandling(behandlingId, brukerTokenInfo)
             if (forrigeIverksatte != null) {
+                logger.info(
+                    "Gir ut det forrige overstyrte beregningsgrunnlaget i behandling ${forrigeIverksatte.behandlingId} for " +
+                        "nåværende behandling under arbeid $behandlingId",
+                )
                 val overstyrtePerioderForrigeBehandling =
                     beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(forrigeIverksatte.behandlingId)
                 OverstyrBeregningGrunnlag(
@@ -331,6 +335,10 @@ class BeregningsGrunnlagService(
                     kilde = overstyrtePerioderForrigeBehandling.firstOrNull()?.kilde ?: automatiskSaksbehandler,
                 ).also {
                     // Lagre ned det grunnlaget vi gir ut fra forrige iverksatte også på behandlingen vi er i
+                    logger.info(
+                        "Kopierte overstyrt beregningsgrunnlag fra ${forrigeIverksatte.behandlingId} til " +
+                            "$behandlingId, med ${overstyrtePerioderForrigeBehandling.size} perioder.",
+                    )
                     if (overstyrtePerioderForrigeBehandling.isNotEmpty()) {
                         beregningsGrunnlagRepository.lagreOverstyrBeregningGrunnlagForBehandling(
                             behandlingId,

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/grunnlag/BeregningsGrunnlagService.kt
@@ -17,6 +17,7 @@ import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning.Companion.auto
 import no.nav.etterlatte.libs.common.grunnlag.hentAvdoedesbarn
 import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import no.nav.etterlatte.libs.common.toJson
+import no.nav.etterlatte.libs.common.vedtak.VedtakSammendragDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
@@ -235,23 +236,17 @@ class BeregningsGrunnlagService(
             return grunnlag
         }
 
+        val forrigeIverksatte = forrigeIverksatteBehandling(behandlingId, brukerTokenInfo)
         // Det kan hende behandlingen er en revurdering, og da må vi finne forrige grunnlag for saken
-        val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
-        return if (behandling.behandlingType == BehandlingType.REVURDERING) {
-            val sisteIverksatteBehandling =
-                vedtaksvurderingKlient
-                    .hentIverksatteVedtak(behandling.sak, brukerTokenInfo)
-                    .sortedByDescending { it.datoFattet }
-                    .first { it.vedtakType != VedtakType.OPPHOER } // Opphør har ikke beregningsgrunnlag
-
+        return if (forrigeIverksatte != null) {
             beregningsGrunnlagRepository
-                .finnBeregningsGrunnlag(sisteIverksatteBehandling.behandlingId)
+                .finnBeregningsGrunnlag(forrigeIverksatte.behandlingId)
                 ?.also {
                     logger.info(
                         "Ga ut forrige beregningsgrunnlag for $behandlingId, funnet i " +
-                            "${sisteIverksatteBehandling.id}. Dette grunnlaget er kopiert inn til $behandlingId.",
+                            "${forrigeIverksatte.id}. Dette grunnlaget er kopiert inn til $behandlingId.",
                     )
-                    beregningsGrunnlagRepository.lagreBeregningsGrunnlag(it.copy(behandlingId = behandling.id))
+                    beregningsGrunnlagRepository.lagreBeregningsGrunnlag(it.copy(behandlingId = behandlingId))
                 }
         } else {
             null
@@ -308,35 +303,62 @@ class BeregningsGrunnlagService(
         }
     }
 
-    fun hentOverstyrBeregningGrunnlag(behandlingId: UUID): OverstyrBeregningGrunnlag {
+    suspend fun hentOverstyrBeregningGrunnlag(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): OverstyrBeregningGrunnlag {
         logger.info("Henter overstyr beregning grunnlag $behandlingId")
 
-        return beregningsGrunnlagRepository
-            .finnOverstyrBeregningGrunnlagForBehandling(
-                behandlingId,
-            ).let { overstyrBeregningGrunnlagDaoListe ->
+        val overstyrtePerioder =
+            beregningsGrunnlagRepository
+                .finnOverstyrBeregningGrunnlagForBehandling(
+                    behandlingId,
+                ).let { overstyrBeregningGrunnlagDaoListe ->
+                    OverstyrBeregningGrunnlag(
+                        perioder =
+                            overstyrBeregningGrunnlagDaoListe.map(OverstyrBeregningGrunnlagDao::tilGrunnlagMedPeriode),
+                        kilde = overstyrBeregningGrunnlagDaoListe.firstOrNull()?.kilde ?: automatiskSaksbehandler,
+                    )
+                }
+        return if (overstyrtePerioder.perioder.isEmpty()) {
+            // Det kan hende behandlingen er en revurdering, og da må vi finne forrige grunnlag for saken
+            val forrigeIverksatte = forrigeIverksatteBehandling(behandlingId, brukerTokenInfo)
+            if (forrigeIverksatte != null) {
+                val overstyrtePerioderForrigeBehandling =
+                    beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(forrigeIverksatte.behandlingId)
                 OverstyrBeregningGrunnlag(
-                    perioder =
-                        overstyrBeregningGrunnlagDaoListe.map { periode ->
-                            GrunnlagMedPeriode(
-                                data =
-                                    OverstyrBeregningGrunnlagData(
-                                        utbetaltBeloep = periode.utbetaltBeloep,
-                                        foreldreloessats = periode.foreldreloessats,
-                                        trygdetid = periode.trygdetid,
-                                        trygdetidForIdent = periode.trygdetidForIdent,
-                                        prorataBroekTeller = periode.prorataBroekTeller,
-                                        prorataBroekNevner = periode.prorataBroekNevner,
-                                        beskrivelse = periode.beskrivelse,
-                                        aarsak = periode.aarsak,
-                                    ),
-                                fom = periode.datoFOM,
-                                tom = periode.datoTOM,
-                            )
-                        },
-                    kilde = overstyrBeregningGrunnlagDaoListe.firstOrNull()?.kilde ?: automatiskSaksbehandler,
-                )
+                    perioder = overstyrtePerioderForrigeBehandling.map(OverstyrBeregningGrunnlagDao::tilGrunnlagMedPeriode),
+                    kilde = overstyrtePerioderForrigeBehandling.firstOrNull()?.kilde ?: automatiskSaksbehandler,
+                ).also {
+                    // Lagre ned det grunnlaget vi gir ut fra forrige iverksatte også på behandlingen vi er i
+                    if (overstyrtePerioderForrigeBehandling.isEmpty()) {
+                        beregningsGrunnlagRepository.lagreOverstyrBeregningGrunnlagForBehandling(
+                            behandlingId,
+                            overstyrtePerioderForrigeBehandling,
+                        )
+                    }
+                }
+            } else {
+                overstyrtePerioder
             }
+        } else {
+            overstyrtePerioder
+        }
+    }
+
+    private suspend fun forrigeIverksatteBehandling(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): VedtakSammendragDto? {
+        val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
+        return if (behandling.behandlingType == BehandlingType.REVURDERING) {
+            vedtaksvurderingKlient
+                .hentIverksatteVedtak(behandling.sak, brukerTokenInfo)
+                .sortedByDescending { it.datoFattet }
+                .first { it.vedtakType != VedtakType.OPPHOER } // Opphør har ikke beregningsgrunnlag
+        } else {
+            null
+        }
     }
 
     suspend fun lagreOverstyrBeregningGrunnlag(
@@ -378,7 +400,7 @@ class BeregningsGrunnlagService(
                 },
             )
             behandlingKlient.statusTrygdetidOppdatert(behandlingId, brukerTokenInfo, commit = true)
-            return hentOverstyrBeregningGrunnlag(behandlingId)
+            return hentOverstyrBeregningGrunnlag(behandlingId, brukerTokenInfo)
         } else {
             throw OverstyrtBeregningFeilBehandlingStatusException(behandlingId, behandling.status)
         }
@@ -444,6 +466,34 @@ class BeregningsGrunnlagService(
             }
         }
     }
+
+    fun sjekkOmOverstyrtGrunnlagErLiktFoerVirk(
+        behandlingId: UUID,
+        virkningstidspunkt: YearMonth,
+        brukerTokenInfo: BrukerTokenInfo,
+    ) {
+        val forrigeIverksatteBehandling = runBlocking { forrigeIverksatteBehandling(behandlingId, brukerTokenInfo) }
+        if (forrigeIverksatteBehandling != null) {
+            // har vi overstyrt beregning for denne behandlingen?
+            val forrigeOverstyrBeregningGrunnlag =
+                runBlocking { hentOverstyrBeregningGrunnlag(forrigeIverksatteBehandling.behandlingId, brukerTokenInfo) }
+            if (forrigeOverstyrBeregningGrunnlag.perioder.isEmpty()) {
+                return
+            }
+            val naavaerendeGrunnlag = runBlocking { hentOverstyrBeregningGrunnlag(behandlingId, brukerTokenInfo) }
+            if (!erGrunnlagLiktFoerEnDato(
+                    naavaerendeGrunnlag.perioder,
+                    forrigeOverstyrBeregningGrunnlag.perioder,
+                    virkningstidspunkt.atDay(1),
+                )
+            ) {
+                throw OverstyrtBeregningsgrunnlagEndresFoerVirk(
+                    behandlingId = behandlingId,
+                    forrigeBehandlingId = forrigeIverksatteBehandling.behandlingId,
+                )
+            }
+        }
+    }
 }
 
 class OverstyrtBeregningUgyldigTrygdetid(
@@ -477,4 +527,15 @@ class BPBeregningsgrunnlagSoeskenMarkertDoedException(
         code = "BP_BEREGNING_SOESKEN_MARKERT_DOED",
         detail = "Barnpensjon beregningsgrunnlag bruker søsken som er døde i beregningen",
         meta = mapOf("behandlingId" to behandlingId),
+    )
+
+class OverstyrtBeregningsgrunnlagEndresFoerVirk(
+    behandlingId: UUID,
+    forrigeBehandlingId: UUID,
+) : UgyldigForespoerselException(
+        code = "OVERSTYRT_GRUNNLAG_ENDRET_FOER_VIRK",
+        detail =
+            "De overstyrte beregningsperiodene er forskjellige fra forrige " +
+                "vedtak (id=$forrigeBehandlingId) før virkningstidpunktet i denne behandlingen (id=$behandlingId). " +
+                "Endringer skal kun skje etter virkningstidspunktet.",
     )

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnOverstyrServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnOverstyrServiceTest.kt
@@ -3,8 +3,10 @@ package no.nav.etterlatte.beregning
 import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.sakId1
@@ -56,7 +58,7 @@ internal class BeregnOverstyrServiceTest {
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
-        every { beregningsGrunnlagService.hentOverstyrBeregningGrunnlag(any()) } returns
+        coEvery { beregningsGrunnlagService.hentOverstyrBeregningGrunnlag(any(), any()) } returns
             OverstyrBeregningGrunnlag(
                 perioder =
                     listOf(
@@ -96,6 +98,7 @@ internal class BeregnOverstyrServiceTest {
                         every { type } returns ""
                     },
             )
+        every { beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(behandling.id, any(), any()) } just Runs
 
         runBlocking {
             val beregning =
@@ -139,7 +142,7 @@ internal class BeregnOverstyrServiceTest {
         val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
 
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
-        every { beregningsGrunnlagService.hentOverstyrBeregningGrunnlag(any()) } returns
+        coEvery { beregningsGrunnlagService.hentOverstyrBeregningGrunnlag(any(), any()) } returns
             OverstyrBeregningGrunnlag(
                 perioder =
                     listOf(
@@ -179,6 +182,7 @@ internal class BeregnOverstyrServiceTest {
                         every { type } returns ""
                     },
             )
+        every { beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(behandling.id, any(), any()) } just Runs
 
         runBlocking {
             val beregning =
@@ -229,7 +233,7 @@ internal class BeregnOverstyrServiceTest {
             mockk {
                 every { utfall } returns VilkaarsvurderingUtfall.OPPFYLT
             }
-        every { beregningsGrunnlagService.hentOverstyrBeregningGrunnlag(any()) } returns
+        coEvery { beregningsGrunnlagService.hentOverstyrBeregningGrunnlag(any(), any()) } returns
             OverstyrBeregningGrunnlag(
                 perioder =
                     listOf(
@@ -269,6 +273,7 @@ internal class BeregnOverstyrServiceTest {
                         every { type } returns ""
                     },
             )
+        every { beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(behandling.id, any(), any()) } just Runs
 
         runBlocking {
             val beregning =
@@ -319,7 +324,7 @@ internal class BeregnOverstyrServiceTest {
             mockk {
                 every { utfall } returns VilkaarsvurderingUtfall.IKKE_OPPFYLT
             }
-        every { beregningsGrunnlagService.hentOverstyrBeregningGrunnlag(any()) } returns
+        coEvery { beregningsGrunnlagService.hentOverstyrBeregningGrunnlag(any(), any()) } returns
             OverstyrBeregningGrunnlag(
                 perioder =
                     listOf(
@@ -359,6 +364,7 @@ internal class BeregnOverstyrServiceTest {
                         every { type } returns ""
                     },
             )
+        every { beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(behandling.id, any(), any()) } just Runs
 
         runBlocking {
             val beregning =

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnOverstyrServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnOverstyrServiceTest.kt
@@ -14,6 +14,7 @@ import no.nav.etterlatte.beregning.grunnlag.BeregningsGrunnlagService
 import no.nav.etterlatte.beregning.grunnlag.GrunnlagMedPeriode
 import no.nav.etterlatte.beregning.grunnlag.OverstyrBeregningGrunnlag
 import no.nav.etterlatte.beregning.grunnlag.OverstyrBeregningGrunnlagData
+import no.nav.etterlatte.beregning.grunnlag.OverstyrtBeregningsgrunnlagEndresFoerVirkException
 import no.nav.etterlatte.beregning.regler.bruker
 import no.nav.etterlatte.klienter.GrunnlagKlientImpl
 import no.nav.etterlatte.klienter.VilkaarsvurderingKlient
@@ -24,6 +25,7 @@ import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.beregning.Beregningstype
 import no.nav.etterlatte.libs.common.beregning.OverstyrtBeregningKategori
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingDto
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
@@ -31,6 +33,7 @@ import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 import java.time.Month
 import java.time.YearMonth
@@ -98,13 +101,24 @@ internal class BeregnOverstyrServiceTest {
                         every { type } returns ""
                     },
             )
-        every { beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(behandling.id, any(), any()) } just Runs
+        every {
+            beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(
+                behandling.id,
+                any(),
+                any(),
+            )
+        } just Runs
 
         runBlocking {
             val beregning =
                 beregnOverstyrBeregningService.beregn(
                     behandling,
-                    OverstyrBeregning(behandling.sak, "Test", Tidspunkt.now(), kategori = OverstyrtBeregningKategori.UKJENT_KATEGORI),
+                    OverstyrBeregning(
+                        behandling.sak,
+                        "Test",
+                        Tidspunkt.now(),
+                        kategori = OverstyrtBeregningKategori.UKJENT_KATEGORI,
+                    ),
                     bruker,
                 )
 
@@ -182,13 +196,24 @@ internal class BeregnOverstyrServiceTest {
                         every { type } returns ""
                     },
             )
-        every { beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(behandling.id, any(), any()) } just Runs
+        every {
+            beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(
+                behandling.id,
+                any(),
+                any(),
+            )
+        } just Runs
 
         runBlocking {
             val beregning =
                 beregnOverstyrBeregningService.beregn(
                     behandling,
-                    OverstyrBeregning(behandling.sak, "Test", Tidspunkt.now(), kategori = OverstyrtBeregningKategori.UKJENT_KATEGORI),
+                    OverstyrBeregning(
+                        behandling.sak,
+                        "Test",
+                        Tidspunkt.now(),
+                        kategori = OverstyrtBeregningKategori.UKJENT_KATEGORI,
+                    ),
                     bruker,
                 )
 
@@ -273,13 +298,24 @@ internal class BeregnOverstyrServiceTest {
                         every { type } returns ""
                     },
             )
-        every { beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(behandling.id, any(), any()) } just Runs
+        every {
+            beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(
+                behandling.id,
+                any(),
+                any(),
+            )
+        } just Runs
 
         runBlocking {
             val beregning =
                 beregnOverstyrBeregningService.beregn(
                     behandling,
-                    OverstyrBeregning(behandling.sak, "Test", Tidspunkt.now(), kategori = OverstyrtBeregningKategori.UKJENT_KATEGORI),
+                    OverstyrBeregning(
+                        behandling.sak,
+                        "Test",
+                        Tidspunkt.now(),
+                        kategori = OverstyrtBeregningKategori.UKJENT_KATEGORI,
+                    ),
                     bruker,
                 )
 
@@ -364,13 +400,24 @@ internal class BeregnOverstyrServiceTest {
                         every { type } returns ""
                     },
             )
-        every { beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(behandling.id, any(), any()) } just Runs
+        every {
+            beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(
+                behandling.id,
+                any(),
+                any(),
+            )
+        } just Runs
 
         runBlocking {
             val beregning =
                 beregnOverstyrBeregningService.beregn(
                     behandling,
-                    OverstyrBeregning(behandling.sak, "Test", Tidspunkt.now(), kategori = OverstyrtBeregningKategori.UKJENT_KATEGORI),
+                    OverstyrBeregning(
+                        behandling.sak,
+                        "Test",
+                        Tidspunkt.now(),
+                        kategori = OverstyrtBeregningKategori.UKJENT_KATEGORI,
+                    ),
                     bruker,
                 )
 
@@ -398,6 +445,48 @@ internal class BeregnOverstyrServiceTest {
                     regelResultat shouldNotBe null
                     regelVersjon shouldNotBe null
                 }
+            }
+        }
+    }
+
+    @Test
+    fun `beregn skal sjekke om overstyrt grunnlag er likt før virk`() {
+        val behandling = mockBehandling(BehandlingType.REVURDERING, YearMonth.of(2019, 11))
+        val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
+
+        val vilkaarsvurderingDto = mockk<VilkaarsvurderingDto>()
+
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { vilkaarsvurderingKlient.hentVilkaarsvurdering(any(), any()) } returns vilkaarsvurderingDto
+        every { vilkaarsvurderingDto.resultat } returns
+            mockk {
+                every { utfall } returns VilkaarsvurderingUtfall.IKKE_OPPFYLT
+            }
+        coEvery { beregningsGrunnlagService.hentOverstyrBeregningGrunnlag(any(), any()) } returns
+            OverstyrBeregningGrunnlag(
+                perioder = emptyList(),
+                kilde = Grunnlagsopplysning.automatiskSaksbehandler,
+            )
+        every {
+            beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(
+                behandling.id,
+                behandling.virkningstidspunkt!!.dato,
+                any(),
+            )
+        } throws OverstyrtBeregningsgrunnlagEndresFoerVirkException(behandling.id, UUID.randomUUID())
+
+        assertThrows<OverstyrtBeregningsgrunnlagEndresFoerVirkException> {
+            runBlocking {
+                beregnOverstyrBeregningService.beregn(
+                    behandling,
+                    OverstyrBeregning(
+                        behandling.sak,
+                        "Test",
+                        Tidspunkt.now(),
+                        kategori = OverstyrtBeregningKategori.UKJENT_KATEGORI,
+                    ),
+                    bruker,
+                )
             }
         }
     }

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
@@ -733,7 +733,7 @@ internal class BeregningsGrunnlagServiceTest {
                 ),
             )
 
-        val grunnlag = beregningsGrunnlagService.hentOverstyrBeregningGrunnlag(behandlingId)
+        val grunnlag = runBlocking { beregningsGrunnlagService.hentOverstyrBeregningGrunnlag(behandlingId, mockk(relaxed = true)) }
 
         grunnlag.perioder.let { perioder ->
             perioder.size shouldBe 2

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 import java.time.Month.APRIL
@@ -484,7 +485,12 @@ internal class BeregningsGrunnlagServiceTest {
             beregningsGrunnlagService.dupliserBeregningsGrunnlag(omregningsId, behandlingsId, bruker)
 
             verify(exactly = 1) { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(any()) }
-            verify(exactly = 0) { beregningsGrunnlagRepository.lagreOverstyrBeregningGrunnlagForBehandling(any(), any()) }
+            verify(exactly = 0) {
+                beregningsGrunnlagRepository.lagreOverstyrBeregningGrunnlagForBehandling(
+                    any(),
+                    any(),
+                )
+            }
         }
     }
 
@@ -525,7 +531,12 @@ internal class BeregningsGrunnlagServiceTest {
             beregningsGrunnlagService.dupliserBeregningsGrunnlag(omregningsId, behandlingsId, bruker)
 
             verify(exactly = 1) { beregningsGrunnlagRepository.lagreBeregningsGrunnlag(any()) }
-            verify(exactly = 1) { beregningsGrunnlagRepository.lagreOverstyrBeregningGrunnlagForBehandling(any(), any()) }
+            verify(exactly = 1) {
+                beregningsGrunnlagRepository.lagreOverstyrBeregningGrunnlagForBehandling(
+                    any(),
+                    any(),
+                )
+            }
         }
     }
 
@@ -678,7 +689,13 @@ internal class BeregningsGrunnlagServiceTest {
             )
         }
         assertEquals(
-            listOf(GrunnlagMedPeriode<List<SoeskenMedIBeregning>>(emptyList(), behandling.virkningstidspunkt?.dato?.atDay(1)!!, null)),
+            listOf(
+                GrunnlagMedPeriode<List<SoeskenMedIBeregning>>(
+                    emptyList(),
+                    behandling.virkningstidspunkt?.dato?.atDay(1)!!,
+                    null,
+                ),
+            ),
             slot.captured.soeskenMedIBeregning,
         )
     }
@@ -733,7 +750,8 @@ internal class BeregningsGrunnlagServiceTest {
                 ),
             )
 
-        val grunnlag = runBlocking { beregningsGrunnlagService.hentOverstyrBeregningGrunnlag(behandlingId, mockk(relaxed = true)) }
+        val grunnlag =
+            runBlocking { beregningsGrunnlagService.hentOverstyrBeregningGrunnlag(behandlingId, mockk(relaxed = true)) }
 
         grunnlag.perioder.let { perioder ->
             perioder.size shouldBe 2
@@ -1034,6 +1052,265 @@ internal class BeregningsGrunnlagServiceTest {
                         OverstyrBeregningGrunnlagDao::reguleringRegelresultat,
                     )
                 },
+            )
+        }
+    }
+
+    @Test
+    fun `sjekkOmOverstyrtGrunnlagErLiktFoerVirk gir ingen feil i revurdering hvis kun denne behandling er overstyrt`() {
+        val sakId = SakId(1L)
+
+        val behandlingId = randomUUID()
+        val virkFoerstegangsbehandling = YearMonth.of(2024, 6)
+        val foerstegangsbehandling =
+            mockBehandling(
+                type = SakType.BARNEPENSJON,
+                virkningstidspunktdato = virkFoerstegangsbehandling,
+                uuid = behandlingId,
+                behandlingstype = BehandlingType.FØRSTEGANGSBEHANDLING,
+                sakId = sakId,
+            )
+
+        val revurderingId = randomUUID()
+        val virkRevurdering = YearMonth.of(2024, 6)
+        val revurdering =
+            mockBehandling(
+                type = SakType.BARNEPENSJON,
+                virkningstidspunktdato = virkRevurdering,
+                uuid = revurderingId,
+                behandlingstype = BehandlingType.REVURDERING,
+                sakId = sakId,
+            )
+        coEvery { behandlingKlient.hentBehandling(revurderingId, any()) } returns revurdering
+        coEvery { behandlingKlient.hentBehandling(behandlingId, any()) } returns foerstegangsbehandling
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(sakId, any()) } returns
+            listOf(
+                mockVedtak(
+                    behandlingId,
+                    VedtakType.INNVILGELSE,
+                ),
+            )
+        every { beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(behandlingId) } returns emptyList()
+        every { beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(revurderingId) } returns
+            listOf(
+                overstyrtBeregningsgrunnlag(
+                    behandlingId = revurderingId,
+                    utbetaltBeloep = 1L,
+                    datoFOM = virkRevurdering.atDay(1),
+                ),
+            )
+
+        assertDoesNotThrow {
+            beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(
+                revurderingId,
+                virkRevurdering,
+                mockk(relaxed = true),
+            )
+        }
+    }
+
+    @Test
+    fun `sjekkOmOverstyrtGrunnlagErLiktFoerVirk gir ingen feil i førstegangsbehandling`() {
+        val sakId = SakId(1L)
+        val behandlingId = UUID.randomUUID()
+        val virk = YearMonth.of(2024, 6)
+        val behandling =
+            mockBehandling(
+                type = SakType.BARNEPENSJON,
+                virkningstidspunktdato = virk,
+                uuid = behandlingId,
+                behandlingstype = BehandlingType.FØRSTEGANGSBEHANDLING,
+                sakId = sakId,
+            )
+        coEvery { behandlingKlient.hentBehandling(behandlingId, any()) } returns behandling
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(sakId, any()) } returns emptyList()
+        assertDoesNotThrow {
+            beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(behandlingId, virk, mockk(relaxed = true))
+        }
+    }
+
+    @Test
+    fun `sjekkOmOverstyrtGrunnlagErLiktFoerVirk kaster ikke feil hvis det kun er endret i detaljer etter virk`() {
+        val sakId = SakId(1L)
+
+        val behandlingId = randomUUID()
+        val virkFoerstegangsbehandling = YearMonth.of(2024, 1)
+        val foerstegangsbehandling =
+            mockBehandling(
+                type = SakType.BARNEPENSJON,
+                virkningstidspunktdato = virkFoerstegangsbehandling,
+                uuid = behandlingId,
+                behandlingstype = BehandlingType.FØRSTEGANGSBEHANDLING,
+                sakId = sakId,
+            )
+
+        val revurderingId = randomUUID()
+        val virkRevurdering = YearMonth.of(2024, 6)
+        val revurdering =
+            mockBehandling(
+                type = SakType.BARNEPENSJON,
+                virkningstidspunktdato = virkRevurdering,
+                uuid = revurderingId,
+                behandlingstype = BehandlingType.REVURDERING,
+                sakId = sakId,
+            )
+        coEvery { behandlingKlient.hentBehandling(revurderingId, any()) } returns revurdering
+        coEvery { behandlingKlient.hentBehandling(behandlingId, any()) } returns foerstegangsbehandling
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(sakId, any()) } returns
+            listOf(
+                mockVedtak(
+                    behandlingId,
+                    VedtakType.INNVILGELSE,
+                ),
+            )
+        every { beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(behandlingId) } returns
+            listOf(
+                overstyrtBeregningsgrunnlag(
+                    behandlingId = behandlingId,
+                    utbetaltBeloep = 1L,
+                    datoFOM = virkFoerstegangsbehandling.atDay(1),
+                ),
+            )
+        every { beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(revurderingId) } returns
+            listOf(
+                overstyrtBeregningsgrunnlag(
+                    behandlingId = behandlingId,
+                    utbetaltBeloep = 1L,
+                    datoFOM = virkFoerstegangsbehandling.atDay(1),
+                    datoTOM = virkRevurdering.minusMonths(1).atEndOfMonth(),
+                ),
+                overstyrtBeregningsgrunnlag(
+                    behandlingId = revurderingId,
+                    utbetaltBeloep = 2L,
+                    datoFOM = virkRevurdering.atDay(1),
+                ),
+            )
+
+        assertDoesNotThrow {
+            beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(
+                revurderingId,
+                virkRevurdering,
+                mockk(relaxed = true),
+            )
+        }
+    }
+
+    @Test
+    fun `sjekkOmOverstyrtGrunnlagErLiktFoerVirk kaster feil hvis det er endret i detaljer før virk`() {
+        val sakId = SakId(1L)
+
+        val behandlingId = randomUUID()
+        val virkFoerstegangsbehandling = YearMonth.of(2024, 1)
+        val foerstegangsbehandling =
+            mockBehandling(
+                type = SakType.BARNEPENSJON,
+                virkningstidspunktdato = virkFoerstegangsbehandling,
+                uuid = behandlingId,
+                behandlingstype = BehandlingType.FØRSTEGANGSBEHANDLING,
+                sakId = sakId,
+            )
+
+        val revurderingId = randomUUID()
+        val virkRevurdering = YearMonth.of(2024, 6)
+        val revurdering =
+            mockBehandling(
+                type = SakType.BARNEPENSJON,
+                virkningstidspunktdato = virkRevurdering,
+                uuid = revurderingId,
+                behandlingstype = BehandlingType.REVURDERING,
+                sakId = sakId,
+            )
+        coEvery { behandlingKlient.hentBehandling(revurderingId, any()) } returns revurdering
+        coEvery { behandlingKlient.hentBehandling(behandlingId, any()) } returns foerstegangsbehandling
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(sakId, any()) } returns
+            listOf(
+                mockVedtak(
+                    behandlingId,
+                    VedtakType.INNVILGELSE,
+                ),
+            )
+        every { beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(behandlingId) } returns
+            listOf(
+                overstyrtBeregningsgrunnlag(
+                    behandlingId = behandlingId,
+                    utbetaltBeloep = 1L,
+                    datoFOM = virkFoerstegangsbehandling.atDay(1),
+                ),
+            )
+        every { beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(revurderingId) } returns
+            listOf(
+                overstyrtBeregningsgrunnlag(
+                    behandlingId = revurderingId,
+                    utbetaltBeloep = 2L,
+                    datoFOM = virkFoerstegangsbehandling.atDay(1),
+                ),
+            )
+
+        assertThrows<OverstyrtBeregningsgrunnlagEndresFoerVirkException> {
+            beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(
+                revurderingId,
+                virkRevurdering,
+                mockk(relaxed = true),
+            )
+        }
+    }
+
+    @Test
+    fun `sjekkOmOverstyrtGrunnlagErLiktFoerVirk kaster feil hvis det er manglende perioder før virk`() {
+        val sakId = SakId(1L)
+
+        val behandlingId = randomUUID()
+        val virkFoerstegangsbehandling = YearMonth.of(2024, 1)
+        val foerstegangsbehandling =
+            mockBehandling(
+                type = SakType.BARNEPENSJON,
+                virkningstidspunktdato = virkFoerstegangsbehandling,
+                uuid = behandlingId,
+                behandlingstype = BehandlingType.FØRSTEGANGSBEHANDLING,
+                sakId = sakId,
+            )
+
+        val revurderingId = randomUUID()
+        val virkRevurdering = YearMonth.of(2024, 6)
+        val revurdering =
+            mockBehandling(
+                type = SakType.BARNEPENSJON,
+                virkningstidspunktdato = virkRevurdering,
+                uuid = revurderingId,
+                behandlingstype = BehandlingType.REVURDERING,
+                sakId = sakId,
+            )
+        coEvery { behandlingKlient.hentBehandling(revurderingId, any()) } returns revurdering
+        coEvery { behandlingKlient.hentBehandling(behandlingId, any()) } returns foerstegangsbehandling
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(sakId, any()) } returns
+            listOf(
+                mockVedtak(
+                    behandlingId,
+                    VedtakType.INNVILGELSE,
+                ),
+            )
+        every { beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(behandlingId) } returns
+            listOf(
+                overstyrtBeregningsgrunnlag(
+                    behandlingId = behandlingId,
+                    utbetaltBeloep = 1L,
+                    datoFOM = virkFoerstegangsbehandling.atDay(1),
+                ),
+            )
+        every { beregningsGrunnlagRepository.finnOverstyrBeregningGrunnlagForBehandling(revurderingId) } returns
+            listOf(
+                overstyrtBeregningsgrunnlag(
+                    behandlingId = revurderingId,
+                    utbetaltBeloep = 2L,
+                    datoFOM = virkRevurdering.atDay(1),
+                ),
+            )
+
+        assertThrows<OverstyrtBeregningsgrunnlagEndresFoerVirkException> {
+            beregningsGrunnlagService.sjekkOmOverstyrtGrunnlagErLiktFoerVirk(
+                revurderingId,
+                virkRevurdering,
+                mockk(relaxed = true),
             )
         }
     }

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
@@ -1115,7 +1115,7 @@ internal class BeregningsGrunnlagServiceTest {
         val grunnlag =
             runBlocking { beregningsGrunnlagService.hentOverstyrBeregningGrunnlag(revurderingId, mockk(relaxed = true)) }
         assertEquals(1, grunnlag.perioder.size)
-        slotOverstyrtePerioder.captured == overstyrtePerioderForrigeBehandling
+        assertEquals(slotOverstyrtePerioder.captured, overstyrtePerioderForrigeBehandling)
     }
 
     @Test

--- a/libs/etterlatte-beregning-model/src/main/kotlin/OverstyrBeregningsGrunnlag.kt
+++ b/libs/etterlatte-beregning-model/src/main/kotlin/OverstyrBeregningsGrunnlag.kt
@@ -22,7 +22,24 @@ data class OverstyrBeregningGrunnlagDao(
     val aarsak: String?,
     val kilde: Grunnlagsopplysning.Saksbehandler,
     val reguleringRegelresultat: JsonNode? = null,
-)
+) {
+    fun tilGrunnlagMedPeriode(): GrunnlagMedPeriode<OverstyrBeregningGrunnlagData> =
+        GrunnlagMedPeriode(
+            data =
+                OverstyrBeregningGrunnlagData(
+                    utbetaltBeloep = this.utbetaltBeloep,
+                    foreldreloessats = this.foreldreloessats,
+                    trygdetid = this.trygdetid,
+                    trygdetidForIdent = this.trygdetidForIdent,
+                    prorataBroekTeller = this.prorataBroekTeller,
+                    prorataBroekNevner = this.prorataBroekNevner,
+                    beskrivelse = this.beskrivelse,
+                    aarsak = this.aarsak,
+                ),
+            fom = this.datoFOM,
+            tom = this.datoTOM,
+        )
+}
 
 data class OverstyrBeregningGrunnlagData(
     val utbetaltBeloep: Long,

--- a/libs/etterlatte-beregning-model/src/main/kotlin/OverstyrBeregningsGrunnlag.kt
+++ b/libs/etterlatte-beregning-model/src/main/kotlin/OverstyrBeregningsGrunnlag.kt
@@ -41,6 +41,15 @@ data class OverstyrBeregningGrunnlagDao(
         )
 }
 
+data class OverstyrtBeregningsgrunnlagSammenligningsperiode(
+    val utbetaltBeloep: Long,
+    val foreldreloessats: Boolean?,
+    val trygdetid: Long,
+    val trygdetidForIdent: String?,
+    val prorataBroekTeller: Long?,
+    val prorataBroekNevner: Long?,
+)
+
 data class OverstyrBeregningGrunnlagData(
     val utbetaltBeloep: Long,
     val foreldreloessats: Boolean?,
@@ -50,7 +59,17 @@ data class OverstyrBeregningGrunnlagData(
     val prorataBroekNevner: Long?,
     val beskrivelse: String,
     val aarsak: String?,
-)
+) {
+    fun tilSammenligningsperiode(): OverstyrtBeregningsgrunnlagSammenligningsperiode =
+        OverstyrtBeregningsgrunnlagSammenligningsperiode(
+            utbetaltBeloep = this.utbetaltBeloep,
+            foreldreloessats = this.foreldreloessats,
+            trygdetid = this.trygdetid,
+            trygdetidForIdent = this.trygdetidForIdent,
+            prorataBroekTeller = this.prorataBroekTeller,
+            prorataBroekNevner = this.prorataBroekNevner,
+        )
+}
 
 data class OverstyrBeregningGrunnlagDTO(
     val perioder: List<GrunnlagMedPeriode<OverstyrBeregningGrunnlagData>>,


### PR DESCRIPTION
Kopierer også inn grunnlaget fra forrige iverksatte behandling i revurderinger, hvis det finnes.