### PR TITLE
Ikke ta med avslag ny soeknad i liste over siste iverksatte

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingService.kt
@@ -346,7 +346,7 @@ internal class BehandlingServiceImpl(
 
     override fun hentSisteIverksatte(sakId: SakId): Behandling? =
         hentBehandlingerForSakId(sakId)
-            .filter { BehandlingStatus.iverksattEllerAttestert().contains(it.status) }
+            .filter { BehandlingStatus.iverksattEllerAttestert().contains(it.status) && !it.erAvslagNySoeknad() }
             .maxByOrNull { it.behandlingOpprettet }
 
     override fun avbrytBehandling(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
@@ -177,6 +177,9 @@ sealed class Behandling {
         }
     }
 
+    fun erAvslagNySoeknad(): Boolean =
+        this is Revurdering && this.revurderingsaarsak == Revurderingaarsak.NY_SOEKNAD && this.status == AVSLAG
+
     open fun tilOpprettet(): Behandling = throw BehandlingStoetterIkkeStatusEndringException(OPPRETTET)
 
     open fun tilVilkaarsvurdert(): Behandling = throw BehandlingStoetterIkkeStatusEndringException(VILKAARSVURDERT)


### PR DESCRIPTION
Siden dette er et "separat" spor fra den innvilgede ytelsen er den ikke relevant i filtreringen på hva som er siste iverksatte behandling i saken