### PR TITLE
Splitter opp trygdetidsgrunnlaget i egne faktumnoder

### DIFF
--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidBeregningService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidBeregningService.kt
@@ -7,7 +7,6 @@ import no.nav.etterlatte.libs.regler.KonstantGrunnlag
 import no.nav.etterlatte.libs.regler.RegelPeriode
 import no.nav.etterlatte.libs.regler.RegelkjoeringResultat
 import no.nav.etterlatte.libs.regler.eksekver
-import no.nav.etterlatte.trygdetid.regler.TrygdetidGrunnlagMedAvdoed
 import no.nav.etterlatte.trygdetid.regler.TrygdetidGrunnlagMedAvdoedGrunnlag
 import no.nav.etterlatte.trygdetid.regler.TrygdetidPeriodeGrunnlag
 import no.nav.etterlatte.trygdetid.regler.TrygdetidPeriodeMedPoengaar
@@ -40,19 +39,42 @@ object TrygdetidBeregningService {
 
         val grunnlag =
             TrygdetidGrunnlagMedAvdoedGrunnlag(
-                FaktumNode(
-                    verdi =
-                        TrygdetidGrunnlagMedAvdoed(
-                            trygdetidGrunnlagListe = trygdetidGrunnlag,
-                            foedselsDato = foedselsDato,
-                            doedsDato = doedsDato,
-                            norskPoengaar = norskPoengaar,
-                            yrkesskade = yrkesskade,
-                            nordiskKonvensjon = nordiskKonvensjon,
-                        ),
-                    kilde = "System",
-                    beskrivelse = "Beregn detaljert trygdetidsgrunnlag",
-                ),
+                trygdetidGrunnlagListe =
+                    FaktumNode(
+                        verdi = trygdetidGrunnlag,
+                        kilde = "System",
+                        beskrivelse = "Trygdetidsperioder",
+                    ),
+                foedselsDato =
+                    FaktumNode(
+                        verdi = foedselsDato,
+                        kilde = "System",
+                        beskrivelse = "Fødselsdato",
+                    ),
+                doedsDato =
+                    FaktumNode(
+                        verdi = doedsDato,
+                        kilde = "System",
+                        beskrivelse = "Dødsdato",
+                    ),
+                norskPoengaar =
+                    FaktumNode(
+                        verdi = norskPoengaar,
+                        kilde = "System",
+                        beskrivelse = "Norske poengår",
+                    ),
+                yrkesskade =
+                    FaktumNode(
+                        verdi = yrkesskade,
+                        kilde = "System",
+                        beskrivelse = "Yrkesskade",
+                    ),
+                nordiskKonvensjon =
+                    FaktumNode(
+                        verdi = nordiskKonvensjon,
+                        kilde = "System",
+                        beskrivelse = "Nordisk konvensjon",
+                    ),
             )
 
         val resultat =

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/regler/BeregnTrygdetid.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/regler/BeregnTrygdetid.kt
@@ -49,25 +49,21 @@ data class TrygdetidPar<T>(
     val teoretisk: T,
 )
 
-data class TrygdetidGrunnlagMedAvdoed(
-    val trygdetidGrunnlagListe: List<TrygdetidGrunnlag>,
-    val foedselsDato: LocalDate,
-    val doedsDato: LocalDate,
-    val norskPoengaar: Int?,
-    val yrkesskade: Boolean,
-    val nordiskKonvensjon: Boolean,
-)
-
 data class TrygdetidGrunnlagMedAvdoedGrunnlag(
-    val trygdetidGrunnlagMedAvdoed: FaktumNode<TrygdetidGrunnlagMedAvdoed>,
+    val trygdetidGrunnlagListe: FaktumNode<List<TrygdetidGrunnlag>>,
+    val foedselsDato: FaktumNode<LocalDate>,
+    val doedsDato: FaktumNode<LocalDate>,
+    val norskPoengaar: FaktumNode<Int?>,
+    val yrkesskade: FaktumNode<Boolean>,
+    val nordiskKonvensjon: FaktumNode<Boolean>,
 )
 
 val nordiskKonvensjon: Regel<TrygdetidGrunnlagMedAvdoedGrunnlag, Boolean> =
     finnFaktumIGrunnlag(
         gjelderFra = TRYGDETID_DATO,
         beskrivelse = "Hent nordisk konvensjon",
-        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::trygdetidGrunnlagMedAvdoed,
-        finnFelt = { it.nordiskKonvensjon },
+        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::nordiskKonvensjon,
+        finnFelt = { it },
     )
 
 val dagerPrMaanedTrygdetidGrunnlag =
@@ -78,41 +74,44 @@ val dagerPrMaanedTrygdetidGrunnlag =
         verdi = 30,
     )
 
