### PR TITLE
Skrur på BRUK_EGEN_DATABASE_FOR_VEDTAK for dev

### DIFF
--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -174,7 +174,7 @@ spec:
     - name: BRUK_NY_VEDTAK_KLIENT
       value: ja
     - name: BRUK_EGEN_DATABASE_FOR_VEDTAK
-      value: nei
+      value: ja
 
   envFrom:
     - secret: my-application-unleash-api-token


### PR DESCRIPTION
Skrur på BRUK_EGEN_DATABASE_FOR_VEDTAK for dev. Dette gjøres samtidig som vi har migrert over database etterlatte-vedtaksvurdering inn i etterlatte-behandling. 