### PR TITLE
Sette idType til FNR i avsnederMottaker

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/EndreAvsenderMottaker.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/EndreAvsenderMottaker.tsx
@@ -3,7 +3,7 @@ import { Alert, BodyShort, Box, Button, Heading, HStack, Label, TextField, VStac
 import { KopierbarVerdi } from '~shared/statusbar/KopierbarVerdi'
 import React, { useState } from 'react'
 import { InputFlexRow } from './OppdaterJournalpost'
-import { fnrHarGyldigFormat } from '~utils/fnr'
+import { fnrErGyldig, fnrHarGyldigFormat } from '~utils/fnr'
 import { useForm } from 'react-hook-form'
 import { PersonSoekModal } from '~components/person/journalfoeringsoppgave/journalpost/modal/PersonSoekModal'
 
@@ -25,7 +25,10 @@ export const EndreAvsenderMottaker = ({
   const [rediger, setRediger] = useState(false)
 
   const lagreEndring = (avsenderMottaker: AvsenderMottaker) => {
-    oppdaterAvsenderMottaker({ ...avsenderMottaker, idType: BrukerIdType.FNR })
+    oppdaterAvsenderMottaker({
+      ...avsenderMottaker,
+      idType: fnrErGyldig(avsenderMottaker.id) ? BrukerIdType.FNR : avsenderMottaker.idType,
+    })
     setRediger(false)
   }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/EndreAvsenderMottaker.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/EndreAvsenderMottaker.tsx
@@ -3,7 +3,7 @@ import { Alert, BodyShort, Box, Button, Heading, HStack, Label, TextField, VStac
 import { KopierbarVerdi } from '~shared/statusbar/KopierbarVerdi'
 import React, { useState } from 'react'
 import { InputFlexRow } from './OppdaterJournalpost'
-import { fnrErGyldig, fnrHarGyldigFormat } from '~utils/fnr'
+import { fnrHarGyldigFormat } from '~utils/fnr'
 import { useForm } from 'react-hook-form'
 import { PersonSoekModal } from '~components/person/journalfoeringsoppgave/journalpost/modal/PersonSoekModal'
 
@@ -27,7 +27,7 @@ export const EndreAvsenderMottaker = ({
   const lagreEndring = (avsenderMottaker: AvsenderMottaker) => {
     oppdaterAvsenderMottaker({
       ...avsenderMottaker,
-      idType: fnrErGyldig(avsenderMottaker.id) ? BrukerIdType.FNR : avsenderMottaker.idType,
+      idType: fnrHarGyldigFormat(avsenderMottaker.id) ? BrukerIdType.FNR : avsenderMottaker.idType,
     })
     setRediger(false)
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/EndreAvsenderMottaker.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/journalfoeringsoppgave/journalpost/EndreAvsenderMottaker.tsx
@@ -25,7 +25,7 @@ export const EndreAvsenderMottaker = ({
   const [rediger, setRediger] = useState(false)
 
   const lagreEndring = (avsenderMottaker: AvsenderMottaker) => {
-    oppdaterAvsenderMottaker(avsenderMottaker)
+    oppdaterAvsenderMottaker({ ...avsenderMottaker, idType: BrukerIdType.FNR })
     setRediger(false)
   }
 


### PR DESCRIPTION
Det ser ut som Dolly ikke setter idType helt, så feiler å oppdatere journalpost. Setter den til FNR ettersom det er de vi bruker