### PR TITLE
EY-4934 fritekst i beregningvedlegg etteroppgjør

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerBrevModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerBrevModel.kt
@@ -76,7 +76,7 @@ object EtteroppgjoerBrevDataMapper {
                 listOf(
                     BrevVedleggRedigerbarNy(
                         data = EtteroppgjoerBrevData.BeregningsVedleggInnhold(data.behandling.aar),
-                        vedlegId = BrevVedleggKey.OMS_EO_FORHAANDSVARSEL_BEREGNING,
+                        vedleggId = BrevVedleggKey.OMS_EO_FORHAANDSVARSEL_BEREGNING,
                         vedlegg = Vedlegg.OMS_EO_FORHANDSVARSEL_BEREGNINGVEDLEGG_INNHOLD,
                     ),
                 ),

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerBrevModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerBrevModel.kt
@@ -77,7 +77,7 @@ object EtteroppgjoerBrevDataMapper {
                     BrevVedleggRedigerbarNy(
                         data = EtteroppgjoerBrevData.BeregningsVedleggInnhold(data.behandling.aar),
                         vedlegId = BrevVedleggKey.OMS_EO_FORHAANDSVARSEL_BEREGNING,
-                        vedlegg = Vedlegg.OMS_EO_FORHANDSVARSEL_VEDLEGG_INNHOLD,
+                        vedlegg = Vedlegg.OMS_EO_FORHANDSVARSEL_BEREGNINGVEDLEGG_INNHOLD,
                     ),
                 ),
             sak = sisteIverksatteBehandling.sak,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerBrevModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerBrevModel.kt
@@ -77,7 +77,7 @@ object EtteroppgjoerBrevDataMapper {
                     BrevVedleggRedigerbarNy(
                         data = EtteroppgjoerBrevData.BeregningsVedleggInnhold(data.behandling.aar),
                         vedleggId = BrevVedleggKey.OMS_EO_FORHAANDSVARSEL_BEREGNING,
-                        vedlegg = Vedlegg.OMS_EO_FORHANDSVARSEL_BEREGNINGVEDLEGG_INNHOLD,
+                        vedlegg = Vedlegg.OMS_EO_FORHAANDSVARSEL_BEREGNINGVEDLEGG_INNHOLD,
                     ),
                 ),
             sak = sisteIverksatteBehandling.sak,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerBrevModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerBrevModel.kt
@@ -4,6 +4,9 @@ import no.nav.etterlatte.behandling.domain.Behandling
 import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.DetaljertForbehandlingDto
 import no.nav.etterlatte.brev.BrevFastInnholdData
 import no.nav.etterlatte.brev.BrevRedigerbarInnholdData
+import no.nav.etterlatte.brev.BrevVedleggKey
+import no.nav.etterlatte.brev.BrevVedleggRedigerbarNy
+import no.nav.etterlatte.brev.Vedlegg
 import no.nav.etterlatte.brev.model.oms.EtteroppgjoerBrevData
 import no.nav.etterlatte.brev.model.oms.EtteroppgjoerBrevGrunnlag
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
@@ -15,6 +18,7 @@ import no.nav.pensjon.brevbaker.api.model.Kroner
 data class EtteroppgjoerBrevRequestData(
     val redigerbar: BrevRedigerbarInnholdData,
     val innhold: BrevFastInnholdData,
+    val vedlegg: List<BrevVedleggRedigerbarNy>,
     val sak: Sak,
 )
 
@@ -29,7 +33,9 @@ object EtteroppgjoerBrevDataMapper {
         }
 
         val bosattUtland = sisteIverksatteBehandling.utlandstilknytning?.type == UtlandstilknytningType.BOSATT_UTLAND
-        val grunnlag = data.faktiskInntekt ?: throw InternfeilException("Etteroppgjør mangler faktisk inntekt og kan ikke vises i brev")
+        val grunnlag =
+            data.faktiskInntekt
+                ?: throw InternfeilException("Etteroppgjør mangler faktisk inntekt og kan ikke vises i brev")
 
         // TODO: usikker om dette blir rett, følge opp ifm testing
         val norskInntekt = pensjonsgivendeInntekt != null && pensjonsgivendeInntekt.inntekter.isNotEmpty()
@@ -65,6 +71,14 @@ object EtteroppgjoerBrevDataMapper {
                             afp = Kroner(grunnlag.afp),
                             utlandsinntekt = Kroner(grunnlag.utlandsinntekt),
                         ),
+                ),
+            vedlegg =
+                listOf(
+                    BrevVedleggRedigerbarNy(
+                        data = EtteroppgjoerBrevData.BeregningsVedleggInnhold(data.behandling.aar),
+                        vedlegId = BrevVedleggKey.OMS_EO_FORHAANDSVARSEL_BEREGNING,
+                        vedlegg = Vedlegg.OMS_EO_FORHANDSVARSEL_VEDLEGG_INNHOLD,
+                    ),
                 ),
             sak = sisteIverksatteBehandling.sak,
         )

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerForbehandlingBrevService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerForbehandlingBrevService.kt
@@ -110,7 +110,7 @@ class EtteroppgjoerForbehandlingBrevService(
                 behandlingService.hentBehandling(detaljertForbehandling.behandling.sisteIverksatteBehandlingId)
                     ?: throw InternfeilException("Fant ikke siste iverksatte behandling, kan ikke utlede brevinnhold")
 
-            val (redigerbartInnhold, brevInnhold, sak) =
+            val (redigerbartInnhold, brevInnhold, vedleggData, sak) =
                 EtteroppgjoerBrevDataMapper.fra(
                     detaljertForbehandling,
                     sisteIverksatteBehandling,
@@ -133,6 +133,7 @@ class EtteroppgjoerForbehandlingBrevService(
                 skalLagre = true, // TODO: vurder riktig logikk for lagring
                 brevFastInnholdData = brevInnhold,
                 brevRedigerbarInnholdData = redigerbartInnhold,
+                brevVedleggData = vedleggData,
             )
         }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerRevurderingBrevService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerRevurderingBrevService.kt
@@ -114,6 +114,7 @@ class EtteroppgjoerRevurderingBrevService(
                 skalLagre = skalLagres,
                 brevFastInnholdData = EtteroppgjoerBrevData.Vedtak(bosattUtland = false),
                 brevRedigerbarInnholdData = EtteroppgjoerBrevData.VedtakInnhold(),
+                brevVedleggData = emptyList(),
             )
         }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/brev/BrevKlientImpl.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/brev/BrevKlientImpl.kt
