### PR TITLE
EY-5099: endring ved uthenting av persongalleri i revurdering

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/ManuellRevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/ManuellRevurderingService.kt
@@ -108,7 +108,7 @@ class ManuellRevurderingService(
         saksbehandler: Saksbehandler,
     ): Revurdering =
         forrigeBehandling.let {
-            val persongalleri = grunnlagService.hentPersongalleri(sakId)
+            val persongalleri = grunnlagService.hentPersongalleri(forrigeBehandling.id)
             val triggendeOppgave = paaGrunnAvOppgave?.let { oppgaveService.hentOppgave(it) }
 
             revurderingService

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/ManuellRevurderingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/ManuellRevurderingServiceTest.kt
@@ -167,7 +167,7 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
             grunnlagService.opprettGrunnlag(any(), any())
         }
         verify {
-            grunnlagService.hentPersongalleri(sak.id)
+            grunnlagService.hentPersongalleri(behandling!!.id)
             grunnlagService.lagreNyePersonopplysninger(sak.id, revurdering.id, any(), any())
             grunnlagService.lagreNyeSaksopplysninger(sak.id, revurdering.id, any())
             oppgaveService.opprettOppgave(
@@ -288,7 +288,7 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
                     gruppeId = defaultPersongalleriGydligeFnr.avdoed.first(),
                 )
                 oppgaveService.tildelSaksbehandler(any(), saksbehandler)
-                grunnlagService.hentPersongalleri(sak.id)
+                grunnlagService.hentPersongalleri(behandling!!.id)
                 grunnlagService.lagreNyePersonopplysninger(sak.id, revurdering.id, any(), any())
                 grunnlagService.lagreNyeSaksopplysninger(sak.id, revurdering.id, any())
             }
@@ -405,7 +405,7 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
                 grunnlagService.opprettGrunnlag(any(), any())
             }
             verify {
-                grunnlagService.hentPersongalleri(sak.id)
+                grunnlagService.hentPersongalleri(behandling!!.id)
                 grunnlagService.lagreNyePersonopplysninger(sak.id, behandling!!.id, any(), any())
                 grunnlagService.lagreNyeSaksopplysninger(sak.id, behandling.id, any())
                 grunnlagService.laasTilVersjonForBehandling(revurdering.id, behandling.id)
@@ -504,7 +504,7 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
             grunnlagService.opprettGrunnlag(any(), any())
         }
         verify {
-            grunnlagService.hentPersongalleri(sak.id)
+            grunnlagService.hentPersongalleri(behandling!!.id)
             grunnlagService.lagreNyePersonopplysninger(sak.id, revurdering.id, any(), any())
             grunnlagService.lagreNyeSaksopplysninger(sak.id, revurdering.id, any())
             oppgaveService.opprettOppgave(

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/ManuellRevurderingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/ManuellRevurderingServiceTest.kt
@@ -6,9 +6,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.runs
 import io.mockk.spyk
 import io.mockk.verify
 import no.nav.etterlatte.BehandlingIntegrationTest
@@ -29,7 +27,6 @@ import no.nav.etterlatte.behandling.domain.Revurdering
 import no.nav.etterlatte.behandling.domain.SamsvarMellomKildeOgGrunnlag
 import no.nav.etterlatte.behandling.domain.toStatistikkBehandling
 import no.nav.etterlatte.behandling.klienter.Norg2Klient
-import no.nav.etterlatte.behandling.sakId1
 import no.nav.etterlatte.behandling.utland.LandMedDokumenter
 import no.nav.etterlatte.behandling.utland.MottattDokument
 import no.nav.etterlatte.common.Enheter
@@ -67,7 +64,6 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.YearMonth
 import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -842,84 +838,6 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
         ) {
             status shouldBe Status.UNDER_BEHANDLING
             referanse shouldBe revurdering.id.toString()
-        }
-    }
-
-    @Test
-    fun `nullstiller fra og med-dato for opphoer for revurdering etter opphoer`() {
-        val revurderingService =
-            mockk<RevurderingService>().also {
-                every { it.maksEnOppgaveUnderbehandlingForKildeBehandling(any()) } just runs
-                every {
-                    it.opprettRevurdering(
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                    )
-                } returns
-                    mockk<RevurderingOgOppfoelging>().also {
-                        every { it.oppdater() } returns mockk()
-                    }
-            }
-        val service =
-            manuellRevurderingService(
-                revurderingService,
-                behandlingService =
-                    mockk<BehandlingService>().also {
-                        every { it.hentSisteIverksatte(any()) } returns
-                            mockk<Behandling>().also {
-                                every { it.sak } returns
-                                    Sak(
-                                        sakType = SakType.BARNEPENSJON,
-                                        id = sakId1,
-                                        enhet = Enheter.defaultEnhet.enhetNr,
-                                        ident = "",
-                                    )
-                                every { it.status } returns BehandlingStatus.IVERKSATT
-                                every { it.opphoerFraOgMed } returns YearMonth.now()
-                                every { it.id } returns UUID.randomUUID()
-                                every { it.utlandstilknytning } returns null
-                                every { it.boddEllerArbeidetUtlandet } returns null
-                                every { it.revurderingsaarsak() } returns Revurderingaarsak.REVURDERE_ETTER_OPPHOER
-                            }
-                    },
-            )
-        service.opprettManuellRevurderingWrapper(
-            sakId = sakId1,
-            aarsak = Revurderingaarsak.REVURDERE_ETTER_OPPHOER,
-            paaGrunnAvHendelseId = null,
-            paaGrunnAvOppgaveId = null,
-            begrunnelse = null,
-            fritekstAarsak = null,
-            saksbehandler = simpleSaksbehandler(),
-        )
-
-        verify {
-            revurderingService.opprettRevurdering(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            )
         }
     }
 


### PR DESCRIPTION
Går tilbake til å hente persongalleriet brukt i forrige iverksatte behandling ved revurdering.

Dette ble endret i forbindelse med å innføre støtte for å endre ident i sak. For å fortsatt støtte dette konseptet, gjøres det nå en uthenting av siste gjeldende ident på søker i persongalleriet slik at dersom dette har blitt endret siden forrige behandling, så vil det også bli oppdatert i ny behandling. 

Dette burde løse problemer som vi har sett i det siste slik som:
https://jira.adeo.no/browse/FAGSYSTEM-373275

Må testes litt for å verifisere.