### PR TITLE
EY-5079: Viser alle oppgaver som har enhet Vikafossen, også de som ikke er gradert

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDaoMedEndringssporing.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveDaoMedEndringssporing.kt
@@ -141,9 +141,6 @@ class OppgaveDaoMedEndringssporingImpl(
     override fun hentAntallOppgaver(innloggetSaksbehandlerIdent: String): OppgavebenkStats =
         oppgaveDao.hentAntallOppgaver(innloggetSaksbehandlerIdent)
 
-    override fun finnOppgaverForStrengtFortroligOgStrengtFortroligUtland(): List<OppgaveIntern> =
-        oppgaveDao.finnOppgaverForStrengtFortroligOgStrengtFortroligUtland()
-
     override fun settNySaksbehandler(
         oppgaveId: UUID,
         saksbehandler: String,

--- a/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgave/OppgaveService.kt
@@ -48,16 +48,12 @@ class OppgaveService(
         oppgaveStatuser: List<String>,
         minOppgavelisteIdentFilter: String? = null,
     ): List<OppgaveIntern> =
-        if (bruker.saksbehandlerMedRoller.harRolleStrengtFortrolig()) {
-            oppgaveDao.finnOppgaverForStrengtFortroligOgStrengtFortroligUtland()
-        } else {
-            oppgaveDao
-                .hentOppgaver(
-                    bruker.enheter(),
-                    oppgaveStatuser,
-                    minOppgavelisteIdentFilter,
-                ).sortedByDescending { it.opprettet }
-        }
+        oppgaveDao
+            .hentOppgaver(
+                bruker.enheter(),
+                oppgaveStatuser,
+                minOppgavelisteIdentFilter,
+            ).sortedByDescending { it.opprettet }
 
     fun genererStatsForOppgaver(innloggetSaksbehandlerIdent: String): OppgavebenkStats =
         oppgaveDao.hentAntallOppgaver(innloggetSaksbehandlerIdent)

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
@@ -498,6 +498,9 @@ class SakServiceImpl(
         return enhet ?: enhetFraNorg
     }
 
+    /**
+     * Denne skal aldri brukes uten og også endre enhet. Tor dette bør gjøres i sammenheng.
+     */
     override fun oppdaterAdressebeskyttelse(
         sakId: SakId,
         adressebeskyttelseGradering: AdressebeskyttelseGradering,

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
@@ -499,7 +499,7 @@ class SakServiceImpl(
     }
 
     /**
-     * Denne skal aldri brukes uten og også endre enhet. Tor dette bør gjøres i sammenheng.
+     * Denne skal aldri brukes uten å også endre enhet. Tror dette egentlig bør gjøres i sammenheng.
      */
     override fun oppdaterAdressebeskyttelse(
         sakId: SakId,

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveDaoTest.kt
@@ -14,7 +14,6 @@ import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
 import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.oppgave.Status
-import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.mockedSakTilgangDao
@@ -274,40 +273,6 @@ internal class OppgaveDaoTest(
         oppgaveDao.endreEnhetPaaOppgave(oppgaveNy.id, Enheter.PORSGRUNN.enhetNr)
         val hentetOppgave = oppgaveDao.hentOppgave(oppgaveNy.id)
         assertEquals(Enheter.PORSGRUNN.enhetNr, hentetOppgave?.enhet)
-    }
-
-    @Test
-    fun `Skal ikke kunne hente adressebeskyttede oppgaver fra vanlig hentoppgaver`() {
-        val sakAalesund = sakSkrivDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
-        val oppgaveNy = lagNyOppgave(sakAalesund)
-        oppgaveDao.opprettOppgave(oppgaveNy)
-        sakSkrivDao.oppdaterAdresseBeskyttelse(sakAalesund.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
-
-        val sakutenbeskyttelse = sakSkrivDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
-        val oppgaveUtenbeskyttelse = lagNyOppgave(sakutenbeskyttelse)
-        oppgaveDao.opprettOppgave(oppgaveUtenbeskyttelse)
-
-        val hentetOppgave =
-            oppgaveDao.hentOppgaver(
-                listOf(Enheter.AALESUND.enhetNr),
-                Status.entries.map { it.name },
-            )
-        assertEquals(1, hentetOppgave.size)
-    }
-
-    @Test
-    fun `Skal kunne hente adressebeskyttede oppgaver fra finnOppgaverForStrengtFortroligOgStrengtFortroligUtland`() {
-        val sakAalesund = sakSkrivDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
-        val oppgaveNy = lagNyOppgave(sakAalesund)
-        oppgaveDao.opprettOppgave(oppgaveNy)
-        sakSkrivDao.oppdaterAdresseBeskyttelse(sakAalesund.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
-
-        val ikkeGradertSak = sakSkrivDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
-        val ikkeGradertOppgave = lagNyOppgave(ikkeGradertSak)
-        oppgaveDao.opprettOppgave(ikkeGradertOppgave)
-
-        val hentetOppgave = oppgaveDao.finnOppgaverForStrengtFortroligOgStrengtFortroligUtland()
-        assertEquals(1, hentetOppgave.size)
     }
 
     @Test

--- a/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/oppgave/OppgaveServiceTest.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.oppgave
 
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.clearAllMocks
@@ -40,6 +41,8 @@ import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.Claims
+import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER2_FOEDSELSNUMMER
+import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
 import no.nav.etterlatte.nyKontekstMedBruker
 import no.nav.etterlatte.nyKontekstMedBrukerOgDatabaseContext
 import no.nav.etterlatte.sak.SakLesDao
@@ -898,17 +901,21 @@ internal class OppgaveServiceTest(
 
     @Test
     fun `Skal kun få saker som ikke er adressebeskyttet tilbake hvis saksbehandler ikke har spesialroller`() {
-        val opprettetSak = sakSkrivDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
-        val nyOppgave =
+        val saksbehandlerRoller = generateSaksbehandlerMedRoller(AzureGroup.SAKSBEHANDLER)
+        every { saksbehandler.enheter() } returns listOf(Enheter.AALESUND.enhetNr)
+        every { saksbehandler.saksbehandlerMedRoller } returns saksbehandlerRoller
+
+        val ikkeAdressebeskyttetSak = sakSkrivDao.opprettSak(SOEKER_FOEDSELSNUMMER.value, SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
+        val ikkeAdressebeskyttetOppgave =
             oppgaveService.opprettOppgave(
-                "referanse",
-                opprettetSak.id,
+                "referanse1",
+                ikkeAdressebeskyttetSak.id,
                 OppgaveKilde.BEHANDLING,
                 OppgaveType.FOERSTEGANGSBEHANDLING,
                 null,
             )
 
-        val adressebeskyttetSak = sakSkrivDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
+        val adressebeskyttetSak = sakSkrivDao.opprettSak(SOEKER2_FOEDSELSNUMMER.value, SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
         oppgaveService.opprettOppgave(
             "referanse",
             adressebeskyttetSak.id,
@@ -917,17 +924,56 @@ internal class OppgaveServiceTest(
             null,
         )
 
+        val sakMedEnhet = SakMedEnhet(adressebeskyttetSak.id, Enheter.STRENGT_FORTROLIG.enhetNr)
         sakSkrivDao.oppdaterAdresseBeskyttelse(adressebeskyttetSak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
-
-        val saksbehandlerRoller = generateSaksbehandlerMedRoller(AzureGroup.SAKSBEHANDLER)
-        every { saksbehandler.enheter() } returns listOf(Enheter.AALESUND.enhetNr)
-        every { saksbehandler.saksbehandlerMedRoller } returns saksbehandlerRoller
+        sakSkrivDao.oppdaterEnhet(sakMedEnhet)
+        oppgaveService.oppdaterEnhetForRelaterteOppgaver(listOf(sakMedEnhet))
 
         val oppgaver = oppgaveService.finnOppgaverForBruker(saksbehandler, Status.entries.map { it.name })
-        assertEquals(1, oppgaver.size)
-        val oppgaveUtenbeskyttelse = oppgaver[0]
-        assertEquals(nyOppgave.id, oppgaveUtenbeskyttelse.id)
-        assertEquals(nyOppgave.sakId, opprettetSak.id)
+
+        oppgaver shouldHaveSize 1
+        ikkeAdressebeskyttetOppgave.id shouldBe oppgaver.first().id
+        ikkeAdressebeskyttetOppgave.sakId shouldBe ikkeAdressebeskyttetSak.id
+    }
+
+    @Test
+    fun `Skal få alle saker tilbake for enhet hvis saksbehandler har spesialroller`() {
+        val saksbehandlerRoller = generateSaksbehandlerMedRoller(AzureGroup.SAKSBEHANDLER)
+        every { saksbehandler.enheter() } returns listOf(Enheter.STRENGT_FORTROLIG_UTLAND.enhetNr)
+        every { saksbehandler.saksbehandlerMedRoller } returns saksbehandlerRoller
+
+        val ikkeAdressebeskyttetSak =
+            sakSkrivDao.opprettSak(
+                SOEKER_FOEDSELSNUMMER.value,
+                SakType.BARNEPENSJON,
+                Enheter.STRENGT_FORTROLIG_UTLAND.enhetNr,
+            )
+        oppgaveService.opprettOppgave(
+            "referanse1",
+            ikkeAdressebeskyttetSak.id,
+            OppgaveKilde.BEHANDLING,
+            OppgaveType.FOERSTEGANGSBEHANDLING,
+            null,
+        )
+
+        val adressebeskyttetSak = sakSkrivDao.opprettSak(SOEKER2_FOEDSELSNUMMER.value, SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
+        oppgaveService.opprettOppgave(
+            "referanse",
+            adressebeskyttetSak.id,
+            OppgaveKilde.BEHANDLING,
+            OppgaveType.FOERSTEGANGSBEHANDLING,
+            null,
+        )
+
+        val sakMedEnhet = SakMedEnhet(adressebeskyttetSak.id, Enheter.STRENGT_FORTROLIG.enhetNr)
+        sakSkrivDao.oppdaterAdresseBeskyttelse(adressebeskyttetSak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
+        sakSkrivDao.oppdaterEnhet(sakMedEnhet)
+        oppgaveService.oppdaterEnhetForRelaterteOppgaver(listOf(sakMedEnhet))
+
+        // Returnerer begge oppgavene, selv om den ene saken ikke har markert adressegradering
+        val oppgaver = oppgaveService.finnOppgaverForBruker(saksbehandler, Status.entries.map { it.name })
+
+        oppgaver shouldHaveSize 2
     }
 
     @Test
@@ -1072,39 +1118,6 @@ internal class OppgaveServiceTest(
         assertEquals(Enheter.STEINKJER.enhetNr, oppgaveMedEndring.enhet)
         assertEquals(Status.ATTESTERING, oppgaveMedEndring.status)
         assertEquals(null, oppgaveMedEndring.saksbehandler)
-    }
-
-    @Test
-    fun `Skal kun få saker som  er strengt fotrolig tilbake hvis saksbehandler har rolle strengt fortrolig`() {
-        val opprettetSak = sakSkrivDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
-        oppgaveService.opprettOppgave(
-            "referanse",
-            opprettetSak.id,
-            OppgaveKilde.BEHANDLING,
-            OppgaveType.FOERSTEGANGSBEHANDLING,
-            null,
-        )
-
-        val adressebeskyttetSak = sakSkrivDao.opprettSak("fnr", SakType.BARNEPENSJON, Enheter.AALESUND.enhetNr)
-        val adressebeskyttetOppgave =
-            oppgaveService.opprettOppgave(
-                "referanse",
-                adressebeskyttetSak.id,
-                OppgaveKilde.BEHANDLING,
-                OppgaveType.FOERSTEGANGSBEHANDLING,
-                null,
-            )
-
-        sakSkrivDao.oppdaterAdresseBeskyttelse(adressebeskyttetSak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
-        val saksbehandlerMedRollerStrengtFortrolig = generateSaksbehandlerMedRoller(AzureGroup.STRENGT_FORTROLIG)
-        every { saksbehandler.enheter() } returns listOf(Enheter.STRENGT_FORTROLIG.enhetNr)
-        every { saksbehandler.saksbehandlerMedRoller } returns saksbehandlerMedRollerStrengtFortrolig
-
-        val oppgaver = oppgaveService.finnOppgaverForBruker(saksbehandler, Status.entries.map { it.name })
-        assertEquals(1, oppgaver.size)
-        val strengtFortroligOppgave = oppgaver[0]
-        assertEquals(adressebeskyttetOppgave.id, strengtFortroligOppgave.id)
-        assertEquals(adressebeskyttetOppgave.sakId, adressebeskyttetSak.id)
     }
 
     @Test


### PR DESCRIPTION
Tidligere ville kun oppgaver som var markert som strengt fortrolig og strengt fortrolig utland vises hvis for vikafossen. Dette er litt uheldig da vi har hatt tilfeller hvor oppgaver har hatt denne enheten, men ikke hatt gradering og derfor ikke har vært synlig for saksbehandler. 

Det bør holde at saksbehandler har enhet Vikafossen for å kunne hente hvilke som helst oppgaver som ligger på denne enheten.  