### PR TITLE
oppdatere domenekontekst etteroppgjør, bedre gjenny-ekspert definisjon

### DIFF
--- a/.github/agents/gjenny-ekspert.md
+++ b/.github/agents/gjenny-ekspert.md
@@ -55,8 +55,11 @@ Vær ærlig – si ifra når noe er feil, også når det er brukeren som tar fei
 
 ## Læring
 
-`.github/lessons.md` er agentens hukommelse. Les den før du starter, oppdater den når du er ferdig.
+Forhold deg til disse filene før du starter:
+- `.github/lessons.md` er til **deg selv** – refleksjoner over din egen tenkning og tilnærming. Ikke om prosjektet.
+- `.github/domenekontekst/` er til **prosjektet** – dokumentasjon om domene, arkitektur og løsninger i Gjenny.
 
+### Lessons.md
 Oppdater `.github/lessons.md` **automatisk** i disse situasjonene: 
 - Bruker gir tilbakemelding som starter med "du burde...", "her skulle du...", "hvorfor gjorde du ikke..." eller lignende
 - Bruker korrigerer deg eller påpeker en feil
@@ -64,9 +67,7 @@ Oppdater `.github/lessons.md` **automatisk** i disse situasjonene:
 - Du bytter tilnærming midt i oppgaven
 - Ved slutten av tekniske oppgaver (etter testing/verifisering)
 
-**Skriv:** Nye innsikter som er overførbare til lignende situasjoner. Fokuser på *hvorfor*, ikke *hva*.
-Vi ønsker ikke detaljstyring av regler eller generelle beste praksiser, gjentakelser, eller ting som kun gjelder ett tilfelle.
-Oppdater lessons.md **i samme response** som du anerkjenner feilen/lærdommen.
+**Skriv:** Refleksjoner til deg selv om *hvorfor* du tenkte feil – ikke hva som skjedde, ikke generelle praksiser. Oppdater i samme response som du anerkjente feilen.
 
 Hold det kort. Bruk formatet:
 ```
@@ -76,3 +77,8 @@ Hold det kort. Bruk formatet:
 ```
 
 **Reflekter:** Før du endrer `.github/lessons.md`, les gjennom alle eksisterende punkter. Når flere peker mot samme underliggende prinsipp — slå dem sammen til ett kortere, sterkere punkt og fjern de gamle. Hold filen så kort som mulig.
+
+### Domenekontekst
+Bruk `.github/domenekontekst/` som en kunnskapsbase for å forstå og forklare domenet. Bruk det som en inngang til å gjøre videre undersøkelser i koden.
+
+Oppdater domenekontekst når du lærer noe nytt om domenet som ikke finnes der – f.eks. etter at bruker har forklart forretningslogikk, avklart flyt eller korrigert en misforståelse om prosjektet.

--- a/.github/agents/gjenny-ekspert.md
+++ b/.github/agents/gjenny-ekspert.md
@@ -67,7 +67,7 @@ Oppdater `.github/lessons.md` **automatisk** i disse situasjonene:
 - Du bytter tilnærming midt i oppgaven
 - Ved slutten av tekniske oppgaver (etter testing/verifisering)
 
-**Skriv:** Refleksjoner til deg selv om *hvorfor* du tenkte feil – ikke hva som skjedde, ikke generelle praksiser. Oppdater i samme response som du anerkjente feilen.
+**Skriv:** Refleksjoner til deg selv om *hvorfor* du tenkte feil – ikke *hva* som skjedde, ikke generelle praksiser. Oppdater i samme response som du annerkjenner feilen/lærdommen. Vi ønsker ikke detaljestyring av regler, gjentagelser eller ting som kun gjelder ett tilfelle.
 
 Hold det kort. Bruk formatet:
 ```

--- a/.github/domenekontekst/beregning.md
+++ b/.github/domenekontekst/beregning.md
@@ -18,6 +18,23 @@ Beregner pensjonsytelser for BP og OMS basert på trygdetid, grunnbeløp og even
 | `Avkorting` | Reduksjon av OMS-ytelse pga. inntekt |
 | `OverstyrBeregning` | Manuell overstyring av beregnet beløp |
 | `Grunnbeløp` | Folketrygdens grunnbeløp (G), brukes som beregningsgrunnlag |
+| `EtteroppgjoerGrense` | Terskel for om differansen mellom utbetalt og faktisk skyldig stønad er stor nok til å gi et handlingsutfall (etterbetaling/tilbakekreving/ingen endring). Påvirker *utfallet*, ikke om vi trigger revurdering. |
+| `BeregnetEtteroppgjoerResultat` | Beregnet differanse mellom hva bruker faktisk fikk utbetalt og hva de skulle hatt basert på faktisk inntekt. Produseres i forbehandlingen, videreføres til revurdering. |
+
+## Etteroppgjør – beregningsperspektiv
+
+Etteroppgjør er en to-trinns prosess der beregning deltar i begge:
+
+**Trinn 1 – Forbehandling (preview)**
+- `EtteroppgjoerService` (i `etterlatte-beregning`) kaller `beregnAvkortingForbehandling` med faktisk inntekt
+- Beregner avkorting basert på faktisk inntekt (fra a-ordningen og pensjonsgivende inntekt fra Skatteetaten) – ingen av kildene er fasit, begge er referansepunkter
+- Resultat: `BeregnetEtteroppgjoerResultat` med differanse, grense og `EtteroppgjoerResultatType`
+- Forbehandlingen er et *preview* av det endelige vedtaket – ikke et eget vedtak
+
+**Trinn 2 – Revurdering**
+- Kopierer forbehandlingen (`kopiertFra`-referanse)
+- Saksbehandler kan korrigere faktisk inntekt etter brukers tilbakemelding
+- Normal behandlingsflyt (fatte → attestere → iverksette)
 
 ## Nøkkelklasser
 

--- a/.github/domenekontekst/beregning.md
+++ b/.github/domenekontekst/beregning.md
@@ -27,7 +27,7 @@ Etteroppgjør er en to-trinns prosess der beregning deltar i begge:
 
 **Trinn 1 – Forbehandling (preview)**
 - `EtteroppgjoerService` (i `etterlatte-beregning`) kaller `beregnAvkortingForbehandling` med faktisk inntekt
-- Beregner avkorting basert på faktisk inntekt (fra a-ordningen og pensjonsgivende inntekt fra Skatteetaten) – ingen av kildene er fasit, begge er referansepunkter
+- Beregner avkorting basert på faktisk inntekt (fra a-ordningen og pensjonsgivende inntekt fra Skatteetaten) – kildene er den dataen vi har på nåværende tidspunkt.
 - Resultat: `BeregnetEtteroppgjoerResultat` med differanse, grense og `EtteroppgjoerResultatType`
 - Forbehandlingen er et *preview* av det endelige vedtaket – ikke et eget vedtak
 

--- a/.github/domenekontekst/saksgangen.md
+++ b/.github/domenekontekst/saksgangen.md
@@ -89,19 +89,21 @@ Hendelsen konsumeres av `etterlatte-vedtaksvurdering-kafka` (og evt. `etterlatte
 
 ## Flyt 4 – Etteroppgjør (kun OMS)
 
