### PR TITLE
EY-5200 vise resultat av etteroppgjøret for revurdering

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/EtteroppgjoerResultatVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/EtteroppgjoerResultatVisning.tsx
@@ -1,0 +1,19 @@
+import { BodyShort, HStack, Label, VStack } from '@navikt/ds-react'
+import { EnvelopeClosedIcon } from '@navikt/aksel-icons'
+
+type Props = {
+  tekst: string
+  body?: string
+}
+
+const EtteroppgjoerResultatVisning = ({ tekst, body }: Props) => (
+  <HStack gap="2" maxWidth="fit-content">
+    <EnvelopeClosedIcon fontSize="1.5rem" aria-hidden />
+    <VStack gap="2" maxWidth="42.5rem" marginBlock="05 0">
+      <Label>{tekst}</Label>
+      {body && <BodyShort>{body}</BodyShort>}
+    </VStack>
+  </HStack>
+)
+
+export default EtteroppgjoerResultatVisning

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/resultatAvForbehandling/BrevutfallAvForbehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/resultatAvForbehandling/BrevutfallAvForbehandling.tsx
@@ -20,11 +20,7 @@ export const BrevutfallAvForbehandling = () => {
     >
       {beregnetEtteroppgjoerResultat.resultatType === EtteroppgjoerResultatType.TILBAKEKREVING && (
         <EtteroppgjoerResultatVisning
-          tekst={
-            behandling.status === EtteroppgjoerBehandlingStatus.FERDIGSTILT
-              ? 'Forbehandlingen viste at det ble tilbakekreving'
-              : 'Forbehandlingen viser at det blir tilbakekreving'
-          }
+          tekst="Forbehandlingen viser at det blir tilbakekreving"
           body={
             behandling.status === EtteroppgjoerBehandlingStatus.FERDIGSTILT
               ? 'Det skal ha blitt sendt varselbrev'
@@ -35,11 +31,7 @@ export const BrevutfallAvForbehandling = () => {
 
       {beregnetEtteroppgjoerResultat.resultatType === EtteroppgjoerResultatType.ETTERBETALING && (
         <EtteroppgjoerResultatVisning
-          tekst={
-            behandling.status === EtteroppgjoerBehandlingStatus.FERDIGSTILT
-              ? 'Forbehandlingen viste at det ble etterbetaling'
-              : 'Forbehandlingen viser at det blir etterbetaling'
-          }
+          tekst="Forbehandlingen viser at det blir etterbetaling"
           body={
             behandling.status === EtteroppgjoerBehandlingStatus.FERDIGSTILT
               ? 'Det skal ha blitt sendt varselbrev'
@@ -50,11 +42,7 @@ export const BrevutfallAvForbehandling = () => {
 
       {beregnetEtteroppgjoerResultat.resultatType === EtteroppgjoerResultatType.IKKE_ETTEROPPGJOER && (
         <EtteroppgjoerResultatVisning
-          tekst={
-            behandling.status === EtteroppgjoerBehandlingStatus.FERDIGSTILT
-              ? 'Forbehandlingen viste at det ble ingen endring'
-              : 'Forbehandlingen viser at det blir ingen endring'
-          }
+          tekst="Forbehandlingen viser at det blir ingen endring"
           body={
             behandling.status === EtteroppgjoerBehandlingStatus.FERDIGSTILT
               ? 'Det skal ha blitt sendt informasjonsbrev'

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/resultatAvForbehandling/BrevutfallAvForbehandling.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/resultatAvForbehandling/BrevutfallAvForbehandling.tsx
@@ -1,7 +1,7 @@
 import { useEtteroppgjoer } from '~store/reducers/EtteroppgjoerReducer'
-import { BodyShort, Box, HStack, Label, VStack } from '@navikt/ds-react'
+import { Box } from '@navikt/ds-react'
 import { EtteroppgjoerBehandlingStatus, EtteroppgjoerResultatType } from '~shared/types/EtteroppgjoerForbehandling'
-import { EnvelopeClosedIcon } from '@navikt/aksel-icons'
+import EtteroppgjoerResultatVisning from '~components/etteroppgjoer/components/EtteroppgjoerResultatVisning'
 
 export const BrevutfallAvForbehandling = () => {
   const { beregnetEtteroppgjoerResultat, behandling } = useEtteroppgjoer()
@@ -19,58 +19,48 @@ export const BrevutfallAvForbehandling = () => {
       maxWidth="42.5rem"
     >
       {beregnetEtteroppgjoerResultat.resultatType === EtteroppgjoerResultatType.TILBAKEKREVING && (
-        <HStack gap="2" maxWidth="fit-content">
-          <EnvelopeClosedIcon fontSize="1.5rem" aria-hidden />
-          <VStack gap="2" maxWidth="42.5rem" marginBlock="05 0">
-            {behandling.status === EtteroppgjoerBehandlingStatus.FERDIGSTILT ? (
-              <>
-                <Label>Forbehandlingen viste at det ble tilbakekreving</Label>
-                <BodyShort>Det skal ha blitt sendt varselbrev</BodyShort>
-              </>
-            ) : (
-              <>
-                <Label>Forbehandlingen viser at det blir tilbakekreving</Label>
-                <BodyShort>Du skal sende varselbrev.</BodyShort>
-              </>
-            )}
-          </VStack>
-        </HStack>
+        <EtteroppgjoerResultatVisning
+          tekst={
+            behandling.status === EtteroppgjoerBehandlingStatus.FERDIGSTILT
+              ? 'Forbehandlingen viste at det ble tilbakekreving'
+              : 'Forbehandlingen viser at det blir tilbakekreving'
+          }
+          body={
+            behandling.status === EtteroppgjoerBehandlingStatus.FERDIGSTILT
+              ? 'Det skal ha blitt sendt varselbrev'
+              : 'Du skal sende varselbrev.'
+          }
+        />
       )}
+
       {beregnetEtteroppgjoerResultat.resultatType === EtteroppgjoerResultatType.ETTERBETALING && (
-        <HStack gap="2" maxWidth="fit-content">
-          <EnvelopeClosedIcon fontSize="1.5rem" aria-hidden />
-          <VStack gap="2" maxWidth="42.5rem" marginBlock="05 0">
-            {behandling.status === EtteroppgjoerBehandlingStatus.FERDIGSTILT ? (
-              <>
-                <Label>Forbehandlingen viste at det ble etterbetaling</Label>
-                <BodyShort>Det skal ha blitt sendt varselbrev</BodyShort>
-              </>
-            ) : (
-              <>
-                <Label>Forbehandlingen viser at det blir etterbetaling</Label>
-                <BodyShort>Du skal sende varselbrev.</BodyShort>
-              </>
-            )}
-          </VStack>
-        </HStack>
+        <EtteroppgjoerResultatVisning
+          tekst={
+            behandling.status === EtteroppgjoerBehandlingStatus.FERDIGSTILT
+              ? 'Forbehandlingen viste at det ble etterbetaling'
+              : 'Forbehandlingen viser at det blir etterbetaling'
+          }
+          body={
+            behandling.status === EtteroppgjoerBehandlingStatus.FERDIGSTILT
+              ? 'Det skal ha blitt sendt varselbrev'
+              : 'Du skal sende varselbrev.'
+          }
+        />
       )}
+
       {beregnetEtteroppgjoerResultat.resultatType === EtteroppgjoerResultatType.IKKE_ETTEROPPGJOER && (
-        <HStack gap="2" maxWidth="fit-content">
-          <EnvelopeClosedIcon fontSize="1.5rem" aria-hidden />
-          <VStack gap="2" maxWidth="42.5rem" marginBlock="05 0">
-            {behandling.status === EtteroppgjoerBehandlingStatus.FERDIGSTILT ? (
-              <>
-                <Label>Forbehandlingen viste at det ble ingen endring</Label>
-                <BodyShort>Det skal ha blitt sendt informasjonsbrev</BodyShort>
-              </>
-            ) : (
-              <>
-                <Label>Forbehandlingen viser at det blir ingen endring</Label>
-                <BodyShort>Du skal sende informasjonsbrev.</BodyShort>
-              </>
-            )}
-          </VStack>
-        </HStack>
+        <EtteroppgjoerResultatVisning
+          tekst={
+            behandling.status === EtteroppgjoerBehandlingStatus.FERDIGSTILT
+              ? 'Forbehandlingen viste at det ble ingen endring'
+              : 'Forbehandlingen viser at det blir ingen endring'
+          }
+          body={
+            behandling.status === EtteroppgjoerBehandlingStatus.FERDIGSTILT
+              ? 'Det skal ha blitt sendt informasjonsbrev'
+              : 'Du skal sende informasjonsbrev.'
+          }
+        />
       )}
     </Box>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/revurdering/EtteroppgjoerRevurderingOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/revurdering/EtteroppgjoerRevurderingOversikt.tsx
@@ -16,6 +16,7 @@ import { BehandlingRouteContext } from '~components/behandling/BehandlingRoutes'
 import AvbrytBehandling from '~components/behandling/handlinger/AvbrytBehandling'
 import { useForm } from 'react-hook-form'
 import { ControlledRadioGruppe } from '~shared/components/radioGruppe/ControlledRadioGruppe'
+import { EtteroppgjoerRevurderingResultat } from '~components/etteroppgjoer/revurdering/EtteroppgjoerRevurderingResultat'
 
 interface EtteroppgjoerRevurderingOversiktSkjema {
   skalKunneRedigereFastsattInntekt: string
@@ -93,6 +94,8 @@ export const EtteroppgjoerRevurderingOversikt = ({ behandling }: { behandling: I
           )}
 
           <ResultatAvForbehandling />
+
+          <EtteroppgjoerRevurderingResultat />
 
           {fastsettInntektSkjemaErSkittentFeilmelding && (
             <HStack width="100%" justify="center">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/revurdering/EtteroppgjoerRevurderingResultat.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/revurdering/EtteroppgjoerRevurderingResultat.tsx
@@ -28,13 +28,13 @@ export const EtteroppgjoerRevurderingResultat = () => {
       maxWidth="42.5rem"
     >
       {beregnetEtteroppgjoerResultat.resultatType === EtteroppgjoerResultatType.TILBAKEKREVING && (
-        <ResultatVisning tekst="Etteroppgjoeret viser at det blir tilbakekreving" />
+        <ResultatVisning tekst="Etteroppgjøret viser at det blir tilbakekreving" />
       )}
       {beregnetEtteroppgjoerResultat.resultatType === EtteroppgjoerResultatType.ETTERBETALING && (
-        <ResultatVisning tekst="Etteroppgjoeret viser at det blir etterbetaling" />
+        <ResultatVisning tekst="Etteroppgjøret viser at det blir etterbetaling" />
       )}
       {beregnetEtteroppgjoerResultat.resultatType === EtteroppgjoerResultatType.IKKE_ETTEROPPGJOER && (
-        <ResultatVisning tekst="Etteroppgjoeret viser ingen endring" />
+        <ResultatVisning tekst="Etteroppgjøret viser ingen endring" />
       )}
     </Box>
   )

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/revurdering/EtteroppgjoerRevurderingResultat.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/revurdering/EtteroppgjoerRevurderingResultat.tsx
@@ -1,0 +1,41 @@
+import { useEtteroppgjoer } from '~store/reducers/EtteroppgjoerReducer'
+import { Box, HStack, Label, VStack } from '@navikt/ds-react'
+import { EtteroppgjoerResultatType } from '~shared/types/EtteroppgjoerForbehandling'
+import { EnvelopeClosedIcon } from '@navikt/aksel-icons'
+
+const ResultatVisning = ({ tekst }: { tekst: string }) => (
+  <HStack gap="2" maxWidth="fit-content">
+    <EnvelopeClosedIcon fontSize="1.5rem" aria-hidden />
+    <VStack gap="2" maxWidth="42.5rem" marginBlock="05 0">
+      <Label>{tekst}</Label>
+    </VStack>
+  </HStack>
+)
+
+export const EtteroppgjoerRevurderingResultat = () => {
+  const { beregnetEtteroppgjoerResultat } = useEtteroppgjoer()
+
+  if (!beregnetEtteroppgjoerResultat) return null
+
+  return (
+    <Box
+      marginBlock="8 0"
+      paddingInline="6"
+      paddingBlock="8"
+      background="surface-action-subtle"
+      borderColor="border-action"
+      borderWidth="0 0 0 4"
+      maxWidth="42.5rem"
+    >
+      {beregnetEtteroppgjoerResultat.resultatType === EtteroppgjoerResultatType.TILBAKEKREVING && (
+        <ResultatVisning tekst="Etteroppgjoeret viser at det blir tilbakekreving" />
+      )}
+      {beregnetEtteroppgjoerResultat.resultatType === EtteroppgjoerResultatType.ETTERBETALING && (
+        <ResultatVisning tekst="Etteroppgjoeret viser at det blir etterbetaling" />
+      )}
+      {beregnetEtteroppgjoerResultat.resultatType === EtteroppgjoerResultatType.IKKE_ETTEROPPGJOER && (
+        <ResultatVisning tekst="Etteroppgjoeret viser ingen endring" />
+      )}
+    </Box>
+  )
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/revurdering/EtteroppgjoerRevurderingResultat.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/revurdering/EtteroppgjoerRevurderingResultat.tsx
@@ -1,11 +1,11 @@
 import { useEtteroppgjoer } from '~store/reducers/EtteroppgjoerReducer'
 import { Box, HStack, Label, VStack } from '@navikt/ds-react'
 import { EtteroppgjoerResultatType } from '~shared/types/EtteroppgjoerForbehandling'
-import { EnvelopeClosedIcon } from '@navikt/aksel-icons'
+import { CurrencyExchangeIcon } from '@navikt/aksel-icons'
 
 const ResultatVisning = ({ tekst }: { tekst: string }) => (
   <HStack gap="2" maxWidth="fit-content">
-    <EnvelopeClosedIcon fontSize="1.5rem" aria-hidden />
+    <CurrencyExchangeIcon fontSize="1.5rem" aria-hidden />
     <VStack gap="2" maxWidth="42.5rem" marginBlock="05 0">
       <Label>{tekst}</Label>
     </VStack>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/revurdering/EtteroppgjoerRevurderingResultat.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/revurdering/EtteroppgjoerRevurderingResultat.tsx
@@ -1,16 +1,7 @@
 import { useEtteroppgjoer } from '~store/reducers/EtteroppgjoerReducer'
-import { Box, HStack, Label, VStack } from '@navikt/ds-react'
+import { Box } from '@navikt/ds-react'
 import { EtteroppgjoerResultatType } from '~shared/types/EtteroppgjoerForbehandling'
-import { CurrencyExchangeIcon } from '@navikt/aksel-icons'
-
-const ResultatVisning = ({ tekst }: { tekst: string }) => (
-  <HStack gap="2" maxWidth="fit-content">
-    <CurrencyExchangeIcon fontSize="1.5rem" aria-hidden />
-    <VStack gap="2" maxWidth="42.5rem" marginBlock="05 0">
-      <Label>{tekst}</Label>
-    </VStack>
-  </HStack>
-)
+import EtteroppgjoerResultatVisning from '~components/etteroppgjoer/components/EtteroppgjoerResultatVisning'
 
 export const EtteroppgjoerRevurderingResultat = () => {
   const { beregnetEtteroppgjoerResultat } = useEtteroppgjoer()
@@ -28,13 +19,13 @@ export const EtteroppgjoerRevurderingResultat = () => {
       maxWidth="42.5rem"
     >
       {beregnetEtteroppgjoerResultat.resultatType === EtteroppgjoerResultatType.TILBAKEKREVING && (
-        <ResultatVisning tekst="Etteroppgjøret viser at det blir tilbakekreving" />
+        <EtteroppgjoerResultatVisning tekst="Etteroppgjøret viser at det blir tilbakekreving" />
       )}
       {beregnetEtteroppgjoerResultat.resultatType === EtteroppgjoerResultatType.ETTERBETALING && (
-        <ResultatVisning tekst="Etteroppgjøret viser at det blir etterbetaling" />
+        <EtteroppgjoerResultatVisning tekst="Etteroppgjøret viser at det blir etterbetaling" />
       )}
       {beregnetEtteroppgjoerResultat.resultatType === EtteroppgjoerResultatType.IKKE_ETTEROPPGJOER && (
-        <ResultatVisning tekst="Etteroppgjøret viser ingen endring" />
+        <EtteroppgjoerResultatVisning tekst="Etteroppgjøret viser ingen endring" />
       )}
     </Box>
   )


### PR DESCRIPTION
Ved beregning av fastsatt inntekt skal vi vise resultat av etteroppgjøret på lik linje som i forbehandling. 

Det kommer potensielt flere endringer her og skiller seg ut fra forbehandling