### PR TITLE
Endring i grunnbeløp barnepensjon

### DIFF
--- a/.github/lessons.md
+++ b/.github/lessons.md
@@ -37,3 +37,7 @@
 **2026-05-04 — Testskriving**
 - Observation: Jeg la inn mock for `SaksbehandlerInfoDao` uten å vurdere om real-DB var mulig og bedre. Brukeren måtte eksplisitt be om det.
 - Action: Når en DAO er enkel og DatabaseExtension finnes i modulen, vurder real-DB som default – ikke mock.
+
+**2026-05-07 — Regelendring / beregning**
+- Observation: Før jeg endret reglene sjekket jeg OMS-koden for å se hvordan de løste det samme problemet – det gav meg korrekt mønster direkte (`multiply(grunnbeloep).divide(12)`), og samsvarte med planens antagelser.
+- Action: Ved beregningsregelendringer, alltid finn den tilsvarende regelen i det andre regelsettet (BP/OMS) som referanseimplementasjon.

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/barnepensjon/InstitusjonsoppholdreglerBP.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/barnepensjon/InstitusjonsoppholdreglerBP.kt
@@ -32,7 +32,7 @@ val institusjonsoppholdSatsRegel =
     RegelMeta(
         gjelderFra = BP_1967_DATO,
         beskrivelse = "Finner satsen for institusjonsoppholdberegning",
-        regelReferanse = RegelReferanse(id = "BP-BEREGNING-1967-REDUKSJON-INSTITUSJON"),
+        regelReferanse = RegelReferanse(id = "BP-BEREGNING-1967-REDUKSJON-INSTITUSJON", versjon = "2"),
     ) benytter grunnbeloep og institusjonsoppholdRegel med { grunnbeloep, prosent ->
-        Beregningstall.somBroek(prosent).multiply(grunnbeloep.grunnbeloepPerMaaned)
+        Beregningstall.somBroek(prosent).multiply(grunnbeloep.grunnbeloep).divide(12)
     }

--- a/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/barnepensjon/sats/BarnepensjonSats.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/beregning/regler/barnepensjon/sats/BarnepensjonSats.kt
@@ -113,27 +113,27 @@ val beloepHvertBarnEnForelderAvdoed2024 =
     RegelMeta(
         gjelderFra = BP_2024_DATO,
         beskrivelse = "Prosentsats benyttet for hvert barn når en forelder er død",
-        regelReferanse = RegelReferanse(id = "BP-BEREGNING-2024-BELOEP-EN-FORELDER-AVDOED"),
+        regelReferanse = RegelReferanse(id = "BP-BEREGNING-2024-BELOEP-EN-FORELDER-AVDOED", versjon = "2"),
     ) benytter prosentsatsHvertBarnEnForelderAvdoed2024 og grunnbeloep med { sats, grunnbeloep ->
-        sats.multiply(grunnbeloep.grunnbeloepPerMaaned)
+        sats.multiply(grunnbeloep.grunnbeloep).divide(12)
     }
 
 val beloepHvertBarnToForeldreAvdoed2024 =
     RegelMeta(
         gjelderFra = BP_2024_DATO,
         beskrivelse = "Prosentsats benyttet for hvert barn når to foreldre er døde",
-        regelReferanse = RegelReferanse(id = "BP-BEREGNING-2024-BELOEP-TO-FORELDRE-AVDOED"),
+        regelReferanse = RegelReferanse(id = "BP-BEREGNING-2024-BELOEP-TO-FORELDRE-AVDOED", versjon = "2"),
     ) benytter prosentsatsHvertBarnToForeldreAvdoed2024 og grunnbeloep med { sats, grunnbeloep ->
-        sats.multiply(grunnbeloep.grunnbeloepPerMaaned)
+        sats.multiply(grunnbeloep.grunnbeloep).divide(12)
     }
 
 val belopForFoersteBarn1967 =
     RegelMeta(
         gjelderFra = BP_1967_DATO,
         beskrivelse = "Satser i kr for første barn",
-        regelReferanse = RegelReferanse(id = "BP-BEREGNING-1967-ETTBARN"),
+        regelReferanse = RegelReferanse(id = "BP-BEREGNING-1967-ETTBARN", versjon = "2"),
     ) benytter prosentsatsFoersteBarnKonstant1967 og grunnbeloep med { prosentsatsFoersteBarn, grunnbeloep ->
-        prosentsatsFoersteBarn.multiply(grunnbeloep.grunnbeloepPerMaaned)
+        prosentsatsFoersteBarn.multiply(grunnbeloep.grunnbeloep).divide(12)
     }
 
 val prosentsatsEtterfoelgendeBarnKonstant1967 =
