### PR TITLE
EY-5212 sende med faktisk inntekt som grunnlag ved oppretting av brev

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerBrevModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerBrevModel.kt
@@ -7,7 +7,6 @@ import no.nav.etterlatte.brev.BrevRedigerbarInnholdData
 import no.nav.etterlatte.brev.model.oms.EtteroppgjoerBrevData
 import no.nav.etterlatte.brev.model.oms.EtteroppgjoerBrevGrunnlag
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
-import no.nav.etterlatte.libs.common.beregning.FaktiskInntektDto
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.pensjon.brevbaker.api.model.Kroner
@@ -28,15 +27,8 @@ object EtteroppgjoerBrevDataMapper {
             "Beregnet etteroppgjoer resultat er null og kan ikke vises i brev"
         }
 
-        krevIkkeNull(data.avkortingFaktiskInntekt?.avkortingGrunnlag?.first()) {
-            "Beregnet etteroppgjoer mangler grunnlag faktisk inntekt"
-        }
-
         val bosattUtland = sisteIverksatteBehandling.utlandstilknytning?.type == UtlandstilknytningType.BOSATT_UTLAND
-
-        val grunnlag =
-            data.avkortingFaktiskInntekt?.avkortingGrunnlag?.firstOrNull() as? FaktiskInntektDto
-                ?: throw InternfeilException("Etteroppgjør mangler faktisk inntekt og kan ikke vises i brev")
+        val grunnlag = data.faktiskInntekt ?: throw InternfeilException("Etteroppgjør mangler faktisk inntekt og kan ikke vises i brev")
 
         // TODO: usikker om dette blir rett, følge opp ifm testing
         val norskInntekt = pensjonsgivendeInntekt != null && pensjonsgivendeInntekt.inntekter.isNotEmpty()

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerBrevModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerBrevModel.kt
@@ -5,7 +5,10 @@ import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.DetaljertForbeha
 import no.nav.etterlatte.brev.BrevFastInnholdData
 import no.nav.etterlatte.brev.BrevRedigerbarInnholdData
 import no.nav.etterlatte.brev.model.oms.EtteroppgjoerBrevData
+import no.nav.etterlatte.brev.model.oms.EtteroppgjoerBrevGrunnlag
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
+import no.nav.etterlatte.libs.common.beregning.FaktiskInntektDto
+import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.pensjon.brevbaker.api.model.Kroner
 
@@ -25,7 +28,15 @@ object EtteroppgjoerBrevDataMapper {
             "Beregnet etteroppgjoer resultat er null og kan ikke vises i brev"
         }
 
+        krevIkkeNull(data.avkortingFaktiskInntekt?.avkortingGrunnlag?.first()) {
+            "Beregnet etteroppgjoer mangler grunnlag faktisk inntekt"
+        }
+
         val bosattUtland = sisteIverksatteBehandling.utlandstilknytning?.type == UtlandstilknytningType.BOSATT_UTLAND
+
+        val grunnlag =
+            data.avkortingFaktiskInntekt?.avkortingGrunnlag?.firstOrNull() as? FaktiskInntektDto
+                ?: throw InternfeilException("Etteroppgjør mangler faktisk inntekt og kan ikke vises i brev")
 
         // TODO: usikker om dette blir rett, følge opp ifm testing
         val norskInntekt = pensjonsgivendeInntekt != null && pensjonsgivendeInntekt.inntekter.isNotEmpty()
@@ -45,6 +56,16 @@ object EtteroppgjoerBrevDataMapper {
                     inntekt = Kroner(data.beregnetEtteroppgjoerResultat.utbetaltStoenad.toInt()),
                     faktiskInntekt = Kroner(data.beregnetEtteroppgjoerResultat.nyBruttoStoenad.toInt()),
                     avviksBeloep = Kroner(data.beregnetEtteroppgjoerResultat.differanse.toInt()),
+                    grunnlag =
+                        EtteroppgjoerBrevGrunnlag(
+                            fom = grunnlag.fom,
+                            tom = grunnlag.tom!!,
+                            innvilgetMaaneder = grunnlag.innvilgaMaaneder,
+                            loensinntekt = Kroner(grunnlag.loennsinntekt),
+                            naeringsinntekt = Kroner(grunnlag.naeringsinntekt),
+                            afp = Kroner(grunnlag.afp),
+                            utlandsinntekt = Kroner(grunnlag.utlandsinntekt),
+                        ),
                 ),
             data = data,
         )

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingModel.kt
@@ -5,6 +5,7 @@ import no.nav.etterlatte.behandling.etteroppgjoer.PensjonsgivendeInntektFraSkatt
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.libs.common.beregning.AvkortingDto
 import no.nav.etterlatte.libs.common.beregning.BeregnetEtteroppgjoerResultatDto