@@ -230,10 +230,3 @@ data class BrevInnholdVedlegg(
     val key: BrevVedleggKey,
     val payload: Slate? = null,
 )
-
-enum class BrevVedleggKey {
-    OMS_BEREGNING,
-    OMS_FORHAANDSVARSEL_FEILUTBETALING,
-    BP_BEREGNING_TRYGDETID,
-    BP_FORHAANDSVARSEL_FEILUTBETALING,
-}

--- a/apps/etterlatte-behandling/src/main/kotlin/brev/TilbakekrevingBrevService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/brev/TilbakekrevingBrevService.kt
@@ -153,6 +153,7 @@ class TilbakekrevingBrevService(
                         vedtak = vedtak,
                     ),
                 brevRedigerbarInnholdData = null,
+                brevVedleggData = emptyList(),
             )
         }
 }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevRoute.kt
@@ -18,7 +18,6 @@ import no.nav.etterlatte.brev.distribusjon.Brevdistribuerer
 import no.nav.etterlatte.brev.distribusjon.DistribusjonsType
 import no.nav.etterlatte.brev.hentinformasjon.behandling.BehandlingService
 import no.nav.etterlatte.brev.hentinformasjon.grunnlag.GrunnlagService
-import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
 import no.nav.etterlatte.brev.model.FerdigstillJournalFoerOgDistribuerOpprettetBrev
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.OpprettJournalfoerOgDistribuerRequest

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -11,7 +11,6 @@ import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevDistribusjonResponse
 import no.nav.etterlatte.brev.model.BrevID
