### PR TITLE
Tetter igjen hull i sjekking av kanFatteVedtak

### DIFF
--- a/.github/lessons.md
+++ b/.github/lessons.md
@@ -45,3 +45,7 @@
 **2026-05-29 — Estimering**
 - Observation: Jeg antok at en mock var "bare bekvemmelighet" og estimerte fjerning som trivielt – uten å verifisere det.
 - Action: Anta at en mock er en del av testkontrakten til det motsatte er bevist. Verifiser antagelsen med en rask sjekk før du estimerer.
+
+**2026-06-03 — Statussmaskin / fikse logikk**
+- Observation: Jeg byttet til en status-basert løsning fordi DAO-tilnærmingen hadde en RETURNERT-bug, men den status-baserte løsningen fikset ikke den faktiske buggen (TRYGDETID_OPPDATERT rutes til tilFattetVedtakUtvidet som tillater TRYGDETID_OPPDATERT). Brukeren måtte si ifra.
+- Action: Når en bug handler om at en status _urettmessig_ passerer en sperre, sjekk at den nye løsningen faktisk _sperrer_ den statusen i det problematiske tilfellet — ikke bare at koden ser logisk ut.

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/BehandlingStatusService.kt
@@ -4,7 +4,6 @@ import io.ktor.server.plugins.NotFoundException
 import no.nav.etterlatte.behandling.aktivitetsplikt.AktivitetspliktService
 import no.nav.etterlatte.behandling.behandlinginfo.BehandlingInfoDao
 import no.nav.etterlatte.behandling.domain.Behandling
-import no.nav.etterlatte.behandling.domain.ManuellRevurdering
 import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerService
 import no.nav.etterlatte.behandling.etteroppgjoer.EtteroppgjoerStatus
 import no.nav.etterlatte.behandling.etteroppgjoer.forbehandling.EtteroppgjoerForbehandlingService
@@ -28,12 +27,14 @@ import no.nav.etterlatte.libs.common.oppgave.VedtakEndringDTO
 import no.nav.etterlatte.libs.common.sak.SakIDListe
 import no.nav.etterlatte.libs.common.sak.SakslisteDTO
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
 import no.nav.etterlatte.libs.ktor.token.Saksbehandler
 import no.nav.etterlatte.libs.ktor.token.Systembruker
 import no.nav.etterlatte.oppgave.OppgaveService
 import no.nav.etterlatte.saksbehandler.SaksbehandlerService
 import no.nav.etterlatte.vedtaksvurdering.VedtakHendelse
+import no.nav.etterlatte.vilkaarsvurdering.dao.VilkaarsvurderingDao
 import org.slf4j.LoggerFactory
 import java.time.Year
 import java.util.UUID
