### PR TITLE
EY-5215 lagre relatertBehandling ved opprettelse av forbehandling

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Application.kt
@@ -181,6 +181,7 @@ private fun Route.settOppRoutes(applicationContext: ApplicationContext) {
         skatteoppgjoerHendelserService = applicationContext.skatteoppgjoerHendelserService,
         etteroppgjoerService = applicationContext.etteroppgjoerService,
         featureToggleService = applicationContext.featureToggleService,
+        etteroppgjoerJobService = applicationContext.etteroppgjoerJobService,
     )
     behandlingRoutes(
         behandlingService = applicationContext.behandlingService,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerRoutes.kt
@@ -14,6 +14,7 @@ import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.BeregnFaktiskInn
 import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.EtteroppgjoerForbehandlingService
 import no.nav.etterlatte.behandling.etteroppgjoer.sigrun.HendelseKjoeringRequest
 import no.nav.etterlatte.behandling.etteroppgjoer.sigrun.SkatteoppgjoerHendelserService
+import no.nav.etterlatte.behandling.job.EtteroppgjoerJobService
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggle
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.inTransaction
@@ -48,6 +49,7 @@ fun Route.etteroppgjoerRoutes(
     forbehandlingBrevService: EtteroppgjoerForbehandlingBrevService,
     skatteoppgjoerHendelserService: SkatteoppgjoerHendelserService,
     etteroppgjoerService: EtteroppgjoerService,
+    etteroppgjoerJobService: EtteroppgjoerJobService,
     featureToggleService: FeatureToggleService,
 ) {
     route("/api/etteroppgjoer") {
@@ -129,7 +131,7 @@ fun Route.etteroppgjoerRoutes(
                         "Inntektsaar mangler"
                     }
                 inTransaction {
-                    etteroppgjoerService.finnOgOpprettEtteroppgjoer(inntektsaar)
+                    etteroppgjoerJobService.finnOgOpprettEtteroppgjoer(inntektsaar)
                 }
                 call.respond(HttpStatusCode.OK)
             }
@@ -144,7 +146,7 @@ fun Route.etteroppgjoerRoutes(
                         "Inntektsaar mangler"
                     }
 
-                forbehandlingService.finnOgOpprettForbehandlinger(inntektsaar)
+                etteroppgjoerJobService.finnOgOpprettForbehandlinger(inntektsaar)
             }
         }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerService.kt
@@ -1,10 +1,8 @@
 package no.nav.etterlatte.behandling.etteroppgjoer
 
-import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.klienter.VedtakKlient
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.sak.SakId
-import no.nav.etterlatte.libs.ktor.token.HardkodaSystembruker
 import no.nav.etterlatte.logger
 import no.nav.etterlatte.sak.SakLesDao
 import no.nav.etterlatte.sak.SakService
@@ -29,23 +27,6 @@ class EtteroppgjoerService(
             skalHaEtteroppgjoer,
             etteroppgjoer,
         )
-    }
-
-    // finn saker som skal ha etteroppgjør for inntektsår og opprett etteroppgjør
-    fun finnOgOpprettEtteroppgjoer(inntektsaar: Int) {
-        logger.info("Starter oppretting av etteroppgjør for inntektsår $inntektsaar")
-        val sakerMedUtbetaling =
-            runBlocking {
-                vedtakKlient.hentSakerMedUtbetalingForInntektsaar(
-                    inntektsaar,
-                    HardkodaSystembruker.etteroppgjoer,
-                )
-            }
-
-        sakerMedUtbetaling
-            .forEach { sakId -> opprettEtteroppgjoer(sakId, inntektsaar) }
-
-        logger.info("Opprettet totalt ${sakerMedUtbetaling.size} etteroppgjoer for inntektsaar=$inntektsaar")
     }
 
     fun hentEtteroppgjoer(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingDao.kt
@@ -339,7 +339,7 @@ class EtteroppgjoerForbehandlingDao(
                 ),
             brevId = getLongOrNull("brev_id"),
             kopiertFra = getString("kopiert_fra")?.let { UUID.fromString(it) },
-            relatertBehandlingId = getString("relatert_behandling_id")!!.let { UUID.fromString(it) },
+            relatertBehandlingId = getString("relatert_behandling_id").let { UUID.fromString(it) },
         )
 
     private fun ResultSet.toPensjonsgivendeInntekt(): PensjonsgivendeInntekt =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingDao.kt
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.etteroppgjoer.AInntekt
 import no.nav.etterlatte.behandling.etteroppgjoer.PensjonsgivendeInntekt
 import no.nav.etterlatte.behandling.etteroppgjoer.PensjonsgivendeInntektFraSkatt
