### PR TITLE
EY-5093 opprette tabell for skatteoppgjoer hendelser kjoering

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/sigrun/SkatteoppgjoerHendelserDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/sigrun/SkatteoppgjoerHendelserDao.kt
@@ -1,0 +1,57 @@
+package no.nav.etterlatte.behandling.etteroppgjoer.sigrun
+
+import no.nav.etterlatte.common.ConnectionAutoclosing
+import no.nav.etterlatte.libs.common.feilhaandtering.krev
+import no.nav.etterlatte.libs.database.single
+
+class SkatteoppgjoerHendelserDao(
+    private val connectionAutoclosing: ConnectionAutoclosing,
+) {
+    fun lagreKjoering(kjoering: HendelserKjoering) =
+        connectionAutoclosing.hentConnection {
+            with(it) {
+                val statement =
+                    prepareStatement(
+                        """
+                        INSERT INTO skatteoppgjoer_hendelse_kjoringer(
+                            siste_sekvensnummer, antall_hendelser, antall_behandlet, antall_relevante
+                        ) 
+                        VALUES (?, ?, ?, ?) 
+                        """.trimIndent(),
+                    )
+                statement.setInt(1, kjoering.sisteSekvensnummer)
+                statement.setInt(2, kjoering.antallHendelser)
+                statement.setInt(3, kjoering.antallBehandlet)
+                statement.setInt(4, kjoering.antallRelevante)
+                statement.executeUpdate().also {
+                    krev(it == 1) {
+                        "Kunne ikke lagre kjoering for skatteoppgjoerHendelser=$kjoering"
+                    }
+                }
+            }
+        }
+
+    fun hentSisteKjoering(): HendelserKjoering =
+        connectionAutoclosing.hentConnection {
+            with(it) {
+                val statement =
+                    prepareStatement(
+                        """
+                        SELECT *
+                        FROM skatteoppgjoer_hendelse_kjoringer
+                        ORDER BY opprettet DESC
+                        LIMIT 1
+                        """.trimIndent(),
+                    )
+
+                statement.executeQuery().single {
+                    HendelserKjoering(
+                        sisteSekvensnummer = getInt("siste_sekvensnummer"),
+                        antallHendelser = getInt("antall_hendelser"),
+                        antallBehandlet = getInt("antall_behandlet"),
+                        antallRelevante = getInt("antall_relevante"),
+                    )
+                }
+            }
+        }
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/sigrun/SkatteoppgjoerHendelserService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/sigrun/SkatteoppgjoerHendelserService.kt
@@ -1,0 +1,32 @@
+package no.nav.etterlatte.behandling.etteroppgjoer.sigrun
+
+import no.nav.etterlatte.inTransaction
+
+class SkatteoppgjoerHendelserService(
+    private val dao: SkatteoppgjoerHendelserDao,
+) {
+    fun hentogBehandleSkatteoppgjoerHendelser() {
+        inTransaction {
+            val sisteKjoering = dao.hentSisteKjoering()
+
+            // TODO: gjør rest kall til Sigrun Skatteoppgjør hendelser
+
+            // TODO: lagre ny kjoering med oppdatert sekvensnummer
+        }
+    }
+}
+
+data class HendelserKjoering(
+    val sisteSekvensnummer: Int,
+    val antallHendelser: Int, // antall vi har etterspurt
+    val antallBehandlet: Int, // antall vi har sjekket
+    val antallRelevante: Int, // antall vi er interessert i (opprettet forbehandling)
+)
+
+data class SkatteoppgjoerHendelser(
+    val gjelderPeriode: String,
+    val hendelsetype: String,
+    val identifikator: String,
+    val sekvensnummer: Int,
+    val somAktoerid: Boolean,
+)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/sigrun/SkatteoppgjoerHendelserService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/sigrun/SkatteoppgjoerHendelserService.kt
@@ -10,7 +10,8 @@ class SkatteoppgjoerHendelserService(
             val sisteKjoering = dao.hentSisteKjoering()
 
             // TODO: gjør rest kall til Sigrun Skatteoppgjør hendelser
-
+            // TODO: sjekke opp mot etteroppgjoer tabell = skal ha etteroppgjoer
+            // TODO: .....
             // TODO: lagre ny kjoering med oppdatert sekvensnummer
         }
     }

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -42,6 +42,8 @@ import no.nav.etterlatte.behandling.etteroppgjoer.inntektskomponent.Inntektskomp
 import no.nav.etterlatte.behandling.etteroppgjoer.inntektskomponent.InntektskomponentService
 import no.nav.etterlatte.behandling.etteroppgjoer.sigrun.SigrunKlient
 import no.nav.etterlatte.behandling.etteroppgjoer.sigrun.SigrunKlientImpl
