### PR TITLE
Rydder bort  BRUK_VEDTAK_FRA_BEHANDLING flagget

### DIFF
--- a/apps/etterlatte-api/.nais/dev.yaml
+++ b/apps/etterlatte-api/.nais/dev.yaml
@@ -89,10 +89,6 @@ spec:
   env:
     - name: MASKINPORTEN_WELL_KNOWN_URL
       value: https://test.maskinporten.no/.well-known/oauth-authorization-server
-    - name: ETTERLATTE_VEDTAKSVURDERING_URL
-      value: http://etterlatte-vedtaksvurdering
-    - name: ETTERLATTE_VEDTAKSVURDERING_SCOPE
-      value: api://dev-gcp.etterlatte.etterlatte-vedtaksvurdering/.default
     - name: ETTERLATTE_BEHANDLING_URL
       value: http://etterlatte-behandling
     - name: ETTERLATTE_BEHANDLING_SCOPE
@@ -105,8 +101,6 @@ spec:
       value: 8bb9b8d1-f46a-4ade-8ee8-5895eccdf8cf
     - name: ROLLE_GJENNYSAKSBEHANDLER
       value: 5b6745de-b65d-40eb-a6f5-860c8b61c27f
-    - name: BRUK_VEDTAK_FRA_BEHANDLING
-      value: "ja"
   accessPolicy:
     inbound:
       rules:
@@ -238,7 +232,6 @@ spec:
               - les-bp-vedtak
     outbound:
       rules:
-        - application: etterlatte-vedtaksvurdering
         - application: etterlatte-behandling
         - application: logging
           namespace: nais-system

--- a/apps/etterlatte-api/.nais/prod.yaml
+++ b/apps/etterlatte-api/.nais/prod.yaml
@@ -87,10 +87,6 @@ spec:
   env:
     - name: MASKINPORTEN_WELL_KNOWN_URL
       value: https://maskinporten.no/.well-known/oauth-authorization-server
-    - name: ETTERLATTE_VEDTAKSVURDERING_URL
-      value: http://etterlatte-vedtaksvurdering
-    - name: ETTERLATTE_VEDTAKSVURDERING_SCOPE
-      value: api://prod-gcp.etterlatte.etterlatte-vedtaksvurdering/.default
     - name: ETTERLATTE_BEHANDLING_URL
       value: http://etterlatte-behandling
     - name: ETTERLATTE_BEHANDLING_SCOPE
@@ -103,8 +99,6 @@ spec:
       value: 0af3955f-df85-4eb0-b5b2-45bf2c8aeb9e
     - name: ROLLE_GJENNYSAKSBEHANDLER
       value: e4eb614b-d37d-4721-ba1b-df8f0fd16f85
-    - name: BRUK_VEDTAK_FRA_BEHANDLING
-      value: "ja"
   accessPolicy:
     inbound:
       rules:
@@ -184,7 +178,6 @@ spec:
               - opprett-jfr-oppgave
     outbound:
       rules:
-        - application: etterlatte-vedtaksvurdering
         - application: etterlatte-behandling
         - application: logging
           namespace: nais-system

--- a/apps/etterlatte-api/.run/etterlatte-api.dev-gcp.run.xml
+++ b/apps/etterlatte-api/.run/etterlatte-api.dev-gcp.run.xml
@@ -1,18 +1,15 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="etterlatte-api.dev-gcp" type="JetRunConfigurationType">
     <envs>
-      <env name="ETTERLATTE_VEDTAKSVURDERING_URL" value="https://etterlatte-vedtaksvurdering.intern.dev.nav.no" />
-      <env name="ETTERLATTE_VEDTAKSVURDERING_SCOPE" value="api://dev-gcp.etterlatte.etterlatte-vedtaksvurdering/.default" />
+      <env name="ETTERLATTE_BEHANDLING_SCOPE" value="api://dev-gcp.etterlatte.etterlatte-behandling/.default" />
       <env name="TJENESTEPENSJON_URL" value="https://tp-api-q2.dev-fss-pub.nais.io" />
       <env name="TJENESTEPENSJON_SCOPE" value="api://dev-fss.pensjonsamhandling.tp-q2/.default" />
-      <env name="ETTERLATTE_BEHANDLING_SCOPE" value="api://dev-gcp.etterlatte.etterlatte-behandling/.default" />
       <env name="ETTERLATTE_BEHANDLING_URL" value="https://etterlatte-behandling.intern.dev.nav.no" />
       <env name="HTTP_PORT" value="8094" />
       <env name="LOGBACK_APPENDER" value="STDOUT" />
       <env name="LOGBACK_LEVEL" value="DEBUG" />
       <env name="ROLLE_PENSJONSAKSBEHANDLER" value="8bb9b8d1-f46a-4ade-8ee8-5895eccdf8cf" />
       <env name="ROLLE_GJENNYSAKSBEHANDLER" value="5b6745de-b65d-40eb-a6f5-860c8b61c27f" />
-      <env name="BRUK_VEDTAK_FRA_BEHANDLING" value="ja" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="no.nav.etterlatte.ApplicationKt" />
     <module name="pensjon-etterlatte-saksbehandling.apps.etterlatte-api.main" />

--- a/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/ApplicationContext.kt
+++ b/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/ApplicationContext.kt
@@ -6,7 +6,6 @@ import no.nav.etterlatte.EnvKey.HTTP_PORT
 import no.nav.etterlatte.behandling.sak.BehandlingKlient
 import no.nav.etterlatte.behandling.sak.BehandlingService
 import no.nav.etterlatte.behandling.sak.VedtaksvurderingSakKlient
-import no.nav.etterlatte.libs.common.EnvEnum
 import no.nav.etterlatte.libs.common.Miljoevariabler
 import no.nav.etterlatte.libs.ktor.AzureEnums.AZURE_APP_CLIENT_ID
 import no.nav.etterlatte.libs.ktor.AzureEnums.AZURE_APP_JWK
