### PR TITLE
Håndterer kopiering av ukjent avdød i trygdetid for omstillingsstønad

### DIFF
--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -247,7 +247,7 @@ class TrygdetidServiceImpl(
                         trygdetider
                     }
                 }
-            // ingen trygdetider i behandling, vi har en riktig avdød i grunnlag
+
             if (eksisterendeTrygdetider.isNotEmpty() && avdoede.size == eksisterendeTrygdetider.size) {
                 throw TrygdetidAlleredeOpprettetException()
             }
@@ -275,12 +275,10 @@ class TrygdetidServiceImpl(
                     val sisteIverksatteBehandling =
                         vedtaksvurderingKlient
                             .hentIverksatteVedtak(behandling.sak, brukerTokenInfo)
-                            .sortedByDescending { it.datoFattet }
+                            .sortedByDescending { it.datoAttestert }
                             .first { it.vedtakType != VedtakType.OPPHOER } // Opphør har ikke trygdetid
-                    // e87d89c5-90b2-4385-9a6a-9571cf8a22c9 sist iverksatt, den har UKJENT_AVDOED trygdetid
                     val forrigeTrygdetider =
                         hentTrygdetiderIBehandling(sisteIverksatteBehandling.behandlingId, brukerTokenInfo)
-                    // ukjent avdoed trygdetid i forrige
                     if (forrigeTrygdetider.isEmpty()) {
                         opprettTrygdetiderForRevurdering(behandling, eksisterendeTrygdetider, avdoede, brukerTokenInfo)
                     } else {
@@ -288,8 +286,10 @@ class TrygdetidServiceImpl(
                             kopierSisteTrygdetidberegninger(behandling, forrigeTrygdetider, eksisterendeTrygdetider)
                         kopierAvtale(behandling.id, sisteIverksatteBehandling.behandlingId)
 
-                        // Revurdering har fått kopiert inn trygdetid med ukjent avdød
                         opprettTrygdetiderForRevurdering(behandling, kopierteTrygdetider, avdoede, brukerTokenInfo)
+
+                        // Vi har oppdatert trydgetiden i databasen, henter på nytt
+                        hentTrygdetiderIBehandling(behandlingId, brukerTokenInfo)
                     }
                 }
             }
