### PR TITLE
Ikke parallelle lisenssjekker

### DIFF
--- a/.github/workflows/.build-and-deploy.yaml
+++ b/.github/workflows/.build-and-deploy.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Validate licenses
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew checkLicense --no-configuration-cache
+        run: ./gradlew checkLicense --no-parallel --no-configuration-cache
   salsa:
     name: Generate SBOM, attest and sign image
     runs-on: ubuntu-latest


### PR DESCRIPTION
Etter oppdatering av gradle vil ikke lissenssjekkene våre kjøre (ref alle "feilende" kjøringer av merges til main nå) siden den ikke kan kjøre i parallell. Setter eksplisitt  `--no-parallel` som argument for å kjøre de ikke-parallellt.