### PR TITLE
EY-4950: Endrer navn fra egne-ansatte-lytter til hendelser-egne-ansatte

### DIFF
--- a/.github/workflows/app-etterlatte-hendelser-egne-ansatte.yaml
+++ b/.github/workflows/app-etterlatte-hendelser-egne-ansatte.yaml
@@ -1,0 +1,46 @@
+name: etterlatte-hendelser-egne-ansatte
+
+on:
+  workflow_dispatch: # Allow manually triggered workflow run
+    inputs:
+      deploy-prod:
+        description: 'Deploy til produksjon'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - true
+          - false
+  push:
+    branches:
+      - main
+    paths:
+      - apps/etterlatte-hendelser-egne-ansatte/**
+      - libs/saksbehandling-common/**
+      - libs/etterlatte-ktor/**
+      - gradle/libs.versions.toml
+      - "!**/test/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - apps/etterlatte-hendelser-egne-ansatte/**
+      - "!apps/etterlatte-hendelser-egne-ansatte/.nais/*"
+      - libs/saksbehandling-common/**
+      - libs/etterlatte-ktor/**
+      - gradle/libs.versions.toml
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  test:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/.test.yaml
+    secrets: inherit
+
+  build-and-deploy:
+    if: github.event_name != 'pull_request'
+    uses: ./.github/workflows/.build-and-deploy.yaml
+    secrets: inherit

--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -196,6 +196,7 @@ spec:
       rules:
         - application: etterlatte-vilkaarsvurdering-kafka
         - application: etterlatte-egne-ansatte-lytter
+        - application: etterlatte-hendelser-egne-ansatte
         - application: etterlatte-beregning
         - application: etterlatte-saksbehandling-ui
         - application: etterlatte-saksbehandling-ui-lokal # for å åpne for lokal utv. Ikke kopier denne til prod.yaml

--- a/apps/etterlatte-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-behandling/.nais/prod.yaml
@@ -202,6 +202,7 @@ spec:
       rules:
         - application: etterlatte-vilkaarsvurdering-kafka
         - application: etterlatte-egne-ansatte-lytter
+        - application: etterlatte-hendelser-egne-ansatte
         - application: etterlatte-beregning
         - application: etterlatte-saksbehandling-ui
         - application: etterlatte-behandling-kafka

--- a/apps/etterlatte-hendelser-egne-ansatte/.nais/dev.yaml
+++ b/apps/etterlatte-hendelser-egne-ansatte/.nais/dev.yaml
@@ -1,0 +1,62 @@
+apiVersion: "nais.io/v1alpha1"
+kind: "Application"
+metadata:
+  name: etterlatte-hendelser-egne-ansatte
+  namespace: etterlatte
+  labels:
+    team: etterlatte
+spec:
+  image: "{{image}}"
+  port: 8080
+  liveness:
+    initialDelay: 5
+    path: /health/isalive
+  readiness:
+    initialDelay: 5
+    path: /health/isready
+  prometheus:
+    enabled: true
+    path: /metrics
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
+  secureLogs:
+    enabled: true
+  strategy:
+    type: Recreate
+  kafka:
+    pool: nav-dev
+  azure:
+    application:
+      enabled: true
+  resources:
+    requests:
+      cpu: 25m
+      memory: 320Mi
+  replicas:
+    max: 1
+    min: 1
+  env:
+    - name: KAFKA_RESET_POLICY
+      value: latest
+    - name: SKJERMING_GROUP_ID
+      value: "etterlatte-v1"
+    - name: SKJERMING_TOPIC
+      value: "nom.skjermede-personer-status-v1"
+    - name: BEHANDLING_AZURE_SCOPE
+      value: api://dev-gcp.etterlatte.etterlatte-behandling/.default
+    - name: ETTERLATTE_BEHANDLING_URL
+      value: http://etterlatte-behandling
+  envFrom:
+    - secret: my-application-unleash-api-token
+  accessPolicy:
+    outbound:
+      rules:
+        - application: etterlatte-behandling
+      external:
+        - host: etterlatte-unleash-api.nav.cloud.nais.io

--- a/apps/etterlatte-hendelser-egne-ansatte/.nais/prod.yaml
+++ b/apps/etterlatte-hendelser-egne-ansatte/.nais/prod.yaml
@@ -1,0 +1,62 @@
+apiVersion: "nais.io/v1alpha1"
+kind: "Application"
+metadata:
+  name: etterlatte-hendelser-egne-ansatte
+  namespace: etterlatte
+  labels:
+    team: etterlatte
+spec:
+  image: "{{image}}"
+  port: 8080
+  liveness:
+    initialDelay: 5
+    path: /health/isalive
+  readiness:
+    initialDelay: 5
+    path: /health/isready
+  prometheus:
+    enabled: true
+    path: /metrics
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
+  secureLogs:
+    enabled: true
+  strategy:
+    type: Recreate
+  kafka:
+    pool: nav-prod
+  azure:
+    application:
+      enabled: true
+  resources:
+    requests:
+      cpu: 25m
+      memory: 320Mi
+  replicas:
+    max: 1
+    min: 1
+  env:
+    - name: KAFKA_RESET_POLICY
+      value: earliest
+    - name: SKJERMING_GROUP_ID
+      value: "etterlatte-v1"
+    - name: SKJERMING_TOPIC
+      value: "nom.skjermede-personer-status-v1"
+    - name: BEHANDLING_AZURE_SCOPE
+      value: api://prod-gcp.etterlatte.etterlatte-behandling/.default
+    - name: ETTERLATTE_BEHANDLING_URL
+      value: http://etterlatte-behandling
+  envFrom:
+    - secret: my-application-unleash-api-token
+  accessPolicy:
+    outbound:
+      rules:
+        - application: etterlatte-behandling
+      external:
+        - host: etterlatte-unleash-api.nav.cloud.nais.io

--- a/apps/etterlatte-hendelser-egne-ansatte/build.gradle.kts
+++ b/apps/etterlatte-hendelser-egne-ansatte/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    alias(libs.plugins.avro)
+    id("etterlatte.common")
+}
+
+dependencies {
+    implementation(project(":libs:saksbehandling-common"))
+    implementation(project(":libs:etterlatte-kafka"))
+    implementation(project(":libs:etterlatte-ktor"))
+    implementation(project(":libs:rapidsandrivers-extras"))
+
+    implementation(libs.kafka.avro) {
+        exclude("org.apache.commons", "commons-compress")
+    }
+    implementation(libs.commons.compress)
+
+    testImplementation(libs.test.testcontainer.kafka)
+    testImplementation(libs.ktor2.servertests)
+    testImplementation(testFixtures((project(":libs:etterlatte-kafka"))))
+}

--- a/apps/etterlatte-hendelser-egne-ansatte/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-hendelser-egne-ansatte/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -1,0 +1,73 @@
+package no.nav.etterlatte
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import io.ktor.server.application.Application
+import no.nav.etterlatte.kafka.BehandlingKlient
+import no.nav.etterlatte.kafka.KafkaConsumerEgneAnsatte
+import no.nav.etterlatte.kafka.KafkaEnvironment
+import no.nav.etterlatte.kafka.startLytting
+import no.nav.etterlatte.libs.common.EnvEnum
+import no.nav.etterlatte.libs.common.Miljoevariabler
+import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstart
+import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
+import no.nav.etterlatte.libs.ktor.initialisering.initEmbeddedServerUtenRest
+import no.nav.etterlatte.libs.ktor.initialisering.run
+import org.slf4j.LoggerFactory
+
+fun main() {
+    Server().run()
+}
+
+class Server {
+    private val defaultConfig: Config = ConfigFactory.load()
+    private val engine = initEmbeddedServerUtenRest(httpPort = 8080, applicationConfig = defaultConfig)
+
+    init {
+        sikkerLoggOppstart("etterlatte-hendelser-egne-ansatte")
+    }
+
+    fun run() {
+        val env = Miljoevariabler.systemEnv()
+        startHendelserEgneAnsatte(env, defaultConfig)
+        engine.run()
+    }
+}
+
+fun startHendelserEgneAnsatte(
+    env: Miljoevariabler,
+    config: Config,
+) {
+    val logger = LoggerFactory.getLogger(Application::class.java)
+
+    val behandlingHttpClient =
+        httpClientClientCredentials(
+            azureAppClientId = config.getString("azure.app.client.id"),
+            azureAppJwk = config.getString("azure.app.jwk"),
+            azureAppWellKnownUrl = config.getString("azure.app.well.known.url"),
+            azureAppScope = config.getString("behandling.azure.scope"),
+        )
+    val behandlingKlient =
+        BehandlingKlient(
+            behandlingHttpClient = behandlingHttpClient,
+            url = config.getString("etterlatte.behandling.url"),
+        )
+
+    startLytting(
+        konsument =
+            KafkaConsumerEgneAnsatte(
+                topic = env.requireEnvValue(EgneAnsatteKey.SKJERMING_TOPIC),
+                kafkaProperties = KafkaEnvironment().generateKafkaConsumerProperties(env),
+                behandlingKlient = behandlingKlient,
+            ),
+        logger = logger,
+    )
+}
+
+enum class EgneAnsatteKey : EnvEnum {
+    SKJERMING_GROUP_ID,
+    SKJERMING_TOPIC,
+    ;
+
+    override fun key() = name
+}

--- a/apps/etterlatte-hendelser-egne-ansatte/src/main/kotlin/no/nav/etterlatte/kafka/BehandlingKlient.kt
+++ b/apps/etterlatte-hendelser-egne-ansatte/src/main/kotlin/no/nav/etterlatte/kafka/BehandlingKlient.kt
@@ -1,0 +1,60 @@
+package no.nav.etterlatte.kafka
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.libs.common.logging.sikkerlogger
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.person.maskerFnr
+import no.nav.etterlatte.libs.common.skjermet.EgenAnsattSkjermet
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.LoggerFactory
+
+class BehandlingKlient(
+    val behandlingHttpClient: HttpClient,
+    val url: String,
+) {
+    private val logger = LoggerFactory.getLogger(this.javaClass.name)
+
+    fun haandterHendelse(record: ConsumerRecord<String, String>) {
+        logger.debug(
+            "Behandler skjermet record med id: {}, partition {}, offset: {}",
+            record.key(),
+            record.partition(),
+            record.offset(),
+        )
+        val skjermet = record.value().toBoolean()
+        val fnr = record.key()
+
+        if (Folkeregisteridentifikator.isValid(fnr)) {
+            logger.info("Haandterer skjermet hendelse for fnr maskert ${fnr.maskerFnr()}")
+            // TODO endre til å poste til behandling når den gamle appen er slått av
+            // postTilBehandling(fnr = fnr, skjermet = skjermet)
+        } else {
+            sikkerlogger().error("Ugyldig fnr. ($fnr) i skjermet hendelse, er skjermet $skjermet")
+            logger.error("Ugyldig fnr i skjermet hendelse, er skjermet $skjermet. Se sikkerlogg. ")
+        }
+    }
+
+    fun postTilBehandling(
+        fnr: String,
+        skjermet: Boolean,
+    ) = runBlocking {
+        behandlingHttpClient.post(
+            "$url/egenansatt",
+        ) {
+            contentType(ContentType.Application.Json)
+            setBody(
+                EgenAnsattSkjermet(
+                    fnr = fnr,
+                    inntruffet = Tidspunkt.now(),
+                    skjermet = skjermet,
+                ),
+            )
+        }
+    }
+}

--- a/apps/etterlatte-hendelser-egne-ansatte/src/main/kotlin/no/nav/etterlatte/kafka/KafkaConsumerEgneAnsatte.kt
+++ b/apps/etterlatte-hendelser-egne-ansatte/src/main/kotlin/no/nav/etterlatte/kafka/KafkaConsumerEgneAnsatte.kt
@@ -1,0 +1,25 @@
+package no.nav.etterlatte.kafka
+
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.util.Properties
+import java.util.concurrent.atomic.AtomicBoolean
+
+class KafkaConsumerEgneAnsatte(
+    topic: String,
+    private val behandlingKlient: BehandlingKlient,
+    kafkaProperties: Properties,
+    pollTimeoutInSeconds: Duration = Duration.ofSeconds(10L),
+    closed: AtomicBoolean = AtomicBoolean(false),
+) : Kafkakonsument<String>(
+        logger = LoggerFactory.getLogger(KafkaConsumerEgneAnsatte::class.java.name),
+        consumer = KafkaConsumer<String, String>(kafkaProperties),
+        topic = topic,
+        pollTimeoutInSeconds = pollTimeoutInSeconds,
+        closed = closed,
+    ) {
+    override fun stream() {
+        stream { meldinger -> meldinger.forEach { behandlingKlient.haandterHendelse(it) } }
+    }
+}

--- a/apps/etterlatte-hendelser-egne-ansatte/src/main/kotlin/no/nav/etterlatte/kafka/KafkaEnvironment.kt
+++ b/apps/etterlatte-hendelser-egne-ansatte/src/main/kotlin/no/nav/etterlatte/kafka/KafkaEnvironment.kt
@@ -1,0 +1,12 @@
+package no.nav.etterlatte.kafka
+
+import no.nav.etterlatte.EgneAnsatteKey
+import org.apache.kafka.common.serialization.StringDeserializer
+
+class KafkaEnvironment :
+    Kafkakonfigurasjon<StringDeserializer>(
+        groupId = EgneAnsatteKey.SKJERMING_GROUP_ID,
+        deserializerClass = StringDeserializer::class.java,
+        userInfoConfigKey = Avrokonstanter.USER_INFO_CONFIG,
+        schemaRegistryUrlConfigKey = Avrokonstanter.SCHEMA_REGISTRY_URL_CONFIG,
+    )

--- a/apps/etterlatte-hendelser-egne-ansatte/src/main/resources/application.conf
+++ b/apps/etterlatte-hendelser-egne-ansatte/src/main/resources/application.conf
@@ -1,0 +1,8 @@
+behandling.azure.scope = ${?BEHANDLING_AZURE_SCOPE}
+
+azure.app.client.id = ${?AZURE_APP_CLIENT_ID}
+azure.app.client.secret = ${?AZURE_APP_CLIENT_SECRET}
+azure.app.jwk = ${?AZURE_APP_JWK}
+azure.app.well.known.url = ${?AZURE_APP_WELL_KNOWN_URL}
+
+etterlatte.behandling.url = ${ETTERLATTE_BEHANDLING_URL}

--- a/apps/etterlatte-hendelser-egne-ansatte/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-hendelser-egne-ansatte/src/main/resources/logback-secure.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <appender name="secureAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/secure-logs/secure.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>1</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>50MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <logger name="sikkerLogg" level="DEBUG" additivity="false">
+        <appender-ref ref="secureAppender"/>
+    </logger>
+</included>

--- a/apps/etterlatte-hendelser-egne-ansatte/src/main/resources/logback.xml
+++ b/apps/etterlatte-hendelser-egne-ansatte/src/main/resources/logback.xml
@@ -1,0 +1,24 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" >
+            <jsonGeneratorDecorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
+                <valueMasker class="no.nav.etterlatte.libs.common.person.logg.FnrMasker"/>
+            </jsonGeneratorDecorator>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT_JSON"/>
+    </root>
+
+    <logger name="org.eclipse.jetty" level="INFO"/>
+    <logger name="io.netty" level="INFO"/>
+    <logger name="no.nav.etterlatte" level="DEBUG"/>
+    <include resource="logback-secure.xml"/>
+</configuration>

--- a/apps/etterlatte-hendelser-egne-ansatte/src/test/kotlin/no/nav/etterlatte/kafka/SkjermingslesingTest.kt
+++ b/apps/etterlatte-hendelser-egne-ansatte/src/test/kotlin/no/nav/etterlatte/kafka/SkjermingslesingTest.kt
@@ -1,0 +1,62 @@
+package no.nav.etterlatte.kafka
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.spyk
+import io.mockk.verify
+import no.nav.etterlatte.kafka.KafkaContainerHelper.Companion.kafkaContainer
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.StringSerializer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class SkjermingslesingTest {
+    companion object {
+        const val PDL_PERSON_TOPIC = "nom.skjermede-personer-status-v1"
+        private val kafkaContainer = kafkaContainer(PDL_PERSON_TOPIC)
+    }
+
+    @Test
+    fun `Les skjermingshendelse og post det til behandlingsapp`() {
+        val fnr = "09508229892"
+        val producer = spyk(KafkaProducerTestImpl<String>(kafkaContainer, StringSerializer::class.java.canonicalName))
+        producer.sendMelding(PDL_PERSON_TOPIC, fnr, "value")
+
+        val behandlingKlient = mockk<BehandlingKlient>()
+        every { behandlingKlient.haandterHendelse(any()) } just runs
+
+        val closed = AtomicBoolean(false)
+
+        val kafkaConsumerEgneAnsatte =
+            KafkaConsumerEgneAnsatte(
+                topic = PDL_PERSON_TOPIC,
+                behandlingKlient = behandlingKlient,
+                closed = closed,
+                kafkaProperties = KafkaConsumerEnvironmentTest().konfigurer(kafkaContainer, StringDeserializer::class.java.canonicalName),
+                pollTimeoutInSeconds = Duration.ofSeconds(4L),
+            )
+        val thread =
+            thread(start = true) {
+                while (true) {
+                    if (kafkaConsumerEgneAnsatte.getAntallMeldinger() >= 1) {
+                        closed.set(true)
+                        kafkaConsumerEgneAnsatte.consumer.wakeup()
+                        return@thread
+                    }
+                    Thread.sleep(800L) // Må stå så ikke denne spiser all cpu, tester er egentlig single threaded
+                }
+            }
+        kafkaConsumerEgneAnsatte.stream()
+        thread.join()
+        verify(exactly = 1) { producer.sendMelding(any(), any(), any()) }
+        assertEquals(kafkaConsumerEgneAnsatte.getAntallMeldinger(), 1)
+        verify { behandlingKlient.haandterHendelse(any()) }
+    }
+}

--- a/apps/etterlatte-hendelser-egne-ansatte/src/test/resources/application.conf
+++ b/apps/etterlatte-hendelser-egne-ansatte/src/test/resources/application.conf
@@ -1,0 +1,6 @@
+behandling.azure.scope = ${?BEHANDLING_AZURE_SCOPE}
+
+azure.app.client.id = ${?AZURE_APP_CLIENT_ID}
+azure.app.client.secret = ${?AZURE_APP_CLIENT_SECRET}
+azure.app.jwk = ${?AZURE_APP_JWK}
+azure.app.well.known.url = ${?AZURE_APP_WELL_KNOWN_URL}

--- a/apps/etterlatte-hendelser-egne-ansatte/src/test/resources/logback.xml
+++ b/apps/etterlatte-hendelser-egne-ansatte/src/test/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ include(
     "apps:etterlatte-pdltjenester",
     "apps:etterlatte-behandling",
     "apps:etterlatte-egne-ansatte-lytter",
+    "apps:etterlatte-hendelser-egne-ansatte",
     "apps:etterlatte-institusjonsopphold",
     "apps:etterlatte-testdata",
     "apps:etterlatte-testdata-behandler",


### PR DESCRIPTION
Siden de andre appene som konsumerer hendelser heter `etterlatte-hendelser*` så gir det mening at denne også gjør det for å følge konvensjonen. Enkleste veien til mål tror jeg er å bare opprette en ny app - og få tilgang til topicen for denne. 99% av koden her er derfor bare copy-paste fra `etterlatte-egne-ansatte-lytter`. 

Verifikasjon:
- [ ] Få tilgang til topic for denne appen
- [ ] Verifisere at den leser hendelser
- [ ] Slå på sending av hendelser mot behandling
- [ ] Slå av og fjerne gammel app + tilganger