### PR TITLE
EY-4963 Sperre endringer på aktivitetspliktsvurderingsbrev via brev r…

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -452,9 +452,6 @@ class BrevService(
         sjekk(brev.behandlingId == null) {
             "Brev med id=$id er et vedtaksbrev og kan ikke slettes"
         }
-        if (sjekkOmErAktivitetsipliktsvurderingsBrev(brev.brevkoder)) {
-            throw BrevKanIkkeEndres(brev, "brevkoden er feil, er ${brev.brevkoder}. Denne kan kun endres i aktivitetsplikts flyten")
-        }
 
         val result = db.settBrevSlettet(id, bruker)
         logger.info("Brev med id=$id slettet=$result")

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
@@ -582,26 +582,6 @@ internal class BrevServiceTest {
                 db.hentBrev(brev.id)
             }
         }
-
-        @ParameterizedTest
-        @EnumSource(Status::class)
-        fun `Skal ikke kunne slette aktivitetspliktsbrev som medfører vurdering, uavhengig av status`(status: Status) {
-            val brev =
-                opprettBrev(
-                    status,
-                    BrevProsessType.REDIGERBAR,
-                ).copy(brevkoder = Brevkoder.OMSTILLINGSSTOENAD_AKTIVITETSPLIKT_INFORMASJON_10MND_INNHOLD)
-
-            every { db.hentBrev(any()) } returns brev
-
-            assertThrows<BrevKanIkkeEndres> {
-                brevService.slett(brev.id, bruker)
-            }
-
-            verify {
-                db.hentBrev(brev.id)
-            }
-        }
     }
 
     private fun opprettBrev(

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/BrevOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/BrevOversikt.tsx
@@ -24,7 +24,13 @@ const mapAdresse = (mottaker: Mottaker) => {
   return `${adresselinje}, ${postlinje}`
 }
 
-const kanEndres = (brev: IBrev) => brev.status !== BrevStatus.DISTRIBUERT
+const kanEndres = (brev: IBrev) => brev.status !== BrevStatus.DISTRIBUERT && gyldigbrevkode(brev.brevkoder)
+
+export const gyldigbrevkode = (brevkoder: string): boolean =>
+  ![
+    'OMSTILLINGSSTOENAD_AKTIVITETSPLIKT_INFORMASJON_10MND_INNHOLD',
+    'OMSTILLINGSSTOENAD_AKTIVITETSPLIKT_INFORMASJON_4MND_INNHOLD',
+  ].includes(brevkoder)
 
 const handlingKnapp = (brev: IBrev) => {
   if (kanEndres(brev)) {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/handlinger/SlettBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/handlinger/SlettBrev.tsx
@@ -6,9 +6,14 @@ import { TrashIcon } from '@navikt/aksel-icons'
 import { isPending } from '~shared/api/apiUtils'
 import { BrevStatus, IBrev } from '~shared/types/Brev'
 import { ClickEvent, trackClick } from '~utils/amplitude'
+import { gyldigbrevkode } from '~components/person/brev/BrevOversikt'
 
 const kanSlettes = (brev: IBrev) => {
-  return !brev.behandlingId && [BrevStatus.OPPRETTET, BrevStatus.OPPDATERT].includes(brev.status)
+  return (
+    !brev.behandlingId &&
+    [BrevStatus.OPPRETTET, BrevStatus.OPPDATERT].includes(brev.status) &&
+    gyldigbrevkode(brev.brevkoder)
+  )
 }
 
 /**


### PR DESCRIPTION
…outes

* og i frontend fjerne knapper for den

TODO: obs må sjekke db om brev uten kobling til oppgave er opprettet
kan ikke merges før de manuelt opprettede brevene er ferdigbehandliet

sjekk disse: 

select b.id from brev b
                  INNER JOIN hendelse h ON b.id = h.brev_id
where brevkoder IN ('OMSTILLINGSSTOENAD_AKTIVITETSPLIKT_INFORMASJON_10MND_INNHOLD', 'OMSTILLINGSSTOENAD_AKTIVITETSPLIKT_INFORMASJON_4MND_INNHOLD')
AND h.id IN (
                SELECT DISTINCT ON (h2.brev_id) h2.id
                FROM hendelse h2
                WHERE h2.brev_id = b.id
                ORDER BY h2.brev_id, h2.opprettet DESC)
AND h.status_id IN ('OPPDATERT', 'OPPRETTET');

i select * from aktivitetsplikt_brevdata where brev_id IN ...