### PR TITLE
FAGSYSTEM-374321: Sjekker kun søsken i beregning før 2024

### DIFF
--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/grunnlag/BeregningsGrunnlagServiceTest.kt
@@ -95,6 +95,10 @@ internal class BeregningsGrunnlagServiceTest {
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns
             mockk {
                 coEvery { sakType } returns SakType.BARNEPENSJON
+                coEvery { virkningstidspunkt } returns
+                    mockk {
+                        coEvery { dato } returns YearMonth.of(2022, 8)
+                    }
             }
         val behandlingId = randomUUID()
         val brukertokeninfo = simpleSaksbehandler()
@@ -129,6 +133,10 @@ internal class BeregningsGrunnlagServiceTest {
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns
             mockk {
                 coEvery { sakType } returns SakType.BARNEPENSJON
+                coEvery { virkningstidspunkt } returns
+                    mockk {
+                        coEvery { dato } returns YearMonth.of(2022, 8)
+                    }
             }
         val behandlingId = randomUUID()
         val brukertokeninfo = simpleSaksbehandler()


### PR DESCRIPTION
Fjerner validering av søsken i beregning dersom virkningstidspunkt er etter reformtidspunkt. Søskenjustering er da ikke aktuelt. 