### PR TITLE
EY-5025 Setter frist på førstegangsbehandlinger / klager ut i fra mottatt dato

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingFactory.kt
@@ -44,6 +44,7 @@ import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
+import no.nav.etterlatte.libs.common.tidspunkt.toNorskTidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
@@ -244,6 +245,7 @@ class BehandlingFactory(
                                 )
                         },
                     gruppeId = persongalleri.avdoed.firstOrNull(),
+                    soeknadMottattDato = behandling.soeknadMottattDato,
                 )
 
             tilgangsService.haandtergraderingOgEgenAnsatt(sakId, persongalleri)
@@ -360,6 +362,7 @@ class BehandlingFactory(
                         oppgaveKilde = OppgaveKilde.BEHANDLING,
                         merknad = merknad,
                         gruppeId = null,
+                        soeknadMottattDato = nyFoerstegangsbehandling.soeknadMottattDato,
                     )
                 oppgaveService.tildelSaksbehandler(oppgave.id, saksbehandler.ident)
 
@@ -397,6 +400,7 @@ class BehandlingFactory(
         referanse: String,
         sakId: SakId,
         oppgaveKilde: OppgaveKilde = OppgaveKilde.BEHANDLING,
+        soeknadMottattDato: LocalDateTime?,
         merknad: String?,
         gruppeId: String?,
     ): OppgaveIntern {
@@ -409,6 +413,7 @@ class BehandlingFactory(
             type = OppgaveType.FOERSTEGANGSBEHANDLING,
             merknad = merknad,
             gruppeId = gruppeId,
+            frist = soeknadMottattDato?.plusMonths(1L)?.toNorskTidspunkt(),
         )
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klage/KlageService.kt
@@ -43,6 +43,7 @@ import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.toNorskTidspunkt
 import no.nav.etterlatte.libs.common.vedtak.VedtakDto
 import no.nav.etterlatte.libs.ktor.route.FeatureIkkeStoettetException
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
@@ -163,6 +164,11 @@ class KlageServiceImpl(
             sakId = sakId,
             kilde = OppgaveKilde.EKSTERN,
             type = OppgaveType.KLAGE,
+            frist =
+                innkommendeKlage.mottattDato
+                    .plusMonths(1L)
+                    .atStartOfDay()
+                    .toNorskTidspunkt(),
             merknad = null,
         )
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
@@ -242,7 +242,7 @@ internal class BehandlingFactoryTest {
             )
         } returns Unit
         coEvery { grunnlagService.opprettGrunnlag(any(), any()) } returns Unit
-        every { oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), gruppeId = any()) } returns mockOppgave
+        every { oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), gruppeId = any(), frist = any()) } returns mockOppgave
         every { sakServiceMock.hentGraderingForSak(any(), any()) } returns
             SakMedGraderingOgSkjermet(
                 opprettetBehandling.sak.id,
@@ -288,6 +288,7 @@ internal class BehandlingFactoryTest {
                 type = OppgaveType.FOERSTEGANGSBEHANDLING,
                 merknad = any(),
                 gruppeId = "Avdoed",
+                frist = any(),
             )
         }
         coVerify(exactly = 1) { grunnlagService.opprettGrunnlag(any(), any()) }
@@ -359,7 +360,7 @@ internal class BehandlingFactoryTest {
             )
         } returns Unit
         coEvery { grunnlagService.opprettGrunnlag(any(), any()) } returns Unit
-        every { oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), gruppeId = any()) } returns mockOppgave
+        every { oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), gruppeId = any(), frist = any()) } returns mockOppgave
 
         val foerstegangsbehandling =
             behandlingFactory
@@ -390,6 +391,7 @@ internal class BehandlingFactoryTest {
                 type = OppgaveType.FOERSTEGANGSBEHANDLING,
                 merknad = any(),
                 gruppeId = persongalleri.avdoed.single(),
+                frist = any(),
             )
         }
         coVerify { grunnlagService.opprettGrunnlag(any(), any()) }
@@ -464,7 +466,7 @@ internal class BehandlingFactoryTest {
             )
         } returns Unit
         coEvery { grunnlagService.opprettGrunnlag(any(), any()) } returns Unit
-        every { oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), gruppeId = any()) } returns mockOppgave
+        every { oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), gruppeId = any(), frist = any()) } returns mockOppgave
         every {
             oppgaveService.avbrytAapneOppgaverMedReferanse(any())
         } just runs
