### PR TITLE
EY-4942: Justerer bruk av proxy for grunnlag

### DIFF
--- a/apps/etterlatte-behandling/src/test/kotlin/VerdikjedeTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/VerdikjedeTest.kt
@@ -149,7 +149,7 @@ class VerdikjedeTest : BehandlingIntegrationTest() {
                         setBody(
                             BehandlingsBehov(
                                 sakId1,
-                                Persongalleri("søker", "innsender", emptyList(), emptyList(), emptyList()),
+                                Persongalleri(soeker, "innsender", emptyList(), emptyList(), emptyList()),
                                 Tidspunkt.now().toLocalDatetimeUTC().toString(),
                             ),
                         )

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/ManuellRevurderingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/ManuellRevurderingServiceTest.kt
@@ -51,7 +51,6 @@ import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.oppgave.Status
 import no.nav.etterlatte.libs.common.sak.Sak
-import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.mockSaksbehandler
 import no.nav.etterlatte.nyKontekstMedBrukerOgDatabase
@@ -82,7 +81,9 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
 
         coEvery { norg2Klient.hentArbeidsfordelingForOmraadeOgTema(any()) } returns listOf(standardEnhet)
 
-        startServer(norg2Klient = norg2Klient)
+        startServer(
+            norg2Klient = norg2Klient,
+        )
         nyKontekstMedBrukerOgDatabase(user, applicationContext.dataSource)
     }
 
@@ -163,8 +164,10 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
             }
 
         coVerify {
-            grunnlagService.hentPersongalleri(any<SakId>())
-            grunnlagService.opprettGrunnlag(revurdering.id, any())
+            grunnlagService.opprettGrunnlag(any(), any())
+            grunnlagService.hentPersongalleri(sak.id)
+            grunnlagService.lagreNyePersonopplysninger(sak.id, revurdering.id, any(), any())
+            grunnlagService.lagreNyeSaksopplysninger(sak.id, revurdering.id, any())
         }
         verify {
             oppgaveService.opprettOppgave(
@@ -286,8 +289,10 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
                 oppgaveService.tildelSaksbehandler(any(), "saksbehandler")
             }
             coVerify {
+                grunnlagService.opprettGrunnlag(any(), any())
                 grunnlagService.hentPersongalleri(sak.id)
-                grunnlagService.opprettGrunnlag(revurdering.id, any())
+                grunnlagService.lagreNyePersonopplysninger(sak.id, revurdering.id, any(), any())
+                grunnlagService.lagreNyeSaksopplysninger(sak.id, revurdering.id, any())
             }
             confirmVerified(hendelser, grunnlagService, oppgaveService)
         }
@@ -397,8 +402,10 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
                 )
             assertEquals(revurdering.id, grunnlaghendelse?.behandlingId)
             coVerify {
+                grunnlagService.opprettGrunnlag(any(), any())
                 grunnlagService.hentPersongalleri(sak.id)
-                grunnlagService.opprettGrunnlag(behandling!!.id, any())
+                grunnlagService.lagreNyePersonopplysninger(sak.id, behandling!!.id, any(), any())
+                grunnlagService.lagreNyeSaksopplysninger(sak.id, behandling.id, any())
                 grunnlagService.laasTilVersjonForBehandling(revurdering.id, behandling.id)
             }
             verify {
@@ -493,8 +500,10 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
             }
 
         coVerify {
+            grunnlagService.opprettGrunnlag(any(), any())
             grunnlagService.hentPersongalleri(sak.id)
-            grunnlagService.opprettGrunnlag(revurdering.id, any())
+            grunnlagService.lagreNyePersonopplysninger(sak.id, revurdering.id, any(), any())
+            grunnlagService.lagreNyeSaksopplysninger(sak.id, revurdering.id, any())
         }
         verify {
             oppgaveService.opprettOppgave(

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/BehandlingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/BehandlingIntegrationTest.kt
@@ -8,7 +8,6 @@ import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.header
 import io.ktor.http.HttpHeaders
 import io.ktor.http.fullPath
-import io.mockk.mockk
 import io.mockk.spyk
 import no.nav.etterlatte.behandling.klienter.BrevApiKlient
 import no.nav.etterlatte.behandling.klienter.Norg2Klient
@@ -19,7 +18,7 @@ import no.nav.etterlatte.common.klienter.SkjermingKlient
 import no.nav.etterlatte.config.ApplicationContext
 import no.nav.etterlatte.funksjonsbrytere.DummyFeatureToggleService
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
-import no.nav.etterlatte.grunnlag.GrunnlagService
+import no.nav.etterlatte.grunnlag.IOpplysningDao
 import no.nav.etterlatte.grunnlag.aldersovergang.IAldersovergangDao
 import no.nav.etterlatte.kafka.KafkaKey
 import no.nav.etterlatte.kafka.TestProdusent
@@ -56,7 +55,7 @@ abstract class BehandlingIntegrationTest {
         testProdusent: TestProdusent<String, String>? = null,
         skjermingKlient: SkjermingKlient? = null,
         aldersovergangDao: IAldersovergangDao? = null,
-        grunnlagService: GrunnlagService? = null,
+        opplysningDao: IOpplysningDao? = null,
     ) {
         mockOAuth2Server.start()
         val props = dbExtension.properties()
@@ -121,8 +120,8 @@ abstract class BehandlingIntegrationTest {
                 axsysKlient = AxsysKlientTest(),
                 pdlTjenesterKlient = pdlTjenesterKlient ?: PdltjenesterKlientTest(),
                 kodeverkKlient = KodeverkKlientTest(),
-                aldersovergangDaoProxy = aldersovergangDao ?: mockk(relaxed = true),
-                grunnlagService = grunnlagService ?: GrunnlagServiceTest(),
+                aldersovergangDaoProxy = aldersovergangDao,
+                opplysningDaoProxy = opplysningDao,
             )
     }
 


### PR DESCRIPTION
Gjør noen justeringer for å gjøre det enklere å bytte til ekte dao i hvert av miljøene. Dette medfører at testene nå kjører med reell dao i stedet for mock.