### PR TITLE
Fikser avhengighetslisten for trigging av github workflows

### DIFF
--- a/.github/workflows/app-etterlatte-api.yaml
+++ b/.github/workflows/app-etterlatte-api.yaml
@@ -15,6 +15,7 @@ on:
       - libs/etterlatte-ktor/**
       - libs/etterlatte-sporingslogg/**
       - libs/etterlatte-vedtaksvurdering-model/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -29,6 +30,7 @@ on:
       - libs/etterlatte-ktor/**
       - libs/etterlatte-sporingslogg/**
       - libs/etterlatte-vedtaksvurdering-model/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-behandling-kafka.yaml
+++ b/.github/workflows/app-etterlatte-behandling-kafka.yaml
@@ -18,6 +18,9 @@ on:
       - libs/etterlatte-vedtaksvurdering-model/**
       - libs/etterlatte-tidshendelser-model/**
       - libs/rapidsandrivers-extras/**
+      - libs/etterlatte-vilkaarsvurdering-model/**
+      - libs/etterlatte-funksjonsbrytere/**
+      - libs/etterlatte-beregning-model/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -37,6 +40,9 @@ on:
       - libs/etterlatte-vedtaksvurdering-model/**
       - libs/etterlatte-tidshendelser-model/**
       - libs/rapidsandrivers-extras/**
+      - libs/etterlatte-vilkaarsvurdering-model/**
+      - libs/etterlatte-funksjonsbrytere/**
+      - libs/etterlatte-beregning-model/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-behandling.yaml
+++ b/.github/workflows/app-etterlatte-behandling.yaml
@@ -24,6 +24,10 @@ on:
       - libs/etterlatte-vilkaarsvurdering-model/**
       - libs/etterlatte-funksjonsbrytere/**
       - libs/rapidsandrivers-extras/**
+      - libs/etterlatte-kafka/**
+      - libs/etterlatte-tilbakekreving-model/**
+      - libs/etterlatte-tidshendelser-model/**
+      - libs/etterlatte-trygdetid-model/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -47,6 +51,10 @@ on:
       - libs/etterlatte-vedtaksvurdering-model/**
       - libs/etterlatte-funksjonsbrytere/**
       - libs/rapidsandrivers-extras/**
+      - libs/etterlatte-kafka/**
+      - libs/etterlatte-tilbakekreving-model/**
+      - libs/etterlatte-tidshendelser-model/**
+      - libs/etterlatte-trygdetid-model/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-beregning-kafka.yaml
+++ b/.github/workflows/app-etterlatte-beregning-kafka.yaml
@@ -13,6 +13,8 @@ on:
       - libs/etterlatte-omregning-model/**
       - libs/etterlatte-inntektsjustering-model/**
       - libs/rapidsandrivers-extras/**
+      - libs/etterlatte-beregning-model/**
+      - libs/etterlatte-vedtaksvurdering-model/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -27,6 +29,8 @@ on:
       - libs/etterlatte-inntektsjustering-model/**
       - libs/etterlatte-omregning-model/**
       - libs/rapidsandrivers-extras/**
+      - libs/etterlatte-beregning-model/**
+      - libs/etterlatte-vedtaksvurdering-model/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-beregning.yaml
+++ b/.github/workflows/app-etterlatte-beregning.yaml
@@ -17,6 +17,9 @@ on:
       - libs/etterlatte-vedtaksvurdering-model/**
       - libs/etterlatte-vilkaarsvurdering-model/**
       - libs/etterlatte-inntektsjustering-model/**
+      - libs/etterlatte-beregning-model/**
+      - libs/etterlatte-jobs/**
+      - libs/etterlatte-oppgave-model/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -35,6 +38,9 @@ on:
       - libs/etterlatte-vedtaksvurdering-model/**
       - libs/etterlatte-vilkaarsvurdering-model/**
       - libs/etterlatte-inntektsjustering-model/**
+      - libs/etterlatte-beregning-model/**
+      - libs/etterlatte-jobs/**
+      - libs/etterlatte-oppgave-model/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-brev-api.yaml
+++ b/.github/workflows/app-etterlatte-brev-api.yaml
@@ -19,6 +19,7 @@ on:
       - libs/etterlatte-brev-model/**
       - libs/etterlatte-oppgave-model/**
       - libs/etterlatte-tilbakekreving-model/**
+      - libs/etterlatte-funksjonsbrytere/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -39,6 +40,7 @@ on:
       - libs/etterlatte-brev-model/**
       - libs/etterlatte-oppgave-model/**
       - libs/etterlatte-tilbakekreving-model/**
+      - libs/etterlatte-funksjonsbrytere/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-brev-kafka.yaml
+++ b/.github/workflows/app-etterlatte-brev-kafka.yaml
@@ -12,6 +12,8 @@ on:
       - libs/etterlatte-behandling-model/**
       - libs/etterlatte-vedtaksvurdering-model/**
       - libs/etterlatte-brev-model/**
+      - libs/rapidsandrivers-extras/**
+      - libs/etterlatte-ktor/**
       - gradle/libs.versions.toml
   pull_request:
     branches:
@@ -23,6 +25,8 @@ on:
       - libs/etterlatte-behandling-model/**
       - libs/etterlatte-vedtaksvurdering-model/**
       - libs/etterlatte-brev-model/**
+      - libs/rapidsandrivers-extras/**
+      - libs/etterlatte-ktor/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-egne-ansatte-lytter.yaml
+++ b/.github/workflows/app-etterlatte-egne-ansatte-lytter.yaml
@@ -10,6 +10,8 @@ on:
       - apps/etterlatte-egne-ansatte-lytter/**
       - libs/saksbehandling-common/**
       - libs/etterlatte-ktor/**
+      - libs/etterlatte-kafka/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -20,6 +22,8 @@ on:
       - "!apps/etterlatte-egne-ansatte-lytter/.nais/*"
       - libs/saksbehandling-common/**
       - libs/etterlatte-ktor/**
+      - libs/etterlatte-kafka/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-hendelser-samordning.yaml
+++ b/.github/workflows/app-etterlatte-hendelser-samordning.yaml
@@ -10,6 +10,7 @@ on:
       - libs/saksbehandling-common/**
       - libs/etterlatte-kafka/**
       - libs/etterlatte-ktor/**
+      - libs/etterlatte-vedtaksvurdering-model/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -21,6 +22,7 @@ on:
       - libs/saksbehandling-common/**
       - libs/etterlatte-kafka/**
       - libs/etterlatte-ktor/**
+      - libs/etterlatte-vedtaksvurdering-model/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-institusjonsopphold.yaml
+++ b/.github/workflows/app-etterlatte-institusjonsopphold.yaml
@@ -10,6 +10,9 @@ on:
       - apps/etterlatte-institusjonsopphold/**
       - libs/saksbehandling-common/**
       - libs/etterlatte-institusjonsopphold-model/**
+      - libs/etterlatte-kafka/**
+      - libs/etterlatte-ktor/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -20,6 +23,9 @@ on:
       - "!apps/etterlatte-institusjonsopphold/.nais/*"
       - libs/saksbehandling-common/**
       - libs/etterlatte-institusjonsopphold-model/**
+      - libs/etterlatte-kafka/**
+      - libs/etterlatte-ktor/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-klage.yaml
+++ b/.github/workflows/app-etterlatte-klage.yaml
@@ -12,6 +12,8 @@ on:
       - libs/saksbehandling-common/**
       - libs/etterlatte-kafka/**
       - libs/etterlatte-ktor/**
+      - libs/etterlatte-funksjonsbrytere/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -24,6 +26,8 @@ on:
       - libs/etterlatte-behandling-model/**
       - libs/etterlatte-kafka/**
       - libs/etterlatte-ktor/**
+      - libs/etterlatte-funksjonsbrytere/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-pdltjenester.yaml
+++ b/.github/workflows/app-etterlatte-pdltjenester.yaml
@@ -12,6 +12,7 @@ on:
       - libs/saksbehandling-common/**
       - libs/etterlatte-ktor/**
       - libs/etterlatte-pdl-model/**
+      - libs/etterlatte-funksjonsbrytere/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -24,6 +25,7 @@ on:
       - libs/saksbehandling-common/**
       - libs/etterlatte-ktor/**
       - libs/etterlatte-pdl-model/**
+      - libs/etterlatte-funksjonsbrytere/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-statistikk.yaml
+++ b/.github/workflows/app-etterlatte-statistikk.yaml
@@ -15,6 +15,9 @@ on:
       - libs/etterlatte-ktor/**
       - libs/etterlatte-vedtaksvurdering-model/**
       - libs/etterlatte-tilbakekreving-model/**
+      - libs/etterlatte-jobs/**
+      - libs/etterlatte-omregning-model/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -30,6 +33,9 @@ on:
       - libs/etterlatte-ktor/**
       - libs/etterlatte-vedtaksvurdering-model/**
       - libs/etterlatte-tilbakekreving-model/**
+      - libs/etterlatte-jobs/**
+      - libs/etterlatte-omregning-model/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-testdata-behandler.yaml
+++ b/.github/workflows/app-etterlatte-testdata-behandler.yaml
@@ -7,7 +7,16 @@ on:
       - main
     paths:
       - apps/etterlatte-testdata-behandler/**
-      - libs/**
+      - libs/saksbehandling-common/**
+      - libs/etterlatte-behandling-model/**
+      - libs/etterlatte-beregning-model/**
+      - libs/etterlatte-brev-model/**
+      - libs/etterlatte-oppgave-model/**
+      - libs/etterlatte-vedtaksvurdering-model/**
+      - libs/etterlatte-omregning-model/**
+      - libs/etterlatte-vilkaarsvurdering-model/**
+      - libs/etterlatte-ktor/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -16,7 +25,16 @@ on:
     paths:
       - apps/etterlatte-testdata-behandler/**
       - "!apps/etterlatte-testdata-behandler/.nais/*"
-      - libs/**
+      - libs/saksbehandling-common/**
+      - libs/etterlatte-behandling-model/**
+      - libs/etterlatte-beregning-model/**
+      - libs/etterlatte-brev-model/**
+      - libs/etterlatte-oppgave-model/**
+      - libs/etterlatte-vedtaksvurdering-model/**
+      - libs/etterlatte-omregning-model/**
+      - libs/etterlatte-vilkaarsvurdering-model/**
+      - libs/etterlatte-ktor/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-testdata.yaml
+++ b/.github/workflows/app-etterlatte-testdata.yaml
@@ -9,6 +9,11 @@ on:
       - apps/etterlatte-testdata/**
       - libs/etterlatte-omregning-model/**
       - libs/etterlatte-ktor/**
+      - libs/etterlatte-kafka/**
+      - libs/saksbehandling-common/**
+      - libs/etterlatte-behandling-model/**
+      - libs/etterlatte-vedtaksvurdering-model/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -19,6 +24,11 @@ on:
       - libs/etterlatte-omregning-model/**
       - "!apps/etterlatte-testdata/.nais/*"
       - libs/etterlatte-ktor/**
+      - libs/etterlatte-kafka/**
+      - libs/saksbehandling-common/**
+      - libs/etterlatte-behandling-model/**
+      - libs/etterlatte-vedtaksvurdering-model/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-tidshendelser.yaml
+++ b/.github/workflows/app-etterlatte-tidshendelser.yaml
@@ -15,6 +15,7 @@ on:
       - libs/etterlatte-behandling-model/**
       - libs/etterlatte-tidshendelser-model/**
       - libs/etterlatte-inntektsjustering-model/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -31,6 +32,7 @@ on:
       - libs/etterlatte-behandling-model/**
       - libs/etterlatte-tidshendelser-model/**
       - libs/etterlatte-inntektsjustering-model/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-tilbakekreving.yaml
+++ b/.github/workflows/app-etterlatte-tilbakekreving.yaml
@@ -11,6 +11,8 @@ on:
       - libs/etterlatte-ktor/**
       - libs/etterlatte-database/**
       - libs/etterlatte-mq/**
+      - libs/etterlatte-tilbakekreving-model/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -23,6 +25,8 @@ on:
       - libs/etterlatte-ktor/**
       - libs/etterlatte-database/**
       - libs/etterlatte-mq/**
+      - libs/etterlatte-tilbakekreving-model/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-trygdetid-kafka.yaml
+++ b/.github/workflows/app-etterlatte-trygdetid-kafka.yaml
@@ -11,6 +11,7 @@ on:
       - libs/etterlatte-trygdetid-model/**
       - libs/etterlatte-omregning-model/**
       - libs/rapidsandrivers-extras/**
+      - libs/etterlatte-ktor/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -23,6 +24,7 @@ on:
       - libs/etterlatte-trygdetid-model/**
       - libs/etterlatte-omregning-model/**
       - libs/rapidsandrivers-extras/**
+      - libs/etterlatte-ktor/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-trygdetid.yaml
+++ b/.github/workflows/app-etterlatte-trygdetid.yaml
@@ -12,6 +12,9 @@ on:
       - libs/etterlatte-ktor/**
       - libs/etterlatte-behandling-model/**
       - libs/etterlatte-database/**
+      - libs/etterlatte-regler/**
+      - libs/etterlatte-funksjonsbrytere/**
+      - libs/etterlatte-vedtaksvurdering-model/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -25,6 +28,9 @@ on:
       - libs/etterlatte-ktor/**
       - libs/etterlatte-behandling-model/**
       - libs/etterlatte-database/**
+      - libs/etterlatte-regler/**
+      - libs/etterlatte-funksjonsbrytere/**
+      - libs/etterlatte-vedtaksvurdering-model/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-utbetaling.yaml
+++ b/.github/workflows/app-etterlatte-utbetaling.yaml
@@ -14,6 +14,10 @@ on:
       - libs/etterlatte-mq/**
       - libs/etterlatte-utbetaling-model/**
       - libs/etterlatte-vedtaksvurdering-model/**
+      - libs/etterlatte-kafka/**
+      - libs/etterlatte-ktor/**
+      - libs/etterlatte-funksjonsbrytere/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -29,6 +33,10 @@ on:
       - libs/etterlatte-mq/**
       - libs/etterlatte-utbetaling-model/**
       - libs/etterlatte-vedtaksvurdering-model/**
+      - libs/etterlatte-kafka/**
+      - libs/etterlatte-ktor/**
+      - libs/etterlatte-funksjonsbrytere/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-vedtaksvurdering-kafka.yaml
+++ b/.github/workflows/app-etterlatte-vedtaksvurdering-kafka.yaml
@@ -16,6 +16,8 @@ on:
       - libs/etterlatte-utbetaling-model/**
       - libs/etterlatte-vedtaksvurdering-model/**
       - libs/etterlatte-inntektsjustering-model/**
+      - libs/etterlatte-brev-model/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -32,6 +34,8 @@ on:
       - libs/etterlatte-oppgave-model/**
       - libs/etterlatte-utbetaling-model/**
       - libs/etterlatte-vedtaksvurdering-model/**
+      - libs/etterlatte-brev-model/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/app-etterlatte-vedtaksvurdering.yaml
+++ b/.github/workflows/app-etterlatte-vedtaksvurdering.yaml
@@ -17,6 +17,11 @@ on:
       - libs/etterlatte-vilkaarsvurdering-model/**
       - libs/etterlatte-tilbakekreving-model/**
       - libs/etterlatte-oppgave-model/**
+      - libs/etterlatte-kafka/**
+      - libs/etterlatte-funksjonsbrytere/**
+      - libs/etterlatte-jobs/**
+      - libs/etterlatte-trygdetid-model/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -35,6 +40,11 @@ on:
       - libs/etterlatte-vilkaarsvurdering-model/**
       - libs/etterlatte-tilbakekreving-model/**
       - libs/etterlatte-oppgave-model/**
+      - libs/etterlatte-kafka/**
+      - libs/etterlatte-funksjonsbrytere/**
+      - libs/etterlatte-jobs/**
+      - libs/etterlatte-trygdetid-model/**
+      - libs/rapidsandrivers-extras/**
       - gradle/libs.versions.toml
 
 permissions:

--- a/.github/workflows/lib-etterlatte-behandling-model.yaml
+++ b/.github/workflows/lib-etterlatte-behandling-model.yaml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - libs/etterlatte-behandling-model/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -14,6 +15,7 @@ on:
       - main
     paths:
       - libs/etterlatte-behandling-model/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
 
 jobs:

--- a/.github/workflows/lib-etterlatte-beregning-model.yaml
+++ b/.github/workflows/lib-etterlatte-beregning-model.yaml
@@ -7,6 +7,9 @@ on:
       - main
     paths:
       - libs/etterlatte-beregning-model/**
+      - libs/saksbehandling-common/**
+      - libs/etterlatte-regler/**
+      - libs/etterlatte-inntektsjustering-model/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -14,6 +17,9 @@ on:
       - main
     paths:
       - libs/etterlatte-beregning-model/**
+      - libs/saksbehandling-common/**
+      - libs/etterlatte-regler/**
+      - libs/etterlatte-inntektsjustering-model/**
       - gradle/libs.versions.toml
 
 jobs:

--- a/.github/workflows/lib-etterlatte-database.yaml
+++ b/.github/workflows/lib-etterlatte-database.yaml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - libs/etterlatte-database/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -14,6 +15,7 @@ on:
       - main
     paths:
       - libs/etterlatte-database/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
 
 jobs:

--- a/.github/workflows/lib-etterlatte-jobs.yaml
+++ b/.github/workflows/lib-etterlatte-jobs.yaml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - libs/etterlatte-jobs/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -14,6 +15,7 @@ on:
       - main
     paths:
       - libs/etterlatte-jobs/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
 
 jobs:

--- a/.github/workflows/lib-etterlatte-kafka.yaml
+++ b/.github/workflows/lib-etterlatte-kafka.yaml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - libs/etterlatte-kafka/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -14,6 +15,7 @@ on:
       - main
     paths:
       - libs/etterlatte-kafka/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
 
 jobs:

--- a/.github/workflows/lib-etterlatte-ktor.yaml
+++ b/.github/workflows/lib-etterlatte-ktor.yaml
@@ -7,6 +7,8 @@ on:
       - main
     paths:
       - libs/etterlatte-ktor/**
+      - libs/saksbehandling-common/**
+      - libs/etterlatte-funksjonsbrytere/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -14,6 +16,8 @@ on:
       - main
     paths:
       - libs/etterlatte-ktor/**
+      - libs/saksbehandling-common/**
+      - libs/etterlatte-funksjonsbrytere/**
       - gradle/libs.versions.toml
 
 jobs:

--- a/.github/workflows/lib-etterlatte-mq.yaml
+++ b/.github/workflows/lib-etterlatte-mq.yaml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - libs/etterlatte-mq/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -14,6 +15,7 @@ on:
       - main
     paths:
       - libs/etterlatte-mq/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
 
 jobs:

--- a/.github/workflows/lib-etterlatte-omregning-model.yaml
+++ b/.github/workflows/lib-etterlatte-omregning-model.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - libs/etterlatte-omregning-model/**
       - libs/saksbehandling-common/**
+      - libs/etterlatte-inntektsjustering-model/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -16,6 +17,7 @@ on:
     paths:
       - libs/etterlatte-omregning-model/**
       - libs/saksbehandling-common/**
+      - libs/etterlatte-inntektsjustering-model/**
       - gradle/libs.versions.toml
 
 jobs:

--- a/.github/workflows/lib-etterlatte-pdl-model.yaml
+++ b/.github/workflows/lib-etterlatte-pdl-model.yaml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - libs/etterlatte-pdl-model/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -14,6 +15,7 @@ on:
       - main
     paths:
       - libs/etterlatte-pdl-model/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
 
 jobs:

--- a/.github/workflows/lib-etterlatte-regler.yaml
+++ b/.github/workflows/lib-etterlatte-regler.yaml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - libs/etterlatte-regler/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -14,6 +15,7 @@ on:
       - main
     paths:
       - libs/etterlatte-regler/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
 
 jobs:

--- a/.github/workflows/lib-etterlatte-sporingslogg.yaml
+++ b/.github/workflows/lib-etterlatte-sporingslogg.yaml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - libs/etterlatte-sporingslogg/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -14,6 +15,7 @@ on:
       - main
     paths:
       - libs/etterlatte-sporingslogg/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
 
 jobs:

--- a/.github/workflows/lib-etterlatte-trygdetid-model.yaml
+++ b/.github/workflows/lib-etterlatte-trygdetid-model.yaml
@@ -7,6 +7,8 @@ on:
       - main
     paths:
       - libs/etterlatte-trygdetid-model/**
+      - libs/saksbehandling-common/**
+      - libs/etterlatte-behandling-model/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -14,6 +16,8 @@ on:
       - main
     paths:
       - libs/etterlatte-trygdetid-model/**
+      - libs/saksbehandling-common/**
+      - libs/etterlatte-behandling-model/**
       - gradle/libs.versions.toml
 
 jobs:

--- a/.github/workflows/lib-etterlatte-utbetaling-model.yaml
+++ b/.github/workflows/lib-etterlatte-utbetaling-model.yaml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - libs/etterlatte-utbetaling-model/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -14,6 +15,7 @@ on:
       - main
     paths:
       - libs/etterlatte-utbetaling-model/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
 
 jobs:

--- a/.github/workflows/lib-etterlatte-vedtaksvurdering-model.yaml
+++ b/.github/workflows/lib-etterlatte-vedtaksvurdering-model.yaml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - libs/etterlatte-vedtaksvurdering-model/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -14,6 +15,7 @@ on:
       - main
     paths:
       - libs/etterlatte-vedtaksvurdering-model/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
 
 jobs:

--- a/.github/workflows/lib-etterlatte-vilkaarsvurdering-model.yaml
+++ b/.github/workflows/lib-etterlatte-vilkaarsvurdering-model.yaml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - libs/etterlatte-vilkaarsvurdering-model/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -14,6 +15,7 @@ on:
       - main
     paths:
       - libs/etterlatte-vilkaarsvurdering-model/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
 
 jobs:

--- a/.github/workflows/lib-rapidsandrivers-extras.yaml
+++ b/.github/workflows/lib-rapidsandrivers-extras.yaml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - libs/rapidsandrivers-extras/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
       - "!**/test/**"
   pull_request:
@@ -14,6 +15,7 @@ on:
       - main
     paths:
       - libs/rapidsandrivers-extras/**
+      - libs/saksbehandling-common/**
       - gradle/libs.versions.toml
 
 jobs:

--- a/sjekk-avhengigheter.js
+++ b/sjekk-avhengigheter.js
@@ -1,0 +1,127 @@
+const fs = require("fs");
+const path = require("path");
+
+async function* walk(dir, maxDepth) {
+  for await (const d of await fs.promises.opendir(dir)) {
+    const entry = path.join(dir, d.name);
+    if (d.isDirectory() && maxDepth > 0) yield* walk(entry, maxDepth - 1);
+    else if (d.isFile()) yield entry;
+  }
+}
+
+async function findBuildFiles(path, maxDepth) {
+  const buildFiles = [];
+  for await (const p of walk(path, maxDepth)) {
+    if (p.endsWith("/build.gradle.kts")) {
+      buildFiles.push(p);
+    }
+  }
+  return buildFiles;
+}
+
+async function findGithubWorkflows() {
+  const workflows = [];
+  for await (const path of walk("./.github/workflows", 0)) {
+    if (path.endsWith(".yaml")) {
+      workflows.push(path);
+    }
+  }
+  return workflows;
+}
+
+const libDependencyRegex =
+  /^\s*implementation\(project\(":libs:((?:\w|-)+)"\)\)\s*$/;
+const workflowLibDep = /^\s*- libs\/((?:\w|-)+)\/\*\*\s*$/;
+
+async function findUsedDependencies(filePath) {
+  const file = await fs.promises.open(filePath);
+  const deps = [];
+  for await (const line of file.readLines()) {
+    if (libDependencyRegex.test(line)) {
+      deps.push(libDependencyRegex.exec(line)[1]);
+    }
+  }
+  await file.close();
+  return new Set(deps);
+}
+
+async function findCheckedDependencies(filePath) {
+  const file = await fs.promises.open(filePath);
+  const dependencies = [];
+  for await (const line of file.readLines()) {
+    if (workflowLibDep.test(line)) {
+      dependencies.push(workflowLibDep.exec(line)[1]);
+    }
+  }
+  await file.close();
+  return new Set(dependencies);
+}
+
+async function checkDependencies(buildFile, workflows) {
+  const [type, app] = buildFile.split("/");
+  const workflowFilename = `${type.slice(0, 3)}-${app}.yaml`;
+  const workflowFullPath = workflows.find((flow) =>
+    flow.endsWith(workflowFilename),
+  );
+  if (!workflowFullPath) {
+    // console.error(`Could not find ${workflowFilename} in list of workflows!`);
+    return [true, app, []];
+  }
+  const usedDependendcies = await findUsedDependencies(buildFile);
+  const checkedDependencies = await findCheckedDependencies(workflowFullPath);
+
+  const missing = usedDependendcies.difference(checkedDependencies);
+  if (missing.size === 0) {
+    return [true, app, []];
+  } else {
+    return [false, app, [...missing]];
+  }
+}
+
+async function listUtManglendeAvhengigheter() {
+  const appBuildFiles = await findBuildFiles("./apps", 1);
+  const libBuildFiles = await findBuildFiles("./libs", 1);
+  const workflows = await findGithubWorkflows();
+
+  const appDependencies = await Promise.all(
+    appBuildFiles.map((file) => checkDependencies(file, workflows)),
+  );
+  const missingAppDependencies = appDependencies.filter(([ok]) => !ok);
+  if (missingAppDependencies.length > 0) {
+    console.log(
+      `${missingAppDependencies.length} apper mangler avhengigheter i github workflow:`,
+    );
+    missingAppDependencies.forEach(([, app, missing]) => {
+      console.log(`${app} mangler følgende avhengigheter:`);
+      missing.forEach((lib) => console.log(`libs/${lib}/**`));
+      console.log();
+    });
+    console.log();
+  } else {
+    console.log(
+      "Ingen apps mangler avhengigheter i github workflows! Bra jobba!",
+    );
+  }
+
+  const libDependencies = await Promise.all(
+    libBuildFiles.map((file) => checkDependencies(file, workflows)),
+  );
+  const missingLibDependencies = libDependencies.filter(([ok]) => !ok);
+  if (missingLibDependencies.length > 0) {
+    console.log(
+      `${missingLibDependencies.length} libs mangler avhengigheter i github workflow:`,
+    );
+    missingLibDependencies.forEach(([, app, missing]) => {
+      console.log(`${app} mangler følgende avhengigheter:`);
+      missing.forEach((lib) => console.log(`libs/${lib}/**`));
+      console.log();
+    });
+    console.log();
+  } else {
+    console.log(
+      "Ingen libs mangler avhengigheter i github workflows! Bra jobba!",
+    );
+  }
+}
+
+listUtManglendeAvhengigheter().then();


### PR DESCRIPTION
Dette er sykt irriterende å sjekke manuelt, så laget et js-script som kan sjekke automatisk og liste ut alle manglende libs per app / lib.

Det brukes med `node sjekk-avhengigheter.js` i rotmappen av repo'et.

eksempel på output når noe mangler:
![Screenshot 2025-05-28 at 17 43 58](https://github.com/user-attachments/assets/f620e75a-63c6-4859-8405-9806ba40c676)

Eksempel på output når alt er ok:
![Screenshot 2025-05-28 at 17 46 44](https://github.com/user-attachments/assets/eb8ea604-95e3-4368-81d3-7ef16cbeff7f)
