### PR TITLE
Oppdatere oppgave tildeling 

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/oppgaveGosys/GosysOppgaveRoute.kt
@@ -97,7 +97,6 @@ internal fun Route.gosysOppgaveRoute(gosysService: GosysOppgaveService) {
             post("ferdigstill") {
                 kunSaksbehandler {
                     val versjon = call.request.queryParameters["versjon"]!!.toLong()
-
                     call.respond(gosysService.ferdigstill(gosysOppgaveId, versjon, brukerTokenInfo))
                 }
             }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/GosysOppgaveModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/GosysOppgaveModal.tsx
@@ -1,4 +1,4 @@
-import { BodyShort, Box, Button, Dropdown, Heading, HStack, Label, Modal } from '@navikt/ds-react'
+import { Alert, BodyShort, Box, Button, Dropdown, Heading, HStack, Label, Modal } from '@navikt/ds-react'
 import styled from 'styled-components'
 import { ChevronDownIcon, ExternalLinkIcon, EyeIcon } from '@navikt/aksel-icons'
 import React, { useContext, useState } from 'react'
@@ -55,6 +55,10 @@ export const GosysOppgaveModal = ({ oppgave }: { oppgave: GosysOppgave }) => {
         </Modal.Header>
 
         <Modal.Body>
+          {innloggetSaksbehandler.ident != oppgave.saksbehandler?.ident && (
+            <Alert variant="warning">Du kan kun endre denne oppgaven hvis du er tildelt den.</Alert>
+          )}
+
           <TagRow>
             <GosysTemaTag tema={tema} />
           </TagRow>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/GosysOppgaveModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/GosysOppgaveModal.tsx
@@ -55,7 +55,7 @@ export const GosysOppgaveModal = ({ oppgave }: { oppgave: GosysOppgave }) => {
         </Modal.Header>
 
         <Modal.Body>
-          {innloggetSaksbehandler.ident != oppgave.saksbehandler?.ident && (
+          {innloggetSaksbehandler.ident !== oppgave.saksbehandler?.ident && (
             <Alert variant="warning">Du kan kun endre denne oppgaven hvis du er tildelt den.</Alert>
           )}
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/ForenkletGosysOppgaverTable.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/person/sakOgBehandling/ForenkletGosysOppgaverTable.tsx
@@ -8,6 +8,10 @@ import { useInnloggetSaksbehandler } from '~components/behandling/useInnloggetSa
 import { formaterEnumTilLesbarString } from '~utils/formatering/formatering'
 import { GosysOppgave } from '~shared/types/Gosys'
 import { GosysOppgaveRow } from '~components/oppgavebenk/gosys/GosysOppgaveRow'
+import { OppdatertOppgaveversjonResponseDto } from '~shared/api/gosys'
+import { OppgaveSaksbehandler } from '~shared/types/oppgave'
+import { sorterOppgaverEtterOpprettetGosys } from '~components/oppgavebenk/GosysOppgaveliste'
+import { useOppgavebenkStateDispatcher } from '~components/oppgavebenk/state/OppgavebenkContext'
 
 export const ForenkletGosysOppgaverTable = ({
   oppgaver,
@@ -18,8 +22,24 @@ export const ForenkletGosysOppgaverTable = ({
 }): ReactNode => {
   const innloggetSaksbehandler = useInnloggetSaksbehandler()
 
+  const oppgaveDispatcher = useOppgavebenkStateDispatcher()
+
   const [saksbehandlereIEnhet, setSaksbehandlereIEnheter] = useState<Array<Saksbehandler>>([])
   const [, saksbehandlereIEnheterFetch] = useApiCall(saksbehandlereIEnhetApi)
+
+  const oppdaterOppgaveTildeling = (
+    oppgaveId: number,
+    versjonDto: OppdatertOppgaveversjonResponseDto,
+    saksbehandler?: OppgaveSaksbehandler
+  ) => {
+    const index = oppgaver.findIndex((o) => o.id === oppgaveId)
+    if (index > -1) {
+      const oppdatertOppgaveState = [...oppgaver]
+      oppdatertOppgaveState[index].saksbehandler = saksbehandler
+      oppdatertOppgaveState[index].versjon = versjonDto.versjon
+      oppgaveDispatcher.setGosysOppgavelisteOppgaver(sorterOppgaverEtterOpprettetGosys(oppdatertOppgaveState))
+    }
+  }
 
   useEffect(() => {
     if (!!innloggetSaksbehandler.enheter.length) {
@@ -49,7 +69,7 @@ export const ForenkletGosysOppgaverTable = ({
             oppgave={oppgave}
             saksbehandlereIEnhet={saksbehandlereIEnhet}
             skjulBruker={true}
-            oppdaterOppgaveTildeling={() => {}}
+            oppdaterOppgaveTildeling={oppdaterOppgaveTildeling}
           />
         ))}
       </Table.Body>


### PR DESCRIPTION
Handlinger for gosys oppgave blir ikke synlig før siden lastes på nytt. Endrer så vi oppdatere oppgave tildeling med en gang slik at handlingene blir synlig. 