-import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.EtteroppgjoerForbehandling
-import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.EtteroppgjoerForbehandlingStatus
 import no.nav.etterlatte.behandling.hendelse.getLongOrNull
 import no.nav.etterlatte.behandling.hendelse.setLong
 import no.nav.etterlatte.common.ConnectionAutoclosing
@@ -71,7 +69,7 @@ class EtteroppgjoerForbehandlingDao(
                     prepareStatement(
                         """
                         INSERT INTO etteroppgjoer_behandling(
-                            id, status, sak_id, opprettet, aar, fom, tom, brev_id, kopiert_fra, relatert_behandling_id
+                            id, status, sak_id, opprettet, aar, fom, tom, brev_id, kopiert_fra, siste_iverksatte_behandling
                         ) 
                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) 
                         ON CONFLICT (id) DO UPDATE SET
@@ -94,7 +92,7 @@ class EtteroppgjoerForbehandlingDao(
                 )
                 statement.setLong(8, forbehandling.brevId)
                 statement.setObject(9, forbehandling.kopiertFra)
-                statement.setObject(10, forbehandling.relatertBehandlingId)
+                statement.setObject(10, forbehandling.sisteIverksatteBehandlingId)
 
                 statement.executeUpdate().also {
                     krev(it == 1) {
@@ -339,7 +337,7 @@ class EtteroppgjoerForbehandlingDao(
                 ),
             brevId = getLongOrNull("brev_id"),
             kopiertFra = getString("kopiert_fra")?.let { UUID.fromString(it) },
-            relatertBehandlingId = getString("relatert_behandling_id").let { UUID.fromString(it) },
+            sisteIverksatteBehandlingId = getString("siste_iverksatte_behandling").let { UUID.fromString(it) },
         )
 
     private fun ResultSet.toPensjonsgivendeInntekt(): PensjonsgivendeInntekt =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingDao.kt
@@ -38,7 +38,7 @@ class EtteroppgjoerForbehandlingDao(
                 val statement =
                     prepareStatement(
                         """
-                        SELECT t.id, t.sak_id, s.saktype, s.fnr, s.enhet, t.opprettet, t.status, t.aar, t.fom, t.tom, t.brev_id, t.kopiert_fra
+                        SELECT *
                         FROM etteroppgjoer_behandling t INNER JOIN sak s on t.sak_id = s.id
                         WHERE t.id = ?
                         """.trimIndent(),
@@ -54,7 +54,7 @@ class EtteroppgjoerForbehandlingDao(
                 val statement =
                     prepareStatement(
                         """
-                        SELECT t.id, t.sak_id, s.saktype, s.fnr, s.enhet, t.opprettet, t.status, t.aar, t.fom, t.tom, t.brev_id, t.kopiert_fra  
+                        SELECT *  
                         FROM etteroppgjoer_behandling t INNER JOIN sak s on t.sak_id = s.id
                         WHERE t.sak_id = ?
                         """.trimIndent(),
@@ -71,9 +71,9 @@ class EtteroppgjoerForbehandlingDao(
                     prepareStatement(
                         """
                         INSERT INTO etteroppgjoer_behandling(
-                            id, status, sak_id, opprettet, aar, fom, tom, brev_id, kopiert_fra
+                            id, status, sak_id, opprettet, aar, fom, tom, brev_id, kopiert_fra, relatert_behandling_id
                         ) 
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) 
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) 
                         ON CONFLICT (id) DO UPDATE SET
                             status = excluded.status,
                             brev_id = excluded.brev_id
@@ -94,6 +94,7 @@ class EtteroppgjoerForbehandlingDao(
                 )
                 statement.setLong(8, forbehandling.brevId)
                 statement.setObject(9, forbehandling.kopiertFra)