@@ -148,9 +148,9 @@ val belopForEtterfoelgendeBarn1967 =
     RegelMeta(
         gjelderFra = BP_1967_DATO,
         beskrivelse = "Satser i kr for etterfølgende barn",
-        regelReferanse = RegelReferanse(id = "BP-BEREGNING-1967-FLERBARN"),
+        regelReferanse = RegelReferanse(id = "BP-BEREGNING-1967-FLERBARN", versjon = "2"),
     ) benytter prosentsatsEtterfoelgendeBarnKonstant1967 og grunnbeloep med { prosentsatsEtterfoelgendeBarn, grunnbeloep ->
-        prosentsatsEtterfoelgendeBarn.multiply(grunnbeloep.grunnbeloepPerMaaned)
+        prosentsatsEtterfoelgendeBarn.multiply(grunnbeloep.grunnbeloep).divide(12)
     }
 
 val barnepensjonSatsRegel1967 =

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnBarnepensjonServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnBarnepensjonServiceTest.kt
@@ -1249,7 +1249,7 @@ internal class BeregnBarnepensjonServiceTest {
         const val GRUNNBELOEP_MAI_24: Int = 10336
         const val BP_BELOEP_INGEN_SOESKEN_JAN_23: Int = 3716
         const val BP_BELOEP_INGEN_SOESKEN_MAI_23: Int = 3954
-        const val BP_BELOEP_INGEN_SOESKEN_JAN_23_PRORATA: Int = 1394
+        const val BP_BELOEP_INGEN_SOESKEN_JAN_23_PRORATA: Int = 1393
         const val BP_BELOEP_ETT_SOESKEN_JAN_23: Int = 3019
         const val BP_BELOEP_TO_SOESKEN_JAN_23: Int = 2787
         const val BP_BELOEP_ETT_SOESKEN_MAI_23: Int = 3213

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/regler/BeregnBarnepensjonTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/regler/BeregnBarnepensjonTest.kt
@@ -17,40 +17,40 @@ import java.time.Month
 
 internal class BeregnBarnepensjonTest {
     @Test
-    fun `beregnBarnepensjon skal gi 3716,00 ved 40 aars trygdetid og ingen soesken`() {
+    fun `beregnBarnepensjon skal gi 3715,90 ved 40 aars trygdetid og ingen soesken`() {
         val resultat =
             beregnBarnepensjon.anvend(
                 grunnlag = barnepensjonGrunnlag(),
                 periode = RegelPeriode(fraDato = LocalDate.of(2023, Month.JANUARY, 1)),
             )
 
-        resultat.verdi shouldBe 3716.00.toBeregningstall()
+        resultat.verdi shouldBe 3715.9.toBeregningstall()
     }
 
     @Test
-    fun `beregnBarnepensjon skal gi 3019,25 ved 40 aars trygdetid og et soesken`() {
+    fun `beregnBarnepensjon skal gi 3019,17 ved 40 aars trygdetid og et soesken`() {
         val resultat =
             beregnBarnepensjon.anvend(
                 grunnlag = barnepensjonGrunnlag(listOf(HELSOESKEN_FOEDSELSNUMMER)),
                 periode = RegelPeriode(fraDato = LocalDate.of(2023, Month.JANUARY, 1)),
             )
 
-        resultat.verdi shouldBe 3019.25.toBeregningstall()
+        resultat.verdi shouldBe 3019.16875.toBeregningstall()
     }
 
     @Test
-    fun `beregnBarnepensjon skal gi 2787,00 ved 40 aars trygdetid og to soesken`() {
+    fun `beregnBarnepensjon skal gi 2786,93 ved 40 aars trygdetid og to soesken`() {
         val resultat =
             beregnBarnepensjon.anvend(
                 grunnlag = barnepensjonGrunnlag(listOf(HELSOESKEN_FOEDSELSNUMMER, HELSOESKEN2_FOEDSELSNUMMER)),
                 periode = RegelPeriode(fraDato = LocalDate.of(2023, Month.JANUARY, 1)),
             )
 
-        resultat.verdi shouldBe 2787.00.toBeregningstall()
+        resultat.verdi shouldBe 2786.925.toBeregningstall()
     }
 
     @Test
-    fun `beregnBarnepensjon gi 2670,875 ved 40 aars trygdetid og tre soesken`() {
+    fun `beregnBarnepensjon gi 2670,80 ved 40 aars trygdetid og tre soesken`() {
         val resultat =
             beregnBarnepensjon.anvend(
                 grunnlag =
@@ -64,11 +64,11 @@ internal class BeregnBarnepensjonTest {
                 periode = RegelPeriode(fraDato = LocalDate.of(2023, Month.JANUARY, 1)),
             )
 
-        resultat.verdi shouldBe 2670.875.toBeregningstall()
+        resultat.verdi shouldBe 2670.803125.toBeregningstall()
     }
 
     @Test
-    fun `beregnBarnepensjon gi 1335,875 ved 20 aars trygdetid og tre soesken`() {
+    fun `beregnBarnepensjon gi 1335,40 ved 20 aars trygdetid og tre soesken`() {
         val resultat =
             beregnBarnepensjon.anvend(
                 grunnlag =
@@ -84,7 +84,7 @@ internal class BeregnBarnepensjonTest {
                 periode = RegelPeriode(fraDato = LocalDate.of(2023, Month.JANUARY, 1)),
             )
 
-        resultat.verdi shouldBe 1335.4375.toBeregningstall()
+        resultat.verdi shouldBe 1335.4015625.toBeregningstall()
     }
 
     @Test
@@ -104,7 +104,7 @@ internal class BeregnBarnepensjonTest {
                 periode = RegelPeriode(fraDato = LocalDate.of(2023, Month.JANUARY, 1)),
             )
 
-        resultat.verdi shouldBe 929.toBeregningstall()
+        resultat.verdi shouldBe 928.975.toBeregningstall()
     }
 
     @Test
@@ -125,7 +125,7 @@ internal class BeregnBarnepensjonTest {
                 periode = RegelPeriode(fraDato = LocalDate.of(2023, Month.JANUARY, 1)),
             )
 
-        resultat.verdi shouldBe 929.toBeregningstall()
+        resultat.verdi shouldBe 928.975.toBeregningstall()
     }
 
     @Test
@@ -225,6 +225,6 @@ internal class BeregnBarnepensjonTest {
             )
 
         Assertions.assertEquals(resultatMedSoeskenjustering.verdi, resultatUtenSoeskenjustering.verdi)
-        Assertions.assertEquals(929.0.toBeregningstall(), resultatUtenSoeskenjustering.verdi)
+        Assertions.assertEquals(928.975.toBeregningstall(), resultatUtenSoeskenjustering.verdi)
     }
 }

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/regler/sats/BarnepensjonSatsTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/regler/sats/BarnepensjonSatsTest.kt
@@ -98,62 +98,62 @@ internal class BarnepensjonSatsTest {
     }
 
     @Test
-    fun `belopForFoersteBarn skal returnere 3716,00 kroner`() {
+    fun `belopForFoersteBarn skal returnere 3715,90 kroner`() {
         val resultat =
             belopForFoersteBarn1967.anvend(
                 grunnlag = barnepensjonGrunnlag(),
                 periode = REGEL_PERIODE,
             )
 
-        resultat.verdi shouldBe 3716.00.toBeregningstall(DESIMALER_DELBEREGNING)
+        resultat.verdi shouldBe 3715.9.toBeregningstall(DESIMALER_DELBEREGNING)
     }
 
     @Test
-    fun `belopForEtterfoelgendeBarn skal returnere 2322,50 kroner`() {
+    fun `belopForEtterfoelgendeBarn skal returnere 2322,44 kroner`() {
         val resultat =
             belopForEtterfoelgendeBarn1967.anvend(
                 grunnlag = barnepensjonGrunnlag(),
                 periode = REGEL_PERIODE,
             )
 
-        resultat.verdi shouldBe 2322.50.toBeregningstall(DESIMALER_DELBEREGNING)
+        resultat.verdi shouldBe 2322.4375.toBeregningstall(DESIMALER_DELBEREGNING)
     }
 
     @Test
-    fun `barnepensjonSatsRegel skal returnere 3716,00 kroner ved 0 soesken`() {
+    fun `barnepensjonSatsRegel skal returnere 3715,90 kroner ved 0 soesken`() {
         val resultat =
             barnepensjonSatsRegel.anvend(
                 grunnlag = barnepensjonGrunnlag(),
                 periode = REGEL_PERIODE,
             )
 
-        resultat.verdi shouldBe 3716.00.toBeregningstall(DESIMALER_DELBEREGNING)
+        resultat.verdi shouldBe 3715.9.toBeregningstall(DESIMALER_DELBEREGNING)
     }
 
     @Test
-    fun `barnepensjonSatsRegel skal returnere 3019,25 kroner ved 1 soesken`() {
+    fun `barnepensjonSatsRegel skal returnere 3019,17 kroner ved 1 soesken`() {
         val resultat =
             barnepensjonSatsRegel.anvend(
                 grunnlag = barnepensjonGrunnlag(soeskenKull = listOf(HELSOESKEN_FOEDSELSNUMMER)),
                 periode = REGEL_PERIODE,
             )
 
-        resultat.verdi shouldBe 3019.25.toBeregningstall(DESIMALER_DELBEREGNING)
+        resultat.verdi shouldBe 3019.16875.toBeregningstall(DESIMALER_DELBEREGNING)
     }
 
     @Test
-    fun `barnepensjonSatsRegel skal returnere 2787,00 kroner ved 2 soesken`() {
+    fun `barnepensjonSatsRegel skal returnere 2786,93 kroner ved 2 soesken`() {
         val resultat =
             barnepensjonSatsRegel.anvend(
                 grunnlag = barnepensjonGrunnlag(soeskenKull = listOf(HELSOESKEN_FOEDSELSNUMMER, HELSOESKEN2_FOEDSELSNUMMER)),
                 periode = REGEL_PERIODE,
             )
 
-        resultat.verdi shouldBe 2787.00.toBeregningstall(DESIMALER_DELBEREGNING)
+        resultat.verdi shouldBe 2786.925.toBeregningstall(DESIMALER_DELBEREGNING)
     }
 
     @Test
-    fun `barnepensjonSatsRegel skal returnere 2670,887 kroner ved 3 soesken`() {
+    fun `barnepensjonSatsRegel skal returnere 2670,80 kroner ved 3 soesken`() {
         val resultat =
             barnepensjonSatsRegel.anvend(
                 grunnlag =
@@ -163,7 +163,7 @@ internal class BarnepensjonSatsTest {
                 periode = REGEL_PERIODE,
             )
 
-        resultat.verdi shouldBe 2670.875.toBeregningstall(DESIMALER_DELBEREGNING)
+        resultat.verdi shouldBe 2670.803125.toBeregningstall(DESIMALER_DELBEREGNING)
     }
 
     @Test


### PR DESCRIPTION
# Endring i grunnbeløp barnepensjon

### Hvorfor er denne endringen nødvendig? ✨

Barnepensjon ble beregnet med et allerede avrundet månedlig grunnbeløp (`grunnbeloepPerMaaned`) som i noen perioder ga en krone for mye utbetalt. Riktig beregning er å starte med årsbeløpet og dele på 12 til slutt, slik at brøkene bevares frem til den endelige avrundingen. Dette er også slik OMS allerede gjør det.

Endringen gjelder for all tid og retter opp fremover.

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-28621).

### Verdt å nevne

* Skal oppdatere Confluence med endringer etter snakk med fagressurs. 