### PR TITLE
Er mer fleksibel på respons med manglende folkeregisteridentifikator

### DIFF
--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/ParallelleSannheterService.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/ParallelleSannheterService.kt
@@ -245,7 +245,7 @@ class ParallelleSannheterService(
     ): PersonDTO =
         runBlocking {
             val folkeregisteridentifikator =
-                if (hentPerson.folkeregisteridentifikator == null) {
+                if (hentPerson.folkeregisteridentifikator.isNullOrEmpty()) {
                     logger.warn(
                         "Fikk person som mangler folkeregisteridentifikator i PDL. Se sikkerlogg for fnr som oppslaget ble utført med.",
                     )


### PR DESCRIPTION
Hvis vi får en tom liste fra PDL så vil vi feile på måten vi ser i produksjon nå.