### PR TITLE
feat: gi dp-andre-ytelser lesetilgang til vedtakshendelser

### DIFF
--- a/apps/etterlatte-behandling/.nais/topic-vedtakshendelser-dev.yaml
+++ b/apps/etterlatte-behandling/.nais/topic-vedtakshendelser-dev.yaml
@@ -30,3 +30,6 @@ spec:
     - team: pensjon-q5
       application: pensjon-pen-q5
       access: read
+    - team: teamdagpenger
+      application: dp-andre-ytelser
+      access: read

--- a/apps/etterlatte-behandling/.nais/topic-vedtakshendelser-prod.yaml
+++ b/apps/etterlatte-behandling/.nais/topic-vedtakshendelser-prod.yaml
@@ -21,3 +21,6 @@ spec:
     - team: pensjondeployer
       application: pensjon-pen
       access: read
+    - team: teamdagpenger
+      application: dp-andre-ytelser
+      access: read


### PR DESCRIPTION
## Hva
Gir `dp-andre-ytelser` (team Dagpenger) lesetilgang til `etterlatte.vedtakshendelser` i dev og prod.

## Hvorfor
Team Dagpenger ønsker å lytte på vedtakshendelser for **barnepensjon (BP)** for å varsle saksbehandlere når en dagpengemottaker får vedtak om barnepensjon. Dette brukes til å vurdere om dagpengene skal stanses.

Vi filtrerer på `sakstype=BP` — omstillingsstønad (OMS) er foreløpig ikke relevant.

Ref. Slack-tråd i #team-etterlatte med @Mona og @Hanne.

## Endrede filer
- `topic-vedtakshendelser-dev.yaml` — lesetilgang for dp-andre-ytelser
- `topic-vedtakshendelser-prod.yaml` — lesetilgang for dp-andre-ytelser

## ⚠️ Husk
**Deploy Kafka topics** workflow må kjøres manuelt etter merge for å oppdatere topics i begge clustere.
