### PR TITLE
infomelding hvis det ikke skal sendes varselbrev

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Varselbrev.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brev/Varselbrev.tsx
@@ -111,12 +111,23 @@ export const Varselbrev = (props: { behandling: IDetaljertBehandling }) => {
 
   if (!currentRouteErGyldig()) {
     return (
-      <Alert variant="error">
-        Varselbrev er ugyldig for denne behandlingen med {props.behandling.status} id: {props.behandling.id} mangler
-        kanskje vilkårsvurdering?
-      </Alert>
+      <Box paddingInline="16" paddingBlock="16 4">
+        <Alert variant="error">
+          Varselbrev er ugyldig for denne behandlingen med {props.behandling.status} id: {props.behandling.id} mangler
+          kanskje vilkårsvurdering?
+        </Alert>
+      </Box>
     )
   }
+
+  if (!props.behandling.sendeBrev) {
+    return (
+      <Box paddingInline="16" paddingBlock="16 4">
+        <Alert variant="info">Det skal ikke sendes varselbrev for denne behandlingen.</Alert>
+      </Box>
+    )
+  }
+
   if (isPendingOrInitial(hentBrevStatus)) {
     return <Spinner label="Henter brev ..." />
   } else if (isPending(opprettBrevStatus)) {


### PR DESCRIPTION
I tilfeller hvor det ikke skal sendes varselbrev oppdateres UI ikke helt korrekt. 

Spinner vises uansett hva verdien til `sendBrev` er
```
if (isPendingOrInitial(hentBrevStatus)) {
  return <Spinner label="Henter brev ..." />
}
```

Så i tilfeller hvor denne slår til
```
useEffect(() => {
  if (!behandlingId || !sakId || !props.behandling.sendeBrev) return
  ...
}
```

Så blir spinneren uendelig