### PR TITLE
Vedtakslinje returnerer tom liste med innvilgede perioder hvis sak ik…

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/Vedtakstidslinje.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/Vedtakstidslinje.kt
@@ -73,6 +73,9 @@ class Vedtakstidslinje(
     }
 
     fun innvilgedePerioder(): List<InnvilgetPeriode> {
+        if (attesterteBehandlingVedtak.isEmpty()) {
+            return emptyList()
+        }
         val foersteVirk = attesterteBehandlingVedtak.minOf { it.virkningstidspunkt }
         val sammenstilt = sammenstill(foersteVirk)
         if (sammenstilt.size == 1) {

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/VedtakstidslinjeTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/VedtakstidslinjeTest.kt
@@ -1063,6 +1063,12 @@ internal class VedtakstidslinjeTest {
             innvilgetPeriode[0].periode.tom shouldBe null
         }
 
+        @Test
+        fun `innvilgedePerioder returnerer tom liste når ingen attesterte vedtak finnes`() {
+            val tidslinje = Vedtakstidslinje(emptyList())
+            tidslinje.innvilgedePerioder() shouldBe emptyList()
+        }
+
         private val Vedtak.utbetalingsperioder: List<Utbetalingsperiode>
             get() = (this.innhold as VedtakInnhold.Behandling).utbetalingsperioder
     }


### PR DESCRIPTION
…ke har noen behandling (som er attestert).

flytter kode fra vedtaksvurderingsapp til behandling. se pr: https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/8552

favro:
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-28638