### PR TITLE
Renamer dodsmelding topic til å hete det samme som i prod: etterlatteytelser

### DIFF
--- a/.github/workflows/kafka-topics.yaml
+++ b/.github/workflows/kafka-topics.yaml
@@ -8,6 +8,23 @@ permissions:
   id-token: write
 
 jobs:
+  deploy-topic-etterlatteytelser:
+    name: etterlatteytelser (rapid)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+      - name: dev-gcp
+        uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: apps/etterlatte-behandling/.nais/topic-etterlatteytelser-dev.yaml
+      # prod-steget utelates inntil dev er verifisert
+      # - name: prod-gcp
+      #   uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1
+      #   env:
+      #     CLUSTER: prod-gcp
+      #     RESOURCE: apps/etterlatte-behandling/.nais/topic-etterlatteytelser-prod.yaml
+
   deploy-topic-vedtakshendelser:
     name: vedtakshendelser
     runs-on: ubuntu-latest

--- a/apps/etterlatte-behandling-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-behandling-kafka/.nais/dev.yaml
@@ -39,7 +39,7 @@ spec:
     min: 1
   env:
     - name: KAFKA_RAPID_TOPIC
-      value: etterlatte.dodsmelding
+      value: etterlatte.etterlatteytelser
     - name: KAFKA_RESET_POLICY
       value: latest
     - name: BEHANDLING_AZURE_SCOPE

--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -84,7 +84,7 @@ spec:
     - name: JOBB_METRIKKER_OPENING_HOURS
       value: "07-18"
     - name: KAFKA_RAPID_TOPIC
-      value: etterlatte.dodsmelding
+      value: etterlatte.etterlatteytelser
     - name: KAFKA_VEDTAKSHENDELSER_TOPIC
       value: etterlatte.vedtakshendelser
     - name: PDLTJENESTER_AZURE_SCOPE

--- a/apps/etterlatte-behandling/.nais/topic-etterlatteytelser-dev.yaml
+++ b/apps/etterlatte-behandling/.nais/topic-etterlatteytelser-dev.yaml
@@ -1,0 +1,84 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: etterlatteytelser
+  namespace: etterlatte
+  labels:
+    team: etterlatte
+spec:
+  pool: nav-dev
+  config:
+    cleanupPolicy: delete
+    localRetentionBytes: -2
+    localRetentionHours: -2
+    maxMessageBytes: 1048588
+    minimumInSyncReplicas: 2
+    partitions: 1
+    replication: 3
+    retentionBytes: -1
+    retentionHours: 336
+    segmentHours: 168
+  acl:
+    - team: etterlatte
+      application: innsendt-soeknad
+      access: readwrite
+    - team: etterlatte
+      application: selvbetjening-api
+      access: readwrite
+    - team: etterlatte
+      application: selvbetjening-backend
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-kafka-manager
+      access: read
+    - team: etterlatte
+      application: etterlatte-notifikasjoner
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-testdata
+      access: write
+    - team: etterlatte
+      application: etterlatte-testdata-behandler
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-brev-api
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-behandling
+      access: write
+    - team: etterlatte
+      application: etterlatte-behandling-kafka
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-beregning-kafka
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-brev-kafka
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-hendelser-pdl
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-hendelser-samordning
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-statistikk
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-tidshendelser
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-tilbakekreving
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-trygdetid-kafka
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-utbetaling
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-vedtaksvurdering
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-vedtaksvurdering-kafka
+      access: readwrite

--- a/apps/etterlatte-behandling/.nais/topic-etterlatteytelser-dev.yaml
+++ b/apps/etterlatte-behandling/.nais/topic-etterlatteytelser-dev.yaml
@@ -19,11 +19,9 @@ spec:
     retentionHours: 336
     segmentHours: 168
   acl:
+    # Felles (dev og prod)
     - team: etterlatte
       application: innsendt-soeknad
-      access: readwrite
-    - team: etterlatte
-      application: selvbetjening-api
       access: readwrite
     - team: etterlatte
       application: selvbetjening-backend
@@ -35,22 +33,16 @@ spec:
       application: etterlatte-notifikasjoner
       access: readwrite
     - team: etterlatte
-      application: etterlatte-testdata
-      access: write
-    - team: etterlatte
-      application: etterlatte-testdata-behandler
-      access: readwrite
-    - team: etterlatte
-      application: etterlatte-brev-api
-      access: readwrite
-    - team: etterlatte
       application: etterlatte-behandling