@@ -517,6 +519,7 @@ internal class BehandlingFactoryTest {
                 type = OppgaveType.FOERSTEGANGSBEHANDLING,
                 merknad = null,
                 gruppeId = persongalleri.avdoed.single(),
+                frist = any(),
             )
         }
         verify(exactly = 1) {
@@ -658,7 +661,7 @@ internal class BehandlingFactoryTest {
         coEvery { grunnlagService.hentPersongalleri(sak.id) } returns Persongalleri(sak.ident)
         coEvery { grunnlagService.opprettGrunnlag(any(), any()) } just runs
         every {
-            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), frist = any())
         } returns
             OppgaveIntern(
                 id = UUID.randomUUID(),
@@ -703,7 +706,7 @@ internal class BehandlingFactoryTest {
             behandlingDaoMock.opprettBehandling(any())
             kommerBarnetTilGodeServiceMock.lagreKommerBarnetTilgode(any())
             oppgaveService.tildelSaksbehandler(any(), saksbehandler.ident)
-            oppgaveService.opprettOppgave(opprettetBehandling.id.toString(), sak.id, any(), any(), any())
+            oppgaveService.opprettOppgave(opprettetBehandling.id.toString(), sak.id, any(), any(), any(), frist = any())
             hendelseDaoMock.behandlingOpprettet(any())
             behandlingHendelserKafkaProducerMock.sendMeldingForHendelseStatistikk(any(), any())
             vilkaarsvurderingService.kopierVilkaarsvurdering(any(), any(), any())
@@ -760,7 +763,7 @@ internal class BehandlingFactoryTest {
         every { behandlingDaoMock.opprettBehandling(capture(opprettBehandlingSlot)) } just runs
         coEvery { grunnlagService.hentPersongalleri(sak.id) } returns Persongalleri(sak.ident)
         coEvery { grunnlagService.opprettGrunnlag(any(), any()) } just runs
-        every { oppgaveService.opprettOppgave(any(), any(), any(), any(), any()) } returns oppgaveInternMock
+        every { oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), frist = any()) } returns oppgaveInternMock
         every { oppgaveService.hentOppgaverForSak(any(), any()) } returns listOf(oppgaveInternMock)
         every { oppgaveService.tildelSaksbehandler(any(), saksbehandler.ident) } just runs
         every { behandlingHendelserKafkaProducerMock.sendMeldingForHendelseStatistikk(any(), any()) } just runs
@@ -783,7 +786,7 @@ internal class BehandlingFactoryTest {
             behandlingDaoMock.hentBehandling(any())
             behandlingDaoMock.opprettBehandling(any())
             oppgaveService.tildelSaksbehandler(any(), saksbehandler.ident)
-            oppgaveService.opprettOppgave(any(), any(), any(), any(), "Omgjøring på grunn av klage")
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), merknad = "Omgjøring på grunn av klage", frist = any())
             hendelseDaoMock.behandlingOpprettet(any())
             behandlingHendelserKafkaProducerMock.sendMeldingForHendelseStatistikk(any(), any())
             behandlingDaoMock.lagreGyldighetsproeving(opprettetBehandling.id, any())
@@ -821,7 +824,7 @@ internal class BehandlingFactoryTest {
         coEvery { grunnlagService.hentPersongalleri(sak.id) } returns Persongalleri(sak.ident)
         coEvery { grunnlagService.opprettGrunnlag(any(), any()) } just runs
         every {
-            oppgaveService.opprettOppgave(any(), any(), any(), any(), any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), frist = any())
         } returns
             OppgaveIntern(
                 id = UUID.randomUUID(),
@@ -858,7 +861,7 @@ internal class BehandlingFactoryTest {
             behandlingDaoMock.hentBehandling(any())
             behandlingDaoMock.opprettBehandling(any())
             oppgaveService.tildelSaksbehandler(any(), saksbehandler.ident)
-            oppgaveService.opprettOppgave(any(), any(), any(), any(), "Omgjøring av førstegangsbehandling")
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), "Omgjøring av førstegangsbehandling", frist = any())
             hendelseDaoMock.behandlingOpprettet(any())
             behandlingHendelserKafkaProducerMock.sendMeldingForHendelseStatistikk(any(), any())
             behandlingDaoMock.lagreGyldighetsproeving(opprettetBehandling.id, any())
@@ -937,7 +940,7 @@ internal class BehandlingFactoryTest {
             oppgaveService.opprettOppgave(any(), any(), any(), any(), "Omgjøring av førstegangsbehandling")
         } returns mockOppgave
         every {
-            oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), gruppeId = any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), gruppeId = any(), frist = any())
         } returns mockOppgave
         every {
             oppgaveService.tildelSaksbehandler(any(), any())
@@ -1023,6 +1026,7 @@ internal class BehandlingFactoryTest {
                 type = OppgaveType.FOERSTEGANGSBEHANDLING,
                 merknad = any(),
                 gruppeId = persongalleri.avdoed.single(),
+                frist = any(),
             )
             oppgaveService.opprettOppgave(
                 referanse = revurderingsBehandling.id.toString(),
@@ -1031,6 +1035,7 @@ internal class BehandlingFactoryTest {
                 type = OppgaveType.FOERSTEGANGSBEHANDLING,
                 merknad = any(),
                 gruppeId = persongalleri.avdoed.single(),
+                frist = any(),
             )
         }
         coVerify { grunnlagService.opprettGrunnlag(any(), any()) }
@@ -1117,10 +1122,10 @@ internal class BehandlingFactoryTest {
         } returns Unit
         coEvery { grunnlagService.opprettGrunnlag(any(), any()) } returns Unit
         every {
-            oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), gruppeId = any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), frist = any(), gruppeId = any())
         } returns mockOppgave
         every {
-            oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), gruppeId = any())
+            oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), frist = any(), gruppeId = any())
         } returns mockOppgave
         every {
             oppgaveService.oppdaterStatusOgMerknad(any(), any(), any())
@@ -1205,6 +1210,7 @@ internal class BehandlingFactoryTest {
                 kilde = any(),
                 type = any(),
                 merknad = any(),
+                frist = any(),
                 gruppeId = persongalleri.avdoed.single(),
             )
             oppgaveService.opprettOppgave(
@@ -1213,6 +1219,7 @@ internal class BehandlingFactoryTest {
                 kilde = any(),
                 type = any(),
                 merknad = any(),
+                frist = any(),
                 gruppeId = persongalleri.avdoed.single(),
             )
         }
@@ -1289,7 +1296,7 @@ internal class BehandlingFactoryTest {
         every { behandlingDaoMock.opprettBehandling(capture(behandlingOpprettes)) } just Runs
         every { behandlingDaoMock.hentBehandling(capture(behandlingHentes)) } returns opprettetBehandling
         every { behandlingDaoMock.hentBehandlingerForSak(any()) } returns emptyList()
-        every { oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), gruppeId = any()) } returns mockOppgave
+        every { oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), gruppeId = any(), frist = any()) } returns mockOppgave
 
         coEvery { pdlTjenesterKlientMock.hentAdressebeskyttelseForPerson(any()) } returns AdressebeskyttelseGradering.UGRADERT
 