@@ -123,6 +124,7 @@ class BehandlingStatusServiceImpl(
     private val etteroppgjoerService: EtteroppgjoerService,
     private val forbehandlingService: EtteroppgjoerForbehandlingService,
     private val grunnlagService: GrunnlagService,
+    private val vilkaarsvurderingDao: VilkaarsvurderingDao,
 ) : BehandlingStatusService {
     private val logger = LoggerFactory.getLogger(BehandlingStatusServiceImpl::class.java)
 
@@ -178,12 +180,7 @@ class BehandlingStatusServiceImpl(
 
     override fun sjekkOmKanFatteVedtak(behandlingId: UUID) {
         val behandling = hentBehandling(behandlingId)
-
-        if (behandling is ManuellRevurdering) {
-            behandling.tilFattetVedtakUtvidet()
-        } else {
-            behandling.tilFattetVedtak()
-        }
+        behandlingTilFattetVedtak(behandling)
     }
 
     override fun settFattetVedtak(
@@ -191,11 +188,7 @@ class BehandlingStatusServiceImpl(
         vedtak: VedtakEndringDTO,
         brukerTokenInfo: BrukerTokenInfo,
     ) {
-        if (behandling is ManuellRevurdering) {
-            lagreNyBehandlingStatus(behandling.tilFattetVedtakUtvidet())
-        } else {
-            lagreNyBehandlingStatus(behandling.tilFattetVedtak())
-        }
+        lagreNyBehandlingStatus(behandlingTilFattetVedtak(behandling))
 
         registrerVedtakHendelse(behandling.id, vedtak.vedtakHendelse, HendelseType.FATTET)
 
@@ -244,6 +237,17 @@ class BehandlingStatusServiceImpl(
             type = OppgaveType.fra(behandling.type),
             merknad = merknad,
         )
+    }
+
+    private fun behandlingTilFattetVedtak(behandling: Behandling): Behandling {
+        val vilkaarsvurderingIkkeOppfylt =
+            vilkaarsvurderingDao.hent(behandling.id)?.resultat?.utfall == VilkaarsvurderingUtfall.IKKE_OPPFYLT
+        return if (vilkaarsvurderingIkkeOppfylt) {
+            // I tilfeller der vi har en ikke oppfylt vilkårsvurdering krever vi ikke beregning før fatting av vedtak
+            behandling.tilFattetVedtakIkkeOppfyltVilkaar()
+        } else {
+            behandling.tilFattetVedtak()
+        }
     }
 
     override fun sjekkOmKanAttestere(behandlingId: UUID) {

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Behandling.kt
@@ -194,6 +194,8 @@ sealed class Behandling {
 
     open fun tilFattetVedtak(): Behandling = throw BehandlingStoetterIkkeStatusEndringException(BehandlingStatus.FATTET_VEDTAK)
 
+    open fun tilFattetVedtakIkkeOppfyltVilkaar(): Behandling = tilFattetVedtak()
+
     open fun tilAttestert(): Behandling = throw BehandlingStoetterIkkeStatusEndringException(BehandlingStatus.ATTESTERT)
 
     open fun tilAvslag(): Behandling = throw BehandlingStoetterIkkeStatusEndringException(BehandlingStatus.AVSLAG)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Foerstegangsbehandling.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/Foerstegangsbehandling.kt
@@ -140,7 +140,25 @@ data class Foerstegangsbehandling(
 
         return hvisTilstandEr(
             listOf(
-                // TODO EY-2927
+                BehandlingStatus.BEREGNET,
+                BehandlingStatus.AVKORTET,
+                BehandlingStatus.RETURNERT,
+            ),
+            BehandlingStatus.FATTET_VEDTAK,
+        ) {
+            endreTilStatus(it)
+        }
+    }
+
+    override fun tilFattetVedtakIkkeOppfyltVilkaar(): Behandling {
+        if (!erFyltUt()) {
+            throw TilstandException.IkkeFyltUt(
+                "Behandling ($id) må ha vurdert gyldig framsatt, " +
+                    "virkningstidspunkt og kommer bruker til gode for å settes til fattet vedtak",
+            )
+        }
+        return hvisTilstandEr(
+            listOf(
                 BehandlingStatus.VILKAARSVURDERT,
                 BehandlingStatus.TRYGDETID_OPPDATERT,
                 BehandlingStatus.BEREGNET,

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ManuellRevurdering.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/domain/ManuellRevurdering.kt
@@ -149,10 +149,7 @@ data class ManuellRevurdering(
             BehandlingStatus.AVKORTET,
         ) { endreTilStatus(it) }
 
-    /**
-     Utforskning av mulighet for vilkaarsvurdert -> fattet_vedtak i kontekst av opphør
-     */
-    fun tilFattetVedtakUtvidet(): Revurdering {
+    override fun tilFattetVedtakIkkeOppfyltVilkaar(): Revurdering {
         if (!erFyltUt()) {
             throw TilstandException.IkkeFyltUt(
                 "Behandling ($id) må ha satt virkningstidspunkt " +

--- a/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/ApplicationContext.kt
@@ -131,6 +131,7 @@ internal class ApplicationContext(
     val behandlingInfoDao get() = daoModule.behandlingInfoDao
     val sakTilgangDao get() = daoModule.sakTilgangDao
     val opplysningDao get() = daoModule.opplysningDao
+    val vilkaarsvurderingDao get() = daoModule.vilkaarsvurderingDao
 
     // Klient
     val norg2Klient get() = klientModule.norg2Klient

--- a/apps/etterlatte-behandling/src/main/kotlin/config/modules/ServiceModule.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/modules/ServiceModule.kt
@@ -389,6 +389,7 @@ class ServiceModule(
             etteroppgjoerService = etteroppgjoerService,
             forbehandlingService = etteroppgjoerForbehandlingService,
             grunnlagService = grunnlagService,
+            vilkaarsvurderingDao = daoModule.vilkaarsvurderingDao,
         )
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingStatusServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingStatusServiceTest.kt
@@ -52,12 +52,16 @@ import no.nav.etterlatte.libs.common.oppgave.VedtakEndringDTO
 import no.nav.etterlatte.libs.common.sak.SakId
 import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
 import no.nav.etterlatte.libs.common.vedtak.VedtakType
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.Vilkaarsvurdering
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
 import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
 import no.nav.etterlatte.nyKontekstMedBruker
 import no.nav.etterlatte.oppgave.OppgaveService
 import no.nav.etterlatte.revurdering
 import no.nav.etterlatte.saksbehandler.SaksbehandlerService
 import no.nav.etterlatte.vedtaksvurdering.VedtakHendelse
+import no.nav.etterlatte.vilkaarsvurdering.dao.VilkaarsvurderingDao
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -85,6 +89,7 @@ internal class BehandlingStatusServiceTest {
     private val etteroppgjoerService: EtteroppgjoerService = mockk()
     private val etteroppgjoerForbehandlingService: EtteroppgjoerForbehandlingService = mockk()
     private val grunnlagService: GrunnlagService = mockk()
+    private val vilkaarsvurderingDao = mockk<VilkaarsvurderingDao>()
 
     private val brukerTokenInfo = simpleSaksbehandler("Z123456")
 
@@ -101,6 +106,7 @@ internal class BehandlingStatusServiceTest {
             etteroppgjoerService,
             etteroppgjoerForbehandlingService,
             grunnlagService,
+            vilkaarsvurderingDao,
         )
 
     @BeforeEach
@@ -171,7 +177,6 @@ internal class BehandlingStatusServiceTest {
     @ParameterizedTest
     @CsvSource(
         value = [
-            "VILKAARSVURDERT",
             "BEREGNET",
             "AVKORTET",
             "RETURNERT",
@@ -208,6 +213,64 @@ internal class BehandlingStatusServiceTest {
             VedtakEndringDTO(SakIdOgReferanse(sakId, behandlingId.toString()), vedtakHendelse, VedtakType.AVSLAG)
 
         every { oppgaveService.tilAttestering(any(), any(), any()) } returns mockk()
+        every { vilkaarsvurderingDao.hent(behandlingId) } returns null
+
+        inTransaction {
+            sut.settFattetVedtak(behandling, vedtakEndringDto, brukerTokenInfo)
+        }
+
+        verify {
+            behandlingDao.lagreStatus(any())
+            behandlingService.registrerVedtakHendelse(behandlingId, vedtakHendelse, HendelseType.FATTET)
+            oppgaveService.tilAttestering(
+                behandlingId.toString(),
+                OppgaveType.FOERSTEGANGSBEHANDLING,
+                any<String>(),
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "VILKAARSVURDERT",
+            "TRYGDETID_OPPDATERT",
+        ],
+    )
+    fun `Foerstegangsbehandling med ikke-oppfylt vilkaarsvurdering kan fatte vedtak uten beregning`(status: BehandlingStatus) {
+        val sakId = sakId1
+        val behandling =
+            foerstegangsbehandling(
+                sakId = sakId,
+                status = status,
+                gyldighetsproeving =
+                    GyldighetsResultat(
+                        resultat = VurderingsResultat.KAN_IKKE_VURDERE_PGA_MANGLENDE_OPPLYSNING,
+                        vurderinger = emptyList(),
+                        vurdertDato = LocalDateTime.now(),
+                    ),
+                virkningstidspunkt =
+                    Virkningstidspunkt(
+                        dato = YearMonth.now(),
+                        kilde = Grunnlagsopplysning.Saksbehandler("", Tidspunkt.now()),
+                        begrunnelse = "Ingen",
+                    ),
+                kommerBarnetTilgode =
+                    KommerBarnetTilgode(
+                        JaNei.JA,
+                        "",
+                        Grunnlagsopplysning.Saksbehandler("", Tidspunkt.now()),
+                    ),
+            )
+        val behandlingId = behandling.id
+        val vedtakHendelse = VedtakHendelse(1L, Tidspunkt.now(), "saksbehandler")
+        val vedtakEndringDto =
+            VedtakEndringDTO(SakIdOgReferanse(sakId, behandlingId.toString()), vedtakHendelse, VedtakType.AVSLAG)
+        val mockResultat = mockk<VilkaarsvurderingResultat> { every { utfall } returns VilkaarsvurderingUtfall.IKKE_OPPFYLT }
+        val mockVilkaarsvurdering = mockk<Vilkaarsvurdering> { every { resultat } returns mockResultat }
+
+        every { oppgaveService.tilAttestering(any(), any(), any()) } returns mockk()
+        every { vilkaarsvurderingDao.hent(behandlingId) } returns mockVilkaarsvurdering
 
         inTransaction {
             sut.settFattetVedtak(behandling, vedtakEndringDto, brukerTokenInfo)

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingStatusServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/BehandlingStatusServiceTest.kt
@@ -213,7 +213,13 @@ internal class BehandlingStatusServiceTest {
             VedtakEndringDTO(SakIdOgReferanse(sakId, behandlingId.toString()), vedtakHendelse, VedtakType.AVSLAG)
 
         every { oppgaveService.tilAttestering(any(), any(), any()) } returns mockk()
-        every { vilkaarsvurderingDao.hent(behandlingId) } returns null
+        every { vilkaarsvurderingDao.hent(behandlingId) } returns
+            mockk<Vilkaarsvurdering> {
+                every { resultat } returns
+                    mockk<VilkaarsvurderingResultat> {
+                        every { utfall } returns VilkaarsvurderingUtfall.OPPFYLT
+                    }
+            }
 
         inTransaction {
             sut.settFattetVedtak(behandling, vedtakEndringDto, brukerTokenInfo)

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/VedtaksvurderingRoutesIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/VedtaksvurderingRoutesIntegrationTest.kt
@@ -129,7 +129,7 @@ class VedtaksvurderingRoutesIntegrationTest : BehandlingIntegrationTest() {
 
             inTransaction {
                 with(vedtaksvurderingService.hentVedtakMedBehandlingId(behandling.id)!!) {
-                    type shouldBe VedtakType.INNVILGELSE
+                    type shouldBe VedtakType.AVSLAG
                     vedtakFattet shouldBe null
                     sakId shouldBe behandling.sak.id
                     id shouldBe opprettetVedtak.id
@@ -161,7 +161,7 @@ class VedtaksvurderingRoutesIntegrationTest : BehandlingIntegrationTest() {
         }
         inTransaction {
             with(vedtaksvurderingService.hentVedtakMedBehandlingId(behandling.id)!!) {
-                type shouldBe VedtakType.INNVILGELSE
+                type shouldBe VedtakType.AVSLAG
                 vedtakFattet?.ansvarligSaksbehandler shouldBe saksbehandlerIdent
                 sakId shouldBe behandling.sak.id
                 val vedtakInnhold = innhold as VedtakInnhold.Behandling
@@ -202,7 +202,7 @@ class VedtaksvurderingRoutesIntegrationTest : BehandlingIntegrationTest() {
         inTransaction {
             val vedtak = vedtaksvurderingService.hentVedtakMedBehandlingId(behandling.id)
             with(vedtak!!) {
-                type shouldBe VedtakType.INNVILGELSE
+                type shouldBe VedtakType.AVSLAG
                 vedtakFattet?.ansvarligSaksbehandler shouldBe saksbehandlerIdent
                 attestasjon?.attestant shouldBe attestantIdent
                 sakId shouldBe behandling.sak.id
@@ -257,7 +257,7 @@ class VedtaksvurderingRoutesIntegrationTest : BehandlingIntegrationTest() {
             settVirkningstidspunkt(behandling)
             lagreOkGyldighetsproeving(behandling)
             lagreOkKommerBarnetTilGode(behandling)
-            lagreOkVilkaarsvurdering(behandling)
+            lagreIkkeOppfyltVilkaarsvurdering(behandling)
         }
         coEvery { applicationContext.beregningKlient.hentBeregning(any(), any()) } returns beregningDto(behandling)
         return behandling
@@ -352,12 +352,12 @@ class VedtaksvurderingRoutesIntegrationTest : BehandlingIntegrationTest() {
             brukerTokenInfo = brukerTokenInfo,
         )
 
-    fun lagreOkVilkaarsvurdering(behandling: Behandling) {
+    fun lagreIkkeOppfyltVilkaarsvurdering(behandling: Behandling) {
         applicationContext.vilkaarsvurderingService.opprettVilkaarsvurdering(behandling.id, brukerTokenInfo)
         applicationContext.vilkaarsvurderingService.oppdaterTotalVurdering(
             behandling.id,
             brukerTokenInfo,
-            VilkaarsvurderingResultat(VilkaarsvurderingUtfall.OPPFYLT, "", LocalDateTime.now(), ""),
+            VilkaarsvurderingResultat(VilkaarsvurderingUtfall.IKKE_OPPFYLT, "", LocalDateTime.now(), ""),
         )
     }
 }

--- a/apps/etterlatte-behandling/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/vilkaarsvurdering/VilkaarsvurderingIntegrationTest.kt
@@ -127,6 +127,7 @@ internal class VilkaarsvurderingIntegrationTest(
                 etteroppgjoerService = applicationContext.etteroppgjoerService,
                 forbehandlingService = applicationContext.etteroppgjoerForbehandlingService,
                 grunnlagService = applicationContext.grunnlagService,
+                vilkaarsvurderingDao = applicationContext.vilkaarsvurderingDao,
             )
         // Må bruke ConnectionAutoclosingImpl for å at den skal kaste exception hvis ikke den er wrappet med inTransaction
         vilkaarsvurderingServiceImpl =


### PR DESCRIPTION
Vi kan kun bruke en utvidet liste over statuser når vilkårsvurderingen ikke er godkjent. Dette gjelder både førstegangsbehandlinger og revurderinger.

Dette fjerner muligheten for å endre noe i beregningsgrunnlaget, og så ikke beregne med det og heller gjenbruke gammelt grunnlag.