+import no.nav.etterlatte.libs.common.beregning.FaktiskInntektDto
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.common.sak.Sak
@@ -76,7 +77,7 @@ data class DetaljertForbehandlingDto(
     val behandling: EtteroppgjoerForbehandling,
     val sisteIverksatteBehandling: UUID,
     val opplysninger: EtteroppgjoerOpplysninger,
-    val avkortingFaktiskInntekt: AvkortingDto?,
+    val faktiskInntekt: FaktiskInntektDto?,
     val beregnetEtteroppgjoerResultat: BeregnetEtteroppgjoerResultatDto?,
 )
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingModel.kt
@@ -76,7 +76,6 @@ data class DetaljertForbehandlingDto(
     val behandling: EtteroppgjoerForbehandling,
     val sisteIverksatteBehandling: UUID,
     val opplysninger: EtteroppgjoerOpplysninger,
-    val faktiskInntekt: FaktiskInntekt?,
     val avkortingFaktiskInntekt: AvkortingDto?,
     val beregnetEtteroppgjoerResultat: BeregnetEtteroppgjoerResultatDto?,
 )
@@ -91,12 +90,4 @@ data class EtteroppgjoerOpplysninger(
     val skatt: PensjonsgivendeInntektFraSkatt,
     val ainntekt: AInntekt,
     val tidligereAvkorting: AvkortingDto,
-)
-
-data class FaktiskInntekt(
-    val loennsinntekt: Long,
-    val afp: Long,
-    val naeringsinntekt: Long,
-    val utland: Long,
-    val spesifikasjon: String,
 )

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -227,7 +227,7 @@ class EtteroppgjoerForbehandlingService(
                 loennsinntekt = request.loennsinntekt,
                 naeringsinntekt = request.naeringsinntekt,
                 afp = request.afp,
-                utlandsinntekt = request.utland,
+                utlandsinntekt = request.utlandsinntekt,
                 spesifikasjon = request.spesifikasjon,
             )
 
@@ -322,7 +322,7 @@ data class BeregnFaktiskInntektRequest(
     val loennsinntekt: Int,
     val afp: Int,
     val naeringsinntekt: Int,
-    val utland: Int,
+    val utlandsinntekt: Int,
     val spesifikasjon: String,
 )
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.libs.common.beregning.BeregnetEtteroppgjoerResultatDto
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerBeregnFaktiskInntektRequest
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerBeregnetAvkortingRequest
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerHentBeregnetResultatRequest
+import no.nav.etterlatte.libs.common.beregning.FaktiskInntektDto
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
 import no.nav.etterlatte.libs.common.oppgave.OppgaveIntern
@@ -148,9 +149,9 @@ class EtteroppgjoerForbehandlingService(
                     ainntekt = aInntekt,
                     tidligereAvkorting = avkorting.avkortingMedForventaInntekt,
                 ),
-            avkortingFaktiskInntekt = avkorting.avkortingMedFaktiskInntekt,
             sisteIverksatteBehandling = sisteIverksatteBehandling.id,
             beregnetEtteroppgjoerResultat = beregnetEtteroppgjoerResultat,
+            faktiskInntekt = avkorting.avkortingMedFaktiskInntekt?.avkortingGrunnlag?.firstOrNull() as? FaktiskInntektDto,
         )
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -207,11 +207,10 @@ class EtteroppgjoerForbehandlingService(
     ): BeregnetEtteroppgjoerResultatDto {
         var forbehandling = dao.hentForbehandling(forbehandlingId) ?: throw FantIkkeForbehandling(forbehandlingId)
 
-        // hvis ferdigstilt, ikke overskriv men opprett ny kopi forbehandling som skal brukes av revurdering
+        // hvis ferdigstilt, ikke overskriv men opprett ny kopi forbehandling
         if (forbehandling.erFerdigstilt()) {
             logger.info("Oppretter ny kopi av forbehandling for behandlingId=$forbehandlingId")
             forbehandling = kopierOgLagreNyForbehandling(forbehandling)
-            // TODO: burde forbehandlingen indikere at den er for revurdering og ikke skal være synlig for sb?
         }
 
         val sisteIverksatteBehandling =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -227,7 +227,7 @@ class EtteroppgjoerForbehandlingService(
                 loennsinntekt = request.loennsinntekt,
                 naeringsinntekt = request.naeringsinntekt,
                 afp = request.afp,
-                utland = request.utland,
+                utlandsinntekt = request.utland,
                 spesifikasjon = request.spesifikasjon,
             )
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -15,7 +15,6 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.beregning.BeregnetEtteroppgjoerResultatDto
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerBeregnFaktiskInntektRequest
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerBeregnetAvkortingRequest
-import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerFaktiskInntektRequest
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerHentBeregnetResultatRequest
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
@@ -129,16 +128,6 @@ class EtteroppgjoerForbehandlingService(
             )
         }
 