@@ -1336,6 +1343,7 @@ internal class BehandlingFactoryTest {
                 type = OppgaveType.FOERSTEGANGSBEHANDLING,
                 merknad = any(),
                 gruppeId = persongalleri.avdoed.single(),
+                frist = any(),
             )
         }
         coVerify {

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingFactoryTest.kt
@@ -58,6 +58,7 @@ import no.nav.etterlatte.libs.common.sak.SakMedGraderingOgSkjermet
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeNorskTid
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
+import no.nav.etterlatte.libs.common.tidspunkt.toNorskTidspunkt
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.Vilkaarsvurdering
 import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingMedBehandlingGrunnlagsversjon
 import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
@@ -203,7 +204,8 @@ internal class BehandlingFactoryTest {
                 behandlingOpprettet = datoNaa,
                 sistEndret = datoNaa,
                 status = BehandlingStatus.OPPRETTET,
-                soeknadMottattDato = Tidspunkt.now().toLocalDatetimeUTC(),
+                // Hvis søknad mottatt dato er null (ukjent) så skal oppgave opprettes med null for frist
+                soeknadMottattDato = null,
                 gyldighetsproeving = null,
                 virkningstidspunkt =
                     Virkningstidspunkt(
@@ -288,7 +290,8 @@ internal class BehandlingFactoryTest {
                 type = OppgaveType.FOERSTEGANGSBEHANDLING,
                 merknad = any(),
                 gruppeId = "Avdoed",
-                frist = any(),
+                // Sjekker at oppgave opprettes med null for frist
+                frist = null,
             )
         }
         coVerify(exactly = 1) { grunnlagService.opprettGrunnlag(any(), any()) }
@@ -304,6 +307,7 @@ internal class BehandlingFactoryTest {
         val behandlingHentes = slot<UUID>()
         val datoNaa = Tidspunkt.now().toLocalDatetimeUTC()
 
+        val tidspunktMottattBehandling = Tidspunkt.now().toLocalDatetimeUTC().minusDays(15L)
         val opprettetBehandling =
             Foerstegangsbehandling(
                 id = UUID.randomUUID(),
@@ -317,7 +321,7 @@ internal class BehandlingFactoryTest {
                 behandlingOpprettet = datoNaa,
                 sistEndret = datoNaa,
                 status = BehandlingStatus.OPPRETTET,
-                soeknadMottattDato = Tidspunkt.now().toLocalDatetimeUTC(),
+                soeknadMottattDato = tidspunktMottattBehandling,
                 gyldighetsproeving = null,
                 virkningstidspunkt =
                     Virkningstidspunkt(
@@ -391,7 +395,7 @@ internal class BehandlingFactoryTest {
                 type = OppgaveType.FOERSTEGANGSBEHANDLING,
                 merknad = any(),
                 gruppeId = persongalleri.avdoed.single(),
-                frist = any(),
+                frist = tidspunktMottattBehandling.plusMonths(1L).toNorskTidspunkt(),
             )
         }
         coVerify { grunnlagService.opprettGrunnlag(any(), any()) }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/ManuellRevurderingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/ManuellRevurderingServiceTest.kt
@@ -413,6 +413,7 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
                     type = OppgaveType.FOERSTEGANGSBEHANDLING,
                     merknad = "2 søsken",
                     gruppeId = defaultPersongalleriGydligeFnr.avdoed.first(),
+                    frist = any(),
                 )
                 oppgaveService.tildelSaksbehandler(any(), saksbehandler.ident)
                 oppgaveService.opprettOppgave(


### PR DESCRIPTION
Reell frist for disse oppgavene er avhengig av når Nav har mottatt søknad / klage, og ikke når vi har registrert behandlingen i vårt system. Setter i stedet fristen ut i fra søknad/klage mottatt.