### PR TITLE
EY-5086 opprette etteroppgjør for saker som skal ha det for inntektsaar

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -177,6 +177,7 @@ private fun Route.settOppRoutes(applicationContext: ApplicationContext) {
     etteroppgjoerRoutes(
         forbehandlingService = applicationContext.etteroppgjoerForbehandlingService,
         skatteoppgjoerHendelserService = applicationContext.skatteoppgjoerHendelserService,
+        etteroppgjoerService = applicationContext.etteroppgjoerService,
         featureToggleService = applicationContext.featureToggleService,
     )
     behandlingRoutes(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerRoutes.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.funksjonsbrytere.FeatureToggle
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.libs.common.appIsInGCP
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
+import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.common.isDev
 import no.nav.etterlatte.libs.ktor.route.ETTEROPPGJOER_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.SAKID_CALL_PARAMETER
@@ -38,6 +39,7 @@ enum class EtteroppgjoerToggles(
 fun Route.etteroppgjoerRoutes(
     forbehandlingService: EtteroppgjoerForbehandlingService,
     skatteoppgjoerHendelserService: SkatteoppgjoerHendelserService,
+    etteroppgjoerService: EtteroppgjoerService,
     featureToggleService: FeatureToggleService,
 ) {
     route("/api/etteroppgjoer") {
@@ -79,6 +81,15 @@ fun Route.etteroppgjoerRoutes(
             val request = call.receive<HendelseKjoeringRequest>()
             skatteoppgjoerHendelserService.startHendelsesKjoering(request)
             call.respond(HttpStatusCode.OK)
+        }
+
+        post("/etteroppgjoer/{inntektsaar}") {
+            sjekkEtteroppgjoerEnabled(featureToggleService)
+            val inntektsaar =
+                krevIkkeNull(call.parameters["inntektsaar"]?.toInt()) {
+                    "Inntektsaar mangler"
+                }
+            etteroppgjoerService.finnSakerForEtteroppgjoer(inntektsaar)
         }
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerRoutes.kt
@@ -21,6 +21,7 @@ import no.nav.etterlatte.libs.common.isDev
 import no.nav.etterlatte.libs.ktor.route.ETTEROPPGJOER_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.etteroppgjoerId
+import no.nav.etterlatte.libs.ktor.route.kunSystembruker
 import no.nav.etterlatte.libs.ktor.route.sakId
 import no.nav.etterlatte.libs.ktor.token.brukerTokenInfo
 import no.nav.etterlatte.tilgangsstyring.kunSkrivetilgang
@@ -78,18 +79,22 @@ fun Route.etteroppgjoerRoutes(
 
         post("/skatteoppgjoerhendelser/start-kjoering") {
             sjekkEtteroppgjoerEnabled(featureToggleService)
-            val request = call.receive<HendelseKjoeringRequest>()
-            skatteoppgjoerHendelserService.startHendelsesKjoering(request)
-            call.respond(HttpStatusCode.OK)
+            kunSystembruker {
+                val request = call.receive<HendelseKjoeringRequest>()
+                skatteoppgjoerHendelserService.startHendelsesKjoering(request)
+                call.respond(HttpStatusCode.OK)
+            }
         }
 
         post("/{inntektsaar}/start-kjoering") {
             sjekkEtteroppgjoerEnabled(featureToggleService)
-            val inntektsaar =
-                krevIkkeNull(call.parameters["inntektsaar"]?.toInt()) {
-                    "Inntektsaar mangler"
-                }
-            etteroppgjoerService.finnSakerForEtteroppgjoer(inntektsaar)
+            kunSystembruker {
+                val inntektsaar =
+                    krevIkkeNull(call.parameters["inntektsaar"]?.toInt()) {
+                        "Inntektsaar mangler"
+                    }
+                etteroppgjoerService.finnSakerForEtteroppgjoer(inntektsaar)
+            }
         }
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerRoutes.kt
@@ -83,7 +83,7 @@ fun Route.etteroppgjoerRoutes(
             call.respond(HttpStatusCode.OK)
         }
 
-        post("/start-etteroppgjoer/{inntektsaar}") {
+        post("/{inntektsaar}/start-kjoering") {
             sjekkEtteroppgjoerEnabled(featureToggleService)
             val inntektsaar =
                 krevIkkeNull(call.parameters["inntektsaar"]?.toInt()) {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerRoutes.kt
@@ -83,7 +83,7 @@ fun Route.etteroppgjoerRoutes(
             call.respond(HttpStatusCode.OK)
         }
 
-        post("/etteroppgjoer/{inntektsaar}") {
+        post("/start-etteroppgjoer/{inntektsaar}") {
             sjekkEtteroppgjoerEnabled(featureToggleService)
             val inntektsaar =
                 krevIkkeNull(call.parameters["inntektsaar"]?.toInt()) {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerService.kt
@@ -24,7 +24,8 @@ class EtteroppgjoerService(
     }
 
     suspend fun finnSakerForEtteroppgjoer(inntektsaar: Int) {
-        val sakerMedUtbetaling = vedtakKlient.hentSakerMedUtbetalingForInntektsaar(inntektsaar, HardkodaSystembruker.etteroppgjoer)
+        val sakerMedUtbetaling =
+            vedtakKlient.hentSakerMedUtbetalingForInntektsaar(inntektsaar, HardkodaSystembruker.etteroppgjoer)
 
         sakerMedUtbetaling
             .filter { sakId -> dao.hentEtteroppgjoer(sakId, inntektsaar) == null }
@@ -34,7 +35,10 @@ class EtteroppgjoerService(
                     inntektsaar,
                     EtteroppgjoerStatus.VENTER_PAA_SKATTEOPPGJOER,
                 )
-                logger.info("Oppretter etteroppgjør for sakId=$sakId, inntektsaar=$inntektsaar")
+                logger.info(
+                    "Oppretter etteroppgjør for inntektsaar=$inntektsaar med " +
+                        "status ${EtteroppgjoerStatus.VENTER_PAA_SKATTEOPPGJOER} for sakId=$sakId",
+                )
             }
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerService.kt
@@ -19,8 +19,14 @@ class EtteroppgjoerService(
         return SkalHaEtteroppgjoerResultat(etteroppgjoer != null, etteroppgjoer)
     }
 
-    fun finnAlleEtteroppgjoerOgLagre(inntektsaar: Int) {
+    fun finnSakerForEtteroppgjoer(inntektsaar: Int) {
         // TODO finn alle som har hatt utbetaling i inntektsår og lagre med status EtteroppgjoerStatus.VENTER_PAA_SKATTEOPPGJOER
+
+        // TODO finn alle saker som har hatt utbetaling i inntektsår
+
+        // TODO opprett etteroppgjoer med status VENTER_PAA_SKATTEOPPGJOER
+
+        // TODO lagre
     }
 
     fun oppdaterStatus(

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -663,6 +663,7 @@ internal class ApplicationContext(
             dao = etteroppgjoerDao,
             sakLesDao = sakLesDao,
             sakService = sakService,
+            vedtakKlient = vedtakKlient,
         )
 
     val etteroppgjoerForbehandlingService =

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
@@ -247,6 +247,13 @@ class VedtakKlientTest : VedtakKlient {
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): VedtakDto? = null
+
+    override suspend fun hentSakerMedUtbetalingForInntektsaar(
+        inntektsaar: Int,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<SakId> {
+        TODO("Not yet implemented")
+    }
 }
 
 class TilbakekrevingKlientTest : TilbakekrevingKlient {

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRepository.kt
@@ -171,84 +171,6 @@ class VedtaksvurderingRepository(
                 ?: throw Exception("Kunne ikke oppdatere vedtak for behandling ${oppdatertVedtak.behandlingId}")
         }
 
-    private fun slettUtbetalingsperioder(
-        vedtakId: Long,
-        tx: TransactionalSession,
-    ) = queryOf(
-        statement = """
-                DELETE FROM utbetalingsperiode
-                WHERE vedtakid = :vedtakid
-                """,
-        paramMap =
-            mapOf(
-                "vedtakid" to vedtakId,
-            ),
-    ).let { query -> tx.run(query.asUpdate) }
-
-    private fun opprettUtbetalingsperioder(
-        vedtakId: Long,
-        utbetalingsperioder: List<Utbetalingsperiode>,
-        tx: TransactionalSession,
-    ) = utbetalingsperioder.forEach {
-        queryOf(
-            statement = """
-                    INSERT INTO utbetalingsperiode(vedtakid, datofom, datotom, type, beloep, regelverk) 
-                    VALUES (:vedtakid, :datofom, :datotom, :type, :beloep, :regelverk)
-                    """,
-            paramMap =
-                mapOf(
-                    "vedtakid" to vedtakId,
-                    "datofom" to
-                        it.periode.fom
-                            .atDay(1)
-                            .let(Date::valueOf),
-                    "datotom" to
-                        it.periode.tom
-                            ?.atEndOfMonth()
-                            ?.let(Date::valueOf),
-                    "type" to it.type.name,
-                    "beloep" to it.beloep,
-                    "regelverk" to it.regelverk.name,
-                ),
-        ).let { query -> tx.run(query.asUpdate) }
-    }
-
-    private fun slettAvkortetYtelsePerioder(
-        vedtakId: Long,
-        tx: TransactionalSession,
-    ) = queryOf(
-        statement = """
-                DELETE FROM avkortet_ytelse_periode
-                WHERE vedtakid = :vedtakid
-                """,
-        paramMap =
-            mapOf(
-                "vedtakid" to vedtakId,
-            ),
-    ).let { query -> tx.run(query.asUpdate) }
-
-    private fun opprettAvkortetYtelsePerioder(
-        vedtakId: Long,
-        avkortetYtelse: List<AvkortetYtelseDto>,
-        tx: TransactionalSession,
-    ) = tx.batchPreparedNamedStatement(
-        statement = """
-                    INSERT INTO avkortet_ytelse_periode(vedtakid, datofom, datotom, type, ytelseFoer, ytelseEtter) 
-                    VALUES (:vedtakid, :datofom, :datotom, :type, :ytelseFoer, :ytelseEtter)
-                    """,
-        params =
-            avkortetYtelse.map {
-                mapOf(
-                    "vedtakid" to vedtakId,
-                    "datofom" to it.fom.atDay(1).let(Date::valueOf),
-                    "datotom" to it.tom?.atEndOfMonth()?.let(Date::valueOf),
-                    "type" to it.type,
-                    "ytelseFoer" to it.ytelseFoerAvkorting,
-                    "ytelseEtter" to it.ytelseEtterAvkorting,
-                )
-            },
-    )
-
     fun hentVedtak(
         vedtakId: Long,
         tx: TransactionalSession? = null,
@@ -289,11 +211,6 @@ class VedtaksvurderingRepository(
                 it.toVedtak(utbetalingsperioder)
             }
         }
-
-    private fun hentVedtakNonNull(
-        behandlingId: UUID,
-        tx: TransactionalSession? = null,
-    ): Vedtak = krevIkkeNull(hentVedtak(behandlingId, tx)) { "Fant ikke vedtak for behandling $behandlingId" }
 
     fun hentVedtakForSak(
         sakId: SakId,
@@ -346,17 +263,6 @@ class VedtaksvurderingRepository(
             }
         }
     }
-
-    private fun hentUtbetalingsPerioder(
-        vedtakId: Long,
-        tx: TransactionalSession? = null,
-    ): List<Utbetalingsperiode> =
-        tx.session {
-            hentListe(
-                queryString = "SELECT * FROM utbetalingsperiode WHERE vedtakid = :vedtakid",
-                params = { mapOf("vedtakid" to vedtakId) },
-            ) { it.toUtbetalingsperiode() }
-        }
 
     fun hentAvkortetYtelsePerioder(
         vedtakIds: Set<Long>,
@@ -499,86 +405,6 @@ class VedtaksvurderingRepository(
             return@session hentVedtakNonNull(behandlingId, this)
         }
 
-    private fun Row.toVedtak(utbetalingsperioder: List<Utbetalingsperiode>) =
-        Vedtak(
-            id = long("id"),
-            sakId = SakId(long("sakid")),
-            sakType = SakType.valueOf(string("saktype")),
-            behandlingId = uuid("behandlingid"),
-            soeker = string("fnr").let { Folkeregisteridentifikator.of(it) },
-            status = string("vedtakstatus").let { VedtakStatus.valueOf(it) },
-            type = string("type").let { VedtakType.valueOf(it) },
-            vedtakFattet =
-                stringOrNull("saksbehandlerid")?.let {
-                    VedtakFattet(
-                        ansvarligSaksbehandler = string("saksbehandlerid"),
-                        ansvarligEnhet = Enhetsnummer(string("fattetVedtakEnhet")),
-                        tidspunkt = sqlTimestamp("datofattet").toTidspunkt(),
-                    )
-                },
-            attestasjon =
-                stringOrNull("attestant")?.let {
-                    Attestasjon(
-                        attestant = string("attestant"),
-                        attesterendeEnhet = Enhetsnummer(string("attestertVedtakEnhet")),
-                        tidspunkt = sqlTimestamp("datoattestert").toTidspunkt(),
-                    )
-                },
-            innhold =
-                when (string("type").let { VedtakType.valueOf(it) }) {
-                    VedtakType.OPPHOER,
-                    VedtakType.AVSLAG,
-                    VedtakType.ENDRING,
-                    VedtakType.INNVILGELSE,
-                    ->
-                        VedtakInnhold.Behandling(
-                            behandlingType = BehandlingType.valueOf(string("behandlingtype")),
-                            virkningstidspunkt = sqlDate("datovirkfom").toLocalDate().let { YearMonth.from(it) },
-                            vilkaarsvurdering = stringOrNull("vilkaarsresultat")?.let { objectMapper.readValue(it) },
-                            beregning = stringOrNull("beregningsresultat")?.let { objectMapper.readValue(it) },
-                            avkorting = stringOrNull("avkorting")?.let { objectMapper.readValue(it) },
-                            utbetalingsperioder = utbetalingsperioder,
-                            revurderingAarsak = stringOrNull("revurderingsaarsak")?.let { Revurderingaarsak.valueOf(it) },
-                            revurderingInfo = stringOrNull("revurderinginfo")?.let { objectMapper.readValue(it) },
-                            opphoerFraOgMed = sqlDateOrNull("opphoer_fom")?.toLocalDate()?.let { YearMonth.from(it) },
-                        )
-
-                    VedtakType.TILBAKEKREVING ->
-                        VedtakInnhold.Tilbakekreving(
-                            tilbakekreving = string("tilbakekreving").let { objectMapper.readValue(it) },
-                        )
-
-                    VedtakType.AVVIST_KLAGE ->
-                        VedtakInnhold.Klage(
-                            klage = string("klage").let { objectMapper.readValue(it) },
-                        )
-                },
-        )
-
-    private fun Row.toUtbetalingsperiode() =
-        Utbetalingsperiode(
-            id = long("id"),
-            periode =
-                Periode(
-                    fom = YearMonth.from(localDate("datoFom")),
-                    tom = localDateOrNull("datoTom")?.let(YearMonth::from),
-                ),
-            beloep = bigDecimalOrNull("beloep"),
-            type = UtbetalingsperiodeType.valueOf(string("type")),
-            regelverk = string("regelverk").let { Regelverk.valueOf(it) },
-        )
-
-    private fun Row.toAvkortetYtelsePeriode() =
-        AvkortetYtelsePeriode(
-            id = uuid("id"),
-            vedtakId = long("vedtakid"),
-            fom = YearMonth.from(localDate("datofom")),
-            tom = localDateOrNull("datotom")?.let(YearMonth::from),
-            type = string("type"),
-            ytelseFoerAvkorting = int("ytelseFoer"),
-            ytelseEtterAvkorting = int("ytelseEtter"),
-        )
-
     fun tilbakestillIkkeIverksatteVedtak(
         behandlingId: UUID,
         tx: TransactionalSession? = null,
@@ -638,5 +464,179 @@ class VedtaksvurderingRepository(
             params = mapOf("samId" to samId),
             loggtekst = "Sletter innslag for manuell samordning pga feil ved ekstern oppdatering",
         )
+    }
+
+    private fun hentVedtakNonNull(
+        behandlingId: UUID,
+        tx: TransactionalSession? = null,
+    ): Vedtak = krevIkkeNull(hentVedtak(behandlingId, tx)) { "Fant ikke vedtak for behandling $behandlingId" }
+
+    private fun Row.toUtbetalingsperiode() =
+        Utbetalingsperiode(
+            id = long("id"),
+            periode =
+                Periode(
+                    fom = YearMonth.from(localDate("datoFom")),
+                    tom = localDateOrNull("datoTom")?.let(YearMonth::from),
+                ),
+            beloep = bigDecimalOrNull("beloep"),
+            type = UtbetalingsperiodeType.valueOf(string("type")),
+            regelverk = string("regelverk").let { Regelverk.valueOf(it) },
+        )
+
+    private fun Row.toAvkortetYtelsePeriode() =
+        AvkortetYtelsePeriode(
+            id = uuid("id"),
+            vedtakId = long("vedtakid"),
+            fom = YearMonth.from(localDate("datofom")),
+            tom = localDateOrNull("datotom")?.let(YearMonth::from),
+            type = string("type"),
+            ytelseFoerAvkorting = int("ytelseFoer"),
+            ytelseEtterAvkorting = int("ytelseEtter"),
+        )
+
+    private fun Row.toVedtak(utbetalingsperioder: List<Utbetalingsperiode>) =
+        Vedtak(
+            id = long("id"),
+            sakId = SakId(long("sakid")),
+            sakType = SakType.valueOf(string("saktype")),
+            behandlingId = uuid("behandlingid"),
+            soeker = string("fnr").let { Folkeregisteridentifikator.of(it) },
+            status = string("vedtakstatus").let { VedtakStatus.valueOf(it) },
+            type = string("type").let { VedtakType.valueOf(it) },
+            vedtakFattet =
+                stringOrNull("saksbehandlerid")?.let {
+                    VedtakFattet(
+                        ansvarligSaksbehandler = string("saksbehandlerid"),
+                        ansvarligEnhet = Enhetsnummer(string("fattetVedtakEnhet")),
+                        tidspunkt = sqlTimestamp("datofattet").toTidspunkt(),
+                    )
+                },
+            attestasjon =
+                stringOrNull("attestant")?.let {
+                    Attestasjon(
+                        attestant = string("attestant"),
+                        attesterendeEnhet = Enhetsnummer(string("attestertVedtakEnhet")),
+                        tidspunkt = sqlTimestamp("datoattestert").toTidspunkt(),
+                    )
+                },
+            innhold =
+                when (string("type").let { VedtakType.valueOf(it) }) {
+                    VedtakType.OPPHOER,
+                    VedtakType.AVSLAG,
+                    VedtakType.ENDRING,
+                    VedtakType.INNVILGELSE,
+                    ->
+                        VedtakInnhold.Behandling(
+                            behandlingType = BehandlingType.valueOf(string("behandlingtype")),
+                            virkningstidspunkt = sqlDate("datovirkfom").toLocalDate().let { YearMonth.from(it) },
+                            vilkaarsvurdering = stringOrNull("vilkaarsresultat")?.let { objectMapper.readValue(it) },
+                            beregning = stringOrNull("beregningsresultat")?.let { objectMapper.readValue(it) },
+                            avkorting = stringOrNull("avkorting")?.let { objectMapper.readValue(it) },
+                            utbetalingsperioder = utbetalingsperioder,
+                            revurderingAarsak = stringOrNull("revurderingsaarsak")?.let { Revurderingaarsak.valueOf(it) },
+                            revurderingInfo = stringOrNull("revurderinginfo")?.let { objectMapper.readValue(it) },
+                            opphoerFraOgMed = sqlDateOrNull("opphoer_fom")?.toLocalDate()?.let { YearMonth.from(it) },
+                        )
+
+                    VedtakType.TILBAKEKREVING ->
+                        VedtakInnhold.Tilbakekreving(
+                            tilbakekreving = string("tilbakekreving").let { objectMapper.readValue(it) },
+                        )
+
+                    VedtakType.AVVIST_KLAGE ->
+                        VedtakInnhold.Klage(
+                            klage = string("klage").let { objectMapper.readValue(it) },
+                        )
+                },
+        )
+
+    private fun hentUtbetalingsPerioder(
+        vedtakId: Long,
+        tx: TransactionalSession? = null,
+    ): List<Utbetalingsperiode> =
+        tx.session {
+            hentListe(
+                queryString = "SELECT * FROM utbetalingsperiode WHERE vedtakid = :vedtakid",
+                params = { mapOf("vedtakid" to vedtakId) },
+            ) { it.toUtbetalingsperiode() }
+        }
+
+    private fun slettAvkortetYtelsePerioder(
+        vedtakId: Long,
+        tx: TransactionalSession,
+    ) = queryOf(
+        statement = """
+                DELETE FROM avkortet_ytelse_periode
+                WHERE vedtakid = :vedtakid
+                """,
+        paramMap =
+            mapOf(
+                "vedtakid" to vedtakId,
+            ),
+    ).let { query -> tx.run(query.asUpdate) }
+
+    private fun opprettAvkortetYtelsePerioder(
+        vedtakId: Long,
+        avkortetYtelse: List<AvkortetYtelseDto>,
+        tx: TransactionalSession,
+    ) = tx.batchPreparedNamedStatement(
+        statement = """
+                    INSERT INTO avkortet_ytelse_periode(vedtakid, datofom, datotom, type, ytelseFoer, ytelseEtter) 
+                    VALUES (:vedtakid, :datofom, :datotom, :type, :ytelseFoer, :ytelseEtter)
+                    """,
+        params =
+            avkortetYtelse.map {
+                mapOf(
+                    "vedtakid" to vedtakId,
+                    "datofom" to it.fom.atDay(1).let(Date::valueOf),
+                    "datotom" to it.tom?.atEndOfMonth()?.let(Date::valueOf),
+                    "type" to it.type,
+                    "ytelseFoer" to it.ytelseFoerAvkorting,
+                    "ytelseEtter" to it.ytelseEtterAvkorting,
+                )
+            },
+    )
+
+    private fun slettUtbetalingsperioder(
+        vedtakId: Long,
+        tx: TransactionalSession,
+    ) = queryOf(
+        statement = """
+                DELETE FROM utbetalingsperiode
+                WHERE vedtakid = :vedtakid
+                """,
+        paramMap =
+            mapOf(
+                "vedtakid" to vedtakId,
+            ),
+    ).let { query -> tx.run(query.asUpdate) }
+
+    private fun opprettUtbetalingsperioder(
+        vedtakId: Long,
+        utbetalingsperioder: List<Utbetalingsperiode>,
+        tx: TransactionalSession,
+    ) = utbetalingsperioder.forEach {
+        queryOf(
+            statement = """
+                    INSERT INTO utbetalingsperiode(vedtakid, datofom, datotom, type, beloep, regelverk) 
+                    VALUES (:vedtakid, :datofom, :datotom, :type, :beloep, :regelverk)
+                    """,
+            paramMap =
+                mapOf(
+                    "vedtakid" to vedtakId,
+                    "datofom" to
+                        it.periode.fom
+                            .atDay(1)
+                            .let(Date::valueOf),
+                    "datotom" to
+                        it.periode.tom
+                            ?.atEndOfMonth()
+                            ?.let(Date::valueOf),
+                    "type" to it.type.name,
+                    "beloep" to it.beloep,
+                    "regelverk" to it.regelverk.name,
+                ),
+        ).let { query -> tx.run(query.asUpdate) }
     }
 }

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -89,6 +89,15 @@ fun Route.vedtaksvurderingRoute(
             }
         }
 
+        get("/sak/har-utbetaling/{inntektsaar}") {
+            val inntektsaar =
+                krevIkkeNull(call.parameters["inntektsaar"]?.toInt()) {
+                    "Inntektsaar mangler"
+                }
+
+            call.respond(vedtakService.hentSakerMedUtbetalingForInntektsaar(inntektsaar))
+        }
+
         get("/{$BEHANDLINGID_CALL_PARAMETER}") {
             withBehandlingId(behandlingKlient) { behandlingId ->
                 logger.info("Henter vedtak for behandling $behandlingId")

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingRoute.kt
@@ -89,7 +89,7 @@ fun Route.vedtaksvurderingRoute(
             }
         }
 
-        get("/sak/har-utbetaling/{inntektsaar}") {
+        get("/sak/med-utbetaling/{inntektsaar}") {
             val inntektsaar =
                 krevIkkeNull(call.parameters["inntektsaar"]?.toInt()) {
                     "Inntektsaar mangler"

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtaksvurderingService.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.vedtaksvurdering
 
+import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.sak.SakId
 import org.slf4j.LoggerFactory
@@ -23,4 +24,10 @@ class VedtaksvurderingService(
     fun hentVedtakISak(sakId: SakId): List<Vedtak> = repository.hentVedtakForSak(sakId)
 
     fun hentVedtak(fnr: Folkeregisteridentifikator): List<Vedtak> = repository.hentFerdigstilteVedtak(fnr)
+
+    // TODO: bedre plassering for denne?
+    fun hentSakerMedUtbetalingForInntektsaar(aar: Int): List<SakId> =
+        repository
+            .hentVedtakMedUtbetalingForInntektsaar(aar, SakType.OMSTILLINGSSTOENAD)
+            .map { it.sakId }
 }

--- a/libs/etterlatte-ktor/src/main/kotlin/token/BrukerTokenInfo.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/token/BrukerTokenInfo.kt
@@ -83,6 +83,7 @@ data class HardkodaSystembruker private constructor(
         val uttrekk = HardkodaSystembruker(Systembrukere.UTTREKK)
         val statistikk = HardkodaSystembruker(Systembrukere.STATISTIKK)
         val tilgang = HardkodaSystembruker(Systembrukere.TILGANG)
+        val etteroppgjoer = HardkodaSystembruker(Systembrukere.ETTEROPPGJOER)
     }
 
     enum class Systembrukere(
@@ -99,6 +100,7 @@ data class HardkodaSystembruker private constructor(
         OMREGNING("omregning"),
         STATISTIKK("statistikk"),
         UTTREKK("uttrekk"),
+        ETTEROPPGJOER("etteroppgjoer"),
     }
 }
 


### PR DESCRIPTION
Alle saker med en utbetalingsperiode for inntektsaar skal ha etteroppgjør

Oppretter etteroppgjør og setter status til `VENTER_PAA_SKATTEOPPGJOER`