### PR TITLE
EY-4942 Koble testdata-behandler til grunnlag via behandling

### DIFF
--- a/apps/etterlatte-testdata-behandler/.nais/dev.yaml
+++ b/apps/etterlatte-testdata-behandler/.nais/dev.yaml
@@ -43,8 +43,6 @@ spec:
       value: etterlatte.dodsmelding
     - name: KAFKA_RESET_POLICY
       value: earliest
-    - name: GRUNNLAG_AZURE_SCOPE
-      value: api://dev-gcp.etterlatte.etterlatte-grunnlag/.default
     - name: BEHANDLING_AZURE_SCOPE
       value: api://dev-gcp.etterlatte.etterlatte-behandling/.default
     - name: BEREGNING_AZURE_SCOPE
@@ -57,8 +55,6 @@ spec:
       value: api://dev-gcp.etterlatte.etterlatte-vedtaksvurdering/.default
     - name: ETTERLATTE_BEREGNING_CLIENT_ID
       value: b07cf335-11fb-4efa-bd46-11f51afd5052
-    - name: ETTERLATTE_GRUNNLAG_CLIENT_ID
-      value: ce96a301-13db-4409-b277-5b27f464d08b
     - name: ETTERLATTE_BEHANDLING_CLIENT_ID
       value: 59967ac8-009c-492e-a618-e5a0f6b3e4e4
     - name: ETTERLATTE_BREV_API_CLIENT_ID
@@ -70,7 +66,6 @@ spec:
   accessPolicy:
     outbound:
       rules:
-        - application: etterlatte-grunnlag
         - application: etterlatte-behandling
         - application: etterlatte-beregning
         - application: etterlatte-trygdetid

--- a/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/AppBuilder.kt
+++ b/apps/etterlatte-testdata-behandler/src/main/kotlin/no/nav/etterlatte/testdata/AppBuilder.kt
@@ -38,9 +38,9 @@ class AppBuilder {
             )
         val grunnlagService =
             GrunnlagService(
-                settOppHttpClient("grunnlag"),
-                "http://etterlatte-grunnlag",
-                config.getString("grunnlag.client.id"),
+                settOppHttpClient("behandling"),
+                "http://etterlatte-behandling",
+                config.getString("behandling.client.id"),
             )
         val behandlingService =
             BehandlingService(

--- a/apps/etterlatte-testdata-behandler/src/main/resources/application.conf
+++ b/apps/etterlatte-testdata-behandler/src/main/resources/application.conf
@@ -3,14 +3,12 @@ azure.app.jwk = ${?AZURE_APP_JWK}
 azure.app.client.secret = ${?AZURE_APP_CLIENT_SECRET}
 azure.app.well.known.url = ${?AZURE_APP_WELL_KNOWN_URL}
 
-grunnlag.azure.scope = ${?GRUNNLAG_AZURE_SCOPE}
 behandling.azure.scope = ${?BEHANDLING_AZURE_SCOPE}
 beregning.azure.scope = ${?BEREGNING_AZURE_SCOPE}
 brev.azure.scope = ${?BREV_AZURE_SCOPE}
 trygdetid.azure.scope = ${?TRYGDETID_AZURE_SCOPE}
 vedtaksvurdering.azure.scope = ${?VEDTAKSVURDERING_AZURE_SCOPE}
 
-grunnlag.client.id = ${?ETTERLATTE_GRUNNLAG_CLIENT_ID}
 behandling.client.id = ${?ETTERLATTE_BEHANDLING_CLIENT_ID}
 beregning.client.id = ${?ETTERLATTE_BEREGNING_CLIENT_ID}
 brev.client.id = ${?ETTERLATTE_BREV_API_CLIENT_ID}


### PR DESCRIPTION
Gå mot identisk route som nå er i `etterlatte-behandling`

Avhenger av https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/7046