### PR TITLE
Renamer reguleringskonfigurasjon til Omregningskonfigurasjon

### DIFF
--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/AppContext.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/AppContext.kt
@@ -28,9 +28,9 @@ import no.nav.etterlatte.tidshendelser.hendelser.HendelsePoller
 import no.nav.etterlatte.tidshendelser.hendelser.HendelsePollerTask
 import no.nav.etterlatte.tidshendelser.hendelser.HendelsePublisher
 import no.nav.etterlatte.tidshendelser.klient.BehandlingKlient
+import no.nav.etterlatte.tidshendelser.omregning.OmregningDao
+import no.nav.etterlatte.tidshendelser.omregning.ReguleringService
 import no.nav.etterlatte.tidshendelser.omstillingsstoenad.OmstillingsstoenadService
-import no.nav.etterlatte.tidshendelser.regulering.ReguleringDao
-import no.nav.etterlatte.tidshendelser.regulering.ReguleringService
 import java.time.Duration
 import java.util.UUID
 
@@ -60,9 +60,9 @@ class AppContext(
     val hendelseDao = HendelseDao(dataSource)
     private val aldersovergangerService = AldersovergangerService(hendelseDao, behandlingKlient)
     private val omstillingsstoenadService = OmstillingsstoenadService(hendelseDao, behandlingKlient)
-    private val reguleringDao = ReguleringDao(dataSource)
-    private val reguleringService = ReguleringService(publisher, reguleringDao)
-    private val inntektsjusteringService = AarligInntektsjusteringService(publisher, reguleringDao)
+    private val omregningDao = OmregningDao(dataSource)
+    private val reguleringService = ReguleringService(publisher, omregningDao)
+    private val inntektsjusteringService = AarligInntektsjusteringService(publisher, omregningDao)
 
     val jobbPollerTask =
         JobbPollerTask(

--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/JobbPoller.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/JobbPoller.kt
@@ -8,8 +8,8 @@ import no.nav.etterlatte.libs.tidshendelser.JobbKategori
 import no.nav.etterlatte.tidshendelser.aarliginntektsjustering.AarligInntektsjusteringService
 import no.nav.etterlatte.tidshendelser.aldersovergang.AldersovergangerService
 import no.nav.etterlatte.tidshendelser.hendelser.HendelseDao
+import no.nav.etterlatte.tidshendelser.omregning.ReguleringService
 import no.nav.etterlatte.tidshendelser.omstillingsstoenad.OmstillingsstoenadService
-import no.nav.etterlatte.tidshendelser.regulering.ReguleringService
 import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.util.Timer

--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/aarliginntektsjustering/AarligInntektsjusteringService.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/aarliginntektsjustering/AarligInntektsjusteringService.kt
@@ -6,8 +6,8 @@ import no.nav.etterlatte.rapidsandrivers.InntektsjusteringHendelseType
 import no.nav.etterlatte.rapidsandrivers.RapidEvents
 import no.nav.etterlatte.rapidsandrivers.tilSeparertString
 import no.nav.etterlatte.tidshendelser.hendelser.HendelserJobb
-import no.nav.etterlatte.tidshendelser.regulering.ReguleringDao
-import no.nav.etterlatte.tidshendelser.regulering.Reguleringskonfigurasjon
+import no.nav.etterlatte.tidshendelser.omregning.OmregningDao
+import no.nav.etterlatte.tidshendelser.omregning.Omregningskonfigurasjon
 import no.nav.helse.rapids_rivers.JsonMessage
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -15,18 +15,18 @@ import java.util.UUID
 
 class AarligInntektsjusteringService(
     private val rapidsPublisher: (UUID, String) -> Unit,
-    private val reguleringDao: ReguleringDao,
+    private val omregningDao: OmregningDao,
 ) {
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     fun execute(jobb: HendelserJobb): List<Long> {
         logger.info("Handling jobb ${jobb.id}, type ${jobb.type} (${jobb.type.beskrivelse})")
-        val konfigurasjon = reguleringDao.hentNyesteKonfigurasjon()
+        val konfigurasjon = omregningDao.hentNyesteKonfigurasjon()
         startAarligInntektsjustering(konfigurasjon)
         return emptyList()
     }
 
-    private fun startAarligInntektsjustering(konfigurasjon: Reguleringskonfigurasjon) {
+    private fun startAarligInntektsjustering(konfigurasjon: Omregningskonfigurasjon) {
         logger.info("StartInntektsJob startet")
         rapidsPublisher(
             UUID.randomUUID(),
@@ -36,7 +36,7 @@ class AarligInntektsjusteringService(
     }
 }
 
-fun createRecord(konfigurasjon: Reguleringskonfigurasjon) =
+fun createRecord(konfigurasjon: Omregningskonfigurasjon) =
     JsonMessage
         .newMessage(
             mapOf(

--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/omregning/OmregningDao.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/omregning/OmregningDao.kt
@@ -1,4 +1,4 @@
-package no.nav.etterlatte.tidshendelser.regulering
+package no.nav.etterlatte.tidshendelser.omregning
 
 import kotliquery.TransactionalSession
 import no.nav.etterlatte.libs.common.sak.SakId
@@ -7,38 +7,40 @@ import no.nav.etterlatte.libs.database.hent
 import no.nav.etterlatte.libs.database.transaction
 import javax.sql.DataSource
 
-class ReguleringDao(
+class OmregningDao(
     private val datasource: DataSource,
-) : Transactions<ReguleringDao> {
-    override fun <R> inTransaction(block: ReguleringDao.(TransactionalSession) -> R): R =
+) : Transactions<OmregningDao> {
+    override fun <R> inTransaction(block: OmregningDao.(TransactionalSession) -> R): R =
         datasource.transaction {
             this.block(it)
         }
 
-    fun hentNyesteKonfigurasjon(): Reguleringskonfigurasjon =
+    fun hentNyesteKonfigurasjon(): Omregningskonfigurasjon =
         datasource.transaction { tx ->
             with(Databasetabell) {
                 tx.hent(
-                    "SELECT $ANTALL, $DATO, $SPESIFIKKE_SAKER, $EKSKLUDERTE_SAKER FROM $TABELLNAVN " +
+                    "SELECT $ANTALL, $DATO, $SPESIFIKKE_SAKER, $EKSKLUDERTE_SAKER, $KJOERING_ID FROM $TABELLNAVN " +
                         "WHERE $AKTIV=true ORDER BY $OPPRETTET DESC LIMIT 1",
                 ) { row ->
-                    Reguleringskonfigurasjon(
+                    Omregningskonfigurasjon(
                         antall = row.int(ANTALL),
                         dato = row.localDate(DATO),
                         spesifikkeSaker = row.arrayOrNull<Long>(SPESIFIKKE_SAKER)?.toList()?.map { SakId(it) } ?: emptyList(),
                         ekskluderteSaker = row.arrayOrNull<Long>(EKSKLUDERTE_SAKER)?.toList()?.map { SakId(it) } ?: emptyList(),
+                        kjoeringId = row.stringOrNull(KJOERING_ID),
                     )
                 }
-            } ?: throw IllegalStateException("Kan ikke kjøre regulering uten å ha gyldig reguleringskonfigurasjon")
+            } ?: throw IllegalStateException("Det finnes ingen omregningskonfigurasjon i databasen som er aktiv")
         }
 
     internal object Databasetabell {
-        const val TABELLNAVN = "reguleringskonfigurasjon"
+        const val TABELLNAVN = "omregningskonfigurasjon"
         const val ANTALL = "antall"
         const val DATO = "dato"
         const val SPESIFIKKE_SAKER = "spesifikke_saker"
         const val EKSKLUDERTE_SAKER = "ekskluderte_saker"
         const val AKTIV = "aktiv"
         const val OPPRETTET = "opprettet"
+        const val KJOERING_ID = "kjoering_id"
     }
 }

--- a/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/omregning/Omregningskonfigurasjon.kt
+++ b/apps/etterlatte-tidshendelser/src/main/kotlin/no/nav/etterlatte/tidshendelser/omregning/Omregningskonfigurasjon.kt
@@ -1,11 +1,12 @@
-package no.nav.etterlatte.tidshendelser.regulering
+package no.nav.etterlatte.tidshendelser.omregning
 
 import no.nav.etterlatte.libs.common.sak.SakId
 import java.time.LocalDate
 
-data class Reguleringskonfigurasjon(
+data class Omregningskonfigurasjon(
     val antall: Int,
     val dato: LocalDate,
     val spesifikkeSaker: List<SakId>,
     val ekskluderteSaker: List<SakId>,
+    val kjoeringId: String? = null,
 )

--- a/apps/etterlatte-tidshendelser/src/main/resources/db/migration/V25__endre_navn_reguleringskonfigurasjon.sql
+++ b/apps/etterlatte-tidshendelser/src/main/resources/db/migration/V25__endre_navn_reguleringskonfigurasjon.sql
@@ -1,0 +1,2 @@
+alter table reguleringskonfigurasjon rename to omregningskonfigurasjon;
+alter table omregningskonfigurasjon add column kjoering_id text;

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/JobbPollerIntegrationTest.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/JobbPollerIntegrationTest.kt
@@ -16,8 +16,8 @@ import no.nav.etterlatte.tidshendelser.aldersovergang.AldersovergangerService
 import no.nav.etterlatte.tidshendelser.hendelser.HendelseDao
 import no.nav.etterlatte.tidshendelser.hendelser.JobbStatus
 import no.nav.etterlatte.tidshendelser.hendelser.Steg
+import no.nav.etterlatte.tidshendelser.omregning.ReguleringService
 import no.nav.etterlatte.tidshendelser.omstillingsstoenad.OmstillingsstoenadService
-import no.nav.etterlatte.tidshendelser.regulering.ReguleringService
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/regulering/OmregningDaoTest.kt
+++ b/apps/etterlatte-tidshendelser/src/test/kotlin/no/nav/etterlatte/tidshendelser/regulering/OmregningDaoTest.kt
@@ -8,7 +8,9 @@ import no.nav.etterlatte.behandling.sakId3
 import no.nav.etterlatte.insert
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.tidshendelser.DatabaseExtension
-import no.nav.etterlatte.tidshendelser.regulering.ReguleringDao.Databasetabell
+import no.nav.etterlatte.tidshendelser.omregning.OmregningDao
+import no.nav.etterlatte.tidshendelser.omregning.OmregningDao.Databasetabell
+import no.nav.etterlatte.tidshendelser.omregning.Omregningskonfigurasjon
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -19,7 +21,7 @@ import javax.sql.DataSource
 
 @ExtendWith(DatabaseExtension::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class ReguleringDaoTest(
+class OmregningDaoTest(
     private val dataSource: DataSource,
 ) {
     @Test
@@ -32,8 +34,8 @@ class ReguleringDaoTest(
             listOf(sakId1, sakId2, sakId3, SakId(4), SakId(5)),
             listOf(sakId1, sakId2, SakId(4)),
         )
-        val dao = ReguleringDao(datasource = dataSource)
-        val konfigurasjon: Reguleringskonfigurasjon = dao.hentNyesteKonfigurasjon()
+        val dao = OmregningDao(datasource = dataSource)
+        val konfigurasjon: Omregningskonfigurasjon = dao.hentNyesteKonfigurasjon()
         assertEquals(20, konfigurasjon.antall)
         assertEquals(dato, konfigurasjon.dato)
         containsInOrder(listOf(1, 2, 3, 4, 5), konfigurasjon.spesifikkeSaker)
@@ -45,8 +47,8 @@ class ReguleringDaoTest(
         val dato = LocalDate.of(2024, Month.JUNE, 22)
         leggInnReguleringskonfigurasjon(dato, 10, null, null)
         leggInnReguleringskonfigurasjon(dato, 20, null, null)
-        val dao = ReguleringDao(datasource = dataSource)
-        val konfigurasjon: Reguleringskonfigurasjon = dao.hentNyesteKonfigurasjon()
+        val dao = OmregningDao(datasource = dataSource)
+        val konfigurasjon: Omregningskonfigurasjon = dao.hentNyesteKonfigurasjon()
         assertEquals(20, konfigurasjon.antall)
         assertEquals(dato, konfigurasjon.dato)
         containsInOrder(listOf(1, 2, 3, 4, 5), konfigurasjon.spesifikkeSaker)
@@ -58,8 +60,8 @@ class ReguleringDaoTest(
         val dato = LocalDate.of(2024, Month.JUNE, 22)
         leggInnReguleringskonfigurasjon(dato, 10, emptyList(), emptyList())
         leggInnReguleringskonfigurasjon(dato, 20, emptyList(), emptyList(), false)
-        val dao = ReguleringDao(datasource = dataSource)
-        val konfigurasjon: Reguleringskonfigurasjon = dao.hentNyesteKonfigurasjon()
+        val dao = OmregningDao(datasource = dataSource)
+        val konfigurasjon: Omregningskonfigurasjon = dao.hentNyesteKonfigurasjon()
         assertEquals(10, konfigurasjon.antall)
         assertEquals(dato, konfigurasjon.dato)
     }


### PR DESCRIPTION
Legger også til et frivillig felt for å kontrollere kjøring-id'en, som brukes i stedet for datoen for konfigurasjonen hvis den er satt.