### PR TITLE
EY-5219 Støtter lagring av flere inntekter i samme gang i avkorting

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/Avkorting.tsx
@@ -4,12 +4,7 @@ import React, { useEffect } from 'react'
 import Spinner from '~shared/Spinner'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { YtelseEtterAvkorting } from '~components/behandling/avkorting/YtelseEtterAvkorting'
-import {
-  IBehandlingReducer,
-  oppdaterAvkorting,
-  oppdaterBehandlingsstatus,
-  resetAvkorting,
-} from '~store/reducers/BehandlingReducer'
+import { oppdaterAvkorting, oppdaterBehandlingsstatus, resetAvkorting } from '~store/reducers/BehandlingReducer'
 import { useAppDispatch, useAppSelector } from '~store/Store'
 import { virkningstidspunkt } from '~shared/types/IDetaljertBehandling'
 import { behandlingErRedigerbar } from '~components/behandling/felles/utils'
@@ -20,33 +15,27 @@ import { Alert, BodyShort, Box, Heading, VStack } from '@navikt/ds-react'
 import { HjemmelLenke } from '~components/behandling/felles/HjemmelLenke'
 import { IAvkorting } from '~shared/types/IAvkorting'
 import { aarFraDatoString } from '~utils/formatering/dato'
-import { FeatureToggle, useFeaturetoggle } from '~useUnleash'
 import { hentBehandlingstatus } from '~shared/api/behandling'
 import { AvkortingInntekt } from '~components/behandling/avkorting/AvkortingInntekt'
 import { Revurderingaarsak } from '~shared/types/Revurderingaarsak'
+import { useBehandling } from '~components/behandling/useBehandling'
 
