### PR TITLE
Fix/testdata vedtaksvurdering kobling

### DIFF
--- a/apps/etterlatte-testdata/.nais/dev.yaml
+++ b/apps/etterlatte-testdata/.nais/dev.yaml
@@ -65,6 +65,7 @@ spec:
   accessPolicy:
     outbound:
       rules:
+        - application: etterlatte-vedtaksvurdering
         - application: testnav-person-service
           namespace: dolly
           cluster: dev-gcp

--- a/apps/etterlatte-testdata/.nais/dev.yaml
+++ b/apps/etterlatte-testdata/.nais/dev.yaml
@@ -62,6 +62,10 @@ spec:
       value: dev-gcp.dolly.testnav-person-service
     - name: TESTNAV_RESOURCE_URL
       value: http://testnav-person-service.dolly/api/v2
+    - name: ETTERLATTE_VEDTAKSVURDERING_URL
+      value: http://etterlatte-vedtaksvurdering
+    - name: ETTERLATTE_VEDTAKSVURDERING_SCOPE
+      value: api://dev-gcp.etterlatte.etterlatte-vedtaksvurdering/.default
   accessPolicy:
     outbound:
       rules:

--- a/apps/etterlatte-testdata/.nais/dev.yaml
+++ b/apps/etterlatte-testdata/.nais/dev.yaml
@@ -31,8 +31,8 @@ spec:
     requests:
       cpu: 10m
   replicas:
-    max: 1
-    min: 1
+    max: 2
+    min: 2
   azure:
     application:
       enabled: true

--- a/apps/etterlatte-testdata/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/Application.kt
@@ -58,6 +58,8 @@ import no.nav.etterlatte.libs.ktor.token.brukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.firstValidTokenClaims
 import no.nav.etterlatte.no.nav.etterlatte.testdata.features.OpprettOgBehandle
 import no.nav.etterlatte.no.nav.etterlatte.testdata.features.automatisk.Familieoppretter
+import no.nav.etterlatte.no.nav.etterlatte.testdata.features.dolly.VedtakService
+import no.nav.etterlatte.no.nav.etterlatte.testdata.features.dolly.VedtaksvurderingKlient
 import no.nav.etterlatte.no.nav.etterlatte.testdata.features.opprettFamilie.OpprettFamilie
 import no.nav.etterlatte.testdata.dolly.DollyClientImpl
 import no.nav.etterlatte.testdata.dolly.DollyMock
@@ -104,12 +106,13 @@ val dollyService =
         DollyClientImpl(config, httpClient),
         TestnavClient(config, httpClient),
     )
