### PR TITLE
Endrer logikk for fallback for antall innvilgede måneder

### DIFF
--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -143,17 +143,9 @@ data class Avkorting(
                                                             fom = inntektsavkorting.grunnlag.periode.fom,
                                                             tom = tom,
                                                         ),
-                                                    // Gammelt grunnlag (opprettet før maanederInnvilget-kolonnen ble innført)
-                                                    // mangler feltet. Rekonstruer fra innvilgaMaaneder startende fra
-                                                    // årsoppgjørets fom – samme startpunkt som den opprinnelige beregningen.
                                                     maanederInnvilget =
                                                         inntektsavkorting.grunnlag.maanederInnvilget
-                                                            ?: (0 until inntektsavkorting.grunnlag.innvilgaMaaneder).map { offset ->
-                                                                MaanedInnvilget(
-                                                                    maaned = aarsoppgjoerFom.plusMonths(offset.toLong()),
-                                                                    innvilget = true,
-                                                                )
-                                                            },
+                                                            ?: fallbackMaanederInnvilget(inntektsavkorting, aarsoppgjoerFom),
                                                 ),
                                             avkortingsperioder =
                                                 if (nullstillAvkortetYtelse) {
@@ -202,6 +194,42 @@ data class Avkorting(
                     }
                 },
         )