-export const Avkorting = ({
-  behandling,
-  resetInntektsavkortingValidering,
-  skalHaInntektNesteAar,
-}: {
-  behandling: IBehandlingReducer
-  resetInntektsavkortingValidering: () => void
-  skalHaInntektNesteAar: boolean
-}) => {
+export const Avkorting = () => {
   const dispatch = useAppDispatch()
+  const behandling = useBehandling()
   const avkorting = useAppSelector((state) => state.behandlingReducer.behandling?.avkorting) as IAvkorting
   const [avkortingStatus, hentAvkortingRequest] = useApiCall(hentAvkorting)
   const [, hentBehandlingstatusRequest] = useApiCall(hentBehandlingstatus)
   const innloggetSaksbehandler = useInnloggetSaksbehandler()
 
-  const visSanksjon = useFeaturetoggle(FeatureToggle.sanksjon)
-
   const harInstitusjonsopphold = behandling?.beregning?.beregningsperioder.find((bp) => bp.institusjonsopphold)
+  if (!behandling) {
+    return null
+  }
 
   const redigerbar =
     behandlingErRedigerbar(behandling.status, behandling.sakEnhetId, innloggetSaksbehandler.skriveEnheter) &&
-    behandling.revurderingsaarsak != Revurderingaarsak.ETTEROPPGJOER
+    behandling.revurderingsaarsak !== Revurderingaarsak.ETTEROPPGJOER
 
   useEffect(() => {
     if (!avkorting) {
@@ -72,46 +61,34 @@ export const Avkorting = ({
   return (
     <Box paddingBlock="8 0">
       <VStack gap="8">
+        <VStack maxWidth="70rem">
+          <Heading spacing size="small" level="2">
+            Inntektsavkorting
+          </Heading>
+          {harInstitusjonsopphold && (
+            <Alert variant="error">
+              Obs! Det er registrert institusjonsopphold i beregningen og dette er ikke støttet sammen med
+              inntektsavkorting, bruk manuel overstyring.
+            </Alert>
+          )}
+          <HjemmelLenke tittel="Folketrygdloven § 17-9" lenke="https://lovdata.no/pro/lov/1997-02-28-19/§17-9" />
+          <BodyShort spacing>
+            Omstillingsstønaden reduseres med 45 prosent av den gjenlevende sin inntekt som på årsbasis overstiger et
+            halvt grunnbeløp. Inntekt rundes ned til nærmeste tusen. Det er forventet årsinntekt for hvert kalenderår
+            som skal legges til grunn.
+          </BodyShort>
+          <BodyShort>
+            I innvilgelsesåret skal inntekt opptjent før innvilgelse trekkes fra, og resterende forventet inntekt
+            fordeles på gjenværende måneder. På samme måte skal inntekt etter opphør holdes utenfor i opphørsåret.
+          </BodyShort>
+        </VStack>
         {mapResult(avkortingStatus, {
           pending: <Spinner label="Henter avkorting" />,
           error: (e) => <ApiErrorAlert>En feil har oppstått: {e.detail}</ApiErrorAlert>,
-          success: () => (
-            <>
-              <VStack maxWidth="70rem">
-                <Heading spacing size="small" level="2">
-                  Inntektsavkorting
-                </Heading>
-                {harInstitusjonsopphold && (
-                  <Alert variant="error">
-                    Obs! Det er registrert institusjonsopphold i beregningen og dette er ikke støttet sammen med
-                    inntektsavkorting, bruk manuel overstyring.
-                  </Alert>
-                )}
-                <HjemmelLenke tittel="Folketrygdloven § 17-9" lenke="https://lovdata.no/pro/lov/1997-02-28-19/§17-9" />
-                <BodyShort spacing>
-                  Omstillingsstønaden reduseres med 45 prosent av den gjenlevende sin inntekt som på årsbasis overstiger
-                  et halvt grunnbeløp. Inntekt rundes ned til nærmeste tusen. Det er forventet årsinntekt for hvert
-                  kalenderår som skal legges til grunn.
-                </BodyShort>
-                <BodyShort>
-                  I innvilgelsesåret skal inntekt opptjent før innvilgelse trekkes fra, og resterende forventet inntekt
-                  fordeles på gjenværende måneder. På samme måte skal inntekt etter opphør holdes utenfor i opphørsåret.
-                </BodyShort>
-              </VStack>
-              <AvkortingInntekt
-                behandling={behandling}
-                avkorting={avkorting}
-                skalHaInntektNesteAar={skalHaInntektNesteAar}
-                redigerbar={redigerbar}
-                resetInntektsavkortingValidering={resetInntektsavkortingValidering}
-              />
-            </>
-          ),
+          success: () => <AvkortingInntekt redigerbar={redigerbar} />,
         })}
 
-        {visSanksjon && (
-          <Sanksjon behandling={behandling} manglerInntektVirkAar={!avkortingGrunnlagInnevaerendeAar()} />
-        )}
+        <Sanksjon behandling={behandling} manglerInntektVirkAar={!avkortingGrunnlagInnevaerendeAar()} />
         {avkorting && (
           <YtelseEtterAvkorting avkortetYtelse={avkortetYtelse} tidligereAvkortetYtelse={tidligereAvkortetYtelse} />
         )}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -51,6 +51,7 @@ export const AvkortingInntekt = ({ redigerbar }: { redigerbar: boolean }) => {
   }, [avkorting])
 
   function vedLagring() {
+    fetchHentManglendeInntektsaar(behandling.id)
     setInntekterForRedigering([])
   }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -4,18 +4,19 @@ import { usePersonopplysninger } from '~components/person/usePersonopplysninger'
 import { AvkortingInntektTabell } from '~components/behandling/avkorting/AvkortingInntektTabell'
 import { Revurderingaarsak } from '~shared/types/Revurderingaarsak'
 import { useBehandling } from '~components/behandling/useBehandling'
-import { useAppSelector } from '~store/Store'
+import { useAppDispatch, useAppSelector } from '~store/Store'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { aarFraDatoString } from '~utils/formatering/dato'
 import { PencilIcon } from '@navikt/aksel-icons'
 import { IAvkorting, IAvkortingGrunnlag, IAvkortingGrunnlagLagre } from '~shared/types/IAvkorting'
-import { Virkningstidspunkt, virkningstidspunkt } from '~shared/types/IDetaljertBehandling'
+import { IBehandlingStatus, Virkningstidspunkt, virkningstidspunkt } from '~shared/types/IDetaljertBehandling'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { hentManglendeInntektsaar } from '~shared/api/avkorting'
 import { mapResult, mapSuccess } from '~shared/api/apiUtils'
 import Spinner from '~shared/Spinner'
 import { AvkortingInntektForm } from '~components/behandling/avkorting/AvkortingInntektForm'
 import { ogSeparertListe } from '../felles/utils'
+import { oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'
 
 function tomInntektForRedigering(aar: number, virkAar: number, virk: Virkningstidspunkt): IAvkortingGrunnlagLagre {
   return {
@@ -43,6 +44,7 @@ export const AvkortingInntekt = ({ redigerbar }: { redigerbar: boolean }) => {
   const personopplysning = usePersonopplysninger()
   const [inntekterForRedigering, setInntekterForRedigering] = useState<IAvkortingGrunnlagLagre[]>([])
   const [statusHentManglendeInntektsaar, fetchHentManglendeInntektsaar] = useApiCall(hentManglendeInntektsaar)
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     fetchHentManglendeInntektsaar(behandling.id, (paakrevdeAar) => {
@@ -53,6 +55,7 @@ export const AvkortingInntekt = ({ redigerbar }: { redigerbar: boolean }) => {
   function vedLagring() {
     fetchHentManglendeInntektsaar(behandling.id)
     setInntekterForRedigering([])
+    dispatch(oppdaterBehandlingsstatus(IBehandlingStatus.AVKORTET))
   }
 
   const paakrevdeAar = mapSuccess(statusHentManglendeInntektsaar, (aar) => aar) ?? []

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntekt.tsx
@@ -24,6 +24,7 @@ function tomInntektForRedigering(aar: number, virkAar: number, virk: Virkningsti
     fom: aar === virkAar ? virk.dato : `${aar}-01`,
   }
 }
+
 function redigerbareInntekterForAvkorting(avkorting?: IAvkorting): IAvkortingGrunnlag[] {
   if (!avkorting) {
     return []
@@ -31,6 +32,7 @@ function redigerbareInntekterForAvkorting(avkorting?: IAvkorting): IAvkortingGru
   if (avkorting.redigerbareInntekter) {
     return avkorting.redigerbareInntekter
   }
+  // Håndtering for gammel dto for avkorting
   return [avkorting.redigerbarForventetInntekt, avkorting.redigerbarForventetInntektNesteAar].filter(
     (inntekt) => !!inntekt
   )
@@ -60,6 +62,7 @@ export const AvkortingInntekt = ({ redigerbar }: { redigerbar: boolean }) => {
 
   const paakrevdeAar = mapSuccess(statusHentManglendeInntektsaar, (aar) => aar) ?? []
 
+  // Vi kan kun avbryte hvis vi ikke har noen påkrevde år som ikke er utfylt enda
   const avbrytRedigering = paakrevdeAar.length > 0 ? undefined : () => setInntekterForRedigering([])
   const fyller67 =
     paakrevdeAar.some((aar) => personopplysning?.soeker?.opplysning.foedselsaar === aar) ||

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntektForm.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntektForm.tsx
@@ -1,3 +1,17 @@
+import { AvkortingFlereInntekter, IAvkortingGrunnlag, IAvkortingGrunnlagLagre } from '~shared/types/IAvkorting'
+import { useAppDispatch } from '~store/Store'
+import { useBehandling } from '~components/behandling/useBehandling'
+import React, { useEffect, useState } from 'react'
+import { useApiCall } from '~shared/hooks/useApiCall'
+import { lagreInntektListe } from '~shared/api/avkorting'
+import { useFieldArray, useForm } from 'react-hook-form'
+import { oppdaterAvkorting } from '~store/reducers/BehandlingReducer'
+import {
+  aarFraDatoString,
+  formaterKanskjeStringDato,
+  kanskjeMaanedFraDatoString,
+  maanedFraDatoString,
+} from '~utils/formatering/dato'
 import {
   BodyShort,
   Box,
@@ -11,328 +25,229 @@ import {
   TextField,
   VStack,
 } from '@navikt/ds-react'
-import { useForm } from 'react-hook-form'
-import { IAvkortingGrunnlag, IAvkortingGrunnlagLagre } from '~shared/types/IAvkorting'
-import { virkningstidspunkt } from '~shared/types/IDetaljertBehandling'
-import { IBehandlingReducer, oppdaterAvkorting, oppdaterBehandlingsstatus } from '~store/reducers/BehandlingReducer'
-import { aarFraDatoString, formaterDato, maanedFraDatoString } from '~utils/formatering/dato'
-import { useApiCall } from '~shared/hooks/useApiCall'
-import { lagreAvkortingGrunnlag } from '~shared/api/avkorting'
-import { isFailureHandler } from '~shared/api/IsFailureHandler'
-import { useAppDispatch } from '~store/Store'
-import { isPending } from '@reduxjs/toolkit'
 import OverstyrInnvilgaMaander from '~components/behandling/avkorting/OverstyrInnvilgaMaaneder'
-import React, { Dispatch, SetStateAction, useState } from 'react'
-import { CogRotationIcon, PencilIcon, TrashIcon } from '@navikt/aksel-icons'
-import { hentBehandlingstatus } from '~shared/api/behandling'
-import { enhetErSkrivbar } from '~components/behandling/felles/utils'
-import { useInnloggetSaksbehandler } from '~components/behandling/useInnloggetSaksbehandler'
+import { isPending, mapFailure } from '~shared/api/apiUtils'
+import { ApiErrorAlert } from '~ErrorBoundary'
+import { CogRotationIcon, TrashIcon } from '@navikt/aksel-icons'
 
-export const AvkortingInntektForm = ({
-  behandling,
-  erInnevaerendeAar,
-  redigerbartGrunnlag,
-  historikk,
-  redigerbar,
-  resetInntektsavkortingValidering,
+export function AvkortingInntektForm({
+  inntekterForRedigering,
+  vedLagring,
+  avbrytRedigering,
+  alleInntektsgrunnlag,
 }: {
-  behandling: IBehandlingReducer
-  redigerbartGrunnlag: IAvkortingGrunnlag | undefined
-  historikk: IAvkortingGrunnlag[]
-  erInnevaerendeAar: boolean
-  redigerbar: boolean
-  resetInntektsavkortingValidering: () => void
-}) => {
-  const erRedigerbar = redigerbar && enhetErSkrivbar(behandling.sakEnhetId, useInnloggetSaksbehandler().skriveEnheter)
-  const [visForm, setVisForm] = useState(false)
-
-  const knappTekst = () => {
-    if (erInnevaerendeAar) {
-      if (redigerbartGrunnlag != null) {
-        return 'Rediger'
-      }
-      return 'Legg til'
-    } else {
-      if (redigerbartGrunnlag != null) {
-        return 'Rediger for neste år'
-      }
-      return 'Legg til for neste år'
-    }
-  }
-
-  return (
-    <>
-      {erRedigerbar && visForm && (
-        <InntektForm
-          behandling={behandling}
-          redigerbartGrunnlag={redigerbartGrunnlag}
-          alleGrunnlag={historikk}
-          erInnevaerendeAar={erInnevaerendeAar}
-          setVisForm={setVisForm}
-        />
-      )}
-      {erRedigerbar && !visForm && (
-        <HStack marginBlock="4 0">
-          <Button
-            size="small"
-            variant="secondary"
-            icon={<PencilIcon title="a11y-title" fontSize="1.5rem" />}
-            onClick={(e) => {
-              e.preventDefault()
-              setVisForm(true)
-              resetInntektsavkortingValidering()
-            }}
-          >
-            {knappTekst()}
-          </Button>
-        </HStack>
-      )}
-    </>
-  )
-}
-
-const InntektForm = ({
-  behandling,
-  erInnevaerendeAar,
-  redigerbartGrunnlag,
-  alleGrunnlag,
-  setVisForm,
-}: {
-  behandling: IBehandlingReducer
-  redigerbartGrunnlag: IAvkortingGrunnlag | undefined
-  alleGrunnlag: IAvkortingGrunnlag[]
-  erInnevaerendeAar: boolean
-  setVisForm: Dispatch<SetStateAction<boolean>>
-}) => {
+  inntekterForRedigering: IAvkortingGrunnlagLagre[]
+  vedLagring: (inntekter: IAvkortingGrunnlagLagre[]) => void
+  alleInntektsgrunnlag: IAvkortingGrunnlag[]
+  avbrytRedigering?: () => void
+}) {
   const dispatch = useAppDispatch()
-
-  const [lagreAvkortingGrunnlagResult, lagreAvkortingGrunnlagRequest] = useApiCall(lagreAvkortingGrunnlag)
-  const [, hentBehandlingstatusRequest] = useApiCall(hentBehandlingstatus)
-
-  const virk = virkningstidspunkt(behandling).dato
-  const aar = erInnevaerendeAar ? aarFraDatoString(virk) : aarFraDatoString(virk) + 1
-  const inntektFom = erInnevaerendeAar ? virk : `${aar}-01`
-
-  /*
-   * Utlede om opptjent før innvilgelse er relevant.
-   * Hvis alle måneder i året er innvilget er det ikke det.
-   * Det er kun innvilgelsesåret som kan være færre enn 12 måneder.
-   * Vi tar ikke stilling til opphør.
-   */
-  const alleMaanederIAaretErInnvilget = () => {
-    if (!erInnevaerendeAar) {
-      return true
-    }
-
-    const fomJanuar = maanedFraDatoString(inntektFom) === 0
-    if (fomJanuar) {
-      return true
-    }
-
-    if (!!redigerbartGrunnlag) {
-      return redigerbartGrunnlag.innvilgaMaaneder === 12
-    }
-
-    if (behandling.revurderingsaarsak != null && new Date(virk).getFullYear() === new Date().getFullYear()) {
-      return alleGrunnlag[0].innvilgaMaaneder === 12
-    }
-    return false
-  }
-
-  /*
-   * Hvis det finnes avkortingGrunnlag med fom samme som virkningstidspunkt fylles den i form med id for å kunne oppdatere.
-   * Hvis det er førstegangsbehandling og avkortingGrunnlag for neste år og det allerede finens avkortingGrunnlag fylles den i form med id for å kunne oppdatere.
-   */
-  const finnRedigerbartGrunnlagEllerOpprettNytt = (): IAvkortingGrunnlagLagre => {
-    if (!!redigerbartGrunnlag) {
-      return redigerbartGrunnlag
-    }
-
-    return {
-      spesifikasjon: '',
-    }
-  }
-
+  const behandling = useBehandling()!
+  const [skalOverstyreMaaneder, setSkalOverstyreMaaneder] = useState(false)
+  const [statusLagreInntektListe, fetchLagreInntektListe] = useApiCall(lagreInntektListe)
   const {
     register,
-    reset,
-    handleSubmit,
-    formState: { errors },
     watch,
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors },
     setValue,
-    getValues,
-  } = useForm<IAvkortingGrunnlagLagre>({
-    defaultValues: finnRedigerbartGrunnlagEllerOpprettNytt(),
+  } = useForm<AvkortingFlereInntekter>({
+    defaultValues: {
+      inntekter: inntekterForRedigering,
+    },
   })
+  const { fields } = useFieldArray({ control, name: 'inntekter' })
 
-  const onSubmit = (data: IAvkortingGrunnlagLagre) => {
-    lagreAvkortingGrunnlagRequest(
+  useEffect(() => {
+    reset({
+      inntekter: inntekterForRedigering,
+    })
+  }, [inntekterForRedigering])
+
+  function lagreInntekter(formdata: AvkortingFlereInntekter) {
+    fetchLagreInntektListe(
       {
         behandlingId: behandling.id,
-        avkortingGrunnlag: {
-          ...data,
-          fratrekkInnAar: data.fratrekkInnAar ?? 0,
-          fratrekkInnAarUtland: data.fratrekkInnAarUtland ?? 0,
-          fom: inntektFom,
-        },
+        inntekter: formdata.inntekter,
       },
-      (nyAvkorting) => {
-        hentBehandlingstatusRequest(behandling.id, (status) => {
-          dispatch(oppdaterBehandlingsstatus(status))
-          const nyttAvkortingGrunnlag = nyAvkorting.avkortingGrunnlag[nyAvkorting.avkortingGrunnlag.length - 1]
-          if (nyttAvkortingGrunnlag) reset(nyttAvkortingGrunnlag)
-          dispatch(oppdaterAvkorting(nyAvkorting))
-          setVisForm(false)
-        })
+      (avkorting) => {
+        dispatch(oppdaterAvkorting(avkorting))
+        vedLagring(formdata.inntekter)
       }
     )
   }
-
-  const [skalOverstyreMaaneder, setSkalOverstyreMaaneder] = useState(!!getValues('overstyrtInnvilgaMaaneder'))
-  const toggleOverstyrtInnvilgaMaaneder = () => {
-    if (skalOverstyreMaaneder) {
-      setValue('overstyrtInnvilgaMaaneder', undefined)
-    }
-    setSkalOverstyreMaaneder(!skalOverstyreMaaneder)
+  function toggleOverstyrMaaneder() {
+    setSkalOverstyreMaaneder((verdi) => !verdi)
+    setValue(`inntekter.${inntekterForRedigering.length - 1}.overstyrtInnvilgaMaaneder`, undefined)
   }
 
   return (
-    <form>
-      <Heading spacing size="small" level="2">
-        {aar}
-      </Heading>
-      <VStack>
-        <HStack marginBlock="8" gap="2" align="start" wrap={false}>
-          <Box maxWidth="14rem">
-            <TextField
-              {...register('inntektTom', {
-                pattern: { value: /^\d+$/, message: 'Kun tall' },
-                required: { value: true, message: 'Må fylles ut' },
-              })}
-              label={
-                <HStack>
-                  Forventet inntekt Norge
-                  <HelpText title="Hva innebærer forventet inntekt totalt">
-                    Registrer forventet norsk inntekt for det aktuelle året (jan-des). Hvis opphør er kjent for dette
-                    året, registrer forventet inntekt fra januar til opphørsdato, og sjekk at innvilgede måneder
-                    stemmer.
-                  </HelpText>
-                </HStack>
-              }
-              name="inntektTom"
-            />
-          </Box>
-          <Box maxWidth="14rem">
-            <TextField
-              {...register('fratrekkInnAar', {
-                required: { value: !alleMaanederIAaretErInnvilget(), message: 'Må fylles ut' },
-                max: {
-                  value: watch('inntektTom') || 0,
-                  message: 'Kan ikke være høyere enn årsinntekt',
-                },
-                pattern: { value: /^\d+$/, message: 'Kun tall' },
-              })}
-              label="Fratrekk inn-år"
-              size="medium"
-              type="tel"
-              inputMode="numeric"
-              disabled={alleMaanederIAaretErInnvilget()}
-              defaultValue={alleMaanederIAaretErInnvilget() ? 0 : undefined}
-              error={errors.fratrekkInnAar?.message}
-            />
-          </Box>
-          <Box maxWidth="14rem">
-            <TextField
-              {...register('inntektUtlandTom', {
-                required: { value: true, message: 'Må fylles ut' },
-                pattern: { value: /^\d+$/, message: 'Kun tall' },
-              })}
-              label={
-                <HStack>
-                  Forventet inntekt utland
-                  <HelpText title="Hva innebærer forventet inntekt totalt">
-                    Registrer forventet utenlandsk inntekt for det aktuelle året (jan-des). Hvis opphør er kjent for
-                    dette året, registrer forventet inntekt fra januar til opphørsdato, og sjekk at innvilgede måneder
-                    stemmer.
-                  </HelpText>
-                </HStack>
-              }
-              size="medium"
-              type="tel"
-              inputMode="numeric"
-              error={errors.inntektUtlandTom?.message}
-            />
-          </Box>
-          <Box maxWidth="14rem">
-            <TextField
-              {...register('fratrekkInnAarUtland', {
-                required: { value: !alleMaanederIAaretErInnvilget(), message: 'Må fylles ut' },
-                max: {
-                  value: watch('inntektUtlandTom') || 0,
-                  message: 'Kan ikke være høyere enn årsinntekt utland',
-                },
-                pattern: { value: /^\d+$/, message: 'Kun tall' },
-              })}
-              label="Fratrekk inn-år"
-              size="medium"
-              type="tel"
-              disabled={alleMaanederIAaretErInnvilget()}
-              defaultValue={alleMaanederIAaretErInnvilget() ? 0 : undefined}
-              inputMode="numeric"
-              error={errors.fratrekkInnAarUtland?.message}
-            />
-          </Box>
-          <VStack gap="4">
-            <Label>Fra og med dato</Label>
-            <BodyShort>{formaterDato(inntektFom)}</BodyShort>
-          </VStack>
-        </HStack>
-        <Box width="39rem">
-          <Textarea {...register('spesifikasjon')} resize="vertical" label="Spesifikasjon av inntekt" />
-        </Box>
+    <form onSubmit={handleSubmit(lagreInntekter)}>
+      {fields.map((item, index) => {
+        const inntektsAar = !!item.fom && aarFraDatoString(item.fom)
+        const inntektGjelderFraStartAvAaret = kanskjeMaanedFraDatoString(item.fom) === 0
 
-        <VStack marginBlock="2" gap="1">
-          <ReadMore header="Hva regnes som inntekt?">
-            Med inntekt menes all arbeidsinntekt og ytelser som likestilles med arbeidsinntekt. Likestilt med
-            arbeidsinntekt er dagpenger etter kap 4, sykepenger etter kap 8, stønad ved barns og andre nærståendes
-            sykdom etter kap 9, arbeidsavklaringspenger etter kap 11, svangerskapspenger og foreldrepenger etter kap 14
-            og pensjonsytelser etter AFP tilskottloven kapitlene 2 og 3.
-          </ReadMore>
-          <ReadMore header="Når du skal overstyre innvilga måneder">
-            Fyll inn riktig antall måneder med innvilget stønad i tilfeller der automatisk registrerte innvilgede
-            måneder ikke stemmer, for eksempel ved uforutsette opphør som tidlig uttak av alderspensjon.
-          </ReadMore>
-        </VStack>
+        // Vi har ikke fratrekk innår hvis inntekten gjelder fra januar, eller vi allerede har inntekt lagt inn
+        // som gjelder for januar dette året
+        const harIkkeFratrekkInnaar =
+          inntektGjelderFraStartAvAaret ||
+          alleInntektsgrunnlag.some(
+            (inntekt) => aarFraDatoString(inntekt.fom) === inntektsAar && maanedFraDatoString(inntekt.fom) === 0
+          )
+        const kanOverstyreInnvilgedeMaaneder = index === watch('inntekter').length - 1
 
-        {skalOverstyreMaaneder && <OverstyrInnvilgaMaander register={register} watch={watch} errors={errors} />}
-        <HStack gap="3" marginBlock="4">
-          <Button size="medium" loading={isPending(lagreAvkortingGrunnlagResult)} onClick={handleSubmit(onSubmit)}>
-            Lagre
-          </Button>
+        return (
+          <React.Fragment key={item.id}>
+            <Heading spacing size="small" level="3">
+              Inntekt for {inntektsAar}
+            </Heading>
+            <VStack>
+              <HStack marginBlock="0 8" gap="2" align="start" wrap={false}>
+                <Box maxWidth="14rem">
+                  <TextField
+                    {...register(`inntekter.${index}.inntektTom`, {
+                      pattern: { value: /^\d+$/, message: 'Kun tall' },
+                      required: { value: true, message: 'Må fylles ut' },
+                    })}
+                    label={
+                      <HStack>
+                        Forventet inntekt Norge
+                        <HelpText title="Hva innebærer forventet inntekt totalt">
+                          Registrer forventet norsk inntekt for det aktuelle året (jan-des). Hvis opphør er kjent for
+                          dette året, registrer forventet inntekt fra januar til opphørsdato, og sjekk at innvilgede
+                          måneder stemmer.
+                        </HelpText>
+                      </HStack>
+                    }
+                    error={errors.inntekter?.[index]?.inntektTom?.message}
+                  />
+                </Box>
+                <Box maxWidth="14rem">
+                  <TextField
+                    {...register(`inntekter.${index}.fratrekkInnAar`, {
+                      required: { value: !harIkkeFratrekkInnaar, message: 'Må fylles ut' },
+                      max: {
+                        value: watch(`inntekter.${index}.inntektTom`) || 0,
+                        message: 'Kan ikke være høyere enn årsinntekt',
+                      },
+                      pattern: { value: /^\d+$/, message: 'Kun tall' },
+                    })}
+                    label="Fratrekk inn-år"
+                    size="medium"
+                    type="tel"
+                    inputMode="numeric"
+                    disabled={harIkkeFratrekkInnaar}
+                    defaultValue={harIkkeFratrekkInnaar ? 0 : ''}
+                    error={errors.inntekter?.[index]?.fratrekkInnAar?.message}
+                  />
+                </Box>
+                <Box maxWidth="14rem">
+                  <TextField
+                    {...register(`inntekter.${index}.inntektUtlandTom`, {
+                      required: { value: true, message: 'Må fylles ut' },
+                      pattern: { value: /^\d+$/, message: 'Kun tall' },
+                    })}
+                    label={
+                      <HStack>
+                        Forventet inntekt utland
+                        <HelpText title="Hva innebærer forventet inntekt totalt">
+                          Registrer forventet utenlandsk inntekt for det aktuelle året (jan-des). Hvis opphør er kjent
+                          for dette året, registrer forventet inntekt fra januar til opphørsdato, og sjekk at innvilgede
+                          måneder stemmer.
+                        </HelpText>
+                      </HStack>
+                    }
+                    size="medium"
+                    type="tel"
+                    inputMode="numeric"
+                    error={errors.inntekter?.[index]?.inntektUtlandTom?.message}
+                  />
+                </Box>
+                <Box maxWidth="14rem">
+                  <TextField
+                    {...register(`inntekter.${index}.fratrekkInnAarUtland`, {
+                      required: { value: !harIkkeFratrekkInnaar, message: 'Må fylles ut' },
+                      max: {
+                        value: watch(`inntekter.${index}.inntektUtlandTom`) || 0,
+                        message: 'Kan ikke være høyere enn årsinntekt utland',
+                      },
+                      pattern: { value: /^\d+$/, message: 'Kun tall' },
+                    })}
+                    label="Fratrekk inn-år"
+                    size="medium"
+                    type="tel"
+                    disabled={harIkkeFratrekkInnaar}
+                    defaultValue={harIkkeFratrekkInnaar ? 0 : ''}
+                    inputMode="numeric"
+                    error={errors.inntekter?.[index]?.fratrekkInnAarUtland?.message}
+                  />
+                </Box>
+                <VStack gap="4">
+                  <Label>Fra og med dato</Label>
+                  <BodyShort>{formaterKanskjeStringDato(item.fom)}</BodyShort>
+                </VStack>
+              </HStack>
+              <Box width="39rem">
+                <Textarea
+                  {...register(`inntekter.${index}.spesifikasjon`)}
+                  resize="vertical"
+                  label="Spesifikasjon av inntekt"
+                />
+              </Box>
+
+              <VStack marginBlock="2" gap="1">
+                <ReadMore header="Hva regnes som inntekt?">
+                  Med inntekt menes all arbeidsinntekt og ytelser som likestilles med arbeidsinntekt. Likestilt med
+                  arbeidsinntekt er dagpenger etter kap 4, sykepenger etter kap 8, stønad ved barns og andre nærståendes
+                  sykdom etter kap 9, arbeidsavklaringspenger etter kap 11, svangerskapspenger og foreldrepenger etter
+                  kap 14 og pensjonsytelser etter AFP tilskottloven kapitlene 2 og 3.
+                </ReadMore>
+                {kanOverstyreInnvilgedeMaaneder && (
+                  <ReadMore header="Når du skal overstyre innvilga måneder">
+                    Fyll inn riktig antall måneder med innvilget stønad i tilfeller der automatisk registrerte
+                    innvilgede måneder ikke stemmer, for eksempel ved uforutsette opphør som tidlig uttak av
+                    alderspensjon.
+                  </ReadMore>
+                )}
+              </VStack>
+
+              {skalOverstyreMaaneder && kanOverstyreInnvilgedeMaaneder && (
+                <OverstyrInnvilgaMaander register={register} watch={watch} errors={errors} index={index} />
+              )}
+            </VStack>
+          </React.Fragment>
+        )
+      })}
+      {mapFailure(statusLagreInntektListe, (error) => (
+        <ApiErrorAlert>Kunne ikke lagre inntekt(er), på grunn av feil: {error.detail}</ApiErrorAlert>
+      ))}
+      <HStack gap="3" marginBlock="4">
+        <Button size="medium" type="submit" loading={isPending(statusLagreInntektListe)}>
+          Lagre
+        </Button>
+        <Button
+          size="medium"
+          variant="secondary"
+          type="button"
+          onClick={toggleOverstyrMaaneder}
+          disabled={isPending(statusLagreInntektListe)}
+          icon={skalOverstyreMaaneder ? <TrashIcon aria-hidden /> : <CogRotationIcon aria-hidden />}
+        >
+          {skalOverstyreMaaneder ? 'Fjern overstyrt innvilga måneder' : 'Overstyr innvilga måneder'}
+        </Button>
+        {avbrytRedigering && (
           <Button
-            size="medium"
-            variant="secondary"
             type="button"
-            onClick={toggleOverstyrtInnvilgaMaaneder}
-            icon={skalOverstyreMaaneder ? <TrashIcon aria-hidden /> : <CogRotationIcon aria-hidden />}
-          >
-            {skalOverstyreMaaneder ? 'Fjern overstyrt innvilga måneder' : 'Overstyr innvilga måneder'}
-          </Button>
-          <Button
-            size="medium"
             variant="tertiary"
-            onClick={() => {
-              setVisForm(false)
-            }}
+            disabled={isPending(statusLagreInntektListe)}
+            onClick={avbrytRedigering}
           >
             Avbryt
           </Button>
-        </HStack>
-      </VStack>
-      {isFailureHandler({
-        apiResult: lagreAvkortingGrunnlagResult,
-        errorMessage: 'En feil har oppstått',
-      })}
+        )}
+      </HStack>
     </form>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntektForm.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/AvkortingInntektForm.tsx
@@ -96,7 +96,7 @@ export function AvkortingInntektForm({
           alleInntektsgrunnlag.some(
             (inntekt) => aarFraDatoString(inntekt.fom) === inntektsAar && maanedFraDatoString(inntekt.fom) === 0
           )
-        const kanOverstyreInnvilgedeMaaneder = index === watch('inntekter').length - 1
+        const kanOverstyreInnvilgedeMaaneder = index === inntekterForRedigering.length - 1
 
         return (
           <React.Fragment key={item.id}>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/OverstyrInnvilgaMaaneder.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/avkorting/OverstyrInnvilgaMaaneder.tsx
@@ -2,19 +2,20 @@ import React from 'react'
 import { Box, Heading, HStack, Select, Textarea, TextField, VStack } from '@navikt/ds-react'
 import { UseFormRegister, UseFormStateReturn, UseFormWatch } from 'react-hook-form'
 import {
+  AvkortingFlereInntekter,
   hentLesbarTekstForInnvilgaMaanederType,
-  IAvkortingGrunnlagLagre,
   OverstyrtInnvilgaMaanederAarsak,
   SystemOverstyrtInnvilgaMaanederAarsak,
 } from '~shared/types/IAvkorting'
 
 interface Props {
-  register: UseFormRegister<IAvkortingGrunnlagLagre>
-  watch: UseFormWatch<IAvkortingGrunnlagLagre>
-  errors: UseFormStateReturn<IAvkortingGrunnlagLagre>['errors']
+  register: UseFormRegister<AvkortingFlereInntekter>
+  watch: UseFormWatch<AvkortingFlereInntekter>
+  errors: UseFormStateReturn<AvkortingFlereInntekter>['errors']
+  index: number
 }
 
-export default function OverstyrInnvilgaMaander({ register, watch, errors }: Props) {
+export default function OverstyrInnvilgaMaander({ register, watch, errors, index }: Props) {
   return (
     <HStack marginBlock="4" gap="1" align="start" wrap={false}>
       <VStack>
@@ -24,26 +25,35 @@ export default function OverstyrInnvilgaMaander({ register, watch, errors }: Pro
         <HStack marginBlock="2" gap="4" align="start" wrap={false}>
           <Box width="13rem">
             <TextField
-              {...register('overstyrtInnvilgaMaaneder.antall', {
+              {...register(`inntekter.${index}.overstyrtInnvilgaMaaneder.antall`, {
                 pattern: { value: /^\d+$/, message: 'Kun tall' },
                 required: { value: true, message: 'Må fylles ut' },
+                min: {
+                  value: 0,
+                  message: 'Kan ikke ha negativt antall innvilgede måneder',
+                },
+                max: {
+                  value: 12,
+                  message: 'Kan maks ha 12 innvilgede måneder',
+                },
               })}
               label="Antall måneder"
               size="medium"
               inputMode="numeric"
-              error={errors?.overstyrtInnvilgaMaaneder?.antall?.message}
+              error={errors?.inntekter?.[index]?.overstyrtInnvilgaMaaneder?.antall?.message}
             />
           </Box>
           <Box width="19rem">
             <Select
               label="Årsak"
-              {...register('overstyrtInnvilgaMaaneder.aarsak', {
+              {...register(`inntekter.${index}.overstyrtInnvilgaMaaneder.aarsak`, {
                 required: { value: true, message: 'Du må velge årsak' },
               })}
-              error={errors?.overstyrtInnvilgaMaaneder?.aarsak?.message}
+              error={errors?.inntekter?.[index]?.overstyrtInnvilgaMaaneder?.aarsak?.message}
             >
               <option value="">Velg årsak</option>
-              {watch('overstyrtInnvilgaMaaneder.aarsak') === SystemOverstyrtInnvilgaMaanederAarsak.BLIR_67 && (
+              {watch(`inntekter.${index}.overstyrtInnvilgaMaaneder.aarsak`) ===
+                SystemOverstyrtInnvilgaMaanederAarsak.BLIR_67 && (
                 <option value={SystemOverstyrtInnvilgaMaanederAarsak.BLIR_67} disabled={true}>
                   {hentLesbarTekstForInnvilgaMaanederType(SystemOverstyrtInnvilgaMaanederAarsak.BLIR_67)} (satt av
                   Gjenny)
@@ -59,12 +69,12 @@ export default function OverstyrInnvilgaMaander({ register, watch, errors }: Pro
         </HStack>
         <Box width="33rem">
           <Textarea
-            {...register('overstyrtInnvilgaMaaneder.begrunnelse', {
+            {...register(`inntekter.${index}.overstyrtInnvilgaMaaneder.begrunnelse`, {
               required: { value: true, message: 'Må fylles ut' },
             })}
             label="Begrunnelse"
             inputMode="text"
-            error={errors?.overstyrtInnvilgaMaaneder?.begrunnelse?.message}
+            error={errors?.inntekter?.[index]?.overstyrtInnvilgaMaaneder?.begrunnelse?.message}
           />
         </Box>
       </VStack>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneEtteroppgjoerOMS.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/BeregneEtteroppgjoerOMS.tsx
@@ -73,11 +73,7 @@ export const BeregneEtteroppgjoerOMS = () => {
             <VStack gap="10">
               <OmstillingsstoenadSammendrag beregning={beregning} />
               {/* TODO må vurdere om denne komponenten skal brukes eller om man skal klare å dra enkelt-deler ut */}
-              <Avkorting
-                behandling={behandling}
-                resetInntektsavkortingValidering={() => {}}
-                skalHaInntektNesteAar={false}
-              />
+              <Avkorting />
             </VStack>
             {erAvkortet() && <SimulerUtbetaling behandling={behandling} />}
           </Box>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/felles/utils.ts
@@ -105,3 +105,15 @@ export const sisteBehandlingHendelse = (hendelser: IHendelse[]): IHendelse => {
 export function hasValue<T>(value?: T | null): value is T {
   return value !== undefined && value !== null
 }
+
+export const ogSeparertListe = (liste: unknown[]): string => {
+  if (liste.length === 0) {
+    return ''
+  }
+  if (liste.length === 1) {
+    return `${liste[0]}`
+  }
+  const kopi = [...liste]
+  const sisteElement = kopi.pop()
+  return `${kopi.join(', ')} og ${sisteElement}`
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/api/avkorting.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/api/avkorting.ts
@@ -16,3 +16,12 @@ export const lagreAvkortingGrunnlag = async (args: {
   avkortingGrunnlag: IAvkortingGrunnlagLagre
 }): Promise<ApiResponse<IAvkorting>> =>
   apiClient.post(`/beregning/avkorting/${args.behandlingId}`, { ...args.avkortingGrunnlag })
+
+export const lagreInntektListe = async (args: {
+  behandlingId: string
+  inntekter: IAvkortingGrunnlagLagre[]
+}): Promise<ApiResponse<IAvkorting>> =>
+  apiClient.post(`/beregning/avkorting/${args.behandlingId}/liste`, { inntekter: args.inntekter })
+
+export const hentManglendeInntektsaar = async (behandlingId: string): Promise<ApiResponse<number[]>> =>
+  apiClient.get(`/beregning/avkorting/${behandlingId}/manglende-inntektsaar`)

--- a/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/shared/types/IAvkorting.ts
@@ -1,11 +1,12 @@
 import { SanksjonType } from '~shared/types/sanksjon'
 
 export interface IAvkorting {
-  redigerbarForventetInntekt: IAvkortingGrunnlag | undefined // Holder med id?
-  redigerbarForventetInntektNesteAar: IAvkortingGrunnlag | undefined
+  redigerbarForventetInntekt: IAvkortingGrunnlag | undefined // TODO: Feltet fjernes i ny DTO
+  redigerbarForventetInntektNesteAar: IAvkortingGrunnlag | undefined // TODO: Feltet fjernes i ny DTO
   avkortingGrunnlag: IAvkortingGrunnlag[]
   avkortetYtelse: IAvkortetYtelse[]
   tidligereAvkortetYtelse: IAvkortetYtelse[]
+  redigerbareInntekter?: IAvkortingGrunnlag[] // TODO: vi kan garantere dette feltet i ny DTO
 }
 
 export interface IAvkortingSkalHaInntektNesteAar {
@@ -67,6 +68,10 @@ export interface IAvkortingGrunnlagLagre {
   spesifikasjon: string
   fom?: string
   overstyrtInnvilgaMaaneder?: IOverstyrtInnvilgaMaaneder
+}
+
+export interface AvkortingFlereInntekter {
+  inntekter: IAvkortingGrunnlagLagre[]
 }
 
 export interface IOverstyrtInnvilgaMaaneder {

--- a/apps/etterlatte-saksbehandling-ui/client/src/utils/formatering/dato.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/utils/formatering/dato.ts
@@ -39,6 +39,8 @@ export const aarFraDatoString = (dato: string) => new Date(dato).getFullYear()
 
 export const maanedFraDatoString = (dato: string) => new Date(dato).getMonth()
 
+export const kanskjeMaanedFraDatoString = (dato?: string) => (dato ? maanedFraDatoString(dato) : undefined)
+
 export const datoIMorgen = (): Date => {
   return add(new Date(), { days: 1 })
 }


### PR DESCRIPTION
Endrer på AvkortingInntektForm til å heller ta imot en liste av inntekter som skal lagres / redigeres, i stedet for å duplisere komponenten. På denne måten får vi sendt alle inntektene over riktig slik at man kan legge inn alle inntektene med en gang før man prøver å beregne avkortingen, slik at man ikke er hindret hvis beregning har knekkpunkt i flere årsoppgjør