### PR TITLE
Lager infobrevoppgaver som mangler i produksjon

### DIFF
--- a/apps/etterlatte-tidshendelser/src/main/resources/db/prod/V23__ekstra_kjoering_av_aktivitetsplikt.sql
+++ b/apps/etterlatte-tidshendelser/src/main/resources/db/prod/V23__ekstra_kjoering_av_aktivitetsplikt.sql
@@ -1,0 +1,5 @@
+-- Legger inn en kjøring av infobrevoppgavene som burde ha blitt kjørt tidligere men ble uheldigvis hoppet over
+-- (med behandlingsmaaned 2025-01 så treffer denne de med dødsdato avdød 2024-03, så kravet løper fra neste
+-- måned allerede)
+insert into jobb (type, kjoeredato, behandlingsmaaned)
+VALUES ('OMS_DOED_10MND', '2025-03-06', '2025-01');

--- a/apps/etterlatte-tidshendelser/src/main/resources/db/prod/V23__ekstra_kjoering_av_aktivitetsplikt.sql
+++ b/apps/etterlatte-tidshendelser/src/main/resources/db/prod/V23__ekstra_kjoering_av_aktivitetsplikt.sql
@@ -2,4 +2,4 @@
 -- (med behandlingsmaaned 2025-01 så treffer denne de med dødsdato avdød 2024-03, så kravet løper fra neste
 -- måned allerede)
 insert into jobb (type, kjoeredato, behandlingsmaaned)
-VALUES ('OMS_DOED_10MND', '2025-03-06', '2025-01');
+VALUES ('OMS_DOED_10MND', '2025-03-07', '2025-01');


### PR DESCRIPTION
Oppgavene som ideelt burde blitt kjørt i januar ble hoppet over når vi fikset behandlingsmåneden-avvikene i tidshendelser