-      access: write
+      access: readwrite
     - team: etterlatte
       application: etterlatte-behandling-kafka
       access: readwrite
     - team: etterlatte
       application: etterlatte-beregning-kafka
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-brev-api
       access: readwrite
     - team: etterlatte
       application: etterlatte-brev-kafka
@@ -68,17 +60,21 @@ spec:
       application: etterlatte-tidshendelser
       access: readwrite
     - team: etterlatte
-      application: etterlatte-tilbakekreving
-      access: readwrite
-    - team: etterlatte
       application: etterlatte-trygdetid-kafka
       access: readwrite
     - team: etterlatte
       application: etterlatte-utbetaling
       access: readwrite
     - team: etterlatte
-      application: etterlatte-vedtaksvurdering
+      application: etterlatte-vedtaksvurdering-kafka
+      access: readwrite
+    # Kun dev
+    - team: etterlatte
+      application: selvbetjening-api
       access: readwrite
     - team: etterlatte
-      application: etterlatte-vedtaksvurdering-kafka
+      application: etterlatte-testdata
+      access: write
+    - team: etterlatte
+      application: etterlatte-testdata-behandler
       access: readwrite

--- a/apps/etterlatte-behandling/.nais/topic-etterlatteytelser-prod.yaml
+++ b/apps/etterlatte-behandling/.nais/topic-etterlatteytelser-prod.yaml
@@ -1,0 +1,72 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: etterlatteytelser
+  namespace: etterlatte
+  labels:
+    team: etterlatte
+spec:
+  pool: nav-prod
+  config:
+    cleanupPolicy: delete
+    localRetentionBytes: -2
+    localRetentionHours: -2
+    maxMessageBytes: 1048588
+    minimumInSyncReplicas: 2
+    partitions: 1
+    replication: 3
+    retentionBytes: -1
+    retentionHours: 336
+    segmentHours: 168
+  acl:
+    - team: etterlatte
+      application: innsendt-soeknad
+      access: readwrite
+    - team: etterlatte
+      application: selvbetjening-backend
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-kafka-manager
+      access: read
+    - team: etterlatte
+      application: etterlatte-notifikasjoner
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-behandling
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-behandling-kafka
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-vedtaksvurdering
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-statistikk
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-brev-api
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-utbetaling
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-hendelser-pdl
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-beregning-kafka
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-vedtaksvurdering-kafka
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-tidshendelser
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-trygdetid-kafka
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-hendelser-samordning
+      access: readwrite
+    - team: etterlatte
+      application: etterlatte-brev-kafka
+      access: readwrite

--- a/apps/etterlatte-behandling/.nais/topic-etterlatteytelser-prod.yaml
+++ b/apps/etterlatte-behandling/.nais/topic-etterlatteytelser-prod.yaml
@@ -38,25 +38,22 @@ spec:
       application: etterlatte-behandling-kafka
       access: readwrite
     - team: etterlatte
-      application: etterlatte-vedtaksvurdering
-      access: readwrite
-    - team: etterlatte
-      application: etterlatte-statistikk
+      application: etterlatte-beregning-kafka
       access: readwrite
     - team: etterlatte
       application: etterlatte-brev-api
       access: readwrite
     - team: etterlatte
-      application: etterlatte-utbetaling
+      application: etterlatte-brev-kafka
       access: readwrite
     - team: etterlatte
       application: etterlatte-hendelser-pdl
       access: readwrite
     - team: etterlatte
-      application: etterlatte-beregning-kafka
+      application: etterlatte-hendelser-samordning
       access: readwrite
     - team: etterlatte
-      application: etterlatte-vedtaksvurdering-kafka
+      application: etterlatte-statistikk
       access: readwrite
     - team: etterlatte
       application: etterlatte-tidshendelser
@@ -65,8 +62,8 @@ spec:
       application: etterlatte-trygdetid-kafka
       access: readwrite
     - team: etterlatte
-      application: etterlatte-hendelser-samordning
+      application: etterlatte-utbetaling
       access: readwrite
     - team: etterlatte
-      application: etterlatte-brev-kafka
+      application: etterlatte-vedtaksvurdering-kafka
       access: readwrite

--- a/apps/etterlatte-beregning-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-beregning-kafka/.nais/dev.yaml
@@ -39,7 +39,7 @@ spec:
     min: 1
   env:
     - name: KAFKA_RAPID_TOPIC
-      value: etterlatte.dodsmelding
+      value: etterlatte.etterlatteytelser
     - name: KAFKA_RESET_POLICY
       #sette tilbake til none senere
       value: earliest

