### PR TITLE
FAGSYSTEM-371156: Legger på simulering ved opphør

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneBP.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneBP.tsx
@@ -82,6 +82,7 @@ export const BeregneBP = (props: { behandling: IBehandlingReducer }) => {
     <>
       {erOpphoer ? (
         <Box paddingInline="18" paddingBlock="4">
+          <SimulerUtbetaling behandling={behandling} />
           <Brevutfall behandling={behandling} resetBrevutfallvalidering={() => setManglerbrevutfall(false)} />
         </Box>
       ) : (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneOMS.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneOMS.tsx
@@ -114,6 +114,7 @@ export const BeregneOMS = () => {
     <>
       {erOpphoer ? (
         <Box paddingInline="18" paddingBlock="4">
+          <SimulerUtbetaling behandling={behandling} />
           <Brevutfall behandling={behandling} resetBrevutfallvalidering={() => setManglerbrevutfall(false)} />
         </Box>
       ) : (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/SimulerUtbetaling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/SimulerUtbetaling.tsx
@@ -15,6 +15,7 @@ import { erFerdigBehandlet } from '~components/behandling/felles/utils'
 import { useAppSelector } from '~store/Store'
 import { compareDesc } from 'date-fns'
 import { SakType } from '~shared/types/sak'
+import { VilkaarsvurderingResultat } from '~shared/api/vilkaarsvurdering'
 
 export const SimulerUtbetaling = (props: { behandling: IBehandlingReducer }) => {
   const { behandling } = props
@@ -24,6 +25,8 @@ export const SimulerUtbetaling = (props: { behandling: IBehandlingReducer }) => 
 
   // For OMS, lytte etter oppdatert beregning/avkorting
   const avkorting = useAppSelector((state) => state.behandlingReducer.behandling?.avkorting)
+
+  const erOpphoer = behandling.vilkaarsvurdering?.resultat?.utfall == VilkaarsvurderingResultat.IKKE_OPPFYLT
 
   function behandlingStatusFerdigEllerVedtakFattet() {
     return erFerdigBehandlet(behandling.status) || behandling.status === IBehandlingStatus.FATTET_VEDTAK
@@ -42,7 +45,11 @@ export const SimulerUtbetaling = (props: { behandling: IBehandlingReducer }) => 
   }, [behandling.status, avkorting])
 
   const simuler = () => {
-    if (behandling.status === IBehandlingStatus.BEREGNET || behandling.status === IBehandlingStatus.AVKORTET) {
+    if (
+      behandling.status === IBehandlingStatus.BEREGNET ||
+      behandling.status === IBehandlingStatus.AVKORTET ||
+      erOpphoer
+    ) {
       simulerUtbetalingRequest(behandling.id)
     }
   }


### PR DESCRIPTION
Legger på simulering ved opphør av ytelse. Dette er nyttig i saker hvor det opphøres tilbake i tid, og dette medfører feilutbetaling. Da er det ønskelig for saksbehandler å se beløp.