### PR TITLE
Migrerer trygdetid schema fra trygdetid inn i behandling

### DIFF
--- a/apps/etterlatte-behandling/src/main/resources/db/migration/V344__flytter_trygdetid_til_sakogbehandlinger.sql
+++ b/apps/etterlatte-behandling/src/main/resources/db/migration/V344__flytter_trygdetid_til_sakogbehandlinger.sql
@@ -1,0 +1,95 @@
+create table trygdetid
+(
+    id                                                       uuid                                                              not null
+        primary key,
+    behandling_id                                            uuid                                                              not null,
+    opprettet                                                timestamp with time zone default (now() AT TIME ZONE 'UTC'::text) not null,
+    trygdetid_total                                          bigint,
+    sak_id                                                   bigint,
+    tidspunkt                                                timestamp,
+    faktisk_trygdetid_norge_total                            text,
+    faktisk_trygdetid_norge_antall_maaneder                  bigint,
+    faktisk_trygdetid_teoretisk_total                        text,
+    faktisk_trygdetid_teoretisk_antall_maaneder              bigint,
+    fremtidig_trygdetid_norge_total                          text,
+    fremtidig_trygdetid_norge_antall_maaneder                bigint,
+    fremtidig_trygdetid_norge_opptjeningstid_maaneder        bigint,
+    fremtidig_trygdetid_norge_mindre_enn_fire_femtedeler     boolean,
+    fremtidig_trygdetid_teoretisk_total                      text,
+    fremtidig_trygdetid_teoretisk_antall_maaneder            bigint,
+    fremtidig_trygdetid_teoretisk_opptjeningstid_maaneder    bigint,
+    fremtidig_trygdetid_teoretisk_mindre_enn_fire_femtedeler boolean,
+    samlet_trygdetid_norge                                   bigint,
+    samlet_trygdetid_teoretisk                               bigint,
+    prorata_broek_teller                                     bigint,
+    prorata_broek_nevner                                     bigint,
+    trygdetid_tidspunkt                                      timestamp,
+    trygdetid_regelresultat                                  text,
+    beregnet_trygdetid_overstyrt                             boolean                  default false                            not null,
+    poengaar_overstyrt                                       bigint,
+    ident                                                    text                                                              not null,
+    yrkesskade                                               boolean                  default false                            not null,
+    beregnet_samlet_trygdetid_norge                          bigint,
+    kopiert_grunnlag_fra_behandling                          uuid,
+    overstyrt_begrunnelse                                    text,
+    begrunnelse                                              text,
+    unique (behandling_id, ident)
+);
+
+create table trygdetid_grunnlag
+(
+    id                     uuid not null
+        primary key,
+    trygdetid_id           uuid
+        references trygdetid
+            on delete cascade,
+    type                   text not null,
+    bosted                 text not null,
+    periode_fra            date not null,
+    periode_til            date not null,
+    kilde                  text not null,
+    trygdetid              integer,
+    beregnet_verdi         text,
+    beregnet_tidspunkt     timestamp with time zone,
+    beregnet_regelresultat text,
+    begrunnelse            text,
+    poeng_inn_aar          boolean,
+    poeng_ut_aar           boolean,
+    prorata                boolean
+);
+
+create index trygdetid_grunnlag_trygdetid_id_idx
+    on trygdetid_grunnlag (trygdetid_id);
+
+create table opplysningsgrunnlag
+(
+    id           uuid not null
+        primary key,
+    trygdetid_id uuid
+        references trygdetid
+            on delete cascade,
+    type         text not null,
+    opplysning   jsonb,
+    kilde        jsonb
+);
+
+create index opplysningsgrunnlag_trygdetid_id_idx
+    on opplysningsgrunnlag (trygdetid_id);
+
+create table trygdeavtale
+(
+    id                             uuid not null
+        primary key,
+    behandling_id                  uuid not null,
+    avtale_kode                    text not null,
+    avtale_dato_kode               text,
+    avtale_kriteria_kode           text,
+    kilde                          text,
+    person_krets                   text,
+    arb_inntekt                    text,
+    arb_inntekt_kommentar          text,
+    bereg_art                      text,
+    bereg_art_kommentar            text,
+    nordisk_trygdeavtale           text,
+    nordisk_trygdeavtale_kommentar text
+);


### PR DESCRIPTION
# Migrerer trygdetid schema fra trygdetid inn i behandling

### Hvorfor er denne endringen nødvendig? ✨

Vi skal etter hvert flytte hele etterlatte-trygdetid inn i etterlatte-behandling. Første steg er at behandlingsbasen må ha trygdetid sine tabeller på plass, før vi flytter databaselag og servicer over.

Denne PRen gjør akkurat det:

- Legger inn trygdetid sitt schema (tabeller, indekser og relasjoner) som en ny Flyway-migrering i behandling. Bare strukturen, ingen data.
- DDL er hentet fra trygdetid sin nåtilstand. Grants til owner og cloudsqliamuser er fjernet, og flyway_schema_history er tatt bort siden behandling har sin egen.
- Ingen konflikts med eksisterende behandling tabeller, så tabellene legges rett i public. Samme mønster som da vi flyttet vedtaksvurdering inn ([V331](https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/8379/changes)).

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29545).

### Verdt å nevne

Litt om versjonsnummeret, siden det kan se rart ut: migreringen heter V344, ikke V337, selv om siste fil i migration-mappen er V336.

Grunnen er at Flyway her laster migreringer fra flere mapper (migration, gcp, dev og prod) inn i samme versjonssekvens. Prod- og gcp-mappene har egne migreringer som allerede har dyttet sekvensen opp til V343. Neste ledige nummer er derfor V344. V337 var både opptatt (ligger i prod) og ville krasjet, fordi prod allerede har kjørt migreringer helt opp til V343 (Flyway tillater ikke å sette inn en lavere versjon i ettertid).