-data class Opptjeningsdatoer(
-    val foedselsDato: LocalDate,
-    val doedsDato: LocalDate,
-)
-
-val opptjeningsDatoer: Regel<TrygdetidGrunnlagMedAvdoedGrunnlag, Opptjeningsdatoer> =
+val foedselsDato: Regel<TrygdetidGrunnlagMedAvdoedGrunnlag, LocalDate> =
     finnFaktumIGrunnlag(
         gjelderFra = TRYGDETID_DATO,
-        beskrivelse = "Hent foedselsdato og doedsdato",
-        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::trygdetidGrunnlagMedAvdoed,
-        finnFelt = { Opptjeningsdatoer(foedselsDato = it.foedselsDato, doedsDato = it.doedsDato) },
+        beskrivelse = "Hent fødselsdato",
+        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::foedselsDato,
+        finnFelt = { it },
+    )
+
+val doedsDato: Regel<TrygdetidGrunnlagMedAvdoedGrunnlag, LocalDate> =
+    finnFaktumIGrunnlag(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Hent dødsdato",
+        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::doedsDato,
+        finnFelt = { it },
     )
 
 val antallPoengaarINorge: Regel<TrygdetidGrunnlagMedAvdoedGrunnlag, Int?> =
     finnFaktumIGrunnlag(
         gjelderFra = TRYGDETID_DATO,
         beskrivelse = "Finner antall poengår i Norge for overstyring av norske TT perioder",
-        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::trygdetidGrunnlagMedAvdoed,
-        finnFelt = { it.norskPoengaar },
+        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::norskPoengaar,
+        finnFelt = { it },
     )
 
 val erYrkesskade: Regel<TrygdetidGrunnlagMedAvdoedGrunnlag, Boolean> =
     finnFaktumIGrunnlag(
         gjelderFra = TRYGDETID_DATO,
         beskrivelse = "Er dette yrkesskade",
-        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::trygdetidGrunnlagMedAvdoed,
-        finnFelt = { it.yrkesskade },
+        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::yrkesskade,
+        finnFelt = { it },
     )
 
 val trygdetidGrunnlagListe: Regel<TrygdetidGrunnlagMedAvdoedGrunnlag, List<TrygdetidGrunnlag>> =
     finnFaktumIGrunnlag(
         gjelderFra = TRYGDETID_DATO,
         beskrivelse = "Grunnlag liste med poengår",
-        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::trygdetidGrunnlagMedAvdoed,
-        finnFelt = { it.trygdetidGrunnlagListe },
+        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::trygdetidGrunnlagListe,
+        finnFelt = { it },
     )
 
 /**
@@ -210,18 +209,19 @@ val finnDatoerForOpptjeningstid =
         gjelderFra = TRYGDETID_DATO,
         beskrivelse = "Konverter foedselsdato og doedsdato eller start fremtidig trygdetid til opptjeningsdatoer",
         regelReferanse = RegelReferanse(id = "REGEL-BEREGN-OPPTJENINGSDATOER", versjon = "2.1"),
-    ) benytter opptjeningsDatoer og fremtidigTrygdetidFra med {
-        opptjeningsDatoer,
+    ) benytter foedselsDato og doedsDato og fremtidigTrygdetidFra med {
+        foedt,
+        doed,
         fremtidigFra,
         ->
         val opptjeningTil =
             if (fremtidigFra != null) {
                 fremtidigFra.withDayOfMonth(1).minusDays(1)
             } else {
-                opptjeningsDatoer.doedsDato.withDayOfMonth(1).minusDays(1)
+                doed.withDayOfMonth(1).minusDays(1)
             }
         Pair(
-            opptjeningsDatoer.foedselsDato.plusYears(16),
+            foedt.plusYears(16),
             opptjeningTil,
         )
     }
@@ -543,13 +543,17 @@ val beregnDetaljertBeregnetTrygdetidMedYrkesskade =
         regelReferanse = RegelReferanse(id = "REGEL-TOTAL-DETALJERT-TRYGDETID-YS"),
     ) benytter beregnDetaljertBeregnetTrygdetid og erYrkesskade med { trygdetid, erYrkesskade ->
         when (erYrkesskade) {
-            false -> trygdetid
-            true ->
+            false -> {
+                trygdetid
+            }
+
+            true -> {
                 trygdetid.copy(
                     yrkesskade = true,
                     beregnetSamletTrygdetidNorge = trygdetid.samletTrygdetidNorge,
                     samletTrygdetidNorge = 40,
                 )
+            }
         }
     }
 

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/regler/BeregnTrygdetidTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/regler/BeregnTrygdetidTest.kt
@@ -137,22 +137,45 @@ internal class BeregnTrygdetidTest {
         norskPoengaar: Int?,
         yrkesskade: Boolean,
     ) {
-        val grunnlag =
-            FaktumNode(
-                verdi =
-                    TrygdetidGrunnlagMedAvdoed(
-                        trygdetidGrunnlagListe = perioder,
-                        foedselsDato = datoer?.first ?: LocalDate.of(1981, 2, 21),
-                        doedsDato = datoer?.second ?: LocalDate.of(2023, 3, 15),
-                        norskPoengaar = norskPoengaar,
-                        yrkesskade = yrkesskade,
-                        nordiskKonvensjon = false,
+        val trygdetidGrunnlagMedAvdoedGrunnlag =
+            TrygdetidGrunnlagMedAvdoedGrunnlag(
+                trygdetidGrunnlagListe =
+                    FaktumNode(
+                        verdi = perioder,
+                        kilde = Grunnlagsopplysning.Saksbehandler("Z12345", Tidspunkt.now()),
+                        beskrivelse = "Trygdetidsperioder",
                     ),
-                kilde = Grunnlagsopplysning.Saksbehandler("Z12345", Tidspunkt.now()),
-                beskrivelse = "Perioder",
+                foedselsDato =
+                    FaktumNode(
+                        verdi = datoer?.first ?: LocalDate.of(1981, 2, 21),
+                        kilde = Grunnlagsopplysning.Saksbehandler("Z12345", Tidspunkt.now()),
+                        beskrivelse = "Fødselsdato",
+                    ),
+                doedsDato =
+                    FaktumNode(
+                        verdi = datoer?.second ?: LocalDate.of(2023, 3, 15),
+                        kilde = Grunnlagsopplysning.Saksbehandler("Z12345", Tidspunkt.now()),
+                        beskrivelse = "Dødsdato",
+                    ),
+                norskPoengaar =
+                    FaktumNode(
+                        verdi = norskPoengaar,
+                        kilde = Grunnlagsopplysning.Saksbehandler("Z12345", Tidspunkt.now()),
+                        beskrivelse = "Norske poengår",
+                    ),
+                yrkesskade =
+                    FaktumNode(
+                        verdi = yrkesskade,
+                        kilde = Grunnlagsopplysning.Saksbehandler("Z12345", Tidspunkt.now()),
+                        beskrivelse = "Yrkesskade",
+                    ),
+                nordiskKonvensjon =
+                    FaktumNode(
+                        verdi = false,
+                        kilde = Grunnlagsopplysning.Saksbehandler("Z12345", Tidspunkt.now()),
+                        beskrivelse = "Nordisk konvensjon",
+                    ),
             )
-
-        val trygdetidGrunnlagMedAvdoedGrunnlag = TrygdetidGrunnlagMedAvdoedGrunnlag(grunnlag)
 
         val resultat =
             beregnDetaljertBeregnetTrygdetidMedYrkesskade.anvend(


### PR DESCRIPTION
Dette gir et mindre tre å lagre når vi lagrer resultatet av trygdetidsberegningen, uten at vi mister noe av informasjonen (den blir lettere å følge). 