--- a/apps/etterlatte-brev-api/.nais/dev.yaml
+++ b/apps/etterlatte-brev-api/.nais/dev.yaml
@@ -93,7 +93,7 @@ spec:
     - name: DOKDISTKANAL_CLIENT_ID
       value: dev-fss.teamdokumenthandtering.dokdistkanal
     - name: KAFKA_RAPID_TOPIC
-      value: etterlatte.dodsmelding
+      value: etterlatte.etterlatteytelser
     - name: REGOPPSLAG_SCOPE
       value: api://dev-fss.teamdokumenthandtering.regoppslag/.default
     - name: REGOPPSLAG_URL

--- a/apps/etterlatte-brev-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-brev-kafka/.nais/dev.yaml
@@ -45,7 +45,7 @@ spec:
     - name: KAFKA_RESET_POLICY
       value: latest
     - name: KAFKA_RAPID_TOPIC
-      value: etterlatte.dodsmelding
+      value: etterlatte.etterlatteytelser
     - name: BREV_API_URL
       value: http://etterlatte-brev-api
     - name: BREV_API_AZURE_SCOPE

--- a/apps/etterlatte-hendelser-pdl/.nais/dev.yaml
+++ b/apps/etterlatte-hendelser-pdl/.nais/dev.yaml
@@ -38,7 +38,7 @@ spec:
     min: 1
   env:
     - name: KAFKA_RAPID_TOPIC
-      value: etterlatte.dodsmelding
+      value: etterlatte.etterlatteytelser
     - name: KAFKA_RESET_POLICY
       value: latest
     - name: KAFKA_CONSUMER_GROUP_ID

--- a/apps/etterlatte-hendelser-samordning/.nais/dev.yaml
+++ b/apps/etterlatte-hendelser-samordning/.nais/dev.yaml
@@ -38,7 +38,7 @@ spec:
     min: 1
   env:
     - name: KAFKA_RAPID_TOPIC
-      value: etterlatte.dodsmelding
+      value: etterlatte.etterlatteytelser
     - name: KAFKA_RESET_POLICY
       value: earliest
     - name: SAMORDNINGVEDTAK_HENDELSE_GROUP_ID

--- a/apps/etterlatte-hendelser-ufoere/.nais/dev.yaml
+++ b/apps/etterlatte-hendelser-ufoere/.nais/dev.yaml
@@ -38,7 +38,7 @@ spec:
     min: 1
   env:
     - name: KAFKA_RAPID_TOPIC
-      value: etterlatte.dodsmelding
+      value: etterlatte.etterlatteytelser
     - name: KAFKA_RESET_POLICY
       value: latest
     - name: UFOERE_KAFKA_GROUP_ID

--- a/apps/etterlatte-statistikk/.nais/dev.yaml
+++ b/apps/etterlatte-statistikk/.nais/dev.yaml
@@ -48,7 +48,7 @@ spec:
       enabled: true
   env:
     - name: KAFKA_RAPID_TOPIC
-      value: etterlatte.dodsmelding
+      value: etterlatte.etterlatteytelser
     - name: BEHANDLING_AZURE_SCOPE
       value: api://dev-gcp.etterlatte.etterlatte-behandling/.default
     - name: BEREGNING_AZURE_SCOPE

--- a/apps/etterlatte-testdata-behandler/.nais/dev.yaml
+++ b/apps/etterlatte-testdata-behandler/.nais/dev.yaml
@@ -40,7 +40,7 @@ spec:
     pool: nav-dev
   env:
     - name: KAFKA_RAPID_TOPIC
-      value: etterlatte.dodsmelding
+      value: etterlatte.etterlatteytelser
     - name: KAFKA_RESET_POLICY
       value: earliest
     - name: BEHANDLING_AZURE_SCOPE

--- a/apps/etterlatte-testdata/.nais/dev.yaml
+++ b/apps/etterlatte-testdata/.nais/dev.yaml
@@ -53,7 +53,7 @@ spec:
     pool: nav-dev
   env:
     - name: KAFKA_TARGET_TOPIC
-      value: etterlatte.dodsmelding
+      value: etterlatte.etterlatteytelser
     - name: DOLLY_CLIENT_ID
       value: dev-gcp.dolly.dolly-backend
     - name: DOLLY_RESOURCE_URL

--- a/apps/etterlatte-tidshendelser/.nais/dev.yaml
+++ b/apps/etterlatte-tidshendelser/.nais/dev.yaml
@@ -47,7 +47,7 @@ spec:
     min: 1
   env:
     - name: KAFKA_RAPID_TOPIC
