### PR TITLE
FAGSYSTEM-396998 sender videre feil i ferdigstilling tilbakekrevingsbrev

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/brev/BrevService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/brev/BrevService.kt
@@ -157,7 +157,9 @@ class BrevService(
 
         when (behandlingMedBrevType) {
             BehandlingMedBrevType.TILBAKEKREVING ->
-                tilbakekrevingBrevService.ferdigstillVedtaksbrev(behandlingId, brukerTokenInfo)
+                videresendInterneFeil {
+                    tilbakekrevingBrevService.ferdigstillVedtaksbrev(behandlingId, brukerTokenInfo)
+                }
 
             BehandlingMedBrevType.ETTEROPPGJOER ->
                 etteroppgjoerForbehandlingBrevService.ferdigstillForbehandlingOgDistribuerBrev(


### PR DESCRIPTION
Feilmeldingene som kan dukke opp er mer relevante å gi saksbehandler enn de er for oss å få i error-logging.