### PR TITLE
Flytt trygdetid sitt databaselag inn i behandling

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/Trygdetid.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/Trygdetid.kt
@@ -1,0 +1,247 @@
+package no.nav.etterlatte.trygdetid
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.ktor.http.HttpStatusCode
+import no.nav.etterlatte.libs.common.feilhaandtering.ForespoerselException
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.toJsonNode
+import no.nav.etterlatte.libs.common.trygdetid.DetaljertBeregnetTrygdetidResultat
+import no.nav.etterlatte.libs.common.trygdetid.GrunnlagOpplysningerDto
+import no.nav.etterlatte.libs.common.trygdetid.OpplysningerDifferanse
+import no.nav.etterlatte.libs.common.trygdetid.OpplysningkildeDto
+import no.nav.etterlatte.libs.common.trygdetid.OpplysningsgrunnlagDto
+import no.nav.etterlatte.libs.common.trygdetid.land.LandNormalisert
+import java.time.LocalDate
+import java.time.MonthDay
+import java.time.Period
+import java.util.UUID
+import java.util.UUID.randomUUID
+
+data class Trygdetid(
+    val id: UUID = randomUUID(),
+    val ident: String,
+    val sakId: SakId,
+    val behandlingId: UUID,
+    val trygdetidGrunnlag: List<TrygdetidGrunnlag> = emptyList(),
+    val opplysninger: List<Opplysningsgrunnlag> = emptyList(),
+    val beregnetTrygdetid: DetaljertBeregnetTrygdetid? = null,
+    val overstyrtNorskPoengaar: Int? = null,
+    val opplysningerDifferanse: OpplysningerDifferanse? = null,
+    val yrkesskade: Boolean,
+    val kopiertGrunnlagFraBehandling: UUID? = null,
+    val begrunnelse: String? = null,
+) {
+    fun leggTilEllerOppdaterTrygdetidGrunnlag(nyttTrygdetidGrunnlag: TrygdetidGrunnlag): Trygdetid {
+        val normalisertNyttTrygdetidGrunnlag = listOf(nyttTrygdetidGrunnlag).normaliser().first()
+
+        trygdetidGrunnlag
+            .normaliser()
+            .filter {
+                it.id != normalisertNyttTrygdetidGrunnlag.id
+            }.find { it.periode.overlapperMed(normalisertNyttTrygdetidGrunnlag.periode) }
+            ?.let {
+                throw OverlappendePeriodeException("Trygdetidsperioder kan ikke være overlappende")
+            }
+
+        val oppdatertGrunnlagListe =
+            trygdetidGrunnlag.toMutableList().apply {
+                removeAll { it.id == nyttTrygdetidGrunnlag.id }
+
+                add(nyttTrygdetidGrunnlag)
+            }
+
+        return this.copy(trygdetidGrunnlag = oppdatertGrunnlagListe)
+    }
+
+    fun slettTrygdetidGrunnlag(trygdetidGrunnlagId: UUID): Trygdetid =
+        this.copy(
+            trygdetidGrunnlag = this.trygdetidGrunnlag.filter { it.id != trygdetidGrunnlagId },
+        )
+
+    fun oppdaterBeregnetTrygdetid(beregnetTrygdetid: DetaljertBeregnetTrygdetid): Trygdetid =
+        this.copy(beregnetTrygdetid = beregnetTrygdetid)
+
+    fun nullstillBeregnetTrygdetid(): Trygdetid = this.copy(beregnetTrygdetid = null)
+
+    fun oppdaterBegrunnelse(begrunnelse: String?) =
+        if (begrunnelse.isNullOrEmpty()) {
+            this.copy(begrunnelse = null)
+        } else {
+            this.copy(begrunnelse = begrunnelse)
+        }
+}
+
+data class DetaljertBeregnetTrygdetid(
+    val resultat: DetaljertBeregnetTrygdetidResultat,
+    val tidspunkt: Tidspunkt,
+    val regelResultat: JsonNode,
+)
+
+data class Opplysningsgrunnlag(
+    val id: UUID,
+    val type: TrygdetidOpplysningType,
+    val opplysning: JsonNode,
+    val kilde: Grunnlagsopplysning.Kilde,
+) {
+    companion object {
+        fun ny(
+            type: TrygdetidOpplysningType,
+            kilde: Grunnlagsopplysning.Kilde,
+            verdi: LocalDate,
+        ): Opplysningsgrunnlag =
+            Opplysningsgrunnlag(
+                id = randomUUID(),
+                type = type,
+                opplysning = verdi.toJsonNode(),
+                kilde = kilde,
+            )
+    }
+}
+
+enum class TrygdetidOpplysningType {
+    FOEDSELSDATO,
+    DOEDSDATO,
+    FYLT_16,
+    FYLLER_66,
+}
+
+data class TrygdetidGrunnlag(
+    val id: UUID,
+    val type: TrygdetidType,
+    val bosted: String,
+    val periode: TrygdetidPeriode,
+    val kilde: Grunnlagsopplysning.Kilde,
+    val beregnetTrygdetid: BeregnetTrygdetidGrunnlag? = null,
+    val begrunnelse: String?,
+    val poengInnAar: Boolean,
+    val poengUtAar: Boolean,
+    val prorata: Boolean,
+) {
+    fun oppdaterBeregnetTrygdetid(beregnetTrygdetid: BeregnetTrygdetidGrunnlag?): TrygdetidGrunnlag =
+        this.copy(beregnetTrygdetid = beregnetTrygdetid)
+
+    fun erNasjonal() = this.bosted == LandNormalisert.NORGE.isoCode
+}
+
+data class BeregnetTrygdetidGrunnlag(
+    val verdi: Period,
+    val tidspunkt: Tidspunkt,
+    val regelResultat: JsonNode,
+)
+
+data class TrygdetidPeriode(
+    val fra: LocalDate,
+    val til: LocalDate,
+) {
+    init {
+        if (fra.isAfter(til)) {
+            throw UgyldigForespoerselException(
+                code = "TRYGDETID_UGYLDIG_PERIODE",
+                detail = "Ugyldig periode, fra må være før eller lik til. Fra var $fra, til var $til",
+            )
+        }
+    }
+
+    fun overlapperMed(other: TrygdetidPeriode): Boolean = this.fra.isBefore(other.til) && other.fra.isBefore(this.til)
+}
+
+fun List<TrygdetidGrunnlag>.normaliser(): List<TrygdetidGrunnlag> {
+    val sortertTrygdetidGrunnlag = this.sortedBy { it.periode.fra }
+    return sortertTrygdetidGrunnlag
+        .mapIndexed { idx, trygdetidGrunnlag ->
+            var fra = trygdetidGrunnlag.periode.fra
+            var til = trygdetidGrunnlag.periode.til
+
+            if (trygdetidGrunnlag.poengInnAar) {
+                fra = fra.with(MonthDay.of(1, 1))
+            }
+
+            if (trygdetidGrunnlag.poengUtAar) {
+                til = til.with(MonthDay.of(12, 31))
+            }
+            // Håndtere at den forrige var et ut år - og at dette hadde en fra i samme år
+            if (idx > 0) {
+                val prev = sortertTrygdetidGrunnlag[idx - 1]
+
+                if (prev.poengUtAar && prev.periode.til.year == fra.year) {
+                    fra = LocalDate.of(prev.periode.til.year + 1, 1, 1)
+                }
+            }
+
+            // Håndtere at den neste var et inn år - og at dette hadde en til i samme år
+            if (idx < sortertTrygdetidGrunnlag.size - 2) {
+                val next = sortertTrygdetidGrunnlag[idx + 1]
+
+                if (next.poengInnAar && next.periode.til.year == fra.year) {
+                    til = LocalDate.of(next.periode.til.year - 1, 12, 31)
+                }
+            }
+            if ((fra != trygdetidGrunnlag.periode.fra || til != trygdetidGrunnlag.periode.til) && fra > til) {
+                throw UgyldigForespoerselException(
+                    "PERIODER_OVERLAPPER",
+                    "På grunn av avhuking for poeng inn eller ut-år overlapper trygdetidsperiodene med hverandre. " +
+                        "Perioden i ${trygdetidGrunnlag.bosted} fra ${trygdetidGrunnlag.periode.fra} til " +
+                        "${trygdetidGrunnlag.periode.til} overlapper med perioden før eller etter.",
+                )
+            }
+
+            trygdetidGrunnlag.copy(periode = TrygdetidPeriode(fra = fra, til = til.plusDays(1)))
+        }
+}
+
+class OverlappendePeriodeException(
+    message: String,
+) : ForespoerselException(
+        status = HttpStatusCode.Conflict.value,
+        code = "OVERLAPPENDE_PERIODE_TRYGDETID",
+        detail = message,
+    )
+
+fun List<Opplysningsgrunnlag>.toDto(): GrunnlagOpplysningerDto =
+    GrunnlagOpplysningerDto(
+        avdoedFoedselsdato = this.finnOpplysning(TrygdetidOpplysningType.FOEDSELSDATO),
+        avdoedDoedsdato = this.finnOpplysning(TrygdetidOpplysningType.DOEDSDATO),
+        avdoedFylteSeksten = this.finnOpplysning(TrygdetidOpplysningType.FYLT_16),
+        avdoedFyllerSeksti = this.finnOpplysning(TrygdetidOpplysningType.FYLLER_66),
+    )
+
+fun List<Opplysningsgrunnlag>.finnOpplysning(type: TrygdetidOpplysningType): OpplysningsgrunnlagDto? =
+    this.find { opplysning -> opplysning.type == type }?.toDto()
+
+private fun Opplysningsgrunnlag.toDto(): OpplysningsgrunnlagDto =
+    OpplysningsgrunnlagDto(
+        opplysning = this.opplysning,
+        kilde =
+            when (this.kilde) {
+                is Grunnlagsopplysning.Pdl -> {
+                    OpplysningkildeDto(
+                        type = this.kilde.type,
+                        tidspunkt = this.kilde.tidspunktForInnhenting.toString(),
+                    )
+                }
+
+                is Grunnlagsopplysning.RegelKilde -> {
+                    OpplysningkildeDto(
+                        type = this.kilde.type,
+                        tidspunkt = this.kilde.ts.toString(),
+                    )
+                }
+
+                else -> {
+                    throw Exception("Mangler gyldig kilde for opplysning $id")
+                }
+            },
+    )
+
+fun List<TrygdetidPartial>.trygdetiderGjelderEksaktSammeAvdoede(avdoede: List<String>): Boolean =
+    this.map { it.ident }.sorted() ==
+        avdoede.sorted()
+
+data class TrygdetidPartial(
+    val behandlingId: UUID,
+    val ident: String,
+    val opprettet: Tidspunkt,
+)

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidRepository.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidRepository.kt
@@ -1,0 +1,733 @@
+package no.nav.etterlatte.trygdetid
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import kotliquery.Row
+import kotliquery.TransactionalSession
+import kotliquery.queryOf
+import kotliquery.sessionOf
+import kotliquery.using
+import no.nav.etterlatte.libs.common.IntBroek
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.common.tidspunkt.toTidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.toTimestamp
+import no.nav.etterlatte.libs.common.toJson
+import no.nav.etterlatte.libs.common.trygdetid.DetaljertBeregnetTrygdetidResultat
+import no.nav.etterlatte.libs.common.trygdetid.FaktiskTrygdetid
+import no.nav.etterlatte.libs.common.trygdetid.FremtidigTrygdetid
+import no.nav.etterlatte.libs.database.hentListe
+import no.nav.etterlatte.libs.database.tidspunkt
+import no.nav.etterlatte.libs.database.transaction
+import java.time.Period
+import java.util.UUID
+import javax.sql.DataSource
+
+class TrygdetidRepository(
+    private val dataSource: DataSource,
+) {
+    fun hentTrygdetidMedId(
+        behandlingId: UUID,
+        trygdetidId: UUID,
+    ): Trygdetid? = hentTrygdetiderForBehandling(behandlingId).find { it.id == trygdetidId }
+
+    fun hentTrygdetid(behandlingId: UUID): Trygdetid? = hentTrygdetiderForBehandling(behandlingId).minByOrNull { it.ident }
+
+    fun hentTrygdetiderForBehandling(behandlingId: UUID): List<Trygdetid> =
+        using(sessionOf(dataSource)) { session ->
+            queryOf(
+                statement =
+                    """
+                    SELECT
+                        id,
+                        sak_id,
+                        behandling_id,
+                        ident,
+                        tidspunkt,
+                        faktisk_trygdetid_norge_total,
+                        faktisk_trygdetid_norge_antall_maaneder,
+                        faktisk_trygdetid_teoretisk_total,
+                        faktisk_trygdetid_teoretisk_antall_maaneder,
+                        fremtidig_trygdetid_norge_total,
+                        fremtidig_trygdetid_norge_antall_maaneder,
+                        fremtidig_trygdetid_norge_opptjeningstid_maaneder,
+                        fremtidig_trygdetid_norge_mindre_enn_fire_femtedeler,
+                        fremtidig_trygdetid_teoretisk_total,
+                        fremtidig_trygdetid_teoretisk_antall_maaneder,
+                        fremtidig_trygdetid_teoretisk_opptjeningstid_maaneder,
+                        fremtidig_trygdetid_teoretisk_mindre_enn_fire_femtedeler,
+                        samlet_trygdetid_norge,
+                        samlet_trygdetid_teoretisk,
+                        prorata_broek_teller,
+                        prorata_broek_nevner,
+                        trygdetid_tidspunkt,
+                        trygdetid_regelresultat,
+                        beregnet_trygdetid_overstyrt,
+                        poengaar_overstyrt,
+                        yrkesskade,
+                        beregnet_samlet_trygdetid_norge,
+                        kopiert_grunnlag_fra_behandling,
+                        overstyrt_begrunnelse,
+                        begrunnelse
+                    FROM trygdetid
+                    WHERE behandling_id = :behandlingId
+                    """.trimIndent(),
+                paramMap = mapOf("behandlingId" to behandlingId),
+            ).let { query ->
+                session.run(
+                    query
+                        .map { row ->
+                            val trygdetidId = row.uuid("id")
+                            val trygdetidGrunnlag = hentTrygdetidGrunnlag(trygdetidId)
+                            val opplysninger = hentGrunnlagOpplysninger(trygdetidId)
+                            row.toTrygdetid(trygdetidGrunnlag, opplysninger)
+                        }.asList,
+                )
+            }
+        }
+
+    fun opprettTrygdetid(trygdetid: Trygdetid): Trygdetid =
+        dataSource
+            .transaction { tx ->
+                opprettTrygdetid(trygdetid, tx)
+                opprettOpplysningsgrunnlag(trygdetid.id, trygdetid.opplysninger, tx)
+                trygdetid.trygdetidGrunnlag.forEach { opprettTrygdetidGrunnlag(trygdetid.id, it, tx) }
+
+                if (trygdetid.beregnetTrygdetid != null) {
+                    oppdaterBeregnetTrygdetid(trygdetid.behandlingId, trygdetid.id, trygdetid.beregnetTrygdetid, tx)
+                }
+            }.let { hentTrygdetidMedIdNotNull(behandlingId = trygdetid.behandlingId, trygdetidId = trygdetid.id) }
+
+    fun oppdaterTrygdetid(oppdatertTrygdetid: Trygdetid): Trygdetid =
+        dataSource
+            .transaction { tx ->
+                val gjeldendeTrygdetid =
+                    hentTrygdetidMedIdNotNull(
+                        behandlingId = oppdatertTrygdetid.behandlingId,
+                        trygdetidId = oppdatertTrygdetid.id,
+                    )
+
+                oppdaterOverstyrtPoengaar(
+                    gjeldendeTrygdetid.id,
+                    gjeldendeTrygdetid.behandlingId,
+                    oppdatertTrygdetid.overstyrtNorskPoengaar,
+                    tx,
+                )
+
+                oppdaterYrkesskade(
+                    gjeldendeTrygdetid.id,
+                    gjeldendeTrygdetid.behandlingId,
+                    oppdatertTrygdetid.yrkesskade,
+                    tx,
+                )
+
+                oppdaterKopiertGrunnlagFraBehandling(
+                    gjeldendeTrygdetid.id,
+                    gjeldendeTrygdetid.behandlingId,
+                    oppdatertTrygdetid.kopiertGrunnlagFraBehandling,
+                    tx,
+                )
+
+                oppdaterBegrunnelse(
+                    gjeldendeTrygdetid.id,
+                    gjeldendeTrygdetid.behandlingId,
+                    oppdatertTrygdetid.begrunnelse,
+                    tx,
+                )
+
+                // opprett grunnlag
+                oppdatertTrygdetid.trygdetidGrunnlag
+                    .filter { gjeldendeTrygdetid.trygdetidGrunnlag.find { tg -> tg.id == it.id } == null }
+                    .forEach { opprettTrygdetidGrunnlag(oppdatertTrygdetid.id, it, tx) }
+
+                // oppdater grunnlag
+                oppdatertTrygdetid.trygdetidGrunnlag.forEach { trygdetidGrunnlag ->
+                    gjeldendeTrygdetid.trygdetidGrunnlag
+                        .find { it.id == trygdetidGrunnlag.id && it != trygdetidGrunnlag }
+                        ?.let { oppdaterTrygdetidGrunnlag(trygdetidGrunnlag, tx) }
+                }
+
+                // slett grunnlag
+                gjeldendeTrygdetid.trygdetidGrunnlag
+                    .filter { oppdatertTrygdetid.trygdetidGrunnlag.find { tg -> tg.id == it.id } == null }
+                    .forEach { slettTrygdetidGrunnlag(it.id, tx) }
+
+                // overskriv opplysningsgrunnlag
+                oppdaterOpplysningsgrunnlag(oppdatertTrygdetid.id, oppdatertTrygdetid.opplysninger, tx)
+
+                if (oppdatertTrygdetid.beregnetTrygdetid != null) {
+                    oppdaterBeregnetTrygdetid(
+                        oppdatertTrygdetid.behandlingId,
+                        oppdatertTrygdetid.id,
+                        oppdatertTrygdetid.beregnetTrygdetid,
+                        tx,
+                    )
+                } else {
+                    nullstillBeregnetTrygdetid(oppdatertTrygdetid.behandlingId, tx)
+                }
+            }.let { hentTrygdetidMedIdNotNull(oppdatertTrygdetid.behandlingId, oppdatertTrygdetid.id) }
+
+    fun slettTrygdetid(trygdetidId: UUID) =
+        dataSource.transaction { tx ->
+            queryOf(
+                statement =
+                    """
+                    DELETE FROM trygdetid CASCADE WHERE id = :id
+                    """.trimIndent(),
+                paramMap =
+                    mapOf(
+                        "id" to trygdetidId,
+                    ),
+            ).let { query ->
+                tx.update(query)
+            }
+        }
+
+    fun hentTrygdetiderForAvdoede(avdoede: List<String>) =
+        using(sessionOf(dataSource)) { session ->
+            session.run(
+                queryOf(
+                    """SELECT DISTINCT behandling_id, ident, opprettet
+                            FROM trygdetid
+                            WHERE ident = ANY(:identer)
+                    """.trimMargin(),
+                    mapOf("identer" to session.createArrayOf("text", avdoede)),
+                ).map { row ->
+                    TrygdetidPartial(
+                        row.uuid("behandling_id"),
+                        row.string("ident"),
+                        row.tidspunkt("opprettet"),
+                    )
+                }.asList,
+            )
+        }
+
+    private fun opprettTrygdetid(
+        trygdetid: Trygdetid,
+        tx: TransactionalSession,
+    ) = queryOf(
+        statement =
+            """
+            INSERT INTO trygdetid(id, behandling_id, sak_id, ident, yrkesskade, poengaar_overstyrt, kopiert_grunnlag_fra_behandling)
+            VALUES(:id, :behandlingId, :sakId, :ident, :yrkesskade, :overstyrtNorskPoengaar, :kopiertGrunnlagFraBehandling)
+            """.trimIndent(),
+        paramMap =
+            mapOf(
+                "id" to trygdetid.id,
+                "behandlingId" to trygdetid.behandlingId,
+                "sakId" to trygdetid.sakId.sakId,
+                "ident" to trygdetid.ident,
+                "yrkesskade" to trygdetid.yrkesskade,
+                "overstyrtNorskPoengaar" to trygdetid.overstyrtNorskPoengaar,
+                "kopiertGrunnlagFraBehandling" to trygdetid.kopiertGrunnlagFraBehandling,
+            ),
+    ).let { query -> tx.update(query) }
+
+    private fun opprettOpplysningsgrunnlag(
+        trygdetidId: UUID?,
+        opplysninger: List<Opplysningsgrunnlag>,
+        tx: TransactionalSession,
+    ) = opplysninger.forEach { opplysningsgrunnlag ->
+        queryOf(
+            statement =
+                """
+                INSERT INTO opplysningsgrunnlag(id, trygdetid_id, type, opplysning, kilde)
+                 VALUES(:id, :trygdetidId, :type, :opplysning::JSONB, :kilde::JSONB)
+                """.trimIndent(),
+            paramMap =
+                mapOf(
+                    "id" to UUID.randomUUID(),
+                    "trygdetidId" to trygdetidId,
+                    "type" to opplysningsgrunnlag.type.name,
+                    "opplysning" to opplysningsgrunnlag.opplysning.toJson(),
+                    "kilde" to opplysningsgrunnlag.kilde.toJson(),
+                ),
+        ).let { query -> tx.update(query) }
+    }
+
+    private fun oppdaterOpplysningsgrunnlag(
+        trygdetidId: UUID?,
+        opplysninger: List<Opplysningsgrunnlag>,
+        tx: TransactionalSession,
+    ) {
+        queryOf(
+            statement =
+                """
+                DELETE FROM opplysningsgrunnlag
+                WHERE trygdetid_id = :trygdetidId
+                """.trimIndent(),
+            paramMap =
+                mapOf(
+                    "trygdetidId" to trygdetidId,
+                ),
+        ).let { query -> tx.update(query) }
+
+        opprettOpplysningsgrunnlag(trygdetidId, opplysninger, tx)
+    }
+
+    private fun opprettTrygdetidGrunnlag(
+        trygdetidId: UUID,
+        trygdetidGrunnlag: TrygdetidGrunnlag,
+        tx: TransactionalSession,
+    ) {
+        queryOf(
+            statement =
+                """
+                INSERT INTO trygdetid_grunnlag(
+                    id,
+                    trygdetid_id,
+                    type, bosted,
+                    periode_fra,
+                    periode_til,
+                    kilde,
+                    beregnet_verdi,
+                    beregnet_tidspunkt,
+                    beregnet_regelresultat,
+                    begrunnelse,
+                    poeng_inn_aar,
+                    poeng_ut_aar,
+                    prorata
+                )
+                VALUES(:id, :trygdetidId, :type, :bosted, :periodeFra, :periodeTil, :kilde,
+                    :beregnetVerdi, :beregnetTidspunkt, :beregnetRegelresultat, :begrunnelse,
+                    :poengInnAar, :poengUtAar, :prorata)
+                """.trimIndent(),
+            paramMap =
+                mapOf(
+                    "id" to trygdetidGrunnlag.id,
+                    "trygdetidId" to trygdetidId,
+                    "type" to trygdetidGrunnlag.type.name,
+                    "bosted" to trygdetidGrunnlag.bosted,
+                    "periodeFra" to trygdetidGrunnlag.periode.fra,
+                    "periodeTil" to trygdetidGrunnlag.periode.til,
+                    "kilde" to trygdetidGrunnlag.kilde.toJson(),
+                    "beregnetVerdi" to trygdetidGrunnlag.beregnetTrygdetid?.verdi?.toString(),
+                    "beregnetTidspunkt" to trygdetidGrunnlag.beregnetTrygdetid?.tidspunkt?.toTimestamp(),
+                    "beregnetRegelresultat" to trygdetidGrunnlag.beregnetTrygdetid?.regelResultat?.toJson(),
+                    "begrunnelse" to trygdetidGrunnlag.begrunnelse,
+                    "poengInnAar" to trygdetidGrunnlag.poengInnAar,
+                    "poengUtAar" to trygdetidGrunnlag.poengUtAar,
+                    "prorata" to trygdetidGrunnlag.prorata,
+                ),
+        ).let { query -> tx.update(query) }
+    }
+
+    private fun oppdaterTrygdetidGrunnlag(
+        trygdetidGrunnlag: TrygdetidGrunnlag,
+        tx: TransactionalSession,
+    ) {
+        queryOf(
+            statement =
+                """
+                UPDATE trygdetid_grunnlag
+                SET bosted = :bosted,
+                 periode_fra = :periodeFra,
+                 periode_til = :periodeTil,
+                 kilde = :kilde,
+                 beregnet_verdi = :beregnetVerdi,
+                 beregnet_tidspunkt = :beregnetTidspunkt,
+                 beregnet_regelresultat = :beregnetRegelresultat,
+                 begrunnelse = :begrunnelse,
+                 poeng_inn_aar = :poengInnAar,
+                 poeng_ut_aar = :poengUtAar,
+                 prorata = :prorata
+                WHERE id = :trygdetidGrunnlagId
+                """.trimIndent(),
+            paramMap =
+                mapOf(
+                    "trygdetidGrunnlagId" to trygdetidGrunnlag.id,
+                    "bosted" to trygdetidGrunnlag.bosted,
+                    "periodeFra" to trygdetidGrunnlag.periode.fra,
+                    "periodeTil" to trygdetidGrunnlag.periode.til,
+                    "kilde" to trygdetidGrunnlag.kilde.toJson(),
+                    "beregnetVerdi" to trygdetidGrunnlag.beregnetTrygdetid?.verdi?.toString(),
+                    "beregnetTidspunkt" to trygdetidGrunnlag.beregnetTrygdetid?.tidspunkt?.toTimestamp(),
+                    "beregnetRegelresultat" to trygdetidGrunnlag.beregnetTrygdetid?.regelResultat?.toJson(),
+                    "begrunnelse" to trygdetidGrunnlag.begrunnelse,
+                    "poengInnAar" to trygdetidGrunnlag.poengInnAar,
+                    "poengUtAar" to trygdetidGrunnlag.poengUtAar,
+                    "prorata" to trygdetidGrunnlag.prorata,
+                ),
+        ).let { query -> tx.update(query) }
+    }
+
+    private fun slettTrygdetidGrunnlag(
+        trygdetidGrunnlagId: UUID,
+        tx: TransactionalSession,
+    ) {
+        queryOf(
+            statement = "DELETE FROM trygdetid_grunnlag WHERE id = :id",
+            paramMap =
+                mapOf(
+                    "id" to trygdetidGrunnlagId,
+                ),
+        ).let { query -> tx.update(query) }
+    }
+
+    private fun oppdaterOverstyrtPoengaar(
+        id: UUID,
+        behandlingId: UUID,
+        overstyrtNorskPoengaar: Int? = null,
+        tx: TransactionalSession,
+    ) {
+        queryOf(
+            statement =
+                """
+                UPDATE trygdetid
+                  SET poengaar_overstyrt = :overstyrtNorskPoengaar WHERE id = :id AND  behandling_id = :behandlingId
+                """.trimIndent(),
+            paramMap =
+                mapOf(
+                    "id" to id,
+                    "behandlingId" to behandlingId,
+                    "overstyrtNorskPoengaar" to overstyrtNorskPoengaar,
+                ),
+        ).let { query ->
+            tx.update(query)
+        }
+    }
+
+    private fun oppdaterKopiertGrunnlagFraBehandling(
+        id: UUID,
+        behandlingId: UUID,
+        kildeBehandlingId: UUID?,
+        tx: TransactionalSession,
+    ) {
+        queryOf(
+            statement =
+                """
+                UPDATE trygdetid
+                  SET kopiert_grunnlag_fra_behandling = :kildeBehandlingId WHERE id = :id AND  behandling_id = :behandlingId
+                """.trimIndent(),
+            paramMap =
+                mapOf(
+                    "id" to id,
+                    "behandlingId" to behandlingId,
+                    "kildeBehandlingId" to kildeBehandlingId,
+                ),
+        ).let { query ->
+            tx.update(query)
+        }
+    }
+
+    private fun oppdaterBegrunnelse(
+        id: UUID,
+        behandlingId: UUID,
+        begrunnelse: String?,
+        tx: TransactionalSession,
+    ) {
+        queryOf(
+            statement =
+                """
+                UPDATE trygdetid
+                  SET begrunnelse = :begrunnelse WHERE id = :id AND  behandling_id = :behandlingId
+                """.trimIndent(),
+            paramMap =
+                mapOf(
+                    "id" to id,
+                    "behandlingId" to behandlingId,
+                    "begrunnelse" to begrunnelse,
+                ),
+        ).let { query ->
+            tx.update(query)
+        }
+    }
+
+    private fun oppdaterYrkesskade(
+        id: UUID,
+        behandlingId: UUID,
+        yrkesskade: Boolean,
+        tx: TransactionalSession,
+    ) {
+        queryOf(
+            statement =
+                """
+                UPDATE trygdetid
+                  SET yrkesskade = :yrkesskade WHERE id = :id AND  behandling_id = :behandlingId
+                """.trimIndent(),
+            paramMap =
+                mapOf(
+                    "id" to id,
+                    "behandlingId" to behandlingId,
+                    "yrkesskade" to yrkesskade,
+                ),
+        ).let { query ->
+            tx.update(query)
+        }
+    }
+
+    private fun oppdaterBeregnetTrygdetid(
+        behandlingId: UUID,
+        trygdetidId: UUID,
+        beregnetTrygdetid: DetaljertBeregnetTrygdetid,
+        tx: TransactionalSession,
+    ) {
+        val beregnetVerdi = beregnetTrygdetid.resultat
+
+        queryOf(
+            statement =
+                """
+                UPDATE trygdetid
+                SET
+                  faktisk_trygdetid_norge_total = :faktiskTrygdetidNorgeTotal,
+                  faktisk_trygdetid_norge_antall_maaneder = :faktiskTrygdetidNorgeAntallMaaneder,
+                  faktisk_trygdetid_teoretisk_total = :faktiskTrygdetidTeoretiskTotal,
+                  faktisk_trygdetid_teoretisk_antall_maaneder = :faktiskTrygdetidTeoretiskAntallMaaneder,
+                  fremtidig_trygdetid_norge_total = :fremtidigTrygdetidNorgeTotal,
+                  fremtidig_trygdetid_norge_antall_maaneder = :fremtidigTrygdetidNorgeAntallMaaneder,
+                  fremtidig_trygdetid_norge_opptjeningstid_maaneder = :fremtidigTrygdetidNorgeOpptjeningstidMaaneder,
+                  fremtidig_trygdetid_norge_mindre_enn_fire_femtedeler =
+                    :fremtidigTrygdetidNorgeMindreEnnFireFemtedeler,
+                  fremtidig_trygdetid_teoretisk_total = :fremtidigTrygdetidTeoretiskTotal,
+                  fremtidig_trygdetid_teoretisk_antall_maaneder = :fremtidigTrygdetidTeoretiskAntallMaaneder,
+                  fremtidig_trygdetid_teoretisk_opptjeningstid_maaneder =
+                    :fremtidigTrygdetidTeoretiskOpptjeningstidMaaneder,
+                  fremtidig_trygdetid_teoretisk_mindre_enn_fire_femtedeler =
+                    :fremtidigTrygdetidTeoretiskMindreEnnFireFemtedeler,
+                  samlet_trygdetid_norge = :samletTrygdetidNorge,
+                  samlet_trygdetid_teoretisk = :samletTrygdetidTeoretisk,
+                  prorata_broek_teller = :prorataBroekTeller,
+                  prorata_broek_nevner = :prorataBroekNevner,
+                  trygdetid_tidspunkt = :trygdetidTidspunkt,
+                  trygdetid_regelresultat = :trygdetidRegelresultat,
+                  beregnet_trygdetid_overstyrt = :overstyrt,
+                  yrkesskade = :yrkesskade,
+                  overstyrt_begrunnelse = :overstyrtBegrunnelse
+                WHERE behandling_id = :behandlingId AND id = :trygdetidId
+                """.trimIndent(),
+            paramMap =
+                mapOf(
+                    "behandlingId" to behandlingId,
+                    "trygdetidId" to trygdetidId,
+                    "faktiskTrygdetidNorgeTotal" to beregnetVerdi.faktiskTrygdetidNorge?.periode?.toString(),
+                    "faktiskTrygdetidNorgeAntallMaaneder" to beregnetVerdi.faktiskTrygdetidNorge?.antallMaaneder,
+                    "faktiskTrygdetidTeoretiskTotal" to beregnetVerdi.faktiskTrygdetidTeoretisk?.periode?.toString(),
+                    "faktiskTrygdetidTeoretiskAntallMaaneder" to
+                        beregnetVerdi.faktiskTrygdetidTeoretisk?.antallMaaneder,
+                    "fremtidigTrygdetidNorgeTotal" to beregnetVerdi.fremtidigTrygdetidNorge?.periode?.toString(),
+                    "fremtidigTrygdetidNorgeAntallMaaneder" to beregnetVerdi.fremtidigTrygdetidNorge?.antallMaaneder,
+                    "fremtidigTrygdetidNorgeOpptjeningstidMaaneder" to
+                        beregnetVerdi.fremtidigTrygdetidNorge?.opptjeningstidIMaaneder,
+                    "fremtidigTrygdetidNorgeMindreEnnFireFemtedeler" to
+                        beregnetVerdi.fremtidigTrygdetidNorge?.mindreEnnFireFemtedelerAvOpptjeningstiden,
+                    "fremtidigTrygdetidTeoretiskTotal" to
+                        beregnetVerdi.fremtidigTrygdetidTeoretisk?.periode?.toString(),
+                    "fremtidigTrygdetidTeoretiskAntallMaaneder" to
+                        beregnetVerdi.fremtidigTrygdetidTeoretisk?.antallMaaneder,
+                    "fremtidigTrygdetidTeoretiskOpptjeningstidMaaneder" to
+                        beregnetVerdi.fremtidigTrygdetidTeoretisk?.opptjeningstidIMaaneder,
+                    "fremtidigTrygdetidTeoretiskMindreEnnFireFemtedeler" to
+                        beregnetVerdi.fremtidigTrygdetidTeoretisk?.mindreEnnFireFemtedelerAvOpptjeningstiden,
+                    "samletTrygdetidNorge" to beregnetVerdi.samletTrygdetidNorge,
+                    "samletTrygdetidTeoretisk" to beregnetVerdi.samletTrygdetidTeoretisk,
+                    "prorataBroekTeller" to beregnetVerdi.prorataBroek?.teller,
+                    "prorataBroekNevner" to beregnetVerdi.prorataBroek?.nevner,
+                    "trygdetidTidspunkt" to beregnetTrygdetid.tidspunkt.toTimestamp(),
+                    "trygdetidRegelresultat" to beregnetTrygdetid.regelResultat.toJson(),
+                    "overstyrt" to beregnetTrygdetid.resultat.overstyrt,
+                    "yrkesskade" to beregnetVerdi.yrkesskade,
+                    "overstyrtBegrunnelse" to beregnetVerdi.overstyrtBegrunnelse,
+                ),
+        ).let { query ->
+            tx.update(query)
+        }
+    }
+
+    private fun nullstillBeregnetTrygdetid(
+        behandlingId: UUID,
+        tx: TransactionalSession,
+    ) = queryOf(
+        statement =
+            """
+            UPDATE trygdetid
+            SET
+                faktisk_trygdetid_norge_total = null,
+                faktisk_trygdetid_norge_antall_maaneder = null,
+                faktisk_trygdetid_teoretisk_total = null,
+                faktisk_trygdetid_teoretisk_antall_maaneder = null,
+                fremtidig_trygdetid_norge_total = null,
+                fremtidig_trygdetid_norge_antall_maaneder = null,
+                fremtidig_trygdetid_norge_opptjeningstid_maaneder = null,
+                fremtidig_trygdetid_norge_mindre_enn_fire_femtedeler = null,
+                fremtidig_trygdetid_teoretisk_total =null,
+                fremtidig_trygdetid_teoretisk_antall_maaneder = null,
+                fremtidig_trygdetid_teoretisk_opptjeningstid_maaneder = null,
+                fremtidig_trygdetid_teoretisk_mindre_enn_fire_femtedeler = null,
+                samlet_trygdetid_norge = null,
+                samlet_trygdetid_teoretisk = null,
+                prorata_broek_teller = null,
+                prorata_broek_nevner = null,
+                trygdetid_tidspunkt = null,
+                trygdetid_regelresultat = null,
+                beregnet_trygdetid_overstyrt = false,
+                yrkesskade = false,
+                overstyrt_begrunnelse = null
+            WHERE behandling_id = :behandlingId
+            """.trimIndent(),
+        paramMap = mapOf("behandlingId" to behandlingId),
+    ).let { query -> tx.update(query) }
+
+    private fun hentTrygdetidGrunnlag(trygdetidId: UUID): List<TrygdetidGrunnlag> =
+        using(sessionOf(dataSource)) { session ->
+            queryOf(
+                statement =
+                    """
+                    SELECT id, trygdetid_id, type, bosted, periode_fra, periode_til, kilde, beregnet_verdi,
+                    beregnet_tidspunkt, beregnet_regelresultat , begrunnelse, poeng_inn_aar, poeng_ut_aar, prorata
+                    FROM trygdetid_grunnlag
+                    WHERE trygdetid_id = :trygdetidId
+                    """.trimIndent(),
+                paramMap = mapOf("trygdetidId" to trygdetidId),
+            ).let { query ->
+                session.run(
+                    query.map { row -> row.toTrygdetidGrunnlag() }.asList,
+                )
+            }
+        }
+
+    private fun hentGrunnlagOpplysninger(trygdetidId: UUID): List<Opplysningsgrunnlag> =
+        dataSource.transaction { tx ->
+            tx.hentListe(
+                queryString =
+                    """
+                    SELECT id, trygdetid_id, type, opplysning, kilde
+                    FROM opplysningsgrunnlag
+                    WHERE trygdetid_id = :trygdetidId
+                    """.trimIndent(),
+                params = { mapOf("trygdetidId" to trygdetidId) },
+                converter = { it.toOpplysningsgrunnlag() },
+            )
+        }
+
+    private fun hentTrygdetidMedIdNotNull(
+        behandlingId: UUID,
+        trygdetidId: UUID,
+    ) = hentTrygdetidMedId(behandlingId, trygdetidId)
+        ?: throw Exception("Fant ikke trygdetid for $behandlingId")
+
+    private fun Row.toFaktiskTrygdetid(
+        totalColumn: String,
+        maanederColumn: String,
+    ) = stringOrNull(totalColumn)?.let { period ->
+        FaktiskTrygdetid(
+            periode = Period.parse(period),
+            antallMaaneder = long(maanederColumn),
+        )
+    }
+
+    private fun Row.toFremtidigTrygdetid(
+        totalColumn: String,
+        maanederColumn: String,
+        opptjeningsColumn: String,
+        fireFemtedelerColumn: String,
+    ) = stringOrNull(totalColumn)?.let { period ->
+        FremtidigTrygdetid(
+            periode = Period.parse(period),
+            antallMaaneder = long(maanederColumn),
+            opptjeningstidIMaaneder = long(opptjeningsColumn),
+            mindreEnnFireFemtedelerAvOpptjeningstiden =
+                boolean(fireFemtedelerColumn),
+        )
+    }
+
+    private fun Row.toDetaljertBeregnetTrygdetid() =
+        DetaljertBeregnetTrygdetid(
+            resultat =
+                DetaljertBeregnetTrygdetidResultat(
+                    faktiskTrygdetidNorge =
+                        this.toFaktiskTrygdetid(
+                            totalColumn = "faktisk_trygdetid_norge_total",
+                            maanederColumn = "faktisk_trygdetid_norge_antall_maaneder",
+                        ),
+                    faktiskTrygdetidTeoretisk =
+                        this.toFaktiskTrygdetid(
+                            totalColumn = "faktisk_trygdetid_teoretisk_total",
+                            maanederColumn = "faktisk_trygdetid_teoretisk_antall_maaneder",
+                        ),
+                    fremtidigTrygdetidNorge =
+                        this.toFremtidigTrygdetid(
+                            totalColumn = "fremtidig_trygdetid_norge_total",
+                            maanederColumn = "fremtidig_trygdetid_norge_antall_maaneder",
+                            opptjeningsColumn = "fremtidig_trygdetid_norge_opptjeningstid_maaneder",
+                            fireFemtedelerColumn = "fremtidig_trygdetid_norge_mindre_enn_fire_femtedeler",
+                        ),
+                    fremtidigTrygdetidTeoretisk =
+                        this.toFremtidigTrygdetid(
+                            totalColumn = "fremtidig_trygdetid_teoretisk_total",
+                            maanederColumn = "fremtidig_trygdetid_teoretisk_antall_maaneder",
+                            opptjeningsColumn = "fremtidig_trygdetid_teoretisk_opptjeningstid_maaneder",
+                            fireFemtedelerColumn = "fremtidig_trygdetid_teoretisk_mindre_enn_fire_femtedeler",
+                        ),
+                    samletTrygdetidNorge = intOrNull("samlet_trygdetid_norge"),
+                    samletTrygdetidTeoretisk = intOrNull("samlet_trygdetid_teoretisk"),
+                    prorataBroek =
+                        IntBroek.fra(
+                            Pair(intOrNull("prorata_broek_teller"), intOrNull("prorata_broek_nevner")),
+                        ),
+                    overstyrt = boolean("beregnet_trygdetid_overstyrt"),
+                    yrkesskade = boolean("yrkesskade"),
+                    beregnetSamletTrygdetidNorge = intOrNull("beregnet_samlet_trygdetid_norge"),
+                    overstyrtBegrunnelse = stringOrNull("overstyrt_begrunnelse"),
+                ),
+            tidspunkt = tidspunkt("trygdetid_tidspunkt"),
+            regelResultat =
+                string("trygdetid_regelresultat").let { regelResultat ->
+                    objectMapper.readTree(regelResultat)
+                },
+        )
+
+    private fun Row.toTrygdetid(
+        trygdetidGrunnlag: List<TrygdetidGrunnlag>,
+        opplysninger: List<Opplysningsgrunnlag>,
+    ) = Trygdetid(
+        id = uuid("id"),
+        sakId = SakId(long("sak_id")),
+        behandlingId = uuid("behandling_id"),
+        beregnetTrygdetid =
+            stringOrNull("trygdetid_tidspunkt")?.let {
+                this.toDetaljertBeregnetTrygdetid()
+            },
+        trygdetidGrunnlag = trygdetidGrunnlag,
+        opplysninger = opplysninger,
+        overstyrtNorskPoengaar = intOrNull("poengaar_overstyrt"),
+        ident = string("ident"),
+        yrkesskade = boolean("yrkesskade"),
+        kopiertGrunnlagFraBehandling = uuidOrNull("kopiert_grunnlag_fra_behandling"),
+        begrunnelse = stringOrNull("begrunnelse"),
+    )
+
+    private fun Row.toTrygdetidGrunnlag() =
+        TrygdetidGrunnlag(
+            id = uuid("id"),
+            type = string("type").let { TrygdetidType.valueOf(it) },
+            bosted = string("bosted"),
+            periode =
+                TrygdetidPeriode(
+                    fra = localDate("periode_fra"),
+                    til = localDate("periode_til"),
+                ),
+            kilde = string("kilde").let { objectMapper.readValue(it) },
+            beregnetTrygdetid =
+                stringOrNull("beregnet_verdi")?.let { verdi ->
+                    BeregnetTrygdetidGrunnlag(
+                        verdi = Period.parse(verdi),
+                        tidspunkt = sqlTimestamp("beregnet_tidspunkt").toTidspunkt(),
+                        regelResultat =
+                            string("beregnet_regelresultat").let {
+                                objectMapper.readTree(it)
+                            },
+                    )
+                },
+            begrunnelse = stringOrNull("begrunnelse"),
+            poengInnAar = boolean("poeng_inn_aar"),
+            poengUtAar = boolean("poeng_ut_aar"),
+            prorata = boolean("prorata"),
+        )
+
+    private fun Row.toOpplysningsgrunnlag(): Opplysningsgrunnlag =
+        Opplysningsgrunnlag(
+            id = uuid("id"),
+            type = string("type").let { TrygdetidOpplysningType.valueOf(it) },
+            opplysning = string("opplysning").let { objectMapper.readValue(it) },
+            kilde = string("kilde").let { objectMapper.readValue(it) },
+        )
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/avtale/AvtaleRepository.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/avtale/AvtaleRepository.kt
@@ -1,0 +1,125 @@
+package no.nav.etterlatte.trygdetid.avtale
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import kotliquery.Row
+import kotliquery.queryOf
+import kotliquery.sessionOf
+import kotliquery.using
+import no.nav.etterlatte.libs.common.behandling.JaNei
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.trygdetid.avtale.Trygdeavtale
+import java.util.UUID
+import javax.sql.DataSource
+
+class AvtaleRepository(
+    private val dataSource: DataSource,
+) {
+    fun hentAvtale(behandlingId: UUID): Trygdeavtale? =
+        using(sessionOf(dataSource)) { session ->
+            queryOf(
+                statement =
+                    """
+                    SELECT id, behandling_id, avtale_kode, avtale_dato_kode, avtale_kriteria_kode, person_krets, arb_inntekt, arb_inntekt_kommentar, bereg_art, bereg_art_kommentar, nordisk_trygdeAvtale, nordisk_trygdeavtale_kommentar, kilde
+                    FROM trygdeavtale
+                    WHERE behandling_id = :behandlingId
+                    """.trimIndent(),
+                paramMap = mapOf("behandlingId" to behandlingId),
+            ).let { query ->
+                session.run(
+                    query
+                        .map { row ->
+                            row.toTrygdeavtale()
+                        }.asSingle,
+                )
+            }
+        }
+
+    fun lagreAvtale(trygdeavtale: Trygdeavtale) {
+        using(sessionOf(dataSource)) { session ->
+            queryOf(
+                statement =
+                    """
+                    UPDATE trygdeavtale
+                    SET
+                    avtale_kode = :avtaleKode,
+                    avtale_dato_kode = :avtaleDatoKode,
+                    avtale_kriteria_kode = :avtaleKriteriaKode,
+                    person_krets = :personKrets,
+                    arb_inntekt = :arbInntekt1G,
+                    arb_inntekt_kommentar = :arbInntekt1GKommentar,
+                    bereg_art = :beregArt50,
+                    bereg_art_kommentar = :beregArt50Kommentar,
+                    nordisk_trygdeavtale = :nordiskTrygdeAvtale,
+                    nordisk_trygdeavtale_kommentar = :nordiskTrygdeAvtaleKommentar,
+                    kilde = :kilde
+                    WHERE id = :id AND behandling_id = :behandlingId
+                    """.trimIndent(),
+                paramMap =
+                    mapOf(
+                        "id" to trygdeavtale.id,
+                        "behandlingId" to trygdeavtale.behandlingId,
+                        "avtaleKode" to trygdeavtale.avtaleKode,
+                        "avtaleDatoKode" to trygdeavtale.avtaleDatoKode,
+                        "avtaleKriteriaKode" to trygdeavtale.avtaleKriteriaKode,
+                        "personKrets" to trygdeavtale.personKrets?.name,
+                        "arbInntekt1G" to trygdeavtale.arbInntekt1G?.name,
+                        "arbInntekt1GKommentar" to trygdeavtale.arbInntekt1GKommentar,
+                        "beregArt50" to trygdeavtale.beregArt50?.name,
+                        "beregArt50Kommentar" to trygdeavtale.beregArt50Kommentar,
+                        "nordiskTrygdeAvtale" to trygdeavtale.nordiskTrygdeAvtale?.name,
+                        "nordiskTrygdeAvtaleKommentar" to trygdeavtale.nordiskTrygdeAvtaleKommentar,
+                        "kilde" to trygdeavtale.kilde.toJson(),
+                    ),
+            ).let { query ->
+                session.execute(query)
+            }
+        }
+    }
+
+    fun opprettAvtale(trygdeavtale: Trygdeavtale) {
+        using(sessionOf(dataSource)) { session ->
+            queryOf(
+                statement =
+                    """
+                    INSERT INTO trygdeavtale(id, behandling_id, avtale_kode, avtale_dato_kode, avtale_kriteria_kode, arb_inntekt, arb_inntekt_kommentar, bereg_art, bereg_art_kommentar, nordisk_trygdeavtale, nordisk_trygdeavtale_kommentar, kilde)
+                    VALUES(:id, :behandlingId, :avtaleKode, :avtaleDatoKode, :avtaleKriteriaKode, :arbInntekt1G, :arbInntekt1GKommentar, :beregArt50, :beregArt50Kommentar, :nordiskTrygdeAvtale, :nordiskTrygdeAvtaleKommentar, :kilde)
+                    """.trimIndent(),
+                paramMap =
+                    mapOf(
+                        "id" to trygdeavtale.id,
+                        "behandlingId" to trygdeavtale.behandlingId,
+                        "avtaleKode" to trygdeavtale.avtaleKode,
+                        "avtaleDatoKode" to trygdeavtale.avtaleDatoKode,
+                        "avtaleKriteriaKode" to trygdeavtale.avtaleKriteriaKode,
+                        "personKrets" to trygdeavtale.personKrets?.name,
+                        "arbInntekt1G" to trygdeavtale.arbInntekt1G?.name,
+                        "arbInntekt1GKommentar" to trygdeavtale.arbInntekt1GKommentar,
+                        "beregArt50" to trygdeavtale.beregArt50?.name,
+                        "beregArt50Kommentar" to trygdeavtale.beregArt50Kommentar,
+                        "nordiskTrygdeAvtale" to trygdeavtale.nordiskTrygdeAvtale?.name,
+                        "nordiskTrygdeAvtaleKommentarto" to trygdeavtale.nordiskTrygdeAvtaleKommentar,
+                        "kilde" to trygdeavtale.kilde.toJson(),
+                    ),
+            ).let { query ->
+                session.execute(query)
+            }
+        }
+    }
+
+    private fun Row.toTrygdeavtale() =
+        Trygdeavtale(
+            id = uuid("id"),
+            behandlingId = uuid("behandling_id"),
+            avtaleKode = string("avtale_kode"),
+            avtaleDatoKode = stringOrNull("avtale_dato_kode"),
+            avtaleKriteriaKode = stringOrNull("avtale_kriteria_kode"),
+            personKrets = stringOrNull("person_krets")?.let { JaNei.valueOf(it) },
+            arbInntekt1G = stringOrNull("arb_inntekt")?.let { JaNei.valueOf(it) },
+            arbInntekt1GKommentar = stringOrNull("arb_inntekt_kommentar"),
+            beregArt50 = stringOrNull("bereg_art")?.let { JaNei.valueOf(it) },
+            beregArt50Kommentar = stringOrNull("bereg_art_kommentar"),
+            nordiskTrygdeAvtale = stringOrNull("nordisk_trygdeavtale")?.let { JaNei.valueOf(it) },
+            nordiskTrygdeAvtaleKommentar = stringOrNull("nordisk_trygdeavtale_kommentar"),
+            kilde = string("kilde").let { objectMapper.readValue(it) },
+        )
+}

--- a/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/DatabaseExtension.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/DatabaseExtension.kt
@@ -1,0 +1,12 @@
+package no.nav.etterlatte.trygdetid
+
+import no.nav.etterlatte.GenerellDatabaseExtension
+import no.nav.etterlatte.ResetDatabaseStatement
+
+@ResetDatabaseStatement(
+    """
+    TRUNCATE trygdetid CASCADE;
+    TRUNCATE trygdeavtale CASCADE;
+""",
+)
+class DatabaseExtension : GenerellDatabaseExtension()

--- a/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TestHelper.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TestHelper.kt
@@ -1,0 +1,197 @@
+package no.nav.etterlatte.trygdetid
+
+import no.nav.etterlatte.behandling.sakId1
+import no.nav.etterlatte.ktor.token.simpleSaksbehandler
+import no.nav.etterlatte.libs.common.Vedtaksloesning
+import no.nav.etterlatte.libs.common.behandling.BehandlingOpprinnelse
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
+import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
+import no.nav.etterlatte.libs.common.behandling.JaNei
+import no.nav.etterlatte.libs.common.behandling.Prosesstype
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import no.nav.etterlatte.libs.common.grunnlag.hentFoedselsnummer
+import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.toJsonNode
+import no.nav.etterlatte.libs.common.trygdetid.DetaljertBeregnetTrygdetidResultat
+import no.nav.etterlatte.libs.common.trygdetid.GrunnlagOpplysningerDto
+import no.nav.etterlatte.libs.common.trygdetid.OpplysningerDifferanse
+import no.nav.etterlatte.libs.common.trygdetid.avtale.Trygdeavtale
+import no.nav.etterlatte.libs.common.trygdetid.land.LandNormalisert
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
+import java.time.LocalDate
+import java.time.Period
+import java.util.UUID
+import java.util.UUID.randomUUID
+
+val saksbehandler = simpleSaksbehandler()
+
+private val pdlKilde: Grunnlagsopplysning.Pdl = Grunnlagsopplysning.Pdl(Tidspunkt.now(), null, "opplysningsId1")
+
+private val regelKilde: Grunnlagsopplysning.RegelKilde = Grunnlagsopplysning.RegelKilde("regel", Tidspunkt.now(), "1")
+
+fun behandling(
+    behandlingId: UUID = randomUUID(),
+    sakId: SakId = sakId1,
+    behandlingStatus: BehandlingStatus = BehandlingStatus.VILKAARSVURDERT,
+) = DetaljertBehandling(
+    id = behandlingId,
+    sak = sakId,
+    sakType = SakType.BARNEPENSJON,
+    soeker = "",
+    status = behandlingStatus,
+    behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+    virkningstidspunkt = null,
+    boddEllerArbeidetUtlandet = null,
+    utlandstilknytning = null,
+    revurderingsaarsak = null,
+    revurderingInfo = null,
+    prosesstype = Prosesstype.AUTOMATISK,
+    vedtaksloesning = Vedtaksloesning.GJENNY,
+    sendeBrev = true,
+    opphoerFraOgMed = null,
+    relatertBehandlingId = null,
+    tidligereFamiliepleier = null,
+    opprinnelse = BehandlingOpprinnelse.UKJENT,
+)
+
+fun trygdetid(
+    behandlingId: UUID = randomUUID(),
+    sakId: SakId = sakId1,
+    ident: String =
+        GrunnlagTestData()
+            .hentOpplysningsgrunnlag()
+            .hentAvdoede()
+            .firstOrNull()
+            ?.hentFoedselsnummer()
+            ?.verdi
+            ?.value
+            ?: throw IllegalStateException("Mangler ident for trygdetid"),
+    beregnetTrygdetid: DetaljertBeregnetTrygdetid? = null,
+    trygdetidGrunnlag: List<TrygdetidGrunnlag> = emptyList(),
+    opplysninger: List<Opplysningsgrunnlag> = standardOpplysningsgrunnlag(),
+    yrkesskade: Boolean = false,
+    overstyrtNorskPoengaar: Int? = null,
+    opplysningerDifferanse: OpplysningerDifferanse = OpplysningerDifferanse(false, GrunnlagOpplysningerDto.tomt()),
+) = Trygdetid(
+    id = randomUUID(),
+    sakId = sakId,
+    behandlingId = behandlingId,
+    trygdetidGrunnlag = trygdetidGrunnlag,
+    opplysninger = opplysninger,
+    beregnetTrygdetid = beregnetTrygdetid,
+    ident = ident,
+    yrkesskade = yrkesskade,
+    opplysningerDifferanse = opplysningerDifferanse,
+    overstyrtNorskPoengaar = overstyrtNorskPoengaar,
+)
+
+fun standardOpplysningsgrunnlag(): List<Opplysningsgrunnlag> {
+    val foedselsdato = LocalDate.of(2000, 1, 1)
+    val doedsdato = LocalDate.of(2020, 1, 1)
+    val seksten = LocalDate.of(2016, 1, 1)
+    val seksti = LocalDate.of(2066, 1, 1)
+
+    return opplysningsgrunnlag(foedselsdato, doedsdato, seksten, seksti)
+}
+
+private fun opplysningsgrunnlag(
+    foedselsdato: LocalDate,
+    doedsdato: LocalDate,
+    seksten: LocalDate,
+    seksti: LocalDate,
+): List<Opplysningsgrunnlag> =
+    listOf(
+        Opplysningsgrunnlag.ny(TrygdetidOpplysningType.FOEDSELSDATO, pdlKilde, foedselsdato),
+        Opplysningsgrunnlag.ny(TrygdetidOpplysningType.DOEDSDATO, pdlKilde, doedsdato),
+        Opplysningsgrunnlag.ny(TrygdetidOpplysningType.FYLT_16, regelKilde, seksten),
+        Opplysningsgrunnlag.ny(TrygdetidOpplysningType.FYLLER_66, regelKilde, seksti),
+    )
+
+fun trygdetidGrunnlag(
+    beregnetTrygdetidGrunnlag: BeregnetTrygdetidGrunnlag? = beregnetTrygdetidGrunnlag(),
+    periode: TrygdetidPeriode =
+        TrygdetidPeriode(
+            fra = LocalDate.of(2023, 1, 1),
+            til = LocalDate.of(2023, 2, 1),
+        ),
+    begrunnelse: String? = null,
+    poengInnAar: Boolean = false,
+    poengUtAar: Boolean = false,
+    prorata: Boolean = false,
+    trygdetidType: TrygdetidType = TrygdetidType.FAKTISK,
+    bosted: String = LandNormalisert.NORGE.isoCode,
+) = TrygdetidGrunnlag(
+    id = randomUUID(),
+    type = trygdetidType,
+    bosted = bosted,
+    periode = periode,
+    beregnetTrygdetid = beregnetTrygdetidGrunnlag,
+    kilde = Grunnlagsopplysning.Saksbehandler(ident = "Z123", tidspunkt = Tidspunkt.now()),
+    begrunnelse = begrunnelse,
+    poengUtAar = poengUtAar,
+    poengInnAar = poengInnAar,
+    prorata = prorata,
+)
+
+fun trygdeavtale(
+    behandlingId: UUID,
+    avtaleKode: String,
+    avtaleDatoKode: String? = null,
+    avtaleKriteriaKode: String? = null,
+    personKrets: JaNei? = null,
+    arbInntekt1G: JaNei? = null,
+    arbInntekt1GKommentar: String? = null,
+    beregArt50: JaNei? = null,
+    beregArt50Kommentar: String? = null,
+    nordiskTrygdeAvtale: JaNei? = null,
+    nordiskTrygdeAvtaleKommentar: String? = null,
+) = Trygdeavtale(
+    id = randomUUID(),
+    behandlingId = behandlingId,
+    avtaleKode = avtaleKode,
+    avtaleDatoKode = avtaleDatoKode,
+    avtaleKriteriaKode = avtaleKriteriaKode,
+    personKrets = null,
+    arbInntekt1G = null,
+    arbInntekt1GKommentar = null,
+    beregArt50 = null,
+    beregArt50Kommentar = null,
+    nordiskTrygdeAvtale = null,
+    nordiskTrygdeAvtaleKommentar = null,
+    kilde = Grunnlagsopplysning.Saksbehandler(ident = "Z123", tidspunkt = Tidspunkt.now()),
+)
+
+fun beregnetTrygdetid(
+    total: Int = 0,
+    tidspunkt: Tidspunkt = Tidspunkt.now(),
+    yrkesskade: Boolean = false,
+    overstyrt: Boolean = false,
+    overstyrtBegrunnelse: String? = null,
+) = DetaljertBeregnetTrygdetid(
+    resultat =
+        DetaljertBeregnetTrygdetidResultat(
+            faktiskTrygdetidNorge = null,
+            faktiskTrygdetidTeoretisk = null,
+            fremtidigTrygdetidNorge = null,
+            fremtidigTrygdetidTeoretisk = null,
+            samletTrygdetidNorge = total,
+            samletTrygdetidTeoretisk = null,
+            prorataBroek = null,
+            overstyrt = overstyrt,
+            yrkesskade = yrkesskade,
+            beregnetSamletTrygdetidNorge = null,
+            overstyrtBegrunnelse = overstyrtBegrunnelse,
+        ),
+    tidspunkt = tidspunkt,
+    regelResultat = "".toJsonNode(),
+)
+
+fun beregnetTrygdetidGrunnlag(verdi: Period = Period.parse("P2Y2D")) =
+    BeregnetTrygdetidGrunnlag(
+        verdi = verdi,
+        tidspunkt = Tidspunkt.now(),
+        regelResultat = "".toJsonNode(),
+    )

--- a/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidRepositoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidRepositoryTest.kt
@@ -1,0 +1,474 @@
+package no.nav.etterlatte.trygdetid
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.toJsonNode
+import no.nav.etterlatte.libs.common.trygdetid.land.LandNormalisert
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.RegisterExtension
+import java.time.LocalDate
+import java.util.UUID
+import java.util.UUID.randomUUID
+import javax.sql.DataSource
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class TrygdetidRepositoryTest(
+    dataSource: DataSource,
+) {
+    companion object {
+        @RegisterExtension
+        val dbExtension = DatabaseExtension()
+    }
+
+    private val repository: TrygdetidRepository = TrygdetidRepository(dataSource)
+
+    @AfterEach
+    fun afterEach() {
+        dbExtension.resetDb()
+    }
+
+    private val pdlKilde: Grunnlagsopplysning.Pdl = Grunnlagsopplysning.Pdl(Tidspunkt.now(), null, "opplysningsId1")
+
+    private val regelKilde: Grunnlagsopplysning.RegelKilde =
+        Grunnlagsopplysning.RegelKilde("regel", Tidspunkt.now(), "1")
+
+    @Test
+    fun `skal opprette trygdetid med opplysninger`() {
+        val behandling = behandlingMock()
+
+        val foedselsdato = LocalDate.of(2000, 1, 1)
+        val doedsdato = LocalDate.of(2020, 1, 1)
+        val seksten = LocalDate.of(2016, 1, 1)
+        val seksti = LocalDate.of(2066, 1, 1)
+
+        val opplysninger = opplysningsgrunnlag(foedselsdato, doedsdato, seksten, seksti)
+
+        val opprettetTrygdetid = trygdetid(behandling.id, behandling.sak, opplysninger = opplysninger)
+
+        val trygdetid = repository.opprettTrygdetid(opprettetTrygdetid)
+
+        trygdetid shouldNotBe null
+        trygdetid.behandlingId shouldBe behandling.id
+        trygdetid.opplysninger.size shouldBe 4
+
+        with(trygdetid.opplysninger[0]) {
+            type shouldBe TrygdetidOpplysningType.FOEDSELSDATO
+            opplysning shouldBe foedselsdato.toJsonNode()
+            kilde shouldBe pdlKilde
+        }
+        with(trygdetid.opplysninger[1]) {
+            type shouldBe TrygdetidOpplysningType.DOEDSDATO
+            opplysning shouldBe doedsdato.toJsonNode()
+            kilde shouldBe pdlKilde
+        }
+        with(trygdetid.opplysninger[2]) {
+            type shouldBe TrygdetidOpplysningType.FYLT_16
+            opplysning shouldBe seksten.toJsonNode()
+            kilde shouldBe regelKilde
+        }
+        with(trygdetid.opplysninger[3]) {
+            type shouldBe TrygdetidOpplysningType.FYLLER_66
+            opplysning shouldBe seksti.toJsonNode()
+            kilde shouldBe regelKilde
+        }
+    }
+
+    private fun opplysningsgrunnlag(
+        foedselsdato: LocalDate,
+        doedsdato: LocalDate,
+        seksten: LocalDate,
+        seksti: LocalDate,
+    ): List<Opplysningsgrunnlag> {
+        val opplysninger =
+            listOf(
+                Opplysningsgrunnlag.ny(TrygdetidOpplysningType.FOEDSELSDATO, pdlKilde, foedselsdato),
+                Opplysningsgrunnlag.ny(TrygdetidOpplysningType.DOEDSDATO, pdlKilde, doedsdato),
+                Opplysningsgrunnlag.ny(TrygdetidOpplysningType.FYLT_16, regelKilde, seksten),
+                Opplysningsgrunnlag.ny(TrygdetidOpplysningType.FYLLER_66, regelKilde, seksti),
+            )
+        return opplysninger
+    }
+
+    @Test
+    fun `skal opprette og hente trygdetid`() {
+        val behandling = behandlingMock()
+        val opprettetTrygdetid = trygdetid(behandling.id, behandling.sak)
+
+        repository.opprettTrygdetid(opprettetTrygdetid)
+        val trygdetid = repository.hentTrygdetid(behandling.id)
+
+        trygdetid shouldNotBe null
+        trygdetid?.id shouldNotBe null
+        trygdetid?.behandlingId shouldBe behandling.id
+        trygdetid?.yrkesskade shouldBe false
+    }
+
+    @Test
+    fun `skal opprette og hente trygdetid med yrkesskade`() {
+        val behandling = behandlingMock()
+        val opprettetTrygdetid = trygdetid(behandling.id, behandling.sak, yrkesskade = true)
+
+        repository.opprettTrygdetid(opprettetTrygdetid)
+        val trygdetid = repository.hentTrygdetid(behandling.id)
+
+        trygdetid shouldNotBe null
+        trygdetid?.id shouldNotBe null
+        trygdetid?.behandlingId shouldBe behandling.id
+        trygdetid?.yrkesskade shouldBe true
+    }
+
+    @Test
+    fun `skal opprette og hente trygdetid med grunnlag og beregning`() {
+        val behandling = behandlingMock()
+        val beregnetTrygdetid = beregnetTrygdetid()
+        val trygdetidGrunnlag = trygdetidGrunnlag()
+        val opprettetTrygdetid =
+            trygdetid(
+                behandling.id,
+                behandling.sak,
+                trygdetidGrunnlag = listOf(trygdetidGrunnlag),
+                beregnetTrygdetid = beregnetTrygdetid,
+            )
+
+        repository.opprettTrygdetid(opprettetTrygdetid)
+        val trygdetid = repository.hentTrygdetid(behandling.id)
+
+        trygdetid shouldNotBe null
+        trygdetid?.id shouldNotBe null
+        trygdetid?.behandlingId shouldBe behandling.id
+        trygdetid?.trygdetidGrunnlag?.first() shouldBe trygdetidGrunnlag
+        trygdetid?.beregnetTrygdetid shouldBe beregnetTrygdetid
+        trygdetid?.yrkesskade shouldBe false
+    }
+
+    @Test
+    fun `skal opprette og hente trygdetid med grunnlag og beregning for yrkesskade`() {
+        val behandling = behandlingMock()
+        val beregnetTrygdetid = beregnetTrygdetid(yrkesskade = true)
+        val trygdetidGrunnlag = trygdetidGrunnlag()
+        val opprettetTrygdetid =
+            trygdetid(
+                behandling.id,
+                behandling.sak,
+                trygdetidGrunnlag = listOf(trygdetidGrunnlag),
+                beregnetTrygdetid = beregnetTrygdetid,
+                yrkesskade = true,
+            )
+
+        repository.opprettTrygdetid(opprettetTrygdetid)
+        val trygdetid = repository.hentTrygdetid(behandling.id)
+
+        trygdetid shouldNotBe null
+        trygdetid?.id shouldNotBe null
+        trygdetid?.behandlingId shouldBe behandling.id
+        trygdetid?.trygdetidGrunnlag?.first() shouldBe trygdetidGrunnlag
+        trygdetid?.beregnetTrygdetid shouldBe beregnetTrygdetid
+        trygdetid?.yrkesskade shouldBe true
+    }
+
+    @Test
+    fun `skal opprette og hente trygdetid med grunnlag og poeng inn og ut aar og prorata`() {
+        val behandling = behandlingMock()
+        val beregnetTrygdetid = beregnetTrygdetid()
+        val trygdetidGrunnlag = trygdetidGrunnlag(poengInnAar = true, poengUtAar = true, prorata = true)
+        val opprettetTrygdetid =
+            trygdetid(
+                behandling.id,
+                behandling.sak,
+                trygdetidGrunnlag = listOf(trygdetidGrunnlag),
+                beregnetTrygdetid = beregnetTrygdetid,
+            )
+
+        repository.opprettTrygdetid(opprettetTrygdetid)
+        val trygdetid = repository.hentTrygdetid(behandling.id)
+
+        trygdetid shouldNotBe null
+        trygdetid?.id shouldNotBe null
+        trygdetid?.behandlingId shouldBe behandling.id
+        trygdetid?.trygdetidGrunnlag?.first() shouldBe trygdetidGrunnlag
+        trygdetid?.beregnetTrygdetid shouldBe beregnetTrygdetid
+    }
+
+    @Test
+    fun `skal opprette et trygdetidsgrunnlag`() {
+        val behandling = behandlingMock()
+        val trygdetidGrunnlag = trygdetidGrunnlag(beregnetTrygdetidGrunnlag = beregnetTrygdetidGrunnlag())
+        val opprettetTrygdetid = trygdetid(behandling.id, behandling.sak)
+
+        val lagretTrygdetid = repository.opprettTrygdetid(opprettetTrygdetid)
+        val trygdetidMedTrygdetidGrunnlag =
+            repository.oppdaterTrygdetid(lagretTrygdetid.leggTilEllerOppdaterTrygdetidGrunnlag(trygdetidGrunnlag))
+
+        trygdetidMedTrygdetidGrunnlag shouldNotBe null
+        with(trygdetidMedTrygdetidGrunnlag.trygdetidGrunnlag.first()) {
+            this shouldBe trygdetidGrunnlag
+        }
+    }
+
+    @Test
+    fun `skal slette et trygdetidsgrunnlag`() {
+        val behandling = behandlingMock()
+        val trygdetidGrunnlag = trygdetidGrunnlag(beregnetTrygdetidGrunnlag = beregnetTrygdetidGrunnlag())
+        val opprettetTrygdetid = trygdetid(behandling.id, behandling.sak)
+
+        val lagretTrygdetid = repository.opprettTrygdetid(opprettetTrygdetid)
+        val trygdetidMedTrygdetidGrunnlag =
+            repository.oppdaterTrygdetid(lagretTrygdetid.leggTilEllerOppdaterTrygdetidGrunnlag(trygdetidGrunnlag))
+
+        trygdetidMedTrygdetidGrunnlag shouldNotBe null
+        with(trygdetidMedTrygdetidGrunnlag.trygdetidGrunnlag.first()) {
+            this shouldBe trygdetidGrunnlag
+        }
+
+        val trygdetidUtenGrunnlag = trygdetidMedTrygdetidGrunnlag.copy(trygdetidGrunnlag = emptyList())
+        val lagretTrygdetidUtenGrunnlag = repository.oppdaterTrygdetid(trygdetidUtenGrunnlag)
+
+        lagretTrygdetidUtenGrunnlag shouldNotBe null
+        lagretTrygdetidUtenGrunnlag.trygdetidGrunnlag.shouldBeEmpty()
+    }
+
+    @Test
+    fun `skal oppdatere et trygdetidsgrunnlag`() {
+        val behandling = behandlingMock()
+        val trygdetidGrunnlag = trygdetidGrunnlag(beregnetTrygdetidGrunnlag = beregnetTrygdetidGrunnlag())
+        val opprettetTrygdetid = trygdetid(behandling.id, behandling.sak, trygdetidGrunnlag = listOf(trygdetidGrunnlag))
+
+        val trygdetid = repository.opprettTrygdetid(opprettetTrygdetid)
+        val endretTrygdetidGrunnlag = trygdetidGrunnlag.copy(bosted = LandNormalisert.POLEN.isoCode)
+        val trygdetidMedOppdatertGrunnlag =
+            repository.oppdaterTrygdetid(trygdetid.leggTilEllerOppdaterTrygdetidGrunnlag(endretTrygdetidGrunnlag))
+
+        trygdetidMedOppdatertGrunnlag shouldNotBe null
+        with(trygdetidMedOppdatertGrunnlag.trygdetidGrunnlag.first()) {
+            this shouldBe endretTrygdetidGrunnlag
+        }
+    }
+
+    @Test
+    fun `skal oppdatere et trygdetidsgrunnlag med begrunnelse`() {
+        val behandling = behandlingMock()
+        val trygdetidGrunnlag =
+            trygdetidGrunnlag(
+                beregnetTrygdetidGrunnlag = beregnetTrygdetidGrunnlag(),
+                begrunnelse = "Test",
+            )
+        val opprettetTrygdetid = trygdetid(behandling.id, behandling.sak, trygdetidGrunnlag = listOf(trygdetidGrunnlag))
+
+        val trygdetid = repository.opprettTrygdetid(opprettetTrygdetid)
+
+        val lagretTrygdetid = repository.hentTrygdetid(behandling.id)
+
+        lagretTrygdetid shouldNotBe null
+        lagretTrygdetid?.trygdetidGrunnlag?.firstOrNull()?.begrunnelse shouldBe "Test"
+
+        val endretTrygdetidGrunnlag =
+            trygdetidGrunnlag.copy(
+                bosted = LandNormalisert.POLEN.isoCode,
+                begrunnelse = "Test2",
+            )
+
+        val trygdetidMedOppdatertGrunnlag =
+            repository.oppdaterTrygdetid(trygdetid.leggTilEllerOppdaterTrygdetidGrunnlag(endretTrygdetidGrunnlag))
+
+        trygdetidMedOppdatertGrunnlag shouldNotBe null
+        with(trygdetidMedOppdatertGrunnlag.trygdetidGrunnlag.first()) {
+            this shouldBe endretTrygdetidGrunnlag
+        }
+    }
+
+    @Test
+    fun `skal oppdatere et trygdetidsgrunnlag med poeng inn og ut aar og prorata`() {
+        val behandling = behandlingMock()
+        val trygdetidGrunnlag =
+            trygdetidGrunnlag(
+                beregnetTrygdetidGrunnlag = beregnetTrygdetidGrunnlag(),
+                begrunnelse = "Test",
+            )
+        val opprettetTrygdetid = trygdetid(behandling.id, behandling.sak, trygdetidGrunnlag = listOf(trygdetidGrunnlag))
+
+        val trygdetid = repository.opprettTrygdetid(opprettetTrygdetid)
+
+        val lagretTrygdetid = repository.hentTrygdetid(behandling.id)
+
+        lagretTrygdetid shouldNotBe null
+        lagretTrygdetid?.trygdetidGrunnlag?.firstOrNull()?.begrunnelse shouldBe "Test"
+
+        val endretTrygdetidGrunnlag =
+            trygdetidGrunnlag.copy(
+                bosted = LandNormalisert.POLEN.isoCode,
+                begrunnelse = "Test2",
+                poengUtAar = true,
+                poengInnAar = true,
+                prorata = true,
+            )
+
+        val trygdetidMedOppdatertGrunnlag =
+            repository.oppdaterTrygdetid(trygdetid.leggTilEllerOppdaterTrygdetidGrunnlag(endretTrygdetidGrunnlag))
+
+        trygdetidMedOppdatertGrunnlag shouldNotBe null
+        with(trygdetidMedOppdatertGrunnlag.trygdetidGrunnlag.first()) {
+            this shouldBe endretTrygdetidGrunnlag
+        }
+    }
+
+    @Test
+    fun `skal oppdatere beregnet trygdetid`() {
+        val beregnetTrygdetid = beregnetTrygdetid(total = 12, tidspunkt = Tidspunkt.now())
+        val behandling = behandlingMock()
+        val opprettetTrygdetid = trygdetid(behandling.id, behandling.sak)
+
+        val trygdetid = repository.opprettTrygdetid(opprettetTrygdetid)
+        val trygdetidMedBeregnetTrygdetid =
+            repository.oppdaterTrygdetid(trygdetid.oppdaterBeregnetTrygdetid(beregnetTrygdetid))
+
+        trygdetidMedBeregnetTrygdetid shouldNotBe null
+        trygdetidMedBeregnetTrygdetid.beregnetTrygdetid shouldBe beregnetTrygdetid
+        trygdetidMedBeregnetTrygdetid.yrkesskade shouldBe false
+    }
+
+    @Test
+    fun `skal oppdatere beregnet trygdetid med yrkesskade`() {
+        val beregnetTrygdetid = beregnetTrygdetid(total = 12, tidspunkt = Tidspunkt.now(), yrkesskade = true)
+        val behandling = behandlingMock()
+        val opprettetTrygdetid = trygdetid(behandling.id, behandling.sak, yrkesskade = true)
+
+        val trygdetid = repository.opprettTrygdetid(opprettetTrygdetid)
+        val trygdetidMedBeregnetTrygdetid =
+            repository.oppdaterTrygdetid(trygdetid.oppdaterBeregnetTrygdetid(beregnetTrygdetid))
+
+        trygdetidMedBeregnetTrygdetid shouldNotBe null
+        trygdetidMedBeregnetTrygdetid.beregnetTrygdetid shouldBe beregnetTrygdetid
+        trygdetidMedBeregnetTrygdetid.yrkesskade shouldBe true
+    }
+
+    @Test
+    fun `skal oppdatere trygdetid with overstyrt poengaar`() {
+        val behandling = behandlingMock()
+        val opprettetTrygdetid = trygdetid(behandling.id, behandling.sak)
+
+        val trygdetid = repository.opprettTrygdetid(opprettetTrygdetid)
+
+        val trygdetidMedOverstyrtPoengaar =
+            repository.oppdaterTrygdetid(
+                trygdetid.copy(overstyrtNorskPoengaar = 10),
+            )
+
+        trygdetidMedOverstyrtPoengaar shouldNotBe null
+        trygdetidMedOverstyrtPoengaar.overstyrtNorskPoengaar shouldBe 10
+    }
+
+    @Test
+    fun `skal nullstille beregnet trygdetid`() {
+        val beregnetTrygdetid = beregnetTrygdetid(total = 12, tidspunkt = Tidspunkt.now())
+        val behandling = behandlingMock()
+        val opprettetTrygdetid = trygdetid(behandling.id, behandling.sak)
+
+        val trygdetid = repository.opprettTrygdetid(opprettetTrygdetid)
+        val trygdetidMedBeregnetTrygdetid =
+            repository.oppdaterTrygdetid(trygdetid.oppdaterBeregnetTrygdetid(beregnetTrygdetid))
+
+        trygdetidMedBeregnetTrygdetid.beregnetTrygdetid shouldBe beregnetTrygdetid
+
+        val trygdetidUtenBeregning =
+            repository.oppdaterTrygdetid(
+                trygdetidMedBeregnetTrygdetid.nullstillBeregnetTrygdetid(),
+            )
+        trygdetidUtenBeregning.beregnetTrygdetid shouldBe null
+    }
+
+    @Test
+    fun `trygdetiderForAvdoede finner behandling med trygdetid for samme avdøde`() {
+        val behandling1 = behandlingMock()
+        val behandling2 = behandlingMock()
+        val behandling3 = behandlingMock()
+        val fnr1 = "02438311109"
+        val fnr2 = "18498248795"
+        repository.opprettTrygdetid(trygdetid(behandling1.id, behandling1.sak, ident = fnr1))
+        repository.opprettTrygdetid(trygdetid(behandling2.id, behandling2.sak, ident = fnr2))
+        repository.opprettTrygdetid(trygdetid(behandling3.id, behandling3.sak, ident = fnr1))
+
+        val behandlinger: List<TrygdetidPartial> =
+            repository
+                .hentTrygdetiderForAvdoede(
+                    listOf(fnr1),
+                ).sortedBy { it.ident }
+
+        behandlinger shouldHaveSize 2
+        behandlinger.find { it.behandlingId == behandling1.id }?.ident shouldBe fnr1
+        behandlinger.find { it.behandlingId == behandling3.id }?.ident shouldBe fnr1
+    }
+
+    @Test
+    fun `trygdetiderForAvdoede finner behandling med trygdetid for to avdøde`() {
+        val behandling1 = behandlingMock()
+        val behandling2 = behandlingMock()
+        val behandling3 = behandlingMock()
+        val fnr1 = "02438311109"
+        val fnr2 = "18498248795"
+        val fnr3 = "31488338237"
+        repository.opprettTrygdetid(trygdetid(behandling1.id, behandling1.sak, ident = fnr1))
+        repository.opprettTrygdetid(trygdetid(behandling1.id, behandling1.sak, ident = fnr2))
+        repository.opprettTrygdetid(trygdetid(behandling2.id, behandling2.sak, ident = fnr1))
+        repository.opprettTrygdetid(trygdetid(behandling3.id, behandling3.sak, ident = fnr3))
+
+        val trygdetider: List<TrygdetidPartial> =
+            repository.hentTrygdetiderForAvdoede(listOf(fnr1, fnr2))
+        trygdetider shouldHaveSize 3
+        trygdetider.groupBy { it.behandlingId }.let { byBehandling ->
+            byBehandling[behandling1.id]!!.map { it.ident } shouldContainExactlyInAnyOrder listOf(fnr1, fnr2)
+            byBehandling[behandling2.id]!!.map { it.ident } shouldContainExactlyInAnyOrder listOf(fnr1)
+        }
+    }
+
+    @Test
+    fun `trygdetiderForAvdoede returnerer tom liste hvis ingen matchende`() {
+        val behandling1 = behandlingMock()
+
+        val fnr1 = "02438311109"
+        val fnr2 = "18498248795"
+        repository.opprettTrygdetid(trygdetid(behandling1.id, behandling1.sak, ident = fnr1))
+
+        val trygdetider: List<TrygdetidPartial> =
+            repository.hentTrygdetiderForAvdoede(
+                listOf(
+                    fnr2,
+                ),
+            )
+        trygdetider shouldBe emptyList()
+    }
+
+    @Test
+    fun `overstyrt trygdetid skal ha begrunnelse`() {
+        val behandling = UUID.randomUUID()
+
+        val beregnet =
+            beregnetTrygdetid(
+                overstyrt = true,
+                overstyrtBegrunnelse = "Er overstyrt",
+            )
+        repository.opprettTrygdetid(trygdetid(behandlingId = behandling, beregnetTrygdetid = beregnet))
+
+        val trygdetid = repository.hentTrygdetid(behandling)
+
+        with(trygdetid!!) {
+            beregnetTrygdetid!!.resultat.overstyrtBegrunnelse shouldBe "Er overstyrt"
+        }
+    }
+
+    private fun behandlingMock() =
+        mockk<DetaljertBehandling>().apply {
+            every { id } returns randomUUID()
+            every { sak } returns SakId(123L)
+        }
+}

--- a/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/avtale/AvtaleRepositoryTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/avtale/AvtaleRepositoryTest.kt
@@ -1,0 +1,88 @@
+package no.nav.etterlatte.trygdetid.avtale
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
+import no.nav.etterlatte.libs.common.behandling.JaNei
+import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.trygdetid.DatabaseExtension
+import no.nav.etterlatte.trygdetid.trygdeavtale
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.RegisterExtension
+import java.util.UUID.randomUUID
+import javax.sql.DataSource
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class AvtaleRepositoryTest(
+    dataSource: DataSource,
+) {
+    companion object {
+        @RegisterExtension
+        val dbExtension = DatabaseExtension()
+    }
+
+    private val repository = AvtaleRepository(dataSource)
+
+    @AfterEach
+    fun afterEach() {
+        dbExtension.resetDb()
+    }
+
+    @Test
+    fun `skal opprette og hente avtaler`() {
+        val behandling = behandlingMock()
+        val avtale = trygdeavtale(behandling.id, "EOS_NOR", "EOS2010", "YRK_MEDL")
+
+        repository.opprettAvtale(avtale)
+
+        repository.hentAvtale(behandling.id) shouldBe avtale
+    }
+
+    @Test
+    fun `skal oppdatere avtaler`() {
+        val behandling = behandlingMock()
+        val avtale =
+            trygdeavtale(
+                behandlingId = behandling.id,
+                avtaleKode = "EOS_NOR",
+                avtaleDatoKode = "EOS2010",
+                avtaleKriteriaKode = "YRK_MEDL",
+                personKrets = JaNei.JA,
+                arbInntekt1G = JaNei.JA,
+                arbInntekt1GKommentar = "hei",
+                beregArt50 = JaNei.NEI,
+                beregArt50Kommentar = "hei",
+                nordiskTrygdeAvtale = JaNei.NEI,
+                nordiskTrygdeAvtaleKommentar = "hei igjen",
+            )
+
+        repository.opprettAvtale(avtale)
+
+        val oppdatertAvtale =
+            repository.hentAvtale(behandling.id)!!.copy(
+                avtaleKode = "ISR",
+                avtaleDatoKode = null,
+                avtaleKriteriaKode = "YRK_TRYGD",
+                personKrets = JaNei.JA,
+                arbInntekt1G = null,
+                arbInntekt1GKommentar = null,
+                beregArt50 = JaNei.JA,
+                beregArt50Kommentar = null,
+                nordiskTrygdeAvtale = JaNei.NEI,
+                nordiskTrygdeAvtaleKommentar = null,
+            )
+
+        repository.lagreAvtale(oppdatertAvtale)
+
+        repository.hentAvtale(behandling.id) shouldBe oppdatertAvtale
+    }
+
+    private fun behandlingMock() =
+        mockk<DetaljertBehandling>().apply {
+            every { id } returns randomUUID()
+            every { sak } returns SakId(123L)
+        }
+}


### PR DESCRIPTION
# Flytt trygdetid sitt databaselag inn i behandling

### Hvorfor er denne endringen nødvendig? ✨

Vi skal flytte all kode fra etterlatte-trygdetid inn i etterlatte-behandling. Dette er første steg og tar databaselaget.

- Kopierer `TrygdetidRepository` og `AvtaleRepository` inn i behandling, sammen med domenemodellene de trenger.
- Tabellene lå allerede i behandling basen fra før.
- Foreløpig en ren kopi. Koden ligger fortsatt i trygdetid også, og slettes i et senere steg.

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29548).

### Verdt å nevne

Jeg har kopiert med testene som går rent på databaselaget og kjørt dem grønt mot behandling-basen:

- `TrygdetidRepositoryTest` (18 tester): opprette, hente, oppdatere og slette trygdetid og grunnlag, beregnet trygdetid, yrkesskade, poeng inn/ut år og prorata, samt oppslag på avdøde.
- `AvtaleRepositoryTest` (2 tester): opprette/hente og oppdatere avtale.