### PR TITLE
Rette byggefeil for etteroppgjoer svarfrist utloept modal

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/EtteroppgjoerSvarfristUtloeptModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/EtteroppgjoerSvarfristUtloeptModal.tsx
@@ -27,8 +27,9 @@ export const EtteroppgjoerSvarfristUtloeptModal = ({ oppgave, oppdaterStatus }: 
 
   const [opprettRevurderingResult, opprettRevurderingRequest] = useApiCall(opprettRevurderingApi)
 
-  const opprettRevurderingEtteroppgjoer = (forbehandlingId: string) => {
-    opprettRevurderingRequest({ sakId: oppgave.sakId, forbehandlingId: forbehandlingId }, () => {
+  const opprettRevurderingEtteroppgjoer = () => {
+    // TODO: burde vi heller opprette fra oppgave.referanse
+    opprettRevurderingRequest({ sakId: oppgave.sakId }, () => {
       ferdigstill({ id: oppgave.id, merknad: oppgave.merknad }, () => {
         oppdaterStatus(oppgave.id, Oppgavestatus.FERDIGSTILT)
         setOpen(false)
@@ -79,7 +80,7 @@ export const EtteroppgjoerSvarfristUtloeptModal = ({ oppgave, oppdaterStatus }: 
                 <Button
                   loading={isPending(opprettRevurderingResult)}
                   size="small"
-                  onClick={() => opprettRevurderingEtteroppgjoer(oppgave.referanse!!)}
+                  onClick={() => opprettRevurderingEtteroppgjoer()}
                 >
                   Opprett revurdering
                 </Button>


### PR DESCRIPTION
Opprett revurdering tar ikke inn forbehandlingId da endepunktet allerede henter siste ferdigstilte forbehandling. 

Må diskutere senere hvorvidt vi skal bruker oppgave.referanse eller alltid ta utgangspunkt i siste ferdigstilte forbehandling, det kan være en corner-case hvor det ikke er snakk om samme forbehandling. 