### PR TITLE
EY-4961: Vise andre klassetyper enn YTEL i tilbakekreving

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingDao.kt
@@ -10,13 +10,13 @@ import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.getTidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.setTidspunkt
-import no.nav.etterlatte.libs.common.tilbakekreving.KlasseType
 import no.nav.etterlatte.libs.common.tilbakekreving.Tilbakekreving
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingBehandling
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingPeriode
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingResultat
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingSkyld
 import no.nav.etterlatte.libs.common.tilbakekreving.Tilbakekrevingsbelop
+import no.nav.etterlatte.libs.common.tilbakekreving.tilbakekrevingsbeloepComparator
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.database.setJsonb
 import no.nav.etterlatte.libs.database.setSakId
@@ -146,14 +146,7 @@ class TilbakekrevingDao(
                     TilbakekrevingPeriode(
                         maaned = maaned,
                         tilbakekrevingsbeloep =
-                            perioder.sortedBy {
-                                // Sorterer basert på klassetype for visning
-                                when (it.klasseType) {
-                                    KlasseType.FEIL.name -> 0
-                                    KlasseType.YTEL.name -> 1
-                                    else -> 2
-                                }
-                            },
+                            perioder.sortedWith(tilbakekrevingsbeloepComparator),
                     )
                 }
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/tilbakekreving/TilbakekrevingDao.kt
@@ -10,6 +10,7 @@ import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.getTidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.setTidspunkt
+import no.nav.etterlatte.libs.common.tilbakekreving.KlasseType
 import no.nav.etterlatte.libs.common.tilbakekreving.Tilbakekreving
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingBehandling
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingPeriode
@@ -144,7 +145,15 @@ class TilbakekrevingDao(
                 .map { (maaned, perioder) ->
                     TilbakekrevingPeriode(
                         maaned = maaned,
-                        tilbakekrevingsbeloep = perioder,
+                        tilbakekrevingsbeloep =
+                            perioder.sortedBy {
+                                // Sorterer basert på klassetype for visning
+                                when (it.klasseType) {
+                                    KlasseType.FEIL.name -> 0
+                                    KlasseType.YTEL.name -> 1
+                                    else -> 2
+                                }
+                            },
                     )
                 }
         }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderRadAndreKlassetyper.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderRadAndreKlassetyper.tsx
