### PR TITLE
Etter merging av vedtak inn i behandling skal bare etterlatte-behandling app skrive til vedtakshendelser-topic

### DIFF
--- a/.github/workflows/kafka-topics.yaml
+++ b/.github/workflows/kafka-topics.yaml
@@ -1,0 +1,25 @@
+name: Deploy Kafka topics
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy-topic-vedtakshendelser:
+    name: vedtakshendelser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+      - name: dev-gcp
+        uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: apps/etterlatte-behandling/.nais/topic-vedtakshendelser-dev.yaml
+      - name: prod-gcp
+        uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: prod-gcp
+          RESOURCE: apps/etterlatte-behandling/.nais/topic-vedtakshendelser-prod.yaml

--- a/apps/etterlatte-behandling/.nais/topic-vedtakshendelser-dev.yaml
+++ b/apps/etterlatte-behandling/.nais/topic-vedtakshendelser-dev.yaml
@@ -18,9 +18,6 @@ spec:
     - team: etterlatte
       application: etterlatte-behandling
       access: readwrite
-    - team: etterlatte
-      application: etterlatte-vedtaksvurdering
-      access: readwrite
     - team: pensjon-q0
       application: pensjon-pen-q0
       access: read

--- a/apps/etterlatte-behandling/.nais/topic-vedtakshendelser-prod.yaml
+++ b/apps/etterlatte-behandling/.nais/topic-vedtakshendelser-prod.yaml
@@ -18,9 +18,6 @@ spec:
     - team: etterlatte
       application: etterlatte-behandling
       access: readwrite
-    - team: etterlatte
-      application: etterlatte-vedtaksvurdering
-      access: readwrite
     - team: pensjondeployer
       application: pensjon-pen
       access: read

--- a/apps/etterlatte-behandling/README.md
+++ b/apps/etterlatte-behandling/README.md
@@ -67,19 +67,13 @@ lyttes det kun til hendelser om dødsfall hos søker.
 
 Kafka-topic'en **etterlatte.vedtakshendelser** benyttes til dette. Kontakt teamet for tilgang.
 
-Oppdateringer av ACL er ikke automatisk, og må kjøres inn manuelt med `kubectl apply -f <manifest>`.
+Oppdateringer av ACL skjer ikke automatisk ved merge. Kjør GitHub Actions-workflowen
+[Deploy Kafka topics](../../../.github/workflows/kafka-topics.yaml) manuelt etter merge for å oppdatere topics i begge clustere.
 
 | context  | manifest                                |
 |:---------|:----------------------------------------|
 | dev-gcp  | .nais/topic-vedtakshendelser-dev.yaml   |
 | prod-gcp | .nais/topic-vedtakshendelser-prod.yaml  |
-
-#### For å oppdatere endringer i topic yamler kjør dette:
-#### Obs: Må stå samme path som filen(e) og ha riktig context! feks kubectl config use-context dev-gcp
-https://docs.nais.io/persistence/kafka/how-to/create/?h=kafka+topic#apply-the-topic-resource
-```
-kubectl apply -f .nais/topic-vedtakshendelser-dev.yaml
-```
 
 #### Meldingsinnhold
 


### PR DESCRIPTION
Lagde en egen workflow fil som deployer kafka topics. Den må kjøres manuelt, men da slipper man kubectl-kommandoer i dev og prod ved endring av topics.