### PR TITLE
Rollen fantes allikevel dev

### DIFF
--- a/apps/etterlatte-behandling/src/main/resources/db/dev/V241__lag_servicerolledev.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/dev/V241__lag_servicerolledev.sql
@@ -1,1 +1,0 @@
-create role "cloudsqliamserviceaccount";


### PR DESCRIPTION
rollen fantes allikevel?
`Caused by: org.postgresql.util.PSQLException: ERROR: role "cloudsqliamserviceaccount" already exists`


selvom den ikke får deploya uten.