### PR TITLE
FAGSYSTEM-386582 validere mottaker adresse ved lagring

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -344,6 +344,11 @@ class BrevService(
             throw InternfeilException("Kan ikke sette hoved-/kopimottaker på vanlig oppdatering av mottaker")
         }
 
+        val harUgyldigAdresse = mottaker.adresse.erGyldig()
+        if (harUgyldigAdresse.isNotEmpty()) {
+            throw UgyldigForespoerselException("MOTTAKER_ADRESSE_IKKE_GYLDIG", harUgyldigAdresse.joinToString())
+        }
+
         logger.info("Oppdaterer mottaker for brev=$brevId (id=${mottaker.id})")
 
         return db

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottakerPanel.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/BrevMottakerPanel.tsx
@@ -122,13 +122,15 @@ export function BrevMottakerPanel({
 
       <HStack gap="2" justify="space-between">
         <Heading spacing level="2" size="medium">
-          {flereMottakere ? formaterMottakerType(mottaker.type) : 'Mottaker'}
+          <HStack gap="2">
+            {flereMottakere ? formaterMottakerType(mottaker.type) : 'Mottaker'}
 
-          {mottaker.adresse.adresseType === AdresseType.UTENLANDSKPOSTADRESSE && (
-            <Tag variant="alt1" size="small">
-              Utenlandsk adresse
-            </Tag>
-          )}
+            {mottaker.adresse.adresseType === AdresseType.UTENLANDSKPOSTADRESSE && (
+              <Tag variant="alt1" size="small">
+                Utenlandsk adresse
+              </Tag>
+            )}
+          </HStack>
         </Heading>
 
         {kanRedigeres && (

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/RedigerMottakerModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/RedigerMottakerModal.tsx
@@ -191,61 +191,62 @@ export function RedigerMottakerModal({ brevId, sakId, mottaker: initialMottaker,
 
               {erUtenlanskAdresse && (
                 <Alert variant="warning" size="small">
-                  OBS: På utenlandske adresser må du kun bruke adresselinjer, land og landkode
+                  OBS: På utenlandske adresser må du kun bruke adresselinjer, land og landkode. Postnummer og poststed
+                  er ikke tillatt
                 </Alert>
               )}
 
               {(erNorskAdresse || erUtenlanskAdresse) && (
-                <VStack>
-                  <Label>Adresselinjer</Label>
-                  <TextField
-                    {...register('adresse.adresselinje1', {
-                      required: {
-                        value: true,
-                        message: 'Det må være minst én adresselinje',
-                      },
-                    })}
-                    label=""
-                    placeholder="Adresselinje 1"
-                    error={errors?.adresse?.adresselinje1?.message}
-                  />
-                  <TextField {...register('adresse.adresselinje2')} label="" placeholder="Adresselinje 2" />
-                  <TextField {...register('adresse.adresselinje3')} label="" placeholder="Adresselinje 3" />
-                </VStack>
-              )}
+                <>
+                  <VStack>
+                    <Label>Adresselinjer</Label>
+                    <TextField
+                      {...register('adresse.adresselinje1', {
+                        required: {
+                          value: true,
+                          message: 'Det må være minst én adresselinje',
+                        },
+                      })}
+                      label=""
+                      placeholder="Adresselinje 1"
+                      error={errors?.adresse?.adresselinje1?.message}
+                    />
+                    <TextField {...register('adresse.adresselinje2')} label="" placeholder="Adresselinje 2" />
+                    <TextField {...register('adresse.adresselinje3')} label="" placeholder="Adresselinje 3" />
+                  </VStack>
 
-              {erNorskAdresse && (
-                <HGrid columns={2} gap="4 4">
-                  <TextField
-                    {...register('adresse.postnummer', {
-                      shouldUnregister: true,
-                      required: {
-                        value: erNorskAdresse,
-                        message: 'Postnummer må være satt på norsk adresse',
-                      },
-                      pattern: erNorskAdresse
-                        ? {
-                            value: /^\d{4}$/,
-                            message: 'Ugyldig tegn i postnummeret. Norske postnummer kan kun bestå av fire siffer.',
-                          }
-                        : undefined,
-                    })}
-                    label="Postnummer"
-                    error={errors?.adresse?.postnummer?.message}
-                  />
+                  <HGrid columns={2} gap="4 4">
+                    <TextField
+                      {...register('adresse.postnummer', {
+                        shouldUnregister: true,
+                        required: {
+                          value: erNorskAdresse,
+                          message: 'Postnummer må være satt på norsk adresse',
+                        },
+                        pattern: erNorskAdresse
+                          ? {
+                              value: /^\d{4}$/,
+                              message: 'Ugyldig tegn i postnummeret. Norske postnummer kan kun bestå av fire siffer.',
+                            }
+                          : undefined,
+                      })}
+                      label="Postnummer"
+                      error={errors?.adresse?.postnummer?.message}
+                    />
 
-                  <TextField
-                    {...register('adresse.poststed', {
-                      shouldUnregister: true,
-                      required: {
-                        value: erNorskAdresse,
-                        message: 'Poststed må være satt på norsk adresse',
-                      },
-                    })}
-                    label="Poststed"
-                    error={errors?.adresse?.poststed?.message}
-                  />
-                </HGrid>
+                    <TextField
+                      {...register('adresse.poststed', {
+                        shouldUnregister: true,
+                        required: {
+                          value: erNorskAdresse,
+                          message: 'Poststed må være satt på norsk adresse',
+                        },
+                      })}
+                      label="Poststed"
+                      error={errors?.adresse?.poststed?.message}
+                    />
+                  </HGrid>
+                </>
               )}
 
               {erUtenlanskAdresse &&

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/RedigerMottakerModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/brev/mottaker/RedigerMottakerModal.tsx
@@ -192,7 +192,7 @@ export function RedigerMottakerModal({ brevId, sakId, mottaker: initialMottaker,
               {erUtenlanskAdresse && (
                 <Alert variant="warning" size="small">
                   OBS: På utenlandske adresser må du kun bruke adresselinjer, land og landkode. Postnummer og poststed
-                  er ikke tillatt
+                  er ikke gyldig
                 </Alert>
               )}
 

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -693,6 +693,7 @@ class TrygdetidServiceImpl(
                             yrkesskade = forrigeTrygdetid.yrkesskade,
                             overstyrtNorskPoengaar = forrigeTrygdetid.overstyrtNorskPoengaar,
                             kopiertGrunnlagFraBehandling = forrigeTrygdetid.behandlingId,
+                            begrunnelse = forrigeTrygdetid.begrunnelse,
                         )
 
                     trygdetidRepository.opprettTrygdetid(kopiertTrygdetid)

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -693,7 +693,6 @@ class TrygdetidServiceImpl(
                             yrkesskade = forrigeTrygdetid.yrkesskade,
                             overstyrtNorskPoengaar = forrigeTrygdetid.overstyrtNorskPoengaar,
                             kopiertGrunnlagFraBehandling = forrigeTrygdetid.behandlingId,
-                            begrunnelse = forrigeTrygdetid.begrunnelse,
                         )
 
                     trygdetidRepository.opprettTrygdetid(kopiertTrygdetid)


### PR DESCRIPTION
Det er tilfeller hvor mottaker med utenlandsadresser har blitt lagret med postnummer / sted. Saksbehandler har ingen enkel måte å rette opp i det.

- Vise postnummer / sted for alle type adresse
- Validere adresse ved lagring for å fange opp feil adresse