### PR TITLE
Bugfix/fagsystem 376040

### DIFF
--- a/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/behandling/BehandlingService.kt
+++ b/apps/etterlatte-behandling-kafka/src/main/kotlin/no/nav/etterlatte/behandling/BehandlingService.kt
@@ -272,6 +272,7 @@ class BehandlingServiceImpl(
             }
         }
 
+    // Ubrukt, fjerne
     override fun finnEllerOpprettSak(
         sakType: SakType,
         foedselsNummerDTO: FoedselsnummerDTO,

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -168,7 +168,9 @@ import no.nav.etterlatte.person.krr.KrrKlientImpl
 import no.nav.etterlatte.sak.SakLesDao
 import no.nav.etterlatte.sak.SakServiceImpl
 import no.nav.etterlatte.sak.SakSkrivDao
+import no.nav.etterlatte.sak.SakTilgang
 import no.nav.etterlatte.sak.SakTilgangDao
+import no.nav.etterlatte.sak.SakTilgangImpl
 import no.nav.etterlatte.sak.SakendringerDao
 import no.nav.etterlatte.sak.TilgangServiceSjekkerImpl
 import no.nav.etterlatte.saksbehandler.SaksbehandlerInfoDao
@@ -525,16 +527,18 @@ internal class ApplicationContext(
         )
     val selfTestService = SelfTestService(externalServices)
 
-    val oppdaterTilgangService: OppdaterTilgangService by lazy {
+    // TODO: vurder om private
+    val sakTilgang: SakTilgang = SakTilgangImpl(sakSkrivDao, sakLesDao)
+    val oppdaterTilgangService =
         OppdaterTilgangService(
-            sakService = sakService,
             skjermingKlient = skjermingKlient,
             pdltjenesterKlient = pdlTjenesterKlient,
             brukerService = brukerService,
             oppgaveService = oppgaveService,
             sakSkrivDao = sakSkrivDao,
+            sakTilgang = sakTilgang,
+            sakLesDao = sakLesDao,
         )
-    }
 
     val sakService =
         SakServiceImpl(
@@ -548,7 +552,9 @@ internal class ApplicationContext(
             pdlTjenesterKlient,
             featureToggleService,
             oppdaterTilgangService,
+            sakTilgang,
         )
+
     val doedshendelseService = DoedshendelseService(doedshendelseDao, pdlTjenesterKlient)
 
     val inntektsjusteringSelvbetjeningService =

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -525,6 +525,17 @@ internal class ApplicationContext(
         )
     val selfTestService = SelfTestService(externalServices)
 
+    val oppdaterTilgangService: OppdaterTilgangService by lazy {
+        OppdaterTilgangService(
+            sakService = sakService,
+            skjermingKlient = skjermingKlient,
+            pdltjenesterKlient = pdlTjenesterKlient,
+            brukerService = brukerService,
+            oppgaveService = oppgaveService,
+            sakSkrivDao = sakSkrivDao,
+        )
+    }
+
     val sakService =
         SakServiceImpl(
             sakSkrivDao,
@@ -536,6 +547,7 @@ internal class ApplicationContext(
             krrKlient,
             pdlTjenesterKlient,
             featureToggleService,
+            oppdaterTilgangService,
         )
     val doedshendelseService = DoedshendelseService(doedshendelseDao, pdlTjenesterKlient)
 
@@ -566,15 +578,6 @@ internal class ApplicationContext(
         )
 
     val grunnlagsendringsHendelseFilter = GrunnlagsendringsHendelseFilter(vedtakKlient, behandlingService)
-    val oppdaterTilgangService =
-        OppdaterTilgangService(
-            sakService = sakService,
-            skjermingKlient = skjermingKlient,
-            pdltjenesterKlient = pdlTjenesterKlient,
-            brukerService = brukerService,
-            oppgaveService = oppgaveService,
-            sakSkrivDao = sakSkrivDao,
-        )
     val grunnlagsendringshendelseService =
         GrunnlagsendringshendelseService(
             oppgaveService = oppgaveService,

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlag/GrunnlagService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlag/GrunnlagService.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.grunnlag
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.readValue
-import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.common.klienter.PdlTjenesterKlient
 import no.nav.etterlatte.libs.common.behandling.PersonMedSakerOgRoller
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
@@ -283,8 +282,8 @@ class GrunnlagServiceImpl(
         logger.info("Oppdatert grunnlag (sakId=${opplysningsbehov.sakId}, behandlingId=$behandlingId)")
     }
 
-    private fun oppdaterPersongalleri(opplysningsbehov: Opplysningsbehov): Opplysningsbehov {
-        val identerForSoeker = runBlocking { pdltjenesterKlient.hentPdlFolkeregisterIdenter(opplysningsbehov.persongalleri.soeker) }
+    private suspend fun oppdaterPersongalleri(opplysningsbehov: Opplysningsbehov): Opplysningsbehov {
+        val identerForSoeker = pdltjenesterKlient.hentPdlFolkeregisterIdenter(opplysningsbehov.persongalleri.soeker)
         val gjeldendeIdentForSoeker = identerForSoeker.identifikatorer.first { !it.historisk }
         return opplysningsbehov.copy(
             persongalleri =
@@ -535,7 +534,7 @@ class GrunnlagServiceImpl(
         }
         oppdaterGrunnlagForSak(sakId, fnr = null, grunnlag.saksopplysninger)
 
-        logger.info("Oppdatert grunnlag (sakId=${opplysningsbehov.sakId}")
+        logger.info("Oppdatert grunnlag (sakId=${opplysningsbehov.sakId})")
     }
 
     private fun oppdaterGrunnlagForSak(

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
@@ -168,8 +168,6 @@ class DoedshendelseJobService(
 
     private fun opprettSakOgLagGrunnlag(doedshendelse: DoedshendelseInternal): Sak {
         logger.info("Oppretter sak for dødshendelse ${doedshendelse.id} avdøde ${doedshendelse.avdoedFnr.maskerFnr()}")
-        // Denne gjør at man ikke sjekker tilgangsting for 3-parter som trengs for egen ansatt og adressebeskyttelse
-        // her må man bruke oppdatertilgangservice for å ikke overskride eventuelle 3-parts skjerminger fra mor eller far.
         val opprettetSak =
             sakService.finnEllerOpprettSakMedGrunnlag(
                 fnr = doedshendelse.beroertFnr,

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
@@ -136,7 +136,7 @@ class DoedshendelseJobService(
             }
 
             false -> {
-                logger.info("Skal håndtere dødshendelse")
+                logger.info("Skal håndtere dødshendelse ${doedshendelse.id}")
                 val sak: Sak =
                     kontrollpunkter.finnSak() ?: opprettSakOgLagGrunnlag(doedshendelse)
 

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
@@ -168,6 +168,8 @@ class DoedshendelseJobService(
 
     private fun opprettSakOgLagGrunnlag(doedshendelse: DoedshendelseInternal): Sak {
         logger.info("Oppretter sak for dødshendelse ${doedshendelse.id} avdøde ${doedshendelse.avdoedFnr.maskerFnr()}")
+        // Denne gjør at man ikke sjekker tilgangsting for 3-parter som trengs for egen ansatt og adressebeskyttelse
+        // her må man bruke oppdatertilgangservice for å ikke overskride eventuelle 3-parts skjerminger fra mor eller far.
         val opprettetSak =
             sakService.finnEllerOpprettSakMedGrunnlag(
                 fnr = doedshendelse.beroertFnr,

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakService.kt
@@ -518,11 +518,12 @@ class SakServiceImpl(
                 skjermingKlient.personErSkjermet(fnr)
             }
         if (erSkjermet) {
-            logger.info("Oppdater egen ansatt for sak $sakId")
+            logger.info("Oppdater egen ansatt for sak: $sakId")
             dao.oppdaterEnhet(
                 SakMedEnhet(sakId, Enheter.EGNE_ANSATTE.enhetNr),
             )
         } else {
+            logger.info("Oppdater egen ansatt for sak, ikke skjermet. Setter ny enhet for sak: $sakId")
             val sakMedSkjerming = lesDao.hentSak(sakId)!!
             if (sakMedSkjerming.enhet == Enheter.EGNE_ANSATTE.enhetNr) {
                 val enhet = sjekkEnhetFraNorg(fnr, type, overstyrendeEnhet)

--- a/apps/etterlatte-behandling/src/main/kotlin/sak/SakTilgang.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/sak/SakTilgang.kt
@@ -1,0 +1,75 @@
+package no.nav.etterlatte.sak
+
+import no.nav.etterlatte.common.Enheter
+import no.nav.etterlatte.grunnlagsendring.SakMedEnhet
+import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
+import no.nav.etterlatte.libs.common.sak.Sak
+import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.common.sak.SakMedGraderingOgSkjermet
+import no.nav.etterlatte.libs.ktor.token.Systembruker
+
+interface SakTilgang {
+    fun oppdaterAdressebeskyttelse(
+        sakId: SakId,
+        adressebeskyttelseGradering: AdressebeskyttelseGradering,
+    )
+
+    fun settEnhetOmAdressebeskyttet(
+        sak: Sak,
+        gradering: AdressebeskyttelseGradering,
+    )
+
+    fun oppdaterSkjerming(
+        sakId: SakId,
+        skjermet: Boolean,
+    )
+
+    fun hentGraderingForSak(
+        sakId: SakId,
+        bruker: Systembruker,
+    ): SakMedGraderingOgSkjermet
+}
+
+class SakTilgangImpl(
+    private val skrivDao: SakSkrivDao,
+    private val lesDao: SakLesDao,
+) : SakTilgang {
+    override fun hentGraderingForSak(
+        sakId: SakId,
+        bruker: Systembruker,
+    ): SakMedGraderingOgSkjermet = lesDao.finnSakMedGraderingOgSkjerming(sakId)
+
+    override fun oppdaterAdressebeskyttelse(
+        sakId: SakId,
+        adressebeskyttelseGradering: AdressebeskyttelseGradering,
+    ) = skrivDao.oppdaterAdresseBeskyttelse(sakId, adressebeskyttelseGradering)
+
+    override fun settEnhetOmAdressebeskyttet(
+        sak: Sak,
+        gradering: AdressebeskyttelseGradering,
+    ) {
+        when (gradering) {
+            AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND -> {
+                if (sak.enhet != Enheter.STRENGT_FORTROLIG_UTLAND.enhetNr) {
+                    skrivDao.oppdaterEnhet(SakMedEnhet(sak.id, Enheter.STRENGT_FORTROLIG_UTLAND.enhetNr))
+                }
+            }
+
+            AdressebeskyttelseGradering.STRENGT_FORTROLIG -> {
+                if (sak.enhet != Enheter.STRENGT_FORTROLIG.enhetNr) {
+                    skrivDao.oppdaterEnhet(SakMedEnhet(sak.id, Enheter.STRENGT_FORTROLIG.enhetNr))
+                }
+            }
+
+            AdressebeskyttelseGradering.FORTROLIG -> return
+            AdressebeskyttelseGradering.UGRADERT -> return
+        }
+    }
+
+    override fun oppdaterSkjerming(
+        sakId: SakId,
+        skjermet: Boolean,
+    ) {
+        skrivDao.oppdaterSkjerming(sakId, skjermet)
+    }
+}

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/AdressebeskyttelseTest.kt
@@ -151,7 +151,7 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
                     Assertions.assertEquals(HttpStatusCode.OK, it.status)
                 }
         }
-        coVerify(exactly = 3) {
+        coVerify(exactly = 4) {
             pdltjenesterKlient.hentAdressebeskyttelseForPerson(match { it.ident.value == fnr })
         }
     }
@@ -302,7 +302,7 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
                     }
             Assertions.assertFalse(harIkkeTilgang)
         }
-        coVerify(exactly = 3) {
+        coVerify(exactly = 4) {
             pdltjenesterKlient.hentAdressebeskyttelseForPerson(match { it.ident.value == fnr })
         }
     }
@@ -349,7 +349,7 @@ class AdressebeskyttelseTest : BehandlingIntegrationTest() {
                     Assertions.assertEquals(HttpStatusCode.Forbidden, status)
                 }
         }
-        coVerify(exactly = 2) {
+        coVerify(exactly = 3) {
             pdltjenesterKlient.hentAdressebeskyttelseForPerson(match { it.ident.value == fnr })
         }
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
@@ -2,24 +2,18 @@ package no.nav.etterlatte.adressebeskyttelse
 
 import behandling.tilbakekreving.kravgrunnlag
 import behandling.tilbakekreving.tilbakekrevingVurdering
-import io.mockk.mockk
 import no.nav.etterlatte.ConnectionAutoclosingTest
 import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.azureAdEgenAnsattClaim
 import no.nav.etterlatte.azureAdFortroligClaim
 import no.nav.etterlatte.azureAdStrengtFortroligClaim
 import no.nav.etterlatte.behandling.BehandlingDao
-import no.nav.etterlatte.behandling.BrukerService
 import no.nav.etterlatte.behandling.klage.KlageDao
 import no.nav.etterlatte.behandling.klage.KlageDaoImpl
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeDao
 import no.nav.etterlatte.behandling.revurdering.RevurderingDao
 import no.nav.etterlatte.behandling.tilbakekreving.TilbakekrevingDao
 import no.nav.etterlatte.common.Enheter
-import no.nav.etterlatte.common.klienter.PdlTjenesterKlient
-import no.nav.etterlatte.common.klienter.SkjermingKlientImpl
-import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
-import no.nav.etterlatte.grunnlag.GrunnlagService
 import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.InnkommendeKlage
@@ -33,17 +27,15 @@ import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingStatus
 import no.nav.etterlatte.libs.ktor.token.Claims
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.opprettBehandling
-import no.nav.etterlatte.person.krr.KrrKlient
 import no.nav.etterlatte.sak.SakLesDao
-import no.nav.etterlatte.sak.SakService
-import no.nav.etterlatte.sak.SakServiceImpl
 import no.nav.etterlatte.sak.SakSkrivDao
+import no.nav.etterlatte.sak.SakTilgang
 import no.nav.etterlatte.sak.SakTilgangDao
+import no.nav.etterlatte.sak.SakTilgangImpl
 import no.nav.etterlatte.sak.SakendringerDao
 import no.nav.etterlatte.sak.TilgangServiceSjekker
 import no.nav.etterlatte.sak.TilgangServiceSjekkerImpl
 import no.nav.etterlatte.tilgangsstyring.AzureGroup
-import no.nav.etterlatte.tilgangsstyring.OppdaterTilgangService
 import no.nav.etterlatte.tilgangsstyring.SaksbehandlerMedRoller
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
@@ -60,41 +52,21 @@ internal class TilgangServiceTest(
     val dataSource: DataSource,
 ) {
     private lateinit var tilgangService: TilgangServiceSjekker
-    private lateinit var sakService: SakService
-    private lateinit var sakRepo: SakSkrivDao
+    private lateinit var sakSkrivDao: SakSkrivDao
     private lateinit var sakLesDao: SakLesDao
     private lateinit var sakendringerDao: SakendringerDao
     private lateinit var behandlingRepo: BehandlingDao
     private lateinit var klageDao: KlageDao
     private lateinit var tilbakekrevingDao: TilbakekrevingDao
-    private val brukerService = mockk<BrukerService>()
-    private val skjermingKlient = mockk<SkjermingKlientImpl>()
-    private val grunnlagservice = mockk<GrunnlagService>()
-    private val krrKlient = mockk<KrrKlient>()
-    private val pdlTjenesterKlient = mockk<PdlTjenesterKlient>()
-    private val featureToggle = mockk<FeatureToggleService>()
-    private val oppdaterTilgangService = mockk<OppdaterTilgangService>()
+    private lateinit var sakTilgang: SakTilgang
 
     @BeforeAll
     fun beforeAll() {
         tilgangService = TilgangServiceSjekkerImpl(SakTilgangDao(dataSource))
         sakLesDao = SakLesDao(ConnectionAutoclosingTest(dataSource))
-        sakRepo = SakSkrivDao(SakendringerDao(ConnectionAutoclosingTest(dataSource)))
+        sakSkrivDao = SakSkrivDao(SakendringerDao(ConnectionAutoclosingTest(dataSource)))
         sakendringerDao = SakendringerDao(ConnectionAutoclosingTest(dataSource))
-
-        sakService =
-            SakServiceImpl(
-                sakRepo,
-                sakLesDao,
-                sakendringerDao,
-                skjermingKlient,
-                brukerService,
-                grunnlagservice,
-                krrKlient,
-                pdlTjenesterKlient,
-                featureToggle,
-                oppdaterTilgangService,
-            )
+        sakTilgang = SakTilgangImpl(sakSkrivDao, sakLesDao)
         behandlingRepo =
             BehandlingDao(
                 KommerBarnetTilGodeDao(ConnectionAutoclosingTest(dataSource)),
@@ -108,13 +80,13 @@ internal class TilgangServiceTest(
     @Test
     fun `Skal kunne sette adressebeskyttelse på sak`() {
         val fnr = AVDOED_FOEDSELSNUMMER.value
-        val sakId = sakRepo.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr).id
+        val sakId = sakSkrivDao.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr).id
         val saksbehandlerMedRoller =
             SaksbehandlerMedRoller(
                 simpleSaksbehandler(),
                 emptyMap(),
             )
-        sakService.oppdaterAdressebeskyttelse(sakId, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
+        sakTilgang.oppdaterAdressebeskyttelse(sakId, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
 
         val opprettBehandling =
             opprettBehandling(
@@ -134,14 +106,14 @@ internal class TilgangServiceTest(
     @Test
     fun `Skal sjekke tilganger til klager med klageId for behandlingId`() {
         val fnr = AVDOED_FOEDSELSNUMMER.value
-        val sak = sakRepo.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr)
+        val sak = sakSkrivDao.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr)
 
         val saksbehandlerMedStrengtfortrolig =
             SaksbehandlerMedRoller(
                 simpleSaksbehandler(ident = "ident", claims = mapOf(Claims.groups to azureAdStrengtFortroligClaim)),
                 mapOf(AzureGroup.STRENGT_FORTROLIG to azureAdStrengtFortroligClaim),
             )
-        sakService.oppdaterAdressebeskyttelse(sak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
+        sakTilgang.oppdaterAdressebeskyttelse(sak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
         val klage =
             Klage.ny(
                 sak,
@@ -187,14 +159,14 @@ internal class TilgangServiceTest(
     @Test
     fun `Skal sjekke tilganger til tilbakekreving med tilbakekrevingId for behandlingId`() {
         val fnr = AVDOED_FOEDSELSNUMMER.value
-        val sak = sakRepo.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr)
+        val sak = sakSkrivDao.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr)
 
         val saksbehandlerMedStrengtfortrolig =
             SaksbehandlerMedRoller(
                 simpleSaksbehandler(ident = "ident", claims = mapOf(Claims.groups to azureAdStrengtFortroligClaim)),
                 mapOf(AzureGroup.STRENGT_FORTROLIG to azureAdStrengtFortroligClaim),
             )
-        sakService.oppdaterAdressebeskyttelse(sak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
+        sakTilgang.oppdaterAdressebeskyttelse(sak.id, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
         val tilbakekreving =
             TilbakekrevingBehandling(
                 UUID.randomUUID(),
@@ -246,14 +218,14 @@ internal class TilgangServiceTest(
     @Test
     fun `Skal kunne sette strengt fortrolig på sak og se på den med riktig rolle men ikke fortrolig rolle`() {
         val fnr = AVDOED_FOEDSELSNUMMER.value
-        val sakId = sakRepo.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr).id
+        val sakId = sakSkrivDao.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.defaultEnhet.enhetNr).id
 
         val saksbehandlerMedStrengtfortrolig =
             SaksbehandlerMedRoller(
                 simpleSaksbehandler(claims = mapOf(Claims.groups to azureAdStrengtFortroligClaim)),
                 mapOf(AzureGroup.STRENGT_FORTROLIG to azureAdStrengtFortroligClaim),
             )
-        sakService.oppdaterAdressebeskyttelse(sakId, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
+        sakTilgang.oppdaterAdressebeskyttelse(sakId, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
 
         val opprettBehandling =
             opprettBehandling(
@@ -286,7 +258,7 @@ internal class TilgangServiceTest(
     @Test
     fun `Skal kunne se på skjermet sak hvis riktig rolle`() {
         val fnr = AVDOED_FOEDSELSNUMMER.value
-        val sakId = sakRepo.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.EGNE_ANSATTE.enhetNr).id
+        val sakId = sakSkrivDao.opprettSak(fnr, SakType.BARNEPENSJON, Enheter.EGNE_ANSATTE.enhetNr).id
         val saksbehandlerMedStrengtfortrolig =
             SaksbehandlerMedRoller(
                 simpleSaksbehandler(claims = mapOf(Claims.groups to azureAdStrengtFortroligClaim)),
@@ -307,7 +279,7 @@ internal class TilgangServiceTest(
 
         Assertions.assertEquals(true, hartilgangtilvanligsak)
 
-        sakRepo.oppdaterSkjerming(sakId, true)
+        sakSkrivDao.oppdaterSkjerming(sakId, true)
 
         val hartilgangSomStrengtFortroligMotEgenAnsattSak =
             tilgangService.harTilgangTilBehandling(

--- a/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/adressebeskyttelse/TilgangServiceTest.kt
@@ -43,6 +43,7 @@ import no.nav.etterlatte.sak.SakendringerDao
 import no.nav.etterlatte.sak.TilgangServiceSjekker
 import no.nav.etterlatte.sak.TilgangServiceSjekkerImpl
 import no.nav.etterlatte.tilgangsstyring.AzureGroup
+import no.nav.etterlatte.tilgangsstyring.OppdaterTilgangService
 import no.nav.etterlatte.tilgangsstyring.SaksbehandlerMedRoller
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
@@ -72,6 +73,7 @@ internal class TilgangServiceTest(
     private val krrKlient = mockk<KrrKlient>()
     private val pdlTjenesterKlient = mockk<PdlTjenesterKlient>()
     private val featureToggle = mockk<FeatureToggleService>()
+    private val oppdaterTilgangService = mockk<OppdaterTilgangService>()
 
     @BeforeAll
     fun beforeAll() {
@@ -91,6 +93,7 @@ internal class TilgangServiceTest(
                 krrKlient,
                 pdlTjenesterKlient,
                 featureToggle,
+                oppdaterTilgangService,
             )
         behandlingRepo =
             BehandlingDao(

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/ManuellRevurderingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/ManuellRevurderingServiceTest.kt
@@ -760,12 +760,13 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
             behandlingInfoService = mockk(),
             tilgangsService =
                 OppdaterTilgangService(
-                    applicationContext.sakService,
                     applicationContext.skjermingKlient,
                     applicationContext.pdlTjenesterKlient,
                     applicationContext.brukerService,
                     applicationContext.oppgaveService,
                     applicationContext.sakSkrivDao,
+                    applicationContext.sakTilgang,
+                    applicationContext.sakLesDao,
                 ),
         )
 }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/OmgjoeringKlageRevurderingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/OmgjoeringKlageRevurderingServiceTest.kt
@@ -260,12 +260,13 @@ class OmgjoeringKlageRevurderingServiceTest : BehandlingIntegrationTest() {
             behandlingInfoService = mockk(),
             tilgangsService =
                 OppdaterTilgangService(
-                    applicationContext.sakService,
                     applicationContext.skjermingKlient,
                     applicationContext.pdlTjenesterKlient,
                     applicationContext.brukerService,
                     applicationContext.oppgaveService,
                     applicationContext.sakSkrivDao,
+                    applicationContext.sakTilgang,
+                    applicationContext.sakLesDao,
                 ),
         )
 }

--- a/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/egenansatt/EgenAnsattServiceTest.kt
@@ -42,6 +42,8 @@ import no.nav.etterlatte.sak.SakLesDao
 import no.nav.etterlatte.sak.SakService
 import no.nav.etterlatte.sak.SakServiceImpl
 import no.nav.etterlatte.sak.SakSkrivDao
+import no.nav.etterlatte.sak.SakTilgang
+import no.nav.etterlatte.sak.SakTilgangImpl
 import no.nav.etterlatte.sak.SakendringerDao
 import no.nav.etterlatte.tilgangsstyring.OppdaterTilgangService
 import no.nav.etterlatte.tilgangsstyring.SaksbehandlerMedRoller
@@ -68,6 +70,7 @@ internal class EgenAnsattServiceTest(
     private lateinit var egenAnsattService: EgenAnsattService
     private lateinit var oppdaterTilgangService: OppdaterTilgangService
     private lateinit var user: SaksbehandlerMedEnheterOgRoller
+    private lateinit var sakTilgang: SakTilgang
     private val grunnlagService: GrunnlagService = mockk(relaxed = true)
     private val hendelser: BehandlingHendelserKafkaProducer = mockk()
     private val pdlTjenesterKlient = spyk<PdltjenesterKlientTest>()
@@ -103,6 +106,7 @@ internal class EgenAnsattServiceTest(
         sakendringerDao = SakendringerDao(ConnectionAutoclosingTest(dataSource))
         oppgaveRepo = OppgaveDaoImpl(ConnectionAutoclosingTest(dataSource))
         oppgaveRepoMedSporing = OppgaveDaoMedEndringssporingImpl(oppgaveRepo, ConnectionAutoclosingTest(dataSource))
+        sakTilgang = SakTilgangImpl(sakSkrivDao, sakLesDao)
         val brukerService = BrukerServiceImpl(pdlTjenesterKlient, norg2Klient)
 
         sakService =
@@ -118,6 +122,7 @@ internal class EgenAnsattServiceTest(
                     pdlTjenesterKlient,
                     featureToggleService,
                     oppdaterTilgangService,
+                    sakTilgang,
                 ),
             )
         oppgaveService =
@@ -186,6 +191,5 @@ internal class EgenAnsattServiceTest(
         egenAnsattService.haandterSkjerming(egenAnsattSkjermet)
 
         verify(exactly = 3) { oppdaterTilgangService.haandtergraderingOgEgenAnsatt(bruktSak.id, any()) }
-        verify(exactly = 0) { sakService.oppdaterSkjerming(any(), any()) }
     }
 }

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/BehandlingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/BehandlingIntegrationTest.kt
@@ -20,7 +20,6 @@ import no.nav.etterlatte.config.ApplicationContext
 import no.nav.etterlatte.funksjonsbrytere.DummyFeatureToggleService
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.grunnlag.GrunnlagService
-import no.nav.etterlatte.grunnlag.aldersovergang.IAldersovergangDao
 import no.nav.etterlatte.kafka.KafkaKey
 import no.nav.etterlatte.kafka.TestProdusent
 import no.nav.etterlatte.ktor.token.issueSaksbehandlerToken
@@ -55,7 +54,6 @@ abstract class BehandlingIntegrationTest {
         tilbakekrevingKlient: TilbakekrevingKlient? = null,
         testProdusent: TestProdusent<String, String>? = null,
         skjermingKlient: SkjermingKlient? = null,
-        aldersovergangDao: IAldersovergangDao? = null,
         vedtakKlient: VedtakKlient? = null,
         grunnlagService: GrunnlagService? = null,
     ) {

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakServiceTest.kt
@@ -60,6 +60,7 @@ import no.nav.etterlatte.person.krr.KrrKlient
 import no.nav.etterlatte.saksbehandler.SaksbehandlerEnhet
 import no.nav.etterlatte.saksbehandler.SaksbehandlerService
 import no.nav.etterlatte.tilgangsstyring.AzureGroup
+import no.nav.etterlatte.tilgangsstyring.OppdaterTilgangService
 import no.nav.etterlatte.tilgangsstyring.SaksbehandlerMedRoller
 import no.nav.security.token.support.core.context.TokenValidationContext
 import no.nav.security.token.support.core.jwt.JwtToken
@@ -84,6 +85,7 @@ internal class SakServiceTest {
     private val grunnlagservice = mockk<GrunnlagService>()
     private val krrKlient = mockk<KrrKlient>()
     private val featureToggleService = mockk<FeatureToggleService>()
+    private val oppdaterTilgangService = mockk<OppdaterTilgangService>()
 
     private val service: SakService =
         SakServiceImpl(
@@ -96,6 +98,7 @@ internal class SakServiceTest {
             krrKlient,
             pdlTjenesterKlient,
             featureToggleService,
+            oppdaterTilgangService,
         )
 
     @BeforeEach
@@ -106,6 +109,7 @@ internal class SakServiceTest {
          Gjelder ikke for oppdaterIdentForSak()
          */
         coEvery { grunnlagservice.opprettGrunnlag(any(), any()) } just runs
+        every { grunnlagservice.hentPersongalleri(any(SakId::class)) } returns null
         every { grunnlagservice.lagreNyeSaksopplysningerBareSak(any(), any()) } just runs
 
         coEvery { krrKlient.hentDigitalKontaktinformasjon(any()) } returns

--- a/apps/etterlatte-behandling/src/test/kotlin/sak/SakServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/sak/SakServiceTest.kt
@@ -86,7 +86,7 @@ internal class SakServiceTest {
     private val krrKlient = mockk<KrrKlient>()
     private val featureToggleService = mockk<FeatureToggleService>()
     private val oppdaterTilgangService = mockk<OppdaterTilgangService>()
-
+    private val saktilgang = mockk<SakTilgang>(relaxed = true)
     private val service: SakService =
         SakServiceImpl(
             sakSkrivDao,
@@ -99,6 +99,7 @@ internal class SakServiceTest {
             pdlTjenesterKlient,
             featureToggleService,
             oppdaterTilgangService,
+            saktilgang,
         )
 
     @BeforeEach
@@ -467,7 +468,7 @@ internal class SakServiceTest {
         verify(exactly = 1) {
             sakSkrivDao.opprettSak(KONTANT_FOT.value, SakType.BARNEPENSJON, Enheter.PORSGRUNN.enhetNr)
         }
-        verify(exactly = 1) { sakSkrivDao.oppdaterAdresseBeskyttelse(sak.id, AdressebeskyttelseGradering.UGRADERT) }
+        verify(exactly = 1) { saktilgang.oppdaterAdressebeskyttelse(sak.id, AdressebeskyttelseGradering.UGRADERT) }
     }
 
     @Test
@@ -522,7 +523,7 @@ internal class SakServiceTest {
             sak1
 
         verify(exactly = 1) {
-            service.oppdaterAdressebeskyttelse(
+            saktilgang.oppdaterAdressebeskyttelse(
                 sak.id,
                 AdressebeskyttelseGradering.STRENGT_FORTROLIG,
             )
@@ -551,7 +552,6 @@ internal class SakServiceTest {
         verify(exactly = 1) {
             sakSkrivDao.opprettSak(KONTANT_FOT.value, SakType.BARNEPENSJON, Enheter.PORSGRUNN.enhetNr)
         }
-        verify(exactly = 1) { sakSkrivDao.oppdaterEnhet(any()) }
     }
 
     @Test
@@ -622,7 +622,7 @@ internal class SakServiceTest {
             sakSkrivDao.opprettSak(KONTANT_FOT.value, SakType.BARNEPENSJON, Enheter.EGNE_ANSATTE.enhetNr)
         }
         verify(exactly = 1) { sakSkrivDao.oppdaterEnhet(any()) }
-        verify(exactly = 1) { sakSkrivDao.oppdaterAdresseBeskyttelse(sak.id, AdressebeskyttelseGradering.UGRADERT) }
+        verify(exactly = 1) { saktilgang.oppdaterAdressebeskyttelse(sak.id, AdressebeskyttelseGradering.UGRADERT) }
     }
 
     @Test


### PR DESCRIPTION
Dødshendelser har overskredet skjerminger ved å fjerne 3-parts markeringer. Gjør slik at det alltid sjekkes etter opprettssaken og basert på om det er persongalleri eller ikke så gjør vi den sjekken. PG er et krav for den sjekken.

Oppfølging:

- Dødsmeldinger må sjekke om det finnes behandlinger på berørt før man sender brev -> https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/7314