### PR TITLE
EY-5196 forbedring av inntektsavkorting

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -5,6 +5,7 @@ import { IAvkorting } from '~shared/types/IAvkorting'
 import { usePersonopplysninger } from '~components/person/usePersonopplysninger'
 import { AvkortingInntektTabell } from '~components/behandling/avkorting/AvkortingInntektTabell'
 import { AvkortingInntektForm } from '~components/behandling/avkorting/AvkortingInntektForm'
+import { Revurderingaarsak } from '~shared/types/Revurderingaarsak'
 
 export const AvkortingInntekt = ({
   behandling,
@@ -42,7 +43,11 @@ export const AvkortingInntekt = ({
               Bruker fyller 67 år i inntektsåret og antall innvilga måneder vil bli tilpasset deretter.
             </Alert>
           )}
-          <AvkortingInntektTabell avkortingGrunnlagListe={avkorting.avkortingGrunnlag} fyller67={fyller67} />
+          <AvkortingInntektTabell
+            avkortingGrunnlagListe={avkorting.avkortingGrunnlag}
+            fyller67={fyller67}
+            erEtteroppgjoerRevurdering={behandling.revurderingsaarsak === Revurderingaarsak.ETTEROPPGJOER}
+          />
         </VStack>
       )}
       <AvkortingInntektForm

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -1,12 +1,10 @@
-import { Alert, Button, VStack } from '@navikt/ds-react'
-import React, { useState } from 'react'
+import { Alert, VStack } from '@navikt/ds-react'
+import React from 'react'
 import { IBehandlingReducer } from '~store/reducers/BehandlingReducer'
 import { IAvkorting } from '~shared/types/IAvkorting'
-import { ChevronDownIcon, ChevronUpIcon } from '@navikt/aksel-icons'
 import { usePersonopplysninger } from '~components/person/usePersonopplysninger'
 import { AvkortingInntektTabell } from '~components/behandling/avkorting/AvkortingInntektTabell'
 import { AvkortingInntektForm } from '~components/behandling/avkorting/AvkortingInntektForm'
-import { Revurderingaarsak } from '~shared/types/Revurderingaarsak'
 
 export const AvkortingInntekt = ({
   behandling,
@@ -21,9 +19,6 @@ export const AvkortingInntekt = ({
   redigerbar: boolean
   resetInntektsavkortingValidering: () => void
 }) => {
-  const [visHistorikk, setVisHistorikk] = useState(behandling.revurderingsaarsak === Revurderingaarsak.ETTEROPPGJOER)
-  const erFoerstegangsbehandling = behandling.revurderingsaarsak == null
-
   // TODO sjekke begge/alle?
   const personopplysning = usePersonopplysninger()
   const fyller67 =
@@ -38,19 +33,6 @@ export const AvkortingInntekt = ({
           personopplysning.soeker.opplysning.foedselsaar ===
           67))
 
-  const listeVisningAvkortingGrunnlag = () => {
-    if (visHistorikk) {
-      return avkorting.avkortingGrunnlag
-    }
-    if (erFoerstegangsbehandling) {
-      return [avkorting.redigerbarForventetInntekt ?? [], avkorting.redigerbarForventetInntektNesteAar ?? []].flat()
-    } else {
-      const siste =
-        avkorting.redigerbarForventetInntekt ?? avkorting.avkortingGrunnlag[avkorting.avkortingGrunnlag.length - 1]
-      return [siste]
-    }
-  }
-
   return (
     <VStack maxWidth="70rem">
       {avkorting && avkorting.avkortingGrunnlag.length > 0 && (
@@ -60,19 +42,8 @@ export const AvkortingInntekt = ({
               Bruker fyller 67 år i inntektsåret og antall innvilga måneder vil bli tilpasset deretter.
             </Alert>
           )}
-          <AvkortingInntektTabell avkortingGrunnlagListe={listeVisningAvkortingGrunnlag()} fyller67={fyller67} />
+          <AvkortingInntektTabell avkortingGrunnlagListe={avkorting.avkortingGrunnlag} fyller67={fyller67} />
         </VStack>
-      )}
-      {avkorting && !erFoerstegangsbehandling && avkorting.avkortingGrunnlag.length > 1 && (
-        <Button
-          variant="tertiary"
-          onClick={() => setVisHistorikk(!visHistorikk)}
-          icon={
-            visHistorikk ? <ChevronUpIcon className="dropdownIcon" /> : <ChevronDownIcon className="dropdownIcon" />
-          }
-        >
-          Vis alle
-        </Button>
       )}
       <AvkortingInntektForm
         behandling={behandling}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntektTabell.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntektTabell.tsx
@@ -18,13 +18,17 @@ import { lastDayOfMonth } from 'date-fns'
 import { Info } from '~components/behandling/soeknadsoversikt/Info'
 import React from 'react'
 
+interface Props {
+  avkortingGrunnlagListe: IAvkortingGrunnlag[]
+  fyller67: boolean
+  erEtteroppgjoerRevurdering?: boolean
+}
+
 export const AvkortingInntektTabell = ({
   avkortingGrunnlagListe,
   fyller67,
-}: {
-  avkortingGrunnlagListe: IAvkortingGrunnlag[]
-  fyller67: boolean
-}) => {
+  erEtteroppgjoerRevurdering = false,
+}: Props) => {
   return (
     <Table className="table" zebraStripes>
       <Table.Header>
@@ -83,7 +87,11 @@ export const AvkortingInntektTabell = ({
                 </HStack>
               </Table.DataCell>
               <Table.DataCell key="Aar">
-                <Tag variant="alt3">{aarFraDatoString(avkortingGrunnlag.fom)}</Tag>
+                {erEtteroppgjoerRevurdering && aarFraDatoString(avkortingGrunnlag.fom) === 2024 ? (
+                  <Tag variant="success">{aarFraDatoString(avkortingGrunnlag.fom)}</Tag>
+                ) : (
+                  <Tag variant="alt3">{aarFraDatoString(avkortingGrunnlag.fom)}</Tag>
+                )}
               </Table.DataCell>
               <Table.DataCell key="Periode">
                 {avkortingGrunnlag.fom && formaterDato(avkortingGrunnlag.fom)} -{' '}


### PR DESCRIPTION
- Fjerning av historikk knappen, viser bare alle uansett,
- Inntektsavkorting år `<Tag />` er grønn hvis året er 2024 og det er etteroppgjør revurdering

![image](https://github.com/user-attachments/assets/a06201c6-6099-40ea-9392-5990b2aa7267)
