### PR TITLE
FAGSYSTEM-371156: Avbryter ikke relevant oppgave for alderovergang 21 år

### DIFF
--- a/apps/etterlatte-behandling/src/main/resources/db/prod/V244__avbryt_oppgave_feil_opphoer.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/prod/V244__avbryt_oppgave_feil_opphoer.sql
@@ -1,0 +1,2 @@
+-- Avbryter oppgave feilaktig opprettet for opphør ved alderovergang 21 år
+update oppgave set status = 'AVBRUTT' where id = '6169976a-976d-47b1-b8ae-dccb033f0e45';


### PR DESCRIPTION
Det ble ikke lagt til opphør fra og med dato i saken, denne gikk derfor helt til 21 år og fikk automatisk opprettet en oppgave på det tidspunktet. Denne er ikke lenger nødvendig da det er gjort et manuelt opphør ved 20 år i etterkant.