### PR TITLE
EY-5008: Flytte rivere for vilkårsvurdering til behandling-kafka

### DIFF
--- a/apps/etterlatte-behandling-kafka/build.gradle.kts
+++ b/apps/etterlatte-behandling-kafka/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     implementation(project(":libs:saksbehandling-common"))
     implementation(project(":libs:etterlatte-behandling-model"))
+    implementation(project(":libs:etterlatte-vilkaarsvurdering-model"))
     implementation(project(":libs:etterlatte-funksjonsbrytere"))
     implementation(project(":libs:etterlatte-ktor"))
     implementation(project(":libs:etterlatte-pdl-model"))

--- a/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/AppBuilder.kt
+++ b/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/AppBuilder.kt
@@ -25,12 +25,22 @@ import no.nav.etterlatte.libs.ktor.AzureEnums.AZURE_APP_WELL_KNOWN_URL
 import no.nav.etterlatte.libs.ktor.httpClient
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 import no.nav.etterlatte.tidshendelser.TidshendelseService
+import no.nav.etterlatte.vilkaarsvurdering.VilkaarsvurderingService
+import no.nav.etterlatte.vilkaarsvurdering.VilkaarsvurderingServiceImpl
 
 class AppBuilder(
     private val props: Miljoevariabler,
 ) {
     val behandlingService: BehandlingService by lazy {
         BehandlingServiceImpl(
+            behandlingAppExpectSuccess,
+            "http://etterlatte-behandling",
+        )
+    }
+
+    // TODO: Slå sammen med behandlingService?
+    val vilkaarsvurderingService: VilkaarsvurderingService by lazy {
+        VilkaarsvurderingServiceImpl(
             behandlingAppExpectSuccess,
             "http://etterlatte-behandling",
         )

--- a/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -39,6 +39,7 @@ private fun settOppRivers(
     val behandlingservice = appBuilder.behandlingService
     val tidshendelseService = appBuilder.tidshendelserService
     val featureToggleService = appBuilder.featureToggleService
+    val vilkaarsvurderingService = appBuilder.vilkaarsvurderingService
 
     PdlHendelserRiver(rapidsConnection, behandlingservice)
     OmregningsHendelserBehandlingRiver(rapidsConnection, behandlingservice)
@@ -54,6 +55,10 @@ private fun settOppRivers(
     OmregningBrevDistribusjonRiver(rapidsConnection, behandlingservice)
 
     StartUthentingFraSoeknadRiver(rapidsConnection, Opplysningsuthenter())
+
+    // TODO tilgjengeliggjør disse riverene når etterlatte-vilkaarsvurdering-kafka er skrudd av
+    // VilkaarsvurderingRiver(rapidsConnection, vilkaarsvurderingService)
+    // TidshendelseVilkaarsvurderingRiver(rapidsConnection, vilkaarsvurderingService)
 
     NySoeknadRiver(
         rapidsConnection = rapidsConnection,

--- a/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/Application.kt
+++ b/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/Application.kt
@@ -20,6 +20,8 @@ import no.nav.etterlatte.regulering.ReguleringsforespoerselRiver
 import no.nav.etterlatte.regulering.VedtakAttestertRiver
 import no.nav.etterlatte.regulering.YtelseIkkeLoependeRiver
 import no.nav.etterlatte.tidshendelser.TidshendelseRiver
+import no.nav.etterlatte.vilkaarsvurdering.VilkaarsvurderingRiver
+import no.nav.etterlatte.vilkaarsvurdering.VilkaarsvurderingTidshendelseRiver
 import no.nav.helse.rapids_rivers.RapidsConnection
 import rapidsandrivers.initRogR
 
@@ -56,9 +58,8 @@ private fun settOppRivers(
 
     StartUthentingFraSoeknadRiver(rapidsConnection, Opplysningsuthenter())
 
-    // TODO tilgjengeliggjør disse riverene når etterlatte-vilkaarsvurdering-kafka er skrudd av
-    // VilkaarsvurderingRiver(rapidsConnection, vilkaarsvurderingService)
-    // TidshendelseVilkaarsvurderingRiver(rapidsConnection, vilkaarsvurderingService)
+    VilkaarsvurderingRiver(rapidsConnection, vilkaarsvurderingService)
+    VilkaarsvurderingTidshendelseRiver(rapidsConnection, vilkaarsvurderingService)
 
     NySoeknadRiver(
         rapidsConnection = rapidsConnection,

--- a/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRiver.kt
+++ b/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRiver.kt
@@ -1,0 +1,47 @@
+package no.nav.etterlatte.vilkaarsvurdering
+
+import no.nav.etterlatte.libs.common.rapidsandrivers.setEventNameForHendelseType
+import no.nav.etterlatte.omregning.OmregningDataPacket
+import no.nav.etterlatte.omregning.OmregningHendelseType
+import no.nav.etterlatte.omregning.omregningData
+import no.nav.etterlatte.rapidsandrivers.HENDELSE_DATA_KEY
+import no.nav.etterlatte.rapidsandrivers.Kontekst
+import no.nav.etterlatte.rapidsandrivers.ListenerMedLoggingOgFeilhaandtering
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.MessageContext
+import no.nav.helse.rapids_rivers.RapidsConnection
+import org.slf4j.LoggerFactory
+
+internal class VilkaarsvurderingRiver(
+    rapidsConnection: RapidsConnection,
+    private val vilkaarsvurderingService: VilkaarsvurderingService,
+) : ListenerMedLoggingOgFeilhaandtering() {
+    private val logger = LoggerFactory.getLogger(VilkaarsvurderingRiver::class.java)
+
+    init {
+        initialiserRiver(rapidsConnection, OmregningHendelseType.BEHANDLING_OPPRETTA) {
+            validate { it.requireKey(HENDELSE_DATA_KEY) }
+            validate { it.requireKey(OmregningDataPacket.SAK_ID) }
+            validate { it.requireKey(OmregningDataPacket.BEHANDLING_ID) }
+            validate { it.requireKey(OmregningDataPacket.FORRIGE_BEHANDLING_ID) }
+        }
+    }
+
+    override fun kontekst() = Kontekst.OMREGNING
+
+    override fun haandterPakke(
+        packet: JsonMessage,
+        context: MessageContext,
+    ) {
+        val omregningData = packet.omregningData
+        val behandlingId = omregningData.hentBehandlingId()
+        val behandlingViOmregnerFra = omregningData.hentForrigeBehandlingid()
+
+        vilkaarsvurderingService.kopierForrigeVilkaarsvurdering(behandlingId, behandlingViOmregnerFra)
+        packet.setEventNameForHendelseType(OmregningHendelseType.VILKAARSVURDERT)
+        context.publish(packet.toJson())
+        logger.info(
+            "Vilkaarsvurdert ferdig for behandling $behandlingId og melding beregningsmelding ble sendt.",
+        )
+    }
+}

--- a/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
+++ b/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingService.kt
@@ -1,0 +1,76 @@
+package no.nav.etterlatte.vilkaarsvurdering
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.coroutines.runBlocking
+import java.util.UUID
+
+interface VilkaarsvurderingService {
+    fun kopierForrigeVilkaarsvurdering(
+        behandlingId: UUID,
+        behandlingViOmregnerFra: UUID,
+    ): HttpResponse
+
+    fun opprettVilkaarsvurdering(behandlingId: UUID): HttpResponse
+
+    fun opphoerAldersovergang(
+        behandlingId: UUID,
+        behandlingKopiereFraId: UUID,
+    ): HttpResponse
+
+    fun harMigrertYrkesskadefordel(behandlingId: String): Boolean
+
+    fun harRettUtenTidsbegrensning(behandlingId: String): Boolean
+}
+
+class VilkaarsvurderingServiceImpl(
+    private val vilkaarsvurderingKlient: HttpClient,
+    private val url: String,
+) : VilkaarsvurderingService {
+    override fun kopierForrigeVilkaarsvurdering(
+        behandlingId: UUID,
+        behandlingViOmregnerFra: UUID,
+    ) = runBlocking {
+        vilkaarsvurderingKlient.post("$url/api/vilkaarsvurdering/$behandlingId/kopier") {
+            contentType(ContentType.Application.Json)
+            setBody(OpprettVilkaarsvurderingMotBehandling(behandlingViOmregnerFra))
+        }
+    }
+
+    override fun opprettVilkaarsvurdering(behandlingId: UUID) =
+        runBlocking {
+            vilkaarsvurderingKlient.post("$url/api/vilkaarsvurdering/$behandlingId/opprett") {
+                contentType(ContentType.Application.Json)
+            }
+        }
+
+    override fun opphoerAldersovergang(
+        behandlingId: UUID,
+        behandlingKopiereFraId: UUID,
+    ) = runBlocking {
+        vilkaarsvurderingKlient.post("$url/api/vilkaarsvurdering/aldersovergang/$behandlingId?fra=$behandlingKopiereFraId") {
+            contentType(ContentType.Application.Json)
+        }
+    }
+
+    override fun harMigrertYrkesskadefordel(behandlingId: String): Boolean =
+        runBlocking {
+            vilkaarsvurderingKlient
+                .get("$url/api/vilkaarsvurdering/$behandlingId/migrert-yrkesskadefordel")
+                .body<MigrertYrkesskadefordel>()
+                .migrertYrkesskadefordel
+        }
+
+    override fun harRettUtenTidsbegrensning(behandlingId: String): Boolean =
+        runBlocking {
+            vilkaarsvurderingKlient
+                .get("$url/api/vilkaarsvurdering/$behandlingId/rett-uten-tidsbegrensning")
+                .body<Map<String, Any>>()["rettUtenTidsbegrensning"] as Boolean
+        }
+}

--- a/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingTidshendelseRiver.kt
+++ b/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingTidshendelseRiver.kt
@@ -1,0 +1,123 @@
+package no.nav.etterlatte.vilkaarsvurdering
+
+import no.nav.etterlatte.libs.common.logging.getCorrelationId
+import no.nav.etterlatte.libs.common.logging.withLogContext
+import no.nav.etterlatte.rapidsandrivers.BEHANDLING_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.BEHANDLING_VI_OMREGNER_FRA_KEY
+import no.nav.etterlatte.rapidsandrivers.DATO_KEY
+import no.nav.etterlatte.rapidsandrivers.DRYRUN
+import no.nav.etterlatte.rapidsandrivers.EventNames
+import no.nav.etterlatte.rapidsandrivers.HENDELSE_DATA_KEY
+import no.nav.etterlatte.rapidsandrivers.ListenerMedLogging
+import no.nav.etterlatte.rapidsandrivers.SAK_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.TIDSHENDELSE_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.TIDSHENDELSE_STEG_KEY
+import no.nav.etterlatte.rapidsandrivers.TIDSHENDELSE_TYPE_KEY
+import no.nav.etterlatte.rapidsandrivers.asUUID
+import no.nav.etterlatte.rapidsandrivers.behandlingId
+import no.nav.etterlatte.rapidsandrivers.sakId
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.MessageContext
+import no.nav.helse.rapids_rivers.RapidsConnection
+import org.slf4j.LoggerFactory
+
+class VilkaarsvurderingTidshendelseRiver(
+    rapidsConnection: RapidsConnection,
+    private val vilkaarsvurderingService: VilkaarsvurderingService,
+) : ListenerMedLogging() {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    init {
+        initialiserRiver(rapidsConnection, EventNames.TIDSHENDELSE) {
+            validate {
+                it.requireAny(
+                    TIDSHENDELSE_STEG_KEY,
+                    listOf("VURDERT_LOEPENDE_YTELSE", "BEHANDLING_OPPRETTET"),
+                )
+            }
+            validate { it.requireKey(TIDSHENDELSE_TYPE_KEY) }
+            validate { it.requireKey(TIDSHENDELSE_ID_KEY) }
+            validate { it.requireKey(SAK_ID_KEY) }
+            validate { it.requireKey(DATO_KEY) }
+            validate { it.requireKey(DRYRUN) }
+            validate { it.requireKey(HENDELSE_DATA_KEY) }
+            validate { it.interestedIn(BEHANDLING_ID_KEY) }
+            validate { it.interestedIn(BEHANDLING_VI_OMREGNER_FRA_KEY) }
+        }
+    }
+
+    override fun haandterPakke(
+        packet: JsonMessage,
+        context: MessageContext,
+    ) {
+        val steg = packet[TIDSHENDELSE_STEG_KEY].asText()
+        val type = packet[TIDSHENDELSE_TYPE_KEY].asText()
+        val hendelseId = packet[TIDSHENDELSE_ID_KEY].asText()
+        val dryrun = packet[DRYRUN].asBoolean()
+        val sakId = packet.sakId
+
+        withLogContext(
+            correlationId = getCorrelationId(),
+            mapOf(
+                "hendelseId" to hendelseId,
+                "sakId" to sakId.toString(),
+                "type" to type,
+                "dryRun" to dryrun.toString(),
+            ),
+        ) {
+            val behandlet =
+                when (steg) {
+                    "VURDERT_LOEPENDE_YTELSE" -> sjekkUnntaksregler(packet, type)
+                    "BEHANDLING_OPPRETTET" -> vilkaarsvurder(packet, dryrun)
+                    else -> false
+                }
+
+            if (behandlet) {
+                // Reply med oppdatert melding
+                context.publish(packet.toJson())
+            }
+        }
+    }
+
+    private fun sjekkUnntaksregler(
+        packet: JsonMessage,
+        type: String,
+    ): Boolean {
+        val hendelseData = packet[HENDELSE_DATA_KEY]
+
+        hendelseData["loependeYtelse_januar2024_behandlingId"]?.let {
+            val behandlingId = it.asText()
+            val result = vilkaarsvurderingService.harMigrertYrkesskadefordel(behandlingId)
+            logger.info("Løpende ytelse: sjekk av yrkesskadefordel før 2024-01-01: $result")
+            packet["yrkesskadefordel_pre_20240101"] = result
+        }
+
+        if (type in arrayOf("OMS_DOED_3AAR", "OMS_DOED_5AAR") && hendelseData["loependeYtelse"]?.asBoolean() == true) {
+            val loependeBehandlingId = hendelseData["loependeYtelse_behandlingId"].asText()
+            val result = vilkaarsvurderingService.harRettUtenTidsbegrensning(loependeBehandlingId)
+            logger.info("OMS: sjekk av rett uten tidsbegrensning: $result")
+            packet["oms_rett_uten_tidsbegrensning"] = result
+        }
+
+        packet[TIDSHENDELSE_STEG_KEY] = "VURDERT_LOEPENDE_YTELSE_OG_VILKAAR"
+        return true
+    }
+
+    private fun vilkaarsvurder(
+        packet: JsonMessage,
+        dryrun: Boolean,
+    ): Boolean {
+        val behandlingId = packet.behandlingId
+        val forrigeBehandlingId = packet[BEHANDLING_VI_OMREGNER_FRA_KEY].asUUID()
+
+        if (dryrun) {
+            logger.info("Dryrun: skipper å behandle vilkårsvurdering for behandlingId=$behandlingId")
+        } else {
+            logger.info("Oppretter vilkårsvurdering for aldersovergang, behandlingId=$behandlingId")
+            vilkaarsvurderingService.opphoerAldersovergang(behandlingId, forrigeBehandlingId)
+        }
+
+        packet[TIDSHENDELSE_STEG_KEY] = "VILKAARSVURDERT"
+        return true
+    }
+}

--- a/apps/etterlatte-behandling-kafka/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRiverTest.kt
+++ b/apps/etterlatte-behandling-kafka/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingRiverTest.kt
@@ -1,0 +1,64 @@
+package no.nav.etterlatte.vilkaarsvurdering
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import no.nav.etterlatte.behandling.randomSakId
+import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
+import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
+import no.nav.etterlatte.libs.common.rapidsandrivers.lagParMedEventNameKey
+import no.nav.etterlatte.omregning.OmregningData
+import no.nav.etterlatte.omregning.OmregningHendelseType
+import no.nav.etterlatte.rapidsandrivers.HENDELSE_DATA_KEY
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.testsupport.TestRapid
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.UUID
+
+internal class VilkaarsvurderingRiverTest {
+    private val vilkaarsvurderingServiceMock =
+        mockk<VilkaarsvurderingService> {
+            coEvery { kopierForrigeVilkaarsvurdering(any(), any()) } returns mockk()
+        }
+    private val testRapid = TestRapid().apply { VilkaarsvurderingRiver(this, vilkaarsvurderingServiceMock) }
+
+    @Test
+    fun `tar opp VILKAARSVURDER-event, kopierer vilkaarsvurdering og poster ny BEREGN-meldig på koen`() {
+        val behandlingId = UUID.randomUUID()
+        val behandlingViOmregnerFra = UUID.randomUUID()
+        val omregningData =
+            OmregningData(
+                kjoering = "kjoering",
+                sakId = randomSakId(),
+                revurderingaarsak = Revurderingaarsak.REGULERING,
+                fradato = LocalDate.now(),
+                behandlingId = behandlingId,
+                forrigeBehandlingId = behandlingViOmregnerFra,
+            )
+
+        val melding =
+            JsonMessage
+                .newMessage(
+                    mapOf(
+                        OmregningHendelseType.BEHANDLING_OPPRETTA.lagParMedEventNameKey(),
+                        HENDELSE_DATA_KEY to omregningData.toPacket(),
+                    ),
+                ).toJson()
+        testRapid.sendTestMessage(melding)
+
+        coVerify(exactly = 1) {
+            vilkaarsvurderingServiceMock.kopierForrigeVilkaarsvurdering(
+                behandlingId,
+                behandlingViOmregnerFra,
+            )
+        }
+        with(testRapid.inspektør.message(0)) {
+            Assertions.assertEquals(
+                OmregningHendelseType.VILKAARSVURDERT.lagEventnameForType(),
+                this[EVENT_NAME_KEY].asText(),
+            )
+        }
+    }
+}

--- a/apps/etterlatte-behandling-kafka/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingTidshendelseRiverTest.kt
+++ b/apps/etterlatte-behandling-kafka/src/test/kotlin/no/nav/etterlatte/vilkaarsvurdering/VilkaarsvurderingTidshendelseRiverTest.kt
@@ -1,0 +1,176 @@
+package no.nav.etterlatte.vilkaarsvurdering
+
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.ktor.client.statement.HttpResponse
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.etterlatte.behandling.randomSakId
+import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
+import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.rapidsandrivers.BEHANDLING_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.BEHANDLING_VI_OMREGNER_FRA_KEY
+import no.nav.etterlatte.rapidsandrivers.DATO_KEY
+import no.nav.etterlatte.rapidsandrivers.DRYRUN
+import no.nav.etterlatte.rapidsandrivers.EventNames
+import no.nav.etterlatte.rapidsandrivers.HENDELSE_DATA_KEY
+import no.nav.etterlatte.rapidsandrivers.SAK_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.TIDSHENDELSE_ID_KEY
+import no.nav.etterlatte.rapidsandrivers.TIDSHENDELSE_STEG_KEY
+import no.nav.etterlatte.rapidsandrivers.TIDSHENDELSE_TYPE_KEY
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.testsupport.TestRapid
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Month
+import java.time.YearMonth
+import java.util.UUID
+
+class VilkaarsvurderingTidshendelseRiverTest {
+    private val vilkaarsvurderingService = mockk<VilkaarsvurderingService>()
+    private val inspector = TestRapid().apply { VilkaarsvurderingTidshendelseRiver(this, vilkaarsvurderingService) }
+
+    @Test
+    fun `skal sjekke yrkesskadefordel og angi property i melding lik true`() {
+        val hendelseId = UUID.randomUUID()
+        val sakId = randomSakId()
+        val behandlingsmaaned = YearMonth.of(2024, Month.APRIL)
+        val behandlingIdPerReformtidspunkt = UUID.randomUUID().toString()
+        val melding =
+            lagMeldingForVurdertLoependeYtelse(
+                hendelseId,
+                sakId,
+                behandlingsmaaned,
+                behandlingIdPerReformtidspunkt,
+            )
+        every { vilkaarsvurderingService.harMigrertYrkesskadefordel(behandlingIdPerReformtidspunkt) } returns true
+
+        with(inspector.apply { sendTestMessage(melding.toJson()) }.inspektør) {
+            size shouldBe 1
+            field(0, EVENT_NAME_KEY).asText() shouldBe EventNames.TIDSHENDELSE.name
+            field(0, TIDSHENDELSE_STEG_KEY).asText() shouldBe "VURDERT_LOEPENDE_YTELSE_OG_VILKAAR"
+            field(0, TIDSHENDELSE_TYPE_KEY).asText() shouldBe "BP20"
+            field(0, TIDSHENDELSE_ID_KEY).asText() shouldBe hendelseId.toString()
+            field(0, DRYRUN).asBoolean() shouldBe false
+            field(0, HENDELSE_DATA_KEY) shouldHaveSize 1
+            field(0, "yrkesskadefordel_pre_20240101").asBoolean() shouldBe true
+        }
+
+        verify { vilkaarsvurderingService.harMigrertYrkesskadefordel(behandlingIdPerReformtidspunkt) }
+    }
+
+    @Test
+    fun `skal ikke sjekke yrkesskadefordel da det ikke finnes en behandlingId for det i melding`() {
+        val hendelseId = UUID.randomUUID()
+        val sakId = randomSakId()
+        val behandlingsmaaned = YearMonth.of(2024, Month.APRIL)
+        val behandlingIdPerReformtidspunkt = UUID.randomUUID().toString()
+        val melding = lagMeldingForVurdertLoependeYtelse(hendelseId, sakId, behandlingsmaaned)
+
+        with(inspector.apply { sendTestMessage(melding.toJson()) }.inspektør) {
+            size shouldBe 1
+            field(0, EVENT_NAME_KEY).asText() shouldBe EventNames.TIDSHENDELSE.name
+            field(0, TIDSHENDELSE_STEG_KEY).asText() shouldBe "VURDERT_LOEPENDE_YTELSE_OG_VILKAAR"
+            field(0, TIDSHENDELSE_TYPE_KEY).asText() shouldBe "BP20"
+            field(0, TIDSHENDELSE_ID_KEY).asText() shouldBe hendelseId.toString()
+            field(0, DRYRUN).asBoolean() shouldBe false
+            field(0, HENDELSE_DATA_KEY) shouldHaveSize 0
+            assertThrows<IllegalArgumentException> { field(0, "yrkesskadefordel_pre_20240101") }
+        }
+
+        verify(exactly = 0) { vilkaarsvurderingService.harMigrertYrkesskadefordel(behandlingIdPerReformtidspunkt) }
+    }
+
+    @Test
+    fun `skal sjekke status for vilkaar om rett uten tidsbegrensning`() {
+        val hendelseId = UUID.randomUUID()
+        val sakId = randomSakId()
+        val behandlingsmaaned = YearMonth.of(2024, Month.APRIL)
+        val behandlingId = UUID.randomUUID().toString()
+        val melding =
+            lagMeldingForVurdertLoependeYtelse(
+                hendelseId,
+                sakId,
+                behandlingsmaaned,
+            )
+        melding[TIDSHENDELSE_TYPE_KEY] = "OMS_DOED_3AAR"
+        melding[HENDELSE_DATA_KEY] =
+            mapOf(
+                "loependeYtelse" to true,
+                "loependeYtelse_behandlingId" to behandlingId,
+            )
+
+        every { vilkaarsvurderingService.harRettUtenTidsbegrensning(behandlingId) } returns true
+
+        with(inspector.apply { sendTestMessage(melding.toJson()) }.inspektør) {
+            size shouldBe 1
+            field(0, EVENT_NAME_KEY).asText() shouldBe EventNames.TIDSHENDELSE.name
+            field(0, TIDSHENDELSE_STEG_KEY).asText() shouldBe "VURDERT_LOEPENDE_YTELSE_OG_VILKAAR"
+            field(0, TIDSHENDELSE_TYPE_KEY).asText() shouldBe "OMS_DOED_3AAR"
+            field(0, TIDSHENDELSE_ID_KEY).asText() shouldBe hendelseId.toString()
+            field(0, DRYRUN).asBoolean() shouldBe false
+            field(0, HENDELSE_DATA_KEY) shouldHaveSize 2
+            field(0, "oms_rett_uten_tidsbegrensning").asBoolean() shouldBe true
+        }
+
+        verify { vilkaarsvurderingService.harRettUtenTidsbegrensning(behandlingId) }
+    }
+
+    @Test
+    fun `skal opprette vilkaarsvurdering og opphoere pga aldersovergang`() {
+        val hendelseId = UUID.randomUUID()
+        val sakId = randomSakId()
+        val behandlingsmaaned = YearMonth.of(2024, Month.APRIL)
+        val behandlingIdLoepende = UUID.randomUUID()
+        val behandlingId = UUID.randomUUID()
+        val melding =
+            lagMeldingForVurdertLoependeYtelse(
+                hendelseId = hendelseId,
+                sakId = sakId,
+                behandlingsmaaned = behandlingsmaaned,
+                steg = "BEHANDLING_OPPRETTET",
+            ).also {
+                it[BEHANDLING_ID_KEY] = behandlingId
+                it[BEHANDLING_VI_OMREGNER_FRA_KEY] = behandlingIdLoepende
+            }
+
+        every { vilkaarsvurderingService.opphoerAldersovergang(behandlingId, behandlingIdLoepende) } returns mockk<HttpResponse>()
+
+        with(inspector.apply { sendTestMessage(melding.toJson()) }.inspektør) {
+            size shouldBe 1
+            field(0, EVENT_NAME_KEY).asText() shouldBe EventNames.TIDSHENDELSE.name
+            field(0, TIDSHENDELSE_STEG_KEY).asText() shouldBe "VILKAARSVURDERT"
+            field(0, TIDSHENDELSE_TYPE_KEY).asText() shouldBe "BP20"
+            field(0, TIDSHENDELSE_ID_KEY).asText() shouldBe hendelseId.toString()
+        }
+
+        verify { vilkaarsvurderingService.opphoerAldersovergang(behandlingId, behandlingIdLoepende) }
+    }
+
+    private fun lagMeldingForVurdertLoependeYtelse(
+        hendelseId: UUID,
+        sakId: SakId,
+        behandlingsmaaned: YearMonth,
+        behandlingIdPerReformtidspunkt: String? = null,
+        steg: String = "VURDERT_LOEPENDE_YTELSE",
+    ): JsonMessage {
+        val hendelsedata = mutableMapOf<String, Any>()
+        behandlingIdPerReformtidspunkt?.let {
+            hendelsedata["loependeYtelse_januar2024_behandlingId"] = it
+        }
+
+        return JsonMessage.newMessage(
+            EventNames.TIDSHENDELSE.lagEventnameForType(),
+            mapOf(
+                TIDSHENDELSE_STEG_KEY to steg,
+                TIDSHENDELSE_TYPE_KEY to "BP20",
+                TIDSHENDELSE_ID_KEY to hendelseId,
+                SAK_ID_KEY to sakId,
+                DATO_KEY to behandlingsmaaned.atDay(1),
+                DRYRUN to false,
+                HENDELSE_DATA_KEY to hendelsedata,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Flytter rivere fra `etterlatte-vilkaarsvurdering-kafka` til `etterlatte-behandling-kafka` da vilkårsvurdering nå er en del av behandling.