### PR TITLE
Ikke nødvendig å behandle institusjonsoppholdshendelser med ugyldig n…

### DIFF
--- a/apps/etterlatte-institusjonsopphold/src/main/kotlin/no/nav/etterlatte/institusjonsopphold/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-institusjonsopphold/src/main/kotlin/no/nav/etterlatte/institusjonsopphold/klienter/BehandlingKlient.kt
@@ -8,7 +8,9 @@ import io.ktor.http.contentType
 import no.nav.etterlatte.institusjonsopphold.kafka.KafkaOppholdHendelse
 import no.nav.etterlatte.institusjonsopphold.model.InstitusjonsoppholdEkstern
 import no.nav.etterlatte.institusjonsopphold.model.InstitusjonsoppholdHendelseBeriket
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.person.maskerFnr
+import no.nav.etterlatte.rapidsandrivers.sikkerLogg
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
 
@@ -32,8 +34,12 @@ class BehandlingKlient(
                 "${oppholdHendelse.norskident.maskerFnr()} hendelseId: ${oppholdHendelse.hendelseId}",
         )
 
+        if (!Folkeregisteridentifikator.isValid(oppholdHendelse.norskident)) {
+            logger.info("Institusjonsoppholdshendelse med ugyldig personident. Ikke relevant. Se sikker-logg. ")
+            sikkerLogg.info("Institusjonsoppholdshendelse med ugyldig personident. Ikke relevant. ${oppholdHendelse.norskident}")
+            return
+        }
         val opphold: InstitusjonsoppholdEkstern = institusjonsoppholdKlient.hentDataForHendelse(oppholdHendelse.oppholdId)
-
         postTilBehandling(
             oppholdHendelse =
                 InstitusjonsoppholdHendelseBeriket(
@@ -50,7 +56,6 @@ class BehandlingKlient(
                     organisasjonsnummer = opphold.organisasjonsnummer,
                 ),
         )
-
         logger.info("Hendelse ${oppholdHendelse.hendelseId} sendt til behandling")
     }
 

--- a/apps/etterlatte-institusjonsopphold/src/test/kotlin/no/nav/etterlatte/institusjonsopphold/klienter/BehandlingKlientTest.kt
+++ b/apps/etterlatte-institusjonsopphold/src/test/kotlin/no/nav/etterlatte/institusjonsopphold/klienter/BehandlingKlientTest.kt
@@ -1,0 +1,84 @@
+package no.nav.etterlatte.institusjonsopphold.klienter
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.jackson.jackson
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.institusjonsopphold.kafka.KafkaOppholdHendelse
+import no.nav.etterlatte.institusjonsopphold.model.InstitusjonsoppholdEkstern
+import no.nav.etterlatte.institusjonsopphold.model.InstitusjonsoppholdKilde
+import no.nav.etterlatte.institusjonsopphold.model.InstitusjonsoppholdsType
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+internal class BehandlingKlientTest {
+    private val institusjonsoppholdKlient = mockk<InstitusjonsoppholdKlient>()
+
+    private fun lagBehandlingKlient(behandlingHttpClient: HttpClient) =
+        BehandlingKlient(
+            behandlingHttpClient = behandlingHttpClient,
+            institusjonsoppholdKlient = institusjonsoppholdKlient,
+            resourceUrl = "http://localhost",
+        )
+
+    private fun lagRecord(norskident: String) =
+        ConsumerRecord(
+            "topic",
+            0,
+            0L,
+            1L,
+            KafkaOppholdHendelse(
+                hendelseId = 1L,
+                oppholdId = 1L,
+                norskident = norskident,
+                type = InstitusjonsoppholdsType.INNMELDING,
+                kilde = InstitusjonsoppholdKilde.INST,
+            ),
+        )
+
+    @Test
+    fun `Ugyldig personident i hendelse skal returnere uten å gjøre noe`() {
+        val behandlingKlient = lagBehandlingKlient(mockk(relaxed = true))
+
+        runBlocking { behandlingKlient.haandterHendelse(lagRecord("ikke-et-gyldig-fnr")) }
+
+        coVerify(exactly = 0) { institusjonsoppholdKlient.hentDataForHendelse(any()) }
+    }
+
+    @Test
+    fun `Gyldig personident i hendelse skal hente data og sende til behandling`() {
+        val mockEngine =
+            MockEngine {
+                respond(
+                    content = "{}",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf("Content-Type" to listOf(ContentType.Application.Json.toString())),
+                )
+            }
+        val behandlingHttpClient =
+            HttpClient(mockEngine) {
+                install(ContentNegotiation) { jackson() }
+            }
+        val behandlingKlient = lagBehandlingKlient(behandlingHttpClient)
+
+        coEvery { institusjonsoppholdKlient.hentDataForHendelse(1L) } returns
+            InstitusjonsoppholdEkstern(
+                oppholdId = 1L,
+                tssEksternId = "123",
+                startdato = LocalDate.now(),
+            )
+
+        runBlocking { behandlingKlient.haandterHendelse(lagRecord("10418305857")) }
+
+        coVerify(exactly = 1) { institusjonsoppholdKlient.hentDataForHendelse(1L) }
+    }
+}


### PR DESCRIPTION
Hvis vi mottar Institusjonsoppholdshendelse med ugyldig personident trenger vi ikke håndtere denne. Det vil ikke finnes noen sak for denne. 

Vurderte å håndtere feil i behandling, men tenker det er unødvendig å legge inn all kode der: 
https://github.com/navikt/pensjon-etterlatte-saksbehandling/compare/main...h%C3%A5ndter-ikke-gyldig-fnr-institusjonshendelse