-import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.BrevStatusResponse
 import no.nav.etterlatte.brev.model.FerdigstillJournalFoerOgDistribuerOpprettetBrev

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/InnholdTilRedigerbartBrevHenter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/InnholdTilRedigerbartBrevHenter.kt
@@ -12,7 +12,6 @@ import no.nav.etterlatte.brev.brevbaker.BrevbakerRequest
 import no.nav.etterlatte.brev.brevbaker.BrevbakerService
 import no.nav.etterlatte.brev.hentinformasjon.BrevdataFacade
 import no.nav.etterlatte.brev.model.BrevInnhold
-import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
 import no.nav.etterlatte.brev.model.BrevkodeRequest
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.Enhetsnummer

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/RedigerbartVedleggHenter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/RedigerbartVedleggHenter.kt
@@ -9,8 +9,6 @@ import no.nav.etterlatte.brev.brevbaker.BrevbakerRequest
 import no.nav.etterlatte.brev.brevbaker.BrevbakerService
 import no.nav.etterlatte.brev.brevbaker.SoekerOgEventuellVerge
 import no.nav.etterlatte.brev.hentinformasjon.behandling.BehandlingService
-import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
-import no.nav.etterlatte.brev.model.BrevVedleggKey
 import no.nav.etterlatte.brev.model.Spraak
 import no.nav.etterlatte.libs.common.Enhetsnummer
 import no.nav.etterlatte.libs.common.behandling.FeilutbetalingValg

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
@@ -5,6 +5,7 @@ import kotliquery.Session
 import kotliquery.queryOf
 import kotliquery.sessionOf
 import kotliquery.using
+import no.nav.etterlatte.brev.BrevInnholdVedlegg
 import no.nav.etterlatte.brev.Brevkoder
 import no.nav.etterlatte.brev.Brevtype
 import no.nav.etterlatte.brev.Slate
@@ -29,7 +30,6 @@ import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevID
 import no.nav.etterlatte.brev.model.BrevInnhold
-import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
 import no.nav.etterlatte.brev.model.BrevProsessType
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.MottakerType

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/BrevModel.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.brev.model
 
+import no.nav.etterlatte.brev.BrevInnholdVedlegg
 import no.nav.etterlatte.brev.Brevkoder
 import no.nav.etterlatte.brev.Brevtype
 import no.nav.etterlatte.brev.Slate
@@ -78,19 +79,6 @@ data class BrevInnhold(
     val spraak: Spraak,
     val payload: Slate? = null,
 )
