### PR TITLE
reformaterer tabellheadernavn i etteroppgjørsoversikt til månedÅr

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/SoeskenjusteringPeriode.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/soeskenjustering/SoeskenjusteringPeriode.tsx
@@ -15,7 +15,7 @@ import {
 } from '~components/behandling/beregningsgrunnlag/soeskenjustering/Soeskenjustering'
 import styled from 'styled-components'
 import { useInnloggetSaksbehandler } from '~components/behandling/useInnloggetSaksbehandler'
-import { formaterMaanedDato } from '~utils/formatering/dato'
+import { formaterMaanednavnAar } from '~utils/formatering/dato'
 
 type SoeskenjusteringPeriodeProps = {
   control: Control<{ soeskenMedIBeregning: SoeskengrunnlagUtfylling }>
@@ -73,7 +73,7 @@ const SoeskenjusteringPeriode = (props: SoeskenjusteringPeriodeProps) => {
                 ) : (
                   <OppdrasSammenLes>
                     <Label>Fra og med</Label>
-                    <BodyShort>{formaterMaanedDato(fom.field.value)}</BodyShort>
+                    <BodyShort>{formaterMaanednavnAar(fom.field.value)}</BodyShort>
                   </OppdrasSammenLes>
                 )
               }
@@ -100,7 +100,7 @@ const SoeskenjusteringPeriode = (props: SoeskenjusteringPeriodeProps) => {
                 ) : (
                   <OppdrasSammenLes>
                     <Label>Til og med</Label>
-                    <BodyShort>{tom.field.value ? formaterMaanedDato(tom.field.value) : 'Ingen slutt'}</BodyShort>
+                    <BodyShort>{tom.field.value ? formaterMaanednavnAar(tom.field.value) : 'Ingen slutt'}</BodyShort>
                   </OppdrasSammenLes>
                 )
               }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/BrevutfallVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/brevutfall/BrevutfallVisning.tsx
@@ -7,7 +7,7 @@ import {
 } from '~components/behandling/brevutfall/Brevutfall'
 import { SakType } from '~shared/types/sak'
 import { PencilIcon } from '@navikt/aksel-icons'
