### PR TITLE
Fjerner referanser til fjernet api

### DIFF
--- a/apps/etterlatte-api/README.md
+++ b/apps/etterlatte-api/README.md
@@ -26,9 +26,6 @@ NB: The default separator is :. If name contains /, the default separator is ins
 
 Eks: https://docs.nais.io/auth/maskinporten/reference/#scope-naming
 
-etterlatte-samordning-vedtak(gammel og skal saneres) krever token utstedt av Maskinporten med scope _nav:
-etterlatteytelser:vedtaksinformasjon.read_
-
 #### Azure & Tokenx
 
 For interne må det legges inn i yaml filene slik som beskrevet her https://docs.nais.io/auth/entra-id/
@@ -46,15 +43,14 @@ Tjenestepensjon endepunkter(maskinporten):
 
 | Endepunkt                      | Headers                           | Body                                      | Method                            | Responstype        | Beskrivelse                                                                                                                         |
 |:-------------------------------|-----------------------------------|-------------------------------------------|-----------------------------------|--------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| /api/vedtak?fomDato=YYYY-MM-DD | fnr(fases ut, se body) <br/> tpnr | ```{ foedselsnummer: String }```          | GET(deprecated)/ POST(fnr i body) | Samordningsvedtak[] | Henter ut vedtaksinformasjon for gitt person fra og med gitt dato.                                                                  |
-| /api/vedtak?virkFom=YYYY-MM-DD | fnr(fases ut, se body) <br/> tpnr | ```{ foedselsnummer: String }```          | GET(deprecated)/ POST(fnr i body) | Samordningsvedtak[] | **DEPRECATED** Henter ut vedtaksinformasjon for gitt person fra og med gitt dato.                                                   |
+| /api/vedtak?fomDato=YYYY-MM-DD | tpnr | ```{ foedselsnummer: String }```          | POST(fnr i body) | Samordningsvedtak[] | Henter ut vedtaksinformasjon for gitt person fra og med gitt dato.                                                                  |
+| /api/vedtak?virkFom=YYYY-MM-DD | tpnr | ```{ foedselsnummer: String }```          | POST(fnr i body) | Samordningsvedtak[] | **DEPRECATED** Henter ut vedtaksinformasjon for gitt person fra og med gitt dato.                                                   |
 | /api/vedtak/{nav-vedtak-id}    | tpnr                              |                                           | GET                               | Samordningsvedtak   | Henter ut informasjon om et spesifikt vedtak. VedtaksIDen kommer fra samordningskøen hvor det varsles løpende om vedtak som gjøres. |
 | /api/v1/oppgave/journalfoering |                                   | ```{ sakId: Long, journalpostId: String, beskrivelse: String }```| POST                              | UUID (`oppgaveId`) | Oppretter journalføringsoppgave i Gjenny (kun for internt bruk)                                                                     |
 
 | Header                                 | Beskrivelse                      |
 |----------------------------------------|----------------------------------|
 | tpnr                                   | kallende tjenestepensjonsordning |
-| **DEPRECATED(skal sendes i body)** fnr | fødselsnummer til aktuell person |
 
 #### Informasjonsmodell
 


### PR DESCRIPTION
Vi tilbyr ikke lengre å sende fnr i header i spørringene, og det må alltid sendes i postbody. Fjerner også informasjonen om etterlatte-samordning-vedtak