### PR TITLE
EY-5258 Lagrer og sender hendelser for etteroppgjør forbehandling

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingDao.kt
@@ -9,6 +9,7 @@ import no.nav.etterlatte.behandling.hendelse.setLong
 import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.Enhetsnummer
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
+import no.nav.etterlatte.libs.common.behandling.EtteroppgjoerForbehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.JaNei
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingModel.kt
@@ -3,6 +3,8 @@ package no.nav.etterlatte.behandling.etteroppgjoer.forbehandling
 import no.nav.etterlatte.behandling.etteroppgjoer.AInntekt
 import no.nav.etterlatte.behandling.etteroppgjoer.PensjonsgivendeInntektFraSkatt
 import no.nav.etterlatte.brev.model.Brev
+import no.nav.etterlatte.libs.common.behandling.EtteroppgjoerForbehandlingDto
+import no.nav.etterlatte.libs.common.behandling.EtteroppgjoerForbehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.JaNei
 import no.nav.etterlatte.libs.common.beregning.AvkortingDto
 import no.nav.etterlatte.libs.common.beregning.BeregnetEtteroppgjoerResultatDto
@@ -80,6 +82,23 @@ data class EtteroppgjoerForbehandling(
             listOf(
                 EtteroppgjoerForbehandlingStatus.FERDIGSTILT,
             )
+
+    fun tilDto(): EtteroppgjoerForbehandlingDto =
+        EtteroppgjoerForbehandlingDto(
+            id = id,
+            hendelseId = hendelseId,
+            opprettet = opprettet,
+            status = status,
+            sak = sak,
+            aar = aar,
+            innvilgetPeriode = innvilgetPeriode,
+            brevId = brevId,
+            kopiertFra = kopiertFra,
+            sisteIverksatteBehandlingId = sisteIverksatteBehandlingId,
+            harMottattNyInformasjon = harMottattNyInformasjon,
+            endringErTilUgunstForBruker = endringErTilUgunstForBruker,
+            beskrivelseAvUgunst = beskrivelseAvUgunst,
+        )
 }
 
 data class DetaljertForbehandlingDto(
@@ -88,12 +107,6 @@ data class DetaljertForbehandlingDto(
     val faktiskInntekt: FaktiskInntektDto?,
     val beregnetEtteroppgjoerResultat: BeregnetEtteroppgjoerResultatDto?,
 )
-
-enum class EtteroppgjoerForbehandlingStatus {
-    OPPRETTET,
-    BEREGNET,
-    FERDIGSTILT,
-}
 
 data class EtteroppgjoerOpplysninger(
     val skatt: PensjonsgivendeInntektFraSkatt,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerHendelseService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerHendelseService.kt
@@ -1,0 +1,100 @@
+package no.nav.etterlatte.behandling.etteroppgjoer.forbehandling
+
+import no.nav.etterlatte.behandling.hendelse.HendelseDao
+import no.nav.etterlatte.kafka.JsonMessage
+import no.nav.etterlatte.kafka.KafkaProdusent
+import no.nav.etterlatte.libs.common.behandling.ETTEROPPGJOER_RESULTAT_RIVER_KEY
+import no.nav.etterlatte.libs.common.behandling.ETTEROPPGJOER_STATISTIKK_RIVER_KEY
+import no.nav.etterlatte.libs.common.behandling.EtteroppgjoerForbehandlingStatistikkDto
+import no.nav.etterlatte.libs.common.behandling.EtteroppgjoerHendelseType
+import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
+import no.nav.etterlatte.libs.common.beregning.BeregnetEtteroppgjoerResultatDto
+import no.nav.etterlatte.libs.common.logging.getCorrelationId
+import no.nav.etterlatte.libs.common.rapidsandrivers.CORRELATION_ID_KEY
+import no.nav.etterlatte.libs.common.rapidsandrivers.TEKNISK_TID_KEY
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.time.LocalDateTime
+
+class EtteroppgjoerHendelseService(
+    private val rapidPubliserer: KafkaProdusent<String, String>,
+    private val hendelseDao: HendelseDao,
+) {
+    private val logger: Logger = LoggerFactory.getLogger(EtteroppgjoerHendelseService::class.java)
+
+    fun registrerOgSendEtteroppgjoerHendelse(
+        etteroppgjoerForbehandling: EtteroppgjoerForbehandling,
+        etteroppgjoerResultat: BeregnetEtteroppgjoerResultatDto? = null,
+        hendelseType: EtteroppgjoerHendelseType,
+        saksbehandler: String?,
+        utlandstilknytningType: UtlandstilknytningType?,
+    ) {
+        hendelseDao.etteroppgjoerHendelse(
+            forbehandlingId = etteroppgjoerForbehandling.id,
+            sakId = etteroppgjoerForbehandling.sak.id,
+            hendelseType = hendelseType,
+            inntruffet = Tidspunkt.Companion.now(),
+            saksbehandler = saksbehandler,
+            kommentar = null,
+            begrunnelse = null,
+        )
+
+        if (hendelseType.skalSendeStatistikk) {
+            sendKafkaMelding(
+                etteroppgjoerForbehandling = etteroppgjoerForbehandling,
+                hendelseType = hendelseType,
+                etteroppgjoerResultat = etteroppgjoerResultat,
+                utlandstilknytningType = utlandstilknytningType,
+                saksbehandler = saksbehandler,
+            )
+        }
+    }
+
+    private fun sendKafkaMelding(
+        etteroppgjoerForbehandling: EtteroppgjoerForbehandling,
+        hendelseType: EtteroppgjoerHendelseType,
+        etteroppgjoerResultat: BeregnetEtteroppgjoerResultatDto?,
+        utlandstilknytningType: UtlandstilknytningType?,
+        saksbehandler: String?,
+    ) {
+        val correlationId = getCorrelationId()
+        val standardfelter =
+            mapOf(
+                CORRELATION_ID_KEY to correlationId,
+                TEKNISK_TID_KEY to LocalDateTime.now(),
+                ETTEROPPGJOER_STATISTIKK_RIVER_KEY to
+                    EtteroppgjoerForbehandlingStatistikkDto(
+                        forbehandling = etteroppgjoerForbehandling.tilDto(),
+                        utlandstilknytningType = utlandstilknytningType,
+                        saksbehandler = saksbehandler,
+                    ),
+            )
+        val meldingMap =
+            when (etteroppgjoerResultat) {
+                null -> standardfelter
+                else ->
+                    standardfelter +
+                        mapOf(
+                            ETTEROPPGJOER_RESULTAT_RIVER_KEY to etteroppgjoerResultat,
+                        )
+            }
+
+        rapidPubliserer
+            .publiser(
+                noekkel = etteroppgjoerForbehandling.id.toString(),
+                verdi =
+                    JsonMessage.Companion
+                        .newMessage(
+                            eventName = hendelseType.lagEventnameForType(),
+                            map = meldingMap,
+                        ).toJson(),
+            ).also { (partition, offset) ->
+                logger.info(
+                    "Sendte ${hendelseType.lagEventnameForType()}-melding for forbehandling med id=" +
+                        "${etteroppgjoerForbehandling.id}, partition: $partition, offset: $offset, " +
+                        "correlationId: $correlationId.",
+                )
+            }
+    }
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/revurdering/EtteroppgjoerRevurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/revurdering/EtteroppgjoerRevurderingService.kt
@@ -6,7 +6,6 @@ import no.nav.etterlatte.behandling.domain.Revurdering
 import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerService
 import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerStatus
 import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.EtteroppgjoerForbehandlingService
-import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.EtteroppgjoerForbehandlingStatus
 import no.nav.etterlatte.behandling.klienter.BeregningKlient
 import no.nav.etterlatte.behandling.klienter.TrygdetidKlient
 import no.nav.etterlatte.behandling.klienter.VedtakKlient
@@ -15,6 +14,7 @@ import no.nav.etterlatte.grunnlag.GrunnlagService
 import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingOpprinnelse
+import no.nav.etterlatte.libs.common.behandling.EtteroppgjoerForbehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/HendelseDao.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/hendelse/HendelseDao.kt
@@ -4,6 +4,7 @@ import no.nav.etterlatte.behandling.domain.Behandling
 import no.nav.etterlatte.behandling.domain.BehandlingOpprettet
 import no.nav.etterlatte.common.ConnectionAutoclosing
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
+import no.nav.etterlatte.libs.common.behandling.EtteroppgjoerHendelseType
 import no.nav.etterlatte.libs.common.generellbehandling.GenerellBehandlingHendelseType
 import no.nav.etterlatte.libs.common.klage.KlageHendelseType
 import no.nav.etterlatte.libs.common.sak.SakId
@@ -104,6 +105,28 @@ class HendelseDao(
             inntruffet = inntruffet,
             vedtakId = null,
             behandlingId = klageId,
+            sakId = sakId,
+            ident = saksbehandler,
+            identType = "SAKSBEHANDLER".takeIf { saksbehandler != null },
+            kommentar = kommentar,
+            valgtBegrunnelse = begrunnelse,
+        ),
+    )
+
+    fun etteroppgjoerHendelse(
+        forbehandlingId: UUID,
+        sakId: SakId,
+        hendelseType: EtteroppgjoerHendelseType,
+        inntruffet: Tidspunkt,
+        saksbehandler: String?,
+        kommentar: String?,
+        begrunnelse: String?,
+    ) = lagreHendelse(
+        UlagretHendelse(
+            hendelse = hendelseType.lagEventnameForType(),
+            inntruffet = inntruffet,
+            vedtakId = null,
+            behandlingId = forbehandlingId,
             sakId = sakId,
             ident = saksbehandler,
             identType = "SAKSBEHANDLER".takeIf { saksbehandler != null },

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -38,6 +38,7 @@ import no.nav.etterlatte.behandling.etteroppgjoer.brev.EtteroppgjoerForbehandlin
 import no.nav.etterlatte.behandling.etteroppgjoer.brev.EtteroppgjoerRevurderingBrevService
 import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.EtteroppgjoerForbehandlingDao
 import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.EtteroppgjoerForbehandlingService
+import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.EtteroppgjoerHendelseService
 import no.nav.etterlatte.behandling.etteroppgjoer.inntektskomponent.InntektskomponentKlient
 import no.nav.etterlatte.behandling.etteroppgjoer.inntektskomponent.InntektskomponentKlientImpl
 import no.nav.etterlatte.behandling.etteroppgjoer.inntektskomponent.InntektskomponentService
@@ -394,7 +395,8 @@ internal class ApplicationContext(
     private val tilbakekrevingHendelserService = TilbakekrevingHendelserServiceImpl(rapid)
     val saksbehandlerService: SaksbehandlerService =
         SaksbehandlerServiceImpl(saksbehandlerInfoDao, axsysKlient, navAnsattKlient)
-    val oppgaveService = OppgaveService(oppgaveDaoEndringer, sakLesDao, hendelseDao, behandlingsHendelser, saksbehandlerService)
+    val oppgaveService =
+        OppgaveService(oppgaveDaoEndringer, sakLesDao, hendelseDao, behandlingsHendelser, saksbehandlerService)
     val oppgaveKommentarService = OppgaveKommentarService(oppgaveKommentarDao, oppgaveService, sakLesDao)
 
     private val aldersovergangDao = AldersovergangDao(dataSource)
@@ -641,6 +643,9 @@ internal class ApplicationContext(
             featureToggleService = featureToggleService,
         )
 
+    private val etteroppgjoerHendelseService =
+        EtteroppgjoerHendelseService(rapid, hendelseDao)
+
     val etteroppgjoerForbehandlingService =
         EtteroppgjoerForbehandlingService(
             dao = etteroppgjoerForbehandlingDao,
@@ -648,6 +653,7 @@ internal class ApplicationContext(
             sakDao = sakLesDao,
             oppgaveService = oppgaveService,
             inntektskomponentService = inntektskomponentService,
+            hendelserService = etteroppgjoerHendelseService,
             sigrunKlient = sigrunKlient,
             beregningKlient = beregningsKlient,
             behandlingService = behandlingService,

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/etteroppgjoer/EtteroppgjoerForbehandlingDaoTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/etteroppgjoer/EtteroppgjoerForbehandlingDaoTest.kt
@@ -11,11 +11,11 @@ import no.nav.etterlatte.behandling.etteroppgjoer.AInntekt
 import no.nav.etterlatte.behandling.etteroppgjoer.PensjonsgivendeInntektFraSkatt
 import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.EtteroppgjoerForbehandling
 import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.EtteroppgjoerForbehandlingDao
-import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.EtteroppgjoerForbehandlingStatus
 import no.nav.etterlatte.behandling.kommerbarnettilgode.KommerBarnetTilGodeDao
 import no.nav.etterlatte.behandling.revurdering.RevurderingDao
 import no.nav.etterlatte.common.Enheter
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.EtteroppgjoerForbehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/database/EtteroppgjoerRepository.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/database/EtteroppgjoerRepository.kt
@@ -1,0 +1,175 @@
+package no.nav.etterlatte.statistikk.database
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.etterlatte.libs.common.behandling.EtteroppgjoerForbehandlingDto
+import no.nav.etterlatte.libs.common.behandling.EtteroppgjoerForbehandlingStatus
+import no.nav.etterlatte.libs.common.behandling.EtteroppgjoerHendelseType
+import no.nav.etterlatte.libs.common.beregning.BeregnetEtteroppgjoerResultatDto
+import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerResultatType
+import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.periode.Periode
+import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.getTidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.setTidspunkt
+import no.nav.etterlatte.libs.database.setNullableDate
+import no.nav.etterlatte.libs.database.setNullableDouble
+import no.nav.etterlatte.libs.database.setNullableInt
+import no.nav.etterlatte.libs.database.setNullableLong
+import no.nav.etterlatte.libs.database.singleOrNull
+import no.nav.etterlatte.libs.database.toList
+import java.sql.ResultSet
+import java.time.LocalDate
+import java.time.Month
+import java.time.YearMonth
+import java.util.UUID
+import javax.sql.DataSource
+
+class EtteroppgjoerRepository(
+    private val dataSource: DataSource,
+) {
+    fun lagreEtteroppgjoerRad(rad: EtteroppgjoerRad) {
+        dataSource.connection.use { connection ->
+            val statement =
+                connection.prepareStatement(
+                    """
+                    INSERT INTO etteroppgjoer_statistikk (forbehandling_id, sak_id, aar, hendelse, forbehandling_status, 
+                    opprettet, maaneder_ytelse, teknisk_tid, utbetalt_stoenad, ny_brutto_stoenad, differanse, 
+                    rettsgebyr, rettsgebyr_gyldig_fra, tilbakekreving_grense, etterbetaling_grense, resultat_type)
+                    values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """.trimIndent(),
+                )
+            statement.setObject(1, rad.forbehandlingId)
+            statement.setLong(2, rad.sakId.sakId)
+            statement.setInt(3, rad.aar)
+            statement.setString(4, rad.hendelse.name)
+            statement.setString(5, rad.forbehandlingStatus.name)
+            statement.setTidspunkt(6, rad.opprettet)
+            statement.setJsonb(7, rad.maanederYtelse)
+            statement.setTidspunkt(8, rad.tekniskTid)
+            statement.setNullableLong(9, rad.utbetaltStoenad)
+            statement.setNullableLong(10, rad.nyBruttoStoenad)
+            statement.setNullableLong(11, rad.differanse)
+            statement.setNullableInt(12, rad.rettsgebyr)
+            statement.setNullableDate(13, rad.rettsgebyrGyldigFra)
+            statement.setNullableDouble(14, rad.tilbakekrevingGrense)
+            statement.setNullableDouble(15, rad.etterbetalingGrense)
+            statement.setString(16, rad.resultatType?.name)
+            statement.executeUpdate()
+        }
+    }
+
+    fun hentEtteroppgjoerRad(radId: Long): EtteroppgjoerRad =
+        dataSource.connection.use { connection ->
+            val statement =
+                connection.prepareStatement(
+                    """
+                    SELECT id, forbehandling_id, sak_id, aar, hendelse, forbehandling_status, 
+                      opprettet, maaneder_ytelse, teknisk_tid, utbetalt_stoenad, ny_brutto_stoenad, differanse, 
+                      rettsgebyr, rettsgebyr_gyldig_fra, tilbakekreving_grense, etterbetaling_grense, resultat_type
+                    FROM etteroppgjoer_statistikk
+                    WHERE id = ?
+                    """.trimIndent(),
+                )
+            statement.setLong(1, radId)
+            statement.executeQuery().singleOrNull {
+                tilEtteroppgjoerRad()
+            } ?: throw IkkeFunnetException("FANT_IKKE_ETTEROPPGJOER", "Fant ikke forespurt rad for etteroppgjøret")
+        }
+
+    fun hentEtteroppgjoerRaderForForbehandling(forbehandlingId: UUID): List<EtteroppgjoerRad> =
+        dataSource.connection.use { connection ->
+            val statement =
+                connection.prepareStatement(
+                    """
+                    SELECT id, forbehandling_id, sak_id, aar, hendelse, forbehandling_status, 
+                      opprettet, maaneder_ytelse, teknisk_tid, utbetalt_stoenad, ny_brutto_stoenad, differanse, 
+                      rettsgebyr, rettsgebyr_gyldig_fra, tilbakekreving_grense, etterbetaling_grense, resultat_type
+                    FROM etteroppgjoer_statistikk
+                    WHERE forbehandling_id = ?
+                    """.trimIndent(),
+                )
+            statement.setObject(1, forbehandlingId)
+            statement.executeQuery().toList { tilEtteroppgjoerRad() }
+        }
+}
+
+private fun ResultSet.tilEtteroppgjoerRad(): EtteroppgjoerRad =
+    EtteroppgjoerRad(
+        id = getLong("id"),
+        forbehandlingId = getObject("forbehandling_id") as UUID,
+        sakId = SakId(getLong("sak_id")),
+        aar = getInt("aar"),
+        hendelse = enumValueOf<EtteroppgjoerHendelseType>(getString("hendelse")),
+        forbehandlingStatus = enumValueOf(getString("forbehandling_status")),
+        opprettet = getTidspunkt("opprettet"),
+        maanederYtelse = objectMapper.readValue<List<Int>>(getString("maaneder_ytelse")),
+        tekniskTid = getTidspunkt("teknisk_tid"),
+        utbetaltStoenad = getLong("utbetalt_stoenad").takeUnless { wasNull() },
+        nyBruttoStoenad = getLong("ny_brutto_stoenad").takeUnless { wasNull() },
+        differanse = getLong("differanse").takeUnless { wasNull() },
+        rettsgebyr = getInt("rettsgebyr").takeUnless { wasNull() },
+        rettsgebyrGyldigFra = getDate("rettsgebyr_gyldig_fra").takeUnless { wasNull() }?.toLocalDate(),
+        tilbakekrevingGrense = getDouble("tilbakekreving_grense").takeUnless { wasNull() },
+        etterbetalingGrense = getDouble("etterbetaling_grense").takeUnless { wasNull() },
+        resultatType =
+            getString("resultat_type")
+                .takeUnless { wasNull() }
+                ?.let { enumValueOf<EtteroppgjoerResultatType>(it) },
+    )
+
+data class EtteroppgjoerRad(
+    val id: Long,
+    val forbehandlingId: UUID,
+    val sakId: SakId,
+    val aar: Int,
+    val hendelse: EtteroppgjoerHendelseType,
+    val forbehandlingStatus: EtteroppgjoerForbehandlingStatus,
+    val opprettet: Tidspunkt,
+    val maanederYtelse: List<Int>,
+    val tekniskTid: Tidspunkt,
+    // Følgende rader går på resultat, som ikke nødvendigvis er gitt
+    val utbetaltStoenad: Long?,
+    val nyBruttoStoenad: Long?,
+    val differanse: Long?,
+    val rettsgebyr: Int?,
+    val rettsgebyrGyldigFra: LocalDate?,
+    val tilbakekrevingGrense: Double?,
+    val etterbetalingGrense: Double?,
+    val resultatType: EtteroppgjoerResultatType?,
+) {
+    companion object {
+        fun fraHendelseOgDto(
+            hendelse: EtteroppgjoerHendelseType,
+            forbehandlingDto: EtteroppgjoerForbehandlingDto,
+            tekniskTid: Tidspunkt,
+            resultat: BeregnetEtteroppgjoerResultatDto?,
+        ): EtteroppgjoerRad =
+            EtteroppgjoerRad(
+                id = -1,
+                forbehandlingId = forbehandlingDto.id,
+                sakId = forbehandlingDto.sak.id,
+                aar = forbehandlingDto.aar,
+                hendelse = hendelse,
+                forbehandlingStatus = forbehandlingDto.status,
+                opprettet = forbehandlingDto.opprettet,
+                maanederYtelse = finnMaanederMedYtelseIEtteroppgjoersaar(forbehandlingDto.innvilgetPeriode),
+                tekniskTid = tekniskTid,
+                utbetaltStoenad = resultat?.utbetaltStoenad,
+                nyBruttoStoenad = resultat?.nyBruttoStoenad,
+                differanse = resultat?.differanse,
+                rettsgebyr = resultat?.grense?.rettsgebyr,
+                rettsgebyrGyldigFra = resultat?.grense?.rettsgebyrGyldigFra,
+                tilbakekrevingGrense = resultat?.grense?.tilbakekreving,
+                etterbetalingGrense = resultat?.grense?.etterbetaling,
+                resultatType = resultat?.resultatType,
+            )
+    }
+}
+
+private fun finnMaanederMedYtelseIEtteroppgjoersaar(periode: Periode): List<Int> {
+    // implisitt hele året med ingen tom
+    val tom = periode.tom ?: YearMonth.of(periode.fom.year, Month.DECEMBER)
+    return (periode.fom.month.value..tom.month.value).toList()
+}

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/EtteroppgjoerHendelseRiver.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/EtteroppgjoerHendelseRiver.kt
@@ -1,0 +1,70 @@
+package no.nav.etterlatte.statistikk.river
+
+import com.fasterxml.jackson.databind.node.NullNode
+import com.fasterxml.jackson.module.kotlin.treeToValue
+import no.nav.etterlatte.libs.common.behandling.ETTEROPPGJOER_RESULTAT_RIVER_KEY
+import no.nav.etterlatte.libs.common.behandling.ETTEROPPGJOER_STATISTIKK_RIVER_KEY
+import no.nav.etterlatte.libs.common.behandling.EtteroppgjoerForbehandlingStatistikkDto
+import no.nav.etterlatte.libs.common.behandling.EtteroppgjoerHendelseType
+import no.nav.etterlatte.libs.common.beregning.BeregnetEtteroppgjoerResultatDto
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
+import no.nav.etterlatte.libs.common.rapidsandrivers.TEKNISK_TID_KEY
+import no.nav.etterlatte.libs.common.rapidsandrivers.correlationId
+import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
+import no.nav.etterlatte.rapidsandrivers.ListenerMedLogging
+import no.nav.etterlatte.statistikk.service.StatistikkService
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.MessageContext
+import no.nav.helse.rapids_rivers.RapidsConnection
+import org.slf4j.LoggerFactory
+
+class EtteroppgjoerHendelseRiver(
+    rapidsConnection: RapidsConnection,
+    private val statistikkService: StatistikkService,
+) : ListenerMedLogging() {
+    private val logger = LoggerFactory.getLogger(EtteroppgjoerHendelseRiver::class.java)
+
+    private val etteroppgjoerHendelser = EtteroppgjoerHendelseType.entries.map { it.lagEventnameForType() }
+
+    init {
+        initialiserRiverUtenEventName(rapidsConnection) {
+            validate { it.demandAny(EVENT_NAME_KEY, etteroppgjoerHendelser) }
+            validate { it.requireKey(ETTEROPPGJOER_STATISTIKK_RIVER_KEY) }
+            validate { it.interestedIn(TEKNISK_TID_KEY) }
+            validate { it.interestedIn(ETTEROPPGJOER_RESULTAT_RIVER_KEY) }
+        }
+    }
+
+    override fun haandterPakke(
+        packet: JsonMessage,
+        context: MessageContext,
+    ) {
+        try {
+            val hendelse: EtteroppgjoerHendelseType = enumValueOf(packet[EVENT_NAME_KEY].textValue().split(":")[1])
+            val tekniskTid = parseTekniskTid(packet, logger)
+            val statistikkDto: EtteroppgjoerForbehandlingStatistikkDto =
+                objectMapper.treeToValue(packet[ETTEROPPGJOER_STATISTIKK_RIVER_KEY])
+            val resultat: BeregnetEtteroppgjoerResultatDto? =
+                when (val resultatNode = packet[ETTEROPPGJOER_RESULTAT_RIVER_KEY]) {
+                    is NullNode -> null
+                    else -> objectMapper.treeToValue(resultatNode)
+                }
+
+            statistikkService.registrerEtteroppgjoerHendelse(
+                hendelse = hendelse,
+                statistikkDto = statistikkDto,
+                tekniskTid = tekniskTid.toTidspunkt(),
+                resultat = resultat,
+            )
+            logger.info("Registrerte statistikk på etteroppgjør for pakke med korrelasjonsid ${packet.correlationId}")
+        } catch (e: Exception) {
+            logger.error(
+                "Kunne ikke registrere statistikk for etteroppgjør i pakken med korrelasjonsid" +
+                    "=${packet.correlationId}. Dette blokkerer lesing av statistikk og må sees på snarest!",
+                e,
+            )
+            throw e
+        }
+    }
+}

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/KlagehendelseRiver.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/river/KlagehendelseRiver.kt
@@ -36,12 +36,12 @@ class KlagehendelseRiver(
     override fun haandterPakke(
         packet: JsonMessage,
         context: MessageContext,
-    ): Any {
+    ) {
         try {
             val klage: StatistikkKlage = objectMapper.treeToValue(packet[KLAGE_STATISTIKK_RIVER_KEY])
             val tekniskTid = parseTekniskTid(packet, logger)
             val hendelse: KlageHendelseType = enumValueOf(packet[EVENT_NAME_KEY].textValue().split(":")[1])
-            return service
+            service
                 .registrerStatistikkForKlagehendelse(klage, tekniskTid, hendelse)
                 ?.also {
                     context.publish(

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/service/EtteroppgjoerStatistikkService.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/service/EtteroppgjoerStatistikkService.kt
@@ -1,0 +1,30 @@
+package no.nav.etterlatte.statistikk.service
+
+import no.nav.etterlatte.libs.common.behandling.EtteroppgjoerForbehandlingDto
+import no.nav.etterlatte.libs.common.behandling.EtteroppgjoerHendelseType
+import no.nav.etterlatte.libs.common.beregning.BeregnetEtteroppgjoerResultatDto
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.statistikk.database.EtteroppgjoerRad
+import no.nav.etterlatte.statistikk.database.EtteroppgjoerRepository
+
+class EtteroppgjoerStatistikkService(
+    private val etteroppgjoerRepository: EtteroppgjoerRepository,
+) {
+    fun registrerEtteroppgjoerHendelse(
+        hendelse: EtteroppgjoerHendelseType,
+        forbehandling: EtteroppgjoerForbehandlingDto,
+        tekniskTid: Tidspunkt,
+        resultat: BeregnetEtteroppgjoerResultatDto?,
+    ): EtteroppgjoerRad {
+        val etteroppgjoerRad =
+            EtteroppgjoerRad.fraHendelseOgDto(
+                hendelse = hendelse,
+                forbehandlingDto = forbehandling,
+                tekniskTid = tekniskTid,
+                resultat = resultat,
+            )
+
+        etteroppgjoerRepository.lagreEtteroppgjoerRad(etteroppgjoerRad)
+        return etteroppgjoerRad
+    }
+}

--- a/apps/etterlatte-statistikk/src/main/resources/db/migration/V60__etteroppgjoer_tabell.sql
+++ b/apps/etterlatte-statistikk/src/main/resources/db/migration/V60__etteroppgjoer_tabell.sql
@@ -1,0 +1,19 @@
+create table etteroppgjoer_statistikk (
+    id BIGSERIAL primary key,
+    forbehandling_id UUID,
+    sak_id BIGINT,
+    aar INT,
+    hendelse TEXT,
+    forbehandling_status TEXT,
+    opprettet TIMESTAMP,
+    maaneder_ytelse JSONB,
+    teknisk_tid TIMESTAMP,
+    utbetalt_stoenad BIGINT,
+    ny_brutto_stoenad BIGINT,
+    differanse BIGINT,
+    rettsgebyr INT,
+    rettsgebyr_gyldig_fra DATE,
+    tilbakekreving_grense DOUBLE PRECISION,
+    etterbetaling_grense DOUBLE PRECISION,
+    resultat_type text
+)

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/database/EtteroppgjoerRepositoryTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/database/EtteroppgjoerRepositoryTest.kt
@@ -1,0 +1,85 @@
+package no.nav.etterlatte.statistikk.database
+
+import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
+import io.kotest.matchers.equals.shouldBeEqual
+import no.nav.etterlatte.libs.common.behandling.EtteroppgjoerForbehandlingStatus
+import no.nav.etterlatte.libs.common.behandling.EtteroppgjoerHendelseType
+import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerResultatType
+import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.RegisterExtension
+import java.time.LocalDate
+import java.util.UUID
+import javax.sql.DataSource
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class EtteroppgjoerRepositoryTest(
+    private val dataSource: DataSource,
+) {
+    @Test
+    fun `kan lagre og hente ut etteroppgjoer-rad`() {
+        val rad =
+            EtteroppgjoerRad(
+                id = -1,
+                forbehandlingId = UUID.randomUUID(),
+                sakId = SakId(1L),
+                aar = 2024,
+                hendelse = EtteroppgjoerHendelseType.OPPRETTET,
+                forbehandlingStatus = EtteroppgjoerForbehandlingStatus.OPPRETTET,
+                opprettet = Tidspunkt.now(),
+                maanederYtelse = listOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12),
+                tekniskTid = Tidspunkt.now(),
+                utbetaltStoenad = 200000,
+                nyBruttoStoenad = 200000,
+                differanse = 0,
+                rettsgebyr = 1234,
+                rettsgebyrGyldigFra = LocalDate.of(2024, 1, 1),
+                tilbakekrevingGrense = 40.0,
+                etterbetalingGrense = 20.0,
+                resultatType = EtteroppgjoerResultatType.INGEN_ENDRING,
+            )
+        val repo = EtteroppgjoerRepository(dataSource)
+        repo.lagreEtteroppgjoerRad(rad)
+        val hentetRad = repo.hentEtteroppgjoerRaderForForbehandling(rad.forbehandlingId).single()
+        hentetRad.shouldBeEqualToIgnoringFields(rad, EtteroppgjoerRad::id)
+        val hentetRadMedId = repo.hentEtteroppgjoerRad(hentetRad.id)
+        hentetRad shouldBeEqual hentetRadMedId
+    }
+
+    @Test
+    fun `kan lagre og hente ut etteroppgjoer-rad uten resultater lagret riktig`() {
+        val rad =
+            EtteroppgjoerRad(
+                id = -1,
+                forbehandlingId = UUID.randomUUID(),
+                sakId = SakId(1L),
+                aar = 2024,
+                hendelse = EtteroppgjoerHendelseType.OPPRETTET,
+                forbehandlingStatus = EtteroppgjoerForbehandlingStatus.OPPRETTET,
+                opprettet = Tidspunkt.now(),
+                maanederYtelse = listOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12),
+                tekniskTid = Tidspunkt.now(),
+                utbetaltStoenad = null,
+                nyBruttoStoenad = null,
+                differanse = null,
+                rettsgebyr = null,
+                rettsgebyrGyldigFra = null,
+                tilbakekrevingGrense = null,
+                etterbetalingGrense = null,
+                resultatType = null,
+            )
+        val repo = EtteroppgjoerRepository(dataSource)
+        repo.lagreEtteroppgjoerRad(rad)
+        val hentetRad = repo.hentEtteroppgjoerRaderForForbehandling(rad.forbehandlingId).single()
+        hentetRad.shouldBeEqualToIgnoringFields(rad, EtteroppgjoerRad::id)
+        val hentetRadMedId = repo.hentEtteroppgjoerRad(hentetRad.id)
+        hentetRad shouldBeEqual hentetRadMedId
+    }
+
+    companion object {
+        @RegisterExtension
+        val dbExtension = DatabaseExtension()
+    }
+}

--- a/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/service/StatistikkServiceTest.kt
+++ b/apps/etterlatte-statistikk/src/test/kotlin/no/nav/etterlatte/statistikk/service/StatistikkServiceTest.kt
@@ -71,6 +71,7 @@ class StatistikkServiceTest {
     private val behandlingKlient = mockk<BehandlingKlient>()
     private val beregningKlient = mockk<BeregningKlient>()
     private val aktivitetspliktService = mockk<AktivitetspliktService>()
+    private val etteroppgjoerService = mockk<EtteroppgjoerStatistikkService>()
     private val service =
         StatistikkService(
             stoenadRepository = stoenadRepo,
@@ -78,6 +79,7 @@ class StatistikkServiceTest {
             behandlingKlient = behandlingKlient,
             beregningKlient = beregningKlient,
             aktivitetspliktService = aktivitetspliktService,
+            etteroppgjoerService = etteroppgjoerService,
         )
 
     @Test
@@ -428,6 +430,7 @@ class StatistikkServiceTest {
                 behandlingKlient = behandlingKlient,
                 beregningKlient = beregningKlient,
                 aktivitetspliktService = aktivitetspliktService,
+                etteroppgjoerService = etteroppgjoerService,
             )
         service.lagreMaanedsstatistikk(MaanedStatistikk(YearMonth.of(2022, 8), emptyList(), emptyMap()))
         verify {
@@ -458,6 +461,7 @@ class StatistikkServiceTest {
                 behandlingKlient = behandlingKlient,
                 beregningKlient = beregningKlient,
                 aktivitetspliktService = mockAktivitetspliktService,
+                etteroppgjoerService = etteroppgjoerService,
             )
         val brukteOmsIder = slot<List<SakId>>()
 

--- a/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Etteroppgjoer.kt
+++ b/libs/etterlatte-behandling-model/src/main/kotlin/no/nav/etterlatte/libs/common/behandling/Etteroppgjoer.kt
@@ -1,0 +1,49 @@
+package no.nav.etterlatte.libs.common.behandling
+
+import no.nav.etterlatte.libs.common.event.EventnameHendelseType
+import no.nav.etterlatte.libs.common.periode.Periode
+import no.nav.etterlatte.libs.common.sak.Sak
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import java.util.UUID
+
+enum class EtteroppgjoerForbehandlingStatus {
+    OPPRETTET,
+    BEREGNET,
+    FERDIGSTILT,
+}
+
+data class EtteroppgjoerForbehandlingDto(
+    val id: UUID,
+    val hendelseId: UUID,
+    val opprettet: Tidspunkt,
+    val status: EtteroppgjoerForbehandlingStatus,
+    val sak: Sak,
+    val aar: Int,
+    val innvilgetPeriode: Periode,
+    val brevId: Long?,
+    val kopiertFra: UUID? = null, // hvis vi oppretter en kopi av forbehandling for å bruke i en revurdering
+    val sisteIverksatteBehandlingId: UUID, // siste iverksatte behandling når forbehandling ble opprettet
+    val harMottattNyInformasjon: JaNei?,
+    val endringErTilUgunstForBruker: JaNei?,
+    val beskrivelseAvUgunst: String?,
+)
+
+enum class EtteroppgjoerHendelseType(
+    val skalSendeStatistikk: Boolean,
+) : EventnameHendelseType {
+    OPPRETTET(true),
+    BEREGNET(false),
+    FERDIGSTILT(true),
+    ;
+
+    override fun lagEventnameForType(): String = "ETTEROPPGJOER_FORBEHANDLING:${this.name}"
+}
+
+const val ETTEROPPGJOER_STATISTIKK_RIVER_KEY = "etteroppgjoer_statistikk"
+const val ETTEROPPGJOER_RESULTAT_RIVER_KEY = "etteroppgave_resultat"
+
+data class EtteroppgjoerForbehandlingStatistikkDto(
+    val forbehandling: EtteroppgjoerForbehandlingDto,
+    val utlandstilknytningType: UtlandstilknytningType?,
+    val saksbehandler: String?,
+)

--- a/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
+++ b/libs/etterlatte-database/src/main/kotlin/JdbcUtils.kt
@@ -4,8 +4,11 @@ import no.nav.etterlatte.libs.common.feilhaandtering.krev
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.sak.SakId
 import org.postgresql.util.PGobject
+import java.sql.Date
 import java.sql.PreparedStatement
 import java.sql.ResultSet
+import java.sql.Types
+import java.time.LocalDate
 
 fun <T> ResultSet.singleOrNull(block: ResultSet.() -> T): T? =
     if (next()) {
@@ -58,3 +61,35 @@ fun PreparedStatement.setSakId(
     index: Int,
     sakId: SakId,
 ) = this.setLong(index, sakId.sakId)
+
+fun PreparedStatement.setNullableInt(
+    index: Int,
+    value: Int?,
+) = when (value) {
+    null -> this.setNull(index, Types.BIGINT)
+    else -> this.setInt(index, value)
+}
+
+fun PreparedStatement.setNullableDate(
+    index: Int,
+    value: LocalDate?,
+) = when (value) {
+    null -> this.setNull(index, Types.DATE)
+    else -> this.setDate(index, Date.valueOf(value))
+}
+
+fun PreparedStatement.setNullableLong(
+    index: Int,
+    value: Long?,
+) = when (value) {
+    null -> this.setNull(index, Types.BIGINT)
+    else -> this.setLong(index, value)
+}
+
+fun PreparedStatement.setNullableDouble(
+    index: Int,
+    value: Double?,
+) = when (value) {
+    null -> this.setNull(index, Types.FLOAT)
+    else -> this.setDouble(index, value)
+}


### PR DESCRIPTION
Løsningen følger et lignende mønster som for klage / tilbakekreving, i at vi både lagrer ned hendelser i behandlingshendelse-databasen, og også sender hendelser til statistikkappen som registrer saksbehandlingsstatistikk på det.

Oppretter i tillegg en dedikert tabell for etteroppgjør-statistikk, som kan holde på informasjon litt mer uavhengig av hva vi skal levere til statistikk- teamene.