### PR TITLE
Går direkte mot behandling for vedtak for etterlatte-beregning og etterlatte-brev-api

### DIFF
--- a/apps/etterlatte-beregning/.nais/dev.yaml
+++ b/apps/etterlatte-beregning/.nais/dev.yaml
@@ -74,6 +74,8 @@ spec:
       value: http://etterlatte-behandling
     - name: ETTERLATTE_BEHANDLING_CLIENT_ID
       value: dev-gcp.etterlatte.etterlatte-behandling
+    - name: BRUK_VEDTAK_FRA_BEHANDLING
+      value: "ja"
     - name: ETTERLATTE_TRYGDETID_URL
       value: http://etterlatte-trygdetid
     - name: ETTERLATTE_TRYGDETID_CLIENT_ID

--- a/apps/etterlatte-beregning/.nais/prod.yaml
+++ b/apps/etterlatte-beregning/.nais/prod.yaml
@@ -89,6 +89,8 @@ spec:
       value: http://etterlatte-behandling
     - name: ETTERLATTE_BEHANDLING_CLIENT_ID
       value: prod-gcp.etterlatte.etterlatte-behandling
+    - name: BRUK_VEDTAK_FRA_BEHANDLING
+      value: "nei"
     - name: ETTERLATTE_TRYGDETID_URL
       value: http://etterlatte-trygdetid
     - name: ETTERLATTE_TRYGDETID_CLIENT_ID

--- a/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
@@ -54,7 +54,12 @@ class ApplicationContext {
         )
 
     val vilkaarsvurderingKlient = BehandlingVilkaarsvurderingKlientImpl(config, httpClient())
-    val vedtaksvurderingKlient = VedtaksvurderingKlientImpl(config, httpClient())
+    val vedtaksvurderingKlient =
+        VedtaksvurderingKlientImpl(
+            config = config,
+            httpClient = httpClient(),
+            brukEtterlatteBehandling = env.props["BRUK_VEDTAK_FRA_BEHANDLING"] == "ja",
+        )
     val grunnlagKlient = GrunnlagKlientImpl(config, httpClient())
     val trygdetidKlient = TrygdetidKlient(config, httpClient())
     val behandlingKlient = BehandlingKlientImpl(config, httpClient())

