### PR TITLE
Siden dødsmeldinger kommer kjempelenge før pdl og parallelklienter

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -710,7 +710,7 @@ internal class ApplicationContext(
                     .of(20, ChronoUnit.MINUTES)
                     .toMillis()
             },
-            interval = if (isProd()) Duration.of(1, ChronoUnit.HOURS) else Duration.of(2, ChronoUnit.HOURS),
+            interval = if (isProd()) Duration.of(1, ChronoUnit.HOURS) else Duration.of(10, ChronoUnit.HOURS),
             dataSource = dataSource,
             sakTilgangDao = sakTilgangDao,
         )


### PR DESCRIPTION
* har fått det med seg så foreslår jeg at jobben bare kjører sjeldent i dev så vi slipper alle error loggene på den


evt bare kjøre om natta i dev?