### PR TITLE
Feature/ey4998 trygdetid nordisk konvensjon

### DIFF
--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidBeregningService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidBeregningService.kt
@@ -25,6 +25,7 @@ object TrygdetidBeregningService {
         doedsDato: LocalDate,
         norskPoengaar: Int?,
         yrkesskade: Boolean,
+        nordiskKonvensjon: Boolean,
     ): DetaljertBeregnetTrygdetid? {
         logger.info("Beregner antall år trygdetid")
 
@@ -45,6 +46,7 @@ object TrygdetidBeregningService {
                             doedsDato = doedsDato,
                             norskPoengaar = norskPoengaar,
                             yrkesskade = yrkesskade,
+                            nordiskKonvensjon = nordiskKonvensjon,
                         ),
                     kilde = "System",
                     beskrivelse = "Beregn detaljert trygdetidsgrunnlag",

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -13,6 +13,7 @@ import no.nav.etterlatte.libs.common.behandling.BehandlingStatus.SAMORDNET
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus.TIL_SAMORDNING
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
+import no.nav.etterlatte.libs.common.behandling.JaNei
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.feilhaandtering.GenerellIkkeFunnetException
@@ -1024,6 +1025,7 @@ class TrygdetidServiceImpl(
         brukerTokenInfo: BrukerTokenInfo,
     ): Trygdetid {
         val datoer = hentDatoerForBehandling(trygdetid)
+        val nordiskKonvensjon = avtaleService.hentAvtaleForBehandling(behandlingId)?.nordiskTrygdeAvtale == JaNei.JA
 
         val nyBeregnetTrygdetid =
             beregnTrygdetidService.beregnTrygdetid(
@@ -1032,8 +1034,8 @@ class TrygdetidServiceImpl(
                 datoer.doedsDato,
                 trygdetid.overstyrtNorskPoengaar,
                 trygdetid.yrkesskade,
+                nordiskKonvensjon,
             )
-
         return when (nyBeregnetTrygdetid) {
             null -> trygdetid.nullstillBeregnetTrygdetid()
             else -> trygdetid.oppdaterBeregnetTrygdetid(nyBeregnetTrygdetid)

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/regler/BeregnTrygdetid.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/regler/BeregnTrygdetid.kt
@@ -24,15 +24,6 @@ import kotlin.math.round
 // TODO dato settes riktig senere
 val TRYGDETID_DATO: LocalDate = LocalDate.of(1900, 1, 1)
 
-// TODO TEMP TEMP
-val nordiskKonvensjon =
-    definerKonstant<TrygdetidGrunnlagMedAvdoedGrunnlag, Boolean>(
-        gjelderFra = TRYGDETID_DATO,
-        beskrivelse = "tullball",
-        regelReferanse = RegelReferanse("BareTull"),
-        verdi = true,
-    )
-
 data class TrygdetidPeriodeMedPoengaar(
     val fra: LocalDate,
     val til: LocalDate,
@@ -63,11 +54,20 @@ data class TrygdetidGrunnlagMedAvdoed(
     val doedsDato: LocalDate,
     val norskPoengaar: Int?,
     val yrkesskade: Boolean,
+    val nordiskKonvensjon: Boolean,
 )
 
 data class TrygdetidGrunnlagMedAvdoedGrunnlag(
     val trygdetidGrunnlagMedAvdoed: FaktumNode<TrygdetidGrunnlagMedAvdoed>,
 )
+
+val nordiskKonvensjon: Regel<TrygdetidGrunnlagMedAvdoedGrunnlag, Boolean> =
+    finnFaktumIGrunnlag(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Hent nordisk konvensjon",
+        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::trygdetidGrunnlagMedAvdoed,
+        finnFelt = { it.nordiskKonvensjon },
+    )
 
 val dagerPrMaanedTrygdetidGrunnlag =
     definerKonstant<TrygdetidGrunnlagMedAvdoedGrunnlag, Int>(

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/regler/BeregnTrygdetid.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/regler/BeregnTrygdetid.kt
@@ -309,7 +309,7 @@ val opptjeningsTidIMnd =
     }
 
 /**
- * NY Regel for Nordisk Art 9
+ * Finne ut om valg av nordisk konvensjon art 9 skal overstyre bruk av 4/5 regel
  */
 val nordiskEllerFireFemtedeler =
     RegelMeta(
@@ -332,7 +332,7 @@ val fremtidigTrygdetidForNasjonal =
     RegelMeta(
         gjelderFra = TRYGDETID_DATO,
         beskrivelse = "Regn ut fremtidig trygdetid nasjonal",
-        regelReferanse = RegelReferanse(id = "REGEL-BEREGN-FREMTIDIG-NASJONAL-TRYGDETID"),
+        regelReferanse = RegelReferanse(id = "REGEL-BEREGN-FREMTIDIG-NASJONAL-TRYGDETID", versjon = "1.1"),
     ) benytter nordiskEllerFireFemtedeler og fremtidigTrygdetid og opptjeningsTidIMnd med
         { nordiskEllerFireFemtedeler, fremtidig, opptjening ->
             if (fremtidig != null) {

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidBeregningServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidBeregningServiceTest.kt
@@ -36,6 +36,7 @@ class TrygdetidBeregningServiceTest {
                 doedsDato = now,
                 norskPoengaar = null,
                 yrkesskade = false,
+                nordiskKonvensjon = false,
             )
         beregnetTrygdetid shouldNotBe null
         with(beregnetTrygdetid!!) {
@@ -68,6 +69,7 @@ class TrygdetidBeregningServiceTest {
                 doedsDato = now,
                 norskPoengaar = null,
                 yrkesskade = false,
+                nordiskKonvensjon = false,
             )
 
         beregnetTrygdetid!!.resultat.samletTrygdetidNorge shouldBe 40
@@ -87,6 +89,7 @@ class TrygdetidBeregningServiceTest {
                 doedsDato = LocalDate.now(),
                 norskPoengaar = null,
                 yrkesskade = false,
+                nordiskKonvensjon = false,
             )
 
         beregnetTrygdetid!!.resultat.samletTrygdetidNorge shouldBe null
@@ -119,6 +122,7 @@ class TrygdetidBeregningServiceTest {
                 doedsDato = now,
                 norskPoengaar = 10,
                 yrkesskade = false,
+                nordiskKonvensjon = false,
             )
         beregnetTrygdetid shouldNotBe null
         with(beregnetTrygdetid!!) {
@@ -141,6 +145,7 @@ class TrygdetidBeregningServiceTest {
                 doedsDato = now,
                 norskPoengaar = 10,
                 yrkesskade = false,
+                nordiskKonvensjon = false,
             )
         beregnetTrygdetid shouldNotBe null
         with(beregnetTrygdetid!!) {
@@ -206,6 +211,7 @@ class TrygdetidBeregningServiceTest {
                 doedsDato = now,
                 norskPoengaar = 10,
                 yrkesskade = true,
+                nordiskKonvensjon = false,
             )
         beregnetTrygdetid shouldNotBe null
         with(beregnetTrygdetid!!) {

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceIntegrationTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceIntegrationTest.kt
@@ -139,6 +139,7 @@ internal class TrygdetidServiceIntegrationTest(
         val sakId = randomSakId()
         val grunnlagTestData = GrunnlagTestData()
 
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
         coEvery { behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler) } returns true
         coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler) } returns true
         coEvery { behandlingKlient.hentBehandling(behandlingId, saksbehandler) } returns

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
@@ -165,6 +165,7 @@ internal class TrygdetidServiceTest {
                 .verdi
         val trygdetid = trygdetid(behandlingId, sakId, ident = forventetIdent.value)
 
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
         every { repository.hentTrygdetiderForBehandling(any()) } returns emptyList() andThen listOf(trygdetid)
         every { repository.hentTrygdetid(any()) } returns trygdetid
         every { repository.hentTrygdetidMedId(any(), any()) } returns trygdetid
@@ -185,6 +186,9 @@ internal class TrygdetidServiceTest {
             }
         }
 
+        coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
+        }
         coVerify {
             grunnlagKlient.hentGrunnlag(behandlingId, saksbehandler)
         }
@@ -233,7 +237,7 @@ internal class TrygdetidServiceTest {
                 },
             )
             beregningService.beregnTrygdetidGrunnlag(any())
-            beregningService.beregnTrygdetid(any(), any(), any(), any(), any())
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), any(), any())
         }
         verify {
             behandling.id
@@ -497,6 +501,7 @@ internal class TrygdetidServiceTest {
         val trygdetid = trygdetid(behandlingId, sakId, ident = forventetIdent.value)
         val vedtakSammendrag = mockVedtak(forrigeBehandlingId, VedtakType.ENDRING)
 
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
         every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
@@ -519,6 +524,10 @@ internal class TrygdetidServiceTest {
         }
 
         coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
+        }
+
+        coVerify(exactly = 1) {
             grunnlagKlient.hentGrunnlag(behandlingId, saksbehandler)
             behandlingKlient.hentBehandling(behandlingId, saksbehandler)
             repository.hentTrygdetiderForBehandling(behandlingId)
@@ -538,7 +547,7 @@ internal class TrygdetidServiceTest {
                 },
             )
             beregningService.beregnTrygdetidGrunnlag(any())
-            beregningService.beregnTrygdetid(any(), any(), any(), any(), any())
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), any(), any())
         }
         verify {
             behandling.revurderingsaarsak
@@ -623,6 +632,7 @@ internal class TrygdetidServiceTest {
         val trygdetid = trygdetid(behandlingId, sakId, ident = forventetIdent.value)
         val vedtakSammendrag = mockVedtak(forrigeBehandlingId, VedtakType.ENDRING)
 
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
         every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
@@ -643,6 +653,10 @@ internal class TrygdetidServiceTest {
 
         coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
+        }
+
+        coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
         }
 
         coVerify(exactly = 2) {
@@ -669,7 +683,7 @@ internal class TrygdetidServiceTest {
                 },
             )
             beregningService.beregnTrygdetidGrunnlag(any())
-            beregningService.beregnTrygdetid(any(), any(), any(), any(), any())
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), any(), any())
         }
         verify {
             behandling.revurderingsaarsak
@@ -725,6 +739,7 @@ internal class TrygdetidServiceTest {
 
         val trygdetid = trygdetid(behandlingId)
 
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
         every { repository.hentTrygdetiderForBehandling(any()) } returns listOf(trygdetid)
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns
             grunnlag
@@ -776,13 +791,16 @@ internal class TrygdetidServiceTest {
                 },
             )
             beregningService.beregnTrygdetidGrunnlag(any())
-            beregningService.beregnTrygdetid(any(), any(), any(), any(), any())
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), any(), any())
         }
         coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
         }
         coVerify(exactly = 2) {
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
+        }
+        coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
         }
 
         verify {
@@ -816,6 +834,7 @@ internal class TrygdetidServiceTest {
         val grunnlag = mockk<Grunnlag>()
         val avdoedGrunnlag = mockk<Grunnlagsdata<JsonNode>>()
 
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
         coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
         every { repository.hentTrygdetid(behandlingId) } returns eksisterendeTrygdetid
         every { repository.hentTrygdetidMedId(behandlingId, eksisterendeTrygdetid.id) } returns eksisterendeTrygdetid
@@ -875,7 +894,11 @@ internal class TrygdetidServiceTest {
             )
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
             beregningService.beregnTrygdetidGrunnlag(any())
-            beregningService.beregnTrygdetid(any(), any(), any(), any(), any())
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), any(), any())
+        }
+
+        coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
         }
     }
 
