### PR TITLE
Tilpasser mapping statistikk etteroppgjør

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -63,8 +63,8 @@ class EtteroppgjoerForbehandlingService(
     ) {
         logger.info("Ferdigstiller forbehandling for behandling=$behandlingId")
         val forbehandling = dao.hentForbehandling(behandlingId) ?: throw FantIkkeForbehandling(behandlingId)
-
-        dao.lagreForbehandling(forbehandling.tilFerdigstilt())
+        val ferdigstiltForbehandling = forbehandling.tilFerdigstilt()
+        dao.lagreForbehandling(ferdigstiltForbehandling)
         etteroppgjoerService.oppdaterEtteroppgjoerStatus(
             forbehandling.sak.id,
             forbehandling.aar,
@@ -77,7 +77,7 @@ class EtteroppgjoerForbehandlingService(
         )
         val utlandstilknytning = behandlingService.hentUtlandstilknytningForSak(forbehandling.sak.id)
         hendelserService.registrerOgSendEtteroppgjoerHendelse(
-            etteroppgjoerForbehandling = forbehandling,
+            etteroppgjoerForbehandling = ferdigstiltForbehandling,
             etteroppgjoerResultat = null,
             hendelseType = EtteroppgjoerHendelseType.FERDIGSTILT,
             saksbehandler = brukerTokenInfo.ident().takeIf { brukerTokenInfo is Saksbehandler },
@@ -222,6 +222,8 @@ class EtteroppgjoerForbehandlingService(
 
         behandlingService.settBeregnetForRevurderingTilForbehandling(forbehandling)
         val utlandstilknytning = behandlingService.hentUtlandstilknytningForSak(forbehandling.sak.id)
+        forbehandling = forbehandling.tilBeregnet()
+        dao.lagreForbehandling(forbehandling)
         hendelserService.registrerOgSendEtteroppgjoerHendelse(
             etteroppgjoerForbehandling = forbehandling,
             etteroppgjoerResultat = beregnetEtteroppgjoerResultat,
@@ -229,7 +231,6 @@ class EtteroppgjoerForbehandlingService(
             saksbehandler = brukerTokenInfo.ident().takeIf { brukerTokenInfo is Saksbehandler },
             utlandstilknytningType = utlandstilknytning?.type,
         )
-        dao.lagreForbehandling(forbehandling.tilBeregnet())
         return beregnetEtteroppgjoerResultat
     }
 

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/service/EtteroppgjoerStatistikkService.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/service/EtteroppgjoerStatistikkService.kt
@@ -6,6 +6,7 @@ import no.nav.etterlatte.libs.common.beregning.BeregnetEtteroppgjoerResultatDto
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.statistikk.database.EtteroppgjoerRad
 import no.nav.etterlatte.statistikk.database.EtteroppgjoerRepository
+import java.util.UUID
 
 class EtteroppgjoerStatistikkService(
     private val etteroppgjoerRepository: EtteroppgjoerRepository,
@@ -26,5 +27,10 @@ class EtteroppgjoerStatistikkService(
 
         etteroppgjoerRepository.lagreEtteroppgjoerRad(etteroppgjoerRad)
         return etteroppgjoerRad
+    }
+
+    fun hentNyesteRad(forbehandlingId: UUID): EtteroppgjoerRad? {
+        val rader = etteroppgjoerRepository.hentEtteroppgjoerRaderForForbehandling(forbehandlingId)
+        return rader.maxByOrNull { it.tekniskTid }
     }
 }

--- a/apps/etterlatte-statistikk/src/main/kotlin/statistikk/service/StatistikkService.kt
+++ b/apps/etterlatte-statistikk/src/main/kotlin/statistikk/service/StatistikkService.kt
@@ -276,6 +276,11 @@ class StatistikkService(
         etteroppgjoerRad: EtteroppgjoerRad,
         statistikkDto: EtteroppgjoerForbehandlingStatistikkDto,
     ): SakRad {
+        val sisteResultat =
+            when (etteroppgjoerRad.hendelse) {
+                EtteroppgjoerHendelseType.FERDIGSTILT -> etteroppgjoerService.hentNyesteRad(etteroppgjoerRad.forbehandlingId)
+                else -> null
+            }
         val foersteMaanedIEtteroppgjoer = etteroppgjoerRad.maanederYtelse.min()
         val sisteMaanedIEtteroppgjoeor = etteroppgjoerRad.maanederYtelse.max()
 
@@ -293,7 +298,7 @@ class StatistikkService(
             vedtakTidspunkt = null,
             type = "ETTEROPPGJOER_FORBEHANDLING",
             status = etteroppgjoerRad.hendelse.name,
-            resultat = etteroppgjoerRad.resultatType?.name,
+            resultat = etteroppgjoerRad.resultatType?.name ?: sisteResultat?.resultatType?.name,
             resultatBegrunnelse = null,
             behandlingMetode = BehandlingMetode.MANUELL, // TODO: hvis vi setter på automatisering her må vi skille her
             soeknadFormat = SoeknadFormat.DIGITAL,


### PR DESCRIPTION
Gjør noen små tilpasninger på statistikken for etteroppgjør forbehandling: Får en bedre status på forbehandlingen, og prøver å laste siste resultat inn i statistikken.