### PR TITLE
Endre til å bruke 403 hvis man mangler tilgang

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -59,7 +59,7 @@ import no.nav.etterlatte.sak.sakSystemRoutes
 import no.nav.etterlatte.sak.sakWebRoutes
 import no.nav.etterlatte.saksbehandler.saksbehandlerRoutes
 import no.nav.etterlatte.tilgangsstyring.PluginConfiguration
-import no.nav.etterlatte.tilgangsstyring.adressebeskyttelsePlugin
+import no.nav.etterlatte.tilgangsstyring.SpesialTilgangPlugin
 import no.nav.etterlatte.vilkaarsvurdering.aldersovergang
 import no.nav.etterlatte.vilkaarsvurdering.vilkaarsvurdering
 import org.slf4j.Logger
@@ -120,7 +120,7 @@ internal fun Application.module(context: ApplicationContext) {
 internal fun Route.settOppApplikasjonen(context: ApplicationContext) {
     attachContekst(context.dataSource, context)
     settOppRoutes(context)
-    settOppTilganger(context, adressebeskyttelsePlugin)
+    settOppTilganger(context, SpesialTilgangPlugin)
 }
 
 private fun Route.attachContekst(

--- a/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
@@ -20,7 +20,7 @@ import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
 import no.nav.etterlatte.SystemUser
 import no.nav.etterlatte.libs.common.Enhetsnummer
 import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
-import no.nav.etterlatte.libs.common.feilhaandtering.GenerellIkkeFunnetException
+import no.nav.etterlatte.libs.common.feilhaandtering.ManglerTilgang
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.sak.tilSakId
@@ -49,7 +49,10 @@ class PluginConfiguration {
     var saksbehandlerGroupIdsByKey: Map<AzureGroup, String> = emptyMap()
 }
 
-private object AdressebeskyttelseHook : Hook<suspend (ApplicationCall) -> Unit> {
+/*
+    Denne sjekker på både adressebeskyttelse og egen ansatt og returnerer http statuscode 401 hvis man mangler tilgang.
+ */
+private object SpesialtilgangsHook : Hook<suspend (ApplicationCall) -> Unit> {
     private val AdressebeskyttelseHook: PipelinePhase = PipelinePhase("Adressebeskyttelse")
     private val AuthenticatePhase: PipelinePhase = PipelinePhase("Authenticate")
 
@@ -67,12 +70,12 @@ private object AdressebeskyttelseHook : Hook<suspend (ApplicationCall) -> Unit> 
 
 const val TILGANG_ROUTE_PATH = "tilgang"
 
-val adressebeskyttelsePlugin: RouteScopedPlugin<PluginConfiguration> =
+val SpesialTilgangPlugin: RouteScopedPlugin<PluginConfiguration> =
     createRouteScopedPlugin(
         name = "Adressebeskyttelsesplugin",
         createConfiguration = ::PluginConfiguration,
     ) {
-        on(AdressebeskyttelseHook) { call ->
+        on(SpesialtilgangsHook) { call ->
             val bruker = call.brukerTokenInfo
 
             if (bruker is Systembruker) {
@@ -97,7 +100,7 @@ val adressebeskyttelsePlugin: RouteScopedPlugin<PluginConfiguration> =
                                     SaksbehandlerMedRoller(bruker, saksbehandlerGroupIdsByKey),
                                 )
                             ) {
-                                throw GenerellIkkeFunnetException()
+                                throw ManglerTilgang()
                             }
                             return@on
                         }
@@ -108,7 +111,7 @@ val adressebeskyttelsePlugin: RouteScopedPlugin<PluginConfiguration> =
                                     SaksbehandlerMedRoller(bruker, saksbehandlerGroupIdsByKey),
                                 )
                             ) {
-                                throw GenerellIkkeFunnetException()
+                                throw ManglerTilgang()
                             }
                             return@on
                         }
@@ -119,7 +122,7 @@ val adressebeskyttelsePlugin: RouteScopedPlugin<PluginConfiguration> =
                                     SaksbehandlerMedRoller(bruker, saksbehandlerGroupIdsByKey),
                                 )
                             ) {
-                                throw GenerellIkkeFunnetException()
+                                throw ManglerTilgang()
                             }
                             return@on
                         }
@@ -130,7 +133,7 @@ val adressebeskyttelsePlugin: RouteScopedPlugin<PluginConfiguration> =
                                     SaksbehandlerMedRoller(bruker, saksbehandlerGroupIdsByKey),
                                 )
                             ) {
-                                throw GenerellIkkeFunnetException()
+                                throw ManglerTilgang()
                             }
                             return@on
                         }
