### PR TITLE
Renamer brevkode som brukes både på forhåndsvarsel og på vedtak

### DIFF
--- a/apps/etterlatte-behandling-kafka/src/test/kotlin/no/nav/etterlatte/brev/model/oms/EtteroppgjoerBrevDataTest.kt
+++ b/apps/etterlatte-behandling-kafka/src/test/kotlin/no/nav/etterlatte/brev/model/oms/EtteroppgjoerBrevDataTest.kt
@@ -45,7 +45,7 @@ class EtteroppgjoerBrevDataTest {
 
     @Test
     fun `tester serialisering og deserialisering av brevVedleggData`() {
-        val vedleggData = EtteroppgjoerBrevData.beregningsVedlegg(2024)
+        val vedleggData = EtteroppgjoerBrevData.beregningsVedlegg(etteroppgjoersAar = 2024, erVedtak = true)
         val json = vedleggData.toJson()
         val gjenskapt = objectMapper.readValue<BrevVedleggRedigerbarNy>(json)
         assertInstanceOf<EtteroppgjoerBrevData.BeregningsVedleggInnhold>(gjenskapt.data)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerForbehandlingBrevService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerForbehandlingBrevService.kt
@@ -232,7 +232,7 @@ class EtteroppgjoerForbehandlingBrevService(
                 ),
             vedlegg =
                 listOf(
-                    EtteroppgjoerBrevData.beregningsVedlegg(data.behandling.aar),
+                    EtteroppgjoerBrevData.beregningsVedlegg(etteroppgjoersAar = data.behandling.aar, erVedtak = false),
                 ),
             sak = sisteIverksatteBehandling.sak,
         )

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerRevurderingBrevService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerRevurderingBrevService.kt
@@ -176,7 +176,7 @@ class EtteroppgjoerRevurderingBrevService(
                     ),
                 brevVedleggData =
                     listOf(
-                        EtteroppgjoerBrevData.beregningsVedlegg(detaljertForbehandling.behandling.aar),
+                        EtteroppgjoerBrevData.beregningsVedlegg(etteroppgjoersAar = detaljertForbehandling.behandling.aar, erVedtak = true),
                     ),
             )
         }

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/BrevData.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/BrevData.kt
@@ -100,7 +100,7 @@ abstract class BrevRedigerbarInnholdData : BrevDataRedigerbar {
 @JsonSubTypes(
     JsonSubTypes.Type(
         value = EtteroppgjoerBrevData.BeregningsVedleggInnhold::class,
-        name = "OMS_EO_FORHAANDSVARSEL_BEREGNINGVEDLEGG_INNHOLD",
+        name = "OMS_EO_BEREGNINGVEDLEGG_INNHOLD",
     ),
 )
 abstract class BrevVedleggInnholdData : BrevDataRedigerbar {
@@ -119,5 +119,5 @@ enum class BrevVedleggKey {
     OMS_FORHAANDSVARSEL_FEILUTBETALING,
     BP_BEREGNING_TRYGDETID,
     BP_FORHAANDSVARSEL_FEILUTBETALING,
-    OMS_EO_FORHAANDSVARSEL_BEREGNING,
+    OMS_EO_BEREGNINGSVEDLEGG,
 }

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/EtterlatteBrevkode.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/EtterlatteBrevkode.kt
@@ -100,5 +100,5 @@ enum class Vedlegg(
     BARNEPENSJON_VEDLEGG_FORHAANDSVARSEL_UTFALL("Utfall ved forhåndsvarsel av feilutbetaling"),
     OMSTILLINGSSTOENAD_VEDLEGG_BEREGNING_UTFALL("Utfall ved beregning av omstillingsstønad"),
     OMSTILLINGSSTOENAD_VEDLEGG_FORHAANDSVARSEL_UTFALL("Utfall ved forhåndsvarsel av feilutbetaling"),
-    OMS_EO_FORHAANDSVARSEL_BEREGNINGVEDLEGG_INNHOLD("Utfall etteroppgjør beregningvedlegg"),
+    OMS_EO_BEREGNINGVEDLEGG_INNHOLD("Utfall etteroppgjør beregningvedlegg"),
 }

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/model/oms/EtteroppgjoerBrevData.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/model/oms/EtteroppgjoerBrevData.kt
@@ -18,11 +18,11 @@ import java.time.LocalDate
 import java.time.YearMonth
 
 object EtteroppgjoerBrevData {
-    fun beregningsVedlegg(etteroppgjoersAar: Int): BrevVedleggRedigerbarNy =
+    fun beregningsVedlegg(etteroppgjoersAar: Int, erVedtak: Boolean): BrevVedleggRedigerbarNy =
         BrevVedleggRedigerbarNy(
-            data = BeregningsVedleggInnhold(etteroppgjoersAar),
-            vedlegg = Vedlegg.OMS_EO_FORHAANDSVARSEL_BEREGNINGVEDLEGG_INNHOLD,
-            vedleggId = BrevVedleggKey.OMS_EO_FORHAANDSVARSEL_BEREGNING,
+            data = BeregningsVedleggInnhold(etteroppgjoersAar, erVedtak),
+            vedlegg = Vedlegg.OMS_EO_BEREGNINGVEDLEGG_INNHOLD,
+            vedleggId = BrevVedleggKey.OMS_EO_BEREGNINGSVEDLEGG,
         )
 
     data class Forhaandsvarsel(
@@ -45,7 +45,7 @@ object EtteroppgjoerBrevData {
                 vedleggInnhold =
                     innhold()
                         .single {
-                            it.key == BrevVedleggKey.OMS_EO_FORHAANDSVARSEL_BEREGNING
+                            it.key == BrevVedleggKey.OMS_EO_BEREGNINGSVEDLEGG
                         }.payload!!
                         .elements,
             )
@@ -68,9 +68,10 @@ object EtteroppgjoerBrevData {
 
     data class BeregningsVedleggInnhold(
         val etteroppgjoersAar: Int,
+        val erVedtak: Boolean
     ) : BrevVedleggInnholdData() {
-        override val type: String = "OMS_EO_FORHAANDSVARSEL_BEREGNINGVEDLEGG_INNHOLD"
-        override val brevKode: Vedlegg = Vedlegg.OMS_EO_FORHAANDSVARSEL_BEREGNINGVEDLEGG_INNHOLD
+        override val type: String = "OMS_EO_BEREGNINGVEDLEGG_INNHOLD"
+        override val brevKode: Vedlegg = Vedlegg.OMS_EO_BEREGNINGVEDLEGG_INNHOLD
     }
 
     data class Vedtak(
@@ -93,7 +94,7 @@ object EtteroppgjoerBrevData {
                     krevIkkeNull(
                         innhold()
                             .singleOrNull {
-                                it.key == BrevVedleggKey.OMS_EO_FORHAANDSVARSEL_BEREGNING
+                                it.key == BrevVedleggKey.OMS_EO_BEREGNINGSVEDLEGG
                             }?.payload,
                     ) {
                         "Mangler påkrevd vedlegg for etteroppgjør beregningsvedlegg"


### PR DESCRIPTION
Brevkoden ble både brukt til forhåndsvarsel og vedtak, renamer den for å gjenspeile dette. Disse brevene skal se litt ulike ut, sender dermed med en ekstra variabel.

PR i pensjonsbrev: https://github.com/navikt/pensjonsbrev/pull/2133