### PR TITLE
Leser en mindre modell for dødhendelser

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
@@ -224,7 +224,7 @@ class DoedshendelseJobService(
 
     private fun hentAnnenForelder(doedshendelse: DoedshendelseInternal): String? =
         pdlTjenesterKlient
-            .hentPdlModellForSaktype(
+            .hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = doedshendelse.beroertFnr,
                 rolle = PersonRolle.BARN,
                 saktype = SakType.BARNEPENSJON,
@@ -259,12 +259,12 @@ class DoedshendelseJobService(
 
     private fun sjekkUnder18aar(doedshendelse: DoedshendelseInternal): Boolean {
         val person =
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = doedshendelse.beroertFnr,
                 rolle = PersonRolle.BARN,
                 saktype = SakType.BARNEPENSJON,
             )
-        return person.toPerson().under18aarPaaDato(LocalDate.now())
+        return person.under18aarPaaDato(LocalDate.now())
     }
 
     private fun sjekkUtlandForBeroertIHendelse(doedshendelse: DoedshendelseInternal): Boolean {

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobService.kt
@@ -271,7 +271,7 @@ class DoedshendelseJobService(
         val beroertPersonDto =
             when (doedshendelse.sakTypeForEpsEllerBarn()) {
                 SakType.BARNEPENSJON -> {
-                    pdlTjenesterKlient.hentPdlModellForSaktype(
+                    pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                         foedselsnummer = doedshendelse.beroertFnr,
                         rolle = PersonRolle.BARN,
                         saktype = SakType.BARNEPENSJON,
@@ -279,7 +279,7 @@ class DoedshendelseJobService(
                 }
 
                 SakType.OMSTILLINGSSTOENAD -> {
-                    pdlTjenesterKlient.hentPdlModellForSaktype(
+                    pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                         foedselsnummer = doedshendelse.beroertFnr,
                         rolle = PersonRolle.GJENLEVENDE,
                         saktype = SakType.OMSTILLINGSSTOENAD,

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseUtil.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/DoedshendelseUtil.kt
@@ -6,16 +6,15 @@ import no.nav.etterlatte.libs.common.person.Adresse
 import no.nav.etterlatte.libs.common.person.AdresseType.UTENLANDSKADRESSE
 import no.nav.etterlatte.libs.common.person.AdresseType.UTENLANDSKADRESSEFRITTFORMAT
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
-import no.nav.etterlatte.libs.common.person.Person
 import no.nav.etterlatte.libs.common.person.Sivilstatus
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import java.time.temporal.Temporal
 import kotlin.math.absoluteValue
 
-fun Person.under18aarPaaDato(dato: LocalDate): Boolean {
+fun PersonDoedshendelseDto.under18aarPaaDato(dato: LocalDate): Boolean {
     val aar18 = 18
-    val benyttetFoedselsdato = foedselsdato ?: LocalDate.of(foedselsaar, 12, 31)
+    val benyttetFoedselsdato = foedselsdato?.verdi ?: LocalDate.of(foedselsaar.verdi, 12, 31)
 
     return ChronoUnit.YEARS.between(benyttetFoedselsdato, dato).absoluteValue < aar18
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/PersonFnrMedRelasjon.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/PersonFnrMedRelasjon.kt
@@ -1,6 +1,6 @@
 package no.nav.etterlatte.grunnlagsendring.doedshendelse
 
-import no.nav.etterlatte.libs.common.pdl.PersonDTO
+import no.nav.etterlatte.libs.common.pdl.PersonDoedshendelseDto
 
 data class PersonFnrMedRelasjon(
     val fnr: String,
@@ -8,6 +8,6 @@ data class PersonFnrMedRelasjon(
 )
 
 data class AvdoedOgAnnenForelderMedFellesbarn(
-    val avdoedPerson: PersonDTO,
-    val gjenlevendeForelder: PersonDTO,
+    val avdoedPerson: PersonDoedshendelseDto,
+    val gjenlevendeForelder: PersonDoedshendelseDto,
 )

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktAvdoedService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktAvdoedService.kt
@@ -1,28 +1,28 @@
 package no.nav.etterlatte.grunnlagsendring.doedshendelse.kontrollpunkt
 
-import no.nav.etterlatte.libs.common.pdl.PersonDTO
+import no.nav.etterlatte.libs.common.pdl.PersonDoedshendelseDto
 
 internal class DoedshendelseKontrollpunktAvdoedService {
-    fun identifiser(avdoed: PersonDTO): List<DoedshendelseKontrollpunkt> =
+    fun identifiser(avdoed: PersonDoedshendelseDto): List<DoedshendelseKontrollpunkt> =
         listOfNotNull(
             kontrollerDoedsdato(avdoed),
             kontrollerDNummer(avdoed),
             kontrollerUtvandring(avdoed),
         )
 
-    private fun kontrollerDoedsdato(avdoed: PersonDTO): DoedshendelseKontrollpunkt? =
+    private fun kontrollerDoedsdato(avdoed: PersonDoedshendelseDto): DoedshendelseKontrollpunkt? =
         when (avdoed.doedsdato) {
             null -> DoedshendelseKontrollpunkt.AvdoedLeverIPDL
             else -> null
         }
 
-    private fun kontrollerDNummer(avdoed: PersonDTO): DoedshendelseKontrollpunkt? =
+    private fun kontrollerDNummer(avdoed: PersonDoedshendelseDto): DoedshendelseKontrollpunkt? =
         when (avdoed.foedselsnummer.verdi.isDNumber()) {
             true -> DoedshendelseKontrollpunkt.AvdoedHarDNummer
             false -> null
         }
 
-    private fun kontrollerUtvandring(avdoed: PersonDTO): DoedshendelseKontrollpunkt? {
+    private fun kontrollerUtvandring(avdoed: PersonDoedshendelseDto): DoedshendelseKontrollpunkt? {
         val utflytting = avdoed.utland?.verdi?.utflyttingFraNorge
         val innflytting = avdoed.utland?.verdi?.innflyttingTilNorge
 

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktBarnService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktBarnService.kt
@@ -54,7 +54,7 @@ internal class DoedshendelseKontrollpunktBarnService(
                 DoedshendelseKontrollpunkt.AnnenForelderIkkeFunnet
             } else {
                 pdlTjenesterKlient
-                    .hentPdlModellForSaktype(
+                    .hentPdlModellDoedshendelseForSaktype(
                         foedselsnummer = annenForelderFnr,
                         rolle = PersonRolle.GJENLEVENDE,
                         saktype = SakType.BARNEPENSJON,

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktBarnService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktBarnService.kt
@@ -4,7 +4,7 @@ import no.nav.etterlatte.behandling.BehandlingService
 import no.nav.etterlatte.common.klienter.PdlTjenesterKlient
 import no.nav.etterlatte.grunnlagsendring.doedshendelse.DoedshendelseInternal
 import no.nav.etterlatte.libs.common.behandling.SakType
-import no.nav.etterlatte.libs.common.pdl.PersonDTO
+import no.nav.etterlatte.libs.common.pdl.PersonDoedshendelseDto
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.sak.Sak
 
@@ -14,9 +14,9 @@ internal class DoedshendelseKontrollpunktBarnService(
 ) {
     fun identifiser(
         hendelse: DoedshendelseInternal,
-        avdoed: PersonDTO,
+        avdoed: PersonDoedshendelseDto,
         sak: Sak?,
-        barn: PersonDTO,
+        barn: PersonDoedshendelseDto,
     ): List<DoedshendelseKontrollpunkt> =
         listOfNotNull(
             kontrollerBarnErSoektFor(sak),
@@ -38,9 +38,9 @@ internal class DoedshendelseKontrollpunktBarnService(
     }
 
     private fun kontrollerSamtidigDoedsfall(
-        avdoed: PersonDTO,
+        avdoed: PersonDoedshendelseDto,
         hendelse: DoedshendelseInternal,
-        barn: PersonDTO,
+        barn: PersonDoedshendelseDto,
     ): DoedshendelseKontrollpunkt? =
         avdoed.doedsdato?.verdi?.let { avdoedDoedsdato ->
             val annenForelderFnr =

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktEktefelleService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktEktefelleService.kt
@@ -8,7 +8,7 @@ import no.nav.etterlatte.grunnlagsendring.doedshendelse.harBarn
 import no.nav.etterlatte.grunnlagsendring.doedshendelse.harFellesBarn
 import no.nav.etterlatte.grunnlagsendring.doedshendelse.safeYearsBetween
 import no.nav.etterlatte.grunnlagsendring.doedshendelse.varEktefelleVedDoedsfall
-import no.nav.etterlatte.libs.common.pdl.PersonDTO
+import no.nav.etterlatte.libs.common.pdl.PersonDoedshendelseDto
 import no.nav.etterlatte.libs.common.person.Sivilstatus.GIFT
 import no.nav.etterlatte.libs.common.person.Sivilstatus.REGISTRERT_PARTNER
 import no.nav.etterlatte.libs.common.person.Sivilstatus.SEPARERT
@@ -20,13 +20,13 @@ import kotlin.math.absoluteValue
 
 internal class DoedshendelseKontrollpunktEktefelleService {
     fun identifiser(
-        eps: PersonDTO,
-        avdoed: PersonDTO,
+        eps: PersonDoedshendelseDto,
+        avdoed: PersonDoedshendelseDto,
     ): List<DoedshendelseKontrollpunkt> = kontrollerEpsVarighet(avdoed, eps)
 
     private fun kontrollerEpsVarighet(
-        avdoed: PersonDTO,
-        eps: PersonDTO,
+        avdoed: PersonDoedshendelseDto,
+        eps: PersonDoedshendelseDto,
     ): List<DoedshendelseKontrollpunkt> =
         if (varEktefelleVedDoedsfall(avdoed, eps.foedselsnummer.verdi.value)) {
             when (val antallAarGiftVedDoedsfall = finnAntallAarGiftVedDoedsfall(avdoed, eps)) {
@@ -45,8 +45,8 @@ internal class DoedshendelseKontrollpunktEktefelleService {
 
     private fun kontrollerEktefelle(
         antallAarGift: Long,
-        avdoed: PersonDTO,
-        eps: PersonDTO,
+        avdoed: PersonDoedshendelseDto,
+        eps: PersonDoedshendelseDto,
     ): List<DoedshendelseKontrollpunkt> =
         if (antallAarGift < 5) {
             if (harFellesBarn(avdoed, eps)) {
@@ -61,8 +61,8 @@ internal class DoedshendelseKontrollpunktEktefelleService {
         }
 
     private fun kontrollerTidligereEktefelle(
-        avdoed: PersonDTO,
-        eps: PersonDTO,
+        avdoed: PersonDoedshendelseDto,
+        eps: PersonDoedshendelseDto,
     ): DoedshendelseKontrollpunkt {
         finnEktefelleSafe(eps)?.let { epsEktefelle ->
             if (epsEktefelle != avdoed.foedselsnummer.verdi.value) {

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktOMSService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktOMSService.kt
@@ -9,7 +9,7 @@ import no.nav.etterlatte.common.klienter.SakSammendragResponse.Status.TIL_BEHAND
 import no.nav.etterlatte.grunnlagsendring.doedshendelse.DoedshendelseInternal
 import no.nav.etterlatte.grunnlagsendring.doedshendelse.safeYearsBetween
 import no.nav.etterlatte.libs.common.behandling.SakType
-import no.nav.etterlatte.libs.common.pdl.PersonDTO
+import no.nav.etterlatte.libs.common.pdl.PersonDoedshendelseDto
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import kotlin.math.absoluteValue
@@ -21,8 +21,8 @@ internal class DoedshendelseKontrollpunktOMSService(
     fun identifiser(
         hendelse: DoedshendelseInternal,
         sak: Sak?,
-        eps: PersonDTO,
-        avdoed: PersonDTO,
+        eps: PersonDoedshendelseDto,
+        avdoed: PersonDoedshendelseDto,
         bruker: BrukerTokenInfo,
     ): List<DoedshendelseKontrollpunkt> =
         listOfNotNull(
@@ -68,8 +68,8 @@ internal class DoedshendelseKontrollpunktOMSService(
         }
 
     private fun kontrollerBeroertFylt67Aar(
-        eps: PersonDTO,
-        avdoed: PersonDTO,
+        eps: PersonDoedshendelseDto,
+        avdoed: PersonDoedshendelseDto,
     ): DoedshendelseKontrollpunkt.EpsKanHaAlderspensjon? =
         if (eps.foedselsdato != null) {
             val foedselsdato = eps.foedselsdato?.verdi
@@ -89,7 +89,7 @@ internal class DoedshendelseKontrollpunktOMSService(
             null
         }
 
-    private fun kontrollerBeroertErDoed(eps: PersonDTO): DoedshendelseKontrollpunkt.EpsHarDoedsdato? =
+    private fun kontrollerBeroertErDoed(eps: PersonDoedshendelseDto): DoedshendelseKontrollpunkt.EpsHarDoedsdato? =
         if (eps.doedsdato != null) {
             DoedshendelseKontrollpunkt.EpsHarDoedsdato
         } else {

--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktService.kt
@@ -12,7 +12,7 @@ import no.nav.etterlatte.grunnlagsendring.doedshendelse.Relasjon
 import no.nav.etterlatte.grunnlagsendring.doedshendelse.harAktivAdresse
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
-import no.nav.etterlatte.libs.common.pdl.PersonDTO
+import no.nav.etterlatte.libs.common.pdl.PersonDoedshendelseDto
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.person.maskerFnr
 import no.nav.etterlatte.libs.common.sak.Sak
@@ -106,13 +106,13 @@ class DoedshendelseKontrollpunktService(
     private fun hentDataForBeroert(
         hendelse: DoedshendelseInternal,
         beroert: PersonRolle,
-    ): Triple<Sak?, PersonDTO, PersonDTO> {
+    ): Triple<Sak?, PersonDoedshendelseDto, PersonDoedshendelseDto> {
         val sakType = hendelse.sakTypeForEpsEllerBarn()
         val sak = hentSakForDoedshendelse(hendelse.beroertFnr, sakType)
 
-        val avdoed = pdlTjenesterKlient.hentPdlModellForSaktype(hendelse.avdoedFnr, PersonRolle.AVDOED, sakType)
+        val avdoed = pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(hendelse.avdoedFnr, PersonRolle.AVDOED, sakType)
         val gjenlevende =
-            pdlTjenesterKlient.hentPdlModellForSaktype(hendelse.beroertFnr, beroert, hendelse.sakTypeForEpsEllerBarn())
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(hendelse.beroertFnr, beroert, hendelse.sakTypeForEpsEllerBarn())
 
         return Triple(sak, avdoed, gjenlevende)
     }
@@ -173,7 +173,7 @@ class DoedshendelseKontrollpunktService(
     private fun fellesKontrollpunkter(
         hendelse: DoedshendelseInternal,
         sak: Sak?,
-        gjenlevende: PersonDTO,
+        gjenlevende: PersonDoedshendelseDto,
     ): List<DoedshendelseKontrollpunkt> {
         val duplikatKontrollpunkt = kontrollerDuplikatHendelse(hendelse, sak)
         val adresseKontrollpunkt = kontrollerAktivAdresse(gjenlevende)
@@ -181,7 +181,7 @@ class DoedshendelseKontrollpunktService(
         return listOfNotNull(duplikatKontrollpunkt, adresseKontrollpunkt)
     }
 
-    private fun kontrollerAktivAdresse(gjenlevende: PersonDTO): DoedshendelseKontrollpunkt? =
+    private fun kontrollerAktivAdresse(gjenlevende: PersonDoedshendelseDto): DoedshendelseKontrollpunkt? =
         when (harAktivAdresse(gjenlevende)) {
             true -> null
             false -> DoedshendelseKontrollpunkt.GjenlevendeManglerAdresse

--- a/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/TestHelper.kt
@@ -42,6 +42,7 @@ import no.nav.etterlatte.libs.common.gyldigSoeknad.GyldighetsResultat
 import no.nav.etterlatte.libs.common.gyldigSoeknad.VurderingsResultat
 import no.nav.etterlatte.libs.common.pdl.OpplysningDTO
 import no.nav.etterlatte.libs.common.pdl.PersonDTO
+import no.nav.etterlatte.libs.common.pdl.PersonDoedshendelseDto
 import no.nav.etterlatte.libs.common.pdlhendelse.DoedshendelsePdl
 import no.nav.etterlatte.libs.common.pdlhendelse.Endringstype
 import no.nav.etterlatte.libs.common.pdlhendelse.ForelderBarnRelasjonHendelse
@@ -513,6 +514,27 @@ fun mockPerson(
     vergemaalEllerFremtidsfullmakt = vergemaal?.map { OpplysningDTO(it, UUID.randomUUID().toString()) },
     pdlStatsborgerskap = null,
 )
+
+fun mockDoedshendelsePerson(
+    utland: Utland? = null,
+    familieRelasjon: FamilieRelasjon? = null,
+): PersonDoedshendelseDto =
+    mockPerson(utland, familieRelasjon).let {
+        PersonDoedshendelseDto(
+            foedselsnummer = it.foedselsnummer,
+            foedselsdato = it.foedselsdato,
+            foedselsaar = it.foedselsaar,
+            doedsdato = it.doedsdato,
+            bostedsadresse = it.bostedsadresse,
+            deltBostedsadresse = it.deltBostedsadresse,
+            kontaktadresse = it.kontaktadresse,
+            oppholdsadresse = it.oppholdsadresse,
+            sivilstand = it.sivilstand,
+            utland = it.utland,
+            familieRelasjon = it.familieRelasjon,
+            avdoedesBarn = it.avdoedesBarn,
+        )
+    }
 
 fun kommerBarnetTilGodeVurdering(behandlingId: UUID) =
     KommerBarnetTilgode(

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseJobServiceTest.kt
@@ -30,7 +30,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
 import no.nav.etterlatte.libs.ktor.token.HardkodaSystembruker
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED2_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
-import no.nav.etterlatte.mockPerson
+import no.nav.etterlatte.mockDoedshendelsePerson
 import no.nav.etterlatte.person.krr.DigitalKontaktinformasjon
 import no.nav.etterlatte.person.krr.KrrKlientImpl
 import no.nav.etterlatte.sak.SakService
@@ -78,7 +78,7 @@ class DoedshendelseJobServiceTest {
 
     private val pdlTjenesterKlient =
         mockk<PdlTjenesterKlient> {
-            every { hentPdlModellForSaktype(any(), any(), SakType.BARNEPENSJON) } returns mockPerson()
+            every { hentPdlModellDoedshendelseForSaktype(any(), any(), SakType.BARNEPENSJON) } returns mockDoedshendelsePerson()
         }
 
     private val krrKlient =

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseServiceTest.kt
@@ -25,7 +25,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.tidspunkt.toLocalDatetimeUTC
 import no.nav.etterlatte.libs.testdata.grunnlag.HELSOESKEN_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
-import no.nav.etterlatte.mockPerson
+import no.nav.etterlatte.mockDoedshendelsePerson
 import no.nav.etterlatte.nyKontekstMedBruker
 import no.nav.etterlatte.personOpplysning
 import org.junit.jupiter.api.BeforeEach
@@ -50,7 +50,7 @@ internal class DoedshendelseServiceTest {
         )
 
     private val avdoed =
-        mockPerson().copy(
+        mockDoedshendelsePerson().copy(
             doedsdato = OpplysningDTO(LocalDate.now().minusYears(2), null),
             avdoedesBarn =
                 listOf(
@@ -115,7 +115,7 @@ internal class DoedshendelseServiceTest {
             )
 
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseFlereSaktyper(
                 avdoed.foedselsnummer.verdi.value,
                 PersonRolle.AVDOED,
                 listOf(SakType.BARNEPENSJON, SakType.OMSTILLINGSSTOENAD),
@@ -123,7 +123,7 @@ internal class DoedshendelseServiceTest {
         } returns avdoed.copy(avdoedesBarn = listOf(fellesbarn, fellesbarn), bostedsadresse = bostedsadresse)
 
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 annenForelder.value,
                 PersonRolle.TILKNYTTET_BARN,
                 SakType.OMSTILLINGSSTOENAD,
@@ -194,7 +194,7 @@ internal class DoedshendelseServiceTest {
             )
 
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseFlereSaktyper(
                 avdoed.foedselsnummer.verdi.value,
                 PersonRolle.AVDOED,
                 listOf(SakType.BARNEPENSJON, SakType.OMSTILLINGSSTOENAD),
@@ -220,7 +220,7 @@ internal class DoedshendelseServiceTest {
             )
 
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 annenForelder.value,
                 PersonRolle.TILKNYTTET_BARN,
                 SakType.OMSTILLINGSSTOENAD,
@@ -291,7 +291,7 @@ internal class DoedshendelseServiceTest {
             )
 
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseFlereSaktyper(
                 avdoed.foedselsnummer.verdi.value,
                 PersonRolle.AVDOED,
                 listOf(SakType.BARNEPENSJON, SakType.OMSTILLINGSSTOENAD),
@@ -328,7 +328,7 @@ internal class DoedshendelseServiceTest {
             )
 
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 annenForelder.value,
                 PersonRolle.TILKNYTTET_BARN,
                 SakType.OMSTILLINGSSTOENAD,
@@ -355,7 +355,7 @@ internal class DoedshendelseServiceTest {
     @Test
     fun `Skal opprette doedshendelse for alle ektefeller`() {
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseFlereSaktyper(
                 avdoed.foedselsnummer.verdi.value,
                 any(),
                 listOf(SakType.BARNEPENSJON, SakType.OMSTILLINGSSTOENAD),
@@ -420,7 +420,7 @@ internal class DoedshendelseServiceTest {
     @Test
     fun `Skal opprette doedshendelse en for avdød uten barn`() {
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseFlereSaktyper(
                 avdoed.foedselsnummer.verdi.value,
                 any(),
                 listOf(SakType.BARNEPENSJON, SakType.OMSTILLINGSSTOENAD),
@@ -446,7 +446,7 @@ internal class DoedshendelseServiceTest {
     @Test
     fun `Skal opprette doedshendelse med barna som kan ha rett paa barnepensjon ved doedsfall`() {
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseFlereSaktyper(
                 avdoed.foedselsnummer.verdi.value,
                 any(),
                 listOf(SakType.BARNEPENSJON, SakType.OMSTILLINGSSTOENAD),
@@ -472,7 +472,7 @@ internal class DoedshendelseServiceTest {
     @Test
     fun `Skal lagre nye hendelser hvis nye beroerte finnes`() {
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseFlereSaktyper(
                 avdoed.foedselsnummer.verdi.value,
                 any(),
                 listOf(SakType.BARNEPENSJON, SakType.OMSTILLINGSSTOENAD),
@@ -517,7 +517,7 @@ internal class DoedshendelseServiceTest {
         val barnfemtenaar = LocalDate.now().minusYears(15)
         val nyttBarn = personOpplysning(foedselsdato = barnfemtenaar).copy(foedselsnummer = HELSOESKEN_FOEDSELSNUMMER)
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseFlereSaktyper(
                 avdoed.foedselsnummer.verdi.value,
                 any(),
                 listOf(SakType.BARNEPENSJON, SakType.OMSTILLINGSSTOENAD),
@@ -548,7 +548,7 @@ internal class DoedshendelseServiceTest {
     @Test
     fun `Skal oppdatere korrigert hendelse`() {
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseFlereSaktyper(
                 avdoed.foedselsnummer.verdi.value,
                 any(),
                 listOf(SakType.BARNEPENSJON, SakType.OMSTILLINGSSTOENAD),
@@ -611,7 +611,7 @@ internal class DoedshendelseServiceTest {
     @Test
     fun `Skal oppdatere annullert hendelse`() {
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseFlereSaktyper(
                 avdoed.foedselsnummer.verdi.value,
                 any(),
                 listOf(SakType.BARNEPENSJON, SakType.OMSTILLINGSSTOENAD),
@@ -675,7 +675,7 @@ internal class DoedshendelseServiceTest {
     @Test
     fun `Skal ikke opprette doedshendelser dersom avdoed ikke er registert som avdoed i PDL`() {
         every {
-            pdlTjenesterKlient.hentPdlModellFlereSaktyper(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseFlereSaktyper(
                 avdoed.foedselsnummer.verdi.value,
                 any(),
                 listOf(SakType.BARNEPENSJON, SakType.OMSTILLINGSSTOENAD),

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseUtilTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/DoedshendelseUtilTest.kt
@@ -7,7 +7,7 @@ import no.nav.etterlatte.libs.common.pdl.OpplysningDTO
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.Sivilstand
 import no.nav.etterlatte.libs.common.person.Sivilstatus
-import no.nav.etterlatte.mockPerson
+import no.nav.etterlatte.mockDoedshendelsePerson
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -15,7 +15,7 @@ internal class DoedshendelseUtilTest {
     @Test
     fun `Skal finne naavaerende ektefelle`() {
         val person =
-            mockPerson().copy(
+            mockDoedshendelsePerson().copy(
                 sivilstand =
                     listOf(
                         sivilstand(
@@ -33,7 +33,7 @@ internal class DoedshendelseUtilTest {
     fun `Skal finne naavaerende ektefelle selv om man tidligere er gift med en annen`() {
         val tidligereEktefelle = "30901699972"
         val person =
-            mockPerson().copy(
+            mockDoedshendelsePerson().copy(
                 sivilstand =
                     listOf(
                         sivilstand(
@@ -61,7 +61,7 @@ internal class DoedshendelseUtilTest {
     fun `Skal returnere null dersom det finnes en skilt sivilstand uten gyldig fomDato`() {
         val tidligereEktefelle = "30901699972"
         val person =
-            mockPerson().copy(
+            mockDoedshendelsePerson().copy(
                 sivilstand =
                     listOf(
                         sivilstand(
@@ -88,7 +88,7 @@ internal class DoedshendelseUtilTest {
     @Test
     fun `Skal returnere null dersom personen er skilt`() {
         val person =
-            mockPerson().copy(
+            mockDoedshendelsePerson().copy(
                 sivilstand =
                     listOf(
                         sivilstand(

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktAvdoedServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktAvdoedServiceTest.kt
@@ -7,7 +7,7 @@ import no.nav.etterlatte.libs.common.pdl.OpplysningDTO
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.UtflyttingFraNorge
 import no.nav.etterlatte.libs.common.person.Utland
-import no.nav.etterlatte.mockPerson
+import no.nav.etterlatte.mockDoedshendelsePerson
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -16,7 +16,7 @@ class DoedshendelseKontrollpunktAvdoedServiceTest {
 
     @Test
     fun `Skal returnere kontrollpunkt hvis avdoed ikke har doedsdato i PDL`() {
-        val avdoed = mockPerson().copy(doedsdato = null)
+        val avdoed = mockDoedshendelsePerson().copy(doedsdato = null)
 
         val kontrollpunkter = kontrollpunktService.identifiser(avdoed)
 
@@ -26,7 +26,7 @@ class DoedshendelseKontrollpunktAvdoedServiceTest {
     @Test
     fun `Skal returnere kontrollpunkt hvis den avdoede har D-nummer`() {
         val avdoed =
-            mockPerson().copy(
+            mockDoedshendelsePerson().copy(
                 doedsdato = OpplysningDTO(LocalDate.now(), null),
                 foedselsnummer = OpplysningDTO(Folkeregisteridentifikator.of("69057949961"), null),
             )
@@ -39,7 +39,7 @@ class DoedshendelseKontrollpunktAvdoedServiceTest {
     @Test
     fun `Skal returnere kontrollpunkt hvis den avdoede hadde utvandring`() {
         val avdoed =
-            mockPerson(
+            mockDoedshendelsePerson(
                 Utland(
                     innflyttingTilNorge = emptyList(),
                     utflyttingFraNorge = listOf(UtflyttingFraNorge("Sverige", LocalDate.now().minusMonths(2))),

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktBarnServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktBarnServiceTest.kt
@@ -23,7 +23,7 @@ import no.nav.etterlatte.libs.common.pdlhendelse.Endringstype
 import no.nav.etterlatte.libs.common.person.FamilieRelasjon
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.sak.Sak
-import no.nav.etterlatte.mockPerson
+import no.nav.etterlatte.mockDoedshendelsePerson
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -35,14 +35,14 @@ class DoedshendelseKontrollpunktBarnServiceTest {
     @Test
     fun `Skal opprette kontrollpunkt ved samtidig doedsfall`() {
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = KONTANT_FOT.value,
                 rolle = PersonRolle.AVDOED,
                 saktype = SakType.BARNEPENSJON,
             )
         } returns avdoed
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = JOVIAL_LAMA.value,
                 rolle = PersonRolle.GJENLEVENDE,
                 saktype = SakType.BARNEPENSJON,
@@ -57,14 +57,14 @@ class DoedshendelseKontrollpunktBarnServiceTest {
     @Test
     fun `Skal opprette kontrollpunkt dersom vi ikke finner den andre forelderen`() {
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = KONTANT_FOT.value,
                 rolle = PersonRolle.AVDOED,
                 saktype = SakType.BARNEPENSJON,
             )
         } returns avdoed
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = JOVIAL_LAMA.value,
                 rolle = PersonRolle.GJENLEVENDE,
                 saktype = SakType.BARNEPENSJON,
@@ -91,14 +91,14 @@ class DoedshendelseKontrollpunktBarnServiceTest {
     @Test
     fun `Skal opprette kontrollpunkt ved iverksatt vedtak`() {
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = KONTANT_FOT.value,
                 rolle = PersonRolle.AVDOED,
                 saktype = SakType.BARNEPENSJON,
             )
         } returns avdoed
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = JOVIAL_LAMA.value,
                 rolle = PersonRolle.GJENLEVENDE,
                 saktype = SakType.BARNEPENSJON,
@@ -115,14 +115,14 @@ class DoedshendelseKontrollpunktBarnServiceTest {
     @Test
     fun `Skal ikke opprette kontrollpunkt ved dersom det kun eksisterer en sak`() {
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = KONTANT_FOT.value,
                 rolle = PersonRolle.AVDOED,
                 saktype = SakType.BARNEPENSJON,
             )
         } returns avdoed
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = JOVIAL_LAMA.value,
                 rolle = PersonRolle.GJENLEVENDE,
                 saktype = SakType.BARNEPENSJON,
@@ -147,16 +147,16 @@ class DoedshendelseKontrollpunktBarnServiceTest {
                 endringstype = Endringstype.OPPRETTET,
             )
         private val avdoed =
-            mockPerson().copy(
+            mockDoedshendelsePerson().copy(
                 foedselsnummer = OpplysningDTO(JOVIAL_LAMA, null),
                 doedsdato = OpplysningDTO(doedsdato, null),
             )
         private val gjenlevende =
-            mockPerson().copy(
+            mockDoedshendelsePerson().copy(
                 foedselsnummer = OpplysningDTO(JOVIAL_LAMA, null),
             )
         private val barnet =
-            mockPerson().copy(
+            mockDoedshendelsePerson().copy(
                 foedselsnummer = OpplysningDTO(JOVIAL_LAMA, null),
                 familieRelasjon =
                     OpplysningDTO(

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktEktefelleServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktEktefelleServiceTest.kt
@@ -15,7 +15,7 @@ import no.nav.etterlatte.libs.common.person.FamilieRelasjon
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.Sivilstand
 import no.nav.etterlatte.libs.common.person.Sivilstatus
-import no.nav.etterlatte.mockPerson
+import no.nav.etterlatte.mockDoedshendelsePerson
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -340,12 +340,12 @@ internal class DoedshendelseKontrollpunktEktefelleServiceTest {
                 endringstype = Endringstype.OPPRETTET,
             )
         private val avdoed =
-            mockPerson().copy(
+            mockDoedshendelsePerson().copy(
                 foedselsnummer = OpplysningDTO(JOVIAL_LAMA, null),
                 doedsdato = OpplysningDTO(doedsdato, null),
             )
         private val gjenlevende =
-            mockPerson().copy(
+            mockDoedshendelsePerson().copy(
                 foedselsnummer = OpplysningDTO(JOVIAL_LAMA, null),
             )
 

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktOMSServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktOMSServiceTest.kt
@@ -26,7 +26,7 @@ import no.nav.etterlatte.libs.common.pdl.OpplysningDTO
 import no.nav.etterlatte.libs.common.pdlhendelse.Endringstype
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.sak.SakId
-import no.nav.etterlatte.mockPerson
+import no.nav.etterlatte.mockDoedshendelsePerson
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -197,12 +197,12 @@ class DoedshendelseKontrollpunktOMSServiceTest {
                 endringstype = Endringstype.OPPRETTET,
             )
         private val avdoed =
-            mockPerson().copy(
+            mockDoedshendelsePerson().copy(
                 foedselsnummer = OpplysningDTO(JOVIAL_LAMA, null),
                 doedsdato = OpplysningDTO(doedsdato, null),
             )
         private val gjenlevende =
-            mockPerson().copy(
+            mockDoedshendelsePerson().copy(
                 foedselsnummer = OpplysningDTO(JOVIAL_LAMA, null),
             )
         private val sak =

--- a/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/grunnlagsendring/doedshendelse/kontrollpunkt/DoedshendelseKontrollpunktServiceTest.kt
@@ -34,7 +34,7 @@ import no.nav.etterlatte.libs.common.person.FamilieRelasjon
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.PersonRolle
 import no.nav.etterlatte.libs.common.sak.Sak
-import no.nav.etterlatte.mockPerson
+import no.nav.etterlatte.mockDoedshendelsePerson
 import no.nav.etterlatte.oppgave.OppgaveService
 import no.nav.etterlatte.sak.SakService
 import org.junit.jupiter.api.BeforeEach
@@ -84,25 +84,33 @@ class DoedshendelseKontrollpunktServiceTest {
         coEvery { pesysKlient.hentSaker(doedshendelseInternalOMS.beroertFnr, bruker) } returns emptyList()
 
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = doedshendelseInternalBP.avdoedFnr,
                 rolle = PersonRolle.AVDOED,
                 saktype = any(),
             )
         } returns
-            mockPerson().copy(
-                foedselsnummer = OpplysningDTO(Folkeregisteridentifikator.of(doedshendelseInternalBP.avdoedFnr), null),
+            mockDoedshendelsePerson().copy(
+                foedselsnummer =
+                    OpplysningDTO(
+                        Folkeregisteridentifikator.of(doedshendelseInternalBP.avdoedFnr),
+                        null,
+                    ),
                 doedsdato = OpplysningDTO(doedshendelseInternalBP.avdoedDoedsdato, null),
             )
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = doedshendelseInternalBP.beroertFnr,
                 rolle = PersonRolle.BARN,
                 saktype = SakType.BARNEPENSJON,
             )
         } returns
-            mockPerson().copy(
-                foedselsnummer = OpplysningDTO(Folkeregisteridentifikator.of(doedshendelseInternalBP.beroertFnr), null),
+            mockDoedshendelsePerson().copy(
+                foedselsnummer =
+                    OpplysningDTO(
+                        Folkeregisteridentifikator.of(doedshendelseInternalBP.beroertFnr),
+                        null,
+                    ),
                 familieRelasjon =
                     OpplysningDTO(
                         FamilieRelasjon(
@@ -114,14 +122,18 @@ class DoedshendelseKontrollpunktServiceTest {
                     ),
             )
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = JOVIAL_LAMA.value,
                 rolle = PersonRolle.GJENLEVENDE,
                 saktype = SakType.BARNEPENSJON,
             )
         } returns
-            mockPerson().copy(
-                foedselsnummer = OpplysningDTO(Folkeregisteridentifikator.of(doedshendelseInternalOMS.beroertFnr), null),
+            mockDoedshendelsePerson().copy(
+                foedselsnummer =
+                    OpplysningDTO(
+                        Folkeregisteridentifikator.of(doedshendelseInternalOMS.beroertFnr),
+                        null,
+                    ),
             )
         every { sakService.finnSak(any(), any()) } returns null
         every {
@@ -155,14 +167,18 @@ class DoedshendelseKontrollpunktServiceTest {
             )
         } returns foerstegangsbehandling(sakId = sak.id, status = BehandlingStatus.IVERKSATT)
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = doedshendelseInternalBP.avdoedFnr,
                 rolle = PersonRolle.AVDOED,
                 saktype = any(),
             )
         } returns
-            mockPerson().copy(
-                foedselsnummer = OpplysningDTO(Folkeregisteridentifikator.of(doedshendelseInternalAvdoed.avdoedFnr), null),
+            mockDoedshendelsePerson().copy(
+                foedselsnummer =
+                    OpplysningDTO(
+                        Folkeregisteridentifikator.of(doedshendelseInternalAvdoed.avdoedFnr),
+                        null,
+                    ),
                 doedsdato = OpplysningDTO(doedshendelseInternalAvdoed.avdoedDoedsdato, null),
             )
 
@@ -193,14 +209,18 @@ class DoedshendelseKontrollpunktServiceTest {
         } returns listOf(sak)
         every { behandlingService.hentSisteIverksatte(sak.id) } returns null
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = doedshendelseInternalBP.avdoedFnr,
                 rolle = PersonRolle.AVDOED,
                 saktype = any(),
             )
         } returns
-            mockPerson().copy(
-                foedselsnummer = OpplysningDTO(Folkeregisteridentifikator.of(doedshendelseInternalAvdoed.avdoedFnr), null),
+            mockDoedshendelsePerson().copy(
+                foedselsnummer =
+                    OpplysningDTO(
+                        Folkeregisteridentifikator.of(doedshendelseInternalAvdoed.avdoedFnr),
+                        null,
+                    ),
                 doedsdato = OpplysningDTO(doedshendelseInternalAvdoed.avdoedDoedsdato, null),
             )
 
@@ -230,14 +250,18 @@ class DoedshendelseKontrollpunktServiceTest {
         } returns emptyList()
 
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = doedshendelseInternalBP.avdoedFnr,
                 rolle = PersonRolle.AVDOED,
                 saktype = any(),
             )
         } returns
-            mockPerson().copy(
-                foedselsnummer = OpplysningDTO(Folkeregisteridentifikator.of(doedshendelseInternalAvdoed.avdoedFnr), null),
+            mockDoedshendelsePerson().copy(
+                foedselsnummer =
+                    OpplysningDTO(
+                        Folkeregisteridentifikator.of(doedshendelseInternalAvdoed.avdoedFnr),
+                        null,
+                    ),
                 doedsdato = OpplysningDTO(doedshendelseInternalAvdoed.avdoedDoedsdato, null),
             )
 
@@ -273,14 +297,18 @@ class DoedshendelseKontrollpunktServiceTest {
             )
         } returns foerstegangsbehandling(sakId = sakIdd, status = BehandlingStatus.IVERKSATT)
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = doedshendelseInternalAvdoed.avdoedFnr,
                 rolle = PersonRolle.AVDOED,
                 saktype = any(),
             )
         } returns
-            mockPerson().copy(
-                foedselsnummer = OpplysningDTO(Folkeregisteridentifikator.of(doedshendelseInternalAvdoed.avdoedFnr), null),
+            mockDoedshendelsePerson().copy(
+                foedselsnummer =
+                    OpplysningDTO(
+                        Folkeregisteridentifikator.of(doedshendelseInternalAvdoed.avdoedFnr),
+                        null,
+                    ),
                 doedsdato = OpplysningDTO(doedshendelseInternalAvdoed.avdoedDoedsdato, null),
             )
 
@@ -311,7 +339,10 @@ class DoedshendelseKontrollpunktServiceTest {
         kontrollpunkter shouldContainExactlyInAnyOrder
             listOf(
                 DoedshendelseKontrollpunkt.AvdoedHarYtelse(sak),
-                DoedshendelseKontrollpunkt.DuplikatGrunnlagsendringsHendelse(grunnlagsendringshendelse.id, oppgaveIntern.id),
+                DoedshendelseKontrollpunkt.DuplikatGrunnlagsendringsHendelse(
+                    grunnlagsendringshendelse.id,
+                    oppgaveIntern.id,
+                ),
             )
     }
 
@@ -339,7 +370,10 @@ class DoedshendelseKontrollpunktServiceTest {
         every {
             grunnlagsendringshendelseDao.hentGrunnlagsendringshendelserMedStatuserISak(any(), any())
         } returns listOf(grunnlagsendringshendelse)
-        every { oppgaveService.hentOppgaverForReferanse(grunnlagsendringshendelseId.toString()) } returns listOf(oppgaveIntern)
+        every { oppgaveService.hentOppgaverForReferanse(grunnlagsendringshendelseId.toString()) } returns
+            listOf(
+                oppgaveIntern,
+            )
         every { behandlingService.hentBehandlingerForSak(any()) } returns emptyList()
 
         val kontrollpunkter =
@@ -360,15 +394,25 @@ class DoedshendelseKontrollpunktServiceTest {
     @Test
     fun `Skal gi kontrollpunkt dersom gjenlevende ikke har aktiv adresse`() {
         every {
-            pdlTjenesterKlient.hentPdlModellForSaktype(
+            pdlTjenesterKlient.hentPdlModellDoedshendelseForSaktype(
                 foedselsnummer = doedshendelseInternalBP.beroertFnr,
                 rolle = PersonRolle.BARN,
                 saktype = SakType.BARNEPENSJON,
             )
         } returns
-            mockPerson().copy(
-                foedselsnummer = OpplysningDTO(Folkeregisteridentifikator.of(doedshendelseInternalBP.beroertFnr), null),
-                bostedsadresse = listOf(OpplysningDTO(Adresse(AdresseType.VEGADRESSE, false, kilde = "FREG"), null)),
+            mockDoedshendelsePerson().copy(
+                foedselsnummer =
+                    OpplysningDTO(
+                        Folkeregisteridentifikator.of(doedshendelseInternalBP.beroertFnr),
+                        null,
+                    ),
+                bostedsadresse =
+                    listOf(
+                        OpplysningDTO(
+                            Adresse(AdresseType.VEGADRESSE, false, kilde = "FREG"),
+                            null,
+                        ),
+                    ),
                 kontaktadresse = emptyList(),
                 oppholdsadresse = emptyList(),
                 familieRelasjon =

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
@@ -63,6 +63,7 @@ import no.nav.etterlatte.libs.common.beregning.InntektsjusteringAvkortingInfoRes
 import no.nav.etterlatte.libs.common.brev.BestillingsIdDto
 import no.nav.etterlatte.libs.common.brev.JournalpostIdDto
 import no.nav.etterlatte.libs.common.pdl.PersonDTO
+import no.nav.etterlatte.libs.common.pdl.PersonDoedshendelseDto
 import no.nav.etterlatte.libs.common.person.AdressebeskyttelseGradering
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.GeografiskTilknytning
@@ -695,11 +696,23 @@ class PdltjenesterKlientTest : PdlTjenesterKlient {
         saktype: SakType,
     ): PersonDTO = mockPerson()
 
+    override fun hentPdlModellDoedshendelseForSaktype(
+        foedselsnummer: String,
+        rolle: PersonRolle,
+        saktype: SakType,
+    ): PersonDoedshendelseDto = mockDoedshendelsePerson()
+
     override fun hentPdlModellFlereSaktyper(
         foedselsnummer: String,
         rolle: PersonRolle,
         saktyper: List<SakType>,
     ): PersonDTO = mockPerson()
+
+    override fun hentPdlModellDoedshendelseFlereSaktyper(
+        foedselsnummer: String,
+        rolle: PersonRolle,
+        saktyper: List<SakType>,
+    ): PersonDoedshendelseDto = mockDoedshendelsePerson()
 
     override fun hentGeografiskTilknytning(
         foedselsnummer: String,

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/ParallelleSannheterService.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/ParallelleSannheterService.kt
@@ -385,6 +385,7 @@ class ParallelleSannheterService(
                         foedselsdato.metadata.opplysningsId,
                     )
                 },
+            foedselsaar = OpplysningDTO(foedselsdato.foedselsaar, foedselsdato.metadata.opplysningsId),
             doedsdato = doedsfall?.doedsdato?.let { OpplysningDTO(it, doedsfall.metadata.opplysningsId) },
             bostedsadresse =
                 hentPerson.bostedsadresse

--- a/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonRoute.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/person/PersonRoute.kt
@@ -36,6 +36,12 @@ fun Route.personRoute(service: PersonService) {
 
                 service.hentOpplysningsperson(hentPersonRequest).let { call.respond(it) }
             }
+
+            post("doedshendelse") {
+                val hentPersonRequest = call.receive<HentPersonRequest>()
+                logger.info("Henter personpplysning med fnr=${hentPersonRequest.foedselsnummer}")
+                call.respond(service.hentDoedshendelseOpplysningsperson(hentPersonRequest))
+            }
         }
 
         post("/adressebeskyttelse") {

--- a/libs/etterlatte-pdl-model/src/main/kotlin/pdl/PersonDTO.kt
+++ b/libs/etterlatte-pdl-model/src/main/kotlin/pdl/PersonDTO.kt
@@ -15,6 +15,7 @@ import java.time.LocalDate
 data class PersonDoedshendelseDto(
     val foedselsnummer: OpplysningDTO<Folkeregisteridentifikator>,
     val foedselsdato: OpplysningDTO<LocalDate>?,
+    val foedselsaar: OpplysningDTO<Int>,
     val doedsdato: OpplysningDTO<LocalDate>?,
     var bostedsadresse: List<OpplysningDTO<Adresse>>?,
     var deltBostedsadresse: List<OpplysningDTO<Adresse>>?,

--- a/libs/etterlatte-pdl-model/src/main/kotlin/pdl/PersonDTO.kt
+++ b/libs/etterlatte-pdl-model/src/main/kotlin/pdl/PersonDTO.kt
@@ -12,6 +12,20 @@ import no.nav.etterlatte.libs.common.person.Utland
 import no.nav.etterlatte.libs.common.person.VergemaalEllerFremtidsfullmakt
 import java.time.LocalDate
 
+data class PersonDoedshendelseDto(
+    val foedselsnummer: OpplysningDTO<Folkeregisteridentifikator>,
+    val foedselsdato: OpplysningDTO<LocalDate>?,
+    val doedsdato: OpplysningDTO<LocalDate>?,
+    var bostedsadresse: List<OpplysningDTO<Adresse>>?,
+    var deltBostedsadresse: List<OpplysningDTO<Adresse>>?,
+    var kontaktadresse: List<OpplysningDTO<Adresse>>?,
+    var oppholdsadresse: List<OpplysningDTO<Adresse>>?,
+    val sivilstand: List<OpplysningDTO<Sivilstand>>?,
+    var utland: OpplysningDTO<Utland>?,
+    var familieRelasjon: OpplysningDTO<FamilieRelasjon>?,
+    var avdoedesBarn: List<Person>?,
+)
+
 data class PersonDTO(
     val fornavn: OpplysningDTO<String>,
     val mellomnavn: OpplysningDTO<String>?,


### PR DESCRIPTION
Siden vi ikke har garanterte opplysninger på alle feltene som ikke brukes men er påkrevde i PersonDTO henter vi i stedet ut en mindre modell som kan brukes til å avklare sjekkpunktene i en dødshendelse