### PR TITLE
Bugfix/smaafeil

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/flereAvdoede/BeregningsMetodeRadForAvdoed.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/flereAvdoede/BeregningsMetodeRadForAvdoed.tsx
@@ -28,7 +28,7 @@ import {
   VStack,
 } from '@navikt/ds-react'
 import { FloppydiskIcon, PencilIcon, TrashIcon, XMarkIcon } from '@navikt/aksel-icons'
-import { isPending } from '~shared/api/apiUtils'
+import { isPending, mapFailure } from '~shared/api/apiUtils'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { lagreBeregningsGrunnlag } from '~shared/api/beregning'
 import {
@@ -46,6 +46,7 @@ import { ControlledMaanedVelger } from '~shared/components/maanedVelger/Controll
 import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
 import { mapNavn, tagTekstForKunEnJuridiskForelder } from '~components/behandling/beregningsgrunnlag/Beregningsgrunnlag'
 import { AnnenForelderVurdering } from '~shared/types/grunnlag'
+import { ApiErrorAlert } from '~ErrorBoundary'
 
 interface Props {
   behandling: IBehandlingReducer
@@ -345,6 +346,9 @@ export const BeregningsMetodeRadForAvdoed = ({ behandling, trygdetid, redigerbar
             Slett
           </Button>
         )}
+        {mapFailure(lagreBeregningsgrunnlagResult, (error) => (
+          <ApiErrorAlert>{error.detail || 'Kunne ikke lagre beregningsgrunnlag'}</ApiErrorAlert>
+        ))}
       </Table.DataCell>
     </Table.ExpandableRow>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/trygdetidPerioder/TrygdetidPerioder.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/trygdetid/trygdetidPerioder/TrygdetidPerioder.tsx
@@ -23,7 +23,7 @@ import { isFailure, isPending, isSuccess, mapFailure, mapResult } from '~shared/
 import Spinner from '~shared/Spinner'
 import { FeatureToggle, useFeaturetoggle } from '~useUnleash'
 import { IBehandlingReducer, oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'
-import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
+import { IBehandlingStatus, IBehandlingsType } from '~shared/types/IDetaljertBehandling'
 import { useAppDispatch } from '~store/Store'
 import { ApiErrorAlert } from '~ErrorBoundary'
 
@@ -57,14 +57,18 @@ export const TrygdetidPerioder = ({
     slettTrygdetidsgrunnlagKildePesys
   )
 
+  const erFoerstegangsbehandling = behandling.behandlingType === IBehandlingsType.FØRSTEGANGSBEHANDLING
+
   useEffect(() => {
-    if (kanHenteTrygdetidFraPesys) {
+    if (kanHenteTrygdetidFraPesys && erFoerstegangsbehandling) {
       sjekkOmAvdoedHarTTIPesysHent(behandling.id)
     }
   }, [kanHenteTrygdetidFraPesys])
+
   const [hentTTPesysStatus, hentOgOppdaterDataFraPesys] = useApiCall(
     hentOgLeggInnTrygdetidsGrunnlagForUfoeretrygdOgAlderspensjon
   )
+
   const oppdaterTrygdetider = (trygdetid: ITrygdetid[]) => {
     setTrygdetider(trygdetid)
     dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.TRYGDETID_OPPDATERT))
@@ -155,9 +159,11 @@ export const TrygdetidPerioder = ({
           </Button>
         </div>
       )}
+
       {kanLeggeTilNyPeriode &&
         faktiskTrygdetid &&
         kanHenteTrygdetidFraPesys &&
+        erFoerstegangsbehandling &&
         mapResult(sjekkOmAvodedHarTTIPesysStatus, {
           initial: null,
           pending: <Spinner label="Sjekker om avdøde har trygdetidsgrunnlag i Pesys" />,


### PR DESCRIPTION
https://logs.adeo.no/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now%2Fd,to:now%2Fd))&_a=(columns:!(level,message,envclass,application,pod),dataSource:(dataViewId:'96e648c0-980a-11e9-830a-e17bbd64b4db',type:dataView),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:e6b478c2-6621-45ea-82ba-cde827ec02f4,key:trace.id,negate:!f,params:(query:'9b4665a119563e308d3c7db0b3ade2ad'),type:phrase),query:(match_phrase:(trace.id:'9b4665a119563e308d3c7db0b3ade2ad')))),grid:(columns:(level:(width:186),message:(width:427))),hideChart:!t,interval:auto,query:(language:lucene,query:'namespace:etterlatte%20AND%20envclass:p'),sort:!(!('@timestamp',desc)))

https://logs.adeo.no/app/discover#/?_g=(time:(from:now-24h%2Fh,to:now))&_a=(columns:!(level,message,envclass,application,pod),dataSource:(dataViewId:'96e648c0-980a-11e9-830a-e17bbd64b4db',type:dataView),filters:!(),grid:(columns:(level:(width:108),message:(width:401))),hideChart:!t,interval:auto,query:(language:lucene,query:'x_correlation_id:0cfd01bd-5709-40c8-9241-9772e2a70722'),sort:!(!('@timestamp',desc)))

Feil propageres ikke til frontend og vi prøver å hente for behandlingstyper som ikke er fb men det er ikke støttet i backend så da får vi feilmeldinger vi kan unngå med å legge på sjekk her.