@@ -26,8 +25,6 @@ class ApplicationContext(
     val config: Config = ConfigFactory.load()
     val httpPort = env.getOrDefault(HTTP_PORT, "8080").toInt()
 
-    private val brukVedtakFraBehandling = env[ApiKey.BRUK_VEDTAK_FRA_BEHANDLING] == "ja"
-
     private val behandlingHttpClient =
         httpClientClientCredentials(
             azureAppClientId = env.requireEnvValue(AZURE_APP_CLIENT_ID),
@@ -36,30 +33,15 @@ class ApplicationContext(
             azureAppScope = config.getString("behandling.outbound"),
         )
 
-    private val vedtakHttpClient by lazy {
-        if (brukVedtakFraBehandling) {
-            behandlingHttpClient
-        } else {
-            httpClientClientCredentials(
-                azureAppClientId = env.requireEnvValue(AZURE_APP_CLIENT_ID),
-                azureAppJwk = env.requireEnvValue(AZURE_APP_JWK),
-                azureAppWellKnownUrl = env.requireEnvValue(AZURE_APP_WELL_KNOWN_URL),
-                azureAppScope = config.getString("vedtak.outbound"),
-            )
-        }
-    }
-
     private val vedtaksvurderingSamordningKlient =
         VedtaksvurderingSamordningKlient(
             config = config,
-            httpClient = vedtakHttpClient,
-            brukEtterlatteBehandling = brukVedtakFraBehandling,
+            httpClient = behandlingHttpClient,
         )
     private val vedtaksvurderingSakKlient =
         VedtaksvurderingSakKlient(
             config = config,
-            httpClient = vedtakHttpClient,
-            brukEtterlatteBehandling = brukVedtakFraBehandling,
+            httpClient = behandlingHttpClient,
         )
 
     private val tpHttpClient =
@@ -79,18 +61,10 @@ class ApplicationContext(
     val vedtakKlient =
         VedtaksvurderingKlient(
             config = config,
-            httpClient = vedtakHttpClient,
-            brukEtterlatteBehandling = brukVedtakFraBehandling,
+            httpClient = behandlingHttpClient,
         )
     val vedtakService = VedtakService(vedtakKlient)
 
     private val oppgaveKlient = OppgaveKlient(config, behandlingHttpClient)
     val oppgaveService = OppgaveService(oppgaveKlient)
-}
-
-enum class ApiKey : EnvEnum {
-    BRUK_VEDTAK_FRA_BEHANDLING,
-    ;
-
-    override fun key() = name
 }

--- a/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/behandling/sak/VedtaksvurderingSakKlient.kt
+++ b/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/behandling/sak/VedtaksvurderingSakKlient.kt
@@ -17,25 +17,14 @@ import java.time.LocalDate
 class VedtaksvurderingSakKlient(
     config: Config,
     private val httpClient: HttpClient,
-    private val brukEtterlatteBehandling: Boolean = false,
 ) {
     private val logger = LoggerFactory.getLogger(VedtaksvurderingSakKlient::class.java)
 
-    private val vedtaksvurderingUrl =
-        if (brukEtterlatteBehandling) {
-            "${config.getString("behandling.url")}/api/vedtak"
-        } else {
-            "${config.getString("vedtak.url")}/api/vedtak"
-        }
+    private val vedtaksvurderingUrl = "${config.getString("behandling.url")}/api/vedtak"
 
     suspend fun hentLoependeVedtak(sakId: SakId): LoependeYtelseDTO {
         val dato = LocalDate.now()
-
-        if (brukEtterlatteBehandling) {
-            logger.info("Henter lopende vedtak, date: $dato fra etterlatte-behandling")
-        } else {
-            logger.info("Henter lopende vedtak, date: $dato")
-        }
+        logger.info("Henter lopende vedtak, date: $dato")
 
         return try {
             httpClient

--- a/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/VedtaksvurderingSamordningKlient.kt
+++ b/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/samordning/vedtak/VedtaksvurderingSamordningKlient.kt
@@ -28,26 +28,16 @@ import java.time.LocalDate
 class VedtaksvurderingSamordningKlient(
     config: Config,
     private val httpClient: HttpClient,
-    private val brukEtterlatteBehandling: Boolean = false,
 ) {
     private val logger = LoggerFactory.getLogger(VedtaksvurderingSamordningKlient::class.java)
 
-    private val vedtaksvurderingUrl =
-        if (brukEtterlatteBehandling) {
-            "${config.getString("behandling.url")}/api/samordning/vedtak"
-        } else {
-            "${config.getString("vedtak.url")}/api/samordning/vedtak"
-        }
+    private val vedtaksvurderingUrl = "${config.getString("behandling.url")}/api/samordning/vedtak"
 
     suspend fun hentVedtak(
         vedtakId: Long,
         callerContext: CallerContext,
     ): VedtakSamordningDto {
-        if (brukEtterlatteBehandling) {
-            logger.info("Henter vedtaksvurdering med vedtakId:$vedtakId fra etterlatte-behandling")
-        } else {
-            logger.info("Henter vedtaksvurdering med vedtakId:$vedtakId")
-        }
+        logger.info("Henter vedtaksvurdering med vedtakId:$vedtakId")
 
         return try {
             retryOgPakkUt {
@@ -79,11 +69,7 @@ class VedtaksvurderingSamordningKlient(
         fnr: String,
         callerContext: CallerContext,
     ): List<VedtakSamordningDto> {
-        if (brukEtterlatteBehandling) {
-            logger.info("Henter vedtaksliste, fomDato=$fomDato fra etterlatte-behandling")
-        } else {
-            logger.info("Henter vedtaksliste, fomDato=$fomDato")
-        }
+        logger.info("Henter vedtaksliste, fomDato=$fomDato")
         val erMaskinPorten = callerContext is MaskinportenTpContext
         if (erMaskinPorten) {
             logger.info("Henter vedtaksliste med orgnr {}", kv(X_ORGNR, callerContext.organisasjonsnr))

--- a/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/vedtak/VedtaksvurderingKlient.kt
+++ b/apps/etterlatte-api/src/main/kotlin/no/nav/etterlatte/vedtak/VedtaksvurderingKlient.kt
@@ -22,16 +22,10 @@ import org.slf4j.LoggerFactory
 class VedtaksvurderingKlient(
     config: Config,
     private val httpClient: HttpClient,
-    private val brukEtterlatteBehandling: Boolean = false,
 ) {
     private val logger = LoggerFactory.getLogger(VedtaksvurderingKlient::class.java)
 
-    private val vedtaksvurderingUrl =
-        if (brukEtterlatteBehandling) {
-            "${config.getString("behandling.url")}/vedtak/fnr"
-        } else {
-            "${config.getString("vedtak.url")}/vedtak/fnr"
-        }
+    private val vedtaksvurderingUrl = "${config.getString("behandling.url")}/vedtak/fnr"
 
     suspend fun hentVedtak(request: Folkeregisteridentifikator): List<VedtakDto> {
         sikkerlogger().info("Henter vedtak med fnr=$request")

--- a/apps/etterlatte-api/src/main/resources/application.conf
+++ b/apps/etterlatte-api/src/main/resources/application.conf
@@ -24,12 +24,6 @@ azure.app.client.secret = ${?AZURE_APP_CLIENT_SECRET}
 azure.app.jwk = ${?AZURE_APP_JWK}
 azure.app.well.known.url = ${?AZURE_APP_WELL_KNOWN_URL}
 
-vedtak {
-    url = ${?ETTERLATTE_VEDTAKSVURDERING_URL}
-    outbound = ${?ETTERLATTE_VEDTAKSVURDERING_SCOPE}
-    client_id = ${?AZURE_APP_CLIENT_ID}
-}
-
 behandling {
     url = ${?ETTERLATTE_BEHANDLING_URL}
     outbound = ${?ETTERLATTE_BEHANDLING_SCOPE}

--- a/apps/etterlatte-api/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/VedtakvurderingKlientTest.kt
+++ b/apps/etterlatte-api/src/test/kotlin/no/nav/etterlatte/samordning/vedtak/VedtakvurderingKlientTest.kt
@@ -22,7 +22,7 @@ import java.time.LocalDate
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class VedtakvurderingKlientTest {
     private val defaultHeaders = headersOf("Content-Type" to listOf(ContentType.Application.Json.toString()))
-    private val config = ConfigFactory.parseMap(mapOf("vedtak.url" to ""))
+    private val config = ConfigFactory.parseMap(mapOf("behandling.url" to ""))
 
     @Test
     fun `hent vedtak`() {
@@ -30,7 +30,7 @@ class VedtakvurderingKlientTest {
         val client =
             createHttpClient { request ->
                 when (request.url.fullPath) {
-                    "/api/samordning/vedtak/$vedtakId" ->
+                    "/api/samordning/vedtak/$vedtakId" -> {
                         respond(
                             vedtak(
                                 sakstype = SakType.OMSTILLINGSSTOENAD,
@@ -38,8 +38,11 @@ class VedtakvurderingKlientTest {
                             HttpStatusCode.OK,
                             defaultHeaders,
                         )
+                    }
 
-                    else -> error("Unhandled ${request.url.fullPath}")
+                    else -> {
+                        error("Unhandled ${request.url.fullPath}")
+                    }
                 }
             }
         val vedtaksvurderingKlient = VedtaksvurderingSamordningKlient(config, client)
@@ -56,7 +59,7 @@ class VedtakvurderingKlientTest {
         val client =
             createHttpClient { request ->
                 when (request.url.fullPath) {
-                    "/api/samordning/vedtak?sakstype=$sakType&fomDato=$fomDato" ->
+                    "/api/samordning/vedtak?sakstype=$sakType&fomDato=$fomDato" -> {
                         respond(
                             listOf(
                                 vedtak(
@@ -66,8 +69,11 @@ class VedtakvurderingKlientTest {
                             HttpStatusCode.OK,
                             defaultHeaders,
                         )
+                    }
 
-                    else -> error("Unhandled ${request.url.fullPath}")
+                    else -> {
+                        error("Unhandled ${request.url.fullPath}")
+                    }
                 }
             }
 

--- a/apps/etterlatte-beregning/.nais/dev.yaml
+++ b/apps/etterlatte-beregning/.nais/dev.yaml
@@ -66,16 +66,10 @@ spec:
           - name: max_connections
             value: "100"
   env:
-    - name: ETTERLATTE_VEDTAKSVURDERING_CLIENT_ID
-      value: dev-gcp.etterlatte.etterlatte-vedtaksvurdering
-    - name: ETTERLATTE_VEDTAKSVURDERING_URL
-      value: http://etterlatte-vedtaksvurdering
     - name: ETTERLATTE_BEHANDLING_URL
       value: http://etterlatte-behandling
     - name: ETTERLATTE_BEHANDLING_CLIENT_ID
       value: dev-gcp.etterlatte.etterlatte-behandling
-    - name: BRUK_VEDTAK_FRA_BEHANDLING
-      value: "ja"
     - name: ETTERLATTE_TRYGDETID_URL
       value: http://etterlatte-trygdetid
     - name: ETTERLATTE_TRYGDETID_CLIENT_ID
@@ -85,7 +79,6 @@ spec:
   accessPolicy:
     outbound:
       rules:
-        - application: etterlatte-vedtaksvurdering
         - application: etterlatte-behandling
         - application: etterlatte-trygdetid
         - application: logging

--- a/apps/etterlatte-beregning/.nais/prod.yaml
+++ b/apps/etterlatte-beregning/.nais/prod.yaml
@@ -81,16 +81,10 @@ spec:
           - name: pgaudit.log_parameter
             value: "on"
   env:
-    - name: ETTERLATTE_VEDTAKSVURDERING_CLIENT_ID
-      value: prod-gcp.etterlatte.etterlatte-vedtaksvurdering
-    - name: ETTERLATTE_VEDTAKSVURDERING_URL
-      value: http://etterlatte-vedtaksvurdering
     - name: ETTERLATTE_BEHANDLING_URL
       value: http://etterlatte-behandling
     - name: ETTERLATTE_BEHANDLING_CLIENT_ID
       value: prod-gcp.etterlatte.etterlatte-behandling
-    - name: BRUK_VEDTAK_FRA_BEHANDLING
-      value: "ja"
     - name: ETTERLATTE_TRYGDETID_URL
       value: http://etterlatte-trygdetid
     - name: ETTERLATTE_TRYGDETID_CLIENT_ID
@@ -100,7 +94,6 @@ spec:
   accessPolicy:
     outbound:
       rules:
-        - application: etterlatte-vedtaksvurdering
         - application: etterlatte-behandling
         - application: etterlatte-trygdetid
         - application: logging

--- a/apps/etterlatte-beregning/.run/etterlatte-beregning.dev-gcp.run.xml
+++ b/apps/etterlatte-beregning/.run/etterlatte-beregning.dev-gcp.run.xml
@@ -10,10 +10,7 @@
             <env name="ETTERLATTE_BEHANDLING_URL" value="https://etterlatte-behandling.intern.dev.nav.no"/>
             <env name="ETTERLATTE_TRYGDETID_CLIENT_ID" value="8385435e-f3d7-45ec-be59-ebd1c71df735"/>
             <env name="ETTERLATTE_TRYGDETID_URL" value="https://etterlatte-trygdetid.intern.dev.nav.no"/>
-            <env name="ETTERLATTE_VEDTAKSVURDERING_CLIENT_ID" value="dev-gcp.etterlatte.etterlatte-vedtaksvurdering"/>
-            <env name="ETTERLATTE_VEDTAKSVURDERING_URL" value="https://etterlatte-vedtaksvurdering.intern.dev.nav.no"/>
             <env name="NAIS_APP_NAME" value="etterlatte-beregning"/>
-            <env name="BRUK_VEDTAK_FRA_BEHANDLING" value="ja"/>
         </envs>
         <option name="MAIN_CLASS_NAME" value="no.nav.etterlatte.ApplicationKt"/>
         <module name="pensjon-etterlatte-saksbehandling.apps.etterlatte-beregning.main"/>

--- a/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/config/ApplicationContext.kt
@@ -58,7 +58,6 @@ class ApplicationContext {
         VedtaksvurderingKlientImpl(
             config = config,
             httpClient = httpClient(),
-            brukEtterlatteBehandling = env.props["BRUK_VEDTAK_FRA_BEHANDLING"] == "ja",
         )
     val grunnlagKlient = GrunnlagKlientImpl(config, httpClient())
     val trygdetidKlient = TrygdetidKlient(config, httpClient())

--- a/apps/etterlatte-beregning/src/main/kotlin/klienter/VedtaksvurderingKlient.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/klienter/VedtaksvurderingKlient.kt
@@ -44,24 +44,13 @@ class VedtaksvurderingKlientException(
 class VedtaksvurderingKlientImpl(
     config: Config,
     httpClient: HttpClient,
-    private val brukEtterlatteBehandling: Boolean = false,
 ) : VedtaksvurderingKlient {
     private val logger = LoggerFactory.getLogger(this::class.java)
     private val azureAdClient = AzureAdClient(config)
     private val downstreamResourceClient = DownstreamResourceClient(azureAdClient, httpClient)
 
-    private val clientId =
-        if (brukEtterlatteBehandling) {
-            config.getString("behandling.client.id")
-        } else {
-            config.getString("vedtaksvurdering.client.id")
-        }
-    private val resourceUrl =
-        if (brukEtterlatteBehandling) {
-            config.getString("behandling.resource.url")
-        } else {
-            config.getString("vedtaksvurdering.resource.url")
-        }
+    private val clientId = config.getString("behandling.client.id")
+    private val resourceUrl = config.getString("behandling.resource.url")
 
     override suspend fun hentIverksatteVedtak(
         sakId: SakId,

--- a/apps/etterlatte-beregning/src/main/resources/application.conf
+++ b/apps/etterlatte-beregning/src/main/resources/application.conf
@@ -11,9 +11,6 @@ no.nav.security.jwt {
 behandling.client.id = ${?ETTERLATTE_BEHANDLING_CLIENT_ID}
 behandling.resource.url = ${?ETTERLATTE_BEHANDLING_URL}
 
-vedtaksvurdering.client.id = ${?ETTERLATTE_VEDTAKSVURDERING_CLIENT_ID}
-vedtaksvurdering.resource.url = ${?ETTERLATTE_VEDTAKSVURDERING_URL}
-
 trygdetid.client.id = ${?ETTERLATTE_TRYGDETID_CLIENT_ID}
 trygdetid.resource.url = ${?ETTERLATTE_TRYGDETID_URL}
 

--- a/apps/etterlatte-brev-api/.nais/dev.yaml
+++ b/apps/etterlatte-brev-api/.nais/dev.yaml
@@ -100,12 +100,6 @@ spec:
       value: https://regoppslag.dev-fss-pub.nais.io
     - name: CLAMAV_ENDPOINT_URL
       value: http://clamav.nais-system.svc.cluster.local
-    - name: ETTERLATTE_VEDTAK_CLIENT_ID
-      value: 069b1b2c-0a06-4cc9-8418-f100b8ff71be
-    - name: ETTERLATTE_VEDTAK_URL
-      value: http://etterlatte-vedtaksvurdering
-    - name: BRUK_VEDTAK_FRA_BEHANDLING
-      value: "ja"
     - name: ETTERLATTE_BEREGNING_CLIENT_ID
       value: b07cf335-11fb-4efa-bd46-11f51afd5052
     - name: ETTERLATTE_BEREGNING_URL
@@ -127,7 +121,6 @@ spec:
   accessPolicy:
     outbound:
       rules:
-        - application: etterlatte-vedtaksvurdering
         - application: etterlatte-beregning
         - application: etterlatte-behandling
         - application: etterlatte-pdltjenester

--- a/apps/etterlatte-brev-api/.nais/prod.yaml
+++ b/apps/etterlatte-brev-api/.nais/prod.yaml
@@ -109,12 +109,6 @@ spec:
       value: https://regoppslag.prod-fss-pub.nais.io
     - name: CLAMAV_ENDPOINT_URL
       value: http://clamav.nais-system.svc.cluster.local
-    - name: ETTERLATTE_VEDTAK_CLIENT_ID
-      value: prod-gcp.etterlatte.etterlatte-vedtaksvurdering
-    - name: ETTERLATTE_VEDTAK_URL
-      value: http://etterlatte-vedtaksvurdering
-    - name: BRUK_VEDTAK_FRA_BEHANDLING
-      value: "ja"
     - name: ETTERLATTE_BEREGNING_CLIENT_ID
       value: prod-gcp.etterlatte.etterlatte-beregning
     - name: ETTERLATTE_BEREGNING_URL
@@ -136,7 +130,6 @@ spec:
   accessPolicy:
     outbound:
       rules:
-        - application: etterlatte-vedtaksvurdering
         - application: etterlatte-beregning
         - application: etterlatte-behandling
         - application: etterlatte-pdltjenester

--- a/apps/etterlatte-brev-api/.run/etterlatte-brev-api.dev-gcp.run.xml
+++ b/apps/etterlatte-brev-api/.run/etterlatte-brev-api.dev-gcp.run.xml
@@ -43,7 +43,6 @@
       <env name="DB_HOST" value="host.docker.internal" />
       <env name="DB_PASSWORD" value="postgres" />
       <env name="DB_PORT" value="5435" />
-      <env name="BRUK_VEDTAK_FRA_BEHANDLING" value="ja" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="no.nav.etterlatte.ApplicationKt" />
     <module name="pensjon-etterlatte-saksbehandling.apps.etterlatte-brev-api.main" />

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationContext.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/ApplicationContext.kt
@@ -5,7 +5,6 @@ import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.auth.Auth
 import no.nav.etterlatte.BrevKey.BREVBAKER_SCOPE
 import no.nav.etterlatte.BrevKey.BREVBAKER_URL
-import no.nav.etterlatte.BrevKey.BRUK_VEDTAK_FRA_BEHANDLING
 import no.nav.etterlatte.BrevKey.CLAMAV_ENDPOINT_URL
 import no.nav.etterlatte.BrevKey.REGOPPSLAG_SCOPE
 import no.nav.etterlatte.BrevKey.REGOPPSLAG_URL
@@ -104,7 +103,7 @@ internal class ApplicationContext {
     val regoppslagKlient =
         RegoppslagKlient(httpClient(REGOPPSLAG_SCOPE), env.requireEnvValue(REGOPPSLAG_URL))
     val saksbehandlerKlient = SaksbehandlerKlient(config, httpClient())
-    val vedtakKlient = VedtaksvurderingKlient(config, httpClient(), brukEtterlatteBehandling = env[BRUK_VEDTAK_FRA_BEHANDLING] == "ja")
+    val vedtakKlient = VedtaksvurderingKlient(config, httpClient())
     val beregningKlient = BeregningKlient(config, httpClient())
     val pdltjenesterKlient = PdlTjenesterKlient(config, httpClient())
     val behandlingKlient = BehandlingKlient(config, httpClient())
@@ -285,7 +284,6 @@ internal class ApplicationContext {
 enum class BrevKey : EnvEnum {
     BREVBAKER_SCOPE,
     BREVBAKER_URL,
-    BRUK_VEDTAK_FRA_BEHANDLING,
     CLAMAV_ENDPOINT_URL,
     REGOPPSLAG_SCOPE,
     REGOPPSLAG_URL,

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/vedtaksvurdering/VedtaksvurderingKlient.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/hentinformasjon/vedtaksvurdering/VedtaksvurderingKlient.kt
@@ -18,25 +18,14 @@ import java.util.UUID
 class VedtaksvurderingKlient(
     config: Config,
     httpClient: HttpClient,
-    private val brukEtterlatteBehandling: Boolean = false,
 ) {
     private val logger = LoggerFactory.getLogger(VedtaksvurderingKlient::class.java)
 
     private val azureAdClient = AzureAdClient(config)
     private val downstreamResourceClient = DownstreamResourceClient(azureAdClient, httpClient)
 
-    private val clientId =
-        if (brukEtterlatteBehandling) {
-            config.getString("behandling.client.id")
-        } else {
-            config.getString("vedtak.client.id")
-        }
-    private val resourceUrl =
-        if (brukEtterlatteBehandling) {
-            config.getString("behandling.resource.url")
-        } else {
-            config.getString("vedtak.resource.url")
-        }
+    private val clientId = config.getString("behandling.client.id")
+    private val resourceUrl = config.getString("behandling.resource.url")
 
     internal suspend fun hentVedtak(
         behandlingId: UUID,

--- a/apps/etterlatte-brev-api/src/main/resources/application.conf
+++ b/apps/etterlatte-brev-api/src/main/resources/application.conf
@@ -12,9 +12,6 @@ azure.app.client.id = ${?AZURE_APP_CLIENT_ID}
 azure.app.client.secret = ${?AZURE_APP_CLIENT_SECRET}
 azure.app.well.known.url = ${?AZURE_APP_WELL_KNOWN_URL}
 
-vedtak.client.id = ${?ETTERLATTE_VEDTAK_CLIENT_ID}
-vedtak.resource.url = ${?ETTERLATTE_VEDTAK_URL}
-
 dokarkiv.client.id=${?DOKARKIV_CLIENT_ID}
 dokarkiv.resource.url=${?DOKARKIV_URL}
 

--- a/apps/etterlatte-trygdetid/.nais/dev.yaml
+++ b/apps/etterlatte-trygdetid/.nais/dev.yaml
@@ -73,16 +73,10 @@ spec:
       value: http://etterlatte-behandling
     - name: ETTERLATTE_BEHANDLING_CLIENT_ID
       value: dev-gcp.etterlatte.etterlatte-behandling
-    - name: ETTERLATTE_VEDTAKSVURDERING_CLIENT_ID
-      value: dev-gcp.etterlatte.etterlatte-vedtaksvurdering
-    - name: ETTERLATTE_VEDTAKSVURDERING_URL
-      value: http://etterlatte-vedtaksvurdering
     - name: PEN_URL
       value: https://pensjon-pen-q2.dev-fss-pub.nais.io/pen
     - name: PEN_CLIENT_ID
       value: ddd52335-cfe8-4ee9-9e68-416a5ab26efa
-    - name: BRUK_VEDTAK_FRA_BEHANDLING
-      value: "ja"
   envFrom:
     - secret: my-application-unleash-api-token
   accessPolicy:
@@ -102,7 +96,6 @@ spec:
     outbound:
       rules:
         - application: etterlatte-behandling
-        - application: etterlatte-vedtaksvurdering
         - application: logging
           namespace: nais-system
       external:

--- a/apps/etterlatte-trygdetid/.nais/prod.yaml
+++ b/apps/etterlatte-trygdetid/.nais/prod.yaml
@@ -82,16 +82,10 @@ spec:
       value: http://etterlatte-behandling
     - name: ETTERLATTE_BEHANDLING_CLIENT_ID
       value: prod-gcp.etterlatte.etterlatte-behandling
-    - name: ETTERLATTE_VEDTAKSVURDERING_CLIENT_ID
-      value: prod-gcp.etterlatte.etterlatte-vedtaksvurdering
-    - name: ETTERLATTE_VEDTAKSVURDERING_URL
-      value: http://etterlatte-vedtaksvurdering
     - name: PEN_URL
       value: https://pensjon-pen.prod-fss-pub.nais.io/pen
     - name: PEN_CLIENT_ID
       value: 53eaf67f-d7b2-46e9-8ffe-3da7cf0ac955
-    - name: BRUK_VEDTAK_FRA_BEHANDLING
-      value: "ja"
   envFrom:
     - secret: my-application-unleash-api-token
   accessPolicy:
@@ -106,7 +100,6 @@ spec:
     outbound:
       rules:
         - application: etterlatte-behandling
-        - application: etterlatte-vedtaksvurdering
         - application: logging
           namespace: nais-system
       external:

--- a/apps/etterlatte-trygdetid/.run/etterlatte-trygdetid.dev-gcp.run.xml
+++ b/apps/etterlatte-trygdetid/.run/etterlatte-trygdetid.dev-gcp.run.xml
@@ -6,15 +6,12 @@
       <env name="DB_USERNAME" value="postgres" />
       <env name="ETTERLATTE_BEHANDLING_CLIENT_ID" value="59967ac8-009c-492e-a618-e5a0f6b3e4e4" />
       <env name="ETTERLATTE_BEHANDLING_URL" value="https://etterlatte-behandling.intern.dev.nav.no" />
-      <env name="ETTERLATTE_VEDTAKSVURDERING_CLIENT_ID" value="dev-gcp.etterlatte.etterlatte-vedtaksvurdering" />
-      <env name="ETTERLATTE_VEDTAKSVURDERING_URL" value="https://etterlatte-vedtaksvurdering.intern.dev.nav.no" />
       <env name="HTTP_PORT" value="8088" />
       <env name="KODEVERK_URL" value="https://kodeverk-api.nav.no/api/v1/kodeverk" />
       <env name="LOGBACK_APPENDER" value="STDOUT" />
       <env name="NAIS_APP_NAME" value="etterlatte-trygdetid" />
       <env name="PEN_CLIENT_ID" value="ddd52335-cfe8-4ee9-9e68-416a5ab26efa" />
       <env name="PEN_URL" value="https://pensjon-pen-q2.dev-fss-pub.nais.io/pen/springapi" />
-      <env name="BRUK_VEDTAK_FRA_BEHANDLING" value="ja" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="no.nav.etterlatte.ApplicationKt" />
     <module name="pensjon-etterlatte-saksbehandling.apps.etterlatte-trygdetid.main" />

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/config/ApplicationContext.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/config/ApplicationContext.kt
@@ -4,7 +4,6 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleProperties
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
-import no.nav.etterlatte.libs.common.EnvEnum
 import no.nav.etterlatte.libs.common.Miljoevariabler
 import no.nav.etterlatte.libs.database.ApplicationProperties
 import no.nav.etterlatte.libs.database.DataSourceBuilder
@@ -18,7 +17,6 @@ import no.nav.etterlatte.trygdetid.klienter.BehandlingKlient
 import no.nav.etterlatte.trygdetid.klienter.GrunnlagKlient
 import no.nav.etterlatte.trygdetid.klienter.PesysKlientImpl
 import no.nav.etterlatte.trygdetid.klienter.VedtaksvurderingBehandlingKlient
-import no.nav.etterlatte.trygdetid.klienter.VedtaksvurderingKlientImpl
 
 class ApplicationContext {
     val config: Config = ConfigFactory.load()
@@ -36,12 +34,7 @@ class ApplicationContext {
     val behandlingKlient = BehandlingKlient(config, httpClient())
     val avtaleService = AvtaleService(avtaleRepository)
 
-    val vedtaksvurderingKlient =
-        if (env[TrygdetidKey.BRUK_VEDTAK_FRA_BEHANDLING] == "ja") {
-            VedtaksvurderingBehandlingKlient(config, httpClient())
-        } else {
-            VedtaksvurderingKlientImpl(config, httpClient())
-        }
+    val vedtaksvurderingKlient = VedtaksvurderingBehandlingKlient(config, httpClient())
 
     val featureToggleService = FeatureToggleService.initialiser(featureToggleProperties(config))
     private val trygdetidRepository = TrygdetidRepository(dataSource)
@@ -57,13 +50,6 @@ class ApplicationContext {
             vedtaksvurderingKlient = vedtaksvurderingKlient,
             featureToggleService = featureToggleService,
         )
-}
-
-enum class TrygdetidKey : EnvEnum {
-    BRUK_VEDTAK_FRA_BEHANDLING,
-    ;
-
-    override fun key() = name
 }
 
 private fun featureToggleProperties(config: Config) =

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/VedtaksvurderingKlient.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/klienter/VedtaksvurderingKlient.kt
@@ -1,19 +1,8 @@
 package no.nav.etterlatte.trygdetid.klienter
 
-import com.fasterxml.jackson.module.kotlin.readValue
-import com.github.michaelbull.result.mapBoth
-import com.typesafe.config.Config
-import io.ktor.client.HttpClient
-import no.nav.etterlatte.libs.common.RetryResult
-import no.nav.etterlatte.libs.common.objectMapper
-import no.nav.etterlatte.libs.common.retry
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.vedtak.VedtakSammendragDto
-import no.nav.etterlatte.libs.ktor.ktor.ktorobo.AzureAdClient
-import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
-import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
-import org.slf4j.LoggerFactory
 
 interface VedtaksvurderingKlient {
     suspend fun hentIverksatteVedtak(
@@ -26,46 +15,3 @@ class VedtaksvurderingKlientException(
     override val message: String,
     override val cause: Throwable,
 ) : Exception(message, cause)
-
-class VedtaksvurderingKlientImpl(
-    config: Config,
-    httpClient: HttpClient,
-) : VedtaksvurderingKlient {
-    private val logger = LoggerFactory.getLogger(this::class.java)
-    private val azureAdClient = AzureAdClient(config)
-    private val downstreamResourceClient = DownstreamResourceClient(azureAdClient, httpClient)
-
-    private val clientId = config.getString("vedtaksvurdering.client.id")
-    private val resourceUrl = config.getString("vedtaksvurdering.resource.url")
-
-    override suspend fun hentIverksatteVedtak(
-        sakId: SakId,
-        brukerTokenInfo: BrukerTokenInfo,
-    ): List<VedtakSammendragDto> {
-        logger.info("Henter iverksatte vedtak for sak=$sakId")
-        return retry<List<VedtakSammendragDto>> {
-            downstreamResourceClient
-                .get(
-                    resource =
-                        Resource(
-                            clientId = clientId,
-                            url = "$resourceUrl/api/vedtak/sak/${sakId.sakId}/iverksatte",
-                        ),
-                    brukerTokenInfo = brukerTokenInfo,
-                ).mapBoth(
-                    success = { resource -> objectMapper.readValue(resource.response.toString()) },
-                    failure = { throwableErrorMessage -> throw throwableErrorMessage },
-                )
-        }.let {
-            when (it) {
-                is RetryResult.Success -> it.content
-                is RetryResult.Failure -> {
-                    throw VedtaksvurderingKlientException(
-                        "Klarte ikke hente iverksatte vedtak for sak=$sakId",
-                        it.samlaExceptions(),
-                    )
-                }
-            }
-        }
-    }
-}

--- a/apps/etterlatte-trygdetid/src/main/resources/application.conf
+++ b/apps/etterlatte-trygdetid/src/main/resources/application.conf
@@ -15,9 +15,6 @@ azure.app.well.known.url = ${?AZURE_APP_WELL_KNOWN_URL}
 behandling.client.id = ${?ETTERLATTE_BEHANDLING_CLIENT_ID}
 behandling.resource.url = ${?ETTERLATTE_BEHANDLING_URL}
 
-vedtaksvurdering.client.id = ${?ETTERLATTE_VEDTAKSVURDERING_CLIENT_ID}
-vedtaksvurdering.resource.url = ${?ETTERLATTE_VEDTAKSVURDERING_URL}
-
 funksjonsbrytere.unleash.applicationName = ${?NAIS_APP_NAME}
 funksjonsbrytere.unleash.host = ${?UNLEASH_SERVER_API_URL}
 funksjonsbrytere.unleash.token = ${?UNLEASH_SERVER_API_TOKEN}

--- a/apps/etterlatte-utbetaling/.nais/dev.yaml
+++ b/apps/etterlatte-utbetaling/.nais/dev.yaml
@@ -99,8 +99,6 @@ spec:
       value: https://etterlatte-proxy.dev-fss-pub.nais.io/aad
     - name: ETTERLATTE_PROXY_SCOPE
       value: api://dev-fss.etterlatte.etterlatte-proxy/.default
-    - name: BRUK_VEDTAK_FRA_BEHANDLING
-      value: "ja"
     - name: GRENSESNITTAVSTEMMING_ENABLED
       value: "true"
     - name: KONSISTENSAVSTEMMING_ENABLED

--- a/apps/etterlatte-utbetaling/.nais/prod.yaml
+++ b/apps/etterlatte-utbetaling/.nais/prod.yaml
@@ -114,8 +114,6 @@ spec:
       value: https://etterlatte-proxy.prod-fss-pub.nais.io/aad
     - name: ETTERLATTE_PROXY_SCOPE
       value: api://prod-fss.etterlatte.etterlatte-proxy/.default
-    - name: BRUK_VEDTAK_FRA_BEHANDLING
-      value: "ja"
     - name: GRENSESNITTAVSTEMMING_ENABLED
       value: "true"
     - name: KONSISTENSAVSTEMMING_ENABLED

--- a/apps/etterlatte-utbetaling/.run/etterlatte-utbetaling.dev-gcp.run.xml
+++ b/apps/etterlatte-utbetaling/.run/etterlatte-utbetaling.dev-gcp.run.xml
@@ -24,14 +24,11 @@
       <env name="GRENSESNITTAVSTEMMING_OMS_ENABLED" value="true" />
       <env name="KONSISTENSAVSTEMMING_ENABLED" value="true" />
       <env name="KONSISTENSAVSTEMMING_OMS_ENABLED" value="true" />
-      <env name="ETTERLATTE_VEDTAK_CLIENT_ID" value="dev-gcp.etterlatte.etterlatte-vedtaksvurdering" />
-      <env name="ETTERLATTE_VEDTAK_URL" value="https://etterlatte-vedtaksvurdering.intern.dev.nav.no" />
       <env name="ETTERLATTE_BEHANDLING_CLIENT_ID" value="dev-gcp.etterlatte.etterlatte-behandling" />
       <env name="ETTERLATTE_BEHANDLING_URL" value="https://etterlatte-behandling.intern.dev.nav.no" />
       <env name="ETTERLATTE_PROXY_SCOPE" value="api://dev-fss.etterlatte.etterlatte-proxy/.default" />
       <env name="ETTERLATTE_PROXY_URL" value="https://etterlatte-proxy.dev-fss-pub.nais.io/aad" />
       <env name="ELECTOR_PATH" value="http://localhost:8096" />
-      <env name="BRUK_VEDTAK_FRA_BEHANDLING" value="ja" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="no.nav.etterlatte.ApplicationKt" />
     <module name="pensjon-etterlatte-saksbehandling.apps.etterlatte-utbetaling.main" />

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationContext.kt
@@ -64,7 +64,7 @@ class ApplicationContext(
     httpClient: HttpClient = httpClient(),
     val behandlingKlient: BehandlingKlient = BehandlingKlient(config, httpClient),
     val vedtaksvurderingKlient: VedtaksvurderingKlient =
-        VedtaksvurderingKlient(config, httpClient, brukEtterlatteBehandling = env[UtbetalingKey.BRUK_VEDTAK_FRA_BEHANDLING] == "ja"),
+        VedtaksvurderingKlient(config, httpClient),
     val simuleringOsKlient: SimuleringOsKlient =
         SimuleringOsKlient(
             config,

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationProperties.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/config/ApplicationProperties.kt
@@ -83,7 +83,6 @@ enum class UtbetalingKey : EnvEnum {
     KONSISTENSAVSTEMMING_ENABLED,
     GRENSESNITTAVSTEMMING_OMS_ENABLED,
     KONSISTENSAVSTEMMING_OMS_ENABLED,
-    BRUK_VEDTAK_FRA_BEHANDLING,
     ;
 
     override fun key() = name

--- a/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/klienter/VedtaksvurderingKlient.kt
+++ b/apps/etterlatte-utbetaling/src/main/kotlin/no/nav/etterlatte/utbetaling/klienter/VedtaksvurderingKlient.kt
@@ -17,33 +17,21 @@ import java.util.UUID
 class VedtaksvurderingKlient(
     config: Config,
     httpClient: HttpClient,
-    private val brukEtterlatteBehandling: Boolean = false,
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     private val azureAdClient = AzureAdClient(config)
     private val downstreamResourceClient = DownstreamResourceClient(azureAdClient, httpClient)
 
-    private val clientId = if (brukEtterlatteBehandling) config.getString("behandling.client.id") else config.getString("vedtak.client.id")
-    private val resourceUrl =
-        if (brukEtterlatteBehandling) {
-            config.getString(
-                "behandling.resource.url",
-            )
-        } else {
-            config.getString("vedtak.resource.url")
-        }
+    private val clientId = config.getString("behandling.client.id")
+    private val resourceUrl = config.getString("behandling.resource.url")
 
     internal suspend fun hentVedtakSimulering(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): VedtakDto {
         try {
-            if (brukEtterlatteBehandling) {
-                logger.info("Henter vedtak for behandlingId=$behandlingId fra etterlatte-behandling.")
-            } else {
-                logger.info("Henter vedtak for behandlingId=$behandlingId")
-            }
+            logger.info("Henter vedtak for behandlingId=$behandlingId")
 
             return downstreamResourceClient
                 .post(

--- a/apps/etterlatte-utbetaling/src/main/resources/application.conf
+++ b/apps/etterlatte-utbetaling/src/main/resources/application.conf
@@ -13,9 +13,6 @@ azure.app.client.secret = ${?AZURE_APP_CLIENT_SECRET}
 azure.app.jwk = ${?AZURE_APP_JWK}
 azure.app.well.known.url = ${?AZURE_APP_WELL_KNOWN_URL}
 
-vedtak.client.id = ${?ETTERLATTE_VEDTAK_CLIENT_ID}
-vedtak.resource.url = ${?ETTERLATTE_VEDTAK_URL}
-
 behandling.client.id = ${?ETTERLATTE_BEHANDLING_CLIENT_ID}
 behandling.resource.url = ${?ETTERLATTE_BEHANDLING_URL}
 

--- a/apps/etterlatte-vedtaksvurdering-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/.nais/dev.yaml
@@ -44,10 +44,6 @@ spec:
       value: earliest
     - name: BEHANDLING_AZURE_SCOPE
       value: api://dev-gcp.etterlatte.etterlatte-behandling/.default
-    - name: VEDTAK_AZURE_SCOPE
-      value: api://dev-gcp.etterlatte.etterlatte-vedtaksvurdering/.default
-    - name: ETTERLATTE_VEDTAK_URL
-      value: http://etterlatte-vedtaksvurdering
     - name: ETTERLATTE_BEHANDLING_URL
       value: http://etterlatte-behandling
     - name: UTBETALING_AZURE_SCOPE
@@ -58,15 +54,12 @@ spec:
       value: api://dev-gcp.etterlatte.etterlatte-brev-api/.default
     - name: ETTERLATTE_BREV_API_URL
       value: http://etterlatte-brev-api
-    - name: BRUK_VEDTAK_FRA_BEHANDLING
-      value: ja
   envFrom:
     - secret: my-application-unleash-api-token
   accessPolicy:
     outbound:
       rules:
         - application: etterlatte-behandling
-        - application: etterlatte-vedtaksvurdering
         - application: etterlatte-utbetaling
         - application: etterlatte-brev-api
         - application: logging

--- a/apps/etterlatte-vedtaksvurdering-kafka/.nais/prod.yaml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/.nais/prod.yaml
@@ -44,10 +44,6 @@ spec:
       value: earliest
     - name: BEHANDLING_AZURE_SCOPE
       value: api://prod-gcp.etterlatte.etterlatte-behandling/.default
-    - name: VEDTAK_AZURE_SCOPE
-      value: api://prod-gcp.etterlatte.etterlatte-vedtaksvurdering/.default
-    - name: ETTERLATTE_VEDTAK_URL
-      value: http://etterlatte-vedtaksvurdering
     - name: ETTERLATTE_BEHANDLING_URL
       value: http://etterlatte-behandling
     - name: UTBETALING_AZURE_SCOPE
@@ -58,15 +54,12 @@ spec:
       value: api://prod-gcp.etterlatte.etterlatte-brev-api/.default
     - name: ETTERLATTE_BREV_API_URL
       value: http://etterlatte-brev-api
-    - name: BRUK_VEDTAK_FRA_BEHANDLING
-      value: ja
   envFrom:
     - secret: my-application-unleash-api-token
   accessPolicy:
     outbound:
       rules:
         - application: etterlatte-behandling
-        - application: etterlatte-vedtaksvurdering
         - application: etterlatte-utbetaling
         - application: etterlatte-brev-api
         - application: logging

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/config/AppBuilder.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/config/AppBuilder.kt
@@ -6,12 +6,9 @@ import io.ktor.client.HttpClient
 import no.nav.etterlatte.EnvKey
 import no.nav.etterlatte.EnvKey.BEHANDLING_AZURE_SCOPE
 import no.nav.etterlatte.EnvKey.UTBETALING_AZURE_SCOPE
-import no.nav.etterlatte.EnvKey.VEDTAK_AZURE_SCOPE
-import no.nav.etterlatte.config.VedtakKafkaKey.BRUK_VEDTAK_FRA_BEHANDLING
 import no.nav.etterlatte.config.VedtakKafkaKey.ETTERLATTE_BEHANDLING_URL
 import no.nav.etterlatte.config.VedtakKafkaKey.ETTERLATTE_BREV_API_URL
 import no.nav.etterlatte.config.VedtakKafkaKey.ETTERLATTE_UTBETALING_URL
-import no.nav.etterlatte.config.VedtakKafkaKey.ETTERLATTE_VEDTAK_URL
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleProperties
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
 import no.nav.etterlatte.klienter.BrevKlient
@@ -30,18 +27,11 @@ class AppBuilder(
     props: Miljoevariabler,
 ) {
     private val behandlingUrl = krevIkkeNull(props[ETTERLATTE_BEHANDLING_URL]) { "Mangler behandling url " }
-    private val vedtakUrl = krevIkkeNull(props[ETTERLATTE_VEDTAK_URL]) { "Mangler vedtak url " }
     private val utbetalingUrl = krevIkkeNull(props[ETTERLATTE_UTBETALING_URL]) { "Mangler utbetaling url " }
     private val brevUrl = krevIkkeNull(props[ETTERLATTE_BREV_API_URL]) { "Mangler brev-api url " }
-    private val brukVedtakFraBehandling = krevIkkeNull(props[BRUK_VEDTAK_FRA_BEHANDLING]) { "Mangler toggle " } == "ja"
     private val env = Miljoevariabler.systemEnv()
 
-    fun lagVedtakKlient(): VedtakServiceImpl =
-        if (brukVedtakFraBehandling) {
-            VedtakServiceImpl(behandlingHttpKlient, behandlingUrl)
-        } else {
-            VedtakServiceImpl(vedtakHttpKlient, vedtakUrl)
-        }
+    fun lagVedtakKlient(): VedtakServiceImpl = VedtakServiceImpl(behandlingHttpKlient, behandlingUrl)
 
     fun lagUtbetalingKlient(): UtbetalingKlient = UtbetalingKlientImpl(utbetalingHttpKlient, utbetalingUrl)
 
@@ -55,15 +45,6 @@ class AppBuilder(
             azureAppJwk = env.requireEnvValue(AZURE_APP_JWK),
             azureAppWellKnownUrl = env.requireEnvValue(AZURE_APP_WELL_KNOWN_URL),
             azureAppScope = env.requireEnvValue(BEHANDLING_AZURE_SCOPE),
-        )
-    }
-
-    private val vedtakHttpKlient: HttpClient by lazy {
-        httpClientClientCredentials(
-            azureAppClientId = props.requireEnvValue(AZURE_APP_CLIENT_ID),
-            azureAppJwk = env.requireEnvValue(AZURE_APP_JWK),
-            azureAppWellKnownUrl = env.requireEnvValue(AZURE_APP_WELL_KNOWN_URL),
-            azureAppScope = env.requireEnvValue(VEDTAK_AZURE_SCOPE),
         )
     }
 
@@ -99,10 +80,8 @@ private fun featureToggleProperties(config: Config) =
 
 enum class VedtakKafkaKey : EnvEnum {
     ETTERLATTE_BEHANDLING_URL,
-    ETTERLATTE_VEDTAK_URL,
     ETTERLATTE_UTBETALING_URL,
     ETTERLATTE_BREV_API_URL,
-    BRUK_VEDTAK_FRA_BEHANDLING,
     ;
 
     override fun key() = name


### PR DESCRIPTION
# Rydder bort  BRUK_VEDTAK_FRA_BEHANDLING flagget
### Hvorfor er denne endringen nødvendig? ✨

Vi er ferdig med migreringen av `etterlatte-vedtaksvurdering` inn i `etterlatte-behandling`. I mellomfasen brukte vi et env flagg (`BRUK_VEDTAK_FRA_BEHANDLING`) til å styre om apper skulle routes mot den gamle `etterlatte-vedtaksvurdering` appen eller nye `etterlatte-behandling`. Nå som migreringen er ferdig og alle apper kjører mot `etterlatte-behandling` blir det riktig å rydde opp:

Apper det gjelder er:

* `etterlatte-utbetaling`
* `etterlatte-beregning`
* `etterlatte-api`
* `etterlatte-vedtaksvurdering-kafka`
* `etterlatte-brev-api`
* `etterlatte-trygdetid`

For hver app er flagget fjernet fra klient implementasjoner, `ApplicationContext`, enums, `application.conf`, nais filer og `.run` configs. Der det fantes to implementasjoner (en mot vedtaksvurdering, en mot behandling) er den gamle fjernet og koden forenklet til kun å peke på `etterlatte-behandling`.

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-27830).