### PR TITLE
EY-5107: Vise sakendringer av typen adressebeskyttelse og skjerming

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
@@ -123,7 +123,7 @@ interface SakService {
         gradering: AdressebeskyttelseGradering,
     )
 
-    fun hentSaksendringer(sakId: SakId): List<SaksendringBegrenset>
+    fun hentSaksendringer(sakId: SakId): List<Saksendring>
 }
 
 class ManglerTilgangTilEnhet(
@@ -403,23 +403,10 @@ class SakServiceImpl(
         }
     }
 
-    override fun hentSaksendringer(sakId: SakId): List<SaksendringBegrenset> {
-        val saksendringer = endringerDao.hentEndringerForSak(sakId)
-
-        // Inntil vi har gått opp om det er greit å vise adressebeskyttelse og skjerming, så ønsker vi ikke å eksponere
-        // dette. Verken som egne endringstyper eller som en del av andre endringstyper.
-        val saksendringerUtenSensitiveEndringer =
-            saksendringer
-                .filter {
-                    it.endringstype in
-                        listOf(
-                            Endringstype.OPPRETT_SAK,
-                            Endringstype.ENDRE_ENHET,
-                            Endringstype.ENDRE_IDENT,
-                        )
-                }.map(Saksendring::toSaksendringBegrenset)
-
-        return saksendringerUtenSensitiveEndringer
+    override fun hentSaksendringer(sakId: SakId): List<Saksendring> {
+        // Sjekk om saksbehandler kan hente historikk for sak
+        val sak = lesDao.hentSak(sakId).sjekkEnhet()
+        return sak?.let { endringerDao.hentEndringerForSak(it.id) } ?: emptyList()
     }
 
     private fun sjekkGraderingOgEnhetStemmer(sak: SakMedGraderingOgSkjermet) {

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/Saksendring.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/Saksendring.kt
@@ -6,7 +6,6 @@ import no.nav.etterlatte.libs.common.Enhetsnummer
 import no.nav.etterlatte.libs.common.behandling.Flyktning
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
-import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import java.util.UUID
@@ -43,8 +42,6 @@ data class Saksendring(
     val identtype: Identtype,
     val kommentar: String? = null,
 ) {
-    fun toSaksendringBegrenset(): SaksendringBegrenset = SaksendringBegrenset.from(this)
-
     companion object {
         fun create(
             user: User,
@@ -69,31 +66,3 @@ data class Saksendring(
             )
     }
 }
-
-data class SaksendringBegrenset(
-    val id: UUID,
-    val endringstype: Endringstype,
-    val foer: Sak?,
-    val etter: Sak,
-    val tidspunkt: Tidspunkt,
-    val ident: String,
-    val identtype: Identtype,
-    val kommentar: String?,
-) {
-    companion object {
-        fun from(saksendring: Saksendring): SaksendringBegrenset =
-            SaksendringBegrenset(
-                id = saksendring.id,
-                endringstype = saksendring.endringstype,
-                foer = saksendring.foer?.toSak(),
-                etter = saksendring.etter.toSak(),
-                tidspunkt = saksendring.tidspunkt,
-                ident = saksendring.ident,
-                identtype = saksendring.identtype,
-                kommentar = saksendring.kommentar,
-            )
-    }
-}
-
-// KomplettSak inneholder sensitive felter adressebeskyttelse og erSkjermet - fjerner disse med denne konverteringen
-private fun KomplettSak.toSak() = Sak(ident, sakType, id, enhet)

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/Sakshistorikk.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/Sakshistorikk.tsx
@@ -6,7 +6,7 @@ import Spinner from '~shared/Spinner'
 import { BodyShort, Box, Detail, List } from '@navikt/ds-react'
 import { formaterDatoMedKlokkeslett } from '~utils/formatering/dato'
 import { Endringstype, Identtype, ISaksendring, tekstEndringstype } from '~shared/types/sak'
-import { BagdeIcon, Buildings3Icon, FolderIcon } from '@navikt/aksel-icons'
+import { BagdeIcon, Buildings3Icon, FolderIcon, PadlockLockedIcon } from '@navikt/aksel-icons'
 import { ENHETER } from '~shared/types/Enhet'
 
 const Ikon = ({ endringstype }: { endringstype: Endringstype }) => {
@@ -16,6 +16,10 @@ const Ikon = ({ endringstype }: { endringstype: Endringstype }) => {
     return <BagdeIcon aria-hidden width="1rem" height="1rem" />
   } else if (endringstype === Endringstype.OPPRETT_SAK) {
     return <FolderIcon aria-hidden width="1rem" height="1rem" />
+  } else if (endringstype === Endringstype.ENDRE_ADRESSEBESKYTTELSE) {
+    return <PadlockLockedIcon aria-hidden width="1rem" height="1rem" />
+  } else if (endringstype === Endringstype.ENDRE_SKJERMING) {
+    return <PadlockLockedIcon aria-hidden width="1rem" height="1rem" />
   }
 }
 
@@ -30,6 +34,22 @@ const Endringstekst = ({ endring }: { endring: ISaksendring }) => {
     return (
       <>
         Identitetsnummer {endring.foer.ident} er erstattet med {endring.etter.ident}
+      </>
+    )
+  } else if (endring.endringstype === Endringstype.ENDRE_ADRESSEBESKYTTELSE) {
+    const adressebeskyttelseFoer = endring.foer.adressebeskyttelse ?? 'UGRADERT'
+    const adressebeskyttelseEtter = endring.etter.adressebeskyttelse ?? 'UGRADERT'
+    return (
+      <>
+        Fra {adressebeskyttelseFoer} til {adressebeskyttelseEtter}
+      </>
+    )
+  } else if (endring.endringstype === Endringstype.ENDRE_SKJERMING) {
+    const skjermingFoer = endring.foer.erSkjermet === true ? 'SKJERMET' : 'IKKE_SKJERMET'
+    const skjermingEtter = endring.etter.erSkjermet === true ? 'SKJERMET' : 'IKKE_SKJERMET'
+    return (
+      <>
+        Fra {skjermingFoer} til {skjermingEtter}
       </>
     )
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/Sakshistorikk.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/Sakshistorikk.tsx
@@ -5,7 +5,14 @@ import { hentSaksendringer } from '~shared/api/sak'
 import Spinner from '~shared/Spinner'
 import { BodyShort, Box, Detail, List } from '@navikt/ds-react'
 import { formaterDatoMedKlokkeslett } from '~utils/formatering/dato'
-import { Endringstype, Identtype, ISaksendring, tekstEndringstype } from '~shared/types/sak'
+import {
+  AdressebeskyttelseGradering,
+  Endringstype,
+  Identtype,
+  ISaksendring,
+  tekstAdressebeskyttelseGradering,
+  tekstEndringstype,
+} from '~shared/types/sak'
 import { BagdeIcon, Buildings3Icon, FolderIcon, PadlockLockedIcon } from '@navikt/aksel-icons'
 import { ENHETER } from '~shared/types/Enhet'
 
@@ -37,16 +44,20 @@ const Endringstekst = ({ endring }: { endring: ISaksendring }) => {
       </>
     )
   } else if (endring.endringstype === Endringstype.ENDRE_ADRESSEBESKYTTELSE) {
-    const adressebeskyttelseFoer = endring.foer.adressebeskyttelse ?? 'UGRADERT'
-    const adressebeskyttelseEtter = endring.etter.adressebeskyttelse ?? 'UGRADERT'
+    const adressebeskyttelseFoer = endring.foer.adressebeskyttelse
+      ? tekstAdressebeskyttelseGradering[endring.foer.adressebeskyttelse]
+      : tekstAdressebeskyttelseGradering[AdressebeskyttelseGradering.UGRADERT]
+    const adressebeskyttelseEtter = endring.etter.adressebeskyttelse
+      ? tekstAdressebeskyttelseGradering[endring.etter.adressebeskyttelse]
+      : tekstAdressebeskyttelseGradering[AdressebeskyttelseGradering.UGRADERT]
     return (
       <>
         Fra {adressebeskyttelseFoer} til {adressebeskyttelseEtter}
       </>
     )
   } else if (endring.endringstype === Endringstype.ENDRE_SKJERMING) {
-    const skjermingFoer = endring.foer.erSkjermet === true ? 'SKJERMET' : 'IKKE_SKJERMET'
-    const skjermingEtter = endring.etter.erSkjermet === true ? 'SKJERMET' : 'IKKE_SKJERMET'
+    const skjermingFoer = endring.foer.erSkjermet === true ? 'Skjermet' : 'Ikke skjermet'
+    const skjermingEtter = endring.etter.erSkjermet === true ? 'Skjermet' : 'Ikke skjermet'
     return (
       <>
         Fra {skjermingFoer} til {skjermingEtter}

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/sak.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/sak.ts
@@ -15,6 +15,11 @@ export interface ISakMedUtlandstilknytning {
   utlandstilknytning?: IUtlandstilknytning
 }
 
+export interface IKomplettSak extends ISak {
+  adressebeskyttelse?: string
+  erSkjermet?: boolean
+}
+
 export enum SakType {
   BARNEPENSJON = 'BARNEPENSJON',
   OMSTILLINGSSTOENAD = 'OMSTILLINGSSTOENAD',
@@ -28,8 +33,8 @@ export interface FoersteVirk {
 export interface ISaksendring {
   id: string
   endringstype: Endringstype
-  foer: ISak
-  etter: ISak
+  foer: IKomplettSak
+  etter: IKomplettSak
   ident: string
   identtype: Identtype
   kommentar: string
@@ -45,10 +50,14 @@ export enum Endringstype {
   OPPRETT_SAK = 'OPPRETT_SAK',
   ENDRE_IDENT = 'ENDRE_IDENT',
   ENDRE_ENHET = 'ENDRE_ENHET',
+  ENDRE_ADRESSEBESKYTTELSE = 'ENDRE_ADRESSEBESKYTTELSE',
+  ENDRE_SKJERMING = 'ENDRE_SKJERMING',
 }
 
 export const tekstEndringstype: Record<Endringstype, string> = {
   OPPRETT_SAK: 'Opprettet sak',
   ENDRE_IDENT: 'Nytt identnummer',
   ENDRE_ENHET: 'Bytte av enhet',
+  ENDRE_ADRESSEBESKYTTELSE: 'Endret adressebeskyttelse',
+  ENDRE_SKJERMING: 'Endret skjerming',
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/sak.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/sak.ts
@@ -16,7 +16,7 @@ export interface ISakMedUtlandstilknytning {
 }
 
 export interface IKomplettSak extends ISak {
-  adressebeskyttelse?: string
+  adressebeskyttelse?: AdressebeskyttelseGradering
   erSkjermet?: boolean
 }
 
@@ -60,4 +60,18 @@ export const tekstEndringstype: Record<Endringstype, string> = {
   ENDRE_ENHET: 'Bytte av enhet',
   ENDRE_ADRESSEBESKYTTELSE: 'Endret adressebeskyttelse',
   ENDRE_SKJERMING: 'Endret skjerming',
+}
+
+export enum AdressebeskyttelseGradering {
+  STRENGT_FORTROLIG_UTLAND = 'STRENGT_FORTROLIG_UTLAND',
+  STRENGT_FORTROLIG = 'STRENGT_FORTROLIG',
+  FORTROLIG = 'FORTROLIG',
+  UGRADERT = 'UGRADERT',
+}
+
+export const tekstAdressebeskyttelseGradering: Record<AdressebeskyttelseGradering, string> = {
+  STRENGT_FORTROLIG_UTLAND: 'Strengt fortrolig (utland)',
+  STRENGT_FORTROLIG: 'Strengt fortrolig',
+  FORTROLIG: 'Fortrolig',
+  UGRADERT: 'Ugradert',
 }


### PR DESCRIPTION
Legger til to nye endringstyper i endringshistorikken for sak: Adressebeskyttelse og Skjerming. 

![Screenshot 2025-03-18 at 11 46 57](https://github.com/user-attachments/assets/b1dc06ac-752d-475c-8253-8553f0ec45ae)
