### PR TITLE
FAGSYSTEM-372317: Fikser visning av "kopier trygdetid" komponent

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidIAnnenBehandlingMedSammeAvdoede.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/TrygdetidIAnnenBehandlingMedSammeAvdoede.tsx
@@ -63,7 +63,7 @@ export const TrygdetidIAnnenBehandlingMedSammeAvdoede = ({
 
   useEffect(() => {
     hentKandidatForKopieringAvTrygdetidReq(behandlingId)
-  }, [])
+  }, [trygdetider])
 
   return (
     <>


### PR DESCRIPTION
Må også kjøre effekt når trygdetider oppdateres. Dette vil typisk være tilfelle når man oppretter trygdetid første gang man går inn på trygdetidssteget.