### PR TITLE
Svitsjet til nytt PEN-endepunkt for Sakssammendrag med enklere datoformat

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/common/klienter/PesysKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/common/klienter/PesysKlient.kt
@@ -43,7 +43,7 @@ class PesysKlientImpl(
                 resource =
                     Resource(
                         clientId = clientId,
-                        url = "$resourceUrl/sak/sammendragWonderful",
+                        url = "$resourceUrl/sak/sammendrag/v2",
                         additionalHeaders = mapOf("fnr" to fnr),
                     ),
                 brukerTokenInfo = bruker,
@@ -57,9 +57,9 @@ class PesysKlientImpl(
 data class SakSammendragResponse(
     val sakType: String,
     val sakStatus: Status,
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssZ")
+    @JsonFormat(pattern = "yyyy-MM-dd")
     val fomDato: LocalDate?,
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssZ")
+    @JsonFormat(pattern = "yyyy-MM-dd")
     val tomDate: LocalDate?,
 ) {
     companion object {

--- a/apps/etterlatte-behandling/src/test/kotlin/common/klienter/PesysKlientImplTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/common/klienter/PesysKlientImplTest.kt
@@ -15,8 +15,8 @@ class PesysKlientImplTest {
             {
                 "sakType": "UFOREP",
                 "sakStatus": "LOPENDE",
-                "fomDato": "2010-04-01T00:00:00+0200",
-                "tomDate": "2010-04-01T00:00:00+0200"
+                "fomDato": "2010-04-01",
+                "tomDate": "2010-04-30"
             }
             """.trimIndent()
 
@@ -27,7 +27,7 @@ class PesysKlientImplTest {
                 sakType = SakSammendragResponse.UFORE_SAKTYPE,
                 sakStatus = SakSammendragResponse.Status.LOPENDE,
                 fomDato = LocalDate.of(2010, 4, 1),
-                tomDate = LocalDate.of(2010, 4, 1),
+                tomDate = LocalDate.of(2010, 4, 30),
             )
     }
 }


### PR DESCRIPTION
Et steg på veien i å rydde opp i datobruken i PEN.

Endepunktet er fra før av tatt i bruk av selvbetjeningsapper i Pensjon. https://nav-it.slack.com/archives/CB8B2R4G6/p1738325495454769?thread_ts=1738247587.380599&cid=CB8B2R4G6