### PR TITLE
Status på etteroppgjør er "venter på svar"

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerModel.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerModel.kt
@@ -18,11 +18,7 @@ data class Etteroppgjoer(
     val harOverstyrtBeregning: Boolean = false,
     val sisteFerdigstilteForbehandling: UUID? = null,
 ) {
-    fun venterPaaSkatteoppgjoer() =
-        status in
-            listOf(
-                EtteroppgjoerStatus.VENTER_PAA_SKATTEOPPGJOER,
-            )
+    fun venterPaaSkatteoppgjoer() = status == EtteroppgjoerStatus.VENTER_PAA_SKATTEOPPGJOER
 
     fun mottattSkatteoppgjoer() = status == EtteroppgjoerStatus.MOTTATT_SKATTEOPPGJOER
 
@@ -31,8 +27,6 @@ data class Etteroppgjoer(
 
     fun kanOppretteForbehandling() =
         status in listOf(EtteroppgjoerStatus.MANGLER_SKATTEOPPGJOER, EtteroppgjoerStatus.MOTTATT_SKATTEOPPGJOER)
-
-    fun erFerdigstilt() = status == EtteroppgjoerStatus.FERDIGSTILT
 
     fun kanOppdateresMedSkatteoppgjoerMottatt(): Boolean = venterPaaSkatteoppgjoer() || mottattSkatteoppgjoer()
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerService.kt
@@ -3,6 +3,14 @@ package no.nav.etterlatte.behandling.etteroppgjoer
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.BehandlingService
 import no.nav.etterlatte.behandling.domain.Behandling
+import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerStatus.FERDIGSTILT
+import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerStatus.MANGLER_SKATTEOPPGJOER
+import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerStatus.MOTTATT_SKATTEOPPGJOER
+import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerStatus.OMGJOERING
+import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerStatus.UNDER_FORBEHANDLING
+import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerStatus.UNDER_REVURDERING
+import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerStatus.VENTER_PAA_SKATTEOPPGJOER
+import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerStatus.VENTER_PAA_SVAR
 import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.EtteroppgjoerForbehandling
 import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.FantIkkeEtteroppgjoer
 import no.nav.etterlatte.behandling.etteroppgjoer.oppgave.EtteroppgjoerOppgaveService
@@ -17,7 +25,6 @@ import no.nav.etterlatte.libs.common.behandling.etteroppgjoer.EtteroppgjoerHende
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerResultatType
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
-import no.nav.etterlatte.libs.common.feilhaandtering.krev
 import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.sak.SakId
@@ -120,7 +127,7 @@ class EtteroppgjoerService(
         val nyEtteroppgjoerStatus = finnStatusForForbehandling(forbehandling)
         val hendelse =
             when (nyEtteroppgjoerStatus) {
-                EtteroppgjoerStatus.FERDIGSTILT -> EtteroppgjoerHendelser.FERDIGSTILT
+                FERDIGSTILT -> EtteroppgjoerHendelser.FERDIGSTILT
                 else -> null
             }
 
@@ -140,30 +147,46 @@ class EtteroppgjoerService(
         etteroppgjoer: Etteroppgjoer,
         sak: Sak,
     ) {
-        if (etteroppgjoer.status === EtteroppgjoerStatus.FERDIGSTILT) {
-            etteroppgjoerOppgaveService.opprettVurderKonsekvensOppgaveForFerdigstiltEtteroppgjoer(sak.id, etteroppgjoer.inntektsaar)
-            logger.info(
-                "Mottok skatteoppgjørhendelse for sakId=${sak.id}, men etteroppgjør for ${etteroppgjoer.inntektsaar} er ferdigstilt - oppretter vurder konsekvens oppgave",
-            )
-            return
+        when (etteroppgjoer.status) {
+            MOTTATT_SKATTEOPPGJOER,
+            VENTER_PAA_SKATTEOPPGJOER,
+            -> {
+                oppdaterEtteroppgjoerStatus(
+                    sak.id,
+                    etteroppgjoer.inntektsaar,
+                    MOTTATT_SKATTEOPPGJOER,
+                    EtteroppgjoerHendelser.MOTTATT_SKATTEOPPGJOER,
+                )
+
+                etteroppgjoerOppgaveService.opprettOppgaveForOpprettForbehandling(
+                    sakId = sak.id,
+                    inntektsAar = etteroppgjoer.inntektsaar,
+                )
+            }
+
+            VENTER_PAA_SVAR -> {
+                // Vi gjør ikke noe for hendelser hvor vi allerede har startet behandling. Vi vil fange opp inntektsendringer i validering før iverksetting i slike tilfeller.
+                logger.info("Mottok skatteoppgjørhendelse for sakId=${sak.id}: status $etteroppgjoer.")
+            }
+
+            FERDIGSTILT -> {
+                etteroppgjoerOppgaveService.opprettVurderKonsekvensOppgaveForFerdigstiltEtteroppgjoer(sak.id, etteroppgjoer.inntektsaar)
+                logger.info(
+                    "Mottok skatteoppgjørhendelse for sakId=${sak.id}, men etteroppgjør for ${etteroppgjoer.inntektsaar} er ferdigstilt - oppretter vurder konsekvens oppgave",
+                )
+            }
+
+            MANGLER_SKATTEOPPGJOER,
+            UNDER_FORBEHANDLING,
+            UNDER_REVURDERING,
+            OMGJOERING,
+            -> {
+                logger.error(
+                    "Mottok skatteoppgjørhendelse for sakId=${sak.id}, men etteroppgjør har status som ikke håndteres: ${etteroppgjoer.status}. ",
+                )
+                throw InternfeilException("Ikke håndtert status på etteroppgjør: ${etteroppgjoer.status}")
+            }
         }
-
-        krev(etteroppgjoer.kanOppdateresMedSkatteoppgjoerMottatt()) {
-            "Mottok skatteoppgjørhendelse for sakId=${sak.id}, men etteroppgjør har status ${etteroppgjoer.status}. " +
-                "Se sikkerlogg for mer informasjon."
-        }
-
-        oppdaterEtteroppgjoerStatus(
-            sak.id,
-            etteroppgjoer.inntektsaar,
-            EtteroppgjoerStatus.MOTTATT_SKATTEOPPGJOER,
-            EtteroppgjoerHendelser.MOTTATT_SKATTEOPPGJOER,
-        )
-
-        etteroppgjoerOppgaveService.opprettOppgaveForOpprettForbehandling(
-            sakId = sak.id,
-            inntektsAar = etteroppgjoer.inntektsaar,
-        )
     }
 
     fun opprettNyttEtteroppgjoer(
@@ -207,7 +230,7 @@ class EtteroppgjoerService(
                     sakId,
                     inntektsaar,
                     sisteIverksatteBehandling,
-                    eksisterendeEtteroppgjoer?.status ?: EtteroppgjoerStatus.VENTER_PAA_SKATTEOPPGJOER,
+                    eksisterendeEtteroppgjoer?.status ?: VENTER_PAA_SKATTEOPPGJOER,
                     harVedtakAvTypeOpphoer || sisteIverksatteBehandling.opphoerFraOgMed != null,
                     eksisterendeEtteroppgjoer?.sisteFerdigstilteForbehandling,
                 )
@@ -255,7 +278,7 @@ class EtteroppgjoerService(
                         .oppdaterEtteroppgjoerStatus(
                             sakId,
                             inntektsaar,
-                            EtteroppgjoerStatus.MOTTATT_SKATTEOPPGJOER,
+                            MOTTATT_SKATTEOPPGJOER,
                         )
                 }
         }
@@ -278,7 +301,7 @@ class EtteroppgjoerService(
         val status =
             try {
                 sigrunKlient.hentPensjonsgivendeInntekt(behandling.sak.ident, inntektsaar)
-                EtteroppgjoerStatus.MOTTATT_SKATTEOPPGJOER
+                MOTTATT_SKATTEOPPGJOER
             } catch (e: Exception) {
                 logger.info(
                     "Vi har opprettet et etteroppgjør for $inntektsaar i sakId=${behandling.sak.id}, " +
@@ -286,7 +309,7 @@ class EtteroppgjoerService(
                         "tilgjengelig, hvis annen feil må saken ryddes opp manuelt",
                     e,
                 )
-                EtteroppgjoerStatus.VENTER_PAA_SKATTEOPPGJOER
+                VENTER_PAA_SKATTEOPPGJOER
             }
 
         return etteroppgjoer(sakId, inntektsaar, behandling, status, harOpphoer)
@@ -328,17 +351,17 @@ class EtteroppgjoerService(
 
     private fun finnStatusForForbehandling(forbehandling: EtteroppgjoerForbehandling): EtteroppgjoerStatus {
         if (forbehandling.skyldesOpphoerDoedsfallIEtteroppgjoersaar()) {
-            return EtteroppgjoerStatus.FERDIGSTILT
+            return FERDIGSTILT
         }
 
         return when (forbehandling.etteroppgjoerResultatType) {
-            EtteroppgjoerResultatType.ETTERBETALING -> EtteroppgjoerStatus.VENTER_PAA_SVAR
+            EtteroppgjoerResultatType.ETTERBETALING -> VENTER_PAA_SVAR
 
-            EtteroppgjoerResultatType.TILBAKEKREVING -> EtteroppgjoerStatus.VENTER_PAA_SVAR
+            EtteroppgjoerResultatType.TILBAKEKREVING -> VENTER_PAA_SVAR
 
-            EtteroppgjoerResultatType.INGEN_ENDRING_MED_UTBETALING -> EtteroppgjoerStatus.FERDIGSTILT
+            EtteroppgjoerResultatType.INGEN_ENDRING_MED_UTBETALING -> FERDIGSTILT
 
-            EtteroppgjoerResultatType.INGEN_ENDRING_UTEN_UTBETALING -> EtteroppgjoerStatus.FERDIGSTILT
+            EtteroppgjoerResultatType.INGEN_ENDRING_UTEN_UTBETALING -> FERDIGSTILT
 
             null -> throw InternfeilException(
                 "Mangler etteroppgjoerResultatType for forbehandling ${forbehandling.id} og kan derfor ikke oppdatere Etteroppgjør status",

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/etteroppgjoer/EtteroppgjoerServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/etteroppgjoer/EtteroppgjoerServiceTest.kt
@@ -421,6 +421,26 @@ class EtteroppgjoerServiceTest {
     }
 
     @Test
+    fun `haandterSkatteoppgjoerMottatt returnerer hvis etteroppgjoer har status VENTER_PAA_SVAR`() {
+        val ctx = TestContext(sakId)
+        val inntektsaar = 2024
+        val etteroppgjoer =
+            Etteroppgjoer(
+                sakId = sakId,
+                inntektsaar = inntektsaar,
+                status = EtteroppgjoerStatus.VENTER_PAA_SVAR,
+            )
+        val sak = sak(sakId = sakId)
+
+        every { ctx.etteroppgjoerOppgaveService.opprettVurderKonsekvensOppgaveForFerdigstiltEtteroppgjoer(any(), any()) } just Runs
+
+        ctx.service.haandterSkatteoppgjoerMottatt(etteroppgjoer, sak)
+
+        verify(exactly = 0) { ctx.dao.oppdaterEtteroppgjoerStatus(any(), any(), any()) }
+        verify(exactly = 0) { ctx.etteroppgjoerOppgaveService.opprettOppgaveForOpprettForbehandling(any(), any(), any()) }
+    }
+
+    @Test
     fun `finnOgOpprettManglendeEtteroppgjoer oppretter etteroppgjoer for manglende aar`() {
         val ctx = TestContext(sakId)
         val brukerTokenInfo = mockk<BrukerTokenInfo>()


### PR DESCRIPTION
Vil fortsette behandlig av skattemeldingshendelser hvis status på etteroppgjør er venter på svar.

Vil gjøre koden litt lettere å lese (bruker when og kaster eksplisitt feil hvis vi har en status vi ikke håndterer)

Evt. inntektsendringer vil fanges opp i validering før iverksetting så vi trenger ikke lage oppgave til saksbehandlere for disse.  

Favro:
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-28785