### PR TITLE
Vi skrur over til egen database behandling i prod

### DIFF
--- a/apps/etterlatte-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-behandling/.nais/prod.yaml
@@ -29,7 +29,7 @@ spec:
             envVarPrefix: DB
         flags:
           - name: cloudsql.enable_pgaudit
-            value: "false" ## TODO: Husk å skru meg på igjen! Kun for migrering av etterlatte-vedtaksvurdering til etterlatte-behandling.
+            value: "true"
           - name: pgaudit.log
             value: 'write,ddl,role'
           - name: pgaudit.log_parameter
@@ -188,7 +188,7 @@ spec:
     - name: BRUK_NY_VEDTAK_KLIENT
       value: ja
     - name: BRUK_EGEN_DATABASE_FOR_VEDTAK
-      value: nei
+      value: ja
 
   envFrom:
     - secret: my-application-unleash-api-token


### PR DESCRIPTION
Etter at vi har flyttet og verifisert data i produksjonsbasen er vi klare for å spinne den opp igjen (nå med å bruke sine egne tabeller for vedtaksvurdering), og skru på audit-logging igjen.