### PR TITLE
Vil logge feil i institusjonsopphold hendelseshåndtering

### DIFF
--- a/apps/etterlatte-egne-ansatte-lytter/src/main/kotlin/no/nav/etterlatte/kafka/KafkaConsumerEgneAnsatte.kt
+++ b/apps/etterlatte-egne-ansatte-lytter/src/main/kotlin/no/nav/etterlatte/kafka/KafkaConsumerEgneAnsatte.kt
@@ -12,7 +12,7 @@ class KafkaConsumerEgneAnsatte(
     kafkaProperties: Properties,
     pollTimeoutInSeconds: Duration = Duration.ofSeconds(10L),
     closed: AtomicBoolean = AtomicBoolean(false),
-) : Kafkakonsument<String>(
+) : Kafkakonsument<String, String>(
         logger = LoggerFactory.getLogger(KafkaConsumerEgneAnsatte::class.java.name),
         consumer = KafkaConsumer<String, String>(kafkaProperties),
         topic = topic,

--- a/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/common/JoarkhendelseKonsument.kt
+++ b/apps/etterlatte-hendelser-joark/src/main/kotlin/joarkhendelser/common/JoarkhendelseKonsument.kt
@@ -13,7 +13,7 @@ class JoarkhendelseKonsument(
     topic: String,
     kafkaProperties: Properties,
     private val joarkHendelseHandler: JoarkHendelseHandler,
-) : Kafkakonsument<JournalfoeringHendelseRecord>(
+) : Kafkakonsument<String, JournalfoeringHendelseRecord>(
         logger = LoggerFactory.getLogger(JoarkhendelseKonsument::class.java.name),
         consumer = KafkaConsumer<String, JournalfoeringHendelseRecord>(kafkaProperties),
         topic = topic,

--- a/apps/etterlatte-hendelser-pdl/src/main/kotlin/hendelserpdl/common/PersonhendelseKonsument.kt
+++ b/apps/etterlatte-hendelser-pdl/src/main/kotlin/hendelserpdl/common/PersonhendelseKonsument.kt
@@ -15,7 +15,7 @@ class PersonhendelseKonsument(
     topic: String,
     kafkaProperties: Properties,
     private val personHendelseFordeler: PersonHendelseFordeler,
-) : Kafkakonsument<Personhendelse>(
+) : Kafkakonsument<String, Personhendelse>(
         logger = LoggerFactory.getLogger(KafkaConsumer::class.java.name),
         consumer = KafkaConsumer<String, Personhendelse>(kafkaProperties),
         topic = topic,

--- a/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/samordning/SamordningHendelseKonsument.kt
+++ b/apps/etterlatte-hendelser-samordning/src/main/kotlin/no/nav/etterlatte/samordning/SamordningHendelseKonsument.kt
@@ -11,7 +11,7 @@ class SamordningHendelseKonsument(
     topic: String,
     kafkaProperties: Properties,
     private val handler: SamordningHendelseHandler,
-) : Kafkakonsument<SamordningVedtakHendelse>(
+) : Kafkakonsument<String, SamordningVedtakHendelse>(
         logger = LoggerFactory.getLogger(SamordningHendelseKonsument::class.java.name),
         consumer = KafkaConsumer<String, SamordningVedtakHendelse>(kafkaProperties),
         topic = topic,

--- a/apps/etterlatte-hendelser-ufoere/src/main/kotlin/hendelserufoere/common/UfoerehendelseKonsument.kt
+++ b/apps/etterlatte-hendelser-ufoere/src/main/kotlin/hendelserufoere/common/UfoerehendelseKonsument.kt
@@ -17,7 +17,7 @@ class UfoerehendelseKonsument(
     topic: String,
     kafkaProperties: Properties,
     private val ufoereHendelseFordeler: UfoereHendelseFordeler,
-) : Kafkakonsument<String>(
+) : Kafkakonsument<String, String>(
         logger = LoggerFactory.getLogger(KafkaConsumer::class.java.name),
         consumer = KafkaConsumer<String, String>(kafkaProperties),
         topic = topic,

--- a/apps/etterlatte-institusjonsopphold/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-institusjonsopphold/src/main/kotlin/Application.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte
 
 import io.ktor.server.application.Application
 import no.nav.etterlatte.kafka.startLytting
+import no.nav.etterlatte.libs.common.logging.sikkerLoggOppstart
 import no.nav.etterlatte.libs.ktor.initialisering.initEmbeddedServerUtenRest
 import no.nav.etterlatte.libs.ktor.initialisering.runEngine
 import org.slf4j.LoggerFactory
@@ -13,6 +14,10 @@ fun main() {
 class Server(
     private val applicationContext: ApplicationContext,
 ) {
+    init {
+        sikkerLoggOppstart("etterlatte-institusjonsopphold")
+    }
+
     private val logger = LoggerFactory.getLogger(Application::class.java)
 
     private val engine =

--- a/apps/etterlatte-institusjonsopphold/src/main/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaConsumerInstitusjonsopphold.kt
+++ b/apps/etterlatte-institusjonsopphold/src/main/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaConsumerInstitusjonsopphold.kt
@@ -19,9 +19,9 @@ class KafkaConsumerInstitusjonsopphold(
     env: Miljoevariabler,
     private val behandlingKlient: BehandlingKlient,
     kafkaEnvironment: KafkaConsumerConfiguration = KafkaEnvironment(),
-) : Kafkakonsument<KafkaOppholdHendelse>(
+) : Kafkakonsument<Long, KafkaOppholdHendelse>(
         logger = LoggerFactory.getLogger(KafkaConsumerInstitusjonsopphold::class.java.name),
-        consumer = KafkaConsumer<String, KafkaOppholdHendelse>(kafkaEnvironment.generateKafkaConsumerProperties(env)),
+        consumer = KafkaConsumer<Long, KafkaOppholdHendelse>(kafkaEnvironment.generateKafkaConsumerProperties(env)),
         topic = env.requireEnvValue(INSTITUSJONSOPPHOLD_TOPIC),
         pollTimeoutInSeconds = Duration.ofSeconds(10L),
     ) {

--- a/apps/etterlatte-institusjonsopphold/src/main/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaConsumerInstitusjonsopphold.kt
+++ b/apps/etterlatte-institusjonsopphold/src/main/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaConsumerInstitusjonsopphold.kt
@@ -9,7 +9,9 @@ import no.nav.etterlatte.kafka.KafkaConsumerConfiguration
 import no.nav.etterlatte.kafka.Kafkakonsument
 import no.nav.etterlatte.libs.common.EnvEnum
 import no.nav.etterlatte.libs.common.Miljoevariabler
+import no.nav.etterlatte.libs.common.logging.sikkerlogger
 import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
 
@@ -23,11 +25,18 @@ class KafkaConsumerInstitusjonsopphold(
         topic = env.requireEnvValue(INSTITUSJONSOPPHOLD_TOPIC),
         pollTimeoutInSeconds = Duration.ofSeconds(10L),
     ) {
+    val sikkerLogg: Logger = sikkerlogger()
+
     override fun stream() {
         stream { meldinger ->
             meldinger.forEach {
                 runBlocking {
-                    behandlingKlient.haandterHendelse(it)
+                    try {
+                        behandlingKlient.haandterHendelse(it)
+                    } catch (e: RuntimeException) {
+                        sikkerLogg.error("Feil i institusjonshendelse: ", e)
+                        throw e
+                    }
                 }
             }
         }

--- a/apps/etterlatte-institusjonsopphold/src/main/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaEnvironment.kt
+++ b/apps/etterlatte-institusjonsopphold/src/main/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaEnvironment.kt
@@ -7,6 +7,7 @@ import no.nav.etterlatte.kafka.Avrokonstanter
 import no.nav.etterlatte.kafka.Kafkakonfigurasjon
 import org.apache.kafka.common.IsolationLevel
 import org.apache.kafka.common.serialization.Deserializer
+import org.apache.kafka.common.serialization.LongDeserializer
 import java.util.Locale
 
 class KafkaEnvironment :
@@ -16,6 +17,7 @@ class KafkaEnvironment :
         userInfoConfigKey = Avrokonstanter.USER_INFO_CONFIG,
         schemaRegistryUrlConfigKey = Avrokonstanter.SCHEMA_REGISTRY_URL_CONFIG,
         isolationLevelConfig = IsolationLevel.READ_COMMITTED.toString().lowercase(Locale.getDefault()),
+        keyDeserializerClass = LongDeserializer::class.java,
     ) {
     class JsonDeserializer : Deserializer<KafkaOppholdHendelse> {
         private val mapper = jacksonObjectMapper()

--- a/apps/etterlatte-institusjonsopphold/src/main/kotlin/no/nav/etterlatte/institusjonsopphold/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-institusjonsopphold/src/main/kotlin/no/nav/etterlatte/institusjonsopphold/klienter/BehandlingKlient.kt
@@ -19,7 +19,7 @@ class BehandlingKlient(
 ) {
     private val logger = LoggerFactory.getLogger(this.javaClass.name)
 
-    suspend fun haandterHendelse(record: ConsumerRecord<String, KafkaOppholdHendelse>) {
+    suspend fun haandterHendelse(record: ConsumerRecord<Long, KafkaOppholdHendelse>) {
         logger.debug(
             "Behandler institusjonsopphold record med id: {}, partition {}, offset: {}",
             record.key(),

--- a/apps/etterlatte-klage/src/main/kotlin/no/nav/etterlatte/klage/KlageKafkakonsument.kt
+++ b/apps/etterlatte-klage/src/main/kotlin/no/nav/etterlatte/klage/KlageKafkakonsument.kt
@@ -14,7 +14,7 @@ class KlageKafkakonsument(
     env: Miljoevariabler,
     topic: String,
     private val behandlingKlient: BehandlingKlient,
-) : Kafkakonsument<String>(
+) : Kafkakonsument<String, String>(
         logger = LoggerFactory.getLogger(KlageKafkakonsument::class.java.name),
         consumer = KafkaConsumer<String, String>(KafkaEnvironment().generateKafkaConsumerProperties(env)),
         topic = topic,

--- a/libs/etterlatte-kafka/src/main/kotlin/kafka/KafkaRunner.kt
+++ b/libs/etterlatte-kafka/src/main/kotlin/kafka/KafkaRunner.kt
@@ -4,8 +4,8 @@ import no.nav.etterlatte.libs.common.logging.withLogContext
 import org.slf4j.Logger
 import kotlin.system.exitProcess
 
-fun <T> startLytting(
-    konsument: Kafkakonsument<in T>,
+fun <K, T> startLytting(
+    konsument: Kafkakonsument<K, in T>,
     logger: Logger,
 ) {
     withLogContext {

--- a/libs/etterlatte-kafka/src/main/kotlin/kafka/Kafkakonfigurasjon.kt
+++ b/libs/etterlatte-kafka/src/main/kotlin/kafka/Kafkakonfigurasjon.kt
@@ -30,6 +30,7 @@ abstract class Kafkakonfigurasjon<T>(
     private val schemaRegistryUrlConfigKey: String,
     private val isolationLevelConfig: String? = null,
     private val specificAvroReaderConfig: Boolean? = null,
+    private val keyDeserializerClass: Class<*> = StringDeserializer::class.java,
 ) : KafkaConsumerConfiguration {
     override fun generateKafkaConsumerProperties(env: Miljoevariabler): Properties =
         if (appIsInGCP()) {
@@ -54,7 +55,7 @@ abstract class Kafkakonfigurasjon<T>(
                 put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
                 put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, Duration.ofMinutes(8L).toMillis().toInt())
                 put(CommonClientConfigs.SESSION_TIMEOUT_MS_CONFIG, Duration.ofSeconds(20L).toMillis().toInt())
-                put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java)
+                put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializerClass)
                 put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializerClass)
 
                 put(Avrokonstanter.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO")
@@ -76,7 +77,7 @@ abstract class Kafkakonfigurasjon<T>(
             Properties().apply {
                 put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, env[KAFKA_BROKERS])
                 put(ConsumerConfig.GROUP_ID_CONFIG, env[groupId])
-                put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java)
+                put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializerClass)
                 put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializerClass)
             }
         }

--- a/libs/etterlatte-kafka/src/main/kotlin/kafka/Kafkakonsument.kt
+++ b/libs/etterlatte-kafka/src/main/kotlin/kafka/Kafkakonsument.kt
@@ -7,9 +7,9 @@ import org.slf4j.Logger
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicBoolean
 
-abstract class Kafkakonsument<T>(
+abstract class Kafkakonsument<K, T>(
     val logger: Logger,
-    val consumer: KafkaConsumer<String, T>,
+    val consumer: KafkaConsumer<K, T>,
     val topic: String,
     val pollTimeoutInSeconds: Duration,
     protected val closed: AtomicBoolean = AtomicBoolean(false),
@@ -29,12 +29,12 @@ abstract class Kafkakonsument<T>(
 
     abstract fun stream()
 
-    fun stream(haandter: (ConsumerRecords<String, T>) -> Unit) {
+    fun stream(haandter: (ConsumerRecords<K, T>) -> Unit) {
         try {
             logger.info("Starter å lese hendelser fra ${this.javaClass.name}")
             consumer.subscribe(listOf(topic))
             while (!closed.get()) {
-                val meldinger: ConsumerRecords<String, T> = consumer.poll(pollTimeoutInSeconds)
+                val meldinger: ConsumerRecords<K, T> = consumer.poll(pollTimeoutInSeconds)
                 haandter(meldinger)
                 consumer.commitSync()
 


### PR DESCRIPTION
Vil logge feil i institusjonsopphold hendelseshåndtering

Vil legge til mulighet for å bruke riktig type på id i KafkaConsumer - tidligere hardkodet til String 
```
abstract class Kafkakonsument<T>(
    val logger: Logger,
    val consumer: KafkaConsumer<String, T>,


```

Dette ga oss litt rar utput i logger: 

Behandler institusjonsopphold record med id: 8�, partition 0, offset: 6060

Etter endring: 
Behandler institusjonsopphold record med id: 14489, partition 0, offset: 6061

Konvertering av Long til String ble først endret til binær, deretter String. 

copilot forklarer det slik: 
The `KafkaConsumer` is created with `KafkaConsumer<String, KafkaOppholdHendelse>` - the key type is `String`. But the producer sends a `Long` as the key. When Kafka serializes a `Long`, it
  uses binary encoding (8 bytes), but when the consumer reads it with `StringDeserializer`, it tries to interpret those 8 binary bytes as a UTF-8 string, resulting in garbage characters like `^`.