-import { formaterMaanedDato } from '~utils/formatering/dato'
+import { formaterMaanednavnAar } from '~utils/formatering/dato'
 import { hasValue } from '~components/behandling/felles/utils'
 
 function aldersgruppeToString(aldersgruppe?: Aldersgruppe | null) {
@@ -59,11 +59,11 @@ export const BrevutfallVisning = (props: {
                 <HStack gap="8">
                   <VStack gap="2">
                     <Label>Fra og med</Label>
-                    <BodyShort>{formaterMaanedDato(brevutfallOgEtterbetaling.etterbetaling.datoFom!!)}</BodyShort>
+                    <BodyShort>{formaterMaanednavnAar(brevutfallOgEtterbetaling.etterbetaling.datoFom!!)}</BodyShort>
                   </VStack>
                   <VStack gap="2">
                     <Label>Til og med</Label>
-                    <BodyShort>{formaterMaanedDato(brevutfallOgEtterbetaling.etterbetaling.datoTom!!)}</BodyShort>
+                    <BodyShort>{formaterMaanednavnAar(brevutfallOgEtterbetaling.etterbetaling.datoTom!!)}</BodyShort>
                   </VStack>
                 </HStack>
               </>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sanksjon/Sanksjon.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/sanksjon/Sanksjon.tsx
@@ -21,7 +21,7 @@ import {
   VStack,
 } from '@navikt/ds-react'
 import { PencilIcon } from '@navikt/aksel-icons'
-import { aarFraDatoString, formaterDato, formaterMaanedDato } from '~utils/formatering/dato'
+import { aarFraDatoString, formaterDato, formaterMaanednavnAar } from '~utils/formatering/dato'
 import { ControlledMaanedVelger } from '~shared/components/maanedVelger/ControlledMaanedVelger'
 import { useForm } from 'react-hook-form'
 import { formatISO, isBefore, startOfDay } from 'date-fns'
@@ -237,9 +237,9 @@ export const Sanksjon = ({
                     <>
                       {sanksjoner.map((lagretSanksjon, index) => (
                         <Table.Row key={index}>
-                          <Table.DataCell>{formaterMaanedDato(lagretSanksjon.fom)}</Table.DataCell>
+                          <Table.DataCell>{formaterMaanednavnAar(lagretSanksjon.fom)}</Table.DataCell>
                           <Table.DataCell>
-                            {lagretSanksjon.tom ? formaterMaanedDato(lagretSanksjon.tom) : '-'}
+                            {lagretSanksjon.tom ? formaterMaanednavnAar(lagretSanksjon.tom) : '-'}
                           </Table.DataCell>
                           <Table.DataCell>{tekstSanksjon[lagretSanksjon.type]}</Table.DataCell>
                           <Table.DataCell>{lagretSanksjon.beskrivelse}</Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/inntektsopplysninger/OpplysningerFraAInntektSummert.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/etteroppgjoer/components/inntektsopplysninger/OpplysningerFraAInntektSummert.tsx
@@ -2,7 +2,7 @@ import { SummerteInntekterAOrdningen } from '~shared/types/EtteroppgjoerForbehan
 import { BodyShort, Heading, Label, VStack, Table } from '@navikt/ds-react'
 import { NOK } from '~utils/formatering/formatering'
 import React from 'react'
-import { formaterDato, formaterDatoMedKlokkeslett } from '~utils/formatering/dato'
+import { formaterDatoMedKlokkeslett, formaterMaanedAar } from '~utils/formatering/dato'
 import { LenkeTilInntektOversikt } from '~components/etteroppgjoer/components/inntektsopplysninger/LenkeTilInntektOversikt'
 
 export function OpplysningerFraAInntektSummert({ inntekter }: { inntekter: SummerteInntekterAOrdningen }) {
@@ -21,7 +21,7 @@ export function OpplysningerFraAInntektSummert({ inntekter }: { inntekter: Summe
             <Table.HeaderCell>Type inntekt</Table.HeaderCell>
             {inntekter.afp.inntekter.map((maaned) => (
               <Table.HeaderCell key={maaned.maaned} scope="col" align="right">
-                {formaterDato(maaned.maaned)}
+                {formaterMaanedAar(maaned.maaned)}
               </Table.HeaderCell>
             ))}
           </Table.Row>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderRadAndreKlassetyper.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderRadAndreKlassetyper.tsx
@@ -1,7 +1,7 @@
 import { Table } from '@navikt/ds-react'
 import React from 'react'
 import { tekstKlasseKode, TilbakekrevingBeloep, TilbakekrevingPeriode } from '~shared/types/Tilbakekreving'
-import { formaterMaanedDato } from '~utils/formatering/dato'
+import { formaterMaanednavnAar } from '~utils/formatering/dato'
 
 export function TilbakekrevingVurderingPerioderRadAndreKlassetyper({
   periode,
@@ -13,7 +13,7 @@ export function TilbakekrevingVurderingPerioderRadAndreKlassetyper({
   return (
     <>
       <Table.Row>
-        <Table.DataCell key="maaned">{formaterMaanedDato(periode.maaned)}</Table.DataCell>
+        <Table.DataCell key="maaned">{formaterMaanednavnAar(periode.maaned)}</Table.DataCell>
         <Table.DataCell key="klasse">{tekstKlasseKode[beloep.klasseKode] ?? beloep.klasseKode}</Table.DataCell>
         <Table.DataCell key="bruttoUtbetaling">{beloep.bruttoUtbetaling} kr</Table.DataCell>
         <Table.DataCell key="nyBruttoUtbetaling">{beloep.nyBruttoUtbetaling} kr</Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderSkjema.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderSkjema.tsx
@@ -22,7 +22,7 @@ import { useNavigate } from 'react-router'
 import { FixedAlert } from '~shared/alerts/FixedAlert'
 import { ApiErrorAlert } from '~ErrorBoundary'
 import { ArrowsCirclepathIcon } from '@navikt/aksel-icons'
-import { formaterMaanedDato } from '~utils/formatering/dato'
+import { formaterMaanednavnAar } from '~utils/formatering/dato'
 import { TilbakekrevingVurderingPerioderRadAndreKlassetyper } from '~components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderRadAndreKlassetyper'
 
 export function TilbakekrevingVurderingPerioderSkjema({
@@ -143,7 +143,7 @@ export function TilbakekrevingVurderingPerioderSkjema({
                   if (klasseTypeYtelse(beloep)) {
                     return (
                       <Table.Row key={`beloepRad-${indexPeriode}-${indexBeloep}`} style={{ alignItems: 'start' }}>
-                        <Table.DataCell key="maaned">{formaterMaanedDato(periode.maaned)}</Table.DataCell>
+                        <Table.DataCell key="maaned">{formaterMaanednavnAar(periode.maaned)}</Table.DataCell>
                         <Table.DataCell key="klasseKode">
                           {tekstKlasseKode[beloep.klasseKode] ?? beloep.klasseKode}
                         </Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderVisning.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderVisning.tsx
@@ -10,7 +10,7 @@ import {
 import React, { useState } from 'react'
 import { Box, Button, HStack, Table } from '@navikt/ds-react'
 import { useNavigate } from 'react-router'
-import { formaterMaanedDato } from '~utils/formatering/dato'
+import { formaterMaanednavnAar } from '~utils/formatering/dato'
 import { TilbakekrevingVurderingPerioderRadAndreKlassetyper } from '~components/tilbakekreving/utbetalinger/TilbakekrevingVurderingPerioderRadAndreKlassetyper'
 
 export function TilbakekrevingVurderingPerioderVisning({ behandling }: { behandling: TilbakekrevingBehandling }) {
@@ -43,7 +43,7 @@ export function TilbakekrevingVurderingPerioderVisning({ behandling }: { behandl
               if (klasseTypeYtelse(beloep)) {
                 return (
                   <Table.Row key={`beloepRad-${indexPeriode}-${beloep.originalIndex}`}>
-                    <Table.DataCell key="maaned">{formaterMaanedDato(periode.maaned)}</Table.DataCell>
+                    <Table.DataCell key="maaned">{formaterMaanednavnAar(periode.maaned)}</Table.DataCell>
                     <Table.DataCell key="klasse">
                       {tekstKlasseKode[beloep.klasseKode] ?? beloep.klasseKode}
                     </Table.DataCell>

--- a/apps/etterlatte-saksbehandling-ui/client/src/utils/formatering/dato.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/utils/formatering/dato.ts
@@ -4,7 +4,8 @@ import { nb } from 'date-fns/locale'
 export enum DatoFormat {
   AAR_MAANED_DAG = 'yyyy-MM-dd',
   DAG_MAANED_AAR = 'dd.MM.yyyy',
-  MAANED_AAR = 'MMMM yyyy',
+  MAANED_AAR = 'MM.yyyy',
+  MAANEDNAVN_AAR = 'MMMM yyyy',
 }
 
 export const formaterDato = (dato: string | Date) => format(dato, DatoFormat.DAG_MAANED_AAR).toString()
@@ -18,7 +19,9 @@ export const formaterTilISOString = (date: Date | string): string => {
   return format(date, DatoFormat.AAR_MAANED_DAG)
 }
 
-export const formaterMaanedDato = (dato: string | Date) => format(dato, DatoFormat.MAANED_AAR).toString()
+export const formaterMaanedAar = (dato: string | Date) => format(dato, DatoFormat.MAANED_AAR).toString()
+
+export const formaterMaanednavnAar = (dato: string | Date) => format(dato, DatoFormat.MAANEDNAVN_AAR).toString()
 
 export const formaterKanskjeStringDato = (dato?: string): string =>
   formaterKanskjeStringDatoMedFallback('Ukjent dato', dato)


### PR DESCRIPTION
Utbedrer funn etter test:
https://nav-it.slack.com/archives/C09G3AYM1GW/p1759486907969369

Før:
<img width="1897" height="229" alt="Skjermbilde 2025-10-07 kl  12 00 08" src="https://github.com/user-attachments/assets/e7f53e66-89e0-4005-848f-c93f54fa0754" />

Etter:
<img width="1882" height="212" alt="Skjermbilde 2025-10-07 kl  12 01 16" src="https://github.com/user-attachments/assets/fc191da4-bdae-4941-8434-1e00fe350ae5" />

