### PR TITLE
Samle hardkodet etteroppgjoersAar til et sted

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerRoutes.kt
@@ -111,7 +111,7 @@ fun Route.etteroppgjoerRoutes(
                 kunSkrivetilgang {
                     val forbehandling =
                         inTransaction {
-                            forbehandlingService.opprettEtteroppgjoerForbehandling(sakId, 2024, oppgaveId, brukerTokenInfo)
+                            forbehandlingService.opprettEtteroppgjoerForbehandling(sakId, ETTEROPPGJOER_AAR, oppgaveId, brukerTokenInfo)
                         }
                     call.respond(forbehandling)
                 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerService.kt
@@ -26,6 +26,9 @@ enum class EtteroppgjoerSvarfrist(
     EN_MND("1 month"),
 }
 
+// TODO: finne en bedre plass for denne, evnt i config
+const val ETTEROPPGJOER_AAR = 2024
+
 class EtteroppgjoerService(
     val dao: EtteroppgjoerDao,
     val vedtakKlient: VedtakKlient,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerTempService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerTempService.kt
@@ -20,7 +20,7 @@ class EtteroppgjoerTempService(
         sakId: SakId,
         merknad: String? = null,
     ) {
-        val defaultMerknad = "Etteroppgjøret for ${2024} er klart til behandling"
+        val defaultMerknad = "Etteroppgjøret for ${ETTEROPPGJOER_AAR} er klart til behandling"
 
         val eksisterendeOppgaver =
             oppgaveService

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/sigrun/SigrunModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/sigrun/SigrunModel.kt
@@ -11,7 +11,7 @@ data class HendelseslisteFraSkatt(
         fun stub(
             startSekvensnummer: Long = 0,
             antall: Int = 10,
-            aar: Int = 2024,
+            aar: Int = ETTEROPPGJOER_AAR,
         ): HendelseslisteFraSkatt {
             val hendelser =
                 List(antall) { index ->
@@ -59,7 +59,7 @@ data class PensjonsgivendeInntektFraSkatt(
 
     companion object {
         fun stub(
-            aar: Int = 2024,
+            aar: Int = ETTEROPPGJOER_AAR,
             aarsinntekt: Int = 300000,
         ) = PensjonsgivendeInntektFraSkatt(
             inntektsaar = aar,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/jobs/etteroppgjoer/EtteroppgjoerSvarfristUtloeptJobService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/jobs/etteroppgjoer/EtteroppgjoerSvarfristUtloeptJobService.kt
@@ -3,6 +3,7 @@ package no.nav.etterlatte.behandling.jobs.etteroppgjoer
 import kotlinx.coroutines.DelicateCoroutinesApi
 import no.nav.etterlatte.Context
 import no.nav.etterlatte.Kontekst
+import no.nav.etterlatte.behandling.etteroppgjoer.ETTEROPPGJOER_AAR
 import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerService
 import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerSvarfrist
 import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerToggles
@@ -13,7 +14,6 @@ import no.nav.etterlatte.libs.common.oppgave.OppgaveKilde
 import no.nav.etterlatte.libs.common.oppgave.OppgaveType
 import no.nav.etterlatte.oppgave.OppgaveService
 import org.slf4j.LoggerFactory
-import java.time.YearMonth
 
 @OptIn(DelicateCoroutinesApi::class)
 class EtteroppgjoerSvarfristUtloeptJobService(
@@ -38,10 +38,8 @@ class EtteroppgjoerSvarfristUtloeptJobService(
     }
 
     private fun opprettNyOppgaveSvarfristUtloept() {
-        // TODO: trekke ut til felles for alle etteroppgjør jobber
-        val inntektsaar = YearMonth.now().year - 1
-
-        val relevanteEtteroppgjoer = etteroppgjoerService.hentEtteroppgjoerMedSvarfristUtloept(inntektsaar, svarfrist)
+        val etteroppgjoersAar = ETTEROPPGJOER_AAR
+        val relevanteEtteroppgjoer = etteroppgjoerService.hentEtteroppgjoerMedSvarfristUtloept(etteroppgjoersAar, svarfrist)
 
         val antallOppgaverOpprettet =
             relevanteEtteroppgjoer?.count { etteroppgjoer ->
@@ -65,13 +63,13 @@ class EtteroppgjoerSvarfristUtloeptJobService(
                         referanse = etteroppgjoer.sisteFerdigstilteForbehandling.toString(),
                         sakId = etteroppgjoer.sakId,
                         type = OppgaveType.ETTEROPPGJOER_SVARFRIST_UTLOEPT,
-                        merknad = "Svarfrist for etteroppgjør $inntektsaar er utløpt",
+                        merknad = "Svarfrist for etteroppgjør $etteroppgjoersAar er utløpt",
                         kilde = OppgaveKilde.HENDELSE,
                     )
                     true
                 }
             }
 
-        logger.info("Opprettet $antallOppgaverOpprettet oppgaver for etteroppgjør med svarfrist utløpt for $inntektsaar")
+        logger.info("Opprettet $antallOppgaverOpprettet oppgaver for etteroppgjør med svarfrist utløpt for $etteroppgjoersAar")
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/jobs/etteroppgjoer/OpprettEtteroppgjoerJobService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/jobs/etteroppgjoer/OpprettEtteroppgjoerJobService.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.Context
 import no.nav.etterlatte.Kontekst
+import no.nav.etterlatte.behandling.etteroppgjoer.ETTEROPPGJOER_AAR
 import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerService
 import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerToggles
 import no.nav.etterlatte.behandling.klienter.VedtakKlient
@@ -46,7 +47,7 @@ class OpprettEtteroppgjoerJobService(
     }
 
     suspend fun startEtteroppgjoerKjoering() {
-        val etteroppgjoersAar = YearMonth.now().year - 1
+        val etteroppgjoersAar = ETTEROPPGJOER_AAR
         finnOgOpprettEtteroppgjoer(etteroppgjoersAar)
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/jobs/etteroppgjoer/behandling/jobs/etteroppgjoer/StartpunktSkatteoppgjoerHendelserJob.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/jobs/etteroppgjoer/behandling/jobs/etteroppgjoer/StartpunktSkatteoppgjoerHendelserJob.kt
@@ -2,7 +2,9 @@ package no.nav.etterlatte.behandling.jobs.etteroppgjoer.behandling.jobs.etteropp
 
 import no.nav.etterlatte.Context
 import no.nav.etterlatte.Self
+import no.nav.etterlatte.behandling.etteroppgjoer.ETTEROPPGJOER_AAR
 import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerToggles
+import no.nav.etterlatte.behandling.etteroppgjoer.inntektskomponent.OMS_GYLDIG_FRA
 import no.nav.etterlatte.behandling.etteroppgjoer.sigrun.HendelseKjoeringRequest
 import no.nav.etterlatte.behandling.etteroppgjoer.sigrun.SkatteoppgjoerHendelserService
 import no.nav.etterlatte.common.DatabaseContext
@@ -63,11 +65,11 @@ class StartpunktSkatteoppgjoerHendelserJob(
     }
 
     private fun inntektsaarListe(): List<Int> {
-        val startaarOmstillingsstoenad = 2024
-        val sisteInntektsaar = LocalDate.now().year - 1
+        val startaarOmstillingsstoenad = OMS_GYLDIG_FRA
+        val sisteInntektsaar = ETTEROPPGJOER_AAR
         val inntektsaar =
             IntRange(
-                start = (sisteInntektsaar - 3).coerceAtLeast(startaarOmstillingsstoenad),
+                start = (sisteInntektsaar - 3).coerceAtLeast(startaarOmstillingsstoenad.year),
                 endInclusive = sisteInntektsaar,
             ).toList()
         return inntektsaar


### PR DESCRIPTION
Vi har ifm mvp hardkodet etteroppgjørsåret et par steder, samler definisjonen til ett sted så det er enklere å få oversikt. Vi har på blokka å finne en bedre løsning når etteroppgjøret for 2024 er gjennomført