### PR TITLE
Oppdaterer kontrollsjekker for reguleringen

### DIFF
--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiver.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiver.kt
@@ -16,6 +16,7 @@ import no.nav.etterlatte.libs.common.vedtak.Periode
 import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
 import no.nav.etterlatte.libs.common.vedtak.VedtakDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakInnholdDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakSammendragDto
 import no.nav.etterlatte.omregning.OmregningData
 import no.nav.etterlatte.omregning.OmregningDataPacket
 import no.nav.etterlatte.omregning.OmregningHendelseType
@@ -93,25 +94,26 @@ internal class OpprettVedtakforespoerselRiver(
         packet: JsonMessage,
     ) {
         try {
-            val forrigeVedtak =
-                krevIkkeNull(vedtak.hentVedtak(omregningData.hentForrigeBehandlingid())) { "Vedtak mangler" }
+            val forrigeVedtakMedUtbetaling = krevIkkeNull(vedtak.hentVedtak(omregningData.hentForrigeBehandlingid())) { "Vedtak mangler" }
+            val sisteAttesterteVedtakISak = hentSisteAttesterteVedtakISak(omregningData.sakId)
 
-            forrigeVedtak.utbetalingsperioder().beloepPaaDato(omregningData.hentFraDato())?.let {
+            forrigeVedtakMedUtbetaling.utbetalingsperioder().beloepPaaDato(omregningData.hentFraDato())?.let {
                 packet[ReguleringEvents.VEDTAK_BELOEP_FOER] = it
             }
             vedtakOgRapid.utbetalingsperioder().beloepPaaDato(omregningData.hentFraDato())?.let {
                 packet[ReguleringEvents.VEDTAK_BELOEP_ETTER] = it
             }
 
-            forrigeVedtak.opphoerFraOgMed()?.let {
+            sisteAttesterteVedtakISak?.opphoerFraOgMed?.let {
                 packet[ReguleringEvents.VEDTAK_OPPHOER_FOER] = it
             }
             (vedtakOgRapid.vedtak.innhold as VedtakInnholdDto.VedtakBehandlingDto).opphoerFraOgMed?.let {
                 packet[ReguleringEvents.VEDTAK_OPPHOER_ETTER] = it
             }
 
-            packet[ReguleringEvents.INNVILGEDE_PERIODER_FOER] =
-                hentInnvilgedePerioderForBehandling(omregningData.hentForrigeBehandlingid())
+            sisteAttesterteVedtakISak?.let {
+                packet[ReguleringEvents.INNVILGEDE_PERIODER_FOER] = hentInnvilgedePerioderForBehandling(it.behandlingId)
+            }
             if (!skalStoppeEtterFattet(omregningData.revurderingaarsak)) {
                 packet[ReguleringEvents.INNVILGEDE_PERIODER_ETTER] =
                     hentInnvilgedePerioderForBehandling(omregningData.hentBehandlingId())
@@ -244,6 +246,12 @@ internal class OpprettVedtakforespoerselRiver(
     private fun VedtakOgRapid.utbetalingsperioder(): List<Utbetalingsperiode> =
         (this.vedtak.innhold as VedtakInnholdDto.VedtakBehandlingDto)
             .utbetalingsperioder
+
+    private fun hentSisteAttesterteVedtakISak(sakId: SakId): VedtakSammendragDto? =
+        vedtak
+            .hentVedtakForSak(sakId)
+            .filter { it.datoAttestert != null }
+            .maxByOrNull { it.datoAttestert!! }
 
     private fun hentInnvilgedePerioderForBehandling(behandlingId: UUID): List<Periode> =
         vedtak

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakService.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakService.kt
@@ -14,6 +14,7 @@ import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.vedtak.InnvilgetPeriodeDto
 import no.nav.etterlatte.libs.common.vedtak.LoependeYtelseDTO
 import no.nav.etterlatte.libs.common.vedtak.VedtakDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakSammendragDto
 import no.nav.etterlatte.migrering.MigreringKjoringVariant
 import java.time.LocalDate
 import java.util.UUID
@@ -52,6 +53,8 @@ interface VedtakService {
     fun hentInnvilgedePerioder(behandlingId: UUID): List<InnvilgetPeriodeDto>
 
     fun hentVedtak(behandlingId: UUID): VedtakDto?
+
+    fun hentVedtakForSak(sakId: SakId): List<VedtakSammendragDto>
 }
 
 class VedtakServiceImpl(
@@ -144,6 +147,11 @@ class VedtakServiceImpl(
     override fun hentVedtak(behandlingId: UUID): VedtakDto? =
         runBlocking {
             httpClient.get("$url/api/vedtak/$behandlingId").body()
+        }
+
+    override fun hentVedtakForSak(sakId: SakId): List<VedtakSammendragDto> =
+        runBlocking {
+            httpClient.get("$url/api/vedtak/sak/$sakId").body()
         }
 }
 

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiverTest.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/regulering/OpprettVedtakforespoerselRiverTest.kt
@@ -20,11 +20,14 @@ import no.nav.etterlatte.libs.common.deserialize
 import no.nav.etterlatte.libs.common.rapidsandrivers.EVENT_NAME_KEY
 import no.nav.etterlatte.libs.common.rapidsandrivers.lagParMedEventNameKey
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.toNorskTid
 import no.nav.etterlatte.libs.common.toJson
 import no.nav.etterlatte.libs.common.vedtak.InnvilgetPeriodeDto
 import no.nav.etterlatte.libs.common.vedtak.Periode
 import no.nav.etterlatte.libs.common.vedtak.VedtakDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakInnholdDto
 import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseHendelseType
+import no.nav.etterlatte.libs.common.vedtak.VedtakSammendragDto
 import no.nav.etterlatte.omregning.OmregningData
 import no.nav.etterlatte.omregning.OmregningHendelseType
 import no.nav.etterlatte.omregning.UtbetalingVerifikasjon
@@ -119,13 +122,14 @@ internal class OpprettVedtakforespoerselRiverTest {
                 forrigeBehandlingId = forrigeBehandlingId,
             )
         val vedtakDto = vedtakDto(virk = YearMonth.of(fraDato.year, fraDato.month))
+        val vedtakSammendragDto = vedtakSammendragDto(vedtakDto)
         every { vedtakServiceMock.opprettVedtakFattOgAttester(any(), any()) } returns
             VedtakOgRapid(
                 vedtakDto,
                 fattetRapidInfo(vedtakDto),
                 attestertRapidInfo(vedtakDto),
             )
-        every { vedtakServiceMock.hentInnvilgedePerioder(forrigeBehandlingId) } returns
+        every { vedtakServiceMock.hentInnvilgedePerioder(vedtakDto.behandlingId) } returns
             listOf(
                 InnvilgetPeriodeDto(Periode(YearMonth.of(2024, 1), null), emptyList()),
             )
@@ -134,12 +138,15 @@ internal class OpprettVedtakforespoerselRiverTest {
                 InnvilgetPeriodeDto(Periode(YearMonth.of(2024, 1), YearMonth.of(2024, 4)), emptyList()),
                 InnvilgetPeriodeDto(Periode(YearMonth.of(2024, 5), null), emptyList()),
             )
+        every { vedtakServiceMock.hentVedtakForSak(sakId) } returns
+            listOf(vedtakSammendragDto)
 
         val inspector = TestRapid().apply { river() }
 
         with(inspector.apply { sendTestMessage(melding.toJson()) }.inspektør) {
             verify { vedtakServiceMock.opprettVedtakFattOgAttester(sakId, behandlingId) }
             verify { vedtakServiceMock.hentVedtak(forrigeBehandlingId) }
+            verify { vedtakServiceMock.hentVedtakForSak(sakId) }
 
             size shouldBe 2
             field(0, EVENT_NAME_KEY).asText() shouldBe VedtakKafkaHendelseHendelseType.FATTET.lagEventnameForType()
@@ -165,6 +172,22 @@ internal class OpprettVedtakforespoerselRiverTest {
         }
     }
 
+    private fun vedtakSammendragDto(vedtakDto: VedtakDto): VedtakSammendragDto {
+        val behandling = vedtakDto.innhold as? VedtakInnholdDto.VedtakBehandlingDto
+        return VedtakSammendragDto(
+            id = vedtakDto.id.toString(),
+            behandlingId = vedtakDto.behandlingId,
+            vedtakType = vedtakDto.type,
+            behandlendeSaksbehandler = vedtakDto.vedtakFattet?.ansvarligSaksbehandler,
+            datoFattet = vedtakDto.vedtakFattet?.tidspunkt?.toNorskTid(),
+            attesterendeSaksbehandler = vedtakDto.attestasjon?.attestant,
+            datoAttestert = vedtakDto.attestasjon?.tidspunkt?.toNorskTid(),
+            virkningstidspunkt = behandling?.virkningstidspunkt,
+            opphoerFraOgMed = behandling?.opphoerFraOgMed,
+            iverksettelsesTidspunkt = vedtakDto.iverksettelsesTidspunkt,
+        )
+    }
+
     @Test
     fun `skal opprette vedtak og bare fatte hvis feature toggle for stopp er paa`() {
         val behandlingId = UUID.randomUUID()
@@ -181,6 +204,7 @@ internal class OpprettVedtakforespoerselRiverTest {
 
         verify { vedtakServiceMock.opprettVedtakOgFatt(sakId, behandlingId) }
         verify { vedtakServiceMock.hentVedtak(forrigeBehandlingId) }
+        verify { vedtakServiceMock.hentVedtakForSak(sakId) }
     }
 
     @Test
@@ -200,6 +224,7 @@ internal class OpprettVedtakforespoerselRiverTest {
 
         verify { vedtakServiceMock.opprettVedtakFattOgAttester(sakId, behandlingId) }
         verify { vedtakServiceMock.hentVedtak(forrigeBehandlingId) }
+        verify { vedtakServiceMock.hentVedtakForSak(sakId) }
     }
 
     @Test
@@ -234,6 +259,7 @@ internal class OpprettVedtakforespoerselRiverTest {
         verify { vedtakServiceMock.attesterVedtak(sakId, behandlingId) }
         verify { vedtakServiceMock.hentVedtak(forrigeBehandlingId) }
         verify { utbetalingKlientMock.simuler(behandlingId) }
+        verify { vedtakServiceMock.hentVedtakForSak(sakId) }
     }
 
     @Test
@@ -316,6 +342,7 @@ internal class OpprettVedtakforespoerselRiverTest {
         verify { vedtakServiceMock.attesterVedtak(sakId, behandlingId) }
         verify { brevKlientMock.opprettBrev(behandlingId, sakId) }
         verify { brevKlientMock.genererPdfOgFerdigstillVedtaksbrev(behandlingId, any()) }
+        verify { vedtakServiceMock.hentVedtakForSak(any()) }
     }
 
     @Test
@@ -338,6 +365,7 @@ internal class OpprettVedtakforespoerselRiverTest {
         verify { vedtakServiceMock.hentVedtak(forrigeBehandlingId) }
         verify { vedtakServiceMock.opprettVedtakOgFatt(sakId, behandlingId) }
         verify { brevKlientMock.opprettBrev(behandlingId, sakId) }
+        verify { vedtakServiceMock.hentVedtakForSak(sakId) }
 
         verify(exactly = 0) { vedtakServiceMock.attesterVedtak(sakId, behandlingId) }
         verify(exactly = 0) { brevKlientMock.genererPdfOgFerdigstillVedtaksbrev(behandlingId, any()) }


### PR DESCRIPTION
forrigeBehandling i omregningsdata er den forrige behandlingen med utbetalingsperioder. Det kan ha kommet vedtak med opphør attestert etter dette, og da må vi hente data for kontrollsjekking på en måte som tar høyde for det.

Skal teste litt igjennom denne for å bekrefte at den faktisk virker denne gangen 🤞 