### PR TITLE
Tilbakestiller EO-behandlinger slik at de kan sendes til attestering og attesteres på nytt.

### DIFF
--- a/apps/etterlatte-behandling/src/main/resources/db/prod/V341__tilbakestill_eo_behandling_for_ny_attestering.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/prod/V341__tilbakestill_eo_behandling_for_ny_attestering.sql
@@ -1,0 +1,12 @@
+
+update oppgave set status = 'UNDERKJENT' where  sak_id = 12912 and referanse = 'd95be9fc-3acb-462b-96a6-91bac22d2fea';
+update oppgave set status = 'UNDERKJENT' where  sak_id = 19447 and referanse = '9987dcf3-61ea-4db8-87a2-7727f06aa75a';
+update oppgave set status = 'UNDERKJENT' where  sak_id = 19425 and referanse = '145cb975-c6b9-4138-9fd9-b59a359a6065';
+
+update behandling set status = 'RETURNERT' where sak_id = 12912 and id = 'd95be9fc-3acb-462b-96a6-91bac22d2fea';
+update behandling set status = 'RETURNERT' where sak_id = 19447 and id = '9987dcf3-61ea-4db8-87a2-7727f06aa75a';
+update behandling set status = 'RETURNERT' where sak_id = 19425 and id = '145cb975-c6b9-4138-9fd9-b59a359a6065';
+
+update vedtak set vedtakstatus = 'RETURNERT' where vedtak.sakid = 12912 and id = 66537;
+update vedtak set vedtakstatus = 'RETURNERT' where vedtak.sakid = 19425 and id = 67311;
+update vedtak set vedtakstatus = 'RETURNERT' where vedtak.sakid = 19447 and id = 66628;

--- a/apps/etterlatte-behandling/src/main/resources/db/prod/V341__tilbakestill_eo_behandling_for_ny_attestering.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/prod/V341__tilbakestill_eo_behandling_for_ny_attestering.sql
@@ -7,6 +7,6 @@ update behandling set status = 'RETURNERT' where sak_id = 12912 and id = 'd95be9
 update behandling set status = 'RETURNERT' where sak_id = 19447 and id = '9987dcf3-61ea-4db8-87a2-7727f06aa75a';
 update behandling set status = 'RETURNERT' where sak_id = 19425 and id = '145cb975-c6b9-4138-9fd9-b59a359a6065';
 
-update vedtak set vedtakstatus = 'RETURNERT' where vedtak.sakid = 12912 and id = 66537;
-update vedtak set vedtakstatus = 'RETURNERT' where vedtak.sakid = 19425 and id = 67311;
-update vedtak set vedtakstatus = 'RETURNERT' where vedtak.sakid = 19447 and id = 66628;
+update vedtak set vedtakstatus = 'RETURNERT' where sakid = 12912 and behandlingid = 'd95be9fc-3acb-462b-96a6-91bac22d2fea';
+update vedtak set vedtakstatus = 'RETURNERT' where sakid = 19447 and behandlingid = '9987dcf3-61ea-4db8-87a2-7727f06aa75a';
+update vedtak set vedtakstatus = 'RETURNERT' where sakid = 19425 and behandlingid = '145cb975-c6b9-4138-9fd9-b59a359a6065';

--- a/apps/etterlatte-brev-api/src/main/resources/db/prod/V42__resett_status_paa_vedtaksbrev_feilet_i_eo.sql
+++ b/apps/etterlatte-brev-api/src/main/resources/db/prod/V42__resett_status_paa_vedtaksbrev_feilet_i_eo.sql
@@ -1,0 +1,3 @@
+insert into hendelse (brev_id, status_id, payload) values (50793, 'OPPDATERT', 'Må ferdigstilles på nytt');
+insert into hendelse (brev_id, status_id, payload) values (52406, 'OPPDATERT', 'Må ferdigstilles på nytt');
+insert into hendelse (brev_id, status_id, payload) values (50743, 'OPPDATERT', 'Må ferdigstilles på nytt');


### PR DESCRIPTION
Gikk greit i dev, bortsett fra at sending til utbetaling feilet da vedtaket var sendt over fra før. Men det er ikke tilfelle i prod.