### PR TITLE
fjerne brevId i logg som ikke sendes inn

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevRouteNy.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevRouteNy.kt
@@ -107,7 +107,7 @@ fun Route.strukturertBrevRoute(
 
         post("ferdigstill/{$BREV_TYPE_CALL_PARAMETER}") {
             withBehandlingId(tilgangssjekker, skrivetilgang = true) { behandlingId ->
-                logger.info("Ferdigstiller strukturert brev med id=$brevId for behandling (id=$behandlingId)")
+                logger.info("Ferdigstiller strukturert brev for behandling (id=$behandlingId)")
                 val brevType =
                     krevIkkeNull(call.request.queryParameters[BREV_TYPE_CALL_PARAMETER]?.let { enumValueOf<Brevtype>(it) }) {
                         "Mangler brevtype-parameter"


### PR DESCRIPTION
Har dukket opp en referanse til brevId i logg som ikke sendes inn som param, feiler ved ferdigstilling av brev