--- a/apps/etterlatte-beregning/src/main/kotlin/klienter/VedtaksvurderingKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/klienter/VedtaksvurderingKlient.kt
@@ -44,13 +44,24 @@ class VedtaksvurderingKlientException(
 class VedtaksvurderingKlientImpl(
     config: Config,
     httpClient: HttpClient,
+    private val brukEtterlatteBehandling: Boolean = false,
 ) : VedtaksvurderingKlient {
     private val logger = LoggerFactory.getLogger(this::class.java)
     private val azureAdClient = AzureAdClient(config)
     private val downstreamResourceClient = DownstreamResourceClient(azureAdClient, httpClient)
 
-    private val clientId = config.getString("vedtaksvurdering.client.id")
-    private val resourceUrl = config.getString("vedtaksvurdering.resource.url")
+    private val clientId =
+        if (brukEtterlatteBehandling) {
+            config.getString("behandling.client.id")
+        } else {
+            config.getString("vedtaksvurdering.client.id")
+        }
+    private val resourceUrl =
+        if (brukEtterlatteBehandling) {
+            config.getString("behandling.resource.url")
+        } else {
+            config.getString("vedtaksvurdering.resource.url")
+        }
 
     override suspend fun hentIverksatteVedtak(
         sakId: SakId,

--- a/apps/etterlatte-brev-api/.nais/dev.yaml
+++ b/apps/etterlatte-brev-api/.nais/dev.yaml
@@ -104,6 +104,8 @@ spec:
       value: 069b1b2c-0a06-4cc9-8418-f100b8ff71be
     - name: ETTERLATTE_VEDTAK_URL
       value: http://etterlatte-vedtaksvurdering
+    - name: BRUK_VEDTAK_FRA_BEHANDLING
+      value: "ja"
     - name: ETTERLATTE_BEREGNING_CLIENT_ID
       value: b07cf335-11fb-4efa-bd46-11f51afd5052
     - name: ETTERLATTE_BEREGNING_URL

--- a/apps/etterlatte-brev-api/.nais/prod.yaml
+++ b/apps/etterlatte-brev-api/.nais/prod.yaml
@@ -113,6 +113,8 @@ spec:
       value: prod-gcp.etterlatte.etterlatte-vedtaksvurdering
     - name: ETTERLATTE_VEDTAK_URL
       value: http://etterlatte-vedtaksvurdering
+    - name: BRUK_VEDTAK_FRA_BEHANDLING
+      value: "nei"
     - name: ETTERLATTE_BEREGNING_CLIENT_ID
       value: prod-gcp.etterlatte.etterlatte-beregning
     - name: ETTERLATTE_BEREGNING_URL

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationContext.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationContext.kt
@@ -5,6 +5,7 @@ import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.auth.Auth
 import no.nav.etterlatte.BrevKey.BREVBAKER_SCOPE
 import no.nav.etterlatte.BrevKey.BREVBAKER_URL
+import no.nav.etterlatte.BrevKey.BRUK_VEDTAK_FRA_BEHANDLING
 import no.nav.etterlatte.BrevKey.CLAMAV_ENDPOINT_URL
 import no.nav.etterlatte.BrevKey.REGOPPSLAG_SCOPE
 import no.nav.etterlatte.BrevKey.REGOPPSLAG_URL
@@ -103,7 +104,7 @@ internal class ApplicationContext {
     val regoppslagKlient =
         RegoppslagKlient(httpClient(REGOPPSLAG_SCOPE), env.requireEnvValue(REGOPPSLAG_URL))
     val saksbehandlerKlient = SaksbehandlerKlient(config, httpClient())
-    val vedtakKlient = VedtaksvurderingKlient(config, httpClient())
+    val vedtakKlient = VedtaksvurderingKlient(config, httpClient(), brukEtterlatteBehandling = env[BRUK_VEDTAK_FRA_BEHANDLING] == "ja")
     val beregningKlient = BeregningKlient(config, httpClient())
     val pdltjenesterKlient = PdlTjenesterKlient(config, httpClient())
     val behandlingKlient = BehandlingKlient(config, httpClient())
@@ -284,6 +285,7 @@ internal class ApplicationContext {
 enum class BrevKey : EnvEnum {
     BREVBAKER_SCOPE,
     BREVBAKER_URL,
+    BRUK_VEDTAK_FRA_BEHANDLING,
     CLAMAV_ENDPOINT_URL,
     REGOPPSLAG_SCOPE,
     REGOPPSLAG_URL,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/vedtaksvurdering/VedtaksvurderingKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/vedtaksvurdering/VedtaksvurderingKlient.kt
@@ -18,14 +18,25 @@ import java.util.UUID
 class VedtaksvurderingKlient(
     config: Config,
     httpClient: HttpClient,
+    private val brukEtterlatteBehandling: Boolean = false,
 ) {
     private val logger = LoggerFactory.getLogger(VedtaksvurderingKlient::class.java)
 
     private val azureAdClient = AzureAdClient(config)
     private val downstreamResourceClient = DownstreamResourceClient(azureAdClient, httpClient)
 
-    private val clientId = config.getString("vedtak.client.id")
-    private val resourceUrl = config.getString("vedtak.resource.url")
+    private val clientId =
+        if (brukEtterlatteBehandling) {
+            config.getString("behandling.client.id")
+        } else {
+            config.getString("vedtak.client.id")
+        }
+    private val resourceUrl =
+        if (brukEtterlatteBehandling) {
+            config.getString("behandling.resource.url")
+        } else {
+            config.getString("vedtak.resource.url")
+        }
 
     internal suspend fun hentVedtak(
         behandlingId: UUID,


### PR DESCRIPTION
# Går direkte mot behandling for vedtak for etterlatte-beregning og etterlatte-brev-api

### Hvorfor er denne endringen nødvendig? ✨

Denne PRen er en fortsettelse av migreringen bort fra `etterlatte-vedtaksvurdering`, der vi introduserer den samme toggle-mekanismen som tidligere er lagt inn i `etterlatte-trygdetid`, `etterlatte-utbetaling` og `etterlatte-api`. På sikt skal disse fases ut og fjernes.

### Endringer i etterlatte-beregning

`VedtaksvurderingKlientImpl` har fått støtte for toggle-en. Tre metoder rutes betinget:
- `hentIverksatteVedtak` → `/api/vedtak/sak/{id}/iverksatte`
- `hentInnvilgedePerioder` → `/api/vedtak/sak/{id}/innvilgede-perioder`
- `hentVedtakslisteIEtteroppgjoersAar` → `/vedtak/etteroppgjoer/{id}`

Miljøvariabelen `BRUK_VEDTAK_FRA_BEHANDLING` styrer klientimplementasjonen. Når den er satt til `"ja"` rutes kallene mot `etterlatte-behandling`, ellers brukes `etterlatte-vedtaksvurdering` som tidligere.

### Endringer i etterlatte-brev-api

`VedtaksvurderingKlient` har fått støtte for toggle-en. Klienten henter vedtak for et gitt `behandlingId` via:
- `hentVedtak` → `/api/vedtak/{behandlingId}`

Samme miljøvariabel `BRUK_VEDTAK_FRA_BEHANDLING` styrer klientimplementasjonen. `BrevKey`-enumen er utvidet med det nye nøkkelet.

### Verdt å nevne

Vi skrur kun på tilnærmingen for dev, der prod forblir det samme inntil videre.
