### PR TITLE
Rette feil ved ferdigstille brev etteroppgjør forbehandling

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerForbehandlingBrevService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerForbehandlingBrevService.kt
@@ -65,10 +65,11 @@ class EtteroppgjoerForbehandlingBrevService(
         )
     }
 
-    suspend fun ferdigstillJournalfoerOgDistribuerBrev(
+    suspend fun ferdigstillForbehandlingOgDistribuerBrev(
         forbehandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ) {
+        etteroppgjoerForbehandlingService.ferdigstillForbehandling(forbehandlingId, brukerTokenInfo)
         brevKlient.ferdigstillJournalfoerStrukturertBrev(
             forbehandlingId,
             Brevkoder.OMS_EO_FORHAANDSVARSEL.brevtype,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingModel.kt
@@ -82,23 +82,6 @@ data class EtteroppgjoerForbehandling(
         }
     }
 
-    fun kanAvbrytes() = status !in listOf(EtteroppgjoerForbehandlingStatus.FERDIGSTILT, EtteroppgjoerForbehandlingStatus.AVBRUTT)
-
-    fun medBrev(opprettetBrev: Brev): EtteroppgjoerForbehandling = this.copy(brevId = opprettetBrev.id)
-
-    fun erUnderBehandling() =
-        status in
-            listOf(
-                EtteroppgjoerForbehandlingStatus.OPPRETTET,
-                EtteroppgjoerForbehandlingStatus.BEREGNET,
-            )
-
-    fun erFerdigstilt() =
-        status in
-            listOf(
-                EtteroppgjoerForbehandlingStatus.FERDIGSTILT,
-            )
-
     fun tilDto(): EtteroppgjoerForbehandlingDto =
         EtteroppgjoerForbehandlingDto(
             id = id,
@@ -116,6 +99,30 @@ data class EtteroppgjoerForbehandling(
             beskrivelseAvUgunst = beskrivelseAvUgunst,
             varselbrevSendt = varselbrevSendt,
         )
+
+    fun kanAvbrytes() = status !in listOf(EtteroppgjoerForbehandlingStatus.FERDIGSTILT, EtteroppgjoerForbehandlingStatus.AVBRUTT)
+
+    fun medBrev(opprettetBrev: Brev): EtteroppgjoerForbehandling = this.copy(brevId = opprettetBrev.id)
+
+    fun medVarselbrevSendt(): EtteroppgjoerForbehandling {
+        if (varselbrevSendt != null) {
+            throw InternfeilException("Forbehandling har allerede varselbrev sendt tidspunkt=$varselbrevSendt")
+        }
+        return this.copy(varselbrevSendt = LocalDate.now())
+    }
+
+    fun erUnderBehandling() =
+        status in
+            listOf(
+                EtteroppgjoerForbehandlingStatus.OPPRETTET,
+                EtteroppgjoerForbehandlingStatus.BEREGNET,
+            )
+
+    fun erFerdigstilt() =
+        status in
+            listOf(
+                EtteroppgjoerForbehandlingStatus.FERDIGSTILT,
+            )
 }
 
 data class DetaljertForbehandlingDto(

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/forbehandling/EtteroppgjoerForbehandlingService.kt
@@ -142,13 +142,7 @@ class EtteroppgjoerForbehandlingService(
 
     fun lagreVarselbrevSendt(forbehandlingId: UUID) {
         val forbehandling = hentForbehandling(forbehandlingId)
-        if (!forbehandling.erUnderBehandling()) {
-            throw IkkeTillattException(
-                "FEIL_STATUS_FORBEHANDLING",
-                "Forbehandling med id=$forbehandlingId kan ikke oppdatere varselbrev sendt siden forbehandling har status ${forbehandling.status}",
-            )
-        }
-        lagreForbehandling(forbehandling.copy(varselbrevSendt = LocalDate.now()))
+        lagreForbehandling(forbehandling.medVarselbrevSendt())
     }
 
     fun hentForbehandling(behandlingId: UUID): EtteroppgjoerForbehandling =

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/jobs/etteroppgjoer/EtteroppgjoerSvarfristUtloeptJobService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/jobs/etteroppgjoer/EtteroppgjoerSvarfristUtloeptJobService.kt
@@ -8,6 +8,7 @@ import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerService
 import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerSvarfrist
 import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerToggles
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
+import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.libs.common.isProd
 import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
@@ -29,7 +30,7 @@ class EtteroppgjoerSvarfristUtloeptJobService(
         Kontekst.set(jobContext)
         if (featureToggleService.isEnabled(EtteroppgjoerToggles.ETTEROPPGJOER_SVARFRISTUTLOEPT_JOBB, false)) {
             logger.info("Starter periodiske jobber for opprette oppgave svarfrist utløpt etteroppgjoer")
-            runBlocking {
+            inTransaction {
                 opprettNyOppgaveSvarfristUtloept()
             }
         } else {

--- a/apps/etterlatte-behandling/src/main/kotlin/brev/BrevService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/brev/BrevService.kt
@@ -159,7 +159,7 @@ class BrevService(
                 tilbakekrevingBrevService.ferdigstillVedtaksbrev(behandlingId, brukerTokenInfo)
 
             BehandlingMedBrevType.ETTEROPPGJOER ->
-                etteroppgjoerForbehandlingBrevService.ferdigstillJournalfoerOgDistribuerBrev(
+                etteroppgjoerForbehandlingBrevService.ferdigstillForbehandlingOgDistribuerBrev(
                     behandlingId,
                     brukerTokenInfo,
                 )

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -927,7 +927,7 @@ internal class ApplicationContext(
             etteroppgjoerSvarfristUtloeptJobService,
             { leaderElectionKlient.isLeader() },
             initialDelay = Duration.of(5, ChronoUnit.MINUTES).toMillis(),
-            interval = if (isProd()) Duration.of(1, ChronoUnit.DAYS) else Duration.of(1, ChronoUnit.HOURS),
+            interval = if (isProd()) Duration.of(1, ChronoUnit.DAYS) else Duration.of(10, ChronoUnit.MINUTES),
             dataSource = dataSource,
             sakTilgangDao = sakTilgangDao,
         )

--- a/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/tilgangsstyring/Tilgangsstyring.kt
@@ -5,7 +5,6 @@ import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.ApplicationCallPipeline
 import io.ktor.server.application.Hook
 import io.ktor.server.application.RouteScopedPlugin
-import io.ktor.server.application.application
 import io.ktor.server.application.call
 import io.ktor.server.application.createRouteScopedPlugin
 import io.ktor.server.application.log
@@ -14,7 +13,6 @@ import io.ktor.server.request.receive
 import io.ktor.server.request.uri
 import io.ktor.server.response.respond
 import io.ktor.server.routing.RoutingContext
-import io.ktor.util.pipeline.PipelineContext
 import io.ktor.util.pipeline.PipelinePhase
 import no.nav.etterlatte.Kontekst
 import no.nav.etterlatte.SaksbehandlerMedEnheterOgRoller
@@ -28,7 +26,7 @@ import no.nav.etterlatte.libs.common.sak.tilSakId
 import no.nav.etterlatte.libs.ktor.route.CallParamAuthId
 import no.nav.etterlatte.libs.ktor.route.FoedselsnummerDTO
 import no.nav.etterlatte.libs.ktor.route.behandlingId
-import no.nav.etterlatte.libs.ktor.route.etteroppgjoerId
+import no.nav.etterlatte.libs.ktor.route.forbehandlingId
 import no.nav.etterlatte.libs.ktor.route.generellBehandlingId
 import no.nav.etterlatte.libs.ktor.route.klageId
 import no.nav.etterlatte.libs.ktor.route.oppgaveId
@@ -258,7 +256,7 @@ private fun RoutingContext.finnSkriveTilgangForId(sakId: SakId? = null): Enhetsn
                 sakTilgangDao.hentSakMedGraderingOgSkjermingPaaTilbakekreving(tilbakekrevingId)?.enhetNr
 
             CallParamAuthId.ETTEROPPGJOERID ->
-                sakTilgangDao.hentSakMedGraderingOgSkjermingPaaEtteroppgjoer(etteroppgjoerId)?.enhetNr
+                sakTilgangDao.hentSakMedGraderingOgSkjermingPaaEtteroppgjoer(forbehandlingId)?.enhetNr
         }
     }
 }

--- a/libs/etterlatte-ktor/src/main/kotlin/route/RouteUtils.kt
+++ b/libs/etterlatte-ktor/src/main/kotlin/route/RouteUtils.kt
@@ -2,11 +2,9 @@ package no.nav.etterlatte.libs.ktor.route
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
-import io.ktor.server.application.call
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.RoutingContext
-import io.ktor.util.pipeline.PipelineContext
 import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
 import no.nav.etterlatte.libs.common.feilhaandtering.GenerellIkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
@@ -30,7 +28,7 @@ const val OPPGAVEID_CALL_PARAMETER = "oppgaveId"
 const val KLAGEID_CALL_PARAMETER = "klageId"
 const val GENERELLBEHANDLINGID_CALL_PARAMETER = "generellBehandlingId"
 const val TILBAKEKREVINGID_CALL_PARAMETER = "tilbakekrevingId"
-const val ETTEROPPGJOER_CALL_PARAMETER = "etteroppgjoerId"
+const val FORBEHANDLINGID_CALL_PARAMETER = "etteroppgjoerId"
 
 enum class CallParamAuthId(
     val value: String,
@@ -41,7 +39,7 @@ enum class CallParamAuthId(
     KLAGEID(KLAGEID_CALL_PARAMETER),
     GENERELLBEHANDLINGID(GENERELLBEHANDLINGID_CALL_PARAMETER),
     TILBAKEKREVINGID(TILBAKEKREVINGID_CALL_PARAMETER),
-    ETTEROPPGJOERID(ETTEROPPGJOER_CALL_PARAMETER),
+    ETTEROPPGJOERID(FORBEHANDLINGID_CALL_PARAMETER),
 }
 
 const val OPPGAVEID_GOSYS_CALL_PARAMETER = "gosysOppgaveId"
@@ -89,14 +87,16 @@ inline val RoutingContext.gosysOppgaveId: String
 
 inline val RoutingContext.tilbakekrevingId: UUID
     get() =
-        call.parameters[TILBAKEKREVINGID_CALL_PARAMETER]?.let { UUID.fromString(it) } ?: throw NullPointerException(
+        call.parameters[TILBAKEKREVINGID_CALL_PARAMETER]?.let { UUID.fromString(it) } ?: throw UgyldigForespoerselException(
+            "TILBAKEKREVINGID_MANGLER",
             "TilbakekrevingId er ikke i path params",
         )
 
-inline val RoutingContext.etteroppgjoerId: UUID
+inline val RoutingContext.forbehandlingId: UUID
     get() =
-        call.parameters[ETTEROPPGJOER_CALL_PARAMETER]?.let { UUID.fromString(it) } ?: throw NullPointerException(
-            "EtteroppgjoerId er ikke i path params",
+        call.parameters[FORBEHANDLINGID_CALL_PARAMETER]?.let { UUID.fromString(it) } ?: throw UgyldigForespoerselException(
+            "FORBEHANDLINGID_MANGLER",
+            "ForbehandlingId er ikke i path params",
         )
 
 val logger = LoggerFactory.getLogger("TilgangsSjekk")


### PR DESCRIPTION
Validering ved ferdigstille brev slår ut ettersom forbehandling ikke er under behandling. Valideringen er overflødig og kan fjernes