### PR TITLE
Oppdaterer vedtak som har gammel enumverdi lagret

### DIFF
--- a/apps/etterlatte-utbetaling/src/main/resources/db/migration/V19__patch_sluttbehandling_utland.sql
+++ b/apps/etterlatte-utbetaling/src/main/resources/db/migration/V19__patch_sluttbehandling_utland.sql
@@ -3,3 +3,10 @@ UPDATE
                                       '{behandling,revurderingsaarsak}' , '"SLUTTBEHANDLING"')::text
 WHERE
     vedtak::json->'behandling'->>'revurderingsaarsak' = 'SLUTTBEHANDLING_UTLAND';
+
+UPDATE
+    utbetaling SET vedtak = jsonb_set(vedtak::jsonb,
+                                      '{behandling,revurderingInfo,type}' , '"SLUTTBEHANDLING"')::text
+WHERE
+    vedtak::json->'behandling'->'revurderingInfo'->>'type' = 'SLUTTBEHANDLING_UTLAND';
+

--- a/apps/etterlatte-utbetaling/src/main/resources/db/migration/V19__patch_sluttbehandling_utland.sql
+++ b/apps/etterlatte-utbetaling/src/main/resources/db/migration/V19__patch_sluttbehandling_utland.sql
@@ -1,0 +1,5 @@
+UPDATE
+    utbetaling SET vedtak = jsonb_set(vedtak::jsonb,
+                                      '{behandling,revurderingsaarsak}' , '"SLUTTBEHANDLING"')::text
+WHERE
+    vedtak::json->'behandling'->>'revurderingsaarsak' = 'SLUTTBEHANDLING_UTLAND';


### PR DESCRIPTION
NBNB: greit å ta en backup av basen før denne kjøres, og dobbeltsjekke den i dev en gang med transaksjon og verifisere at det blir rett