-        val faktiskInntekt =
-            runBlocking {
-                beregningKlient.hentAvkortingFaktiskInntekt(
-                    EtteroppgjoerFaktiskInntektRequest(
-                        forbehandlingId = forbehandlingId,
-                    ),
-                    brukerTokenInfo,
-                )
-            }
-
         val beregnetEtteroppgjoerResultat =
             runBlocking {
                 beregningKlient.hentBeregnetEtteroppgjoerResultat(
@@ -159,7 +148,6 @@ class EtteroppgjoerForbehandlingService(
                     ainntekt = aInntekt,
                     tidligereAvkorting = avkorting.avkortingMedForventaInntekt,
                 ),
-            faktiskInntekt = faktiskInntekt,
             avkortingFaktiskInntekt = avkorting.avkortingMedFaktiskInntekt,
             sisteIverksatteBehandling = sisteIverksatteBehandling.id,
             beregnetEtteroppgjoerResultat = beregnetEtteroppgjoerResultat,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/BeregningKlientImpl.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/BeregningKlientImpl.kt
@@ -5,12 +5,10 @@ import com.github.michaelbull.result.mapBoth
 import com.github.michaelbull.result.mapError
 import com.typesafe.config.Config
 import io.ktor.client.HttpClient
-import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.FaktiskInntekt
 import no.nav.etterlatte.libs.common.beregning.BeregnetEtteroppgjoerResultatDto
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerBeregnFaktiskInntektRequest
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerBeregnetAvkorting
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerBeregnetAvkortingRequest
-import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerFaktiskInntektRequest
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerHentBeregnetResultatRequest
 import no.nav.etterlatte.libs.common.beregning.InntektsjusteringAvkortingInfoRequest
 import no.nav.etterlatte.libs.common.beregning.InntektsjusteringAvkortingInfoResponse
@@ -57,11 +55,6 @@ interface BeregningKlient {
         request: EtteroppgjoerBeregnFaktiskInntektRequest,
         brukerTokenInfo: BrukerTokenInfo,
     ): BeregnetEtteroppgjoerResultatDto
-
-    suspend fun hentAvkortingFaktiskInntekt(
-        request: EtteroppgjoerFaktiskInntektRequest,
-        brukerTokenInfo: BrukerTokenInfo,
-    ): FaktiskInntekt?
 
     suspend fun opprettBeregningsgrunnlagFraForrigeBehandling(
         behandlingId: UUID,
@@ -224,33 +217,6 @@ class BeregningKlientImpl(
         } catch (e: Exception) {
             throw InternfeilException(
                 "Beregning av avkorting for forbehandling med id=${request.forbehandlingId} feilet",
-                e,
-            )
-        }
-    }
-
-    override suspend fun hentAvkortingFaktiskInntekt(
-        request: EtteroppgjoerFaktiskInntektRequest,
-        brukerTokenInfo: BrukerTokenInfo,
-    ): FaktiskInntekt? {
-        logger.info("Henter avkorting faktisk inntekt for etteroppgjør med forbehandling ${request.forbehandlingId}")
-        try {
-            return downstreamResourceClient
-                .post(
-                    resource =
-                        Resource(
-                            clientId = clientId,
-                            url = "$resourceUrl/api/beregning/avkorting/etteroppgjoer/faktisk-inntekt",
-                        ),
-                    brukerTokenInfo = brukerTokenInfo,
-                    postBody = request,
-                ).mapBoth(
-                    success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },
-                    failure = { throwableErrorMessage -> throw throwableErrorMessage },
-                )
-        } catch (e: Exception) {
-            throw InternfeilException(
-                "Henting av avkorting faktisk inntekt for forbehandling med id=${request.forbehandlingId} feilet",
                 e,
             )
         }

--- a/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/integration/EksterneKlienter.kt
@@ -7,7 +7,6 @@ import no.nav.etterlatte.behandling.domain.ArbeidsFordelingRequest
 import no.nav.etterlatte.behandling.domain.Navkontor
 import no.nav.etterlatte.behandling.etteroppgjoer.HendelseslisteFraSkatt
 import no.nav.etterlatte.behandling.etteroppgjoer.PensjonsgivendeInntektFraSkatt
-import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.FaktiskInntekt
 import no.nav.etterlatte.behandling.etteroppgjoer.inntektskomponent.AInntektReponsData
 import no.nav.etterlatte.behandling.etteroppgjoer.inntektskomponent.InntektskomponentKlient
 import no.nav.etterlatte.behandling.etteroppgjoer.sigrun.SigrunKlient
@@ -57,7 +56,6 @@ import no.nav.etterlatte.libs.common.beregning.BeregnetEtteroppgjoerResultatDto
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerBeregnFaktiskInntektRequest
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerBeregnetAvkorting
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerBeregnetAvkortingRequest
-import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerFaktiskInntektRequest
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerHentBeregnetResultatRequest
 import no.nav.etterlatte.libs.common.beregning.InntektsjusteringAvkortingInfoResponse
 import no.nav.etterlatte.libs.common.brev.BestillingsIdDto
@@ -152,11 +150,6 @@ class BeregningKlientTest :
         request: EtteroppgjoerBeregnFaktiskInntektRequest,
         brukerTokenInfo: BrukerTokenInfo,
     ): BeregnetEtteroppgjoerResultatDto = throw NotImplementedError("Ikke implementert for testklient")
-
-    override suspend fun hentAvkortingFaktiskInntekt(
-        request: EtteroppgjoerFaktiskInntektRequest,
-        brukerTokenInfo: BrukerTokenInfo,
-    ): FaktiskInntekt? = mockk()
 
     override suspend fun opprettBeregningsgrunnlagFraForrigeBehandling(
         behandlingId: UUID,

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRepository.kt
@@ -37,11 +37,6 @@ class AvkortingRepository(
             alleAarsoppgjoer.isNotEmpty()
         }
 
-    fun hentAvkortingFaktiskInntekt(behandlingId: UUID): FaktiskInntekt? =
-        dataSource.transaction { tx ->
-            selectFaktiskInntektPaaBehandlingId(behandlingId = behandlingId, tx = tx)
-        }
-
     fun hentAvkorting(behandlingId: UUID): Avkorting? =
         dataSource.transaction { tx ->
             val alleAarsoppgjoer =
@@ -164,26 +159,6 @@ class AvkortingRepository(
     ) = queryOf(
         "SELECT * FROM avkortingsgrunnlag_faktisk WHERE aarsoppgjoer_id = ? ORDER BY fom ASC",
         aarsoppgjoerId,
-    ).let { query ->
-        tx.run(
-            query
-                .map { row ->
-                    val avkortingGrunnlagId = row.uuid("id")
-                    val inntektInnvilgetPeriode =
-                        selectInntektInnvilgetPeriode(avkortingGrunnlagId, tx)
-                            ?: throw InternfeilException("Grunnlag for etteroppgjør mangler inntekt innvilgede måneder")
-
-                    row.toFaktiskInntekt(avkortingGrunnlagId, inntektInnvilgetPeriode)
-                }.asSingle,
-        )
-    }
-
-    private fun selectFaktiskInntektPaaBehandlingId(
-        behandlingId: UUID,
-        tx: TransactionalSession,
-    ) = queryOf(
-        "SELECT * FROM avkortingsgrunnlag_faktisk WHERE behandling_id = ? ORDER BY fom ASC",
-        behandlingId,
     ).let { query ->
         tx.run(
             query

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRoutes.kt
@@ -20,8 +20,6 @@ import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagLagreDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingOverstyrtInnvilgaMaanederDto
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerBeregnFaktiskInntektRequest
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerBeregnetAvkortingRequest
-import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerFaktiskInntektRequest
-import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerFaktiskInntektResponse
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerHentBeregnetResultatRequest
 import no.nav.etterlatte.libs.common.beregning.FaktiskInntektDto
 import no.nav.etterlatte.libs.common.beregning.ForventetInntektDto
@@ -162,26 +160,6 @@ fun Route.avkorting(
                         brukerTokenInfo = brukerTokenInfo,
                     )
                 call.respond(dto)
-            }
-
-            post("faktisk-inntekt") {
-                val request = call.receive<EtteroppgjoerFaktiskInntektRequest>()
-
-                val faktiskInntekt = etteroppgjoerService.hentAvkortingFaktiskInntekt(request)
-
-                if (faktiskInntekt == null) {
-                    call.respond(HttpStatusCode.NoContent)
-                } else {
-                    call.respond(
-                        EtteroppgjoerFaktiskInntektResponse(
-                            loennsinntekt = faktiskInntekt.loennsinntekt.toLong(),
-                            afp = faktiskInntekt.afp.toLong(),
-                            naeringsinntekt = faktiskInntekt.naeringsinntekt.toLong(),
-                            utland = faktiskInntekt.utlandsinntekt.toLong(),
-                            spesifikasjon = faktiskInntekt.spesifikasjon,
-                        ),
-                    )
-                }
             }
 
             post("beregn_faktisk_inntekt") {

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/etteroppgjoer/EtteroppgjoerService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/etteroppgjoer/EtteroppgjoerService.kt
@@ -102,7 +102,7 @@ class EtteroppgjoerService(
                     loennsinntekt = loennsinntekt,
                     afp = afp,
                     naeringsinntekt = naeringsinntekt,
-                    utland = utland,
+                    utland = utlandsinntekt,
                     sanksjoner = sanksjoner,
                     spesifikasjon = spesifikasjon,
                 )

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/etteroppgjoer/EtteroppgjoerService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/etteroppgjoer/EtteroppgjoerService.kt
@@ -8,17 +8,14 @@ import no.nav.etterlatte.avkorting.Avkorting
 import no.nav.etterlatte.avkorting.AvkortingRepository
 import no.nav.etterlatte.avkorting.AvkortingService
 import no.nav.etterlatte.avkorting.Etteroppgjoer
-import no.nav.etterlatte.avkorting.FaktiskInntekt
 import no.nav.etterlatte.avkorting.regler.EtteroppgjoerDifferanseGrunnlag
 import no.nav.etterlatte.avkorting.regler.EtteroppgjoerGrense
 import no.nav.etterlatte.avkorting.regler.beregneEtteroppgjoerRegel
 import no.nav.etterlatte.avkorting.toDto
-import no.nav.etterlatte.beregning.BeregningService
 import no.nav.etterlatte.libs.common.beregning.AvkortingDto
 import no.nav.etterlatte.libs.common.beregning.BeregnetEtteroppgjoerResultatDto
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerBeregnFaktiskInntektRequest
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerBeregnetAvkorting
-import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerFaktiskInntektRequest
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerResultatType
 import no.nav.etterlatte.libs.common.feilhaandtering.GenerellIkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
@@ -38,7 +35,6 @@ import java.util.UUID
 
 class EtteroppgjoerService(
     private val avkortingRepository: AvkortingRepository,
-    private val beregningService: BeregningService,
     private val sanksjonService: SanksjonService,
     private val etteroppgjoerRepository: EtteroppgjoerRepository,
     private val avkortingService: AvkortingService,
@@ -114,9 +110,6 @@ class EtteroppgjoerService(
 
         avkortingRepository.lagreAvkorting(request.forbehandlingId, request.sakId, avkorting) // TODO lagre med flagg forbehandling?
     }
-
-    fun hentAvkortingFaktiskInntekt(request: EtteroppgjoerFaktiskInntektRequest): FaktiskInntekt? =
-        avkortingRepository.hentAvkortingFaktiskInntekt(behandlingId = request.forbehandlingId)
 
     private fun beregnEtteroppgjoerResultat(
         aar: Int,
@@ -194,7 +187,7 @@ class EtteroppgjoerService(
 
             is Etteroppgjoer ->
                 AvkortingDto(
-                    avkortingGrunnlag = emptyList(),
+                    avkortingGrunnlag = listOf(aarsoppgjoer.inntekt.toDto()),
                     avkortetYtelse = aarsoppgjoer.avkortetYtelse.map { it.toDto() },
                 )
 

--- a/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
@@ -139,7 +139,6 @@ class ApplicationContext {
     val etteroppgjoerService =
         EtteroppgjoerService(
             avkortingRepository = avkortingRepository,
-            beregningService = beregningService,
             sanksjonService = sanksjonService,
             etteroppgjoerRepository = etteroppgjoerRepository,
             avkortingService = avkortingService,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/fastsettFaktiskInntekt/FaktiskInntektSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/fastsettFaktiskInntekt/FaktiskInntektSkjema.tsx
@@ -9,7 +9,6 @@ import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { hentEtteroppgjoer, lagreFaktiskInntekt } from '~shared/api/etteroppgjoer'
 import { useAppDispatch } from '~store/Store'
-import { FaktiskInntektGrunnlag } from '~shared/types/IAvkorting'
 
 const fastsettFaktiskInntektSkjemaValuesTilFaktiskInntekt = ({
   loennsinntekt,
@@ -22,7 +21,7 @@ const fastsettFaktiskInntektSkjemaValuesTilFaktiskInntekt = ({
     loennsinntekt: Number(loennsinntekt.replace(/[^0-9.]/g, '')),
     afp: Number(afp.replace(/[^0-9.]/g, '')),
     naeringsinntekt: Number(naeringsinntekt.replace(/[^0-9.]/g, '')),
-    utland: Number(utland.replace(/[^0-9.]/g, '')),
+    utlandsinntekt: Number(utland.replace(/[^0-9.]/g, '')),
     spesifikasjon,
   }
 }
@@ -44,12 +43,8 @@ export const FaktiskInntektSkjema = ({ setRedigerFaktiskInntekt, setFastsettInnt
   const [lagreFaktiskInntektResult, lagreFaktiskInntektRequest] = useApiCall(lagreFaktiskInntekt)
   const [hentEtteroppgjoerResult, hentEtteroppgjoerFetch] = useApiCall(hentEtteroppgjoer)
 
-  const { behandling, avkortingFaktiskInntekt } = useEtteroppgjoer()
+  const { behandling, faktiskInntekt } = useEtteroppgjoer()
   const dispatch = useAppDispatch()
-
-  const grunnlag = avkortingFaktiskInntekt?.avkortingGrunnlag.pop()
-  const faktiskInntekt: FaktiskInntektGrunnlag | undefined =
-    grunnlag?.type === 'FAKTISK_INNTEKT' ? (grunnlag as FaktiskInntektGrunnlag) : undefined
 
   const {
     register,

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/fastsettFaktiskInntekt/FaktiskInntektSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/fastsettFaktiskInntekt/FaktiskInntektSkjema.tsx
@@ -9,6 +9,7 @@ import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { hentEtteroppgjoer, lagreFaktiskInntekt } from '~shared/api/etteroppgjoer'
 import { useAppDispatch } from '~store/Store'
+import { FaktiskInntektGrunnlag } from '~shared/types/IAvkorting'
 
 const fastsettFaktiskInntektSkjemaValuesTilFaktiskInntekt = ({
   loennsinntekt,
@@ -43,8 +44,12 @@ export const FaktiskInntektSkjema = ({ setRedigerFaktiskInntekt, setFastsettInnt
   const [lagreFaktiskInntektResult, lagreFaktiskInntektRequest] = useApiCall(lagreFaktiskInntekt)
   const [hentEtteroppgjoerResult, hentEtteroppgjoerFetch] = useApiCall(hentEtteroppgjoer)
 
-  const { behandling, faktiskInntekt } = useEtteroppgjoer()
+  const { behandling, avkortingFaktiskInntekt } = useEtteroppgjoer()
   const dispatch = useAppDispatch()
+
+  const grunnlag = avkortingFaktiskInntekt?.avkortingGrunnlag.pop()
+  const faktiskInntekt: FaktiskInntektGrunnlag | undefined =
+    grunnlag?.type === 'FAKTISK_INNTEKT' ? (grunnlag as FaktiskInntektGrunnlag) : undefined
 
   const {
     register,
@@ -58,7 +63,7 @@ export const FaktiskInntektSkjema = ({ setRedigerFaktiskInntekt, setFastsettInnt
           loennsinntekt: new Intl.NumberFormat('nb').format(faktiskInntekt.loennsinntekt),
           afp: new Intl.NumberFormat('nb').format(faktiskInntekt.afp),
           naeringsinntekt: new Intl.NumberFormat('nb').format(faktiskInntekt.naeringsinntekt),
-          utland: new Intl.NumberFormat('nb').format(faktiskInntekt.utland),
+          utland: new Intl.NumberFormat('nb').format(faktiskInntekt.utlandsinntekt),
           spesifikasjon: faktiskInntekt.spesifikasjon,
         }
       : {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/fastsettFaktiskInntekt/FaktiskInntektSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/fastsettFaktiskInntekt/FaktiskInntektSkjema.tsx
@@ -14,14 +14,14 @@ const fastsettFaktiskInntektSkjemaValuesTilFaktiskInntekt = ({
   loennsinntekt,
   afp,
   naeringsinntekt,
-  utland,
+  utlandsinntekt,
   spesifikasjon,
 }: FastsettFaktiskInntektSkjema): FaktiskInntekt => {
   return {
     loennsinntekt: Number(loennsinntekt.replace(/[^0-9.]/g, '')),
     afp: Number(afp.replace(/[^0-9.]/g, '')),
     naeringsinntekt: Number(naeringsinntekt.replace(/[^0-9.]/g, '')),
-    utlandsinntekt: Number(utland.replace(/[^0-9.]/g, '')),
+    utlandsinntekt: Number(utlandsinntekt.replace(/[^0-9.]/g, '')),
     spesifikasjon,
   }
 }
@@ -30,7 +30,7 @@ interface FastsettFaktiskInntektSkjema {
   loennsinntekt: string
   afp: string
   naeringsinntekt: string
-  utland: string
+  utlandsinntekt: string
   spesifikasjon: string
 }
 
@@ -58,14 +58,14 @@ export const FaktiskInntektSkjema = ({ setRedigerFaktiskInntekt, setFastsettInnt
           loennsinntekt: new Intl.NumberFormat('nb').format(faktiskInntekt.loennsinntekt),
           afp: new Intl.NumberFormat('nb').format(faktiskInntekt.afp),
           naeringsinntekt: new Intl.NumberFormat('nb').format(faktiskInntekt.naeringsinntekt),
-          utland: new Intl.NumberFormat('nb').format(faktiskInntekt.utlandsinntekt),
+          utlandsinntekt: new Intl.NumberFormat('nb').format(faktiskInntekt.utlandsinntekt),
           spesifikasjon: faktiskInntekt.spesifikasjon,
         }
       : {
           loennsinntekt: '0',
           afp: '0',
           naeringsinntekt: '0',
-          utland: '0',
+          utlandsinntekt: '0',
           spesifikasjon: '',
         },
   })
@@ -99,7 +99,7 @@ export const FaktiskInntektSkjema = ({ setRedigerFaktiskInntekt, setFastsettInnt
           />
           <ControlledInntektTextField name="afp" control={control} label="Avtalefestet pensjon" />
           <ControlledInntektTextField name="naeringsinntekt" control={control} label="Næringsinntekt" />
-          <ControlledInntektTextField name="utland" control={control} label="Inntekt fra utland" />
+          <ControlledInntektTextField name="utlandsinntekt" control={control} label="Inntekt fra utland" />
         </VStack>
 
         <SumAvFaktiskInntekt faktiskInntekt={fastsettFaktiskInntektSkjemaValuesTilFaktiskInntekt(watch())} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/fastsettFaktiskInntekt/FaktiskInntektVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/fastsettFaktiskInntekt/FaktiskInntektVisning.tsx
@@ -21,7 +21,7 @@ export const FaktiskInntektVisning = () => {
       </VStack>
       <VStack gap="2">
         <Label>Inntekt fra utland</Label>
-        <BodyShort>{new Intl.NumberFormat('nb').format(faktiskInntekt.utland)}</BodyShort>
+        <BodyShort>{new Intl.NumberFormat('nb').format(faktiskInntekt.utlandsinntekt)}</BodyShort>
       </VStack>
 
       <SumAvFaktiskInntekt faktiskInntekt={faktiskInntekt} />

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/fastsettFaktiskInntekt/SumAvFaktiskInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/fastsettFaktiskInntekt/SumAvFaktiskInntekt.tsx
@@ -14,8 +14,8 @@ export const SumAvFaktiskInntekt = ({ faktiskInntekt }: { faktiskInntekt: Faktis
     if (isNaN(faktiskInntekt.naeringsinntekt)) inntekt += 0
     else inntekt += faktiskInntekt.naeringsinntekt
 
-    if (isNaN(faktiskInntekt.utland)) inntekt += 0
-    else inntekt += faktiskInntekt.utland
+    if (isNaN(faktiskInntekt.utlandsinntekt)) inntekt += 0
+    else inntekt += faktiskInntekt.utlandsinntekt
 
     return `${new Intl.NumberFormat('nb').format(inntekt)} kr`
   }

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Etteroppgjoer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Etteroppgjoer.ts
@@ -5,7 +5,7 @@ import { GrunnlagKilde } from '~shared/types/grunnlag'
 export interface Etteroppgjoer {
   behandling: EtteroppgjoerBehandling
   opplysninger: EtteroppgjoerOpplysninger
-  avkortingFaktiskInntekt: Avkorting | undefined
+  faktiskInntekt?: FaktiskInntekt
   beregnetEtteroppgjoerResultat: BeregnetEtteroppgjoerResultatDto | undefined
 }
 
@@ -45,7 +45,7 @@ export interface FaktiskInntekt {
   loennsinntekt: number
   afp: number
   naeringsinntekt: number
-  utland: number
+  utlandsinntekt: number
   spesifikasjon: string
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Etteroppgjoer.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/Etteroppgjoer.ts
@@ -5,7 +5,6 @@ import { GrunnlagKilde } from '~shared/types/grunnlag'
 export interface Etteroppgjoer {
   behandling: EtteroppgjoerBehandling
   opplysninger: EtteroppgjoerOpplysninger
-  faktiskInntekt?: FaktiskInntekt
   avkortingFaktiskInntekt: Avkorting | undefined
   beregnetEtteroppgjoerResultat: BeregnetEtteroppgjoerResultatDto | undefined
 }

--- a/libs/etterlatte-beregning-model/src/main/kotlin/BeregningDTO.kt
+++ b/libs/etterlatte-beregning-model/src/main/kotlin/BeregningDTO.kt
@@ -207,18 +207,6 @@ data class EtteroppgjoerBeregnetAvkortingRequest(
     val sakId: SakId,
 )
 
-data class EtteroppgjoerFaktiskInntektRequest(
-    val forbehandlingId: UUID,
-)
-
-data class EtteroppgjoerFaktiskInntektResponse(
-    val loennsinntekt: Long,
-    val afp: Long,
-    val naeringsinntekt: Long,
-    val utland: Long,
-    val spesifikasjon: String,
-)
-
 data class EtteroppgjoerBeregnetAvkorting(
     val avkortingMedForventaInntekt: AvkortingDto,
     val avkortingMedFaktiskInntekt: AvkortingDto?,

--- a/libs/etterlatte-beregning-model/src/main/kotlin/BeregningDTO.kt
+++ b/libs/etterlatte-beregning-model/src/main/kotlin/BeregningDTO.kt
@@ -232,7 +232,7 @@ data class EtteroppgjoerBeregnFaktiskInntektRequest(
     val loennsinntekt: Int,
     val afp: Int,
     val naeringsinntekt: Int,
-    val utland: Int,
+    val utlandsinntekt: Int,
     val spesifikasjon: String,
 )
 

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/model/oms/EtteroppgjoerBrevData.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/model/oms/EtteroppgjoerBrevData.kt
@@ -6,6 +6,7 @@ import no.nav.etterlatte.brev.Brevkoder
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerResultatType
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.pensjon.brevbaker.api.model.Kroner
+import java.time.YearMonth
 
 object EtteroppgjoerBrevData {
     data class Forhaandsvarsel(
@@ -17,6 +18,7 @@ object EtteroppgjoerBrevData {
         val inntekt: Kroner,
         val faktiskInntekt: Kroner,
         val avviksBeloep: Kroner,
+        val grunnlag: EtteroppgjoerBrevGrunnlag,
     ) : BrevFastInnholdData() {
         override val type: String = "OMS_EO_FORHAANDSVARSEL"
         override val brevKode: Brevkoder = Brevkoder.OMS_EO_FORHAANDSVARSEL
@@ -41,3 +43,13 @@ object EtteroppgjoerBrevData {
         override val brevKode: Brevkoder = Brevkoder.OMS_EO_VEDTAK
     }
 }
+
+data class EtteroppgjoerBrevGrunnlag(
+    val fom: YearMonth,
+    val tom: YearMonth,
+    val innvilgetMaaneder: Int,
+    val loensinntekt: Kroner,
+    val naeringsinntekt: Kroner,
+    val afp: Kroner,
+    val utlandsinntekt: Kroner,
+)


### PR DESCRIPTION
- Sende med faktisk inntekt ved oppretting av brev, dette for å vise tabell over grunnlag i brev
- FaktiskInntekt vises i frontend som del av etteroppgjør, rydder opp endepunkt for å hente det ut


Se PR i pensjonsbrev
https://github.com/navikt/pensjonsbrev/pull/1502