### PR TITLE
Legger til HelpText i modal for svarfrist utløpt

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/EtteroppgjoerSvarfristUtloeptModal.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/oppgaveModal/EtteroppgjoerSvarfristUtloeptModal.tsx
@@ -1,4 +1,4 @@
-import { Alert, BodyShort, Button, HStack, Modal, Textarea, VStack } from '@navikt/ds-react'
+import { Alert, BodyShort, Button, HelpText, HStack, Modal, Textarea, VStack } from '@navikt/ds-react'
 import { EyeIcon } from '@navikt/aksel-icons'
 import React, { useState } from 'react'
 
@@ -91,7 +91,7 @@ export const EtteroppgjoerSvarfristUtloeptModal = ({ oppgave, oppdaterStatus }: 
                       message: 'Du må legge til en kommentar',
                     },
                   })}
-                  label="Kommentar"
+                  label={<TextAreaLabel />}
                   error={errors.kommentar?.message}
                 />
               ) : (
@@ -127,3 +127,12 @@ export const EtteroppgjoerSvarfristUtloeptModal = ({ oppgave, oppdaterStatus }: 
     </>
   )
 }
+
+const TextAreaLabel = () => (
+  <HStack gap="1">
+    Kommentar
+    <HelpText>
+      Legg til kommentar hvis du avslutter oppgaven. Det er ikke nødvendig dersom du oppretter revurdering.
+    </HelpText>
+  </HStack>
+)


### PR DESCRIPTION

Legger til HelpText i modal for svarfrist utløpt:
<img width="689" height="455" alt="Skjermbilde 2025-10-02 kl  14 55 45" src="https://github.com/user-attachments/assets/9f02e842-18c6-4058-b780-86344fc7be1c" />
<img width="694" height="456" alt="Skjermbilde 2025-10-02 kl  14 55 41" src="https://github.com/user-attachments/assets/22975f94-3c53-41f7-ad07-21ef87c1c1d4" />
