### PR TITLE
EY-5058: Dato må være satt ved videreført opphør

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
@@ -142,6 +142,12 @@ class VilkaarMaaFinnesHvisViderefoertOpphoer :
         "Vilkår må angis hvis opphør skal videreføres",
     )
 
+class DatoMaaFinnesHvisViderefoertOpphoer :
+    UgyldigForespoerselException(
+        "VIDEREFOERT_OPPHOER_MAA_HA_DATO",
+        "Dato må angis hvis opphør skal videreføres",
+    )
+
 class PleieforholdMaaStarteFoerDetOpphoerer :
     UgyldigForespoerselException(
         code = "PLEIEFORHOLD_MAA_STARTE_FOER_DET_OPPHOERER",
@@ -846,17 +852,19 @@ internal class BehandlingServiceImpl(
             hentBehandling(behandlingId)
                 ?: throw InternfeilException("Kunne ikke oppdatere videreført opphør fordi behandlingen ikke finnes")
 
-        if (viderefoertOpphoer.skalViderefoere == JaNei.JA &&
-            viderefoertOpphoer.vilkaar == null
-        ) {
-            throw VilkaarMaaFinnesHvisViderefoertOpphoer()
-        }
-
-        if (virkningstidspunktErEtterOpphoerFraOgMed(behandling.virkningstidspunkt?.dato, viderefoertOpphoer.dato)) {
-            throw VirkningstidspunktKanIkkeVaereEtterOpphoer(
-                behandling.virkningstidspunkt?.dato,
-                viderefoertOpphoer.dato,
-            )
+        if (viderefoertOpphoer.skalViderefoere == JaNei.JA) {
+            if (viderefoertOpphoer.vilkaar == null) {
+                throw VilkaarMaaFinnesHvisViderefoertOpphoer()
+            }
+            if (viderefoertOpphoer.dato == null) {
+                throw DatoMaaFinnesHvisViderefoertOpphoer()
+            }
+            if (virkningstidspunktErEtterOpphoerFraOgMed(behandling.virkningstidspunkt?.dato, viderefoertOpphoer.dato)) {
+                throw VirkningstidspunktKanIkkeVaereEtterOpphoer(
+                    behandling.virkningstidspunkt?.dato,
+                    viderefoertOpphoer.dato,
+                )
+            }
         }
 
         behandling

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/ViderefoertOpphoerTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/ViderefoertOpphoerTest.kt
@@ -244,9 +244,37 @@ class ViderefoertOpphoerTest(
         }
     }
 
+    @Test
+    fun `feiler ved oppretting hvis det skal viderefoeres og dato mangler`() {
+        val sak =
+            SakSkrivDao(SakendringerDao(ConnectionAutoclosingTest(dataSource))).opprettSak(
+                SOEKER_FOEDSELSNUMMER.value,
+                SakType.BARNEPENSJON,
+                Enheter.defaultEnhet.enhetNr,
+            )
+        val opprettBehandling = opprettBehandling(type = BehandlingType.FØRSTEGANGSBEHANDLING, sakId = sak.id)
+        behandlingDao.opprettBehandling(behandling = opprettBehandling)
+
+        shouldThrow<UgyldigForespoerselException> {
+            runBlocking {
+                service.oppdaterViderefoertOpphoer(
+                    behandlingId = opprettBehandling.id,
+                    viderefoertOpphoer =
+                        viderefoertOpphoer(
+                            opprettBehandling.id,
+                            null,
+                            skalViderefoere = JaNei.JA,
+                            vilkaar = VilkaarType.BP_FORMAAL_2024,
+                        ),
+                    mockk(),
+                )
+            }
+        }
+    }
+
     private fun viderefoertOpphoer(
         behandlingId: UUID,
-        opphoersdato: YearMonth,
+        opphoersdato: YearMonth? = null,
         skalViderefoere: JaNei,
         vilkaar: VilkaarType? = VilkaarType.BP_FORMAAL_2024,
     ): ViderefoertOpphoer =


### PR DESCRIPTION
Dersom det er valgt ja ved videreført opphør, må det finnes en dato. 