-Gjennomføres i to steg etter at skatteoppgjøret for et ytelsesår er ferdig:
+Gjennomføres etter at skatteoppgjøret for et ytelsesår er ferdig. Primærtrigger er skatteoppgjørshendelser fra Skatteetaten. Saker som ikke har mottatt skatteoppgjør innen desember fanges opp av en jobb som setter status `MANGLER_SKATTEOPPGJOER` og presser dem videre med et eget flagg.
 
-**Steg 1 – Forbehandling / varselbrev**
-- Data hentes fra Skatteetaten og a-inntekt
-- Saksbehandler fastsetter riktig inntekt for det aktuelle året
-- Hvis inntekten stemte godt nok skal informasjonsbrev sendes, ingen revurdering med mindre bruker kommer med ny informasjon
-- Hvis inntekten ikke stemte blir det et varselbrev, og det skal gjøres en revurdering
+**Steg 1 – Forbehandling**
+- Data hentes fra Skatteetaten (pensjonsgivende inntekt) og a-ordningen – begge er referansepunkter, ingen er fasit
+- Saksbehandler fastsetter faktisk inntekt og beregner differansen mot utbetalt stønad
+- Informasjonsbrev (ingen avvik) eller varselbrev (avvik) sendes til bruker
+- Ferdigstilling av forbehandlingen setter automatisk status `VENTER_PAA_SVAR`
 
-**Steg 2 – Revurdering med vedtak** (hvis avvik)
-- Revurdering med årsak `ETTEROPPGJOER` opprettes
-- Vedtaket slår fast om bruker skal etterbetales eller tilbakekreves
-- Normal vedtaksflyt (fatte → attestere → iverksette)
+**Steg 2 – Revurdering med vedtak**
+- Revurderingen kopierer forbehandlingen (`kopiertFra`); forbehandlingen er et preview av det endelige vedtaket
+- Saksbehandler kan korrigere faktisk inntekt basert på brukers tilbakemelding
+- Vedtaket slår fast om bruker skal etterbetales, tilbakekreves, eller ingen endring
+- Normal vedtaksflyt: fatte → attestere → iverksette
 
+> `EtteroppgjoerGrense` avgjør utfallet (etterbetaling/tilbakekreving/ingen endring), ikke om vi trigger revurdering.
 > Beregning av restanse i avkortingen er reelt kompleks – se ikke etter en forenkling som ikke er der.
 
 ---

--- a/.github/lessons.md
+++ b/.github/lessons.md
@@ -1,3 +1,7 @@
 **2026-04-09 — Kommunikasjon**
 - Observation: Lange svar uten oppsummering gjør at essensen drukner.
 - Action: Avslutt alltid lange svar med en TL;DR – 2–4 linjer, cave-man stil.
+
+**2026-04-10 — Redigering**
+- Observation: Jeg fjerner viktig innhold når jeg gjør målrettede edits – ser ikke nøye nok på hva som forsvinner.
+- Action: Ved edits: les old_str nøye, sjekk at ny tekst bevarer alt som ikke eksplisitt skal bort.


### PR DESCRIPTION
- legge til mer presisering av etteroppgjøret
- retter feil med at agenten legger prosjekt spesifikke lærdommer i `lessons.md` som burde ligge i domenekontekst 