### PR TITLE
skal fjerne alertstripe for manglende utfylling i etteroppgjørsoversi…

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/revurdering/EtteroppgjoerRevurderingOversikt.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/revurdering/EtteroppgjoerRevurderingOversikt.tsx
@@ -48,20 +48,20 @@ export const EtteroppgjoerRevurderingOversikt = ({ behandling }: { behandling: I
     (!informasjonFraBrukerSkjemaErrors || isEmpty(informasjonFraBrukerSkjemaErrors)) &&
     (!fastsettFaktiskInntektSkjemaErrors || isEmpty(fastsettFaktiskInntektSkjemaErrors))
 
-  const revurderingStammerFraSvarfristUtløpt =
+  const revurderingStammerFraSvarfristUtloept =
     behandling.opprinnelse === Opprinnelse.AUTOMATISK_JOBB && !etteroppgjoer.behandling.harMottattNyInformasjon
 
   const erForbehandling = etteroppgjoer.behandling.kopiertFra === undefined
 
-  const manglerFastsattInntektPåForbehandling =
+  const manglerFastsattInntektPaaForbehandling =
     etteroppgjoer.behandling.harMottattNyInformasjon === JaNei.JA && erForbehandling
 
   const navigerTilNesteSteg = () => {
     if (harIngenSkjemaErrors) {
-      if (revurderingStammerFraSvarfristUtløpt) {
+      if (revurderingStammerFraSvarfristUtloept) {
         setValideringFeilmelding('Du må ta stilling til informasjon fra bruker')
         return
-      } else if (manglerFastsattInntektPåForbehandling) {
+      } else if (manglerFastsattInntektPaaForbehandling) {
         setValideringFeilmelding('Du må gjøre en endring i fastsatt inntekt')
         return
       }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/revurdering/informasjonFraBruker/InformasjonFraBruker.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/revurdering/informasjonFraBruker/InformasjonFraBruker.tsx
@@ -1,5 +1,5 @@
 import { Button, Heading, VStack } from '@navikt/ds-react'
-import { useState } from 'react'
+import { Dispatch, SetStateAction, useState } from 'react'
 import { useInnloggetSaksbehandler } from '~components/behandling/useInnloggetSaksbehandler'
 import { behandlingErRedigerbar } from '~components/behandling/felles/utils'
 import { IDetaljertBehandling } from '~shared/types/IDetaljertBehandling'
@@ -13,9 +13,14 @@ import { IInformasjonFraBruker } from '~shared/types/EtteroppgjoerForbehandling'
 interface Props {
   behandling: IDetaljertBehandling
   setInformasjonFraBrukerSkjemaErrors: (errors: FieldErrors<IInformasjonFraBruker> | undefined) => void
+  setValideringFeilmedling: Dispatch<SetStateAction<string>>
 }
 
-export const InformasjonFraBruker = ({ behandling, setInformasjonFraBrukerSkjemaErrors }: Props) => {
+export const InformasjonFraBruker = ({
+  behandling,
+  setInformasjonFraBrukerSkjemaErrors,
+  setValideringFeilmedling,
+}: Props) => {
   const innloggetSaksbehandler = useInnloggetSaksbehandler()
 
   const etteroppgjoer = useEtteroppgjoer()
@@ -40,6 +45,7 @@ export const InformasjonFraBruker = ({ behandling, setInformasjonFraBrukerSkjema
           setInformasjonFraBrukerSkjemaErAapen={setInformasjonFraBrukerSkjemaErAapen}
           erRedigerbar={erRedigerbar}
           setInformasjonFraBrukerSkjemaErrors={setInformasjonFraBrukerSkjemaErrors}
+          setValideringFeilmedling={setValideringFeilmedling}
         />
       ) : (
         <VStack gap="4">

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/revurdering/informasjonFraBruker/InformasjonFraBrukerSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/revurdering/informasjonFraBruker/InformasjonFraBrukerSkjema.tsx
@@ -10,12 +10,14 @@ import { isPending } from '~shared/api/apiUtils'
 import { isFailureHandler } from '~shared/api/IsFailureHandler'
 import { useAppDispatch } from '~store/Store'
 import { JaNei } from '~shared/types/ISvar'
+import { Dispatch, SetStateAction } from 'react'
 
 interface Props {
   behandling: IDetaljertBehandling
   setInformasjonFraBrukerSkjemaErAapen: (erAapen: boolean) => void
   erRedigerbar: boolean
   setInformasjonFraBrukerSkjemaErrors: (errors: FieldErrors<IInformasjonFraBruker> | undefined) => void
+  setValideringFeilmedling: Dispatch<SetStateAction<string>>
 }
 
 export const InformasjonFraBrukerSkjema = ({
@@ -23,6 +25,7 @@ export const InformasjonFraBrukerSkjema = ({
   setInformasjonFraBrukerSkjemaErAapen,
   erRedigerbar,
   setInformasjonFraBrukerSkjemaErrors,
+  setValideringFeilmedling,
 }: Props) => {
   const etteroppgjoer = useEtteroppgjoer()
 
@@ -52,6 +55,7 @@ export const InformasjonFraBrukerSkjema = ({
 
   const submitEndringFraBruker = (data: IInformasjonFraBruker) => {
     setInformasjonFraBrukerSkjemaErrors(errors)
+    setValideringFeilmedling('')
     informasjonFraBrukerRequest({ forbehandlingId: behandling.relatertBehandlingId!, endringFraBruker: data }, () => {
       hentEtteroppgjoerRequest(behandling.relatertBehandlingId!, (etteroppgjoer) => {
         dispatch(addEtteroppgjoer(etteroppgjoer))


### PR DESCRIPTION
…kt ved endringer fra bruker. Trekker ut kodesjekker i variabler med beskrivende navn. Nullsjekker etteropgjoer-variabel øverst i fil

Skal utbedre følgende funn etter test:
https://nav-it.slack.com/archives/C09G3AYM1GW/p1759314421936129

Nå skal rød alertstripe forsvinne dersom bruker foretar seg endringer. 
Tillater meg samtidig å gjøre filen mer lesbar ved å trekke ut kodesnutter i egne variabler med beskrivende navn.