### PR TITLE
Sjekker om vi har løpende sanksjon i regulering

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/Vedtak.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/Vedtak.kt
@@ -125,6 +125,7 @@ data class LoependeYtelse(
     val erLoepende: Boolean,
     val underSamordning: Boolean,
     val dato: LocalDate,
+    val sakType: SakType? = null,
     val behandlingId: UUID? = null,
     val sisteLoependeBehandlingId: UUID? = null,
 )

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/Vedtakstidslinje.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/Vedtakstidslinje.kt
@@ -12,6 +12,8 @@ import java.time.YearMonth
 class Vedtakstidslinje(
     vedtak: List<Vedtak>,
 ) {
+    private val sakType = vedtak.firstOrNull()?.sakType
+
     private val attesterteBehandlingVedtak =
         vedtak
             .filter { it.innhold is VedtakInnhold.Behandling }
@@ -25,7 +27,7 @@ class Vedtakstidslinje(
         val erUnderSamordning =
             attesterteBehandlingVedtak.any { listOf(VedtakStatus.TIL_SAMORDNING, VedtakStatus.SAMORDNET).contains(it.status) }
 
-        if (iverksatteBehandlingVedtak.isEmpty()) return LoependeYtelse(false, erUnderSamordning, dato)
+        if (iverksatteBehandlingVedtak.isEmpty()) return LoependeYtelse(false, erUnderSamordning, dato, sakType)
 
         val senesteVedtakPaaDato = hentSenesteVedtakSomKanLoepePaaDato(dato)
         val erLoepende = senesteVedtakPaaDato?.type in listOf(VedtakType.INNVILGELSE, VedtakType.ENDRING)
@@ -33,6 +35,7 @@ class Vedtakstidslinje(
             erLoepende = erLoepende,
             underSamordning = erUnderSamordning,
             dato = if (erLoepende) foersteMuligeVedtaksdag(dato) else dato,
+            sakType = sakType,
             behandlingId = if (erLoepende) senesteVedtakPaaDato!!.behandlingId else null,
             sisteLoependeBehandlingId =
                 if (erLoepende) {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/routes/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/routes/VedtaksvurderingRoute.kt
@@ -10,7 +10,6 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.vedtaksvurdering.InnvilgetPeriode
-import no.nav.etterlatte.behandling.vedtaksvurdering.LoependeYtelse
 import no.nav.etterlatte.behandling.vedtaksvurdering.OppdaterSamordningsmelding
 import no.nav.etterlatte.behandling.vedtaksvurdering.service.KanskjeAlleredeUtfoertOppdatering
 import no.nav.etterlatte.behandling.vedtaksvurdering.service.VedtakBehandlingService
@@ -23,7 +22,6 @@ import no.nav.etterlatte.libs.common.feilhaandtering.IkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.vedtak.AttesterVedtakDto
-import no.nav.etterlatte.libs.common.vedtak.LoependeYtelseDTO
 import no.nav.etterlatte.libs.common.vedtak.VedtakKafkaHendelseHendelseType
 import no.nav.etterlatte.libs.ktor.route.BEHANDLINGID_CALL_PARAMETER
 import no.nav.etterlatte.libs.ktor.route.SAKID_CALL_PARAMETER
@@ -304,8 +302,9 @@ fun Route.vedtaksvurderingRoute(
                     ?: throw Exception("dato er påkrevet på formatet YYYY-MM-DD")
 
             logger.info("Sjekker om sak har løpende for vedtak $sakId på dato $dato")
-            val loependeYtelse = inTransaction { vedtakService.sjekkOmVedtakErLoependePaaDato(sakId, dato) }
-            call.respond(loependeYtelse.toDto())
+            val loependeYtelse = vedtakService.sjekkOmVedtakErLoependeMedSanksjonPaaDato(sakId, dato, brukerTokenInfo)
+
+            call.respond(loependeYtelse)
         }
 
         patch("/{$BEHANDLINGID_CALL_PARAMETER}/tilbakestill") {
@@ -347,12 +346,3 @@ fun Route.vedtaksvurderingRoute(
         }
     }
 }
-
-private fun LoependeYtelse.toDto() =
-    LoependeYtelseDTO(
-        erLoepende = erLoepende,
-        underSamordning = underSamordning,
-        dato = dato,
-        behandlingId = behandlingId,
-        sisteLoependeBehandlingId = sisteLoependeBehandlingId,
-    )

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/routes/VedtaksvurderingRoute.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/routes/VedtaksvurderingRoute.kt
@@ -302,7 +302,7 @@ fun Route.vedtaksvurderingRoute(
                     ?: throw Exception("dato er påkrevet på formatet YYYY-MM-DD")
 
             logger.info("Sjekker om sak har løpende for vedtak $sakId på dato $dato")
-            val loependeYtelse = vedtakService.sjekkOmVedtakErLoependeMedSanksjonPaaDato(sakId, dato, brukerTokenInfo)
+            val loependeYtelse = vedtakService.sjekkOmVedtakErLoepende(sakId, dato, brukerTokenInfo)
 
             call.respond(loependeYtelse)
         }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/service/VedtaksvurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/service/VedtaksvurderingService.kt
@@ -51,7 +51,7 @@ class VedtaksvurderingService(
         return Vedtakstidslinje(alleVedtakForSak).harLoependeVedtakPaaEllerEtter(dato)
     }
 
-    suspend fun sjekkOmVedtakErLoependeMedSanksjonPaaDato(
+    suspend fun sjekkOmVedtakErLoepende(
         sakId: SakId,
         dato: LocalDate,
         brukerTokenInfo: BrukerTokenInfo,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/service/VedtaksvurderingService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/vedtaksvurdering/service/VedtaksvurderingService.kt
@@ -1,6 +1,7 @@
 package no.nav.etterlatte.behandling.vedtaksvurdering.service
 
 import io.ktor.server.plugins.NotFoundException
+import no.nav.etterlatte.behandling.klienter.BeregningKlient
 import no.nav.etterlatte.behandling.vedtaksvurdering.InnvilgetPeriode
 import no.nav.etterlatte.behandling.vedtaksvurdering.LoependeYtelse
 import no.nav.etterlatte.behandling.vedtaksvurdering.Vedtak
@@ -11,14 +12,18 @@ import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.feilhaandtering.sjekk
 import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
 import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.common.vedtak.LoependeYtelseDTO
 import no.nav.etterlatte.libs.common.vedtak.VedtakStatus
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
+import java.time.YearMonth
 import java.util.UUID
 
 class VedtaksvurderingService(
     private val repository: VedtaksvurderingRepository,
+    private val beregningKlient: BeregningKlient,
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -45,6 +50,36 @@ class VedtaksvurderingService(
                 .filter { it.vedtakFattet != null && it.attestasjon != null }
         return Vedtakstidslinje(alleVedtakForSak).harLoependeVedtakPaaEllerEtter(dato)
     }
+
+    suspend fun sjekkOmVedtakErLoependeMedSanksjonPaaDato(
+        sakId: SakId,
+        dato: LocalDate,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): LoependeYtelseDTO {
+        val loependeYtelse = sjekkOmVedtakErLoependePaaDato(sakId, dato)
+        val harAktivSanksjon =
+            if (loependeYtelse.erLoepende &&
+                loependeYtelse.behandlingId != null &&
+                loependeYtelse.sakType == SakType.OMSTILLINGSSTOENAD
+            ) {
+                val sanksjoner =
+                    beregningKlient.hentSanksjoner(loependeYtelse.behandlingId, brukerTokenInfo) ?: emptyList()
+                sanksjoner.any { it.fom <= YearMonth.from(dato) && it.tom == null }
+            } else {
+                false
+            }
+        return loependeYtelse.toDto(harAktivSanksjon)
+    }
+
+    private fun LoependeYtelse.toDto(harAktivSanksjon: Boolean) =
+        LoependeYtelseDTO(
+            erLoepende = erLoepende,
+            underSamordning = underSamordning,
+            dato = dato,
+            behandlingId = behandlingId,
+            sisteLoependeBehandlingId = sisteLoependeBehandlingId,
+            harAktivSanksjon = harAktivSanksjon,
+        )
 
     fun hentIverksatteVedtakISak(sakId: SakId): List<Vedtak> =
         repository

--- a/apps/etterlatte-behandling/src/main/kotlin/config/modules/ServiceModule.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/modules/ServiceModule.kt
@@ -393,7 +393,10 @@ class ServiceModule(
     }
 
     val vedtaksvurderingService by lazy {
-        VedtaksvurderingService(daoModule.vedtaksvurderingRepository)
+        VedtaksvurderingService(
+            repository = daoModule.vedtaksvurderingRepository,
+            beregningKlient = klientModule.beregningKlient,
+        )
     }
 
     val vedtaksvurderingRapidService by lazy {

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/OutboxIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/OutboxIntegrationTest.kt
@@ -2,6 +2,7 @@ package no.nav.etterlatte.behandling.vedtaksvurdering
 
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
+import io.mockk.mockk
 import no.nav.etterlatte.ConnectionAutoclosingTest
 import no.nav.etterlatte.DatabaseExtension
 import no.nav.etterlatte.behandling.randomSakId
@@ -36,7 +37,7 @@ class OutboxIntegrationTest(
 ) {
     private val testProdusent = TestProdusent<String, String>()
     private val vedtaksvurderingRepository = VedtaksvurderingRepository(ConnectionAutoclosingTest(dataSource))
-    private val vedtaksvurderingService = VedtaksvurderingService(vedtaksvurderingRepository)
+    private val vedtaksvurderingService = VedtaksvurderingService(vedtaksvurderingRepository, mockk())
     private val outboxRepository = OutboxRepository(dataSource)
     private val outboxService =
         OutboxService(

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/VedtaksvurderingRouteTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/VedtaksvurderingRouteTest.kt
@@ -349,15 +349,15 @@ internal class VedtaksvurderingRouteTest(
     @Test
     fun `skal sjekke om sak har loepende vedtak`() {
         val sakId = sakId1
-        val loependeYtelse = LoependeYtelse(erLoepende = true, underSamordning = false, LocalDate.now(), UUID.randomUUID())
+        val loependeYtelseDto = LoependeYtelseDTO(erLoepende = true, underSamordning = false, LocalDate.now(), UUID.randomUUID())
 
-        every { vedtaksvurderingService.sjekkOmVedtakErLoependePaaDato(any(), any()) } returns loependeYtelse
+        coEvery { vedtaksvurderingService.sjekkOmVedtakErLoependeMedSanksjonPaaDato(any(), any(), any()) } returns loependeYtelseDto
 
         withTestApplication(context) { client ->
 
             val hentetLoependeYtelse =
                 client
-                    .get("/api/vedtak/loepende/${sakId.sakId}?dato=${loependeYtelse.dato}") {
+                    .get("/api/vedtak/loepende/${sakId.sakId}?dato=${loependeYtelseDto.dato}") {
                         header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                         header(HttpHeaders.Authorization, "Bearer $saksbehandlerToken")
                     }.let {
@@ -365,11 +365,12 @@ internal class VedtaksvurderingRouteTest(
                         deserialize<LoependeYtelseDTO>(it.bodyAsText())
                     }
 
-            hentetLoependeYtelse.erLoepende shouldBe loependeYtelse.erLoepende
-            hentetLoependeYtelse.dato shouldBe loependeYtelse.dato
+            hentetLoependeYtelse.erLoepende shouldBe loependeYtelseDto.erLoepende
+            hentetLoependeYtelse.dato shouldBe loependeYtelseDto.dato
+            hentetLoependeYtelse.harAktivSanksjon shouldBe false
 
             coVerify(exactly = 1) {
-                vedtaksvurderingService.sjekkOmVedtakErLoependePaaDato(any(), any())
+                vedtaksvurderingService.sjekkOmVedtakErLoependeMedSanksjonPaaDato(any(), any(), any())
             }
         }
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/VedtaksvurderingRouteTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/VedtaksvurderingRouteTest.kt
@@ -351,7 +351,7 @@ internal class VedtaksvurderingRouteTest(
         val sakId = sakId1
         val loependeYtelseDto = LoependeYtelseDTO(erLoepende = true, underSamordning = false, LocalDate.now(), UUID.randomUUID())
 
-        coEvery { vedtaksvurderingService.sjekkOmVedtakErLoependeMedSanksjonPaaDato(any(), any(), any()) } returns loependeYtelseDto
+        coEvery { vedtaksvurderingService.sjekkOmVedtakErLoepende(any(), any(), any()) } returns loependeYtelseDto
 
         withTestApplication(context) { client ->
 
@@ -370,7 +370,7 @@ internal class VedtaksvurderingRouteTest(
             hentetLoependeYtelse.harAktivSanksjon shouldBe false
 
             coVerify(exactly = 1) {
-                vedtaksvurderingService.sjekkOmVedtakErLoependeMedSanksjonPaaDato(any(), any(), any())
+                vedtaksvurderingService.sjekkOmVedtakErLoepende(any(), any(), any())
             }
         }
     }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/VedtaksvurderingServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/VedtaksvurderingServiceTest.kt
@@ -26,7 +26,7 @@ import java.util.UUID
 
 internal class VedtaksvurderingServiceTest {
     private val repository = mockk<VedtaksvurderingRepository>()
-    private val service = VedtaksvurderingService(repository)
+    private val service = VedtaksvurderingService(repository, mockk())
 
     @Nested
     inner class HentInnvilgedePerioder {

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/LoependeYtelserforespoerselRiver.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/kotlin/no/nav/etterlatte/regulering/LoependeYtelserforespoerselRiver.kt
@@ -61,7 +61,7 @@ internal class LoependeYtelserforespoerselRiver(
 
         omregningData.endreFraDato(respons.dato)
         packet.omregningData = omregningData
-        if (respons.erLoepende) {
+        if (respons.erLoepende && !respons.harAktivSanksjon) {
             packet.setEventNameForHendelseType(ReguleringHendelseType.LOEPENDE_YTELSE_FUNNET)
             context.publish(packet.toJson())
             logger.info("Grunnbeløpsreguleringmelding ble sendt for sak $sakId. Dato=${respons.dato}")

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/regulering/LoependeYtelserforespoerselRiverTest.kt
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/test/kotlin/no/nav/etterlatte/regulering/LoependeYtelserforespoerselRiverTest.kt
@@ -139,6 +139,30 @@ internal class LoependeYtelserforespoerselRiverTest {
     }
 
     @Test
+    fun `sender avbryt-melding naar ytelse er loepende men har aktiv sanksjon`() {
+        val melding = genererReguleringMelding(foersteMai2023)
+        val vedtakServiceMock = mockk<VedtakService>(relaxed = true)
+        every { vedtakServiceMock.harLoependeYtelserFra(sakId, foersteMai2023) } returns
+            LoependeYtelseDTO(
+                erLoepende = true,
+                underSamordning = false,
+                dato = foersteMai2023,
+                harAktivSanksjon = true,
+            )
+        val inspector = TestRapid().apply { LoependeYtelserforespoerselRiver(this, vedtakServiceMock) }
+
+        inspector.sendTestMessage(melding.toJson())
+        Assertions.assertEquals(1, inspector.inspektør.size)
+        Assertions.assertEquals(
+            inspector.inspektør
+                .message(0)
+                .get(EVENT_NAME_KEY)
+                .asText(),
+            ReguleringHendelseType.YTELSE_IKKE_LOEPENDE.lagEventnameForType(),
+        )
+    }
+
+    @Test
     fun `avbryter hvis sak er under samordning`() {
         val melding = genererReguleringMelding(foersteMai2023)
         val vedtakServiceMock = mockk<VedtakService>(relaxed = true)

--- a/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/LoependeYtelseDTO.kt
+++ b/libs/etterlatte-vedtaksvurdering-model/src/main/kotlin/LoependeYtelseDTO.kt
@@ -12,4 +12,5 @@ data class LoependeYtelseDTO(
     val sisteLoependeBehandlingId: UUID? = null,
     // TODO kun relevant for regulering 2024 da feltet opphoerFraOgMed er innført i forkant av reguleringen 2024
     val opphoerFraOgMed: YearMonth? = null,
+    val harAktivSanksjon: Boolean = false,
 )


### PR DESCRIPTION
Hvis saken har løpende sanksjon kan den ikke få ytelse > 0 etter regulering, og vi trenger ikke regulere den automatisk. Hvis sanksjon evt. fjernes vil ytelsen bli beregnet med ny G.