+val vedtakService = VedtakService(VedtaksvurderingKlient(config, httpClient))
 val features: List<TestDataFeature> =
     listOf(
         IndexFeature,
         EgendefinertMeldingFeature,
         OpprettSoeknadFeature,
-        DollyFeature(dollyService),
+        DollyFeature(dollyService, vedtakService),
         OpprettOgBehandle(dollyService, Familieoppretter(dollyService)),
         OpprettFamilie(
             dollyService =

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/dolly/DollyFeature.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/dolly/DollyFeature.kt
@@ -189,31 +189,8 @@ class DollyFeature(
             post("api/v1/hent-ytelse") {
                 try {
                     val request = call.receive<FoedselsnummerDTO>()
-                    // TODO hente faktisk vedtak
                     val fnr = haandterUgyldigIdent(request.foedselsnummer)
                     val vedtak = vedtakService.hentVedtak(fnr)
-                    /*val vedtak =
-                        VedtakTilPerson(
-                            vedtak =
-                                listOf(
-                                    Vedtak(
-                                        sakId = 1,
-                                        sakType = "BARNEPENSJON",
-                                        virkningstidspunkt = LocalDate.now(),
-                                        type = VedtakType.INNVILGELSE,
-                                        utbetaling =
-                                            listOf(
-                                                VedtakUtbetaling(
-                                                    fraOgMed = LocalDate.now(),
-                                                    tilOgMed = LocalDate.now(),
-                                                    beloep = BigDecimal(1000),
-                                                ),
-                                            ),
-                                    ),
-                                ),
-                           )
-                     */
-
                     call.respond(vedtak)
                 } catch (e: UgyldigFoedselsnummerException) {
                     call.respondNullable(HttpStatusCode.BadRequest, e.detail)

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/dolly/DollyFeature.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/dolly/DollyFeature.kt
@@ -23,6 +23,7 @@ import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.ktor.route.FoedselsnummerDTO
 import no.nav.etterlatte.libs.ktor.token.brukerTokenInfo
+import no.nav.etterlatte.no.nav.etterlatte.testdata.features.dolly.VedtakService
 import no.nav.etterlatte.objectMapper
 import no.nav.etterlatte.rapidsandrivers.Behandlingssteg
 import no.nav.etterlatte.testdata.dolly.BestillingRequest
@@ -34,6 +35,7 @@ import java.time.LocalDate
 
 class DollyFeature(
     private val dollyService: DollyService,
+    private val vedtakService: VedtakService,
 ) : TestDataFeature {
     private val logger: Logger = LoggerFactory.getLogger(DollyFeature::class.java)
     override val beskrivelse: String
@@ -189,8 +191,8 @@ class DollyFeature(
                     val request = call.receive<FoedselsnummerDTO>()
                     // TODO hente faktisk vedtak
                     val fnr = haandterUgyldigIdent(request.foedselsnummer)
-                    // val vedtak = vedtakService.hentVedtak(fnr)
-                    val vedtak =
+                    val vedtak = vedtakService.hentVedtak(fnr)
+                    /*val vedtak =
                         VedtakTilPerson(
                             vedtak =
                                 listOf(
@@ -209,7 +211,9 @@ class DollyFeature(
                                             ),
                                     ),
                                 ),
-                        )
+                           )
+                     */
+
                     call.respond(vedtak)
                 } catch (e: UgyldigFoedselsnummerException) {
                     call.respondNullable(HttpStatusCode.BadRequest, e.detail)

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/dolly/VedtakService.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/dolly/VedtakService.kt
@@ -1,0 +1,42 @@
+package no.nav.etterlatte.no.nav.etterlatte.testdata.features.dolly
+
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.vedtak.VedtakDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakInnholdDto
+import no.nav.etterlatte.testdata.features.dolly.Vedtak
+import no.nav.etterlatte.testdata.features.dolly.VedtakTilPerson
+import no.nav.etterlatte.testdata.features.dolly.VedtakType
+import no.nav.etterlatte.testdata.features.dolly.VedtakUtbetaling
+import java.time.LocalDate
+import java.time.YearMonth
+
+class VedtakService(
+    private val vedtaksvurderingKlient: VedtaksvurderingKlient,
+) {
+    suspend fun hentVedtak(fnr: Folkeregisteridentifikator): VedtakTilPerson {
+        val vedtak = vedtaksvurderingKlient.hentVedtak(fnr)
+        return VedtakTilPerson(
+            vedtak = vedtak.filter { it.type.vanligBehandling }.map { it.fromDto() },
+        )
+    }
+}
+
+fun VedtakDto.fromDto(): Vedtak {
+    val vedtakInnhold = (innhold as VedtakInnholdDto.VedtakBehandlingDto)
+    return Vedtak(
+        sakId = sak.id.sakId,
+        sakType = sak.sakType.name,
+        virkningstidspunkt = vedtakInnhold.virkningstidspunkt.atStartOfMonth(),
+        type = VedtakType.valueOf(type.name),
+        utbetaling =
+            vedtakInnhold.utbetalingsperioder.map { utbetaling ->
+                VedtakUtbetaling(
+                    fraOgMed = utbetaling.periode.fom.atStartOfMonth(),
+                    tilOgMed = utbetaling.periode.tom?.atEndOfMonth(),
+                    beloep = utbetaling.beloep,
+                )
+            },
+    )
+}
+
+fun YearMonth.atStartOfMonth(): LocalDate = this.atDay(1)

--- a/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/dolly/VedtaksvurderingKlient.kt
+++ b/apps/etterlatte-testdata/src/main/kotlin/no/nav/etterlatte/testdata/features/dolly/VedtaksvurderingKlient.kt
@@ -1,0 +1,58 @@
+package no.nav.etterlatte.no.nav.etterlatte.testdata.features.dolly
+
+import com.typesafe.config.Config
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.request.url
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
+import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
+import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.common.logging.sikkerlogger
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.vedtak.VedtakDto
+import org.slf4j.LoggerFactory
+
+class VedtaksvurderingKlient(
+    config: Config,
+    private val httpClient: HttpClient,
+) {
+    private val logger = LoggerFactory.getLogger(VedtaksvurderingKlient::class.java)
+
+    private val vedtaksvurderingUrl = "${config.getString("vedtak.url")}/vedtak/fnr"
+
+    suspend fun hentVedtak(request: Folkeregisteridentifikator): List<VedtakDto> {
+        sikkerlogger().info("Henter vedtak med fnr=$request")
+
+        return try {
+            httpClient
+                .post {
+                    url(vedtaksvurderingUrl)
+                    contentType(ContentType.Application.Json)
+                    setBody(request)
+                }.body()
+        } catch (e: ClientRequestException) {
+            logger.error("Det oppstod feil i kall til vedtak API", e)
+            when (e.response.status) {
+                HttpStatusCode.Unauthorized -> throw IkkeTillattException("VEDTAK-TILGANG", "Vedtak: Ikke tilgang")
+                HttpStatusCode.BadRequest -> throw UgyldigForespoerselException(
+                    "VEDTAK-FORESPOERSEL",
+                    "Vedtak: Ugyldig forespørsel",
+                )
+
+                HttpStatusCode.NotFound -> throw IkkeFunnetException(
+                    "VEDTAK-IKKE-FUNNET",
+                    "Vedtak: Ressurs ikke funnet",
+                )
+
+                else -> throw InternfeilException("Intern feil ved uthenting av vedtak")
+            }
+        }
+    }
+}

--- a/apps/etterlatte-testdata/src/main/resources/application.conf
+++ b/apps/etterlatte-testdata/src/main/resources/application.conf
@@ -18,3 +18,9 @@ dolly.resource.url = ${DOLLY_RESOURCE_URL}
 
 testnav.client.id = ${TESTNAV_CLIENT_ID}
 testnav.resource.url = ${TESTNAV_RESOURCE_URL}
+
+vedtak {
+    url = ${?ETTERLATTE_VEDTAKSVURDERING_URL}
+    outbound = ${?ETTERLATTE_VEDTAKSVURDERING_SCOPE}
+    client_id = ${?AZURE_APP_CLIENT_ID}
+}

--- a/apps/etterlatte-testdata/src/test/kotlin/DollyRoutesTest.kt
+++ b/apps/etterlatte-testdata/src/test/kotlin/DollyRoutesTest.kt
@@ -172,6 +172,28 @@ class DollyRoutesTest {
                 pensjonSaksbehandler = pensjonSaksbehandler,
             )
         val request = FoedselsnummerDTO("09437432993")
+        val forventetRetur =
+            VedtakTilPerson(
+                vedtak =
+                    listOf(
+                        Vedtak(
+                            sakId = 1,
+                            sakType = "BARNEPENSJON",
+                            virkningstidspunkt = LocalDate.now(),
+                            type = VedtakType.INNVILGELSE,
+                            utbetaling =
+                                listOf(
+                                    VedtakUtbetaling(
+                                        fraOgMed = LocalDate.now(),
+                                        tilOgMed = LocalDate.now(),
+                                        beloep = BigDecimal(1000),
+                                    ),
+                                ),
+                        ),
+                    ),
+            )
+
+        coEvery { vedtakService.hentVedtak(any()) } returns forventetRetur
 
         testApplication {
             val client =
@@ -179,26 +201,7 @@ class DollyRoutesTest {
                     applicationConfig = conff,
                     routes = DollyFeature(dollyService = dollyService, vedtakService = vedtakService).routes,
                 )
-            val forventetRetur =
-                VedtakTilPerson(
-                    vedtak =
-                        listOf(
-                            Vedtak(
-                                sakId = 1,
-                                sakType = "BARNEPENSJON",
-                                virkningstidspunkt = LocalDate.now(),
-                                type = VedtakType.INNVILGELSE,
-                                utbetaling =
-                                    listOf(
-                                        VedtakUtbetaling(
-                                            fraOgMed = LocalDate.now(),
-                                            tilOgMed = LocalDate.now(),
-                                            beloep = BigDecimal(1000),
-                                        ),
-                                    ),
-                            ),
-                        ),
-                )
+
             val response =
                 client.post("/api/v1/hent-ytelse") {
                     contentType(ContentType.Application.Json)

--- a/apps/etterlatte-testdata/src/test/kotlin/DollyRoutesTest.kt
+++ b/apps/etterlatte-testdata/src/test/kotlin/DollyRoutesTest.kt
@@ -27,6 +27,7 @@ import no.nav.etterlatte.libs.common.innsendtsoeknad.common.SoeknadType
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.ktor.route.FoedselsnummerDTO
 import no.nav.etterlatte.libs.ktor.token.Issuer
+import no.nav.etterlatte.no.nav.etterlatte.testdata.features.dolly.VedtakService
 import no.nav.etterlatte.testdata.dolly.DollyService
 import no.nav.etterlatte.testdata.features.dolly.DollyFeature
 import no.nav.etterlatte.testdata.features.dolly.NySoeknadRequest
@@ -49,6 +50,7 @@ class DollyRoutesTest {
     private val mockOAuth2Server =
         MockOAuth2Server()
     private val dollyService: DollyService = mockk<DollyService>()
+    private val vedtakService: VedtakService = mockk<VedtakService>()
 
     @BeforeAll
     fun before() {
@@ -75,7 +77,10 @@ class DollyRoutesTest {
                 Issuer.AZURE.issuerName,
             )
         testApplication {
-            runServerWithConfig(applicationConfig = conff, routes = DollyFeature(dollyService = dollyService).routes)
+            runServerWithConfig(
+                applicationConfig = conff,
+                routes = DollyFeature(dollyService = dollyService, vedtakService = vedtakService).routes,
+            )
 
             val response =
                 client.post("/api/v1/opprett-ytelse") {
@@ -96,7 +101,10 @@ class DollyRoutesTest {
                 pensjonSaksbehandler = pensjonSaksbehandler,
             )
         testApplication {
-            runServerWithConfig(applicationConfig = conff, routes = DollyFeature(dollyService = dollyService).routes)
+            runServerWithConfig(
+                applicationConfig = conff,
+                routes = DollyFeature(dollyService = dollyService, vedtakService = vedtakService).routes,
+            )
 
             val response =
                 client.post("/api/v1/opprett-ytelse") {
@@ -134,7 +142,10 @@ class DollyRoutesTest {
 
         testApplication {
             val client =
-                runServerWithConfig(applicationConfig = conff, routes = DollyFeature(dollyService = dollyService).routes)
+                runServerWithConfig(
+                    applicationConfig = conff,
+                    routes = DollyFeature(dollyService = dollyService, vedtakService = vedtakService).routes,
+                )
 
             val response =
                 client.post("/api/v1/opprett-ytelse") {
@@ -164,7 +175,10 @@ class DollyRoutesTest {
 
         testApplication {
             val client =
-                runServerWithConfig(applicationConfig = conff, routes = DollyFeature(dollyService = dollyService).routes)
+                runServerWithConfig(
+                    applicationConfig = conff,
+                    routes = DollyFeature(dollyService = dollyService, vedtakService = vedtakService).routes,
+                )
             val forventetRetur =
                 VedtakTilPerson(
                     vedtak =
@@ -213,7 +227,10 @@ class DollyRoutesTest {
 
         testApplication {
             val client =
-                runServerWithConfig(applicationConfig = conff, routes = DollyFeature(dollyService = dollyService).routes)
+                runServerWithConfig(
+                    applicationConfig = conff,
+                    routes = DollyFeature(dollyService = dollyService, vedtakService = vedtakService).routes,
+                )
 
             val response =
                 client.post("/api/v1/hent-ytelse") {

--- a/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
@@ -107,6 +107,7 @@ spec:
         - application: etterlatte-vedtaksvurdering-kafka
         - application: etterlatte-utbetaling
         - application: etterlatte-trygdetid
+        - application: etterlatte-testdata
         - application: azure-token-generator # https://docs.nais.io/auth/entra-id/how-to/generate/?h=token+azure
           namespace: nais
           cluster: dev-gcp


### PR DESCRIPTION
Lagt til en hent tjeneste på vedtak for dolly som kaller vedtaksvurdering på tilsvarende måte som etterlatte-api