### PR TITLE
hente type i graphql spørring journalpost

### DIFF
--- a/apps/etterlatte-brev-api/src/main/resources/graphql/journalpost.graphql
+++ b/apps/etterlatte-brev-api/src/main/resources/graphql/journalpost.graphql
@@ -27,6 +27,7 @@ query(
         }
         avsenderMottaker {
             id
+            type
             navn
             erLikBruker
         }


### PR DESCRIPTION
AvsenderMottaker har type, men den blir aldri etterspurt i graphql 