### PR TITLE
Bruke språk fra brev i brevRequest hvis det er satt 

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerForbehandlingBrevService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/brev/EtteroppgjoerForbehandlingBrevService.kt
@@ -139,9 +139,6 @@ class EtteroppgjoerForbehandlingBrevService(
                     brukerTokenInfo,
                 )
 
-            val sakId = detaljertForbehandling.behandling.sak.id
-            val brevId = detaljertForbehandling.behandling.brevId
-
             krevIkkeNull(detaljertForbehandling.beregnetEtteroppgjoerResultat) {
                 "Forbehandlingen må ha et utregnet resultat for å sende et varselbrev"
             }
@@ -174,18 +171,13 @@ class EtteroppgjoerForbehandlingBrevService(
                 grunnlagService.hentOpplysningsgrunnlagForSak(sak.id)
                     ?: throw InternfeilException("Fant ikke grunnlag med sakId=${sak.id}")
 
-            val spraak =
-                brevId?.let {
-                    brevKlient.hentBrev(sakId, it, brukerTokenInfo).spraak
-                } ?: grunnlag.mapSpraak()
-
             return@coroutineScope BrevRequest(
                 sak = sak,
                 innsender = grunnlag.mapInnsender(),
                 soeker = grunnlag.mapSoeker(null),
                 avdoede = grunnlag.mapAvdoede(),
                 verge = hentVergeForSak(sak.sakType, null, grunnlag),
-                spraak = spraak,
+                spraak = grunnlag.mapSpraak(),
                 saksbehandlerIdent = brukerTokenInfo.ident(),
                 attestantIdent = null,
                 skalLagre = true, // TODO: vurder riktig logikk for lagring

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/StrukturertBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/StrukturertBrevService.kt
@@ -259,7 +259,7 @@ class StrukturertBrevService(
             db.oppdaterPayload(brevId, brevinnhold.payload, bruker)
         }
 
-        val innholdVedlegg = hentInnholdForVedlegg(brevRequest.brevVedleggData, avsender, soekerOgEventuellVerge, spraak, sak)
+        val innholdVedlegg = hentInnholdForVedlegg(brevRequest.brevVedleggData, avsender, soekerOgEventuellVerge, spraakIBrev, sak)
         if (innholdVedlegg.isNotEmpty()) {
             db.oppdaterPayloadVedlegg(brevId, innholdVedlegg, bruker)
         }


### PR DESCRIPTION
Når vi henter brev bruker vi språk som er satt i brev-api `innhold.spraak`.

Men oppdaget en liten feil hvor språk for vedlegg alltid er på NB selv om språk for brev er satt til EN, `grunnlag.mapSpraak()` samsvarer ikke med språk valgt for brev, endrer derfor til at vi forholder oss til språk i brev hvis det er satt 