@@ -1,0 +1,32 @@
+import { Table } from '@navikt/ds-react'
+import React from 'react'
+import { tekstKlasseKode, TilbakekrevingBeloep, TilbakekrevingPeriode } from '~shared/types/Tilbakekreving'
+import { formaterMaanedDato } from '~utils/formatering/dato'
+
+export function TilbakekrevingVurderingPerioderRadAndreKlassetyper({
+  periode,
+  beloep,
+}: {
+  periode: TilbakekrevingPeriode
+  beloep: TilbakekrevingBeloep
+}) {
+  return (
+    <>
+      <Table.Row>
+        <Table.DataCell key="maaned">{formaterMaanedDato(periode.maaned)}</Table.DataCell>
+        <Table.DataCell key="klasse">{tekstKlasseKode[beloep.klasseKode] ?? beloep.klasseKode}</Table.DataCell>
+        <Table.DataCell key="bruttoUtbetaling">{beloep.bruttoUtbetaling} kr</Table.DataCell>
+        <Table.DataCell key="nyBruttoUtbetaling">{beloep.nyBruttoUtbetaling} kr</Table.DataCell>
+        <Table.DataCell key="beregnetFeilutbetaling"></Table.DataCell>
+        <Table.DataCell key="skatteprosent"></Table.DataCell>
+        <Table.DataCell key="bruttoTilbakekreving"></Table.DataCell>
+        <Table.DataCell key="nettoTilbakekreving"></Table.DataCell>
+        <Table.DataCell key="skatt"></Table.DataCell>
+        <Table.DataCell key="skyld"></Table.DataCell>
+        <Table.DataCell key="resultat"></Table.DataCell>
+        <Table.DataCell key="tilbakekrevingsprosent"></Table.DataCell>
+        <Table.DataCell key="rentetillegg"></Table.DataCell>
+      </Table.Row>
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderSkjema.tsx
@@ -137,11 +137,9 @@ export function TilbakekrevingVurderingPerioderSkjema({
             </Table.Header>
             <Table.Body>
               {watch().values.map((periode, indexPeriode) => {
-                return periode.tilbakekrevingsbeloep
-                  .map(leggPaaOrginalIndex)
-                  .filter(klasseTypeYtelse)
-                  .map((beloep) => {
-                    const indexBeloep = beloep.originalIndex
+                return periode.tilbakekrevingsbeloep.map(leggPaaOrginalIndex).map((beloep) => {
+                  const indexBeloep = beloep.originalIndex
+                  if (klasseTypeYtelse(beloep)) {
                     return (
                       <Table.Row key={`beloepRad-${indexPeriode}-${indexBeloep}`} style={{ alignItems: 'start' }}>
                         <Table.DataCell key="maaned">{formaterMaanedDato(periode.maaned)}</Table.DataCell>
@@ -288,7 +286,28 @@ export function TilbakekrevingVurderingPerioderSkjema({
                         </Table.DataCell>
                       </Table.Row>
                     )
-                  })
+                  } else {
+                    return (
+                      <Table.Row key={`beloepRad-${indexPeriode}-${beloep.originalIndex}`}>
+                        <Table.DataCell key="maaned">{formaterMaanedDato(periode.maaned)}</Table.DataCell>
+                        <Table.DataCell key="klasse">
+                          {tekstKlasseKode[beloep.klasseKode] ?? beloep.klasseKode}
+                        </Table.DataCell>
+                        <Table.DataCell key="bruttoUtbetaling">{beloep.bruttoUtbetaling} kr</Table.DataCell>
+                        <Table.DataCell key="nyBruttoUtbetaling">{beloep.nyBruttoUtbetaling} kr</Table.DataCell>
+                        <Table.DataCell key="beregnetFeilutbetaling"></Table.DataCell>
+                        <Table.DataCell key="skatteprosent"></Table.DataCell>
+                        <Table.DataCell key="bruttoTilbakekreving"></Table.DataCell>
+                        <Table.DataCell key="nettoTilbakekreving"></Table.DataCell>
+                        <Table.DataCell key="skatt"></Table.DataCell>
+                        <Table.DataCell key="skyld"></Table.DataCell>
+                        <Table.DataCell key="resultat"></Table.DataCell>
+                        <Table.DataCell key="tilbakekrevingsprosent"></Table.DataCell>
+                        <Table.DataCell key="rentetillegg"></Table.DataCell>
+                      </Table.Row>
+                    )
+                  }
+                })
               })}
             </Table.Body>
           </Table>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderSkjema.tsx
@@ -23,6 +23,7 @@ import { FixedAlert } from '~shared/alerts/FixedAlert'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { ArrowsCirclepathIcon } from '@navikt/aksel-icons'
 import { formaterMaanedDato } from '~utils/formatering/dato'
+import { TilbakekrevingVurderingPerioderRadAndreKlassetyper } from '~components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderRadAndreKlassetyper'
 
 export function TilbakekrevingVurderingPerioderSkjema({
   behandling,
@@ -287,24 +288,13 @@ export function TilbakekrevingVurderingPerioderSkjema({
                       </Table.Row>
                     )
                   } else {
+                    // Kun visning av andre klassetyper enn YTEL - Disse har ikke vurderingsfelter
                     return (
-                      <Table.Row key={`beloepRad-${indexPeriode}-${beloep.originalIndex}`}>
-                        <Table.DataCell key="maaned">{formaterMaanedDato(periode.maaned)}</Table.DataCell>
-                        <Table.DataCell key="klasse">
-                          {tekstKlasseKode[beloep.klasseKode] ?? beloep.klasseKode}
-                        </Table.DataCell>
-                        <Table.DataCell key="bruttoUtbetaling">{beloep.bruttoUtbetaling} kr</Table.DataCell>
-                        <Table.DataCell key="nyBruttoUtbetaling">{beloep.nyBruttoUtbetaling} kr</Table.DataCell>
-                        <Table.DataCell key="beregnetFeilutbetaling"></Table.DataCell>
-                        <Table.DataCell key="skatteprosent"></Table.DataCell>
-                        <Table.DataCell key="bruttoTilbakekreving"></Table.DataCell>
-                        <Table.DataCell key="nettoTilbakekreving"></Table.DataCell>
-                        <Table.DataCell key="skatt"></Table.DataCell>
-                        <Table.DataCell key="skyld"></Table.DataCell>
-                        <Table.DataCell key="resultat"></Table.DataCell>
-                        <Table.DataCell key="tilbakekrevingsprosent"></Table.DataCell>
-                        <Table.DataCell key="rentetillegg"></Table.DataCell>
-                      </Table.Row>
+                      <TilbakekrevingVurderingPerioderRadAndreKlassetyper
+                        key={`beloepRad-${indexPeriode}-${indexBeloep}`}
+                        periode={periode}
+                        beloep={beloep}
+                      />
                     )
                   }
                 })

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderVisning.tsx
@@ -11,6 +11,7 @@ import React, { useState } from 'react'
 import { Box, Button, HStack, Table } from '@navikt/ds-react'
 import { useNavigate } from 'react-router'
 import { formaterMaanedDato } from '~utils/formatering/dato'
+import { TilbakekrevingVurderingPerioderRadAndreKlassetyper } from '~components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderRadAndreKlassetyper'
 
 export function TilbakekrevingVurderingPerioderVisning({ behandling }: { behandling: TilbakekrevingBehandling }) {
   const navigate = useNavigate()
@@ -60,24 +61,13 @@ export function TilbakekrevingVurderingPerioderVisning({ behandling }: { behandl
                   </Table.Row>
                 )
               } else {
+                // Kun visning av andre klassetyper enn YTEL - Disse har ikke vurderingsfelter
                 return (
-                  <Table.Row key={`beloepRad-${indexPeriode}-${beloep.originalIndex}`}>
-                    <Table.DataCell key="maaned">{formaterMaanedDato(periode.maaned)}</Table.DataCell>
-                    <Table.DataCell key="klasse">
-                      {tekstKlasseKode[beloep.klasseKode] ?? beloep.klasseKode}
-                    </Table.DataCell>
-                    <Table.DataCell key="bruttoUtbetaling">{beloep.bruttoUtbetaling} kr</Table.DataCell>
-                    <Table.DataCell key="nyBruttoUtbetaling">{beloep.nyBruttoUtbetaling} kr</Table.DataCell>
-                    <Table.DataCell key="beregnetFeilutbetaling"></Table.DataCell>
-                    <Table.DataCell key="skatteprosent"></Table.DataCell>
-                    <Table.DataCell key="bruttoTilbakekreving"></Table.DataCell>
-                    <Table.DataCell key="nettoTilbakekreving"></Table.DataCell>
-                    <Table.DataCell key="skatt"></Table.DataCell>
-                    <Table.DataCell key="skyld"></Table.DataCell>
-                    <Table.DataCell key="resultat"></Table.DataCell>
-                    <Table.DataCell key="tilbakekrevingsprosent"></Table.DataCell>
-                    <Table.DataCell key="rentetillegg"></Table.DataCell>
-                  </Table.Row>
+                  <TilbakekrevingVurderingPerioderRadAndreKlassetyper
+                    key={`beloepRad-${indexPeriode}-${beloep.originalIndex}`}
+                    periode={periode}
+                    beloep={beloep}
+                  />
                 )
               }
             })

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderVisning.tsx
@@ -38,10 +38,8 @@ export function TilbakekrevingVurderingPerioderVisning({ behandling }: { behandl
         </Table.Header>
         <Table.Body>
           {perioder.map((periode, indexPeriode) => {
-            return periode.tilbakekrevingsbeloep
-              .map(leggPaaOrginalIndex)
-              .filter(klasseTypeYtelse)
-              .map((beloep) => {
+            return periode.tilbakekrevingsbeloep.map(leggPaaOrginalIndex).map((beloep) => {
+              if (klasseTypeYtelse(beloep)) {
                 return (
                   <Table.Row key={`beloepRad-${indexPeriode}-${beloep.originalIndex}`}>
                     <Table.DataCell key="maaned">{formaterMaanedDato(periode.maaned)}</Table.DataCell>
@@ -61,7 +59,28 @@ export function TilbakekrevingVurderingPerioderVisning({ behandling }: { behandl
                     <Table.DataCell key="rentetillegg">{beloep.rentetillegg} kr</Table.DataCell>
                   </Table.Row>
                 )
-              })
+              } else {
+                return (
+                  <Table.Row key={`beloepRad-${indexPeriode}-${beloep.originalIndex}`}>
+                    <Table.DataCell key="maaned">{formaterMaanedDato(periode.maaned)}</Table.DataCell>
+                    <Table.DataCell key="klasse">
+                      {tekstKlasseKode[beloep.klasseKode] ?? beloep.klasseKode}
+                    </Table.DataCell>
+                    <Table.DataCell key="bruttoUtbetaling">{beloep.bruttoUtbetaling} kr</Table.DataCell>
+                    <Table.DataCell key="nyBruttoUtbetaling">{beloep.nyBruttoUtbetaling} kr</Table.DataCell>
+                    <Table.DataCell key="beregnetFeilutbetaling"></Table.DataCell>
+                    <Table.DataCell key="skatteprosent"></Table.DataCell>
+                    <Table.DataCell key="bruttoTilbakekreving"></Table.DataCell>
+                    <Table.DataCell key="nettoTilbakekreving"></Table.DataCell>
+                    <Table.DataCell key="skatt"></Table.DataCell>
+                    <Table.DataCell key="skyld"></Table.DataCell>
+                    <Table.DataCell key="resultat"></Table.DataCell>
+                    <Table.DataCell key="tilbakekrevingsprosent"></Table.DataCell>
+                    <Table.DataCell key="rentetillegg"></Table.DataCell>
+                  </Table.Row>
+                )
+              }
+            })
           })}
         </Table.Body>
       </Table>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Tilbakekreving.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Tilbakekreving.ts
@@ -201,4 +201,9 @@ export const leggPaaOrginalIndex = (beloep: TilbakekrevingBeloep, index: number)
 export const tekstKlasseKode: Record<string, string> = {
   'BARNEPENSJON-OPTP': 'Barnepensjon',
   'BARNEPEFØR2024-OPTP': 'Barnepensjon før 2024',
+  OMSTILLINGSTOENAD_OPTP: 'Omstillingsstønad',
+  KL_KODE_FEIL_PEN: 'Feilkonto barnepensjon',
+  KL_KODE_FEIL_OMSTILL: 'Feilkonto omstillingsstønad',
+
+  BPSKSKAT: 'Skattetrekk barnepensjon',
 } as const

--- a/libs/etterlatte-tilbakekreving-model/src/main/kotlin/Tilbakekreving.kt
+++ b/libs/etterlatte-tilbakekreving-model/src/main/kotlin/Tilbakekreving.kt
@@ -75,6 +75,15 @@ data class TilbakekrevingPeriode(
 
 fun List<Tilbakekrevingsbelop>.kunYtelse() = filter { it.klasseType == KlasseType.YTEL.name }
 
+val tilbakekrevingsbeloepComparator =
+    compareBy<Tilbakekrevingsbelop> {
+        when (it.klasseType) {
+            KlasseType.FEIL.name -> 0
+            KlasseType.YTEL.name -> 1
+            else -> 2
+        }
+    }
+
 data class Tilbakekrevingsbelop(
     val id: UUID,
     val klasseKode: String,
@@ -97,24 +106,25 @@ fun List<KravgrunnlagPeriode>.tilTilbakekrevingPerioder(): List<TilbakekrevingPe
         TilbakekrevingPeriode(
             maaned = periode.periode.fraOgMed,
             tilbakekrevingsbeloep =
-                periode.grunnlagsbeloep.map {
-                    Tilbakekrevingsbelop(
-                        id = UUID.randomUUID(),
-                        klasseKode = it.klasseKode.value,
-                        klasseType = it.klasseType.name,
-                        bruttoUtbetaling = it.bruttoUtbetaling.toInt(),
-                        nyBruttoUtbetaling = it.nyBruttoUtbetaling.toInt(),
-                        skatteprosent = it.skatteProsent,
-                        bruttoTilbakekreving = it.bruttoTilbakekreving.toInt(),
-                        beregnetFeilutbetaling = null,
-                        nettoTilbakekreving = null,
-                        skatt = null,
-                        skyld = null,
-                        resultat = null,
-                        tilbakekrevingsprosent = null,
-                        rentetillegg = null,
-                    )
-                },
+                periode.grunnlagsbeloep
+                    .map {
+                        Tilbakekrevingsbelop(
+                            id = UUID.randomUUID(),
+                            klasseKode = it.klasseKode.value,
+                            klasseType = it.klasseType.name,
+                            bruttoUtbetaling = it.bruttoUtbetaling.toInt(),
+                            nyBruttoUtbetaling = it.nyBruttoUtbetaling.toInt(),
+                            skatteprosent = it.skatteProsent,
+                            bruttoTilbakekreving = it.bruttoTilbakekreving.toInt(),
+                            beregnetFeilutbetaling = null,
+                            nettoTilbakekreving = null,
+                            skatt = null,
+                            skyld = null,
+                            resultat = null,
+                            tilbakekrevingsprosent = null,
+                            rentetillegg = null,
+                        )
+                    }.sortedWith(tilbakekrevingsbeloepComparator),
         )
     }
 


### PR DESCRIPTION
For at saksbehandler skal få et bedre overblikk over tilbakekrevingsperiodene, er det ønsket å også kunne se andre klassetyper slik som feilkonto og skattetrekk. Legger på dette (som readonly) i tilbakekrevingsvisningen.