@@ -891,6 +914,7 @@ internal class TrygdetidServiceTest {
 
         val grunnlag = mockk<Grunnlag>()
 
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
         coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
         every { repository.hentTrygdetid(behandlingId) } returns eksisterendeTrygdetid
         every { repository.hentTrygdetidMedId(behandlingId, eksisterendeTrygdetid.id) } returns eksisterendeTrygdetid
@@ -917,6 +941,9 @@ internal class TrygdetidServiceTest {
         trygdetid.beregnetTrygdetid?.resultat?.samletTrygdetidNorge shouldBe 10
 
         coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
+        }
+        coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
             repository.hentTrygdetidMedId(behandlingId, trygdetid.id)
             repository.oppdaterTrygdetid(
@@ -926,7 +953,7 @@ internal class TrygdetidServiceTest {
             )
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
             beregningService.beregnTrygdetidGrunnlag(any())
-            beregningService.beregnTrygdetid(any(), any(), any(), any(), any())
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), any(), any())
         }
     }
 
@@ -942,6 +969,7 @@ internal class TrygdetidServiceTest {
         val grunnlag = mockk<Grunnlag>()
         val avdoedGrunnlag = mockk<Grunnlagsdata<JsonNode>>()
 
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
         every { repository.hentTrygdetid(behandlingId) } returns eksisterendeTrygdetid
         every { repository.hentTrygdetidMedId(behandlingId, eksisterendeTrygdetid.id) } returns eksisterendeTrygdetid
         every { repository.oppdaterTrygdetid(any()) } answers { firstArg() }
@@ -992,6 +1020,10 @@ internal class TrygdetidServiceTest {
         }
 
         coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
+        }
+
+        coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
             repository.hentTrygdetidMedId(behandlingId, eksisterendeTrygdetid.id)
             repository.oppdaterTrygdetid(
@@ -1003,7 +1035,7 @@ internal class TrygdetidServiceTest {
                 },
             )
             beregningService.beregnTrygdetidGrunnlag(any())
