### PR TITLE
Feilmelding til saksbehandler + fjerne error logg

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -379,7 +379,6 @@ class BrevService(
         val brev = sjekkOmBrevKanEndres(id)
 
         if (brev.mottakere.size !in 1..2) {
-            logger.error("Brev ${brev.id} har ${brev.mottakere.size} mottakere. Dette skal ikke være mulig...")
             throw UgyldigAntallMottakere()
         } else if (brev.mottakere.any { it.erGyldig().isNotEmpty() }) {
             sikkerlogger.error("Ugyldig mottaker: ${brev.mottakere.toJson()}")

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevService.kt
@@ -291,7 +291,7 @@ class VedtaksbrevKanIkkeSlettes(
 class UgyldigAntallMottakere :
     UgyldigForespoerselException(
         code = "FOR_MANGE_MOTTAKERE",
-        detail = "Ugyldig antall mottakere på brevet. Må ma minst 1 og maks 2 mottakere per brev (hoved og kopi).",
+        detail = "Brevet må ha minst 1, maks 2 mottakere.",
     )
 
 class UgyldigMottakerKanIkkeFerdigstilles(

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottakerWrapper.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottakerWrapper.tsx
@@ -1,6 +1,6 @@
 import { IBrev } from '~shared/types/Brev'
 import { BrevMottakerPanel } from '~components/person/brev/mottaker/BrevMottakerPanel'
-import { Button, HStack, VStack } from '@navikt/ds-react'
+import { Alert, Button, HStack, VStack } from '@navikt/ds-react'
 import React, { useState } from 'react'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { opprettMottaker } from '~shared/api/brev'
@@ -26,6 +26,8 @@ export const BrevMottakerWrapper = ({ brev, kanRedigeres }: { brev: IBrev; kanRe
 
   return (
     <VStack gap="4">
+      {!mottakere.length && <Alert variant="error">Brevet har ingen mottaker!</Alert>}
+
       {mottakere.map((mottaker) => (
         <BrevMottakerPanel
           key={mottaker.id}


### PR DESCRIPTION
Funksjonen `ferdigstill` i `BrevService` brukes kun fra frontend, så det holder å kaste `UgyldigForespoerselException`