### PR TITLE
EY-4995: Bedre visning av trygdetid etter lagring

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/EnkelPersonTrygdetid.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/EnkelPersonTrygdetid.tsx
@@ -8,7 +8,7 @@ import { TrygdetidDetaljer } from '~components/behandling/trygdetid/detaljer/Try
 import React, { useEffect, useState } from 'react'
 import { IBehandlingStatus, IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
 import { useApiCall } from '~shared/hooks/useApiCall'
-import { TrygdetidManueltOverstyrt } from '~components/behandling/trygdetid/TrygdetidManueltOverstyrt'
+import { TrygdetidManueltOverstyrt } from '~components/behandling/trygdetid/manueltoverstyrt/TrygdetidManueltOverstyrt'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { useAppDispatch } from '~store/Store'
 import { oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/manueltoverstyrt/TrygdetidManueltOverstyrt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/manueltoverstyrt/TrygdetidManueltOverstyrt.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react'
+import { Alert, BodyLong, Box, Button, Heading, VStack } from '@navikt/ds-react'
+import { IDetaljertBeregnetTrygdetid, ITrygdetid, opprettTrygdetider } from '~shared/api/trygdetid'
+import { TrygdetidManueltOverstyrtVisning } from '~components/behandling/trygdetid/manueltoverstyrt/TrygdetidManueltOverstyrtVisning'
+import { TrygdetidManueltOverstyrtSkjema } from '~components/behandling/trygdetid/manueltoverstyrt/TrygdetidManueltOverstyrtSkjema'
+import { usePersonopplysninger } from '~components/person/usePersonopplysninger'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { useBehandling } from '~components/behandling/useBehandling'
+import { isPending, mapResult } from '~shared/api/apiUtils'
+import Spinner from '~shared/Spinner'
+import { ApiErrorAlert } from '~ErrorBoundary'
+import { Toast } from '~shared/alerts/Toast'
+
+export const TrygdetidManueltOverstyrt = ({
+  trygdetidId,
+  ident,
+  beregnetTrygdetid,
+  oppdaterTrygdetid,
+  redigerbar,
+}: {
+  trygdetidId: string
+  ident: string
+  beregnetTrygdetid: IDetaljertBeregnetTrygdetid
+  oppdaterTrygdetid: (trygdetid: ITrygdetid) => void
+  tidligereFamiliepleier?: boolean
+  redigerbar: boolean
+}) => {
+  const trygdetidErSatt = !!beregnetTrygdetid.resultat.prorataBroek
+    ? beregnetTrygdetid.resultat.samletTrygdetidTeoretisk
+    : beregnetTrygdetid.resultat.samletTrygdetidNorge
+  const [visSkjema, setVisSkjema] = useState(!trygdetidErSatt && redigerbar)
+
+  return (
+    <VStack gap="4">
+      <Heading size="small" level="3">
+        Manuelt overstyrt trygdetid
+      </Heading>
+
+      {visSkjema ? (
+        <TrygdetidManueltOverstyrtSkjema
+          trygdetidId={trygdetidId}
+          beregnetTrygdetid={beregnetTrygdetid}
+          oppdaterTrygdetid={oppdaterTrygdetid}
+          setVisSkjema={setVisSkjema}
+        />
+      ) : (
+        <TrygdetidManueltOverstyrtVisning
+          beregnetTrygdetid={beregnetTrygdetid}
+          setVisSkjema={setVisSkjema}
+          redigerbar={redigerbar}
+        />
+      )}
+
+      {redigerbar && <TrygdetidUkjentAvdoed ident={ident} />}
+    </VStack>
+  )
+}
+
+const TrygdetidUkjentAvdoed = ({
+  ident,
+  tidligereFamiliepleier,
+}: {
+  ident: string
+  tidligereFamiliepleier?: boolean
+}) => {
+  const personopplysninger = usePersonopplysninger()
+  const behandling = useBehandling()
+  const [opprettStatus, opprettTrygdetid] = useApiCall(opprettTrygdetider)
+
+  const identErIGrunnlag = personopplysninger?.avdoede?.find((person) => person.opplysning.foedselsnummer === ident)
+
+  const opprettNyTrygdetid = () => {
+    opprettTrygdetid({ behandlingId: behandling!!.id, overskriv: true }, () => window.location.reload())
+  }
+
+  return (
+    <>
+      {ident == 'UKJENT_AVDOED' ? (
+        <Box maxWidth="40rem" marginBlock="8 0">
+          <VStack gap="3">
+            <Alert variant="warning">
+              <VStack gap="4">
+                <BodyLong>
+                  Trygdetiden er koblet til en ukjent avdød. Hvis avdøde i saken er kjent, og familieoversikten er
+                  oppdatert, bør trygdetid opprettes på nytt. Dette for å unngå å bruke manuelt overstyrt trygdetid der
+                  dette ikke er nødvendig.
+                </BodyLong>
+                <VStack gap="4">
+                  {mapResult(opprettStatus, {
+                    pending: <Spinner label="Oppretter trygdetid" />,
+                    error: () => <ApiErrorAlert>En feil har oppstått ved opprettelse av trygdetid</ApiErrorAlert>,
+                    success: () => <Toast melding="Trygdetid opprettet" position="bottom-center" />,
+                  })}
+                  <Box>
+                    <Button
+                      variant="primary"
+                      size="small"
+                      onClick={opprettNyTrygdetid}
+                      loading={isPending(opprettStatus)}
+                    >
+                      Opprett ny trygdetid
+                    </Button>
+                  </Box>
+                </VStack>
+              </VStack>
+            </Alert>
+          </VStack>
+        </Box>
+      ) : (
+        !identErIGrunnlag &&
+        !tidligereFamiliepleier && <Alert variant="error">Fant ikke avdød ident {ident} i behandlingsgrunnlaget</Alert>
+      )}
+    </>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/manueltoverstyrt/TrygdetidManueltOverstyrtVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/manueltoverstyrt/TrygdetidManueltOverstyrtVisning.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { BodyLong, BodyShort, Box, Button, Heading, VStack } from '@navikt/ds-react'
+import { IDetaljertBeregnetTrygdetid } from '~shared/api/trygdetid'
+import { PencilIcon } from '@navikt/aksel-icons'
+
+export const TrygdetidManueltOverstyrtVisning = ({
+  beregnetTrygdetid,
+  setVisSkjema,
+  redigerbar,
+}: {
+  beregnetTrygdetid: IDetaljertBeregnetTrygdetid
+  setVisSkjema: (visSkjema: boolean) => void
+  redigerbar: boolean
+}) => {
+  const harProrata = !!beregnetTrygdetid.resultat.prorataBroek
+  const trygdetidAar = harProrata
+    ? beregnetTrygdetid.resultat.samletTrygdetidTeoretisk
+    : beregnetTrygdetid.resultat.samletTrygdetidNorge
+
+  return (
+    <VStack gap="4">
+      <Box>
+        <Heading size="xsmall">Anvendt trygdetid</Heading>
+        <BodyShort>{trygdetidAar} år</BodyShort>
+      </Box>
+
+      {harProrata && (
+        <Box>
+          <Heading size="xsmall">Prorata brøk</Heading>
+          <BodyShort>
+            {beregnetTrygdetid.resultat.prorataBroek?.teller} / {beregnetTrygdetid.resultat.prorataBroek?.nevner}
+          </BodyShort>
+        </Box>
+      )}
+
+      <Box>
+        <Heading size="xsmall">Begrunnelse</Heading>
+        <BodyLong>{beregnetTrygdetid.resultat.overstyrtBegrunnelse}</BodyLong>
+      </Box>
+
+      {redigerbar && (
+        <Box>
+          <Button icon={<PencilIcon />} size="small" variant="tertiary" onClick={() => setVisSkjema(true)}>
+            Rediger
+          </Button>
+        </Box>
+      )}
+    </VStack>
+  )
+}


### PR DESCRIPTION
Egen visning for skjema, og egen visning når skjema er lagret. Også fikset litt på validering. 

![Screenshot 2025-03-04 at 13 05 34](https://github.com/user-attachments/assets/720d19c2-24c2-47de-b5a9-50e4533e0c9b)

![Screenshot 2025-03-04 at 13 05 43](https://github.com/user-attachments/assets/e0b0f488-9dfe-4637-a1b0-9f32e36245eb)

