### PR TITLE
Oppdaterer scope for dokdistfordeling

### DIFF
--- a/apps/etterlatte-brev-api/.nais/dev.yaml
+++ b/apps/etterlatte-brev-api/.nais/dev.yaml
@@ -89,7 +89,7 @@ spec:
     - name: DOKDIST_URL
       value: https://dokdistfordeling.dev-fss-pub.nais.io/rest/v1
     - name: DOKDIST_CLIENT_ID
-      value: dev-fss.teamdokumenthandtering.saf
+      value: dev-fss.teamdokumenthandtering.dokdistfordeling
     - name: DOKDISTKANAL_URL
       value: https://dokdistkanal.dev-fss-pub.nais.io/rest
     - name: DOKDISTKANAL_CLIENT_ID

--- a/apps/etterlatte-brev-api/.nais/prod.yaml
+++ b/apps/etterlatte-brev-api/.nais/prod.yaml
@@ -98,7 +98,7 @@ spec:
     - name: DOKDIST_URL
       value: https://dokdistfordeling.prod-fss-pub.nais.io/rest/v1
     - name: DOKDIST_CLIENT_ID
-      value: prod-fss.teamdokumenthandtering.saf
+      value: prod-fss.teamdokumenthandtering.dokdistfordeling
     - name: DOKDISTKANAL_URL
       value: https://dokdistkanal.prod-fss-pub.nais.io/rest
     - name: DOKDISTKANAL_CLIENT_ID


### PR DESCRIPTION
* Fra saf-scope til dokdistfordeling-scope for dokdistfordeling integrasjonen

> Vi gjør endringer på autentisering i dokdistfordeling, for å sørge for at autentisering med EntraID er implementert som tiltenkt. Pr i dag kalles distribuerJournalpost med EntraID tokens scopet mot SAF, hvor dokdistfordeling proxyer dette tokenet videre i kall til SAF. Vi ønsker på sikt å endre dette til av dokdistfordeling kun kan kalles med tokens som er scopet mot seg selv. Steg 1 av denne endringen innføres nå, hvor dokdistfordeling i en overgangsperiode vil akseptere tokens med enten saf- eller dokdistfordeling-scope. Dette innebærer at konsumenter ikke trenger å gjøre noe umiddelbart, men på sikt (helst så snart som mulig) må endre scope for tokenet de kaller dokdistfordeling med. Vi kommer til å bistå konsumenter med denne endringen. Liste med pre-autentiserte applikasjoner er populert for hvert miljø basert på kall mot distribuertJournalpost siste 7 dager.

Har dobbeltsjekket dokdistfordeling config og `prod-gcp:etterlatte:etterlatte-brev-api` ligger inne i dokdistfordeling sin preauthorized liste. Så dere skal ikke merke noe. 🙇