### PR TITLE
Kontrollsjekker mot sak og siste vedtak

### DIFF
--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiver.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiver.kt
@@ -110,8 +110,9 @@ internal class OpprettVedtakforespoerselRiver(
                 packet[ReguleringEvents.VEDTAK_OPPHOER_ETTER] = it
             }
 
-            packet[ReguleringEvents.INNVILGEDE_PERIODER_FOER] =
-                hentInnvilgedePerioderForSak(omregningData.sakId)
+            sisteAttesterteVedtakISak?.let {
+                packet[ReguleringEvents.INNVILGEDE_PERIODER_FOER] = hentInnvilgedePerioderForBehandling(it.behandlingId)
+            }
             if (!skalStoppeEtterFattet(omregningData.revurderingaarsak)) {
                 packet[ReguleringEvents.INNVILGEDE_PERIODER_ETTER] =
                     hentInnvilgedePerioderForBehandling(omregningData.hentBehandlingId())
@@ -244,12 +245,6 @@ internal class OpprettVedtakforespoerselRiver(
     private fun VedtakOgRapid.utbetalingsperioder(): List<Utbetalingsperiode> =
         (this.vedtak.innhold as VedtakInnholdDto.VedtakBehandlingDto)
             .utbetalingsperioder
-
-    private fun hentInnvilgedePerioderForSak(sakId: SakId): List<Periode> =
-        vedtak
-            .hentInnvilgedePerioderForSak(sakId)
-            .map { it.periode }
-            .sortedBy { it.fom }
 
     private fun hentSisteAttesterteVedtakISak(sakId: SakId): VedtakDto? =
         vedtak

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiver.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiver.kt
@@ -92,16 +92,17 @@ internal class OpprettVedtakforespoerselRiver(
         vedtakOgRapid: VedtakOgRapid,
         packet: JsonMessage,
     ) {
-        val forrigeVedtak = krevIkkeNull(vedtak.hentVedtak(omregningData.hentForrigeBehandlingid())) { "Vedtak mangler" }
+        val forrigeVedtakMedUtbetaling = krevIkkeNull(vedtak.hentVedtak(omregningData.hentForrigeBehandlingid())) { "Vedtak mangler" }
+        val sisteAttesterteVedtakISak = hentSisteAttesterteVedtakISak(omregningData.sakId)
 
-        forrigeVedtak.utbetalingsperioder().beloepPaaDato(omregningData.hentFraDato())?.let {
+        forrigeVedtakMedUtbetaling.utbetalingsperioder().beloepPaaDato(omregningData.hentFraDato())?.let {
             packet[ReguleringEvents.VEDTAK_BELOEP_FOER] = it
         }
         vedtakOgRapid.utbetalingsperioder().beloepPaaDato(omregningData.hentFraDato())?.let {
             packet[ReguleringEvents.VEDTAK_BELOEP_ETTER] = it
         }
 
-        forrigeVedtak.opphoerFraOgMed()?.let {
+        sisteAttesterteVedtakISak?.let {
             packet[ReguleringEvents.VEDTAK_OPPHOER_FOER] = it
         }
         (vedtakOgRapid.vedtak.innhold as VedtakInnholdDto.VedtakBehandlingDto).opphoerFraOgMed?.let {
@@ -109,7 +110,7 @@ internal class OpprettVedtakforespoerselRiver(
         }
 
         packet[ReguleringEvents.INNVILGEDE_PERIODER_FOER] =
-            hentInnvilgedePerioderForBehandling(omregningData.hentForrigeBehandlingid())
+            hentInnvilgedePerioderForSak(omregningData.sakId)
         if (!skalStoppeEtterFattet(omregningData.revurderingaarsak)) {
             packet[ReguleringEvents.INNVILGEDE_PERIODER_ETTER] =
                 hentInnvilgedePerioderForBehandling(omregningData.hentBehandlingId())
@@ -239,6 +240,18 @@ internal class OpprettVedtakforespoerselRiver(
     private fun VedtakOgRapid.utbetalingsperioder(): List<Utbetalingsperiode> =
         (this.vedtak.innhold as VedtakInnholdDto.VedtakBehandlingDto)
             .utbetalingsperioder
+
+    private fun hentInnvilgedePerioderForSak(sakId: SakId): List<Periode> =
+        vedtak
+            .hentInnvilgedePerioderForSak(sakId)
+            .map { it.periode }
+            .sortedBy { it.fom }
+
+    private fun hentSisteAttesterteVedtakISak(sakId: SakId): VedtakDto? =
+        vedtak
+            .hentVedtakForSak(sakId)
+            .filter { it.attestasjon != null }
+            .maxByOrNull { it.attestasjon!!.tidspunkt }
 
     private fun hentInnvilgedePerioderForBehandling(behandlingId: UUID): List<Periode> =
         vedtak

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakService.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakService.kt
@@ -51,7 +51,11 @@ interface VedtakService {
 
     fun hentInnvilgedePerioder(behandlingId: UUID): List<InnvilgetPeriodeDto>
 
+    fun hentInnvilgedePerioderForSak(sakId: SakId): List<InnvilgetPeriodeDto>
+
     fun hentVedtak(behandlingId: UUID): VedtakDto?
+
+    fun hentVedtakForSak(sakId: SakId): List<VedtakDto>
 }
 
 class VedtakServiceImpl(
@@ -141,9 +145,19 @@ class VedtakServiceImpl(
             httpClient.get("$url/api/vedtak/$behandlingId/innvilgede-perioder").body()
         }
 
+    override fun hentInnvilgedePerioderForSak(sakId: SakId): List<InnvilgetPeriodeDto> =
+        runBlocking {
+            httpClient.get("$url/api/vedtak/sak/$sakId/innvilgede-perioder").body()
+        }
+
     override fun hentVedtak(behandlingId: UUID): VedtakDto? =
         runBlocking {
             httpClient.get("$url/api/vedtak/$behandlingId").body()
+        }
+
+    override fun hentVedtakForSak(sakId: SakId): List<VedtakDto> =
+        runBlocking {
+            httpClient.get("$url/api/vedtak/sak").body()
         }
 }
 

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakService.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakService.kt
@@ -51,8 +51,6 @@ interface VedtakService {
 
     fun hentInnvilgedePerioder(behandlingId: UUID): List<InnvilgetPeriodeDto>
 
-    fun hentInnvilgedePerioderForSak(sakId: SakId): List<InnvilgetPeriodeDto>
-
     fun hentVedtak(behandlingId: UUID): VedtakDto?
 
     fun hentVedtakForSak(sakId: SakId): List<VedtakDto>
@@ -143,11 +141,6 @@ class VedtakServiceImpl(
     override fun hentInnvilgedePerioder(behandlingId: UUID): List<InnvilgetPeriodeDto> =
         runBlocking {
             httpClient.get("$url/api/vedtak/$behandlingId/innvilgede-perioder").body()
-        }
-
-    override fun hentInnvilgedePerioderForSak(sakId: SakId): List<InnvilgetPeriodeDto> =
-        runBlocking {
-            httpClient.get("$url/api/vedtak/sak/$sakId/innvilgede-perioder").body()
         }
 
     override fun hentVedtak(behandlingId: UUID): VedtakDto? =

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiverTest.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiverTest.kt
@@ -125,7 +125,7 @@ internal class OpprettVedtakforespoerselRiverTest {
                 fattetRapidInfo(vedtakDto),
                 attestertRapidInfo(vedtakDto),
             )
-        every { vedtakServiceMock.hentInnvilgedePerioder(forrigeBehandlingId) } returns
+        every { vedtakServiceMock.hentInnvilgedePerioder(vedtakDto.behandlingId) } returns
             listOf(
                 InnvilgetPeriodeDto(Periode(YearMonth.of(2024, 1), null), emptyList()),
             )
@@ -134,12 +134,15 @@ internal class OpprettVedtakforespoerselRiverTest {
                 InnvilgetPeriodeDto(Periode(YearMonth.of(2024, 1), YearMonth.of(2024, 4)), emptyList()),
                 InnvilgetPeriodeDto(Periode(YearMonth.of(2024, 5), null), emptyList()),
             )
+        every { vedtakServiceMock.hentVedtakForSak(sakId) } returns
+            listOf(vedtakDto)
 
         val inspector = TestRapid().apply { river() }
 
         with(inspector.apply { sendTestMessage(melding.toJson()) }.inspektør) {
             verify { vedtakServiceMock.opprettVedtakFattOgAttester(sakId, behandlingId) }
             verify { vedtakServiceMock.hentVedtak(forrigeBehandlingId) }
+            verify { vedtakServiceMock.hentVedtakForSak(sakId) }
 
             size shouldBe 2
             field(0, EVENT_NAME_KEY).asText() shouldBe VedtakKafkaHendelseHendelseType.FATTET.lagEventnameForType()
@@ -181,6 +184,7 @@ internal class OpprettVedtakforespoerselRiverTest {
 
         verify { vedtakServiceMock.opprettVedtakOgFatt(sakId, behandlingId) }
         verify { vedtakServiceMock.hentVedtak(forrigeBehandlingId) }
+        verify { vedtakServiceMock.hentVedtakForSak(sakId) }
     }
 
     @Test
@@ -200,6 +204,7 @@ internal class OpprettVedtakforespoerselRiverTest {
 
         verify { vedtakServiceMock.opprettVedtakFattOgAttester(sakId, behandlingId) }
         verify { vedtakServiceMock.hentVedtak(forrigeBehandlingId) }
+        verify { vedtakServiceMock.hentVedtakForSak(sakId) }
     }
 
     @Test
@@ -234,6 +239,7 @@ internal class OpprettVedtakforespoerselRiverTest {
         verify { vedtakServiceMock.attesterVedtak(sakId, behandlingId) }
         verify { vedtakServiceMock.hentVedtak(forrigeBehandlingId) }
         verify { utbetalingKlientMock.simuler(behandlingId) }
+        verify { vedtakServiceMock.hentVedtakForSak(sakId) }
     }
 
     @Test
@@ -316,6 +322,7 @@ internal class OpprettVedtakforespoerselRiverTest {
         verify { vedtakServiceMock.attesterVedtak(sakId, behandlingId) }
         verify { brevKlientMock.opprettBrev(behandlingId, sakId) }
         verify { brevKlientMock.genererPdfOgFerdigstillVedtaksbrev(behandlingId, any()) }
+        verify { vedtakServiceMock.hentVedtakForSak(any()) }
     }
 
     @Test
@@ -338,6 +345,7 @@ internal class OpprettVedtakforespoerselRiverTest {
         verify { vedtakServiceMock.hentVedtak(forrigeBehandlingId) }
         verify { vedtakServiceMock.opprettVedtakOgFatt(sakId, behandlingId) }
         verify { brevKlientMock.opprettBrev(behandlingId, sakId) }
+        verify { vedtakServiceMock.hentVedtakForSak(sakId) }
 
         verify(exactly = 0) { vedtakServiceMock.attesterVedtak(sakId, behandlingId) }
         verify(exactly = 0) { brevKlientMock.genererPdfOgFerdigstillVedtaksbrev(behandlingId, any()) }


### PR DESCRIPTION
forrigeBehandling i omregningsdata er den forrige behandlingen med
utbetalingsperioder. Det kan ha kommet vedtak med opphør attestert etter
dette, og da må vi hente data for kontrollsjekking på en måte
som tar høyde for det.