### PR TITLE
Granter servicebruker for migrering av database

### DIFF
--- a/apps/etterlatte-vedtaksvurdering/src/main/resources/db/gcp/V63__grant_servicebruker.sql
+++ b/apps/etterlatte-vedtaksvurdering/src/main/resources/db/gcp/V63__grant_servicebruker.sql
@@ -1,0 +1,2 @@
+GRANT USAGE ON SCHEMA public TO "cloudsqliamserviceaccount";
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO "cloudsqliamserviceaccount";


### PR DESCRIPTION
Granter service brukere for migrering steg. Vi jobber med å migrere over data fra etterlatte-vedtaksvurdering til etterlatte-behandling, der vi bruker en service bruker for utføring. Denne grant for både dev/prod og ligger under GCP pakken. 

Se [denne](https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/5997/changes) som har gjort det samme. 