### PR TITLE
Fikser overstyr innvilgede måneder

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntektForm.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntektForm.tsx
@@ -304,7 +304,7 @@ const InntektForm = ({
           </ReadMore>
         </VStack>
 
-        {skalOverstyreMaaneder && <OverstyrInnvilgaMaander />}
+        {skalOverstyreMaaneder && <OverstyrInnvilgaMaander register={register} watch={watch} errors={errors} />}
         <HStack gap="3" marginBlock="4">
           <Button size="medium" loading={isPending(lagreAvkortingGrunnlagResult)} onClick={handleSubmit(onSubmit)}>
             Lagre
@@ -312,6 +312,7 @@ const InntektForm = ({
           <Button
             size="medium"
             variant="secondary"
+            type="button"
             onClick={toggleOverstyrtInnvilgaMaaneder}
             icon={skalOverstyreMaaneder ? <TrashIcon aria-hidden /> : <CogRotationIcon aria-hidden />}
           >

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/OverstyrInnvilgaMaaneder.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/OverstyrInnvilgaMaaneder.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Box, Heading, HStack, Select, Textarea, TextField, VStack } from '@navikt/ds-react'
-import { useFormContext } from 'react-hook-form'
+import { UseFormRegister, UseFormStateReturn, UseFormWatch } from 'react-hook-form'
 import {
   hentLesbarTekstForInnvilgaMaanederType,
   IAvkortingGrunnlagLagre,
@@ -8,13 +8,13 @@ import {
   SystemOverstyrtInnvilgaMaanederAarsak,
 } from '~shared/types/IAvkorting'
 
-export default function OverstyrInnvilgaMaander() {
-  const {
-    register,
-    watch,
-    formState: { errors },
-  } = useFormContext<IAvkortingGrunnlagLagre>()
+interface Props {
+  register: UseFormRegister<IAvkortingGrunnlagLagre>
+  watch: UseFormWatch<IAvkortingGrunnlagLagre>
+  errors: UseFormStateReturn<IAvkortingGrunnlagLagre>['errors']
+}
 
+export default function OverstyrInnvilgaMaander({ register, watch, errors }: Props) {
   return (
     <HStack marginBlock="4" gap="1" align="start" wrap={false}>
       <VStack>


### PR DESCRIPTION
Sender med skjemaelementer som props i stedet -- siden context rundt var magisk fjernet og vi kun brukte den contexten dette stedet er det mer naturlig å sende med props i stedet