### PR TITLE
Henter årsoppgjør på en tryggere måte hvis avkorting mangler

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/etteroppgjoer/EtteroppgjoerService.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/etteroppgjoer/EtteroppgjoerService.kt
@@ -87,9 +87,15 @@ class EtteroppgjoerService(
         val sanksjoner = sanksjonService.hentSanksjon(request.sisteIverksatteBehandling) ?: emptyList()
 
         val tidligereAarsoppgjoer =
-            avkortingRepository.hentAvkorting(request.sisteIverksatteBehandling)?.let {
+            runBlocking {
+                avkortingService.hentAvkortingMedReparertAarsoppgjoer(
+                    sakId = request.sakId,
+                    behandlingId = request.sisteIverksatteBehandling,
+                    brukerTokenInfo = brukerTokenInfo,
+                )
+            }.let {
                 it.aarsoppgjoer.single { aarsoppgjoer -> aarsoppgjoer.aar == request.aar }
-            } ?: throw InternfeilException("Mangler avkorting")
+            }
 
         val avkorting =
             with(request) {


### PR DESCRIPTION
Siden den årlige inntektsjusteringen ikke fikk med alle historiske årsoppgjør riktig, kan vi mangle årsoppgjøret for 2024 i siste iverksatte behandling.

Dette skal ideelt sett ha blitt fikset i reguleringen, men det stemmer ikke alltid for saker i dev i alle fall, og er en grei ting å verne om uansett.