### PR TITLE
Fiks oppgavetype for etteroppgjør med nye inntektsopplysninger fra skatt

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/oppgave/EtteroppgjoerOppgaveService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/oppgave/EtteroppgjoerOppgaveService.kt
@@ -113,7 +113,7 @@ class EtteroppgjoerOppgaveService(
             referanse = "",
             sakId = sakId,
             kilde = OppgaveKilde.HENDELSE,
-            type = OppgaveType.VURDER_KONSEKVENS,
+            type = OppgaveType.ETTEROPPGJOER_OPPRETT_REVURDERING,
             merknad =
                 "Nye inntektsopplysninger fra skatt på ferdigstilt etteroppgjør $inntektsAar - vurder " +
                     "om det har betydning for stønaden",


### PR DESCRIPTION
# Fiks oppgavetype for etteroppgjør med nye inntektsopplysninger fra skatt

### Hvorfor er denne endringen nødvendig? ✨

Når nye inntektsopplysninger fra skatt ankommer et ferdigstilt etteroppgjør, opprettes det en oppgave til saksbehandler om å vurdere om det har konsekvenser for stønaden. Denne oppgaven ble feilaktig opprettet med typen `VURDER_KONSEKVENS`, noe som gjorde det umulig for saksbehandler å ferdigstille den.

`VURDER_KONSEKVENS` er egentlig laget for grunnlagsendrings-hendelser (f.eks. adressebytte i PDL) og ferdigstilles automatisk i backend når saksbehandler arkiverer hendelsen eller oppretter en revurdering basert på den. Flyten er koblet via en konkret referanse (hendelseId). Etteroppgjørsoppgaven ble opprettet uten referanse, så det fantes ingen mekanisme for å lukke den, og frontend viste bare en "Se hendelse"-lenke uten ferdigstillingsknapp.

Løsningen er å bruke `ETTEROPPGJOER_OPPRETT_REVURDERING` i stedet. Denne typen har allerede en modal i frontend der saksbehandler enten kan opprette en revurdering eller avslutte oppgaven med kommentar.