### PR TITLE
Bedre exception for kravpakke med feil status

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/generellbehandling/GenerellBehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/generellbehandling/GenerellBehandlingService.kt
@@ -404,7 +404,7 @@ class GenerellBehandlingService(
 
             return KravPakkeMedAvdoed(kravpakke, objectMapper.readValue(avdoed.opplysning.toJson(), Person::class.java))
         } else {
-            throw RuntimeException("Kravpakken for sak $sakId har ikke blitt attestert, status: ${kravpakke.status}")
+            throw KravpakkeIkkeAttestertException("Kravpakken for sak $sakId har ikke blitt attestert, status: ${kravpakke.status}")
         }
     }
 
@@ -420,6 +420,10 @@ class GenerellBehandlingService(
         }
     }
 }
+
+class KravpakkeIkkeAttestertException(
+    detail: String,
+) : UgyldigForespoerselException(code = "KRAVPAKKE_IKKE_ATTESTERT", detail = detail)
 
 class FantIkkeAvdoedException(
     msg: String,


### PR DESCRIPTION
Kravpakke for sak hentes ut og vises i frontend når man gjør en sluttbehandling, så feilmeldingen er viktig å få vist til saksbehandler. Dette er også en feilmelding som ikke trenger alarm i prod, siden dette er som følge av saksbehandlingen i saken