@@ -141,7 +144,7 @@ val adressebeskyttelsePlugin: RouteScopedPlugin<PluginConfiguration> =
                                     SaksbehandlerMedRoller(bruker, saksbehandlerGroupIdsByKey),
                                 )
                             ) {
-                                throw GenerellIkkeFunnetException()
+                                throw ManglerTilgang()
                             }
                             return@on
                         }
@@ -152,7 +155,7 @@ val adressebeskyttelsePlugin: RouteScopedPlugin<PluginConfiguration> =
                                     SaksbehandlerMedRoller(bruker, saksbehandlerGroupIdsByKey),
                                 )
                             ) {
-                                throw GenerellIkkeFunnetException()
+                                throw ManglerTilgang()
                             }
                             return@on
                         }
@@ -163,7 +166,7 @@ val adressebeskyttelsePlugin: RouteScopedPlugin<PluginConfiguration> =
                                     SaksbehandlerMedRoller(bruker, saksbehandlerGroupIdsByKey),
                                 )
                             ) {
-                                throw GenerellIkkeFunnetException()
+                                throw ManglerTilgang()
                             }
                             return@on
                         }
@@ -192,7 +195,7 @@ suspend inline fun PipelineContext<*, ApplicationCall>.withFoedselsnummerInterna
             if (harTilgang) {
                 onSuccess(foedselsnummer)
             } else {
-                throw GenerellIkkeFunnetException()
+                throw ManglerTilgang()
             }
         }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
@@ -50,7 +50,7 @@ class PluginConfiguration {
 }
 
 /*
-    Denne sjekker på både adressebeskyttelse og egen ansatt og returnerer http statuscode 401 hvis man mangler tilgang.
+    Denne sjekker på både adressebeskyttelse og egen ansatt og returnerer http statuscode 403 hvis man mangler tilgang.
  */
 private object SpesialtilgangsHook : Hook<suspend (ApplicationCall) -> Unit> {
     private val AdressebeskyttelseHook: PipelinePhase = PipelinePhase("Adressebeskyttelse")

--- a/apps/etterlatte-behandling/src/test/kotlin/VerdikjedeTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/VerdikjedeTest.kt
@@ -115,6 +115,7 @@ class VerdikjedeTest : BehandlingIntegrationTest() {
 
             assertTrue(applicationContext.featureToggleService.isEnabled(FellesFeatureToggle.NoOperationToggle, false))
 
+            // Verifiserer at saken ikke finnes og da skal man få HttpStatusCode.NotFound
             client
                 .get("/saker/1") {
                     addAuthToken(tokenSaksbehandler)
@@ -631,7 +632,7 @@ class VerdikjedeTest : BehandlingIntegrationTest() {
                 .get("/behandlinger/$behandlingId") {
                     addAuthToken(tokenSaksbehandler)
                 }.also {
-                    assertEquals(HttpStatusCode.NotFound, it.status) // 404 pga adressebeskyttelse
+                    assertEquals(HttpStatusCode.Forbidden, it.status) // 403 pga adressebeskyttelse
                 }
         }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
@@ -128,12 +128,14 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
                 )
             }
 
+            // TODO: noe rart skjer her
             client
                 .get("/behandlinger/$behandlingId") {
                     addAuthToken(tokenSaksbehandler)
                 }.let {
-                    Assertions.assertEquals(HttpStatusCode.NotFound, it.status)
+                    Assertions.assertEquals(HttpStatusCode.Forbidden, it.status)
                 }
+
             // smoketest
             client
                 .get("/fakeurlwithbehandlingsid/$behandlingId") {
@@ -141,6 +143,7 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
                 }.let {
                     Assertions.assertEquals(HttpStatusCode.NotFound, it.status)
                 }
+
             // systemBruker skal alltid ha tilgang
             client
                 .get("/behandlinger/$behandlingId") {
@@ -344,7 +347,7 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
                     contentType(ContentType.Application.Json)
                     setBody(FoedselsnummerDTO(fnr))
                 }.apply {
-                    Assertions.assertEquals(HttpStatusCode.NotFound, status)
+                    Assertions.assertEquals(HttpStatusCode.Forbidden, status)
                 }
         }
         coVerify(exactly = 2) {

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
@@ -128,7 +128,6 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
                 )
             }
 
