### PR TITLE
Kaster riktige exceptions i revurderingservice

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/ManuellRevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/revurdering/ManuellRevurderingService.kt
@@ -47,7 +47,8 @@ class ManuellRevurderingService(
             try {
                 paaGrunnAvHendelseId?.let { UUID.fromString(it) }
             } catch (_: Exception) {
-                throw BadRequestException(
+                throw UgyldigForespoerselException(
+                    "UGYLDIG_HENDELSE_ID",
                     "$aarsak har en ugyldig hendelse id for sakid" +
                         " $sakId. " +
                         "Hendelsesid: $paaGrunnAvHendelseId",
@@ -67,8 +68,11 @@ class ManuellRevurderingService(
                 ?: throw RevurderingManglerIverksattBehandling(sakId)
 
         if (forrigeIverksatteBehandling.status != BehandlingStatus.IVERKSATT) {
-            throw BadRequestException(
-                "Kan ikke opprette ny revurdering når forrige behandling har status ${forrigeIverksatteBehandling.status}, id=${forrigeIverksatteBehandling.id}",
+            throw UgyldigForespoerselException(
+                code = "BEHANDLING_BLOKKERER_REVURDERING",
+                detail =
+                    "Kan ikke opprette ny revurdering når forrige behandling har status " +
+                        "${forrigeIverksatteBehandling.status}, id=${forrigeIverksatteBehandling.id}",
             )
         }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/ManuellRevurderingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/revurdering/ManuellRevurderingServiceTest.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.behandling.revurdering
 
 import io.kotest.matchers.shouldBe
-import io.ktor.server.plugins.BadRequestException
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.confirmVerified
@@ -38,6 +37,7 @@ import no.nav.etterlatte.libs.common.behandling.BoddEllerArbeidetUtlandet
 import no.nav.etterlatte.libs.common.behandling.RevurderingInfo
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
@@ -487,7 +487,7 @@ class ManuellRevurderingServiceTest : BehandlingIntegrationTest() {
         val (sak, _) = opprettSakMedFoerstegangsbehandling(fnr, behandlingFactory)
 
         val err =
-            assertThrows<BadRequestException> {
+            assertThrows<UgyldigForespoerselException> {
                 manuellRevurderingService.opprettManuellRevurderingWrapper(
                     sakId = sak.id,
                     aarsak = Revurderingaarsak.REGULERING,


### PR DESCRIPTION
Slik at vi ikke får unødvendig støy i prodloggene og saksbehandler får bedre informasjon om hvorfor noe går galt