+import no.nav.etterlatte.behandling.etteroppgjoer.sigrun.SkatteoppgjoerHendelserDao
+import no.nav.etterlatte.behandling.etteroppgjoer.sigrun.SkatteoppgjoerHendelserService
 import no.nav.etterlatte.behandling.generellbehandling.GenerellBehandlingDao
 import no.nav.etterlatte.behandling.generellbehandling.GenerellBehandlingService
 import no.nav.etterlatte.behandling.hendelse.HendelseDao
@@ -360,6 +362,7 @@ internal class ApplicationContext(
     val klageDao = KlageDaoImpl(autoClosingDatabase)
     val tilbakekrevingDao = TilbakekrevingDao(autoClosingDatabase)
     val etteroppgjoerForbehandlingDao = EtteroppgjoerForbehandlingDao(autoClosingDatabase)
+    val skatteoppgjoerHendelserDao = SkatteoppgjoerHendelserDao(autoClosingDatabase)
     val etteroppgjoerDao = EtteroppgjoerDao(autoClosingDatabase)
     val behandlingInfoDao = BehandlingInfoDao(autoClosingDatabase)
     val bosattUtlandDao = BosattUtlandDao(autoClosingDatabase)
@@ -671,6 +674,11 @@ internal class ApplicationContext(
             sigrunKlient = sigrunKlient,
             beregningKlient = beregningsKlient,
             behandlingService = behandlingService,
+        )
+
+    val skatteoppgjoerHendelserService =
+        SkatteoppgjoerHendelserService(
+            dao = skatteoppgjoerHendelserDao,
         )
 
     val saksbehandlerJobService = SaksbehandlerJobService(saksbehandlerInfoDao, navAnsattKlient, axsysKlient)

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V250__opprette_tabell_skatteoppgjoer_hendelser_kjoeringer.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V250__opprette_tabell_skatteoppgjoer_hendelser_kjoeringer.sql
@@ -1,0 +1,7 @@
+CREATE TABLE skatteoppgjoer_hendelse_kjoringer (
+    siste_sekvensnummer INT,
+    antall_hendelser INT,
+    antall_behandlet INT,
+    antall_relevante INT,
+    opprettet TIMESTAMP DEFAULT NOW()
+);

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/etteroppgjoer/sigrun/SkatteoppgjoerHendelseDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/etteroppgjoer/sigrun/SkatteoppgjoerHendelseDaoTest.kt
@@ -1,0 +1,66 @@
+package no.nav.etterlatte.behandling.etteroppgjoer.sigrun
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.etterlatte.ConnectionAutoclosingTest
+import no.nav.etterlatte.DatabaseExtension
+import no.nav.etterlatte.User
+import no.nav.etterlatte.nyKontekstMedBrukerOgDatabase
+import no.nav.etterlatte.sak.SakSkrivDao
+import no.nav.etterlatte.sak.SakendringerDao
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import javax.sql.DataSource
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseExtension::class)
+class SkatteoppgjoerHendelseDaoTest(
+    val dataSource: DataSource,
+) {
+    private lateinit var sakSkrivDao: SakSkrivDao
+    private lateinit var skatteoppgjoerHendelserDao: SkatteoppgjoerHendelserDao
+
+    @BeforeAll
+    fun setup() {
+        sakSkrivDao = SakSkrivDao(SakendringerDao(ConnectionAutoclosingTest(dataSource)))
+        skatteoppgjoerHendelserDao = SkatteoppgjoerHendelserDao(ConnectionAutoclosingTest(dataSource))
+
+        nyKontekstMedBrukerOgDatabase(
+            mockk<User>().also { every { it.name() } returns this::class.java.simpleName },
+            dataSource,
+        )
+    }
+
+    @BeforeEach
+    fun resetTabell() {
+        dataSource.connection.use {
+            it.prepareStatement("""TRUNCATE TABLE skatteoppgjoer_hendelse_kjoringer CASCADE""").executeUpdate()
+        }
+    }
+
+    @Test
+    fun `skal lagre kjoering og hente siste kjoering`() {
+        for (sekvensnummer in 1..5) {
+            val kjoering =
+                HendelserKjoering(
+                    sisteSekvensnummer = sekvensnummer,
+                    antallHendelser = 100 + sekvensnummer,
+                    antallBehandlet = 100 + sekvensnummer,
+                    antallRelevante = 10 + sekvensnummer,
+                )
+
+            skatteoppgjoerHendelserDao.lagreKjoering(kjoering)
+        }
+
+        with(skatteoppgjoerHendelserDao.hentSisteKjoering()) {
+            sisteSekvensnummer shouldBe 5
+            antallHendelser shouldBe 105
+            antallBehandlet shouldBe 105
+            antallRelevante shouldBe 15
+        }
+    }
+}


### PR DESCRIPTION
Deloppgave

Opprette tabell som holder styr på sekvensnummer som brukes for å hente skatteoppgjoer hendelser. 

```
antallHendelser = hvor mangen hendelser vi ønsker
antallBehandlet = hvor mangen vi har sjekket opp mot hvem som skal ha etteroppgjør
antallRelevante = hvor mangen som det er opprettet forbehandling for 
```