### PR TITLE
EY-5160 opprette kopi av forbehandling ved oppretting av revurdering

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerModel.kt
@@ -97,6 +97,7 @@ enum class EtteroppgjoerForbehandlingStatus {
     OPPRETTET,
     BEREGNET,
     VARSELBREV_SENDT,
+    REVURDERING,
 }
 
 data class DetaljertForbehandlingDto(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerModel.kt
@@ -39,6 +39,7 @@ data class EtteroppgjoerForbehandling(
     val hendelseId: UUID,
     val opprettet: Tidspunkt,
     val status: EtteroppgjoerForbehandlingStatus,
+    val relatertForbehandlingId: UUID? = null,
     val sak: Sak,
     val aar: Int,
     val innvilgetPeriode: Periode,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerModel.kt
@@ -69,7 +69,7 @@ data class EtteroppgjoerForbehandling(
         }
     }
 
-    fun tilVarselbrevSendt(): EtteroppgjoerForbehandling {
+    fun tilFerdigstilt(): EtteroppgjoerForbehandling {
         if (status == EtteroppgjoerForbehandlingStatus.BEREGNET) {
             return copy(status = EtteroppgjoerForbehandlingStatus.FERDIGSTILT)
         } else {
@@ -79,14 +79,14 @@ data class EtteroppgjoerForbehandling(
 
     fun medBrev(opprettetBrev: Brev): EtteroppgjoerForbehandling = this.copy(brevId = opprettetBrev.id)
 
-    fun isUnderBehandling() =
+    fun erUnderBehandling() =
         status in
             listOf(
                 EtteroppgjoerForbehandlingStatus.OPPRETTET,
                 EtteroppgjoerForbehandlingStatus.BEREGNET,
             )
 
-    fun isFerdigstilt() =
+    fun erFerdigstilt() =
         status in
             listOf(
                 EtteroppgjoerForbehandlingStatus.FERDIGSTILT,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerModel.kt
@@ -71,9 +71,9 @@ data class EtteroppgjoerForbehandling(
 
     fun tilVarselbrevSendt(): EtteroppgjoerForbehandling {
         if (status == EtteroppgjoerForbehandlingStatus.BEREGNET) {
-            return copy(status = EtteroppgjoerForbehandlingStatus.VARSELBREV_SENDT)
+            return copy(status = EtteroppgjoerForbehandlingStatus.FERDIGSTILT)
         } else {
-            throw InternfeilException("Kunne ikke endre status fra $status til ${EtteroppgjoerForbehandlingStatus.VARSELBREV_SENDT}")
+            throw InternfeilException("Kunne ikke endre status fra $status til ${EtteroppgjoerForbehandlingStatus.FERDIGSTILT}")
         }
     }
 
@@ -89,15 +89,14 @@ data class EtteroppgjoerForbehandling(
     fun isFerdigstilt() =
         status in
             listOf(
-                EtteroppgjoerForbehandlingStatus.VARSELBREV_SENDT,
+                EtteroppgjoerForbehandlingStatus.FERDIGSTILT,
             )
 }
 
 enum class EtteroppgjoerForbehandlingStatus {
     OPPRETTET,
     BEREGNET,
-    VARSELBREV_SENDT,
-    REVURDERING,
+    FERDIGSTILT,
 }
 
 data class DetaljertForbehandlingDto(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingDao.kt
@@ -36,7 +36,7 @@ class EtteroppgjoerForbehandlingDao(
                 val statement =
                     prepareStatement(
                         """
-                        SELECT t.id, t.sak_id, s.saktype, s.fnr, s.enhet, t.opprettet, t.status, t.aar, t.fom, t.tom, t.brev_id
+                        SELECT t.id, t.sak_id, s.saktype, s.fnr, s.enhet, t.opprettet, t.status, t.aar, t.fom, t.tom, t.brev_id, t.relatert_forbehandling_id
                         FROM etteroppgjoer_behandling t INNER JOIN sak s on t.sak_id = s.id
                         WHERE t.id = ?
                         """.trimIndent(),
@@ -52,7 +52,7 @@ class EtteroppgjoerForbehandlingDao(
                 val statement =
                     prepareStatement(
                         """
-                        SELECT t.id, t.sak_id, s.saktype, s.fnr, s.enhet, t.opprettet, t.status, t.aar, t.fom, t.tom, t.brev_id
+                        SELECT t.id, t.sak_id, s.saktype, s.fnr, s.enhet, t.opprettet, t.status, t.aar, t.fom, t.tom, t.brev_id, t.relatert_forbehandling_id
                         FROM etteroppgjoer_behandling t INNER JOIN sak s on t.sak_id = s.id
                         WHERE t.sak_id = ?
                         """.trimIndent(),
@@ -69,9 +69,9 @@ class EtteroppgjoerForbehandlingDao(
                     prepareStatement(
                         """
                         INSERT INTO etteroppgjoer_behandling(
-                            id, status, sak_id, opprettet, aar, fom, tom, brev_id
+                            id, status, sak_id, opprettet, aar, fom, tom, brev_id, relatert_forbehandling_id
                         ) 
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?) 
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) 
                         ON CONFLICT (id) DO UPDATE SET
                             status = excluded.status,
                             brev_id = excluded.brev_id
@@ -91,6 +91,8 @@ class EtteroppgjoerForbehandlingDao(
                     ),
                 )
                 statement.setLong(8, forbehandling.brevId)
+                statement.setObject(9, forbehandling.relatertForbehandlingId)
+
                 statement.executeUpdate().also {
                     krev(it == 1) {
                         "Kunne ikke lagre forbehandling etteroppgjør for sakId=${forbehandling.sak.id}"
@@ -231,6 +233,7 @@ class EtteroppgjoerForbehandlingDao(
                     tom = getDate("tom").let { YearMonth.from(it.toLocalDate()) },
                 ),
             brevId = getLongOrNull("brev_id"),
+            relatertForbehandlingId = getString("relatert_forbehandling_id").let { UUID.fromString(it) },
         )
 
     private fun ResultSet.toPensjonsgivendeInntekt(): PensjonsgivendeInntekt =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingDao.kt
@@ -233,7 +233,7 @@ class EtteroppgjoerForbehandlingDao(
                     tom = getDate("tom").let { YearMonth.from(it.toLocalDate()) },
                 ),
             brevId = getLongOrNull("brev_id"),
-            relatertForbehandlingId = getString("relatert_forbehandling_id").let { UUID.fromString(it) },
+            relatertForbehandlingId = getString("relatert_forbehandling_id")?.let { UUID.fromString(it) },
         )
 
     private fun ResultSet.toPensjonsgivendeInntekt(): PensjonsgivendeInntekt =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -129,7 +129,11 @@ class EtteroppgjoerForbehandlingService(
 
         // hvis relatertForbehandlingId er satt, vis faktiskInntekt fra forrige ferdigstilte forbehandling
         // slik at saksbehandler kan se hva som ble satt og kan korrigere
-        val relevantBehandlingId = forbehandling.relatertForbehandlingId ?: forbehandling.id
+        val relevantBehandlingId = forbehandling.relatertForbehandlingId ?: forbehandlingId
+        if (relevantBehandlingId != forbehandlingId) {
+            logger.info("Henter faktiskInntekt for forbehandling $forbehandlingId fra forbehandling $relevantBehandlingId")
+        }
+
         val faktiskInntekt =
             runBlocking {
                 beregningKlient.hentAvkortingFaktiskInntekt(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -29,6 +29,7 @@ import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vedtak.FoersteVirkOgOppoerTilSak
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.HardkodaSystembruker
@@ -83,6 +84,7 @@ class EtteroppgjoerForbehandlingService(
                 id = UUID.randomUUID(),
                 relatertForbehandlingId = forbehandling.id,
                 status = EtteroppgjoerForbehandlingStatus.OPPRETTET,
+                opprettet = Tidspunkt.now(), // ny dato
             )
 
         dao.lagreForbehandling(forbehandlingCopy)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -253,7 +253,7 @@ class EtteroppgjoerForbehandlingService(
         inntektsaar: Int,
     ) {
         val forbehandlinger = hentEtteroppgjoerForbehandlinger(sak.id)
-        if (forbehandlinger.any { it.aar == inntektsaar && !it.isFerdigstilt() }) {
+        if (forbehandlinger.any { it.aar == inntektsaar && !it.erFerdigstilt() }) {
             throw InternfeilException("Kan ikke opprette forbehandling fordi det allerede finnes en forbehandling som ikke er ferdigstilt")
         }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -82,14 +82,12 @@ class EtteroppgjoerForbehandlingService(
             forbehandling.copy(
                 id = UUID.randomUUID(),
                 relatertForbehandlingId = forbehandling.id,
-                status = EtteroppgjoerForbehandlingStatus.REVURDERING,
+                status = EtteroppgjoerForbehandlingStatus.OPPRETTET,
             )
 
         dao.lagreForbehandling(forbehandlingCopy)
         dao.kopierAInntekt(forbehandling.id, forbehandlingCopy.id)
         dao.kopierPensjonsgivendeInntekt(forbehandling.id, forbehandlingCopy.id)
-
-        // TODO: burde egentlig kopiere faktiskInntekt også i beregning, hvis ikke vil dette vises som null?
 
         return forbehandlingCopy
     }
@@ -129,7 +127,8 @@ class EtteroppgjoerForbehandlingService(
             )
         }
 
-        // WIP - hente de som ble oppgitt i forrige forbehandling
+        // hvis relatertForbehandlingId er satt, vis faktiskInntekt fra forrige ferdigstilte forbehandling
+        // slik at saksbehandler kan se hva som ble satt og kan korrigere
         val relevantBehandlingId = forbehandling.relatertForbehandlingId ?: forbehandling.id
         val faktiskInntekt =
             runBlocking {
@@ -151,7 +150,6 @@ class EtteroppgjoerForbehandlingService(
                     brukerTokenInfo,
                 )
             }
-        // WIP END
 
         return DetaljertForbehandlingDto(
             behandling = forbehandling,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -76,6 +76,8 @@ class EtteroppgjoerForbehandlingService(
     fun hentForbehandling(behandlingId: UUID): EtteroppgjoerForbehandling =
         dao.hentForbehandling(behandlingId) ?: throw FantIkkeForbehandling(behandlingId)
 
+    fun lagreForbehandling(forbehandling: EtteroppgjoerForbehandling) = dao.lagreForbehandling(forbehandling)
+
     fun hentDetaljertForbehandling(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/revurdering/EtteroppgjoerRevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/revurdering/EtteroppgjoerRevurderingService.kt
@@ -48,7 +48,7 @@ class EtteroppgjoerRevurderingService(
                     throw InternfeilException("Forbehandlingen har ikke riktig status: ${forbehandling.status}")
                 }
 
-                // opprett ny kopi av forbehandling for revurdering så vi overskriver tidligere oppgitt inntekter
+                // lager kopi av forbehandling for revurdering slik at vi ikke overskriver tidligere oppgitt inntekt
                 val forbehandlingCopy = forbehandling.copy(id = UUID.randomUUID(), relatertForbehandlingId = forbehandling.id)
                 etteroppgjoerForbehandlingService.lagreForbehandling(forbehandlingCopy)
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/revurdering/EtteroppgjoerRevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/revurdering/EtteroppgjoerRevurderingService.kt
@@ -116,7 +116,7 @@ class EtteroppgjoerRevurderingService(
                     brukerTokenInfo = brukerTokenInfo,
                 )
 
-                etteroppgjoerService.oppdaterStatus(sakId, forbehandling.aar, EtteroppgjoerStatus.UNDER_REVURDERING)
+                etteroppgjoerService.oppdaterStatus(sakId, forbehandlingCopy.aar, EtteroppgjoerStatus.UNDER_REVURDERING)
 
                 revurdering to sisteIverksatte
             }
@@ -128,7 +128,6 @@ class EtteroppgjoerRevurderingService(
                 forrigeBehandlingId = sisteIverksatte.id,
                 brukerTokenInfo = brukerTokenInfo,
             )
-
             beregningKlient.opprettBeregningsgrunnlagFraForrigeBehandling(
                 behandlingId = revurdering.id,
                 forrigeBehandlingId = sisteIverksatte.id,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/revurdering/EtteroppgjoerRevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/revurdering/EtteroppgjoerRevurderingService.kt
@@ -44,7 +44,7 @@ class EtteroppgjoerRevurderingService(
         val (revurdering, sisteIverksatte) =
             inTransaction {
                 val forbehandling = etteroppgjoerForbehandlingService.hentForbehandling(forbehandlingId)
-                if (forbehandling.status !in listOf(EtteroppgjoerForbehandlingStatus.VARSELBREV_SENDT)) {
+                if (forbehandling.status !in listOf(EtteroppgjoerForbehandlingStatus.FERDIGSTILT)) {
                     throw InternfeilException("Forbehandlingen har ikke riktig status: ${forbehandling.status}")
                 }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/revurdering/EtteroppgjoerRevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/revurdering/EtteroppgjoerRevurderingService.kt
@@ -49,7 +49,12 @@ class EtteroppgjoerRevurderingService(
                 }
 
                 // lager kopi av forbehandling for revurdering slik at vi ikke overskriver tidligere oppgitt inntekt
-                val forbehandlingCopy = forbehandling.copy(id = UUID.randomUUID(), relatertForbehandlingId = forbehandling.id)
+                val forbehandlingCopy =
+                    forbehandling.copy(
+                        id = UUID.randomUUID(),
+                        relatertForbehandlingId = forbehandling.id,
+                        status = EtteroppgjoerForbehandlingStatus.REVURDERING,
+                    )
                 etteroppgjoerForbehandlingService.lagreForbehandling(forbehandlingCopy)
 
                 // TODO hva blir riktig her? vi ønsker ikke mer enn en oppgave, men kan det være oppgaver åpne på forbehandling?

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/revurdering/EtteroppgjoerRevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/revurdering/EtteroppgjoerRevurderingService.kt
@@ -49,13 +49,7 @@ class EtteroppgjoerRevurderingService(
                 }
 
                 // lager kopi av forbehandling for revurdering slik at vi ikke overskriver tidligere oppgitt inntekt
-                val forbehandlingCopy =
-                    forbehandling.copy(
-                        id = UUID.randomUUID(),
-                        relatertForbehandlingId = forbehandling.id,
-                        status = EtteroppgjoerForbehandlingStatus.REVURDERING,
-                    )
-                etteroppgjoerForbehandlingService.lagreForbehandling(forbehandlingCopy)
+                val forbehandlingCopy = etteroppgjoerForbehandlingService.lagreForbehandlingKopi(forbehandling)
 
                 // TODO hva blir riktig her? vi ønsker ikke mer enn en oppgave, men kan det være oppgaver åpne på forbehandling?
                 // revurderingService.maksEnOppgaveUnderbehandlingForKildeBehandling(sakId)

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V263__legge_til_nytt_felt_etteroppgjoer_forbehandling.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V263__legge_til_nytt_felt_etteroppgjoer_forbehandling.sql
@@ -1,0 +1,2 @@
+ALTER TABLE postgres.public.etteroppgjoer_behandling
+    ADD COLUMN relatert_forbehandling_id UUID;

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V263__legge_til_nytt_felt_etteroppgjoer_forbehandling.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V263__legge_til_nytt_felt_etteroppgjoer_forbehandling.sql
@@ -1,2 +1,2 @@
-ALTER TABLE postgres.public.etteroppgjoer_behandling
+ALTER TABLE etteroppgjoer_behandling
     ADD COLUMN relatert_forbehandling_id UUID;

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V263__legge_til_nytt_felt_etteroppgjoer_forbehandling.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V263__legge_til_nytt_felt_etteroppgjoer_forbehandling.sql
@@ -1,2 +1,6 @@
 ALTER TABLE etteroppgjoer_behandling
     ADD COLUMN relatert_forbehandling_id UUID;
+
+UPDATE etteroppgjoer_behandling
+SET status = 'FERDIGSTILT'
+WHERE status = 'VARSELBREV_SENDT';

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/etteroppgjoer/EtteroppgjoerForbehandlingDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/etteroppgjoer/EtteroppgjoerForbehandlingDaoTest.kt
@@ -125,4 +125,47 @@ class EtteroppgjoerForbehandlingDaoTest(
             inntektsmaaneder shouldBe AInntekt.stub(inntektsaar).inntektsmaaneder
         }
     }
+
+    @Test
+    fun `kopier aInntekt til ny forbehandling`() {
+        val inntektsaar = 2024
+        val forbehandlingId = UUID.randomUUID()
+        val nyForbehandlingId = UUID.randomUUID()
+        etteroppgjoerForbehandlingDao.hentAInntekt(forbehandlingId) shouldBe null
+        etteroppgjoerForbehandlingDao.hentAInntekt(nyForbehandlingId) shouldBe null
+        etteroppgjoerForbehandlingDao.lagreAInntekt(
+            AInntekt.stub(inntektsaar),
+            forbehandlingId,
+        )
+
+        etteroppgjoerForbehandlingDao.kopierAInntekt(forbehandlingId, nyForbehandlingId)
+
+        val aInntekt = etteroppgjoerForbehandlingDao.hentAInntekt(forbehandlingId)!!
+        val aInntektKopi = etteroppgjoerForbehandlingDao.hentAInntekt(nyForbehandlingId)!!
+
+        aInntekt.inntektsmaaneder shouldBe aInntektKopi.inntektsmaaneder
+        aInntekt.aar shouldBe aInntektKopi.aar
+    }
+
+    @Test
+    fun `kopier pensjonsgivendeInntekt til ny forbehandling`() {
+        val inntektsaar = 2024
+        val forbehandlingId = UUID.randomUUID()
+        val nyForbehandlingId = UUID.randomUUID()
+
+        etteroppgjoerForbehandlingDao.hentPensjonsgivendeInntekt(forbehandlingId) shouldBe null
+        etteroppgjoerForbehandlingDao.hentPensjonsgivendeInntekt(nyForbehandlingId) shouldBe null
+        etteroppgjoerForbehandlingDao.lagrePensjonsgivendeInntekt(
+            PensjonsgivendeInntektFraSkatt.stub(inntektsaar),
+            forbehandlingId,
+        )
+
+        etteroppgjoerForbehandlingDao.kopierPensjonsgivendeInntekt(forbehandlingId, nyForbehandlingId)
+
+        val pensjonsgivendeInntekt = etteroppgjoerForbehandlingDao.hentPensjonsgivendeInntekt(forbehandlingId)!!
+        val pensjonsgivendeInntektKopi = etteroppgjoerForbehandlingDao.hentPensjonsgivendeInntekt(nyForbehandlingId)!!
+
+        pensjonsgivendeInntekt.inntekter shouldBe pensjonsgivendeInntektKopi.inntekter
+        pensjonsgivendeInntekt.inntektsaar shouldBe pensjonsgivendeInntektKopi.inntektsaar
+    }
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/Etteroppgjoeroversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/Etteroppgjoeroversikt.tsx
@@ -43,7 +43,6 @@ export const Etteroppgjoeroversikt = ({ behandling }: { behandling: IDetaljertBe
           faktiskInntekt={etteroppgjoer.faktiskInntekt}
         />
         <ResultatAvForbehandling />
-
         <Box borderWidth="1 0 0 0" borderColor="border-subtle" paddingBlock="8 16">
           <HStack width="100%" justify="center">
             <NesteOgTilbake />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/oversiktOverEtteroppgjoer/fastsettFaktiskInntekt/FastsettFaktiskInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/oversiktOverEtteroppgjoer/fastsettFaktiskInntekt/FastsettFaktiskInntekt.tsx
@@ -53,8 +53,7 @@ export const FastsettFaktiskInntekt = ({
 
   const erRedigerbar =
     (behandling.status == EtteroppgjoerBehandlingStatus.OPPRETTET ||
-      behandling.status == EtteroppgjoerBehandlingStatus.BEREGNET ||
-      behandling.status == EtteroppgjoerBehandlingStatus.REVURDERING) &&
+      behandling.status == EtteroppgjoerBehandlingStatus.BEREGNET) &&
     enhetErSkrivbar(behandling.sak.enhet, innloggetSaksbehandler.skriveEnheter)
 
   const {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/oversiktOverEtteroppgjoer/fastsettFaktiskInntekt/FastsettFaktiskInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/oversiktOverEtteroppgjoer/fastsettFaktiskInntekt/FastsettFaktiskInntekt.tsx
@@ -52,8 +52,7 @@ export const FastsettFaktiskInntekt = ({
   const dispatch = useAppDispatch()
 
   const erRedigerbar =
-    (behandling.status == EtteroppgjoerBehandlingStatus.OPPRETTET ||
-      behandling.status == EtteroppgjoerBehandlingStatus.BEREGNET) &&
+    behandling.status != EtteroppgjoerBehandlingStatus.VARSELBREV_SENDT &&
     enhetErSkrivbar(behandling.sak.enhet, innloggetSaksbehandler.skriveEnheter)
 
   const {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/oversiktOverEtteroppgjoer/fastsettFaktiskInntekt/FastsettFaktiskInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/oversiktOverEtteroppgjoer/fastsettFaktiskInntekt/FastsettFaktiskInntekt.tsx
@@ -52,7 +52,9 @@ export const FastsettFaktiskInntekt = ({
   const dispatch = useAppDispatch()
 
   const erRedigerbar =
-    behandling.status != EtteroppgjoerBehandlingStatus.VARSELBREV_SENDT &&
+    (behandling.status == EtteroppgjoerBehandlingStatus.OPPRETTET ||
+      behandling.status == EtteroppgjoerBehandlingStatus.BEREGNET ||
+      behandling.status == EtteroppgjoerBehandlingStatus.REVURDERING) &&
     enhetErSkrivbar(behandling.sak.enhet, innloggetSaksbehandler.skriveEnheter)
 
   const {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/EtteroppgjoerForbehandlingListe.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/EtteroppgjoerForbehandlingListe.tsx
@@ -66,7 +66,7 @@ function EtteroppgjoerForbehandlingTabell({
               <Link href={lenkeTilForbehandlingMedId(forbehandling.id)}>Gå til behandling</Link>
             </Table.DataCell>
             <Table.DataCell>
-              {forbehandling.status == EtteroppgjoerBehandlingStatus.VARSELBREV_SENDT && (
+              {forbehandling.status == EtteroppgjoerBehandlingStatus.FERDIGSTILT && (
                 <Button
                   loading={isPending(opprettRevurderingResult)}
                   size="small"

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Etteroppgjoer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Etteroppgjoer.ts
@@ -27,16 +27,12 @@ export interface EtteroppgjoerBehandling {
 export enum EtteroppgjoerBehandlingStatus {
   OPPRETTET = 'OPPRETTET',
   BEREGNET = 'BEREGNET',
-  VARSELBREV_SENDT = 'VARSELBREV_SENDT',
-  REVURDERING = 'REVURDERING',
   FERDIGSTILT = 'FERDIGSTILT',
 }
 
 export const teksterEtteroppgjoerBehandlingStatus: Record<EtteroppgjoerBehandlingStatus, string> = {
   OPPRETTET: 'Opprettet',
   BEREGNET: 'Beregnet',
-  VARSELBREV_SENDT: 'Forhåndsvarsel sendt',
-  REVURDERING: 'Til revurdering',
   FERDIGSTILT: 'Ferdigstilt',
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Etteroppgjoer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Etteroppgjoer.ts
@@ -28,6 +28,7 @@ export enum EtteroppgjoerBehandlingStatus {
   BEREGNET = 'BEREGNET',
   VARSELBREV_SENDT = 'VARSELBREV_SENDT',
   REVURDERING = 'REVURDERING',
+  FERDIGSTILT = 'FERDIGSTILT',
 }
 
 export const teksterEtteroppgjoerBehandlingStatus: Record<EtteroppgjoerBehandlingStatus, string> = {
@@ -35,6 +36,7 @@ export const teksterEtteroppgjoerBehandlingStatus: Record<EtteroppgjoerBehandlin
   BEREGNET: 'Beregnet',
   VARSELBREV_SENDT: 'Forhåndsvarsel sendt',
   REVURDERING: 'Til revurdering',
+  FERDIGSTILT: 'Ferdigstilt',
 }
 
 export interface EtteroppgjoerOpplysninger {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Etteroppgjoer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Etteroppgjoer.ts
@@ -13,6 +13,7 @@ export interface Etteroppgjoer {
 export interface EtteroppgjoerBehandling {
   id: string
   status: EtteroppgjoerBehandlingStatus
+  relatertForbehandlingId: string // burde bruke denne for å hente faktiskInntekt etteroppgjør revurdering
   sak: ISak
   aar: number
   innvilgetPeriode: {

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Etteroppgjoer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Etteroppgjoer.ts
@@ -27,12 +27,14 @@ export enum EtteroppgjoerBehandlingStatus {
   OPPRETTET = 'OPPRETTET',
   BEREGNET = 'BEREGNET',
   VARSELBREV_SENDT = 'VARSELBREV_SENDT',
+  REVURDERING = 'REVURDERING',
 }
 
 export const teksterEtteroppgjoerBehandlingStatus: Record<EtteroppgjoerBehandlingStatus, string> = {
   OPPRETTET: 'Opprettet',
   BEREGNET: 'Beregnet',
   VARSELBREV_SENDT: 'Forhåndsvarsel sendt',
+  REVURDERING: 'Til revurdering',
 }
 
 export interface EtteroppgjoerOpplysninger {


### PR DESCRIPTION
Ved oppretting av revurdering for etteroppgjør oppretter vi og en kopi av forbehandling. Dette for å ikke overskrive inntekter i den første forbehandlingen. Den nye forbehandlingen viser faktisk inntekt fra forrige forbehandling via `relatertForbehandlingId`

TODO
- [ ] må ferdigstille forbehandling når revurdering ferdigstilles