### PR TITLE
Sender attestert tidspunkt for vedtak

### DIFF
--- a/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/vedtak/VedtakRoute.kt
+++ b/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/vedtak/VedtakRoute.kt
@@ -1,8 +1,6 @@
 package no.nav.etterlatte.vedtak
 
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.call
-import io.ktor.server.application.install
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondNullable
@@ -49,6 +47,7 @@ data class Vedtak(
     val type: VedtakType,
     val utbetaling: List<VedtakUtbetaling>,
     val iverksettelsesTidspunkt: Tidspunkt? = null,
+    val attestertTidspunkt: Tidspunkt? = null,
 )
 
 enum class VedtakType {

--- a/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/vedtak/VedtakService.kt
+++ b/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/vedtak/VedtakService.kt
@@ -32,5 +32,6 @@ fun VedtakDto.fromDto(): Vedtak {
                 )
             },
         iverksettelsesTidspunkt = iverksettelsesTidspunkt,
+        attestertTidspunkt = attestasjon?.tidspunkt,
     )
 }


### PR DESCRIPTION
Sender med attestert tidspunkt for vedtak-route'en som brukes av EESSI, slik at de har et relevant tidspunkt også for avslag som ikke blir iverksatt.