-
-data class BrevInnholdVedlegg(
-    val tittel: String,
-    val key: BrevVedleggKey,
-    val payload: Slate? = null,
-)
-
-enum class BrevVedleggKey {
-    OMS_BEREGNING,
-    OMS_FORHAANDSVARSEL_FEILUTBETALING,
-    BP_BEREGNING_TRYGDETID,
-    BP_FORHAANDSVARSEL_FEILUTBETALING,
-}
 
 data class OpprettNyttBrev(
     val sakId: SakId,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/FeilutbetalingUtils.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/FeilutbetalingUtils.kt
@@ -1,5 +1,6 @@
 package no.nav.etterlatte.brev.model
 
+import no.nav.etterlatte.brev.BrevVedleggKey
 import no.nav.etterlatte.libs.common.behandling.FeilutbetalingValg
 
 fun toFeilutbetalingType(feilutbetalingValg: FeilutbetalingValg) =

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/InnholdMedVedlegg.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/InnholdMedVedlegg.kt
@@ -1,5 +1,7 @@
 package no.nav.etterlatte.brev.model
 
+import no.nav.etterlatte.brev.BrevInnholdVedlegg
+import no.nav.etterlatte.brev.BrevVedleggKey
 import no.nav.etterlatte.brev.Slate
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
 import org.slf4j.LoggerFactory

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonBeregning.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonBeregning.kt
@@ -1,11 +1,11 @@
 package no.nav.etterlatte.brev.model.bp
 
+import no.nav.etterlatte.brev.BrevVedleggKey
 import no.nav.etterlatte.brev.behandling.Avdoed
 import no.nav.etterlatte.brev.behandling.Beregningsperiode
 import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
 import no.nav.etterlatte.brev.model.BarnepensjonBeregning
 import no.nav.etterlatte.brev.model.BarnepensjonBeregningsperiode
-import no.nav.etterlatte.brev.model.BrevVedleggKey
 import no.nav.etterlatte.brev.model.FantIkkeIdentTilTrygdetidBlantAvdoede
 import no.nav.etterlatte.brev.model.ForskjelligTrygdetid
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOpphoer.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonOpphoer.kt
@@ -2,8 +2,8 @@ package no.nav.etterlatte.brev.model.bp
 
 import no.nav.etterlatte.brev.BrevDataFerdigstilling
 import no.nav.etterlatte.brev.BrevDataRedigerbar
+import no.nav.etterlatte.brev.BrevVedleggKey
 import no.nav.etterlatte.brev.Slate
-import no.nav.etterlatte.brev.model.BrevVedleggKey
 import no.nav.etterlatte.brev.model.FeilutbetalingType
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
 import no.nav.etterlatte.brev.model.toFeilutbetalingType

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonRevurdering.kt
@@ -2,11 +2,11 @@ package no.nav.etterlatte.brev.model.bp
 
 import no.nav.etterlatte.brev.BrevDataFerdigstilling
 import no.nav.etterlatte.brev.BrevDataRedigerbar
+import no.nav.etterlatte.brev.BrevVedleggKey
 import no.nav.etterlatte.brev.Slate
 import no.nav.etterlatte.brev.behandling.Avdoed
 import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
 import no.nav.etterlatte.brev.model.BarnepensjonBeregning
-import no.nav.etterlatte.brev.model.BrevVedleggKey
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
 import no.nav.etterlatte.brev.model.FeilutbetalingType
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelse.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelse.kt
@@ -2,10 +2,10 @@ package no.nav.etterlatte.brev.model.oms
 
 import no.nav.etterlatte.brev.BrevDataFerdigstilling
 import no.nav.etterlatte.brev.BrevDataRedigerbar
+import no.nav.etterlatte.brev.BrevVedleggKey
 import no.nav.etterlatte.brev.Slate
 import no.nav.etterlatte.brev.behandling.Avdoed
 import no.nav.etterlatte.brev.behandling.Avkortingsinfo
-import no.nav.etterlatte.brev.model.BrevVedleggKey
 import no.nav.etterlatte.brev.model.Etterbetaling
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadOpphoer.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadOpphoer.kt
@@ -2,8 +2,8 @@ package no.nav.etterlatte.brev.model.oms
 
 import no.nav.etterlatte.brev.BrevDataFerdigstilling
 import no.nav.etterlatte.brev.BrevDataRedigerbar
+import no.nav.etterlatte.brev.BrevVedleggKey
 import no.nav.etterlatte.brev.Slate
-import no.nav.etterlatte.brev.model.BrevVedleggKey
 import no.nav.etterlatte.brev.model.FeilutbetalingType
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
 import no.nav.etterlatte.brev.model.toFeilutbetalingType

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadRevurdering.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadRevurdering.kt
@@ -2,9 +2,9 @@ package no.nav.etterlatte.brev.model.oms
 
 import no.nav.etterlatte.brev.BrevDataFerdigstilling
 import no.nav.etterlatte.brev.BrevDataRedigerbar
+import no.nav.etterlatte.brev.BrevVedleggKey
 import no.nav.etterlatte.brev.Slate
 import no.nav.etterlatte.brev.behandling.Avkortingsinfo
-import no.nav.etterlatte.brev.model.BrevVedleggKey
 import no.nav.etterlatte.brev.model.Etterbetaling
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
 import no.nav.etterlatte.brev.model.FeilutbetalingType

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/StrukturertBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/StrukturertBrevService.kt
@@ -349,7 +349,7 @@ class StrukturertBrevService(
             .map {
                 BrevInnholdVedlegg(
                     tittel = it.vedlegg.tittel,
-                    key = it.vedlegId,
+                    key = it.vedleggId,
                     payload =
                         brevbaker.hentRedigerbarTekstFraBrevbakeren(
                             BrevbakerRequest.fra(

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -42,10 +42,8 @@ import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevDataMapperFerdigstillingVedtak
 import no.nav.etterlatte.brev.model.BrevDataMapperRedigerbartUtfallVedtak
 import no.nav.etterlatte.brev.model.BrevInnhold
-import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
 import no.nav.etterlatte.brev.model.BrevKodeMapperVedtak
 import no.nav.etterlatte.brev.model.BrevProsessType
-import no.nav.etterlatte.brev.model.BrevVedleggKey
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.OpprettNyttBrev
 import no.nav.etterlatte.brev.model.Pdf

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/db/BrevRepositoryIntegrationTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/db/BrevRepositoryIntegrationTest.kt
@@ -9,6 +9,8 @@ import kotliquery.queryOf
 import kotliquery.sessionOf
 import kotliquery.using
 import no.nav.etterlatte.behandling.randomSakId
+import no.nav.etterlatte.brev.BrevInnholdVedlegg
+import no.nav.etterlatte.brev.BrevVedleggKey
 import no.nav.etterlatte.brev.Brevkoder
 import no.nav.etterlatte.brev.Brevtype
 import no.nav.etterlatte.brev.DatabaseExtension
@@ -17,9 +19,7 @@ import no.nav.etterlatte.brev.distribusjon.DistribuerJournalpostResponse
 import no.nav.etterlatte.brev.model.Adresse
 import no.nav.etterlatte.brev.model.Brev
 import no.nav.etterlatte.brev.model.BrevInnhold
-import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
 import no.nav.etterlatte.brev.model.BrevProsessType
-import no.nav.etterlatte.brev.model.BrevVedleggKey
 import no.nav.etterlatte.brev.model.Mottaker
 import no.nav.etterlatte.brev.model.OpprettJournalpostResponse
 import no.nav.etterlatte.brev.model.OpprettNyttBrev

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgetDTOTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/model/bp/BarnepensjonInnvilgetDTOTest.kt
@@ -1,13 +1,13 @@
 package no.nav.etterlatte.brev.model.bp
 
 import io.mockk.mockk
+import no.nav.etterlatte.brev.BrevInnholdVedlegg
+import no.nav.etterlatte.brev.BrevVedleggKey
 import no.nav.etterlatte.brev.Slate
 import no.nav.etterlatte.brev.behandling.Avdoed
 import no.nav.etterlatte.brev.behandling.Beregningsperiode
 import no.nav.etterlatte.brev.behandling.Utbetalingsinfo
 import no.nav.etterlatte.brev.model.BarnepensjonBeregningsperiode
-import no.nav.etterlatte.brev.model.BrevInnholdVedlegg
-import no.nav.etterlatte.brev.model.BrevVedleggKey
 import no.nav.etterlatte.brev.model.EtterbetalingDTO
 import no.nav.etterlatte.brev.model.InnholdMedVedlegg
 import no.nav.etterlatte.grunnbeloep.Grunnbeloep

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/BrevData.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/BrevData.kt
@@ -40,12 +40,19 @@ data class ManueltBrevMedTittelData(
 
 data class BrevDataFerdigstillingNy(
     override val innhold: List<Slate.Element>,
+    // TODO: få inn vedleggInnhold?
     val data: BrevFastInnholdData,
 ) : BrevDataFerdigstilling
 
 data class BrevDataRedigerbarNy(
     val data: BrevRedigerbarInnholdData?,
 ) : BrevDataRedigerbar
+
+data class BrevVedleggRedigerbarNy(
+    val data: BrevDataRedigerbar?,
+    val vedlegId: BrevVedleggKey,
+    val vedlegg: Vedlegg,
+)
 
 data class BrevRequest(
     val spraak: Spraak, // TODO ?
@@ -59,6 +66,7 @@ data class BrevRequest(
     val skalLagre: Boolean,
     val brevFastInnholdData: BrevFastInnholdData,
     val brevRedigerbarInnholdData: BrevRedigerbarInnholdData?,
+    val brevVedleggData: List<BrevVedleggRedigerbarNy>,
 )
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
@@ -70,6 +78,9 @@ data class BrevRequest(
 abstract class BrevFastInnholdData : BrevData {
     abstract val brevKode: Brevkoder
     abstract val type: String
+
+    // TODO: finn bedre måte senere
+    abstract fun medVedleggInnhold(innhold: () -> List<BrevInnholdVedlegg>): BrevFastInnholdData
 }
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
@@ -83,4 +94,18 @@ abstract class BrevFastInnholdData : BrevData {
 abstract class BrevRedigerbarInnholdData : BrevDataRedigerbar {
     abstract val brevKode: Brevkoder
     abstract val type: String
+}
+
+data class BrevInnholdVedlegg(
+    val tittel: String,
+    val key: BrevVedleggKey,
+    val payload: Slate? = null,
+)
+
+enum class BrevVedleggKey {
+    OMS_BEREGNING,
+    OMS_FORHAANDSVARSEL_FEILUTBETALING,
+    BP_BEREGNING_TRYGDETID,
+    BP_FORHAANDSVARSEL_FEILUTBETALING,
+    OMS_EO_FORHAANDSVARSEL_BEREGNING,
 }

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/BrevData.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/BrevData.kt
@@ -50,7 +50,7 @@ data class BrevDataRedigerbarNy(
 
 data class BrevVedleggRedigerbarNy(
     val data: BrevDataRedigerbar?,
-    val vedlegId: BrevVedleggKey,
+    val vedleggId: BrevVedleggKey,
     val vedlegg: Vedlegg,
 )
 

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/EtterlatteBrevkode.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/EtterlatteBrevkode.kt
@@ -100,4 +100,5 @@ enum class Vedlegg(
     BARNEPENSJON_VEDLEGG_FORHAANDSVARSEL_UTFALL("Utfall ved forhåndsvarsel av feilutbetaling"),
     OMSTILLINGSSTOENAD_VEDLEGG_BEREGNING_UTFALL("Utfall ved beregning av omstillingsstønad"),
     OMSTILLINGSSTOENAD_VEDLEGG_FORHAANDSVARSEL_UTFALL("Utfall ved forhåndsvarsel av feilutbetaling"),
+    OMS_EO_FORHANDSVARSEL_VEDLEGG_INNHOLD("Utfall ved forhåndsvarsel etteroppgjør vedlegg"),
 }

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/EtterlatteBrevkode.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/EtterlatteBrevkode.kt
@@ -100,5 +100,5 @@ enum class Vedlegg(
     BARNEPENSJON_VEDLEGG_FORHAANDSVARSEL_UTFALL("Utfall ved forhåndsvarsel av feilutbetaling"),
     OMSTILLINGSSTOENAD_VEDLEGG_BEREGNING_UTFALL("Utfall ved beregning av omstillingsstønad"),
     OMSTILLINGSSTOENAD_VEDLEGG_FORHAANDSVARSEL_UTFALL("Utfall ved forhåndsvarsel av feilutbetaling"),
-    OMS_EO_FORHANDSVARSEL_BEREGNINGVEDLEGG_INNHOLD("Utfall ved forhåndsvarsel etteroppgjør vedlegg"),
+    OMS_EO_FORHAANDSVARSEL_BEREGNINGVEDLEGG_INNHOLD("Utfall ved forhåndsvarsel etteroppgjør vedlegg"),
 }

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/EtterlatteBrevkode.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/EtterlatteBrevkode.kt
@@ -100,5 +100,5 @@ enum class Vedlegg(
     BARNEPENSJON_VEDLEGG_FORHAANDSVARSEL_UTFALL("Utfall ved forhåndsvarsel av feilutbetaling"),
     OMSTILLINGSSTOENAD_VEDLEGG_BEREGNING_UTFALL("Utfall ved beregning av omstillingsstønad"),
     OMSTILLINGSSTOENAD_VEDLEGG_FORHAANDSVARSEL_UTFALL("Utfall ved forhåndsvarsel av feilutbetaling"),
-    OMS_EO_FORHANDSVARSEL_VEDLEGG_INNHOLD("Utfall ved forhåndsvarsel etteroppgjør vedlegg"),
+    OMS_EO_FORHANDSVARSEL_BEREGNINGVEDLEGG_INNHOLD("Utfall ved forhåndsvarsel etteroppgjør vedlegg"),
 }

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/model/oms/EtteroppgjoerBrevData.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/model/oms/EtteroppgjoerBrevData.kt
@@ -1,8 +1,12 @@
 package no.nav.etterlatte.brev.model.oms
 
+import no.nav.etterlatte.brev.BrevDataRedigerbar
 import no.nav.etterlatte.brev.BrevFastInnholdData
+import no.nav.etterlatte.brev.BrevInnholdVedlegg
 import no.nav.etterlatte.brev.BrevRedigerbarInnholdData
+import no.nav.etterlatte.brev.BrevVedleggKey
 import no.nav.etterlatte.brev.Brevkoder
+import no.nav.etterlatte.brev.Slate
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerResultatType
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.pensjon.brevbaker.api.model.Kroner
@@ -10,6 +14,7 @@ import java.time.YearMonth
 
 object EtteroppgjoerBrevData {
     data class Forhaandsvarsel(
+        val vedleggInnhold: List<Slate.Element> = emptyList(),
         val bosattUtland: Boolean,
         val norskInntekt: Boolean,
         val etteroppgjoersAar: Int,
@@ -21,6 +26,18 @@ object EtteroppgjoerBrevData {
         val grunnlag: EtteroppgjoerBrevGrunnlag,
     ) : BrevFastInnholdData() {
         override val type: String = "OMS_EO_FORHAANDSVARSEL"
+
+        // TODO: litt mer sjekker
+        override fun medVedleggInnhold(innhold: () -> List<BrevInnholdVedlegg>): BrevFastInnholdData =
+            this.copy(
+                vedleggInnhold =
+                    innhold()
+                        .single {
+                            it.key == BrevVedleggKey.OMS_EO_FORHAANDSVARSEL_BEREGNING
+                        }.payload!!
+                        .elements,
+            )
+
         override val brevKode: Brevkoder = Brevkoder.OMS_EO_FORHAANDSVARSEL
     }
 
@@ -37,10 +54,17 @@ object EtteroppgjoerBrevData {
         override val brevKode: Brevkoder = Brevkoder.OMS_EO_FORHAANDSVARSEL
     }
 
+    data class BeregningsVedleggInnhold(
+        val etteroppgjoersAar: Int,
+    ) : BrevDataRedigerbar
+
     data class Vedtak(
         val bosattUtland: Boolean,
     ) : BrevFastInnholdData() {
         override val type: String = "OMS_EO_VEDTAK"
+
+        override fun medVedleggInnhold(innhold: () -> List<BrevInnholdVedlegg>): BrevFastInnholdData = this
+
         override val brevKode: Brevkoder = Brevkoder.OMS_EO_VEDTAK
     }
 

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/model/tilbakekreving/TilbakekrevingBrevData.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/model/tilbakekreving/TilbakekrevingBrevData.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.brev.model.tilbakekreving
 
 import com.fasterxml.jackson.annotation.JsonTypeName
 import no.nav.etterlatte.brev.BrevFastInnholdData
+import no.nav.etterlatte.brev.BrevInnholdVedlegg
 import no.nav.etterlatte.brev.Brevkoder
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.tilbakekreving.TilbakekrevingResultat
@@ -21,6 +22,9 @@ data class TilbakekrevingBrevInnholdDataNy(
     val tilbakekreving: TilbakekrevingDataNy,
 ) : BrevFastInnholdData() {
     override val type: String = "TILBAKEKREVING"
+
+    override fun medVedleggInnhold(innhold: () -> List<BrevInnholdVedlegg>): BrevFastInnholdData = this
+
     override val brevKode: Brevkoder = Brevkoder.TILBAKEKREVING
 }
 


### PR DESCRIPTION
Se endring i pensjonsbrev også -> https://github.com/navikt/pensjonsbrev/pull/1522

- legge til støtte for innhold for vedlegg i strukturert brev
