### PR TITLE
EY-5076: Ikke lov å endre manuelt fra vikafossen eller egne ansatte

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/EndreEnhet.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/EndreEnhet.tsx
@@ -42,6 +42,8 @@ export const EndreEnhet = ({ sakId, gjeldendeEnhet }: { sakId: number; gjeldende
     resetApiCall()
   }
 
+  const enhetErVikafossenEllerEgneAnsatte = (enhet: string) => enhet === '2103' || enhet === '4883'
+
   return (
     <div>
       <Button
@@ -82,6 +84,18 @@ export const EndreEnhet = ({ sakId, gjeldendeEnhet }: { sakId: number; gjeldende
                   </Button>
                 )}
               </HStack>
+            </VStack>
+          ) : enhetErVikafossenEllerEgneAnsatte(gjeldendeEnhet) ? (
+            <VStack gap="4">
+              <Alert variant="warning">
+                Saken tilhører {ENHETER[gjeldendeEnhet]} og kan ikke flyttes til en annen enhet i Gjenny på grunn av
+                adressebeskyttelse eller skjerming. Dersom saken skal flyttes, må dette endres i Pdl eller
+                skjermingsløsningen. Dette vil føre til at saken oppdateres og enhet setter riktig i Gjenny.
+              </Alert>
+
+              <Button type="button" variant="secondary" onClick={() => setOpen(false)}>
+                Lukk
+              </Button>
             </VStack>
           ) : (
             <VStack gap="4">


### PR DESCRIPTION
Fjerner muligheten for å endre enhet for en sak som er tildelt Vikafossen eller Egne ansatte da dette bør skje ved å endre i Pdl eller skjermingsløsningen.

![Screenshot 2025-03-18 at 16 15 18](https://github.com/user-attachments/assets/e77ac417-5208-4269-a1f2-d3c16f0e8869)