-            beregningService.beregnTrygdetid(any(), any(), any(), any(), any())
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), any(), any())
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
         }
     }
@@ -1019,6 +1051,7 @@ internal class TrygdetidServiceTest {
         val grunnlag = mockk<Grunnlag>()
         val avdoedGrunnlag = mockk<Grunnlagsdata<JsonNode>>()
 
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
         every { repository.hentTrygdetiderForBehandling(behandlingId) } returns listOf(eksisterendeTrygdetid)
         every { repository.hentTrygdetid(behandlingId) } returns eksisterendeTrygdetid
         every { repository.hentTrygdetidMedId(behandlingId, eksisterendeTrygdetid.id) } returns eksisterendeTrygdetid
@@ -1067,6 +1100,10 @@ internal class TrygdetidServiceTest {
         trygdetid.beregnetTrygdetid shouldBe null
 
         coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
+        }
+
+        coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
             repository.hentTrygdetidMedId(behandlingId, trygdetid.id)
             repository.oppdaterTrygdetid(
@@ -1074,7 +1111,7 @@ internal class TrygdetidServiceTest {
                     it.trygdetidGrunnlag shouldBe emptyList()
                 },
             )
-            beregningService.beregnTrygdetid(any(), any(), any(), any(), any())
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), any(), any())
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
         }
     }
