### PR TITLE
Grunnbeløp 2026

### DIFF
--- a/apps/etterlatte-beregning/src/main/resources/grunnbelop.json
+++ b/apps/etterlatte-beregning/src/main/resources/grunnbelop.json
@@ -1,6 +1,12 @@
 {
   "grunnbeløp": [
     {
+      "dato": "2026-05",
+      "grunnbeløp": 136160,
+      "grunnbeløpPerMåned": 11346,
+      "omregningsfaktor": 1.046097
+    },
+    {
       "dato": "2025-05",
       "grunnbeløp": 130160,
       "grunnbeløpPerMåned": 10847,

--- a/apps/etterlatte-beregning/src/main/resources/grunnbelop.json
+++ b/apps/etterlatte-beregning/src/main/resources/grunnbelop.json
@@ -2,9 +2,9 @@
   "grunnbeløp": [
     {
       "dato": "2026-05",
-      "grunnbeløp": 136160,
-      "grunnbeløpPerMåned": 11346,
-      "omregningsfaktor": 1.046097
+      "grunnbeløp": 136549,
+      "grunnbeløpPerMåned": 11379,
+      "omregningsfaktor": 1.049085
     },
     {
       "dato": "2025-05",

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -5,6 +5,9 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import no.nav.etterlatte.beregning.regler.aarsoppgjoer
 import no.nav.etterlatte.beregning.regler.avkortetYtelse
 import no.nav.etterlatte.beregning.regler.avkorting
@@ -17,6 +20,8 @@ import no.nav.etterlatte.beregning.regler.bruker
 import no.nav.etterlatte.beregning.regler.etteroppgjoer
 import no.nav.etterlatte.beregning.regler.inntektsavkorting
 import no.nav.etterlatte.beregning.regler.ytelseFoerAvkorting
+import no.nav.etterlatte.grunnbeloep.Grunnbeloep
+import no.nav.etterlatte.grunnbeloep.GrunnbeloepRepository
 import no.nav.etterlatte.libs.common.beregning.AvkortetYtelseDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingGrunnlagLagreDto
 import no.nav.etterlatte.libs.common.beregning.AvkortingOverstyrtInnvilgaMaanederDto
@@ -26,15 +31,49 @@ import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.toJsonNode
 import no.nav.etterlatte.libs.ktor.token.HardkodaSystembruker
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
 import java.time.Month
 import java.time.YearMonth
 import java.util.UUID
 import kotlin.test.assertEquals
 
 internal class AvkortingTest {
+    @BeforeEach
+    fun `mock grunnbeloep`() {
+        mockkObject(GrunnbeloepRepository)
+        every { GrunnbeloepRepository.historiskeGrunnbeloep } returns
+            listOf(
+                Grunnbeloep(
+                    dato = YearMonth.of(2023, 5),
+                    grunnbeloep = 118620,
+                    grunnbeloepPerMaaned = 9885,
+                    omregningsfaktor = BigDecimal("1.045591"),
+                ),
+                Grunnbeloep(
+                    dato = YearMonth.of(2024, 5),
+                    grunnbeloep = 124028,
+                    grunnbeloepPerMaaned = 10336,
+                    omregningsfaktor = BigDecimal("1.064076"),
+                ),
+                Grunnbeloep(
+                    dato = YearMonth.of(2025, 5),
+                    grunnbeloep = 130160,
+                    grunnbeloepPerMaaned = 10847,
+                    omregningsfaktor = BigDecimal("1.049440"),
+                ),
+            )
+    }
+
+    @AfterEach
+    fun `unmock grunnbeloep`() {
+        unmockkObject(GrunnbeloepRepository)
+    }
+
     @Nested
     inner class AvkortigTilDto {
         val avkorting =

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/AvkortingTest.kt
@@ -1116,102 +1116,99 @@ internal class AvkortingTest {
         }
     }
 
-    @Nested
-    inner class BeregnAvkortingMedNyeGrunnlag {
-        @Test
-        fun `skal haandtere gammelt grunnlag uten maanederInnvilget naar ny inntekt legges inn`() {
-            // Simulerer prod-scenario: to gamle inntektsgrunnlag (maanederInnvilget=null) fra forrige behandling,
-            // og saksbehandler legger inn ny inntekt fra april i en ny revurdering.
-            // Grunnlagene ble opprettet før maanederInnvilget-kolonnen ble innført → null i DB.
-            // kopierAvkorting populerer maanederInnvilget fra innvilgaMaaneder ved opprettelse av ny revurdering,
-            // slik at beregnRestanse ikke møter null når lukkSisteInntektsperiode har endret periode.tom.
+    @Test
+    fun `skal haandtere gammelt grunnlag uten maanederInnvilget naar ny inntekt legges inn`() {
+        // Simulerer prod-scenario: to gamle inntektsgrunnlag (maanederInnvilget=null) fra forrige behandling,
+        // og saksbehandler legger inn ny inntekt fra april i en ny revurdering.
+        // Grunnlagene ble opprettet før maanederInnvilget-kolonnen ble innført → null i DB.
+        // kopierAvkorting populerer maanederInnvilget fra innvilgaMaaneder ved opprettelse av ny revurdering,
+        // slik at beregnRestanse ikke møter null når lukkSisteInntektsperiode har endret periode.tom.
 
-            val regelKilde = Grunnlagsopplysning.RegelKilde(navn = "regel", ts = Tidspunkt.now(), versjon = "1")
+        val regelKilde = Grunnlagsopplysning.RegelKilde(navn = "regel", ts = Tidspunkt.now(), versjon = "1")
 
-            fun gammeltGrunnlag(fom: YearMonth) =
-                ForventetInntekt(
-                    id = UUID.randomUUID(),
-                    periode = Periode(fom = fom, tom = null),
-                    inntektTom = 300_000,
-                    fratrekkInnAar = 0,
-                    inntektUtlandTom = 0,
-                    fratrekkInnAarUtland = 0,
-                    innvilgaMaaneder = 12,
-                    spesifikasjon = "",
-                    kilde = Grunnlagsopplysning.Saksbehandler.create("Z123456"),
-                    overstyrtInnvilgaMaanederAarsak = null,
-                    overstyrtInnvilgaMaanederBegrunnelse = null,
-                    inntektInnvilgetPeriode =
-                        BenyttetInntektInnvilgetPeriode(
-                            verdi = 300_000,
-                            tidspunkt = Tidspunkt.now(),
-                            regelResultat = "{}".toJsonNode(),
-                            kilde = regelKilde,
-                        ),
-                    maanederInnvilget = null,
-                    maanederInnvilgetRegelResultat = null,
-                )
+        fun gammeltGrunnlag(fom: YearMonth) =
+            ForventetInntekt(
+                id = UUID.randomUUID(),
+                periode = Periode(fom = fom, tom = null),
+                inntektTom = 300_000,
+                fratrekkInnAar = 0,
+                inntektUtlandTom = 0,
+                fratrekkInnAarUtland = 0,
+                innvilgaMaaneder = 12,
+                spesifikasjon = "",
+                kilde = Grunnlagsopplysning.Saksbehandler.create("Z123456"),
+                overstyrtInnvilgaMaanederAarsak = null,
+                overstyrtInnvilgaMaanederBegrunnelse = null,
+                inntektInnvilgetPeriode =
+                    BenyttetInntektInnvilgetPeriode(
+                        verdi = 300_000,
+                        tidspunkt = Tidspunkt.now(),
+                        regelResultat = "{}".toJsonNode(),
+                        kilde = regelKilde,
+                    ),
+                maanederInnvilget = null,
+                maanederInnvilgetRegelResultat = null,
+            )
 
-            val avkorting =
-                Avkorting(
-                    aarsoppgjoer =
-                        listOf(
-                            AarsoppgjoerLoepende(
-                                id = UUID.randomUUID(),
-                                aar = 2025,
-                                fom = YearMonth.of(2025, Month.JANUARY),
-                                inntektsavkorting =
-                                    listOf(
-                                        Inntektsavkorting(gammeltGrunnlag(YearMonth.of(2025, Month.JANUARY))),
-                                        Inntektsavkorting(gammeltGrunnlag(YearMonth.of(2025, Month.FEBRUARY))),
-                                    ),
-                                ytelseFoerAvkorting =
-                                    listOf(
-                                        YtelseFoerAvkorting(
-                                            beregning = 15_000,
-                                            periode = Periode(YearMonth.of(2025, Month.JANUARY), null),
-                                            beregningsreferanse = UUID.randomUUID(),
-                                        ),
-                                    ),
-                            ),
-                        ),
-                )
-
-            // Åpen beregningsperiode: tomSluttenAvAaret=null (ingen neste årsoppgjør) → beregningen må dekke frem i tid
-            val beregningForAaret =
-                beregning(
-                    beregninger =
-                        listOf(
-                            beregningsperiode(
-                                datoFOM = YearMonth.of(2025, Month.APRIL),
-                                utbetaltBeloep = 15_000,
-                            ),
-                        ),
-                )
-
-            val resultat =
-                avkorting
-                    .kopierAvkorting()
-                    .beregnAvkortingMedNyeGrunnlag(
-                        nyttGrunnlag =
-                            listOf(
-                                avkortinggrunnlagLagreDto(
-                                    aarsinntekt = 200_000,
-                                    fom = YearMonth.of(2025, Month.APRIL),
+        val avkorting =
+            Avkorting(
+                aarsoppgjoer =
+                    listOf(
+                        AarsoppgjoerLoepende(
+                            id = UUID.randomUUID(),
+                            aar = 2025,
+                            fom = YearMonth.of(2025, Month.JANUARY),
+                            inntektsavkorting =
+                                listOf(
+                                    Inntektsavkorting(gammeltGrunnlag(YearMonth.of(2025, Month.JANUARY))),
+                                    Inntektsavkorting(gammeltGrunnlag(YearMonth.of(2025, Month.FEBRUARY))),
                                 ),
-                            ),
-                        bruker = bruker,
-                        beregning = beregningForAaret,
-                        sanksjoner = emptyList(),
-                        opphoerFom = null,
-                        brukNyeReglerAvkorting = true,
-                    )
+                            ytelseFoerAvkorting =
+                                listOf(
+                                    YtelseFoerAvkorting(
+                                        beregning = 15_000,
+                                        periode = Periode(YearMonth.of(2025, Month.JANUARY), null),
+                                        beregningsreferanse = UUID.randomUUID(),
+                                    ),
+                                ),
+                        ),
+                    ),
+            )
 
-            resultat.aarsoppgjoer
-                .single()
-                .inntektsavkorting()
-                .size shouldBe 3
-        }
+        // Åpen beregningsperiode: tomSluttenAvAaret=null (ingen neste årsoppgjør) → beregningen må dekke frem i tid
+        val beregningForAaret =
+            beregning(
+                beregninger =
+                    listOf(
+                        beregningsperiode(
+                            datoFOM = YearMonth.of(2025, Month.APRIL),
+                            utbetaltBeloep = 15_000,
+                        ),
+                    ),
+            )
+
+        val resultat =
+            avkorting
+                .kopierAvkorting()
+                .beregnAvkortingMedNyeGrunnlag(
+                    nyttGrunnlag =
+                        listOf(
+                            avkortinggrunnlagLagreDto(
+                                aarsinntekt = 200_000,
+                                fom = YearMonth.of(2025, Month.APRIL),
+                            ),
+                        ),
+                    bruker = bruker,
+                    beregning = beregningForAaret,
+                    sanksjoner = emptyList(),
+                    opphoerFom = null,
+                    brukNyeReglerAvkorting = true,
+                )
+
+        resultat.aarsoppgjoer
+            .single()
+            .inntektsavkorting()
+            .size shouldBe 3
     }
 
     @Nested

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingMedToInntektsTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingMedToInntektsTest.kt
@@ -2,6 +2,9 @@ package no.nav.etterlatte.beregning.regler.avkorting
 
 import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
 import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import no.nav.etterlatte.avkorting.AvkortetYtelse
 import no.nav.etterlatte.avkorting.AvkortetYtelseType
 import no.nav.etterlatte.avkorting.Avkorting
@@ -11,13 +14,49 @@ import no.nav.etterlatte.beregning.regler.beregning
 import no.nav.etterlatte.beregning.regler.beregningsperiode
 import no.nav.etterlatte.beregning.regler.bruker
 import no.nav.etterlatte.beregning.regler.inntektsavkorting
+import no.nav.etterlatte.grunnbeloep.Grunnbeloep
+import no.nav.etterlatte.grunnbeloep.GrunnbeloepRepository
 import no.nav.etterlatte.libs.common.periode.Periode
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
 import java.time.Month
 import java.time.YearMonth
 
 class BeregnAvkortingMedToInntektsTest {
+    @BeforeEach
+    fun `mock grunnbeloep`() {
+        mockkObject(GrunnbeloepRepository)
+        every { GrunnbeloepRepository.historiskeGrunnbeloep } returns
+            listOf(
+                Grunnbeloep(
+                    dato = YearMonth.of(2023, 5),
+                    grunnbeloep = 118620,
+                    grunnbeloepPerMaaned = 9885,
+                    omregningsfaktor = BigDecimal("1.045591"),
+                ),
+                Grunnbeloep(
+                    dato = YearMonth.of(2024, 5),
+                    grunnbeloep = 124028,
+                    grunnbeloepPerMaaned = 10336,
+                    omregningsfaktor = BigDecimal("1.064076"),
+                ),
+                Grunnbeloep(
+                    dato = YearMonth.of(2025, 5),
+                    grunnbeloep = 130160,
+                    grunnbeloepPerMaaned = 10847,
+                    omregningsfaktor = BigDecimal("1.049440"),
+                ),
+            )
+    }
+
+    @AfterEach
+    fun `unmock grunnbeloep`() {
+        unmockkObject(GrunnbeloepRepository)
+    }
+
     @Test
     @Order(0)
     fun `Beregner avkortet ytelse for foerstegangsbehandling`() {

--- a/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnOmstillingsstoenadServiceTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/beregning/BeregnOmstillingsstoenadServiceTest.kt
@@ -5,6 +5,8 @@ import io.kotest.matchers.shouldNotBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.sakId1
 import no.nav.etterlatte.beregning.grunnlag.BeregningsGrunnlag
@@ -17,6 +19,8 @@ import no.nav.etterlatte.beregning.regler.STANDARDSAK
 import no.nav.etterlatte.beregning.regler.bruker
 import no.nav.etterlatte.beregning.regler.toGrunnlag
 import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
+import no.nav.etterlatte.grunnbeloep.Grunnbeloep
+import no.nav.etterlatte.grunnbeloep.GrunnbeloepRepository
 import no.nav.etterlatte.klienter.GrunnlagKlientImpl
 import no.nav.etterlatte.klienter.TrygdetidKlient
 import no.nav.etterlatte.klienter.VilkaarsvurderingKlient
@@ -37,10 +41,12 @@ import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.sanksjon.SanksjonService
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.Month
 import java.time.YearMonth
@@ -72,6 +78,34 @@ internal class BeregnOmstillingsstoenadServiceTest {
 
         every { featureToggleService.isEnabled(any(), any()) } returns false
         every { sanksjonService.hentSanksjon(any()) } returns emptyList()
+
+        mockkObject(GrunnbeloepRepository)
+        every { GrunnbeloepRepository.historiskeGrunnbeloep } returns
+            listOf(
+                Grunnbeloep(
+                    dato = YearMonth.of(2023, 5),
+                    grunnbeloep = 118620,
+                    grunnbeloepPerMaaned = 9885,
+                    omregningsfaktor = BigDecimal("1.045591"),
+                ),
+                Grunnbeloep(
+                    dato = YearMonth.of(2024, 5),
+                    grunnbeloep = 124028,
+                    grunnbeloepPerMaaned = 10336,
+                    omregningsfaktor = BigDecimal("1.064076"),
+                ),
+                Grunnbeloep(
+                    dato = YearMonth.of(2025, 5),
+                    grunnbeloep = 130160,
+                    grunnbeloepPerMaaned = 10847,
+                    omregningsfaktor = BigDecimal("1.049440"),
+                ),
+            )
+    }
+
+    @AfterEach
+    fun `unmock grunnbeloep`() {
+        unmockkObject(GrunnbeloepRepository)
     }
 
     @Test


### PR DESCRIPTION
Vi legger med det faktiske grunnbeløpet samt mocker grunnbeløp for testene som feiler med nytt grunnbeløp. Feilen er pga. rart testoppsett, ikke fordi g-beløpene er feil.