### PR TITLE
Legger til override for å laste brev via behandling for etteroppgjøret

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/ForhaandsvisningBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/ForhaandsvisningBrev.tsx
@@ -8,7 +8,13 @@ import { genererPdf } from '~shared/api/brev'
 import { mapResult } from '~shared/api/apiUtils'
 import { ApiErrorAlert } from '~ErrorBoundary'
 
-export default function ForhaandsvisningBrev({ brev }: { brev: IBrev }) {
+export default function ForhaandsvisningBrev({
+  brev,
+  skalGaaViaBehandling,
+}: {
+  brev: IBrev
+  skalGaaViaBehandling?: boolean
+}) {
   const [fileURL, setFileURL] = useState<string>()
   const [pdf, genererBrevPdf] = useApiCall(genererPdf)
 
@@ -26,6 +32,7 @@ export default function ForhaandsvisningBrev({ brev }: { brev: IBrev }) {
         behandlingId: brev.behandlingId,
         sakId: brev.sakId,
         brevtype: brev.brevtype,
+        skalGaaViaBehandling: skalGaaViaBehandling,
       },
       (bytes) => {
         const blob = new Blob([bytes], { type: 'application/pdf' })

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/RedigerbartBrev.tsx
@@ -30,6 +30,7 @@ interface RedigerbartBrevProps {
   kanRedigeres: boolean
   lukkAdvarselBehandlingEndret?: () => void
   tilbakestillingsaction: () => void
+  skalGaaViaBehandling?: boolean
 }
 
 export default function RedigerbartBrev({
@@ -37,6 +38,7 @@ export default function RedigerbartBrev({
   kanRedigeres,
   lukkAdvarselBehandlingEndret,
   tilbakestillingsaction,
+  skalGaaViaBehandling,
 }: RedigerbartBrevProps) {
   const [fane, setFane] = useState<string>(kanRedigeres ? ManueltBrevFane.REDIGER : ManueltBrevFane.FORHAANDSVIS)
   const [content, setContent] = useState<any[]>([])
@@ -208,7 +210,7 @@ export default function RedigerbartBrev({
         </Tabs.Panel>
 
         <Tabs.Panel value={ManueltBrevFane.FORHAANDSVIS}>
-          <ForhaandsvisningBrev brev={brev} />
+          <ForhaandsvisningBrev skalGaaViaBehandling={skalGaaViaBehandling} brev={brev} />
         </Tabs.Panel>
       </Tabs>
     </Container>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/brev/EtteroppgjoerBrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/brev/EtteroppgjoerBrev.tsx
@@ -36,7 +36,7 @@ export function EtteroppgjoerBrev() {
   return (
     <HStack height="100%" minHeight="100%" wrap={false}>
       <Box minWidth="30rem" maxWidth="40rem" borderColor="border-subtle" borderWidth="0 1 0 0">
-        <VStack gap="4" margin="16" width="100%">
+        <VStack gap="4" margin="16">
           <Heading level="1" size="large">
             Brev
           </Heading>
@@ -56,7 +56,12 @@ export function EtteroppgjoerBrev() {
         })}
         {mapResult(brevResult, {
           success: (brev) => (
-            <RedigerbartBrev brev={brev} kanRedigeres={true} tilbakestillingsaction={() => alert('Not supported')} />
+            <RedigerbartBrev
+              brev={brev}
+              kanRedigeres={true}
+              skalGaaViaBehandling
+              tilbakestillingsaction={() => alert('Not supported')}
+            />
           ),
           error: (error) => (
             <ApiErrorAlert>

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/brev.ts
@@ -87,8 +87,9 @@ export const genererPdf = async (props: {
   sakId?: number
   behandlingId?: string
   brevtype: Brevtype
+  skalGaaViaBehandling?: boolean
 }): Promise<ApiResponse<ArrayBuffer>> => {
-  if (props.brevtype === Brevtype.VEDTAK) {
+  if (props.brevtype === Brevtype.VEDTAK || props.skalGaaViaBehandling) {
     return apiClient.get(`/behandling/brev/${props.behandlingId}/pdf?brevId=${props.brevId}&sakId=${props.sakId}`)
   } else if (props.brevtype === Brevtype.VARSEL) {
     return apiClient.get(`/brev/behandling/${props.behandlingId}/varsel/pdf?brevId=${props.brevId}`)


### PR DESCRIPTION
Siden eksisterende sjekker ser på brevtypen, og etteroppgjør har andre brev enn vedtak som skal gå via behandlingsflyten for brev, så legges på et parameter som overstyrer at vi skal gå via behandling for å generere brevene.