-      value: etterlatte.dodsmelding
+      value: etterlatte.etterlatteytelser
     - name: KAFKA_RESET_POLICY
       value: earliest
     - name: JOBB_POLLER_INITIAL_DELAY

--- a/apps/etterlatte-trygdetid-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-trygdetid-kafka/.nais/dev.yaml
@@ -39,7 +39,7 @@ spec:
     min: 1
   env:
     - name: KAFKA_RAPID_TOPIC
-      value: etterlatte.dodsmelding
+      value: etterlatte.etterlatteytelser
     - name: KAFKA_RESET_POLICY
       #sette tilbake til none senere
       value: earliest

--- a/apps/etterlatte-utbetaling/.nais/dev.yaml
+++ b/apps/etterlatte-utbetaling/.nais/dev.yaml
@@ -69,7 +69,7 @@ spec:
     min: 1
   env:
     - name: KAFKA_RAPID_TOPIC
-      value: etterlatte.dodsmelding
+      value: etterlatte.etterlatteytelser
     - name: KAFKA_RESET_POLICY
       #sette tilbake til none senere
       value: latest

--- a/apps/etterlatte-vedtaksvurdering-kafka/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/.nais/dev.yaml
@@ -39,7 +39,7 @@ spec:
     min: 1
   env:
     - name: KAFKA_RAPID_TOPIC
-      value: etterlatte.dodsmelding
+      value: etterlatte.etterlatteytelser
     - name: KAFKA_RESET_POLICY
       value: earliest
     - name: BEHANDLING_AZURE_SCOPE

--- a/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
+++ b/apps/etterlatte-vedtaksvurdering/.nais/dev.yaml
@@ -70,7 +70,7 @@ spec:
     - name: JOBB_METRIKKER_OPENING_HOURS
       value: "07-18"
     - name: KAFKA_RAPID_TOPIC
-      value: etterlatte.dodsmelding
+      value: etterlatte.etterlatteytelser
     - name: KAFKA_VEDTAKSHENDELSER_TOPIC
       value: etterlatte.vedtakshendelser
     - name: ETTERLATTE_BEREGNING_CLIENT_ID


### PR DESCRIPTION
Legger inn topic.yaml filer for dokumentasjon. Har brukt samme config som dodsmelding-topicet i dev. 
Har også lagt til dev-topicet for etterlatteytelser i deploy-fil for topics, slik at den blir oppdatert. Venter med å legge i prod deploy av topic til at det er verifisert at dette virker som forventet.

Ny ACL har tatt utgangspunkt i hvordan dodsmeldinger sin ACL så ut i dev. Med bruk av AI har noen apper blitt fjernet i ny ACL:
  | App | Årsak |
   |-----|-------|
   | `dodsfall-fra-leesah` | Erstattet av `etterlatte-hendelser-pdl` |
   | `journalfoer-soeknad` | Erstattet av `etterlatte-hendelser-joark` |
   | `sjekk-adressebeskyttelse` | Absorbert i `etterlatte-behandling` |
   | `etterlatte-fordeler` / `test-fordeler` | Slettet, funksjonalitet i `etterlatte-behandling-kafka` |
   | `etterlatte-opplysninger-fra-soeknad` | Slettet, funksjonalitet i `etterlatte-behandling-kafka` |
   | `etterlatte-oppdater-behandling` | Gammelt navn, ble `etterlatte-behandling-kafka` |
   | `etterlatte-gyldig-soeknad` | Slettet, funksjonalitet i `etterlatte-behandling-kafka` |
   | `etterlatte-opplysninger-fra-pdl` | Slettet 2023 |
   | `etterlatte-grunnlag` | Slettet feb 2025, merget inn i `etterlatte-behandling` |
   | `etterlatte-vilkaarsvurdering-kafka` | Slettet feb 2025, merget inn i `etterlatte-behandling` |
   | `etterlatte-migrering` | Slettet mar 2025 |
   | `start-regulering` | Erstattet av `etterlatte-tidshendelser` |
   | `etterlatte-tilbakekreving` | Bruker kun MQ og REST |

  Det ser ut til at etterlatte-brev-api ikke fantes i dev acl ved en feil, så denne er nå lagt til.

Prod sin ACL skal nå være helt lik, med unntak av dev-spesifikke apper som selvbetjening-api, etterlatte-testdata og etterlatte-testdata-behandler.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-28761