### PR TITLE
ikke ferdigstille forbehandling før brev er ferdigstilt

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerRoutes.kt
@@ -107,11 +107,11 @@ fun Route.etteroppgjoerRoutes(
                         // Runblocking rundt ferdigstilling av brevet for å unngå å ferdigstille forbehandlingen uten at
                         // brevet er ok.
                         runBlocking {
-                            forbehandlingService.ferdigstillForbehandling(etteroppgjoerId, brukerTokenInfo)
                             forbehandlingBrevService.ferdigstillJournalfoerOgDistribuerBrev(
                                 etteroppgjoerId,
                                 brukerTokenInfo,
                             )
+                            forbehandlingService.ferdigstillForbehandling(etteroppgjoerId, brukerTokenInfo)
                         }
                     }
                     call.respond(HttpStatusCode.OK)


### PR DESCRIPTION
FerdigstillJournalfoerOgDistribuerBrev feiler fordi forbehandling er ferdigstilt, da skal vi ikke få lov til å gjøre endringer.

Endre derfor til å forsøke å ferdigstille brev før vi ferdigstiller forbehandling. 