### PR TITLE
Endrer til standard generering av SBOM, dette vil nå også gjelde dev-images

### DIFF
--- a/.github/workflows/.build-and-deploy.yaml
+++ b/.github/workflows/.build-and-deploy.yaml
@@ -46,7 +46,7 @@ jobs:
           team: etterlatte
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
-          salsa: false
+          salsa: true
           dockerfile: docker/Dockerfile
           docker_context: apps/${{ github.workflow }}/
           image_suffix: ${{ github.workflow }}
@@ -77,30 +77,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew checkLicense --no-parallel --no-configuration-cache
-  salsa:
-    name: Generate SBOM, attest and sign image
-    runs-on: ubuntu-latest
-    needs: build-and-publish
-    permissions:
-      id-token: write
-    steps:
-      - name: NAIS login
-        uses: nais/login@d6ab5d83f735e9f155eb9d7d29cd20ae46820ea9 # ratchet:nais/login@v0
-        id: login
-        with:
-          team: etterlatte
-      - name: Lag image-referanse med digest
-        run: |
-          IMAGE_WITH_TAG="${{ needs.build-and-publish.outputs.image }}"
-          IMAGE="${IMAGE_WITH_TAG%%:*}"
-          echo "IMAGE_WITH_DIGEST=${IMAGE}@${{ needs.build-and-publish.outputs.digest }}" >> $GITHUB_ENV
-      - name: Generate SBOM, attest and sign image
-        id: attest-sign
-        uses: nais/attest-sign@75ea4636c578affaf49d98d98d280879b3ae54b6 # ratchet:nais/attest-sign@v2.0.7
-        env:
-          TRIVY_JAVA_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-java-db:1"
-        with:
-          image_ref: ${{ env.IMAGE_WITH_DIGEST }}
   deploy-to-dev-gcp:
     name: dev-gcp
     runs-on: ubuntu-latest

--- a/.github/workflows/app-etterlatte-saksbehandling-ui.yaml
+++ b/.github/workflows/app-etterlatte-saksbehandling-ui.yaml
@@ -70,35 +70,12 @@ jobs:
           team: etterlatte
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
-          salsa: false
+          salsa: true
           docker_context: apps/${{ env.APP_NAME }}/
           image_suffix: ${{ github.workflow }}
           tag: ${{ env.GITHUB_REF_SLUG }}
 
-  salsa:
-    name: Generate SBOM, attest and sign image
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      id-token: write
-    steps:
-      - name: NAIS login
-        uses: nais/login@d6ab5d83f735e9f155eb9d7d29cd20ae46820ea9 # ratchet:nais/login@v0
-        id: login
-        with:
-          team: etterlatte
-      - name: Lag image-referanse med digest
-        run: |
-          IMAGE_WITH_TAG="${{ needs.build.outputs.image }}"
-          IMAGE="${IMAGE_WITH_TAG%%:*}"
-          echo "IMAGE_WITH_DIGEST=${IMAGE}@${{ needs.build.outputs.digest }}" >> $GITHUB_ENV
-      - name: Generate SBOM, attest and sign image
-        id: attest-sign
-        uses: nais/attest-sign@75ea4636c578affaf49d98d98d280879b3ae54b6 # ratchet:nais/attest-sign@v2.0.7
-        env:
-          TRIVY_JAVA_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-java-db:1"
-        with:
-          image_ref: ${{ env.IMAGE_WITH_DIGEST }}
+
   deploy-to-dev-gcp:
     if: github.event_name != 'pull_request'
     name: Deploy to dev-gcp


### PR DESCRIPTION
I dag legger vi kun på SBOM på prod-images, ikke dev. Dette gjøres fordi vi tar det som et separat steg i stedet for å benytte oss av nais/docker-build-push sin [standardmåte å gjøre det på](https://doc.nais.io/services/vulnerabilities/how-to/sbom/). Endrer til å bruke standardmåten, da vil SBOM bli generert opp for både dev og prod.