### PR TITLE
Henter ut vergemål for statuslinjen mer stabilt hvis det er flere vergemål

### DIFF
--- a/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/ParallelleSannheterService.kt
+++ b/apps/etterlatte-pdltjenester/src/main/kotlin/pdl/mapper/ParallelleSannheterService.kt
@@ -210,7 +210,7 @@ class ParallelleSannheterService(
                 foedselsaar = foedselsdato.foedselsaar,
                 doedsdato = doedsfall?.doedsdato,
                 // PPS støtter p.t. ikke verge. Henter derfor ut første fra listen hvis den ikke er null/tom
-                vergemaal = hentPerson.vergemaalEllerFremtidsfullmakt?.firstOrNull()?.let(VergeMapper::mapVerge),
+                vergemaal = hentPerson.vergemaalEllerFremtidsfullmakt?.firstNotNullOfOrNull { VergeMapper.mapVerge(it) },
             )
         }
 


### PR DESCRIPTION
Fikser en potensiell regresjon hvis det første vergemålet i listen er historisk vergemål, men bruker har fremdeles aktivt vergemål.