-            // TODO: noe rart skjer her
             client
                 .get("/behandlinger/$behandlingId") {
                     addAuthToken(tokenSaksbehandler)

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlFeilLogger.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlFeilLogger.kt
@@ -40,7 +40,8 @@ fun loggDelvisReturnerteData(
 
 /*
     Statuskoden her tolkes rett i frontend.
-    401 vil si at man er utlogget så 403 er i compliance med nye etterlevelseskrav om at informasjonsflyt
+    401 vil si at man er utlogget(fra frontends perspektiv)
+    Derfor vil vi returnere  403 er i compliance med nye etterlevelseskrav om at informasjonsflyt
     er lov for beskyttede personer.
  */
 class ManglerTilgangTilPerson :

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlFeilLogger.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/PdlFeilLogger.kt
@@ -38,9 +38,14 @@ fun loggDelvisReturnerteData(
     }
 }
 
+/*
+    Statuskoden her tolkes rett i frontend.
+    401 vil si at man er utlogget så 403 er i compliance med nye etterlevelseskrav om at informasjonsflyt
+    er lov for beskyttede personer.
+ */
 class ManglerTilgangTilPerson :
     ForespoerselException(
-        status = HttpStatusCode.Unauthorized.value,
+        status = HttpStatusCode.Forbidden.value,
         code = "MANGLER_TILGANG_TIL_PERSON",
         detail = "Mangler tilgang til person",
     )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/aktivitet/AktivitetspliktSakoversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/aktivitet/AktivitetspliktSakoversikt.tsx
@@ -12,6 +12,7 @@ import { Familiemedlem } from '~shared/types/familieOpplysninger'
 import { VurderingAvAktivitetspliktSak } from '~components/person/aktivitet/vurderingAvAktivitetsplikt/VurderingAvAktivitetspliktSak'
 import { AktivitetspliktStatusTagOgGyldig } from '~shared/tags/AktivitetspliktStatusOgGyldig'
 import { AktivitetspliktOppgaveVurderingType, harVurdering } from '~shared/types/Aktivitetsplikt'
+import { ApiError } from '~shared/api/apiClient'
 
 export const velgDoedsdato = (avdoede: Familiemedlem[] | []): Date => {
   if (avdoede.length === 0) return new Date()
@@ -43,16 +44,19 @@ export const AktivitetspliktSakoversikt = ({
     }
   }, [sakResult])
 
+  const feilkodehaandtering = (error: ApiError) => {
+    switch (error.status) {
+      case 404:
+        return <ApiWarningAlert>Kan ikke hente aktivitetsplikt: {error.detail}</ApiWarningAlert>
+      case 403:
+        return <ApiWarningAlert>Du mangler tilgang til saken {error.detail}</ApiWarningAlert>
+      default:
+        return <ApiErrorAlert>{error.detail || 'Feil ved henting av sak'}</ApiErrorAlert>
+    }
+  }
+
   if (isFailure(sakResult)) {
-    return (
-      <Box padding="8">
-        {sakResult.error.status === 404 ? (
-          <ApiWarningAlert>Kan ikke hente aktivitetsplikt: {sakResult.error.detail}</ApiWarningAlert>
-        ) : (
-          <ApiErrorAlert>{sakResult.error.detail || 'Feil ved henting av sak'}</ApiErrorAlert>
-        )}
-      </Box>
-    )
+    return <Box padding="8">{feilkodehaandtering(sakResult.error)}</Box>
   }
 
   return (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/KnyttTilAnnenBruker.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/KnyttTilAnnenBruker.tsx
@@ -16,6 +16,7 @@ import { SakOverfoeringDetailjer } from 'src/components/person/dokumenter/avvik/
 import { OppgaveKilde, Oppgavetype } from '~shared/types/oppgave'
 import { useInnloggetSaksbehandler } from '~components/behandling/useInnloggetSaksbehandler'
 import { ClickEvent, trackClick } from '~utils/amplitude'
+import { ApiError } from '~shared/api/apiClient'
 
 export const KnyttTilAnnenBruker = ({
   journalpost,
@@ -92,6 +93,17 @@ export const KnyttTilAnnenBruker = ({
 
   const isLoading = isPending(oppdaterResult) || isPending(opprettOppgaveStatus)
 
+  const feilkodehaandtering = (error: ApiError) => {
+    switch (error.status) {
+      case 404:
+        return <Alert variant="warning">Fant ikke sak {sakid}</Alert>
+      case 403:
+        return <Alert variant="error">Du mangler tilgang til saken {error.detail}</Alert>
+      default:
+        return <Alert variant="error">Ukjent feil ved henting av sak {sakid}</Alert>
+    }
+  }
+
   return mapResult(annenSakStatus, {
     initial: (
       <HStack gap="4" align="end">
@@ -128,11 +140,6 @@ export const KnyttTilAnnenBruker = ({
         </HStack>
       </VStack>
     ),
-    error: (error) =>
-      error.status === 404 ? (
-        <Alert variant="warning">Fant ikke sak {sakid}</Alert>
-      ) : (
-        <Alert variant="error">Ukjent feil ved henting av sak {sakid}</Alert>
-      ),
+    error: (error) => feilkodehaandtering(error),
   })
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/KnyttTilAnnenSak.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/dokumenter/avvik/KnyttTilAnnenSak.tsx
@@ -18,6 +18,7 @@ import { useInnloggetSaksbehandler } from '~components/behandling/useInnloggetSa
 import { JaNei } from '~shared/types/ISvar'
 import { formaterSakstype } from '~utils/formatering/formatering'
 import { ClickEvent, trackClick } from '~utils/amplitude'
+import { ApiError } from '~shared/api/apiClient'
 
 const erSammeSak = (sak: ISak, journalpost: Journalpost): boolean => {
   const { sak: journalpostSak, tema } = journalpost
@@ -145,7 +146,16 @@ export const KnyttTilAnnenSak = ({
       </>
     ))
   }
-
+  const feilkodehaandtering = (error: ApiError) => {
+    switch (error.status) {
+      case 404:
+        return <Alert variant="warning">Fant ikke sak {sakid}</Alert>
+      case 403:
+        return <Alert variant="error">Du mangler tilgang til saken {error.detail}</Alert>
+      default:
+        return <Alert variant="error">Ukjent feil ved henting av sak {sakid}</Alert>
+    }
+  }
   return (
     <>
       {mapResult(sakStatus, {
@@ -160,6 +170,8 @@ export const KnyttTilAnnenSak = ({
           ),
         error: (error) => (
           <>
+            {' '}
+            TODO sjekke mot 401
             {error.status === 404 ? (
               <Alert variant="warning">Brukeren har ingen sak i Gjenny</Alert>
             ) : (
@@ -231,15 +243,7 @@ export const KnyttTilAnnenSak = ({
             </HStack>
           </>
         ),
-        error: (error) => (
-          <>
-            {error.status === 404 ? (
-              <Alert variant="warning">Fant ikke sak {sakid}</Alert>
-            ) : (
-              <Alert variant="error">Ukjent feil ved henting av sak {sakid}</Alert>
-            )}
-          </>
-        ),
+        error: (error) => feilkodehaandtering(error),
       })}
     </>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/SakIkkeFunnet.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/SakIkkeFunnet.tsx
@@ -5,6 +5,7 @@ import { OpprettSakModal } from '~components/person/sakOgBehandling/OpprettSakMo
 import { Box } from '@navikt/ds-react'
 
 export const SakIkkeFunnet = ({ error, fnr }: { error: ApiError; fnr: string }) => {
+  //TODO håndtere 401
   return (
     <Box padding="8">
       {error.status === 404 ? (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/Sakshistorikk.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/Sakshistorikk.tsx
@@ -21,7 +21,7 @@ export const Sakshistorikk = ({ sakId }: { sakId: number }) => {
 
   useEffect(() => {
     hentSaksendringerKall(sakId)
-  }, [])
+  }, [sakId])
 
   const sorterNyligsteFoerstOgBakover = (a: ISaksendring, b: ISaksendring) =>
     new Date(b.tidspunkt).getTime() - new Date(a.tidspunkt).getTime()

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/Sakshistorikk.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/Sakshistorikk.tsx
@@ -16,6 +16,47 @@ import {
 import { BagdeIcon, Buildings3Icon, FolderIcon, PadlockLockedIcon } from '@navikt/aksel-icons'
 import { ENHETER } from '~shared/types/Enhet'
 
+export const Sakshistorikk = ({ sakId }: { sakId: number }) => {
+  const [hentSaksendringerStatus, hentSaksendringerKall] = useApiCall(hentSaksendringer)
+
+  useEffect(() => {
+    hentSaksendringerKall(sakId)
+  }, [])
+
+  const sorterNyligsteFoerstOgBakover = (a: ISaksendring, b: ISaksendring) =>
+    new Date(b.tidspunkt).getTime() - new Date(a.tidspunkt).getTime()
+
+  return mapResult(hentSaksendringerStatus, {
+    pending: <Spinner label="Henter historikk..." />,
+    success: (sakshistorikk) => (
+      <List as="ul" size="small">
+        {sakshistorikk.sort(sorterNyligsteFoerstOgBakover).map((endring) => (
+          <List.Item
+            title={tekstEndringstype[endring.endringstype]}
+            icon={<Ikon endringstype={endring.endringstype} />}
+            key={endring.id}
+          >
+            <Box maxWidth="18rem" borderWidth="0 0 1 0" paddingBlock="0 2" borderColor="border-subtle">
+              <BodyShort size="small">
+                <Endringstekst endring={endring} />
+              </BodyShort>
+              {endring.kommentar && (
+                <Box marginBlock="3 3">
+                  <BodyShort size="small">{endring.kommentar}</BodyShort>
+                </Box>
+              )}
+              <Detail textColor="subtle">{formaterDatoMedKlokkeslett(endring.tidspunkt)}</Detail>
+              <Detail textColor="subtle">
+                {endring.identtype == Identtype.SAKSBEHANDLER ? endring.ident : 'Gjenny (automatisk)'}
+              </Detail>
+            </Box>
+          </List.Item>
+        ))}
+      </List>
+    ),
+  })
+}
+
 const Ikon = ({ endringstype }: { endringstype: Endringstype }) => {
   if (endringstype === Endringstype.ENDRE_ENHET) {
     return <Buildings3Icon aria-hidden width="1rem" height="1rem" />
@@ -60,45 +101,4 @@ const Endringstekst = ({ endring }: { endring: ISaksendring }) => {
       </>
     )
   }
-}
-
-export const Sakshistorikk = ({ sakId }: { sakId: number }) => {
-  const [hentSaksendringerStatus, hentSaksendringerKall] = useApiCall(hentSaksendringer)
-
-  useEffect(() => {
-    hentSaksendringerKall(sakId)
-  }, [])
-
-  const sorterNyligsteFoerstOgBakover = (a: ISaksendring, b: ISaksendring) =>
-    new Date(b.tidspunkt).getTime() - new Date(a.tidspunkt).getTime()
-
-  return mapResult(hentSaksendringerStatus, {
-    pending: <Spinner label="Henter historikk..." />,
-    success: (sakshistorikk) => (
-      <List as="ul" size="small">
-        {sakshistorikk.sort(sorterNyligsteFoerstOgBakover).map((endring) => (
-          <List.Item
-            title={tekstEndringstype[endring.endringstype]}
-            icon={<Ikon endringstype={endring.endringstype} />}
-            key={endring.id}
-          >
-            <Box maxWidth="18rem" borderWidth="0 0 1 0" paddingBlock="0 2" borderColor="border-subtle">
-              <BodyShort size="small">
-                <Endringstekst endring={endring} />
-              </BodyShort>
-              {endring.kommentar && (
-                <Box marginBlock="3 3">
-                  <BodyShort size="small">{endring.kommentar}</BodyShort>
-                </Box>
-              )}
-              <Detail textColor="subtle">{formaterDatoMedKlokkeslett(endring.tidspunkt)}</Detail>
-              <Detail textColor="subtle">
-                {endring.identtype == Identtype.SAKSBEHANDLER ? endring.ident : 'Gjenny (automatisk)'}
-              </Detail>
-            </Box>
-          </List.Item>
-        ))}
-      </List>
-    ),
-  })
 }

--- a/libs/saksbehandling-common/src/main/kotlin/feilhaandtering/ForespoerselException.kt
+++ b/libs/saksbehandling-common/src/main/kotlin/feilhaandtering/ForespoerselException.kt
@@ -30,10 +30,6 @@ open class IkkeFunnetException(
     override val cause: Throwable? = null,
 ) : ForespoerselException(status = 404, code = code, detail = detail, meta = meta, cause = cause)
 
-/**
- * Brukes felles alle steder der vi ikke vil lekke noe informasjon om vi faktisk har funnet noe eller ikke ref.
- * informasjonssikring
- */
 class GenerellIkkeFunnetException : IkkeFunnetException(code = "NOT_FOUND", detail = "Kunne ikke finne ønsket ressurs")
 
 open class TimeoutForespoerselException(
@@ -42,6 +38,8 @@ open class TimeoutForespoerselException(
     override val meta: Map<String, Any>? = null,
     override val cause: Throwable? = null,
 ) : ForespoerselException(status = 408, code = code, detail = detail, meta = meta, cause = cause)
+
+class ManglerTilgang : IkkeTillattException(code = "MANGLER_TILGANG", detail = "Mangler tilgang")
 
 open class IkkeTillattException(
     override val code: String,


### PR DESCRIPTION
- egen pr for spesialsøk på fnr
- egen pr for div fjerning av info i oppgavelisten blant annet fnr

Spørsmål:
Hvilke andre steder burde vi tenke på statuskode håndtering som kan bli påvirket av dette? Som feks pdl-tjenester var det litt tilfeldig at jeg fant.