### PR TITLE
Dropp indekser for grunnlag i prod i behandling(ingen data der enda)

### DIFF
--- a/apps/etterlatte-behandling/src/main/resources/db/prod/V234__dropp_indekser_foer_merge_grunnlag.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/prod/V234__dropp_indekser_foer_merge_grunnlag.sql
@@ -1,0 +1,8 @@
+-- fordi det tar kjempelang tid å bygge disse på all data i prod, så vil
+-- vi ikke ha denne tregheten innebygget i migreringen av dataen fra grunnlag til behandling
+DROP INDEX IF EXISTS behandling_versjon_behandling_id_sak_id_idx;
+DROP INDEX IF EXISTS grunnlagshendelse_fnr_idx;
+DROP INDEX IF EXISTS grunnlagshendelse_opplysning_gin_idx;
+DROP INDEX IF EXISTS grunnlagshendelse_opplysning_id_index;
+DROP INDEX IF EXISTS grunnlagshendelse_opplysning_type_idx;
+DROP INDEX IF EXISTS grunnlagshendelse_sak_id_idx;


### PR DESCRIPTION
* Da det tar kjempelang tid å kjøre migreringen med de på.
* De må legges på senere da dataen er i behandling, ikke i kjøringen