### PR TITLE
Kafka institusjon-consumer: Les én om gangen

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/grunnlagsendring/GrunnlagsendringshendelseRoute.kt
@@ -23,6 +23,7 @@ import no.nav.etterlatte.libs.common.person.maskerFnr
 import no.nav.etterlatte.libs.ktor.route.SAKID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.kunSystembruker
 import no.nav.etterlatte.libs.ktor.route.sakId
+import no.nav.etterlatte.sikkerLogg
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 
@@ -119,7 +120,12 @@ internal fun Route.grunnlagsendringshendelseRoute(grunnlagsendringshendelseServi
             kunSystembruker {
                 val oppholdsHendelse = call.receive<InstitusjonsoppholdHendelseBeriket>()
                 logger.info("Mottar institusjons-hendelse med ID ${oppholdsHendelse.hendelseId} fra inst2")
-                grunnlagsendringshendelseService.opprettInstitusjonsOppholdhendelse(oppholdsHendelse)
+                try {
+                    grunnlagsendringshendelseService.opprettInstitusjonsOppholdhendelse(oppholdsHendelse)
+                } catch (e: Exception) {
+                    sikkerLogg.error("Mottak av institusjons-hendelse feilet: $oppholdsHendelse", e)
+                    throw e
+                }
                 call.respond(HttpStatusCode.OK)
             }
         }

--- a/apps/etterlatte-egne-ansatte-lytter/src/test/kotlin/no/nav/etterlatte/kafka/SkjermingslesingTest.kt
+++ b/apps/etterlatte-egne-ansatte-lytter/src/test/kotlin/no/nav/etterlatte/kafka/SkjermingslesingTest.kt
@@ -1,18 +1,17 @@
 package no.nav.etterlatte.kafka
 
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.runs
 import io.mockk.spyk
 import io.mockk.verify
 import no.nav.etterlatte.kafka.KafkaContainerHelper.Companion.kafkaContainer
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.apache.kafka.common.serialization.StringSerializer
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.concurrent.thread
 
@@ -29,8 +28,9 @@ class SkjermingslesingTest {
         val producer = spyk(KafkaProducerTestImpl<String>(kafkaContainer, StringSerializer::class.java.canonicalName))
         producer.sendMelding(PDL_PERSON_TOPIC, fnr, "value")
 
+        val latch = CountDownLatch(1)
         val behandlingKlient = mockk<BehandlingKlient>()
-        every { behandlingKlient.haandterHendelse(any()) } just runs
+        every { behandlingKlient.haandterHendelse(any()) } answers { latch.countDown() }
 
         val closed = AtomicBoolean(false)
 
@@ -44,19 +44,13 @@ class SkjermingslesingTest {
             )
         val thread =
             thread(start = true) {
-                while (true) {
-                    if (kafkaConsumerEgneAnsatte.getAntallMeldinger() >= 1) {
-                        closed.set(true)
-                        kafkaConsumerEgneAnsatte.consumer.wakeup()
-                        return@thread
-                    }
-                    Thread.sleep(800L) // Må stå så ikke denne spiser all cpu, tester er egentlig single threaded
-                }
+                latch.await(10, TimeUnit.SECONDS)
+                closed.set(true)
+                kafkaConsumerEgneAnsatte.consumer.wakeup()
             }
         kafkaConsumerEgneAnsatte.stream()
         thread.join()
         verify(exactly = 1) { producer.sendMelding(any(), any(), any()) }
-        assertEquals(kafkaConsumerEgneAnsatte.getAntallMeldinger(), 1)
-        verify { behandlingKlient.haandterHendelse(any()) }
+        verify(exactly = 1) { behandlingKlient.haandterHendelse(any()) }
     }
 }

--- a/apps/etterlatte-institusjonsopphold/build.gradle.kts
+++ b/apps/etterlatte-institusjonsopphold/build.gradle.kts
@@ -13,4 +13,5 @@ dependencies {
     testImplementation(libs.ktor.clientmock)
     testImplementation(libs.ktor.servertests)
     testImplementation(libs.test.navfelles.rapidsandriversktor)
+    testRuntimeOnly(libs.test.junit.platform.launcher)
 }