+    }
+
+    /**
+     * Gammelt grunnlag (opprettet før maanederInnvilget-kolonnen ble innført)
+     * mangler feltet. Rekonstruer fra innvilgaMaaneder startende fra
+     * årsoppgjørets fom – samme startpunkt som den opprinnelige beregningen.
+     *
+     * @returns liste med måneder innvilget i aktuelt år, basert på innvilgaMaaneder
+     */
+    private fun fallbackMaanederInnvilget(
+        inntektsavkorting: Inntektsavkorting,
+        aarsoppgjoerFom: YearMonth,
+    ): List<MaanedInnvilget> {
+        val maaneder =
+            (0 until inntektsavkorting.grunnlag.innvilgaMaaneder).map { offset ->
+                MaanedInnvilget(
+                    maaned = aarsoppgjoerFom.plusMonths(offset.toLong()),
+                    innvilget = true,
+                )
+            }
+        if (maaneder.any { it.maaned.year != aarsoppgjoerFom.year }) {
+            throw InternfeilException(
+                "Utleder fallback for måneder innvilget utenfor etteroppgjørsåret: " +
+                    "$aarsoppgjoerFom for inntektsavkortingen med id=${inntektsavkorting.grunnlag.id} og periode " +
+                    "${inntektsavkorting.grunnlag.periode}",
+            )
+        }
+        if (maaneder.count { it.innvilget } != inntektsavkorting.grunnlag.innvilgaMaaneder) {
+            throw InternfeilException(
+                "Utleder feil antall måneder innvilget for inntekten med id=" +
+                    "${inntektsavkorting.grunnlag.id} og periode=${inntektsavkorting.grunnlag.periode}, " +
+                    "forventet ${inntektsavkorting.grunnlag.innvilgaMaaneder} men fikk " +
+                    "${maaneder.count { it.innvilget }}.",
+            )
+        }
+        return maaneder
     }
 
     /**

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -117,6 +117,7 @@ data class Avkorting(
                 relevanteAaroppgjoer.map {
                     when (it) {
                         is AarsoppgjoerLoepende -> {
+                            val aarsoppgjoerFom = it.fom
                             it.copy(
                                 id = UUID.randomUUID(),
                                 inntektsavkorting =
@@ -142,6 +143,17 @@ data class Avkorting(
                                                             fom = inntektsavkorting.grunnlag.periode.fom,
                                                             tom = tom,
                                                         ),
+                                                    // Gammelt grunnlag (opprettet før maanederInnvilget-kolonnen ble innført)
+                                                    // mangler feltet. Rekonstruer fra innvilgaMaaneder startende fra
+                                                    // årsoppgjørets fom – samme startpunkt som den opprinnelige beregningen.
+                                                    maanederInnvilget =
+                                                        inntektsavkorting.grunnlag.maanederInnvilget
+                                                            ?: (0 until inntektsavkorting.grunnlag.innvilgaMaaneder).map { offset ->
+                                                                MaanedInnvilget(
+                                                                    maaned = aarsoppgjoerFom.plusMonths(offset.toLong()),
+                                                                    innvilget = true,
+                                                                )
+                                                            },
                                                 ),
                                             avkortingsperioder =
                                                 if (nullstillAvkortetYtelse) {

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
@@ -421,32 +421,25 @@ object AvkortingRegelkjoring {
                         beskrivelse = "Måneder innvilget i forventet inntekt",
                     )
                 } else {
-                    val tom = nyInntektsavkorting.grunnlag.periode.tom ?: YearMonth.of(fraOgMed.year, 12)
-                    val ytelse =
-                        finnAntallInnvilgaMaanederForAar(
-                            fom = fraOgMed,
-                            tom = tom,
-                            aldersovergang = tom,
-                            ytelse = emptyList(),
-                            // Bruk nye regler avkorting er satt som false, siden denne inntekten og utregningen av
-                            // innvilget periode er gjort med gammel regel
-                            brukNyeReglerAvkorting = false,
-                        )
+                    // Gammelt grunnlag uten maanederInnvilget (opprettet før kolonnen ble innført).
+                    // Vi kan ikke rekonstruere fra periode.tom, siden lukkSisteInntektsperiode kan ha
+                    // satt den til måneden før neste inntekt trer i kraft etter at grunnlaget ble lagret.
+                    // innvilgaMaaneder ble derimot satt korrekt ved opprettelse og er fasiten.
+                    val innvilgaMaaneder = nyInntektsavkorting.grunnlag.innvilgaMaaneder
+                    val maaneder =
+                        (0 until innvilgaMaaneder).map { offset ->
+                            MaanedInnvilget(
+                                maaned = fraOgMed.plusMonths(offset.toLong()),
+                                innvilget = true,
+                            )
+                        }
                     logger.info(
-                        "Mangler maanederInnvilget i inntektsgrunnlag, utledet ${ytelse.maaneder}. regelresultat: ${ytelse.regelResultat}",
+                        "Mangler maanederInnvilget i inntektsgrunnlag ${nyInntektsavkorting.grunnlag.id}, " +
+                            "rekonstruert $innvilgaMaaneder måneder fra $fraOgMed",
                     )
-                    val antallMaanederInnvilget = ytelse.maaneder.count { it.innvilget }
-                    if (antallMaanederInnvilget != nyInntektsavkorting.grunnlag.innvilgaMaaneder) {
-                        throw InternfeilException(
-                            "Kunne ikke bygge opp riktig antall måneder " +
-                                "innvilget for grunnlag med id=${nyInntektsavkorting.grunnlag.id}, " +
-                                "forventet ${nyInntektsavkorting.grunnlag.innvilgaMaaneder}, " +
-                                "men fikk $antallMaanederInnvilget (${ytelse.maaneder}).",
-                        )
-                    }
                     FaktumNode(
-                        verdi = ytelse.maaneder,
-                        kilde = "finnAntallInnvilgaMaanederForAar",
+                        verdi = maaneder,
+                        kilde = "fallback-fra-innvilga-maaneder",
                         beskrivelse = "Fallback for henting av liste av måneder innvilget",
                     )
                 }

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/AvkortingRegelkjoring.kt
@@ -414,35 +414,16 @@ object AvkortingRegelkjoring {
                 }
         val maanederInnvilget: FaktumNode<List<MaanedInnvilget>> =
             if (brukNyeReglerAvkorting) {
-                if (nyInntektsavkorting.grunnlag.maanederInnvilget != null) {
-                    FaktumNode(
-                        verdi = nyInntektsavkorting.grunnlag.maanederInnvilget,
-                        kilde = nyInntektsavkorting.grunnlag.id.toString(),
-                        beskrivelse = "Måneder innvilget i forventet inntekt",
-                    )
-                } else {
-                    // Gammelt grunnlag uten maanederInnvilget (opprettet før kolonnen ble innført).
-                    // Vi kan ikke rekonstruere fra periode.tom, siden lukkSisteInntektsperiode kan ha
-                    // satt den til måneden før neste inntekt trer i kraft etter at grunnlaget ble lagret.
-                    // innvilgaMaaneder ble derimot satt korrekt ved opprettelse og er fasiten.
-                    val innvilgaMaaneder = nyInntektsavkorting.grunnlag.innvilgaMaaneder
-                    val maaneder =
-                        (0 until innvilgaMaaneder).map { offset ->
-                            MaanedInnvilget(
-                                maaned = fraOgMed.plusMonths(offset.toLong()),
-                                innvilget = true,
-                            )
-                        }
-                    logger.info(
-                        "Mangler maanederInnvilget i inntektsgrunnlag ${nyInntektsavkorting.grunnlag.id}, " +
-                            "rekonstruert $innvilgaMaaneder måneder fra $fraOgMed",
-                    )
-                    FaktumNode(
-                        verdi = maaneder,
-                        kilde = "fallback-fra-innvilga-maaneder",
-                        beskrivelse = "Fallback for henting av liste av måneder innvilget",
-                    )
-                }
+                FaktumNode(
+                    verdi =
+                        requireNotNull(nyInntektsavkorting.grunnlag.maanederInnvilget) {
+                            "Inntekt i kopiert avkorting med periode=${nyInntektsavkorting.grunnlag.periode} mangler " +
+                                "maanederInnvilget. Avkortingen må kopieres på nytt ved å sette virkningstidspunkt" +
+                                " en gang til og så gå igjennom stegene fra start."
+                        },
+                    kilde = nyInntektsavkorting.grunnlag.id.toString(),
+                    beskrivelse = "Måneder innvilget i forventet inntekt",
+                )
             } else {
                 FaktumNode(emptyList(), "", "Placeholder i grunnlag hvis vi ikke bruker nye regler")
             }

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingServiceTest.kt
@@ -10,6 +10,7 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.randomSakId
@@ -84,6 +85,7 @@ internal class AvkortingServiceTest {
     fun afterEach() {
         confirmVerified()
         clearAllMocks()
+        unmockkObject(AvkortingMapper, AvkortingValider)
     }
 
     @Nested

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -1078,6 +1078,103 @@ internal class AvkortingTest {
     }
 
     @Nested
+    inner class BeregnAvkortingMedNyeGrunnlag {
+        @Test
+        fun `skal haandtere gammelt grunnlag uten maanederInnvilget naar ny inntekt legges inn`() {
+            // Simulerer prod-scenario: to gamle inntektsgrunnlag (maanederInnvilget=null) i årsoppgjøret,
+            // og saksbehandler legger inn ny inntekt fra april.
+            // Grunnlagene ble opprettet før maanederInnvilget-kolonnen ble innført → null i DB.
+            // lukkSisteInntektsperiode setter periode.tom=mars på feb-inntekten etter at april legges inn.
+            // Fallbacklogikken i beregnRestanse skal ikke bruke den låste periode.tom,
+            // men heller rekonstruere fra innvilgaMaaneder.
+
+            val regelKilde = Grunnlagsopplysning.RegelKilde(navn = "regel", ts = Tidspunkt.now(), versjon = "1")
+
+            fun gammeltGrunnlag(fom: YearMonth) =
+                ForventetInntekt(
+                    id = UUID.randomUUID(),
+                    periode = Periode(fom = fom, tom = null),
+                    inntektTom = 300_000,
+                    fratrekkInnAar = 0,
+                    inntektUtlandTom = 0,
+                    fratrekkInnAarUtland = 0,
+                    innvilgaMaaneder = 12,
+                    spesifikasjon = "",
+                    kilde = Grunnlagsopplysning.Saksbehandler.create("Z123456"),
+                    overstyrtInnvilgaMaanederAarsak = null,
+                    overstyrtInnvilgaMaanederBegrunnelse = null,
+                    inntektInnvilgetPeriode =
+                        BenyttetInntektInnvilgetPeriode(
+                            verdi = 300_000,
+                            tidspunkt = Tidspunkt.now(),
+                            regelResultat = "{}".toJsonNode(),
+                            kilde = regelKilde,
+                        ),
+                    maanederInnvilget = null,
+                    maanederInnvilgetRegelResultat = null,
+                )
+
+            val avkorting =
+                Avkorting(
+                    aarsoppgjoer =
+                        listOf(
+                            AarsoppgjoerLoepende(
+                                id = UUID.randomUUID(),
+                                aar = 2025,
+                                fom = YearMonth.of(2025, Month.JANUARY),
+                                inntektsavkorting =
+                                    listOf(
+                                        Inntektsavkorting(gammeltGrunnlag(YearMonth.of(2025, Month.JANUARY))),
+                                        Inntektsavkorting(gammeltGrunnlag(YearMonth.of(2025, Month.FEBRUARY))),
+                                    ),
+                                ytelseFoerAvkorting =
+                                    listOf(
+                                        YtelseFoerAvkorting(
+                                            beregning = 15_000,
+                                            periode = Periode(YearMonth.of(2025, Month.JANUARY), null),
+                                            beregningsreferanse = UUID.randomUUID(),
+                                        ),
+                                    ),
+                            ),
+                        ),
+                )
+
+            // Åpen beregningsperiode: tomSluttenAvAaret=null (ingen neste årsoppgjør) → beregningen må dekke frem i tid
+            val beregningForAaret =
+                beregning(
+                    beregninger =
+                        listOf(
+                            beregningsperiode(
+                                datoFOM = YearMonth.of(2025, Month.APRIL),
+                                utbetaltBeloep = 15_000,
+                            ),
+                        ),
+                )
+
+            val resultat =
+                avkorting.beregnAvkortingMedNyeGrunnlag(
+                    nyttGrunnlag =
+                        listOf(
+                            avkortinggrunnlagLagreDto(
+                                aarsinntekt = 200_000,
+                                fom = YearMonth.of(2025, Month.APRIL),
+                            ),
+                        ),
+                    bruker = bruker,
+                    beregning = beregningForAaret,
+                    sanksjoner = emptyList(),
+                    opphoerFom = null,
+                    brukNyeReglerAvkorting = true,
+                )
+
+            resultat.aarsoppgjoer
+                .single()
+                .inntektsavkorting()
+                .size shouldBe 3
+        }
+    }
+
+    @Nested
     inner class ErstattAarsoppgjoer {
         val avkorting =
             Avkorting(

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -1081,12 +1081,11 @@ internal class AvkortingTest {
     inner class BeregnAvkortingMedNyeGrunnlag {
         @Test
         fun `skal haandtere gammelt grunnlag uten maanederInnvilget naar ny inntekt legges inn`() {
-            // Simulerer prod-scenario: to gamle inntektsgrunnlag (maanederInnvilget=null) i årsoppgjøret,
-            // og saksbehandler legger inn ny inntekt fra april.
+            // Simulerer prod-scenario: to gamle inntektsgrunnlag (maanederInnvilget=null) fra forrige behandling,
+            // og saksbehandler legger inn ny inntekt fra april i en ny revurdering.
             // Grunnlagene ble opprettet før maanederInnvilget-kolonnen ble innført → null i DB.
-            // lukkSisteInntektsperiode setter periode.tom=mars på feb-inntekten etter at april legges inn.
-            // Fallbacklogikken i beregnRestanse skal ikke bruke den låste periode.tom,
-            // men heller rekonstruere fra innvilgaMaaneder.
+            // kopierAvkorting populerer maanederInnvilget fra innvilgaMaaneder ved opprettelse av ny revurdering,
+            // slik at beregnRestanse ikke møter null når lukkSisteInntektsperiode har endret periode.tom.
 
             val regelKilde = Grunnlagsopplysning.RegelKilde(navn = "regel", ts = Tidspunkt.now(), versjon = "1")
 
@@ -1152,20 +1151,22 @@ internal class AvkortingTest {
                 )
 
             val resultat =
-                avkorting.beregnAvkortingMedNyeGrunnlag(
-                    nyttGrunnlag =
-                        listOf(
-                            avkortinggrunnlagLagreDto(
-                                aarsinntekt = 200_000,
-                                fom = YearMonth.of(2025, Month.APRIL),
+                avkorting
+                    .kopierAvkorting()
+                    .beregnAvkortingMedNyeGrunnlag(
+                        nyttGrunnlag =
+                            listOf(
+                                avkortinggrunnlagLagreDto(
+                                    aarsinntekt = 200_000,
+                                    fom = YearMonth.of(2025, Month.APRIL),
+                                ),
                             ),
-                        ),
-                    bruker = bruker,
-                    beregning = beregningForAaret,
-                    sanksjoner = emptyList(),
-                    opphoerFom = null,
-                    brukNyeReglerAvkorting = true,
-                )
+                        bruker = bruker,
+                        beregning = beregningForAaret,
+                        sanksjoner = emptyList(),
+                        opphoerFom = null,
+                        brukNyeReglerAvkorting = true,
+                    )
 
             resultat.aarsoppgjoer
                 .single()

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingTest.kt
@@ -3,9 +3,9 @@ package no.nav.etterlatte.beregning.regler.avkorting
 import io.kotest.assertions.asClue
 import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
 import io.kotest.matchers.shouldBe
-import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import no.nav.etterlatte.avkorting.AvkortetYtelse
 import no.nav.etterlatte.avkorting.AvkortetYtelseType
 import no.nav.etterlatte.avkorting.Avkorting
@@ -35,7 +35,6 @@ import kotlin.test.assertEquals
 class BeregnAvkortingTest {
     @BeforeEach
     fun `mock grunnbeloep`() {
-        clearAllMocks()
         mockkObject(GrunnbeloepRepository)
         every { GrunnbeloepRepository.historiskeGrunnbeloep } returns
             listOf(
@@ -55,8 +54,8 @@ class BeregnAvkortingTest {
     }
 
     @AfterEach
-    fun afterEach() {
-        clearAllMocks()
+    fun `unmock grunnbeloep`() {
+        unmockkObject(GrunnbeloepRepository)
     }
 
     @Test


### PR DESCRIPTION
Vi må gjenskape virkelighetsbildet vi har fra "fasit" for gamle inntekter - så vi lager heller innvilgete måneder fra første måned i årsoppgjøret med antall måneder innvilget, i stedet for å prøve å gjenskape gammel fasit.

Problemet med gjenskaping dukker opp når vi prøver å beregne restanse for en inntekt som er lagret med gammel håndtering etter at vi har lagt til en ny inntekt. Da har vi lukket perioden, og gjenskapingen på måneder blir endret.

Tar derfor å heller gjenskaper feltet riktig når vi kopierer en avkorting, slik at beregningskoden holdes så "enkel" som mulig.