### PR TITLE
Ikke kunne lagre på nytt før siden har blitt refreshet

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/RedigerFamilieforholdModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/soeknadsoversikt/familieforhold/RedigerFamilieforholdModal.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react'
 import { PencilIcon, PlusIcon, XMarkIcon } from '@navikt/aksel-icons'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { redigerFamilieforhold } from '~shared/api/behandling'
-import { isPending, mapResult } from '~shared/api/apiUtils'
+import { isPending, isSuccess, mapResult } from '~shared/api/apiUtils'
 import { Personopplysninger } from '~shared/types/grunnlag'
 import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 import { useFieldArray, useForm } from 'react-hook-form'
@@ -176,7 +176,7 @@ export const RedigerFamilieforholdModal = ({ behandling, personopplysninger }: P
             <Button variant="secondary" onClick={avbryt} disabled={isPending(status)}>
               Avbryt
             </Button>
-            <Button onClick={handleSubmit(lagre)} loading={isPending(status)}>
+            <Button onClick={handleSubmit(lagre)} loading={isPending(status) || isSuccess(status)}>
               Lagre
             </Button>
           </HStack>


### PR DESCRIPTION
Nå kan man lagre etter en oppdatering av grunnlag før siden refreshes som vil vise feil state potensielt. 
Ingen grunn til å støtte lagring 1 sek før siden oppdateres