@@ -1347,6 +1384,7 @@ internal class TrygdetidServiceTest {
                     ),
             )
 
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
         coEvery { repository.hentTrygdetidMedId(any(), any()) } returns eksisterendeTrygdetid
@@ -1366,9 +1404,12 @@ internal class TrygdetidServiceTest {
             behandlingKlient.kanOppdatereTrygdetid(any(), any())
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any())
         }
+        coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
+        }
         verify(exactly = 1) {
             repository.hentTrygdetidMedId(any(), any())
-            beregningService.beregnTrygdetid(any(), any(), any(), any(), true)
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), true, any())
             repository.oppdaterTrygdetid(
                 withArg {
                     it.yrkesskade shouldBe true
@@ -1440,7 +1481,7 @@ internal class TrygdetidServiceTest {
                         ),
                     ),
             )
-
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
         coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
         coEvery { repository.hentTrygdetidMedId(any(), any()) } returns eksisterendeTrygdetid
@@ -1457,12 +1498,16 @@ internal class TrygdetidServiceTest {
         trygdetid.beregnetTrygdetid?.resultat?.samletTrygdetidNorge shouldBe 10
 
         coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
+        }
+
+        coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(any(), any())
             behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any())
         }
         verify(exactly = 1) {
             repository.hentTrygdetidMedId(any(), any())
-            beregningService.beregnTrygdetid(any(), any(), any(), 10, any())
+            beregningService.beregnTrygdetid(any(), any(), any(), 10, any(), any())
             repository.oppdaterTrygdetid(
                 withArg {
                     it.overstyrtNorskPoengaar shouldBe 10

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/regler/BeregnTrygdetidTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/regler/BeregnTrygdetidTest.kt
@@ -146,6 +146,7 @@ internal class BeregnTrygdetidTest {
                         doedsDato = datoer?.second ?: LocalDate.of(2023, 3, 15),
                         norskPoengaar = norskPoengaar,
                         yrkesskade = yrkesskade,
+                        nordiskKonvensjon = false,
                     ),
                 kilde = Grunnlagsopplysning.Saksbehandler("Z12345", Tidspunkt.now()),
                 beskrivelse = "Perioder",

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/regler/BeregnTrygdetidTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/regler/BeregnTrygdetidTest.kt
@@ -691,6 +691,84 @@ internal class BeregnTrygdetidTest {
                 ),
                 Arguments.of(
                     // ...arguments =
+                    "Skal ikke treffe 4/5 regel hvis nordisk konvensjon",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.SVERIGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2013, 5, 1),
+                                til = LocalDate.of(2018, 12, 31),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2019, 1, 1),
+                                til = LocalDate.of(2024, 9, 30),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            type = TrygdetidType.FREMTIDIG,
+                            bosted = LandNormalisert.NORGE.isoCode,
+                            periode =
+                                TrygdetidPeriode(
+                                    fra = LocalDate.of(2024, 10, 15),
+                                    til = LocalDate.of(2041, 10, 20),
+                                ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.of(5, 9, 0),
+                                antallMaaneder = 69,
+                            ),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(11, 5, 0),
+                                antallMaaneder = 137,
+                            ),
+                        fremtidigTrygdetidNorge =
+                            FremtidigTrygdetid(
+                                periode = Period.of(22, 9, 0),
+                                antallMaaneder = 273,
+                                opptjeningstidIMaaneder = 259,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = true,
+                            ),
+                        fremtidigTrygdetidTeoretisk =
+                            FremtidigTrygdetid(
+                                periode = Period.of(22, 9, 0),
+                                antallMaaneder = 273,
+                                opptjeningstidIMaaneder = 259,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = true,
+                            ),
+                        samletTrygdetidNorge = 29,
+                        samletTrygdetidTeoretisk = 34,
+                        prorataBroek = IntBroek(teller = 69, nevner = 137),
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                    Pair(
+                        LocalDate.of(2023, 2, 21).minusYears(36),
+                        LocalDate.of(2023, 2, 21),
+                    ),
+                    null,
+                    false,
+                ),
+                Arguments.of(
+                    // ...arguments =
                     "Skal ikke få mer enn 40 år i brøken",
                     listOf(
                         byggTrygdetidGrunnlag(


### PR DESCRIPTION
Hvis saksbehandler velger nordisk konvensjon skal vi ikke bruke 4/5 regelen ved beregning av trygdetid