### PR TITLE
Vil at det skal være mulig å vurdere om en hendelse fra skatt er rele…

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerService.kt
@@ -17,7 +17,6 @@ import no.nav.etterlatte.libs.common.behandling.etteroppgjoer.EtteroppgjoerHende
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerResultatType
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
-import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.feilhaandtering.krev
 import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.common.sak.Sak
@@ -311,13 +310,6 @@ class EtteroppgjoerService(
         brukerTokenInfo: BrukerTokenInfo,
     ): List<Int> {
         val innvilgedePerioder = runBlocking { vedtakKlient.hentInnvilgedePerioder(sakId, brukerTokenInfo) }
-
-        if (innvilgedePerioder.isEmpty()) {
-            throw UgyldigForespoerselException(
-                "MANGLER_INNVILGET_PERIODE",
-                "Saken har ingen innvilget periode.",
-            )
-        }
 
         val innvilgedeAar =
             innvilgedePerioder

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/etteroppgjoer/EtteroppgjoerServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/etteroppgjoer/EtteroppgjoerServiceTest.kt
@@ -47,6 +47,7 @@ import java.time.Instant
 import java.time.Year
 import java.time.YearMonth
 import java.util.UUID
+import kotlin.test.assertTrue
 import no.nav.etterlatte.libs.common.vedtak.Periode as VedtakPeriode
 
 class EtteroppgjoerServiceTest {
@@ -378,6 +379,17 @@ class EtteroppgjoerServiceTest {
             this.harUtlandstilsnitt shouldBe true
         }
         coVerify(exactly = 1) { ctx.dao.lagreEtteroppgjoer(any()) }
+    }
+
+    @Test
+    fun `finnInnvilgedeAarForSak skal fungere naar sak ikke har innvilgede perioder`() {
+        val ctx = TestContext(sakId)
+        val brukerTokenInfo = mockk<BrukerTokenInfo>()
+
+        coEvery { ctx.vedtakKlient.hentInnvilgedePerioder(sakId, brukerTokenInfo) } returns emptyList()
+
+        val innvilgedeAarForSak = ctx.service.finnInnvilgedeAarForSak(sakId, brukerTokenInfo)
+        assertTrue(innvilgedeAarForSak.isEmpty())
     }
 
     private fun utlandstilsnitt(): Utlandstilknytning =

--- a/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Vedtakstidslinje.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/Vedtakstidslinje.kt
@@ -73,6 +73,10 @@ class Vedtakstidslinje(
     }
 
     fun innvilgedePerioder(): List<InnvilgetPeriode> {
+        if (attesterteBehandlingVedtak.isEmpty()) {
+            return emptyList()
+        }
+
         val foersteVirk = attesterteBehandlingVedtak.minOf { it.virkningstidspunkt }
         val sammenstilt = sammenstill(foersteVirk)
         if (sammenstilt.size == 1) {

--- a/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakstidslinjeTest.kt
+++ b/apps/etterlatte-vedtaksvurdering/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakstidslinjeTest.kt
@@ -1062,6 +1062,12 @@ internal class VedtakstidslinjeTest {
             innvilgetPeriode[0].periode.tom shouldBe null
         }
 
+        @Test
+        fun `innvilgedePerioder returnerer tom liste når ingen attesterte vedtak finnes`() {
+            val tidslinje = Vedtakstidslinje(emptyList())
+            tidslinje.innvilgedePerioder() shouldBe emptyList()
+        }
+
         private val Vedtak.utbetalingsperioder: List<Utbetalingsperiode>
             get() = (this.innhold as VedtakInnhold.Behandling).utbetalingsperioder
     }


### PR DESCRIPTION
…vant, eller ikke. Hvis det ikke er noen innvilgede perioder i en sak ønsker vi returnere tom liste, ikke kaste feil.I praksis betyr det at vi ikke vurderer hendelsen som relevant for etteroppgjør.

Vedtakslinje returnerer tom liste hvis sak ikke har noen behandling (som er attestert).

Favrooppgave:
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-28638

