### PR TITLE
Skrur av audit log for etterlatte-behandling prod for database migrering

### DIFF
--- a/apps/etterlatte-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-behandling/.nais/prod.yaml
@@ -29,7 +29,7 @@ spec:
             envVarPrefix: DB
         flags:
           - name: cloudsql.enable_pgaudit
-            value: "true"
+            value: "false" ## TODO: Husk å skru meg på igjen! Kun for migrering av etterlatte-vedtaksvurdering til etterlatte-behandling.
           - name: pgaudit.log
             value: 'write,ddl,role'
           - name: pgaudit.log_parameter


### PR DESCRIPTION
# Skrur av audit log for etterlatte-behandling prod for database migrering

### Hvorfor er denne endringen nødvendig? ✨ 

Vi ønsker å skru av database audit logging når vi nå utfører migrering av etterlatte-vedtaksvurdering sin database inn i etterlatte-behandling. Dette er gjort i regi av å slippe masse innslag på inserts. Dette VIL bli skrudd på igjen. 

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-27829).

### Verdt å nevne

VI sjekker om at audit verdien er satt riktig i GCP etter deploy har gått gjennom. 