### PR TITLE
Kaster faktisk den opprinnelige responseexception, ikke parseexception

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/brev/BrevService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/brev/BrevService.kt
@@ -245,7 +245,7 @@ class BrevService(
                             "Kaster opprinnelig exception videre",
                         internException,
                     )
-                    throw internException
+                    throw responseException
                 }
             when (exceptionResponse.status) {
                 // ForespoerselException


### PR DESCRIPTION
Så denne når jeg leste igjennom kode, riktig oppførsel (som også er beskrevet) er å ikke kaste internException her