### PR TITLE
filtrere bort ikke relevante oppgaver

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerOppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerOppgaveService.kt
@@ -16,7 +16,11 @@ class EtteroppgjoerOppgaveService(
     ) {
         val defaultMerknad = "Etteroppgjøret for ${2024} er klart til behandling"
 
-        val eksisterendeOppgaver = oppgaveService.hentOppgaverForSakAvType(sakId, listOf(OppgaveType.ETTEROPPGJOER))
+        val eksisterendeOppgaver =
+            oppgaveService
+                .hentOppgaverForSakAvType(sakId, listOf(OppgaveType.ETTEROPPGJOER))
+                .filter { it.erIkkeAvsluttet() && it.referanse.isEmpty() }
+
         if (eksisterendeOppgaver.isEmpty()) {
             oppgaveService.opprettOppgave(
                 referanse = "",


### PR DESCRIPTION
Vi skal opprette oppgave for ny forbehandling hvis revurdering for etteroppgjøret avsluttes pga endring er til ugunst for bruker. 

I dag feiler det pga vi allerede har en oppgave under behandling. Må derfor filtrere bort ikke relevante oppgaver