### PR TITLE
Endre dev til å gå mot q2 istedenfor q1 for utbetaling og tilbakekreving

### DIFF
--- a/apps/etterlatte-tilbakekreving/.nais/dev.yaml
+++ b/apps/etterlatte-tilbakekreving/.nais/dev.yaml
@@ -52,13 +52,13 @@ spec:
     min: 1
   env:
     - name: KRAVGRUNNLAG_MQ_NAME
-      value: QA.Q1_ETTERLATTE.KRAVGRUNNLAG
+      value: QA.Q2_ETTERLATTE.KRAVGRUNNLAG
     - name: MQ_HOSTNAME
       value: b27apvl222.preprod.local
     - name: MQ_PORT
       value: "1413"
     - name: MQ_CHANNEL
-      value: Q1_ETTERLATTE
+      value: Q2_ETTERLATTE
     - name: MQ_MANAGER
       value: MQLS04
     - name: ETTERLATTE_BEHANDLING_URL

--- a/apps/etterlatte-utbetaling/.nais/dev.yaml
+++ b/apps/etterlatte-utbetaling/.nais/dev.yaml
@@ -80,13 +80,13 @@ spec:
     - name: OPPDRAG_AVSTEMMING_MQ_NAME
       value: QA.Q2_234.OB29_AVSTEMMING_XML
     - name: OPPDRAG_KVITTERING_MQ_NAME
-      value: QA.Q2_BARNEPENSJON.OPPDRAG_KVITTERING
+      value: QA.Q2_ETTERLATTE.OPPDRAG_KVITTERING
     - name: OPPDRAG_MQ_HOSTNAME
       value: b27apvl222.preprod.local
     - name: OPPDRAG_MQ_PORT
       value: "1413"
     - name: OPPDRAG_MQ_CHANNEL
-      value: Q2_BARNEPENSJON
+      value: Q2_ETTERLATTE
     - name: OPPDRAG_MQ_MANAGER
       value: MQLS04
     - name: ETTERLATTE_VEDTAK_URL

--- a/apps/etterlatte-utbetaling/.nais/dev.yaml
+++ b/apps/etterlatte-utbetaling/.nais/dev.yaml
@@ -76,17 +76,17 @@ spec:
       #sette tilbake til none senere
       value: latest
     - name: OPPDRAG_SEND_MQ_NAME
-      value: QA.Q1_231.OB04_OPPDRAG_XML
+      value: QA.Q2_231.OB04_OPPDRAG_XML
     - name: OPPDRAG_AVSTEMMING_MQ_NAME
-      value: QA.Q1_234.OB29_AVSTEMMING_XML
+      value: QA.Q2_234.OB29_AVSTEMMING_XML
     - name: OPPDRAG_KVITTERING_MQ_NAME
-      value: QA.Q1_ETTERLATTE.OPPDRAG_KVITTERING
+      value: QA.Q2_BARNEPENSJON.OPPDRAG_KVITTERING
     - name: OPPDRAG_MQ_HOSTNAME
       value: b27apvl222.preprod.local
     - name: OPPDRAG_MQ_PORT
       value: "1413"
     - name: OPPDRAG_MQ_CHANNEL
-      value: Q1_ETTERLATTE
+      value: Q2_BARNEPENSJON
     - name: OPPDRAG_MQ_MANAGER
       value: MQLS04
     - name: ETTERLATTE_VEDTAK_URL


### PR DESCRIPTION
Endrer miljø for utbetaling / tilbakekreving til Q2 for å gå mot et miljø med syntetiske data i stedet for skarpe data.

Gjenstående:

- [x] Sjekke med Akhtar at navnene på køene er oppdatert for oppdrag
- [x] Sjekke med Akhtar at kø for tilbakekreving er opprettet i q2
- [x] Sjekke at srvetterlatte har tilgang i q2 i stedet for srvbarnepensjon
- [x] Oppdatere url'er for tilbakekreving og simulering i etterlatte-proxy
- [ ] Sjekke at tilganger er på plass for tilbakekreving og simulering mot q2
- [ ] Vente til etteroppgjør er sjekket i Q1 - se videre om det er aktuelt å gå til Q2 etter dette.