### PR TITLE
Httpklienten kjører med forventsuksess må wrappes med trycatch da

### DIFF
--- a/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/brukerdialog/soeknad/NySoeknadRiver.kt
+++ b/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/brukerdialog/soeknad/NySoeknadRiver.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.brukerdialog.soeknad
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.module.kotlin.treeToValue
 import io.ktor.client.plugins.ResponseException
+import io.ktor.client.plugins.ServerResponseException
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.brukerdialog.soeknad.client.BehandlingClient
 import no.nav.etterlatte.brukerdialog.soeknad.journalfoering.JournalfoerSoeknadService
@@ -153,7 +154,10 @@ internal class NySoeknadRiver(
             }
         } catch (e: ResponseException) {
             logger.error("Avbrutt fordeling - kunne ikke hente eller opprette sak: ${e.message}")
-
+            // Svelg slik at Innsendt søknad vil retrye
+            null
+        } catch (e: ServerResponseException) {
+            logger.error("Avbrutt fordeling - kunne ikke hente eller opprette sak: ${e.message}")
             // Svelg slik at Innsendt søknad vil retrye
             null
         }

--- a/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/brukerdialog/soeknad/client/BehandlingClient.kt
+++ b/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/brukerdialog/soeknad/client/BehandlingClient.kt
@@ -7,7 +7,6 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
-import io.ktor.http.isSuccess
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.libs.common.behandling.BehandlingsBehov
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
@@ -48,16 +47,17 @@ class BehandlingClient(
         persongalleri: Persongalleri,
     ): UUID =
         runBlocking {
-            val response =
-                sakOgBehandlingApp
-                    .post("$url/behandlinger/opprettbehandling") {
-                        contentType(ContentType.Application.Json)
-                        setBody(BehandlingsBehov(sakId, persongalleri, mottattDato.toString()))
-                    }
-            if (!response.status.isSuccess()) {
+            try {
+                val response =
+                    sakOgBehandlingApp
+                        .post("$url/behandlinger/opprettbehandling") {
+                            contentType(ContentType.Application.Json)
+                            setBody(BehandlingsBehov(sakId, persongalleri, mottattDato.toString()))
+                        }
+                UUID.fromString(response.body())
+            } catch (_: Exception) {
                 throw FeiletVedOpprettBehandling(sakId)
             }
-            UUID.fromString(response.body())
         }
 
     fun behandleInntektsjustering(request: MottattInntektsjustering) {

--- a/apps/etterlatte-behandling-kafka/src/test/kotlin/no/nav/etterlatte/brukerdialog/soeknad/client/BehandlingClientTest.kt
+++ b/apps/etterlatte-behandling-kafka/src/test/kotlin/no/nav/etterlatte/brukerdialog/soeknad/client/BehandlingClientTest.kt
@@ -5,12 +5,14 @@ import com.fasterxml.jackson.module.kotlin.treeToValue
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
 import io.ktor.client.engine.mock.toByteArray
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.HttpRequestData
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import io.ktor.http.isSuccess
 import io.ktor.serialization.jackson.jackson
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.runBlocking
@@ -22,6 +24,9 @@ import no.nav.etterlatte.libs.common.innsendtsoeknad.barnepensjon.Barnepensjon
 import no.nav.etterlatte.libs.common.objectMapper
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import java.util.UUID
 
 internal class BehandlingClientTest {
@@ -48,6 +53,34 @@ internal class BehandlingClientTest {
                     (runBlocking { String(requestList[0].body.toByteArray()) }),
                 ).sakId,
         )
+    }
+
+    @ParameterizedTest
+    @MethodSource("ugyldigeHttpStatuskoder")
+    fun `Skal kaste FeiletVedOpprettBehandling ved feil`(ugyldigStatusCode: HttpStatusCode) {
+        val hendelseJson = objectMapper.readTree(javaClass.getResource("/behandlingsbehov/barnepensjon.json")!!.readText())
+        val soeknad = objectMapper.treeToValue<Barnepensjon>(hendelseJson[FordelerFordelt.skjemaInfoKey])
+        val client =
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        respondError(ugyldigStatusCode)
+                    }
+                }
+            }
+        val behandlingClient = BehandlingClient(client, "")
+        assertThrows<FeiletVedOpprettBehandling> {
+            behandlingClient.opprettBehandling(
+                sakId1,
+                soeknad.mottattDato,
+                PersongalleriMapper.hentPersongalleriFraSoeknad(soeknad),
+            )
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        private fun ugyldigeHttpStatuskoder(): List<HttpStatusCode> = HttpStatusCode.allStatusCodes.filter { !it.isSuccess() }
     }
 
     private fun createBehandlingClient(


### PR DESCRIPTION
Nå ender kafka appen i crash loop siden man kan sjekke på `isSuccess` da exceptionen kastet av selve httpklienten dersom man har satt expectSuccess.


ref https://logs.adeo.no/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-15m,to:now))&_a=(columns:!(level,message,envclass,application,pod,trace.id),dataSource:(dataViewId:'70570ce5-3a44-4fff-8877-937ec8c47be1',type:dataView),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'70570ce5-3a44-4fff-8877-937ec8c47be1',key:x_correlation_id,negate:!f,params:(query:'5728ab3b-78e8-4247-8b75-7910eaeb0cfb'),type:phrase),query:(match_phrase:(x_correlation_id:'5728ab3b-78e8-4247-8b75-7910eaeb0cfb')))),grid:(columns:(level:(width:90),message:(width:518))),hideChart:!t,interval:auto,query:(language:lucene,query:'namespace:etterlatte%20AND%20envclass:q'),sort:!(!('@timestamp',desc)))