### PR TITLE
rette feil ved henting av forbehandling etteroppgjør

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerModel.kt
@@ -33,10 +33,10 @@ enum class EtteroppgjoerStatus {
 // TODO falte ut behandling..
 data class DetaljertForbehandlingDto(
     val behandling: EtteroppgjoerForbehandling,
+    val sisteIverksatteBehandling: UUID,
     val opplysninger: EtteroppgjoerOpplysninger,
     val faktiskInntekt: FaktiskInntekt?,
     val avkortingFaktiskInntekt: AvkortingDto?,
-    val beregnetEtteroppgjoerResultat: BeregnetEtteroppgjoerResultatDto,
 )
 
 enum class EtteroppgjoerForbehandlingStatus {
@@ -232,25 +232,27 @@ data class EtteroppgjoerBrevRequestData(
 )
 
 object EtteroppgjoerBrevDataMapper {
-    fun fra(data: DetaljertForbehandlingDto) =
-        EtteroppgjoerBrevRequestData(
-            redigerbar =
-                ForhaandsvarselInnhold(
-                    sak = data.behandling.sak,
-                ),
-            innhold =
-                Forhaandsvarsel(
-                    bosattUtland = false, // TODO
-                    norskInntekt = false, // TODO
-                    etteroppgjoersAar = data.behandling.aar,
-                    rettsgebyrBeloep = Kroner(data.beregnetEtteroppgjoerResultat.grense.rettsgebyr),
-                    resultatType = data.beregnetEtteroppgjoerResultat.resultatType,
-                    inntekt = Kroner(data.beregnetEtteroppgjoerResultat.utbetaltStoenad.toInt()),
-                    faktiskInntekt = Kroner(data.beregnetEtteroppgjoerResultat.nyBruttoStoenad.toInt()),
-                    avviksBeloep = Kroner(data.beregnetEtteroppgjoerResultat.differanse.toInt()),
-                ),
-            data = data,
-        )
+    fun fra(
+        data: DetaljertForbehandlingDto,
+        beregnetEtteroppgjoerResultat: BeregnetEtteroppgjoerResultatDto,
+    ) = EtteroppgjoerBrevRequestData(
+        redigerbar =
+            ForhaandsvarselInnhold(
+                sak = data.behandling.sak,
+            ),
+        innhold =
+            Forhaandsvarsel(
+                bosattUtland = false, // TODO
+                norskInntekt = false, // TODO
+                etteroppgjoersAar = data.behandling.aar,
+                rettsgebyrBeloep = Kroner(beregnetEtteroppgjoerResultat.grense.rettsgebyr),
+                resultatType = beregnetEtteroppgjoerResultat.resultatType,
+                inntekt = Kroner(beregnetEtteroppgjoerResultat.utbetaltStoenad.toInt()),
+                faktiskInntekt = Kroner(beregnetEtteroppgjoerResultat.nyBruttoStoenad.toInt()),
+                avviksBeloep = Kroner(beregnetEtteroppgjoerResultat.differanse.toInt()),
+            ),
+        data = data,
+    )
 }
 
 data class FaktiskInntekt(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -17,7 +17,6 @@ import no.nav.etterlatte.libs.common.beregning.BeregnetEtteroppgjoerResultatDto
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerBeregnFaktiskInntektRequest
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerBeregnetAvkortingRequest
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerFaktiskInntektRequest
-import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerHentBeregnetResultatRequest
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
@@ -92,18 +91,6 @@ class EtteroppgjoerForbehandlingService(
                 )
             }
 
-        val beregnetEtteroppgjoerResultat =
-            runBlocking {
-                beregningKlient.hentBeregnetEtteroppgjoerResultat(
-                    EtteroppgjoerHentBeregnetResultatRequest(
-                        forbehandling.aar,
-                        forbehandling.id,
-                        sisteIverksatteBehandling.id,
-                    ),
-                    brukerTokenInfo,
-                )
-            }
-
         val pensjonsgivendeInntekt = dao.hentPensjonsgivendeInntekt(behandlingId)
         val aInntekt = dao.hentAInntekt(behandlingId)
 
@@ -133,7 +120,7 @@ class EtteroppgjoerForbehandlingService(
                 ),
             faktiskInntekt = faktiskInntekt,
             avkortingFaktiskInntekt = avkorting.avkortingMedFaktiskInntekt,
-            beregnetEtteroppgjoerResultat = beregnetEtteroppgjoerResultat,
+            sisteIverksatteBehandling = sisteIverksatteBehandling.id,
         )
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -687,6 +687,7 @@ internal class ApplicationContext(
             brevApiKlient = brevApiKlient,
             grunnlagService = grunnlagService,
             etteroppgjoerForbehandlingService = etteroppgjoerForbehandlingService,
+            beregningKlient = beregningsKlient,
         )
     val brevService =
         BrevService(


### PR DESCRIPTION
Henting av beregnet resultat ble kjørt ved henting av forbehandling. Dette feiler for nye forbehandlinger som ikke enda har beregnet etteroppgjøret