### PR TITLE
EY-5345 Plukker ikke opp journalposter som skal til Kabal

### DIFF
--- a/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/joark/SafGraphql.kt
+++ b/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/joark/SafGraphql.kt
@@ -55,12 +55,29 @@ data class Journalpost(
     val bruker: Bruker?,
     val tittel: String?,
     val journalstatus: Journalstatus,
+    val journalfoerendeEnhet: String?,
+    val dokumenter: List<DokumentInfo>,
     val sak: Fagsak?,
     val kanal: Kanal,
 ) {
     fun erFerdigstilt(): Boolean =
         (journalstatus == Journalstatus.FERDIGSTILT || journalstatus == Journalstatus.JOURNALFOERT) &&
             sak?.fagsaksystem == Fagsaksystem.EY.navn
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class DokumentInfo(
+    val dokumentInfoId: String,
+    val tittel: String?,
+    val brevkode: String?,
+    val dokumentStatus: DokumentStatus,
+)
+
+enum class DokumentStatus {
+    FERDIGSTILT,
+    AVBRUTT,
+    UNDER_REDIGERING,
+    KASSERT,
 }
 
 enum class Journalstatus {

--- a/apps/etterlatte-hendelser-joark/src/main/resources/graphql/journalpost.id.graphql
+++ b/apps/etterlatte-hendelser-joark/src/main/resources/graphql/journalpost.id.graphql
@@ -6,6 +6,7 @@ query(
         tittel
         journalposttype
         journalstatus
+        journalfoerendeEnhet
         bruker {
             id
             type
@@ -13,6 +14,8 @@ query(
         dokumenter {
             dokumentInfoId
             tittel
+            brevkode
+            dokumentStatus
             dokumentvarianter {
                 saksbehandlerHarTilgang
             }


### PR DESCRIPTION
Logger også mer informasjon hvis vi mottar en hendelse som har journalførende enhet satt, siden dette kan indikere at noen™ prøver å få en spesifikk journalførende enhet inn.