### PR TITLE
Vi sjekker om vi faktisk har perioder med ytelse > 0 i regulering er …

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/VedtakInternalService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/klienter/VedtakInternalService.kt
@@ -218,7 +218,7 @@ class VedtakInternalServiceImpl(
         brukerTokenInfo: BrukerTokenInfo,
     ): LoependeYtelseDTO {
         logger.info("Sjekker om sak $sakId er løpende på $dato")
-        val loependeYtelse = vedtaksvurderingService.sjekkOmVedtakErLoependePaaDato(sakId, dato)
+        val loependeYtelse = vedtaksvurderingService.sjekkOmVedtakErLoependePaaDato(sakId, dato, sjekkNullBeloep = false)
         return loependeYtelse.toDto()
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/Vedtakstidslinje.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/Vedtakstidslinje.kt
@@ -34,13 +34,14 @@ class Vedtakstidslinje(
 
         val senesteVedtakPaaDato = hentSenesteVedtakSomKanLoepePaaDato(dato)
         val erLoepende =
-            senesteVedtakPaaDato?.type in listOf(VedtakType.INNVILGELSE, VedtakType.ENDRING) &&
-                (!sjekkNullBeloep || senesteVedtakPaaDato!!.harYtelseOver0FraDato(dato))
+            senesteVedtakPaaDato?.let {
+                it.type in listOf(VedtakType.INNVILGELSE, VedtakType.ENDRING) && (!sjekkNullBeloep || it.harYtelseOver0FraDato(dato))
+            } ?: false
         return LoependeYtelse(
             erLoepende = erLoepende,
             underSamordning = erUnderSamordning,
             dato = if (erLoepende) foersteMuligeVedtaksdag(dato) else dato,
-            behandlingId = if (erLoepende) senesteVedtakPaaDato!!.behandlingId else null,
+            behandlingId = if (erLoepende) senesteVedtakPaaDato.behandlingId else null,
             sisteLoependeBehandlingId =
                 if (erLoepende) {
                     sammenstill(YearMonth.from(dato))
@@ -174,7 +175,7 @@ class Vedtakstidslinje(
         return (innhold as VedtakInnhold.Behandling)
             .utbetalingsperioder
             .filter { it.type == UtbetalingsperiodeType.UTBETALING }
-            .filter { !it.periode.fom.isAfter(maaned) && (it.periode.tom == null || !it.periode.tom!!.isBefore(maaned)) }
+            .filter { it.periode.tom == null || it.periode.tom!! < maaned }
             .any { (it.beloep ?: BigDecimal.ZERO) > BigDecimal.ZERO }
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/Vedtakstidslinje.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/Vedtakstidslinje.kt
@@ -4,8 +4,10 @@ import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselExceptio
 import no.nav.etterlatte.libs.common.vedtak.InnvilgetPeriodeDto
 import no.nav.etterlatte.libs.common.vedtak.Periode
 import no.nav.etterlatte.libs.common.vedtak.Utbetalingsperiode
+import no.nav.etterlatte.libs.common.vedtak.UtbetalingsperiodeType
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
 
@@ -21,14 +23,19 @@ class Vedtakstidslinje(
         attesterteBehandlingVedtak
             .filter { it.status == VedtakStatus.IVERKSATT }
 
-    fun harLoependeVedtakPaaEllerEtter(dato: LocalDate): LoependeYtelse {
+    fun harLoependeVedtakPaaEllerEtter(
+        dato: LocalDate,
+        sjekkNullBeloep: Boolean,
+    ): LoependeYtelse {
         val erUnderSamordning =
             attesterteBehandlingVedtak.any { listOf(VedtakStatus.TIL_SAMORDNING, VedtakStatus.SAMORDNET).contains(it.status) }
 
         if (iverksatteBehandlingVedtak.isEmpty()) return LoependeYtelse(false, erUnderSamordning, dato)
 
         val senesteVedtakPaaDato = hentSenesteVedtakSomKanLoepePaaDato(dato)
-        val erLoepende = senesteVedtakPaaDato?.type in listOf(VedtakType.INNVILGELSE, VedtakType.ENDRING)
+        val erLoepende =
+            senesteVedtakPaaDato?.type in listOf(VedtakType.INNVILGELSE, VedtakType.ENDRING) &&
+                (!sjekkNullBeloep || senesteVedtakPaaDato!!.harYtelseOver0FraDato(dato))
         return LoependeYtelse(
             erLoepende = erLoepende,
             underSamordning = erUnderSamordning,
@@ -156,6 +163,19 @@ class Vedtakstidslinje(
         }
 
         return innvilgedePerioder
+    }
+
+    /**
+     * Sjekker om vedtaket har minst én utbetalingsperiode med beloep > 0 som dekker gitt dato.
+     * Brukes kun i reguleringsflyt for å skille saker uten faktisk ytelse fra løpende saker.
+     */
+    private fun Vedtak.harYtelseOver0FraDato(dato: LocalDate): Boolean {
+        val maaned = YearMonth.from(dato)
+        return (innhold as VedtakInnhold.Behandling)
+            .utbetalingsperioder
+            .filter { it.type == UtbetalingsperiodeType.UTBETALING }
+            .filter { !it.periode.fom.isAfter(maaned) && (it.periode.tom == null || !it.periode.tom!!.isBefore(maaned)) }
+            .any { (it.beloep ?: BigDecimal.ZERO) > BigDecimal.ZERO }
     }
 
     private fun foersteMuligeVedtaksdag(fraDato: LocalDate): LocalDate {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/routes/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/routes/VedtaksvurderingRoute.kt
@@ -302,9 +302,10 @@ fun Route.vedtaksvurderingRoute(
             val dato =
                 call.request.queryParameters["dato"]?.let { LocalDate.parse(it) }
                     ?: throw Exception("dato er påkrevet på formatet YYYY-MM-DD")
+            val sjekkNullBeloep = call.request.queryParameters["sjekkNullBeloep"]?.toBoolean() ?: false
 
-            logger.info("Sjekker om sak har løpende for vedtak $sakId på dato $dato")
-            val loependeYtelse = inTransaction { vedtakService.sjekkOmVedtakErLoependePaaDato(sakId, dato) }
+            logger.info("Sjekker om sak har løpende for vedtak $sakId på dato $dato (sjekkNullBeloep=$sjekkNullBeloep)")
+            val loependeYtelse = inTransaction { vedtakService.sjekkOmVedtakErLoependePaaDato(sakId, dato, sjekkNullBeloep) }
             call.respond(loependeYtelse.toDto())
         }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/service/VedtaksvurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/service/VedtaksvurderingService.kt
@@ -37,13 +37,14 @@ class VedtaksvurderingService(
     fun sjekkOmVedtakErLoependePaaDato(
         sakId: SakId,
         dato: LocalDate,
+        sjekkNullBeloep: Boolean,
     ): LoependeYtelse {
         logger.info("Sjekker om det finnes løpende vedtak for sak $sakId på dato $dato")
         val alleVedtakForSak =
             repository
                 .hentVedtakForSak(sakId)
                 .filter { it.vedtakFattet != null && it.attestasjon != null }
-        return Vedtakstidslinje(alleVedtakForSak).harLoependeVedtakPaaEllerEtter(dato)
+        return Vedtakstidslinje(alleVedtakForSak).harLoependeVedtakPaaEllerEtter(dato, sjekkNullBeloep)
     }
 
     fun hentIverksatteVedtakISak(sakId: SakId): List<Vedtak> =

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/VedtakstidslinjeTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/VedtakstidslinjeTest.kt
@@ -39,7 +39,7 @@ internal class VedtakstidslinjeTest {
      * */
     @Test
     fun `sak uten vedtak er ikke loepende`() {
-        val actual = Vedtakstidslinje(emptyList()).harLoependeVedtakPaaEllerEtter(fraOgMed)
+        val actual = Vedtakstidslinje(emptyList()).harLoependeVedtakPaaEllerEtter(fraOgMed, sjekkNullBeloep = false)
         assertEquals(false, actual.erLoepende)
         assertEquals(LocalDate.of(2023, 5, 1), actual.dato)
         assertNull(actual.sisteLoependeBehandlingId)
@@ -58,7 +58,7 @@ internal class VedtakstidslinjeTest {
                 virkningsDato = LocalDate.of(2023, 1, 1),
                 vedtakStatus = VedtakStatus.FATTET_VEDTAK,
             )
-        val actual = Vedtakstidslinje(listOf(fattetVedtak)).harLoependeVedtakPaaEllerEtter(fraOgMed)
+        val actual = Vedtakstidslinje(listOf(fattetVedtak)).harLoependeVedtakPaaEllerEtter(fraOgMed, sjekkNullBeloep = false)
         assertEquals(false, actual.erLoepende)
         assertEquals(LocalDate.of(2023, 5, 1), actual.dato)
         assertNull(actual.sisteLoependeBehandlingId)
@@ -82,7 +82,7 @@ internal class VedtakstidslinjeTest {
                 vedtakType = VedtakType.INNVILGELSE,
             )
 
-        val actual = Vedtakstidslinje(listOf(iverksattDato)).harLoependeVedtakPaaEllerEtter(fraOgMed)
+        val actual = Vedtakstidslinje(listOf(iverksattDato)).harLoependeVedtakPaaEllerEtter(fraOgMed, sjekkNullBeloep = false)
         assertEquals(true, actual.erLoepende)
         assertEquals(LocalDate.of(2023, 5, 1), actual.dato)
         assertEquals(sisteLoependeBehandlingId, actual.sisteLoependeBehandlingId)
@@ -121,7 +121,7 @@ internal class VedtakstidslinjeTest {
                     iverksattDato,
                     opphoertDato,
                 ),
-            ).harLoependeVedtakPaaEllerEtter(fraOgMed)
+            ).harLoependeVedtakPaaEllerEtter(fraOgMed, sjekkNullBeloep = false)
         assertEquals(false, actual.erLoepende)
         assertEquals(LocalDate.of(2023, 5, 1), actual.dato)
         assertNull(actual.sisteLoependeBehandlingId)
@@ -163,7 +163,7 @@ internal class VedtakstidslinjeTest {
                     iverksattDato,
                     opphoertDato,
                 ),
-            ).harLoependeVedtakPaaEllerEtter(fraOgMed)
+            ).harLoependeVedtakPaaEllerEtter(fraOgMed, sjekkNullBeloep = false)
         assertEquals(true, actual.erLoepende)
         assertEquals(LocalDate.of(2023, 5, 1), actual.dato)
         assertEquals(sisteLoependeBehandlingId, actual.sisteLoependeBehandlingId)
@@ -189,7 +189,7 @@ internal class VedtakstidslinjeTest {
                 datoAttestert = attesteringsdato,
             )
 
-        val actual = Vedtakstidslinje(listOf(iverksattDato)).harLoependeVedtakPaaEllerEtter(fraOgMed)
+        val actual = Vedtakstidslinje(listOf(iverksattDato)).harLoependeVedtakPaaEllerEtter(fraOgMed, sjekkNullBeloep = false)
         assertEquals(true, actual.erLoepende)
         assertEquals(LocalDate.of(2023, 6, 1), actual.dato)
         assertEquals(sisteLoependeBehandlingId, actual.sisteLoependeBehandlingId)
@@ -225,7 +225,7 @@ internal class VedtakstidslinjeTest {
                 datoAttestert = attesteringsdato.plus(1, DAYS),
             )
 
-        val actual = Vedtakstidslinje(listOf(iverksattDato, opphoertDato)).harLoependeVedtakPaaEllerEtter(fraOgMed)
+        val actual = Vedtakstidslinje(listOf(iverksattDato, opphoertDato)).harLoependeVedtakPaaEllerEtter(fraOgMed, sjekkNullBeloep = false)
         assertEquals(true, actual.erLoepende)
         assertEquals(LocalDate.of(2023, 6, 1), actual.dato)
         assertEquals(sisteLoependeBehandlingId, actual.sisteLoependeBehandlingId)
@@ -258,7 +258,7 @@ internal class VedtakstidslinjeTest {
                 datoAttestert = attesteringsdato.plus(1, DAYS),
             )
 
-        val actual = Vedtakstidslinje(listOf(iverksattDato, opphoertDato)).harLoependeVedtakPaaEllerEtter(fraOgMed)
+        val actual = Vedtakstidslinje(listOf(iverksattDato, opphoertDato)).harLoependeVedtakPaaEllerEtter(fraOgMed, sjekkNullBeloep = false)
         assertEquals(false, actual.erLoepende)
         assertEquals(LocalDate.of(2023, 5, 1), actual.dato)
         assertNull(actual.sisteLoependeBehandlingId)
@@ -312,6 +312,7 @@ internal class VedtakstidslinjeTest {
                     6,
                     4,
                 ),
+                sjekkNullBeloep = false,
             )
         assertEquals(false, actual.erLoepende)
     }
@@ -345,7 +346,7 @@ internal class VedtakstidslinjeTest {
                 datoAttestert = attesteringsdato.plus(1, DAYS),
             )
 
-        val actual = Vedtakstidslinje(listOf(iverksattDato, opphoertDato)).harLoependeVedtakPaaEllerEtter(fraOgMed)
+        val actual = Vedtakstidslinje(listOf(iverksattDato, opphoertDato)).harLoependeVedtakPaaEllerEtter(fraOgMed, sjekkNullBeloep = false)
         assertEquals(true, actual.erLoepende)
         assertEquals(LocalDate.of(2023, 6, 1), actual.dato)
         assertEquals(sisteLoependeBehandlingId, actual.sisteLoependeBehandlingId)
@@ -378,7 +379,7 @@ internal class VedtakstidslinjeTest {
             )
 
         val actual =
-            Vedtakstidslinje(listOf(iverksattDato, vedtakTilSamordning)).harLoependeVedtakPaaEllerEtter(fraOgMed)
+            Vedtakstidslinje(listOf(iverksattDato, vedtakTilSamordning)).harLoependeVedtakPaaEllerEtter(fraOgMed, sjekkNullBeloep = false)
         assertEquals(true, actual.erLoepende)
         assertEquals(true, actual.underSamordning)
         assertEquals(LocalDate.of(2023, 5, 1), actual.dato)
@@ -430,7 +431,7 @@ internal class VedtakstidslinjeTest {
                     opphoertDato,
                     revurdertDato,
                 ),
-            ).harLoependeVedtakPaaEllerEtter(fraOgMed)
+            ).harLoependeVedtakPaaEllerEtter(fraOgMed, sjekkNullBeloep = false)
         assertEquals(true, actual.erLoepende)
         assertEquals(LocalDate.of(2023, 6, 1), actual.dato)
         assertEquals(sisteLoependeBehandlingId, actual.sisteLoependeBehandlingId)
@@ -481,7 +482,7 @@ internal class VedtakstidslinjeTest {
                     opphoertDato,
                     revurdertDato,
                 ),
-            ).harLoependeVedtakPaaEllerEtter(fraOgMed)
+            ).harLoependeVedtakPaaEllerEtter(fraOgMed, sjekkNullBeloep = false)
         assertEquals(false, actual.erLoepende)
         assertEquals(fraOgMed, actual.dato)
         assertNull(actual.sisteLoependeBehandlingId)
@@ -526,6 +527,7 @@ internal class VedtakstidslinjeTest {
         val actual =
             Vedtakstidslinje(listOf(iverksattDato, revurderingDato, opphoerDato)).harLoependeVedtakPaaEllerEtter(
                 fraOgMed,
+                sjekkNullBeloep = false,
             )
         assertEquals(false, actual.erLoepende)
         assertEquals(LocalDate.of(2023, 5, 1), actual.dato)
@@ -572,7 +574,7 @@ internal class VedtakstidslinjeTest {
             )
 
         val actual =
-            Vedtakstidslinje(listOf(innvilgelse, revurdering, opphoer)).harLoependeVedtakPaaEllerEtter(fraOgMed)
+            Vedtakstidslinje(listOf(innvilgelse, revurdering, opphoer)).harLoependeVedtakPaaEllerEtter(fraOgMed, sjekkNullBeloep = false)
         assertEquals(true, actual.erLoepende)
         assertEquals(LocalDate.of(2023, 5, 1), actual.dato)
         assertEquals(sisteLoependeBehandlingId, actual.sisteLoependeBehandlingId)

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/VedtaksvurderingRouteTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/VedtaksvurderingRouteTest.kt
@@ -351,7 +351,7 @@ internal class VedtaksvurderingRouteTest(
         val sakId = sakId1
         val loependeYtelse = LoependeYtelse(erLoepende = true, underSamordning = false, LocalDate.now(), UUID.randomUUID())
 
-        every { vedtaksvurderingService.sjekkOmVedtakErLoependePaaDato(any(), any()) } returns loependeYtelse
+        every { vedtaksvurderingService.sjekkOmVedtakErLoependePaaDato(any(), any(), any()) } returns loependeYtelse
 
         withTestApplication(context) { client ->
 
@@ -369,7 +369,7 @@ internal class VedtaksvurderingRouteTest(
             hentetLoependeYtelse.dato shouldBe loependeYtelse.dato
 
             coVerify(exactly = 1) {
-                vedtaksvurderingService.sjekkOmVedtakErLoependePaaDato(any(), any())
+                vedtaksvurderingService.sjekkOmVedtakErLoependePaaDato(any(), any(), any())
             }
         }
     }

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/LoependeYtelserforespoerselRiver.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/LoependeYtelserforespoerselRiver.kt
@@ -54,7 +54,7 @@ internal class LoependeYtelserforespoerselRiver(
             }
         }
 
-        val respons = vedtak.harLoependeYtelserFra(sakId, reguleringsdato)
+        val respons = vedtak.harLoependeYtelserFra(sakId, reguleringsdato, sjekkNullBeloep = true)
         if (respons.underSamordning) {
             throw SakErUnderSamordning()
         }

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakService.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/VedtakService.kt
@@ -23,6 +23,7 @@ interface VedtakService {
     fun harLoependeYtelserFra(
         sakId: SakId,
         dato: LocalDate,
+        sjekkNullBeloep: Boolean,
     ): LoependeYtelseDTO
 
     fun opprettVedtakFattOgAttester(
@@ -64,9 +65,10 @@ class VedtakServiceImpl(
     override fun harLoependeYtelserFra(
         sakId: SakId,
         dato: LocalDate,
+        sjekkNullBeloep: Boolean,
     ): LoependeYtelseDTO =
         runBlocking {
-            httpClient.get("$url/api/vedtak/loepende/${sakId.sakId}?dato=$dato").body()
+            httpClient.get("$url/api/vedtak/loepende/${sakId.sakId}?dato=$dato&sjekkNullBeloep=$sjekkNullBeloep").body()
         }
 
     override fun opprettVedtakFattOgAttester(

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/rivers/TidshendelseRiver.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/vedtaksvurdering/rivers/TidshendelseRiver.kt
@@ -116,7 +116,7 @@ class TidshendelseRiver(
         val maanedEtterBehandlingsdato = behandlingsdato.plusMonths(1)
         logger.info("Sjekker løpende ytelse for sak $sakId, behandlingsmåned=$behandlingsdato, dryrun=$dryrun")
 
-        val loependeYtelse = vedtakService.harLoependeYtelserFra(sakId, maanedEtterBehandlingsdato)
+        val loependeYtelse = vedtakService.harLoependeYtelserFra(sakId, maanedEtterBehandlingsdato, sjekkNullBeloep = false)
         logger.info("Sak $sakId har løpende ytelse per $maanedEtterBehandlingsdato? ${loependeYtelse.erLoepende}")
         hendelseData["loependeYtelse"] = loependeYtelse.erLoepende
         loependeYtelse.behandlingId?.let {
@@ -124,7 +124,12 @@ class TidshendelseRiver(
         }
 
         if (loependeYtelse.erLoepende && type == "AO_BP20") {
-            val loependeYtelsePerJanuar2024 = vedtakService.harLoependeYtelserFra(sakId, ikrafttredenEtterlattereformen)
+            val loependeYtelsePerJanuar2024 =
+                vedtakService.harLoependeYtelserFra(
+                    sakId,
+                    ikrafttredenEtterlattereformen,
+                    sjekkNullBeloep = false,
+                )
             hendelseData["loependeYtelse_januar2024"] = loependeYtelsePerJanuar2024.erLoepende
             loependeYtelsePerJanuar2024.behandlingId?.let {
                 hendelseData["loependeYtelse_januar2024_behandlingId"] = it.toString()

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/VedtakServiceImplTest.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/VedtakServiceImplTest.kt
@@ -42,8 +42,8 @@ internal class VedtakServiceImplTest {
             }
         val vedtakService = VedtakServiceImpl(httpClientMock, "http://test")
         val dato = LocalDate.of(2023, 1, 1)
-        vedtakService.harLoependeYtelserFra(sakId1, dato)
+        vedtakService.harLoependeYtelserFra(sakId1, dato, sjekkNullBeloep = false)
 
-        Assertions.assertEquals("/api/vedtak/loepende/1?dato=2023-01-01", request.encodedPathAndQuery)
+        Assertions.assertEquals("/api/vedtak/loepende/1?dato=2023-01-01&sjekkNullBeloep=false", request.encodedPathAndQuery)
     }
 }

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/regulering/LoependeYtelserforespoerselRiverTest.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/regulering/LoependeYtelserforespoerselRiverTest.kt
@@ -56,7 +56,7 @@ internal class LoependeYtelserforespoerselRiverTest {
 
         inspector.sendTestMessage(melding.toJson())
         verify(exactly = 1) {
-            vedtakServiceMock.harLoependeYtelserFra(sakId, LocalDate.of(2023, 5, 1))
+            vedtakServiceMock.harLoependeYtelserFra(sakId, LocalDate.of(2023, 5, 1), sjekkNullBeloep = true)
         }
     }
 
@@ -66,7 +66,7 @@ internal class LoependeYtelserforespoerselRiverTest {
         val melding = genererReguleringMelding(foersteMai2023)
         val vedtakServiceMock = mockk<VedtakService>(relaxed = true)
         every { vedtakServiceMock.tilbakestillVedtak(any()) } just runs
-        every { vedtakServiceMock.harLoependeYtelserFra(sakId, foersteMai2023) } returns
+        every { vedtakServiceMock.harLoependeYtelserFra(sakId, foersteMai2023, sjekkNullBeloep = true) } returns
             LoependeYtelseDTO(
                 erLoepende = true,
                 underSamordning = false,
@@ -89,7 +89,7 @@ internal class LoependeYtelserforespoerselRiverTest {
     fun `sender avbryt-melding dersom det ikke er en loepende ytelse`() {
         val melding = genererReguleringMelding(foersteMai2023)
         val vedtakServiceMock = mockk<VedtakService>(relaxed = true)
-        every { vedtakServiceMock.harLoependeYtelserFra(sakId, foersteMai2023) } returns
+        every { vedtakServiceMock.harLoependeYtelserFra(sakId, foersteMai2023, sjekkNullBeloep = true) } returns
             LoependeYtelseDTO(
                 erLoepende = false,
                 underSamordning = false,
@@ -125,7 +125,7 @@ internal class LoependeYtelserforespoerselRiverTest {
             ).let { JsonMessage.newMessage(it) }
 
         val vedtakServiceMock = mockk<VedtakService>(relaxed = true)
-        every { vedtakServiceMock.harLoependeYtelserFra(sakId, foersteMai2023) } returns
+        every { vedtakServiceMock.harLoependeYtelserFra(sakId, foersteMai2023, sjekkNullBeloep = true) } returns
             LoependeYtelseDTO(
                 erLoepende = true,
                 underSamordning = false,
@@ -142,7 +142,7 @@ internal class LoependeYtelserforespoerselRiverTest {
     fun `avbryter hvis sak er under samordning`() {
         val melding = genererReguleringMelding(foersteMai2023)
         val vedtakServiceMock = mockk<VedtakService>(relaxed = true)
-        every { vedtakServiceMock.harLoependeYtelserFra(sakId, foersteMai2023) } returns
+        every { vedtakServiceMock.harLoependeYtelserFra(sakId, foersteMai2023, sjekkNullBeloep = true) } returns
             LoependeYtelseDTO(
                 erLoepende = true,
                 underSamordning = true,

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/rivers/TidshendelseRiverTest.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/vedtaksvurdering/rivers/TidshendelseRiverTest.kt
@@ -39,12 +39,13 @@ class TidshendelseRiverTest {
 
     @Test
     fun `skal lese melding og sjekke loepende ytelse`() {
-        every { vedtakService.harLoependeYtelserFra(sakId, datoFom.plusMonths(1)) } returns
+        every { vedtakService.harLoependeYtelserFra(sakId, datoFom.plusMonths(1), sjekkNullBeloep = false) } returns
             LoependeYtelseDTO(erLoepende = true, underSamordning = false, dato = datoFom, behandlingId = behandlingId)
         every {
             vedtakService.harLoependeYtelserFra(
                 sakId,
                 datoFomJanuar2024,
+                sjekkNullBeloep = false,
             )
         } returns
             LoependeYtelseDTO(
@@ -78,13 +79,13 @@ class TidshendelseRiverTest {
             field(0, DRYRUN).asBoolean() shouldBe false
         }
 
-        verify { vedtakService.harLoependeYtelserFra(sakId, datoFom.plusMonths(1)) }
-        verify { vedtakService.harLoependeYtelserFra(sakId, datoFomJanuar2024) }
+        verify { vedtakService.harLoependeYtelserFra(sakId, datoFom.plusMonths(1), sjekkNullBeloep = false) }
+        verify { vedtakService.harLoependeYtelserFra(sakId, datoFomJanuar2024, sjekkNullBeloep = false) }
     }
 
     @Test
     fun `skal lese melding og returnere negativt svar for loepende ytelse`() {
-        every { vedtakService.harLoependeYtelserFra(sakId, datoFom.plusMonths(1)) } returns
+        every { vedtakService.harLoependeYtelserFra(sakId, datoFom.plusMonths(1), sjekkNullBeloep = false) } returns
             LoependeYtelseDTO(erLoepende = false, underSamordning = false, dato = datoFom)
 
         val melding =
@@ -110,7 +111,7 @@ class TidshendelseRiverTest {
             field(0, DRYRUN).asBoolean() shouldBe true
         }
 
-        verify { vedtakService.harLoependeYtelserFra(sakId, datoFom.plusMonths(1)) }
+        verify { vedtakService.harLoependeYtelserFra(sakId, datoFom.plusMonths(1), sjekkNullBeloep = false) }
     }
 
     @Test


### PR DESCRIPTION
…løpende-sjekken

Som @trondvalen påpekte kan ikke denne sjekken gå live, siden vi har tilfeller der vi går fra 0 til utbetaling for OMS som følge av regulering. Sjekken må være mer målrettet mot at det er en aktiv sanksjon uten opphold for OMS sin del.