### PR TITLE
Tillater ikke tom liste med beregningsperioder i vedtak om endring / innvilgelse

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/service/VedtakBehandlingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/service/VedtakBehandlingService.kt
@@ -642,10 +642,10 @@ class VedtakBehandlingService(
                 VedtakType.INNVILGELSE, VedtakType.ENDRING -> {
                     when (sakType) {
                         SakType.BARNEPENSJON -> {
-                            val beregningsperioder =
-                                krevIkkeNull(beregningOgAvkorting?.beregning?.beregningsperioder) {
-                                    "Mangler beregning"
-                                }
+                            val beregningsperioder = beregningOgAvkorting?.beregning?.beregningsperioder
+                            if (beregningsperioder.isNullOrEmpty()) {
+                                throw ManglerBeregningsperioder()
+                            }
                             beregningsperioder.map {
                                 Utbetalingsperiode(
                                     periode =
@@ -663,8 +663,9 @@ class VedtakBehandlingService(
                         SakType.OMSTILLINGSSTOENAD -> {
                             val avkortetYtelse =
                                 beregningOgAvkorting?.avkorting?.avkortetYtelse
-                                    ?: throw ManglerAvkortetYtelse()
-
+                            if (avkortetYtelse.isNullOrEmpty()) {
+                                throw ManglerAvkortetYtelse()
+                            }
                             avkortetYtelse.map {
                                 Utbetalingsperiode(
                                     periode =
@@ -829,6 +830,13 @@ class ManglerAvkortetYtelse :
         code = "VEDTAKSVURDERING_MANGLER_AVKORTET_YTELSE",
         detail =
             "Det må legges til inntektsavkorting selv om mottaker ikke har inntekt. Legg inn \"0\" kr i alle felter.",
+    )
+
+class ManglerBeregningsperioder :
+    UgyldigForespoerselException(
+        code = "VEDTAKSVURDERING_MANGLER_BEREGNINGSPERIODER",
+        detail =
+            "Det mangler beregnet ytelse. Gå igjennom stegene fra beregningsgrunnlag en gang til.",
     )
 
 class VirkningstidspunktEtterOpphoerException :

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/VedtaksvurderingRoutesIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/VedtaksvurderingRoutesIntegrationTest.kt
@@ -31,6 +31,7 @@ import no.nav.etterlatte.funksjonsbrytere.DummyFeatureToggleService
 import no.nav.etterlatte.grunnlag.GrunnlagVersjonValidering
 import no.nav.etterlatte.inTransaction
 import no.nav.etterlatte.ktor.runServerWithModule
+import no.nav.etterlatte.libs.common.Regelverk
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.JaNei
 import no.nav.etterlatte.libs.common.behandling.JaNeiMedBegrunnelse
@@ -38,6 +39,8 @@ import no.nav.etterlatte.libs.common.behandling.KommerBarnetTilgode
 import no.nav.etterlatte.libs.common.behandling.NyBehandlingRequest
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.beregning.BeregningDTO
+import no.nav.etterlatte.libs.common.beregning.BeregningsMetode
+import no.nav.etterlatte.libs.common.beregning.Beregningsperiode
 import no.nav.etterlatte.libs.common.beregning.Beregningstype
 import no.nav.etterlatte.libs.common.deserialize
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -264,7 +267,32 @@ class VedtaksvurderingRoutesIntegrationTest : BehandlingIntegrationTest() {
             beregningId = UUID.randomUUID(),
             behandlingId = behandling.id,
             type = Beregningstype.BP,
-            beregningsperioder = emptyList(),
+            beregningsperioder =
+                listOf(
+                    Beregningsperiode(
+                        id = UUID.randomUUID(),
+                        datoFOM = YearMonth.of(2024, 1),
+                        datoTOM = null,
+                        utbetaltBeloep = 10_000,
+                        soeskenFlokk = emptyList(),
+                        institusjonsopphold = null,
+                        grunnbelop = 118620,
+                        grunnbelopMnd = 9885,
+                        trygdetid = 40,
+                        trygdetidForIdent = "avdød",
+                        beregningsMetode = BeregningsMetode.NASJONAL,
+                        samletNorskTrygdetid = 40,
+                        samletTeoretiskTrygdetid = 40,
+                        broek = null,
+                        avdoedeForeldre = emptyList(),
+                        regelResultat = null,
+                        regelVersjon = "1.1",
+                        regelverk = Regelverk.REGELVERK_FOM_JAN_2024,
+                        kunEnJuridiskForelder = false,
+                        kilde = null,
+                        harForeldreloessats = false,
+                    ),
+                ),
             beregnetDato = mottattTidspunkt.toTidspunkt(),
             grunnlagMetadata = mockk(relaxed = true),
             overstyrBeregning = null,

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakBehandlingService.kt
@@ -676,10 +676,10 @@ class VedtakBehandlingService(
                 VedtakType.INNVILGELSE, VedtakType.ENDRING -> {
                     when (sakType) {
                         SakType.BARNEPENSJON -> {
-                            val beregningsperioder =
-                                krevIkkeNull(beregningOgAvkorting?.beregning?.beregningsperioder) {
-                                    "Mangler beregning"
-                                }
+                            val beregningsperioder = beregningOgAvkorting?.beregning?.beregningsperioder
+                            if (beregningsperioder.isNullOrEmpty()) {
+                                throw ManglerBeregningsperioder()
+                            }
                             beregningsperioder.map {
                                 Utbetalingsperiode(
                                     periode =
@@ -697,8 +697,9 @@ class VedtakBehandlingService(
                         SakType.OMSTILLINGSSTOENAD -> {
                             val avkortetYtelse =
                                 beregningOgAvkorting?.avkorting?.avkortetYtelse
-                                    ?: throw ManglerAvkortetYtelse()
-
+                            if (avkortetYtelse.isNullOrEmpty()) {
+                                throw ManglerAvkortetYtelse()
+                            }
                             avkortetYtelse.map {
                                 Utbetalingsperiode(
                                     periode =
@@ -852,6 +853,13 @@ class ManglerAvkortetYtelse :
         code = "VEDTAKSVURDERING_MANGLER_AVKORTET_YTELSE",
         detail =
             "Det må legges til inntektsavkorting selv om mottaker ikke har inntekt. Legg inn \"0\" kr i alle felter.",
+    )
+
+class ManglerBeregningsperioder :
+    UgyldigForespoerselException(
+        code = "VEDTAKSVURDERING_MANGLER_BEREGNINGSPERIODER",
+        detail =
+            "Det mangler beregnet ytelse. Gå igjennom stegene fra beregningsgrunnlag en gang til.",
     )
 
 class VirkningstidspunktEtterOpphoerException :


### PR DESCRIPTION
Dette indikerer alltid en feil i hvordan vedtaket er bygget opp, og vil ikke kunne prosesseres av utbetaling-mapperen vår.

Ref vedtaket vi har måttet rydde opp etter i https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/8520 og https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/8521 