--- a/apps/etterlatte-institusjonsopphold/src/main/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaConsumerInstitusjonsopphold.kt
+++ b/apps/etterlatte-institusjonsopphold/src/main/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaConsumerInstitusjonsopphold.kt
@@ -45,7 +45,7 @@ class KafkaConsumerInstitusjonsopphold(
     }
 }
 
-private fun properties(
+internal fun properties(
     kafkaEnvironment: KafkaConsumerConfiguration,
     env: Miljoevariabler,
 ): Properties =

--- a/apps/etterlatte-institusjonsopphold/src/main/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaConsumerInstitusjonsopphold.kt
+++ b/apps/etterlatte-institusjonsopphold/src/main/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaConsumerInstitusjonsopphold.kt
@@ -23,7 +23,7 @@ class KafkaConsumerInstitusjonsopphold(
     kafkaEnvironment: KafkaConsumerConfiguration = KafkaEnvironment(),
 ) : Kafkakonsument<Long, KafkaOppholdHendelse>(
         logger = LoggerFactory.getLogger(KafkaConsumerInstitusjonsopphold::class.java.name),
-        consumer = KafkaConsumer<Long, KafkaOppholdHendelse>(properties(kafkaEnvironment, env)),
+        consumer = KafkaConsumer<Long, KafkaOppholdHendelse>(lagInstitusjonsoppholdProperties(kafkaEnvironment, env)),
         topic = env.requireEnvValue(INSTITUSJONSOPPHOLD_TOPIC),
         pollTimeoutInSeconds = Duration.ofSeconds(10L),
     ) {
@@ -45,7 +45,7 @@ class KafkaConsumerInstitusjonsopphold(
     }
 }
 
-internal fun properties(
+internal fun lagInstitusjonsoppholdProperties(
     kafkaEnvironment: KafkaConsumerConfiguration,
     env: Miljoevariabler,
 ): Properties =

--- a/apps/etterlatte-institusjonsopphold/src/main/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaConsumerInstitusjonsopphold.kt
+++ b/apps/etterlatte-institusjonsopphold/src/main/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaConsumerInstitusjonsopphold.kt
@@ -9,9 +9,11 @@ import no.nav.etterlatte.kafka.KafkaConsumerConfiguration
 import no.nav.etterlatte.kafka.Kafkakonsument
 import no.nav.etterlatte.libs.common.EnvEnum
 import no.nav.etterlatte.libs.common.Miljoevariabler
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.slf4j.LoggerFactory
 import java.time.Duration
+import java.util.Properties
 
 class KafkaConsumerInstitusjonsopphold(
     env: Miljoevariabler,
@@ -19,7 +21,7 @@ class KafkaConsumerInstitusjonsopphold(
     kafkaEnvironment: KafkaConsumerConfiguration = KafkaEnvironment(),
 ) : Kafkakonsument<KafkaOppholdHendelse>(
         logger = LoggerFactory.getLogger(KafkaConsumerInstitusjonsopphold::class.java.name),
-        consumer = KafkaConsumer<String, KafkaOppholdHendelse>(kafkaEnvironment.generateKafkaConsumerProperties(env)),
+        consumer = KafkaConsumer<String, KafkaOppholdHendelse>(properties(kafkaEnvironment, env)),
         topic = env.requireEnvValue(INSTITUSJONSOPPHOLD_TOPIC),
         pollTimeoutInSeconds = Duration.ofSeconds(10L),
     ) {
@@ -33,6 +35,14 @@ class KafkaConsumerInstitusjonsopphold(
         }
     }
 }
+
+private fun properties(
+    kafkaEnvironment: KafkaConsumerConfiguration,
+    env: Miljoevariabler,
+): Properties =
+    kafkaEnvironment.generateKafkaConsumerProperties(env).apply {
+        put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1)
+    }
 
 data class KafkaOppholdHendelse(
     val hendelseId: Long,

--- a/apps/etterlatte-institusjonsopphold/src/test/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaConsumerInstitusjonsoppholdTest.kt
+++ b/apps/etterlatte-institusjonsopphold/src/test/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaConsumerInstitusjonsoppholdTest.kt
@@ -11,10 +11,11 @@ class KafkaConsumerInstitusjonsoppholdTest {
     @Test
     fun `properties overstyrer MAX_POLL_RECORDS_CONFIG til 1`() {
         val stubConfig =
-            KafkaConsumerConfiguration { _ ->
-                Properties().apply {
-                    put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 100)
-                }
+            object : KafkaConsumerConfiguration {
+                override fun generateKafkaConsumerProperties(env: Miljoevariabler) =
+                    Properties().apply {
+                        put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 100)
+                    }
             }
         val env = Miljoevariabler.httpClient(emptyMap())
 

--- a/apps/etterlatte-institusjonsopphold/src/test/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaConsumerInstitusjonsoppholdTest.kt
+++ b/apps/etterlatte-institusjonsopphold/src/test/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaConsumerInstitusjonsoppholdTest.kt
@@ -18,7 +18,7 @@ class KafkaConsumerInstitusjonsoppholdTest {
             }
         val env = Miljoevariabler.httpClient(emptyMap())
 
-        val props = properties(stubConfig, env)
+        val props = lagInstitusjonsoppholdProperties(stubConfig, env)
 
         assertEquals(1, props[ConsumerConfig.MAX_POLL_RECORDS_CONFIG])
     }

--- a/apps/etterlatte-institusjonsopphold/src/test/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaConsumerInstitusjonsoppholdTest.kt
+++ b/apps/etterlatte-institusjonsopphold/src/test/kotlin/no/nav/etterlatte/institusjonsopphold/kafka/KafkaConsumerInstitusjonsoppholdTest.kt
@@ -1,0 +1,25 @@
+package no.nav.etterlatte.institusjonsopphold.kafka
+
+import no.nav.etterlatte.kafka.KafkaConsumerConfiguration
+import no.nav.etterlatte.libs.common.Miljoevariabler
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.Properties
+
+class KafkaConsumerInstitusjonsoppholdTest {
+    @Test
+    fun `properties overstyrer MAX_POLL_RECORDS_CONFIG til 1`() {
+        val stubConfig =
+            KafkaConsumerConfiguration { _ ->
+                Properties().apply {
+                    put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 100)
+                }
+            }
+        val env = Miljoevariabler.httpClient(emptyMap())
+
+        val props = properties(stubConfig, env)
+
+        assertEquals(1, props[ConsumerConfig.MAX_POLL_RECORDS_CONFIG])
+    }
+}

--- a/libs/etterlatte-kafka/src/main/kotlin/kafka/Kafkakonfigurasjon.kt
+++ b/libs/etterlatte-kafka/src/main/kotlin/kafka/Kafkakonfigurasjon.kt
@@ -19,7 +19,7 @@ import org.apache.kafka.common.serialization.StringDeserializer
 import java.time.Duration
 import java.util.Properties
 
-interface KafkaConsumerConfiguration {
+fun interface KafkaConsumerConfiguration {
     fun generateKafkaConsumerProperties(env: Miljoevariabler): Properties
 }
 

--- a/libs/etterlatte-kafka/src/main/kotlin/kafka/Kafkakonfigurasjon.kt
+++ b/libs/etterlatte-kafka/src/main/kotlin/kafka/Kafkakonfigurasjon.kt
@@ -19,7 +19,7 @@ import org.apache.kafka.common.serialization.StringDeserializer
 import java.time.Duration
 import java.util.Properties
 
-fun interface KafkaConsumerConfiguration {
+interface KafkaConsumerConfiguration {
     fun generateKafkaConsumerProperties(env: Miljoevariabler): Properties
 }
 

--- a/libs/etterlatte-kafka/src/main/kotlin/kafka/Kafkakonsument.kt
+++ b/libs/etterlatte-kafka/src/main/kotlin/kafka/Kafkakonsument.kt
@@ -23,10 +23,6 @@ abstract class Kafkakonsument<T>(
         )
     }
 
-    private var antallMeldinger = 0
-
-    fun getAntallMeldinger() = antallMeldinger
-
     abstract fun stream()
 
     fun stream(haandter: (ConsumerRecords<String, T>) -> Unit) {
@@ -38,7 +34,6 @@ abstract class Kafkakonsument<T>(
                 haandter(meldinger)
                 consumer.commitSync()
 
-                antallMeldinger += meldinger.count()
                 if (meldinger.isEmpty) Thread.sleep(500L)
             }
         } catch (e: WakeupException) {


### PR DESCRIPTION
Endrer kafkaconsumer som leser institusjonshendelser til å bare lese én record om gangen, i håp om enklere feilsøking.
Fjernet antallMeldinger-telleren i kafkakonsument da den er ubrukt.