### PR TITLE
FAGSYSTEM-372626 Kan ferdigstille oppgave også hvis brev er ferdigstilt

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/brev/AktivitetspliktBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/aktivitetsplikt/brev/AktivitetspliktBrev.tsx
@@ -15,6 +15,7 @@ import { useAktivitetspliktOppgaveVurdering } from '~components/aktivitetsplikt/
 import { InfobrevKnapperad } from '~components/aktivitetsplikt/brev/VurderingInfoBrevOgOppsummering'
 import { FerdigstillAktivitetspliktBrevModal } from '~components/aktivitetsplikt/brev/FerdigstillBrevModal'
 import { LoependeUnntakInfo } from '~components/aktivitetsplikt/brev/LoependeUnntakInfo'
+import { erOppgaveRedigerbar } from '~shared/types/oppgave'
 
 export function Aktivitetspliktbrev({ brevId }: { brevId: number }) {
   const { oppgave, sistEndret } = useAktivitetspliktOppgaveVurdering()
@@ -83,7 +84,9 @@ export function Aktivitetspliktbrev({ brevId }: { brevId: number }) {
                   <Box maxHeight="955px" width="100%" height="100%" marginBlock="0 16">
                     <ForhaandsvisningBrev brev={brev} />
                   </Box>
-                  <InfobrevKnapperad />
+                  <InfobrevKnapperad>
+                    {erOppgaveRedigerbar(oppgave.status) ? <FerdigstillAktivitetspliktBrevModal /> : undefined}
+                  </InfobrevKnapperad>
                 </>
               ) : (
                 <>


### PR DESCRIPTION
Backend håndterer dette fint (verifisert i dev), men vi viser ikke knappen til saksbehandler hvis brevet allerede er distribuert. 

Viser også en melding om at brevet allerede er distribuert hvis det er det når oppgaven ferdigstilles