### PR TITLE
EY-4947: Fjerner urelevant vilkår fra OMS førstegangsbehandling

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/vilkaarsvurdering/service/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/vilkaarsvurdering/service/VilkaarsvurderingService.kt
@@ -353,10 +353,8 @@ class VilkaarsvurderingService(
 
             SakType.OMSTILLINGSSTOENAD ->
                 when (behandlingType) {
-                    BehandlingType.FØRSTEGANGSBEHANDLING,
-                    BehandlingType.REVURDERING,
-                    ->
-                        OmstillingstoenadVilkaar.inngangsvilkaar()
+                    BehandlingType.FØRSTEGANGSBEHANDLING -> OmstillingstoenadVilkaar.inngangsvilkaar()
+                    BehandlingType.REVURDERING -> OmstillingstoenadVilkaar.loependevilkaar()
                 }
         }
 
@@ -435,7 +433,10 @@ class VilkaarsvurderingService(
     private fun finnRelevanteTyper(behandlingId: UUID): List<Vilkaar> {
         val behandling = behandlingService.hentBehandling(behandlingId)!!
         if (behandling.sak.sakType == SakType.OMSTILLINGSSTOENAD) {
-            return OmstillingstoenadVilkaar.inngangsvilkaar()
+            return when (behandling.type) {
+                BehandlingType.FØRSTEGANGSBEHANDLING -> OmstillingstoenadVilkaar.inngangsvilkaar()
+                BehandlingType.REVURDERING -> OmstillingstoenadVilkaar.loependevilkaar()
+            }
         }
         return if (behandling.virkningstidspunkt!!.erPaaNyttRegelverk()) {
             BarnepensjonVilkaar2024.inngangsvilkaar()

--- a/apps/etterlatte-behandling/src/main/kotlin/vilkaarsvurdering/vilkaar/OmstillingstoenadVilkaar.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/vilkaarsvurdering/vilkaar/OmstillingstoenadVilkaar.kt
@@ -12,7 +12,6 @@ object OmstillingstoenadVilkaar {
             doedsfall(),
             oevrigeVilkaar(),
             overlappendeYtelser(),
-            sivilstand(),
             yrkesskade(),
             avdoedesMedlemskap(),
             avdoedesMedlemskapEoes(),
@@ -21,6 +20,8 @@ object OmstillingstoenadVilkaar {
             rettTilStoenadUtenTidsbegrensning(),
             aktivitetsplikt(),
         )
+
+    fun loependevilkaar() = inngangsvilkaar() + sivilstand()
 
     private fun etterlatteLever() =
         Vilkaar(

--- a/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
@@ -284,6 +284,7 @@ fun foerstegangsbehandling(
 fun revurdering(
     id: UUID = UUID.randomUUID(),
     sakId: SakId,
+    sakType: SakType = SakType.BARNEPENSJON,
     behandlingOpprettet: LocalDateTime = Tidspunkt.now().toLocalDatetimeUTC(),
     sistEndret: LocalDateTime = Tidspunkt.now().toLocalDatetimeUTC(),
     status: BehandlingStatus = BehandlingStatus.OPPRETTET,
@@ -306,7 +307,7 @@ fun revurdering(
     sak =
         Sak(
             ident = persongalleri.soeker,
-            sakType = SakType.BARNEPENSJON,
+            sakType = sakType,
             id = sakId,
             enhet = enhet,
         ),

--- a/apps/etterlatte-behandling/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.vilkaarsvurdering
 
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
@@ -767,7 +768,7 @@ internal class VilkaarsvurderingServiceTest(
     }
 
     @Test
-    fun `skal ikke ha vilkaar OMS_SIVILSTAND ved foerstegangsbehandling, men ved revurdering av omstillingsstoenad`() {
+    fun `skal kun inkludere vilkaar OMS_SIVILSTAND ved revurdering`() {
         val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.now())
         val foerstegangsbehandling =
             foerstegangsbehandling(
@@ -797,7 +798,10 @@ internal class VilkaarsvurderingServiceTest(
             runBlocking { vilkaarsvurderingServiceImpl.opprettVilkaarsvurdering(revurdering.id, brukerTokenInfo) }
 
         vilkaarsvurderingFoerstegangsbehandling.vilkaarsvurdering.vilkaar.size shouldBe OmstillingstoenadVilkaar.inngangsvilkaar().size
+        vilkaarsvurderingFoerstegangsbehandling.vilkaarsvurdering.vilkaar.map { it.hovedvilkaar.type } shouldNotContain
+            VilkaarType.OMS_SIVILSTAND
         vilkaarsvurderingRevurdering.vilkaarsvurdering.vilkaar.size shouldBe OmstillingstoenadVilkaar.loependevilkaar().size
+        vilkaarsvurderingRevurdering.vilkaarsvurdering.vilkaar.map { it.hovedvilkaar.type } shouldContain VilkaarType.OMS_SIVILSTAND
     }
 
     @Test

--- a/apps/etterlatte-behandling/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingServiceTest.kt
@@ -68,6 +68,7 @@ import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.kilde
 import no.nav.etterlatte.mockSaksbehandler
 import no.nav.etterlatte.nyKontekstMedBrukerOgDatabase
+import no.nav.etterlatte.revurdering
 import no.nav.etterlatte.vilkaarsvurdering.dao.DelvilkaarDao
 import no.nav.etterlatte.vilkaarsvurdering.dao.VilkaarsvurderingDao
 import no.nav.etterlatte.vilkaarsvurdering.service.BehandlingstilstandException
@@ -76,6 +77,7 @@ import no.nav.etterlatte.vilkaarsvurdering.service.VilkaarsvurderingManglerResul
 import no.nav.etterlatte.vilkaarsvurdering.service.VilkaarsvurderingService
 import no.nav.etterlatte.vilkaarsvurdering.service.VirkningstidspunktSamsvarerIkke
 import no.nav.etterlatte.vilkaarsvurdering.vilkaar.BarnepensjonVilkaar2024
+import no.nav.etterlatte.vilkaarsvurdering.vilkaar.OmstillingstoenadVilkaar
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
@@ -253,7 +255,7 @@ internal class VilkaarsvurderingServiceTest(
 
         vilkaarsvurdering shouldNotBe null
         vilkaarsvurdering.behandlingId shouldBe behandlingId
-        vilkaarsvurdering.vilkaar shouldHaveSize 12
+        vilkaarsvurdering.vilkaar shouldHaveSize OmstillingstoenadVilkaar.inngangsvilkaar().size
     }
 
     @Test
@@ -762,6 +764,40 @@ internal class VilkaarsvurderingServiceTest(
 
         verify(exactly = 3) { behandlingStatus.settVilkaarsvurdert(behandlingId, brukerTokenInfo, true) }
         verify(exactly = 2) { behandlingStatus.settVilkaarsvurdert(behandlingId, brukerTokenInfo, false) }
+    }
+
+    @Test
+    fun `skal ikke ha vilkaar OMS_SIVILSTAND ved foerstegangsbehandling, men ved revurdering av omstillingsstoenad`() {
+        val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(YearMonth.now())
+        val foerstegangsbehandling =
+            foerstegangsbehandling(
+                sakId = sakId1,
+                sakType = SakType.OMSTILLINGSSTOENAD,
+                virkningstidspunkt = virkningstidspunkt,
+            )
+        val revurdering =
+            revurdering(
+                sakId = sakId1,
+                sakType = SakType.OMSTILLINGSSTOENAD,
+                virkningstidspunkt = virkningstidspunkt,
+                revurderingAarsak = Revurderingaarsak.ANNEN,
+            )
+
+        coEvery { behandlingService.hentBehandling(foerstegangsbehandling.id) } returns foerstegangsbehandling
+        coEvery { behandlingService.hentBehandling(revurdering.id) } returns revurdering
+        coEvery { behandlingService.hentSisteIverksatte(sakId1) } returns foerstegangsbehandling
+
+        every { behandlingStatus.settVilkaarsvurdert(any(), any(), any()) } just Runs
+        every { behandlingStatus.settOpprettet(any(), any(), any()) } just Runs
+
+        val vilkaarsvurderingFoerstegangsbehandling =
+            runBlocking { opprettVilkaarsvurderingOgFyllUtAlleVurderinger(foerstegangsbehandling.id) }
+
+        val vilkaarsvurderingRevurdering =
+            runBlocking { vilkaarsvurderingServiceImpl.opprettVilkaarsvurdering(revurdering.id, brukerTokenInfo) }
+
+        vilkaarsvurderingFoerstegangsbehandling.vilkaarsvurdering.vilkaar.size shouldBe OmstillingstoenadVilkaar.inngangsvilkaar().size
+        vilkaarsvurderingRevurdering.vilkaarsvurdering.vilkaar.size shouldBe OmstillingstoenadVilkaar.loependevilkaar().size
     }
 
     @Test


### PR DESCRIPTION
Fjerner vilkåret med følgende ordlyd fra førstegangssøknad for OMS:

`Hvis en etterlatt som er innvilget omstillingsstønad etter § 17-5 tredje ledd (hadde rettigheter utover 3-5 år på grunn av lav inntekt siste fem år før dødsfall) inngår skilsmisse innen to år, får vedkommende rett til omstillingsstønad igjen.`

Dette gir kun mening i en revurdering. Når en revurdering opprettes vil dette vilkåret nå legges til. Saksbehandler slipper dermed å behandle dette i førstegangsbehandling. 