@@ -312,7 +312,10 @@ class TrygdetidServiceImpl(
         }
 
     /**
-     * Det TODO
+     * Vi har sett en sak der trydgetiden på forrige iverksatte behandling er feil. Dermed trenger vi å ikke kopiere
+     * med denne feilen videre i neste behandling.
+     *
+     * Se porten-sak FAGSYSTEM-425200
      */
     private fun ryddBortKopiertTrygdetidMedDaarligData(
         behandling: DetaljertBehandling,
@@ -327,6 +330,9 @@ class TrygdetidServiceImpl(
         }
         val eksisterendeTrygdetid = eksisterendeTrygdetider.single()
         if (eksisterendeTrygdetid.ident != UKJENT_AVDOED) {
+            return eksisterendeTrygdetider
+        }
+        if (avdoede.isEmpty()) {
             return eksisterendeTrygdetider
         }
         if (avdoede.any { it.hentFoedselsnummer()?.verdi?.value == null }) {

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -17,6 +17,7 @@ import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
 import no.nav.etterlatte.libs.common.behandling.JaNei
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
+import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.feilhaandtering.GenerellIkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
@@ -230,79 +231,117 @@ class TrygdetidServiceImpl(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         overskriv: Boolean,
-    ) = kanOppdatereTrygdetid(
-        behandlingId,
-        brukerTokenInfo,
-    ) {
-        val avdoede = grunnlagKlient.hentGrunnlag(behandlingId, brukerTokenInfo).hentAvdoede()
-        val eksisterendeTrygdetider =
-            trygdetidRepository.hentTrygdetiderForBehandling(behandlingId).let { trygdetider ->
-                if (overskriv) {
-                    trygdetider
-                        .forEach { trygdetid -> trygdetidRepository.slettTrygdetid(trygdetid.id) }
-                    emptyList()
-                } else {
-                    trygdetider
+    ): List<Trygdetid> =
+        kanOppdatereTrygdetid(
+            behandlingId,
+            brukerTokenInfo,
+        ) {
+            val avdoede = grunnlagKlient.hentGrunnlag(behandlingId, brukerTokenInfo).hentAvdoede()
+            val eksisterendeTrygdetider =
+                trygdetidRepository.hentTrygdetiderForBehandling(behandlingId).let { trygdetider ->
+                    if (overskriv) {
+                        trygdetider
+                            .forEach { trygdetid -> trygdetidRepository.slettTrygdetid(trygdetid.id) }
+                        emptyList()
+                    } else {
+                        trygdetider
+                    }
                 }
+            // ingen trygdetider i behandling, vi har en riktig avdød i grunnlag
+            if (eksisterendeTrygdetider.isNotEmpty() && avdoede.size == eksisterendeTrygdetider.size) {
+                throw TrygdetidAlleredeOpprettetException()
             }
 
-        if (eksisterendeTrygdetider.isNotEmpty() && avdoede.size == eksisterendeTrygdetider.size) {
-            throw TrygdetidAlleredeOpprettetException()
-        }
+            val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
 
-        val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
+            when (behandling.behandlingType) {
+                BehandlingType.FØRSTEGANGSBEHANDLING -> {
+                    val ukjentAvdoed = avdoede.isEmpty()
+                    val tidligereFamiliepleier = behandling.tidligereFamiliepleier?.svar ?: false
 
-        when (behandling.behandlingType) {
-            BehandlingType.FØRSTEGANGSBEHANDLING -> {
-                val ukjentAvdoed = avdoede.isEmpty()
-                val tidligereFamiliepleier = behandling.tidligereFamiliepleier?.svar ?: false
+                    if (ukjentAvdoed || tidligereFamiliepleier) {
+                        logger.info(
+                            "Oppretter overstyrt trygdetid for behandling $behandlingId " +
+                                "(ukjentAvdoed=$ukjentAvdoed, tidligereFamiliepleier=$tidligereFamiliepleier)",
+                        )
+                        listOf(opprettOverstyrtBeregnetTrygdetid(behandlingId, true, brukerTokenInfo))
+                    } else {
+                        logger.info("Oppretter trygdetid for behandling $behandlingId")
+                        opprettTrygdetiderForBehandling(behandling, eksisterendeTrygdetider, avdoede, brukerTokenInfo)
+                    }
+                }
 
-                if (ukjentAvdoed || tidligereFamiliepleier) {
-                    logger.info(
-                        "Oppretter overstyrt trygdetid for behandling $behandlingId " +
-                            "(ukjentAvdoed=$ukjentAvdoed, tidligereFamiliepleier=$tidligereFamiliepleier)",
-                    )
-                    listOf(opprettOverstyrtBeregnetTrygdetid(behandlingId, true, brukerTokenInfo))
-                } else {
-                    logger.info("Oppretter trygdetid for behandling $behandlingId")
-                    opprettTrygdetiderForBehandling(behandling, eksisterendeTrygdetider, avdoede, brukerTokenInfo)
+                BehandlingType.REVURDERING -> {
+                    val sisteIverksatteBehandling =
+                        vedtaksvurderingKlient
+                            .hentIverksatteVedtak(behandling.sak, brukerTokenInfo)
+                            .sortedByDescending { it.datoFattet }
+                            .first { it.vedtakType != VedtakType.OPPHOER } // Opphør har ikke trygdetid
+                    // e87d89c5-90b2-4385-9a6a-9571cf8a22c9 sist iverksatt, den har UKJENT_AVDOED trygdetid
+                    val forrigeTrygdetider =
+                        hentTrygdetiderIBehandling(sisteIverksatteBehandling.behandlingId, brukerTokenInfo)
+                    // ukjent avdoed trygdetid i forrige
+                    if (forrigeTrygdetider.isEmpty()) {
+                        opprettTrygdetiderForRevurdering(behandling, eksisterendeTrygdetider, avdoede, brukerTokenInfo)
+                    } else {
+                        val kopierteTrygdetider =
+                            kopierSisteTrygdetidberegninger(behandling, forrigeTrygdetider, eksisterendeTrygdetider)
+                        kopierAvtale(behandling.id, sisteIverksatteBehandling.behandlingId)
+
+                        // Revurdering har fått kopiert inn trygdetid med ukjent avdød
+                        opprettTrygdetiderForRevurdering(behandling, kopierteTrygdetider, avdoede, brukerTokenInfo)
+                    }
                 }
             }
-
-            BehandlingType.REVURDERING -> {
-                val sisteIverksatteBehandling =
-                    vedtaksvurderingKlient
-                        .hentIverksatteVedtak(behandling.sak, brukerTokenInfo)
-                        .sortedByDescending { it.datoFattet }
-                        .first { it.vedtakType != VedtakType.OPPHOER } // Opphør har ikke trygdetid
-
-                val forrigeTrygdetider =
-                    hentTrygdetiderIBehandling(sisteIverksatteBehandling.behandlingId, brukerTokenInfo)
-                if (forrigeTrygdetider.isEmpty()) {
-                    opprettTrygdetiderForRevurdering(behandling, eksisterendeTrygdetider, avdoede, brukerTokenInfo)
-                } else {
-                    val kopierteTrygdetider =
-                        kopierSisteTrygdetidberegninger(behandling, forrigeTrygdetider, eksisterendeTrygdetider)
-                    kopierAvtale(behandling.id, sisteIverksatteBehandling.behandlingId)
-                    opprettTrygdetiderForRevurdering(behandling, kopierteTrygdetider, avdoede, brukerTokenInfo)
-                }
-            }
-        }
-    }.also { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, brukerTokenInfo) }
+        }.also { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, brukerTokenInfo) }
 
     private suspend fun opprettTrygdetiderForRevurdering(
         behandling: DetaljertBehandling,
         eksisterendeTrygdetider: List<Trygdetid>,
         avdoede: List<Grunnlagsdata<JsonNode>>,
         brukerTokenInfo: BrukerTokenInfo,
-    ) = if (behandling.revurderingsaarsak == Revurderingaarsak.REGULERING &&
-        behandling.prosesstype == Prosesstype.AUTOMATISK
-    ) {
-        logger.info("Forrige trygdetid for ${behandling.id} finnes ikke - må reguleres manuelt")
-        throw ManglerForrigeTrygdetidMaaReguleresManuelt()
-    } else {
-        logger.info("Oppretter trygdetid for behandling ${behandling.id} revurdering")
-        opprettTrygdetiderForBehandling(behandling, eksisterendeTrygdetider, avdoede, brukerTokenInfo)
+    ): List<Trygdetid> =
+        if (behandling.revurderingsaarsak == Revurderingaarsak.REGULERING &&
+            behandling.prosesstype == Prosesstype.AUTOMATISK
+        ) {
+            logger.info("Forrige trygdetid for ${behandling.id} finnes ikke - må reguleres manuelt")
+            throw ManglerForrigeTrygdetidMaaReguleresManuelt()
+        } else {
+            logger.info("Oppretter trygdetid for behandling ${behandling.id} revurdering")
+            opprettTrygdetiderForBehandling(behandling, eksisterendeTrygdetider, avdoede, brukerTokenInfo)
+        }
+
+    /**
+     * Det TODO
+     */
+    private fun ryddBortKopiertTrygdetidMedDaarligData(
+        behandling: DetaljertBehandling,
+        eksisterendeTrygdetider: List<Trygdetid>,
+        avdoede: List<Grunnlagsdata<JsonNode>>,
+    ): List<Trygdetid> {
+        if (behandling.sakType != SakType.OMSTILLINGSSTOENAD) {
+            return eksisterendeTrygdetider
+        }
+        if (eksisterendeTrygdetider.size != 1) {
+            return eksisterendeTrygdetider
+        }
+        val eksisterendeTrygdetid = eksisterendeTrygdetider.single()
+        if (eksisterendeTrygdetid.ident != UKJENT_AVDOED) {
+            return eksisterendeTrygdetider
+        }
+        if (avdoede.any { it.hentFoedselsnummer()?.verdi?.value == null }) {
+            logger.error(
+                "Vi har en OMS-sak med UKJENT_AVDOED, og mangler kjent avdød i grunnlaget. Trygedtid er " +
+                    "sannsynligvis ikke bra i denne saken. SakId = ${behandling.sak.sakId}, behandlingId = ${behandling.id}. " +
+                    "Denne bør følges opp av et menneske for å se om behandlingen blir riktig, og eventuelt om det trengs " +
+                    "å få på plass riktig avdød i saken.",
+            )
+            return eksisterendeTrygdetider
+        }
+        // Hvis vi har en OMS sak der vi har kun en kopiert trygedtid med ukjent avdød, og vi har en gyldig avdød i
+        // grunnlaget i saken, kan vi bare rydde bort den kopierte trygdetiden med UKJENT_AVDOED, siden den er broken
+        trygdetidRepository.slettTrygdetid(eksisterendeTrygdetid.id)
+        return emptyList()
     }
 
     private suspend fun opprettTrygdetiderForBehandling(
@@ -310,36 +349,41 @@ class TrygdetidServiceImpl(
         eksisterendeTrygdetider: List<Trygdetid>,
         avdoede: List<Grunnlagsdata<JsonNode>>,
         brukerTokenInfo: BrukerTokenInfo,
-    ) = avdoede
-        .map { avdoed ->
-            val fnr =
-                krevIkkeNull(avdoed.hentFoedselsnummer()?.verdi?.value) {
-                    "Kunne ikke hente identifikator for avdød til trygdetid i " +
-                        "behandlingen med id=${behandling.id}"
-                }
+    ): List<Trygdetid> {
+        val eksisterendeTrygdetidEtterRydding =
+            ryddBortKopiertTrygdetidMedDaarligData(behandling, eksisterendeTrygdetider, avdoede)
 
-            Pair(fnr, avdoed)
-        }.filter { avdoedMedFnr ->
-            eksisterendeTrygdetider.none { avdoedMedFnr.first == it.ident }
-        }.map { avdoedMedFnr ->
-            val trygdetid =
-                Trygdetid(
-                    sakId = behandling.sak,
-                    behandlingId = behandling.id,
-                    opplysninger = hentOpplysninger(avdoedMedFnr.second, behandling.id),
-                    ident = avdoedMedFnr.first,
-                    yrkesskade = false,
-                )
+        return avdoede
+            .map { avdoed ->
+                val fnr =
+                    krevIkkeNull(avdoed.hentFoedselsnummer()?.verdi?.value) {
+                        "Kunne ikke hente identifikator for avdød til trygdetid i " +
+                            "behandlingen med id=${behandling.id}"
+                    }
 
-            val opprettetTrygdetid = trygdetidRepository.opprettTrygdetid(trygdetid)
+                Pair(fnr, avdoed)
+            }.filter { avdoedMedFnr ->
+                eksisterendeTrygdetidEtterRydding.none { avdoedMedFnr.first == it.ident }
+            }.map { avdoedMedFnr ->
+                val trygdetid =
+                    Trygdetid(
+                        sakId = behandling.sak,
+                        behandlingId = behandling.id,
+                        opplysninger = hentOpplysninger(avdoedMedFnr.second, behandling.id),
+                        ident = avdoedMedFnr.first,
+                        yrkesskade = false,
+                    )
 
-            val oppdatertTrygdetid =
-                opprettFremtidigTrygdetidForAvdoed(opprettetTrygdetid, avdoedMedFnr.second, brukerTokenInfo)
+                val opprettetTrygdetid = trygdetidRepository.opprettTrygdetid(trygdetid)
 
-            oppdatertTrygdetid ?: opprettetTrygdetid
-        }.also {
-            logger.info("Opprettet ${it.size} trygdetider for behandling=${behandling.id}")
-        }
+                val oppdatertTrygdetid =
+                    opprettFremtidigTrygdetidForAvdoed(opprettetTrygdetid, avdoedMedFnr.second, brukerTokenInfo)
+
+                oppdatertTrygdetid ?: opprettetTrygdetid
+            }.also {
+                logger.info("Opprettet ${it.size} trygdetider for behandling=${behandling.id}")
+            }
+    }
 
     override suspend fun harTrygdetidsgrunnlagIPesysForApOgUfoere(
         behandlingId: UUID,

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceIntegrationTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceIntegrationTest.kt
@@ -16,12 +16,14 @@ import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.behandling.BehandlingType
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
+import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.deserialize
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
 import no.nav.etterlatte.libs.common.grunnlag.Opplysning
 import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.toNorskTid
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.common.trygdetid.DetaljertBeregnetTrygdetidResultat
@@ -30,8 +32,11 @@ import no.nav.etterlatte.libs.common.trygdetid.OpplysningerDifferanse
 import no.nav.etterlatte.libs.common.trygdetid.OpplysningsgrunnlagDto
 import no.nav.etterlatte.libs.common.trygdetid.UKJENT_AVDOED
 import no.nav.etterlatte.libs.common.trygdetid.avtale.Trygdeavtale
+import no.nav.etterlatte.libs.common.vedtak.VedtakSammendragDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakType
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.kilde
+import no.nav.etterlatte.logger
 import no.nav.etterlatte.trygdetid.avtale.AvtaleService
 import no.nav.etterlatte.trygdetid.klienter.BehandlingKlient
 import no.nav.etterlatte.trygdetid.klienter.GrunnlagKlient
@@ -43,6 +48,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.RegisterExtension
 import java.time.LocalDate
+import java.time.YearMonth
 import java.util.UUID
 import javax.sql.DataSource
 
@@ -71,7 +77,7 @@ internal class TrygdetidServiceIntegrationTest(
 
     @BeforeAll
     fun beforeAll() {
-        no.nav.etterlatte.logger
+        logger
             .info(dbExtension.properties().toString())
         trygdetidService =
             TrygdetidServiceImpl(
@@ -151,6 +157,7 @@ internal class TrygdetidServiceIntegrationTest(
             mockk {
                 every { id } returns behandlingId
                 every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
                 every { behandlingType } returns BehandlingType.FØRSTEGANGSBEHANDLING
                 every { tidligereFamiliepleier } returns null
             }
@@ -244,6 +251,62 @@ internal class TrygdetidServiceIntegrationTest(
         with(trygdetider.first()) {
             ident shouldBe UKJENT_AVDOED
             opplysningerDifferanse!! shouldBeEqual OpplysningerDifferanse(false, GrunnlagOpplysningerDto.tomt())
+        }
+    }
+
+    @Test
+    fun `skal forkaste forrige behandlings trygdetid hvis den feilaktig setter UKJENT_AVDOED`() {
+        val sakId = randomSakId()
+        val forrigeBehandlingId = UUID.randomUUID()
+        val behandlingId = UUID.randomUUID()
+        val grunnlagTestData = GrunnlagTestData()
+        val standardOpplysningsgrunnlag = grunnlagTestData.hentOpplysningsgrunnlag()
+
+        coEvery {
+            grunnlagKlient.hentGrunnlag(any(), any())
+        } returns standardOpplysningsgrunnlag
+        coEvery { behandlingKlient.hentBehandling(behandlingId, saksbehandler) } returns
+            mockk {
+                every { id } returns behandlingId
+                every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
+                every { behandlingType } returns BehandlingType.REVURDERING
+                every { tidligereFamiliepleier } returns null
+                every { revurderingsaarsak } returns Revurderingaarsak.AKTIVITETSPLIKT
+                every { prosesstype } returns Prosesstype.MANUELL
+            }
+        coEvery { behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler) } returns true
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(sakId, saksbehandler) } returns
+            listOf(
+                VedtakSammendragDto(
+                    id = "1",
+                    behandlingId = forrigeBehandlingId,
+                    vedtakType = VedtakType.INNVILGELSE,
+                    behandlendeSaksbehandler = null,
+                    datoFattet = Tidspunkt.now().toNorskTid(),
+                    attesterendeSaksbehandler = null,
+                    datoAttestert = Tidspunkt.now().toNorskTid(),
+                    virkningstidspunkt = YearMonth.of(2024, 5),
+                    opphoerFraOgMed = null,
+                    iverksettelsesTidspunkt = Tidspunkt.now(),
+                ),
+            )
+        every { avtaleService.hentAvtaleForBehandling(any()) } returns null
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler) } returns true
+
+        repository.opprettTrygdetid(
+            trygdetid(
+                behandlingId = forrigeBehandlingId,
+                sakId = sakId,
+                ident = UKJENT_AVDOED,
+                opplysninger = emptyList(),
+            ),
+        )
+
+        val trygdetider = runBlocking { trygdetidService.opprettTrygdetiderForBehandling(behandlingId, saksbehandler) }
+
+        with(trygdetider.single()) {
+            ident shouldNotBe UKJENT_AVDOED
         }
     }
 

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
@@ -319,7 +319,6 @@ internal class TrygdetidServiceTest {
 
         coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
-            repository.hentTrygdetiderForBehandling(behandlingId)
             behandlingKlient.hentBehandling(behandlingId, saksbehandler)
             vedtaksvurderingKlient.hentIverksatteVedtak(sakId, saksbehandler)
             repository.hentTrygdetiderForBehandling(forrigebehandlingId)
@@ -341,6 +340,7 @@ internal class TrygdetidServiceTest {
             grunnlagKlient.hentGrunnlag(behandlingId, saksbehandler)
         }
         verify {
+            repository.hentTrygdetiderForBehandling(behandlingId)
             behandling.behandlingType
             behandling.sak
             behandling.sakType
@@ -396,7 +396,6 @@ internal class TrygdetidServiceTest {
         }
         coVerify(exactly = 1) {
             behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
-            repository.hentTrygdetiderForBehandling(behandlingId)
             behandlingKlient.hentBehandling(behandlingId, saksbehandler)
             vedtaksvurderingKlient.hentIverksatteVedtak(sakId, saksbehandler)
             repository.hentTrygdetiderForBehandling(forrigebehandlingId)
@@ -414,6 +413,7 @@ internal class TrygdetidServiceTest {
             }
         }
         verify {
+            repository.hentTrygdetiderForBehandling(behandlingId)
             behandling.id
             behandling.sak
             behandling.sakType

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
@@ -26,6 +26,7 @@ import no.nav.etterlatte.libs.common.behandling.JaNei
 import no.nav.etterlatte.libs.common.behandling.Persongalleri
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
+import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.SisteIverksatteBehandling
 import no.nav.etterlatte.libs.common.behandling.TidligereFamiliepleier
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
@@ -164,6 +165,7 @@ internal class TrygdetidServiceTest {
             mockk<DetaljertBehandling>().apply {
                 every { id } returns behandlingId
                 every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
                 every { behandlingType } returns BehandlingType.FØRSTEGANGSBEHANDLING
                 every { tidligereFamiliepleier } returns null
             }
@@ -266,6 +268,7 @@ internal class TrygdetidServiceTest {
         verify {
             behandling.id
             behandling.sak
+            behandling.sakType
             behandling.behandlingType
             behandling.tidligereFamiliepleier
         }
@@ -279,6 +282,7 @@ internal class TrygdetidServiceTest {
             mockk<DetaljertBehandling>().apply {
                 every { id } returns behandlingId
                 every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
                 every { behandlingType } returns BehandlingType.REVURDERING
                 every { revurderingsaarsak } returns Revurderingaarsak.DOEDSFALL
             }
@@ -339,6 +343,7 @@ internal class TrygdetidServiceTest {
         verify {
             behandling.behandlingType
             behandling.sak
+            behandling.sakType
             behandling.id
             behandling.revurderingsaarsak
             vedtakSammendrag.behandlingId
@@ -361,6 +366,7 @@ internal class TrygdetidServiceTest {
             mockk<DetaljertBehandling>().apply {
                 every { id } returns behandlingId
                 every { sak } returns sakId
+                every { sakType } returns SakType.BARNEPENSJON
                 every { behandlingType } returns BehandlingType.REVURDERING
                 every { revurderingsaarsak } returns Revurderingaarsak.DOEDSFALL
             }
@@ -410,6 +416,7 @@ internal class TrygdetidServiceTest {
         verify {
             behandling.id
             behandling.sak
+            behandling.sakType
             behandling.behandlingType
             behandling.revurderingsaarsak
             vedtakSammendrag.behandlingId
@@ -425,6 +432,7 @@ internal class TrygdetidServiceTest {
             mockk<DetaljertBehandling> {
                 every { id } returns behandlingId
                 every { sak } returns randomSakId()
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
                 every { status } returns BehandlingStatus.VILKAARSVURDERT
                 every { behandlingType } returns BehandlingType.FØRSTEGANGSBEHANDLING
                 every { tidligereFamiliepleier } returns null
@@ -472,6 +480,7 @@ internal class TrygdetidServiceTest {
             mockk<DetaljertBehandling> {
                 every { id } returns behandlingId
                 every { sak } returns randomSakId()
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
                 every { status } returns BehandlingStatus.VILKAARSVURDERT
                 every { behandlingType } returns BehandlingType.FØRSTEGANGSBEHANDLING
                 every { soeker } returns SOEKER_FOEDSELSNUMMER.value
@@ -521,6 +530,7 @@ internal class TrygdetidServiceTest {
             mockk<DetaljertBehandling>().apply {
                 every { id } returns behandlingId
                 every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
                 every { behandlingType } returns BehandlingType.REVURDERING
                 every { revurderingsaarsak } returns Revurderingaarsak.SOESKENJUSTERING
             }
@@ -587,6 +597,7 @@ internal class TrygdetidServiceTest {
             behandling.revurderingsaarsak
             behandling.id
             behandling.sak
+            behandling.sakType
             behandling.behandlingType
             vedtakSammendrag.behandlingId
             vedtakSammendrag.vedtakType
@@ -601,6 +612,7 @@ internal class TrygdetidServiceTest {
             mockk<DetaljertBehandling>().apply {
                 every { id } returns behandlingId
                 every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
                 every { behandlingType } returns BehandlingType.REVURDERING
                 every { revurderingsaarsak } returns Revurderingaarsak.REGULERING
                 every { prosesstype } returns Prosesstype.AUTOMATISK
@@ -651,6 +663,7 @@ internal class TrygdetidServiceTest {
             mockk<DetaljertBehandling>().apply {
                 every { id } returns behandlingId
                 every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
                 every { behandlingType } returns BehandlingType.REVURDERING
                 every { revurderingsaarsak } returns Revurderingaarsak.REGULERING
                 every { prosesstype } returns Prosesstype.MANUELL
@@ -724,6 +737,7 @@ internal class TrygdetidServiceTest {
             behandling.prosesstype
             behandling.id
             behandling.sak
+            behandling.sakType
             behandling.behandlingType
             vedtakSammendrag.behandlingId
             vedtakSammendrag.vedtakType
@@ -762,6 +776,7 @@ internal class TrygdetidServiceTest {
             mockk<DetaljertBehandling>().apply {
                 every { id } returns behandlingId
                 every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
                 every { behandlingType } returns BehandlingType.FØRSTEGANGSBEHANDLING
                 every { tidligereFamiliepleier } returns null
             }
@@ -840,6 +855,7 @@ internal class TrygdetidServiceTest {
         verify {
             behandling.id
             behandling.sak
+            behandling.sakType
             behandling.behandlingType
             behandling.tidligereFamiliepleier
         }
@@ -1229,6 +1245,7 @@ internal class TrygdetidServiceTest {
             mockk<DetaljertBehandling>().apply {
                 every { id } returns behandlingId
                 every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
             }
 
         coEvery { behandlingKlient.hentBehandling(behandlingId, saksbehandler) } returns regulering
@@ -1302,6 +1319,7 @@ internal class TrygdetidServiceTest {
             mockk<DetaljertBehandling>().apply {
                 every { id } returns behandlingId
                 every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
                 every { prosesstype } returns Prosesstype.MANUELL
             }
 
@@ -1663,6 +1681,7 @@ internal class TrygdetidServiceTest {
             mockk {
                 every { id } returns behandlingId
                 every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
                 every { status } returns BehandlingStatus.OPPRETTET
             }
         coEvery { behandlingKlient.hentBehandling(behandlingId, any()) } returns behandling
@@ -1716,6 +1735,7 @@ internal class TrygdetidServiceTest {
             mockk {
                 every { id } returns behandlingId
                 every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
                 every { status } returns BehandlingStatus.OPPRETTET
                 every { tidligereFamiliepleier } returns null
             }
@@ -1772,6 +1792,7 @@ internal class TrygdetidServiceTest {
             mockk {
                 every { id } returns behandlingId
                 every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
                 every { status } returns BehandlingStatus.OPPRETTET
                 every { soeker } returns "12345678901"
                 every { tidligereFamiliepleier } returns
@@ -1843,6 +1864,7 @@ internal class TrygdetidServiceTest {
             mockk<DetaljertBehandling>().apply {
                 every { id } returns behandlingId
                 every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
                 every { behandlingType } returns BehandlingType.FØRSTEGANGSBEHANDLING
                 every { tidligereFamiliepleier } returns null
             }
@@ -1918,6 +1940,7 @@ internal class TrygdetidServiceTest {
         verify {
             behandling.id
             behandling.sak
+            behandling.sakType
             behandling.behandlingType
             behandling.tidligereFamiliepleier
         }


### PR DESCRIPTION
Når vi oppretter en revurdering kopierer vi over trygdetidsgrunnlaget fra forrige behandling. Men hvis trygdetiden er feil i forrige behandling vil vi få samme feil i revurderingen. Dette skjedde i en portensak. Fjerner dermed trygdetider som gjelder ukjent avdød i omstillingssøknad-saker, noe som ikke skal skje.