### PR TITLE
Øker timeout på kall til ferdigstill-journalfoer-og-distribuer i brev-api

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/BrevApiKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/BrevApiKlient.kt
@@ -183,6 +183,10 @@ class BrevApiKlientObo(
             },
             brukerTokenInfo = brukerTokenInfo,
             postBody = req,
+            timeoutConfig = {
+                socketTimeoutMillis = Duration.ofSeconds(20).toMillis()
+                requestTimeoutMillis = Duration.ofSeconds(20).toMillis()
+            },
         )
 
     override suspend fun opprettSpesifiktBrev(


### PR DESCRIPTION
Er det ok? Ikke så kult for SB å vente over 10 sekunder (som er default), men... 