+                statement.setObject(10, forbehandling.relatertBehandlingId)
 
                 statement.executeUpdate().also {
                     krev(it == 1) {
@@ -338,6 +339,7 @@ class EtteroppgjoerForbehandlingDao(
                 ),
             brevId = getLongOrNull("brev_id"),
             kopiertFra = getString("kopiert_fra")?.let { UUID.fromString(it) },
+            relatertBehandlingId = getString("relatert_behandling_id")!!.let { UUID.fromString(it) },
         )
 
     private fun ResultSet.toPensjonsgivendeInntekt(): PensjonsgivendeInntekt =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingModel.kt
@@ -21,13 +21,14 @@ data class EtteroppgjoerForbehandling(
     val aar: Int,
     val innvilgetPeriode: Periode,
     val brevId: Long?,
-    // hvis vi oppretter en kopi av forbehandling for å bruke i en revurdering
-    val kopiertFra: UUID? = null,
+    val kopiertFra: UUID? = null, // hvis vi oppretter en kopi av forbehandling for å bruke i en revurdering
+    val relatertBehandlingId: UUID, // siste iverksatte behandling når forbehandling ble opprettet
 ) {
     companion object {
         fun opprett(
             sak: Sak,
             innvilgetPeriode: Periode,
+            sisteIverksatteBehandling: UUID,
         ) = EtteroppgjoerForbehandling(
             id = UUID.randomUUID(),
             hendelseId = UUID.randomUUID(),
@@ -38,6 +39,7 @@ data class EtteroppgjoerForbehandling(
             opprettet = Tidspunkt.now(),
             brevId = null,
             kopiertFra = null,
+            relatertBehandlingId = sisteIverksatteBehandling,
         )
     }
 
@@ -75,7 +77,6 @@ data class EtteroppgjoerForbehandling(
 
 data class DetaljertForbehandlingDto(
     val behandling: EtteroppgjoerForbehandling,
-    val sisteIverksatteBehandling: UUID,
     val opplysninger: EtteroppgjoerOpplysninger,
     val faktiskInntekt: FaktiskInntektDto?,
     val beregnetEtteroppgjoerResultat: BeregnetEtteroppgjoerResultatDto?,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingModel.kt
@@ -22,7 +22,7 @@ data class EtteroppgjoerForbehandling(
     val innvilgetPeriode: Periode,
     val brevId: Long?,
     val kopiertFra: UUID? = null, // hvis vi oppretter en kopi av forbehandling for å bruke i en revurdering
-    val relatertBehandlingId: UUID, // siste iverksatte behandling når forbehandling ble opprettet
+    val sisteIverksatteBehandlingId: UUID, // siste iverksatte behandling når forbehandling ble opprettet
 ) {
     companion object {
         fun opprett(
@@ -39,7 +39,7 @@ data class EtteroppgjoerForbehandling(
             opprettet = Tidspunkt.now(),
             brevId = null,
             kopiertFra = null,
-            relatertBehandlingId = sisteIverksatteBehandling,
+            sisteIverksatteBehandlingId = sisteIverksatteBehandling,
         )
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -31,7 +31,6 @@ import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vedtak.FoersteVirkOgOppoerTilSak
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
-import no.nav.etterlatte.libs.ktor.token.HardkodaSystembruker
 import no.nav.etterlatte.oppgave.OppgaveService
 import no.nav.etterlatte.sak.SakLesDao
 import org.slf4j.Logger
@@ -53,27 +52,6 @@ class EtteroppgjoerForbehandlingService(
 ) {
     private val logger: Logger = LoggerFactory.getLogger(EtteroppgjoerForbehandlingService::class.java)
 
-    // finn saker med etteroppgjoer og mottatt skatteoppgjoer som skal ha forbehandling
-    fun finnOgOpprettForbehandlinger(inntektsaar: Int) {
-        logger.info(
-            "Starter oppretting av forbehandling for etteroppgjør med mottatt skatteoppgjør for inntektsår $inntektsaar",
-        )
-        val etteroppgjoerListe =
-            etteroppgjoerService.hentEtteroppgjoerForStatus(EtteroppgjoerStatus.MOTTATT_SKATTEOPPGJOER, inntektsaar)
-
-        for (etteroppgjoer in etteroppgjoerListe) {
-            try {
-                opprettEtteroppgjoerForbehandling(
-                    etteroppgjoer.sakId,
-                    etteroppgjoer.inntektsaar,
-                    HardkodaSystembruker.etteroppgjoer,
-                )
-            } catch (e: Exception) {
-                logger.error("Kunne ikke opprette forbehandling for sakId=${etteroppgjoer.sakId} grunnen: ${e.message}")
-            }
-        }
-    }
-
     fun ferdigstillForbehandling(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
@@ -89,8 +67,6 @@ class EtteroppgjoerForbehandlingService(
         )
         oppgaveService.ferdigStillOppgaveUnderBehandling(forbehandling.id.toString(), OppgaveType.ETTEROPPGJOER, brukerTokenInfo)
     }
-
-    fun hentPensjonsgivendeInntekt(behandlingId: UUID): PensjonsgivendeInntektFraSkatt? = dao.hentPensjonsgivendeInntekt(behandlingId)
 
     fun lagreForbehandling(forbehandling: EtteroppgjoerForbehandling) = dao.lagreForbehandling(forbehandling)
 
@@ -150,6 +126,8 @@ class EtteroppgjoerForbehandlingService(
         val forbehandling = dao.hentForbehandling(forbehandlingId) ?: throw FantIkkeForbehandling(forbehandlingId)
         dao.lagreForbehandling(forbehandling.medBrev(brev))
     }
+
+    fun hentPensjonsgivendeInntekt(behandlingId: UUID): PensjonsgivendeInntektFraSkatt? = dao.hentPensjonsgivendeInntekt(behandlingId)
 
     fun hentEtteroppgjoerForbehandlinger(sakId: SakId): List<EtteroppgjoerForbehandling> = dao.hentForbehandlinger(sakId)
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -195,17 +195,21 @@ class EtteroppgjoerForbehandlingService(
     ): BeregnetEtteroppgjoerResultatDto {
         var forbehandling = dao.hentForbehandling(forbehandlingId) ?: throw FantIkkeForbehandling(forbehandlingId)
 
+        val sisteIverksatteBehandling =
+            behandlingService.hentSisteIverksatte(forbehandling.sak.id)
+                ?: throw InternfeilException("Fant ikke siste iverksatte")
+
         // hvis ferdigstilt, ikke overskriv men opprett ny kopi forbehandling
         if (forbehandling.erFerdigstilt()) {
             logger.info("Oppretter ny kopi av forbehandling for behandlingId=$forbehandlingId")
-            forbehandling = kopierOgLagreNyForbehandling(forbehandling)
+            forbehandling = kopierOgLagreNyForbehandling(forbehandling, sisteIverksatteBehandling.id)
         }
 
         val beregningRequest =
             EtteroppgjoerBeregnFaktiskInntektRequest(
                 sakId = forbehandling.sak.id,
                 forbehandlingId = forbehandling.id,
-                sisteIverksatteBehandling = forbehandling.relatertBehandlingId,
+                sisteIverksatteBehandling = sisteIverksatteBehandling.id,
                 aar = forbehandling.aar,
                 loennsinntekt = request.loennsinntekt,
                 naeringsinntekt = request.naeringsinntekt,
@@ -313,18 +317,17 @@ class EtteroppgjoerForbehandlingService(
         }
     }
 
-    private fun kopierOgLagreNyForbehandling(forbehandling: EtteroppgjoerForbehandling): EtteroppgjoerForbehandling {
-        val sisteIverksatteBehandling =
-            behandlingService.hentSisteIverksatte(forbehandling.sak.id)
-                ?: throw InternfeilException("Fant ikke siste iverksatte behandling")
-
+    private fun kopierOgLagreNyForbehandling(
+        forbehandling: EtteroppgjoerForbehandling,
+        relatertBehandlingId: UUID,
+    ): EtteroppgjoerForbehandling {
         val forbehandlingCopy =
             forbehandling.copy(
                 id = UUID.randomUUID(),
                 status = EtteroppgjoerForbehandlingStatus.OPPRETTET,
                 opprettet = Tidspunkt.now(), // ny dato
                 kopiertFra = forbehandling.id,
-                relatertBehandlingId = sisteIverksatteBehandling.id,
+                relatertBehandlingId = relatertBehandlingId,
             )
 
         dao.lagreForbehandling(forbehandlingCopy)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -173,21 +173,17 @@ class EtteroppgjoerForbehandlingService(
     ): BeregnetEtteroppgjoerResultatDto {
         var forbehandling = dao.hentForbehandling(forbehandlingId) ?: throw FantIkkeForbehandling(forbehandlingId)
 
-        val sisteIverksatteBehandling =
-            behandlingService.hentSisteIverksatte(forbehandling.sak.id)
-                ?: throw InternfeilException("Fant ikke siste iverksatte")
-
         // hvis ferdigstilt, ikke overskriv men opprett ny kopi forbehandling
         if (forbehandling.erFerdigstilt()) {
             logger.info("Oppretter ny kopi av forbehandling for behandlingId=$forbehandlingId")
-            forbehandling = kopierOgLagreNyForbehandling(forbehandling, sisteIverksatteBehandling.id)
+            forbehandling = kopierOgLagreNyForbehandling(forbehandling)
         }
 
         val beregningRequest =
             EtteroppgjoerBeregnFaktiskInntektRequest(
                 sakId = forbehandling.sak.id,
                 forbehandlingId = forbehandling.id,
-                sisteIverksatteBehandling = sisteIverksatteBehandling.id,
+                sisteIverksatteBehandling = forbehandling.relatertBehandlingId,
                 aar = forbehandling.aar,
                 loennsinntekt = request.loennsinntekt,
                 naeringsinntekt = request.naeringsinntekt,
@@ -295,17 +291,18 @@ class EtteroppgjoerForbehandlingService(
         }
     }
 
-    private fun kopierOgLagreNyForbehandling(
-        forbehandling: EtteroppgjoerForbehandling,
-        relatertBehandlingId: UUID,
-    ): EtteroppgjoerForbehandling {
+    private fun kopierOgLagreNyForbehandling(forbehandling: EtteroppgjoerForbehandling): EtteroppgjoerForbehandling {
+        val sisteIverksatteBehandling =
+            behandlingService.hentSisteIverksatte(forbehandling.sak.id)
+                ?: throw InternfeilException("Fant ikke siste iverksatte")
+
         val forbehandlingCopy =
             forbehandling.copy(
                 id = UUID.randomUUID(),
                 status = EtteroppgjoerForbehandlingStatus.OPPRETTET,
                 opprettet = Tidspunkt.now(), // ny dato
                 kopiertFra = forbehandling.id,
-                relatertBehandlingId = relatertBehandlingId,
+                relatertBehandlingId = sisteIverksatteBehandling.id,
             )
 
         dao.lagreForbehandling(forbehandlingCopy)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -78,13 +78,13 @@ class EtteroppgjoerForbehandlingService(
         brukerTokenInfo: BrukerTokenInfo,
     ): DetaljertForbehandlingDto {
         val forbehandling = hentForbehandling(forbehandlingId)
-        val relatertBehandling =
-            behandlingService.hentBehandling(forbehandling.relatertBehandlingId)
+        val sisteIverksatteBehandling =
+            behandlingService.hentBehandling(forbehandling.sisteIverksatteBehandlingId)
                 ?: throw InternfeilException(
-                    "Fant ikke relatert behandling=${forbehandling.relatertBehandlingId} for forbehandling=$forbehandlingId",
+                    "Fant ikke relatert behandling=${forbehandling.sisteIverksatteBehandlingId} for forbehandling=$forbehandlingId",
                 )
 
-        val avkorting = hentAvkortingForForbehandling(forbehandling, relatertBehandling, brukerTokenInfo)
+        val avkorting = hentAvkortingForForbehandling(forbehandling, sisteIverksatteBehandling, brukerTokenInfo)
         val pensjonsgivendeInntekt = dao.hentPensjonsgivendeInntekt(forbehandlingId)
         val aInntekt = dao.hentAInntekt(forbehandlingId)
 
@@ -100,7 +100,7 @@ class EtteroppgjoerForbehandlingService(
                     EtteroppgjoerHentBeregnetResultatRequest(
                         forbehandling.aar,
                         forbehandlingId,
-                        relatertBehandling.id,
+                        sisteIverksatteBehandling.id,
                     ),
                     brukerTokenInfo,
                 )
@@ -183,7 +183,7 @@ class EtteroppgjoerForbehandlingService(
             EtteroppgjoerBeregnFaktiskInntektRequest(
                 sakId = forbehandling.sak.id,
                 forbehandlingId = forbehandling.id,
-                sisteIverksatteBehandling = forbehandling.relatertBehandlingId,
+                sisteIverksatteBehandling = forbehandling.sisteIverksatteBehandlingId,
                 aar = forbehandling.aar,
                 loennsinntekt = request.loennsinntekt,
                 naeringsinntekt = request.naeringsinntekt,
@@ -302,7 +302,7 @@ class EtteroppgjoerForbehandlingService(
                 status = EtteroppgjoerForbehandlingStatus.OPPRETTET,
                 opprettet = Tidspunkt.now(), // ny dato
                 kopiertFra = forbehandling.id,
-                relatertBehandlingId = sisteIverksatteBehandling.id,
+                sisteIverksatteBehandlingId = sisteIverksatteBehandling.id,
             )
 
         dao.lagreForbehandling(forbehandlingCopy)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -272,15 +272,15 @@ class EtteroppgjoerForbehandlingService(
 
     private fun hentAvkortingForForbehandling(
         forbehandling: EtteroppgjoerForbehandling,
-        relatertBehandling: Behandling,
+        sisteIverksatteBehandling: Behandling,
         brukerTokenInfo: BrukerTokenInfo,
     ): EtteroppgjoerBeregnetAvkorting {
         val request =
             EtteroppgjoerBeregnetAvkortingRequest(
                 forbehandling = forbehandling.id,
-                sisteIverksatteBehandling = relatertBehandling.id,
+                sisteIverksatteBehandling = sisteIverksatteBehandling.id,
                 aar = forbehandling.aar,
-                sakId = relatertBehandling.sak.id,
+                sakId = sisteIverksatteBehandling.sak.id,
             )
         logger.info("Henter avkorting for forbehandling: $request")
         return runBlocking {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/jobs/EtteroppgjoerJobService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/jobs/EtteroppgjoerJobService.kt
@@ -73,8 +73,7 @@ class EtteroppgjoerJobService(
 
     // finn saker som skal ha etteroppgjør for inntektsår og opprett etteroppgjør
     fun finnOgOpprettEtteroppgjoer(inntektsaar: Int) {
-        no.nav.etterlatte.logger
-            .info("Starter oppretting av etteroppgjør for inntektsår $inntektsaar")
+        logger.info("Starter oppretting av etteroppgjør for inntektsår $inntektsaar")
         val sakerMedUtbetaling =
             runBlocking {
                 vedtakKlient.hentSakerMedUtbetalingForInntektsaar(
@@ -86,7 +85,6 @@ class EtteroppgjoerJobService(
         sakerMedUtbetaling
             .forEach { sakId -> etteroppgjoerService.opprettEtteroppgjoer(sakId, inntektsaar) }
 
-        no.nav.etterlatte.logger
-            .info("Opprettet totalt ${sakerMedUtbetaling.size} etteroppgjoer for inntektsaar=$inntektsaar")
+        logger.info("Opprettet totalt ${sakerMedUtbetaling.size} etteroppgjoer for inntektsaar=$inntektsaar")
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/jobs/EtteroppgjoerJobService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/jobs/EtteroppgjoerJobService.kt
@@ -4,10 +4,12 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerService
+import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerStatus
 import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerToggles
 import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.EtteroppgjoerForbehandlingService
-import no.nav.etterlatte.behandling.etteroppgjoer.sigrun.SkatteoppgjoerHendelserService
+import no.nav.etterlatte.behandling.klienter.VedtakKlient
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
+import no.nav.etterlatte.libs.ktor.token.HardkodaSystembruker
 import org.slf4j.LoggerFactory
 import java.time.YearMonth
 
@@ -15,7 +17,7 @@ import java.time.YearMonth
 class EtteroppgjoerJobService(
     private val etteroppgjoerService: EtteroppgjoerService,
     private val etteroppgjoerForbehandlingService: EtteroppgjoerForbehandlingService,
-    private val skatteoppgjoerHendelserService: SkatteoppgjoerHendelserService,
+    private val vedtakKlient: VedtakKlient,
     private val featureToggleService: FeatureToggleService,
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
@@ -26,31 +28,65 @@ class EtteroppgjoerJobService(
             runBlocking(ctx) {
                 if (featureToggleService.isEnabled(EtteroppgjoerToggles.ETTEROPPGJOER_PERIODISK_JOBB, false)) {
                     logger.info("Starter periodiske jobber for etteroppgjoer")
-                    startEtteroppgjoerKjoering(etteroppgjoerService, etteroppgjoerForbehandlingService, skatteoppgjoerHendelserService)
+                    startEtteroppgjoerKjoering()
                 } else {
                     logger.info("Periodisk jobber for etteroppgjoer er deaktivert")
                 }
             }
         }
     }
-}
 
-internal fun startEtteroppgjoerKjoering(
-    etteroppgjoerService: EtteroppgjoerService,
-    etteroppgjoerForbehandlingService: EtteroppgjoerForbehandlingService,
-    skatteoppgjoerHendelserService: SkatteoppgjoerHendelserService,
-) {
-    val yearNow = YearMonth.now().year
-    val aarMellom2024OgNaa = (2024..yearNow).toList()
+    fun startEtteroppgjoerKjoering() {
+        val yearNow = YearMonth.now().year
+        val aarMellom2024OgNaa = (2024..yearNow).toList()
 
-    val antallHendelser = 500
+        for (inntektsaar in aarMellom2024OgNaa) {
+            finnOgOpprettEtteroppgjoer(inntektsaar)
 
-    for (inntektsaar in aarMellom2024OgNaa) {
-        etteroppgjoerService.finnOgOpprettEtteroppgjoer(inntektsaar)
+            // TODO: legge inn denne når vi har testet litt mer?
+            // skatteoppgjoerHendelserService.startHendelsesKjoering(HendelseKjoeringRequest(500),"automatisk")
 
-        // TODO: legge inn denne når vi har testet litt mer?
-        // skatteoppgjoerHendelserService.startHendelsesKjoering(HendelseKjoeringRequest(500),"automatisk")
+            finnOgOpprettForbehandlinger(inntektsaar)
+        }
+    }
 
-        etteroppgjoerForbehandlingService.finnOgOpprettForbehandlinger(inntektsaar)
+    // finn saker med etteroppgjoer og mottatt skatteoppgjoer som skal ha forbehandling
+    fun finnOgOpprettForbehandlinger(inntektsaar: Int) {
+        logger.info(
+            "Starter oppretting av forbehandling for etteroppgjør med mottatt skatteoppgjør for inntektsår $inntektsaar",
+        )
+        val etteroppgjoerListe =
+            etteroppgjoerService.hentEtteroppgjoerForStatus(EtteroppgjoerStatus.MOTTATT_SKATTEOPPGJOER, inntektsaar)
+
+        for (etteroppgjoer in etteroppgjoerListe) {
+            try {
+                etteroppgjoerForbehandlingService.opprettEtteroppgjoerForbehandling(
+                    etteroppgjoer.sakId,
+                    etteroppgjoer.inntektsaar,
+                    HardkodaSystembruker.etteroppgjoer,
+                )
+            } catch (e: Exception) {
+                logger.error("Kunne ikke opprette forbehandling for sakId=${etteroppgjoer.sakId} grunnen: ${e.message}")
+            }
+        }
+    }
+
+    // finn saker som skal ha etteroppgjør for inntektsår og opprett etteroppgjør
+    fun finnOgOpprettEtteroppgjoer(inntektsaar: Int) {
+        no.nav.etterlatte.logger
+            .info("Starter oppretting av etteroppgjør for inntektsår $inntektsaar")
+        val sakerMedUtbetaling =
+            runBlocking {
+                vedtakKlient.hentSakerMedUtbetalingForInntektsaar(
+                    inntektsaar,
+                    HardkodaSystembruker.etteroppgjoer,
+                )
+            }
+
+        sakerMedUtbetaling
+            .forEach { sakId -> etteroppgjoerService.opprettEtteroppgjoer(sakId, inntektsaar) }
+
+        no.nav.etterlatte.logger
+            .info("Opprettet totalt ${sakerMedUtbetaling.size} etteroppgjoer for inntektsaar=$inntektsaar")
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -733,7 +733,7 @@ internal class ApplicationContext(
         EtteroppgjoerJobService(
             etteroppgjoerService,
             etteroppgjoerForbehandlingService,
-            skatteoppgjoerHendelserService,
+            vedtakKlient,
             featureToggleService,
         )
 

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V266__legge_til_relatertb_behandling_id_forbehandling.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V266__legge_til_relatertb_behandling_id_forbehandling.sql
@@ -1,0 +1,2 @@
+ALTER TABLE etteroppgjoer_behandling
+    ADD COLUMN relatert_forbehandling_id UUID;

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V266__legge_til_relatertb_behandling_id_forbehandling.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V266__legge_til_relatertb_behandling_id_forbehandling.sql
@@ -1,2 +1,0 @@
-ALTER TABLE etteroppgjoer_behandling
-    ADD COLUMN relatert_behandling_id UUID;

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V266__legge_til_relatertb_behandling_id_forbehandling.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V266__legge_til_relatertb_behandling_id_forbehandling.sql
@@ -1,2 +1,2 @@
 ALTER TABLE etteroppgjoer_behandling
-    ADD COLUMN relatert_forbehandling_id UUID;
+    ADD COLUMN relatert_behandling_id UUID;

--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V266__legge_til_siste_iverksatte_behandling_for_forbehandling.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V266__legge_til_siste_iverksatte_behandling_for_forbehandling.sql
@@ -1,0 +1,2 @@
+ALTER TABLE etteroppgjoer_behandling
+    ADD COLUMN siste_iverksatte_behandling UUID;

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/etteroppgjoer/EtteroppgjoerForbehandlingDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/etteroppgjoer/EtteroppgjoerForbehandlingDaoTest.kt
@@ -87,7 +87,7 @@ class EtteroppgjoerForbehandlingDaoTest(
                 brevId = null,
                 innvilgetPeriode = Periode(YearMonth.of(2024, 1), YearMonth.of(2024, 12)),
                 kopiertFra = kopiertFra,
-                relatertBehandlingId = UUID.randomUUID(),
+                sisteIverksatteBehandlingId = UUID.randomUUID(),
             )
 
         etteroppgjoerForbehandlingDao.lagreForbehandling(ny)
@@ -115,7 +115,7 @@ class EtteroppgjoerForbehandlingDaoTest(
                 brevId = null,
                 innvilgetPeriode = Periode(YearMonth.of(2024, 1), YearMonth.of(2024, 12)),
                 kopiertFra = UUID.randomUUID(),
-                relatertBehandlingId = UUID.randomUUID(),
+                sisteIverksatteBehandlingId = UUID.randomUUID(),
             ),
         )
         etteroppgjoerForbehandlingDao.lagreForbehandling(
@@ -129,7 +129,7 @@ class EtteroppgjoerForbehandlingDaoTest(
                 brevId = null,
                 innvilgetPeriode = Periode(YearMonth.of(2024, 1), YearMonth.of(2024, 12)),
                 kopiertFra = null,
-                relatertBehandlingId = UUID.randomUUID(),
+                sisteIverksatteBehandlingId = UUID.randomUUID(),
             ),
         )
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/etteroppgjoer/EtteroppgjoerForbehandlingDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/etteroppgjoer/EtteroppgjoerForbehandlingDaoTest.kt
@@ -87,6 +87,7 @@ class EtteroppgjoerForbehandlingDaoTest(
                 brevId = null,
                 innvilgetPeriode = Periode(YearMonth.of(2024, 1), YearMonth.of(2024, 12)),
                 kopiertFra = kopiertFra,
+                relatertBehandlingId = UUID.randomUUID(),
             )
 
         etteroppgjoerForbehandlingDao.lagreForbehandling(ny)
@@ -114,6 +115,7 @@ class EtteroppgjoerForbehandlingDaoTest(
                 brevId = null,
                 innvilgetPeriode = Periode(YearMonth.of(2024, 1), YearMonth.of(2024, 12)),
                 kopiertFra = UUID.randomUUID(),
+                relatertBehandlingId = UUID.randomUUID(),
             ),
         )
         etteroppgjoerForbehandlingDao.lagreForbehandling(
@@ -127,6 +129,7 @@ class EtteroppgjoerForbehandlingDaoTest(
                 brevId = null,
                 innvilgetPeriode = Periode(YearMonth.of(2024, 1), YearMonth.of(2024, 12)),
                 kopiertFra = null,
+                relatertBehandlingId = UUID.randomUUID(),
             ),
         )
 


### PR DESCRIPTION
Tidligere brukte vi sisteIverksatteBehandling for å hente beregnetEtteroppgjoerResultat, problemet der er at hvis en forbehandling er ferdigstilt og vi har gjennomført en revurdering så finner vi ikke et resultat fordi sisteIverksattebehandling har endret seg. 

- Ender til å lagre relatertBehandlingId som brukes for å hente beregnetEtteroppgjoerResultat

NB! Dette vil bryte tidligere saker i Gjenny da relatertBehandlingId er påkrevd og forventet...

- Vi bør kanskje ha en sjekk som sjekker om sisteIverksatteBehandling har endret seg mens forbehandling er under behandling. Da vil relatertBehandlingId ikke peke på siste